### PR TITLE
[Windows] Keyboard Options dialog no longer crashes on save.

### DIFF
--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -134,12 +134,12 @@ BOOL IntLoadKeyboardOptions(LPCSTR key, LPINTKEYBOARDINFO kp)
   RegistryReadOnly r(HKEY_CURRENT_USER);
   if(r.OpenKeyReadOnly(REGSZ_KeymanActiveKeyboards) && r.OpenKeyReadOnly(kp->Name) && r.OpenKeyReadOnly(key))
   {
-    WCHAR buf[255];
+    WCHAR buf[256];
     int n = 0;
     while(r.GetValueNames(buf, sizeof(buf) / sizeof(buf[0]), n))
     {
       buf[255] = 0;
-      WCHAR val[255];
+      WCHAR val[256];
       if(r.ReadString(buf, val, sizeof(val) / sizeof(val[0])) && val[0])
       {
         val[255] = 0;

--- a/windows/src/engine/kmcomapi/com/keyboardoptions/keymankeyboardoptions.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardoptions/keymankeyboardoptions.pas
@@ -84,13 +84,23 @@ var
 begin
   Result := nil;
 
-  if VarType(Index) = varOleStr
-    then i := IndexOf(Index)
-    else i := Index;
+  if VarType(Index) = varOleStr then
+  begin
+    i := IndexOf(Index);
+    if i < 0 then
+      i := FKeyboardOptions.Add(TKeymanKeyboardOption.Create(Context, FKeyboardID, Index, ''));
+  end
+  else
+  begin
+    i := Index;
+    if (i < 0) or (i >= Get_Count) then
+    begin
+      ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+      Exit;
+    end;
+  end;
 
-  if (i < Get_Count) and (i >= 0)
-    then Result := FKeyboardOptions[i] as IKeymanKeyboardOption
-    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+  Result := FKeyboardOptions[i] as IKeymanKeyboardOption;
 end;
 
 function TKeymanKeyboardOptions.IndexOf(const Name: WideString): Integer;


### PR DESCRIPTION
Fixes sillsdev/keyman-issues#5613. Fixes two bugs with the refactored keyboard options implementation:

1. The Keyboard Options dialog would crash when trying to add a new keyboard option.
2. Keyman Engine crashed trying to read keyboard options from registry due to buffer overrun.