### PR TITLE
Enable keyboard supplementary plane mode based on keyboard metadata rather than stub metadata

### DIFF
--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -607,7 +607,7 @@ class KeyboardManager {
             manager.keymanweb.domManager._SetTargDir(manager.keymanweb.domManager.getLastActiveElement());
           }
 
-          String.kmwEnableSupplementaryPlane(kbdStub && ((kbdStub['KS'] && (kbdStub['KS'] == 1)) || (kbd['KN'] == 'Hieroglyphic'))); // I3319 - SMP extension, I3363 (Build 301)
+          String.kmwEnableSupplementaryPlane(kbd && ((kbd['KS'] && kbd['KS'] == 1) || kbd['KN'] == 'Hieroglyphic')); // I3319 - SMP extension, I3363 (Build 301)
           manager.saveCurrentKeyboard(kbd['KI'], kbdStub['KLC']);
         
           // Prepare and show the OSK for this keyboard


### PR DESCRIPTION
KeymanWeb includes special string handling for keyboards with supplementary plane characters. By default, this is disabled for BMP-only keyboards because the SMP-aware functions are significantly slower. The flag `keyboard.KS` should be set to `1` on keyboards with SMP characters.

The compiler was doing this correctly, however KMW was checking the stub metadata rather than the keyboard metadata for the flag.