### PR TITLE
Add -source-path to kmcomp for merging .keyboard_info

### DIFF
--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -111,6 +111,7 @@ var
   FParamDistribution: Boolean;
   FMergingValidateIds: Boolean;
   FJsonSchemaPath: string;
+  FParamSourcePath: string;
 begin
   FSilent := False;
   FFullySilent := False;
@@ -170,6 +171,11 @@ begin
         FParamInfile2 := ParamStr(i);
       end;
     end
+    else if s = '-source-path' then
+    begin
+      Inc(i);
+      FParamSourcePath := ParamStr(i);
+    end
     else if s = '-schema-path' then
     begin
       Inc(i);
@@ -205,7 +211,8 @@ begin
   if FError or (FParamInfile = '') then
   begin
     writeln('');
-    writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-schema-path path] [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
+    writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-schema-path path] ');
+    writeln('              [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
     writeln('              [-extract-keyboard-info field[,field...]]');
     writeln('          infile        can be a .kmn file (Keyboard Source, .kps file (Package Source), or .kpj (project)');   // I4699   // I4825
     writeln('                        if -v specified, can also be a .keyboard_info file');
@@ -227,6 +234,7 @@ begin
     writeln('          -m       merge information from infile (can be .kmp and .js) into .keyboard_info output file');
     writeln('          -m-validate-id  validate the id against the .js, .kmx and .kmp filenames when merging');
     writeln('          -json-extract   print json data .keyboard_info for build script integration');
+    writeln('          -source-path    specify path to add to the sourcePath field in the .keyboard_info output file');
     writeln('          -schema-path    specify path to the keyboard_info json schema definitions');
     writeln('                          if not specified, then defaults to same folder as kmcomp.exe');
 
@@ -246,7 +254,7 @@ begin
       hOutfile := 0;
 
     if FMerging then
-      FError := not TMergeKeyboardInfo.Execute(FParamInfile, FParamInfile2, FParamOutfile, FMergingValidateIds, FSilent, @CompilerMessage)
+      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FMergingValidateIds, FSilent, @CompilerMessage)
     else if FValidating then
       FError := not TValidateKeyboardInfo.Execute(FParamInfile, FJsonSchemaPath, FParamDistribution, FSilent, @CompilerMessage)
     else if FJsonExtract then


### PR DESCRIPTION
This allows us to get GitHub source path from the compiled repository. The field is added automatically by the build and is restricted to paths in the Keyman keyboards repo.