### PR TITLE
[windows] Implement IKeymanKeyboardFile.DefaultHotkey

### DIFF
--- a/windows/src/desktop/kmshell/main/UImportOlderVersionKeyboards.pas
+++ b/windows/src/desktop/kmshell/main/UImportOlderVersionKeyboards.pas
@@ -305,7 +305,6 @@ begin
       regWrite.WriteString(SRegValue_KeymanFile, pathname + ExtractFileName(filename));
 
       CopyValue(SRegValue_Legacy_DefaultLanguageID);   // I4220
-      CopyValue(SRegValue_KeymanDefaultHotkey);
 
       CopyValue(SRegValue_PackageName);
 

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
@@ -1,18 +1,18 @@
 (*
   Name:             keymankeyboardfile
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    29 Mar 2010
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     14 Sep 2006 - mcdurdin - Pass graphics as icons instead of bitmaps
                     04 Dec 2006 - mcdurdin - Add Get_LayoutType, Serialize functions
@@ -43,6 +43,8 @@ type
     FError: Boolean;
     FKeyboardInfo: TKeyboardInfo;
     FLanguages: IKeymanKeyboardLanguagesFile;
+    FDefaultHotkey: IKeymanHotkey;
+    procedure CreateDefaultHotkey;
   protected
     function Serialize(Flags: TOleEnum; const ImagePath: WideString; References: TStrings): WideString;
       override;
@@ -65,6 +67,8 @@ type
     function Get_DefaultPrimaryLanguage: Integer; override; safecall;
     function Get_Version: WideString; override; safecall;
     function Get_Languages: IKeymanKeyboardLanguagesFile; safecall;
+    function Get_DefaultHotkey: IKeymanHotkey; override; safecall;
+
   public
     constructor Create(AContext: TKeymanContext; const Filename: Widestring; pk: TPackageKeyboard);
     destructor Destroy; override;
@@ -75,6 +79,7 @@ implementation
 uses
   Graphics,
   keymanerrorcodes,
+  keymanhotkey,
   kmxfileusedchars,
   kpinstallkeyboard,
   Keyman.System.LanguageCodeUtils,
@@ -104,6 +109,13 @@ begin
   if Assigned(pk)
     then FLanguages := TKeymanKeyboardLanguagesFile.Create(AContext, Self, pk.Languages)
     else FLanguages := TKeymanKeyboardLanguagesFile.Create(AContext, Self, nil);
+end;
+
+procedure TKeymanKeyboardFile.CreateDefaultHotkey;
+begin
+  if Assigned(FDefaultHotkey) then
+    Exit;
+  FDefaultHotkey := TKeymanHotkey.Create(Context, FKeyboardInfo.DefaultHotkey, khKeyboard);
 end;
 
 destructor TKeymanKeyboardFile.Destroy;
@@ -198,6 +210,12 @@ end;
 function TKeymanKeyboardFile.Get_DefaultBCP47Languages: WideString;
 begin
   Result := TLanguageCodeUtils.TranslateMultipleISO6393ToBCP47(FKeyboardInfo.ISO6393Languages);
+end;
+
+function TKeymanKeyboardFile.Get_DefaultHotkey: IKeymanHotkey;
+begin
+  CreateDefaultHotkey;
+  Result := FDefaultHotkey;
 end;
 
 function TKeymanKeyboardFile.Get_DefaultPrimaryLanguage: Integer;

--- a/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
@@ -227,7 +227,6 @@ begin
 
         WriteString(SRegValue_Legacy_DefaultLanguageID, IntToHex(ki.KeyboardID, 8));   // I4220
 
-        WriteString(SRegValue_KeymanDefaultHotkey, IntToStr(ki.DefaultHotkey));
         if ikPartOfPackage in FInstallOptions
           then WriteString(SRegValue_PackageName, GetShortPackageName(PackageName))
           else if ValueExists(SRegValue_PackageName) then DeleteValue(SRegValue_PackageName);

--- a/windows/src/global/delphi/general/RegKeyboards.pas
+++ b/windows/src/global/delphi/general/RegKeyboards.pas
@@ -331,7 +331,6 @@ begin
 
     if OpenKeyReadOnly(GetRegistryKeyboardInstallKey_LM(FName)) then
     begin
-      FDefaultHotkey := StrToIntDef(ReadString(SRegValue_KeymanDefaultHotkey), 0);
       FKeymanFile := ReadString(SRegValue_KeymanFile);
       Legacy_FKeyboardID := StrToIntDef('$'+ReadString(SRegValue_Legacy_KeymanKeyboardID), 0);   // I3613
       FPackageName := ReadString(SRegValue_PackageName);
@@ -411,6 +410,7 @@ begin
     FWindowsLanguages := ki.WindowsLanguages;
     FISO6393Languages := ki.ISO6393Languages;
     FKeyboardLanguageID := ki.KeyboardID;
+    FDefaultHotkey := ki.DefaultHotkey;
     FKeyboardVersion := ki.KeyboardVersion;   // I4136
 
     if ki.Icon <> nil then

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -206,7 +206,6 @@ const
 
   SRegValue_KeymanFile_MnemonicOverride = 'keyman file mnemonic override';          // LM   // I4169
   SRegValue_KeymanFile_MnemonicOverride_Deadkey = 'keyman file mnemonic override deadkey';          // LM   // I4552
-  SRegValue_KeymanDefaultHotkey = 'keyman default hotkey';                          // LM CU
   SRegValue_KeymanFile          = 'keyman file';                                    // LM CU
   SRegValue_Legacy_KeymanKeyboardID    = 'keyman keyboard id';                             // LM CU   // I3613
   SRegValue_PackageName         = 'package name';                                   // LM CU


### PR DESCRIPTION
Fixes #515, IKeymanKeyboardFile.DefaultHotkey not implemented

Also fixes the issue of the default hotkey not being read from the keyboard info when loading installed keyboard metadata