### PR TITLE
Moves Web alpha notes to beta, fixes iOS history interactions.

### DIFF
--- a/resources/validateHistory.sh
+++ b/resources/validateHistory.sh
@@ -1,0 +1,4 @@
+. historyUtils.sh
+
+# Insert the shorthand for a platform as the command-line argument.
+validate_history_file "$1"

--- a/web/history.md
+++ b/web/history.md
@@ -1,6 +1,9 @@
 # KeymanWeb Version History
 
 ## 2018-03-22 10.0.83 beta
+* Initial beta for KeymanWeb v 10.0.
+
+## 10.0 alpha
 * Updated versioning scheme for uniformity across all Keyman products.
 * Reworked the KeymanWeb attachment model significantly to allow greater user control. (#98)
   * The 'kmw-disabled' flag may now be used to automatically enable and disable KMW for attached controls.

--- a/web/history.md
+++ b/web/history.md
@@ -1,6 +1,6 @@
 # KeymanWeb Version History
 
-## 10.0 alpha
+## 2018-03-22 10.0.83 beta
 * Updated versioning scheme for uniformity across all Keyman products.
 * Reworked the KeymanWeb attachment model significantly to allow greater user control. (#98)
   * The 'kmw-disabled' flag may now be used to automatically enable and disable KMW for attached controls.


### PR DESCRIPTION
The changes here to resources/historyUtils.sh are necessary to let iOS fetch the _most recent_ history for its iTunesConnect changelogs, rather than requiring the _exact_ version number to be matched.  Since KeymanWeb triggers iOS builds, the original behavior would pose quite an annoying problem to handle moving forward.

It still ensures that the `major.minor` component of the version string is a perfect match - the only added flexibility is to ensure that the reported history's `.build` component is less than or equal to the requested one.