### PR TITLE
[ios] Move to using api.keyman.com instead of r.keymanweb.com for 10.0

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
@@ -24,10 +24,12 @@ public class APIKeyboardRepository: KeyboardRepository {
 
   public func fetch(completionHandler: CompletionHandler?) {
     let deviceType = UIDevice.current.userInterfaceIdiom == .phone ? "iphone" : "ipad"
+    let keymanVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     var urlComponents = languagesAPIURL
     urlComponents.queryItems = [
       URLQueryItem(name: "dateformat", value: "seconds"),
-      URLQueryItem(name: "device", value: deviceType)
+      URLQueryItem(name: "device", value: deviceType),
+      URLQueryItem(name: "version", value: keymanVersion)
     ]
     log.info("Connecting to Keyman cloud: \(urlComponents.url!).")
     let task = URLSession.shared.dataTask(with: urlComponents.url!) { (data, response, error) in

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
@@ -15,7 +15,7 @@ public enum APIKeyboardFetchError: Error {
 }
 
 public class APIKeyboardRepository: KeyboardRepository {
-  private let languagesAPIURL = URLComponents(string: "https://r.keymanweb.com/api/4.0/languages")!
+  private let languagesAPIURL = URLComponents(string: "https://api.keyman.com/cloud/4.0/languages")!
 
   public weak var delegate: KeyboardRepositoryDelegate?
   public private(set) var languages: [String: Language]?
@@ -29,6 +29,7 @@ public class APIKeyboardRepository: KeyboardRepository {
       URLQueryItem(name: "dateformat", value: "seconds"),
       URLQueryItem(name: "device", value: deviceType)
     ]
+    log.info("Connecting to Keyman cloud: \(urlComponents.url!).")
     let task = URLSession.shared.dataTask(with: urlComponents.url!) { (data, response, error) in
       self.apiCompletionHandler(data: data, response: response, error: error,
                                 fetchCompletionHandler: completionHandler)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -27,10 +27,8 @@ public enum KeyboardState {
 // Strings
 private let keyboardChangeHelpText = "Tap here to change keyboard"
 
-// URLs
-private let apiBaseURL = "https://r.keymanweb.com/api/4.0/"
-private let apiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url="
-private let keymanHostName = "r.keymanweb.com"
+// URLs - used for reachability test
+private let keymanHostName = "api.keyman.com"
 
 // UI In-App Keyboard Constants
 private let phonePortraitInAppKeyboardHeight: CGFloat = 183.0

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 import QuartzCore
 
 // Internal strings
-private let baseUri = "http://r.keymanweb.com/20/fonts/get_mobileconfig.php?id="
+private let baseUri = "https://r.keymanweb.com/20/fonts/get_mobileconfig.php?id="
 private let profileKey = "profile"
 private let checkedProfilesKey = "CheckedProfiles"
 


### PR DESCRIPTION
- Removed unused references to r.keymanweb.com.
- Pointed new references to api.keyman.com where possible.
- (Note: fonts url will be a separate update)

Before merging, please also test this with the live api.keyman.com endpoint to see that you are getting what you expect for keyboard downloads and installs.