### PR TITLE
Disables touch-based behavior on desktops/laptops

### DIFF
--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -573,8 +573,13 @@ var __BUILD__ = 300;
   device.OS = 'iOS';
   
    END DEBUG */
-                       
- 
+
+ /* If we've made it to this point of initialization, KeymanWeb assumes we're a desktop.  Since 
+  * we don't yet support desktops with touch-based input, we disable it here.
+  */                     
+ if(device.formFactor == 'desktop') {
+   device.touchable = false;
+ }
                        
   /**
    * Expose the touchable state for UIs - will disable external UIs entirely

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -574,8 +574,8 @@ var __BUILD__ = 300;
   
    END DEBUG */
 
- /* If we've made it to this point of initialization, KeymanWeb assumes we're a desktop.  Since 
-  * we don't yet support desktops with touch-based input, we disable it here.
+ /* If we've made it to this point of initialization and aren't anything else, KeymanWeb assumes 
+  * we're a desktop.  Since we don't yet support desktops with touch-based input, we disable it here.
   */                     
  if(device.formFactor == 'desktop') {
    device.touchable = false;


### PR DESCRIPTION
As a stop-gap measure for #61.  Doesn't enable touch-based behavior on them, but at least makes KeymanWeb usable in one form.