### PR TITLE
[Android] Fix KMAPro/build.sh to use bash instead of sh

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Build KMAPro
 
 display_usage ( ) {


### PR DESCRIPTION
A Linux user reports issues building KMAPro because the script uses bash syntax instead of sh.
```
while [[ $# -gt 0 ]] ; do
```

KMEA is already using `#!/bin/bash`