### PR TITLE
[Android] Fix path of special OSK font used for longpress of special keys

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -242,6 +242,16 @@ final class KMKeyboard extends WebView {
     return keyboardRoot + oskFont;
   }
 
+  /**
+   * Return the full path to the special OSK font,
+   * which is with all the keyboard assets at the root app_data folder
+   * @param String filename
+   * @return String
+   */
+  public String specialOSKFontFilename(String filename) {
+    return context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator + filename;
+  }
+
   public boolean setKeyboard(String packageID, String keyboardID, String languageID) {
     if (packageID == null || keyboardID == null || languageID == null)
       return false;
@@ -635,7 +645,7 @@ final class KMKeyboard extends WebView {
       button.setText(title);
 
       if (!specialOskFont.isEmpty()) {
-        button.setTypeface(KMManager.getFontTypeface(context, specialOskFont));
+        button.setTypeface(KMManager.getFontTypeface(context, specialOSKFontFilename(specialOskFont)));
       } else {
         Typeface font = KMManager.getFontTypeface(context, (oskFont != null) ? oskFontFilename() : textFontFilename());
         if (font != null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1388,7 +1388,7 @@ public final class KMManager {
           end = url.length();
           InAppKeyboard.specialOskFont = "";
         } else {
-          InAppKeyboard.specialOskFont = "keymanweb-osk.ttf";
+          InAppKeyboard.specialOskFont = KMFilename_Osk_Ttf_Font;
         }
 
         String keys = url.substring(start, end);
@@ -1562,7 +1562,7 @@ public final class KMManager {
           end = url.length();
           SystemKeyboard.specialOskFont = "";
         } else {
-          SystemKeyboard.specialOskFont = "keymanweb-osk.ttf";
+          SystemKeyboard.specialOskFont = KMFilename_Osk_Ttf_Font;
         }
 
         String keys = url.substring(start, end);

--- a/android/history.md
+++ b/android/history.md
@@ -12,6 +12,7 @@
 * Add feature to install ad-hoc keyboards via .kmp packages
 * Add [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics/) for generating crash reports
 * Add Material Design [icons](https://material.io/icons/)
+* Fix path to special OSK font for longpress of special keys (#239) 
 
 ## 2017-08-10 2.8.300 stable
 * No changes, just published latest beta as stable


### PR DESCRIPTION
Fixes #239 

In contrast to the iOS fix, the URL was already appending the special OSK font name. However, the Android code wasn't applying the full path of the special OSK font for the longpress keys.