### PR TITLE
[Android] Fix globe button for system keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -324,15 +324,9 @@ public final class KMManager {
   public static void onPause() {
     if (InAppKeyboard != null) {
       InAppKeyboard.onPause();
-      if (InAppKeyboardLoaded) {
-        InAppKeyboard.pauseTimers();
-      }
     }
     if (SystemKeyboard != null) {
       SystemKeyboard.onPause();
-      if (SystemKeyboardLoaded) {
-        SystemKeyboard.pauseTimers();
-      }
     }
   }
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,7 +1,11 @@
 # Keyman for Android
 
+## 2018-06-05 10.0.398 beta
+* Fix globe button for system keyboard (#940)
+
 ## 2018-05-27 10.0.397 beta
-* Improve intent-filter for *.kmp extensions (902)
+
+* Improve intent-filter for *.kmp extensions (#902)
 
 ## 2018-05-22 10.0.396 beta
 * No changes to Keyman for Android.
@@ -16,7 +20,7 @@
 * No changes to Keyman for Android.
 
 ## 2018-05-11 10.0.392 beta
-* Fix globe button when exiting in-app browser (#231)
+* Fix globe button when exiting in-app browser (#848)
 
 ## 2018-05-11 10.0.391 beta
 * Update compile and target Android SDK version to 27 (#750)

--- a/android/history.md
+++ b/android/history.md
@@ -1,7 +1,7 @@
 # Keyman for Android
 
 ## 2018-06-05 10.0.398 beta
-* Fix globe button for system keyboard (#940)
+* Fix globe button for system keyboard (#942)
 
 ## 2018-05-27 10.0.397 beta
 


### PR DESCRIPTION
Fixes #913

In #848, we used [webView.pauseTimers()](https://developer.android.com/reference/android/webkit/WebView#pauseTimers()) to disable JavaScript for transitioning between in-app and system keyboards. Unfortunately, `pauseTimers()` globally affects all the WebViews, breaking the globe button in system keyboards.

(This worked going from the Keyman app to in-app browser because the browser "resumed" its keyboard)

Solution is removing calls to `pauseTimers()`.