### PR TITLE
[Web] A better fix for attachment-API directionality.

### DIFF
--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -4484,7 +4484,7 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
         } else {
           if(typeof Ptarg.value == "string" && Ptarg.value.length == 0) {
               Ptarg.dir=elDir;
-          } else if(Ptarg.textContent && Ptarg.textContent.length == 0) { // As with contenteditable DIVs, for example.
+          } else if(typeof Ptarg.textContent == "string" && Ptarg.textContent.length == 0) { // As with contenteditable DIVs, for example.
             Ptarg.dir=elDir;
           }
         }

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -4482,7 +4482,7 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
             keymanweb.setTextCaret(Ptarg,10000);
           }
         } else {
-          if(Ptarg.value && Ptarg.value.length == 0) {
+          if(typeof Ptarg.value == "string" && Ptarg.value.length == 0) {
               Ptarg.dir=elDir;
           } else if(Ptarg.textContent && Ptarg.textContent.length == 0) { // As with contenteditable DIVs, for example.
             Ptarg.dir=elDir;

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -4482,8 +4482,10 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
             keymanweb.setTextCaret(Ptarg,10000);
           }
         } else {
-          if(typeof Ptarg.value == "string" && Ptarg.value.length == 0) {
+          if(typeof Ptarg.value == "string") {
+            if(Ptarg.value.length == 0) {
               Ptarg.dir=elDir;
+            }
           } else if(typeof Ptarg.textContent == "string" && Ptarg.textContent.length == 0) { // As with contenteditable DIVs, for example.
             Ptarg.dir=elDir;
           }

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -4482,10 +4482,10 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
             keymanweb.setTextCaret(Ptarg,10000);
           }
         } else {
-          if(Ptarg.value) {
-            if(Ptarg.value.length == 0) {
+          if(Ptarg.value && Ptarg.value.length == 0) {
               Ptarg.dir=elDir;
-            } 
+          } else if(Ptarg.textContent && Ptarg.textContent.length == 0) { // As with contenteditable DIVs, for example.
+            Ptarg.dir=elDir;
           }
         }
       }


### PR DESCRIPTION
Setting directionality now covers `contenteditable` DIV elements and others.  (Improves the fix made with #213.)