### PR TITLE
Resets context (including deadkeys) upon any control's loss of focus.

### DIFF
--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -1269,6 +1269,12 @@ namespace com.keyman {
       if(!this.keyman.isEmbedded) {
         this.keyman.touchAliasing._BlurKeyboardSettings();
       }
+
+      // No need to reset context if we stay within the same element.
+      if(DOMEventHandlers.states.activeElement != e) {
+        this.keyman.interface.resetContext();
+      }
+
       DOMEventHandlers.states.activeElement = DOMEventHandlers.states.lastActiveElement=e;
       if(!this.keyman.isEmbedded) {
         this.keyman.touchAliasing._FocusKeyboardSettings(false);

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -327,6 +327,7 @@ namespace com.keyman {
       }
 
       this.doChangeEvent(Ltarg);
+      this.keyman.interface.resetContext();
 
       return true;
     }.bind(this);
@@ -1379,6 +1380,9 @@ namespace com.keyman {
      */
     setBlur: (e: FocusEvent) => void = function(this: DOMTouchHandlers, e: FocusEvent) {
       // This works OK for iOS, but may need something else for other platforms
+
+      this.keyman.interface.resetContext();
+
       if(('relatedTarget' in e) && e.relatedTarget) {
         var elem: HTMLElement = e.relatedTarget as HTMLElement;
         this.doChangeEvent(elem);


### PR DESCRIPTION
Fixes #615.