### PR TITLE
Ios/json parsing miliseconds

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/JSONDecoder.DateDecodingStrategy+ISO8601Fallback.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/JSONDecoder.DateDecodingStrategy+ISO8601Fallback.swift
@@ -18,4 +18,13 @@ extension JSONDecoder.DateDecodingStrategy {
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
     return .formatted(formatter)
   }
+  
+  static var ios8601WithMilliseconds: JSONDecoder.DateDecodingStrategy {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .iso8601)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    return .formatted( formatter )
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -582,15 +582,24 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
       downloadFailed(forKeyboards: [], error: error)
       return
     }
+    
+    decodeKeyboardData(data, decodingStrategy: .ios8601WithFallback)
+  }
 
+  private func decodeKeyboardData(_ data: Data, decodingStrategy : JSONDecoder.DateDecodingStrategy) {
     let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .ios8601WithFallback
-    do {
-      let keyboard = try decoder.decode(KeyboardAPICall.self, from: data)
-      return downloadKeyboard(keyboard)
-    } catch {
-      downloadFailed(forKeyboards: [], error: error)
-      return
+    decoder.dateDecodingStrategy = decodingStrategy
+  
+    if let keyboard = try? decoder.decode(KeyboardAPICall.self, from: data) {
+      downloadKeyboard(keyboard)
+    } else {
+      decoder.dateDecodingStrategy = .ios8601WithMilliseconds
+      do {
+        let keyboard = try decoder.decode(KeyboardAPICall.self, from: data)
+        downloadKeyboard(keyboard)
+      } catch {
+        downloadFailed(forKeyboards: [], error: error)
+      }
     }
   }
 


### PR DESCRIPTION
This fixes #420.  The link to install the version 1.1 of the keyboard found here: https://marc.durdin.net/2015/11/notes-on-a-khmer-mobile-keyboard-for-keyman/  will show that this is working. 

This is part of the code I had implemented in the earlier fixes for legacy ad hoc, so I cleaned that up and brought it into this PR since @mcdurdin pushed a fix for legacy ad hoc before I finished this.