### PR TITLE
[linux] packaging path variables

### DIFF
--- a/linux/kmflcomp/Makefile.am
+++ b/linux/kmflcomp/Makefile.am
@@ -5,7 +5,7 @@
 
 SUBDIRS = include src kmfl_compiler
 
-kmflcompdocdir = ${prefix}/doc/kmflcomp
+kmflcompdocdir = ${docdir}
 kmflcompdoc_DATA = \
 	README\
 	COPYING\

--- a/linux/libkmfl/Makefile.am
+++ b/linux/libkmfl/Makefile.am
@@ -2,7 +2,7 @@
 
 SUBDIRS = include src
 ACLOCAL_AMFLAGS = -I m4
-libkmfldocdir = ${prefix}/doc/libkmfl
+libkmfldocdir = ${docdir}
 libkmfldoc_DATA = \
 	README\
 	COPYING\


### PR DESCRIPTION
Related to #985. Path `${docdir}` is set by [./configure](https://github.com/keymanapp/keyman/blob/master/linux/kmflcomp/configure) as:
```bash
docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
```