### PR TITLE
Add support for follow-keyboard-version to package compiler and package editor

### DIFF
--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -7,7 +7,7 @@
         <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Application</AppType>
         <FrameworkType>VCL</FrameworkType>
-        <ProjectVersion>18.2</ProjectVersion>
+        <ProjectVersion>18.3</ProjectVersion>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.dfm
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.dfm
@@ -174,7 +174,6 @@ inherited frmPackageEditor: TfrmPackageEditor
   KeyPreview = True
   OnKeyDown = FormKeyDown
   ExplicitWidth = 681
-  ExplicitHeight = 447
   PixelsPerInch = 96
   TextHeight = 13
   object pages: TLeftTabbedPageControl
@@ -182,7 +181,7 @@ inherited frmPackageEditor: TfrmPackageEditor
     Top = 0
     Width = 681
     Height = 447
-    ActivePage = pageFiles
+    ActivePage = pageDetails
     Align = alClient
     Images = modActionsMain.ilEditorPages
     MultiLine = True
@@ -195,9 +194,6 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageFiles: TTabSheet
       Caption = 'Files'
       ImageIndex = 3
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel1: TPanel
         Left = 0
         Top = 0
@@ -354,9 +350,6 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageKeyboards: TTabSheet
       Caption = 'Keyboards'
       ImageIndex = 5
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel5: TPanel
         Left = 0
         Top = 0
@@ -541,9 +534,6 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageDetails: TTabSheet
       Caption = 'Details'
       ImageIndex = 2
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel2: TPanel
         Left = 0
         Top = 0
@@ -559,7 +549,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           447)
         object lblKMPImageFile: TLabel
           Left = 15
-          Top = 303
+          Top = 327
           Width = 53
           Height = 13
           Caption = 'Image file:'
@@ -567,7 +557,7 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblKMPImageSize: TLabel
           Left = 108
-          Top = 324
+          Top = 348
           Width = 92
           Height = 13
           Caption = 'Image size: (w x h)'
@@ -596,28 +586,28 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblStep2d: TLabel
           Left = 15
-          Top = 179
+          Top = 203
           Width = 54
           Height = 13
           Caption = 'Copyright:'
         end
         object lblStep2e: TLabel
           Left = 15
-          Top = 211
+          Top = 235
           Width = 39
           Height = 13
           Caption = 'Author:'
         end
         object lblStep2f: TLabel
           Left = 15
-          Top = 235
+          Top = 259
           Width = 77
           Height = 13
           Caption = 'E-mail address:'
         end
         object lblStep2g: TLabel
           Left = 15
-          Top = 259
+          Top = 283
           Width = 49
           Height = 13
           Caption = 'Web Site:'
@@ -700,59 +690,59 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object editInfoCopyright: TEdit
           Left = 108
-          Top = 176
-          Width = 215
-          Height = 21
-          Anchors = [akLeft, akTop, akRight]
-          TabOrder = 3
-          Text = #169
-          OnChange = editInfoCopyrightChange
-        end
-        object editInfoAuthor: TEdit
-          Left = 108
-          Top = 208
+          Top = 200
           Width = 215
           Height = 21
           Anchors = [akLeft, akTop, akRight]
           TabOrder = 4
-          OnChange = editInfoAuthorChange
+          Text = #169
+          OnChange = editInfoCopyrightChange
         end
-        object editInfoEmail: TEdit
+        object editInfoAuthor: TEdit
           Left = 108
           Top = 232
           Width = 215
           Height = 21
           Anchors = [akLeft, akTop, akRight]
           TabOrder = 5
-          OnChange = editInfoEmailChange
+          OnChange = editInfoAuthorChange
         end
-        object editInfoWebSite: TEdit
+        object editInfoEmail: TEdit
           Left = 108
           Top = 256
           Width = 215
           Height = 21
           Anchors = [akLeft, akTop, akRight]
           TabOrder = 6
+          OnChange = editInfoEmailChange
+        end
+        object editInfoWebSite: TEdit
+          Left = 108
+          Top = 280
+          Width = 215
+          Height = 21
+          Anchors = [akLeft, akTop, akRight]
+          TabOrder = 7
           OnChange = editInfoWebSiteChange
         end
         object cmdInsertCopyright: TButton
           Left = 330
-          Top = 176
+          Top = 200
           Width = 49
           Height = 21
           Anchors = [akTop, akRight]
           Caption = '&Insert '#169
