### PR TITLE
Fixes display of longpress special keys.

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 2018-04-25 10.0.86 beta
+* Fixes display of popup keys representing modifiers and other special characters. (#698)
+
 ## 2018-03-22 10.0.83 beta
 * Initial beta for KeymanWeb v 10.0.
 

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -759,12 +759,16 @@ if(!window['keyman']['initialized']) {
         var i, 
           idx = e.id.split('-'), 
           baseId = idx[idx.length-1], 
-          layer = e['key'] && e['key']['layer'] ? e['key']['layer'] : (idx.length > 1 ? idx[0] : '');
+          layer = e['key'] && e['key']['layer'] ? e['key']['layer'] : (idx.length > 1 ? idx[0] : ''),
+          sp = e['key'] && e['key']['sp'];
         if(typeof e.subKeys != 'undefined' && e.subKeys.length > 0 && (e.subKeys[0].id != baseId || e.subKeys[0].layer != layer))
         {
           var eCopy={'id':baseId,'layer':'','key':undefined};
           if(layer != '') {
             eCopy['layer'] = layer;
+          }
+          if(sp) {
+            eCopy['sp'] = sp;
           }
           for(i = 0; i < e.childNodes.length; i++) {
             if(osk.hasClass(e.childNodes[i],'kmw-key-text')) break;

--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -66,7 +66,7 @@ module.exports = function(config) {
   
   var CURRENT_IOS_LAUNCHERS = {
     bs_iphoneX: {
-      device: 'iPhone X',
+      device: 'iPhone 8 Plus', // Ideally, we'd use 'iPhone X', but BrowserStack's version is being problematic lately.
       real_mobile: false,
       os: 'ios',
       os_version: '11.0'


### PR DESCRIPTION
Fixes #698.

The key problem is that `sp = 1` is required for the OSK to utilize the SpecialOSK font used for our PUA codes; this was not being tracked when prepending a base key to the popup key list.