### PR TITLE
Keyman Developer Compiler should warn on deprecated language tags for Keyman 10 keyboards

### DIFF
--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -736,7 +736,6 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     }
 	case T_KEYTOKEY:			// A rule
 		if(fk->currentGroup == 0xFFFFFFFF) return CERR_CodeInvalidInThisSection;
-		if(fk->version == 0) return CERR_NoVersionLine;
 		if((msg = ProcessKeyLine(fk, p, IsUnicode)) != CERR_None) return msg;
 		break;
 

--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -79,6 +79,9 @@
 #include <comperr.h>
 #include <vkeys.h>
 #include <versioning.h>
+#include <kmcmpdll.h>
+#include <DeprecationChecks.h>
+
 #include "virtualcharkeys.h"
 
 #include "crc32.h"
@@ -288,10 +291,6 @@ BOOL AddCompileMessage(DWORD msg)
 
 	return FALSE;
 }
-
-#define SetError(err)       { if(AddCompileMessage(err)) return FALSE; }
-#define AddWarning(warn)    { if(AddCompileMessage(warn)) return FALSE; }
-
 	
 extern "C" BOOL __declspec(dllexport) CompileKeyboardFile(PSTR pszInfile, PSTR pszOutfile, BOOL ASaveDebug, BOOL ACompilerWarningsAsErrors, BOOL AWarnDeprecatedCode, CompilerMessageProc pMsgProc)   // I4865   // I4866
 {
@@ -560,7 +559,14 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 
 	delete str;
 
-  return CheckKeyboardFinalVersion(fk);
+  if (!CheckKeyboardFinalVersion(fk)) {
+    return FALSE;
+  }
+
+  /* Flag presence of deprecated features */
+  CheckForDeprecatedFeatures(fk);
+
+  return TRUE;
 }
 
 DWORD ProcessBeginLine(PFILE_KEYBOARD fk, PWSTR p)
@@ -598,13 +604,6 @@ DWORD ProcessBeginLine(PFILE_KEYBOARD fk, PWSTR p)
 	return CERR_None;
 }
 
-DWORD WarnDeprecatedCode() {   // I4866
-  if(FWarnDeprecatedCode) {
-    AddWarning(CWARN_HeaderStatementIsDeprecated);
-  }
-  return CERR_None;
-}
-
 DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 {
 	PWSTR p, q, pp;
@@ -640,7 +639,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		break;
 
 	case T_NAME:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
 		if( !q ) return CERR_InvalidName;
 		
@@ -648,7 +647,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		break;
 
 	case T_COPYRIGHT:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
 		if(!q) return CERR_InvalidCopyright;
 
@@ -656,7 +655,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		break;
 	
   case T_MESSAGE:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
 		if(!q) return CERR_InvalidMessage;
 
@@ -664,7 +663,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		break;
 
 	case T_LANGUAGENAME:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
 		if(!q) return CERR_InvalidLanguageName;
 
@@ -673,7 +672,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 
 	case T_LANGUAGE:
     {
-      WarnDeprecatedCode();   // I4866
+      WarnDeprecatedHeader();   // I4866
       wchar_t *tokcontext = NULL;
 		  q = wcstok_s(p, L"\n", &tokcontext);  // I3481
 		  if((msg = AddStore(fk, TSS_LANGUAGE, q)) != CERR_None) return msg;
@@ -681,30 +680,30 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     }
 	case T_LAYOUT:
     {
-      WarnDeprecatedCode();   // I4866
+      WarnDeprecatedHeader();   // I4866
       wchar_t *tokcontext = NULL;
   		q = wcstok_s(p, L"\n", &tokcontext);  // I3481
 	  	if((msg = AddStore(fk, TSS_LAYOUT, q)) != CERR_None) return msg;
 		  break;
     }
 	case T_CAPSOFF:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_CAPSALWAYSOFF, L"1")) != CERR_None) return msg;
 		break;
 	
 	case T_CAPSON:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_CAPSONONLY, L"1")) != CERR_None) return msg;
 		break;
 	
 	case T_SHIFT:
