### PR TITLE
Fix computation of latest keyboard version

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -1438,8 +1438,8 @@ UIGestureRecognizerDelegate {
       let version = String(filename[dashRange.upperBound..<extensionRange.lowerBound])
 
       if let previousMax = latestVersion {
-        if let result = compareVersions(previousMax, version), result == .orderedAscending {
-          latestVersion = previousMax
+        if compareVersions(previousMax, version) == .orderedAscending {
+          latestVersion = version
         }
       } else if compareVersions(version, version) != nil {  // Ensure that the version number is valid
         latestVersion = version


### PR DESCRIPTION
Embarrassing typo meant that the first listed keyboard version would be returned instead of the maximum.