### PR TITLE
Change connection timeout from 10 to 20 sec

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
@@ -9,7 +9,7 @@ import java.net.URL;
 
 public final class Connection {
   private static final int MAX_REDIRECTS = 5;
-  private static final int TIMEOUT = 10 * 1000; // seconds
+  private static final int TIMEOUT = 20 * 1000; // seconds
 
   private static HttpURLConnection urlConnection;
 


### PR DESCRIPTION
This addresses part of #575 so users in low-bandwidth areas can still download resources.

The feature to allow users to cancel downloads in progress will be implemented at TBD