### PR TITLE
TypeScript conversion:  kmwkeymaps.ts

### DIFF
--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -8,6 +8,8 @@
 /// <reference path="kmwcallback.ts" />
 // Defines keyboard data & management classes.
 /// <reference path="kmwkeyboards.ts" />
+// Defines built-in keymapping.
+/// <reference path="kmwkeymaps.ts" />
 // Defines KMW's hotkey management object.
 /// <reference path="kmwhotkeys.ts" />
 // Defines the ui management code that tracks UI activation and such.
@@ -62,6 +64,7 @@ class KeymanBase {
   domManager: DOMManager;
   hotkeyManager: HotkeyManager;
   uiManager: UIManager;
+  keyMapManager: KeyMapManager;
 
   touchAliasing: DOMEventHandlers;
 
@@ -105,6 +108,7 @@ class KeymanBase {
     this.domManager = new DOMManager(this);
     this.hotkeyManager = new HotkeyManager(this);
     this.uiManager = new UIManager(this);
+    this.keyMapManager = new KeyMapManager();
 
     // Load properties from their static variants.
     this['build'] = KeymanBase.__BUILD__;
@@ -165,7 +169,7 @@ class KeymanBase {
           elem = elem.ownerDocument;
           var win: Window;
           if(elem) {
-            win = elem.parentWindow;
+            win = elem.defaultView;
           }
           if(!win) {
             return null;

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -128,9 +128,6 @@ class KeyboardInterface {
       if(Lelem instanceof HTMLIFrameElement && this.keymanweb.domManager._IsMozillaEditableIframe(Lelem,0)) {
         Lelem = (<any>Lelem).documentElement;  // I3363 (Build 301)
       }
-      if(document.selection  &&  Lsel != null) {
-        Lsel.select();
-      }
       Lelem._KeymanWebSelectionStart=Ls;
       Lelem._KeymanWebSelectionEnd=Le;
       DOMEventHandlers.states._IgnoreNextSelChange = 0;
@@ -247,7 +244,7 @@ class KeyboardInterface {
     if(this.keymanweb.keyboardManager.activeKeyboard['KM']) {   // I1380 - support KIK for positional layouts
       return !e.LisVirtualKey;             // will now return true for U_xxxx keys, but not for T_xxxx keys
     } else {
-      return (<any>this.keymanweb)._USKeyCodeToCharCode(e) ? true : false; // I1380 - support KIK for positional layouts
+      return this.keymanweb.keyMapManager._USKeyCodeToCharCode(e) ? true : false; // I1380 - support KIK for positional layouts
     }
   }
   

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -670,8 +670,8 @@ class DOMEventHandlers {
     if(!window.event) {
       // I1466 - Convert the - keycode on mnemonic as well as positional layouts
       // FireFox, Mozilla Suite
-      if((<any>this.keyman)._VKMap_FF_IE['k'+Levent.Lcode]) {
-        Levent.Lcode=(<any>this.keyman)._VKMap_FF_IE['k'+Levent.Lcode];
+      if(this.keyman.keyMapManager.browserMap.FF['k'+Levent.Lcode]) {
+        Levent.Lcode=this.keyman.keyMapManager.browserMap.FF['k'+Levent.Lcode];
       }
     }
     //else 
@@ -684,7 +684,7 @@ class DOMEventHandlers {
 
       var LeventMatched=0;
       /* 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard */
-      var Lbase=(<any>this.keyman)._VKMap[osk._BaseLayout];
+      var Lbase=this.keyman.keyMapManager.languageMap[osk._BaseLayout];
       if(Lbase && Lbase['k'+Levent.Lcode]) {
         Levent.Lcode=Lbase['k'+Levent.Lcode];
       }
@@ -693,7 +693,7 @@ class DOMEventHandlers {
       if(typeof(activeKeyboard['KM'])=='undefined'  &&  !(Levent.Lmodifiers & 0x60)) {
         // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
         var Levent2: LegacyKeyEvent = {
-          Lcode:(<any>this.keyman)._USKeyCodeToCharCode(Levent) as number,
+          Lcode:this.keyman.keyMapManager._USKeyCodeToCharCode(Levent),
           Ltarg:Levent.Ltarg,
           Lmodifiers:0,
           LisVirtualKey:0

--- a/web/source/kmwkeymaps.ts
+++ b/web/source/kmwkeymaps.ts
@@ -3,52 +3,59 @@
    Copyright 2017 SIL International
 ***/
 
-// If KMW is already initialized, the KMW script has been loaded more than once. We wish to prevent resetting the 
-// KMW system, so we use the fact that 'initialized' is only 1 / true after all scripts are loaded for the initial
-// load of KMW.
-if(!window['keyman']['initialized']) { 
-  /**
-   * Cross-browser compatibility keymaps    
-   */    
-  (function() {
-    // Declare KeymanWeb object
-    var keymanweb=window['keyman'];
+class KeyMap {
+  [keycode: string]: number;
+}
 
-    /* I732 START - 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard #2 */
-    var ffie = keymanweb._VKMap_FF_IE = {};
-    
+class BrowserKeyMaps {
+  FF:     KeyMap = new KeyMap();
+  Safari: KeyMap = new KeyMap();
+  Opera:  KeyMap = new KeyMap();
+
+  constructor() {
     //ffie['k109'] = 189; // -    // These two number-pad VK rules are *not* correct for more recent FF! JMD 8/11/12
     //ffie['k107'] = 187; // =    // FF 3.0 // I2062
-    ffie['k61'] = 187;  // =      // FF 2.0
-    ffie['k59'] = 186;  // ;
-    
-    keymanweb._VKMap_Opera_IE = {};
-    
-    keymanweb._VKMap_Safari_IE = {};
-      
+    this.FF['k61'] = 187;  // =   // FF 2.0
+    this.FF['k59'] = 186;  // ;
+  }
+}
+
+class LanguageKeyMaps {
+  [languageCode: string]: KeyMap;
+
+  constructor() {
+    /* I732 START - 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard #2 */
     // Swedish key map
-    var kmap = keymanweb._VKMap = {};
-  
-    kmap['se'] = {};
-    kmap['se']['k220'] =  192; // `
-    kmap['se']['k187'] =  189; // -
-    kmap['se']['k219'] =  187; // =
-    kmap['se']['k221'] =  219; // [
-    kmap['se']['k186'] =  221; // ]
-    kmap['se']['k191'] =  220; // \
-    kmap['se']['k192'] =  186; // ;
-    kmap['se']['k189'] =  191; // /
+    this['se'] = new KeyMap();
+    this['se']['k220'] =  192; // `
+    this['se']['k187'] =  189; // -
+    this['se']['k219'] =  187; // =
+    this['se']['k221'] =  219; // [
+    this['se']['k186'] =  221; // ]
+    this['se']['k191'] =  220; // \
+    this['se']['k192'] =  186; // ;
+    this['se']['k189'] =  191; // /
 
-    kmap['uk'] = {};  // I1299
-    kmap['uk']['k223'] =  192; // // ` U+00AC (logical not) =>  ` ~
-    kmap['uk']['k192'] =  222; // ' @  =>  ' "
-    kmap['uk']['k222'] =  226; // # ~  => K_oE2     // I1504 - UK keyboard mixup #, \
-    kmap['uk']['k220'] =  220; // \ |  => \ |       // I1504 - UK keyboard mixup #, \
-  
-    /* I732 END - 13/03/2007 MCD: Swedish: mapping of keystroke to US keyboard #2 */
+    this['uk'] = new KeyMap();  // I1299
+    this['uk']['k223'] =  192; // // ` U+00AC (logical not) =>  ` ~
+    this['uk']['k192'] =  222; // ' @  =>  ' "
+    this['uk']['k222'] =  226; // # ~  => K_oE2     // I1504 - UK keyboard mixup #, \
+    this['uk']['k220'] =  220; // \ |  => \ |       // I1504 - UK keyboard mixup #, \
+  }
+}
 
-    /* 13/03/2007 MCD: Swedish: Legacy keyboards - map US Key Code to Character Code */  
-    var s0={},s1={};
+class KeyMapManager {
+  browserMap: BrowserKeyMaps = new BrowserKeyMaps();
+  languageMap: LanguageKeyMaps = new LanguageKeyMaps();
+
+  _usCharCodes: KeyMap[];
+
+  constructor() {
+    this._usCodeInit();
+  }
+
+  _usCodeInit() {
+    var s0=new KeyMap(),s1=new KeyMap();
 
     s0['k192'] = 96;
     s0['k49'] = 49;
@@ -146,17 +153,17 @@ if(!window['keyman']['initialized']) {
     s1['k190'] = 62;
     s1['k191'] = 63;
 
-    keymanweb._USCharCode = [s0,s1];
-    
-    /**
-     * Function     _USKeyCodeToCharCode
-     * Scope        Private
-     * @param       {Event}     Levent      KMW event object
-     * @return      {number}                Character code 
-     * Description Translate keyboard codes to standard US layout codes
-     */    
-    keymanweb._USKeyCodeToCharCode = function(Levent) {
-      return keymanweb._USCharCode[Levent.Lmodifiers & 0x10 ? 1 : 0]['k'+Levent.Lcode];
-    };
-  })();
+    this._usCharCodes = [s0,s1];
+  }
+
+  /**
+   * Function     _USKeyCodeToCharCode
+   * Scope        Private
+   * @param       {Event}     Levent      KMW event object
+   * @return      {number}                Character code 
+   * Description Translate keyboard codes to standard US layout codes
+   */    
+  _USKeyCodeToCharCode(Levent: KeyEvent) {
+    return this._usCharCodes[Levent.Lmodifiers & 0x10 ? 1 : 0]['k'+Levent.Lcode];
+  };
 }

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -985,7 +985,6 @@ if(!window['keyman']['initialized']) {
         DOMEventHandlers.states._IgnoreNextSelChange = 100;
         keymanweb.domManager.focusLastActiveElement();
         if(keymanweb.domManager._IsMozillaEditableIframe(Lelem,0)) Lelem = Lelem.documentElement;
-        if(document.selection && Lsel != null) Lsel.select();
         Lelem._KeymanWebSelectionStart=Ls;
         Lelem._KeymanWebSelectionEnd=Le;
         DOMEventHandlers.states._IgnoreNextSelChange = 0;
@@ -1059,7 +1058,8 @@ if(!window['keyman']['initialized']) {
         // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
         if(typeof activeKeyboard['KM'] == 'undefined')
         {
-          Lkc.Lcode=keymanweb._USKeyCodeToCharCode(Lkc); Lkc.LisVirtualKey=false;
+          Lkc.Lcode=keymanweb.keyMapManager._USKeyCodeToCharCode(Lkc);
+          Lkc.LisVirtualKey=false;
         }
 
         // Pass this key code and state to the keyboard program

--- a/web/source/tsconfig.embedded.json
+++ b/web/source/tsconfig.embedded.json
@@ -7,9 +7,7 @@
 		"kmwbase.ts",
 		"keymanweb.ts",
 		"kmwosk.ts", 
-		"kmwembedded.ts", 
-		"kmwcallback.ts",
-		"kmwkeymaps.ts",
+		"kmwembedded.ts",
 		"kmwlayout.ts",
 		"kmwinit.ts",
 		"kmwapi.ts"

--- a/web/source/tsconfig.web.json
+++ b/web/source/tsconfig.web.json
@@ -7,9 +7,7 @@
 		"kmwbase.ts",
 		"keymanweb.ts",
 		"kmwosk.ts", 
-		"kmwnative.ts", 
-		"kmwcallback.ts",
-		"kmwkeymaps.ts",
+		"kmwnative.ts",
 		"kmwlayout.ts",
 		"kmwinit.ts",
 		"kmwapi.ts"


### PR DESCRIPTION
Converts the existing keymapping infrastructure into something slightly more OO and including it in the new object chain for proper TypeScript accessibility.

A few minor legacy re-edits slipped in for compilation; the IDE was reporting errors, but might just have neglected to refresh the kmwexthtml.ts file.