### PR TITLE
Clarify macOS setup instructions

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -15,7 +15,8 @@ To build Keyman for macOS, do the following:
 ### Running Keyman
 1. Deploy Keyman locally using `./build.sh -deploy local -deploy-only`.
     * Alternatively copy **keyman/mac/Keyman4MacIM/build/Debug/Keyman.app** to **~/Library/Input Methods**
-2. Follow the installation instructions at [Installing Keyman for Mac OS X](https://help.keyman.com/products/mac/1.0/docs/start_download-install_keyman.php).
+2. If running for the first time, follow the installation instructions at
+[Installing Keyman for Mac OS X](https://help.keyman.com/products/mac/1.0/docs/start_download-install_keyman.php).
 
 ### Compiling from Xcode
 To build using Xcode, you will need to build KeymanEngine4Mac first and then build Keyman4MacIM.
@@ -26,9 +27,9 @@ To build using Xcode, you will need to build KeymanEngine4Mac first and then bui
 4. Open **keyman/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj**
 5. Open the Project Navigator: View > Navigators > Show Project Navigator (Cmd-1)
 6. Select Keyman4MacIM. Click Build Settings, scroll down to the Signing section and change Code Signing Identity to
-    Don't Code Sign.
+Don't Code Sign.
     * This will modify **Keyman4MacIM.xcodeproj**. Do not commit the change.
-5. Build the project
+7. Build the project. Refer to [Running Keyman](#running-keyman) on how to install the app.
 
 ### Sample Projects
 Not yet available on Mac...

--- a/mac/README.md
+++ b/mac/README.md
@@ -8,7 +8,7 @@ Keyman for macOS can be built from a command line (preferred) or Xcode.
 
 ### Compiling from Command Line
 To build Keyman for macOS, do the following:
-1. Open a terminal.
+1. Open a Terminal window.
 2. cd to **keyman/mac**. **build.sh** must be run in the directory containing the script.
 3. Build using `./build.sh -no-codesign`. Run `./build.sh -help` to see all options.
     * If you have signing credentials from the core development team, you can build a signed version by omitting

--- a/mac/README.md
+++ b/mac/README.md
@@ -6,47 +6,29 @@ Xcode 8.3.3 (it might also work to use an older version)
 ## Keyman for macOS Development
 Keyman for macOS can be built from a command line (preferred) or Xcode.
 
-### Compiling from Command line
+### Compiling from Command Line
 To build Keyman for macOS, do the following:
-1. Open a Terminal window.
-2. Change to please run the build.sh build script within this folder. Run
-with the -help switch to see all options.
-You will need to either run with the command-line argument -no-codesign or obtain the
-necessary security permissions and certificate data as part of our core development team
-to complete the build for the final app.
-To build using Xcode, you will need to build KeymanEngine4Mac first and then build
-Keyman4MacIM.
+1. Open a terminal
+2. cd to **keyman/mac**. **build.sh** must be run in the directory containing the script.
+3. Build using `./build.sh -no-codesign`. Run `./build.sh -help` to see all options.
 
-Keyman4MacIM is an input method, and as such is installed in the Input Methods folder.
-The easiest way to install it locally for testing is to specify "-deploy local" on the
-command line. See https://help.keyman.com/products/macosx/start_download-install_keyman.php
-for complete instructions on setting up Keyman for the first time and installing keyboards.
-
-The Keyman4Mac project builds a “test-bed” app that can be used to test keyboards without
-installing the input method. This also serves as a rudimentary example of how the Keyman
-engine might be incorporated directly into a custom app, if desired.
-
-1. Launch a command prompt
-2. Change to the directory mac subdirectory of the keyman repo directory.
-3. Run `./build.sh -help` to see all build options. For example:
-   i. To build and run tests on a debug version of the engine and input method, without code-signing:
-		`./build.sh -test -no-codesign`
-		The input method app will be in Keyman4MacIM/build/Debug
-   ii. To build a release version and deploy it as an installed input method on your local machine:
-		`./build.sh -deploy local -config release`
-		The input method will be deployed in ~/Library/Input Methods/
-   iii. To do a clean release build of engine, input method and test app, plus prepare the files that would be deployed to the alpha download site for version 10.2.56:
-		`./build.sh -clean -deploy preprelease -version 10.2.56 -tier alpha` engine im testapp
-		The input method files for upload will be in Keyman4MacIM/output/upload/10.2.56
-		The test app will be in Keyman4Mac/build/Release/
+### Running Keyman
+1. Deploy Keyman locally using `./build.sh -deploy local -deploy-only`.
+    * Alternatively copy **keyman/mac/Keyman4MacIM/build/Debug/Keyman.app** to **~/Library/Input Methods**
+2. Follow the installation instructions at [Installing Keyman for Mac OS X](https://help.keyman.com/products/mac/1.0/docs/start_download-install_keyman.php).
 
 ### Compiling from Xcode
-1. Launch Xcode and open **keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj
-2. Press Command-B to build.
-3. Open **keyman/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj
-4. Press Command-B to build.
-5. Open **keyman/mac/Keyman4Mac/Keyman4Mac.xcodeproj
-6. Press Command-B to build.
+To build using Xcode, you will need to build KeymanEngine4Mac first and then build Keyman4MacIM.
 
-### Sample Projects #
+1. Launch Xcode
+2. Open **keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj**
+3. Build the project: Product > Build (or Cmd-B)
+4. Open **keyman/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj**
+5. Open the Project Navigator: View > Navigators > Show Project Navigator (Cmd-1)
+6. Select Keyman4MacIM. Click Build Settings, scroll down to the Signing section and change Code Signing Identity to
+    Don't Code Sign.
+    * This will modify **Keyman4MacIM.xcodeproj**. Do not commit the change.
+5. Build the project
+
+### Sample Projects
 Not yet available on Mac...

--- a/mac/README.md
+++ b/mac/README.md
@@ -8,9 +8,11 @@ Keyman for macOS can be built from a command line (preferred) or Xcode.
 
 ### Compiling from Command Line
 To build Keyman for macOS, do the following:
-1. Open a terminal
+1. Open a terminal.
 2. cd to **keyman/mac**. **build.sh** must be run in the directory containing the script.
 3. Build using `./build.sh -no-codesign`. Run `./build.sh -help` to see all options.
+    * If you have signing credentials from the core development team, you can build a signed version by omitting
+  `-no-codesign`.
 
 ### Running Keyman
 1. Deploy Keyman locally using `./build.sh -deploy local -deploy-only`.
@@ -25,11 +27,15 @@ To build using Xcode, you will need to build KeymanEngine4Mac first and then bui
 2. Open **keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj**
 3. Build the project: Product > Build (or Cmd-B)
 4. Open **keyman/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj**
-5. Open the Project Navigator: View > Navigators > Show Project Navigator (Cmd-1)
-6. Select Keyman4MacIM. Click Build Settings, scroll down to the Signing section and change Code Signing Identity to
-Don't Code Sign.
-    * This will modify **Keyman4MacIM.xcodeproj**. Do not commit the change.
-7. Build the project. Refer to [Running Keyman](#running-keyman) on how to install the app.
+5. If you do not have signing credentials from the core development team, disable code signing in Xcode.
+    1. Open the Project Navigator: View > Navigators > Show Project Navigator (Cmd-1)
+    2. Select Keyman4MacIM and click Build Settings
+    3. In the Signing section, change Code Signing Identity to Don't Code Sign. This will modify
+    **Keyman4MacIM.xcodeproj**. Do not commit the change.
+6. Build the project. Refer to [Running Keyman](#running-keyman) on how to install the app.
 
-### Sample Projects
-Not yet available on Mac...
+### Testing
+The Keyman4Mac project builds a test-bed app that can be used to test keyboards without installing the input method.
+It can also be used as reference for the usage of Keyman Engine.
+
+Keyman4Mac tests are run using `./build.sh -test -no-codesign`.

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -22,7 +22,10 @@ display_usage() {
     echo "                  the deploy option is used to specify preprelease, in which configuration will be"
     echo "                  Release (i.e., -config option is ignored)."
     echo "  -clean          Removes all previously-existing build products for anything to be built before building."
-    echo "  -test           Runs unit tests (when we get some)"
+    # Note: it's fairly unlikely that we will ever need/want unit tests for the IM or the test app, but
+    # FWIW, the -test option is currently only implemented for KeymanEngine4Mac. Not sure exactly what the
+    # problem is, but I can't get it to work with the other two (two different build errors).
+    echo "  -test           Runs KeymanEngine4Mac unit tests (when we get some)"
     echo "  -no-codesign    Disables code-signing for Keyman4MacIM, allowing it to be performed separately later"
     echo "                  (ignored if a deploy option other than 'none' is specified)."
     echo "  -quiet          Do not display any output except for warnings and errors."
@@ -104,6 +107,7 @@ DO_KEYMANTESTAPP=false
 CODESIGNING_SUPPRESSION=""
 BUILD_OPTIONS=""
 BUILD_ACTIONS="build"
+TEST_ACTIONS=""
 CLEAN=false
 QUIET=false
 SKIP_BUILD=false
@@ -172,7 +176,7 @@ while [[ $# -gt 0 ]] ; do
             BUILD_ACTIONS="clean $BUILD_ACTIONS"
             ;;
         -test)
-            BUILD_ACTIONS="$BUILD_ACTIONS test"
+            TEST_ACTIONS="test -scheme $ENGINE_NAME"
             ;;
         -no-codesign)
             if $LOCALDEPLOY || $PREPRELEASE ; then
@@ -216,6 +220,7 @@ if $SKIP_BUILD ; then
     DO_KEYMANIM=false
     DO_KEYMANTESTAPP=false
     BUILD_ACTIONS=""
+    TEST_ACTIONS=""
     BUILD_OPTIONS=""
     CODESIGNING_SUPPRESSION=""
 fi
@@ -233,6 +238,7 @@ displayInfo "" \
     "CODESIGNING_SUPPRESSION: $CODESIGNING_SUPPRESSION" \
     "BUILD_OPTIONS: $BUILD_OPTIONS" \
     "BUILD_ACTIONS: $BUILD_ACTIONS" \
+    "TEST_ACTIONS: $TEST_ACTIONS" \
     ""
 
 ### START OF THE BUILD ###
@@ -274,7 +280,7 @@ updatePlist() {
 
 if $DO_KEYMANENGINE ; then
     updatePlist "$KME4M_BASE_PATH" "$ENGINE_NAME"
-    execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS $BUILD_ACTIONS"
+    execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS $BUILD_ACTIONS $TEST_ACTIONS"
 fi
 
 if $DO_KEYMANIM ; then


### PR DESCRIPTION
Added instructions on avoiding a build error for KeymanEngine4Mac when missing credentials. I'm unsure whether checking in Keyman4MacIM.xcodeproj breaks anything since I don't have credentials to try a signed build, so I didn't check it in.

`./build.sh -test -no-codesign` failed with:
```
xcodebuild -project "/Users/gabriel/workspace/keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj" -configuration Debug build test
xcodebuild: error: The test action requires that the name of a scheme in the project is provided using the "-scheme" option. The "-list" option can be used to find the names of the schemes in the project.
Build of KeymanEngine4Mac failed! Error: [65] when executing command: 'xcodebuild -project "/Users/gabriel/workspace/keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj" -configuration Debug  build test'
```
and I didn't see any tests in Keyman4Mac so I removed references to the tests for now. Should those be in the README right now?