### PR TITLE
Fixes for deleting keyboards

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
@@ -118,11 +118,6 @@ class KeyboardInfoViewController: UITableViewController, UIAlertViewDelegate {
     }
   }
 
-  private var isCurrentKeyboard: Bool {
-    return Manager.shared.keyboardID == keyboardID &&
-      Manager.shared.languageID == languageID
-  }
-
   private var canDeleteKeyboard: Bool {
     if !Manager.shared.canRemoveKeyboards {
       return false
@@ -156,14 +151,8 @@ class KeyboardInfoViewController: UITableViewController, UIAlertViewDelegate {
     if alertView.tag == 1 {
       let userData = Manager.shared.activeUserDefaults()
       let userKeyboards = userData.userKeyboards!
-      let kb = userKeyboards[keyboardIndex]
 
       if Manager.shared.removeKeyboard(at: keyboardIndex) {
-        if isCurrentKeyboard {
-          // Select default keyboard
-          Manager.shared.setKeyboard(kb)
-        }
-        NotificationCenter.default.post(name: Notifications.keyboardRemoved, object: self, value: kb)
         navigationController?.popToRootViewController(animated: true)
       }
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -128,7 +128,7 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     }
 
     if Manager.shared.removeKeyboard(at: indexPath.row) {
-      self.tableView.reloadData()
+      loadUserKeyboards()
     }
     setIsDoneButtonEnabled(true)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -128,12 +128,6 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     }
 
     if Manager.shared.removeKeyboard(at: indexPath.row) {
-      let kb = userKeyboards[indexPath.row]
-      if isCurrentKeyboard(languageID: kb.id, keyboardID: kb.languageID) {
-        let userData = Manager.shared.activeUserDefaults()
-        userKeyboards = userData.userKeyboards!
-        Manager.shared.setKeyboard(userKeyboards[0])
-      }
       self.tableView.reloadData()
     }
     setIsDoneButtonEnabled(true)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -377,6 +377,11 @@ UIGestureRecognizerDelegate {
     userData.set([Date()], forKey: Key.synchronizeSWKeyboard)
     userData.synchronize()
 
+    // Set a new keyboard if deleting the current one
+    if kb.id == keyboardID && kb.languageID == languageID {
+      setKeyboard(userKeyboards[0])
+    }
+
     NotificationCenter.default.post(name: Notifications.keyboardRemoved, object: self, value: kb)
     return true
   }


### PR DESCRIPTION
1. Ensure a new keyboard is selected if the current keyboard is deleted.
2. Reload the list of keyboards after deleting so that the keyboard is removed from the view.