-    WarnDeprecatedCode();   // I4866
+    WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_SHIFTFREESCAPS, L"1")) != CERR_None) return msg;
 		break;
 
 	case T_HOTKEY:
     {
-      WarnDeprecatedCode();   // I4866
+      WarnDeprecatedHeader();   // I4866
       wchar_t *tokcontext = NULL;
       if((q = wcstok_s(p, L"\n", &tokcontext)) == NULL) return CERR_CodeInvalidInThisSection;  // I3481
 	  	if((msg = AddStore(fk, TSS_HOTKEY, q)) != CERR_None) return msg;
@@ -712,7 +711,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     }
 	case T_BITMAP:
     {
-      WarnDeprecatedCode();   // I4866
+      WarnDeprecatedHeader();   // I4866
       wchar_t *tokcontext = NULL;
   		if((q = wcstok_s(p, L"\n", &tokcontext)) == NULL) return CERR_InvalidBitmapLine;  // I3481
 
@@ -724,7 +723,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     }
 	case T_BITMAPS:
     {
-      WarnDeprecatedCode();   // I4866
+      WarnDeprecatedHeader();   // I4866
       wchar_t *tokcontext = NULL;
   		AddWarning(CWARN_BitmapNotUsed);
 
@@ -1003,6 +1002,7 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
 	fk->dpStoreArray = sp;
 	sp = &fk->dpStoreArray[fk->cxStoreArray];
 
+  sp->line = currentLine;
   sp->fIsOption = FALSE;
   sp->fIsReserved = FALSE;
   sp->fIsStore = FALSE;
@@ -1066,6 +1066,7 @@ DWORD AddStore(PFILE_KEYBOARD fk, DWORD SystemID, PWSTR str, DWORD *dwStoreID)
 	fk->dpStoreArray = sp;
 	sp = &fk->dpStoreArray[fk->cxStoreArray];
 
+  sp->line = currentLine;
   sp->fIsOption = FALSE;   // I3686
   sp->fIsReserved = (SystemID != TSS_NONE);
   sp->fIsStore = FALSE;
@@ -1109,7 +1110,7 @@ DWORD AddDebugStore(PFILE_KEYBOARD fk, PWSTR str)
 
 	sp->dpString = new WCHAR[wcslen(tstr)+1];
 	wcscpy_s(sp->dpString, wcslen(tstr)+1, tstr);  // I3481
-
+  sp->line = 0;
   sp->fIsOption = FALSE;
   sp->fIsReserved = TRUE;
   sp->fIsStore = FALSE;

--- a/windows/src/developer/kmcmpdll/Compiler.rc
+++ b/windows/src/developer/kmcmpdll/Compiler.rc
@@ -217,3 +217,8 @@ BEGIN
     CWARN_DontMixChiralAndNonChiralModifiers "Don't mix the use of left/right modifiers with non-left/right modifiers in the same platform"
     CWARN_MixingLeftAndRightModifiers        "Left and right modifiers should not both be used in the same rule"
 END
+
+STRINGTABLE
+BEGIN
+    CWARN_LanguageHeadersDeprecatedInKeyman10 "This language header has been deprecated in Keyman 10. Instead, add language metadata in the package file"
+END

--- a/windows/src/developer/kmcmpdll/DeprecationChecks.cpp
+++ b/windows/src/developer/kmcmpdll/DeprecationChecks.cpp
@@ -1,0 +1,60 @@
+
+#include <ctype.h>
+#include <stdio.h>
+
+#include <string.h>
+#include <windows.h>
+
+// Keyman includes
+
+#include <keyman64.h>
+#include <compfile.h>
+#include <compiler.h>
+#include <comperr.h>
+#include <kmcmpdll.h>
+
+BOOL WarnDeprecatedHeader() {   // I4866
+  if (FWarnDeprecatedCode) {
+    AddWarning(CWARN_HeaderStatementIsDeprecated);
+  }
+  return TRUE;
+}
+
+/* Flag presence of deprecated features */
+BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
+  /* 
+    For Keyman 10, we deprecated:
+      // < Keyman 7
+      #define TSS_LANGUAGE			4
+      #define TSS_LAYOUT				5
+      #define TSS_LANGUAGENAME		12
+      #define TSS_ETHNOLOGUECODE		15
+
+      // Keyman 7
+      #define TSS_WINDOWSLANGUAGES 29 
+  */
+  int currentLineBackup = currentLine;
+  DWORD i;
+  PFILE_STORE sp;
+
+  if (!FWarnDeprecatedCode) {
+    return TRUE;
+  }
+
+  if (fk->version >= VERSION_100) {
+    for (i = 0, sp = fk->dpStoreArray; i < fk->cxStoreArray; i++, sp++) {
+      if (sp->dwSystemID == TSS_LANGUAGE ||
+          sp->dwSystemID == TSS_LAYOUT ||
+          sp->dwSystemID == TSS_LANGUAGENAME ||
+          sp->dwSystemID == TSS_ETHNOLOGUECODE ||
+          sp->dwSystemID == TSS_WINDOWSLANGUAGES) {
+        currentLine = sp->line;
+        AddWarning(CWARN_LanguageHeadersDeprecatedInKeyman10);
+      }
+    }
+  }
+
+  currentLine = currentLineBackup;
+
+  return TRUE;
+}

