### PR TITLE
[Android] Improve UX for KMP distribution

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <!-- local kmp file -->
+                <!-- Android's implementation of PatternMatcher for pathPattern limits special characters to '.', '*', and '\\' -->
                 <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.kmp" />
 
                 <!-- Android DownloadManager doesn't have ".kmp" in the names it passes to the intent -->

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -669,9 +669,12 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
           int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
           filename = cursor.getString(nameIndex);
           if (!filename.endsWith(".kmp")) {
+            Toast.makeText(getApplicationContext(),
+              filename + " is not a valid KMP.\nNo keyboards installed", Toast.LENGTH_LONG).show();
             break;
           }
 
+          // Copy KMP to app cache
           cacheKmpFile = new File(MainActivity.this.getCacheDir().toString(), filename);
           if (cacheKmpFile.exists()) {
             cacheKmpFile.delete();
@@ -684,16 +687,20 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
         case "file":
           File kmpFile = new File(data.getPath());
           filename = kmpFile.getName();
-          if (data.toString().endsWith(".kmp")) {
-            // KMP already exists locally. Copy KMP to app cache and start PackageActivity
-            cacheKmpFile = new File(MainActivity.this.getCacheDir().toString(), kmpFile.getName());
-            if (cacheKmpFile.exists()) {
-              cacheKmpFile.delete();
-            }
-
-            Log.d(TAG, "Copying " + filename + " to app cache");
-            FileUtils.copy(new FileInputStream(kmpFile), new FileOutputStream(cacheKmpFile));
+          if (!data.toString().endsWith(".kmp")) {
+            Toast.makeText(getApplicationContext(),
+              filename + " is not a valid KMP.\nNo keyboards installed", Toast.LENGTH_LONG).show();
+            break;
           }
+
+          // Copy KMP to app cache
+          cacheKmpFile = new File(MainActivity.this.getCacheDir().toString(), kmpFile.getName());
+          if (cacheKmpFile.exists()) {
+            cacheKmpFile.delete();
+          }
+
+          Log.d(TAG, "Copying " + filename + " to app cache");
+          FileUtils.copy(new FileInputStream(kmpFile), new FileOutputStream(cacheKmpFile));
           break;
       }
     } catch (Exception e) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -7,6 +7,7 @@ package com.tavultesoft.kmapro;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -658,9 +659,12 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
 
   private void useLocalKMP(Uri data) {
     String filename = "";
-    File cacheKmpFile = null;
+    String cacheKMPFilename = "";
+    File cacheKMPFile = null;
+    InputStream inputFile = null;
     Bundle bundle = new Bundle();
     try {
+      boolean fileEndsWithKMP = false;
       switch (data.getScheme().toLowerCase()) {
         case "content":
           // DownloadManager passes a path "/document/number" so we need to extract the .kmp filename
@@ -668,40 +672,33 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
           cursor.moveToFirst();
           int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
           filename = cursor.getString(nameIndex);
-          if (!filename.endsWith(".kmp")) {
-            Toast.makeText(getApplicationContext(),
-              filename + " is not a valid KMP.\nNo keyboards installed", Toast.LENGTH_LONG).show();
-            break;
-          }
-
-          // Copy KMP to app cache
-          cacheKmpFile = new File(MainActivity.this.getCacheDir().toString(), filename);
-          if (cacheKmpFile.exists()) {
-            cacheKmpFile.delete();
-          }
-
-          Log.d(TAG, "Copying " + filename + " from " + data.toString() + " to app cache");
-          FileUtils.copy(getContentResolver().openInputStream(data), new FileOutputStream(cacheKmpFile));
+          fileEndsWithKMP = filename.endsWith(".kmp");
+          cacheKMPFilename = filename;
+          inputFile = getContentResolver().openInputStream(data);
           break;
 
         case "file":
           File kmpFile = new File(data.getPath());
           filename = kmpFile.getName();
-          if (!data.toString().endsWith(".kmp")) {
-            Toast.makeText(getApplicationContext(),
-              filename + " is not a valid KMP.\nNo keyboards installed", Toast.LENGTH_LONG).show();
-            break;
-          }
-
-          // Copy KMP to app cache
-          cacheKmpFile = new File(MainActivity.this.getCacheDir().toString(), kmpFile.getName());
-          if (cacheKmpFile.exists()) {
-            cacheKmpFile.delete();
-          }
-
-          Log.d(TAG, "Copying " + filename + " to app cache");
-          FileUtils.copy(new FileInputStream(kmpFile), new FileOutputStream(cacheKmpFile));
+          fileEndsWithKMP = data.toString().endsWith(".kmp");
+          cacheKMPFilename = kmpFile.getName();
+          inputFile = new FileInputStream(kmpFile);
           break;
+      }
+
+      if (fileEndsWithKMP) {
+        // Copy KMP to app cache
+        cacheKMPFile = new File(MainActivity.this.getCacheDir().toString(), cacheKMPFilename);
+        if (cacheKMPFile.exists()) {
+          cacheKMPFile.delete();
+        }
+
+        Log.d(TAG, "Copying " + filename + " to app cache");
+        FileUtils.copy(inputFile, new FileOutputStream(cacheKMPFile));
+      } else {
+        String noKeyboardsInstalledMessage = " is not a valid keyboard package file.\nNo keyboards were installed.";
+        Toast.makeText(getApplicationContext(),
+          filename + noKeyboardsInstalledMessage, Toast.LENGTH_LONG).show();
       }
     } catch (Exception e) {
       String message = "Access denied to " + filename +
@@ -711,8 +708,8 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
       return;
     }
 
-    if (cacheKmpFile != null) {
-      bundle.putString("kmpFile", cacheKmpFile.getAbsolutePath());
+    if (cacheKMPFile != null) {
+      bundle.putString("kmpFile", cacheKMPFile.getAbsolutePath());
 
       Intent packageIntent = new Intent(getApplicationContext(), PackageActivity.class);
       packageIntent.putExtras(bundle);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -51,12 +51,13 @@ public class PackageActivity extends Activity {
       kmpFile = new File(bundle.getString("kmpFile"));
     }
 
-    final String pkgId = PackageProcessor.getPackageName(kmpFile);
-    String version = PackageProcessor.getPackageVersion(kmpFile, false);
-    if (version == null || version.isEmpty()) {
+    final String pkgId = PackageProcessor.getPackageID(kmpFile);
+    String pkgVersion = PackageProcessor.getPackageVersion(kmpFile, false);
+    if (pkgVersion == null || pkgVersion.isEmpty()) {
       String message = "Invalid package version in " + kmpFile.getName();
       showErrorDialog(context, pkgId, message);
     }
+    String pkgName = PackageProcessor.getPackageName(kmpFile, false);
 
     try {
       tempPackagePath = PackageProcessor.unzipKMP(kmpFile);
@@ -77,8 +78,8 @@ public class PackageActivity extends Activity {
     packageActivityTitle.setGravity(Gravity.CENTER);
 
     String titleStr = "Install Keyboard Package";
-    if (version != null) {
-      titleStr += " " + version;
+    if (pkgVersion != null) {
+      titleStr += " " + pkgVersion;
     }
     packageActivityTitle.setText(titleStr);
     actionBar.setCustomView(packageActivityTitle);
@@ -139,7 +140,11 @@ public class PackageActivity extends Activity {
     if (files.length > 0 && files[0].exists() && files[0].length() > 0) {
       webView.loadUrl("file:///" + files[0].getAbsolutePath());
     } else {
-      String htmlString = "<div id='welcome'><H1>Package: " + pkgId + "</H1></div>";
+      // No welcome.htm so display minimal package information
+      String keyboardString = (pkgName.toLowerCase().endsWith("keyboard")) ? "" : " Keyboard ";
+      String htmlString = String.format(
+        "<body style=\"max-width:600px;\"><H1>The %s%s Package</H1></body>",
+        pkgName, keyboardString);
       webView.loadData(htmlString, "text/html; charset=utf-8", "UTF-8");
     }
 

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -36,6 +36,7 @@ public class PackageProcessorTest {
     File.separator + TEST_GFF_KMP_NAME_ALT);
 
   private static final int TEST_GFF_KBD_COUNT = 2;
+  private static final String TEST_GFF_PACKAGE_NAME = "GFF Amharic Keyboard";
   private static final String TEST_GFF_KBD_ID = "gff_amh_7";
 
   private static File tempPkg;
@@ -199,6 +200,20 @@ public class PackageProcessorTest {
     JSONObject json = PackageProcessor.loadPackageInfo(tempPkg);
 
     Assert.assertEquals("1.4", PackageProcessor.getKeyboardVersion(json, TEST_GFF_KBD_ID));
+  }
+
+  @Test
+  public void test_getPackageID() {
+    Assert.assertEquals(TEST_GFF_KMP_NAME, PackageProcessor.getPackageID(TEST_GFF_KMP_FILE));
+    Assert.assertNotEquals(TEST_GFF_KBD_ID, PackageProcessor.getPackageID(TEST_GFF_KMP_FILE));
+  }
+
+  @Test
+  public void test_getPackageName() throws Exception {
+    JSONObject json = PackageProcessor.loadPackageInfo(tempPkg);
+
+    Assert.assertEquals(TEST_GFF_PACKAGE_NAME, PackageProcessor.getPackageName(json));
+    Assert.assertNotEquals(TEST_GFF_KMP_NAME, PackageProcessor.getPackageName(json));
   }
 
   @Test


### PR DESCRIPTION
Due to Android's limited set of regex characters for intent actions, any local `.kmp*` file triggers the Keyman app. (e.g. `.kmp` is treated the same as `.kmpo`). Added Toast notifications for when the intent inadvertently triggers the Keyman app.

Also updated PackageActivity to display the package name description when no `welcome.htm`  file exists.