### PR TITLE
[Web] CODE_BEEP in stores

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 2018-05-08 10.0.90 beta
+* Fixes support for Keyman-language 'beep' statements as part of keyboard stores. (#733)
+
 ## 2018-05-07 10.0.89 beta
 * Fixes an issue with case sensitive virtual keys used by some Keyman keyboards. (#162)
 

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -13,14 +13,14 @@ namespace com.keyman {
   * No constructors or methods since keyboards will not utilize the same backing prototype, and
   * property names are shorthanded to promote minification.
   */
+ type PlainKeyboardStore = string;
 
-  type PlainKeyboardStore = string;
+ // TODO:  Implement the new 'store object-orientation proposal.
+ export type KeyboardStoreElement = (string|StoreNonCharEntry);
+ export type ComplexKeyboardStore = KeyboardStoreElement[]; 
 
-  // TODO:  Implement the new 'store object-orientation proposal.
-  export type KeyboardStoreElement = (string|{'d': number});
-  export type ComplexKeyboardStore = KeyboardStoreElement[]; 
+ type KeyboardStore = PlainKeyboardStore | ComplexKeyboardStore;
 
-  type KeyboardStore = PlainKeyboardStore | ComplexKeyboardStore;
   type RuleChar = string;
 
   class RuleDeadkey {
@@ -478,7 +478,14 @@ namespace com.keyman {
               }
               break;
             case 'a':
-              var lookup = (typeof(context[i]) == 'string' ? context[i] as string : {'d': context[i] as number});
+              var lookup: KeyboardStoreElement;
+
+              if(typeof context[i] == 'string') {
+                lookup = context[i] as string;
+              } else {
+                lookup = {'t': 'd', 'd': context[i] as number};
+              }
+
               var result = this.any(i, lookup, r.a);
 
               if(!r.n) { // If it's a standard 'any'...
@@ -494,7 +501,8 @@ namespace com.keyman {
               }
               break;
             case 'i':
-              var ch = this._Index(r.i, r.o);
+              // The context will never hold a 'beep.'
+              var ch = this._Index(r.i, r.o) as string | RuleDeadkey;
 
               if(ch !== undefined && (typeof(ch) == 'string' ? ch : ch.d) !== context[i]) {
                 mismatch = true;

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -83,7 +83,13 @@ namespace com.keyman {
     ['t']: 'n';
   }
 
-  type ContextNonCharEntry = RuleDeadkey | ContextAny | RuleIndex | ContextEx | ContextNul;
+  class ContextBeep {
+    /** Discriminant field - 'b' for `beep`
+     */
+    ['t']: 'b';
+  }
+
+  type ContextNonCharEntry = RuleDeadkey | ContextAny | RuleIndex | ContextEx | ContextNul | ContextBeep ;
   type ContextEntry = RuleChar | ContextNonCharEntry;
 
   /**
@@ -506,6 +512,9 @@ namespace com.keyman {
               if(context[i] != NUL_CONTEXT) {
                 mismatch = true;
               }
+              break;
+            case 'b':
+              this.beep(Ptarg);
               break;
             default:
               assertNever(r);

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -13,13 +13,12 @@ namespace com.keyman {
   * No constructors or methods since keyboards will not utilize the same backing prototype, and
   * property names are shorthanded to promote minification.
   */
- type PlainKeyboardStore = string;
+  type PlainKeyboardStore = string;
 
- // TODO:  Implement the new 'store object-orientation proposal.
- export type KeyboardStoreElement = (string|StoreNonCharEntry);
- export type ComplexKeyboardStore = KeyboardStoreElement[]; 
+  export type KeyboardStoreElement = (string|StoreNonCharEntry);
+  export type ComplexKeyboardStore = KeyboardStoreElement[]; 
 
- type KeyboardStore = PlainKeyboardStore | ComplexKeyboardStore;
+  type KeyboardStore = PlainKeyboardStore | ComplexKeyboardStore;
 
   type RuleChar = string;
 
@@ -89,7 +88,7 @@ namespace com.keyman {
     ['t']: 'b';
   }
 
-  type ContextNonCharEntry = RuleDeadkey | ContextAny | RuleIndex | ContextEx | ContextNul ;
+  type ContextNonCharEntry = RuleDeadkey | ContextAny | RuleIndex | ContextEx | ContextNul;
   type ContextEntry = RuleChar | ContextNonCharEntry;
 
   type StoreNonCharEntry = RuleDeadkey | StoreBeep;

--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -1111,7 +1111,11 @@ begin
       begin
         if rec.Code = CODE_DEADKEY then
         begin
-          Result := Result + Format('{d:%d}', [rec.Deadkey.DeadKey]);
+          Result := Result + Format('{t:''d'',d:%d}', [rec.Deadkey.DeadKey]);
+        end
+        else if rec.Code = CODE_BEEP then
+        begin
+          Result := Result + '{t:''b''}'
         end
         else //if rec.Code = CODE_EXTENDED then
         begin

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 2018-05-08 10.0.1082.0 beta
+* Fixes support for 'beep' statements in keyboard stores when compiling for web or mobile targets (#733)
+
 ## 2018-05-03 10.0.1076.0 beta
 * Restrict modifier options to a small set by default in touch layout editor (#810)
 * Touch layout editor no longer leaves broken JSON when deleting or modifying some keys (#811)


### PR DESCRIPTION
Fixes #733.

Allows CODE_BEEP-representing objects to be part of stores and "output" via the `index` keyboard language statement within KeymanWeb.

This implementation assumes that CODE_BEEP should never appear within the context and so cannot be matched by `any` statements.