### PR TITLE
Remove unused subkey notifications

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -1631,7 +1631,6 @@ UIGestureRecognizerDelegate {
       subKeysView.subviews.forEach { $0.removeFromSuperview() }
       self.subKeysView = nil
       setPopupVisible(false)
-      NotificationCenter.default.post(name: Notifications.subKeysMenuDismissed, object: self, value: ())
     }
     subKeys.removeAll()
     subKeyIDs.removeAll()
@@ -2075,7 +2074,6 @@ UIGestureRecognizerDelegate {
         subKeysView.subviews.forEach { $0.removeFromSuperview() }
         self.subKeysView = nil
         setPopupVisible(false)
-        NotificationCenter.default.post(name: Notifications.subKeysMenuDismissed, object: self, value: ())
       }
       var buttonClicked = false
       for button in subKeys where button.isHighlighted {
@@ -2167,7 +2165,6 @@ UIGestureRecognizerDelegate {
 
     dismissKeyPreview()
     subKeysView = SubKeysView(keyFrame: keyFrame, subKeys: subKeys)
-    NotificationCenter.default.post(name: Notifications.subKeysMenuWillShow, object: self, value: ())
     inputView.addSubview(subKeysView!)
     setPopupVisible(true)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
@@ -23,8 +23,6 @@ public typealias KeyboardChangedNotification = InstallableKeyboard
 public typealias KeyboardRemovedNotification = InstallableKeyboard
 
 public typealias KeyboardPickerDismissedNotification = Void
-public typealias SubKeysMenuWillShowNotification = Void
-public typealias SubKeysMenuDismissedNotification = Void
 
 public struct Notifications {
   public static let languagesUpdated =
@@ -48,8 +46,4 @@ public struct Notifications {
 
   public static let keyboardPickerDismissed =
     NotificationName<KeyboardPickerDismissedNotification>("KeymanKeyboardPickerDismissed")
-  public static let subKeysMenuWillShow =
-    NotificationName<SubKeysMenuWillShowNotification>("KeymanSubKeysMenuWillShow")
-  public static let subKeysMenuDismissed =
-    NotificationName<SubKeysMenuDismissedNotification>("KeymanSubKeysMenuDismissed")
 }


### PR DESCRIPTION
Notifications for when the subkeys are shown and hidden are unused throughout the codebase. The subkeys should also be encapsulated in the keyboard's view controller.