### PR TITLE
[windows] Fixes a crash in Keyman Configuration if the focused element has no id

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.js
+++ b/windows/src/desktop/kmshell/xml/config.js
@@ -160,11 +160,15 @@ document.addEventListener("DOMContentLoaded", windowResize);
   }
 
   document.onfocusin = function() {
-    var itemtype, blah;
+    var itemtype, blah, elemid;
     
     globalfocus = event.srcElement;
     if(!event.srcElement) { return true; }
     elemid = event.srcElement.id;
+    if(typeof elemid != 'string') { 
+      // e.g. if document has received focus, id may be undefined
+      return true;
+    }
     itemtype = elemid.substr(0, 5);
     
     if(event.srcElement.className.substr(0,8) != 'menuitem' && event.srcElement != menudiv


### PR DESCRIPTION
Fixes #5606, crash in Keyman Configuration if focus element/object has no id