### PR TITLE
[Web] Automatic keyboard activation

### DIFF
--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -232,10 +232,12 @@ class KeyboardManager {
    **/
   mergeStub(kp: any, lp: any, options) {
     var sp: KeyboardStub = this.findStub(kp['id'], lp['id']);
+    var isNew: boolean = false;
 
     if(sp == null) {
       sp= new KeyboardStub(kp['id'], lp['id']);
       this.keyboardStubs.push(sp);
+      isNew = true;
     }
 
     // Accept region as number (from Cloud server), code, or name
@@ -315,6 +317,12 @@ class KeyboardManager {
 
     // Update the UI 
     this.doKeyboardRegistered(sp['KI'],sp['KL'],sp['KN'],sp['KLC'],sp['KP']);
+
+    // If we have no activeStub because there were no stubs, set the new keyboard as active.
+    // Do not trigger on merges.
+    if(!this.activeStub && isNew && this.keyboardStubs.length == 1) {
+      this.setActiveKeyboard(sp['KI'], sp['KLC']);
+    }
   }
 
   /**
@@ -627,12 +635,13 @@ class KeyboardManager {
         
           // Prepare and show the OSK for this keyboard
           osk._Load();
+        } 
 
-          // Remove the wait message, if defined
-          if(!manager.keymanweb.isEmbedded) {
-            util.wait(false);
-          }
-        } // A handler portion for cases where the new <script> block loads, but fails to process.
+        // Remove the wait message, if defined
+        if(!manager.keymanweb.isEmbedded) {
+          util.wait(false);
+        }
+        // A handler portion for cases where the new <script> block loads, but fails to process.
       } else {  // Output error messages even when embedded - they're useful when debugging the apps and KMEA/KMEI engines.
           kbdStub.asyncLoader.callback('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '.', 'error');
       }
@@ -1347,6 +1356,12 @@ class KeyboardManager {
     // make any changes needed by UI for new keyboard stub
     // (Uncommented for Build 360)
     this.doKeyboardRegistered(Pstub['KI'],Pstub['KL'],Pstub['KN'],Pstub['KLC'],Pstub['KP']);
+
+    // If we have no activeStub because there were no stubs, set the new keyboard as active.
+    // Do not trigger on merges.
+    if(!this.activeStub && this.dfltStub == Pstub && this.keyboardStubs.length == 1) {
+      this.setActiveKeyboard(Pstub['KI'], Pstub['KLC']);
+    }
 
     return null;
   }

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -364,6 +364,11 @@ class KeyboardManager {
     //TODO: This does not make sense: the callbacks should be in _SetActiveKeyboard, not here,
     //      since this is always called FROM the UI, which should not need notification.
     //      If UI callbacks are needed at all, they should be within _SetActiveKeyboard  
+
+    if(PInternalName && PInternalName.indexOf("Keyboard_") != 0) {
+      PInternalName = "Keyboard_" + PInternalName;
+    }
+
     this.doBeforeKeyboardChange(PInternalName,PLgCode);     
     this._SetActiveKeyboard(PInternalName,PLgCode,true);    
     if(this.keymanweb.domManager.getLastActiveElement() != null) {

--- a/web/unit_tests/cases/engine.js
+++ b/web/unit_tests/cases/engine.js
@@ -769,13 +769,14 @@ describe('Engine', function() {
       this.timeout(10000);
 
       var test_callback = function() {
-        assert.equal(keyman.getActiveKeyboard(), "Keyboard_lao_2008_basic", "Keyboard not set correctly!");
+        assert.isNotNull(keyman.getKeyboard("lao_2008_basic", "lo"), "Keyboard stub was not registered!");
+        assert.equal(keyman.getActiveKeyboard(), "Keyboard_lao_2008_basic", "Keyboard not set automatically!");
         keyman.removeKeyboards('lao_2008_basic');
         assert.equal(keyman.getActiveKeyboard(), '', "Keyboard not removed correctly!");
         done();
       }
 
-      loadKeyboardFromJSON("/keyboards/lao_2008_basic.json", test_callback, 10000);
+      loadKeyboardFromJSON("/keyboards/lao_2008_basic.json", test_callback, 10000, {passive: true});
     });
   });
 

--- a/web/unit_tests/test_utils.js
+++ b/web/unit_tests/test_utils.js
@@ -160,11 +160,13 @@ var onScriptLoad = function(scriptURL, callback, timeout) {
   slo.observe();
 };
 
-var loadKeyboardStub = function(stub, callback, timeout) {
+var loadKeyboardStub = function(stub, callback, timeout, params) {
   var kbdName = "Keyboard_" + stub.id;
 
   keyman.addKeyboards(stub);
-  keyman.setActiveKeyboard(kbdName, stub.languages.id);
+  if(!params || !params.passive) {
+    keyman.setActiveKeyboard(kbdName, stub.languages.id);
+  }
 
   if(keyman.getActiveKeyboard() != kbdName) {
     onScriptLoad(stub.filename, function() {


### PR DESCRIPTION
Fixes #636.

While #635 fixed up some of the use cases that were causing #636's issues, there were other paths that were yet unaddressed - some of which show up in our help.keyman.com KMW Guide section.  This corrects those and adds a condition in one of the engine tests to check for proper automatic keyboard selection.