### PR TITLE
Removes IE legacy check for touch-based aliases.

### DIFF
--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -1087,7 +1087,7 @@ class DOMTouchHandlers extends DOMEventHandlers {
       return '';
     }
 
-    return (typeof(e.textContent) == 'string' ? e.textContent : e.innerText);
+    return e.textContent;
   } 
 
   setText(e: HTMLElement, t?: string, cp?: number): void {
@@ -1098,8 +1098,8 @@ class DOMTouchHandlers extends DOMEventHandlers {
         
         // Read current text if null passed (for caret positioning)
         if(t === null) {
-          t1=(typeof(s1.textContent) == 'string' ? s1.textContent : s1.innerText);
-          t2=(typeof(s2.textContent) == 'string' ? s2.textContent : s2.innerText);
+          t1=s1.textContent;
+          t2=s2.textContent;
           t=t1+t2;        
         }
 
@@ -1114,17 +1114,8 @@ class DOMTouchHandlers extends DOMEventHandlers {
         t1=t._kmwSubstr(0,cp);
         t2=t._kmwSubstr(cp);
                             
-        if(typeof(s1.textContent) == 'string') {
-          s1.textContent=t1;
-        } else {
-          s1.innerText=t1;
-        }
-
-        if(typeof(s2.textContent) == 'string') {
-          s2.textContent=t2;
-        } else {
-          s2.innerText=t2;
-        }  
+        s1.textContent=t1;
+        s2.textContent=t2;
       }
     }
 
@@ -1136,12 +1127,7 @@ class DOMTouchHandlers extends DOMEventHandlers {
       var d=e.firstChild;
       if(d.childNodes.length > 0) {
         var s1=<HTMLElement> d.childNodes[0];
-        if('textContent' in s1) {
-          return s1.textContent;
-        }
-        if('innerText' in s1) {
-          return s1.innerText;
-        }
+        return s1.textContent;
       }
     }
 
@@ -1155,12 +1141,10 @@ class DOMTouchHandlers extends DOMEventHandlers {
         var s1=<HTMLElement> d.childNodes[0], s2=<HTMLElement> d.childNodes[2];
         // Collapse (trailing) whitespace to a single space for INPUT fields (also prevents wrapping)
         if(e.base.nodeName != 'TEXTAREA') t=t.replace(/\s+$/,' ');
-        if('textContent' in s1) s1.textContent=t;
-        else if('innerText' in s1) s1.innerText=t; 
+        s1.textContent=t;
         // Test total length in order to control base element visibility 
         tLen=t.length;
-        if('textContent' in s2) tLen=tLen+s2.textContent.length;
-        else if('innerText' in s2) tLen=tLen+s2.innerText.length;            
+        tLen=tLen+s2.textContent.length;            
       }
     }
     


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent, IE 9+ supports `textContent`.  The `innerText` checks were the IE 8- way of handling certain touch-aliasing functionalities.

As we now only target IE 9+, it's safe to remove these checks.

(Affects IDE error reporting when working in kmwdomevents.ts.)