### PR TITLE
[Android] Move Android to 11.0 alpha

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -33,8 +33,9 @@ android {
             // Because TeamCity does not bubble build.counter into system properties...
             versionName "${project.ext['build.number']}"
         } else {
+            String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
             versionCode 100
-            versionName '10.0.0.0'
+            versionName majorMinorVersion + '.0.0'
         }
 
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -12,8 +12,9 @@ android {
             versionCode project.ext['build_counter'] as Integer // Because TeamCity does not bubble build.counter into system properties...
             versionName "${project.ext['build.number']}"
         } else {
+            String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
             versionCode 100
-            versionName '10.0.0.0'
+            versionName majorMinorVersion + '.0.0'
         }
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -53,7 +53,6 @@ import org.json.JSONObject;
 
 public final class KMManager {
 
-  private static final String KMEngineVersion = "2.4.3";
   private static final String TAG = "KMManager";
 
   private static FirebaseAnalytics mFirebaseAnalytics;
@@ -146,10 +145,6 @@ public final class KMManager {
   public static final String KMFilename_KeyboardsList = "keyboards_list.dat";
 
   private static Context appContext;
-
-  public static String getVersion() {
-    return KMEngineVersion;
-  }
 
   protected static String getResourceRoot() {
     return appContext.getDir("data", Context.MODE_PRIVATE).toString() + File.separator;

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 11.0 alpha
+* Move to 11.0
+
 ## 10.0 alpha
 * Refactor how longpress keys on touch layout are processed in KMW engine. This prevents key text 
   from being processed as key codes, and fixes the app crash when longpress with K_SPACE.


### PR DESCRIPTION
* Get major.minor version from `./resources/VERSION.md`
* Remove legacy KMEA `getVersion()` call that was returning a stale `2.4.3` value