### PR TITLE
[developer] Developer no longer crashes if a .kpj.user file is deleted while project is loaded.

### DIFF
--- a/windows/src/developer/TIKE/project/ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/ProjectFile.pas
@@ -142,8 +142,8 @@ type
     function Load: Boolean; virtual;   // I4694
     function Save: Boolean; virtual;   // I4694
 
-    function StandardTemplatePath: string;
-    function StringsTemplatePath: string;
+    class function StandardTemplatePath: string;
+    class function StringsTemplatePath: string;
 
     function GetTargetFilename(ATargetFile, ASourceFile, AVersion: string): string;   // I4688
 
@@ -918,12 +918,12 @@ begin
   Result := Result + ExtractFileName(ATargetFile);
 end;
 
-function TProject.StandardTemplatePath: string; //(const FileName: string): string;
+class function TProject.StandardTemplatePath: string; //(const FileName: string): string;
 begin
   Result := StringsTemplatePath; // GetXMLTemplatePath + 'project\';
 end;
 
-function TProject.StringsTemplatePath: string;
+class function TProject.StringsTemplatePath: string;
 begin
   Result := ExtractFilePath(ParamStr(0)) + 'locale\' + 'en';  // I2595
   if FileExists(Result + '\xml\project\project.xsl') then

--- a/windows/src/developer/TIKE/project/ProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/ProjectFileUI.pas
@@ -101,6 +101,8 @@ uses
 
   System.SysUtils,
 
+  utilhttp,
+
   ProjectLoader,
   UfrmMessages;
 
@@ -195,6 +197,8 @@ var
   output: WideString;
   FLastDir: string;
   i: Integer;
+  node: IXMLDOMElement;
+  nodes: IXMLDOMNodeList;
 begin
   if not FileExists(SavedFileName) then Save;
 
@@ -202,13 +206,15 @@ begin
   FLastDir := GetCurrentDir;
   SetCurrentDir(StringsTemplatePath);
   try
-    //doc :=  LoadXMLDocument(SavedFileName); //TXMLDocument.Create(nil);
     doc := MSXMLDOMDocumentFactory.CreateDOMDocument;
     try
       doc.async := False;
       doc.load(SavedFileName);
 
+      //
       // Inject the user settings to the loaded file
+      //
+
       if FileExists(SavedFileName + '.user') then   // I4698
       begin
         userdoc := MSXMLDOMDocumentFactory.CreateDOMDocument;
@@ -222,13 +228,36 @@ begin
         end;
       end;
 
+      //
+      // Remove existing path references from the saved .user file and append the
+      // correct ones for this computer
+      //
+
+      // TODO: refactor with similar code in ProjectLoader.LoadUser and ProjectSaver.SaveUser
+      nodes := doc.documentElement.getElementsByTagName('templatepath');
+      for i := 0 to nodes.length - 1 do
+        doc.documentElement.removeChild(nodes[i]);
+
+      nodes := doc.documentElement.getElementsByTagName('stringspath');
+      for i := 0 to nodes.length - 1 do
+        doc.documentElement.removeChild(nodes[i]);
+
+      node := doc.createElement('templatepath');
+      node.appendChild(doc.createTextNode(ConvertPathToFileURL(TProject.StandardTemplatePath)));
+      doc.documentElement.appendChild(node);
+
+      node := doc.createElement('stringspath');
+      node.appendChild(doc.createTextNode(ConvertPathToFileURL(TProject.StringsTemplatePath)));
+      doc.documentElement.appendChild(node);
+      // end TODO
+
       xsl := MSXMLDOMDocumentFactory.CreateDOMDocument;
       try
         xsl.async := False;
         xsl.resolveExternals := True;
         xsl.validateOnParse := False;
-        xsl.load(StringsTemplatePath + 'project.xsl'); // StandardTemplatePath + 'project.xsl');
-        output := doc.transformNode(xsl); //,  Node.TransformNode(xsl.DocumentElement, output);
+        xsl.load(StringsTemplatePath + 'project.xsl');
+        output := doc.transformNode(xsl);
       finally
         xsl := nil;
       end;

--- a/windows/src/developer/TIKE/project/ProjectLoader.pas
+++ b/windows/src/developer/TIKE/project/ProjectLoader.pas
@@ -171,6 +171,7 @@ begin
   if root.NodeName <> 'KeymanDeveloperProjectUser' then
     raise EProjectLoader.Create('Not a Keyman Developer project .user file');
 
+  // TODO: refactor with similar code in ProjectFileUI.TProjectUI.Render
   FStandardTemplatePath := ConvertPathToFileURL(FProject.StandardTemplatePath);
   FStringsTemplatePath := ConvertPathToFileURL(FProject.StringsTemplatePath);
   if (root.ChildValues['templatepath'] <> FStandardTemplatePath) or (root.ChildValues['stringspath'] <> FStringsTemplatePath) then


### PR DESCRIPTION
Fixes #1010. This also addresses a rare situation where a .kpj.user file has the wrong template path, 
or opening a project from Explorer when no .kpj.user file is present.