### PR TITLE
Catch missing files when building .kps files

### DIFF
--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -262,7 +262,7 @@ begin
         for i := 0 to pack.Files.Count - 1 do
         begin
           if not FileExists(pack.Files[i].FileName) then
-            WriteMessage(plsWarning, 'Warning: File '+pack.Files[i].FileName+' does not exist.')
+            WriteMessage(plsWarning, 'File '+pack.Files[i].FileName+' does not exist.')
           else
           begin
             // When compiling the package, save the kvk keyboard into binary for delivery
@@ -291,7 +291,7 @@ begin
               Add(pack.Files[i].FileName);
           end;
         end;
-        if FileCount < pack.Files.Count + 1 then
+        if FileCount < pack.Files.Count + 2 then
           WriteMessage(plsError, 'The build was not successful. Some files were skipped.')
         else
         begin

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -123,7 +123,9 @@ begin
   for i := 0 to pack.Keyboards.Count - 1 do
   begin
     ids := FindKeyboardFilesByID(pack.Keyboards[i].ID);
-    Assert(Length(ids) > 0);
+    if Length(ids) = 0 then
+      // This can happen if a keyboard file is invalid
+      Continue;
 
     if Length(ids) = 1 then
       Continue;
@@ -208,6 +210,7 @@ begin
       end;
     except
       on E:EKMXError do ;
+      on E:EFOpenError do ;
     end;
   end
   else if f.FileType = ftJavascript then
@@ -231,6 +234,7 @@ begin
       pki.Version := ki.KeyboardVersion;
     except
       on E:EKMXError do Result := False;
+      on E:EFOpenError do Result := False;
     end;
   end
   else if f.FileType = ftJavascript then


### PR DESCRIPTION
Fix out-by-one error after adding kmp.json so missing files in kps still passed build, and minor UI issues with missing keyboards in kps