### PR TITLE
[Mac] Fixes 894, Fixes 962 - Fixed timer problems in OSK

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -237,7 +237,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 
 - (void)startTimerWithTimeInterval:(NSTimeInterval)interval {
     @synchronized(self.target) {
-        NSLog(@"KeyView TIMER - starting");
+        //NSLog(@"KeyView TIMER - starting");
         if (_keyEventTimer == nil) {
             // The TimerTarget class and the following two lines allow the timer to hold a *weak*
             // reference to this KeyView object, so it can be disposed even if there is a timer waiting
@@ -255,7 +255,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 
 - (void)stopTimer {
     @synchronized(self.target) {
-        NSLog(@"KeyView TIMER - stopping");
+        //NSLog(@"KeyView TIMER - stopping");
         if (_keyEventTimer != nil) {
             [_keyEventTimer invalidate];
             _keyEventTimer = nil;
@@ -265,7 +265,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 
 - (void)timerAction:(NSTimer *)timer {
     @synchronized(self.target) {
-        NSLog(@"KeyView TIMER - Fired");
+        //NSLog(@"KeyView TIMER - Fired");
         [self processKeyClick];
         
         if ([timer timeInterval] == delayBeforeRepeating) {

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,5 +1,8 @@
 # Keyman for macOS Version History
 
+## 2018-06-20 10.0.50 beta
+* Fixed problems with OSK timer that caused crashes, e.g., when Shift was pressed (#1013)
+
 ## 2018-06-19 10.0.49 beta
 * Enabled displaying keyboard names in native script in information window (#1001)
 


### PR DESCRIPTION
Ensured that timer is never instantiated for modifier keys, since they should never repeat. Made synchronizing more robust to ensure that there can never be timers simultaneously active (i.e., for two different keys on the same OSK). Removed deprecated finalize method that was never getting called anyway.