### PR TITLE
[Android] Disable text suggestions and hide system OSK when resuming app

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -152,6 +152,9 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
     textView.setTextSize((float) textSize);
     textView.setSelection(textView.getText().length());
 
+
+
+
     boolean didCheckUserData = prefs.getBoolean(MainActivity.didCheckUserDataKey, false);
     if (!didCheckUserData && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)) {
       try {
@@ -227,6 +230,8 @@ public class MainActivity extends Activity implements OnKeyboardEventListener, O
   protected void onResume() {
     super.onResume();
     KMManager.onResume();
+    KMManager.hideSystemKeyboard();
+
     if (!KMManager.keyboardExists(this, KMManager.KMDefault_UndefinedPackageID,
       KMManager.KMDefault_KeyboardID, KMManager.KMDefault_LanguageID)) {
       HashMap<String, String> kbInfo = new HashMap<String, String>();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -224,14 +224,10 @@ public class WebBrowserActivity extends Activity {
     closeButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        // Hide the current keyboard so when Keyman app returns, there aren't 2 keyboards visible #220
-        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-        imm.hideSoftInputFromWindow(addressField.getWindowToken(), 0);
         finish();
         overridePendingTransition(0, android.R.anim.fade_out);
       }
     });
-
 
     webView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
     webView.getSettings().setJavaScriptEnabled(true);
@@ -381,13 +377,8 @@ public class WebBrowserActivity extends Activity {
     if (webView != null && webView.canGoBack()) {
       webView.goBack();
     } else {
-      // Hide the current keyboard so when Keyman app returns, there aren't 2 keyboards visible
-      InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-      imm.hideSoftInputFromWindow(addressField.getWindowToken(), 0);
-
       super.onBackPressed();
       finish();
-      //overridePendingTransition(0, android.R.anim.fade_out);
     }
   }
 

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
@@ -13,10 +13,10 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:ems="10"
-        android:inputType="textMultiLine"
+        android:inputType="textMultiLine|textNoSuggestions"
         android:hint="@string/textview_hint"
         android:gravity="top"
-        android:scrollbars="vertical" >
+        android:scrollbars="vertical">
 
         <requestFocus />
     </com.tavultesoft.kmea.KMTextView>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -168,6 +168,11 @@ final class KMKeyboard extends WebView {
     setBackgroundColor(0);
   }
 
+  public void hideKeyboard() {
+    String jsString = "javascript:hideKeyboard()";
+    loadUrl(jsString);
+  }
+
   public void executeHardwareKeystroke(int code, int shift, int lstates) {
     String jsFormat = "javascript:executeHardwareKeystroke(%d,%d, %d)";
     String jsString = String.format(jsFormat, code, shift, lstates);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -257,6 +257,12 @@ public final class KMManager {
     }
   }
 
+  public static void hideSystemKeyboard() {
+    if (SystemKeyboard != null) {
+      SystemKeyboard.hideKeyboard();
+    }
+  }
+
   @SuppressLint("InflateParams")
   public static View createInputView(InputMethodService inputMethodService) {
     //final Context context = appContext;

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-04-24 10.0.376 beta
+* Hide system OSK when resuming Keyman app (#711)
+
 ## 2018-03-22 10.0.373 beta
 * Initial beta release of Keyman for Android 10.0
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,7 +1,7 @@
 # Keyman for Android
 
 ## 2018-04-24 10.0.376 beta
-* Hide system OSK when resuming Keyman app (#711)
+* Hide system OSK when resuming Keyman app. Disable text suggestions (#711)
 
 ## 2018-03-22 10.0.373 beta
 * Initial beta release of Keyman for Android 10.0


### PR DESCRIPTION
Fixes #711 

This handles all transitions where an external app/dialog using the system OSK returns to the Keyman app such as resuming:
* from WebBrowserActivity
* from Android Oreo's "Add to dictionary" dialog

Also disabled text suggestions in the app so users won't see red underlines in their text.