### PR TITLE
[Android] Add feature crash reporting

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -26,3 +26,6 @@
 KMEA/app/src/main/assets/
 KMAPro/assets/keyman.js
 
+# Firebase configuration
+**/google-services.json
+

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -26,6 +26,4 @@
 KMEA/app/src/main/assets/
 KMAPro/assets/keyman.js
 
-# Firebase configuration
-**/google-services.json
 

--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -1,18 +1,24 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
+        classpath 'com.google.gms:google-services:3.1.2'
+        classpath 'io.fabric.tools:gradle:1.25.1'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
+        mavenCentral()
     }
 }

--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -6,6 +6,7 @@ display_usage ( ) {
     echo
     echo "Build Keyman for Android"
     echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"
+    echo "  -debug                  Compile only Debug variant"
     exit 1
 }
 
@@ -17,6 +18,7 @@ echo Build KMAPro
 SHLVL=0
 
 NO_DAEMON=false
+ONLY_DEBUG=false
 
 # Parse args
 while [[ $# -gt 0 ]] ; do
@@ -24,6 +26,9 @@ while [[ $# -gt 0 ]] ; do
     case $key in
         -no-daemon)
             NO_DAEMON=true
+            ;;
+        -debug)
+            ONLY_DEBUG=true
             ;;
         -h|-?)
             display_usage
@@ -34,6 +39,7 @@ done
 
 echo
 echo "NO_DAEMON: $NO_DAEMON"
+echo "ONLY_DEBUG: $ONLY_DEBUG"
 echo
 
 if [ "$NO_DAEMON" = true ]; then
@@ -42,4 +48,11 @@ else
   DAEMON_FLAG=
 fi
 
-./gradlew $DAEMON_FLAG clean build
+if [ "$ONLY_DEBUG" = true ]; then
+  BUILD_FLAG=assembleDebug
+else
+  BUILD_FLAG=build
+fi
+
+./gradlew $DAEMON_FLAG clean $BUILD_FLAG
+

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -54,10 +54,6 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-
-            // TODO: enable this when ready to disable Crashlytics on debug builds
-            // Disable fabric build ID generation for debug builds
-            // ext.enableCrashlytics = false
         }
         release {
             minifyEnabled false
@@ -112,9 +108,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-crash:11.8.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
         transitive = true
-    }
-    compile('com.crashlytics.sdk.android:answers:1.4.1@aar') {
-        transitive = true;
     }
 }
 

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -20,11 +20,11 @@ android {
         //dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
 
         if (project.hasProperty("services_json_file")) {
-            println "Using Production google-services.json"
+            println "Copying production google-services.json and using at kMAPro/"
             copy {
                 from project.ext.services_json_file
                 include '*.json'
-                into './kMAPro/'
+                into './'
             }
         }
 
@@ -106,15 +106,16 @@ repositories {
 dependencies {
     api(name: 'keyman-engine', ext: 'aar')
 
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:support-v4:25.4.0'
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
         transitive = true
     }
-    implementation 'com.google.firebase:firebase-core:11.8.0'
-    implementation 'com.google.firebase:firebase-crash:11.8.0'
-
+    compile('com.crashlytics.sdk.android:answers:1.4.1@aar') {
+        transitive = true;
+    }
 }
 
 /*

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.github.triplet.play'
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 25
@@ -18,8 +19,18 @@ android {
 
         //dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
 
+        if (project.hasProperty("services_json_file")) {
+            println "Using Production google-services.json"
+            copy {
+                from project.ext.services_json_file
+                include '*.json'
+                into './kMAPro/'
+            }
+        }
+
         if (project.hasProperty("build.number")) {
-            versionCode project.ext['build_counter'] as Integer // Because TeamCity does not bubble build.counter into system properties...
+            versionCode project.ext['build_counter'] as Integer
+            // Because TeamCity does not bubble build.counter into system properties...
             versionName "${project.ext['build.number']}"
         } else {
             versionCode 100
@@ -41,7 +52,14 @@ android {
     }
 
     buildTypes {
-         release {
+        debug {
+            applicationIdSuffix ".debug"
+
+            // TODO: enable this when ready to disable Crashlytics on debug builds
+            // Disable fabric build ID generation for debug builds
+            // ext.enableCrashlytics = false
+        }
+        release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             if (project.hasProperty("release_store_file")) {
@@ -59,15 +77,15 @@ android {
     play {
         // Deactivate lower conflicting version APKs
         untrackOld = true
-        switch(System.env.TIER) {
-            case 'beta' :
+        switch (System.env.TIER) {
+            case 'beta':
                 track = 'beta'
                 break
 
-            case 'stable' :
+            case 'stable':
                 track = 'production'
                 break
-            
+
             default:
                 track = 'alpha'
         }
@@ -76,17 +94,27 @@ android {
 }
 
 repositories {
-    mavenCentral()
-    google()
     flatDir {
         dirs 'libs'
+    }
+    google()
+    maven {
+        url 'https://maven.fabric.io/public'
     }
 }
 
 dependencies {
+    api(name: 'keyman-engine', ext: 'aar')
+
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:support-v4:25.4.0'
-    api (name: 'keyman-engine', ext: 'aar')
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true
+    }
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
+
 }
 
 /*
@@ -103,3 +131,5 @@ def void dumpProperties(it){
             .sort().toString().replaceAll(", ","\n")
 }
 */
+
+apply plugin: 'com.google.gms.google-services'

--- a/android/KMAPro/kMAPro/src/debug/google-services.json
+++ b/android/KMAPro/kMAPro/src/debug/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "681178123610",
+    "firebase_url": "https://kmapro-ee779.firebaseio.com",
+    "project_id": "kmapro-ee779",
+    "storage_bucket": "kmapro-ee779.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:681178123610:android:df408a26aaaf1c9e",
+        "android_client_info": {
+          "package_name": "com.tavultesoft.kmapro.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "681178123610-6j7phpt5jqh1mf44oup6lt8mooomd1tn.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDFeaVAFdwkrVfUq01aVoBQQ2g5bOUfUUI"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
+import com.crashlytics.android.answers.Answers;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.crash.FirebaseCrash;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -141,12 +141,10 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     actionBar.setDisplayShowTitleEnabled(false);
     actionBar.setBackgroundDrawable(getActionBarDrawable(this));
 
-    if (BuildConfig.DEBUG) {
-      KMManager.setDebugMode(true);
-    }
-
     mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
+    Fabric.with(this, new Answers());
 
+    /*
     // TODO: uncomment this block to disable crashlytics for debug builds
     // Set up Crashlytics, disabled for debug builds
     Crashlytics crashlyticsKit = new Crashlytics.Builder()
@@ -156,6 +154,10 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     // Initialize Fabric with the debug-disabled crashlytics.
     Fabric.with(this, crashlyticsKit);
     /* */
+
+    if (BuildConfig.DEBUG) {
+      KMManager.setDebugMode(true);
+    }
 
     KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_INAPP);
     setContentView(R.layout.activity_main);
@@ -382,7 +384,6 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
         return true;
       // action_crash is temporary for testing integration of Crashlytics, and will be removed
       case R.id.action_crash:
-        FirebaseCrash.report(new Exception("Dev: action crash"));
         Crashlytics.getInstance().crash(); // Force a crash
         return true;
       case R.id.action_share:

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -17,9 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.answers.Answers;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.crash.FirebaseCrash;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
@@ -76,8 +74,6 @@ import android.view.View.OnClickListener;
 import android.view.WindowManager;
 import android.widget.SeekBar;
 import android.widget.Toast;
-
-import io.fabric.sdk.android.Fabric;
 
 public class MainActivity extends Activity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener,
   ActivityCompat.OnRequestPermissionsResultCallback {
@@ -142,18 +138,6 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     actionBar.setBackgroundDrawable(getActionBarDrawable(this));
 
     mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
-    Fabric.with(this, new Answers());
-
-    /*
-    // TODO: uncomment this block to disable crashlytics for debug builds
-    // Set up Crashlytics, disabled for debug builds
-    Crashlytics crashlyticsKit = new Crashlytics.Builder()
-      .core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build())
-      .build();
-
-    // Initialize Fabric with the debug-disabled crashlytics.
-    Fabric.with(this, crashlyticsKit);
-    /* */
 
     if (BuildConfig.DEBUG) {
       KMManager.setDebugMode(true);

--- a/android/KMAPro/kMAPro/src/main/res/menu/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu/main.xml
@@ -41,7 +41,13 @@
                 android:id="@+id/action_info"
                 android:title="@string/action_info"
                 android:icon="@drawable/ic_light_action_info" />
-            
+
+            <!-- For testing Crashlytics. Not for release -->
+            <item
+                android:id="@+id/action_crash"
+                android:title="Crash"
+                android:icon="@drawable/ic_light_action_trash" />
+
             <item
                 android:id="@+id/action_get_started"
                 android:title="@string/get_started"

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -41,10 +41,18 @@ android {
     }
 }
 
+ext {
+    currentFirebaseVersion = "11.8.0"
+}
+
 dependencies {
     implementation 'com.android.support:support-v4:25.4.0'
     implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-text:1.2'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:3.5.1"
+
+    /* We only want these firebase dependencies for KMEA */
+    implementation "com.google.firebase:firebase-analytics:$currentFirebaseVersion"
+    implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
 }

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -52,7 +52,10 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:3.5.1"
 
-    /* We only want these firebase dependencies for KMEA */
+    /* We only want these Firebase Crashlytics dependencies for KMEA */
     implementation "com.google.firebase:firebase-analytics:$currentFirebaseVersion"
     implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true;
+    }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -24,6 +24,7 @@ import android.graphics.Typeface;
 import android.inputmethodservice.InputMethodService;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.InputType;
@@ -42,6 +43,8 @@ import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
+import com.google.firebase.analytics.FirebaseAnalytics;
+import com.google.firebase.crash.FirebaseCrash;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.packages.PackageProcessor;
@@ -52,6 +55,9 @@ import org.json.JSONObject;
 public final class KMManager {
 
   private static final String KMEngineVersion = "2.4.3";
+  private static final String TAG = "KMManager";
+
+  private static FirebaseAnalytics mFirebaseAnalytics;
 
   // Keyboard types
   public enum KeyboardType {
@@ -169,6 +175,8 @@ public final class KMManager {
   public static void initialize(Context context, KeyboardType keyboardType) {
     appContext = context.getApplicationContext();
 
+    mFirebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
     if (!didCopyAssets) {
       copyAssets(appContext);
       migrateOldKeyboardFiles(appContext);
@@ -181,7 +189,7 @@ public final class KMManager {
     } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       initSystemKeyboard(appContext);
     } else {
-      Log.w("KMManager", "Cannot initialize: Invalid keyboard type");
+      Log.w(TAG, "Cannot initialize: Invalid keyboard type");
     }
 
     // Initializes the PackageProcessor with the base resource directory, which is the parent directory
@@ -219,7 +227,7 @@ public final class KMManager {
   private static void initInAppKeyboard(Context appContext) {
     if (InAppKeyboard == null) {
       if (isDebugMode())
-        Log.d("KMManager", "Initializing In-App Keyboard...");
+        Log.d(TAG, "Initializing In-App Keyboard...");
       int kbHeight = appContext.getResources().getDimensionPixelSize(R.dimen.keyboard_height);
       RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, kbHeight);
       params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
@@ -236,7 +244,7 @@ public final class KMManager {
   private static void initSystemKeyboard(Context appContext) {
     if (SystemKeyboard == null) {
       if (isDebugMode())
-        Log.d("KMManager", "Initializing System Keyboard...");
+        Log.d(TAG, "Initializing System Keyboard...");
       int kbHeight = appContext.getResources().getDimensionPixelSize(R.dimen.keyboard_height);
       RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, kbHeight);
       params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
@@ -384,7 +392,7 @@ public final class KMManager {
         copyAsset(context, keyboardFile, KMDefault_UndefinedPackageID, true);
       }
     } catch (Exception e) {
-      Log.e("Failed to copy assets", "Error: " + e);
+      Log.e(TAG, "Failed to copy assets. Error: " + e);
     }
   }
 
@@ -416,7 +424,7 @@ public final class KMManager {
         result = 0;
       }
     } catch (Exception e) {
-      Log.e("KMManager", "Failed to copy asset. Error: " + e);
+      Log.e(TAG, "Failed to copy asset. Error: " + e);
       result = -1;
     }
     return result;
@@ -507,7 +515,7 @@ public final class KMManager {
         FileUtils.deleteDirectory(legacyFontsDir);
       }
     } catch (IOException e) {
-      Log.e("KMManager", "Failed to migrate assets. Error: " + e);
+      Log.e(TAG, "Failed to migrate assets. Error: " + e);
     }
   }
 
@@ -642,6 +650,13 @@ public final class KMManager {
   }
 
   public static boolean addKeyboard(Context context, HashMap<String, String> keyboardInfo) {
+    Bundle params = new Bundle();
+    params.putString("packageID", keyboardInfo.get(KMManager.KMKey_PackageID));
+    params.putString("keyboardID", keyboardInfo.get(KMManager.KMKey_KeyboardID));
+    params.putString("keyboardName", keyboardInfo.get(KMManager.KMKey_KeyboardName));
+    params.putString("keyboardVersion", keyboardInfo.get(KMManager.KMKey_KeyboardVersion));
+    mFirebaseAnalytics.logEvent("km_add_keyboard", params);
+
     return KeyboardPickerActivity.addKeyboard(context, keyboardInfo);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -43,6 +43,9 @@ import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.answers.Answers;
+import com.crashlytics.android.answers.CustomEvent;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.crash.FirebaseCrash;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
@@ -650,12 +653,19 @@ public final class KMManager {
   }
 
   public static boolean addKeyboard(Context context, HashMap<String, String> keyboardInfo) {
+    // Log Firebase analytic event
     Bundle params = new Bundle();
     params.putString("packageID", keyboardInfo.get(KMManager.KMKey_PackageID));
     params.putString("keyboardID", keyboardInfo.get(KMManager.KMKey_KeyboardID));
     params.putString("keyboardName", keyboardInfo.get(KMManager.KMKey_KeyboardName));
     params.putString("keyboardVersion", keyboardInfo.get(KMManager.KMKey_KeyboardVersion));
     mFirebaseAnalytics.logEvent("km_add_keyboard", params);
+
+    Answers.getInstance().logCustom(new CustomEvent("Add Keyboard")
+      .putCustomAttribute("packageID", keyboardInfo.get(KMManager.KMKey_PackageID))
+      .putCustomAttribute("keyboardID", keyboardInfo.get(KMManager.KMKey_KeyboardID))
+      .putCustomAttribute("keyboardName", keyboardInfo.get(KMManager.KMKey_KeyboardName))
+      .putCustomAttribute("keyboardVersion", keyboardInfo.get(KMManager.KMKey_KeyboardVersion)));
 
     return KeyboardPickerActivity.addKeyboard(context, keyboardInfo);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -43,11 +43,7 @@ import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.answers.Answers;
-import com.crashlytics.android.answers.CustomEvent;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.crash.FirebaseCrash;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.packages.PackageProcessor;
@@ -653,19 +649,13 @@ public final class KMManager {
   }
 
   public static boolean addKeyboard(Context context, HashMap<String, String> keyboardInfo) {
-    // Log Firebase analytic event
+    // Log Firebase analytic event.
     Bundle params = new Bundle();
     params.putString("packageID", keyboardInfo.get(KMManager.KMKey_PackageID));
     params.putString("keyboardID", keyboardInfo.get(KMManager.KMKey_KeyboardID));
     params.putString("keyboardName", keyboardInfo.get(KMManager.KMKey_KeyboardName));
     params.putString("keyboardVersion", keyboardInfo.get(KMManager.KMKey_KeyboardVersion));
     mFirebaseAnalytics.logEvent("km_add_keyboard", params);
-
-    Answers.getInstance().logCustom(new CustomEvent("Add Keyboard")
-      .putCustomAttribute("packageID", keyboardInfo.get(KMManager.KMKey_PackageID))
-      .putCustomAttribute("keyboardID", keyboardInfo.get(KMManager.KMKey_KeyboardID))
-      .putCustomAttribute("keyboardName", keyboardInfo.get(KMManager.KMKey_KeyboardName))
-      .putCustomAttribute("keyboardVersion", keyboardInfo.get(KMManager.KMKey_KeyboardVersion)));
 
     return KeyboardPickerActivity.addKeyboard(context, keyboardInfo);
   }

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -1,11 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-      jcenter()
-      google()
+        jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/android/README.md
+++ b/android/README.md
@@ -23,13 +23,15 @@ yes | ./sdkmanager.bat --licenses
 ## Keyman for Android Development
 Keyman for Android (formerly named KMAPro) can be built from a command line (preferred) or Android Studio.
 
+Firebase Crashlytics is used for crash reporting, and it depends on a configured google-services.json file. For this reason, only the Debug variant of KMAPro is intended to be built on a Developer machine. The analytics for Debug are associated with an application ID `com.tavultesoft.kmapro.debug`.
+
 ### Compiling From Command Line
 1. Launch a command prompt
 2. Change to one of these directories depending on what you want to compile:
     * For compiling KMEA and KMAPro, cd to the directory **keyman/android**
     * For compiling only KMAPro, cd to the directory **keyman/android/KMAPro**
-3. `./build.sh`
-4. The APK will be found in **KMAPro/kMAPro/build/outputs/apk/kMAPro-*.apk**
+3. `./build.sh -debug`
+4. The APK will be found in **KMAPro/kMAPro/build/outputs/apk/debug/kMAPro-debug.apk**
 
 ### Compiling From Android Studio
 1. Ensure that [Keyman Engine for Android](#how-to-build-keyman-engine-for-android) is built.

--- a/android/history.md
+++ b/android/history.md
@@ -10,6 +10,7 @@
 * Fix KMEA http:// to https:// redirects for downloading keyboard resources (#370)
 * Change internal keyboard assets from languages/ and fonts/ folders to packages/
 * Add feature to install ad-hoc keyboards via .kmp packages
+* Add [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics/) for generating crash reports
 
 ## 2017-08-10 2.8.300 stable
 * No changes, just published latest beta as stable


### PR DESCRIPTION
While legacy stable kmapro releases have analytics on the Google Play Console, Google recommends [Firebase Crashlytics](https://firebase.google.com/docs/crash/) for crash reporting.
This requires a `google-services.json` file for gradle builds. A sanitized version intended for developers/Debug variant is checked into the repo, and is associated with an appliction ID `com.tavultesoft.kmapro.debug`. The one for `com.tavultesoft.kmapro` releaeses will go on the CI servers.

Just adding Crashlytics into the projects is enough for it to run in the background.

Breaking change: Consuming apps of KMEA will be responsible for including the Firebase dependencies. At the moment, only kmapro has been updated.
TBD: Registering KMSamples and the Test Harness with Firebase for their own `google.services.json` file.

- Log `km_add_keyboard` as an analytic event. Note, the log may not persist between app restarts. 
- Update kmapro build.sh script to allow debug-only variant
- Add info to history.md and README.md
- Add Gradle setting so CI server can use production `google-services.json` file
- Temporarily add a menu button to force a crash. This is engineering code that will be removed once analytics in a Release build is confirmed.

Note: This PR shouldn't be merged into `master` until the production google-services.json file has been uploaded to the CI server. 
The external CI server for PR checks will be also be configured for Debug-only build