### PR TITLE
[Mac]: Prevent Keyman processing command keys

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -53,6 +53,8 @@
         [self performSelector:@selector(updateContextBuffer:) withObject:sender afterDelay:0.25];
         return NO;
     }
+    else if ((event.modifierFlags & NSEventModifierFlagCommand) == NSEventModifierFlagCommand)
+        return NO; // We ignore any Command-key events.
     
     BOOL handled = NO;
     NSArray *actions = nil;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -90,7 +90,10 @@ DWORD VKMap[0x80];
     
     if (!gp)
         return nil;
-    
+
+    if (([event modifierFlags] & NSEventModifierFlagCommand) == NSEventModifierFlagCommand)
+        return nil; // Engine should NEVER attempt to process characters when the Command key is pressed.
+
     if (gp.fUsingKeys) {
         // Begin group using keys
         unsigned short keyCode = [event keyCode];
@@ -121,24 +124,24 @@ DWORD VKMap[0x80];
             NSLog(@"[event modifierFlags] = %lX", [event modifierFlags]);
         }
         DWORD mask = 0;
-        if (([event modifierFlags] & NSShiftKeyMask) == NSShiftKeyMask)
+        if (([event modifierFlags] & NSEventModifierFlagShift) == NSEventModifierFlagShift)
             mask |= K_SHIFTFLAG;
         
-        if (([event modifierFlags] & NSAlphaShiftKeyMask) == NSAlphaShiftKeyMask)
+        if (([event modifierFlags] & NSEventModifierFlagCapsLock) == NSEventModifierFlagCapsLock)
             mask |= CAPITALFLAG;
 
         if (([event modifierFlags] & MK_LEFT_ALT_MASK) == MK_LEFT_ALT_MASK)
             mask |= LALTFLAG;
         else if (([event modifierFlags] & MK_RIGHT_ALT_MASK) == MK_RIGHT_ALT_MASK)
             mask |= RALTFLAG;
-        else if (([event modifierFlags] & NSAlternateKeyMask) == NSAlternateKeyMask)
+        else if (([event modifierFlags] & NSEventModifierFlagOption) == NSEventModifierFlagOption)
             mask |= K_ALTFLAG;
         
         if (([event modifierFlags] & MK_LEFT_CTRL_MASK) == MK_LEFT_CTRL_MASK)
             mask |= LCTRLFLAG;
         else if (([event modifierFlags] & MK_RIGHT_CTRL_MASK) == MK_RIGHT_CTRL_MASK)
             mask |= RCTRLFLAG;
-        else if (([event modifierFlags] & NSControlKeyMask) == NSControlKeyMask)
+        else if (([event modifierFlags] & NSEventModifierFlagControl) == NSEventModifierFlagControl)
             mask |= K_CTRLFLAG;
         
         if (self.debugMode)


### PR DESCRIPTION
Issue #380: Cherry picked a few small changes from "mac compatibility" branch to fix bug whereby command keys were sometimes causing characters to be output.