### PR TITLE
Toolbar UI / setActiveKeyboard API interaction bugfix

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -16,6 +16,7 @@
 * Set the default behavior of KMW to auto-attach for all devices, rather than only desktops. (#375)
 * Fixed key codes for longpress keys and handle default keys beyond U_FFFF
 * Enhanced the removeKeyboards API function (#5)
+* Fixed an issue with the Toolbar UI under certain scenarios (#271)
 
 ## 2017-07-10 2.0.473 stable
 * 2.0 stable release build.

--- a/web/source/kmwuitoolbar.js
+++ b/web/source/kmwuitoolbar.js
@@ -894,8 +894,8 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
      **/    
     ui.changeKeyboardEvent = function(p)
     {                   
-      if(p['indirect']) 
-      {          
+      //if(p['indirect']) 
+      //{          
         var kbName=p['internalName'],
             lgName=p['languageCode'];
         if(lgName != '' && kbName != '')
@@ -913,7 +913,7 @@ if(!window['tavultesoft']['keymanweb']['ui']['name']) {
             }
           }
         }
-      }
+      //}
       return true;
     }
     keymanweb['addEventListener']('keyboardchange',ui.changeKeyboardEvent);

--- a/web/testing/index.html
+++ b/web/testing/index.html
@@ -35,5 +35,6 @@
   <h2><a href="./issue115/">Long-press on numeric and symbolic layer testing</a></h2>
   <h2><a href="./issue116/">Next-layer processing testing</a></h2>
   <h2><a href="./issue160/">Uxxxx code testing</a></h2>
+  <h2><a href="./issue271">Test page for interactions between setActiveKeyboard and the toolbar UI.</a></h2>
   </body>
 </html>

--- a/web/testing/issue271/header.js
+++ b/web/testing/issue271/header.js
@@ -1,0 +1,122 @@
+// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
+
+/* 
+    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    If the same keyboard is used for several languages, it must be listed for each
+    language, but the keyboard itself will only be loaded once. 
+    If two (or more) keyboards are to be available for a given language, both must be listed.
+    Any number of keyboards may be specified in one or more calls. 
+    Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path. 
+    The actual keyboard object will be downloaded asynchronously when first selected for use.
+  
+    Each argument to addKeyboards() is a string, for example:
+      european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
+      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      
+    Argument syntax also supports the following extensions:
+      @fra              load the current version of the default keyboard for French
+      @fra$             load all available keyboards (current version) for French
+          
+    Each call to addKeyboards() requires a single call to the remote server, 
+    (unless all keyboards listed are local and fully specified) so it is better
+    to use multiple arguments rather than separate function calls. 
+    
+    Calling addKeyboards() with no arguments returns a list of *all* available keyboards. 
+    The Toolbar (desktop browser) UI is best suited for allowing users to select 
+    the appropriate language and keyboard in this case.
+
+    Keyboards may also be specified by language name using addKeyboardsForLanguage()
+    for example:
+      keymanweb.addKeyboardsForLanguage('Burmese');
+    
+    Appending $ to the language name will again cause all available keyboards for that
+    language to be loaded rather than the default keyboard.
+        
+    The first call to addKeyboardsForLanguage() makes an additional call to the 
+    keyman API to load the current list of keyboard/language associations.
+
+    In this example, the following function loads the indicated keyboards,
+    and is called when the page loads. 
+*/
+
+  function loadKeyboards() 
+  { 
+    var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
+    
+    // The first keyboard added will be the default keyboard for touch devices.
+    // For faster loading, it may be best for the default keybaord to be 
+    // locally sourced.
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+      filename:'../us-1.0.js'});
+      
+    // Add more keyboards to the language menu, by keyboard name,
+    // keyboard name and language code, or just the ISO 639 language code.  
+    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+  
+    // Add a keyboard by language name.  Note that the name must be spelled
+    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // usually easier.)
+    kmw.addKeyboardsForLanguage('Dzongkha');
+    
+    // Add a fully-specified, locally-sourced, keyboard with custom font  
+    kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
+      languages:{
+        id:'lao',name:'Lao',region:'Asia',
+        font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
+        },
+      filename:'../lao_2008_basic.js'
+      });   
+
+    // The following two optional calls should be delayed until language menus are fully loaded:
+    //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
+    //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
+  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  
+    // Note that locally specified keyboards will be listed before keyboards 
+    // requested from the remote server by user interfaces that do not order
+    // keyboards alphabetically by language.
+  }
+  
+    // Script to allow a user to add any keyboard to the keyboard menu 
+  function addKeyboard(n)
+  { 
+    var sKbd, kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
+    switch(n)
+    {
+      case 1:
+        sKbd=document.getElementById('kbd_id1').value;
+        kmw.addKeyboards(sKbd);
+        break;
+      case 2:
+        sKbd=document.getElementById('kbd_id2').value.toLowerCase();
+        var rx=new RegExp(/^\w{3,3}$\$?/);    
+        if(rx.test(sKbd))
+          kmw.addKeyboards('@'+sKbd);
+        else        
+          alert('An ISO 639 language code must be exactly 3 letters long!');
+        break;
+      case 3:
+        sKbd=document.getElementById('kbd_id3').value;
+        kmw.addKeyboardsForLanguage(sKbd);
+        break;
+    }
+  }
+  
+  // Add keyboard on Enter (as well as pressing button)
+  function clickOnEnter(e,id)
+  {                                       
+    e = e || window.event;
+    if(e.keyCode == 13) addKeyboard(id); 
+  }
+  
+  function setActiveKeyboard() {
+    var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
+    
+    var sKbd = document.getElementById('kbd_id4').value;
+    var sLng = document.getElementById('lang_id4').value;
+    var result = kmw.setActiveKeyboard("Keyboard_" + sKbd, sLng);
+  }
+  
+  

