### PR TITLE
Rewrite all context help links to match Developer 10.0 help paths and identifiers

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -263,7 +263,8 @@ uses
   Keyman.System.KMXFileLanguages in '..\..\global\delphi\keyboards\Keyman.System.KMXFileLanguages.pas',
   Keyman.System.LanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.LanguageCodeUtils.pas',
   Keyman.System.RegExGroupHelperRSP19902 in '..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas',
-  Keyman.System.UpdateCheckResponse in '..\..\global\delphi\general\Keyman.System.UpdateCheckResponse.pas';
+  Keyman.System.UpdateCheckResponse in '..\..\global\delphi\general\Keyman.System.UpdateCheckResponse.pas',
+  Keyman.Developer.System.HelpTopics in 'help\Keyman.Developer.System.HelpTopics.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -503,6 +503,7 @@
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.LanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.UpdateCheckResponse.pas"/>
+        <DCCReference Include="help\Keyman.Developer.System.HelpTopics.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/child/UfrmBitmapEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmBitmapEditor.pas
@@ -35,8 +35,8 @@ type
     procedure FormCreate(Sender: TObject);
   private
     procedure FrameModified(Sender: TObject);
-
   protected
+    function GetHelpTopic: string; override;
     function DoOpenFile: Boolean; override;
     function DoSaveFile: Boolean; override;
     function GetFileNameFilter: string; override;
@@ -48,7 +48,13 @@ type
 
 implementation
 
-uses Clipbrd, UfrmMain, UfrmMessages;
+uses
+  Clipbrd,
+
+  Keyman.Developer.System.HelpTopics,
+
+  UfrmMain,
+  UfrmMessages;
 
 {$R *.DFM}
 
@@ -76,6 +82,11 @@ end;
 function TfrmBitmapEditor.GetFileNameFilter: string;
 begin
   Result := 'Bitmap files (*.bmp)|*.bmp|All files (*.*)|*.*';
+end;
+
+function TfrmBitmapEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_BitmapEditor;
 end;
 
 function TfrmBitmapEditor.DoOpenFile: Boolean;

--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -199,6 +199,9 @@ type
     procedure WMUSERUpdateForceKeyboard(var Message: TMessage); message WM_USER_UpdateForceKeyboard;   // I4767
     procedure UpdateCharacterGrid;   // I4808
 
+  protected
+    function GetHelpTopic: string; override;
+
   public
     function CanChangeANSITest: Boolean;
     property ANSITest: Boolean read FANSITest write SetANSITest;
@@ -261,6 +264,8 @@ implementation
 {$R *.DFM}
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   ActiveX,
   dmActionsKeyboardEditor,
   dmActionsMain,
@@ -1302,6 +1307,11 @@ end;
 function TfrmDebug.GetDebugKeyboard: TDebugKeyboard;
 begin
   Result := debugkeyboard;
+end;
+
+function TfrmDebug.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Debug;
 end;
 
 function TfrmDebug.GetStatusText: string;

--- a/windows/src/developer/TIKE/child/UfrmDebugStatus.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebugStatus.pas
@@ -60,6 +60,8 @@ type
     procedure SetDebugForm(const Value: TfrmDebug);
     procedure SetDisplayFont(const Value: TFont);
 
+  protected
+    function GetHelpTopic: string; override;
   public
     property DebugForm: TfrmDebug read FDebugForm write SetDebugForm;
 
@@ -72,12 +74,11 @@ type
     property RegTest: TfrmDebugStatus_RegTest read FRegTest;
   end;
 
-//var
-//  frmDebugStatus: TfrmDebugStatus;
-
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   UfrmMain;
 
 {$R *.dfm}
@@ -106,6 +107,11 @@ begin
   FRegTest := TfrmDebugStatus_RegTest.Create(Self);
   FRegTest.Parent := tabDebugRegressionTesting;
   FRegTest.Visible := True;
+end;
+
+function TfrmDebugStatus.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus;
 end;
 
 procedure TfrmDebugStatus.SetDebugForm(const Value: TfrmDebug);

--- a/windows/src/developer/TIKE/child/UfrmEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmEditor.pas
@@ -86,6 +86,7 @@ type
     function GetTextFileFormat: TTextFileFormat;
 
   protected
+    function GetHelpTopic: string; override;
     function DoSaveFile: Boolean; override;
     function DoOpenFile: Boolean; override;
     function GetFileNameFilter: string; override;
@@ -116,6 +117,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   CharacterDragObject,
   CharMapDropTool,
   ClipBrd,
@@ -326,6 +329,11 @@ end;
 function TfrmEditor.GetFileNameFilter: string;
 begin
   Result := 'Keyboard definitions (*.kmn)|*.kmn|HTML files (*.htm, *.html)|*.htm?|XML files (*.xml)|*.xml|Text files (*.txt)|*.txt|All files (*.*)|*.*';
+end;
+
+function TfrmEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Editor;
 end;
 
 function TfrmEditor.GetTextFileFormat: TTextFileFormat;

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -466,6 +466,7 @@ type
     procedure OrderDetailsPanels;
 
   protected
+    function GetHelpTopic: string; override;
 
     procedure FocusTab;
 
@@ -547,6 +548,8 @@ implementation
 uses
   System.Math,
   System.Win.ComObj,
+
+  Keyman.Developer.System.HelpTopics,
 
   CharacterDragObject,
   CharacterInfo,
@@ -1822,6 +1825,11 @@ begin
         end;
       end;
   end;
+end;
+
+function TfrmKeymanWizard.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_KeyboardEditor;
 end;
 
 function TfrmKeymanWizard.GetIsDebugVisible: Boolean;

--- a/windows/src/developer/TIKE/child/UfrmOSKEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmOSKEditor.pas
@@ -31,6 +31,7 @@ type
     frameOSK: TframeOnScreenKeyboardEditor;
     procedure OSKModified(Sender: TObject);
   protected
+    function GetHelpTopic: string; override;
     function GetFileNameFilter: string; override;
     function GetDefaultExt: string; override;
 
@@ -43,6 +44,9 @@ type
   end;
 
 implementation
+
+uses
+  Keyman.Developer.System.HelpTopics;
 
 {$R *.dfm}
 
@@ -89,6 +93,11 @@ end;
 function TfrmOSKEditor.GetFileNameFilter: string;
 begin
   Result := 'On Screen Keyboard Files (*.kvk)|*.kvk';
+end;
+
+function TfrmOSKEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_OSKEditor;
 end;
 
 end.

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -251,6 +251,7 @@ type
       State: TProjectLogState);
 
   protected
+    function GetHelpTopic: string; override;
     function DoOpenFile: Boolean; override;
     function DoSaveFile: Boolean; override;
     function GetFileNameFilter: string; override;
@@ -273,6 +274,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   CharMapDropTool,
   CharMapInsertMode,
   CompilePackageInstaller,
@@ -460,6 +463,11 @@ end;
 function TfrmPackageEditor.GetFileNameFilter: string;
 begin
   Result := 'Package source files (*.kps)|*.kps|All files (*.*)|*.*';
+end;
+
+function TfrmPackageEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_PackageEditor;
 end;
 
 function TfrmPackageEditor.DoOpenFile: Boolean;

--- a/windows/src/developer/TIKE/child/UfrmTestKeyboard.pas
+++ b/windows/src/developer/TIKE/child/UfrmTestKeyboard.pas
@@ -93,6 +93,8 @@ type
     procedure SaveFont;
     procedure FocusTestWindow;
     procedure ShowEditControl;
+  protected
+    function GetHelpTopic: string; override;
   public
     procedure Reload;
     property KeyboardName: string read FKeyboardName write SetKeyboardName;
@@ -102,6 +104,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   KeymanDeveloperUtils,
   kmxfile,
   UfrmMessages,
@@ -429,6 +433,11 @@ begin
   end;
 end;
 
+
+function TfrmTestKeyboard.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_TestKeyboard;
+end;
 
 { Debug menu }
 

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_CallStack.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_CallStack.pas
@@ -34,6 +34,9 @@ type
     function SetEditorCursorLine(ALine: Integer): Boolean;
     { Call stack functions }
 
+  protected
+    function GetHelpTopic: string; override;
+
   public
     { Public declarations }
     procedure CallStackPush(rule: TDebugEventRuleData);
@@ -44,6 +47,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   UKeyBitmap;
 
 {$R *.dfm}
@@ -86,6 +91,11 @@ begin
     QID_NOMATCH_ENTER:
       lbCallStack.Items.AddObject('nomatch rule', rule);
   end;
+end;
+
+function TfrmDebugStatus_CallStack.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus_CallStack;
 end;
 
 procedure TfrmDebugStatus_CallStack.lbCallStackDblClick(Sender: TObject);

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_Child.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_Child.pas
@@ -52,7 +52,8 @@ type
 
 implementation
 
-uses UfrmDebugStatus;
+uses
+  UfrmDebugStatus;
 
 {$R *.dfm}
 

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_Deadkeys.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_Deadkeys.pas
@@ -32,6 +32,10 @@ type
   private
     { Deadkey functions }
     procedure ClearDeadKeys;
+
+  protected
+    function GetHelpTopic: string; override;
+
   public
     procedure UpdateDeadkeyDisplay(deadkeys: TList);
     procedure DeselectDeadkeys;
@@ -39,7 +43,10 @@ type
 
 implementation
 
-uses UfrmDebugStatus;
+uses
+  Keyman.Developer.System.HelpTopics,
+
+  UfrmDebugStatus;
 
 {$R *.dfm}
 
@@ -52,6 +59,11 @@ procedure TfrmDebugStatus_DeadKeys.DeselectDeadkeys;
 begin
   lbDeadkeys.ItemIndex := -1;
   lbDeadkeysClick(lbDeadkeys);
+end;
+
+function TfrmDebugStatus_DeadKeys.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus_DeadKeys;
 end;
 
 procedure TfrmDebugStatus_DeadKeys.lbDeadkeysClick(Sender: TObject);

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_Elements.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_Elements.pas
@@ -53,9 +53,8 @@ type
     function GetStoreDisplayWidth(Element: TXStringElement): Integer;
     procedure ResizeStoreGrid;
 
