### PR TITLE
[Android] Fix undefined fonts that get passed to KMW

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -63,7 +63,7 @@
 
     // Query KMW if a given keyboard uses chiral modifiers.
     function setIsChiral(keyboardProperties) {
-      var name = typeof(keyboardProperties.internalName) == "undefined" ? keyboardProperties.keyboardName : keyboardProperties.internalName;
+      var name = typeof(keyboardProperties.internalName) == 'undefined' ? keyboardProperties.keyboardName : keyboardProperties.internalName;
       var kmw=window['keyman'];
       var isChiral = kmw.isChiral(name);
       window.console.log('For keyboard "' + name + '"');

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -98,8 +98,24 @@
           break;
       }
 
-      kbdInterface.registerStub({KN:keyboardName,KI:'Keyboard_'+internalName,KLC:langId,KL:languageName,
-        KF:kbdFile,KFont:font,KOskFont:oskFont,KP:package});
+      var k = {
+        KN:keyboardName,
+        KI:'Keyboard_'+internalName,
+        KLC:langId,
+        KL:languageName,
+        KF:kbdFile,
+        KP:package
+      };
+      if (font) {
+        k.KFont = font;
+        window.console.log('keyboard.html assigning k.KFont = ' + font);
+      }
+      if (oskFont) {
+        k.KOskFont = oskFont;
+        window.console.log('keyboard.html assigning k.KOskFont = ' + oskFont);
+      }
+      kbdInterface.registerStub(k);
+
       kmw['setActiveKeyboard'](package + '::Keyboard_'+internalName,langId);
       kmw['osk']['show'](true);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -54,6 +54,7 @@ final class KMKeyboard extends WebView {
   private static String txtFont = "";
   private static String oskFont = null;
   private static String keyboardRoot = "";
+  private final String fontUndefined = "undefined";
   private GestureDetector gestureDetector;
   private static ArrayList<OnKeyboardEventListener> kbEventListeners = null;
   private boolean ShouldShowHelpBubble = false;
@@ -297,11 +298,16 @@ final class KMKeyboard extends WebView {
       return false;
     }
 
+    if (tFont.equals("''")) {
+      tFont = fontUndefined;
+    }
+    if (oFont.equals("''")) {
+      oFont = fontUndefined;
+    }
+
     // Escape single-quoted names for javascript call
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
-    Log.v("KMEA", "Unescaped language name: " + languageName);
     languageName = languageName.replaceAll("\'", "\\\\'");
-    Log.v("KMEA", "Escaped language name: " + languageName);
 
     String jsFormat = "javascript:setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
     String jsString = String.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
@@ -366,8 +372,9 @@ final class KMKeyboard extends WebView {
         tFont = String.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kFont.substring(0, kFont.length() - 4), keyboardRoot, kFont);
       } else {
         txtFont = getFontFilename(kFont);
-        if (!txtFont.isEmpty())
+        if (!txtFont.isEmpty()) {
           tFont = makeFontPaths(kFont);
+        }
       }
     }
 
@@ -391,11 +398,16 @@ final class KMKeyboard extends WebView {
       oFont = tFont;
     }
 
+    if (tFont.equals("''")) {
+      tFont = fontUndefined;
+    }
+    if (oFont.equals("''")) {
+      oFont = fontUndefined;
+    }
+
     // Escape single-quoted names for javascript call
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
-    Log.v("KMEA", "Unescaped language name: " + languageName);
     languageName = languageName.replaceAll("\'", "\\\\'");
-    Log.v("KMEA", "Escaped language name: " + languageName);
 
     String jsFormat = "javascript:setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
     String jsString = String.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
@@ -481,6 +493,12 @@ final class KMKeyboard extends WebView {
     editor.commit();
   }
 
+  /**
+   * getFontFilename
+   * Parse a Font JSON object and return the font filename (ending in .ttf or .otf)
+   * @param jsonString String - Font JSON object as a string
+   * @return String - Filename for the font. If font is invalid, return ""
+   */
   private String getFontFilename(String jsonString) {
     String font = "";
     try {
@@ -505,7 +523,7 @@ final class KMKeyboard extends WebView {
         }
       }
     } catch (JSONException e) {
-      font = "undefined";
+      font = "";
     }
 
     return font;
@@ -722,7 +740,7 @@ final class KMKeyboard extends WebView {
    * 2. Create full font paths for .ttf or
    * .svg for Android 4.2 or 4.3 OSK
    * @param font String font JSON object as a string
-   * @return String of modified font information with full paths. If font is invalid, return "undefined"
+   * @return String of modified font information with full paths. If font is invalid, return "''"
    */
   private String makeFontPaths(String font) {
     try {
@@ -756,7 +774,7 @@ final class KMKeyboard extends WebView {
         }
       }
     } catch (JSONException e) {
-      return "undefined";
+      return "''";
     }
 
     return font;


### PR DESCRIPTION
 Clean up font parsing so undefined fonts get passed to KMW as `undefined`, and not `'undefined'`.

This bug was likely introduced during keyboard download refactoring.