### PR TITLE
Delete the output package file if it already exists to avoid mismatched content

### DIFF
--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -252,6 +252,9 @@ begin
     { Create output file }
 
     try
+
+      if FileExists(FOutputFilename) then DeleteFile(FOutputFilename);
+
       with TZipFile.Create do
       try
         Open(FOutputFilename, TZipMode.zmWrite);


### PR DESCRIPTION
This bug meant that when rebuilding package files, the metadata was not refreshed because it was already in the zip (kmp). Caused build of incorrectly versioned packages.