### PR TITLE
[Android] [web] Cancel attempt to cancel a touchcancel event that can't be cancelled. Enough cancels there for ya?

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -130,6 +130,7 @@ final class KMKeyboard extends WebView {
         // Send console errors to Firebase Analytics.
         // (Ignoring spurious message "No keyboard stubs exist = ...")
         // TODO: Analyze if this error warrants reverting to default keyboard
+        // TODO: Fix base error rather than trying to ignore it "No keyboard stubs exist"
         if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
           sendKMWError(cm.lineNumber(), cm.sourceId(), cm.message());
           Toast.makeText(context, "Fatal Error with " + currentKeyboard +

--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -4335,10 +4335,22 @@ if(!window['keyman']['initialized']) {
         // TODO: are these needed, or do they interfere with other OSK event handling ????
         if(device.touchable) // I3363 (Build 301)
         {
-          util.attachDOMEvent(osk._Box,'touchstart',function(e){keymanweb.uiManager.setActivatingUI(true); e.preventDefault();e.stopPropagation();});
-          util.attachDOMEvent(osk._Box,'touchend',function(e){e.preventDefault(); e.stopPropagation();});
-          util.attachDOMEvent(osk._Box,'touchmove',function(e){e.preventDefault();e.stopPropagation();});
-          util.attachDOMEvent(osk._Box,'touchcancel',function(e){e.preventDefault();e.stopPropagation();});
+          var cancelEventFunc = function(e) {
+            if(e.cancelable) {
+              e.preventDefault();
+            }
+            e.stopPropagation();
+            return false;
+          };
+          
+          util.attachDOMEvent(osk._Box, 'touchstart', function(e) {
+            keymanweb.uiManager.setActivatingUI(true); 
+            return cancelEventFunc(e);
+          });
+          
+          util.attachDOMEvent(osk._Box, 'touchend', cancelEventFunc);
+          util.attachDOMEvent(osk._Box, 'touchmove', cancelEventFunc);
+          util.attachDOMEvent(osk._Box, 'touchcancel', cancelEventFunc);
 
           // Can only get (initial) viewport scale factor after page is fully loaded!
           osk.vpScale=util.getViewportScale();


### PR DESCRIPTION
Fixes #992. This resolves the cascading error report that then forces the keyboard back to the default: the touchcancel event cannot be cancelled in this instance (is it even needed? question for another day). There may be other error reports elsewhere in the code but we want to keep them for stability, which is why I didn't change the error handling code.