### PR TITLE
[android] Fix globe button when exiting in-app browser

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -83,7 +83,7 @@ public class InfoActivity extends Activity {
       installedKbs = currentKbID;
 
     kmUrl = String.format("%s?active=%s&installed=%s", kmBaseUrl, currentKbID, installedKbs);
-    WebView webView = (WebView) findViewById(R.id.webView);
+    WebView webView = (WebView) findViewById(R.id.infoWebView);
     webView.getSettings().setLayoutAlgorithm(LayoutAlgorithm.SINGLE_COLUMN);
     webView.getSettings().setJavaScriptEnabled(true);
     webView.getSettings().setUseWideViewPort(true);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -82,7 +82,7 @@ public class PackageActivity extends Activity {
     final Button installButton = (Button) findViewById(R.id.installButton);
     final Button cancelButton = (Button) findViewById(R.id.cancelButton);
 
-    webView = (WebView) findViewById(R.id.webView);
+    webView = (WebView) findViewById(R.id.packageWebView);
     webView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
     webView.getSettings().setJavaScriptEnabled(true);
     webView.getSettings().setUseWideViewPort(true);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -72,7 +72,7 @@ public class WebBrowserActivity extends Activity {
     actionBar.setCustomView(webBarLayout);
     setContentView(R.layout.activity_web_browser);
 
-    webView = (WebView) findViewById(R.id.webView);
+    webView = (WebView) findViewById(R.id.browserWebView);
     addressField = (EditText) findViewById(R.id.address_field);
     clearButton = (ImageButton) findViewById(R.id.clear_button);
     stopButton = (ImageButton) findViewById(R.id.stop_button);

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
@@ -6,7 +6,7 @@
     tools:context=".WebBrowserActivity" >
 
     <WebView
-        android:id="@+id/webView"
+        android:id="@+id/infoWebView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentLeft="true"

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
@@ -7,7 +7,7 @@
     tools:context=".PackageActivity" >
 
     <WebView
-        android:id="@+id/webView"
+        android:id="@+id/packageWebView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/buttonBar"/>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_web_browser.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_web_browser.xml
@@ -6,7 +6,7 @@
     tools:context=".WebBrowserActivity" >
 
     <WebView
-        android:id="@+id/webView"
+        android:id="@+id/browserWebView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_alignParentLeft="true"

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -260,7 +260,7 @@ final class KMKeyboard extends WebView {
    * @return String
    */
   public static String textFontFilename() {
-    return keyboardRoot + txtFont;
+    return txtFont.isEmpty() ? "" : keyboardRoot + txtFont;
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -324,11 +324,15 @@ public final class KMManager {
   public static void onPause() {
     if (InAppKeyboard != null) {
       InAppKeyboard.onPause();
-      InAppKeyboard.pauseTimers();
+      if (InAppKeyboardLoaded) {
+        InAppKeyboard.pauseTimers();
+      }
     }
     if (SystemKeyboard != null) {
       SystemKeyboard.onPause();
-      SystemKeyboard.pauseTimers();
+      if (SystemKeyboardLoaded) {
+        SystemKeyboard.pauseTimers();
+      }
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -312,9 +312,11 @@ public final class KMManager {
 
   public static void onResume() {
     if (InAppKeyboard != null) {
+      InAppKeyboard.resumeTimers();
       InAppKeyboard.onResume();
     }
     if (SystemKeyboard != null) {
+      SystemKeyboard.resumeTimers();
       SystemKeyboard.onResume();
     }
   }
@@ -322,9 +324,11 @@ public final class KMManager {
   public static void onPause() {
     if (InAppKeyboard != null) {
       InAppKeyboard.onPause();
+      InAppKeyboard.pauseTimers();
     }
     if (SystemKeyboard != null) {
       SystemKeyboard.onPause();
+      SystemKeyboard.pauseTimers();
     }
   }
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-05-10 10.0.391 beta
+* Fix globe button when exiting in-app browser (#231)
+
 ## 2018-05-08 10.0.386 beta
 * Fix crashes from invalid package name/version (#819)
 * Clean up console log (#748)


### PR DESCRIPTION
Fixes #231

The in-app and system keyboards are [WebView](https://developer.android.com/reference/android/webkit/WebView) classes. During transitions between the `MainActivity` and `WebBrowserActivity`, calls to `pauseTimers()` and `resumeTimers()` were missing, resulting in the globe button not working in the main app.

Also cleaned up 2 things during investigation of this issue
* Created unique IDs for the webView layouts
* Fixed `KMKeyboard.textFontFilename()` to return an empty string when `txtFont` was empty. (Previously, this was returning the font base path)