### PR TITLE
KMW namespace change - Developer fix

### DIFF
--- a/windows/src/developer/TIKE/xml/kmw/index.html
+++ b/windows/src/developer/TIKE/xml/kmw/index.html
@@ -119,7 +119,7 @@
       <a href='' id='install_link'>Install Keyboard into native Keyman</a>
     </div>
     <script> 
-      tavultesoft.keymanweb.init({
+      keyman.init({
         ui:'button',
         resources:'/resource/',
         keyboards:'/keyboard/',
@@ -127,20 +127,20 @@
         attachType:'auto'
       });
 
-      tavultesoft.keymanweb.addEventListener('keyboardchange',
+      keyman.addEventListener('keyboardchange',
         function (p) {
           //alert(p.internalName);
           var nm = p.internalName.substr('Keyboard_'.length);
           document.getElementById('install_link').href='keyman://localhost/open?direct=true&url='+location.protocol+'//'+location.host+'/kbinstall/'+nm+'-'+debugKeyboards[nm].version+'.json';
         });
         
-      //tavultesoft.keymanweb.addEventListener
+      //keyman.addEventListener
       
       window.onload = function() {
         window.setTimeout(
           function () {
             //document.getElementById('ta1').focus();
-            tavultesoft.keymanweb.moveToElement('ta1');
+            keyman.moveToElement('ta1');
           }, 10);
       }
     </script>

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,7 @@
 ## 10.0 alpha
 * Keyman Developer moved to open source (#121)
 * KeymanWeb is now continuously integrated with Developer, ensuring that each update uses the most current version possible (#122)
+  - Additional KeymanWeb compatibility fixes (#349)
 * Keyman Developer compiler now generates keyboards that distinguish left and right ctrl/alt (#313)
 * Keyman Developer visual editors now supports keyboards that distinguish left and right ctrl/alt for web/mobile targets (#342)
 * The `&version` store is now optional and the compiler will determine and report on the minimum version required if it is not present (#334)


### PR DESCRIPTION
Addresses the Keyman Developer namespace portion of #349.

Does not change Keyman Developer's compilation results for KMW to directly use the new human-friendly interface function names.