### PR TITLE
Fix keyboard menu popup view width

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
@@ -85,7 +85,7 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
     super.init(frame: mainFrame)
 
     let screenWidth = UIScreen.main.bounds.width
-    let maxWidth = CGFloat.maximum(getMaxWidth(), screenWidth)
+    let maxWidth = CGFloat.minimum(getMaxWidth(), screenWidth)
     let baseHeight = keyFrame.size.height
     let containerWidth = maxWidth - strokeWidth * 2
     var containerHeight = CGFloat(tableList.count) * rowHeight

--- a/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
@@ -198,7 +198,7 @@ class SubKeysView: UIView {
     }
 
     if viewRight.rounded() == keyRight.rounded() || viewRight.rounded(.down) == keyRight.rounded(.down) {
-      keyRight = viewRight > keyRight ? viewRight : keyRight
+      keyRight = CGFloat.maximum(viewRight, keyRight)
       viewRight = keyRight
     }
 


### PR DESCRIPTION
Before:
<img width="487" alt="screen shot 2017-11-17 at 3 31 55 pm" src="https://user-images.githubusercontent.com/3857617/32937798-7d0daa64-cbac-11e7-9e79-cc5996fc9b97.png">

After:
<img width="487" alt="screen shot 2017-11-17 at 3 31 01 pm" src="https://user-images.githubusercontent.com/3857617/32937797-7ccaf606-cbac-11e7-8fff-9d97e6b2be4a.png">

Also including some cleanup while checking if similar bugs are present with other uses of `minimum()` and `maximum()`.
