### PR TITLE
Fix for 2 keyboards being displayed when closing Keyman browser to Keyman for Android

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -72,6 +72,7 @@ public class WebBrowserActivity extends Activity {
     actionBar.setCustomView(webBarLayout);
     setContentView(R.layout.activity_web_browser);
 
+    //webView = new WebView(getApplicationContext());
     webView = (WebView) findViewById(R.id.webView);
     addressField = (EditText) findViewById(R.id.address_field);
     clearButton = (ImageButton) findViewById(R.id.clear_button);
@@ -224,6 +225,9 @@ public class WebBrowserActivity extends Activity {
     closeButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
+        // Hide the current keyboard so when Keyman app returns, there aren't 2 keyboards visible #220
+        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(addressField.getWindowToken(), 0);
         finish();
         overridePendingTransition(0, android.R.anim.fade_out);
       }
@@ -334,6 +338,7 @@ public class WebBrowserActivity extends Activity {
     super.onResume();
     if (webView != null) {
       webView.resumeTimers();
+      webView.onResume();
 
       if (didFinishLoading) {
         String fontFilename = KMManager.getKeyboardTextFontFilename();
@@ -349,6 +354,7 @@ public class WebBrowserActivity extends Activity {
     super.onPause();
     if (webView != null) {
       webView.pauseTimers();
+      webView.onPause();
     }
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -72,7 +72,6 @@ public class WebBrowserActivity extends Activity {
     actionBar.setCustomView(webBarLayout);
     setContentView(R.layout.activity_web_browser);
 
-    //webView = new WebView(getApplicationContext());
     webView = (WebView) findViewById(R.id.webView);
     addressField = (EditText) findViewById(R.id.address_field);
     clearButton = (ImageButton) findViewById(R.id.clear_button);
@@ -338,7 +337,6 @@ public class WebBrowserActivity extends Activity {
     super.onResume();
     if (webView != null) {
       webView.resumeTimers();
-      webView.onResume();
 
       if (didFinishLoading) {
         String fontFilename = KMManager.getKeyboardTextFontFilename();
@@ -354,7 +352,6 @@ public class WebBrowserActivity extends Activity {
     super.onPause();
     if (webView != null) {
       webView.pauseTimers();
-      webView.onPause();
     }
   }
 

--- a/android/KMAPro/settings.gradle
+++ b/android/KMAPro/settings.gradle
@@ -1,2 +1,1 @@
-include ':facebookSDK'
 include ':kMAPro'

--- a/android/history.md
+++ b/android/history.md
@@ -2,6 +2,7 @@
 
 ## 10.0 alpha
 * Removed "Share to Facebook" feature (#156)
+* Fix dual keyboards that appear when closing Keyman Browser (#220)
 
 ## 2017-08-10 2.8.300 stable
 * No changes, just published latest beta as stable
@@ -28,15 +29,15 @@
 ## 2015-01-27 2.1 stable
 * New feature: Keyman browser allows use of your language online (Pro edition only)
 
-# 2014-11-14 2.0 stable
+## 2014-11-14 2.0 stable
 * Major release: split into Pro and Free editions, retired Beta edition
 * Bug fixes and performance improvements
 
-# 2014-09-26 1.5 stable
+## 2014-09-26 1.5 stable
 * Added a new "Get Started" menu that lists key tasks such as adding a keyboard or implementing system wide keyboards
 * Other bug fixes
 
-# 2014-06-30 1.4 stable
+## 2014-06-30 1.4 stable
 * You will now see a key preview on phone devices when you touch a key
 * You can now swipe to select popup keys
 * Installed keyboards now have keyboard version and help available
@@ -45,21 +46,21 @@
 * System keyboard no longer loses context or fails to respond on switch
 * Other minor bug fixes
 
-# 2014-05-27 1.3 stable
+## 2014-05-27 1.3 stable
 * Keyboards will update automatically when bug fixes or new features are added
 * Bug fix: A slightly longer press on a key would sometimes fail to input the keystroke
 * Default English keyboard is now enhanced for European language diacritics
 * Behind the scenes: Now uses Keyman Cloud API 3.0 for access to newest keyboard layouts
 * Other minor bug fixes
 
-# 2014-04-22 1.2 stable
+## 2014-04-22 1.2 stable
 * Install custom keyboards created with Keyman Developer 9
 
-# 2014-02-27 1.1 stable
+## 2014-02-27 1.1 stable
 * Keyman is now available as Android system keyboard.
 * Touch and hold keys crash issue solved for Android 4.0.3 - 4.0.4 devices
 * Keyman can now be launched from custom link *keyman://* in a web page
 * Fixed bug with some keyboards loading with incorrect character set (instead of UTF-8)
 
-# 2014-01-29 1.0 stable
+## 2014-01-29 1.0 stable
 * Keyman for Android original release


### PR DESCRIPTION
Fix for #220 