### PR TITLE
Add commented code for default font

### DIFF
--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -39,6 +39,7 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     kbInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
     kbInfo.put(KMManager.KMKey_Font, "aava1.ttf");
+    //kbInfo.put(KMManager.KMKey_Font, KMManager.KMDefault_KeyboardFont); // Use the default font
     KMManager.addKeyboard(this, kbInfo);
   }
 

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -45,6 +45,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     kbInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
     kbInfo.put(KMManager.KMKey_Font, "aava1.ttf");
+    //kbInfo.put(KMManager.KMKey_Font, KMManager.KMDefault_KeyboardFont); // Use the default font
     KMManager.addKeyboard(this, kbInfo);
   }
 


### PR DESCRIPTION
help.keyman.com [in-app guide](http://help.keyman.com.local/developer/engine/android/guides/in-app/)  refers to setting default keyboard font.

This PR just adds that commented code for users to follow along.