### PR TITLE
[Android] Remove test button that forced crashes

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 SIL International. All rights reserved.
+ * Copyright (C) 2018 SIL International. All rights reserved.
  */
 
 package com.tavultesoft.kmapro;
@@ -365,10 +365,6 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     switch (item.getItemId()) {
       case R.id.action_info:
         showInfo();
-        return true;
-      // action_crash is temporary for testing integration of Crashlytics, and will be removed
-      case R.id.action_crash:
-        Crashlytics.getInstance().crash(); // Force a crash
         return true;
       case R.id.action_share:
         showShareDialog();

--- a/android/KMAPro/kMAPro/src/main/res/menu/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu/main.xml
@@ -42,12 +42,6 @@
                 android:title="@string/action_info"
                 android:icon="@drawable/ic_light_action_info" />
 
-            <!-- For testing Crashlytics. Not for release -->
-            <item
-                android:id="@+id/action_crash"
-                android:title="Crash"
-                android:icon="@drawable/ic_light_action_trash" />
-
             <item
                 android:id="@+id/action_get_started"
                 android:title="@string/get_started"


### PR DESCRIPTION
Now that Crashlytics is verified to run on nightly Release builds, the test button to force crashes can be removed.