### PR TITLE
Test that project is present before attempting to check project options in build

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -344,7 +344,10 @@ begin
       Callback, CKF_KEYMANWEB) > 0 then  // I3482   // I4866   // I4865
       // TODO: Free fk
     begin
-      if AOwnerProject.CompilerMessageFile.HasCompileWarning and FCompilerWarningsAsErrors then
+      if Assigned(AOwnerProject) and
+          Assigned(AOwnerProject.CompilerMessageFile) and
+          AOwnerProject.CompilerMessageFile.HasCompileWarning and
+          FCompilerWarningsAsErrors then
         FError := True;
 
       if not FError then


### PR DESCRIPTION
PR #662 causes a crash if a command line build does not include a project. This fixes that.

Note: later on, I want to refactor the compiler interfaces so that we don't have all this global parameter passing, which will make this more stable and cleaner. But that's a lot more work than I want to do today.