### PR TITLE
Patches up KMW >= 10.0 layout processing

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -1089,7 +1089,7 @@ function TCompileKeymanWeb.VisualKeyboardFromFile(const FVisualKeyboardFileName:
 
     // Build the layer array
 
-    Result := nl+FTabStop+'this.KLS={'+nl;
+    Result := nl+FTabStop+'this.KV.KLS={'+nl;
 
     for i := 0 to High(layers) do
     begin
@@ -1126,7 +1126,7 @@ function TCompileKeymanWeb.VisualKeyboardFromFile(const FVisualKeyboardFileName:
     '    return result;'#13#10+
     '  }';
   begin
-    Result := nl+FTabStop+'this.KV.BK=('+IfThen(FDebug,func_debug,func)+')(this.KLS)';
+    Result := nl+FTabStop+'this.KV.BK=('+IfThen(FDebug,func_debug,func)+')(this.KV.KLS)';
   end;
 
 var


### PR DESCRIPTION
It took some debugging with our first version 10 keyboard to figure out, but the original implementation of the `KLS` property for keyboards was slightly flawed due to how KMW forwards keyboard layout data.  The issue was affecting desktop OSKs for said keyboard (Khmer Angkor) and may be easily fixed by slightly relocating the property to within the existing `KV` property.

`osk.buildDefaultLayout` is passed only `KV`, not the whole keyboard object; this relocation maintains the existing pattern for minimal impact.