### PR TITLE
Ios/case insensitive alpha list

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -115,7 +115,7 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     sectionIndexTitles = []
     indices = []
     for (index, language) in languages.enumerated() {
-      let firstLetter = String(language.name.prefix(1))
+      let firstLetter = String(language.name.prefix(1)).uppercased()
       if !sectionIndexTitles.contains(firstLetter) {
         sectionIndexTitles.append(firstLetter)
         indices.append(index)

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2018-04-25 10.0.141 beta
+* Fix alphabetical list to be case insensitive on new keyboard list
+
 ## 2018-04-25 10.0.140 beta
 * Fixed lack of output for certain punctuation longpress keys. (#702)
 


### PR DESCRIPTION
fixes the section index titles to not have mixed case letters. issue #722 