### PR TITLE
iOS css for embedded regression

### DIFF
--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -19,16 +19,16 @@
 
 /* kmw-key-square applies only to OSK key elements, kmw-key-square-ex applies only to popup key elements */
 
-.phone .kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
+.phone.kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
         background-color:rgba(0,0,0,0.8);-webkit-user-select:none;}
 .phone .kmw-osk-inner-frame{margin:0;background:transparent;}
-.phone .kmw-key-layer-group{position:fixed;left:0;bottom:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}
+.phone .kmw-key-layer-group{position:fixed;left:0;top:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}
 .phone .kmw-key-layer{position:fixed;left:0;bottom:0;width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
 .phone .kmw-key-row {position:fixed;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .phone .kmw-key-square {position:fixed; display:inline-block;height:100%;max-height:100%;overflow:visible; margin:0 0 0 0;z-index: 10000;padding:0 0 0 0;background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 .phone .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001;padding:0; background-color:transparent;cursor:default;}
 .phone .kmw-key {display:block;position:fixed;margin:0px;border-radius:6px;text-align:center; box-sizing:border-box; overflow:hidden;
-        border:solid 2px #999999;
+        border:solid 2px red;#999999;
         box-shadow: 0px -1px 1px 0px rgba(0,0,0,1) inset;
         }
  
@@ -290,3 +290,25 @@ div.android #keytip {background-color:#f00;}
           overflow:hidden;width:100%;height:100%;}
 .tablet-static .kmw-key-label{position:absolute;left:2px;top:2px;font:0.5em Arial;color:#888;background-color:transparent;}
 .tablet-static .kmw-key-text{position:relative;left:2px;top:2px;}
+
+.kmw-embedded .ios .kmw-key {
+    left: 0 !important;
+    bottom: 4px !important;
+}
+
+.kmw-embedded .ios .kmw-key-square {
+    height: 100% !important;
+}
+
+.kmw-embedded .ios.kmw-osk-frame {top:0 !important;bottom:initial !important; width:100% !important;}
+
+.kmw-embedded .ios.kmw-osk-frame {position: absolute !important;}
+
+.kmw-embedded .ios.kmw-osk-frame .kmw-key-layer-group {position: absolute !important; top: 0 !important; bottom: initial !important;}
+
+.kmw-embedded .ios.kmw-osk-frame .kmw-key-layer {position: absolute !important; top: 0 !important; bottom: initial !important;}
+
+.kmw-embedded .ios.kmw-osk-frame .kmw-key-square {position: absolute !important;}
+.kmw-embedded .ios.kmw-osk-frame .kmw-key-row {position: absolute !important;}
+.kmw-embedded .ios.kmw-osk-frame .kmw-key {position: absolute !important;}
+

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -22,13 +22,13 @@
 .phone.kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
         background-color:rgba(0,0,0,0.8);-webkit-user-select:none;}
 .phone .kmw-osk-inner-frame{margin:0;background:transparent;}
-.phone .kmw-key-layer-group{position:fixed;left:0;top:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}
+.phone .kmw-key-layer-group{position:fixed;left:0;bottom:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}
 .phone .kmw-key-layer{position:fixed;left:0;bottom:0;width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
 .phone .kmw-key-row {position:fixed;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .phone .kmw-key-square {position:fixed; display:inline-block;height:100%;max-height:100%;overflow:visible; margin:0 0 0 0;z-index: 10000;padding:0 0 0 0;background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 .phone .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001;padding:0; background-color:transparent;cursor:default;}
 .phone .kmw-key {display:block;position:fixed;margin:0px;border-radius:6px;text-align:center; box-sizing:border-box; overflow:hidden;
-        border:solid 2px red;#999999;
+        border:solid 2px #999999;
         box-shadow: 0px -1px 1px 0px rgba(0,0,0,1) inset;
         }
  
@@ -57,7 +57,7 @@
 .phone.android .kmw-key.kmw-spacebar.kmw-key-touched {background-color: #bbb;}
 .phone.android .kmw-spacebar-caption {color: #aaa;}
 
-.tablet .kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
+.tablet.kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
         background-color:rgba(0,0,0,0.8);-webkit-user-select:none;}
 .tablet .kmw-osk-inner-frame{margin:0;background:transparent;}
 .tablet .kmw-key-layer-group{position:fixed;left:0;bottom:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}


### PR DESCRIPTION
This is an interim fix. The CSS needs reworking and simplifying but this is to resolve the regression with the osk disappearing after 1 second in 2.6.3.