### PR TITLE
Improved keyboard error reporting

### DIFF
--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3072,6 +3072,7 @@
 
     // Add a handler for cases where the new <script> block fails to load.
     Lscript.addEventListener('error', function() {
+      // Clear the timeout timer.
       window.clearTimeout(keymanweb.loadTimer);
       keymanweb.loadTimer = null;
 
@@ -3082,16 +3083,15 @@
 
     // Add a handler for cases where the new <script> block loads, but fails to process.
     Lscript.addEventListener('load', function() {
+      // Clear the timeout timer.
       window.clearTimeout(keymanweb.loadTimer);
       keymanweb.loadTimer = null;
 
-      // Did we load successfully?  Remember, the keyboard will directly call KeymanWeb!
+      // Since the keyboard will directly call KeymanWeb, we only need to check if the registration succeeded.
       if(keymanweb._LoadingInternalName != null) {  // Is cleared upon a successful load.
         keymanweb.loadFailureHandler('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '!');
         console.log('Error registering the', kbdName, 'keyboard for', kbdLang + '!');
       }
-      //util.wait(false);
-      //util.alert("Keyboard loaded.");
     }, true);
 
     // Set here because IE likes to instantly start loading the script when this is set, even before it's formally added to the document.  

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3070,29 +3070,31 @@
     var kbdLang = kbdStub['KL'];
     var kbdName = kbdStub['KN'];
 
-    // Add a handler for cases where the new <script> block fails to load.
-    Lscript.addEventListener('error', function() {
-      // Clear the timeout timer.
-      window.clearTimeout(keymanweb.loadTimer);
-      keymanweb.loadTimer = null;
+    if(keymanweb.loadFailureHandler) {
+      // Add a handler for cases where the new <script> block fails to load.
+      Lscript.addEventListener('error', function() {
+        // Clear the timeout timer.
+        window.clearTimeout(keymanweb.loadTimer);
+        keymanweb.loadTimer = null;
 
-      // We already know the load has failed... why wait?
-      keymanweb.loadFailureHandler('Cannot find the ' + kbdName + ' keyboard for ' + kbdLang + '!');
-      console.log('Error:  cannot find the', kbdName, 'keyboard for', kbdLang, 'at', kbdFile + '!');
-    }, true);
+        // We already know the load has failed... why wait?
+        keymanweb.loadFailureHandler('Cannot find the ' + kbdName + ' keyboard for ' + kbdLang + '!');
+        console.log('Error:  cannot find the', kbdName, 'keyboard for', kbdLang, 'at', kbdFile + '!');
+      }, true);
 
-    // Add a handler for cases where the new <script> block loads, but fails to process.
-    Lscript.addEventListener('load', function() {
-      // Clear the timeout timer.
-      window.clearTimeout(keymanweb.loadTimer);
-      keymanweb.loadTimer = null;
+      // Add a handler for cases where the new <script> block loads, but fails to process.
+      Lscript.addEventListener('load', function() {
+        // Clear the timeout timer.
+        window.clearTimeout(keymanweb.loadTimer);
+        keymanweb.loadTimer = null;
 
-      // Since the keyboard will directly call KeymanWeb, we only need to check if the registration succeeded.
-      if(keymanweb._LoadingInternalName != null) {  // Is cleared upon a successful load.
-        keymanweb.loadFailureHandler('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '!');
-        console.log('Error registering the', kbdName, 'keyboard for', kbdLang + '!');
-      }
-    }, true);
+        // Since the keyboard will directly call KeymanWeb, we only need to check if the registration succeeded.
+        if(keymanweb._LoadingInternalName != null) {  // Is cleared upon a successful load.
+          keymanweb.loadFailureHandler('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '!');
+          console.log('Error registering the', kbdName, 'keyboard for', kbdLang + '!');
+        }
+      }, true);
+    }
 
     // Set here because IE likes to instantly start loading the script when this is set, even before it's formally added to the document.  
     // We want it to trigger after we've set handlers.

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3061,12 +3061,38 @@
  *  @param  {string}  kbdFile   keyboard filename
  *    
  **/      
-  keymanweb.installKeyboard = function(kbdFile)
-  {
+  keymanweb.installKeyboard = function(kbdFile) {
     var Lscript = util._CreateElement('SCRIPT');
-    Lscript.charset="UTF-8";        // KMEW-89
-    Lscript.src = keymanweb.getKeyboardPath(kbdFile);       
+    Lscript.charset="UTF-8";        // KMEW-89       
     Lscript.type = 'text/javascript';
+
+    // Add a handler for cases where the new <script> block fails to load.
+    Lscript.addEventListener('error', function() {
+      window.clearTimeout(keymanweb.loadTimer);
+      keymanweb.loadTimer = null;
+
+      // We already know the load has failed... why wait?
+      keymanweb.loadFailureHandler();
+    }, true);
+
+    // Add a handler for cases where the new <script> block loads, but fails to process.
+    Lscript.addEventListener('load', function() {
+      window.clearTimeout(keymanweb.loadTimer);
+      keymanweb.loadTimer = null;
+
+      // Did we load successfully?  Remember, the keyboard will directly call KeymanWeb!
+      if(keymanweb._LoadingInternalName != null) {  // Is cleared upon a successful load.
+        keymanweb.loadFailureHandler();
+      }
+      //util.wait(false);
+      //util.alert("Keyboard loaded.");
+    }, true);
+
+    // Set here because IE likes to instantly start loading the script when this is set,
+    // even before it's formally added to the document.
+    Lscript.src = keymanweb.getKeyboardPath(kbdFile);
+
+    // Append our SCRIPT block; let's get loading!
     try {                                  
       document.body.appendChild(Lscript);  
       }

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3038,7 +3038,7 @@
             // It works much more reliably if deferred (KMEW-101, build 356)
             // The effect of a delay can also be tested, for example, by setting the timeout to 5000
             //keymanweb.installKeyboard(keymanweb._KeyboardStubs[Ln]);
-            window.setTimeout(function(){keymanweb.installKeyboard(keymanweb._KeyboardStubs[Ln]['KF']);},0);
+            window.setTimeout(function(){keymanweb.installKeyboard(keymanweb._KeyboardStubs[Ln]);},0);
           }          
           keymanweb._ActiveStub=keymanweb._KeyboardStubs[Ln];
           return;
@@ -3058,13 +3058,17 @@
 /**
  * Install a keyboard script that has been downloaded from a keyboard server
  * 
- *  @param  {string}  kbdFile   keyboard filename
+ *  @param  {object}  kbdStub   keyboard filename
  *    
  **/      
-  keymanweb.installKeyboard = function(kbdFile) {
+  keymanweb.installKeyboard = function(kbdStub) {
     var Lscript = util._CreateElement('SCRIPT');
     Lscript.charset="UTF-8";        // KMEW-89       
     Lscript.type = 'text/javascript';
+
+    kbdFile = kbdStub['KF'];
+    kbdLang = kbdStub['KL'];
+    kbdName = kbdStub['KN'];
 
     // Add a handler for cases where the new <script> block fails to load.
     Lscript.addEventListener('error', function() {
@@ -3072,7 +3076,8 @@
       keymanweb.loadTimer = null;
 
       // We already know the load has failed... why wait?
-      keymanweb.loadFailureHandler();
+      keymanweb.loadFailureHandler('Cannot find the ' + kbdName + ' keyboard for ' + kbdLang + '!');
+      console.log('Error:  cannot find the', kbdName, 'keyboard for', kbdLang, 'at', kbdFile + '!');
     }, true);
 
     // Add a handler for cases where the new <script> block loads, but fails to process.
@@ -3082,14 +3087,15 @@
 
       // Did we load successfully?  Remember, the keyboard will directly call KeymanWeb!
       if(keymanweb._LoadingInternalName != null) {  // Is cleared upon a successful load.
-        keymanweb.loadFailureHandler();
+        keymanweb.loadFailureHandler('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '!');
+        console.log('Error registering the', kbdName, 'keyboard for', kbdLang + '!');
       }
       //util.wait(false);
       //util.alert("Keyboard loaded.");
     }, true);
 
-    // Set here because IE likes to instantly start loading the script when this is set,
-    // even before it's formally added to the document.
+    // Set here because IE likes to instantly start loading the script when this is set, even before it's formally added to the document.  
+    // We want it to trigger after we've set handlers.
     Lscript.src = keymanweb.getKeyboardPath(kbdFile);
 
     // Append our SCRIPT block; let's get loading!

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3066,9 +3066,9 @@
     Lscript.charset="UTF-8";        // KMEW-89       
     Lscript.type = 'text/javascript';
 
-    kbdFile = kbdStub['KF'];
-    kbdLang = kbdStub['KL'];
-    kbdName = kbdStub['KN'];
+    var kbdFile = kbdStub['KF'];
+    var kbdLang = kbdStub['KL'];
+    var kbdName = kbdStub['KN'];
 
     // Add a handler for cases where the new <script> block fails to load.
     Lscript.addEventListener('error', function() {

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3058,7 +3058,7 @@
 /**
  * Install a keyboard script that has been downloaded from a keyboard server
  * 
- *  @param  {object}  kbdStub   keyboard filename
+ *  @param  {Object}  kbdStub   keyboard filename
  *    
  **/      
   keymanweb.installKeyboard = function(kbdStub) {

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -62,7 +62,9 @@ var __BUILD__ = 300;
     srcPath: '',              // Path to folder containing executing keymanweb script
     rootPath: '',             // Path to server root
     mustReloadKeyboard: false,// Force keyboard refreshing even if already loaded
-    fullInitialization: true  // Force full page initialization unless overridden
+    fullInitialization: true, // Force full page initialization unless overridden
+    loadFailureHandler: function() {}   // A error-reporting callback function; is set by keymanweb.keyboardUnavailable 
+                                        // when attempting to load keyboards.
   };
 
   keymanweb['initialized'] = 0;

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -63,8 +63,6 @@ var __BUILD__ = 300;
     rootPath: '',             // Path to server root
     mustReloadKeyboard: false,// Force keyboard refreshing even if already loaded
     fullInitialization: true, // Force full page initialization unless overridden
-    loadFailureHandler: function() {}   // A error-reporting callback function; is set by keymanweb.keyboardUnavailable 
-                                        // when attempting to load keyboards.
   };
 
   keymanweb['initialized'] = 0;
@@ -88,6 +86,8 @@ var __BUILD__ = 300;
   keymanweb.handleRotationEvents = function(){}
   keymanweb.alignInputs = function(b){}
   keymanweb.refreshElementContent = null; 
+  keymanweb.loadFailureHandler = null;  // A error-reporting callback function; is set by keymanweb.keyboardUnavailable 
+                                        // when attempting to load keyboards.  Leave this null for embedded applications.
   
   osk.highlightSubKeys = function(k,x,y){}
   osk.createKeyTip = function(){}

--- a/web/source/kmwnative.js
+++ b/web/source/kmwnative.js
@@ -94,15 +94,21 @@
   * 
   * @param  {Object}  Ln  keyboard stub object    
   */    
-  keymanweb.keyboardUnavailable = function(Ln)
-  {
-    keymanweb.loadFailureHandler = function() {
+  keymanweb.keyboardUnavailable = function(Ln) {
+    keymanweb.loadFailureHandler = function(altString) {
       util.wait(false);
       var Ps=keymanweb._KeyboardStubs[Ln],kbdName=Ps['KN'],lgName=Ps['KL'];
       kbdName=kbdName.replace(/\s*keyboard\s*/i,'');
-      util.alert('Sorry, the '+kbdName+' keyboard for '+lgName+' is not currently available!', function() { 
-        keymanweb['setActiveKeyboard']('');
-      });
+
+      if(altString) {
+        util.alert(altString, function() {
+          keymanweb['setActiveKeyboard']('');
+        });
+      } else {
+        util.alert('Sorry, the '+kbdName+' keyboard for '+lgName+' is not currently available!', function() { 
+          keymanweb['setActiveKeyboard']('');
+        });
+      }
 
       // Restore base keyboard if requested keyboard doesn't load
       if(Ln > 0) {         

--- a/web/source/kmwnative.js
+++ b/web/source/kmwnative.js
@@ -96,20 +96,22 @@
   */    
   keymanweb.keyboardUnavailable = function(Ln)
   {
-    return window.setTimeout(function() {
-        util.wait(false);
-        var Ps=keymanweb._KeyboardStubs[Ln],kbdName=Ps['KN'],lgName=Ps['KL'];
-        kbdName=kbdName.replace(/\s*keyboard\s*/i,'');
-        util.alert('Sorry, the '+kbdName+' keyboard for '+lgName+' is not currently available!', function() { 
-          keymanweb['setActiveKeyboard']('');
-        });
+    keymanweb.loadFailureHandler = function() {
+      util.wait(false);
+      var Ps=keymanweb._KeyboardStubs[Ln],kbdName=Ps['KN'],lgName=Ps['KL'];
+      kbdName=kbdName.replace(/\s*keyboard\s*/i,'');
+      util.alert('Sorry, the '+kbdName+' keyboard for '+lgName+' is not currently available!', function() { 
+        keymanweb['setActiveKeyboard']('');
+      });
 
-        // Restore base keyboard if requested keyboard doesn't load
-        if(Ln > 0) {         
-          Ps=keymanweb._KeyboardStubs[0];
-          keymanweb._SetActiveKeyboard(Ps['KI'],Ps['KLC'],true);
-        }
-      }, 10000);
+      // Restore base keyboard if requested keyboard doesn't load
+      if(Ln > 0) {         
+        Ps=keymanweb._KeyboardStubs[0];
+        keymanweb._SetActiveKeyboard(Ps['KI'],Ps['KLC'],true);
+      }
+    }
+      
+    return window.setTimeout(keymanweb.loadFailureHandler, 10000);
   }
   
   /**


### PR DESCRIPTION
Addresses #87, allowing for three separate error messages to be displayed depending upon circumstance.  (Javascript heavily restricts script error information, so we can't give finer-grained feedback for script registration errors.)  It also presents errors much more quickly when possible, instead of always delaying for the timeout.

- The timeout is still around, as it's a good failsafe/fallback, and sometimes things simply do take too long.
- If the script source cannot be found, this fact is immediately reported with its own message.  The console-based version of the message additionally displays the attempted `src` URL for use in debugging path and init configurations.
- If the source was found but an error occurred during script loading/registration, this also has its own message and will immediately display when detected.

It is worth noting that the original issue mentioned the possibility of reconfiguring/redesigning the keyboard
loading model, but this has not been incorporated into this PR, as a relatively simple workaround was possible.