### PR TITLE
Create FullKeyboardID to identify user keyboards

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		C07A9D8C1FD176AB00828ADD /* KeyboardRepositoryDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07A9D8B1FD176AB00828ADD /* KeyboardRepositoryDelegate.swift */; };
 		C07A9D8E1FD1798900828ADD /* APIKeyboardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07A9D8D1FD1798900828ADD /* APIKeyboardRepository.swift */; };
 		C082CE151F90AFD400860F02 /* Collection+SafeAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = C082CE141F90AFD400860F02 /* Collection+SafeAccess.swift */; };
+		C08E69911FDA6F6F0026056B /* FullKeyboardID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E69901FDA6F6F0026056B /* FullKeyboardID.swift */; };
 		C0959CD41F99C44E00B616BC /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0959CD31F99C44E00B616BC /* Constants.swift */; };
 		C0A93A541F8B21240079948B /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A93A531F8B21240079948B /* Manager.swift */; };
 		C0B09EAE1FCFD10F002F39AF /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B09EAD1FCFD10F002F39AF /* FontManager.swift */; };
@@ -222,6 +223,7 @@
 		C08C62121F67C31100268D03 /* KeyboardNameTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardNameTableViewCell.swift; sourceTree = "<group>"; };
 		C08C62141F67C8D500268D03 /* KeyboardInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardInfoViewController.swift; sourceTree = "<group>"; };
 		C08C62161F67CFB800268D03 /* KeyboardPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardPickerViewController.swift; sourceTree = "<group>"; };
+		C08E69901FDA6F6F0026056B /* FullKeyboardID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullKeyboardID.swift; sourceTree = "<group>"; };
 		C092D8381F6A70C8005C5485 /* LanguageDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageDetailViewController.swift; sourceTree = "<group>"; };
 		C0959CD31F99C44E00B616BC /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C0A5FF361F6682EB00BE740C /* PopoverView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 				C055E6EA1F99ED090035C2DD /* RegisteredFont.swift */,
 				C007C4641F9F52D8006461B9 /* LanguagesAPICall.swift */,
 				C05F432C1FBD5A4C0058CBD4 /* KeyboardAPICall.swift */,
+				C08E69901FDA6F6F0026056B /* FullKeyboardID.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -862,6 +865,7 @@
 				C082CE151F90AFD400860F02 /* Collection+SafeAccess.swift in Sources */,
 				C06D37441F81F5C400F61AE0 /* KeyboardNameTableViewCell.swift in Sources */,
 				C07A9D8A1FD1762700828ADD /* KeyboardRepository.swift in Sources */,
