### PR TITLE
Fix SPACEBAR and ENTER key on external keyboard

### DIFF
--- a/web/source/kmwembedded.js
+++ b/web/source/kmwembedded.js
@@ -498,12 +498,21 @@
         return true;
       }
       
-      // Use default mapping only if necessary (last resort) 
+      // Use default mapping only if necessary (last resort)
+      if (Lkc.Lcode == osk.keyCodes.K_SPACE) {
+        keymanweb.KO(0, Lelem, ' ');
+        return true;
+      }
+      else if (Lkc.Lcode == osk.keyCodes.K_ENTER) {
+        keymanweb.KO(0, Lelem, '\n');
+        return true;
+      }
       var ch = osk.defaultKeyOutput('', Lkc.Lcode, shift);
       if(ch) {
         keymanweb.KO(0, Lelem, ch);                     
         return true;
-      } 
+      }
+
       return false;
   };
 


### PR DESCRIPTION
Fix for sillsdev/keyman/issues/12 where SPACEBAR and ENTER key on an external keyoard weren't registering a keystroke.