### PR TITLE
Check valid file size when downloading keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1284,7 +1284,7 @@ public final class KMManager {
         Log.e("FD: Download failed!", "Error: " + e);
       } finally {
         if (ret > 0) {
-          if (tmpFile.exists()) {
+          if (tmpFile.exists() && tmpFile.length() > 0) {
             if (file.exists()) {
               file.delete();
             }


### PR DESCRIPTION
Addresses the second part of #370 which adds a check that the downloaded keyboard has a non-zero size.

history.md is updated on #437 