### PR TITLE
[Developer] The debugger should check that build succeeded before attempting to start.

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -564,6 +564,7 @@ uses
   kmxfile,
   OnlineConstants,
   Project,
+  ProjectFileUI,
   RegExpr,
   ErrorControlledRegistry,
   RedistFiles,
@@ -989,6 +990,9 @@ procedure TfrmKeymanWizard.StartDebugging(FStartTest: Boolean);
     ki: TKeyboardInfo;
     buf: WideString;
   begin
+    if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
+      Exit(False);
+
     try
       GetKeyboardInfo((ProjectFile as TkmnProjectFile).TargetFilename, True, ki);   // I4695
       try
@@ -1038,7 +1042,20 @@ begin
       FDebugForm.CanDebug := True;
       FDebugForm.UIStatus := duiReadyForInput;
       (ProjectFileUI as TkmnProjectFileUI).Debug := True;   // I4687
-      modActionsKeyboardEditor.actKeyboardCompile.Execute;
+
+      frmMessages.Clear;   // I4686
+
+      if not (ProjectFileUI as TkmnProjectFileUI).DoAction(pfaCompile, False) then
+      begin
+        ShowMessage(SKErrorsInCompile);
+        Exit;
+      end;
+
+      if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
+      begin
+        ShowMessage(SKKeyboardKMXDoesNotExist);
+        Exit;
+      end;
 
       if not KeyboardContainsDebugInformation then
       begin

--- a/windows/src/developer/TIKE/rel/keymanstrings.pas
+++ b/windows/src/developer/TIKE/rel/keymanstrings.pas
@@ -21,6 +21,8 @@ interface
 
 const
   SKMustIncludeDebug = 'You must include debug information to start the debugger.  Check ''Include debug information'' in the Keyboard menu.';
+  SKErrorsInCompile = 'The keyboard did not compile successfully. Unable to start debugger.';
+  SKKeyboardKMXDoesNotExist = 'The keyboard .kmx output file does not exist. The keyboard must target Windows or macOS for interactive debugging.';
 
 implementation
 


### PR DESCRIPTION
Fixes #762.