+				C08E69911FDA6F6F0026056B /* FullKeyboardID.swift in Sources */,
 				C040E5101F8606E300901EE4 /* TextField.swift in Sources */,
 				C0324B8D1F87480700AF3785 /* TextFieldDelegateProxy.swift in Sources */,
 				C075EB061F8EFF870041F4BD /* String+Helpers.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -17,7 +17,7 @@ public extension UserDefaults {
     do {
       return try array.map { try decoder.decode(InstallableKeyboard.self, from: $0) }
     } catch {
-      log.error("UserDefaults: Error decoding keyboards: \(error)")
+      log.error("Error decoding keyboards: \(error)")
       return nil
     }
   }
@@ -32,32 +32,32 @@ public extension UserDefaults {
       let array = try keyboards.map { try encoder.encode($0) }
       set(array, forKey: key)
     } catch {
-      log.error("UserDefaults: Error encoding keyboards: \(error)")
+      log.error("Error encoding keyboards: \(error)")
     }
   }
 
-  public func installableKeyboard(forKey key: String) -> InstallableKeyboard? {
+  public func fullKeyboardID(forKey key: String) -> FullKeyboardID? {
     guard let data = data(forKey: key) else {
       return nil
     }
     do {
-      return try PropertyListDecoder().decode(InstallableKeyboard.self, from: data)
+      return try PropertyListDecoder().decode(FullKeyboardID.self, from: data)
     } catch {
-      log.error("UserDefaults: Error decoding keyboard: \(error)")
+      log.error("Error decoding FullKeyboardID: \(error)")
       return nil
     }
   }
 
-  public func set(_ keyboard: InstallableKeyboard?, forKey key: String) {
-    guard let keyboard = keyboard else {
+  public func set(_ fullKeyboardID: FullKeyboardID?, forKey key: String) {
+    guard let id = fullKeyboardID else {
       removeObject(forKey: key)
       return
     }
     do {
-      let data = try PropertyListEncoder().encode(keyboard)
+      let data = try PropertyListEncoder().encode(id)
       set(data, forKey: key)
     } catch {
-      log.error("UserDefaults: Error encoding keyboard: \(error)")
+      log.error("Error encoding FullKeyboardID: \(error)")
     }
   }
 
@@ -71,17 +71,17 @@ public extension UserDefaults {
     }
   }
 
-  public var currentKeyboard: InstallableKeyboard? {
+  public var currentKeyboardID: FullKeyboardID? {
     get {
-      return installableKeyboard(forKey: Key.userCurrentKeyboard)
+      return fullKeyboardID(forKey: Key.userCurrentKeyboard)
     }
 
-    set(keyboard) {
-      set(keyboard, forKey: Key.userCurrentKeyboard)
+    set(fullKeyboardID) {
+      set(fullKeyboardID, forKey: Key.userCurrentKeyboard)
     }
   }
 
-  public func userKeyboard(withID keyboardID: String, languageID: String) -> InstallableKeyboard? {
-    return userKeyboards?.first { $0.id == keyboardID && $0.languageID == languageID }
+  public func userKeyboard(withFullID fullID: FullKeyboardID) -> InstallableKeyboard? {
+    return userKeyboards?.first { $0.fullID == fullID }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
@@ -284,7 +284,7 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
       let keyboard = tableList[indexPath.row] as! InstallableKeyboard
       cell.textLabel?.text = keyboard.name
       cell.tag = indexPath.row
-      if (Manager.shared.languageID == keyboard.languageID) && (Manager.shared.keyboardID == keyboard.id) {
+      if Manager.shared.currentKeyboardID == keyboard.fullID {
         cell.selectionStyle = .none
         cell.isSelected = true
         cell.accessoryType = .checkmark

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -164,7 +164,7 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     cell.detailTextLabel?.text = kb.name
     cell.tag = indexPath.row
 
-    if isCurrentKeyboard(languageID: kb.languageID, keyboardID: kb.id) {
+    if Manager.shared.currentKeyboardID == kb.fullID {
       cell.selectionStyle = .blue
       cell.isSelected = true
       cell.accessoryType = .detailDisclosureButton
@@ -365,7 +365,7 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
 
   private func scroll(toSelectedKeyboard animated: Bool) {
     let index = userKeyboards.index { kb in
-      return isCurrentKeyboard(languageID: kb.languageID, keyboardID: kb.id)
+      return Manager.shared.currentKeyboardID == kb.fullID
     }
 
     if let index = index {
@@ -386,11 +386,6 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
                                          action: #selector(self.cancelClicked))
       navigationItem.leftBarButtonItem = cancelButton
     }
-  }
-
-  private func isCurrentKeyboard(languageID: String?, keyboardID: String?) -> Bool {
-    return Manager.shared.keyboardID == keyboardID &&
-      Manager.shared.languageID == languageID
   }
 
   @objc func hideToolbarDelayed(_ timer: Timer) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -91,8 +91,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   /// Set this to `UIApplication.shared.openURL` in your application.
   public var openURL: ((URL) -> Bool)?
 
-  var keyboardID: String?
-  var languageID: String?
+  var currentKeyboardID: FullKeyboardID?
   weak var keymanWebDelegate: KeymanWebDelegate?
   var currentRequest: HTTPDownloadRequest?
   var shouldReloadKeyboard = false
@@ -206,8 +205,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   /// - SeeAlso:
   ///   - addKeyboard()
   /// - Returns: Whether the keyboard was set successfully
-  public func setKeyboard(withID keyboardID: String, languageID: String) -> Bool {
-    if let keyboard = Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID) {
+  public func setKeyboard(withFullID fullID: FullKeyboardID) -> Bool {
+    if let keyboard = Storage.active.userDefaults.userKeyboard(withFullID: fullID) {
       return setKeyboard(keyboard)
     }
     return false
@@ -217,15 +216,14 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   ///
   /// - Returns: Whether the keyboard was set successfully
   public func setKeyboard(_ kb: InstallableKeyboard) -> Bool {
-    if kb.languageID == self.languageID && kb.id == self.keyboardID {
-      log.info("Keyboard unchanged: \(kb.languageID)_\(kb.id)")
+    if kb.fullID == currentKeyboardID {
+      log.info("Keyboard unchanged: \(kb.fullID)")
       return false
     }
 
-    log.info("Setting language: \(kb.languageID)_\(kb.id)")
+    log.info("Setting language: \(kb.fullID)")
 
-    self.languageID = kb.languageID
-    self.keyboardID = kb.id
+    currentKeyboardID = kb.fullID
 
     if let fontFilename = kb.font?.source.first(where: { $0.hasFontExtension }) {
       _ = FontManager.shared.registerFont(at: Storage.active.fontURL(forFilename: fontFilename))
@@ -238,8 +236,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
                           fileURL: Storage.active.keyboardURL(for: kb), font: kb.font, oskFont: kb.oskFont)
 
     let userData = Util.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
-
-    userData.currentKeyboard = kb
+    userData.currentKeyboardID = kb.fullID
     userData.synchronize()
 
     if isKeymanHelpOn {
@@ -269,7 +266,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     var userKeyboards = userDefaults.userKeyboards ?? []
 
     // Update keyboard if it exists
-    if let index = userKeyboards.index(where: { $0.id == keyboard.id && $0.languageID == keyboard.languageID }) {
+    if let index = userKeyboards.index(where: { $0.fullID == keyboard.fullID }) {
       userKeyboards[index] = keyboard
     } else {
       userKeyboards.append(keyboard)
@@ -282,9 +279,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
   /// Removes a keyboard from the list in the keyboard picker if it exists.
   /// - Returns: The keyboard exists and was removed
-  public func removeKeyboard(withID keyboardID: String, languageID: String) -> Bool {
+  public func removeKeyboard(withFullID fullID: FullKeyboardID) -> Bool {
     // Remove keyboard from the list if it exists
-    let index = Storage.active.userDefaults.userKeyboards?.index { $0.id == keyboardID && $0.languageID == languageID }
+    let index = Storage.active.userDefaults.userKeyboards?.index { $0.fullID == fullID }
     if let index = index {
       return removeKeyboard(at: index)
     }
@@ -312,7 +309,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     userData.synchronize()
 
     // Set a new keyboard if deleting the current one
-    if kb.id == keyboardID && kb.languageID == languageID {
+    if kb.fullID == currentKeyboardID {
       setKeyboard(userKeyboards[0])
     }
 
@@ -321,18 +318,19 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   /// - Returns: Info for the current keyboard, if a keyboard is set
-  public var currentKeyboardInfo: InstallableKeyboard? {
-    guard let keyboardID = keyboardID, let languageID = languageID else {
+  public var currentKeyboard: InstallableKeyboard? {
+    guard let fullID = currentKeyboardID else {
       return nil
     }
-    return Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID)
+    return Storage.active.userDefaults.userKeyboard(withFullID: fullID)
   }
 
   /// Switch to the next keyboard.
   /// - Returns: Index of the newly selected keyboard.
   public func switchToNextKeyboard() -> Int? {
     guard let userKeyboards = Storage.active.userDefaults.userKeyboards,
-          let index = userKeyboards.index(where: { isCurrentKeyboard($0) }) else {
+      let index = userKeyboards.index(where: { self.currentKeyboardID == $0.fullID })
+    else {
       return nil
     }
     let newIndex = (index + 1) % userKeyboards.count
@@ -340,19 +338,11 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     return newIndex
   }
 
-  func isCurrentKeyboard(withID keyboardID: String?, languageID: String?) -> Bool {
-    return self.keyboardID == keyboardID && self.languageID == languageID
-  }
-
-  func isCurrentKeyboard(_ keyboard: InstallableKeyboard) -> Bool {
-    return keyboard.id == self.keyboardID && keyboard.languageID == self.languageID
-  }
-
   /// - Returns: The font name for the given keyboard ID and languageID, or returns nil if
   ///   - The keyboard doesn't have a font
   ///   - The keyboard info is not available in the user keyboards list
-  public func fontNameForKeyboard(withID keyboardID: String, languageID: String) -> String? {
-    let kb = Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID)
+  public func fontNameForKeyboard(withFullID fullID: FullKeyboardID) -> String? {
+    let kb = Storage.active.userDefaults.userKeyboard(withFullID: fullID)
     if let filename = kb?.font?.source.first(where: { $0.hasFontExtension }) {
       let fontURL = Storage.active.fontURL(forFilename: filename)
       return FontManager.shared.fontName(at: fontURL)
@@ -363,8 +353,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   /// - Returns: the OSK font name for the given keyboard ID and languageID, or returns nil if
   ///   - The keyboard doesn't have an OSK font
   ///   - The keyboard info is not available in the user keyboards list
-  func oskFontNameForKeyboard(withID keyboardID: String, languageID: String) -> String? {
-    let kb = Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID)
+  func oskFontNameForKeyboard(withFullID fullID: FullKeyboardID) -> String? {
+    let kb = Storage.active.userDefaults.userKeyboard(withFullID: fullID)
     if let filename = kb?.oskFont?.source.first(where: { $0.hasFontExtension }) {
       let fontURL = Storage.active.fontURL(forFilename: filename)
       return FontManager.shared.fontName(at: fontURL)
@@ -777,27 +767,13 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
         if kb.languageID == newKeyboard.languageID {
           kb = newKeyboard
         } else {
-          kb.version = newKeyboard.id
+          kb.version = newKeyboard.version
         }
         userKeyboards[i] = kb
       }
     }
     userData.userKeyboards = userKeyboards
     userData.synchronize()
-
-    // Set version for current keyboard
-    let currentUserData = Util.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
-    if var kb = currentUserData.currentKeyboard {
-      if kb.id == newKeyboard.id {
-        if kb.languageID == newKeyboard.languageID {
-          kb = newKeyboard
-        } else {
-          kb.version = newKeyboard.id
-        }
-        currentUserData.currentKeyboard = kb
-        currentUserData.synchronize()
-      }
-    }
   }
 
   func synchronizeSWKeyboard() {
@@ -964,9 +940,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   @objc func resetKeyboard() {
-    let keyboard = currentKeyboardInfo
-    keyboardID = nil
-    languageID = nil
+    let keyboard = currentKeyboard
+    currentKeyboardID = nil
 
     if let keyboard = keyboard {
       setKeyboard(keyboard)
@@ -1134,13 +1109,11 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     keymanWeb.setDeviceType(UIDevice.current.userInterfaceIdiom)
 
     var newKb = Defaults.keyboard
-    if (keyboardID == nil || languageID == nil) && !shouldReloadKeyboard {
+    if currentKeyboardID == nil && !shouldReloadKeyboard {
       let userData = Util.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
-      if let currentKb = userData.currentKeyboard {
-        let kbID = currentKb.id
-        let langID = currentKb.languageID
-        if Storage.active.userDefaults.userKeyboard(withID: kbID, languageID: langID) != nil {
-          newKb = currentKb
+      if let id = userData.currentKeyboardID {
+        if let kb = Storage.active.userDefaults.userKeyboard(withFullID: id) {
+          newKb = kb
         }
       } else if let userKbs = Storage.active.userDefaults.userKeyboards, !userKbs.isEmpty {
         newKb = userKbs[0]
@@ -1178,8 +1151,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     keyPreviewView = KeyPreviewView(frame: keyFrame)
 
     keyPreviewView!.setLabelText(preview)
-    var oskFontName = oskFontNameForKeyboard(withID: keyboardID!, languageID: languageID!)
-    oskFontName = oskFontName ?? fontNameForKeyboard(withID: keyboardID!, languageID: languageID!)
+    var oskFontName = oskFontNameForKeyboard(withFullID: currentKeyboardID!)
+    oskFontName = oskFontName ?? fontNameForKeyboard(withFullID: currentKeyboardID!)
     keyPreviewView!.setLabelFont(oskFontName)
     keymanWeb.view.addSubview(keyPreviewView!)
   }
@@ -1307,9 +1280,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     let isPad = UIDevice.current.userInterfaceIdiom == .pad
     let fontSize = isPad ? UIFont.buttonFontSize * 2 : UIFont.buttonFontSize
 
-    var oskFontName = oskFontNameForKeyboard(withID: keyboardID!, languageID: languageID!)
+    var oskFontName = oskFontNameForKeyboard(withFullID: currentKeyboardID!)
     if oskFontName == nil {
-      oskFontName = fontNameForKeyboard(withID: keyboardID!, languageID: languageID!)
+      oskFontName = fontNameForKeyboard(withFullID: currentKeyboardID!)
     }
 
     if subKeyIDs.isEmpty {
@@ -1393,7 +1366,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
     if (!didSynchronize || shouldSynchronize) && Storage.shared != nil {
       synchronizeSWKeyboard()
-      if keyboardID != nil && languageID != nil {
+      if currentKeyboardID != nil {
         shouldReloadKeyboard = true
         reloadKeyboard(in: keymanWeb)
       }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
@@ -1,0 +1,29 @@
+//
+//  FullKeyboardID.swift
+//  KeymanEngine
+//
+//  Created by Gabriel Wong on 2017-12-08.
+//  Copyright © 2017 SIL International. All rights reserved.
+//
+
+import Foundation
+
+/// A complete identifier for an `InstallableKeyboard`. Keyboards must have unique `FullKeyboardID`s.
+public struct FullKeyboardID: Codable {
+  public var keyboardID: String
+  public var languageID: String
+}
+
+// MARK: - Equatable
+extension FullKeyboardID: Equatable {
+  public static func ==(lhs: FullKeyboardID, rhs: FullKeyboardID) -> Bool {
+    return lhs.keyboardID == rhs.keyboardID && lhs.languageID == rhs.languageID
+  }
+}
+
+// MARK: - CustomStringConvertible
+extension FullKeyboardID: CustomStringConvertible {
+  public var description: String {
+    return "<keyboardID: \"\(keyboardID)\", languageID: \"\(languageID)\">"
+  }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -20,6 +20,10 @@ public struct InstallableKeyboard: Codable {
   public var oskFont: Font?
   public var isCustom: Bool
 
+  public var fullID: FullKeyboardID {
+    return FullKeyboardID(keyboardID: id, languageID: languageID)
+  }
+
   public init(id: String,
               name: String,
               languageID: String,

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
@@ -144,8 +144,7 @@ public class TextField: UITextField {
       return
     }
 
-    // TODO: Get font name directly from keyboard object
-    let fontName = Manager.shared.fontNameForKeyboard(withID: kb.id, languageID: kb.languageID)
+    let fontName = Manager.shared.fontNameForKeyboard(withFullID: kb.fullID)
     let fontSize = font?.pointSize ?? UIFont.systemFontSize
     if let fontName = fontName {
       font = UIFont(name: fontName, size: fontSize)
@@ -240,10 +239,8 @@ extension TextField: UITextFieldDelegate {
     let textWD = baseWritingDirection(for: beginningOfDocument, in: .forward)
 
     let isRTL: Bool
-    if let keyboardID = Manager.shared.keyboardID,
-      let languageID = Manager.shared.languageID {
-      let keyboard = Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID)
-      isRTL = keyboard?.isRTL ?? false
+    if let keyboard = Manager.shared.currentKeyboard {
+      isRTL = keyboard.isRTL
     } else {
       isRTL = false
     }
@@ -278,9 +275,8 @@ extension TextField: UITextFieldDelegate {
     Manager.shared.keymanWebDelegate = self
 
     let fontName: String?
-    if let keyboardID = Manager.shared.keyboardID,
-      let languageID = Manager.shared.languageID {
-      fontName = Manager.shared.fontNameForKeyboard(withID: keyboardID, languageID: languageID)
+    if let id = Manager.shared.currentKeyboardID {
+      fontName = Manager.shared.fontNameForKeyboard(withFullID: id)
     } else {
       fontName = nil
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
@@ -133,8 +133,7 @@ public class TextView: UITextView {
       return
     }
 
-    // TODO: Get font name directly from keyboard
-    let fontName = Manager.shared.fontNameForKeyboard(withID: kb.id, languageID: kb.languageID)
+    let fontName = Manager.shared.fontNameForKeyboard(withFullID: kb.fullID)
     let fontSize = font?.pointSize ?? UIFont.systemFontSize
     if let fontName = fontName {
       font = UIFont(name: fontName, size: fontSize)
@@ -239,10 +238,8 @@ extension TextView: UITextViewDelegate {
     let textWD = baseWritingDirection(for: beginningOfDocument, in: .forward)
 
     let isRTL: Bool
-    if let keyboardID = Manager.shared.keyboardID,
-       let languageID = Manager.shared.languageID {
-      let keyboard = Storage.active.userDefaults.userKeyboard(withID: keyboardID, languageID: languageID)
-      isRTL = keyboard?.isRTL ?? false
+    if let keyboard = Manager.shared.currentKeyboard {
+      isRTL = keyboard.isRTL
     } else {
       isRTL = false
     }
@@ -279,9 +276,8 @@ extension TextView: UITextViewDelegate {
     Manager.shared.keymanWebDelegate = self
 
     let fontName: String?
-    if let keyboardID = Manager.shared.keyboardID,
-       let languageID = Manager.shared.languageID {
-      fontName = Manager.shared.fontNameForKeyboard(withID: keyboardID, languageID: languageID)
+    if let id = Manager.shared.currentKeyboardID {
+      fontName = Manager.shared.fontNameForKeyboard(withFullID: id)
     } else {
       fontName = nil
     }

--- a/ios/keyman/Keyman/Keyman/InfoViewController/InfoViewController.swift
+++ b/ios/keyman/Keyman/Keyman/InfoViewController/InfoViewController.swift
@@ -52,7 +52,7 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
   }
 
   private func loadFromServer() {
-    let keyboardInfo = Manager.shared.currentKeyboardInfo
+    let keyboardInfo = Manager.shared.currentKeyboard
     let currentKeyboardId = keyboardInfo?.id ?? Defaults.keyboard.id
     let userData = AppDelegate.activeUserDefaults()
     let keyboards = userData.userKeyboards

--- a/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
@@ -273,7 +273,7 @@ class WebBrowserViewController: UIViewController, UIWebViewDelegate, UIAlertView
   }
 
   private func keyboardChanged(_ kb: InstallableKeyboard) {
-    if let fontName = Manager.shared.fontNameForKeyboard(withID: kb.id, languageID: kb.languageID) {
+    if let fontName = Manager.shared.fontNameForKeyboard(withFullID: kb.fullID) {
       newFontFamily = fontName
     } else {
       newFontFamily = UIFont.systemFont(ofSize: UIFont.systemFontSize).fontName

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -470,7 +470,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       didDownload = false
     }
 
-    checkProfile(forKeyboardID: kb.id, languageID: kb.languageID, doListCheck: listCheck)
+    checkProfile(forFullID: kb.fullID, doListCheck: listCheck)
   }
 
   private func keyboardDownloadStarted() {
@@ -869,8 +869,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     }
   }
 
-  private func profileName(withKeyboardID kbID: String, languageID langID: String) -> String? {
-    guard let keyboard = AppDelegate.activeUserDefaults().userKeyboard(withID: kbID, languageID: langID),
+  private func profileName(withFullID fullID: FullKeyboardID) -> String? {
+    guard let keyboard = AppDelegate.activeUserDefaults().userKeyboard(withFullID: fullID),
           let font = keyboard.font else {
       return nil
     }
@@ -882,15 +882,15 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     return font.source.first { $0.lowercased().hasSuffix(FileExtensions.configurationProfile) }
   }
 
-  private func checkProfile(forKeyboardID kbID: String, languageID langID: String, doListCheck: Bool) {
-    if kbID == Defaults.keyboard.id && langID == Defaults.keyboard.languageID {
+  private func checkProfile(forFullID fullID: FullKeyboardID, doListCheck: Bool) {
+    if fullID == Defaults.keyboard.fullID {
       return
     }
     if profileName != nil {
       return  // already installing a profile
     }
 
-    guard let profile = profileName(withKeyboardID: kbID, languageID: langID) else {
+    guard let profile = profileName(withFullID: fullID) else {
       return
     }
 
@@ -906,7 +906,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
 
     if doInstall {
       profileName = profile
-      let keyboard = AppDelegate.activeUserDefaults().userKeyboard(withID: kbID, languageID: langID)!
+      let keyboard = AppDelegate.activeUserDefaults().userKeyboard(withFullID: fullID)!
       let languageName = keyboard.languageName
       let title = "\(languageName) Font"
       let msg = "Touch Install to make \(languageName) display correctly in all your apps"

--- a/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
@@ -57,7 +57,7 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
   }
 
   private func loadFromServer() {
-    let keyboardInfo = Manager.shared.currentKeyboardInfo
+    let keyboardInfo = Manager.shared.currentKeyboard
     let currentKeyboardId = keyboardInfo?.id ?? Defaults.keyboard.id
     let userData = AppDelegate.activeUserDefaults()
     let keyboards = userData.userKeyboards


### PR DESCRIPTION
Identify an `InstallableKeyboard` by `FullKeyboardID`, which currently contains `keyboardID` and `languageID`, but will later be extended to contain an optional `packageID`.

Also instead of saving an `InstallableKeyboard` in `UserDefaults` to track the current keyboard, we keep a `FullKeyboardID` to avoid having to keep two copies of the keyboard up to date.