### PR TITLE
[Mac] Limited context to 80 chars in KMInputMethodBrowserClientEventHandler

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodBrowserClientEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodBrowserClientEventHandler.m
@@ -40,9 +40,7 @@ NSUInteger _failuresToRetrieveExpectedContext;
             if (location != NSNotFound && location > 0) {
                 if ([self AppDelegate].debugMode)
                     NSLog(@"Trying to get context up to location %lu", location);
-                NSString* clientContext = nil;
-                if ([client respondsToSelector:@selector(attributedSubstringFromRange:)])
-                    clientContext = [[client attributedSubstringFromRange:NSMakeRange(0, location)] string];
+                NSString* clientContext = [self getLimitedContextFrom:client at:location];
                 if (clientContext == nil)
                 {
                     // Client is failing to provide useful response to attributedSubstringFromRange.

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -178,20 +178,8 @@ NSRange _previousSelRange;
         len = selRange.location;
     }
     
-    NSUInteger start = 0;
-    if (len > kMaxContext) {
-        start = len - kMaxContext;
-        len = kMaxContext;
-    }
-    
-    NSString *preBuffer = [[sender attributedSubstringFromRange:NSMakeRange(start, len)] string];
-    if ([self.AppDelegate debugMode]) {
-        NSLog(@"preBuffer = \"%@\"", preBuffer);
-        if (preBuffer.length)
-            NSLog(@"First character: '%x'", [preBuffer characterAtIndex:0]);
-        else
-            NSLog(@"preBuffer has a length of 0");
-    }
+    NSString *preBuffer = [self getLimitedContextFrom:sender at:len];
+
     // REVIEW: If there is ever a situation where preBuffer gets some text but the client reports its
     // selectedRange as not found, we probably can't reliably assume that the current location is really
     // at the end of the "preBuffer", so maybe we just need to assume no context.
@@ -202,6 +190,30 @@ NSRange _previousSelRange;
         NSLog(@"***");
     }
     _previousSelRange = selRange;
+}
+
+-(NSString *)getLimitedContextFrom:(id)sender at:(NSUInteger) len {
+    if (![sender respondsToSelector:@selector(attributedSubstringFromRange:)])
+        return nil;
+        
+    NSUInteger start = 0;
+    if (len > kMaxContext) {
+        if ([self.AppDelegate debugMode])
+            NSLog(@"Limiting context to %lu characters", kMaxContext);
+        start = len - kMaxContext;
+        len = kMaxContext;
+    }
+    
+    NSString *preBuffer = [[sender attributedSubstringFromRange:NSMakeRange(start, len)] string];
+    if ([self.AppDelegate debugMode]) {
+        NSLog(@"preBuffer = \"%@\"", preBuffer ? preBuffer : @"nil");
+        if (preBuffer.length)
+            NSLog(@"First character: '%x'", [preBuffer characterAtIndex:0]);
+        else
+            NSLog(@"preBuffer has a length of 0");
+    }
+    
+    return preBuffer;
 }
 
 // Return the pending buffer.  If it is NIL create it.

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandlerProtected.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandlerProtected.h
@@ -36,6 +36,7 @@
 - (void)insertPendingBufferTextIn:(id)client;
 - (KMInputMethodAppDelegate *)AppDelegate;
 - (NSMutableString *)contextBuffer;
+- (NSString *)getLimitedContextFrom:(id)sender at:(NSUInteger) len;
 // Return the pending buffer.  If it is NIL create it.
 -(NSMutableString*)pendingBuffer;
 -(void)setPendingBuffer:(NSString*)string;


### PR DESCRIPTION
I had previously made a change to do this in the base class but overloooked that it was also a factor in this subclass, so I refactored a little to have a single method  in the base class that handles this. (Note: the base class method also checks to be sure that the client responds to the attributedSubstringFromRange method before calling it. This used to be done only in the subclass, but it seems like a useful safeguard in case some other client fails to implement this.