### PR TITLE
Fix crash on iOS 8 due to nil nibName

### DIFF
--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -32,11 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ = overlayWindow
 
     // Override point for customization after application launch.
-    if UIDevice.current.userInterfaceIdiom == .phone {
-      viewController = MainViewController(nibName: "MainViewController_iPhone", bundle: nil)
-    } else {
-      viewController = MainViewController(nibName: "MainViewController_iPad", bundle: nil)
-    }
+    viewController = MainViewController()
     let navigationController = UINavigationController(rootViewController: viewController)
 
     // Navigation bar became translucent by default in iOS7 SDK, however we don't want it to be translucent.

--- a/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
@@ -18,6 +18,10 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
     NotificationCenter.default.removeObserver(self)
   }
 
+  convenience init() {
+    self.init(nibName: "GetStartedViewController", bundle: nil)
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -141,7 +145,7 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       Manager.shared.showKeyboardPicker(in: mainViewController, shouldAddKeyboard: true)
     case 1:
       mainViewController.dismissGetStartedView(nil)
-      let setUpVC = SetUpViewController(nibName: "SetUpViewController", bundle: nil)
+      let setUpVC = SetUpViewController()
       mainViewController.present(setUpVC, animated: true, completion: nil)
     case 2:
       mainViewController.dismissGetStartedView(nil)

--- a/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
@@ -141,7 +141,7 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       Manager.shared.showKeyboardPicker(in: mainViewController, shouldAddKeyboard: true)
     case 1:
       mainViewController.dismissGetStartedView(nil)
-      let setUpVC = SetUpViewController()
+      let setUpVC = SetUpViewController(nibName: "SetUpViewController", bundle: nil)
       mainViewController.present(setUpVC, animated: true, completion: nil)
     case 2:
       mainViewController.dismissGetStartedView(nil)

--- a/ios/keyman/Keyman/Keyman/InfoViewController/InfoViewController.swift
+++ b/ios/keyman/Keyman/Keyman/InfoViewController/InfoViewController.swift
@@ -14,6 +14,14 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
 
   private var networkReachable: Reachability?
 
+  convenience init() {
+    if UIDevice.current.userInterfaceIdiom == .phone {
+      self.init(nibName: "InfoViewController_iPhone", bundle: nil)
+    } else {
+      self.init(nibName: "InfoViewController_iPad", bundle: nil)
+    }
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     extendedLayoutIncludesOpaqueBars = true

--- a/ios/keyman/Keyman/Keyman/KMWebBrowser/BookmarksViewController.swift
+++ b/ios/keyman/Keyman/Keyman/KMWebBrowser/BookmarksViewController.swift
@@ -21,6 +21,10 @@ class BookmarksViewController: UIViewController, UITableViewDelegate, UITableVie
   // TODO: Create struct for bookmarks
   private var bookmarks = [[String: String]]()
 
+  convenience init() {
+    self.init(nibName: "BookmarksViewController", bundle: nil)
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     loadBookmarks()

--- a/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
@@ -34,6 +34,10 @@ class WebBrowserViewController: UIViewController, UIWebViewDelegate, UIAlertView
   private var keyboardChangedObserver: NotificationObserver?
   private var keyboardPickerDismissedObserver: NotificationObserver?
 
+  convenience init() {
+    self.init(nibName: "WebBrowserViewController", bundle: nil)
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -213,7 +217,7 @@ class WebBrowserViewController: UIViewController, UIWebViewDelegate, UIAlertView
   }
 
   @IBAction func bookmarks(_ sender: Any) {
-    let bookmarksVC = BookmarksViewController(nibName: "BookmarksViewController", bundle: nil)
+    let bookmarksVC = BookmarksViewController()
     bookmarksVC.webBrowser = self
     present(bookmarksVC, animated: true, completion: nil)
   }

--- a/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
@@ -213,7 +213,7 @@ class WebBrowserViewController: UIViewController, UIWebViewDelegate, UIAlertView
   }
 
   @IBAction func bookmarks(_ sender: Any) {
-    let bookmarksVC = BookmarksViewController()
+    let bookmarksVC = BookmarksViewController(nibName: "BookmarksViewController", bundle: nil)
     bookmarksVC.webBrowser = self
     present(bookmarksVC, animated: true, completion: nil)
   }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -1065,7 +1065,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
     overlayWindow.isHidden = false
-    getStartedVC = GetStartedViewController()
+    getStartedVC = GetStartedViewController(nibName: "GetStartedViewController", bundle: nil)
     getStartedVC.mainViewController = self
     let containerView: UIView! = getStartedVC.view
     let navBar = containerView?.viewWithTag(786586) as? UINavigationBar
@@ -1122,7 +1122,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   @objc func showKMWebBrowserView(_ sender: Any) {
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
-    let webBrowserVC = WebBrowserViewController()
+    let webBrowserVC = WebBrowserViewController(nibName: "WebBrowserViewController", bundle: nil)
     if let fontFamily = textView.font?.fontName {
       webBrowserVC.fontFamily = fontFamily
     }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -74,6 +74,14 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     return appDelegate?.overlayWindow
   }
 
+  convenience init() {
+    if UIDevice.current.userInterfaceIdiom == .phone {
+      self.init(nibName: "MainViewController_iPhone", bundle: nil)
+    } else {
+      self.init(nibName: "MainViewController_iPad", bundle: nil)
+    }
+  }
+
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
@@ -223,10 +231,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     textView.isEditable = false
 
     // Setup Info View
-    if UIDevice.current.userInterfaceIdiom == .phone {
-      infoView = InfoViewController(nibName: "InfoViewController_iPhone", bundle: nil)
-    } else {
-      infoView = InfoViewController(nibName: "InfoViewController_iPad", bundle: nil)
+    infoView = InfoViewController()
+    if UIDevice.current.userInterfaceIdiom != .phone {
       textSize *= 2
       textView.font = textView?.font?.withSize(textSize)
     }
@@ -1065,7 +1071,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
     overlayWindow.isHidden = false
-    getStartedVC = GetStartedViewController(nibName: "GetStartedViewController", bundle: nil)
+    getStartedVC = GetStartedViewController()
     getStartedVC.mainViewController = self
     let containerView: UIView! = getStartedVC.view
     let navBar = containerView?.viewWithTag(786586) as? UINavigationBar
@@ -1122,7 +1128,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   @objc func showKMWebBrowserView(_ sender: Any) {
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
-    let webBrowserVC = WebBrowserViewController(nibName: "WebBrowserViewController", bundle: nil)
+    let webBrowserVC = WebBrowserViewController()
     if let fontFamily = textView.font?.fontName {
       webBrowserVC.fontFamily = fontFamily
     }

--- a/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
@@ -15,6 +15,10 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
 
   private var networkReachable: Reachability?
 
+  convenience init() {
+    self.init(nibName: "SetUpViewController", bundle: nil)
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 


### PR DESCRIPTION
Apparently `@IBOutlet` variables are not set on iOS 8 if `nibName` is `nil`.