### PR TITLE
[Android] Fix api.keyman.com/cloud query for BCP 47 language tags

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -44,7 +44,7 @@ public class KMKeyboardDownloaderActivity extends Activity {
   public static final String ARG_URL = "KMKeyboardActivity.url";
   public static final String ARG_FILENAME = "KMKeyboardActivity.filename";
 
-  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/3.0/";
+  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
   public static final String kKeymanApiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url=";
 
   // Keyman public keys
@@ -191,7 +191,7 @@ public class KMKeyboardDownloaderActivity extends Activity {
           remoteUrl = url;
         } else {
           // Keyman cloud
-          remoteUrl = String.format("%slanguages/%s/%s?version=%s&device=%s", kKeymanApiBaseURL, langID, kbID, BuildConfig.VERSION_NAME, deviceType);
+          remoteUrl = String.format("%s/%s/%s?version=%s&device=%s&languageidtype=bcp47", kKeymanApiBaseURL, langID, kbID, BuildConfig.VERSION_NAME, deviceType);
         }
 
         ret = downloadNonKMPKeyboard(remoteUrl);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -44,7 +44,7 @@ public class KMKeyboardDownloaderActivity extends Activity {
   public static final String ARG_URL = "KMKeyboardActivity.url";
   public static final String ARG_FILENAME = "KMKeyboardActivity.filename";
 
-  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
+  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/3.0/languages";
   public static final String kKeymanApiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url=";
 
   // Keyman public keys

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -567,7 +567,8 @@ public final class KeyboardPickerActivity extends Activity implements OnKeyboard
               String languageID = keyboardsList.get(i).get(KMManager.KMKey_LanguageID);
               String keyboardID = keyboardsList.get(i).get(KMManager.KMKey_KeyboardID);
               String kbVersion = keyboardsList.get(i).get(KMManager.KMKey_KeyboardVersion);
-              String url = String.format("%slanguages/%s/%s?version=%s&device=%s", KMKeyboardDownloaderActivity.kKeymanApiBaseURL, languageID, keyboardID,  BuildConfig.VERSION_NAME, deviceType);
+              String url = String.format("%s/%s/%s?version=%s&device=%s&languageidtype=bcp47",
+                KMKeyboardDownloaderActivity.kKeymanApiBaseURL, languageID, keyboardID,  BuildConfig.VERSION_NAME, deviceType);
               JSONObject kbData = jsonParser.getJSONObjectFromUrl(url);
               JSONObject language = kbData.optJSONObject(KMKeyboardDownloaderActivity.KMKey_Language);
               JSONArray keyboards = language.getJSONArray(KMKeyboardDownloaderActivity.KMKey_LanguageKeyboards);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -363,8 +363,9 @@ public final class LanguageListActivity extends Activity implements OnKeyboardDo
           } else {
             deviceType = "androidphone";
           }
-
-          jsonObj = jsonParser.getJSONObjectFromUrl(KMKeyboardDownloaderActivity.kKeymanApiBaseURL + "languages?version=" +  BuildConfig.VERSION_NAME + "&device=" + deviceType);
+          String remoteUrl = String.format("%s?version=%s&device=%s&languageidtype=bcp47",
+            KMKeyboardDownloaderActivity.kKeymanApiBaseURL, BuildConfig.VERSION_NAME, deviceType);
+          jsonObj = jsonParser.getJSONObjectFromUrl(remoteUrl);
         } catch (Exception e) {
           jsonObj = null;
         }


### PR DESCRIPTION
Fixes #992 

Update api.keyman.com query to:
* ~Update to cloud 4.0~ Reverted to 3.0
* Include `&languageidtype=bcp47