--- a/web/testing/issue271/header.js
+++ b/web/testing/issue271/header.js
@@ -47,7 +47,7 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English', region:'North America'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,

--- a/web/testing/issue271/index.html
+++ b/web/testing/issue271/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    
+    <!-- Set the viewport width to match phone and tablet device widths -->                         
+    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
+      
+    <title>KeymanWeb Sample Page - Uncompiled Source</title>
+
+    <!-- Your page CSS --> 
+    <style type='text/css'>   
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}       
+    </style> 
+ 
+    <!-- Insert uncompiled KeymanWeb source scripts -->              
+    <script src="../../source/kmwstring.js" type="application/javascript"></script>
+    <script src="../../source/kmwbase.js" type="application/javascript"></script>
+    <script src="../../source/keymanweb.js" type="application/javascript"></script>
+    <script src="../../source/kmwosk.js" type="application/javascript"></script>
+    <script src="../../source/kmwnative.js" type="application/javascript"></script>
+    <script src="../../source/kmwcallback.js" type="application/javascript"></script>
+    <script src="../../source/kmwkeymaps.js" type="application/javascript"></script>
+    <script src="../../source/kmwlayout.js" type="application/javascript"></script>
+    <script src="../../source/kmwinit.js" type="application/javascript"></script>             
+
+    <!-- 
+      For desktop browsers, a script for the user interface must be inserted here.
+       
+      Standard UIs are toggle, button, float and toolbar.  
+      The toolbar UI is best for any page designed to support keyboards for 
+      a large number of languages.
+    -->
+    <script src="../../source/kmwuitoolbar.js"></script>                                                                                            
+ 
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
+      kmw.init({
+          resources:'resources',
+          attachType:'auto'
+        });
+    </script> 
+    
+    <!-- Add keyboard management script for local selection of keyboards to use -->
+    <script src="./header.js"></script> 
+  
+  </head>
+
+<!-- Sample page HTML -->  
+  <body onload='loadKeyboards();'> 
+    <h2>KeymanWeb Sample Page - Uncompiled Source</h2>
+                                                                             
+	<h3>This version is used to test the interactions of <code>SetActiveKeyboard</code> with the Toolbar UI.</h3>
+  <p>Automatically-loaded keyboard IDs:
+  <ul>
+  <li>us, eng</li>
+  <li>french, fra</li>
+  <li>european2, nor</li>
+  <li>european2, swe</li>
+  <li>hebrew, heb</li>
+  <li>dzongkha, dzo</li>
+  <li>lao_2008_basic, lao</li>
+  </ul>
+  </p>
+      <div id='DynamicTextboxes'>
+    <!-- 
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>      
+	<input id="plaininput" placeholder="A simple input element." />
+	<hr>
+  </div> 	
+    <h3>Set active keyboard:</h3>
+    <p>Keyboard id: <input type='input' id='kbd_id4' class='kmw-disabled'/>, Language Code: <input type='input' id='lang_id4' class='kmw-disabled'/></p>
+    <input type='button' id='btn4' onclick="setActiveKeyboard()" value="Set as Active Keyboard" />
+    
+    <hr>
+    
+    <h3>Add a keyboard by keyboard name:</h3>
+    <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
+    <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
+ 
+    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
+    <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
+
+    <h3>Add a keyboard by language name:</h3>
+    <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
+
+    <h3><a href="../index.html">Return to testing home page</a></h3>
+
+  
+ 
+  </body>
+  
+  <!-- 
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard. 
+    * 
+    * To work around this Firefox bug, navigate to <b>about:config</b> 
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b> 
+    * while testing. 
+    * 
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *   
+    ***   
+  -->     
+</html>


### PR DESCRIPTION
Fixes #271.

Of note:  there was prior design work done toward this that relied upon an unimplemented control path.  Namely, if a `setActiveKeyboard` request were "indirect," the Toolbar UI should update, but not otherwise.  There is nothing in the KMW APIs that allows specification of whether or not a `setActiveKeyboard` call should be considered indirect.

It turns out that removing this check corrects the issue and appears to raise no additional issues outside of a potential performance impact when setting the keyboard from the Toolbar UI itself.

Otherwise, we'll need to properly define what "indirect" should mean and redesign KMW to facilitate this paradigm for a proper fix.