### PR TITLE
[Windows] Incorrect icons caused by lookup against non-installed language profile.

### DIFF
--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
@@ -78,6 +78,9 @@ procedure TKeymanKeyboardLanguageInstalled.ApplyEnabled(
 var
   AEnabledInt: Integer;
 begin
+  if not Get_IsInstalled then
+    Exit;
+
   if AEnabled then AEnabledInt := 1 else AEnabledInt := 0;
   try   // I4494
     OleCheck(pInputProcessorProfiles.EnableLanguageProfile(c_clsidKMTipTextService,

--- a/windows/src/engine/kmcomapi/com/languages/keymanlanguage.pas
+++ b/windows/src/engine/kmcomapi/com/languages/keymanlanguage.pas
@@ -192,7 +192,7 @@ begin
       kbd := Items[i] as IKeymanKeyboardInstalled;
       for j := 0 to kbd.Languages.Count - 1 do
       begin
-        if kbd.Languages[j].ProfileGUID = Get_ProfileGUID then
+        if kbd.Languages[j].IsInstalled and (kbd.Languages[j].ProfileGUID = Get_ProfileGUID) then
           Exit(kbd.Languages[j]);
       end;
     end;


### PR DESCRIPTION
Fixes #858. 

Also addresses an invisible, related issue: Keyman Configuration would attempt to 
enable non-installed profiles on exit, which would error silently.