### PR TITLE
Web Testing - Centralizing configuration data

### DIFF
--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -1,9 +1,5 @@
-// Karma configuration
-// Generated on Mon Jan 29 2018 11:58:53 GMT+0700 (SE Asia Standard Time)
-
-// Super-useful!  http://www.bradoncode.com/blog/2015/02/27/karma-tutorial/#handling-html-fixtures
-
 module.exports = function(config) {
+  var base = require("./base.conf.js");
 
   /*
    * Definition of utility functions for managing our browser lists.
@@ -132,11 +128,7 @@ module.exports = function(config) {
    * Final definition of our BrowserStack testing Karma configuration.
    */
 
-  config.set({
-
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
-
+  var specifics = {
     // BrowserStack configuration options
     browserStack: {
       video: false,
@@ -146,66 +138,17 @@ module.exports = function(config) {
 
     captureTimeout: 180000, // in milliseconds
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'fixture'],
-
-
-    // list of files / patterns to load in the browser
-    files: [
-      'unit_tests/test_utils.js', // A basic utility script useful for constructing tests
-      'unit_tests/modernizr.js', // A dependency-managed utility script that helps with browser feature detection.
-      'unit_tests/cases/**/*.js', // Where the tests actually reside.
-      {pattern: 'release/unminified/web/**/*.css', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/**/*.gif', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/**/*.png', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/*.js', watched: true, served: true, included: false},  // The actual KMW code.
-      {pattern: 'release/unminified/web/*.map', watched: true, served: true, included: false}, // + sourcemaps.
-      {pattern: 'unit_tests/fixtures/**/*.html', watched: true} // HTML structures useful for testing.
-    ],
-
-    proxies: {
-      "/source/": "/base/release/unminified/web/"
-    },
-
-
-    // list of files / patterns to exclude
-    exclude: [
-    ],
-
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-		'**/*.html'	: ['html2js']
-    },
-
+    // Avoids generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.
+    failOnEmptyTestSuite: false,
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['teamcity'],
 
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-	  // if false, it generates the pages and acts as a persistent server.
-    singleRun: true,
 
     // Concurrency level
     // For CI, it really helps to keep a nice, clean set of output logs.
@@ -214,5 +157,7 @@ module.exports = function(config) {
     customLaunchers: FINAL_LAUNCHER_DEFS,
 
     browsers: FINAL_BROWSER_LIST
-  })
+  };
+
+  config.set(Object.assign(specifics, base));
 }

--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -132,11 +132,15 @@ module.exports = function(config) {
     // BrowserStack configuration options
     browserStack: {
       video: false,
+      browserDisconnectTimeout: 3e5,
       retryLimit: 1, // 0 is ignored.
       startTunnel: true,
     },
 
-    captureTimeout: 180000, // in milliseconds
+    captureTimeout: 6e5, // in milliseconds
+    browserNoActivityTimeout: 3e5,
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 3,
 
     // Avoids generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.
     failOnEmptyTestSuite: false,

--- a/web/unit_tests/base.conf.js
+++ b/web/unit_tests/base.conf.js
@@ -16,7 +16,6 @@ module.exports = {
     'unit_tests/test_utils.js', // A basic utility script useful for constructing tests
     'unit_tests/modernizr.js', // A dependency-managed utility script that helps with browser feature detection.
     'unit_tests/cases/**/*.js', // Where the tests actually reside.
-    'unit_tests/json/**/*.json', // Where pre-loaded JSON resides.
     {pattern: 'unit_tests/resources/**/*.*', watched: true, served: true, included: false}, // General testing resources.
     {pattern: 'release/unminified/web/**/*.css', watched: false, served: true, included: false}, // OSK resources
     {pattern: 'release/unminified/web/**/*.gif', watched: false, served: true, included: false}, // OSK resources
@@ -39,17 +38,10 @@ module.exports = {
   exclude: [
   ],
 
-
-  jsonFixturesPreprocessor: {
-    stripPrefix: 'unit_tests/json',
-    variableName: '__json__'
-  },
-
   // preprocess matching files before serving them to the browser
   // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
   preprocessors: {
     'unit_tests/fixtures/**/*.html'	: ['html2js'],
-    'unit_tests/json/**/*.json' : ['json_fixtures']
   },
 
   // web server port

--- a/web/unit_tests/base.conf.js
+++ b/web/unit_tests/base.conf.js
@@ -1,0 +1,68 @@
+// Karma configuration
+// Generated on Mon Jan 29 2018 11:58:53 GMT+0700 (SE Asia Standard Time)
+
+// Super-useful!  http://www.bradoncode.com/blog/2015/02/27/karma-tutorial/#handling-html-fixtures
+
+module.exports = {
+  // base path that will be used to resolve all patterns (eg. files, exclude)
+  basePath: '..',
+
+  // frameworks to use
+  // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+  frameworks: ['mocha', 'chai', 'fixture'],
+
+  // list of files / patterns to load in the browser
+  files: [
+    'unit_tests/test_utils.js', // A basic utility script useful for constructing tests
+    'unit_tests/modernizr.js', // A dependency-managed utility script that helps with browser feature detection.
+    'unit_tests/cases/**/*.js', // Where the tests actually reside.
+    'unit_tests/json/**/*.json', // Where pre-loaded JSON resides.
+    {pattern: 'unit_tests/resources/**/*.*', watched: true, served: true, included: false}, // General testing resources.
+    {pattern: 'release/unminified/web/**/*.css', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/**/*.gif', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/**/*.png', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/**/*.eot', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/**/*.ttf', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/**/*.woff', watched: false, served: true, included: false}, // OSK resources
+    {pattern: 'release/unminified/web/*.js', watched: true, served: true, included: false},  // The actual KMW code.
+    {pattern: 'release/unminified/web/*.map', watched: true, served: true, included: false}, // + sourcemaps.
+    {pattern: 'unit_tests/fixtures/**/*.html', watched: true} // HTML structures useful for testing.
+  ],
+
+  proxies: {
+    "/source/": "/base/release/unminified/web/",
+    "/resources/": "/base/unit_tests/resources/"
+  },
+
+
+  // list of files / patterns to exclude
+  exclude: [
+  ],
+
+
+  jsonFixturesPreprocessor: {
+    stripPrefix: 'unit_tests/json',
+    variableName: '__json__'
+  },
+
+  // preprocess matching files before serving them to the browser
+  // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+  preprocessors: {
+    'unit_tests/fixtures/**/*.html'	: ['html2js'],
+    'unit_tests/json/**/*.json' : ['json_fixtures']
+  },
+
+  // web server port
+  port: 9876,
+
+  // enable / disable colors in the output (reporters and logs)
+  colors: true,
+
+  // enable / disable watching file and executing tests whenever any file changes
+  autoWatch: true,
+
+  // Continuous Integration mode
+  // if true, Karma captures browsers, runs the tests and exits
+  // if false, it generates the pages and acts as a persistent server.
+  singleRun: true,
+}

--- a/web/unit_tests/manual.conf.js
+++ b/web/unit_tests/manual.conf.js
@@ -7,13 +7,6 @@ module.exports = function(config) {
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['mocha'],
 
-    customLaunchers: {
-      ChromeAndroidNoShutdown: {
-        base: 'ChromeAndroid',
-        shutdownEmulator: false
-      }  
-    },
-
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['Firefox', 'IE', 'Chrome', 'Edge'], // Can be specified at run-time instead!

--- a/web/unit_tests/manual.conf.js
+++ b/web/unit_tests/manual.conf.js
@@ -1,83 +1,33 @@
-// Karma configuration
-// Generated on Mon Jan 29 2018 11:58:53 GMT+0700 (SE Asia Standard Time)
-
-// Super-useful!  http://www.bradoncode.com/blog/2015/02/27/karma-tutorial/#handling-html-fixtures
-
 module.exports = function(config) {
-  config.set({
+  var base = require("./base.conf.js");
 
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
-
-
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'fixture'],
-
-
-    // list of files / patterns to load in the browser
-    files: [
-      'unit_tests/test_utils.js', // A basic utility script useful for constructing tests
-      'unit_tests/modernizr.js', // A dependency-managed utility script that helps with browser feature detection.
-      'unit_tests/cases/**/*.js', // Where the tests actually reside.
-      {pattern: 'release/unminified/web/**/*.css', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/**/*.gif', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/**/*.png', watched: false, served: true, included: false}, // OSK resources
-      {pattern: 'release/unminified/web/*.js', watched: true, served: true, included: false},  // The actual KMW code.
-      {pattern: 'release/unminified/web/*.map', watched: true, served: true, included: false}, // + sourcemaps.
-      {pattern: 'unit_tests/fixtures/**/*.html', watched: true} // HTML structures useful for testing.
-    ],
-
-    proxies: {
-      "/source/": "/base/release/unminified/web/"
-    },
-
-
-    // list of files / patterns to exclude
-    exclude: [
-    ],
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-		'**/*.html'	: ['html2js']
-    },
-
+  var specifics = {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['mocha'],
 
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
+    customLaunchers: {
+      ChromeAndroidNoShutdown: {
+        base: 'ChromeAndroid',
+        shutdownEmulator: false
+      }  
+    },
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['Firefox', 'IE', 'Chrome', 'Edge'], // Can be specified at run-time instead!
-	// Future note for us:  https://www.npmjs.com/package/karma-browserstack-launcher
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-	  // if false, it generates the pages and acts as a persistent server.
-    singleRun: true,
+	  // Future note for us:  https://www.npmjs.com/package/karma-browserstack-launcher
 
     // Concurrency level
     // how many browser should be started simultaneous
-    concurrency: Infinity
-  })
+    concurrency: Infinity,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    // Can't set in base.conf.js b/c of constant's definition style.
+    logLevel: config.LOG_INFO
+  };
+
+  config.set(Object.assign(specifics, base));
 }


### PR DESCRIPTION
Pardon my slowness in making this little change; the common data for the CI and manual Karma configuration files has been centralized into a 'base' configuration file that can be drawn in via Node's `require` statement.  Took me a bit to get it right.

At any rate, this greatly simplifies maintenance of our Karma testing configurations.  I've also imported BrowserStack's recommended settings for Karma to the CI config, which should hopefully bring greater testing stability.