### PR TITLE
[Web] Document Linux steps for building kmw

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,12 +1,17 @@
 # Keyman Web
-The Original Code is (C) 2017 SIL International
+The Original Code is (C) 2017-2018 SIL International
 
 ## Minimum Web Compilation Requirements
 
-* A local installation of [Node.js](https://nodejs.org/).
-	* Builds will call `npm install` to automatically install further necessary build dependencies.
 * Java 7+ (required by the Google Closure Compiler for minification builds)
-
+* A local installation of [Node.js](https://nodejs.org/) v8.9+.
+	* Builds will call `npm install` to automatically install further necessary build dependencies.
+	* Linux users can run the following to update to LTS version of nodejs
+```
+sudo apt-get install python-software-properties
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+sudo apt-get install nodejs
+```
 **********************************************************************
 
 The following folders contain the distribution for KeymanWeb:


### PR DESCRIPTION
The default versions of nodejs and npm on Ubuntu aren't compatible for building kmw.

Update the readme.md 