### PR TITLE
KMW: Treat warnings as errors

### DIFF
--- a/web/source/build.bat
+++ b/web/source/build.bat
@@ -20,7 +20,8 @@ if "%CLOSURECOMPILERPATH%"=="" set CLOSURECOMPILERPATH=..\tools
 if "%JAVA%"=="" set JAVA=java
 
 set compiler=%CLOSURECOMPILERPATH%\compiler.jar
-set compilecmd="%JAVA%" -jar "%compiler%"
+set compiler_warnings=--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables
+set compilecmd="%JAVA%" -jar "%compiler%" %compiler_warnings%
 
 if not exist %compiler% (
   echo File %compiler% does not exist: have you set the environment variable CLOSURECOMPILERPATH?

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -54,7 +54,8 @@ readonly BUILD
 : ${JAVA:=java}
 
 compiler=$CLOSURECOMPILERPATH/compiler.jar
-compilecmd="$JAVA -jar $compiler"
+compiler_warnings=--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables
+compilecmd="$JAVA -jar $compiler $compiler_warnings"
 
 if ! [ -f $compiler ];
 then

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,7 +3,7 @@
    Copyright 2017 SIL International
 ***/
 
-this is a failed commit....
+this is a failed commit.....
  
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,7 +3,7 @@
    Copyright 2017 SIL International
 ***/
 
-this is a failed commit......
+this is a failed commit.......
  
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,7 +3,7 @@
    Copyright 2017 SIL International
 ***/
 
-this is a failed commit...
+this is a failed commit....
  
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,8 +3,6 @@
    Copyright 2017 SIL International
 ***/
 
-this is a failed commit.......
- 
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 
  */  

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,6 +3,7 @@
    Copyright 2017 SIL International
 ***/
 
+this is a failed commit...
  
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -3,7 +3,7 @@
    Copyright 2017 SIL International
 ***/
 
-this is a failed commit.....
+this is a failed commit......
  
 /**  
  * Base code: Declare tavultesoft, major component namespaces and instances, utility functions 


### PR DESCRIPTION
This PR was used to test the build integration in order to ensure that PRs for KeymanWeb would get a test build automatically. When researching Google Closures warning levels, I was able to change the defaults to ensure that warnings are treated as errors in the build, and have updated the build scripts accordingly.

Thus, even though this build fails, it's because it's now warning on errors in the master branch. Future master branch builds should always build because no PRs should be merged if they fail to build.