### PR TITLE
Ios bugfix reset default layer

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -35,7 +35,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   open var topBarImageView: UIImageView?
   var barHeightConstraints: [NSLayoutConstraint] = []
 
-  var currentTextDocumentProxy: UITextDocumentProxy? = nil
   var containerView: UIView?
   var containerHeightConstraints: [NSLayoutConstraint] = []
   var heightConstraint: NSLayoutConstraint!
@@ -295,10 +294,4 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   private class func isSurrogate(_ c: unichar) -> Bool {
     return UTF16.isLeadSurrogate(c) || UTF16.isTrailSurrogate(c)
   }
-}
-
-extension CGFloat {
-    static func random() -> CGFloat {
-        return CGFloat(arc4random()) / CGFloat(UInt32.max)
-    }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -35,6 +35,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   open var topBarImageView: UIImageView?
   var barHeightConstraints: [NSLayoutConstraint] = []
 
+  static var currentTextDocumentProxy: UITextDocumentProxy?
   var containerView: UIView?
   var containerHeightConstraints: [NSLayoutConstraint] = []
   var heightConstraint: NSLayoutConstraint!
@@ -162,14 +163,24 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       newRange = context.startIndex..<context.startIndex
     }
 
+    if let currentProxy = InputViewController.currentTextDocumentProxy {
+        
+      let cpHash = String(ObjectIdentifier(currentProxy).hashValue)
+      let tHash = String(ObjectIdentifier(textDocumentProxy).hashValue)
+
+      if cpHash != tHash {
+        Manager.shared.keymanWeb.resetContext()
+        textDocumentProxy.insertText("X")
+      }
+    } else {
+        Manager.shared.keymanWeb.resetContext()
+    }
+    
     Manager.shared.setText(context)
     Manager.shared.setSelectionRange(NSRange(newRange, in: context), manually: false)
-
-    if let webView = self.kmInputView as? WKWebView {
-      webView.evaluateJavaScript("resetContext();")
-    }
-
-  }
+    
+    InputViewController.currentTextDocumentProxy = textDocumentProxy
+}
 
   func insertText(_ keymanWeb: KeymanWebViewController, numCharsToDelete: Int, newText: String) {
     if Manager.shared.isSubKeysMenuVisible {

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -8,6 +8,7 @@
 
 import AudioToolbox
 import UIKit
+import WebKit
 
 public enum GlobeKeyTapBehaviour {
   case switchToNextKeyboard
@@ -34,6 +35,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   open var topBarImageView: UIImageView?
   var barHeightConstraints: [NSLayoutConstraint] = []
 
+  var currentTextDocumentProxy: UITextDocumentProxy? = nil
   var containerView: UIView?
   var containerHeightConstraints: [NSLayoutConstraint] = []
   var heightConstraint: NSLayoutConstraint!
@@ -163,6 +165,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     Manager.shared.setText(context)
     Manager.shared.setSelectionRange(NSRange(newRange, in: context), manually: false)
+
+    if let webView = self.kmInputView as? WKWebView {
+      webView.evaluateJavaScript("resetContext();")
+    }
+
   }
 
   func insertText(_ keymanWeb: KeymanWebViewController, numCharsToDelete: Int, newText: String) {
@@ -288,4 +295,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   private class func isSurrogate(_ c: unichar) -> Bool {
     return UTF16.isLeadSurrogate(c) || UTF16.isTrailSurrogate(c)
   }
+}
+
+extension CGFloat {
+    static func random() -> CGFloat {
+        return CGFloat(arc4random()) / CGFloat(UInt32.max)
+    }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -94,6 +94,10 @@ extension KeymanWebViewController {
     }
   }
 
+  func resetContext() {
+    webView.evaluateJavaScript("resetContext();")
+  }
+
   func setText(_ text: String?) {
     var text = text ?? ""
     text = text.replacingOccurrences(of: "\\", with: "\\\\")

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -53,6 +53,12 @@
                 kmw['correctOSKTextSize']();
             }
         
+            function resetContext()
+            {
+                var kmw=window['keyman'];
+                kmw.resetContext();
+            }
+        
             function setOskWidth(width) {
                 oskWidth = width;
             }


### PR DESCRIPTION
Fixes #306 

@gabrielwong can you take a look specifically at `InputViewController.swift` I tried a bunch of stuff in this textDidChange method to compare the textInput value and it is always nil. I was expecting this to be called anytime the user typed on the keyboard, but I could only get it to fire when switching inputs, which is why there is no conditional here on calling reset.  I have tested this in the Keyman app and as a systemWide keyboard, but wanted to make sure something else isn't missing.