### PR TITLE
[Developer] Prevents a crash when Keyman Developer attempts to load an invalid project file.

### DIFF
--- a/windows/src/developer/TIKE/project/ProjectLoader.pas
+++ b/windows/src/developer/TIKE/project/ProjectLoader.pas
@@ -79,7 +79,12 @@ var
   node, root: IXMLNode;
   pf: TProjectFile;
 begin
-  doc := LoadXMLDocument(FFileName);
+  try
+    doc := LoadXMLDocument(FFileName);
+  except
+    on E:Exception do
+      raise EProjectLoader.Create('Error loading project file: '+E.Message);
+  end;
 
   root := doc.DocumentElement;
   if root.NodeName <> 'KeymanDeveloperProject' then


### PR DESCRIPTION
Fixes sillsdev/keyman-issues#5568. Prevents a crash when Keyman Developer attempts to load an invalid project file.