### PR TITLE
[Web] Basic mnenomic keyboard support

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,9 @@
 # KeymanWeb Version History
 
+## 2018-05-08 10.0.91 beta
+* Fixes basic support for mnemonic keyboards.  (#517)
+  * At this time, all mnemonic keyboards will assume a US keyboard layout within KeymanWeb.
+
 ## 2018-05-08 10.0.90 beta
 * Fixes support for Keyman-language 'beep' statements as part of keyboard stores. (#733)
 

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -492,6 +492,22 @@ namespace com.keyman {
       if (s.Lcode == null) {
         return null;
       }
+
+      var activeKeyboard = this.keyman.keyboardManager.activeKeyboard;
+      if(activeKeyboard && activeKeyboard['KM']) {
+        // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
+        // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
+        var mappedChar: string = this.keyman.osk.defaultKeyOutput('K_xxxx', s.Lcode, (e.getModifierState("Shift") ? 0x10 : 0), false, null);
+        if(mappedChar) {
+          s.Lcode = mappedChar.charCodeAt(0);
+          if(s.Lcode >= 'a'.charCodeAt(0) && s.Lcode <= 'z'.charCodeAt(0)) {
+            // Apply an uppercase effect to the key, since K_A etc are based on the upper-case character codes.
+            s.Lcode -= 32;
+          }
+        } else {
+          return null;
+        }
+      }
       
       // Stage 1 - track the true state of the keyboard's modifiers.
       var osk = this.keyman.osk, prevModState = DOMEventHandlers.states.modStateFlags, curModState = 0x0000;
@@ -727,6 +743,7 @@ namespace com.keyman {
         }
         else {
           DOMEventHandlers.states._KeyPressToSwallow = 0;
+          LeventMatched = LeventMatched || kbdInterface.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent);
         }
       }
 

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -504,6 +504,10 @@ namespace com.keyman {
             // Apply an uppercase effect to the key, since K_A etc are based on the upper-case character codes.
             s.Lcode -= 32;
           }
+
+          if(s.Lcode == 160) {
+            s.Lcode = 0;
+          }
         } else {
           return null;
         }

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -1141,22 +1141,28 @@ if(!window['keyman']['initialized']) {
         }
 
         // Include *limited* support for mnemonic keyboards (Sept 2012)
-        if(activeKeyboard && (activeKeyboard['KM']))
-        {
-          var keyText=e.firstChild.firstChild.wholeText;
-          Lkc.LisVirtualKey=false; Lkc.LisVirtualKeyCode=false;
-          Lkc.vkCode=Lkc.Lcode;
-          if(Lkc.Lcode != osk.keyCodes['K_SPACE']) // exception required, March 2013
-          {
-            if(typeof keyText == 'string' && keyText != '')
-              Lkc.Lcode=keyText.charCodeAt(0);
-            else
-              Lkc.Lcode=0;
-            if(Lkc.Lcode == 160) Lkc.Lcode = 0;
+        // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
+        if(activeKeyboard && activeKeyboard['KM'] && !(activeKeyboard['KVKL'] && device.formFactor != 'desktop')) {
+          if(Lkc.Lcode != osk.keyCodes['K_SPACE']) { // exception required, March 2013
+            // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
+            // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
+            var mappedChar: string = osk.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
+            if(mappedChar) {
+              Lkc.Lcode = mappedChar.charCodeAt(0);
+              if(Lkc.Lcode >= 'a'.charCodeAt(0) && Lkc.Lcode <= 'z'.charCodeAt(0)) {
+                // Apply an uppercase effect to the key, since K_A etc are based on the upper-case character codes.
+                Lkc.Lcode -= 32;
+              }
+            } // No 'else' - avoid remapping control + modifier keys!
+
+            if(Lkc.Lcode == 160) {
+              Lkc.Lcode = 0;
+            }
+            Lkc.vkCode = Lkc.Lcode;
           }
-          Lkc.Lmodifiers=0;
+        } else {
+          Lkc.vkCode=Lkc.Lcode;
         }
-        else Lkc.vkCode=Lkc.Lcode;
 
         // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
         if(typeof activeKeyboard['KM'] == 'undefined')

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -1144,6 +1144,7 @@ if(!window['keyman']['initialized']) {
         // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
         if(activeKeyboard && activeKeyboard['KM'] && !(activeKeyboard['KVKL'] && device.formFactor != 'desktop')) {
           if(Lkc.Lcode != osk.keyCodes['K_SPACE']) { // exception required, March 2013
+            Lkc.vkCode = Lkc.Lcode;
             // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
             // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
             var mappedChar: string = osk.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
@@ -1158,7 +1159,6 @@ if(!window['keyman']['initialized']) {
             if(Lkc.Lcode == 160) {
               Lkc.Lcode = 0;
             }
-            Lkc.vkCode = Lkc.Lcode;
           }
         } else {
           Lkc.vkCode=Lkc.Lcode;


### PR DESCRIPTION
Fixes #517.

Does not fully implement support for mnemonic keyboards within KeymanWeb.

This PR will allow mnemonic keyboards to operate from a base layout corresponding to the standard US English keyboard.  Furthermore, it will allow mnemonic mappings to be disabled when non-default layouts (for touch) are in use.

Together, these should address the main issues plaguing #517 and allow a basic path forward for similar keyboards for now, until a more long-term solution is available.  (See #309.)