### PR TITLE
Do not use remote filename to set local filename

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -556,12 +556,8 @@ UIGestureRecognizerDelegate {
     ]
     downloadQueue!.userInfo = commonUserData
 
-    let kbVersion = keyboard.version
-    let keyboardPath = self.keyboardPath(forFilename: keyboardURL.lastPathComponent,
-                                         keyboardVersion: kbVersion)
-
     var request = HTTPDownloadRequest(url: keyboardURL, userInfo: commonUserData)
-    request.destinationFile = keyboardPath?.path
+    request.destinationFile = keyboardPath(forID: keyboardID, keyboardVersion: keyboard.version)?.path
     request.tag = 0
     downloadQueue!.addRequest(request)
 
@@ -638,7 +634,7 @@ UIGestureRecognizerDelegate {
       return
     }
 
-    let keyboardLocalPath = self.keyboardPath(forFilename: filename, keyboardVersion: keyboard.version)!
+    let keyboardLocalPath = self.keyboardPath(forID: keyboard.id, keyboardVersion: keyboard.version)!
     let isUpdate = latestKeyboardFileVersion(withID: keyboard.id) != nil
 
     downloadQueue = HTTPDownloader.init(self)
@@ -788,8 +784,6 @@ UIGestureRecognizerDelegate {
     case .downloadFile:
       let keyboards = request.userInfo[Key.keyboardInfo] as! [InstallableKeyboard]
       let keyboard = keyboards[0]
-      let kbID = keyboard.id
-      let kbVersion = keyboard.version
       let isUpdate = request.userInfo[Key.update] as! Bool
 
       if let statusCode = request.responseStatusCode, statusCode == 200 {
@@ -798,7 +792,7 @@ UIGestureRecognizerDelegate {
           // Download queue finished.
           downloadQueue = nil
           registerCustomFonts()
-          kmLog("Downloaded keyboard: \(kbID).", checkDebugPrinting: true)
+          kmLog("Downloaded keyboard: \(keyboard.id).", checkDebugPrinting: true)
 
           NotificationCenter.default.post(name: Notifications.keyboardDownloadCompleted,
                                           object: self,
@@ -821,19 +815,10 @@ UIGestureRecognizerDelegate {
         kmLog("Keyboard download failed: \(error).", checkDebugPrinting: true)
 
         if !isUpdate {
-          let fileName = request.url.lastPathComponent
-          if fileName.hasJavaScriptExtension {
-            if let kbPath = keyboardPath(forFilename: fileName, keyboardVersion: kbVersion) {
-              try? FileManager.default.removeItem(at: kbPath)
-            }
-          } else if fileName.hasFontExtension {
-            // TODO: Why do we delete a keyboard with that name?
-            if let kbPath = keyboardPath(forFilename: fileName, keyboardVersion: kbVersion) {
-              try? FileManager.default.removeItem(at: kbPath)
-            }
-            if let fontPath = activeFontDirectory()?.appendingPathComponent(fileName) {
-              try? FileManager.default.removeItem(at: fontPath)
-            }
+          // Clean up keyboard file if anything fails
+          // TODO: Also clean up remaining fonts
+          if let kbPath = keyboardPath(forID: keyboard.id, keyboardVersion: keyboard.version) {
+            try? FileManager.default.removeItem(at: kbPath)
           }
         }
         downloadFailed(forKeyboards: keyboards, error: error)
@@ -880,23 +865,13 @@ UIGestureRecognizerDelegate {
 
       let keyboards = request.userInfo[Key.keyboardInfo] as! [InstallableKeyboard]
       let keyboard = keyboards[0]
-      let kbID = keyboard.id
-      let kbVersion = keyboard.version
       let isUpdate = request.userInfo[Key.update] as! Bool
 
       if !isUpdate {
-        let fileManager = FileManager.default
-        let fileName = request.url.lastPathComponent
-        if fileName.hasJavaScriptExtension {
-          if let kbPath = keyboardPath(forFilename: fileName, keyboardVersion: kbVersion) {
-            try? fileManager.removeItem(at: kbPath)
-          }
-        }
-        if fileName.hasFontExtension {
-          // TODO: Check why this doesn't match the error case in downloadRequestFinished().
-          if let kbPath = keyboardPath(forID: kbID, keyboardVersion: kbVersion) {
-            try? fileManager.removeItem(at: kbPath)
-          }
+        // Clean up keyboard file if anything fails
+        // TODO: Also clean up remaining fonts
+        if let kbPath = keyboardPath(forID: keyboard.id, keyboardVersion: keyboard.version) {
+          try? FileManager.default.removeItem(at: kbPath)
         }
       }
       downloadFailed(forKeyboards: keyboards, error: error as NSError)
@@ -1371,14 +1346,6 @@ UIGestureRecognizerDelegate {
       return nil
     }
     return activeLanguageDirectory()?.appendingPathComponent("\(keyboardID)-\(version).js")
-  }
-
-  func keyboardPath(forFilename filename: String, keyboardVersion: String?) -> URL? {
-    if !filename.contains("-") {
-      let name = "\(filename.dropLast(3))-\(keyboardVersion ?? "1.0").js"
-      return activeLanguageDirectory()?.appendingPathComponent(name)
-    }
-    return activeLanguageDirectory()?.appendingPathComponent(filename)
   }
 
   func fontPath(forFilename filename: String) -> URL? {


### PR DESCRIPTION
Remove `keyboardPath(forFilename:keyboardVersion:)` which computes the destination path for a download based on the filename in the keyboard JSON file. We shouldn't care where a remote file is located in computing its destination.

This fixes downloading the [SIL IPA keyboard](https://keyman.com/keyboards/ipauni11).