### PR TITLE
Small usability tweak so F7 can compile a package file as well as a keyboard file

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
@@ -13,6 +13,7 @@ object modActionsKeyboardEditor: TmodActionsKeyboardEditor
       ImageIndex = 37
       ShortCut = 118
       OnExecute = actKeyboardCompileExecute
+      OnUpdate = actKeyboardCompileUpdate
     end
     object actKeyboardIncludeDebugInformation: TAction
       Category = 'Keyboard'


### PR DESCRIPTION
So I've kinda hacked in the change to the F7 key which is associated with a keyboard action in Keyman Developer. It works fine but is not as elegant as it could be, given that an elegant fix would refactor the compile action away from Keyboard and into CompilableFile or something silly like that. I think I'd actually call that an elephant fix.