### PR TITLE
Update to Android Studio and Gradle 3.0

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -2,10 +2,10 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
     }
 }
@@ -13,8 +13,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }

--- a/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 27 15:43:16 ICT 2017
+#Mon Oct 30 09:32:59 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.triplet.play'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.2"
     playAccountConfigs {
         defaultAccountConfig {
             if (project.hasProperty("keys_json_file")) {
@@ -77,14 +77,16 @@ android {
 
 repositories {
     mavenCentral()
+    google()
     flatDir {
         dirs 'libs'
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.4.0'
-    compile(name: 'keyman-engine', ext: 'aar')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:support-v4:25.4.0'
+    api (name: 'keyman-engine', ext: 'aar')
 }
 
 /*

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 15
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.4.0'
+    implementation 'com.android.support:support-v4:25.4.0'
 }

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -1,18 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+      jcenter()
+      google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }

--- a/android/KMEA/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMEA/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 14 10:53:37 ICT 2017
+#Mon Oct 30 08:32:52 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/android/README.md
+++ b/android/README.md
@@ -96,11 +96,11 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
     b. If you choose to use your own build of the Keyman Engine, get the library from **android/Samples/KMSample1/app/libs/keyman-engine.aar**
 2. Open your project in Android Studio.
 3. Open **build.gradle** (Module: app) in "Gradle Scripts".
-4. include `compile(name:'keyman-engine', ext:'aar')` in dependencies.
+4. include `api (name:'keyman-engine', ext:'aar')` in dependencies.
 5. after dependencies, insert
 ````gradle
     repositories {
-        mavenCentral()
+        google()
         flatDir {
             dirs 'libs'
         }

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.keyman.kmsample1"
@@ -20,14 +20,14 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    google()
     flatDir {
         dirs 'libs'
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile(name:'keyman-engine', ext:'aar')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.1.0'
+    api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Oct 30 10:08:21 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.keyman.kmsample2"
@@ -20,14 +20,14 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    google()
     flatDir {
         dirs 'libs'
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile(name:'keyman-engine', ext:'aar')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.1.0'
+    api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Oct 30 10:13:07 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
@@ -20,14 +20,14 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    google()
     flatDir {
         dirs 'libs'
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile(name:'keyman-engine', ext:'aar')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.1.0'
+    api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Oct 30 11:02:32 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Per Android Studio 3.0 [Release Notes](https://android-developers.googleblog.com/2017/10/android-studio-30.html)

- Update gradle version
- Change deprecated `compile` dependencies to `implementation` or `api`
- Change maven repositories to google (triplet plugin still on maven)
- Update readme instructions for using the engine