### PR TITLE
Windows History and Readme

### DIFF
--- a/ios/history.md
+++ b/ios/history.md
@@ -45,7 +45,7 @@
 * Now displays version and build number in info page
 * Other bug fixes & improvements
 
-## 2014-11-2014 2.0.0 stable
+## 2014-11-10 2.0.0 stable
 ### New Features
 * Use any Keyman keyboard throughout your entire iOS 8 device
 * Custom installable fonts with iOS 8

--- a/mac/history.md
+++ b/mac/history.md
@@ -2,3 +2,6 @@
 
 ## 2017-08-13 1.1.14 beta
 * Fixed blank download dialog
+
+## 1.0.136 beta
+* Keyman for Mac OS X 1.0.136 - General release

--- a/resources/historyUtils.sh
+++ b/resources/historyUtils.sh
@@ -5,9 +5,9 @@ _hu_base_dir=$(dirname "$BASH_SOURCE")/..
 . $_hu_base_dir/resources/shellHelperFunctions.sh
 
 get_history_file_path() {
-  verify_project $1
+  get_platform_folder $1
 
-  history_file_path="$_hu_base_dir/$1/history.md"
+  history_file_path="$platform_folder/history.md"
 }
 
 # Creates and initializes a variable called `history_file` that contains the raw content

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+_shf_base_dir=$(dirname "$BASH_SOURCE")/..
+
 # Allows for a quick macOS check for those scripts requiring a macOS environment.
 verify_on_mac() {
   if [[ "${OSTYPE}" != "darwin"* ]]; then
@@ -23,6 +25,36 @@ verify_project() {
 
   if [ $match = false ]; then
     fail "Invalid project specified!"
+  fi
+}
+
+# The list of valid platforms that our build scripts ought expect.
+platforms=("android" "ios" "mac" "web" "desktop" "developer")
+
+# Used to validate a specified 'platform' parameter.
+verify_platform() {
+  match=false
+  for proj in ${platforms[@]}
+  do
+    if [ $proj = $1 ]; then
+      match=true
+    fi
+  done
+
+  if [ $match = false ]; then
+    fail "Invalid platform specified!"
+  fi
+}
+
+# Gets the folder containing each platform's history.md file, which is also the base folder for most of the platforms.
+# Sets $platform_folder accordingly.
+get_platform_folder() {
+  verify_platform $1
+  
+  if [[ $1 = "desktop" || $1 = "developer" ]]; then
+    platform_folder="$_shf_base_dir/windows/src/$1"
+  else
+    platform_folder="$_shf_base_dir/$1"
   fi
 }
 

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -8,15 +8,15 @@
 4. Add the Keyman root folder to antivirus exclusions for performance and file lock reasons (optional - but highly recommended).
 5. Start Delphi 10.2 IDE once after installation to create default environment files and ensure registration is complete.
 6. Set environment variables per [notes below](#environment-variables): `KEYMAN_ROOT`, `DELPHI_STARTER`, `USERDEFINES`, (`USE_PLUSMEMO`, `KEYMAN_ENCUMBERED_ROOT`).
-7. Add the **windows/lib** folder in the Keyman repository to your `PATH` environment variable (required for packages in Delphi)
+7. Add the **windows/lib** folder in the Keyman repository to your `PATH` environment variable (required for packages in Delphi).
 
 ### Release build prerequisites
 
 For local development you do not need to perform a release build so these are optional.
 
 1. Install [7-Zip](http://www.7-zip.org/) 64-bit (or 32-bit on x86 Windows). 7-Zip is used for archiving build files -- may be eliminated in future.
-2. Install [HTML Help Workshop](https://www.microsoft.com/en-us/download/details.aspx?id=21138)
-4. Install [WiX](https://wix.codeplex.com/releases/view/60102) to **C:\Program Files (x86)\Windows Installer XML v3.5**
+2. Install [HTML Help Workshop](https://www.microsoft.com/en-us/download/details.aspx?id=21138).
+4. Install [WiX](https://wix.codeplex.com/releases/view/60102) to **C:\Program Files (x86)\Windows Installer XML v3.5**.
 
 ## Building Keyman Desktop and Keyman Developer
 
@@ -48,7 +48,7 @@ install it over a later version of Keyman, and will need to uninstall and reinst
 
 These steps are only required the first time you install Keyman:
 1. Install release versions of Keyman 10.0 and Keyman Developer 10.0.
-    * Download the [latest official builds (alpha)](https://keyman.com/beta/) and run the installers.
+  * Download the [latest official builds (alpha)](https://keyman.com/beta/) and run the installers.
 2. Install the Keyman test certificates. Do the following for each KeymanTestCA cert in
 **windows/src/buildtools/certificates**:
     1. Open the certificate and click 'Install certificate...' to open the Certificate Import Wizard.
@@ -73,10 +73,10 @@ In Visual Studio 2017, you need to have the following components installed:
 * Desktop development with C++
 
 Configure Visual Studio to use two-space tab stops:
-1. Open the options dialog: Tools > Options
-2. Navigate to Text Editor > All Languages > Tabs
-3. Change 'Tab size' to 2 and 'Indent size' to 2
-4. Select 'Insert spaces'
+1. Open the options dialog: Tools > Options.
+2. Navigate to Text Editor > All Languages > Tabs.
+3. Change 'Tab size' to 2 and 'Indent size' to 2.
+4. Select 'Insert spaces'.
 
 ### Delphi setup requirements
 
@@ -140,9 +140,10 @@ Keyman Developer can be built with an encumbered text editor, `TPlusMemo`. The s
 open source release uses a very basic `TMemo` without syntax highlighting and lots of 
 other niceties. To build with the `TPlusMemo` version, use the `-DUSE_PLUSMEMO` define, and
 make sure you have pulled the private `keyman-encumbered-components` repo to `<path>\src`. 
-You will also need to set the `KEYMAN_ENCUMBERED_ROOT` environment variable to `<path>`. 
-If you will be working with this regularly, you should set an environment variable 
-`USE_PLUSMEMO=USE_PLUSMEMO`, and then the command line build and the
+(That is, set the base folder of the repo to have the name `src`.)
+You will also need to set the `KEYMAN_ENCUMBERED_ROOT` environment variable to `<path>`,
+the repo's parent folder. If you will be working with this regularly, you should set an 
+environment variable `USE_PLUSMEMO=USE_PLUSMEMO`, and then the command line build and the
 IDE build will include the component correctly.
 
 At some point, this editor will be replaced with an unencumbered one.

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,0 +1,359 @@
+# Keyman Desktop Version History
+
+## 10.0 alpha
+* Keyman Desktop moved to open source
+* Support for custom BCP-47 language codes: you can now associate a keyboard with any valid language code in Windows 8 and later
+* Keyman API extensively rewritten and improved
+* Additional user interface language - Turkish (translation done by Stevan Vanderwerf)
+* Support for Unicode 10.0
+
+## 9.0.522 stable
+* Keyboard hotkey toggles are not working in 9.0 (I5086)
+* Improve compatibility with Firefox 42 and Internet Explorer 11 (I4933)
+* Fix hang when closing Keyman if Windows compatibility flag is incorrectly set (I5018)
+
+## 9.0.521 stable
+* Updated digital certificate for Windows 8, 8.1 and 10 (I4978)
+
+## 9.0.519 stable
+* Keyboard options do not work always work correctly because they are set twice while processing (I4978)
+* Update requirements in Help for Windows 10 (I4984)
+
+## 9.0.518 stable
+* OEM products now have a cleaner menu display with indented keyboards and languages (I4920)
+
+## 9.0.516 stable
+* Added: Note on why "Select keyboard layout for all applications" is disabled on Win 8.1+ (I4871)
+
+## 9.0.514 stable
+* Fixed: Inconsistent display of panels through Desktop (I4851)
+
+## 9.0.513 stable
+* Fixed: Keyman Desktop title in OSK has wrong grey background (I4849)
+
+## 9.0.512 stable
+* Fixed: If no baselayout is specified by the user, default to en-US (kbdus.dll) (I4786)
+* Fixed: Shift keys would sometimes 'stick' in Mozilla Firefox (I4793)
+* Fixed: Log reported modifier state as well as Keyman current modifier state in debug logs (I4843)
+* Fixed: FileMakerPro 14 causes crash in Keyman Engine (I4846)
+
+## 9.0.510 stable
+* Keyman needs to rebuild its language profiles if they are inadvertently deleted (I4773)
+
+## 9.0.507 stable
+* Keyman loses focus sometimes when switching keyboards using the menu (I4731)
+
+## 9.0.506 stable
+* Language profile change notification while Keyman menu is visible sometimes causes a crash (I4715, I4683, I4591, I4577, I4541, I4472, I4431)
+* Improve reporting on registry errors (I4565, I4657)
+
+## 9.0.503 stable
+* MSKLC keyboards do not get correct name in Configuration Hotkeys tab (I4712)
+* MSKLC keyboards are not shown in the Keyman menu (I4713)
+* Keyboard and language hotkeys don't always work (I4714)
+
+## 9.0.494 stable
+* Fixed hotkeys not always working consistently (I4674)
+* Fixed read of invalid registry setting on some computers (I4660)
+
+## 9.0.493 stable
+* Add more detailed keyboard diagnostics (I4659)
+* Add Keep in Touch screen (I4658)
+
+## 9.0.492 stable
+* On Screen keyboard translates keys wrongly for European keyboards (I4650)
+* Mnemonic layout recompiler maps AltGr+# rather than \ on UK layouts (I4651)
+
+## 9.0.491 stable
+* Add logging for registration of keyboards for hotkey matching (I4648)
+
+## 9.0.490 stable
+* Add 'Enter License Key' link to splash screen (I4645)
+* Fix crash on startup on some computers with multiple Keyman products installed (I4624, I4519, I4602, I4640, I4633, I4636, I4637, I4638, I4639)
+
+## 9.0.489 stable
+* Backspace key was not working in Logos (I4642)
+
+## 9.0.488 stable
+* Keyman could crash silently on exit due to null hotkeys being addressed (I4623)
+
+## 9.0.487 stable
+* .kmx installs upgraded from earlier versions were placed in the wrong folder (I4623)
+
+## 9.0.485 stable
+* keymanimport.log was generated incorrectly as unicode strings in an ansi file (I4617)
+* Keyman crashed when trying to recompile a missing mnemonic layout (I4615)
+
+## 9.0.483 stable
+* Support install of keyboard against fallback locales (I4607)
+* Support single keyboard buttons on OSK toolbar for OEM products (I4606)
+
+## 9.0.482 stable
+* Keyman installer did not show EULA when bundled with a keyboard (I4598)
+* Keyman Configuration enabled keyboards when OK clicked even if Keyman not running (I4382)
+
+## 9.0.481 stable
+* If a computer does not have US keyboard installed, then AltGr rules can go wrong (I4592)
+* The keyboard usage page can appear outside the OSK in some situations (I4593)
+
+## 9.0.480 stable
+* Spacebar results in incorrect output for subsequent letters on some keyboards (I4585)
+* If Ctrl+Alt simulates RAlt is on, then Ctrl+Alt rules don't work at all (I4551, I4583)
+* Add option to treat base keyboard deadkey as plain keys (I4552)
+* Switch for all languages not disabled on Win8 upgrades (I4576)
+* Support if(&baselayout) with all of the ISO names (I4588)
+* Keyman fails to install shortcuts for keyboard documentation correctly (I4590)
+
+## 9.0.479 stable
+* Solution for output of Enter and Tab keys for some keyboards (I4575)
+
+## 9.0.478 stable
+* Solution for output of Enter and Tab keys for some keyboards (I4575)
+
+## 9.0.477 stable
+* Test solution for output of Enter and Tab keys for some keyboards (I4562)
+
+## 9.0.476 stable
+* Hotkey switching resulted in stuck Ctrl,Alt,Shift keys in some apps (I4511)
+* On Win 8, Keyman keyboards appear as "Unavailable Input Method" in Control Panel - mitigation only, not fixed (I4531)
+* Fixed: when Alt is down, release of Ctrl, Shift is not detectable within Keyman in some languages (I4548)
+* Mnemonic layout recompiler did not translate Lctrl Ralt for deadkeys correctly (I4549)
+* Logical flaw in mnemonic layout recompiler meant that AltGr base keys were never processed (I4550)
+* Upgrade to 476 or later requires recompile of all mnemonic layouts (I4553)
+* Keyboards without an icon must specify a default icon when registering to prevent control panel crashing (I4555)
+* Attached files were not shown when loading diag files (I4559)
+* Binary data in diagnostics was not streamed correctly (I4560)
+
+## 9.0.475 stable
+* Language hotkeys associated with non-primary keyboards do not trigger language change (I4516)
+* Switch for all apps is not disabled in Win 8 (I4515)
+
+## 9.0.474 stable
+* Crash when saving OSK to file, changing keyboard midstream [CrashID:keyman.exe_9.0.473.0_2C59B75E_EAccessViolation] (I4487)
+* The character map is not falling back to system fonts well when Code2000 missing (I4488)
+* Crash calling TSF [CrashID:kmshell.exe_9.0.473.0_2C45D42D_EOleSysError] (I4494)
+* Damaged package causes crash when trying to uninstall [CrashID:kmshell.exe_9.0.473.0_2C6B80C4_EOleException] (I4495)
+
+## 9.0.473 stable
+* Verify that Internet Explorer 9.0 or later is present at install time (I4470)
+* Fix crash showing keyboard menu when product details are missing (I4458)
+* Fix crash when menu popup is dynamically resized by system (I4429)
+* Setup bootstrapper now handles upgrade scenarios with a prompt (I4460)
+* Upgrade dialog showed wrong version of Keyman Desktop (I4445)
+* Keyman Desktop Update dialog showed broken Tavultesoft image (I4456)
+* API fix: Keyman had a mismatch between KEYBOARDINFO and INTKEYBOARDINFO (I4462)
+* API fix: Keyman_BuildKeyboardList was including keyboards installed but with no profiles (I4461)
+
+## 9.0.472 stable
+* Chinese keyboard was not working correctly (I4452)
+* Language hotkeys were not working (I4451)
+
+## 9.0.471 stable
+* Browser emulation control for kmshell breaks downlevel versions of Keyman (I4436)
+* Crash if Keyman Engine 7 or 8-based product installed when starting Keyman Desktop 9 (I4421)
+* Show Send to Tavultesoft button in Diagnostics (I4439)
+
+## 9.0.470 stable
+* Download Keyboard dialog had broken link (I4419)
+
+## 9.0.469 stable
+* Download Keyboard dialog does not display correctly (I4414)
+* OSK does not show underlying characters if base keyboard is not loaded (I4415)
+    
+## 9.0.467 stable
+* Character Map needs to insert characters using SendInput (I4412)
+* Manual Activate dialog is misformatted (I4408)
+* Add HKCU FEATURE_BROWSER_EMULATION 9000 for kmshell.exe (I4400)
+* Character map allows Ctrl+Click to insert character (I4411)
+
+### What's New
+* Free Edition – Keyman Desktop now has a Free Edition with no restrictions on use – use it in your office, your home, your school. Upgrade to Pro for powerful features, additional keyboards, and personalized technical support.
+* Rewritten for Windows 7, 8 and 8.1. Now integrates deeply into Windows Text Services Framework and presents as a keyboard through all Windows language interfaces. This means that keyboard input support is more consistent and more efficient in all applications.
+* Behind the scenes, Keyman is now fully Unicode internally.
+* User interface extensively redesigned, cleaned up and simplified.
+* Keyboards now support hi-res icons for clean presentation on large screens.
+* Keyboards now have more version information and online help integration.
+* Keyman now supports iPhone, iPad and Android – all your favourite keyboard layouts available on your phone and tablet devices
+
+## 9.0.466 beta
+* OK and Cancel buttons are no longer missing on Proxy dialog (I4387)
+
+## 9.0.465 beta
+* Added HKCU FEATURE_BROWSER_EMULATION 9000 for kmshell.exe (I4400)
+
+## 9.0.464 beta
+* Added clean user interface selection for associated language in Free Edition (I4395)
+* Keyman Desktop Free Edition polish (I4393)
+* When configuration run from Splash and license key entered, splash didn't refresh (I4396)
+* Get Started got impatient and showed nag too quickly on start (I4397)
+* Hotkeys didn't show on keyboard list (I4398)
+* HTTP download now reports progress more cleanly (I4399)
+
+## 9.0.463 beta
+* Initial Free Edition changes (I4390)
+
+## 9.0.462 beta
+* Unticked keyboards in Keyman Configuration are not now shown in Windows Languages (I4376)
+* Keyman keyboards are no longer visible in Windows Languages when Keyman is not running (I4381)
+
+## 9.0.461 beta
+* Rapid typing in legacy mode no longer breaks (regression from 9.0.460.0) (I4378)
+
+## 9.0.460 beta
+* Icon size in tool tray is now correct when using large fonts (I4314)
+* Keyboard Upgrade from 6.0, 7.0, 8.0 now supports keyboards installed for Current User, fonts and Start Menu entries (I4324)
+* When On Screen Keyboard opens, if Keyman is off then icon now shows correctly (I4360)
+* On Screen Keyboard now always shows correct base layout when keyboard active (I4363)
+* Installer now enforces Windows 7 or later (I4366)
+* Deadkeys are now working with Microsoft Word in TSF-aware mode (I4370)
+* WOW64 is now tested consistently in all locations (I4374)
+* Add registry flag 'deep tsf integration' to allow us to disable enhanced integration with TSF-aware applications (I4375)
+    
+## 9.0.459 beta
+* Deadkeys are now working correctly in all cases in Wordpad and other TSF-aware applications (except Word) (I4278)
+* All .ico formats do not load correctly in icon conversion for keyboard layouts (I4317)
+* Alt+LeftShift hotkey is now set on clean install (I4318)
+* If Keyman is not running, selecting a Keyman layout in Windows will no longer have any effect (I4325)
+* Keyboard and interface hotkeys are now working (I4326)
+* Deadkeys are now working correctly with mnemonic layouts (I4353, I4327)
+* AltGr keys are now working correctly in enhanced integration mode (I4351)
+* If splash screen is minimized, it can now be restored (I4356)
+* Splash screen buy links now go to correct version of Keyman (I4357)
+* COM registration updated for new interfaces in Keyman 9 (I4358)
+* OSK now shows correct base keyboard and refreshes when switching languages (I4359)
+    
+## 9.0.458 beta
+* Getting Started window gave instructions that were not valid for KM9 (I3674)
+* Script error dialog was appearing behind splash dialog (regression from I3710) (I3730)
+* Balloon tip and About page had wrong product version (I4311)
+* Keyboard icons are now converted to 32BPP RGBA on install for Windows 8 compatibility (I4316)
+
+## 9.0.457 beta
+* Fixed: Keys that have rules but are not matched due to context did not generate output (I4290)
+* Fixed: Additional minor bug fixes (I4302)
+    
+## 9.0.456 beta
+* Fixed: Crash in Keyman Configuration (I4296)
+* Fixed: Upgrade of keyboards failed to register in local machine context (I4297)
+* Fixed: Old TSF addin remained registered when upgrading (I4298)
+* Fixed: Keyman-installed Windows languages needed to be removed when upgrading (I4299)
+
+## 9.0.455 beta
+* Added: Support for upgrading configuration and keyboards from 8.0 to 9.0 (I4292, I4293)
+
+## 9.0.454 beta
+* Fixed: Switch from Keyman to Keyman keyboard caused loop in global language switch (I4277)
+* Fixed: Keyboard switching and legacy support edge case scenarios (I4285, I4286, I4287, I4288)
+    
+## 9.0.453 beta
+* Fixed: Shift states were not being preserved correctly (I3605)
+* Fixed: Opening User Interface Language menu causes crash [CrashID:kmshell.exe_9.0.447.0_script_TfrmMain_0] (I4199)
+* Fixed: Deadkeys only work in first 61 characters of document (I4266)
+* Fixed: If Keyboard usage refreshes during exit, Keyman crashes [CrashID:keyman.exe_9.0.452.0_2C5FB0CD_EAccessViolation] (I4268)
+* Fixed: Switch language for all applications is not working (I4271)
+* Fixed: TIP only outputs first 127 characters of a rule result (I4272)
+* Fixed: kmtip does not work if already active before KM starts (I4274)
+    
+## 9.0.452 beta
+* Fixed: Keyman installed keyboards do not seem to appear in Windows Language control panel in Win 8 (I4202)
+* Fixed: Icons do not show background correctly in lang switch window and Win 8 languages controls (also I4316) (I4204)
+* Fixed: Crash in Keyman Configuration [kmshell.exe_9.0.451.0_script_TfrmMain_0] (I4251)
+* Fixed: kmtip install does not register Win 8 support features (I4252)
+* Fixed: TSF deadkeys do not function correctly (I4262)
+* Fixed: Test for text editor running fails (I4265)
+
+## 9.0.451 beta
+* Fixed: Keyman Configuration crashed on first run due to koKeymanUniscribeManager reference (I4250)
+
+## 9.0.450 beta
+* Fixed: If kmtip CKMTipTextService::Activate fails, cleanup (I3706)
+* Minor: Refactor kmxfile utility functions (I3757)
+* Added: Removed all legacy keyboard management Win32 API calls and use only TSF (I4220)
+* Fixed: Crash when OSK closed/reopened without dismissing hint window [CrashID:keyman.exe_9.0.449.0_2C405C5D_EInvalidPointer] (I4242)
+
+## 9.0.449 beta
+* Opening font helper or keyboard usage from Keyman menu on Win 8 still shows HTML outside window (I4225)
+* Excmagic.debug left scattered around program file directories after uninstall (I4218)
+
+## 9.0.448 beta
+* Shift + Arrows do not select text (only move caret) in Win 8 when Keyman keyboard is active (I4201)
+* Keyman TIP should use ITfTextInputProcessorEx (I4216)
+* Keyman leaks an Internet Explorer window handle (I4214)
+* Help dialog appears below OSK and is inaccessible (I4209)
+* Font helper and Keyboard usage appear outside frame in Win 8 (I4208)
+* Shift states still not working with unprocessed keys in V9 (I4128)
+* Activate/Purchase dialogs are incomplete and the Buy Modules button doesn't work (I4090)
+
+## 9.0.447 beta
+* Exit Keyman hint appears to be blank on Win8? (I4187)
+* Pressing Enter in install keyboard dialog gives error about admin req (I4172)
+* Help Contents link does not work from Keyman menu (I3993)
+* Help window Help and Help on Keyboard links don't work (I3676)
+* Base Keyboard dialog has wrong style of buttons (I4184)
+* Use TTempFileManager for all temporary files (I4195)
+* Lang switch window shows wrong selection with Alt+LeftShift when TIP is active (I4191)
+* keyman.exe seems to be missing icon (I3769)
+* Lang switch window shifts on first view (I4190)
+* wm_kmmoreposting must be refactored for TIP work as it is not sequential (I4196)
+* Avoid interactions with full-screen RDP (I4197)
+* mcompile logs should be stored in diag folder (I4174)
+* Uninstalling a keyboard leaves the mnemonic recompiled layouts behind (I4173)
+
+## 9.0.446 beta
+* Keyman Engine installer does not include mcompile.exe (I4171)
+
+## 9.0.445 beta
+* Mnemonic layouts should be recompiled to positional based on user-selected base keyboard (I4169)
+* Console execute in utilexecute.pas needs a temp copy of buffer to avoid write access violations (I4170)
+* Shift states still not working with unprocessed keys in V9 (I4128)
+    
+## 9.0.444 beta
+* Keyman Desktop installer does not install x64 TIP (I4161)
+
+## 9.0.442 beta
+* Add keyboard version information to Keyman Configuration (Tweak) (I4136)
+
+# Old Release Notes - What's New?
+
+## 8.0.0 stable
+
+Here are some of the great things we have added to Keyman Desktop 8.0.
+
+* 64-bit Support — Run Keyman Desktop in 64-bit Windows operating systems and applications.
+* Language Switcher — Access all your Keyman keyboards, Windows languages and Windows keyboards in one pop-up menu with a single hotkey (by default Alt+LeftShift).
+* Universal Language Switching — Switch keyboards once to use the same Keyman keyboard across all applications.
+* Keyboard Options — Keyboards for Keyman Desktop 8 can come with options which let you type as you prefer. Options allow you to do things like type French accents before or after the vowel, type Lao with or without spaces, or type Tigrigna with Ethipian or Eritrean punctiaton.
+* Enhanced UI — The Keyman interface has been redesigned, from much simpler setup to cleaner, more polished menus and dialogs.
+* Enhanced Keyman Menu — Access any tool in the Keyman Toolbox directly from the menu.
+* Enhanced On Screen Keyboard — The OSK better mimics your hardware keyboard, matching both the language and layout.
+* Enhanced Font Helper — Now see exactly which keyboard characters your fonts support.
+* Enhanced Character Map — Support for Planes 1-15 of the Unicode Standard has been greatly improved, as has filtering and search. For example, search now with instant feedback by part or all of character code point or name.
+* Support for Unicode 5.2 & 6.0 — Type in everything from Egyptian to Emoji.
+* Improved Application Compatibility — The keystroke processor in Keyman Desktop has been made more compatible with major applications such as OpenOffice, Microsoft Office and popular web browsers.
+* Single Installer — Both Keyman Desktop Light & Keyman Desktop Professional now install from the same file, which there's no longer any need to worry about downloading the wrong edition. 
+
+# 7.0.0 stable
+
+* The Keyman Character Map — Enables instant input of any Unicode character into the active application. Characters can be searched by name, number, block, font, and more.
+* The Keyman Font Helper — Lists all currently-installed fonts which work with the active Keyman keyboard.
+* The Keyman Usage View — Includes keyboard-specific help, especially useful for layouts with no On Screen Keyboard.
+* The Keyman Text Editor with Getting Started Tutorial — Teaches new users how to start using Keyman Desktop.
+* Tips & Hints — Assist new users throughout the program.
+* Improved Language Linking — Say goodbye to the Language Bar, Keyman Desktop now handles language switching in addition to switching Keyman keyboards.
+* Enhanced Keyman Toolbox — Resizable, supports non-Latin Windows keyboards, and improved font-linking.
+* Localisable Keyman Menus — Translate the Keyman Desktop user interface into any language.
+* Modern COM API — Control all aspects of Keyman Desktop from Windows Scripting, Visual Basic for Applications, or your application!
+* Windows Installer (.msi) — Permits straightforward deployment of Keyman Desktop.
+
+# 6.2.0 stable
+* Text Services Framework support - Keyman 6.2 supports the new Text Services Framework that is part of Microsoft Office XP. This enables Keyman to integrate with Microsoft Word 2002 much better than previously. Click here for more information.
+* Enhanced European keyboard support - Keyman 5.0 required you to use a US English keyboard (QWERTY layout) for full compatibility with Keyman keyboards. Version 6.2 now supports any layout you wish to use, and is not dependent on US English in any way.
+* Visual keyboards - An on-screen and printable keyboard is now available for Keyman 6.2 keyboards.
+* Add-ins - Keyman now supports add-ins for other applications. Included with Keyman 6.2 are add-ins for Word and RichEdit. The RichEdit add-in does not require RichEdit 3.0.
+* Enhanced integration with Windows languages - It is now possible to switch Keyman keyboards on automatically when a language is selected as a non-Administrative user.
+
+# 5.0.0 stable
+* Unicode support - With the release of version 5.0, Keyman now includes full support for Unicode. Unicode is a character encoding standard that supports most of the world's more common scripts, and includes support for user-defined scripts. Keyman 5.0 keyboards now support input and output of any of the thousands of characters defined in Unicode, including characters outside the Basic Multilingual Plane which are encoded with surrogate pairs.
+* Integration with Windows - Keyman 5.0 integrates more tightly with the multilingual features of Windows 9x, Me, NT, and 2000. Keyman 5.0 also features full shell integration, so that you can install a keyboard by simply double-clicking on its icon in Windows Explorer.
+* Keyman Developer- From version 5.0 and up, the Keyman Developer (previously TIKE) is a separate application, which must be downloaded and registered independently. This simplifies the deployment of Keyman on the majority of systems, where keyboard development is not required. See the Keyman Developer website for more information.
+

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -313,7 +313,7 @@
 ## 9.0.442 beta
 * Add keyboard version information to Keyman Configuration (Tweak) (I4136)
 
-# Old Release Notes - What's New?
+# Legacy Release Notes - What's New?
 
 ## 8.0.0 stable
 

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -423,7 +423,6 @@
 * Create your own product using the Branding Pack and the Keyman Engine
 * Fully customisable user interface for your product with Branding Editor
 * Distribution Editor to create a Windows Installer .msi for your product
-
 * Customer Relationship Manager
     * manage your customers and their licences from your desktop
     * fully integrated with the Tavultesoft Online Store

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,0 +1,438 @@
+# Keyman Developer Version History
+
+## 10.0 alpha
+* Keyman Developer moved to open source
+* KeymanWeb is now continuously integrated with Developer, ensuring that each update uses the most current version possible.
+
+## 9.0.523 stable
+* Fix: When a longpress popup is being edited, selecting another primary key can copy the details to that key's popup (additional scenario, I4926)
+* Update: Updated KeymanWeb to latest build 408
+
+## 9.0.519 stable
+* Fix: When a longpress popup is being edited, selecting another primary key can copy the details to that key's popup (I4926)
+* Fix: If 'find char under cursor automatically' is on, OSK editor opens charmap if it is closed (I4927)
+* Fix: Keyman 9 product installers should test for XP or Vista (I4934)
+* Fix: Redraw not reliably working in text editor (I4962)
+* Fix: Importing a KMN into a KVK does not work if includecodes are in the keyboard (I4979)
+* Fix: Keyboard fonts dialog has incorrect tab order (I4980)
+* Fix: Character Map is being updated even when not visible (I4981)
+* Fix: Defined character constants cannot be referenced correctly in other stores (I4982)
+* Fix: Starting a subprocess can fail due to constant buffer for CreateProcessW (I4983)
+
+## 9.0.518 stable
+* Fixed: Compiler does not warn on an index() statement that has an offset one past the key (I4914)
+* Improved: Text editor refresh is now faster after fix for I4870 (I4918)
+
+## 9.0.517 stable
+* Fixed: Blank font filename entry in JSON metadata UI editor crashes on save [CrashID:tike.exe_9.0.516.0_009CD793_EAssertionFailed] (I4878)
+
+## 9.0.516 stable
+* Fixed: Keyman Developer crashes when starting regression test [CrashID:tike.exe_9.0.511.0_0058BC63_EInvalidOperation] (I4839)
+* Fixed: Editor does not always refresh immediately with new theming (I4870)
+* Fixed: OSK font and Touch Layout font should be the same in Developer (I4872)
+* Fixed: Keyman Configuration test windows do not always display correctly (I4874)
+* Fixed: RTL flag is not mapped in the JSON editor (I4875)
+* Fixed: Default "eng" language should be added if missing during debug to JSON (I4876)
+* Fixed: JSON format is inconsistent with documentation (I4877)
+* Added: "Treat hints and warnings as errors" option to compiler (I4865)
+* Added: "Warn on deprecated features" option to compiler (I4866)
+* Added: "Test for code after use()" warning to compiler (I4867)
+* Added: Branding editor needs smoother interactions with test window (I4873)
+
+## 9.0.515 stable
+* Added: Dynamically refresh Branding Pack UI Test window as edits happen (I4855)
+* Fixed: Support view of particular pages of Keyman Configuration and missing pages in KCT Test (I4856)
+* Fixed: Allow edit of dtd files in kct editor (I4857)
+* Fixed: Asset files not always upgrading in Keyman Developer (I4858)
+
+## 9.0.514 stable
+* Added: New File dialog now creates folders automatically (I4852)
+* Fixed: Inconsistent display of panels through Developer (I4851)
+
+## 9.0.513 stable
+* Fixed: Backspace doesn't always work in the keyboard debugger (I4838)
+
+## 9.0.512 stable
+* Added: Update KeymanWeb to build 403 (I4837)
+* Added: Context-sensitive help missing V8 and V9 keywords (I4840)
+* Added: Restructure version 9 developer help (I4841)
+* Fixed: Ctrl+N, Ctrl+O not working in Developer Project view (I2986)
+* Fixed: Compiler does not recognise baselayout, layer or platform at the start of a line (I4784)
+* Fixed: Character Identifier cells are too narrow for entire U+xxxxxx caption (I4832)
+* Fixed: Character Identifier blank font grid needs formatting (I4834)
+* Fixed: Project window needs Keyman 9 icons (I4835)
+* Fixed: Character Map and Character Identifier don't match tokens at start of line (I4842)
+* Fixed: Delete key doesn't work in the keyboard debugger (I4845)
+* Fixed: Code editor does not get focus automatically when file is loaded (I4847)
+  
+## 9.0.511 stable
+* Added: Refresh Keyman Developer look and feel for release (I4796)
+* Added: Split Path and Name boxes in New File dialogs (I4798)
+* Added: Add Character Identifier to Keyman Developer (I4807)
+* Added: Add character preview to debug window (I4808)
+* Added: Track keystrokes in debug status form (I4809)
+* Added: Add Restart Debugger button to debug status window (I4815)
+* Added: Note in compile log if symbols are included in build (I4823)
+* Added: Add Unicode 8.0.0 to Keyman Developer 9 (I4829)
+* Fixed: Convert to Characters tool is inconsistent (I4797)
+* Fixed: Preview keys are wrong colour in Developer (I4799)
+* Fixed: Targets box overlaps name box in keyboard editor (I4810)
+* Fixed: Hide JSON metadata tab for desktop keyboards (I4811)
+* Fixed: Tab order in Details page for Keyboard Editor is incorrect (I4812)
+* Fixed: Keyboard preview background colour is incorrect (I4813)
+* Fixed: Image preview in package editor doesn't refresh after changes (I4814)
+* Fixed: Tidy up display of key in debug status window (I4816)
+* Fixed: Regression test buttons have incorrect labels (I4817)
+* Fixed: Remove obsolete files from Keyman Developer source (I4818)
+* Fixed: Keyman Developer home page in About dialog is incorrect (I4819)
+* Fixed: Keyboard fonts dialog box has incorrect control types (I4820)
+* Fixed: Update icons for version 9.0 in New File dialog (I4821)
+* Fixed: Form sizes are incorrect with new theming (I4822)
+* Fixed: Fonts don't always load correctly in KeymanWeb test page (I4824)
+* Fixed: Make kmcomp command line details consistent (I4825)
+* Fixed: Navigation keys don't work in debugger (I4826)
+* Fixed: Key down debug events are not always processed correctly (I4827)
+* Fixed: Font identifier miscalculates percentages when supplementary plane characters in string (I4828)
+
+## 9.0.510 stable
+* Keyboard debugger does not always activate profile correctly (I4767)
+* Add "open in code view" default option for keyboards (I4751)
+* Opening a keyboard externally can open it multiple times (I4749)
+* V9.0 - Enable SHIFT+ESC to pause debugger with TSF (I4033)
+
+## 9.0.509 stable
+* Package compiler (buildpkg) needs to specify username and password on command line (I4763)
+* Buildpkg needs to support different paths for msi and kmp files (I4764)
+* Add "open in code view" default option for keyboards (I4751)
+* Double-click on message does not find source line since build 500 (I4765)
+* EthnologueCode system store does not correlate to control on first page of wizard for messages (I4766)
+* Keyboard debugger does not always activate profile correctly (I4767)
+* Opening a keyboard externally can open it multiple times (I4749)
+* KeymanWeb key is no longer required for debugger in Keyman Developer (I4768)
+* Keyman Developer missing keymanweb-osk.ttf from layoutbuilder install (I4747)
+* Command line package compiler should trap exceptions and report rather than crashing (I4769)
+* Product compiler does not create output path if required (I4756)
+* Add "open in code view" default option for keyboards (I4751)
+* If kmcmpdll.dll does not exist in debug path, try default paths (I4770)
+* Update regressiontest app for Engine and Developer 9.0 (I4771)
+
+## 9.0.508 stable
+* Fixed: Project files need to build package installers (I4734)
+* Added: Clean and Build single file commands to project (I4735)
+* Fixed: Product files don't include version in output filename in project (I4736)
+* Fixed: Clean package should also clean installer (I4737)
+* Fixed: Product compiler crashes with stack overflow in build 507 (I4738)
+* Fixed: Don't show "keep in touch" for non-keyman products (I4740)
+* Fixed: Package installer compiler references wrong path for compiled package file (I4741)
+* Fixed: Product compiler does not save .msi or .pxx into project output folder (I4743)
+* Fixed: Keyman Developer 9.0 fails to upgrade from Developer 8.0 cleanly (I4744)
+
+## 9.0.505 stable
+* Fixed: Crash when developer tries Upload to Tavultesoft and internet connection is down [CrashID:tike.exe_9.0.504.0_0068E2DC_ESOAPHTTPException] (I4726)
+* Fixed: Changing font while touch layout editor in Code mode results in broken \ rules (I4727)
+* Fixed: Saving a keyboard with a locked feature file causes Developer to crash [CrashID:tike.exe_9.0.504.0_0045876A_EFCreateError] (I4728)
+* Fixed: If you attempt to load a non-XML file as a project, it silently fails and overwrites the file (I4729)
+* Fixed: Loading a kvk file in a keyboard, where content is invalid, crashes developer [CrashID:tike.exe_9.0.504.0_0078D23F_EVisualKeyboardLoader] (I4730)
+
+## 9.0.504 stable
+* Fixed: Project display crashes if project render output file is locked [CrashID:tike.exe_9.0.489.0_0045876A_EFCreateError] (I4654)
+* Fixed: Developer crashes when changing font settings and in code view for touch layout if not on first line [CrashID:tike.exe_9.0.487.0_0069BE51_ERangeError] (I4655)
+* Fixed: Loading a non-project file as a project crashes Developer [CrashID:tike.exe_9.0.497.0_00813E09_EProjectLoader] (I4703)
+* Fixed: Compiling a standalone keyboard crashes Developer [CrashID:tike.exe_9.0.503.0_00A4316C_EAccessViolation] (I4720)
+* Fixed: Developer crashes if a file is in use and a reload is attempted (I4721)
+* Fixed: Keyboard uploads fail due to incorrect server name (I4722)
+* Fixed: Switching from source tab to design tab in layout fails to refresh the layout (I4723)
+* Fixed: Compiler generates warnings for JSON files if output path is source path (I4724)
+
+## 9.0.502 stable
+* Project no longer crashes if file parameters change during build (I4710)
+* Closing a modified package no longer crashes Developer (I4708)
+
+## 9.0.501 stable
+* kmcomp no longer modifies project files during a build (I4709)
+
+## 9.0.500 stable
+* Add silent and warning-as-error parameters to kmcomp (I4706)
+* Add clean target to kmcomp (I4707)
+
+## 9.0.499 stable
+* Add KeymanDeveloperPath environment variable to installer (I4705)
+
+## 9.0.498 stable
+* Project files should be formatted XML (I4704)
+
+## 9.0.497 stable
+* section should be in project .user file (I4700)
+* If version is not specified in keyboard file, it gets blank instead of 1.0 in kmcomp .kpj (I4701)
+* Package actions crash if package not part of a project [CrashID:tike.exe_9.0.496.0_008033BD_EAccessViolation] (I4702)
+
+## 9.0.496 stable
+* Remove VCL dependency for mrulist (I4697)
+* Split project and user preferences files (I4698)
+* Compile .kpj files from kmcomp (I4699)
+* Split UI actions from non-UI actions in projects (I4694)
+* Debugger needs to use project file filename not internal name (I4695)
+* Refactor compile into project file action (I4686)
+* Split project UI actions into separate classes (I4687)
+* Add build path to project settings (I4688)
+* Redesign package editor as left tabbed (I4689)
+* Pull keyboard version into package version when adding a keyboard (I4690)
+* Always save project automatically (I4691)
+* Add Clean as project action (I4692)
+* Fix crash when creating left tabbed page control without images (I4693)
+
+## 9.0.495 stable
+* Move Developer help to online only (I4677)
+* Fixup Ctrl+PgUp, Ctrl+PgDn, Alt+Left, Alt+Right hotkeys (I4678)
+* Remember focus for active editor when swapping editors (I4679)
+* Ctrl+S often activates the "select key" dialog in editor (I4680)
+* mnemoniclayout store should be enough to block design view (I4681)
+* Installing a keyboard with an OSK from Developer fails to install the OSK (I4682)
+
+## 9.0.489 stable
+* WiX file generator in Keyman Developer was failing due to security (I4643)
+
+## 9.0.488 stable
+* Debug host keyboard did not correctly map through some Keyman keyboard keys (I4156)
+
+## 9.0.485 stable
+* Keyman Developer failed to import kvk xml file (I4619)
+
+## 9.0.484 stable
+* context statement in output could fail in some situations in KeymanWeb compiler (I4611)
+
+## 9.0.476 stable
+* The text editor in the keyboard wizard is no longer blanked in some circumstances when switching tabs (I4557)
+* Keyboard parser no longer forces keyboard version to 9.0 (I4558)
+* Debugger development - disable debug tip when stopping debugging (I4331)
+
+## 9.0.475 stable
+* JSON search needs to do cleanname on the keyboard filename to find candidates (I4508)
+
+## 9.0.474 stable
+* Consolidate the compile action into single command (I4504)
+* Add JSON metadata editor to keyboard wizard (I4505)
+* Add command to send email with targets (I4506)
+* Move tab close button onto tabs (I4507)
+
+## 9.0.473 stable
+* Add kmw_embedcss to feature support in Developer (I4369)
+* Tab and Dismiss keys have been removed from touch templates (I4475)
+* Added source version of KMW to Keyman Developer (I4476)
+
+## 9.0.472 stable
+* The dismiss keyboard and tab buttons should not be required by Keyman Developer now (I4447)
+* Sometimes when saving, the list of &WINDOWSLANGUAGES is doubled (I4329)
+* Standard fonts should not be downloaded to devices in test window (I4448)
+* Font CSS responds as ISO-8859-1 instead of UTF-8 (I4449)
+* Layout Builder is missing OSK special keys font in some situations (I4450)
+* Touch layout editor polish (I4330)
+
+## 9.0.471 stable
+* JSON hosting for installing keyboard into native app has wrong extension (I4437)
+* Keyboard debugger does not show button control in desktop mode (I4438)
+* If more than one language listed for a keyboard, the JSON file becomes invalid (I4440)
+
+## 9.0.469 stable
+* Download Keyboard dialog does not display correctly (I4414)
+* OSK does not show underlying characters if base keyboard is not loaded (I4415)
+
+## 9.0.467 stable
+* Manual Activate dialog is misformatted (I4408)
+* Wrong font selected in keyboard debugger touch layout (I4409)
+* Metrics should be visible in touch layout editor (I4410)
+* Character map allows Ctrl+Click to insert character (I4411)
+* Wrong font selected in keyboard debugger touch layout (I4409)
+
+## 9.0.463 stable
+* Line number comments are no longer incorrectly added to non-debug builds (I4384)
+
+## 9.0.460 stable
+* Web and touch keyboards now support custom stylesheets with &kmw_embedcss (I4368)
+* Line number comments are now included in generated Javascript when compiling with debug (I4373)
+
+## 9.0.458 stable
+* Added: Require Windows 7 or later for install (I4313)
+
+## 9.0.454 stable
+* Fixed: Compiling a product installer failed with xsl security error (I3734)
+
+## 9.0.453 stable
+* Fixed: Clicking Remove Feature when no feature selected crashes [CrashID:tike.exe_9.0.449.0_00987F63_EAccessViolation] (I4247)
+
+## 9.0.452 stable
+* Fixed: File format dropdown should be disabled in project view (I3733)
+* Fixed: Crash opening project in read-only location [CrashID:tike.exe_9.0.443.0_005E202D_EOleException] (I4212)
+* Added: Added BCP-47 language codes to unicodedata (I4257)
+* Fixed: Keyboard font dialog crashed if in text editor view (I4258)
+* Added: Generate a .json file when compiling keyboard for web (I4259)
+* Added: Add link to install keyboard file into native app into debug web (I4260)
+* Added: Build 357 of KeymanWeb into Developer (I4261)
+* Fixed: Compile to web and test fails when keyboard version is not 1.0 (I4263)
+* Fixed: If Keyman Developer is running, double clicking a file in Explorer doesn't open it (I4264)
+
+## 9.0.449 stable
+* Keyboard wizard crashes with missing template-default.js when adding Touch Layout (I4226)
+
+## 9.0.448 stable
+* Manifests missing or malformed in some executables (I4205)
+* Block U_0000-U_001F and U_0080-U_009F in layout files (I4198)
+* adding a subkey array generates an invalid "?" id (I4213)
+* template-default should be called template-latin (I4217)
+* Activate/Purchase dialogs are incomplete and the Buy Modules button doesn't work (I4090)
+
+## 9.0.447 stable
+* Add Windows compatibility values to all manifests (I4194)
+
+## 9.0.443 stable
+* Need keyboard version control in Keyman Developer Wizard (I4157)
+* Keyboardversion is not compiled into kmw js (I4155)
+* keyboardversion is not read by KeymanWeb compiler and applied to filename. (I4154)
+
+## 9.0.442 stable
+* Edit platform button still in editor even though it does nothing (Bug) (I4126)
+* OSK Import KMX breaks some shift states (Bug) (I4127)
+* Edit Platform dialog is deleted but button is still there in touch layout editor (Bug) (I4129)
+* Build php help files to help.keyman.com (Tweak) (I4135)
+* Add keyboard version information to Keyman Configuration (Tweak) (I4136)
+* Don't prompt to sort out L/R shift on save of keyboard (Bug) (I4137)
+* If the KVK is removed from the keyboard, it can still be imported into the touch layout until the file is closed (Bug) (I4138)
+* Compress layout file when compiling to KMW (Tweak) (I4139)
+* Add keyboard version information to keyboards (Develop) (I4140)
+* Warn when unusable key ids are used (Develop) (I4141)
+* Validate key ids are in an acceptable format (Develop) (I4142)
+* Support modifier layers of KVK when importing a KMX (Bug) (I4143)
+* When character is dropped or double-clicked to insert into html text field, no modified event is triggered (Bug) (I4144)
+* Deadkeys are corrupted by KeyboardParser (Bug) (I4145)
+* When importing OSK into touch layout, unused layers are populated with base layer (Bug) (I4146)
+* If a touch layout is added to a keyboard, it doesn't get saved until the tab is visited (Bug) (I4147)
+* Touch layout editor is missing a number of standard key names (Bug) (I4148)
+* If a touch layout key has no id, the builder fails to load the json (Bug) (I4149)
+* Double clicking on a key should activate its 'nextlayer' in touch layout editor (Tweak) (I4150)
+* key id is not saved until field is blurred in touch layout editor (Bug) (I4151)
+* Resizing a key with the grab handle causes other keys to overlap during the resize operation (Bug) (I4152)
+* Pressing and releasing Ctrl in touch layout editor should allow selection of standard keys a-la layout editor (Tweak) (I4153)
+
+## 9.0.441 stable
+* Double-click on Character Map when in Touch Layout Editor crashes TIKE (I4110)
+* Double-click in char map when no input element focused in touch layout editor crashes TIKE (I4111)
+* Installer links should be to keyman.com (I4115)
+* KMW compiler should warn when extended shift flags are used (I4118)
+* KMW compiler should only warn unassociated keys that are not special keys (I4119)
+* Remove platform properties from touch layout editor as font details are now accessible via Keyboard|Font menu (I4120)
+* Rename 'subkey' to 'touch+hold popup' (I4121)
+* traditional touch template has K_SEMICOLON and K_SQUOTE wrongly named key ids (I4122)
+* Keyman Developer installer should required Vista or later (I4123)
+
+## 9.0.440 stable
+* Keyman Developer installer icon is still v8.0 style (I4100)
+* Touch layout editor still has the font options in its Edit Platform dialog (I4091)
+
+## 9.0.439 stable
+* Trace compile errors in subfiles in Keyman Developer (I4081)
+* Make details tab scrollable with mouse wheel (I4082)
+* When errors encountered in JSON layout file, locate the error in the source view (I4083)
+* Remove old font selection controls from wizard (I4085)
+* About should be version 9.0 style (I4086)
+* Splash should be version 9.0 style (I4084)
+* KeymanWeb compiler does not clear messages before starting (I4087)
+
+## 9.0.438 stable
+* Keyman Developer Keyboard Font dialog helpful to reduce font confusion (I4057)
+* Touch Layout Import OSK fails with weird error if OSK is missing (I4058)
+* If OSK is not saved, then changes do not flow through in Touch Layout Import (I4059)
+* KeymanWeb compiler should validate the layout file (I4060)
+* KeymanWeb compiler needs defined codes for some errors (I4061)
+* Touch Layout platforms do not allow font size specification (I4062)
+* Web Debugger needs to embed fonts for OSK and text area (I4063)
+* Touch layout editor does not apply fonts consistently to keys (I4064)
+* Deleting a touch layout layer leaves a "null" entry in the layout file (I4065)
+
+## 9.0.437 stable
+* Layout editor needs to refresh character map (I4046)
+* TIKE shows an error if you try to save before viewing the touch layout tab (I4047)
+* Various fixes and features for touch layout editor: (I4049)
+    * Deselecting main key does not disable subkey or clear other controls
+    * Drag+drop not sticking
+    * Drag+drop not allowing drop at end
+    * Key height not right
+    * Not showing editor in line for key
+    * Not showing key code on key
+    * No wedges showing
+    * No delete icon showing
+    * Deselecting does not disable controls
+    * If inserting or removing key padding, the key display does not refresh correctly
+    * 'Label:' label should be removed
+    * Key id does not update on keyboard view when changed
+* Character map does not show currently selected char from keyboard view (I4049)
+* Button UI not displaying in KMDev KMW test window (I4048)
+
+## 9.0.436 stable
+* Add support for Redo to Keyman Developer actions (I4032)
+* Enable SHIFT+ESC to pause debugger with TSF (I4033)
+* Restructure keyboard wizard for source views and features (I4034)
+* Parsing of UTF-8 in JSON layout file crashes TIKE (I4035)
+* Keyboard Debug HTTP Host should be thread safe (I4036)
+* Keyboard HTTP debugger sometimes caches old keyboards (I4037)
+
+## 9.0.434 stable
+* Redesign Keyboard Wizard to integrate V9 features (I4021)
+* Rework Import KMX to work with V9.0 Debug Host Keyboard (I4022)
+* Touch Layout Editor crashes with file in use sometimes (I4023)
+* Installer is missing jquery support files for Configuration UI (I4011)
+
+# Legacy "What's New" sections
+
+## 8.0.0 stable
+
+### Fully integrated source editors
+* Changes to source are instantly reflected in the Design Editor and vice-versa
+* Keyboard, Package and Distribution editors all have Source tabs
+* On Screen Keyboard Editor integrated into Keyboard Editor
+* Keyboard, Package and Distribution editors feature integrated upload to Tavultesoft
+
+### Much improved character map
+* Displays all characters from Unicode 5.0
+* Filter characters by range, name, font and more
+* Exceptionally clear display with ClearType and font linking
+* Resizeable character cells
+
+### Tightly integrated project
+* Project provides a clear step-by-step process for developing keyboard solutions
+* Links in the project take you to tutorials, help, and more
+
+### User Interface Redesign
+* Much clearer user interface - every screen revisited and polished
+
+### Language Changes
+* 'notany' Statement - provides the opposite of the 'any' statement
+* Maximum store or rule length now 4095 characters, up from 255
+* New system stores for KeymanWeb and On Screen Keyboard links
+
+### Keyboard Icons
+* Keyboard icons support 256 colour and transparency
+
+### Tutorials
+* New tutorials for Packages, Branding and Distribution
+
+### KeymanWeb Pack
+* KeymanWeb compiler and design tools integrated into Keyboard Editor
+* KeymanWeb keyboard test window
+  
+### Branding Pack
+* Create your own product using the Branding Pack and the Keyman Engine
+* Fully customisable user interface for your product with Branding Editor
+* Distribution Editor to create a Windows Installer .msi for your product
+
+* Customer Relationship Manager
+    * manage your customers and their licences from your desktop
+    * fully integrated with the Tavultesoft Online Store
+* Simple integration of your product into Tavultesoft Online Store for instant online sales
+* Integration with WiX provides modern installation techniques for product installers
+* Keyman Engine separated from Keyman Desktop to enable straightforward use in your own product
+
+### Modern installation and operating system support
+* Modern Windows Installer for straightforward deployment
+* Windows Vista support
+* Unicode support throughout Keyman Developer
+* Automated online updates 


### PR DESCRIPTION
Implements history.md for the last two remaining products in need of it - desktop and developer.  Also makes some small tweaks to the Windows readme.md and to the resource scripts given the special location in which the new history.md files needed to be placed.