### PR TITLE
Recent change from escape/unescape to encodeURI/decodeURI should have been to encodeURIComponent/decodeURIComponent

### DIFF
--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -1108,7 +1108,7 @@ class KeyboardInterface {
     this.resetContextCache();
     var cName='KeymanWeb_'+kbdName+'_Option_'+storeName,cValue=this.keymanweb.util.loadCookie(cName);
     if(typeof cValue[storeName] != 'undefined') {
-      return decodeURI(cValue[storeName]);
+      return decodeURIComponent(cValue[storeName]);
     } else {
       return dfltValue;
     }
@@ -1128,7 +1128,7 @@ class KeyboardInterface {
       return false;
     }
     
-    var cName='KeymanWeb_'+kbd['KI']+'_Option_'+storeName, cValue=encodeURI(optValue);
+    var cName='KeymanWeb_'+kbd['KI']+'_Option_'+storeName, cValue=encodeURIComponent(optValue);
 
     this.keymanweb.util.saveCookie(cName,cValue);
     return true;

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -747,7 +747,7 @@ class Util {
       var cx = this.loadCookie();
       for(var t in cx) {
         if(t == cn) {
-          var d = decodeURI(cx[t]).split(';');
+          var d = decodeURIComponent(cx[t]).split(';');
           for(var i=0; i<d.length; i++) {
             var xc = d[i].split('=');
             if(xc.length > 1) {
@@ -785,7 +785,7 @@ class Util {
     }
 
     var d = new Date(new Date().valueOf() + 1000 * 60 * 60 * 24 * 30).toUTCString();
-    document.cookie = cn+'='+encodeURI(s)+'; path=/; expires='+d;//Fri, 31 Dec 2099 23:59:59 GMT;';
+    document.cookie = cn+'='+encodeURIComponent(s)+'; path=/; expires='+d;//Fri, 31 Dec 2099 23:59:59 GMT;';
   }
   
   /**


### PR DESCRIPTION
This issue impacted primarily loading and saving of cookies for keyboard state. It presented visibly on keymanweb.com where saved keyboard state would fail to reload