### PR TITLE
[Web] Removes now-deprecated shim elements.

### DIFF
--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3627,11 +3627,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
       // However, it possibly may be called before the OSK has been fully defined with the current keyboard, need to check.    
       //osk._Load(); 
       
-      
-      // I1476 - Handle SELECT overlapping BEGIN   TODO: Move this to float UI code ??
-      if(util._GetIEVersion() == 6) osk.shim = util['createShim']();  // I3363 (Build 301)
-      // I1476 - Handle SELECT overlapping END
-      
       //document.body.appendChild(osk._Box); 
 
       //osk._Load(false);
@@ -3703,8 +3698,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
         } 
       }
 
-      if(osk.shim) 
-        document.body.appendChild(osk.shim);  // I1476 - Handle SELECT overlapping
       //document.body.appendChild(keymanweb._StyleBlock);
 
       // IE: call _SelectionChange when the user changes the selection 

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -679,23 +679,16 @@ if(!tavultesoft['keymanweb']) {
       return P_txt.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;');  // I1452 part 2
     }  
 
-
     /**
      * Function     createShim
-     * Scope        Public
-     * @return      {Object}      IFRAME element           
-     * Description  Create an IFRAME element to go between KMW and drop down (to fix IE6 bug)
+     * Scope        Public  
+     * Description  [Deprecated] Create an IFRAME element to go between KMW and drop down (to fix IE6 bug)
      */    
     util['createShim'] = util.createShim = function()     // I1476 - Handle SELECT overlapping BEGIN
     {
-      var e = util._CreateElement('IFRAME');
-      e.src = '';
-      e.style.display = 'none';
-      e.style.position = 'absolute';
-      e.style.filter = 'progid:DXImageTransform.Microsoft.Alpha(style=0,opacity=0)';
-      e.frameBorder = '0';
-      e.scrolling = 'no';
-      return e;
+      console.warn("The util.createShim function is deprecated, as its old functionality is no longer needed.  " +
+        "It and references to its previously-produced shims may be safely removed.");
+      return;
     }
 
     // I1476 - Handle SELECT overlapping BEGIN
