### PR TITLE
[Mac] #769 - Switched to using Cocoapods to get Crashlytics framework

### DIFF
--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -3,6 +3,7 @@
 **/xcuserdata
 Keyman4MacIM/output/*
 Keyman4MacIM/Keyman4MacIM/Frameworks/**
+Keyman4MacIM/Pods/**
 Keyman4Mac/Keyman4Mac/Frameworks/**
 Carthage/**
 **/build

--- a/mac/Cartfile
+++ b/mac/Cartfile
@@ -1,2 +1,0 @@
-binary "https://raw.githubusercontent.com/Building42/Specs/master/Carthage/macOS/Fabric.json" ~> 1.7.6
-binary "https://raw.githubusercontent.com/Building42/Specs/master/Carthage/macOS/Crashlytics.json" ~> 3.10.1

--- a/mac/Cartfile.resolved
+++ b/mac/Cartfile.resolved
@@ -1,3 +1,1 @@
-binary "https://raw.githubusercontent.com/Building42/Specs/master/Carthage/macOS/Crashlytics.json" "3.10.1"
-binary "https://raw.githubusercontent.com/Building42/Specs/master/Carthage/macOS/Fabric.json" "1.7.6"
 github "erikdoe/ocmock" "v3.4.1"

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -847,7 +847,7 @@
 					"$(PROJECT_DIR)/Keyman4MacIM/Frameworks",
 					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
 				);
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -874,7 +874,7 @@
 					"$(PROJECT_DIR)/Keyman4MacIM/Frameworks",
 					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
 				);
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -908,7 +908,10 @@
 					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Carthage/Build/Mac/**";
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = KeymanTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		37407275F02D5CDA553EE07E /* libPods-Keyman.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97064F9FBF9E0D09264AF6C5 /* libPods-Keyman.a */; };
 		9800EC5A1C02940300BF0FB5 /* keyman-for-mac-os-license.html in Resources */ = {isa = PBXBuildFile; fileRef = 9800EC591C02940300BF0FB5 /* keyman-for-mac-os-license.html */; };
 		9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9803C9D71B0EFB3B0082A6F9 /* WebKit.framework */; };
 		983247281A9EA28F0010B90C /* KeymanEngine4Mac.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -67,6 +68,7 @@
 		E28914D72024E6220048E71E /* KeymanEngine4Mac.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E28914D92028A78C0048E71E /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E28914D82028A78C0048E71E /* OCMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E29F22F4201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E29F22F3201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m */; };
+		E61216E78B7F03FE755687F1 /* libPods-KeymanTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E7FB3417C46A01721AD32D0 /* libPods-KeymanTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +118,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B51C9B443060BB3B4A1AE8E /* Pods-Keyman.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.debug.xcconfig"; sourceTree = "<group>"; };
+		750C7C7BCA2917BAF99E6B69 /* Pods-Keyman.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.release.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.release.xcconfig"; sourceTree = "<group>"; };
+		8577C0C788461AFE564DDF4F /* Pods-KeymanTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KeymanTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KeymanTests/Pods-KeymanTests.debug.xcconfig"; sourceTree = "<group>"; };
+		97064F9FBF9E0D09264AF6C5 /* libPods-Keyman.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Keyman.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9800EC591C02940300BF0FB5 /* keyman-for-mac-os-license.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "keyman-for-mac-os-license.html"; sourceTree = "<group>"; };
 		9803C9D71B0EFB3B0082A6F9 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		9832472C1A9EABC70010B90C /* KMConfigColumn1CellView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KMConfigColumn1CellView.h; path = Keyman4MacIM/KMConfiguration/KMConfigColumn1CellView.h; sourceTree = "<group>"; };
@@ -180,6 +186,7 @@
 		98FE10601B4DEE5600525F54 /* KMInfoWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KMInfoWindowController.h; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.h; sourceTree = "<group>"; };
 		98FE10611B4DEE5600525F54 /* KMInfoWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KMInfoWindowController.m; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m; sourceTree = "<group>"; };
 		98FE10621B4DEE5600525F54 /* KMInfoWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = KMInfoWindowController.xib; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.xib; sourceTree = "<group>"; };
+		9E7FB3417C46A01721AD32D0 /* libPods-KeymanTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KeymanTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E211CCF520B600A500505C36 /* KeymanEngine4Mac.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = KeymanEngine4Mac.framework.dSYM; path = Keyman4MacIM/Frameworks/KeymanEngine4Mac.framework.dSYM; sourceTree = "<group>"; };
 		E21291A820A4DD680049790C /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = ../../Carthage/Build/Mac/Crashlytics.framework; sourceTree = "<group>"; };
 		E21291AA20A4DDE70049790C /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = ../../Carthage/Build/Mac/Fabric.framework; sourceTree = "<group>"; };
@@ -202,6 +209,7 @@
 		E29F22F3201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KMInputMethodBrowserClientEventHandlerTests.m; sourceTree = "<group>"; };
 		E29F22F5201A59B2005EA234 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E2C92D4720B46CEA00742A7D /* KeymanEngine4Mac.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = KeymanEngine4Mac.framework.dSYM; path = Keyman4MacIM/Frameworks/KeymanEngine4Mac.framework.dSYM; sourceTree = "<group>"; };
+		FA67C64E3D2743D2BCF46ED1 /* Pods-KeymanTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KeymanTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KeymanTests/Pods-KeymanTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +222,7 @@
 				E21291A920A4DD680049790C /* Crashlytics.framework in Frameworks */,
 				984C2B221A79DF1B0023F89D /* KeymanEngine4Mac.framework in Frameworks */,
 				9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */,
