### PR TITLE
Removed calls to framework methods that are not available before Mac OS X 10.9

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMBarView.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMBarView.m
@@ -17,19 +17,19 @@
     NSRect rect2 = NSMakeRect(rect1.size.width, 0, rect.size.width*0.23, rect.size.height);
     NSRect rect3 = NSMakeRect(rect2.origin.x + rect2.size.width, 0, rect.size.width*0.21, rect.size.height);
     
-    CGContextSetFillColorWithColor(context, [NSColor colorWithRed:246.0/255.0 green:137.0/255.0 blue:36.0/255.0 alpha:1.0].CGColor);
+    CGContextSetFillColorWithColor(context, [NSColor colorWithSRGBRed:246.0/255.0 green:137.0/255.0 blue:36.0/255.0 alpha:1.0].CGColor);
     CGContextBeginPath(context);
     CGContextAddRect(context, rect1);
     CGContextClosePath(context);
     CGContextDrawPath(context, kCGPathFill);
     
-    CGContextSetFillColorWithColor(context, [NSColor colorWithRed:204.0/255.0 green:56.0/255.0 blue:70.0/255.0 alpha:1.0].CGColor);
+    CGContextSetFillColorWithColor(context, [NSColor colorWithSRGBRed:204.0/255.0 green:56.0/255.0 blue:70.0/255.0 alpha:1.0].CGColor);
     CGContextBeginPath(context);
     CGContextAddRect(context, rect2);
     CGContextClosePath(context);
     CGContextDrawPath(context, kCGPathFill);
     
-    CGContextSetFillColorWithColor(context, [NSColor colorWithRed:121.0/255.0 green:195.0/255.0 blue:218.0/255.0 alpha:1.0].CGColor);
+    CGContextSetFillColorWithColor(context, [NSColor colorWithSRGBRed:121.0/255.0 green:195.0/255.0 blue:218.0/255.0 alpha:1.0].CGColor);
     CGContextBeginPath(context);
     CGContextAddRect(context, rect3);
     CGContextClosePath(context);

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -164,7 +164,7 @@
         [textField setBackgroundColor:[NSColor clearColor]];
         [textField setAlignment:NSLeftTextAlignment];
         [textField setFont:[NSFont systemFontOfSize:tableView.rowHeight*0.5]];
-        [textField setTextColor:[NSColor colorWithRed:0.0 green:0.0 blue:0.1 alpha:1.0]];
+        [textField setTextColor:[NSColor colorWithSRGBRed:0.0 green:0.0 blue:0.1 alpha:1.0]];
         [textField setStringValue:[info objectForKey:@"HeaderTitle"]];
         [rowView addSubview:textField];
         return rowView;
@@ -177,7 +177,7 @@
     NSDictionary *info = [self.tableContents objectAtIndex:row];
     BOOL isHeader = ([info objectForKey:@"HeaderTitle"] != nil);
     if (isHeader)
-        [rowView setBackgroundColor:[NSColor colorWithRed:186.0/255.0 green:211.0/255.0 blue:1.0 alpha:1.0]];
+        [rowView setBackgroundColor:[NSColor colorWithSRGBRed:186.0/255.0 green:211.0/255.0 blue:1.0 alpha:1.0]];
 }
 
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -93,11 +93,10 @@ typedef enum {
                 _downloadFilename = [NSString stringWithString:[value substringFromIndex:index+9]];
             else if ((index = [value rangeOfString:@"url="].location) != NSNotFound) {
                 NSString *urlString = [NSString stringWithString:[value substringFromIndex:index+4]];
-                @try {
+                if ([urlString respondsToSelector:@selector(stringByRemovingPercentEncoding)])
                     urlString = [urlString stringByRemovingPercentEncoding];
-                }
-                @catch (NSException *e) {
-                    // Must be an OS version prior to 10.9 - try this (now deprecated) method instead:
+                else if ([urlString respondsToSelector:@selector(stringByReplacingPercentEscapesUsingEncoding:)]) {
+                    // OS version prior to 10.9 - use this (now deprecated) method instead:
                     urlString = [urlString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
                 }
                 downloadUrl = [NSURL URLWithString:urlString];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -91,8 +91,17 @@ typedef enum {
             NSUInteger index = NSNotFound;
             if ((index = [value rangeOfString:@"filename="].location) != NSNotFound)
                 _downloadFilename = [NSString stringWithString:[value substringFromIndex:index+9]];
-            else if ((index = [value rangeOfString:@"url="].location) != NSNotFound)
-                downloadUrl = [NSURL URLWithString:[[NSString stringWithString:[value substringFromIndex:index+4]] stringByRemovingPercentEncoding]];
+            else if ((index = [value rangeOfString:@"url="].location) != NSNotFound) {
+                NSString *urlString = [NSString stringWithString:[value substringFromIndex:index+4]];
+                @try {
+                    urlString = [urlString stringByRemovingPercentEncoding];
+                }
+                @catch (NSException *e) {
+                    // Must be an OS version prior to 10.9 - try this (now deprecated) method instead:
+                    urlString = [urlString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                }
+                downloadUrl = [NSURL URLWithString:urlString];
+            }
         }
         
         if (downloadUrl && _downloadFilename) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -34,7 +34,7 @@
     NSSize size = self.window.frame.size;
     [self.window setMaxSize:NSMakeSize(size.width*1.6, size.height*1.6)];
     [self.window setMinSize:NSMakeSize(size.width*0.8, size.height*0.8)];
-    [self.window setBackgroundColor:[NSColor colorWithRed:241.0/255.0 green:242.0/255.0 blue:242.0/255.0 alpha:1.0]];
+    [self.window setBackgroundColor:[NSColor colorWithSRGBRed:241.0/255.0 green:242.0/255.0 blue:242.0/255.0 alpha:1.0]];
     
     _helpButton = [[NSButton alloc] initWithFrame:NSMakeRect(0, 0, 17, 17)];
     [_helpButton setTitle:@""];


### PR DESCRIPTION
WIP: Replaced calls to NSColor colorWithRed:green:blue:alpha with calls to colorWithSRGBRed:green:blue:alpha because the former was not available until OS version 10.9