### PR TITLE
[iOS] Downloading legacy adhoc keyboard fixes

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
@@ -78,9 +78,16 @@ URLSessionDataDelegate {
 
     // If a destination file for the download has already been specified, let's go ahead and copy it over.
     if let destFile = currentRequest.destinationFile {
+      let destFileUrl = URL(fileURLWithPath: destFile)
       do {
+
+        // Need to delete the file if it already exists (e.g. in case of a previous partial download)
+        if(FileManager.default.fileExists(atPath: destFileUrl.path)) {
+            try FileManager.default.removeItem(at: destFileUrl)
+        }
+
         try FileManager.default.copyItem(at: location,
-                                         to: URL(fileURLWithPath: destFile))
+                                         to: destFileUrl)
       } catch {
         log.error("Error saving the download: \(error)")
       }

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -19,19 +19,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   var viewController: MainViewController!
   var navigationController: UINavigationController?
-  
+
   func application(_ app: UIApplication, open url: URL,
                    options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
     if url.scheme == "keyman" {
       // legacy ad-hoc keyboard install.
       // Deprecated; remove in Keyman 11
-      // Extract parameter for .json file and pass to keyboard manager
-      log.info("installing "+url.absoluteString)
-      let queryItems = URLComponents(string: url.absoluteString)?.queryItems
-      let urlComponent: String? = queryItems?.filter({$0.name == "url"}).first?.value
-      let directUrl: URL? = URL.init(string: urlComponent!)
-      
-      Manager.shared.downloadKeyboard(from: directUrl!)
+      log.info("installing legacy ad-hoc keyboard from "+url.absoluteString)
+      viewController.launchFromUrl(fromUrl: url)
     } else {
       // .kmp package install, Keyman 10 onwards
       var destinationUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
@@ -43,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         showKMPError(KMPError.copyFiles)
       }
     }
-    
+
     return true
   }
 

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -19,16 +19,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   var viewController: MainViewController!
   var navigationController: UINavigationController?
-
+  
   func application(_ app: UIApplication, open url: URL,
                    options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
-    var destinationUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-    destinationUrl.appendPathComponent("\(url.lastPathComponent).zip")
-    do {
-      try FileManager.default.copyItem(at: url, to: destinationUrl)
-      installAdhocKeyboard(url: destinationUrl)
-    } catch {
-      showKMPError(KMPError.copyFiles)
+    if url.scheme == "keyman" {
+      // legacy ad-hoc keyboard install.
+      // Deprecated; remove in Keyman 11
+      // Extract parameter for .json file and pass to keyboard manager
+      log.info("installing "+url.absoluteString)
+      let queryItems = URLComponents(string: url.absoluteString)?.queryItems
+      let urlComponent: String? = queryItems?.filter({$0.name == "url"}).first?.value
+      let directUrl: URL? = URL.init(string: urlComponent!)
+      
+      Manager.shared.downloadKeyboard(from: directUrl!)
+    } else {
+      // .kmp package install, Keyman 10 onwards
+      var destinationUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+      destinationUrl.appendPathComponent("\(url.lastPathComponent).zip")
+      do {
+        try FileManager.default.copyItem(at: url, to: destinationUrl)
+        installAdhocKeyboard(url: destinationUrl)
+      } catch {
+        showKMPError(KMPError.copyFiles)
+      }
     }
     
     return true

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -533,6 +533,23 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
 
   // MARK: - View Actions
 
+  //
+  // Called from AppDelegate when a keyman:// legacy ad-hoc keyboard
+  // install URL is encountered. Deprecated, remove in Keyman 11
+  //
+  func launchFromUrl(fromUrl: URL) {
+    launchUrl = fromUrl
+    if didKeyboardLoad {
+      performAction(from: fromUrl)
+    } else {
+      launchUrl = nil
+    }
+  }
+
+  //
+  // TODO: Is this notification-based launched event ever used any more? If not,
+  // refactor it into oblivion. Probably deprecated with legacy ad-hoc keyboard.
+  //
   @objc func launched(fromUrl notification: Notification) {
     if let url = notification.userInfo?[urlKey] as? URL, url.query != nil {
       launchUrl = url


### PR DESCRIPTION
Part 1: now downloads but doesn't register correctly yet. URL handler detects if scheme is `keyman` and passes it on to the legacy handler. But it looks like the legacy handler has never worked correctly in the Swift code, as it downloads the keyboard and the font but doesn't register. Shouldn't be too hard to fix, but running out of steam for the evening.