### PR TITLE
[Web] Keystroke control path rework

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -18,6 +18,8 @@
 * Fixed key codes for longpress keys and handle default keys beyond U_FFFF
 * Enhanced the removeKeyboards API function (#5)
 * Fixed an issue with the Toolbar UI under certain scenarios (#271)
+* New feature:  physical keyboard input now supported on touch-enabled inputs. (#237) (#311)
+  * Note that hardware-based keyboard input will always follow 'hardware' and 'desktop' platform rules to ensure consistency.
 
 ## 2017-07-10 2.0.473 stable
 * 2.0 stable release build.

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3201,24 +3201,18 @@ if(!window['keyman']['initialized']) {
      * @returns     {number}        0 if no match is made, otherwise 1.
      */
     keymanweb.processKeystroke = function(device, element, keystroke) {
+      // Clear internal state tracking data from prior keystrokes.
       keymanweb._CachedSelectionStart = null; // I3319     
       keymanweb._DeadkeyResetMatched();       // I3318    
       keymanweb.cachedContext.reset();
 
+      // Ensure the settings are in place so that KIFS/ifState activates and deactivates
+      // the appropriate rule(s) for the modeled device.
       util.activeDevice = device;
 
+      // Calls the start-group of the active keyboard.
       return keymanweb._ActiveKeyboard['gs'](element, keystroke);
     }
-
-    // keymanweb.callKeyboardStartGroup = function(Ltarg, Levent) {
-    //   keymanweb._CachedSelectionStart = null; // I3319     
-    //   keymanweb._DeadkeyResetMatched();       // I3318    
-    //   keymanweb.cachedContext.reset();
-
-    //   // As this function should only be called for hardware keyboard input processing,
-    //   // this processes the keystroke through hardware-based rules.
-    //   return keymanweb.processKeystroke(util.physicalDevice, Ltarg, Levent);
-    // }
 
     /**
      * Function     _KeyPress

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -1321,21 +1321,6 @@ if(!window['keyman']['initialized']) {
     // End of I3363 (Build 301) additions
 
     /**
-     * Function     processKeystroke
-     * Scope        Private
-     * @param       {Object}        device      The device object properties to be utilized for this keystroke.
-     * @param       {Object}        element     The page element receiving input
-     * @param       {Object}        keystroke   The input keystroke (with its properties) to be mapped by the keyboard.
-     * Description  Encapsulates calls to keyboard input processing.
-     * @returns     {number}        0 if no match is made, otherwise 1.
-     */
-    keymanweb.processKeystroke = function(device, element, keystroke) {
-      util.activeDevice = device;
-
-      return keymanweb._ActiveKeyboard['gs'](element, keystroke);
-    }
-
-    /**
      * Function     resetContext
      * Scope        Public
      * Description  Revert OSK to default layer and clear any deadkeys and modifiers
@@ -3135,12 +3120,12 @@ if(!window['keyman']['initialized']) {
         if(typeof(keymanweb._ActiveKeyboard['KM'])=='undefined'  &&  !(Levent.Lmodifiers & 0x60)) {
           // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
           var Levent2={Lcode:keymanweb._USKeyCodeToCharCode(Levent),Ltarg:Levent.Ltarg,Lmodifiers:0,LisVirtualKey:0};
-          if(keymanweb.callKeyboardStartGroup(Levent2.Ltarg,Levent2)) {
+          if(keymanweb.processKeystroke(util.physicalDevice, Levent2.Ltarg,Levent2)) {
             LeventMatched=1;
           }
         }
         
-        LeventMatched = LeventMatched || keymanweb.callKeyboardStartGroup(Levent.Ltarg,Levent);
+        LeventMatched = LeventMatched || keymanweb.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent);
         
         // Support backspace in simulated input DIV from physical keyboard where not matched in rule  I3363 (Build 301)
         if(Levent.Lcode == 8 && !LeventMatched && Levent.Ltarg.className != null && Levent.Ltarg.className.indexOf('keymanweb-input') >= 0) {
@@ -3150,7 +3135,7 @@ if(!window['keyman']['initialized']) {
         // Mnemonic layout
         if(Levent.Lcode == 8) { // I1595 - Backspace for mnemonic
           keymanweb._KeyPressToSwallow = 1;
-          if(!keymanweb.callKeyboardStartGroup(Levent.Ltarg,Levent)) {
+          if(!keymanweb.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent)) {
             kbdInterface.output(1,keymanweb._LastActiveElement,""); // I3363 (Build 301)
           }
           return false;  //added 16/3/13 to fix double backspace on mnemonic layouts on desktop
@@ -3206,15 +3191,34 @@ if(!window['keyman']['initialized']) {
       return true;
     }                
 
-    keymanweb.callKeyboardStartGroup = function(Ltarg, Levent) {
+    /**
+     * Function     processKeystroke
+     * Scope        Private
+     * @param       {Object}        device      The device object properties to be utilized for this keystroke.
+     * @param       {Object}        element     The page element receiving input
+     * @param       {Object}        keystroke   The input keystroke (with its properties) to be mapped by the keyboard.
+     * Description  Encapsulates calls to keyboard input processing.
+     * @returns     {number}        0 if no match is made, otherwise 1.
+     */
+    keymanweb.processKeystroke = function(device, element, keystroke) {
       keymanweb._CachedSelectionStart = null; // I3319     
       keymanweb._DeadkeyResetMatched();       // I3318    
       keymanweb.cachedContext.reset();
 
-      // As this function should only be called for hardware keyboard input processing,
-      // this processes the keystroke through hardware-based rules.
-      return keymanweb.processKeystroke(util.physicalDevice, Ltarg, Levent);
+      util.activeDevice = device;
+
+      return keymanweb._ActiveKeyboard['gs'](element, keystroke);
     }
+
+    // keymanweb.callKeyboardStartGroup = function(Ltarg, Levent) {
+    //   keymanweb._CachedSelectionStart = null; // I3319     
+    //   keymanweb._DeadkeyResetMatched();       // I3318    
+    //   keymanweb.cachedContext.reset();
+
+    //   // As this function should only be called for hardware keyboard input processing,
+    //   // this processes the keystroke through hardware-based rules.
+    //   return keymanweb.processKeystroke(util.physicalDevice, Ltarg, Levent);
+    // }
 
     /**
      * Function     _KeyPress
@@ -3256,7 +3260,7 @@ if(!window['keyman']['initialized']) {
       }
       /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
       
-      if(keymanweb._KeyPressToSwallow || keymanweb.callKeyboardStartGroup(Levent.Ltarg,Levent)) {
+      if(keymanweb._KeyPressToSwallow || keymanweb.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent)) {
         keymanweb._KeyPressToSwallow=0;
         if(e  &&  e.preventDefault) {
           e.preventDefault();

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3360,17 +3360,9 @@ if(!window['keyman']['initialized']) {
       }   
 
       // Find the next (or previous) element in the list
-      if(bBack) {
-        i=i-1;
-      } else {
-        i=i+1;
-      }
-      if(i >= t.length) {
-        i=i-t.length;
-      }
-      if(i < 0) {
-        i=i+t.length;
-      }
+      i = bBack ? i-1 : i+1;
+      // Treat the list as circular, wrapping the index if necessary.
+      i = i >= t.length ? i-t.length : (i < 0 ? i+t.length : i) ;
 
       // Move to the selected element
       if(device.touchable) {                     

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -1153,15 +1153,10 @@ if(!window['keyman']['initialized']) {
           util.attachDOMEvent(baseElement,'focus', keymanweb._ControlFocus);
           util.attachDOMEvent(baseElement,'blur', keymanweb._ControlBlur);
 
-          // TODO:  Rework KMW to properly support physical keyboard use while in touch mode properly.
-          //        As not all the proper infrastructure exists (regarding certain keyboard stores/rules),
-          //        we leave physical keystroke input disabled when in touch mode.
-          if(!isAlias) {
-            // These need to be on the actual input element, as otherwise the keyboard will disappear on touch.
-            Pelem.onkeypress = keymanweb._KeyPress;
-            Pelem.onkeydown = keymanweb._KeyDown;
-            Pelem.onkeyup = keymanweb._KeyUp;      
-          }
+          // These need to be on the actual input element, as otherwise the keyboard will disappear on touch.
+          Pelem.onkeypress = keymanweb._KeyPress;
+          Pelem.onkeydown = keymanweb._KeyDown;
+          Pelem.onkeyup = keymanweb._KeyUp;      
         }
       } 
     }; 
@@ -3294,8 +3289,12 @@ if(!window['keyman']['initialized']) {
         case 20: //"K_CAPS":20, "K_NUMLOCK":144,"K_SCROLL":145
         case 144:
         case 145:
-          keymanweb._NotifyKeyboard(Levent.Lcode,Levent.Ltarg,0); 
-          return osk._UpdateVKShift(Levent, Levent.Lcode-15, 1);  // I2187
+          keymanweb._NotifyKeyboard(Levent.Lcode,Levent.Ltarg,0);
+          if(!device.touchable) {
+            return osk._UpdateVKShift(Levent, Levent.Lcode-15, 1);  // I2187
+          } else {
+            return true;
+          }
       }
       
       if(Levent.LmodifierChange){

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -3360,7 +3360,8 @@ if(!window['keyman']['initialized']) {
       // Find the next (or previous) element in the list
       i = bBack ? i-1 : i+1;
       // Treat the list as circular, wrapping the index if necessary.
-      i = i >= t.length ? i-t.length : (i < 0 ? i+t.length : i) ;
+      i = i >= t.length ? i-t.length : i;
+      i = i < 0 ? i+t.length : i;
 
       // Move to the selected element
       if(device.touchable) {                     

--- a/web/source/keymanweb.js
+++ b/web/source/keymanweb.js
@@ -1326,6 +1326,21 @@ if(!window['keyman']['initialized']) {
     // End of I3363 (Build 301) additions
 
     /**
+     * Function     processKeystroke
+     * Scope        Private
+     * @param       {Object}        device      The device object properties to be utilized for this keystroke.
+     * @param       {Object}        element     The page element receiving input
+     * @param       {Object}        keystroke   The input keystroke (with its properties) to be mapped by the keyboard.
+     * Description  Encapsulates calls to keyboard input processing.
+     * @returns     {number}        0 if no match is made, otherwise 1.
+     */
+    keymanweb.processKeystroke = function(device, element, keystroke) {
+      util.activeDevice = device;
+
+      return keymanweb._ActiveKeyboard['gs'](element, keystroke);
+    }
+
+    /**
      * Function     resetContext
      * Scope        Public
      * Description  Revert OSK to default layer and clear any deadkeys and modifiers
@@ -3190,7 +3205,10 @@ if(!window['keyman']['initialized']) {
       keymanweb._CachedSelectionStart = null; // I3319     
       keymanweb._DeadkeyResetMatched();       // I3318    
       keymanweb.cachedContext.reset();
-      return keymanweb._ActiveKeyboard['gs'](Ltarg, Levent);
+
+      // As this function should only be called for hardware keyboard input processing,
+      // this processes the keystroke through hardware-based rules.
+      return keymanweb.processKeystroke(util.physicalDevice, Ltarg, Levent);
     }
 
     /**

--- a/web/source/kmwbase.js
+++ b/web/source/kmwbase.js
@@ -577,12 +577,23 @@ if(!window['keyman']['loaded']) {
     
     END DEBUG */
 
-  /* If we've made it to this point of initialization and aren't anything else, KeymanWeb assumes 
-    * we're a desktop.  Since we don't yet support desktops with touch-based input, we disable it here.
-    */                     
-  if(device.formFactor == 'desktop') {
-    device.touchable = false;
-  }
+    /* If we've made it to this point of initialization and aren't anything else, KeymanWeb assumes 
+      * we're a desktop.  Since we don't yet support desktops with touch-based input, we disable it here.
+      */                     
+    if(device.formFactor == 'desktop') {
+      device.touchable = false;
+    }
+
+    /**
+     * Represents hardware-based keystrokes regardless of the 'true' device, facilitating hardware keyboard input
+     * whenever touch-based input is available.
+     */
+    util.physicalDevice = {
+      touchable: false,
+      browser: device.browser,
+      formFactor: 'desktop',
+      OS: device.OS
+    };
                         
     /**
      * Expose the touchable state for UIs - will disable external UIs entirely

--- a/web/source/kmwcallback.js
+++ b/web/source/kmwcallback.js
@@ -706,7 +706,7 @@ if(!window['keyman']['initialized']) {
           switch(constraint) {
             case 'touch':
             case 'hardware':
-              if(device.touchable != (constraint == 'touch')) {
+              if(util.activeDevice.touchable != (constraint == 'touch')) {
                 result=false;
               }
           }
@@ -717,7 +717,7 @@ if(!window['keyman']['initialized']) {
             case 'ios':
             case 'macosx':
             case 'linux':
-              if(device.OS.toLowerCase() != constraint) {
+              if(util.activeDevice.OS.toLowerCase() != constraint) {
                 result=false;
               }
           }
@@ -726,14 +726,14 @@ if(!window['keyman']['initialized']) {
             case 'tablet':
             case 'phone':
             case 'desktop':
-              if(device.formFactor != constraint) {
+              if(util.activeDevice.formFactor != constraint) {
                 result=false;
               }
           }
 
           switch(constraint) {
             case 'web':
-              if(device.browser == 'native') {
+              if(util.activeDevice.browser == 'native') {
                 result=false; // web matches anything other than 'native'
               }
               break;
@@ -743,7 +743,7 @@ if(!window['keyman']['initialized']) {
             case 'firefox':
             case 'safari':
             case 'opera':
-              if(device.browser != constraint) {
+              if(util.activeDevice.browser != constraint) {
                 result=false;
               }
           }

--- a/web/source/kmwembedded.js
+++ b/web/source/kmwembedded.js
@@ -450,7 +450,7 @@
       if(!keymanweb._ActiveKeyboard ||  Lkc.Lcode == 0) return false;
       
       // If key is mapped, return true
-      if(keymanweb.processKeystroke(util.physicalDevice, Lelem, Lkc)) return true;
+      if(keymanweb.processKeystroke(util.device, Lelem, Lkc)) return true;
 
       keymanweb.processDefaultMapping(Lkc.Lcode, keyShiftState, Lelem, keyName);
 

--- a/web/source/kmwembedded.js
+++ b/web/source/kmwembedded.js
@@ -522,7 +522,7 @@
         kbdInterface.output(0, Lelem, '\n');
         return true;
     }
-    var ch = osk.defaultKeyOutput(keyName, code, shift);
+    var ch = osk.defaultKeyOutput(keyName, code, shift, false);
     if(ch) {
         kbdInterface.output(0, Lelem, ch);
         return true;

--- a/web/source/kmwembedded.js
+++ b/web/source/kmwembedded.js
@@ -450,7 +450,7 @@
       if(!keymanweb._ActiveKeyboard ||  Lkc.Lcode == 0) return false;
       
       // If key is mapped, return true
-      if(keymanweb._ActiveKeyboard['gs'](Lelem, Lkc)) return true;
+      if(keymanweb.processKeystroke(util.physicalDevice, Lelem, Lkc)) return true;
 
       keymanweb.processDefaultMapping(Lkc.Lcode, keyShiftState, Lelem, keyName);
 
@@ -469,57 +469,39 @@
     if(!keymanweb._ActiveKeyboard || code == 0) {
       return false;
     }
-    var cachedTouchable = device.touchable, cachedFormFactor = device.formFactor;
-    var result = false; // Signals if we successfully handled the keystroke.
-    device.touchable = false;
-    device.formFactor = 'desktop'; 
-    try {
-      result = keymanweb.executeHardwareKeystrokeInternal(code, shift, lstates);
-    } catch (err) {
-      console.error(err.message, err);
-    }
-    device.touchable = cachedTouchable; 
-    device.formFactor = cachedFormFactor;
-    return result;
-  };
-  
-  /**
-   *  Process the hardware key to the keyboard mapping
-   *  
-   *  @param  {number}  code   key identifier
-   *  @param  {number}  shift  shift state (0x01=left ctrl 0x02=right ctrl 0x04=left alt 0x08=right alt
-   *                                        0x10=shift 0x20=ctrl 0x40=alt)
-   *  @param  {number}  lstates lock state (0x0200=no caps 0x0400=num 0x0800=no num 0x1000=scroll 0x2000=no scroll locks)
-   **/            
-  keymanweb.executeHardwareKeystrokeInternal = function(code, shift, lstates) {
-    
-      // Clear any pending (non-popup) key
-      osk.keyPending = null;
-              
-      var Lelem = keymanweb._LastActiveElement;
-      
-      if(keymanweb._ActiveElement == null) {
-        keymanweb._ActiveElement = Lelem;
-      }
 
-      // Check the virtual key 
-      var Lkc = {
-        Ltarg: keymanweb._ActiveElement,
-        Lmodifiers: shift,
-        vkCode: code,
-        Lcode: code,
-        Lstates: lstates,
-        LisVirtualKey: true,
-        LisVirtualKeyCode: false
-      }; 
-      
+    // Clear any pending (non-popup) key
+    osk.keyPending = null;
+            
+    var Lelem = keymanweb._LastActiveElement;
+    
+    if(keymanweb._ActiveElement == null) {
+      keymanweb._ActiveElement = Lelem;
+    }
+
+    // Check the virtual key 
+    var Lkc = {
+      Ltarg: keymanweb._ActiveElement,
+      Lmodifiers: shift,
+      vkCode: code,
+      Lcode: code,
+      Lstates: lstates,
+      LisVirtualKey: true,
+      LisVirtualKeyCode: false
+    }; 
+
+    try {
       // Pass this key code and state to the keyboard program
       // If key is mapped, return true
-      if(keymanweb._ActiveKeyboard['gs'](Lelem, Lkc)) {
+      if(keymanweb.processKeystroke(util.physicalDevice, Lelem, Lkc)) {
         return true;
       }
 
       return keymanweb.processDefaultMapping(Lkc.Lcode, shift, Lelem, '');
+    } catch (err) {
+      console.error(err.message, err);
+      return false;
+    }
   };
 
   /**

--- a/web/source/kmwosk.js
+++ b/web/source/kmwosk.js
@@ -827,9 +827,10 @@ if(!window['keyman']['initialized']) {
             break;
           case osk.keyCodes['K_SPACE']:
             return ' ';
-            break;
-          // Problem:  clusters, and doing them right.
-          // The commented-out code below should be a decent starting point, but clusters make it complex.
+          // break;
+          //
+          // // Problem:  clusters, and doing them right.
+          // // The commented-out code below should be a decent starting point, but clusters make it complex.
           //
           // case osk.keyCodes['K_LEFT']:
           //   if(touchAlias) {
@@ -857,7 +858,6 @@ if(!window['keyman']['initialized']) {
           //     }
           //     kbdInterface.output(1, keymanweb._LastActiveElement,"");
           //   }
-          //   break;
         }
       }
 

--- a/web/source/kmwosk.js
+++ b/web/source/kmwosk.js
@@ -955,7 +955,7 @@ if(!window['keyman']['initialized']) {
         }
 
         // Pass this key code and state to the keyboard program
-        if(!keymanweb._ActiveKeyboard || (Lkc.Lcode != 0 && !keymanweb._ActiveKeyboard['gs'](Lelem, Lkc)))
+        if(!keymanweb._ActiveKeyboard || (Lkc.Lcode != 0 && !keymanweb.processKeystroke(util.device, Lelem, Lkc)))
         {
           // Restore the virtual key code if a mnemonic keyboard is being used
           Lkc.Lcode=Lkc.vkCode;

--- a/web/source/kmwosk.js
+++ b/web/source/kmwosk.js
@@ -780,7 +780,7 @@ if(!window['keyman']['initialized']) {
      */
     osk.defaultKeyOutput = function(keyName,n,keyShiftState,usingOSK,Lelem) {
       var ch = '', checkCodes = false;
-
+      var touchAlias = (Lelem && typeof(Lelem.base) != 'undefined');
       // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
       if(keyShiftState == 0) {
         checkCodes = true;
@@ -790,7 +790,7 @@ if(!window['keyman']['initialized']) {
       }
 
       // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
-      if((Lelem && typeof(Lelem.base) != 'undefined') || usingOSK) {
+      if(touchAlias || usingOSK) {
         var code = osk.keyCodes[keyName];
         if(!code) {
           code = n;
@@ -828,6 +828,36 @@ if(!window['keyman']['initialized']) {
           case osk.keyCodes['K_SPACE']:
             return ' ';
             break;
+          // Problem:  clusters, and doing them right.
+          // The commented-out code below should be a decent starting point, but clusters make it complex.
+          //
+          // case osk.keyCodes['K_LEFT']:
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos - 1 >= 0 ? caretPos - 1 : 0);
+          //   }
+          //   break;
+          // case osk.keyCodes['K_RIGHT']:
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
+          //   }
+          //   if(code == osk.keyCodes['K_RIGHT']) {
+          //     break;
+          //   }
+          // // Should we include this?  It could be tricky to do correctly...
+          // case osk.keyCodes['K_DEL']:
+          //   // Move caret right one unit, then backspace.
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
+          //     if(caretPos == keymanweb.getTextCaret(Lelem)) {
+          //       // Failed to move right - there's nothing to delete.
+          //       break;
+          //     }
+          //     kbdInterface.output(1, keymanweb._LastActiveElement,"");
+          //   }
+          //   break;
         }
       }
 


### PR DESCRIPTION
Fixes #237 and fixes #311.

This PR aims to enhance the consistency of keystroke evaluation within KeymanWeb by permitting differentiation of hardware keystroke input from OSK-based input within the system.  The former will always follow the 'hardware desktop' rule set, while the latter's functionality is unchanged.  This also streamlines the connection between KMW and KMEA, eliminating the need for device aliasing when processing hardware keystrokes on Android devices.

As a result of this enhancement, we can now safely enable hardware-based input on touch-based devices and ensure that input is handled correctly for both input methods.  Additional work and refactoring was necessary to support keyboards that rely upon system-default behaviors, like EuroLatin2, which (in native mode) relies upon the browser to output base Latin characters instead of using rules to evaluate them.

Some initial work is included toward supporting caret manipulation and further command-type keystrokes to for better touch-alias emulation, but it is incomplete due to its inability to properly account for character clusters.  As such, it is disabled at this time.