### PR TITLE
Default output null guarding

### DIFF
--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -1002,14 +1002,18 @@ if(!window['keyman']['initialized']) {
         }
         // Hereafter, we refer to keyCodes.
       } else if(checkCodes) {
-        if(n >= osk.keyCodes['K_0'] && n <= osk.keyCodes['K_9']) { // The number keys.
-          ch = codesUS[keyShiftState][0][n-osk.keyCodes['K_0']];
-        } else if(n >=osk.keyCodes['K_A'] && n <= osk.keyCodes['K_Z']) { // The base letter keys
-          ch = String.fromCharCode(n+(keyShiftState?0:32));  // 32 is the offset from uppercase to lowercase.
-        } else if(n >= osk.keyCodes['K_COLON'] && n <= osk.keyCodes['K_BKQUOTE']) {
-          ch = codesUS[keyShiftState][1][n-osk.keyCodes['K_COLON']];
-        } else if(n >= osk.keyCodes['K_LBRKT'] && n <= osk.keyCodes['K_QUOTE']) {
-          ch = codesUS[keyShiftState][2][n-osk.keyCodes['K_LBRKT']];
+        try {
+          if(n >= osk.keyCodes['K_0'] && n <= osk.keyCodes['K_9']) { // The number keys.
+            ch = codesUS[keyShiftState][0][n-osk.keyCodes['K_0']];
+          } else if(n >=osk.keyCodes['K_A'] && n <= osk.keyCodes['K_Z']) { // The base letter keys
+            ch = String.fromCharCode(n+(keyShiftState?0:32));  // 32 is the offset from uppercase to lowercase.
+          } else if(n >= osk.keyCodes['K_COLON'] && n <= osk.keyCodes['K_BKQUOTE']) {
+            ch = codesUS[keyShiftState][1][n-osk.keyCodes['K_COLON']];
+          } else if(n >= osk.keyCodes['K_LBRKT'] && n <= osk.keyCodes['K_QUOTE']) {
+            ch = codesUS[keyShiftState][2][n-osk.keyCodes['K_LBRKT']];
+          }
+        } catch (e) {
+          console.error("Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default'));
         }
       }
       return ch;

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -910,6 +910,8 @@ if(!window['keyman']['initialized']) {
       } else if (keyShiftState == osk.modifierCodes['SHIFT']) {
         checkCodes = true; 
         keyShiftState = 1; // It's used as an index.
+      } else {
+        console.warn("KMW only defines default key output for the 'default' and 'shift' layers!");
       }
 
       // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
@@ -1001,7 +1003,7 @@ if(!window['keyman']['initialized']) {
           ch=String.kmwFromCharCode(codePoint);
         }
         // Hereafter, we refer to keyCodes.
-      } else if(checkCodes) {
+      } else if(checkCodes) { // keyShiftState can only be '1' or '2'.
         try {
           if(n >= osk.keyCodes['K_0'] && n <= osk.keyCodes['K_9']) { // The number keys.
             ch = codesUS[keyShiftState][0][n-osk.keyCodes['K_0']];


### PR DESCRIPTION
Fixes #763.
Fixes #258.

It turns out that the extra issues contained in #258 past those mentioned in #763 were previously addressed at some point since the original issue's creation; the `keyShiftState` parameter was already being validated, acting as a null guard to prevent the error.

This PR adds additional code to print warning and error messages in the developer console when erroneous uses of the method are detected, which should address any remaining loose ends.