### PR TITLE
Properly display U_* subkeys that are missing text

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -204,8 +204,10 @@ extension KeymanWebViewController: WKScriptMessageHandler {
           let id = values[0]
           subkeyIDs.append(id)
           // id is in the form layer-keyID. We only process keyIDs with prefix U_.
-          if let index = id.range(of: "-U_", options: .backwards)?.upperBound {
-            subkeyTexts.append(String(id[index...]).stringFromUTF16CodeUnits() ?? "")
+          if let index = id.range(of: "-U_", options: .backwards)?.upperBound,
+            let codepoint = UInt32(id[index...], radix: 16),
+            let scalar = Unicode.Scalar(codepoint) {
+            subkeyTexts.append(String(Character(scalar)))
           } else {
             subkeyTexts.append("")
           }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -201,11 +201,17 @@ extension KeymanWebViewController: WKScriptMessageHandler {
         let values = key.components(separatedBy: ":")
         switch values.count {
         case 1:
-          subkeyIDs.append(values[0])
-          subkeyTexts.append("")
+          let id = values[0]
+          subkeyIDs.append(id)
+          // id is in the form layer-keyID. We only process keyIDs with prefix U_.
+          if let index = id.range(of: "-U_", options: .backwards)?.upperBound {
+            subkeyTexts.append(String(id[index...]).stringFromUTF16CodeUnits() ?? "")
+          } else {
+            subkeyTexts.append("")
+          }
         case 2:
           subkeyIDs.append(values[0])
-          subkeyTexts.append(values[1].stringFromUTF16CodeUnits()!)
+          subkeyTexts.append(values[1].stringFromUTF16CodeUnits() ?? "")
         default:
           Manager.shared.kmLog("Unexpected subkey key: \(key)", checkDebugPrinting: false)
         }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -1903,7 +1903,6 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     default:
       // Hold & Move
       guard let subKeysView = subKeysView else {
-        kmLog("Unexpected hold and move while subKeysView = nil", checkDebugPrinting: false)
         return
       }
       let touchPoint = sender.location(in: subKeysView.containerView)

--- a/ios/history.md
+++ b/ios/history.md
@@ -2,8 +2,14 @@
 
 ## 10.0 alpha
 * Updated versioning scheme for uniformity across all Keyman products.
-* KeymanEngine is now built as a Swift 4.0 framework
-* Keyman app migrated to Swift 4.0
+* Keyman app migrated to Swift 4.0 (#305)
+* KeymanEngine is now built as a Swift 4.0 framework (#378)
+* Refactored internal app data structures to be more strictly typed (#384, #388)
+* Add types to notifications posted by KeymanEngine (#389)
+* Refactor KeymanEngine's internal usage of KeymanWeb (#406)
+* Fixed bugs introduced by refactoring (#408, #413, #414, #416, #422, #443, #453, #463, #464, #465)
+* Removed notifications for subkey displayed, subkey dismissed and debug log messages (#389, #415)
+* Removed migration from old app data directory structure (#418)
 
 ## 2017-08-26 2.6.4 stable
 * Fixed bug with blank keyboard on some devices (#218)


### PR DESCRIPTION
Bug introduced in #463. Keyman Developer doesn't automatically generate text for some keys.