### PR TITLE
Add guards on lastElem properties

### DIFF
--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -358,7 +358,7 @@ namespace com.keyman {
       var keyboardID = this.keyman.keyboardManager.activeKeyboard ? this.keyman.keyboardManager.activeKeyboard['KI'] : '';
       
       var lastElem = DOMEventHandlers.states.lastActiveElement;
-      if(lastElem && lastElem._kmwAttachment.keyboard != null) {
+      if(lastElem && lastElem._kmwAttachment != null && lastElem._kmwAttachment.keyboard != null) {
         lastElem._kmwAttachment.keyboard = keyboardID;
         lastElem._kmwAttachment.languageCode = this.keyman.keyboardManager.getActiveLanguage();
       } else {
@@ -376,7 +376,7 @@ namespace com.keyman {
      */ 
     _FocusKeyboardSettings(blockGlobalChange: boolean) {
       var lastElem = DOMEventHandlers.states.lastActiveElement;
-      if(lastElem._kmwAttachment.keyboard != null) {      
+      if(lastElem && lastElem._kmwAttachment != null && lastElem._kmwAttachment.keyboard != null) {
         this.keyman.keyboardManager.setActiveKeyboard(lastElem._kmwAttachment.keyboard, 
           lastElem._kmwAttachment.languageCode); 
       } else if(!blockGlobalChange) { 


### PR DESCRIPTION
Keyman Android is showing console errors about `'keyboard'` property not existing. 
This doesn't appear on KMW.

I  ran into this trying to get the test chirality keyboard to change layers on Keyman Android. (This fix cleans up the console, but doesn't fix the keyboard issue)