### PR TITLE
re-parent and update delegates if they are lost during keyboard initi…

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -134,12 +134,13 @@ open class InputViewController: UIInputViewController, KeymanWebViewDelegate {
     super.viewDidAppear(animated)
     setConstraints()
     inputView?.setNeedsUpdateConstraints()
-    
+
     //TODO: find out why this is actually happening
-    if(self.containerView?.subviews.count == 0)
-    {
-      Manager.shared.inputDelegate = self
-      self.containerView?.addSubview(kmInputView)
+    if let containerView = self.containerView {
+      if containerView.subviews.isEmpty {
+        Manager.shared.inputDelegate = self
+        containerView.addSubview(kmInputView)
+      }
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -134,6 +134,13 @@ open class InputViewController: UIInputViewController, KeymanWebViewDelegate {
     super.viewDidAppear(animated)
     setConstraints()
     inputView?.setNeedsUpdateConstraints()
+    
+    //TODO: find out why this is actually happening
+    if(self.containerView?.subviews.count == 0)
+    {
+      Manager.shared.inputDelegate = self
+      self.containerView?.addSubview(kmInputView)
+    }
   }
 
   open override func willRotate(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {


### PR DESCRIPTION
I'd like to do some more digging to see why this is actually happening, but I've tried quite a few things that have turned up nothing.  This fixes the keyboard so that it should never appear blank when being used system wide. 