### PR TITLE
Fixes to web set up

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,8 @@
-# Keyman Web #   
+# Keyman Web
 The Original Code is (C) 2017 SIL International
 
 ## Minimum Web Requirements
-Google Closures Compiler is used to compile the javascript modules into a single module.  Java must be installed to run the compiler, which is stored in the tools folder.
+Google Closures Compiler is used to compile the JavaScript modules into a single module. Java must be installed to run the compiler, which is stored in the tools folder.
 
 **********************************************************************
 
@@ -13,6 +13,11 @@ The following folders contain the distribution for KeymanWeb 2.0:
 	embedded		Fully-compiled KMEA/KMEI modules for inclusion in mobile app builds
 	samples			Sample and test-case web-pages
 
+## Usage
+Open **index.html** or **samples/index.html** in your browser. The pages using uncompiled KeymanWeb should work as-is.
 
+To view pages using compiled KeymanWeb,
+1. cd to **keyman/web/source**
+2. Run `/.build.sh`
 
-
+Refer to the samples for usage details.

--- a/web/samples/compiled.html
+++ b/web/samples/compiled.html
@@ -38,7 +38,8 @@
     <script>
       var kmw=window.tavultesoft.keymanweb;
       kmw.init({
-        resources:'resources'
+        attachType:'auto',
+        resources:''
         });
     </script> 
 

--- a/web/samples/multilingual.html
+++ b/web/samples/multilingual.html
@@ -30,7 +30,8 @@
     <script>
       var kmw=window.tavultesoft.keymanweb;
       kmw.init({
-        resources:'resources'
+        attachType:'auto',
+        resources:''
         });
     </script> 
   <!-- 

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -30,21 +30,9 @@ WEB_OUTPUT="../output"
 EMBED_OUTPUT="../embedded"
 SOURCE="."
 
-# If we're on Mac OS X, the `cp` command doesn't like to create a new folder mirroring the original of a
-# cp -R command, dumping its contents into the destination folder rather than a new, copied subfolder.
-#
-# The RESOURCES variable is used to compensate for this behavior when necessary.
-# Expand this section if necessary for other shells.
-if [ $OSTYPE = "darwin16" ]; then
-    resources="resources/"
-else
-    resources=""
-fi
-
 readonly WEB_OUTPUT
 readonly EMBED_OUTPUT
 readonly SOURCE
-readonly resources
 
 # Get build version -- if not building in TeamCity, then always use 300
 : ${BUILD_COUNTER:=300}
@@ -159,7 +147,7 @@ if [ $BUILD_EMBED = true ]; then
 
     # echo Copy or update resources
 
-    cp -Rf $SOURCE/resources/ $EMBED_OUTPUT/$resources >/dev/null
+    cp -Rf $SOURCE/resources $EMBED_OUTPUT/ >/dev/null
 
     # Update build number if successful
     echo
@@ -205,23 +193,15 @@ if [ $BUILD_FULLWEB = true ]; then
     echo 
     echo Copy resources to $WEB_OUTPUT/ui, .../osk
 
-    if [ -z $resources ]; then  #if the string is empty.
-        ui=""
-        osk=""
-    else
-        ui=ui/
-        osk=osk/
-    fi
-
-    cp -Rf $SOURCE/resources/ui/  $WEB_OUTPUT/$ui  >/dev/null
-    cp -Rf $SOURCE/resources/osk/ $WEB_OUTPUT/$osk  >/dev/null
+    cp -Rf $SOURCE/resources/ui  $WEB_OUTPUT/  >/dev/null
+    cp -Rf $SOURCE/resources/osk $WEB_OUTPUT/  >/dev/null
 
     echo Copy source to $WEB_OUTPUT/src
     cp -Rf $SOURCE/*.js $WEB_OUTPUT/src
     echo $BUILD > $WEB_OUTPUT/src/version.txt
 
-    cp -Rf $SOURCE/resources/ui/  $WEB_OUTPUT/src/$ui >/dev/null
-    cp -Rf $SOURCE/resources/osk/ $WEB_OUTPUT/src/$osk >/dev/null
+    cp -Rf $SOURCE/resources/ui  $WEB_OUTPUT/src/ >/dev/null
+    cp -Rf $SOURCE/resources/osk $WEB_OUTPUT/src/ >/dev/null
 
     # Update build number if successful
     echo


### PR DESCRIPTION
* Point the compiled web samples to the correct resources folder
* Web build script doesn't need a special case for Mac as long as the source file doesn't end in a slash. From the Mac `cp` manpage:

> If source_file designates a directory, cp copies the directory and the entire subtree connected at that point.  If the source_file ends in a /, the contents of the directory are copied rather than the directory itself.