-//    procedure RefreshOptions;
-
   protected
+    function GetHelpTopic: string; override;
     procedure DisplayFontChanged; override;
   public
     procedure UpdateStores(Event: TDebugEvent);
@@ -65,6 +64,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   KeymanDeveloperOptions,
   UfrmDebugStatus;
 
@@ -320,6 +321,11 @@ procedure TfrmDebugStatus_Elements.FormResize(Sender: TObject);
 begin
   ResizeStoreGrid;
   lvElements.Repaint;
+end;
+
+function TfrmDebugStatus_Elements.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus_Elements;
 end;
 
 function TfrmDebugStatus_Elements.GetStoreDisplayWidth(Element: TXStringElement): Integer;

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_Key.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_Key.pas
@@ -47,6 +47,8 @@ type
     FRegTest: TRegressionTest;   // I4809
     FUIStatus: TDebugUIStatus;   // I4809
     procedure SetUIStatus(const Value: TDebugUIStatus);   // I4809
+  protected
+    function GetHelpTopic: string; override;
   public
     procedure ClearLog;   // I4809
     procedure ShowKey(key: PAIDebugKeyInfo);
@@ -56,6 +58,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   KeyNames,
   UKeyBitmap;
 
@@ -78,6 +82,11 @@ procedure TfrmDebugStatus_Key.FormDestroy(Sender: TObject);
 begin
   inherited;
   FRegTest.Free;   // I4809
+end;
+
+function TfrmDebugStatus_Key.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus_Key
 end;
 
 procedure TfrmDebugStatus_Key.panKeyPaint(Sender: TObject);

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_RegTest.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_RegTest.pas
@@ -77,6 +77,7 @@ type
     procedure BatchRegTest;
 
   protected
+    function GetHelpTopic: string; override;
     procedure DebugKeyboardChanged; override;
 
   public
@@ -94,6 +95,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   debugDeadkeys,
   KeyNames,
   TextFileFormat,
@@ -386,6 +389,11 @@ procedure TfrmDebugStatus_RegTest.FormDestroy(Sender: TObject);
 begin
   inherited;
   FreeAndNil(FRegTest);
+end;
+
+function TfrmDebugStatus_RegTest.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DebugStatus_RegTest;
 end;
 
 end.

--- a/windows/src/developer/TIKE/debug/UfrmKeyTest.pas
+++ b/windows/src/developer/TIKE/debug/UfrmKeyTest.pas
@@ -58,6 +58,7 @@ type
     FLastActiveControl: TWinControl;
     procedure WMKey(var Msg: TMsg);
   protected
+    function GetHelpTopic: string; override;
   public
     function ShowModal: Integer; override;
   end;
@@ -66,7 +67,10 @@ function FormatKeyName(Shift, Key: Integer):  string;
 
 implementation
 
-uses UfrmMain, KeyNames, UfrmMDIChild, CharMapInsertMode, CharMapDropTool;
+uses
+  Keyman.Developer.System.HelpTopics,
+
+UfrmMain, KeyNames, UfrmMDIChild, CharMapInsertMode, CharMapDropTool;
 
 {$R *.DFM}
 
@@ -364,6 +368,11 @@ begin
   Close;
   if Assigned(FLastActiveControl) then
     GetCharMapDropTool.InsertToControl(FLastActiveControl, FormatKeyName(FLastShift, FLastKey), cmimCode);
+end;
+
+function TfrmKeyTest.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_KeyTest;
 end;
 
 function TfrmKeyTest.ShowModal: Integer;

--- a/windows/src/developer/TIKE/debug/UfrmSelectSystemKeyboard.pas
+++ b/windows/src/developer/TIKE/debug/UfrmSelectSystemKeyboard.pas
@@ -54,7 +54,8 @@ type
     function GetSystemKeyboardName: string;
     procedure SetSystemKeyboardName(Value: string);
     procedure InvalidateCell(ACol, ARow: Integer);
