### PR TITLE
[windows] Fixes crash starting Keyman Configuration if high bit is set in underlying keyboard id

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -287,7 +287,7 @@ begin
   SaveState;
 
   s := '<state>'+FState+'</state>';
-  s := s + '<basekeyboard id="'+IntToHex(kmcom.Options[KeymanOptionName(koBaseLayout)].Value,8)+'">'+
+  s := s + '<basekeyboard id="'+IntToHex(Cardinal(kmcom.Options[KeymanOptionName(koBaseLayout)].Value),8)+'">'+
     XMLEncode(TBaseKeyboards.GetName(kmcom.Options[KeymanOptionName(koBaseLayout)].Value))+
     '</basekeyboard>';   // I4169
 


### PR DESCRIPTION
Fixes sillsdev/keyman-issues#5595 crash if high bit is set in underlying keyboard id