### PR TITLE
Rename embedded artifact to keyman.js

### DIFF
--- a/web/source/build.bat
+++ b/web/source/build.bat
@@ -65,10 +65,10 @@ del kmwtemp.js 2>nul
 if not exist kmwtemp.js goto fail
 
 echo Append SMP extensions
-copy /B %EMBED_OUTPUT%\kmw-smpstring.js+kmwtemp.js %EMBED_OUTPUT%\keymanweb.js >nul
+copy /B %EMBED_OUTPUT%\kmw-smpstring.js+kmwtemp.js %EMBED_OUTPUT%\keyman.js >nul
 del kmwtemp.js
 
-echo Compiled embedded application saved as keymanweb.js
+echo Compiled embedded application saved as keyman.js
 
 rem Update any changed resources
 


### PR DESCRIPTION
Android projects are expecting the web embedded artifact to be named keyman.js instead of keymanweb.js