### PR TITLE
[Android] Improve intent-filter 

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -57,16 +57,99 @@
                 <data android:scheme="keyman" android:host="localhost" android:path="/open" />
             </intent-filter>
 
-            <intent-filter>
+            <!-- See http://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension/2062112#2062112 -->
+
+            <!--
+                 Capture content by MIME type, which is how Gmail broadcasts
+                 attachment open requests.  pathPattern and file extensions
+                 are ignored, so the MIME type *MUST* be explicit, otherwise
+                 we will match absolutely every file opened.
+            -->
+            <intent-filter
+                android:priority="50">
                 <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
+
                 <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
 
-                <!-- Android's implementation of PatternMatcher for pathPattern limits special characters to '.', '*', and '\\' -->
-                <data android:scheme="file" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*\\.kmp" />
+                <!-- needed for properly formatted email messages -->
+                <data
+                    android:mimeType="application/vnd.keyman"
+                    android:scheme="content" />
+                <!-- needed for mangled email messages -->
+                <data
+                    android:mimeType="application/keyman"
+                    android:scheme="content" />
+                <!-- needed for mangled email messages -->
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:scheme="content" />
+            </intent-filter>
 
-                <!-- Android DownloadManager doesn't have ".kmp" in the names it passes to the intent -->
-                <data android:scheme="content" android:host="*" android:mimeType="application/octet-stream" android:pathPattern=".*" />
+            <!--
+                 Capture file open requests (pathPattern is honoured) where no
+                 MIME type is provided in the Intent.  An Intent with a null
+                 MIME type will never be matched by a filter with a set MIME
+                 type, so we need a second intent-filter if we wish to also
+                 match files with this extension and a non-null MIME type
+                 (even if it is non-null but zero length).
+            -->
+            <intent-filter
+                android:priority="50">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="file" />
+                <data android:host="*" />
+
+                <!--
+                     Work around Android's ugly primitive PatternMatcher
+                     implementation that can't cope with finding a . early in
+                     the path unless it's explicitly matched.
+                -->
+                <data android:pathPattern=".*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
+            </intent-filter>
+
+            <!--
+                 Capture file open requests (pathPattern is honoured) where a
+                 (possibly blank) MIME type is provided in the Intent.  This
+                 filter may only be necessary for supporting ES File Explorer,
+                 which has the probably buggy behaviour of using an Intent
+                 with a MIME type that is set but zero-length.  It's
+                 impossible to match such a type except by using a global
+                 wildcard.
+            -->
+            <intent-filter
+                android:priority="50">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:mimeType="*/*" />
+
+                <!--
+                     Work around Android's ugly primitive PatternMatcher
+                     implementation that can't cope with finding a . early in
+                     the path unless it's explicitly matched.
+                -->
+                <data android:pathPattern=".*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
             </intent-filter>
 
             <intent-filter>

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,20 @@
 # Keyman for Android
 
+## 2018-05-27 10.0.397 beta
+* Improve intent-filter for *.kmp extensions (902)
+
+## 2018-05-22 10.0.396 beta
+* No changes to Keyman for Android.
+
+## 2018-05-22 10.0.395 beta
+* No changes to Keyman for Android.
+
+## 2018-05-18 10.0.394 beta
+* No changes to Keyman for Android.
+
+## 2018-05-17 10.0.393 beta
+* No changes to Keyman for Android.
+
 ## 2018-05-11 10.0.392 beta
 * Fix globe button when exiting in-app browser (#231)
 


### PR DESCRIPTION
Fixes #902

For greater compatibility with 3rd party file browsers (e.g. Motorola "File Manager")

Update the intent-filter for file scheme (based on BloomReader's [AndroidManifest.xml](https://github.com/BloomBooks/BloomReader/blob/master/app/src/main/AndroidManifest.xml))

