### PR TITLE
Fix for nul bytes appearing in compiled js from the KVK file

### DIFF
--- a/windows/src/global/delphi/visualkeyboard/VisualKeyboardLoaderBinary.pas
+++ b/windows/src/global/delphi/visualkeyboard/VisualKeyboardLoaderBinary.pas
@@ -42,6 +42,7 @@ begin
   Stream.Read(w, sizeof(w));
   SetLength(str, w);
   Stream.Read(PChar(str)^, w*2);
+  SetLength(str, w-1);  // Remove nul byte at end of string
   Result := str;
 end;
 

--- a/windows/src/global/delphi/visualkeyboard/VisualKeyboardLoaderBinary.pas
+++ b/windows/src/global/delphi/visualkeyboard/VisualKeyboardLoaderBinary.pas
@@ -42,8 +42,12 @@ begin
   Stream.Read(w, sizeof(w));
   SetLength(str, w);
   Stream.Read(PChar(str)^, w*2);
-  SetLength(str, w-1);  // Remove nul byte at end of string
-  Result := str;
+  // The string read is a C-style null terminated string. We need
+  // to remove the null character because Pascal strings don't
+  // use null termination in the same way. Best way to do this is
+  // to cast it as a C-style string, which reliably terminates at
+  // first null byte.
+  Result := PWideChar(str);
 end;
 
 procedure TVisualKeyboardLoaderBinary.ReadFont(Stream: TStream; FFont: TFont);


### PR DESCRIPTION
This seems to have appeared around the same time as Delphi 10.2 changeover. It may be related or it may be a consequence of the changes to the KVK reader. In some situations, strings read from the binary KVK file have nul bytes on the end which are placed in the output string.

I'm not satisfied with this as a fix because it doesn't demonstrate the root cause of the problem. But this gets us started.