### PR TITLE
[Mac] #872 - Added Pages and Keynote as legacy apps

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -44,7 +44,9 @@ NSRange _previousSelRange;
 
 // This is the public initializer.
 - (instancetype)initWithClient:(NSString *)clientAppId {
-    BOOL legacy = ([clientAppId isEqual: @"com.github.atom"] ||
+    BOOL legacy = ([clientAppId isEqual: @"com.apple.iWork.Pages"] ||
+            [clientAppId isEqual: @"com.apple.iWork.Keynote"] ||
+            [clientAppId isEqual: @"com.github.atom"] ||
             [clientAppId isEqual: @"com.collabora.libreoffice-free"] ||
             [clientAppId isEqual: @"com.axosoft.gitkraken"] ||
             [clientAppId isEqual: @"org.sil.app.builder.scripture.ScriptureAppBuilder"] ||

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -44,6 +44,10 @@ NSRange _previousSelRange;
 
 // This is the public initializer.
 - (instancetype)initWithClient:(NSString *)clientAppId {
+    // Note: Pages and Keynote (and possibly lots of other undiscovered apps that are otherwise compliant
+    // with Apple's IM faramework) need to be treated as "legacy" because if the user selects a different
+    // font (or other formatting) and then types a sequence that causes characters to be added to the document
+    // and then subsequently replaced, the replacement causes the formatting decision to be forgotten.
     BOOL legacy = ([clientAppId isEqual: @"com.apple.iWork.Pages"] ||
             [clientAppId isEqual: @"com.apple.iWork.Keynote"] ||
             [clientAppId isEqual: @"com.github.atom"] ||

--- a/mac/history.md
+++ b/mac/history.md
@@ -2,6 +2,7 @@
 
 ## 2018-05-28 10.0.43 beta
 * Error-reporting improvements (settings modified to upload symbols for Engine (#884)
+* Solved problem of losing font/style information in Pages and Keynote (#930)
 
 ## 2018-05-25 10.0.42 beta
 * Prevented crashes and performance problems with "event tap" (#883)


### PR DESCRIPTION
This allows them to retain font/style information when a character sequence causes the character(s) holding that info to be replaced.