+				37407275F02D5CDA553EE07E /* libPods-Keyman.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -225,12 +234,24 @@
 				E218402F20A539E20035AADB /* Crashlytics.framework in Frameworks */,
 				E28914D32024D1B80048E71E /* KeymanEngine4Mac.framework in Frameworks */,
 				E27BA9CE2020322000D273E7 /* OCMock.framework in Frameworks */,
+				E61216E78B7F03FE755687F1 /* libPods-KeymanTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2CDC487CDFFBB26D621D73BD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2B51C9B443060BB3B4A1AE8E /* Pods-Keyman.debug.xcconfig */,
+				750C7C7BCA2917BAF99E6B69 /* Pods-Keyman.release.xcconfig */,
+				8577C0C788461AFE564DDF4F /* Pods-KeymanTests.debug.xcconfig */,
+				FA67C64E3D2743D2BCF46ED1 /* Pods-KeymanTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		983246EC1A9E8E860010B90C /* KMConfiguration */ = {
 			isa = PBXGroup;
 			children = (
@@ -315,6 +336,7 @@
 				E29F22F2201A59B1005EA234 /* KeymanTests */,
 				989C9C091A7876DE00A20425 /* Products */,
 				E27BA9CC2020321F00D273E7 /* Frameworks */,
+				2CDC487CDFFBB26D621D73BD /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -441,6 +463,8 @@
 			isa = PBXGroup;
 			children = (
 				E27BA9CD2020322000D273E7 /* OCMock.framework */,
+				97064F9FBF9E0D09264AF6C5 /* libPods-Keyman.a */,
+				9E7FB3417C46A01721AD32D0 /* libPods-KeymanTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -462,6 +486,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 989C9C251A7876DE00A20425 /* Build configuration list for PBXNativeTarget "Keyman" */;
 			buildPhases = (
+				D2FF67BB6C749BA6861F5E25 /* [CP] Check Pods Manifest.lock */,
 				E2588F2E1F2644850061C9C4 /* ShellScript */,
 				989C9C041A7876DE00A20425 /* Sources */,
 				989C9C051A7876DE00A20425 /* Frameworks */,
@@ -483,6 +508,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E29F22F8201A59B2005EA234 /* Build configuration list for PBXNativeTarget "KeymanTests" */;
 			buildPhases = (
+				3263C54E5ED17882C05003D5 /* [CP] Check Pods Manifest.lock */,
 				E29F22ED201A59B1005EA234 /* Sources */,
 				E29F22EE201A59B1005EA234 /* Frameworks */,
 				E29F22EF201A59B1005EA234 /* Resources */,
@@ -579,6 +605,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3263C54E5ED17882C05003D5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-KeymanTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D2FF67BB6C749BA6861F5E25 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Keyman-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		E21291A120A33CA50049790C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -590,7 +652,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" = \"Release\" ]; then\n   if [ \"${FABRIC_API_KEY_KEYMAN4MACIM}\" != \"\" ]; then\n      ../Carthage/Build/Mac/Fabric.framework/run ${FABRIC_API_KEY_KEYMAN4MACIM} ${FABRIC_BUILD_SECRET_KEYMAN4MACIM}\n   fi\nelse\n    ../Carthage/Build/Mac/Fabric.framework/run 68056571ada44ad2d93864380272808ada308b24 23863472894073dc672f5027ecdd239df93ebe58830ee9c7bb383e9abaeabee7\nfi\n";
+			shellScript = "if [ \"${CONFIGURATION}\" = \"Release\" ]; then\n   if [ \"${FABRIC_API_KEY_KEYMAN4MACIM}\" != \"\" ]; then\nPods/Fabric/upload-symbols -a ${FABRIC_API_KEY_KEYMAN4MACIM} -p mac build/${CONFIGURATION}\n   fi\nelse\n    Pods/Fabric/upload-symbols -a 68056571ada44ad2d93864380272808ada308b24 -p mac build/${CONFIGURATION}\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E2588F2E1F2644850061C9C4 /* ShellScript */ = {
@@ -771,6 +833,7 @@
 		};
 		989C9C261A7876DE00A20425 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2B51C9B443060BB3B4A1AE8E /* Pods-Keyman.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
@@ -784,7 +847,7 @@
 					"$(PROJECT_DIR)/Keyman4MacIM/Frameworks",
 					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
 				);
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Carthage/Build/Mac/**";
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -798,6 +861,7 @@
 		};
 		989C9C271A7876DE00A20425 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 750C7C7BCA2917BAF99E6B69 /* Pods-Keyman.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
@@ -810,7 +874,7 @@
 					"$(PROJECT_DIR)/Keyman4MacIM/Frameworks",
 					"$(PROJECT_DIR)/../Carthage/Build/Mac/**",
 				);
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../Carthage/Build/Mac/**";
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -824,6 +888,7 @@
 		};
 		E29F22F9201A59B2005EA234 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8577C0C788461AFE564DDF4F /* Pods-KeymanTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -855,6 +920,7 @@
 		};
 		E29F22FA201A59B2005EA234 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FA67C64E3D2743D2BCF46ED1 /* Pods-KeymanTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcworkspace/contents.xcworkspacedata
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Keyman4MacIM.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -43,6 +43,7 @@ extern NSString *const kVersion;
 extern NSString *const kWebSite;
 
 @interface KMInputMethodAppDelegate : NSObject
+#define USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE 1
 #ifdef USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE
     <NSAlertDelegate>
 #endif

--- a/mac/Keyman4MacIM/Podfile
+++ b/mac/Keyman4MacIM/Podfile
@@ -1,0 +1,17 @@
+# Uncomment the next line to define a global platform for your project
+platform :osx, '10.7'
+
+target 'Keyman' do
+  # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
+  # use_frameworks!
+
+  # Pods for Keyman
+  pod 'Fabric'
+  pod 'Crashlytics'
+
+  target 'KeymanTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+end

--- a/mac/Keyman4MacIM/Podfile.lock
+++ b/mac/Keyman4MacIM/Podfile.lock
@@ -1,0 +1,21 @@
+PODS:
+  - Crashlytics (3.10.2):
+    - Fabric (~> 1.7.7)
+  - Fabric (1.7.7)
+
+DEPENDENCIES:
+  - Crashlytics
+  - Fabric
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Crashlytics
+    - Fabric
+
+SPEC CHECKSUMS:
+  Crashlytics: 0360624eea1c978a743feddb2fb1ef8b37fb7a0d
+  Fabric: bda89e242bce1b7b8ab264248cf3407774ce0095
+
+PODFILE CHECKSUM: f97fe7081827fd61ed7a61b5a0820d4e0df01dee
+
+COCOAPODS: 1.5.3

--- a/mac/README.md
+++ b/mac/README.md
@@ -3,6 +3,7 @@
 ## Mac Tools Requirements/Setup
 Install Xcode 8.3.3 or later (it might also work to use an older version)
 Install [Carthage](https://github.com/Carthage/Carthage/blob/master/README.md) *see Homebrew note below
+Install cocoapods (sudo gem install cocoapods) if not already installed.
 
 ## Keyman for macOS Development
 Keyman for macOS can be built from a command line (preferred) or Xcode.
@@ -24,7 +25,7 @@ Note: If Carthage prompts you to allow it access to your github credentials, it'
 [Installing Keyman for Mac OS X](https://help.keyman.com/products/mac/1.0/docs/start_download-install_keyman.php).
 
 ### Compiling from Xcode
-To build using Xcode, you will need to build KeymanEngine4Mac first and then build Keyman4MacIM.
+To build using Xcode, you will need to build KeymanEngine4Mac first and then build Keyman4MacIM. The very _first_ time after getting the source code (and any time the Podfile is edited; e.g., to install new pods), you need to go to **keyman/mac/Keyman4MacIM and run "pod install" in Terminal.
 
 1. Launch Xcode
 2. Open **keyman/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj**

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -79,7 +79,7 @@ KM4MIM_BASE_PATH="$KEYMAN_MAC_BASE_PATH/$IM_NAME"
 
 KME4M_PROJECT_PATH="$KME4M_BASE_PATH/$ENGINE_NAME$XCODE_PROJ_EXT"
 KMTESTAPP_PROJECT_PATH="$KMTESTAPP_BASE_PATH/$TESTAPP_NAME$XCODE_PROJ_EXT"
-KMIM_PROJECT_PATH="$KM4MIM_BASE_PATH/$IM_NAME$XCODE_PROJ_EXT"
+KMIM_WORKSPACE_PATH="$KM4MIM_BASE_PATH/$IM_NAME.xcworkspace"
 
 # KME4M_BUILD_PATH=engine/KME4M/build
 # APP_RESOURCES=keyman/Keyman/Keyman/libKeyman
@@ -252,8 +252,10 @@ if $CLEAN ; then
     do_clean
 fi
 
-carthage bootstrap
-
+if [ "$TEST_ACTION" == "test" ]; then
+	carthage bootstrap		
+fi
+ 
 execBuildCommand() {
     typeset component="$1"
     shift
@@ -298,10 +300,10 @@ fi
 
 if $DO_KEYMANIM ; then
     updatePlist "$KM4MIM_BASE_PATH" "$IM_NAME"
-    execBuildCommand $IM_NAME "xcodebuild -project \"$KMIM_PROJECT_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS $BUILD_ACTIONS"
+    execBuildCommand $IM_NAME "xcodebuild -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS $BUILD_ACTIONS -scheme Keyman"
     if [ "$TEST_ACTION" == "test" ]; then
     	if [ "$CONFIG" == "Debug" ]; then
-    		execBuildCommand "$IM_NAME tests" "xcodebuild $TEST_ACTION -project \"$KMIM_PROJECT_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS -scheme Keyman"
+    		execBuildCommand "$IM_NAME tests" "xcodebuild $TEST_ACTION -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS -scheme Keyman"
     	fi
     fi
 fi

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -299,6 +299,9 @@ if $DO_KEYMANENGINE ; then
 fi
 
 if $DO_KEYMANIM ; then
+	cd "$KM4MIM_BASE_PATH"
+	pod install
+	cd "$KEYMAN_MAC_BASE_PATH"
     updatePlist "$KM4MIM_BASE_PATH" "$IM_NAME"
     execBuildCommand $IM_NAME "xcodebuild -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS $BUILD_ACTIONS -scheme Keyman"
     if [ "$TEST_ACTION" == "test" ]; then

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,10 +1,13 @@
 # Keyman for macOS Version History
 
+## 2018-06-05 10.0.45 beta
+* Error-reporting improvements (better method to ensure upload of symbols for Engine) (#935)
+
 ## 2018-06-01 10.0.44 beta
 * Improved double-clicking KMP (#929)
 
 ## 2018-05-28 10.0.43 beta
-* Error-reporting improvements (settings modified to upload symbols for Engine (#884)
+* Error-reporting improvements (settings modified to upload symbols for Engine) (#884)
 * Solved problem of losing font/style information in Pages and Keynote (#930)
 
 ## 2018-05-25 10.0.42 beta


### PR DESCRIPTION
This also gets the upload-symbols script, which seems to be necessary to upload the dSYM file for the Keyman Engine.