### PR TITLE
[Android] Tweak back button for WebBrowserActivity

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -15,6 +15,7 @@
 
 # Gradle generated files
 **/.gradle/
+build_file_checksums.ser
 
 # OS-specific files
 **/.DS_Store

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -378,8 +378,17 @@ public class WebBrowserActivity extends Activity {
 
   @Override
   public void onBackPressed() {
-    finish();
-    overridePendingTransition(0, android.R.anim.fade_out);
+    if (webView != null && webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      // Hide the current keyboard so when Keyman app returns, there aren't 2 keyboards visible
+      InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+      imm.hideSoftInputFromWindow(addressField.getWindowToken(), 0);
+
+      super.onBackPressed();
+      finish();
+      //overridePendingTransition(0, android.R.anim.fade_out);
+    }
   }
 
   private void loadFont() {


### PR DESCRIPTION
This is a follow-on to #220 that fixed 2 OSK that were appearing when exiting WebBrowserActivity.

* If navigation is possible, backButton navigates back.
* Hide the system OSK so returning to Keyman app won't have 2 keyboards visible (similar to `closeButton` listener)

Also ignore build_file_checksums file that Android Gradle 3.1 generates.