### PR TITLE
Pressing backspace corrupts cached context with SMP characters

### DIFF
--- a/windows/src/engine/keyman32/appint/appint.cpp
+++ b/windows/src/engine/keyman32/appint/appint.cpp
@@ -84,8 +84,11 @@ WCHAR *AppContext::BufMax(int n)  // Used only by IMX DLLs
 
 void AppContext::Delete()
 {
-	if(CharIsDeadkey())	pos -= 2;
-
+  if (CharIsDeadkey()) {
+    pos -= 2;
+  } else if (CharIsSurrogatePair()) {
+    pos--;
+  }
 	//SendDebugMessageFormat(0, sdmAIDefault, 0, "AppContext::Delete");
 
 	if(pos > 0) pos--;
@@ -142,6 +145,15 @@ BOOL AppContext::CharIsDeadkey()
 		return FALSE;
 	return CurContext[pos-3] == UC_SENTINEL && 
 		   CurContext[pos-2] == CODE_DEADKEY;
+}
+
+BOOL AppContext::CharIsSurrogatePair()
+{
+  if (pos < 2) // low_surrogate, high_surrogate
+    return FALSE;
+
+  return Uni_IsSurrogate1(CurContext[pos - 2]) &&
+    Uni_IsSurrogate2(CurContext[pos - 1]);
 }
 
 /* AppActionQueue */

--- a/windows/src/engine/keyman32/appint/appint.h
+++ b/windows/src/engine/keyman32/appint/appint.h
@@ -95,6 +95,7 @@ public:
 	WCHAR *BufMax(int n);
 	WCHAR *Buf(int n);
 	BOOL CharIsDeadkey();
+  BOOL CharIsSurrogatePair();
 };
 
 class AppContextWithStores : public AppContext   // I4978


### PR DESCRIPTION
Fixes #729