### PR TITLE
Proper escaping for popup keys between Swift and JS

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -12,6 +12,7 @@ display_usage ( ) {
     echo "  -clean                  Removes all previously-existing build products for KMEI and the Keyman app before building."
     echo "  -no-kmw                 Uses existing keyman.js, doesn't try to build"
     echo "  -only-framework         Builds only the KeymanEngine framework; does not attempt to build the app."
+    echo "  -no-carthage            Disables downloading and building for dependencies."
     echo "  -no-codesign            Disables code-signing for the Keyman application, allowing it to be performed separately later."
     echo "                          Will not construct the archive and .ipa.  (includes -no-archive)"
     echo "  -no-archive             Bypasses the archive and .ipa preparation stage."

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -78,7 +78,21 @@ extension KeymanWebViewController {
 
   // FIXME: text is unused in the JS
   func executePopupKey(id: String, text: String) {
-    webView.evaluateJavaScript("executePopupKey('\(id)','\(text)');", completionHandler: nil)
+    //var escapedText: String;
+    // Text must be checked for ', ", and \ characters; they must be escaped properly!
+    do {
+      let encodingArray = [ text ];
+      let jsonString = try String(data: JSONSerialization.data(withJSONObject: encodingArray), encoding: .utf8)!
+      let start = jsonString.index(jsonString.startIndex, offsetBy: 2)
+      let end = jsonString.index(jsonString.endIndex, offsetBy: -2)
+      let escapedText = jsonString[start..<end]
+      
+      let cmd = "executePopupKey(\"\(id)\",\"\(escapedText)\");"
+      webView.evaluateJavaScript(cmd, completionHandler: nil)
+    } catch {
+      log.error(error)
+      return
+    }
   }
 
   func setOskWidth(_ width: Int) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -78,7 +78,6 @@ extension KeymanWebViewController {
 
   // FIXME: text is unused in the JS
   func executePopupKey(id: String, text: String) {
-    //var escapedText: String;
     // Text must be checked for ', ", and \ characters; they must be escaped properly!
     do {
       let encodingArray = [ text ];

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2018-04-25 10.0.140 beta
+* Fixed lack of output for certain punctuation longpress keys. (#702)
+
 ## 2018-03-22 10.0.139 beta
 * Initial beta release of Keyman for iPhone and iPad 10
 


### PR DESCRIPTION
Fixes #702.

As it turns out, part of the app wasn't properly escaping the `'` and `\` characters when passing strings from Swift to JavaScript through the WebView barrier, which resulted in instant JS errors that prevented our default punctuation popup keys from working properly on the default app keyboard (EuroLatin2), among others.

This aims to fix the issue by using Swift's JSON-oriented escaping functionality to create the appropriate escaped string.

I also threw in a small tweak to build.sh to properly document one of the newer parameters to build.sh.