### PR TITLE
[ios] Cleaning up constraint violations and confused keyboard resizing code

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -58,7 +58,12 @@ public enum Resources {
 }
 
 public enum Util {
-  /// Is the process of a custom keyboard extension.
+  /// Is the process of a custom keyboard extension. Avoid using this
+  /// in most situations as Manager.shared.isSystemKeyboard is more
+  /// reliable in situations where in-app and system keyboard can
+  /// be used in the same app, for example using the Web Browser in
+  /// the Keyman app. However, in initialization scenarios this test
+  /// makes sense.
   public static let isSystemKeyboard: Bool = {
     let infoDict = Bundle.main.infoDictionary
     let extensionInfo = infoDict?["NSExtension"] as? [AnyHashable: Any]

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -275,7 +275,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     view.addConstraints(barVerticalPositionConstraints)
     view.addConstraints(barHorizontalPositionConstraints)
 
-    // note this appears to relate to the rotation fix bug; may not work on iPads as 1000 is not enough
     containerHeightConstraints = NSLayoutConstraint.constraints(
       withVisualFormat: "V:[container(\(Manager.shared.keyboardHeight))]",
       metrics: nil, views: viewsDict)

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -153,10 +153,12 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
   open override func viewWillDisappear(_ animated: Bool) {
     Manager.shared.isSystemKeyboard = false
+    super.viewWillDisappear(animated)
   }
 
   open override func willRotate(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
     Manager.shared.inputViewWillRotate(to: toInterfaceOrientation, duration: duration)
+    super.willRotate(to: toInterfaceOrientation, duration: duration)
   }
 
   open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -33,9 +33,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
   open var topBarImageView: UIImageView?
   var barHeightConstraints: [NSLayoutConstraint] = []
-
+  var barWidthConstraints: [NSLayoutConstraint] = []
   var containerView: UIView?
   var containerHeightConstraints: [NSLayoutConstraint] = []
+  var containerWidthConstraints: [NSLayoutConstraint] = []
   var heightConstraint: NSLayoutConstraint!
   var isTopBarEnabled: Bool
 
@@ -59,7 +60,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   private var expandedHeight: CGFloat {
-    return CGFloat(Int(kmInputView.frame.height) % 1000) +
+    return Manager.shared.keyboardHeight +
       (isTopBarEnabled ? CGFloat(InputViewController.topBarHeight) : 0)
   }
 
@@ -73,35 +74,39 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   open override func updateViewConstraints() {
-    if view.frame.width == 0 || view.frame.height == 0 {
-      super.updateViewConstraints()
-      return
+    func addConstraints(_ constraints: [NSLayoutConstraint]) {
+      for constraint in constraints {
+        if !view.constraints.contains(constraint) {
+          view.addConstraint(constraint)
+        }
+      }
     }
 
     Manager.shared.updateViewConstraints()
 
     let topBarHeight = isTopBarEnabled ? CGFloat(InputViewController.topBarHeight) : 0
     barHeightConstraints[0].constant = topBarHeight
+    addConstraints(barHeightConstraints)
 
-    for constraint in barHeightConstraints {
-      if !view.constraints.contains(constraint) {
-        view.addConstraint(constraint)
-      }
-    }
+    barWidthConstraints[0].constant = Manager.shared.keyboardWidth
+    addConstraints(barWidthConstraints)
 
-    containerHeightConstraints[0].constant = CGFloat(Int(kmInputView.frame.height) % 1000)
-    for constraint in containerHeightConstraints {
-      if !view.constraints.contains(constraint) {
-        view.addConstraint(constraint)
-      }
-    }
+    containerHeightConstraints[0].constant = Manager.shared.keyboardHeight
+    addConstraints(containerHeightConstraints)
 
+    containerWidthConstraints[0].constant = Manager.shared.keyboardWidth
+    addConstraints(containerWidthConstraints)
+
+    heightConstraint.constant = expandedHeight
     if !view.constraints.contains(heightConstraint) {
-      heightConstraint.constant = expandedHeight
       view.addConstraint(heightConstraint)
-    } else if heightConstraint.constant != expandedHeight {
-      heightConstraint.constant = expandedHeight
     }
+
+    // After superview is resized, tell the
+    // manager to resize the keyboard view again
+    // because it loses its size?
+    Manager.shared.updateViewConstraints()
+
     super.updateViewConstraints()
   }
 
@@ -110,6 +115,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     let bgColor = UIColor(red: 210.0 / 255.0, green: 214.0 / 255.0, blue: 220.0 / 255.0, alpha: 1.0)
     view.backgroundColor = bgColor
+
+    view.translatesAutoresizingMaskIntoConstraints = false
 
     Manager.shared.inputViewDidLoad()
     Manager.shared.keymanWebDelegate = self
@@ -130,6 +137,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   open override func viewDidAppear(_ animated: Bool) {
+    Manager.shared.isSystemKeyboard = true
     super.viewDidAppear(animated)
     setConstraints()
     inputView?.setNeedsUpdateConstraints()
@@ -143,8 +151,20 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     }
   }
 
+  open override func viewWillDisappear(_ animated: Bool) {
+    Manager.shared.isSystemKeyboard = false
+  }
+
   open override func willRotate(to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
     Manager.shared.inputViewWillRotate(to: toInterfaceOrientation, duration: duration)
+  }
+
+  open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+    coordinator.animateAlongsideTransition(in: nil, animation: nil, completion: {
+      _ in
+      self.updateViewConstraints()
+    })
   }
 
   open override func textDidChange(_ textInput: UITextInput?) {
@@ -236,12 +256,13 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   private func setConstraints() {
     let topBarHeight = isTopBarEnabled ? InputViewController.topBarHeight : 0
     let viewsDict = ["bar": topBarImageView!, "container": containerView!]
+    let screenWidth = UIScreen.main.bounds.width
+
     barHeightConstraints = NSLayoutConstraint.constraints(
       withVisualFormat: "V:[bar(\(topBarHeight))]", metrics: nil, views: viewsDict)
+    barWidthConstraints = NSLayoutConstraint.constraints(
+      withVisualFormat: "H:[bar(\(Int(screenWidth)))]", metrics: nil, views: viewsDict)
 
-    let screenWidth = UIScreen.main.bounds.width
-    let barWidthConstraints = NSLayoutConstraint.constraints(
-      withVisualFormat: "H:[bar(>=\(Int(screenWidth)))]", metrics: nil, views: viewsDict)
     let barVerticalPositionConstraints = NSLayoutConstraint.constraints(
       withVisualFormat: "V:|-0-[bar]", metrics: nil, views: viewsDict)
     let barHorizontalPositionConstraints = NSLayoutConstraint.constraints(
@@ -254,11 +275,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     // note this appears to relate to the rotation fix bug; may not work on iPads as 1000 is not enough
     containerHeightConstraints = NSLayoutConstraint.constraints(
-      withVisualFormat: "V:[container(\(Int(kmInputView.frame.height) % 1000))]",
+      withVisualFormat: "V:[container(\(Manager.shared.keyboardHeight))]",
       metrics: nil, views: viewsDict)
 
-    let containerWidthConstraints = NSLayoutConstraint.constraints(
-      withVisualFormat: "H:[container(>=\(UInt(screenWidth)))]", metrics: nil, views: viewsDict)
+    containerWidthConstraints = NSLayoutConstraint.constraints(
+      withVisualFormat: "H:[container(\(UInt(screenWidth)))]", metrics: nil, views: viewsDict)
     let containerVericalPositionConstraints = NSLayoutConstraint.constraints(
       withVisualFormat: "V:[container]-0-|", metrics: nil, views: viewsDict)
     let containerHorizontalPositionConstraints = NSLayoutConstraint.constraints(

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyPreviewView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyPreviewView.swift
@@ -22,7 +22,7 @@ class KeyPreviewView: UIView {
 
   override init(frame: CGRect) {
     let isPortrait: Bool
-    if Util.isSystemKeyboard {
+    if Manager.shared.isSystemKeyboard {
       isPortrait = InputViewController.isPortrait
     } else {
       isPortrait = UIDevice.current.orientation.isPortrait
@@ -37,7 +37,7 @@ class KeyPreviewView: UIView {
 
     let tbHeight = Manager.shared.isSystemKeyboardTopBarEnabled ?
       CGFloat(InputViewController.topBarHeight) : 0
-    if Util.isSystemKeyboard && (viewPosY < -tbHeight) {
+    if Manager.shared.isSystemKeyboard && (viewPosY < -tbHeight) {
       adjY = viewPosY + tbHeight
       viewPosY = CGFloat(-tbHeight)
       viewHeight += adjY

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
@@ -57,7 +57,7 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
 
   init(keyFrame frame: CGRect, inputViewController: InputViewController, closeButtonTitle: String?) {
     let isPortrait: Bool
-    if Util.isSystemKeyboard {
+    if Manager.shared.isSystemKeyboard {
       isPortrait = InputViewController.isPortrait
     } else {
       isPortrait = UIDevice.current.orientation.isPortrait

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -45,6 +45,7 @@ class KeymanWebViewController: UIViewController {
 
     webView = WKWebView(frame: frame ?? .zero, configuration: config)
     webView.isOpaque = false
+    webView.translatesAutoresizingMaskIntoConstraints = false
     webView.backgroundColor = UIColor.clear
     webView.navigationDelegate = self
     webView.scrollView.isScrollEnabled = false

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -31,16 +31,25 @@ private let keyboardChangeHelpText = "Tap here to change keyboard"
 private let keymanHostName = "api.keyman.com"
 
 // UI In-App Keyboard Constants
-private let phonePortraitInAppKeyboardHeight: CGFloat = 183.0
+/*
+These values are currently determined by the default keyboard size
+ provided by iOS. TODO: In the future, we may want to allow a custom size
+to cater for larger keyboard layouts. This can be achieved by
+implementing allowsSelfSizing:
+https://stackoverflow.com/questions/33261686/how-can-i-set-height-of-custom-inputview
+
+private let phonePortraitInAppKeyboardHeight: CGFloat = 253.0
 private let phoneLandscapeInAppKeyboardHeight: CGFloat = 183.0
 private let padPortraitInAppKeyboardHeight: CGFloat = 385.0
 private let padLandscapeInAppKeyboardHeight: CGFloat = 385.0
+*/
 
 // UI System Keyboard Constants
 private let phonePortraitSystemKeyboardHeight: CGFloat = 216.0
 private let phoneLandscapeSystemKeyboardHeight: CGFloat = 162.0
 private let padPortraitSystemKeyboardHeight: CGFloat = 264.0
 private let padLandscapeSystemKeyboardHeight: CGFloat = 352.0
+
 
 public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegate, KeymanWebDelegate {
   /// Application group identifier for shared container. Set this before accessing the shared manager.
@@ -50,6 +59,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
   /// Display the help bubble on first use.
   public var isKeymanHelpOn = true
+
+  public var isSystemKeyboard = false
 
   // TODO: Change API to not disable removing as well
   /// Allow users to add new keyboards in the keyboard picker.
@@ -100,7 +111,6 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   private var reachability: Reachability!
   private var didSynchronize = false
   private var didResizeToOrientation = false
-  private var lastKeyboardSize: CGSize = .zero
   private var useSpecialFontForSubkeys = false
 
   private let subKeyColor = #colorLiteral(red: 244.0 / 255.0, green: 244.0 / 255.0, blue: 244.0 / 255.0, alpha: 1.0)
@@ -399,7 +409,16 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
                 languageName = l["name"]!
                 languageId = l["id"]!
                 
-                installableKeyboards.append( InstallableKeyboard(id: keyboardID, name: name, languageID: languageId, languageName: languageName, version: version, isRTL: false, font: displayFont, oskFont: oskFont, isCustom: false))
+                installableKeyboards.append( InstallableKeyboard(
+                  id: keyboardID,
+                  name: name,
+                  languageID: languageId,
+                  languageName: languageName,
+                  version: version,
+                  isRTL: false,
+                  font: displayFont,
+                  oskFont: oskFont,
+                  isCustom: false))
               }
             }
             
@@ -855,7 +874,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   // MARK: - View management
 
   public var keyboardHeight: CGFloat {
-    if Util.isSystemKeyboard {
+    if isSystemKeyboard {
       return keyboardHeight(isPortrait: InputViewController.isPortrait)
     } else {
       return keyboardHeight(isPortrait: UIDevice.current.orientation.isPortrait)
@@ -867,17 +886,18 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   func keyboardHeight(isPortrait: Bool) -> CGFloat {
+    let parentHeight: CGFloat = keymanWeb.parent != nil ? keymanWeb.parent!.view.frame.height : CGFloat(100.0)
     if UIDevice.current.userInterfaceIdiom == .pad {
       if isPortrait {
-        return Util.isSystemKeyboard ? padPortraitSystemKeyboardHeight : padPortraitInAppKeyboardHeight
+        return isSystemKeyboard ? padPortraitSystemKeyboardHeight : parentHeight
       } else {
-        return Util.isSystemKeyboard ? padLandscapeSystemKeyboardHeight : padLandscapeInAppKeyboardHeight
+        return isSystemKeyboard ? padLandscapeSystemKeyboardHeight : parentHeight
       }
     } else {
       if isPortrait {
-        return Util.isSystemKeyboard ? phonePortraitSystemKeyboardHeight : phonePortraitInAppKeyboardHeight
+        return isSystemKeyboard ? phonePortraitSystemKeyboardHeight : parentHeight
       } else {
-        return Util.isSystemKeyboard ? phoneLandscapeSystemKeyboardHeight : phoneLandscapeInAppKeyboardHeight
+        return isSystemKeyboard ? phoneLandscapeSystemKeyboardHeight : parentHeight
       }
     }
   }
@@ -888,30 +908,6 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
   var keyboardSize: CGSize {
     return CGSize(width: keyboardWidth, height: keyboardHeight)
-  }
-
-  // Keyman interaction
-  private func resizeKeyboard() {
-    let newSize = keyboardSize
-    if didResizeToOrientation && Util.isSystemKeyboard && lastKeyboardSize == newSize {
-      didResizeToOrientation = false
-      return
-    }
-    lastKeyboardSize = newSize
-
-    keymanWeb.frame = CGRect(origin: .zero, size: newSize)
-
-    // Workaround for WKWebView bug with landscape orientation
-    // TODO: Check if still necessary and if there's a better solution
-    if Util.isSystemKeyboard {
-      perform(#selector(self.resizeDelay), with: self, afterDelay: 1.0)
-    }
-
-    var oskHeight = Int(newSize.height)
-    oskHeight -= oskHeight % (Util.isSystemKeyboard ? 10 : 20)
-
-    keymanWeb.setOskWidth(Int(newSize.width))
-    keymanWeb.setOskHeight(oskHeight)
   }
 
   private var keymanScrollView: UIScrollView {
@@ -1016,7 +1012,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
   @objc func showHelpBubble() {
     // Help bubble is always disabled for system-wide keyboard
-    if Util.isSystemKeyboard || keyboardMenuView != nil {
+    if Manager.shared.isSystemKeyboard || keyboardMenuView != nil {
       return
     }
 
@@ -1077,12 +1073,18 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   func resizeKeyboardIfNeeded() {
-    // TODO: Check if necessary since resizeKeyboard() checks old size
+    // TODO: Eliminate this function; performance cost of resizing is
+    //       probably minimal if no resizing actually happens
+    resizeKeyboard()
+  }
+
+  // Keyman interaction
+  private func resizeKeyboard() {
     let newSize = keyboardSize
-    if newSize != lastKeyboardSize {
-      resizeKeyboard()
-      lastKeyboardSize = newSize
-    }
+
+    keymanWeb.frame = CGRect(origin: .zero, size: newSize)
+    keymanWeb.setOskWidth(Int(newSize.width))
+    keymanWeb.setOskHeight(Int(newSize.height))
   }
 
   func resizeKeyboard(with orientation: UIInterfaceOrientation) {
@@ -1092,11 +1094,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     let kbHeight = keyboardHeight(with: orientation)
     keymanWeb.frame = CGRect(x: 0.0, y: 0.0, width: kbWidth, height: kbHeight)
 
-    var oskHeight = Int(kbHeight)
-    oskHeight -= oskHeight % (Util.isSystemKeyboard ? 10 : 20)
-
     keymanWeb.setOskWidth(Int(kbWidth))
-    keymanWeb.setOskHeight(oskHeight)
+    keymanWeb.setOskHeight(Int(kbHeight))
   }
 
   // MARK: - Text
@@ -1148,7 +1147,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
     var newKb = Defaults.keyboard
     if currentKeyboardID == nil && !shouldReloadKeyboard {
-      let userData = Util.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
+      let userData = Manager.shared.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
       if let id = userData.currentKeyboardID {
         if let kb = Storage.active.userDefaults.userKeyboard(withFullID: id) {
           newKb = kb
@@ -1178,7 +1177,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     keymanWebDelegate?.showKeyPreview(keymanWeb, keyFrame: keyFrame, preview: preview)
 
     if UIDevice.current.userInterfaceIdiom == .pad
-      || (Util.isSystemKeyboard && !isSystemKeyboardTopBarEnabled)
+      || (Manager.shared.isSystemKeyboard && !isSystemKeyboardTopBarEnabled)
       || subKeysView != nil {
       return
     }
@@ -1239,7 +1238,7 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
 
     dismissHelpBubble()
     isKeymanHelpOn = false
-    if Util.isSystemKeyboard {
+    if Manager.shared.isSystemKeyboard {
       let userData = UserDefaults.standard
       userData.set(true, forKey: Key.keyboardPickerDisplayed)
       userData.synchronize()

--- a/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
@@ -23,7 +23,7 @@ class SubKeysView: UIView {
   let containerView: UIView
 
   init(keyFrame frame: CGRect, subKeys: [UIButton]) {
-    let isSystemKeyboard = Util.isSystemKeyboard
+    let isSystemKeyboard = Manager.shared.isSystemKeyboard
     var isPortrait = true
     if isSystemKeyboard {
       isPortrait = InputViewController.isPortrait


### PR DESCRIPTION
This fixes numerous incorrect assumptions around keyboard resizing and simplifies the logic and calculations. It appears that some bugs in earlier versions have been resolved which means we can remove some messy workarounds.

This does need significant testing on actual devices so would like to merge into beta asap.