### PR TITLE
addKeyboards parameter property:  'language' -> 'languages'.

### DIFF
--- a/web/samples/compiled.html
+++ b/web/samples/compiled.html
@@ -80,7 +80,7 @@
     <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
 
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../samples/index.html">Return to samples home page</a></h3>
   </div>
 
   </body>

--- a/web/samples/multilingual.html
+++ b/web/samples/multilingual.html
@@ -74,7 +74,7 @@
     <input class='test'/>
    
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../samples/index.html">Return to samples home page</a></h3>
   </div>
 
   </body>

--- a/web/samples/samplehdr.js
+++ b/web/samples/samplehdr.js
@@ -47,12 +47,12 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'./us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
     // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    kmw.addKeyboards('french', 'european2@nor,swe', '@heb'); // Loads all from uniquely-identifying strings.
   
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using ISO codes is
@@ -61,7 +61,7 @@
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      language:{
+      languages:{
         id:'lao',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/samples/uncompiled - manual.html
+++ b/web/samples/uncompiled - manual.html
@@ -88,7 +88,7 @@
     <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
 
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../samples/index.html">Return to samples home page</a></h3>
   </div>
 
   </body>

--- a/web/samples/uncompiled.html
+++ b/web/samples/uncompiled.html
@@ -88,7 +88,7 @@
     <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
 
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../samples/index.html">Return to samples home page</a></h3>
   </div>
 
   </body>

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -1436,18 +1436,23 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
               alert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
             }
           } else {
-            lList=x[i]['language'];
+            if(x[i]['language']) {
+              console.warn("The 'language' property for keyboard stubs has been deprecated.  Please use the 'languages' property instead.");
+              x[i]['languages'] = x[i]['language'];
+            }
+
+            lList=x[i]['languages'];
                 
             //Array or single entry?
             if(typeof(lList.length) == 'number') {
               for(j=0; j<lList.length; j++) {
-                var tEntry = {'id':x[i]['id'],'language':x[i]['language'][j]['id']};
+                var tEntry = {'id':x[i]['id'],'language':x[i]['languages'][j]['id']};
                 if(isUniqueRequest(tEntry)) {
                   keymanweb.cloudList.push(tEntry);
                 }
               }
             } else { // Single language element
-              var tEntry = {'id':x[i]['id'],'language':x[i]['language'][j]['id']};
+              var tEntry = {'id':x[i]['id'],'language':x[i]['languages'][j]['id']};
               if(isUniqueRequest(tEntry)) {
                 keymanweb.cloudList.push(tEntry);
               }
@@ -1587,7 +1592,11 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
     keymanweb.addStub = function(arg)
     {                         
       if(typeof(arg['id']) != 'string') return false;
-      if(typeof(arg['language']) == 'undefined') return false;
+      if(typeof(arg['language']) != "undefined") {
+        console.warn("The 'language' property for keyboard stubs has been deprecated.  Please use the 'languages' property instead.");
+        arg['languages'] = arg['language'];
+      }
+      if(typeof(arg['languages']) == 'undefined') return false;
       
       // Default the keyboard name to its id, capitalized
       if(typeof(arg['name']) != 'string')
@@ -1596,7 +1605,7 @@ if(!window['tavultesoft']['keymanweb']['initialized']) {
         arg['name'] = arg['name'].substr(0,1).toUpperCase()+arg['name'].substr(1);
       }
 
-      var lgArg=arg['language'],lgList=[],i,lg;
+      var lgArg=arg['languages'],lgList=[],i,lg;
       if(typeof(lgArg.length) == 'undefined') lgList[0] = lgArg; else lgList = lgArg; 
 
       var localOptions={

--- a/web/testing/attachment-api/utilities.js
+++ b/web/testing/attachment-api/utilities.js
@@ -5,7 +5,7 @@ function loadKeyboards()
 	// The first keyboard added will be the default keyboard for touch devices.
 	// For faster loading, it may be best for the default keybaord to be 
 	// locally sourced.
-	kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+	kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
 	  filename:'../us-1.0.js'});
 	  
 	// Add more keyboards to the language menu, by keyboard name,
@@ -19,7 +19,7 @@ function loadKeyboards()
 
 	// Add a fully-specified, locally-sourced, keyboard with custom font  
 	kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-	  language:{
+	  languages:{
 		id:'lao',name:'Lao',region:'Asia',
 		font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
 		},

--- a/web/testing/chirality/utilities.js
+++ b/web/testing/chirality/utilities.js
@@ -4,7 +4,7 @@ function loadKeyboards()
 
   // A testing keyboard handwritten with chirality information.
   kmw.addKeyboards({id:'chirality',name:'Chirality Testing',
-    language:{
+    languages:{
     id:'eng',name:'English',region:'North America'
     },
     filename:'chirality.js'
@@ -14,7 +14,7 @@ function loadKeyboards()
   // without the 'shift' layer properly defined.
   // Add a fully-specified, locally-sourced, keyboard with custom font  
   kmw.addKeyboards({id:'halfDefined',name:'Undefined Shift Layer Keyboard',
-    language:{
+    languages:{
     id:'eng',name:'English',region:'North America'
     },
     filename:'halfDefined.js'

--- a/web/testing/issue115/index.html
+++ b/web/testing/issue115/index.html
@@ -49,7 +49,7 @@
         resources:'resources',
         attachType:'auto'
         });
-      kmw.addKeyboards({id:'issue115a',name:'Issue 115',language:{id:'eng',name:'English'},
+      kmw.addKeyboards({id:'issue115a',name:'Issue 115',languages:{id:'eng',name:'English'},
         filename:'./issue115a-1.0.js'});
     </script> 
     
@@ -74,7 +74,7 @@
     <h3>or in this input field:</h3>
     <input class='test' value='' placeholder='or here'/>
     
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../index.html">Return to testing home page</a></h3>
   </div>
 
   </body>

--- a/web/testing/issue116/index.html
+++ b/web/testing/issue116/index.html
@@ -49,7 +49,7 @@
         resources:'resources',
         attachType:'auto'
         });
-      kmw.addKeyboards({id:'next_layer_tests',name:'Issue 116',language:{id:'eng',name:'English'},
+      kmw.addKeyboards({id:'next_layer_tests',name:'Issue 116',languages:{id:'eng',name:'English'},
         filename:'./next_layer_tests-1.0.js'});
     </script> 
     

--- a/web/testing/issue160/index.html
+++ b/web/testing/issue160/index.html
@@ -49,8 +49,8 @@
         resources:'resources'
         });
       kmw.addKeyboards(
-        {id:'issue160',name:'Issue 160',language:{id:'eng',name:'English'}, filename:'./issue160-1.0.js'},
-        {id:'tchaduni',name:'tchaduni',language:{id:'fra',name:'TChad'}, filename:'./tchaduni-3.1.js'}
+        {id:'issue160',name:'Issue 160',languages:{id:'eng',name:'English'}, filename:'./issue160-1.0.js'},
+        {id:'tchaduni',name:'tchaduni',languages:{id:'fra',name:'TChad'}, filename:'./tchaduni-3.1.js'}
         );
     </script> 
     
@@ -75,7 +75,7 @@
     <h3>or in this input field:</h3>
     <input class='test' value='' placeholder='or here'/>
     
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../index.html">Return to testing home page</a></h3>
   </div>
 
   </body>

--- a/web/testing/issue29/issue-29.js
+++ b/web/testing/issue29/issue-29.js
@@ -47,7 +47,7 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
@@ -61,7 +61,7 @@
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      language:{
+      languages:{
         id:'lao',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/testing/issue53/issue53.js
+++ b/web/testing/issue53/issue53.js
@@ -46,7 +46,7 @@
 
     // Add a fully-specified, locally-sourced, keyboard.
     kmw.addKeyboards({id:'layered_debug_keyboard',name:'Web_Layer_Debugging',
-      language:{
+      languages:{
         id:'dbg',name:'Debug',region:'North America'
         },
       filename:'./layered_debug_keyboard-1.0.js'

--- a/web/testing/issue62/issue-62.js
+++ b/web/testing/issue62/issue-62.js
@@ -47,7 +47,7 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
@@ -61,7 +61,7 @@
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      language:{
+      languages:{
         id:'lao',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/testing/issue63/issue-63.js
+++ b/web/testing/issue63/issue-63.js
@@ -47,7 +47,7 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
@@ -61,7 +61,7 @@
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      language:{
+      languages:{
         id:'lao',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/testing/keyboard-errors/errorhdr.js
+++ b/web/testing/keyboard-errors/errorhdr.js
@@ -9,12 +9,12 @@
     var kmw=tavultesoft.keymanweb;
     
     // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'../us-1.0.js'});
       
     // Insert a keyboard that cannot be found.
     kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
-      language:{
+      languages:{
         id:'lao',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
@@ -23,7 +23,7 @@
 	  
 	// Insert a keyboard that will generate a timing error.  
     kmw.addKeyboards({id:'unparsable',name:'non-parsable',
-      language:{
+      languages:{
         id:'lao',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
@@ -33,7 +33,7 @@
 	  
 	// Insert a keyboard that will generate a timing error.  
     kmw.addKeyboards({id:'timeout',name:'timeout',
-      language:{
+      languages:{
         id:'lao',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/testing/samplehdr.js
+++ b/web/testing/samplehdr.js
@@ -47,12 +47,14 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
       filename:'./us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
     // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
+    kmw.addKeyboards('french','@heb');
+    kmw.addKeyboards({id:'european2', name:'EuroLatin2', languages: [{id:'nor'}, {id:'swe'}]}); // Loads from partial stub instead of the compact string.
   
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using ISO codes is
@@ -61,7 +63,7 @@
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      language:{
+      languages:{
         id:'lao',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },

--- a/web/testing/uncompiled - manual.html
+++ b/web/testing/uncompiled - manual.html
@@ -88,7 +88,7 @@
     <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
 
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../index.html">Return to testing home page</a></h3>
   </div>
 
   </body>

--- a/web/testing/uncompiled.html
+++ b/web/testing/uncompiled.html
@@ -88,7 +88,7 @@
     <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
 
 
-    <h3><a href="../samples/index.html">Return to testing home page</a></h3>
+    <h3><a href="../index.html">Return to testing home page</a></h3>
   </div>
 
   </body>


### PR DESCRIPTION
Fixes #45.  

The old `language` property now emits console-based deprecation warnings and is internally reassigned to the correct `languages` property in order to facilitate a smoother transition to the new API parameter structure.

Also fixes up minor details with the testing pages, since changes there were already necessitated to avoid console warnings with the API shift.

------

To do:
- [ ] Modify the appropriate page on help.keyman.com's KMW reference section accordingly.  
(Addressed by https://github.com/sillsdev/keyman-help.keyman.com/pull/115.)