### PR TITLE
[Web] Check API endpoints for BCP-47

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -132,7 +132,7 @@ public final class KMManager {
 
   // Default Keyboard Info
   public static final String KMDefault_KeyboardID = "european2";
-  public static final String KMDefault_LanguageID = "eng";
+  public static final String KMDefault_LanguageID = "en";
   public static final String KMDefault_KeyboardName = "EuroLatin2 Keyboard";
   public static final String KMDefault_LanguageName = "English";
   public static final String KMDefault_KeyboardFont = "{\"family\":\"LatinWeb\",\"source\":[\"DejaVuSans.ttf\"]}";

--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -36,7 +36,7 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     HashMap<String, String> kbInfo = new HashMap<String, String>();
     kbInfo.put(KMManager.KMKey_PackageID, "cloud");
     kbInfo.put(KMManager.KMKey_KeyboardID, "tamil99m");
-    kbInfo.put(KMManager.KMKey_LanguageID, "tam");
+    kbInfo.put(KMManager.KMKey_LanguageID, "ta");
     kbInfo.put(KMManager.KMKey_KeyboardName, "Tamil 99M");
     kbInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
@@ -94,7 +94,7 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
   public void onKeyboardLoaded(KeyboardType keyboardType) {
     // Handle Keyman keyboard loaded event here if needed
     // We can set our custom keyboard here
-    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "tam");
+    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "ta");
     KMManager.setKeyboard(this, kbIndex);
   }
 

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -40,7 +40,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     HashMap<String, String> kbInfo = new HashMap<String, String>();
     kbInfo.put(KMManager.KMKey_PackageID, "cloud");
     kbInfo.put(KMManager.KMKey_KeyboardID, "tamil99m");
-    kbInfo.put(KMManager.KMKey_LanguageID, "tam");
+    kbInfo.put(KMManager.KMKey_LanguageID, "ta");
     kbInfo.put(KMManager.KMKey_KeyboardName, "Tamil 99M");
     kbInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     kbInfo.put(KMManager.KMKey_KeyboardVersion, "1.1");
@@ -163,7 +163,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   public void onKeyboardLoaded(KeyboardType keyboardType) {
     // Handle Keyman keyboard loaded event here if needed
     // We can set our custom keyboard here
-    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "tam");
+    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "ta");
     KMManager.setKeyboard(this, kbIndex);
   }
 

--- a/android/Tests/KeyboardHarness/app/src/main/java/com/keyman/android/tests/keyboardHarness/MainActivity.java
+++ b/android/Tests/KeyboardHarness/app/src/main/java/com/keyman/android/tests/keyboardHarness/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     HashMap<String, String> chiralityKBInfo = new HashMap<String, String>();
     chiralityKBInfo.put(KMManager.KMKey_PackageID, "cloud");
     chiralityKBInfo.put(KMManager.KMKey_KeyboardID, "chirality");
-    chiralityKBInfo.put(KMManager.KMKey_LanguageID, "eng");
+    chiralityKBInfo.put(KMManager.KMKey_LanguageID, "en");
     chiralityKBInfo.put(KMManager.KMKey_KeyboardName, "Chirality Keyboard");
     chiralityKBInfo.put(KMManager.KMKey_LanguageName, "English");
     chiralityKBInfo.put(KMManager.KMKey_KeyboardVersion, "1.0");
@@ -50,7 +50,7 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     HashMap<String, String> longpressKBbInfo = new HashMap<String, String>();
     longpressKBbInfo.put(KMManager.KMKey_PackageID, "cloud");
     longpressKBbInfo.put(KMManager.KMKey_KeyboardID, "longpress");
-    longpressKBbInfo.put(KMManager.KMKey_LanguageID, "eng");
+    longpressKBbInfo.put(KMManager.KMKey_LanguageID, "en");
     longpressKBbInfo.put(KMManager.KMKey_KeyboardName, "Longpress Keyboard");
     longpressKBbInfo.put(KMManager.KMKey_LanguageName, "English");
     longpressKBbInfo.put(KMManager.KMKey_KeyboardVersion, "1.0");

