### PR TITLE
[Mac] #994 - Use keyboard names w/ native script from KMX instead of inf

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
@@ -112,15 +112,26 @@
         "</html>";
         
         NSString *pBodyFormat = @"<p class='body'>%@</p><br>";
-        NSArray *kbs = [self.infoDict objectForKey:kKeyboard];
         NSMutableString *kbsStr = [NSMutableString stringWithString:@""];
+        NSArray *kbs = [[self AppDelegate] keyboardNamesFromFolder:self.packagePath];
         if (kbs != nil && kbs.count) {
-            for (NSArray *kb in kbs) {
-                [kbsStr appendString:[NSString stringWithFormat:pBodyFormat, [kb objectAtIndex:0]]];
+            for (NSArray *kbName in kbs) {
+                [kbsStr appendString:[NSString stringWithFormat:pBodyFormat, kbName]];
             }
         }
         else {
-            kbsStr = [NSMutableString stringWithString:@"<p class='body'><none></p><br>"];
+            // This was the old logic (prior to fixing issue #994). Keeping as fallback, though
+            // it's unlikely to be useful/needed.
+            kbs = [self.infoDict objectForKey:kKeyboard];
+        
+            if (kbs != nil && kbs.count) {
+                for (NSArray *kb in kbs) {
+                    [kbsStr appendString:[NSString stringWithFormat:pBodyFormat, [kb objectAtIndex:0]]];
+                }
+            }
+            else {
+                kbsStr = [NSMutableString stringWithString:@"<p class='body'><none></p><br>"];
+            }
         }
         
         NSArray *fonts = [self.infoDict objectForKey:kFont];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -104,6 +104,7 @@ extern NSString *const kWebSite;
 - (NSInteger)indexForPackageFolder:(NSString *)packageFolder;
 - (NSString *)packageFolderFromPath:(NSString *)path;
 - (NSString *)packageNameFromFolder:(NSString *)packageFolder;
+- (NSArray *)keyboardNamesFromFolder:(NSString *)packageFolder;
 - (NSDictionary *)infoDictionaryFromFile:(NSString *)infoFile;
 - (NSString *)kvkFilePathFromFilename:(NSString *)kvkFilename;
 - (NSString *)oskWindowTitle;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -474,6 +474,22 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     return packageName;
 }
 
+- (NSArray *)keyboardNamesFromFolder:(NSString *)packageFolder {
+    NSMutableArray *kbNames = [[NSMutableArray alloc] initWithCapacity:0];;
+    for (NSString *kmxFile in [self KMXFilesAtPath:packageFolder]) {
+        NSDictionary * infoDict = [KMXFile infoDictionaryFromFilePath:kmxFile];
+        if (infoDict != nil) {
+            NSString *name = [infoDict objectForKey:kKMKeyboardNameKey];
+            if (name != nil && [name length]) {
+                if (self.debugMode)
+                    NSLog(@"Adding keyboard name: %@", name);
+                [kbNames addObject:name];
+            }
+        }
+    }
+    return kbNames;
+}
+
 - (NSDictionary *)infoDictionaryFromFile:(NSString *)infoFile {
     NSMutableDictionary *infoDict = [NSMutableDictionary dictionaryWithCapacity:0];
     NSMutableArray *files = [NSMutableArray arrayWithCapacity:0];

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,5 +1,8 @@
 # Keyman for macOS Version History
 
+## 2018-06-19 10.0.49 beta
+* Added suport for displaying keyboard names in native script in information window (#999)
+
 ## 2018-06-18 10.0.48 beta
 * Made other version(s) of LibreOffice use "legacy" mode for character replacements (#990)
 * Corrected the way Keyman responds evaluates tokens in **platform** statement (#971)

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,7 +1,7 @@
 # Keyman for macOS Version History
 
 ## 2018-06-19 10.0.49 beta
-* Added suport for displaying keyboard names in native script in information window (#999)
+* Enabled displaying keyboard names in native script in information window (#1001)
 
 ## 2018-06-18 10.0.48 beta
 * Made other version(s) of LibreOffice use "legacy" mode for character replacements (#990)


### PR DESCRIPTION
Fixes #994 
It seems the *.inf files are not UTF-8, so any non-Roman characters used in keyboard names turn into question marks. The native script name is stored in the kmx file, so getting it from there seems to work.