### PR TITLE
Modified the KMEA keyboard.html to use the new `keyman` JS namespace

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -18,7 +18,7 @@
       //document.body.style.backgroundColor="transparent";
       window.console.log('Device type = '+device);
       window.console.log('Keyboard height = '+oskHeight);
-      var kmw=window['tavultesoft']['keymanweb'];
+      var kmw=window['keyman'];
       kmw.init({'app':device,'fonts':'fonts/'});
       kmw['util']['setOption']('attachType','manual');
       kmw['oninserttext'] = insertText;
@@ -38,7 +38,7 @@
       if(h > 0) {
         oskHeight = h;
       }
-      var kmw=window['tavultesoft']['keymanweb'];
+      var kmw=window['keyman'];
       kmw['correctOSKTextSize']();
     }
 
@@ -63,7 +63,7 @@
     // Query KMW if a given keyboard uses chiral modifiers.
     function setIsChiral(keyboardProperties) {
       var name = typeof(keyboardProperties.internalName) == "undefined" ? keyboardProperties.keyboardName : keyboardProperties.internalName;
-      var isChiral = tavultesoft.keymanweb.isChiral(name);
+      var isChiral = keymanweb.isChiral(name);
       window.console.log('For keyboard "' + name + '"');
       window.console.log('setIsChiral = ' + isChiral);
 
@@ -74,7 +74,9 @@
     function setKeymanLanguage(keyboardName, internalName, languageName, langId, version, font, oskFont) {
       //oskFont.files = ['NotoSansSyriacWestern-Regular.svg#NotoSansSyriacWesternRegular'];
       //window.console.log('oskFonts = '+JSON.stringify(oskFont));
-      var kmw=window['tavultesoft']['keymanweb'];
+      var kmw=window['keyman'];
+      var kbdInterface=kmw['interface'];
+
       // Defaults for mising arguments
       switch (arguments.length) {
         case 1:
@@ -94,7 +96,7 @@
           break;
       }
 
-      kmw['KRS']({KN:keyboardName,KI:'Keyboard_'+internalName,KLC:langId,KL:languageName,
+      kbdInterface.registerStub({KN:keyboardName,KI:'Keyboard_'+internalName,KLC:langId,KL:languageName,
         KF:internalName+'-'+version+'.js',KFont:font,KOskFont:oskFont});
       kmw['setActiveKeyboard']('Keyboard_'+internalName,langId);
       kmw['osk']['show'](true);
@@ -106,7 +108,7 @@
     }
 
     function resetContext() {
-      tavultesoft.keymanweb.resetContext();
+      keymanweb.resetContext();
     }
 
     function updateKMText(text) {
@@ -114,14 +116,14 @@
           text = '';
       }
       var ta = document.getElementById('ta');
-      var kmw = window['tavultesoft']['keymanweb'];
+      var kmw = window['keyman'];
       ta.value = text;
       kmw['setActiveElement'](ta);
     }
 
     function updateKMSelectionRange(start, end) {
       var ta = document.getElementById('ta');
-      var kmw = window['tavultesoft']['keymanweb'];
+      var kmw = window['keyman'];
       ta.selectionStart = ta._KeymanWebSelectionStart = start;
       ta.selectionEnd = ta._KeymanWebSelectionEnd = end;
       kmw['setActiveElement'](ta);
@@ -175,22 +177,22 @@
 
     function showHelpBubble() {
       fragmentToggle = (fragmentToggle + 1) % 100;
-      var kmw = window['tavultesoft']['keymanweb'];
+      var kmw = window['keyman'];
       var pos = kmw['touchMenuPos']();
       window.console.log('showHelpBubble ' + pos);
       window.location.hash = 'showHelpBubble-' + fragmentToggle + '+keyPos=' + pos;
     }
 
     function executePopupKey(keyID, keyText) {
-      var kmw=window['tavultesoft']['keymanweb'];
-
+      var kmw=window['keyman'];
+      
       // KMW only needs keyID to process the popup key. keyText merely logged to console
       window.console.log('executePopupKey('+keyID+'); keyText: ' + keyText);
       kmw['executePopupKey'](keyID);
     }
 
     function executeHardwareKeystroke(code, shift, lstates) {
-      var kmw=window['tavultesoft']['keymanweb'];
+      var kmw=window['keyman'];
       window.console.log('executeHardwareKeystroke:('+code+', ' + shift + ', ' + lstates + ');');
       try {
         var r = kmw['executeHardwareKeystroke'](code, shift, lstates);
@@ -201,7 +203,7 @@
     }
 
     function popupVisible(value) {
-      var kmw=window['tavultesoft']['keymanweb'];
+      var kmw=window['keyman'];
       kmw['popupVisible'](value);
     }
 

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -63,7 +63,8 @@
     // Query KMW if a given keyboard uses chiral modifiers.
     function setIsChiral(keyboardProperties) {
       var name = typeof(keyboardProperties.internalName) == "undefined" ? keyboardProperties.keyboardName : keyboardProperties.internalName;
-      var isChiral = keymanweb.isChiral(name);
+      var kmw=window['keyman'];
+      var isChiral = kmw.isChiral(name);
       window.console.log('For keyboard "' + name + '"');
       window.console.log('setIsChiral = ' + isChiral);
 
@@ -108,7 +109,8 @@
     }
 
     function resetContext() {
-      keymanweb.resetContext();
+      var kmw=window['keyman'];
+      kmw.resetContext();
     }
 
     function updateKMText(text) {

--- a/android/Tests/KeyboardHarness/app/src/main/assets/languages/chirality.js
+++ b/android/Tests/KeyboardHarness/app/src/main/assets/languages/chirality.js
@@ -12,8 +12,8 @@
 function Keyboard_chirality() {
   this.KI = "Keyboard_chirality";
   this.KN = "Development Chirality Test Keyboard";
+  this.KMBM = 0x001F;
   this.KV = {
-      KMBM: 0x001F,
       F: ' 1em "Arial"',
       K102: 0,
       KLS: { 'default': new Array("`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "", "", "", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\", "", "", "", "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'",  "", "", "", "", "", "", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "", "", "", "", "", ""),
@@ -42,6 +42,7 @@ function Keyboard_chirality() {
   };
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
+    var osk = keyman.osk;
     
     // Handwritten time!
     var kls = this.KV.KLS;
@@ -52,7 +53,7 @@ function Keyboard_chirality() {
     for(var i = 0; i < layers.length; i++) {
       // Obtain the modifier code to match for the selected layer.
       // The following uses a non-public property potentially subject to change in the future.
-      var modCode = k.osk.modifierCodes['VIRTUAL_KEY'] | k.osk.getModifierState(layers[i]);
+      var modCode = osk.modifierCodes['VIRTUAL_KEY'] | osk.getModifierState(layers[i]);
       var layer = layers[i];
       
       for(var key=0; key < kls[layer].length; key++) {
@@ -61,9 +62,9 @@ function Keyboard_chirality() {
         if(keySymbol == "K_*") {
           continue;
         } else if(kls[layer][key] != '') {
-          if (k.KKM(e, modCode, k.osk.keyCodes[keySymbol])) {
+          if (k.KKM(e, modCode, osk.keyCodes[keySymbol])) {
             r = m = 1;
-            if(k.KSM(e, k.osk.modifierCodes['CAPS'])) {
+            if(k.KSM(e, osk.modifierCodes['CAPS'])) {
               k.KO(0, t, kls[layer][key].toUpperCase());
             } else {
               k.KO(0, t, kls[layer][key]);


### PR DESCRIPTION
Addresses the KMEA portion of #349

Modify keyboard.html to use the new `keyman` JS namespace instead of `tavultesoft.keymanweb`