--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -37,7 +37,7 @@ public enum Defaults {
   private static let font = Font(family: "LatinWeb", source: ["DejaVuSans.ttf"], size: nil)
   public static let keyboard = InstallableKeyboard(id: "european2",
                                                    name: "EuroLatin2 Keyboard",
-                                                   languageID: "eng",
+                                                   languageID: "en",
                                                    languageName: "English",
                                                    version: "1.6",
                                                    isRTL: false,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/Language.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/Language.swift
@@ -13,7 +13,7 @@ public struct Language: Codable {
   /// Name of language.
   public let name: String
 
-  /// ISO639-3 language code.
+  /// BCP-47 language code.
   public let id: String
 
   /// Corresponding Keyboard objects.

--- a/ios/samples/KMSample1/KMSample1/ViewController.swift
+++ b/ios/samples/KMSample1/KMSample1/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController, TextViewDelegate {
 
     let kb = InstallableKeyboard(id: "tamil99m",
                                  name: "Tamil 99M",
-                                 languageID: "tam",
+                                 languageID: "ta",
                                  languageName: "Tamil",
                                  version: "1.1",
                                  isRTL: false,

--- a/ios/samples/KMSample2/KMSample2/ViewController.swift
+++ b/ios/samples/KMSample2/KMSample2/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController, TextViewDelegate {
 
     let kb = InstallableKeyboard(id: "tamil99m",
                                  name: "Tamil 99M",
-                                 languageID: "tam",
+                                 languageID: "ta",
                                  languageName: "Tamil",
                                  version: "1.1",
                                  isRTL: false,

--- a/web/history.md
+++ b/web/history.md
@@ -24,6 +24,7 @@
 * Converted KeymanWeb (largely) to TypeScript and streamlined the code to reflect new minimum requirements.
 * Fixed styling of "Special" keys on touch layouts
 * Added automated testing for KeymanWeb builds. (#350)
+* Change from ISO 639-3 language codes to BCP-47 language codes
 
 ## 2017-07-10 2.0.473 stable
 * 2.0 stable release build.

--- a/web/samples/issue103/samplehdr.js
+++ b/web/samples/issue103/samplehdr.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,26 +45,26 @@
     var kmw=tavultesoft.keymanweb;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',language:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',language:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@swe','european2@swe','european2@swe','european2@swe','european2@swe','european2@nor','@heb');
-    kmw.addKeyboards('@heb');
-    kmw.addKeyboards('@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
+    kmw.addKeyboards('@he');
+    kmw.addKeyboards('@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       language:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -74,7 +74,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
@@ -93,11 +93,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/samples/issue103/uncompiled.html
+++ b/web/samples/issue103/uncompiled.html
@@ -79,7 +79,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/samples/minified.html
+++ b/web/samples/minified.html
@@ -71,7 +71,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/samples/multilingual.html
+++ b/web/samples/multilingual.html
@@ -49,7 +49,7 @@
         kmw.addKeyboards();
         
         // Set US English as the default, allowing time to fully initialize
-        window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_us','eng');},2500);
+        window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_us','en');},2500);
       }
     </script>
   

--- a/web/samples/samplehdr.js
+++ b/web/samples/samplehdr.js
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr               load the current version of the default keyboard for French
+      @fr$              load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,7 +45,7 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
     kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'./us-1.0.js'});
@@ -71,8 +71,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
-  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
@@ -91,11 +91,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{2,3}$\$?/);
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('A BCP-47 language code must be exactly 2-3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
@@ -106,7 +102,7 @@
   
   // Add keyboard on Enter (as well as pressing button)
   function clickOnEnter(e,id)
-  {                                       
+  {
     e = e || window.event;
     if(e.keyCode == 13) addKeyboard(id); 
   }

--- a/web/samples/samplehdr.js
+++ b/web/samples/samplehdr.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -47,22 +47,22 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'./us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french', 'european2@nor,swe', '@heb'); // Loads all from uniquely-identifying strings.
+    // keyboard name and language code, or just the BCP-47 language code.  
+    kmw.addKeyboards('french', 'european2@no,sv', '@he'); // Loads all from uniquely-identifying strings.
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'./lao_2008_basic.js'
@@ -91,11 +91,11 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
+        var rx=new RegExp(/^\w{2,3}$\$?/);
         if(rx.test(sKbd))
           kmw.addKeyboards('@'+sKbd);
         else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+          alert('A BCP-47 language code must be exactly 2-3 letters long!');
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/samples/unminified.html
+++ b/web/samples/unminified.html
@@ -70,7 +70,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/source/kmwRecorder.html
+++ b/web/source/kmwRecorder.html
@@ -94,7 +94,7 @@
         <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
         <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
       
-        <h3>Add a keyboard by ISO 639 or BCP-47 language code:</h3>
+        <h3>Add a keyboard by BCP-47 language code:</h3>
         <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
         <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
       

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -233,7 +233,7 @@ class KeymanBase {
    * @param {string|Object} x keyboard name string or keyboard metadata JSON object
    * 
    */  
-  ['addKeyboards'](x) {                       
+  ['addKeyboards'](x) {
     if(arguments.length == 0) {
       this.keyboardManager.keymanCloudRequest('',false);
     } else {

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1133,7 +1133,7 @@ class KeyboardManager {
       Lscript = this.keymanweb.util._CreateElement('script');
     
     URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
-      +'?jsonp=keyman.register&version='+this.keymanweb['version']+'.'+KeymanBase['__BUILD__'];
+      +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+KeymanBase['__BUILD__'];
 
     var kbdManager = this;
     

--- a/web/source/recorder_KeyboardScripts.js
+++ b/web/source/recorder_KeyboardScripts.js
@@ -1,7 +1,7 @@
 // JavaScript Document keyboardScripts.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr               load the current version of the default keyboard for French
+      @fr$              load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,26 +45,26 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../testing/us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
+    // keyboard name and language code, or just the BCP-47 language code.
     // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
-    kmw.addKeyboards('french','@heb');
-    kmw.addKeyboards({id:'european2', name:'EuroLatin2', languages: [{id:'nor'}, {id:'swe'}]}); // Loads from partial stub instead of the compact string.
+    kmw.addKeyboards('french','@he');
+    kmw.addKeyboards({id:'european2', name:'EuroLatin2', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         },
       filename:'../testing/lao_2008_basic.js'
       });   
@@ -73,7 +73,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
@@ -92,7 +92,11 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        keyman.addKeyboards('@'+sKbd);
+        var rx=new RegExp(/^\w{2,3}$\$?/);
+        if(rx.test(sKbd))
+            keyman.addKeyboards('@'+sKbd);
+        else
+            alert('A BCP-47 language code must be exactly 2-3 letters long!');
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/source/recorder_KeyboardScripts.js
+++ b/web/source/recorder_KeyboardScripts.js
@@ -92,11 +92,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{2,3}$\$?/);
-        if(rx.test(sKbd))
-            keyman.addKeyboards('@'+sKbd);
-        else
-            alert('A BCP-47 language code must be exactly 2-3 letters long!');
+        keyman.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/testing/attachment-api/utilities.js
+++ b/web/testing/attachment-api/utilities.js
@@ -3,24 +3,24 @@ function loadKeyboards()
   var kmw=keyman;
 
   // The first keyboard added will be the default keyboard for touch devices.
-  // For faster loading, it may be best for the default keybaord to be 
+  // For faster loading, it may be best for the default keyboard to be
   // locally sourced.
-  kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+  kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
     filename:'../us-1.0.js'});
     
   // Add more keyboards to the language menu, by keyboard name,
-  // keyboard name and language code, or just the ISO 639 language code.  
-  kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+  // keyboard name and language code, or just the BCP-47 language code.
+  kmw.addKeyboards('french','european2@sv','european2@no','@he');
 
   // Add a keyboard by language name.  Note that the name must be spelled
-  // correctly, or the keyboard will not be found.  (Using ISO codes is
+  // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
   // usually easier.)
   kmw.addKeyboardsForLanguage('Dzongkha');
 
   // Add a fully-specified, locally-sourced, keyboard with custom font  
   kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
     languages:{
-    id:'lao',name:'Lao',region:'Asia',
+    id:'lo',name:'Lao',region:'Asia',
     font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
     },
     filename:'../lao_2008_basic.js'

--- a/web/testing/basic-iframe/script.js
+++ b/web/testing/basic-iframe/script.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr               load the current version of the default keyboard for French
+      @fr$              load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,34 +45,34 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
-      });   
+      });
 
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
-  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
+    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order

--- a/web/testing/chirality/utilities.js
+++ b/web/testing/chirality/utilities.js
@@ -5,18 +5,18 @@ function loadKeyboards()
   // A testing keyboard handwritten with chirality information.
   kmw.addKeyboards({id:'chirality',name:'Chirality Testing',
     languages:{
-    id:'eng',name:'English',region:'North America'
+      id:'en',name:'English',region:'North America'
     },
     filename:'chirality.js'
-    });   
+  });
     
   // A testing keyboard using 10.0 format and the KLS layout specifier
   // without the 'shift' layer properly defined.
   // Add a fully-specified, locally-sourced, keyboard with custom font  
   kmw.addKeyboards({id:'halfDefined',name:'Undefined Shift Layer Keyboard',
     languages:{
-    id:'eng',name:'English',region:'North America'
+      id:'en',name:'English',region:'North America'
     },
     filename:'halfDefined.js'
-    });   
+  });
 }

