### PR TITLE
[Android] Add Crashlytics dependencies to Samples and Test projects

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -2,7 +2,7 @@
 # Build KMAPro
 
 display_usage ( ) {
-    echo "build.sh [-no-daemon]"
+    echo "build.sh [-no-daemon] [-debug]"
     echo
     echo "Build Keyman for Android"
     echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"

--- a/android/README.md
+++ b/android/README.md
@@ -23,7 +23,7 @@ yes | ./sdkmanager.bat --licenses
 ## Keyman for Android Development
 Keyman for Android (formerly named KMAPro) can be built from a command line (preferred) or Android Studio.
 
-Firebase Crashlytics is used for crash reporting, and it depends on a configured google-services.json file. For this reason, only the Debug variant of KMAPro is intended to be built on a Developer machine. The analytics for Debug are associated with an application ID `com.tavultesoft.kmapro.debug`.
+Firebase Crashlytics is used for crash reporting, and it depends on a configured google-services.json file. For this reason, only the Debug variant of KMAPro is intended to be built on a Developer machine. The analytics for Debug are associated with a "Package name" `com.tavultesoft.kmapro.debug`.
 
 ### Compiling From Command Line
 1. Launch a command prompt
@@ -103,14 +103,25 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
     b. If you choose to use your own build of the Keyman Engine, get the library from **android/Samples/KMSample1/app/libs/keyman-engine.aar**
 2. Open your project in Android Studio.
 3. Open **build.gradle** (Module: app) in "Gradle Scripts".
-4. include `api (name:'keyman-engine', ext:'aar')` in dependencies.
-5. after dependencies, insert
+4. After the `android {}` object, include the following:
 ````gradle
-    repositories {
-        google()
-        flatDir {
-            dirs 'libs'
-        }
+repositories {
+    flatDir {
+        dirs 'libs'
     }
+    google()
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.2.0'
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true
+    }
+    api (name:'keyman-engine', ext:'aar')
+}
+
 ````
-6. include `import com.tavultesoft.kmea.*;` to use Keyman Engine in a class.
+5. include `import com.tavultesoft.kmea.*;` to use Keyman Engine in a class.

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -20,14 +20,19 @@ android {
 }
 
 repositories {
-    google()
     flatDir {
         dirs 'libs'
     }
+    google()
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.1.0'
+    implementation 'com.android.support:appcompat-v7:25.2.0'
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true
+    }
     api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -1,10 +1,58 @@
-#!/bin/sh
+#!/bin/bash
 # Build KMSample1
+
+display_usage ( ) {
+    echo "build.sh [-no-daemon] [-debug]"
+    echo
+    echo "Build KM Sample 1"
+    echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"
+    echo "  -debug                  Compile only Debug variant"
+    exit 1
+}
+
+echo Build KMSample1
 
 #
 # Prevents 'clear' on exit of mingw64 bash shell
 #
 SHLVL=0
 
-echo Build KMSample1
-./gradlew clean build
+NO_DAEMON=false
+ONLY_DEBUG=false
+
+# Parse args
+while [[ $# -gt 0 ]] ; do
+    key="$1"
+    case $key in
+        -no-daemon)
+            NO_DAEMON=true
+            ;;
+        -debug)
+            ONLY_DEBUG=true
+            ;;
+        -h|-?)
+            display_usage
+            ;;
+    esac
+    shift # past argument
+done
+
+echo
+echo "NO_DAEMON: $NO_DAEMON"
+echo "ONLY_DEBUG: $ONLY_DEBUG"
+echo
+
+if [ "$NO_DAEMON" = true ]; then
+  DAEMON_FLAG=--no-daemon
+else
+  DAEMON_FLAG=
+fi
+
+if [ "$ONLY_DEBUG" = true ]; then
+  BUILD_FLAG=assembleDebug
+else
+  BUILD_FLAG=build
+fi
+
+./gradlew $DAEMON_FLAG clean $BUILD_FLAG
+

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -20,14 +20,19 @@ android {
 }
 
 repositories {
-    google()
     flatDir {
         dirs 'libs'
     }
+    google()
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.1.0'
+    implementation 'com.android.support:appcompat-v7:25.2.0'
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true
+    }
     api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -20,14 +20,19 @@ android {
 }
 
 repositories {
-    google()
     flatDir {
         dirs 'libs'
     }
+    google()
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.1.0'
+    implementation 'com.android.support:appcompat-v7:25.2.0'
+    implementation 'com.google.firebase:firebase-core:11.8.0'
+    implementation 'com.google.firebase:firebase-crash:11.8.0'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+        transitive = true
+    }
     api (name:'keyman-engine', ext:'aar')
 }

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -1,16 +1,67 @@
-#!/bin/sh
+#!/bin/bash
 # Build KeyboardHarness test app
+
+
+display_usage ( ) {
+    echo "build.sh [-no-daemon] [-debug]"
+    echo
+    echo "Build KeyboardHarness test app"
+    echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"
+    echo "  -debug                  Compile only Debug variant"
+    exit 1
+}
+
+echo Build KeyboardHarness test app
 
 #
 # Prevents 'clear' on exit of mingw64 bash shell
 #
 SHLVL=0
 
-echo Build KMEA
+echo Build KMEA first
 cd ../../KMEA
 ./build.sh
 cd ../Tests/KeyboardHarness
 cp ../keyman-engine.aar app/libs/
 
-echo Build KeyboardHarness test app
-./gradlew clean build
+
+NO_DAEMON=false
+ONLY_DEBUG=false
+
+# Parse args
+while [[ $# -gt 0 ]] ; do
+    key="$1"
+    case $key in
+        -no-daemon)
+            NO_DAEMON=true
+            ;;
+        -debug)
+            ONLY_DEBUG=true
+            ;;
+        -h|-?)
+            display_usage
+            ;;
+    esac
+    shift # past argument
+done
+
+echo
+echo "NO_DAEMON: $NO_DAEMON"
+echo "ONLY_DEBUG: $ONLY_DEBUG"
+echo
+
+if [ "$NO_DAEMON" = true ]; then
+  DAEMON_FLAG=--no-daemon
+else
+  DAEMON_FLAG=
+fi
+
+if [ "$ONLY_DEBUG" = true ]; then
+  BUILD_FLAG=assembleDebug
+else
+  BUILD_FLAG=build
+fi
+
+echo Build KeyboardHarness
+./gradlew $DAEMON_FLAG clean $BUILD_FLAG
+


### PR DESCRIPTION
This is follow-on to #599 

Consumers of KMEA need to include Firebase and Crashlytics dependencies, but don't need to run the Google services. This simplifies these projects from having to setup a Firebase account and installing a  `google-services.json` file.

Also added `-no-daemon` and `-debug` options to KMSamples and KeyboardHarness `build.sh` scripts so they can be run on CI servers.