### PR TITLE
[Android] Change parameter names for firebase logging

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -514,9 +514,9 @@ final class KMKeyboard extends WebView {
   private void sendKMWError(int lineNumber, String sourceId, String message) {
     Bundle params = new Bundle();
     // Error info
-    params.putInt("cm.lineNumber", lineNumber);
-    params.putString("cm.sourceID", sourceId);
-    params.putString("cm.message", message);
+    params.putInt("cm_lineNumber", lineNumber);
+    params.putString("cm_sourceID", sourceId);
+    params.putString("cm_message", message);
 
     // Keyboard info
     if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {


### PR DESCRIPTION
The `.` character isn't allowed in parameter names passed to Firebase analytics. This was flagging Firebase errors when trying to view the events in the Firebase console.

Replacing `cm.` with `cm_` works. (cm is just the naming convention I used for JS ConsoleMessage properties)