-          TabOrder = 7
+          TabOrder = 8
           OnClick = cmdInsertCopyrightClick
         end
         object cbKMPImageFile: TComboBox
           Left = 108
-          Top = 300
+          Top = 324
           Width = 215
           Height = 21
           Style = csDropDownList
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 8
+          TabOrder = 9
           OnClick = cbKMPImageFileClick
         end
         object panKMPImageSample: TPanel
@@ -762,7 +752,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 251
           Anchors = [akTop, akRight]
           BevelOuter = bvLowered
-          TabOrder = 9
+          TabOrder = 10
           object imgKMPSample: TImage
             Left = 1
             Top = 0
@@ -770,14 +760,20 @@ inherited frmPackageEditor: TfrmPackageEditor
             Height = 250
           end
         end
+        object chkFollowKeyboardVersion: TCheckBox
+          Left = 108
+          Top = 178
+          Width = 237
+          Height = 17
+          Caption = 'Package version follows keyboard version'
+          TabOrder = 3
+          OnClick = chkFollowKeyboardVersionClick
+        end
       end
     end
     object pageShortcuts: TTabSheet
       Caption = 'Shortcuts'
       ImageIndex = 8
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel3: TPanel
         Left = 0
         Top = 0
@@ -941,16 +937,10 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageSource: TTabSheet
       Caption = 'Source'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageCompile: TTabSheet
       Caption = 'Compile'
       ImageIndex = 1
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel4: TPanel
         Left = 0
         Top = 0
@@ -1093,22 +1083,22 @@ inherited frmPackageEditor: TfrmPackageEditor
     Filter = 'All Files (*.*)|*.*'
     Options = [ofHideReadOnly, ofAllowMultiSelect, ofPathMustExist, ofFileMustExist, ofEnableSizing]
     Title = 'Add Files'
-    Left = 208
-    Top = 156
+    Left = 592
+    Top = 340
   end
   object dlgNewCustomisation: TSaveDialog
     DefaultExt = 'kct'
     Filter = 'Customisation file (*.kct)|*.kct|All files (*.*)|*.*'
     Options = [ofOverwritePrompt, ofHideReadOnly, ofPathMustExist, ofEnableSizing]
-    Left = 208
-    Top = 188
+    Left = 592
+    Top = 380
   end
   object dlgOpenProductInstaller: TOpenDialog
     DefaultExt = 'msi'
     Filter = 'Product Installer Files (*.msi)|*.msi|All Files (*.*)|*.*'
     Options = [ofHideReadOnly, ofPathMustExist, ofFileMustExist, ofEnableSizing]
     Title = 'Select Product Installer'
-    Left = 208
-    Top = 120
+    Left = 592
+    Top = 304
   end
 end

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -166,6 +166,7 @@ type
     lblKeyboardLanguages: TLabel;
     cmdKeyboardAddLanguage: TButton;
     cmdKeyboardRemoveLanguage: TButton;
+    chkFollowKeyboardVersion: TCheckBox;
     procedure cmdCloseClick(Sender: TObject);
     procedure cmdAddFileClick(Sender: TObject);
     procedure cmdRemoveFileClick(Sender: TObject);
@@ -212,6 +213,7 @@ type
       ARow: Integer; const Value: string);
     procedure cmdKeyboardRemoveLanguageClick(Sender: TObject);
     procedure cmdKeyboardAddLanguageClick(Sender: TObject);
