### PR TITLE
Prevent the build of makejcldbg from stalling a Delphi Starter build

### DIFF
--- a/windows/src/ext/jedi/Makefile
+++ b/windows/src/ext/jedi/Makefile
@@ -21,13 +21,13 @@ build-jcldbg:
     # It also needs to be called after make install
     cd $(EXT)\jedi\jcl\jcl\examples\windows\debug\tools
 
+!IFDEF DELPHI_STARTER
+    $(DCC32) makejcldbg.dpr    
+    $(COPY) ..\..\..\..\bin\makejcldbg.exe $(PROGRAM)\buildtools
+!ELSE
     # We use a direct build to ignore platform warnings
     # as we don't control the source of this code
 
-!IFDEF DELPHI_STARTER
-    start /wait $(MAKEDIR)\bds.exe -ns -b makejcldbg.dpr
-    $(COPY) ..\..\..\..\bin\makejcldbg.exe $(PROGRAM)\buildtools
-!ELSE
     $(MAKEDIR)\dcc32.exe $(DELPHIDPRPARAMS) makejcldbg.dpr
     $(COPY) makejcldbg.exe $(PROGRAM)\buildtools
 !ENDIF


### PR DESCRIPTION
Delphi Starter build doesn't parse warnings anyway, so we just use the Delphi Starter build wrapper to build it.