### PR TITLE
Create InstallableKeyboard from v2 dictionaries

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -273,16 +273,7 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func loadUserKeyboards() {
-    let userData = Storage.active.userDefaults
-
-    if let userKeyboards = userData.userKeyboards {
-      self.userKeyboards = userKeyboards
-    } else {
-      userKeyboards = [Defaults.keyboard]
-      userData.userKeyboards = userKeyboards
-      userData.synchronize()
-    }
-
+    userKeyboards = Storage.active.userDefaults.userKeyboards ?? []
     tableView.reloadData()
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -139,6 +139,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     URLProtocol.registerClass(KeymanURLProtocol.self)
 
     Migrations.migrate(storage: Storage.active)
+    if Storage.active.userDefaults.userKeyboards?.isEmpty ?? true {
+      Storage.active.userDefaults.userKeyboards = [Defaults.keyboard]
+    }
 
     if Util.isSystemKeyboard || Storage.active.userDefaults.bool(forKey: Key.keyboardPickerDisplayed) {
       isKeymanHelpOn = false


### PR DESCRIPTION
Performs the migration which was omitted from #388.

Depends on the migration mechanism introduced in #484.