### PR TITLE
[Windows] Improve crash reporting stability

### DIFF
--- a/windows/src/engine/tsysinfo/UfrmRemoteExceptionHandler.pas
+++ b/windows/src/engine/tsysinfo/UfrmRemoteExceptionHandler.pas
@@ -386,7 +386,6 @@ begin
       Free;
     end;
     FTempFileName := TSIFileName;
-    DeleteFile(FLogFile);
   end
   else
     FTempFileName := FLogFile;
@@ -409,6 +408,9 @@ end;
 
 procedure TfrmExceptionHandler.FormDestroy(Sender: TObject);
 begin
+  if FileExists(FLogFile) then
+    DeleteFile(FLogFile);
+
   Application.UnhookMainWindow(AppMessage);
 end;
 

--- a/windows/src/engine/tsysinfo/si_base.pas
+++ b/windows/src/engine/tsysinfo/si_base.pas
@@ -324,7 +324,11 @@ begin
       Open(AFileName, TZipMode.zmWrite);
       Add(FTempFileName);
       for i := 0 to FFiles.Count - 1 do
+      try
         Add(FFiles[i]);
+      except
+        on E:EFOpenError do ;
+      end;
       Close;
     finally
       Free;


### PR DESCRIPTION
Fixes #852, Fixes #854. Remove logfile only on close of crash report dialog, not after
failing to send, and locked files are ignored and no longer block crash report from
uploading.