### PR TITLE
Ignore zero-byte JS keyboard files

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -44,6 +44,7 @@ import android.widget.GridLayout;
 import android.widget.PopupWindow;
 import android.widget.PopupWindow.OnDismissListener;
 import android.widget.TextView;
+import android.widget.Toast;
 
 final class KMKeyboard extends WebView {
   private final Context context;
@@ -236,6 +237,7 @@ final class KMKeyboard extends WebView {
     boolean retVal = true;
     String keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), keyboardID);
     if (!KMManager.shouldAllowSetKeyboard() || keyboardVersion == null) {
+      Toast.makeText(context, "Invalid keyboard! Loading default", Toast.LENGTH_LONG).show();
       keyboardID = KMManager.KMDefault_KeyboardID;
       languageID = KMManager.KMDefault_LanguageID;
       retVal = false;
@@ -323,6 +325,7 @@ final class KMKeyboard extends WebView {
     boolean retVal = true;
     String keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), keyboardID);
     if (!KMManager.shouldAllowSetKeyboard() || keyboardVersion == null) {
+      Toast.makeText(context, "Invalid keyboard! Loading default", Toast.LENGTH_LONG).show();
       keyboardID = KMManager.KMDefault_KeyboardID;
       languageID = KMManager.KMDefault_LanguageID;
       keyboardName = KMManager.KMDefault_KeyboardName;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -472,7 +472,7 @@ public final class KMManager {
         String langID = kbInfo.get(KMKey_LanguageID);
         String kbVersion = kbInfo.get(KMManager.KMKey_KeyboardVersion);
         String latestKbVersion = getLatestKeyboardFileVersion(context, kbID);
-        if (kbVersion == null || !kbVersion.equals(latestKbVersion)) {
+        if ((latestKbVersion != null) && (kbVersion == null || !kbVersion.equals(latestKbVersion))) {
           kbInfo.put(KMManager.KMKey_KeyboardVersion, latestKbVersion);
           kbList.set(i, kbInfo);
           shouldUpdateList = true;
@@ -1456,8 +1456,10 @@ public final class KMManager {
       return kbFileVersion;
 
     for (String file : files) {
-      if (!file.endsWith(".js"))
+      // Ensure keyboard file is JS and non-zero size
+      if (!file.endsWith(".js") || new File(path + file).length() == 0) {
         continue;
+      }
 
       String base = String.format("%s-", keyboardID);
       int index = file.indexOf(base);


### PR DESCRIPTION
For the 3rd part of #370, ignore 0-byte JS files in `KMManager.getLatestKeyboardFileVersion)`

If a keyboard doesn't have a valid version, attempting to load it will revert to the default (EuroLatin2) keyboard.

Also added a check so null version keyboard doesn't get added to OldKeyboardsList. (null version would cause the app to crash)