### PR TITLE
[Developer] Report output filename in success message for package compiler

### DIFF
--- a/windows/src/developer/TIKE/project/kpsProjectFile.pas
+++ b/windows/src/developer/TIKE/project/kpsProjectFile.pas
@@ -119,7 +119,7 @@ begin
         Result := False;
 
       if Result then
-        Log(plsInfo, '''' + FileName + ''' compiled successfully.')
+        Log(plsInfo, '''' + FileName + ''' compiled successfully to '''+TargetFileName+'''.')
       else
       begin
         if FileExists(TargetFilename) then


### PR DESCRIPTION
Fixes #758. Report output filename in success message