### PR TITLE
Sets init param 'attachType' to 'auto' for all devices.

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -13,6 +13,7 @@
 * Fixed keyboard loading upon initialization, redundant cloud requests for keyboards.  (#103)
 * Fixed next-layer processing (#116) (#358)
 * Fixed auto-attaching mode bug. (#352)
+* Set the default behavior of KMW to auto-attach for all devices, rather than only desktops. (#375)
 * Fixed key codes for longpress keys and handle default keys beyond U_FFFF
 
 ## 2017-07-10 2.0.473 stable

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -4098,7 +4098,7 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
       opt['fonts'] = fixPath(opt['fonts']);    
 
       // Set element attachment type    
-      if(opt['attachType'] == '') opt['attachType'] = (device.touchable ? 'manual' : 'auto');
+      if(opt['attachType'] == '') opt['attachType'] = 'auto';
 
   /*    
 


### PR DESCRIPTION
Fixes #375.

I've tested the result with the Android app just to be safe; the change poses no problems for our embedded uses.