### PR TITLE
Mobile default-layer shifting regression fix

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -10,7 +10,7 @@
 * Refactored code paths relating to KMW's embedding in the iOS and Android apps.  (#211)
 * Added support for L/R Alt and Ctrl modifiers for keyboards. (#9) (#52)
 * Added support for use of the Caps Lock state within keyboards if specified by a keyboard designer.
-* Fixed next-layer processing (#116)
+* Fixed next-layer processing (#116) (#358)
 * Fixed auto-attaching mode bug. (#352)
 
 ## 2017-07-10 2.0.473 stable

--- a/web/source/kmwosk.js
+++ b/web/source/kmwosk.js
@@ -1008,14 +1008,8 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
         // Test if this key has a non-default next layer
         if(typeof e.key != 'undefined' && e.key['nextlayer'] !== null) osk.nextLayer=e.key['nextlayer'];
 
-        // TODO: Verify the layer name is valid?
-
-        // Refresh the OSK if a different layer must be displayed
-        if(osk.nextLayer != osk.layerId)
-        {
-          osk.layerId=osk.nextLayer;
-          osk._Show();
-        }
+        // Swap layer as appropriate.
+        osk.selectLayer(keyName, nextLayer);
 
         /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
         Lelem._KeymanWebSelectionStart=null;


### PR DESCRIPTION
Addresses #358.

Turns out that we had separately-written layer management stuff at the end of the OSK's click-response code from the `osk.selectLayer` that the latter could easily and safely replace.  It already performs the filtering check mentioned for the original code and comment being replaced, with additional checks to ensure the layer name is valid.