### PR TITLE
Fix some warnings

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
@@ -68,7 +68,7 @@ class KeyboardInfoViewController: UITableViewController, UIAlertViewDelegate {
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     if !isCustomKeyboard {
       if indexPath.row == 1 {
-        let url = URL(string:"http://help.keyman.com/keyboard/\(keyboardID)/\(keyboardVersion)/")!
+        let url = URL(string: "http://help.keyman.com/keyboard/\(keyboardID)/\(keyboardVersion)/")!
         if let openURL = Manager.shared.openURL {
           openURL(url)
         } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerBarButtonItem.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerBarButtonItem.swift
@@ -30,7 +30,7 @@ public class KeyboardPickerBarButtonItem: UIBarButtonItem {
 
     if UIDevice.current.userInterfaceIdiom == .phone {
       let landscapeImagePath = keymanBundle.path(
-        forResource:"keyboard_icon_landscape\(retinaSuffix)", ofType: "png")!
+        forResource: "keyboard_icon_landscape\(retinaSuffix)", ofType: "png")!
       landscapeImagePhone = UIImage(contentsOfFile: landscapeImagePath)
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerButton.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerButton.swift
@@ -21,7 +21,7 @@ public class KeyboardPickerButton: UIButton {
     setColor(UIColor(red: 0.62, green: 0.68, blue: 0.76, alpha: 1.0))
     addTarget(self, action: #selector(self.showKeyboardPicker), for: .touchUpInside)
 
-    let bundlePath = Bundle(for: type(of :self)).path(forResource: "Keyman", ofType: "bundle")!
+    let bundlePath = Bundle(for: type(of: self)).path(forResource: "Keyman", ofType: "bundle")!
     let retinaSuffix = Manager.shared.retinaScreen ? "@2x" : ""
     let imagePath = Bundle(path: bundlePath)!.path(forResource: "keyboard_icon\(retinaSuffix)", ofType: "png")!
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -138,7 +138,7 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
 
     if Manager.shared.removeKeyboard(at: indexPath.row) {
       let userData = Manager.shared.activeUserDefaults()
-      userKeyboards = userData.array(forKey: Key.userKeyboardsList) as! [[String : String]]
+      userKeyboards = userData.array(forKey: Key.userKeyboardsList) as! [[String: String]]
       if isCurrentKB {
         let kbID = userKeyboards[0][Key.keyboardId]
         let langID = userKeyboards[0][Key.languageId]

--- a/ios/engine/KMEI/KeymanEngineDemo/AppDelegate.swift
+++ b/ios/engine/KMEI/KeymanEngineDemo/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
   func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
     Manager.applicationGroupIdentifier = "group.KMEI"
     Manager.shared.isDebugPrintingOn = true
     Manager.shared.canRemoveDefaultKeyboard = true

--- a/ios/keyman/Keyman/Keyman/ActivityItemProvider.swift
+++ b/ios/keyman/Keyman/Keyman/ActivityItemProvider.swift
@@ -36,10 +36,7 @@ class ActivityItemProvider: UIActivityItemProvider {
     case UIActivityType.postToFacebook?:
       return "\(text)\n\n\(fbText)"
     case UIActivityType.postToTwitter?:
-        if text.characters.count > 140 {
-          return text[..<text.index(text.startIndex, offsetBy: 140)]
-        }
-        return text
+      return text.prefix(140)
     default:
       return text
     }

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var navigationController: UINavigationController?
 
   func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
     Manager.applicationGroupIdentifier = "group.KM4I"
     #if DEBUG
       Manager.shared.isDebugPrintingOn = true


### PR DESCRIPTION
An older version of swiftlint failed to catch some comma violations.

`text.characters.count` is deprecated in favour of `text.count`. Using `prefix()` is better though. It returns a prefix with max length `n`.