--- a/windows/src/developer/kmcmpdll/DeprecationChecks.h
+++ b/windows/src/developer/kmcmpdll/DeprecationChecks.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <windows.h>
+#include <Compfile.h>
+
+BOOL WarnDeprecatedHeader();
+BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk);

--- a/windows/src/developer/kmcmpdll/Makefile
+++ b/windows/src/developer/kmcmpdll/Makefile
@@ -10,6 +10,10 @@ build: version.res dirs
     $(COPY) kmcmpdll.dll $(PROGRAM)\developer
     $(COPY) kmcmpdll.lib $(OUTLIB)
     $(COPY) kmcmpdll.pdb $(DEBUGPATH)\developer
+    # for debugging purposes, it's useful to have a copy
+    # of kmcmpdll.dll in the TIKE project folder; it is
+    # .gitignored
+    $(COPY) kmcmpdll.dll ..\tike\kmcmpdll.dll
 
 clean: def-clean
     $(MSBUILD) kmcmpdll.sln $(MSBUILD_CLEAN)

--- a/windows/src/developer/kmcmpdll/kmcmpdll.h
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <windows.h>
+
+BOOL AddCompileString(LPSTR buf);
+BOOL AddCompileMessage(DWORD msg);
+
+#define SetError(err)       { if(AddCompileMessage(err)) return FALSE; }
+#define AddWarning(warn)    { if(AddCompileMessage(warn)) return FALSE; }
+
+extern BOOL FWarnDeprecatedCode;
+extern int currentLine;

--- a/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
@@ -172,8 +172,10 @@
     <ClInclude Include="..\..\global\inc\ConvertUTF.h" />
     <ClInclude Include="..\..\global\inc\crc32.h" />
     <ClInclude Include="..\..\global\inc\debugstore.h" />
+    <ClInclude Include="DeprecationChecks.h" />
     <ClInclude Include="Edition.h" />
     <ClInclude Include="keyman64.h" />
+    <ClInclude Include="kmcmpdll.h" />
     <ClInclude Include="NamedCodeConstants.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="..\..\global\inc\unicode.h" />
@@ -199,6 +201,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\global\vc\crc32.cpp" />
+    <ClCompile Include="DeprecationChecks.cpp" />
     <ClCompile Include="Edition.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj.filters
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj.filters
@@ -61,6 +61,12 @@
     <ClInclude Include="versioning.h">
       <Filter>Header files</Filter>
     </ClInclude>
+    <ClInclude Include="kmcmpdll.h">
+      <Filter>Header files</Filter>
+    </ClInclude>
+    <ClInclude Include="DeprecationChecks.h">
+      <Filter>Header files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Compiler.cpp" />
@@ -78,6 +84,7 @@
     <ClCompile Include="..\..\ext\json-schema-validator\json-validator.cpp" />
     <ClCompile Include="json-validation.cpp" />
     <ClCompile Include="versioning.cpp" />
+    <ClCompile Include="DeprecationChecks.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Compiler.rc" />

--- a/windows/src/developer/kmcmpdll/versioning.cpp
+++ b/windows/src/developer/kmcmpdll/versioning.cpp
@@ -11,9 +11,7 @@
 #include <compfile.h>
 #include <compiler.h>
 #include <comperr.h>
-
-BOOL AddCompileString(LPSTR buf);
-BOOL AddCompileMessage(DWORD msg);
+#include <kmcmpdll.h>
 
 BOOL CheckKeyboardFinalVersion(PFILE_KEYBOARD fk) {
   char buf[128];

--- a/windows/src/global/delphi/general/compile.pas
+++ b/windows/src/global/delphi/general/compile.pas
@@ -45,6 +45,7 @@ type
     fIsOption: BOOL;    // I2556
     fIsDebug: BOOL;     // I2556
     fIsCall: BOOL;      // I2556
+    line: Integer;
   end;
 
   PFILE_STORE = ^FILE_STORE;

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -182,6 +182,8 @@
 #define CWARN_DontMixChiralAndNonChiralModifiers 0x000020A3
 #define CWARN_MixingLeftAndRightModifiers        0x000020A4
 
+#define CWARN_LanguageHeadersDeprecatedInKeyman10 0x00020A5
+
 #define CERR_BufferOverflow							0x000080C0
 #define CERR_Break									0x000080C1
 

--- a/windows/src/global/inc/Compfile.h
+++ b/windows/src/global/inc/Compfile.h
@@ -79,6 +79,7 @@ struct FILE_STORE {
   BOOL fIsOption;
   BOOL fIsDebug;
   BOOL fIsCall;
+  int line;
 	};
 
 typedef FILE_STORE *PFILE_STORE;


### PR DESCRIPTION
This fixes a bug with the version check when no version line is present, and then warns on deprecated language tags in .kmn files (for the BCP 47 feature in Keyman 10).