### PR TITLE
[android] Update compile SDKVersion from 25 to 27

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
         classpath 'com.google.gms:google-services:3.1.2'
         classpath 'io.fabric.tools:gradle:1.25.1'

--- a/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 30 09:32:59 ICT 2017
+#Sat Apr 14 11:26:38 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.github.triplet.play'
 apply plugin: 'io.fabric'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     playAccountConfigs {
         defaultAccountConfig {
             if (project.hasProperty("keys_json_file")) {
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "com.tavultesoft.kmapro"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
 
         //dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
 
@@ -99,14 +99,17 @@ repositories {
     }
 }
 
-dependencies {
-    api(name: 'keyman-engine', ext: 'aar')
+ext {
+    currentFirebaseVersion = "15.0.2"
+}
 
+dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:support-v4:25.4.0'
-    implementation 'com.google.firebase:firebase-core:11.8.0'
-    implementation 'com.google.firebase:firebase-crash:11.8.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+    implementation 'com.android.support:support-v4:27.1.1'
+    api(name: 'keyman-engine', ext: 'aar')
+    implementation "com.google.firebase:firebase-core:$currentFirebaseVersion"
+    implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }
 }

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
 
         if (project.hasProperty("build.number")) {
             versionCode project.ext['build_counter'] as Integer // Because TeamCity does not bubble build.counter into system properties...
@@ -42,20 +42,20 @@ android {
 }
 
 ext {
-    currentFirebaseVersion = "11.8.0"
+    currentFirebaseVersion = "15.0.2"
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:25.4.0'
+    implementation 'com.android.support:support-v4:27.1.1'
     implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-text:1.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:3.5.1"
+    testImplementation "org.robolectric:robolectric:3.8"
 
     /* We only want these Firebase Crashlytics dependencies for KMEA */
     implementation "com.google.firebase:firebase-analytics:$currentFirebaseVersion"
     implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true;
     }
 }

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 

--- a/android/KMEA/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMEA/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.keyman.kmsample1"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -20,18 +20,23 @@ android {
 }
 
 repositories {
+    google()
     flatDir {
         dirs 'libs'
     }
-    google()
+}
+
+ext {
+    currentFirebaseVersion = "15.0.2"
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.2.0'
-    implementation 'com.google.firebase:firebase-core:11.8.0'
-    implementation 'com.google.firebase:firebase-crash:11.8.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation "com.google.firebase:firebase-core:$currentFirebaseVersion"
+    implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }
     api (name:'keyman-engine', ext:'aar')

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.keyman.kmsample2"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -20,18 +20,23 @@ android {
 }
 
 repositories {
+    google()
     flatDir {
         dirs 'libs'
     }
-    google()
+}
+
+ext {
+    currentFirebaseVersion = "15.0.2"
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.2.0'
-    implementation 'com.google.firebase:firebase-core:11.8.0'
-    implementation 'com.google.firebase:firebase-crash:11.8.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation "com.google.firebase:firebase-core:$currentFirebaseVersion"
+    implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }
     api (name:'keyman-engine', ext:'aar')

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -20,18 +20,23 @@ android {
 }
 
 repositories {
+    google()
     flatDir {
         dirs 'libs'
     }
-    google()
+}
+
+ext {
+    currentFirebaseVersion = "15.0.2"
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:25.2.0'
-    implementation 'com.google.firebase:firebase-core:11.8.0'
-    implementation 'com.google.firebase:firebase-crash:11.8.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation "com.google.firebase:firebase-core:$currentFirebaseVersion"
+    implementation "com.google.firebase:firebase-crash:$currentFirebaseVersion"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }
     api (name:'keyman-engine', ext:'aar')

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-05-11 10.0.391 beta
+* Update compile and target Android SDK version to 27
+
 ## 2018-05-08 10.0.386 beta
 * Fix crashes from invalid package name/version (#819)
 * Clean up console log (#748)


### PR DESCRIPTION
Fixes #750 

Currently, Keyman for Android targets SDK version 25 (Nougat). 

This PR targets the latest Android API and updates all the Gradle dependencies to the latest. This will remove some lint Obsolete warnings.

Sample and Test projects needed to add 
```
implementation 'com.android.support:support-v4:27.1.1'
```
to ensure all dependencies use the same version.