### PR TITLE
[Developer] Improve support for BCP 47 in Package Editor

### DIFF
--- a/windows/src/buildtools/buildpkg/buildpkg.dpr
+++ b/windows/src/buildtools/buildpkg/buildpkg.dpr
@@ -71,7 +71,8 @@ uses
   BCP47Tag in '..\..\global\delphi\general\BCP47Tag.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas';
+  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
 
 begin
   Run;

--- a/windows/src/buildtools/buildpkg/buildpkg.dproj
+++ b/windows/src/buildtools/buildpkg/buildpkg.dproj
@@ -159,6 +159,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -267,7 +267,8 @@ uses
   Keyman.Developer.System.HelpTopics in 'help\Keyman.Developer.System.HelpTopics.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas';
+  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -507,6 +507,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
+++ b/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
@@ -75,6 +75,7 @@ uses
   System.Generics.Collections,
 
   Keyman.Developer.System.HelpTopics,
+  Keyman.System.CanonicalLanguageCodeUtils,
   Keyman.System.KMXFileLanguages,
   Keyman.System.LanguageCodeUtils,
   utilexecute;
@@ -151,9 +152,28 @@ begin
 end;
 
 procedure TfrmSelectBCP47Language.cbLanguageTagChange(Sender: TObject);
+var
+  t: string;
 begin
   inherited;
   tag.Language := TKMXFileLanguages.TranslateISO6393ToBCP47(cbLanguageTag.Text);
+  t := TCanonicalLanguageCodeUtils.FindBestTag(Tag.Tag);
+  if t <> '' then
+  begin
+    with TBCP47Tag.Create(t) do
+    try
+      cbScriptTag.Text := Script;
+      Self.tag.Script := Script;
+    finally
+      Free;
+    end;
+  end
+  else
+  begin
+    cbScriptTag.Text := '';
+    tag.Script := '';
+  end;
+  FCustomLanguageName := False; // Always reset when entering a language tag.
   RefreshLanguageName;
 end;
 

--- a/windows/src/developer/TIKE/main/mrulist.pas
+++ b/windows/src/developer/TIKE/main/mrulist.pas
@@ -196,3 +196,4 @@ begin
 end;
 
 end.
+

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -102,7 +102,8 @@ uses
   Keyman.System.RegExGroupHelperRSP19902 in '..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas';
+  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -205,6 +205,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
@@ -57,7 +57,7 @@ begin
       Exit('');
     if TLanguageCodeUtils.SuppressScripts.TryGetValue(t.Language, script) then
     begin
-      if SameText(t.Script, script) then
+      if SameText(t.Script, script) or (t.Script = '') then
       begin
         // The script should be suppressed because it is known to Windows (**really?)
         // We won't do a region check because this is not really required.

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -51,9 +51,11 @@ uses
 
   BCP47Tag,
 
+  Keyman.System.CanonicalLanguageCodeUtils,
   Keyman.System.KMXFileLanguages,
   Keyman.System.KeyboardJSInfo,
   Keyman.System.KeyboardUtils,
+  Keyman.System.LanguageCodeUtils,
   kmxfile;
 
 const
@@ -239,6 +241,7 @@ var
   codes: TStringDynArray;
   lang: TPackageKeyboardLanguage;
   i: Integer;
+  s, t: string;
 begin
   //
   k.Languages.Clear;
@@ -248,10 +251,32 @@ begin
       codes := TKMXFileLanguages.GetKMXFileBCP47Codes(f.FileName);
       for i := 0 to High(codes) do
       begin
+        t := TCanonicalLanguageCodeUtils.FindBestTag(codes[i]);
+        if t = '' then
+          // We won't add codes that are unrecognised
+          Continue;
+
         lang := TPackageKeyboardLanguage.Create(f.Package);
-        lang.ID := codes[i];
-        // TODO: BCP47: <DeveloperBCP47LanguageLookup> Lookup default names
-        lang.Name := codes[i];
+
+        with TBCP47Tag.Create(t) do
+        try
+          Region := '';
+          lang.ID := Tag;
+
+          if not TLanguageCodeUtils.BCP47Languages.TryGetValue(Language, lang.Name) then
+          begin
+            lang.Name := Language;
+          end;
+
+          if Script <> '' then
+          begin
+            if TLanguageCodeUtils.BCP47Languages.TryGetValue(Script, s) then
+              lang.Name := lang.Name + ' ('+s+')';
+          end;
+        finally
+          Free;
+        end;
+
         k.Languages.Add(lang);
       end;
     except


### PR DESCRIPTION
Fixes #885. Fixes #891.
* Canonicalizes, as far as possible, new language IDs as keyboards added to package
* Adds script where possible to incomplete tags in BCP 47 selection dialog
* Looks up language name automatically when adding keyboard to package