--- a/web/testing/issue005/header.js
+++ b/web/testing/issue005/header.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr               load the current version of the default keyboard for French
+      @fr$              load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,24 +45,24 @@
     var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -71,15 +71,15 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
-  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
     // keyboards alphabetically by language.
   }
   
-    // Script to allow a user to add any keyboard to the keyboard menu 
+  // Script to allow a user to add any keyboard to the keyboard menu 
   function addKeyboard(n)
   { 
     var sKbd, kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
@@ -91,11 +91,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
@@ -106,7 +102,7 @@
   
   // Add keyboard on Enter (as well as pressing button)
   function clickOnEnter(e,id)
-  {                                       
+  {
     e = e || window.event;
     if(e.keyCode == 13) addKeyboard(id); 
   }

--- a/web/testing/issue115/index.html
+++ b/web/testing/issue115/index.html
@@ -40,7 +40,7 @@
       kmw.init({
         attachType:'auto'
         });
-      kmw.addKeyboards({id:'issue115a',name:'Issue 115',languages:{id:'eng',name:'English'},
+      kmw.addKeyboards({id:'issue115a',name:'Issue 115',languages:{id:'en',name:'English'},
         filename:'./issue115a-1.0.js'});
     </script> 
     

--- a/web/testing/issue116/index.html
+++ b/web/testing/issue116/index.html
@@ -40,7 +40,7 @@
       kmw.init({
         attachType:'auto'
         });
-      kmw.addKeyboards({id:'next_layer_tests',name:'Issue 116',languages:{id:'eng',name:'English'},
+      kmw.addKeyboards({id:'next_layer_tests',name:'Issue 116',languages:{id:'en',name:'English'},
         filename:'./next_layer_tests-1.0.js'});
     </script> 
     

--- a/web/testing/issue160/index.html
+++ b/web/testing/issue160/index.html
@@ -41,8 +41,8 @@
         attachType:'auto'
         });
       kmw.addKeyboards(
-        {id:'issue160',name:'Issue 160',languages:{id:'eng',name:'English'}, filename:'./issue160-1.0.js'},
-        {id:'tchaduni',name:'tchaduni',languages:{id:'fra',name:'TChad'}, filename:'./tchaduni-3.1.js'}
+        {id:'issue160',name:'Issue 160',languages:{id:'en',name:'English'}, filename:'./issue160-1.0.js'},
+        {id:'tchaduni',name:'tchaduni',languages:{id:'fr',name:'TChad'}, filename:'./tchaduni-3.1.js'}
         );
     </script> 
     

--- a/web/testing/issue271/header.js
+++ b/web/testing/issue271/header.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,24 +45,24 @@
     var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English', region:'North America'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English', region:'North America'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -72,7 +72,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
@@ -91,11 +91,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/testing/issue271/index.html
+++ b/web/testing/issue271/index.html
@@ -54,13 +54,13 @@
 	<h3>This version is used to test the interactions of <code>SetActiveKeyboard</code> with the Toolbar UI.</h3>
   <p>Automatically-loaded keyboard IDs:
   <ul>
-  <li>us, eng</li>
-  <li>french, fra</li>
-  <li>european2, nor</li>
-  <li>european2, swe</li>
+  <li>us, en</li>
+  <li>french, fr</li>
+  <li>european2, no</li>
+  <li>european2, sv</li>
   <li>hebrew, heb</li>
   <li>dzongkha, dzo</li>
-  <li>lao_2008_basic, lao</li>
+  <li>lao_2008_basic, lo</li>
   </ul>
   </p>
       <div id='DynamicTextboxes'>
@@ -83,7 +83,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/testing/issue29/issue-29.js
+++ b/web/testing/issue29/issue-29.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,24 +45,24 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -72,7 +72,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order

--- a/web/testing/issue53/index.html
+++ b/web/testing/issue53/index.html
@@ -70,7 +70,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/testing/issue53/issue53.js
+++ b/web/testing/issue53/issue53.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -65,11 +65,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
@@ -86,7 +82,7 @@
   
   // Add keyboard on Enter (as well as pressing button)
   function clickOnEnter(e,id)
-  {                                       
+  {
     e = e || window.event;
     if(e.keyCode == 13) addKeyboard(id); 
   }

--- a/web/testing/issue62/issue-62.js
+++ b/web/testing/issue62/issue-62.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,24 +45,24 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -72,7 +72,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order

--- a/web/testing/issue63/issue-63.js
+++ b/web/testing/issue63/issue-63.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr     loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr              load the current version of the default keyboard for French
+      @fr$             load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,24 +45,24 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
-    kmw.addKeyboards('french','european2@swe','european2@nor','@heb');
+    // keyboard name and language code, or just the BCP-47 language code.
+    kmw.addKeyboards('french','european2@sv','european2@no','@he');
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'../lao_2008_basic.js'
@@ -72,7 +72,7 @@
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
   //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order

--- a/web/testing/keyboard-errors/errorhdr.js
+++ b/web/testing/keyboard-errors/errorhdr.js
@@ -9,13 +9,13 @@
     var kmw=keyman;
     
     // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
       
     // Insert a keyboard that cannot be found.
     kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
       languages:{
-        id:'lao',name:'debugging',region:'Asia',
+        id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'./missing_file.js' // Intentional error - the file doesn't exist, so the <script> tag will raise an error event.
@@ -24,17 +24,17 @@
 	// Insert a keyboard that will generate a timing error.  
     kmw.addKeyboards({id:'unparsable',name:'non-parsable',
       languages:{
-        id:'lao',name:'debugging',region:'Asia',
+        id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'./unparsable.js' // Intentional error - the file has no parsable keyboard, so while the <script> tag will load,
-								 // registration will fail.
-      }); 	  
-	  
+        // registration will fail.
+      });
+
 	// Insert a keyboard that will generate a timing error.  
     kmw.addKeyboards({id:'timeout',name:'timeout',
       languages:{
-        id:'lao',name:'debugging',region:'Asia',
+        id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'./timeout.js' // Intentional (simulated) error - the file never loads, simulating a server timeout.

--- a/web/testing/samplehdr.js
+++ b/web/testing/samplehdr.js
@@ -1,7 +1,7 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
 /* 
-    The keyboard name and/or ISO language code must be specified for each keyboard that is to be available.  
+    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
     If the same keyboard is used for several languages, it must be listed for each
     language, but the keyboard itself will only be loaded once. 
     If two (or more) keyboards are to be available for a given language, both must be listed.
@@ -47,24 +47,24 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keybaord to be 
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'eng',name:'English'},
+    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'./us-1.0.js'});
       
     // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the ISO 639 language code.  
+    // keyboard name and language code, or just the BCP-47 language code.
     // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
-    kmw.addKeyboards('french','@heb');
-    kmw.addKeyboards({id:'european2', name:'EuroLatin2', languages: [{id:'nor'}, {id:'swe'}]}); // Loads from partial stub instead of the compact string.
+    kmw.addKeyboards('french','@he');
+    kmw.addKeyboards({id:'european2', name:'EuroLatin2', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
   
     // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using ISO codes is
+    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
     kmw.addKeyboardsForLanguage('Dzongkha');
     
     // Add a fully-specified, locally-sourced, keyboard with custom font  
     kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
-        id:'lao',name:'Lao',region:'Asia',
+        id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
       filename:'./lao_2008_basic.js'
@@ -93,11 +93,11 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{3,3}$\$?/);    
+        var rx=new RegExp(/^\w{2,3}$\$?/);
         if(rx.test(sKbd))
           kmw.addKeyboards('@'+sKbd);
         else        
-          alert('An ISO 639 language code must be exactly 3 letters long!');
+          alert('A BCP-47 language code must be exactly 2-3 letters long!');
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;

--- a/web/testing/samplehdr.js
+++ b/web/testing/samplehdr.js
@@ -11,12 +11,12 @@
   
     Each argument to addKeyboards() is a string, for example:
       european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fra     loads the current version of the Eurolatin 2 keyboard for French
-      european2@fra@1.2 loads version 1.2 of the Eurolatin 2 keyboard for French
+      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
+      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
       
     Argument syntax also supports the following extensions:
-      @fra              load the current version of the default keyboard for French
-      @fra$             load all available keyboards (current version) for French
+      @fr               load the current version of the default keyboard for French
+      @fr$              load all available keyboards (current version) for French
           
     Each call to addKeyboards() requires a single call to the remote server, 
     (unless all keyboards listed are local and fully specified) so it is better
@@ -45,7 +45,7 @@
     var kmw=keyman;
     
     // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keybaord to be 
+    // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
     kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'./us-1.0.js'});
@@ -73,8 +73,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
-  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fra');},3000);
+    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
   
     // Note that locally specified keyboards will be listed before keyboards 
     // requested from the remote server by user interfaces that do not order
@@ -93,11 +93,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        var rx=new RegExp(/^\w{2,3}$\$?/);
-        if(rx.test(sKbd))
-          kmw.addKeyboards('@'+sKbd);
-        else        
-          alert('A BCP-47 language code must be exactly 2-3 letters long!');
+        kmw.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
@@ -108,7 +104,7 @@
   
   // Add keyboard on Enter (as well as pressing button)
   function clickOnEnter(e,id)
-  {                                       
+  {
     e = e || window.event;
     if(e.keyCode == 13) addKeyboard(id); 
   }

--- a/web/testing/unminified - manual.html
+++ b/web/testing/unminified - manual.html
@@ -70,7 +70,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/testing/unminified.html
+++ b/web/testing/unminified.html
@@ -70,7 +70,7 @@
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
  
-    <h3>Add a keyboard by ISO 639 language code:</h3>
+    <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 

--- a/web/unit_tests/json/engine_tests/basic_lao_simulation.json
+++ b/web/unit_tests/json/engine_tests/basic_lao_simulation.json
@@ -5,7 +5,7 @@
     "filename": "resources/keyboards/lao_2008_basic.js",
     "languages": [
       {
-        "id": "lao",
+        "id": "lo",
         "name": "Lao",
         "region": "Asia"
       }

--- a/web/unit_tests/json/keyboards/lao_2008_basic.json
+++ b/web/unit_tests/json/keyboards/lao_2008_basic.json
@@ -2,7 +2,7 @@
   "id": "lao_2008_basic",
   "name":"Lao Basic",
   "languages":{
-    "id":"lao",
+    "id":"lo",
     "name": "Lao",
     "region": "Asia"
   },


### PR DESCRIPTION
 * Update `keymanCloudRequest` to query for `languageidtype=bcp47`
 * Change root Samples and Testing pages from using ISO 639-3 codes to BCP-47 codes
 * Change Android and iOS keyboard registrations to use BCP-47 codes 