### PR TITLE
Integrate KeymanWeb TypeScript changes into Keyman Developer build

### DIFF
--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -19,12 +19,30 @@ xml: pull-keymanweb
     cd $(ROOT)\src\developer\tike
 
 pull-keymanweb:
+    #
+    # Requires us to build KMW in order to get the output files
+    # If GIT_BASH_FOR_KEYMAN variable is not defined, then will just throw up
+    # a new window to do the build. This means we lose logging and 
+    # potentially exit values as well. So GIT_BASH should be set for
+    # build agents, etc, to something like
+    #
+    # GIT_BASH_FOR_KEYMAN="C:\Program Files\Git\bin\bash.exe" --init-file "c:\Program Files\Git\etc\profile" -l    
+    #
+    cd $(ROOT)\..\web\source
+!ifdef GIT_BASH_FOR_KEYMAN
+    $(GIT_BASH_FOR_KEYMAN) build.sh
+!else
+    start /wait ./build.sh
+!endif
+
     -rd /s/q $(ROOT)\src\developer\tike\xml\kmw\resource
     mkdir $(ROOT)\src\developer\tike\xml\kmw\resource
-    xcopy /y $(ROOT)\..\web\source\*.js $(ROOT)\src\developer\tike\xml\kmw\resource\ #
+    xcopy /y $(ROOT)\..\web\release\web\*.js $(ROOT)\src\developer\tike\xml\kmw\resource\ #
+    xcopy /y $(ROOT)\..\web\release\web\*.js.map $(ROOT)\src\developer\tike\xml\kmw\resource\ #
     xcopy /y $(ROOT)\..\web\LICENSE $(ROOT)\src\developer\tike\xml\kmw\resource\ #
     xcopy /y $(ROOT)\..\web\README.md $(ROOT)\src\developer\tike\xml\kmw\resource\ #
-    xcopy /s /y $(ROOT)\..\web\source\resources\* $(ROOT)\src\developer\tike\xml\kmw\resource\ #
+    xcopy /s /y $(ROOT)\..\web\release\web\osk\* $(ROOT)\src\developer\tike\xml\kmw\resource\osk\ #
+    xcopy /s /y $(ROOT)\..\web\release\web\ui\* $(ROOT)\src\developer\tike\xml\kmw\resource\ui\ #
 
 icons:
     rc icons.rc

--- a/windows/src/developer/TIKE/xml/kmw/index.html
+++ b/windows/src/developer/TIKE/xml/kmw/index.html
@@ -64,29 +64,9 @@
 
       
     </style> 
-<!--
-    <script src="kmw-release.js" type="text/javascript"></script>
--->
 
-    <script src="resource/kmwreleasestub.js"></script>   
-    <script src="resource/kmwbase.js"></script>
-    <script src="resource/kmwstring.js"></script>
-    <script src="resource/keymanweb.js"></script>
-    <script src="resource/kmwkeymaps.js"></script>
-    <script src="resource/kmwcallback.js"></script>
-    <script src="resource/kmwlayout.js"></script> 
-    <script src="resource/kmwosk.js"></script>
-    <script src="resource/kmwnative.js"></script>
-    <!--<script src="resource/kmwdebug.js"></script>-->
-
-    <script src="resource/kmwuibutton.js"></script>
-
-  <!-- The following scripts should be inserted at the end of the page after visible elements but before the closing 'body' tag. -->
-  
-  <!-- If a custom user interface is used, its script should be inserted here, and will override any ui specified during initialization.  --> 
-  
-  <!-- <script src="kmwuibutton-release.js"></script>  
-  <script src="resource/kmwuibutton.js"></script> --> 
+  <script src="resource/keymanweb.js"></script>   
+  <script src="resource/kmwuibutton.js"></script>
     
   <!-- The following dynamic script will register each of the additional keyboards -->
     

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -153,23 +153,18 @@
                   </Component>
 
                   <Directory Id='xmlkmwresource' Name='resource' DiskId='1'>
-                      <Component><File Id='xml_kmw_resource_keymanweb.js' Name='keymanweb.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwbase.js' Name='kmwbase.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwcallback.js' Name='kmwcallback.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwdebug.js' Name='kmwdebug.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwinit.js' Name='kmwinit.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwkeymaps.js' Name='kmwkeymaps.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwlayout.js' Name='kmwlayout.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwnative.js' Name='kmwnative.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwosk.js' Name='kmwosk.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwreleasestub.js' Name='kmwreleasestub.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwstring.js' Name='kmwstring.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwuibutton.js' Name='kmwuibutton.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwuifloat.js' Name='kmwuifloat.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwuitoggle.js' Name='kmwuitoggle.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_kmwuitoolbar.js' Name='kmwuitoolbar.js' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_license' Name='LICENSE' KeyPath="yes" /></Component>
-                      <Component><File Id='xml_kmw_resource_readme_md' Name='README.md' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_keymanweb.js' Name='keymanweb.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuibutton.js' Name='kmwuibutton.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuifloat.js' Name='kmwuifloat.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuitoggle.js' Name='kmwuitoggle.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuitoolbar.js' Name='kmwuitoolbar.js' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_keymanweb.js.map' Name='keymanweb.js.map' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuibutton.js.map' Name='kmwuibutton.js.map' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuifloat.js.map' Name='kmwuifloat.js.map' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuitoggle.js.map' Name='kmwuitoggle.js.map' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_kmwuitoolbar.js.map' Name='kmwuitoolbar.js.map' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_license' Name='LICENSE' KeyPath="yes" /></Component>
+                    <Component><File Id='xml_kmw_resource_readme_md' Name='README.md' KeyPath="yes" /></Component>
                     
                     <Directory Id='xmlkmwresourceosk' Name='osk' FileSource='..\..\developer\tike\xml\kmw\resource\osk\' DiskId='1'>
                         <Component><File Id='xml_kmw_resource_osk_ajax_loader.gif'             Name='ajax-loader.gif'               KeyPath="yes" /></Component>

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -402,20 +402,15 @@
       <ComponentRef Id="xml_project.css"/>
 
       <ComponentRef Id='xml_kmw_resource_keymanweb.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwbase.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwcallback.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwdebug.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwinit.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwkeymaps.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwlayout.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwnative.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwosk.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwreleasestub.js'/>
-      <ComponentRef Id='xml_kmw_resource_kmwstring.js'/>
       <ComponentRef Id='xml_kmw_resource_kmwuibutton.js'/>
       <ComponentRef Id='xml_kmw_resource_kmwuifloat.js'/>
       <ComponentRef Id='xml_kmw_resource_kmwuitoggle.js'/>
       <ComponentRef Id='xml_kmw_resource_kmwuitoolbar.js'/>
+      <ComponentRef Id='xml_kmw_resource_keymanweb.js.map' />
+      <ComponentRef Id='xml_kmw_resource_kmwuibutton.js.map' />
+      <ComponentRef Id='xml_kmw_resource_kmwuifloat.js.map'  />
+      <ComponentRef Id='xml_kmw_resource_kmwuitoggle.js.map' />
+      <ComponentRef Id='xml_kmw_resource_kmwuitoolbar.js.map' />
       <ComponentRef Id='xml_kmw_resource_license'/>
       <ComponentRef Id='xml_kmw_resource_readme_md'/>
 


### PR DESCRIPTION
Note: this drops in a dependency on Node and Java for Desktop/Developer build which was not previously present. Not ideal but no real alternative at this point.