### PR TITLE
[Developer] Fixes memory corruption when creating project file ui classes

### DIFF
--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -492,7 +492,6 @@
         <DCCReference Include="..\..\global\delphi\comp\KeymanDeveloperDebuggerMemo.pas"/>
         <DCCReference Include="dockforms\UfrmCharacterMapDock.pas">
             <Form>frmCharacterMapDock</Form>
-            <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshKeyboards.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.ISO6393ToBCP47Registry.pas"/>

--- a/windows/src/developer/TIKE/project/ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/ProjectFile.pas
@@ -496,6 +496,8 @@ begin
 
   FreeAndNil(FIDEState);
 
+  FreeAndNil(FUI);
+
   FNotifiers.Free;
   inherited Destroy;
 end;

--- a/windows/src/developer/TIKE/project/ProjectFileType.pas
+++ b/windows/src/developer/TIKE/project/ProjectFileType.pas
@@ -100,8 +100,6 @@ begin
     else if FRegisteredFileTypes[i].Extension = Ext then
     begin
       Result := FRegisteredFileTypes[i].ProjectFileClass.Create(FGlobalProject, AFileName, AParent);
-      if Assigned(FDoCreateProjectFileUI) then
-        FDoCreateProjectFileUI(Result);   // I4687
 
       if Assigned(AParent) then
       begin

--- a/windows/src/developer/TIKE/project/ProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/ProjectFileUI.pas
@@ -70,7 +70,7 @@ type
     property Refreshing: Boolean read FRefreshing write FRefreshing;
   end;
 
-  TProjectFileUI = class(TInterfacedObject)
+  TProjectFileUI = class
   protected
     FOwner: TProjectFile;
     procedure OpenFile; virtual; abstract;
@@ -282,7 +282,6 @@ constructor TProjectFileUI.Create(AOwner: TProjectFile);
 begin
   inherited Create;
   FOwner := AOwner;
-  _AddRef;
 end;
 
 destructor TProjectFileUI.Destroy;


### PR DESCRIPTION
This was probably responsible for a number of random crashes in Keyman Developer over the years. The projectfileui objects were being created twice and never released at the right time, because of improper use of `TInterfacedObject` reference counting.

The issue was traced easily with FastMM4.pas full debug mode.