+    procedure chkFollowKeyboardVersionClick(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -224,6 +226,7 @@ type
     procedure WMUserFormShown(var Message: TMessage); message WM_User_FormShown;
     procedure WMSysCommand(var Message: TWMSysCommand); message WM_SYSCOMMAND;
     procedure EnableStartMenuControls;
+    procedure EnableDetailsTabControls;
     function DoAction(action: TProjectFileAction): Boolean;
     procedure UpdateReadme;
     procedure UpdateImageFiles;
@@ -318,6 +321,7 @@ begin
     pages.ActivePage := pageFiles;
     pack := TKPSFile.Create;
     EnableStartMenuControls;
+    EnableDetailsTabControls;
     UpdateStartMenuPrograms;
     UpdateReadme;
     UpdateImageFiles;
@@ -802,6 +806,14 @@ begin
   Modified := True;
 end;
 
+procedure TfrmPackageEditor.chkFollowKeyboardVersionClick(Sender: TObject);
+begin
+  if FSetup > 0 then Exit;
+  pack.KPSOptions.FollowKeyboardVersion := chkFollowKeyboardVersion.Checked;
+  EnableDetailsTabControls;
+  Modified := True;
+end;
+
 procedure TfrmPackageEditor.chkStartMenuUninstallClick(Sender: TObject);
 begin
   pack.StartMenu.AddUninstallEntry := chkStartMenuUninstall.Checked;
@@ -1070,6 +1082,8 @@ begin
 
     for i := 0 to pack.Info.Count - 1 do
       UpdateInfo(pack.Info[i].Name, pack.Info[i].Description, pack.Info[i].URL);
+    chkFollowKeyboardVersion.Checked := pack.KPSOptions.FollowKeyboardVersion;
+    EnableDetailsTabControls;
 
     lbStartMenuEntries.Clear;
     
@@ -1393,6 +1407,16 @@ begin
     then k.OSKFont := nil
     else k.OSKFont := cbKeyboardOSKFont.Items.Objects[cbKeyboardOSKFont.ItemIndex] as TPackageContentFile;
   Modified := True;
+end;
+
+procedure TfrmPackageEditor.EnableDetailsTabControls;
+var
+  e: Boolean;
+begin
+  e := not chkFollowKeyboardVersion.Checked;
+  editInfoVersion.Enabled := e;
+  lblStep2C.Enabled := e;
+  lblVersionHint.Enabled := e;
 end;
 
 procedure TfrmPackageEditor.EnableKeyboardTabControls;

--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -145,7 +145,7 @@ begin
       if pack.Keyboards[i].Version <> FPackageVersion then
       begin
         FatalMessage(
-          'The option "Follow Keyboard Version" is set but there the package contains more than one keyboard, '+
+          'The option "Follow Keyboard Version" is set but the package contains more than one keyboard, '+
           'and the keyboards have mismatching versions.');
         Exit;
       end;

--- a/windows/src/global/delphi/general/PackageInfo.pas
+++ b/windows/src/global/delphi/general/PackageInfo.pas
@@ -52,6 +52,7 @@ uses
 { Package Information Classes }
 
 function GetJsonValueString(o: TJSONObject; const n: string): string;
+function GetJsonValueBool(o: TJSONObject; const n: string): Boolean;
 
 type
   TPackageInfoEntryType = (pietName, pietVersion, pietCopyright, pietAuthor, pietWebsite, pietOther);
@@ -154,7 +155,6 @@ type
     property ExecuteProgram: WideString read FExecuteProgram write SetExecuteProgram;
     property ReadmeFile: TPackageContentFile read FReadmeFile write SetReadmeFile;
     property GraphicFile: TPackageContentFile read FGraphicFile write SetGraphicFile;
-
   end;
 
   { Package Information }
@@ -1097,8 +1097,7 @@ begin
 
   Path := GetJsonValueString(ANode, SJSON_StartMenu_Folder);
   DoCreate := Path <> '';
-  AddUninstallEntry := Assigned(ANode.Values[SJSON_StartMenu_AddUninstallEntry]) and
-    (ANode.Values[SJSON_StartMenu_AddUninstallEntry] is TJSONTrue);
+  AddUninstallEntry := GetJsonValueBool(ANode, SJSON_StartMenu_AddUninstallEntry);
   Entries.LoadJSON(ANode);
 end;
 
@@ -2041,6 +2040,11 @@ begin
   if not Assigned(v)
     then Result := ''
     else Result := Trim(v.Value);
+end;
+
+function GetJsonValueBool(o: TJSONObject; const n: string): Boolean;
+begin
+  Result := Assigned(o.Values[n]) and (o.Values[n] is TJSONTrue);
 end;
 
 end.

--- a/windows/src/global/delphi/general/kpsfile.pas
+++ b/windows/src/global/delphi/general/kpsfile.pas
@@ -43,7 +43,8 @@ type
   TKPSOptions = class(TPackageOptions)
   private
     FMSIFileName: WideString;
-    FMSIOptions: WideString;  // I3126
+    FMSIOptions: WideString;
+    FFollowKeyboardVersion: Boolean;  // I3126
   public
     procedure Assign(Source: TPackageOptions); override;
     procedure LoadXML(ARoot: IXMLNode); override;
@@ -54,6 +55,7 @@ type
     procedure SaveIni(AIni: TIniFile); override;
     property MSIFileName: WideString read FMSIFileName write FMSIFileName;
     property MSIOptions: WideString read FMSIOptions write FMSIOptions;  // I3126
+    property FollowKeyboardVersion: Boolean read FFollowKeyboardVersion write FFollowKeyboardVersion;
   end;
 
   TKPSFile = class(TPackage)
@@ -92,7 +94,11 @@ const
   SJSON_Options = 'options';
   SJSON_Options_MSIFileName = 'msiFilename';
   SJSON_Options_MSIOptions = 'msiOptions';
+  SJSON_Options_FollowKeyboardVersion = 'followKeyboardVersion';
+
   SJSON_Strings = 'strings';
+
+  SXML_PackageOptions_FollowKeyboardVersion = 'FollowKeyboardVersion';
 
 { TKPSFile }
 
@@ -362,6 +368,7 @@ begin
   inherited;
   FMSIFileName := (Source as TKPSOptions).MSIFileName;
   FMSIOptions := (Source as TKPSOptions).MSIOptions;  // I3126
+  FFollowKeyboardVersion := (Source as TKPSOptions).FollowKeyboardVersion;
 end;
 
 procedure TKPSOptions.LoadIni(AIni: TIniFile);
@@ -379,6 +386,7 @@ begin
   FOptions := ARoot.Values[SJSON_Options] as TJSONObject;
   FMSIFileName := GetJsonValueString(FOptions, SJSON_Options_MSIFileName);
   FMSIOptions := GetJsonValueString(FOptions, SJSON_Options_MSIOptions);
+  FollowKeyboardVersion :=      GetJsonValueBool(FOptions, SJSON_Options_FollowKeyboardVersion);
 end;
 
 procedure TKPSOptions.LoadXML(ARoot: IXMLNode);
@@ -386,6 +394,7 @@ begin
   inherited;
   FMSIFileName := VarToWideStr(ARoot.ChildNodes['Options'].ChildNodes['MSIFileName'].NodeValue);
   FMSIOptions := VarToWideStr(ARoot.ChildNodes['Options'].ChildNodes['MSIOptions'].NodeValue);  // I3126
+  FFollowKeyboardVersion := ARoot.ChildNodes['Options'].ChildNodes.IndexOf(SXML_PackageOptions_FollowKeyboardVersion) >= 0;
 end;
 
 procedure TKPSOptions.SaveIni(AIni: TIniFile);
@@ -395,6 +404,8 @@ begin
     AIni.WriteString('Options', 'MSIFileName', FMSIFileName);
   if FMSIOptions <> '' then
     AIni.WriteString('Options', 'MSIOptions', FMSIOptions);
+  if FollowKeyboardVersion then
+    AIni.WriteBool('Options', 'FollowKeyboardVersion', FollowKeyboardVersion);
 end;
 
 procedure TKPSOptions.SaveJSON(ARoot: TJSONObject);
@@ -407,6 +418,8 @@ begin
     FOptions.AddPair(SJSON_Options_MSIFileName, FMSIFileName);
   if FMSIOptions <> '' then
     FOptions.AddPair(SJSON_Options_MSIOptions, FMSIOptions);
+  if FollowKeyboardVersion then
+    FOptions.AddPair(SJSON_Options_FollowKeyboardVersion, TJSONTrue.Create);
 end;
 
 procedure TKPSOptions.SaveXML(ARoot: IXMLNode);
@@ -414,6 +427,8 @@ begin
   inherited;
   ARoot.ChildNodes['Options'].ChildNodes['MSIFileName'].NodeValue := FMSIFileName;
   ARoot.ChildNodes['Options'].ChildNodes['MSIOptions'].NodeValue := FMSIOptions;  // I3126
+  if FollowKeyboardVersion then
+    ARoot.ChildNodes['Options'].AddChild(SXML_PackageOptions_FollowKeyboardVersion);
 end;
 
 end.

--- a/windows/src/global/delphi/general/kpsfile.pas
+++ b/windows/src/global/delphi/general/kpsfile.pas
@@ -376,6 +376,7 @@ begin
   inherited;
   FMSIFileName := AIni.ReadString('Options', 'MSIFileName', '');
   FMSIOptions := AIni.ReadString('Options', 'MSIOptions', '');
+  FollowKeyboardVersion := AIni.ReadBool('Options', 'FollowKeyboardVersion', False);
 end;
 
 procedure TKPSOptions.LoadJSON(ARoot: TJSONObject);


### PR DESCRIPTION
The Keyman Developer compiler now supports using the keyboard version so that a separate package version and keyboard version are not required, which is useful for single-keyboard packages. Whether or not a keyboard developer uses this is completely up to them; we don't plan to enforce the use of this flag in the keyboard repo, although I anticipate it being useful for the releases/ folder and reducing the metadata work there.