### PR TITLE
[windows] Fixes ampersand in keyboard name can cause Keyman Configuration to crash

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -286,7 +286,7 @@ var
 begin
   SaveState;
 
-  s := '<state>'+FState+'</state>';
+  s := '<state>'+XMLEncode(FState)+'</state>';
   s := s + '<basekeyboard id="'+IntToHex(kmcom.Options[KeymanOptionName(koBaseLayout)].Value,8)+'">'+
     XMLEncode(TBaseKeyboards.GetName(kmcom.Options[KeymanOptionName(koBaseLayout)].Value))+
     '</basekeyboard>';   // I4169


### PR DESCRIPTION
Fixes sillsdev/keyman-issues#5507, ampersand in keyboard name can cause Keyman Configuration to crash