-    { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     property SystemKeyboardName: string read GetSystemKeyboardName write SetSystemKeyboardName;
@@ -71,6 +72,8 @@ function GetSystemKeyboardIndex(keyboardlist: TStrings; id: string): Integer;
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   ErrorControlledRegistry, 
   RegistryKeys,
   utilstr;
@@ -153,6 +156,11 @@ begin
     str.Free;
     Free;
   end;
+end;
+
+function TfrmSelectSystemKeyboard.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_SelectSystemKeyboard;
 end;
 
 function TfrmSelectSystemKeyboard.GetSystemKeyboardName: string;

--- a/windows/src/developer/TIKE/dialogs/UfrmAboutTike.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmAboutTike.pas
@@ -50,6 +50,8 @@ type
     procedure imgKeymanClick(Sender: TObject);
   private
     FOnIconClick: TNotifyEvent;
+  protected
+    function GetHelpTopic: string; override;
   public
     property OnIconClick: TNotifyEvent read FOnIconClick write FOnIconClick;
   end;
@@ -58,6 +60,8 @@ implementation
 
 uses
   VCL.Themes,
+
+  Keyman.Developer.System.HelpTopics,
 
   KeymanVersion,
   onlineconstants,
@@ -82,6 +86,11 @@ end;
 procedure TfrmAboutTike.lblWebsiteClick(Sender: TObject);
 begin
   TUtilExecute.URL(lblWebsite.Caption);  // I3349
+end;
+
+function TfrmAboutTike.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_About;
 end;
 
 procedure TfrmAboutTike.imgKeymanClick(Sender: TObject);

--- a/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.pas
@@ -59,7 +59,8 @@ type
     procedure SetInsertFont(const Value: TFont);
     procedure DrawPreview;
     procedure SetDisplayQuality(const Value: TClearTypeDisplayQuality);
-    { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     property DisplayQuality: TClearTypeDisplayQuality read FDisplayQuality write SetDisplayQuality;
@@ -72,6 +73,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   UFixFontDialogBold,
   UframeBitmapEditor;
 
@@ -124,6 +127,11 @@ begin
   SetBounds(X, Y, Width, Height);
 
   DrawPreview;
+end;
+
+function TfrmBitmapEditorText.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_BitmapEditorText;
 end;
 
 function TfrmBitmapEditorText.GetInsertText: WideString;

--- a/windows/src/developer/TIKE/dialogs/UfrmKeyboardFonts.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmKeyboardFonts.pas
@@ -72,12 +72,17 @@ type
     FControls: array[TKeyboardFont] of TKeyboardFontControl;
     function GetFontInfo(Index: TKeyboardFont): TKeyboardFontInfo;
     procedure SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     property FontInfo[Index: TKeyboardFont]: TKeyboardFontInfo read GetFontInfo write SetFontInfo;
   end;
 
 implementation
+
+uses
+  Keyman.Developer.System.HelpTopics;
 
 {$R *.dfm}
 
@@ -123,6 +128,11 @@ begin
   Result.Size := FControls[Index].SizeEdit.Text;
   Result.Enabled := FControls[Index].NameCombo.Enabled;
   //Result.Filename := IncludeTrailingPathDelimiter(FControls[Index].PathEdit.Text) + FControls[Index].FilenameEdit.Text;
+end;
+
+function TfrmKeyboardFonts.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_KeyboardFonts;
 end;
 
 procedure TfrmKeyboardFonts.SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);

--- a/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.pas
@@ -33,14 +33,18 @@ type
     chkAutoRecompile: TCheckBox;
     procedure cmdOKClick(Sender: TObject);
   private
-    { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
   end;
 
 implementation
 
-uses KeymanDeveloperOptions;
+uses
+  Keyman.Developer.System.HelpTopics,
+
+  KeymanDeveloperOptions;
 
 {$R *.DFM}
 
@@ -54,6 +58,11 @@ begin
   end
   else
     ModalResult := mrYes;
+end;
+
+function TfrmMustIncludeDebug.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_MustIncludeDebug;
 end;
 
 end.

--- a/windows/src/developer/TIKE/dialogs/UfrmNew.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNew.pas
@@ -72,6 +72,8 @@ type
     function GetAddToProject: Boolean;
     function GetFileName: string;
     function GetDefaultExt: string;
+  protected
+    function GetHelpTopic: string; override;
   public
     property FileType: TKMFileType read GetFileType;
     property AddToProject: Boolean read GetAddToProject;
@@ -81,6 +83,8 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   Project,
   shlobj,
   utilsystem;
@@ -247,6 +251,11 @@ begin
     Result := ftHTMLFile
   else
     Result := ftOther;
+end;
+
+function TfrmNew.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_New;
 end;
 
 procedure TfrmNew.mnuShowIconsClick(Sender: TObject);

--- a/windows/src/developer/TIKE/dialogs/UfrmNewFileDetails.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNewFileDetails.pas
@@ -55,6 +55,8 @@ type
     procedure EnableControls;
     function GetFileName: string;
     procedure SetBaseFileName(Value: string);
+  protected
+    function GetHelpTopic: string; override;
   public
     property FileName: string read GetFileName;
     property FileType: TKMFileType read FFileType write SetFileType;
@@ -65,6 +67,9 @@ implementation
 
 uses
   ShlObj,
+
+  Keyman.Developer.System.HelpTopics,
+
   utilsystem;
 
 {$R *.DFM}
@@ -148,6 +153,11 @@ begin
   Result := IncludeTrailingPathDelimiter(editFilePath.Text) + editFileName.Text;   // I4798
   if AnsiCompareText(ExtractFileExt(Result), FDefaultExt) <> 0 then
     Result := Result + FDefaultExt;
+end;
+
+function TfrmNewFileDetails.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_NewFileDetails;
 end;
 
 end.

--- a/windows/src/developer/TIKE/dialogs/UfrmOptions.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmOptions.pas
@@ -156,6 +156,8 @@ type
     procedure RefreshColourPanels;
   {$ENDIF}
     { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
   end;
@@ -165,6 +167,8 @@ implementation
 {$R *.DFM}
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   JvDockControlForm,
   OnlineConstants,
   RedistFiles,
@@ -316,6 +320,11 @@ begin
 {$ENDIF}
   FDefaultFont.Free;
   FQuotedFont.Free;
+end;
+
+function TfrmOptions.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Options;
 end;
 
 procedure TfrmOptions.cmdOKClick(Sender: TObject);

--- a/windows/src/developer/TIKE/dialogs/UfrmRegressionTestFailure.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmRegressionTestFailure.pas
@@ -45,7 +45,8 @@ type
     procedure SetActualString(Value: WideString);
     procedure SetExpectedString(Value: WideString);
     procedure SetTestName(Value: string);
-    { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     property TestName: string read FTestName write SetTestName;
@@ -56,9 +57,17 @@ type
 
 implementation
 
+uses
+  Keyman.Developer.System.HelpTopics;
+
 {$R *.DFM}
 
 { TfrmRegressionTestFailure }
+
+function TfrmRegressionTestFailure.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_RegressionTestFailure;
+end;
 
 procedure TfrmRegressionTestFailure.SetActualString(Value: WideString);
 begin

--- a/windows/src/developer/TIKE/dialogs/UfrmSelectKey.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmSelectKey.pas
@@ -33,6 +33,8 @@ type
     FVKey: Word;
     FShiftState: TExtShiftState;
     FDistinguishLeftRight: Boolean;
+  protected
+    function GetHelpTopic: string; override;
   public
     property VKey: Word read FVKey;
     property ShiftState: TExtShiftState read FShiftState;
@@ -40,6 +42,9 @@ type
   end;
 
 implementation
+
+uses
+  Keyman.Developer.System.HelpTopics;
 
 {$R *.DFM}
 
@@ -65,6 +70,11 @@ begin
 
   Key := 0;
   ModalResult := mrOk;
+end;
+
+function TfrmSelectKey.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_SelectKey;
 end;
 
 end.

--- a/windows/src/developer/TIKE/dialogs/UfrmVisualKeyboardImportKMX.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmVisualKeyboardImportKMX.pas
@@ -66,6 +66,7 @@ type
     procedure Validate102Key;
     procedure SetStatus(const msg: string);
   protected
+    function GetHelpTopic: string; override;
     procedure WndProc(var Message: TMessage); override;
   public
     property FileName: WideString read FFileName write FFileName;
@@ -77,6 +78,7 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
   keyman32_int,
   KeymanDeveloperUtils,
   kmxfileconsts,
@@ -492,6 +494,11 @@ begin
     Inc(kp);
   end;
 
+end;
+
+function TfrmVisualKeyboardImportKMX.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_VisualKeyboardImportKMX;
 end;
 
 function TfrmVisualKeyboardImportKMX.GetKeyboardKeys: Boolean;

--- a/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
+++ b/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
@@ -52,7 +52,8 @@ type
     function GetLanguageID: string;
     function GetLanguageName: string;
     procedure RefreshPreview;
-    { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     property LanguageID: string read GetLanguageID;
@@ -62,6 +63,7 @@ type
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
   Keyman.System.KMXFileLanguages,
   utilexecute;
 
@@ -79,6 +81,11 @@ procedure TfrmSelectBCP47Language.FormDestroy(Sender: TObject);
 begin
   inherited;
   FreeAndNil(tag);
+end;
+
+function TfrmSelectBCP47Language.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_SelectBCP47Language;
 end;
 
 function TfrmSelectBCP47Language.GetLanguageID: string;

--- a/windows/src/developer/TIKE/dialogs/languages/UfrmSelectWindowsLanguages.pas
+++ b/windows/src/developer/TIKE/dialogs/languages/UfrmSelectWindowsLanguages.pas
@@ -37,6 +37,8 @@ type
     function GetLanguageNames(Index: Integer): WideString;
     function GetLanguages(Index: Integer): Integer;
     { Private declarations }
+  protected
+    function GetHelpTopic: string; override;
   public
     { Public declarations }
     procedure RemoveLanguage(ID: Integer);
@@ -47,6 +49,9 @@ type
 
 implementation
 
+uses
+  Keyman.Developer.System.HelpTopics;
+
 {$R *.dfm}
 
 procedure TfrmSelectWindowsLanguages.FormCreate(Sender: TObject);
@@ -56,6 +61,11 @@ begin
   cmdOK.Enabled := False;
   for i := 0 to High(CWindowsLanguages) do
     lbLanguages.Items.AddObject(CWindowsLanguages[i].Name, Pointer(CWindowsLanguages[i].ID));
+end;
+
+function TfrmSelectWindowsLanguages.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_SelectWindowsLanguages;
 end;
 
 function TfrmSelectWindowsLanguages.GetLanguageCount: Integer;

--- a/windows/src/developer/TIKE/dockforms/UfrmCharacterMapDock.pas
+++ b/windows/src/developer/TIKE/dockforms/UfrmCharacterMapDock.pas
@@ -11,6 +11,8 @@ type
   TfrmCharacterMapDock = class(TTikeDockForm)
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
+  protected
+    function GetHelpTopic: string; override;
   public
     procedure RefreshOptions;
   end;
@@ -23,6 +25,8 @@ implementation
 {$R *.dfm}
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   RegistryKeys,
   UfrmMain;
 
@@ -33,6 +37,7 @@ begin
   frmCharacterMapNew.BorderStyle := bsNone;
   frmCharacterMapNew.Parent := Self;
   frmCharacterMapNew.Visible := True;
+  frmCharacterMapNew.HelpKeyword := SHelpTopic_Context_CharacterMap;
 
   frmCharacterMapNew.OnCancelFocus := frmKeymanDeveloper.CharMapCancelFocus;
   frmCharacterMapNew.OnInsertCode := frmKeymanDeveloper.CharMapInsertCode;
@@ -44,6 +49,11 @@ procedure TfrmCharacterMapDock.FormDestroy(Sender: TObject);
 begin
   inherited;
   FreeAndNil(frmCharacterMapNew);
+end;
+
+function TfrmCharacterMapDock.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_CharacterMap;
 end;
 
 procedure TfrmCharacterMapDock.RefreshOptions;

--- a/windows/src/developer/TIKE/help/Keyman.Developer.System.HelpTopics.pas
+++ b/windows/src/developer/TIKE/help/Keyman.Developer.System.HelpTopics.pas
@@ -1,0 +1,51 @@
+unit Keyman.Developer.System.HelpTopics;
+
+interface
+
+const
+  SHelpTopic_Context_About = 'context/about-tike';
+  SHelpTopic_Context_BitmapEditorText = 'context/keyboard-editor#toc-icon-tab';
+  SHelpTopic_Context_CharacterMap = 'context/character-map';
+  SHelpTopic_Context_CharacterIdentifier = 'context/character-identifier';
+  SHelpTopic_Context_Debug = 'context/debug';
+  SHelpTopic_Context_DebugStatus = 'context/debug#toc-state';
+  SHelpTopic_Context_DebugStatus_CallStack = 'context/debug#toc-call-stack';
+  SHelpTopic_Context_DebugStatus_DeadKeys = 'context/debug#toc-deadkeys';
+  SHelpTopic_Context_DebugStatus_Elements = 'context/debug#toc-elements';
+  SHelpTopic_Context_DebugStatus_Key = 'context/debug#toc-state';
+  SHelpTopic_Context_DebugStatus_RegTest = 'context/debug#toc-regression-testing';
+  SHelpTopic_Context_DownloadProgress = 'context/download-progress';
+  SHelpTopic_Context_Help = 'context/help';
+  SHelpTopic_Context_KeyTest = 'context/key-test';
+  SHelpTopic_Context_KeyboardFonts = 'context/keyboard-fonts';
+  SHelpTopic_Context_Messages = 'context/messages';
+  SHelpTopic_Context_MustIncludeDebug = 'context/must-include-debug';
+  SHelpTopic_Context_New = 'context/new';
+  SHelpTopic_Context_NewFileDetails = 'context/new-file-details';
+  SHelpTopic_Context_OnScreenKeyboardEditor = 'context/keyboard-editor#toc-on-screen-tab';
+  SHelpTopic_Context_Options = 'context/options';
+  SHelpTopic_Context_Project = 'context/project';
+  SHelpTopic_Context_RegressionTestFailure = 'context/debug#toc-regression-testing';
+  SHelpTopic_Context_SelectBCP47Language = 'context/select-bcp47-language';
+  SHelpTopic_Context_SelectKey = 'context/keyboard-editor#toc-layout-tab';
+  SHelpTopic_Context_SelectSystemKeyboard = 'context/select-system-keyboard';
+  SHelpTopic_Context_SelectWindowsLanguages = 'context/select-windows-languages';
+  SHelpTopic_Context_Startup = 'context/startup';
+  SHelpTopic_Context_TextEditor = 'context/editor';
+  SHelpTopic_Context_VisualKeyboardImportKMX = 'context/keyboard-editor#toc-on-screen-tab';
+  SHelpTopic_Context_VisualKeyboardExportHtmlParams = 'context/keyboard-editor#toc-on-screen-tab';
+
+  SHelpTopic_Context_Editor = 'context/editor';
+  SHelpTopic_Context_PackageEditor = 'context/package-editor';
+  SHelpTopic_Context_OSKEditor = 'context/keyboard-editor#toc-on-screen-tab';
+  SHelpTopic_Context_BitmapEditor = 'context/keyboard-editor#toc-icon-tab';
+  SHelpTopic_Context_KeyboardEditor = 'context/keyboard-editor';
+  SHelpTopic_Context_TouchLayoutBuilder = 'context/keyboard-editor#toc-touch-layout-tab';
+  SHelpTopic_Context_TestKeyboard = 'context/debug#toc-test-mode';
+
+  // For all .kmn language reference topics, prefix with this path:
+  SHelpTopic_LanguageReference_Prefix = 'language/reference/';
+  SHelpTopic_LanguageGuide_Prefix = 'language/guide/';
+implementation
+
+end.

--- a/windows/src/developer/TIKE/help/webhelp.pas
+++ b/windows/src/developer/TIKE/help/webhelp.pas
@@ -37,6 +37,7 @@ type
 implementation
 
 uses
+  System.StrUtils,
   System.SysUtils,
 
   utilexecute;
@@ -45,6 +46,8 @@ constructor TWebHookHelpSystem.Create(aRootWebPath: string);
 begin
   inherited Create;
   FRootWebPath := aRootWebPath;
+  if (FRootWebPath <> '') and (FRootWebPath[Length(FRootWebPath)] <> '/') then
+    FRootWebPath := FRootWebPath + '/';
 end;
 
 function TWebHookHelpSystem.HelpContext(aContextId: DWord): Boolean;
@@ -64,7 +67,7 @@ begin
   begin
     for i := 1 to Length(aTopic) do if aTopic[i] = '\' then aTopic[i] := '/';
     if aTopic[1] = '/' then Delete(aTopic, 1, 1);
-    s := FRootWebPath + aTopic + '.php';
+    s := FRootWebPath + aTopic;
   end
   else
     s := FRootWebPath;

--- a/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
@@ -182,6 +182,8 @@ type
     function DoesKeyboardSupportXMLVisualKeyboard: Boolean;
     function TransferDesignToSource: Boolean;
     function TransferSourceToDesign(ASilent: Boolean): Boolean;   // I4057
+  protected
+    function GetHelpTopic: string; override;
   public
     procedure Load;
     procedure Save;
@@ -201,6 +203,8 @@ implementation
 
 uses
   Xml.Xmldom,
+
+  Keyman.Developer.System.HelpTopics,
 
   CharacterInfo,
   CharMapInsertMode,
@@ -1238,6 +1242,11 @@ begin
   finally
     Free;
   end;
+end;
+
+function TframeOnScreenKeyboardEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_OnScreenKeyboardEditor;
 end;
 
 function TframeOnScreenKeyboardEditor.GetHTMLExportParams(FFileName: string;

--- a/windows/src/developer/TIKE/main/UfrmCharacterIdentifier.pas
+++ b/windows/src/developer/TIKE/main/UfrmCharacterIdentifier.pas
@@ -68,6 +68,8 @@ type
     procedure FontSizeChanged(Sender: TObject);
     procedure UpdateFont;
     procedure CancelFocus;
+  protected
+    function GetHelpTopic: string; override;
   public
     property Chars: string read FChars write SetChars;
     property OnCancelFocus: TNotifyEvent read FOnCancelFocus write FOnCancelFocus;
@@ -79,6 +81,8 @@ var
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   UfrmCharacterMapNew,
   Unicode;
 
@@ -291,6 +295,7 @@ end;
 
 procedure TfrmCharacterIdentifier.FormActivate(Sender: TObject);
 begin
+  inherited;
   RefreshFonts;
 end;
 
@@ -302,6 +307,8 @@ end;
 
 procedure TfrmCharacterIdentifier.FormCreate(Sender: TObject);
 begin
+  inherited;
+
   FDrawChar := TCleartypeDrawCharacter.Create;
   FFontName := frmCharacterMapNew.CharMapFontName;
   frmCharacterMapNew.OnFontSizeChanged := FontSizeChanged;
@@ -314,6 +321,7 @@ end;
 
 procedure TfrmCharacterIdentifier.FormDestroy(Sender: TObject);
 begin
+  inherited;
   if Assigned(frmCharacterMapNew) then
     frmCharacterMapNew.OnFontSizeChanged := nil;
   FreeAndNil(FDrawChar);
@@ -321,7 +329,13 @@ end;
 
 procedure TfrmCharacterIdentifier.FormResize(Sender: TObject);
 begin
+  inherited;
   AdjustPanes;
+end;
+
+function TfrmCharacterIdentifier.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_CharacterIdentifier;
 end;
 
 procedure TfrmCharacterIdentifier.AdjustPanes;

--- a/windows/src/developer/TIKE/main/UfrmDownloadProgress.pas
+++ b/windows/src/developer/TIKE/main/UfrmDownloadProgress.pas
@@ -40,6 +40,8 @@ type
     FCallback: TDownloadProgressCallback;
     FCancel: Boolean;
     procedure WMUserFormShown(var Message: TMessage); message WM_USER_FormShown;
+  protected
+    function GetHelpTopic: string; override;
   public
 
     procedure HTTPCheckCancel(Sender: THTTPUploader; var Cancel: Boolean);
@@ -51,12 +53,20 @@ type
 
 implementation
 
+uses
+  Keyman.Developer.System.HelpTopics;
+
 {$R *.dfm}
 
 procedure TfrmDownloadProgress.cmdCancelClick(Sender: TObject);
 begin
   inherited;
   FCancel := True;
+end;
+
+function TfrmDownloadProgress.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_DownloadProgress;
 end;
 
 procedure TfrmDownloadProgress.HTTPCheckCancel(Sender: THTTPUploader; var Cancel: Boolean);

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -377,7 +377,8 @@ type
     function OpenTestWindow(FFileName: string): TfrmTikeChild;
     function OpenFile(FFileName: string; FCloseNewFile: Boolean): TfrmTikeChild;
 
-    procedure HelpTopic(s: string);
+    procedure HelpTopic(s: string); overload;
+    procedure HelpTopic(Sender: TTIKEForm); overload;
 
     property ChildWindows: TChildWindowList read FChildWindows;
     property CharMapSettings: TCharMapSettings read FCharMapSettings;
@@ -760,9 +761,12 @@ begin
       FInOnHelp := True;
       try
         s := PChar(Data);
-        frm := GetParentForm(Screen.ActiveControl, False);
-        if frm is TTikeForm then
-          (frm as TTikeForm).GetHelpTopic(s);
+        if s = '' then
+        begin
+          frm := GetParentForm(Screen.ActiveControl, False);
+          if frm is TTikeForm then
+            s := (frm as TTikeForm).HelpTopic;
+        end;
         if s <> '' then
           mHHelp.HelpTopic(s);
       finally
@@ -1030,6 +1034,11 @@ begin
     not DoForm(frmHelp) and
     not DoForm(frmCharacterMapDock) then
     DoForm(frmCharacterIdentifier);   // I4807
+end;
+
+procedure TfrmKeymanDeveloper.HelpTopic(Sender: TTIKEForm);
+begin
+  HelpTopic(Sender.HelpTopic);
 end;
 
 function TfrmKeymanDeveloper.OpenTestWindow(FFileName: string): TfrmTikeChild;

--- a/windows/src/developer/TIKE/main/UfrmMessages.pas
+++ b/windows/src/developer/TIKE/main/UfrmMessages.pas
@@ -33,7 +33,8 @@ interface
 
 uses
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
-  StdCtrls, ExtCtrls, CaptionPanel, Menus, Contnrs, UfrmTikeDock, UfrmTike;
+  StdCtrls, ExtCtrls, CaptionPanel, Menus, Contnrs, UfrmTikeDock, UfrmTike,
+  JvComponentBase, JvDockControlForm;
 
 type
   TMessageItem = class
@@ -69,6 +70,7 @@ type
     function GetSelLine: Integer;
     procedure SetSelLine(Value: Integer);
   protected
+    function GetHelpTopic: string; override;
     property SelLine: Integer read GetSelLine write SetSelLine;
   public
     procedure RefreshOptions;
@@ -91,6 +93,8 @@ function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Int
 implementation
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   UfrmMain,
   UfrmMDIEditor,
   dmActionsMain,
@@ -252,6 +256,11 @@ end;
 procedure TfrmMessages.RefreshOptions;
 begin
 
+end;
+
+function TfrmMessages.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Messages;
 end;
 
 function TfrmMessages.GetSelLine: Integer;

--- a/windows/src/developer/TIKE/main/UfrmStartup.pas
+++ b/windows/src/developer/TIKE/main/UfrmStartup.pas
@@ -65,6 +65,7 @@ type
     procedure WMUserFormShown(var Message: TMessage); message WM_USER_FORMSHOWN;
     procedure AppMinimize(Sender: TObject);
   protected
+    function GetHelpTopic: string; override;
     procedure WndProc(var Message: TMessage); override;
   end;
 
@@ -80,6 +81,9 @@ implementation
 
 uses
   Dialogs,
+
+  Keyman.Developer.System.HelpTopics,
+
   OnlineConstants,
   UfrmMain,
   utilexecute,
@@ -188,6 +192,11 @@ end;
 procedure TfrmStartup.FormShow(Sender: TObject);
 begin
   PostMessage(Handle, WM_USER_FormShown, 0, 0);
+end;
+
+function TfrmStartup.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Startup;
 end;
 
 procedure ForceShowStartup(Parent: TForm);

--- a/windows/src/developer/TIKE/main/UfrmTike.pas
+++ b/windows/src/developer/TIKE/main/UfrmTike.pas
@@ -39,27 +39,21 @@ type
     procedure WMUserFormShown(var Message: TMessage); message WM_USER_FormShown;   // I4873
   protected
     procedure FormShown; virtual;   // I4873
+    function GetHelpTopic: string; virtual;
   public
     { Public declarations }
-    procedure GetHelpTopic(var s: string); virtual;
+    property HelpTopic: string read GetHelpTopic;
   end;
 
 implementation
 
 {$R *.dfm}
 
-type
-  TFormHelper = class helper for Forms.TCustomForm   // I4822
-  private
-    procedure RestoreDesignClientSize;
-  end;
-
 procedure TTikeForm.FormCreate(Sender: TObject);
 begin
-  RestoreDesignClientSize;   // I4822
   inherited;
   HelpContext := 0;
-  HelpKeyword := 'context_'+Copy(ClassName, 2, MAXINT);   // I4677   // I4841
+  HelpKeyword := HelpTopic; // 'context/'+Copy(ClassName, 2, MAXINT);   // I4677   // I4841
 end;
 
 procedure TTikeForm.FormShow(Sender: TObject);   // I4873
@@ -71,26 +65,14 @@ procedure TTikeForm.FormShown;   // I4873
 begin
 end;
 
-procedure TTikeForm.GetHelpTopic(var s: string);
+function TTikeForm.GetHelpTopic: string;
 begin
+  Result := '';
 end;
 
 procedure TTikeForm.WMUserFormShown(var Message: TMessage);   // I4873
 begin
   FormShown;
-end;
-
-
-
-{ TFormHelper }
-
-procedure TFormHelper.RestoreDesignClientSize;   // I4822
-begin
-(*  if BorderStyle in [bsSingle, bsDialog] then
-  begin
-    if Self.FClientWidth > 0 then ClientWidth := Self.FClientWidth;
-    if Self.FClientHeight > 0 then ClientHeight := Self.FClientHeight;
-  end;  *)
 end;
 
 end.

--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -84,6 +84,7 @@ type
     procedure SetupModifierKeysForImportedLayout;
     { Private declarations }
   protected
+    function GetHelpTopic: string; override;
 
     procedure CopyToClipboard;
     procedure CutToClipboard;
@@ -125,6 +126,8 @@ uses
   mshtmcid,
   xmlintf,
   xmldoc,
+
+  Keyman.Developer.System.HelpTopics,
 
   KeymanDeveloperOptions,
   VKeys,
@@ -677,6 +680,11 @@ begin
   finally
     Free;
   end;
+end;
+
+function TframeTouchLayoutBuilder.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_TouchLayoutBuilder;
 end;
 
 function TframeTouchLayoutBuilder.GetLayoutJS: string;

--- a/windows/src/developer/TIKE/project/UfrmProject.pas
+++ b/windows/src/developer/TIKE/project/UfrmProject.pas
@@ -113,6 +113,8 @@ type
     procedure EditFileExternal(FileName: WideString);
     function DoNavigate(URL: WideString): Boolean;
     procedure ClearMessages;
+  protected
+    function GetHelpTopic: string; override;
   public
     procedure SetFocus; override;
     procedure SetGlobalProject;
@@ -123,6 +125,9 @@ implementation
 uses
   Winapi.ShellApi,
   ComObj,
+
+  Keyman.Developer.System.HelpTopics,
+
   dmActionsMain,
   KeymanDeveloperOptions,
   kmnProjectFile,
@@ -627,6 +632,11 @@ begin
     web.Go(bstrUrl);
 end;
 
+function TfrmProject.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_Project;
+end;
+
 function TfrmProject.GetIEVersionString: WideString;
 begin
   with TRegistryErrorControlled.Create do  // I2890
@@ -683,7 +693,7 @@ function TfrmProject.webShowHelpRequest(Sender: TObject; HWND: NativeUInt;
   pszHelpFile: PWideChar; uCommand, dwData: Integer; ptMouse: TPoint;
   var pDispatchObjectHit: IDispatch): HRESULT;
 begin
-  frmKeymanDeveloper.HelpTopic('context_frmProject');
+  frmKeymanDeveloper.HelpTopic(Self);
   Result := S_OK;
 end;
 

--- a/windows/src/developer/TIKE/xml/help/contexthelp.xml
+++ b/windows/src/developer/TIKE/xml/help/contexthelp.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <?xml-stylesheet type="text/xsl" href="help.xsl" ?>
 <ContextHelp>
-  <Form Name="TframeBitmapEditor">
+  <Form Name="context/keyboard-editor">
     <Control Name="cmdbitmapChange" Title="Change">
       <p>The Change option allows the editing of the icon filename.</p>
     </Control>
@@ -15,7 +15,8 @@
       <p>The toolbox allows for the changing of the colours, addition of text and shapes.  It also allows for the moving of the icon around the button and also a preview of the button is displayed.</p>
     </Control>
   </Form>
-  <Form Name="TframeOnScreenKeyboardEditor">
+  
+  <Form Name="context/keyboard-editor#toc-on-screen-tab">
     <Control Name="chkVKDisplayUnderlyingChars" Title="Display Underlying Character Layouts">
       <p>If selected, then the visual keyboard will only be used if the current underlying layout is active. </p>
     </Control>
@@ -42,274 +43,72 @@
       <p>Allows the user to enter text to be displayed on the selected key.</p>
     </Control>
   </Form>
-  <Form Name="TfrmCharacterMapNew">
-    <Control Name="editFilter" Title="Filter">
+  
+  <Form Name="context/character-map">
+    <Control Name="editFilter" Title="Character Map Filter">
       <p>The Filter allows a user to reduce the number of characters displayed in the character map.  The standard filter options used are by font name or block name.</p>
     </Control>
-    <Control Name="Grid" Title="Unicode">
+    <Control Name="grid" Title="Character Map">
       <p>The Character Map Grid displays each character in a square, with a visual representation of the character and the Unicode value displayed at the bottom of the square. Each font group is divided into a block headed by the font name.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmInstallerEditor">
-    <Control Name="cbEULA" Title="EULA" />
-    <Control Name="cbStartMenuLocation" Title="Location" />
-    <Control Name="cbStartMenuProgram" Title="Program" />
-    <Control Name="chkCreateStartMenu" Title="Start menu">
-      <p>To create a folder on the Start menu when the keyboard package is installed.</p>
-    </Control>
-    <Control Name="chkStartMenuUninstall" Title="Uninstall">
-      <p>The uninstall shortcut will be added automatically to the shortcut menu list when the package is installed.</p>
-    </Control>
-    <Control Name="clbAddins" Title="Include Addins">
-      <p>Addins can be added to be distributed with the install process by checking the required options.</p>
-    </Control>
-    <Control Name="cmdAddFile" Title="Add">
-      <p>To add additional files to the keyboard package to be distributed.  If you need to include fonts or documentation, put them into a package and include the package in this list. Do not include fonts or documentation directly.</p>
-    </Control>
-    <Control Name="cmdAddToProject" Title="Project" />
-    <Control Name="cmdCompile" Title="Windows Installer">
-      <p>Compiling the product takes all the files you have selected and compresses them into a single Windows Installer .msi file.</p>
-      <p>This option will check for errors an missing files. The success of the compiling will be displayed at the bottom of the screen.</p>
-    </Control>
-    <Control Name="cmdDeleteStartMenuEntry" Title="Delete">
-      <p>To delete the selected shortcut menu item.</p>
-    </Control>
-    <Control Name="cmdExportToWiX" Title="WIX" />
-    <Control Name="cmdInsertCopyright" Title="Copyright Symbol">
-      <p>Allows for the insertion of the copyright symbol.</p>
-    </Control>
-    <Control Name="cmdInstallProduct" Title="Install Product">
-      <p>This option allows for the installation of the package on to the computer when compiling has been completed.</p>
-    </Control>
-    <Control Name="cmdNewStartMenuEntry" Title="New">
-      <p>To add a new menu item to the list of shortcuts in the folder on the Start menu created during installation.</p>
-    </Control>
-    <Control Name="cmdOpenContainingFolder" Title="Open Containing Folder">
-      <p>This option opens the source folder of the selected file.</p>
-    </Control>
-    <Control Name="cmdOpenFile" Title="Edit">
-      <p>To open an editor to make changes to the selected file.</p>
-    </Control>
-    <Control Name="cmdRemoveFile" Title="Remove">
-      <p>This option allows the user to remove a selected file from the distribution list.</p>
-    </Control>
-    <Control Name="cmdSelectKCT" Title="Select">
-      <p>To select an existing branding file.</p>
-    </Control>
-    <Control Name="cmdUpload" Title="Upload">
-      <p>This option allows for the uploading of the keyboard package onto the Tavultesoft website.</p>
-    </Control>
-    <Control Name="editDestinationPath" Title="Program Files">
-      <p>The destination path will always be created under Program Files. The actual name of the Program Files folder may vary from computer to computer and language to language, but the installer will manage that automatically.</p>
-    </Control>
-    <Control Name="editFilePath" Title="Path">
-      <p>The location of the selected file.</p>
-    </Control>
-    <Control Name="editFileType" Title="File Type">
-      <p>Read Only.  Shows information about the type of file selected.</p>
-    </Control>
-    <Control Name="editInfoAuthor" Title="Author's">
-      <p>The name of the developer of the keyboard to displayed as part of the keyboard package details when installed.</p>
-    </Control>
-    <Control Name="editInfoCopyright" Title="Keyman Configuration">
-      <p>Copyright details for the keyboard are displayed when the keyboard is installed. They can also be viewed in Keyman Configuration.</p>
-    </Control>
-    <Control Name="editInfoEmail" Title="Email address">
-      <p>The email address of the developer to allow the user to contact them if required.</p>
-    </Control>
-    <Control Name="editInfoName" Title="Tavultesoft website">
-      <p>The name of the keyboard package to be displayed in many locations after installation and on the Tavultesoft website for downloading.</p>
-    </Control>
-    <Control Name="editInfoVersion" Title="Version">
-      <p>The version number allows for users to see if they have the latest version of the keyboard.  Version numbers should be in major.minor.patch format, where major,minor and patch are all numbers.  Other formats are not valid.  Also important information when upgrading a keyboard package.</p>
-    </Control>
-    <Control Name="editInfoWebSite" Title="Website">
-      <p>Displays a website address for the users to visit to view more information on the keyboard package.</p>
-    </Control>
-    <Control Name="editOptionalPostInstallationCommandLine" Title="WordPad">
-      <p>You can choose to run a program after installation. This can be a program in the package or another program such as WordPad to display a Readme file. Enclose the program name in quotation marks and use $INSTALLDIR\ as a prefix to reference the installed file location.</p>
-    </Control>
-    <Control Name="editOutPath" Title="">
-      <p>Output Path and File name</p>
-      <p>Displays the output path and filename of the file when the package is compiled.</p>
-    </Control>
-    <Control Name="editStartMenuDescription" Title="Start">
-      <p>The text to be displayed for the selected file as a menu item in the Start up folder that is created when the package is installed.</p>
-    </Control>
-    <Control Name="editStartMenuParameters" Title="Parameters" />
-    <Control Name="editStartMenuPath" Title="">
-      <p>Start Menu Path</p>
-      <p>Enter the path for the start menu folder to be created on installation.</p>
-    </Control>
-    <Control Name="lblProductFiles" Title="Wxs">
-      <p>If you need to include fonts or documentation, put them into a package and include the package in this list. Do not include fonts or documentation directly. If you are not using the Keyman Desktop user interface, then include all the files for your application here as well.</p>
-      <p>The distribution editor does not allow you to create multiple folders for your application. You can export the distribution source file created in this editor to a WiX source file (.wxs) and extend it there.</p>
-    </Control>
-    <Control Name="memoFileDetails" Title="File Details">
-      <p>Read Only.  Shows further information about the selected file, for example what the file is used for in the keyboard package.</p>
-    </Control>
-    <Control Name="SpTBXButton2" Title="Open Containing Folder" />
-  </Form>
-  <Form Name="TfrmKCTIconEditor">
-    <Control Name="frameBitmap" Title="Toolbox">
-      <p>The Toolbox allows for the editing of an existing icon or the creation of a new icon. The user cane change colours, add shapes and text. Use the move buttons to move the image on the icon and also displays a preview of the icon.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTMenuEditor">
-    <Control Name="cbAction" Title="Toolbars">
-      <p>This option selects the action that will occur when a user selects an item from one of the menus or toolbars.</p>
-    </Control>
-    <Control Name="cbCmdLine" Title="Program Command Line" />
-    <Control Name="cbItemType" Title="Typing">
-      <p>The drop down list allows the user to select the type of menu item to be added.</p>
-      <p>The options available in the list are dependent on the location of the menu item:</p>
-      <p>Text</p>
-      <p>Graphics</p>
-      <p>Separator</p>
-      <p>Keyboards List</p>
-    </Control>
-    <Control Name="cmdAdd" Title="Add">
-      <p>This option allows for the addition of a new menu item to one of the menu locations.</p>
-    </Control>
-    <Control Name="cmdDelete" Title="Delete">
-      <p>This option allows for the deletion of an existing menu item.</p>
-    </Control>
-    <Control Name="cmdFont" Title="Font">
-      <p>This option allows for the selection of font attributes for the caption text to be displayed in the menu.</p>
-    </Control>
-    <Control Name="cmdImportIcon" Title="Import">
-      <p>This option allows for the importing of a graphic file to be used as an icon in the list to the left of the menu item.</p>
-    </Control>
-    <Control Name="cmdMoveDown" Title="Move down">
-      <p>This option allows for the moving of menu items down a list or move buttons across to the right on a toolbar.</p>
-    </Control>
-    <Control Name="cmdMoveToOtherMenu." Title="Other location">
-      <p>This option allows the user to move an existing menu item to another location. It gives the user the a drop down list to choose the new location.</p>
-    </Control>
-    <Control Name="cmdMoveUp" Title="Move Up">
-      <p>This option allows for the moving of menu items up a list or move buttons across to the left on a toolbar.</p>
-    </Control>
-    <Control Name="editCaption" Title="Hotkey">
-      <p>The text to be displayed in the menu. A hotkey can also be assigned by placing an ampersand &amp; symbol before the letter to be used in the caption</p>
-    </Control>
-    <Control Name="hkHotkey" Title="Menu item">
-      <p>This option allows for the assigning of a hotkey for the menu item. A hotkey can also be assigned by placing an ampersand &amp; symbol before the letter to be used in the caption, but a different hotkey can be assigned by using this option.</p>
-    </Control>
-    <Control Name="tcbLocation" Title="Tray Right Button Menu">
-      <p>The location of the menu item gives the user the choice of placing the item in one of four locations</p>
-      <p>Tool Tray Left Button Menu</p>
-      <p>Tool Tray Right Button Menu</p>
-      <p>On Screen Keyboard Toolbar</p>
-      <p>On Screen Keyboard Context Menu</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTMessageEditor">
-    <Control Name="cmdMessageFont" Title="Message Font" />
-    <Control Name="cmdReset" Title="Reset all">
-      <p>Reset the selected string back to its original value.</p>
-    </Control>
-    <Control Name="cmdResetAll" Title="Reset all">
-      <p>To set all strings back to original values.</p>
-    </Control>
-    <Control Name="editDefault" Title="Default" />
-    <Control Name="editIdentifier" Title="Identifier" />
-    <Control Name="memoParams" Title="Parameters" />
-    <Control Name="memoText" Title="Text">
-      <p>A description of the string.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTNewFile">
-    <Control Name="lblTemplates" Title="New Customisation">
-      <p>This option allows the use of the default keyman template, an existing template or Blank Customisation.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTOptionEditor">
-    <Control Name="cbOnlineLicenceType" Title="Licence Type" />
-    <Control Name="editAboutCommandLine" Title="About Command">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application. Don't forget to surround the program path in double quotes.</p>
-    </Control>
-    <Control Name="editConfigurationCommandLine" Title="Configuration Command">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application. Don't forget to surround the program path in double quotes.</p>
-    </Control>
-    <Control Name="editControllerFileName" Title="Help Command">
-      <p>The standard controller file name is keyman.exe. Use another executable name here if you wish to write your own controller application for your product. Please review the Keyman COM API documentation for details. Use the values $INSTALLDIR and $ENGINEDIR to reference the installation folder and Keyman Engine folders respectively. Read the Keyman COM API documentation for more information.</p>
-    </Control>
-    <Control Name="editHelpCommandLine" Title="Help Command">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application. Don't forget to surround the program path in double quotes.</p>
-    </Control>
-    <Control Name="editOnlineName" Title="Website">
-      <p>The name of the keyboard package is displayed on the website or when installed. It should be a descriptive name, in any language, but remember that some applications may use a font that does not include the language you are writing the keyboard name in. Don't include a version number, help information or hotkey in the name.</p>
-    </Control>
-    <Control Name="editOnlineTrialDayCount" Title="Trial Day Count">
-      <p>The number of days a user can use the product on trial before buying the software.</p>
-    </Control>
-    <Control Name="editStartCommandLine" Title="Start Command">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application. Don't forget to surround the program path in double quotes.</p>
-    </Control>
-    <Control Name="optCustomiseUserInterface" Title="XML">
-      <p>You can make changes to the Keyman Desktop user interface on the User Interface tab. The image and XML files will automatically be included in the installer when you select this branding file as the product licence option in the Distribution Editor, and kmshell.exe and related files will be included when the product is compiled.</p>
-    </Control>
-    <Control Name="optUseYourOwnInterface" Title="Use">
-      <p>You can create your own application, displaying your own splash screen, configuration, help and about dialogs, as well as any additional functionality that you want. You will need to include the appropriate files in the Distribution Editor when you select this branding file as the product licence option.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTStartupEditor">
-    <Control Name="chkIncludeWelcome" Title="Welcome Screen">
-      <p>This option allows for the displaying of a welcome screen when the keyboard is opened. It can be used to inform the user of the features and uses of the keyboard.</p>
-    </Control>
-    <Control Name="chkSplashImage" Title="Splash Screen">
-      <p>The Splash screen can be turned on or off. If the option is unchecked a warning message will be displayed to warn that the image will be deleted and to have a copy of the file. The Splash screen can be turned off using Keyman Configuration.</p>
-    </Control>
-    <Control Name="cmdChangeSplash" Title="Splash">
-      <p>This option allows for the importing of a file to be used for the Splash screen.</p>
-    </Control>
-    <Control Name="editSplashFileName" Title="">
-      <p>Splash Screen file name</p>
-      <p>Displays the filename of the file selected as the Splash screen image.</p>
-    </Control>
-    <Control Name="editWelcomeHeight" Title="Welcome Screen Height">
-      <p>This option allows for the adjustment of the height of the welcome screen.</p>
-    </Control>
-    <Control Name="editWelcomeWidth" Title="Welcome Screen Width">
-      <p>This option allows for the adjustment of the width of the welcome screen.</p>
-    </Control>
-  </Form>
-  <Form Name="TfrmKCTUserInterfaceEditor">
-    <Control Name="cmdDelete" Title="Delete">
-      <p>The Delete option allows for the removing of a file from the user interface.</p>
-    </Control>
-    <Control Name="cmdEdit" Title="Open">
-      <p>This option allows for the user interface element for example a graphic to be opened in the default external editor for the file type to make editing changes.</p>
-    </Control>
-    <Control Name="cmdExport" Title="Export">
-      <p>The Export option allows for the exporting of a file from the user interface for example a graphic, this will allow it to be used for another keyboard package.</p>
-    </Control>
-    <Control Name="cmdImport" Title="Import">
-      <p>The Import option allows for the importing of a file for the user interface for example a graphic, this will allow it to be used for more than one keyboard package.</p>
-    </Control>
-    <Control Name="cmdOpenWith" Title="Open With">
-      <p>This option will display a list of recommended and optional programs to allow the selection of the required editor for the selected file to be edited.</p>
-    </Control>
-    <Control Name="cmdTestXML" Title="Test Page">
-      <p>This option will allow for the previewing of the customisation made to the user interface.</p>
-    </Control>
-  </Form>
-
-  <Form Name="TfrmKeyboardWizard">
-    <Control Name="KeyboardName" Title="Keyman Configuration">
-      <p>The name of the keyboard is displayed in Keyman Configuration, in the tray menu and in many other places. It should be a descriptive name, in any language, but remember that some applications may use a font that does not include the language you are writing the keyboard name in. Don't include a version number, help information or hotkey in the name.</p>
     </Control>
   </Form>
   
   <!-- ========================================================================
-  
        Keyboard Editor
-  
        ======================================================================== -->
 
-  <Form Name="TfrmKeymanWizard">
+  <Form Name="context/keyboard-editor">
   
     <!-- Details tab -->
+    <Control Name="editName" Title="Keyboard Name">
+      <p>The name of the keyboard is displayed in Keyman Configuration, in the tray menu and in many other places.  It should be a descriptive 
+      name, in any language, but remember that some applications may use a font that does not include the language you are writing the 
+      keyboard name in.  Don't include a version number, help information or hotkey in the name.</p>
+
+      <p>This corresponds to the following source line:</p>
+      <div class="code">store(&amp;name) 'My Keyboard'</div>
+    </Control>
+    <Control Name="cbType" Title="Character Set">
+      <p>Your keyboard should be either Unicode or Codepage based.  Most keyboards today will be Unicode.  If you are designing in the source editor,
+      you can create a keyboard that is includes both Unicode and Codepage (or "ANSI") rules.</p>
+
+      <p>This corresponds to either of the following source lines:</p>
+      <div class="code">
+        begin ANSI &gt; use(main)<br />
+        begin Unicode &gt; use(main)
+      </div>
+    </Control>
+    <Control Name="editCopyright" Title="Copyright">
+      <p>Copyright details for the keyboard are displayed when the keyboard is installed.  They can also be viewed in Keyman Configuration.</p>
+
+      <p>This corresponds to the following source line:</p>
+      <div class="code">store(&amp;copyright) '© 2006 My Company'</div>
+    </Control>
+    <Control Name="editMessage" Title="Message">
+      <p>The message provides some additional information to a user of your keyboard, when they install the keyboard.</p>
+
+      <p>This corresponds to the following source line:</p>
+      <div class="code">store(&amp;message) 'Here is a message about a keyboard'</div>
+    </Control>
+    <Control Name="memoComments" Title="Comments">
+      <p>In this field, enter information about the keyboard for your own reference.  These comments will only be visible in the 
+      source file, and not to users of your keyboard.</p>
+
+      <p>The comments are placed at the top of the source file, e.g.:</p>
+      <div class="code">
+        c Version 1.2 - fixed a bug with the 'k' key<br/>
+        c Version 1.1 - improved matching on vowels<br/>
+        c Version 1.0 - initial version
+      </div>
+    </Control>
+    <Control Name="editKeyOutputText" Title="Output Character(s)">
+      <p>To select another key in the keyboard, either:</p>
+      <ul>
+        <li>Click on the key with the mouse, or</li>
+        <li>Press and release the Ctrl key to choose with the keyboard</li>
+      </ul>
+    </Control>
+
     <!-- Layout tab -->
     <!-- Icon tab -->
     <!-- On-Screen tab -->
@@ -427,20 +226,21 @@
     </Control>
   </Form>
 
-  <Form Name="TfrmMustIncludeDebug">
-    <Control Name="chkAutoRecompile" Title="">
+  <Form Name="context/must-include-debug">
+    <Control Name="*" Title="TIKE Debugger 'Include Debug Information' Confirmation Screen">
       <p>TIKE Debugger</p>
       <p>Debug information must be included in the compile keyboard before the debugger process can be started. From the Keyboard menu select Include Debug Information. The debug information will display the error sources when compiling.</p>
       <p>The debugger can be used without the debug information by clicking on Test without debugger.</p>
     </Control>
   </Form>
-  <Form Name="TfrmNewFileDetails">
-    <Control Name="editFileName" Title="New Keyboard">
+  
+  <Form Name="context/new-file-details">
+    <Control Name="*" Title="New File">
       <p>Enter the name for your new keyboard. Click on the Browse button to change the location of the new keyboard.</p>
     </Control>
   </Form>
 
-  <Form Name="TfrmPackageEditor">
+  <Form Name="context/package-editor">
     <Control Name="cbImageFile" Title="Image File">
       <p>You can include an image file that will be displayed to the left of the install details when the package is installed. This image should be 140 pixels wide and 250 pixels high.</p>
     </Control>
@@ -464,6 +264,19 @@
       <p>This allows for the insertion of a copyright symbol if needed.</p>
     </Control>
 
+    <Control Name="cbReadMe" Title="Read Me Details">
+      <p>A readme file can be a text file (ANSI, UTF-8, or UTF-16), or an HTML file (recommended).  Other file types are also acceptable, 
+      but the package installer will load the file in a separate program.</p>
+    </Control>
+    <Control Name="cbKMPImageFile" Title="Package Image">
+      <p>You can include an image file that will be displayed to the left of the install details when the package is 
+        installed.  This image should be 140 pixels wide and 250 pixels high.</p>
+    </Control>
+    <Control Name="cmdTestPackage" Title="Test Package">
+      <p>You should try installing your package on your system before distributing it, to ensure that all files are 
+      installed correctly.  If you can, try installing your package on several different machines.</p>
+    </Control>
+    
     <!-- Compile Page -->
     
     <Control Name="editOutPath" Title="Compile">
@@ -555,143 +368,10 @@
       <p>This option allows the user to enter details and other additional information about the selected file.</p>
     </Control>
   </Form>
-  <Form Name="TfrmProject">
-    <Control Name="web" Title="Project Manager" />
-  </Form>
-  <Form Name="TfrmKeymanWizard">
-    <Control Name="editName" Title="Keyboard Name">
-      <p>The name of the keyboard is displayed in Keyman Configuration, in the tray menu and in many other places.  It should be a descriptive 
-      name, in any language, but remember that some applications may use a font that does not include the language you are writing the 
-      keyboard name in.  Don't include a version number, help information or hotkey in the name.</p>
-
-      <p>This corresponds to the following source line:</p>
-      <div class="code">store(&amp;name) 'My Keyboard'</div>
-    </Control>
-    <Control Name="cbType" Title="Character Set">
-      <p>Your keyboard should be either Unicode or Codepage based.  Most keyboards today will be Unicode.  If you are designing in the source editor,
-      you can create a keyboard that is includes both Unicode and Codepage (or "ANSI") rules.</p>
-
-      <p>This corresponds to either of the following source lines:</p>
-      <div class="code">
-        begin ANSI &gt; use(main)<br />
-        begin Unicode &gt; use(main)
-      </div>
-    </Control>
-    <Control Name="editCopyright" Title="Copyright">
-      <p>Copyright details for the keyboard are displayed when the keyboard is installed.  They can also be viewed in Keyman Configuration.</p>
-
-      <p>This corresponds to the following source line:</p>
-      <div class="code">store(&amp;copyright) '© 2006 My Company'</div>
-    </Control>
-    <Control Name="editMessage" Title="Message">
-      <p>The message provides some additional information to a user of your keyboard, when they install the keyboard.</p>
-
-      <p>This corresponds to the following source line:</p>
-      <div class="code">store(&amp;message) 'Here is a message about a keyboard'</div>
-    </Control>
-    <Control Name="memoComments" Title="Comments">
-      <p>In this field, enter information about the keyboard for your own reference.  These comments will only be visible in the 
-      source file, and not to users of your keyboard.</p>
-
-      <p>The comments are placed at the top of the source file, e.g.:</p>
-      <div class="code">
-        c Version 1.2 - fixed a bug with the 'k' key<br/>
-        c Version 1.1 - improved matching on vowels<br/>
-        c Version 1.0 - initial version
-      </div>
-    </Control>
-    <Control Name="editKeyOutputText" Title="Output Character(s)">
-      <p>To select another key in the keyboard, either:</p>
-      <ul>
-        <li>Click on the key with the mouse, or</li>
-        <li>Press and release the Ctrl key to choose with the keyboard</li>
-      </ul>
-    </Control>
-  </Form>
-
-
-  <Form Name="TfrmPackageEditor">
-    <Control Name="cbReadMe" Title="Read Me Details">
-      <p>A readme file can be a text file (ANSI, UTF-8, or UTF-16), or an HTML file (recommended).  Other file types are also acceptable, 
-      but the package installer will load the file in a separate program.</p>
-    </Control>
-    <Control Name="cbKMPImageFile" Title="Package Image">
-      <p>You can include an image file that will be displayed to the left of the install details when the package is 
-        installed.  This image should be 140 pixels wide and 250 pixels high.</p>
-    </Control>
-    <Control Name="cmdTestPackage" Title="Test Package">
-      <p>You should try installing your package on your system before distributing it, to ensure that all files are 
-      installed correctly.  If you can, try installing your package on several different machines.</p>
-    </Control>
-  </Form>
-
-
-  <Form Name="TfrmKCTOptionEditor">
-    <Control Name="rbKeymanDesktopUI" Title="Customise the Keyman Desktop user interface">
-      <p>You can make changes to the Keyman Desktop user interface on the User Interface tab.  The image and XML files will 
-      automatically be included in the installer when you select this branding file as the product licence option in the 
-      Distribution Editor, and kmshell.exe and related files will be included when the product is compiled.
-      </p>
-    </Control>
-    <Control Name="rbCustomUI" Title="Use your own user interface">
-      <p>You can create your own application, displaying your own splash screen, configuration, help and about dialogs, as well
-      as any additional functionality that you want.  You will need to include the appropriate files in the Distribution Editor
-      when you select this branding file as the product licence option.
-      </p>
-    </Control>
-    <Control Name="editControllerFileName" Title="Controller file name">
-      <p>
-        The standard controller file name is keyman.exe.  Use another executable name here if you wish to write your own 
-        controller application for your product.  Please review the Keyman COM API documentation for details.  Use the values
-        $INSTALLDIR and $ENGINEDIR to reference the installation folder and Keyman Engine folders respectively.  Read the
-        Keyman COM API documentation for more information.
-      </p>
-    </Control>
-    <Control Name="editConfigurationCommandLine" Title="Configuration command line">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application.  Don't forget to surround the program 
-      path in double quotes.</p>
-    </Control>
-    <Control Name="editAboutCommandLine" Title="About command line">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application.  Don't forget to surround the program 
-      path in double quotes.</p>
-    </Control>
-    <Control Name="editHelpCommandLine" Title="Help command line">
-      <p>Use the value $INSTALLDIR to refer to the install path of your application.  Don't forget to surround the program 
-      path in double quotes.</p>
-    </Control>
-  </Form>
-
-  <Form Name="TfrmInstallerEditor">
-    <Control Name="lbFiles" Title="Product Files">
-      <p>
-        If you need to include fonts or documentation, put them into a package and include the package in 
-        this list.  Do not include fonts or documentation directly.  If you are <b>not</b> using the Keyman Desktop user interface,
-        then include all the files for your application here as well.
-      </p>
-      <p>
-        The distribution editor does not allow you to create multiple folders for your application.  You can export the distribution
-        source file created in this editor to a WiX source file (.wxs) and extend it there.
-      </p>
-    </Control>
-    <Control Name="editDestinationPath" Title="Destination Path">
-      <p>The destination path will always be created under Program Files.  The actual name of the Program Files folder may vary from 
-      computer to computer and language to language, but the installer will manage that automatically.</p>
-    </Control>
-    <Control Name="editCmdLine" Title="Optional Post-Installation Command">
-      <p>You can choose to run a program after installation.  This can be 
-      a program in the package or another program such as WordPad to display a Readme file.  Enclose the program name in quotation marks
-      and use $INSTALLDIR\ as a prefix to reference the installed file location.</p>
-    </Control>
-    <Control Name="cmdCompileProduct" Title="Build Product">
-      <p>Building the product takes all the files you have selected and compiles them into a single product file.</p>
-    </Control>
-    <Control Name="cmdTestProduct" Title="Test Product">
-      <p>You should try installing your product  on your system before distributing it, to ensure that all 
-      files are installed correctly.  If you can, try installing your product on several different machines.</p>
-      <p>If you are a registered user of Keyman Developer Professional, then you have access to a free product
-      validation service from Tavultesoft.  Tavultesoft will review your product's installer, user interface, and
-      integration and provide feedback on issues and resolution of these issues.  Simply upload your product to the
-      Tavultesoft website and click the Request Validation link on the site.</p>
+  
+  <Form Name="context/project">
+    <Control Name="*" Title="Project Manager">
+      <p>The Project Manager allows you to manage all the files related to a keyboard layout in a single location.</p>
     </Control>
   </Form>
 </ContextHelp>

--- a/windows/src/developer/TIKE/xml/help/help.xsl
+++ b/windows/src/developer/TIKE/xml/help/help.xsl
@@ -4,6 +4,8 @@
     <html>
       <head>
         <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+        <meta charset="UTF-8" />
+        
         <title>Help</title>
         <style>
           .title { 
@@ -22,14 +24,23 @@
         <script type="text/javascript">
           
             var LastElem = null;
-            function ActivatePage(frm, ctrl)
-            {
-              var elem = document.getElementById(frm+'-'+ctrl);
-              if(!elem)
-              {
+            function ActivatePage(frm, ctrl) {
+              //frm = frm.replace(/[#/]/g, '_');
+              var id = frm.substr(0, 'language/'.length) == 'language/' ?
+                frm :
+                frm + '-' + ctrl;
+              
+              var elem = document.getElementById(id);
+              if(!elem) {
+                var wildcard_id = frm + '-*';
+                elem = document.getElementById(wildcard_id);
+              }
+              if(!elem) {
                 elem = document.getElementById('nohelp_name');
-                elem.innerHTML = frm+'-'+ctrl;
+                elem.innerHTML = id;
                 elem = document.getElementById('nohelp');
+                var e = document.getElementById('nohelp_link');
+                e.href='help:'+frm;
               }
               if(LastElem) LastElem.style.display = 'none';
               LastElem = elem;
@@ -41,8 +52,8 @@
         <xsl:apply-templates select="//Control" />
         <div class="control" id="nohelp">
           Context help is not available for <b><span id="nohelp_name"></span></b>.
+          <div class="morehelp"><a id='nohelp_link' href="help:">Look for online help for this screen...</a></div>
         </div>
-        <div class="morehelp"><a href="help:">More help...</a></div>
       </body>
     </html>
   </xsl:template>
@@ -56,6 +67,7 @@
       <xsl:attribute name="id"><xsl:value-of select="../@Name"/>-<xsl:value-of select="@Name"/></xsl:attribute>
       <div class="title"><xsl:value-of select="@Title"/></div>
       <xsl:copy-of select="." />
+      <div class="morehelp"><a><xsl:attribute name='href'>help:<xsl:value-of select='@Url'/></xsl:attribute>More help...</a></div>
     </div>
   </xsl:template>
 </xsl:stylesheet>

--- a/windows/src/developer/TIKE/xml/project/elements.xsl
+++ b/windows/src/developer/TIKE/xml/project/elements.xsl
@@ -232,7 +232,7 @@
     <xsl:param name="icontype">gif</xsl:param>
     <xsl:param name="title" />
     <td><a>
-      <xsl:attribute name="href">help:filetype_<xsl:value-of select="$type" /></xsl:attribute>
+      <xsl:attribute name="href">help:reference/file-types/<xsl:value-of select="$type" /></xsl:attribute>
       <xsl:attribute name="title"><xsl:value-of select="$title"/></xsl:attribute>
       <img>
         <xsl:attribute name="src"><xsl:value-of select='/KeymanDeveloperProject/templatepath'/>icon32_<xsl:value-of select="$type" />.<xsl:value-of select="$icontype" /></xsl:attribute>

--- a/windows/src/developer/TIKE/xml/project/keyboards.xsl
+++ b/windows/src/developer/TIKE/xml/project/keyboards.xsl
@@ -13,8 +13,8 @@
             <h3>Quick Links</h3>
           
             <ul>
-              <li><a href="help:tutorial_keyboard">Keyboard Tutorial</a></li>
-              <li><a href="help:reference">Keyman Keyboard Language Reference</a></li>
+              <li><a href="help:guides/develop/tutorial">Keyboard Tutorial</a></li>
+              <li><a href="help:language/">Keyman Keyboard Language Reference</a></li>
             </ul>
           </div>
         </div>
@@ -26,14 +26,14 @@
 
           <ul>
             <li>
-              The <a href="help:context_frmKeymanWizard_Layout">Layout page</a> in the Keyboard Editor lets you quickly create 
+              The <a href="help:context/keyboard-editor#toc-layout-tab">Layout page</a> in the Keyboard Editor lets you quickly create 
               a keyboard using a visual representation of a computer keyboard. You can drag and drop characters from the 
-              <a href="help:context_frmCharacterMapNew">Character Map</a> to create Unicode keyboard layouts.
+              <a href="help:context/character-map">Character Map</a> to create Unicode keyboard layouts.
             </li>
             <li>
-              The <a href="help:context_frmKeymanWizard_Source">Source tab</a> of the layout page shows the keyboard's design in the 
+              The <a href="help:context/keyboard-editor#toc-layout-tab">Source tab</a> of the layout page shows the keyboard's design in the 
               <a href="help:reference">Keyman Keyboard Language</a>.  From here, you can enhance keyboards with input management features
-              such as constraints, dead keys, character reordering, and more.  Read the <a href="help:tutorial_keyboard">Tutorial</a>
+              such as constraints, dead keys, character reordering, and more.  Read the <a href="help:guides/develop/tutorial">Tutorial</a>
               for an introduction to these features.
             </li>
           </ul>

--- a/windows/src/developer/TIKE/xml/project/packages.xsl
+++ b/windows/src/developer/TIKE/xml/project/packages.xsl
@@ -13,8 +13,8 @@
             <h3>Quick Links</h3>
           
             <ul>
-              <li><a href="help:tutorial_package">Package Tutorial</a></li>
-              <li><a href="help:context_frmPackageEditor">Package Editor Help</a></li>
+              <li><a href="help:guides/distribute/tutorial">Package Tutorial</a></li>
+              <li><a href="help:context/package-editor">Package Editor Help</a></li>
             </ul>
           </div>
         </div>

--- a/windows/src/developer/TIKE/xml/project/welcome.xsl
+++ b/windows/src/developer/TIKE/xml/project/welcome.xsl
@@ -15,8 +15,7 @@
             <ul>
               <li><a href="keyman:checkforupdates">Check for Updates</a></li>
               <li><a href="help:index">Help Contents</a></li>
-              <li><a href="help:context_frmProject">Project Help</a></li>
-              <li><a href="keyman:upgrade">Purchase Additional Modules</a></li>
+              <li><a href="help:context/project">Project Help</a></li>
             </ul>
           </div>
         </div>

--- a/windows/src/global/delphi/visualkeyboard/UfrmVisualKeyboardExportHTMLParams.pas
+++ b/windows/src/global/delphi/visualkeyboard/UfrmVisualKeyboardExportHTMLParams.pas
@@ -43,6 +43,8 @@ type
     procedure SetFileName(const Value: string);
     function GetFolders: Boolean;
     function GetGraphical: Boolean;
+  protected
+    function GetHelpTopic: string; override;
   public
     property FileName: string write SetFileName;
     property Folders: Boolean read GetFolders;
@@ -54,6 +56,8 @@ implementation
 {$R *.DFM}
 
 uses
+  Keyman.Developer.System.HelpTopics,
+
   messageidentifiers;
 
 { TfrmVisualKeyboardExportHTMLParams }
@@ -71,6 +75,11 @@ end;
 function TfrmVisualKeyboardExportHTMLParams.GetGraphical: Boolean;
 begin
   Result := chkGraphical.Checked;
+end;
+
+function TfrmVisualKeyboardExportHTMLParams.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_VisualKeyboardExportHtmlParams;
 end;
 
 procedure TfrmVisualKeyboardExportHTMLParams.cmdOKClick(Sender: TObject);


### PR DESCRIPTION
Fixes #133; fixes #723.

Rewrites all the context help identifiers and linking code so consistent identifiers are used online and in the help.xsl
pattern. Also updates language reference help to track keywords more reliably. This does not include missing help topics
in either help.xsl or online; this is rather just infrastructure, new help topics will be tracked separately.