### PR TITLE
[Android] Fix text area ('ta') reference that gets passed to KMW

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -26,7 +26,8 @@
       kmw['hideKeyboard'] = hideKeyboard;
       kmw['getOskHeight'] = getOskHeight;
       kmw['getOskWidth'] = getOskWidth;
-      kmw['setActiveElement']('ta');
+      var ta = document.getElementById('ta');
+      kmw['setActiveElement'](ta);
 
       ta.readOnly = false;
 


### PR DESCRIPTION
The text area that gets passed to KMW wasn't being properly initialized. This impacted "cloud" keyboards from working