### PR TITLE
[Windows] Fixes Ctrl+Alt simulation

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,8 @@
 # Keyman Desktop Version History
 
+## 2018-04-16 10.0.1091.0 beta
+* Fixes Ctrl+Alt simulation regression (#835)
+
 ## 2018-04-12 10.0.1057.0 beta
 * Fix for backspace in legacy mode breaking SMP characters (#729)
 


### PR DESCRIPTION
Ctrl+Alt simulation was never mapped through the preserved keys
code for TSF so we never received key events

Fixes #835.