### PR TITLE
Fix build issue with hyphen in identifier in kmdev.wxs

### DIFF
--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -215,7 +215,7 @@
 
                 <Directory Id='xmllayout' Name='layoutbuilder' FileSource='..\..\developer\tike\xml\layoutbuilder\'>
                     <Component><File Id='xml_file_layoutbuilder_builder.css' Name='builder.css' KeyPath="yes" /></Component>
-                    <Component><File Id='xml_file_layoutbuilder_physical-keyboard-template.js' Name='physical-keyboard-template.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_file_layoutbuilder_physical_keyboard_template' Name='physical-keyboard-template.js' KeyPath="yes" /></Component>
                     <Component><File Id='xml_file_layoutbuilder_builder.js' Name='builder.js' KeyPath="yes" /></Component>
                     <Component><File Id='xml_file_layoutbuilder_builder.xsl' Name='builder.xsl' KeyPath="yes" /></Component>
                     <Component><File Id='xml_file_layoutbuilder_jquery_1.10.2.js' Name='jquery-1.10.2.js' KeyPath="yes" /></Component>


### PR DESCRIPTION
Minor issue with build, not picked up with the PR checks because the PR checks don't build the msi installers at present