### PR TITLE
[developer] context and index are not valid in the output of a match or nomatch rule

### DIFF
--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -604,6 +604,21 @@ DWORD ProcessBeginLine(PFILE_KEYBOARD fk, PWSTR p)
 	return CERR_None;
 }
 
+DWORD ValidateMatchNomatchOutput(PWSTR p) {
+  while (p) {
+    if (*p == UC_SENTINEL) {
+      switch (*(p + 1)) {
+      case CODE_CONTEXT:
+      case CODE_CONTEXTEX:
+      case CODE_INDEX:
+        return CERR_ContextAndIndexInvalidInMatchNomatch;
+      }
+    }
+    p = incxstr(p);
+  }
+  return CERR_None;
+}
+
 DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 {
 	PWSTR p, q, pp;
@@ -748,7 +763,12 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		    return msg;
 		  }
 
-		  gp = &fk->dpGroupArray[fk->currentGroup];
+      if ((msg = ValidateMatchNomatchOutput(buf)) != CERR_None) {
+        delete buf;
+        return msg;
+      }
+      
+      gp = &fk->dpGroupArray[fk->currentGroup];
 		
 		  gp->dpMatch = new WCHAR[wcslen(buf) + 1];
 		  wcscpy_s(gp->dpMatch, wcslen(buf)+1, buf);  // I3481
@@ -781,6 +801,11 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
         return msg;
       }
 
+      if ((msg = ValidateMatchNomatchOutput(buf)) != CERR_None) {
+        delete buf;
+        return msg;
+      }
+
 		  gp = &fk->dpGroupArray[fk->currentGroup];
 		
 		  gp->dpNoMatch = new WCHAR[wcslen(buf) + 1];
@@ -806,7 +831,6 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 }
 
 //**********************************************************************************************************************
-
 
 DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p)
 {

--- a/windows/src/developer/kmcmpdll/Compiler.rc
+++ b/windows/src/developer/kmcmpdll/Compiler.rc
@@ -202,6 +202,7 @@ BEGIN
     CERR_ContextExHasInvalidOffset       "context() statement has offset out of range"
     CERR_90FeatureOnlyEmbedCSS           "Embedding CSS requires store(&version) '9.0'"
     CERR_90FeatureOnlyTargets            "&TARGETS system store requires store(&version) '9.0'"
+    CERR_ContextAndIndexInvalidInMatchNomatch "context and index statements cannot be used in a match or nomatch statement"
     CWARN_PlatformNotInTargets           "The specified platform is not a target platform"
 END
 

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -136,6 +136,7 @@
 #define CERR_ContextExHasInvalidOffset                     0x0000405F
 #define CERR_90FeatureOnlyEmbedCSS                         0x00004060
 #define CERR_90FeatureOnlyTargets                          0x00004061
+#define CERR_ContextAndIndexInvalidInMatchNomatch          0x00004062
 
 #define CWARN_TooManyWarnings						0x00002080
 #define CWARN_OldVersion							0x00002081


### PR DESCRIPTION
Fixes #718.