@@ -706,43 +699,23 @@ if(!tavultesoft['keymanweb']) {
      * @param       {Object}      Pvkbd         Visual keyboard DIV element 
      * @param       {Object}      Pframe        IFRAME shim element
      * @param       {Object}      Phelp         OSK Help DIV element               
-     * Description  Display iFrame under OSK at its currently defined position, to allow OSK to overlap SELECT elements (IE6 fix)  
+     * Description  [Deprecated] Display iFrame under OSK at its currently defined position, to allow OSK to overlap SELECT elements (IE6 fix)  
      */    
     util['showShim'] = util.showShim = function(Pvkbd,Pframe,Phelp)     
     {
-      if(Pframe)
-        try
-        {
-          Pframe.style.left = util._GetAbsoluteX(Pvkbd)+'px';
-          Pframe.style.top = util._GetAbsoluteY(Pvkbd)+'px';
-          if(Phelp)
-          {
-            Pframe.style.width = (util._GetAbsoluteX(Phelp)-util._GetAbsoluteX(Pvkbd)+Phelp.offsetWidth)+"px";
-            Pframe.style.height = (util._GetAbsoluteY(Phelp)-util._GetAbsoluteY(Pvkbd)+Phelp.offsetHeight)+"px";
-          }
-          else
-          {
-            Pframe.style.width = Pvkbd.offsetWidth+"px";
-            Pframe.style.height = Pvkbd.offsetHeight+"px";
-          }
-          Pframe.style.zindex = '9999';
-          Pframe.style.display = 'block';
-        } catch (Lerr) {} 
+      console.warn("The util.showShim function is deprecated, as its old functionality is no longer needed.  It may be safely removed.");
     }
 
     /**
      * Function     hideShim
      * Scope        Public
      * @param       {Object}      Pframe        IFRAME shim element
-     * Description  Hide iFrame shim containing OSK 
+     * Description  [Deprecated] Hide iFrame shim containing OSK 
      */    
     util['hideShim'] = function(Pframe)
     {
-      try {
-        if(Pframe) Pframe.style.display = 'none';
-      } catch (err) {}      
+      console.warn("The util.hideShim function is deprecated, as its old functionality is no longer needed.  It may be safely removed."); 
     }
-    // I1476 - Handle SELECT overlapping END
 
     /**
      * Function     rgba

--- a/web/source/kmwosk.js
+++ b/web/source/kmwosk.js
@@ -124,7 +124,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
     osk.dfltX = '';               // Left position set by page code
     osk.dfltY = '';               // Top position set by page code
     osk.noDrag = false;           // allow page to override user OSK dragging
-    osk.shim = null;              // Shim DIV for OSK
     osk.keytip = null;            // Key preview (phones)
     osk.touchY = 0;               // First y position of touched key
 
@@ -3093,8 +3092,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
         osk._DivVKbd.style.height=newHeight+'px';
         osk._DivVKbd.style.fontSize=(newHeight/8)+'px';
 
-        util['showShim'](osk._DivVKbd, osk.shim, osk._DivVKbdHelp);  // I1476 - Handle SELECT overlapping
-
         if(e  &&  e.preventDefault) e.preventDefault();
         e.cancelBubble = true;
         return false;
@@ -3171,13 +3168,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
           { Lposx = e.clientX + document.body.scrollLeft; Lposy = e.clientY + document.body.scrollTop; }
         osk._Box.style.left = (Lposx-osk._VMoveX)+'px';
         osk._Box.style.top = (Lposy-osk._VMoveY)+'px';
-
-        // I1476 - Handle SELECT overlapping BEGIN
-        if(osk._DivVKbd)
-          util['showShim'](osk._DivVKbd, osk.shim, osk._DivVKbdHelp);
-        else
-          util['showShim'](osk._Box, osk.shim);
-        // I1476 - Handle SELECT overlapping END
 
         if(e  &&  e.preventDefault) e.preventDefault();
         var r=osk.getRect();
@@ -3570,7 +3560,6 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
       else
       {
         if(osk._Box) osk._Box.style.display = 'none';
-        util['hideShim'](osk.shim);  // I1476 - Handle SELECT overlapping
       }
 
       // Allow UI to execute code when hiding the OSK

--- a/web/source/kmwuifloat.js
+++ b/web/source/kmwuifloat.js
@@ -97,10 +97,6 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
           
       // Register keymanweb events
       ui.registerEvents();        
-          
-      // I1476 - Handle SELECT overlapping BEGIN   //todo***** make shim div local**************
-      if (window.createPopup  &&  !('XmlHttpRequest' in window)) ui._Shim = util['createShim']();    
-      // I1476 - Handle SELECT overlapping END
 
       ui.kbdIcon.src = imgPath+'kbdicon.gif';
       ui.kbdIcon.title = 'Display visual keyboard';
@@ -115,8 +111,6 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
       ui.innerDiv.appendChild(Lhdiv);
       ui.outerDiv.appendChild(ui.innerDiv);
       document.body.appendChild(ui.outerDiv);
-    
-      if(ui._Shim) document.body.appendChild(ui._Shim);  // I1476 - Handle SELECT overlapping
 
       ui.KeyboardSelector =  util['createElement']('SELECT'); // ControlSelector - KeymanWeb keyboard selector
       
@@ -446,7 +440,6 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
       if(!ui.initialized) return;
       
       ui.outerDiv.style.display = 'none';
-      util['hideShim'](ui._Shim);   // I1476 - Handle SELECT overlapping
     }
 
 

--- a/web/source/kmwuitoggle.js
+++ b/web/source/kmwuitoggle.js
@@ -35,7 +35,6 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
     var ui=keymanweb['ui'] = {
       name: 'toggle',
       initialized: false,
-      shim: null,
       controller: null,
       oskButton: null,
       kbdButton: null,
@@ -479,21 +478,10 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
         ui.kbdButton._onmouseover = function()
           {
             ui.keyboardMenu.className="sfhover";
-            if(ui.shim)
-            {
-              var ss=ui.shim.style;
-              ss.left = ui.keyboardMenu.style.left;
-              ss.top = ui.keyboardMenu.style.top;
-              ss.width = ui.keyboardMenu.offsetWidth+"px";
-              ss.height = ui.keyboardMenu.offsetHeight+"px";
-              ss.zIndex = ui.keyboardMenu.style.zIndex-1;
-              ss.display = 'block';
-            }
           };
         ui.kbdButton._onmouseout = function()
           {
             ui.keyboardMenu.className="sfunhover";
-            if(ui.shim) ui.shim.style.display = 'none';
           };
         ui.kbdButton._onclick = null;
         ui.createMenu();
@@ -693,18 +681,6 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
     {    
       if(typeof(ui.keyboardMenu) == 'undefined')  // I2403 - Allow toggle design to be loaded twice
       {
-        if (window.createPopup && !('XmlHttpRequest' in window))
-        {
-          ui.shim = util['createElement']('iframe');
-          ui.shim.src = '';
-          ui.shim.style.display = 'none';
-          ui.shim.style.position = 'absolute';
-          ui.shim.style.filter = 'progidXImageTransform.Microsoft.Alpha(style=0,opacity=0)';
-          ui.shim.frameBorder = '0';
-          ui.shim.scrolling = 'no';
-          ui.kbdButton.getElem().appendChild(ui.shim);
-        }
-        
         ui.keyboardMenu=util['createElement']('ul');
         ui.keyboardMenu.id='KeymanWeb_KbdList';
         ui.keyboardMenu.className='sfunhover';


### PR DESCRIPTION
Addresses #135, removing IE 6-oriented shim elements from KeymanWeb.  They turned out to be far less ingrained than previously thought.

Corresponding elements were also removed from the UI elements, including the version in `kmwuitoggle.js` that duplicated `createShim`'s functionality.

Functionality tested in current versions of IE, Firefox, Chrome, Edge, and Safari.  IE 9 and 10 work fine (sans MutationObserver-ness) under the emulation functionality of IE 11.