### PR TITLE
[Windows] Fix issues attempting to install custom languages in Windows 7

### DIFF
--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
@@ -312,7 +312,17 @@ begin
         if Tag <> '' then
         begin
           FLanguage := TInstLanguage.Create(True, Language, Script, FKeyboard.Languages[i].Name);
-          FLanguage.Variants.Add(TInstLanguageVariant.Create(Language, Tag, Script, FKeyboard.Languages[i].Name));
+          try
+            FLanguage.Variants.Add(TInstLanguageVariant.Create(Language, Tag, Script, FKeyboard.Languages[i].Name));
+          except
+            on E:EOSError do
+            begin
+              // The language tag is not supported on this OS - probably Win7
+              // Don't offer it as an option
+              FLanguage.Free;
+              Continue;
+            end;
+          end;
           FLanguages.Add(FLanguage);
         end;
       finally

--- a/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboardlanguageprofiles.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboardlanguageprofiles.pas
@@ -44,7 +44,7 @@ type
   TKPInstallKeyboardLanguageProfiles = class(TKPBase)
     // Expects LANGIDs and LocaleNames in format 'en-US en 0409';
     procedure Execute(const KeyboardName, KeyboardDescription: string; LangIDs: array of Integer; IconFileName: string; InstallFirstOnly: Boolean); overload;  // I3707   // I3768   // I4607
-    procedure Execute(const KeyboardName, KeyboardDescription, BCP47Tag, IconFileName, LanguageName: string); overload;  // I3707   // I3768   // I4607
+    function Execute(const KeyboardName, KeyboardDescription, BCP47Tag, IconFileName, LanguageName: string): Boolean; overload;  // I3707   // I3768   // I4607
     constructor Create(AContext: TKeymanContext);
     destructor Destroy; override;
   private
@@ -162,7 +162,7 @@ begin
   Context.Control.AutoApplyKeyman;
 end;
 
-procedure TKPInstallKeyboardLanguageProfiles.Execute(const KeyboardName, KeyboardDescription, BCP47Tag, IconFileName, LanguageName: string);
+function TKPInstallKeyboardLanguageProfiles.Execute(const KeyboardName, KeyboardDescription, BCP47Tag, IconFileName, LanguageName: string): Boolean;
 var
   FIsAdmin: Boolean;
 begin
@@ -185,8 +185,9 @@ begin
       RootPath := GetRegistryKeyboardInstallKey_CU(KeyboardName) + SRegSubKey_LanguageProfiles;
     end;
 
-    if reg.OpenKey(RootPath, True) then
-      RegisterLocale(KeyboardDescription, BCP47Tag, 0, IconFileName, LanguageName);   // I3707   // I3768   // I4607
+    if reg.OpenKey(RootPath, True)
+      then Result := RegisterLocale(KeyboardDescription, BCP47Tag, 0, IconFileName, LanguageName)   // I3707   // I3768   // I4607
+      else Result := False;
   finally
     reg.Free;
   end;
@@ -236,8 +237,15 @@ begin
     if not ConvertLangIDToBCP47Tag(LangID, BCP47Tag) then
       Exit;
   end
-  else if not ConvertBCP47TagToLangID(BCP47Tag, LangID) and FWin8Languages.IsSupported then
+  else if not ConvertBCP47TagToLangID(BCP47Tag, LangID) then
   begin
+    //
+    // Installing a custom language only supported with Win8 and later
+    //
+
+    if not FWin8Languages.IsSupported then
+      Exit;
+
     //
     // Install user language with Powershell if it isn't present
     //


### PR DESCRIPTION
Fixes #919. Fixes sillsdev/keyman-issues#5641. Doesn't attempt to install a 
custom language in Windows 7, and falls back to a default language when
necessary. Also, doesn't crash when later trying to enumerate that custom
language when user wants to add another language to their keyboard installation.