### PR TITLE
[iOS] Fixes accidental event interrupts due to window.location.hash use.

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -83,9 +83,10 @@
             var fragmentToggle = 0;
             function insertText(dn, s) {
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                window.location.hash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
+                var insertHash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
+                //window.location.hash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + insertHash);
             }
         
             function oskCreateKeyPreview(x,y,w,h,t)
@@ -94,17 +95,19 @@
                 var div = document.createElement('div');
                 div.innerHTML = t;
                 var dt = div.firstChild.nodeValue;
-                window.location.hash = 'showKeyPreview-'+fragmentToggle+'+x='+x+'+y='+y+'+w='+w+'+h='+h+'+t='+toHex(dt);
+                var previewHash = 'showKeyPreview-'+fragmentToggle+'+x='+x+'+y='+y+'+w='+w+'+h='+h+'+t='+toHex(dt);
+                //window.location.hash = 'showKeyPreview-'+fragmentToggle+'+x='+x+'+y='+y+'+w='+w+'+h='+h+'+t='+toHex(dt);
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + previewHash);
             }
         
             function oskClearKeyPreview()
             {
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                window.location.hash = 'dismissKeyPreview-'+fragmentToggle;
+                var dismissHash = 'dismissKeyPreview-'+fragmentToggle;
+                //window.location.hash = 'dismissKeyPreview-'+fragmentToggle;
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + dismissHash);
             }
         
             oskCreatePopup = function(obj,x,y,w,h)
@@ -126,32 +129,35 @@
                     if(shift) {
                         hash = hash + '+font=' + 'SpecialOSK';
                     }
-                    window.location.hash = hash;
+                    //window.location.hash = hash;
                     if (typeof(window.webkit) != 'undefined')
-                        window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                        window.webkit.messageHandlers.keyman.postMessage('#' + hash);
                 }
             }
         
             function menuKeyDown() {
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                window.location.hash = 'menuKeyDown-' + fragmentToggle;
+                var keyDownHash = 'menuKeyDown-' + fragmentToggle;
+                //window.location.hash = 'menuKeyDown-' + fragmentToggle;
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + keyDownHash);
             }
         
             function menuKeyUp()
             {
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                window.location.hash = 'menuKeyUp-'+fragmentToggle;
+                var keyUpHash = 'menuKeyUp-'+fragmentToggle;
+                //window.location.hash = 'menuKeyUp-'+fragmentToggle;
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + keyUpHash);
             }
         
             function hideKeyboard() {
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                window.location.hash = 'hideKeyboard-' + fragmentToggle;
+                var hideHash = 'hideKeyboard-' + fragmentToggle;
+                //window.location.hash = 'hideKeyboard-' + fragmentToggle;
                 if (typeof(window.webkit) != 'undefined')
-                    window.webkit.messageHandlers.keyman.postMessage(window.location.hash);
+                    window.webkit.messageHandlers.keyman.postMessage('#' + hideHash);
             }
         
             function langMenuPos() {


### PR DESCRIPTION
Partially addresses #818.

As it turns out, setting `window.location.hash` within a `WKWebView` instantly interrupts any events currently in processing in order to handle newly generated events.  It rightly generates navigation events, but for whatever reason, it's also allowing new touch events to be handled in the middle of processing old touch events!

For proof of this behavior, I've uploaded the branch https://github.com/keymanapp/keyman/tree/ios-818-location-hash-reentrancy-proof - compiling this version of the code on physical devices (in order to accurately test rapid touch) can generate logs within Xcode showcasing logs such as the following.  Spacing added for emphasis.

```[Touch] start:  key = 'default-K_SPACE'
[Touch] Move
[Touch] Move
[Touch] end:  key = 'default-K_SPACE'

clickKey call-stack: 
clickKey@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:244:168
release@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:286:11

[Touch] Clicked key: default-K_SPACE
[Touch] Starting keystroke processing for key default-K_SPACE
Output command: insertText-25+dn=0+s=0x0020
[Touch] start:  key = 'default-K_D'

clickKey call-stack: 
clickKey@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:244:168
touch@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:284:259
insertText@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keyboard.html:109:32
output@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:146:237
clickKey@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:248:504
release@file:///private/var/mobile/Containers/Shared/AppGroup/D53EAECE-2E6C-417F-88E0-58537A08F819/keyman/keymanios.js:286:11

[Touch] Clicked key: default-K_SPACE
[Touch] Starting keystroke processing for key default-K_SPACE
Output command: insertText-27+dn=0+s=0x0020
```

With that branch, any output of call stack logs must be prefixed with "clickKey call-stack:" - the second call stack features the first call stack at its bottom... and with no intervening layers corresponding to the event interrupt!

The offending line from `insertText`, numbered 109 in that log?

```
window.location.hash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
```

Fortunately, we can restructure the code to eliminate all use of this property with no negative effects; this addresses the 'spookiest' part of the errors we've been seeing.  Some additional problems still remain, which have been confirmed as part of the bug underlying #863.
