### PR TITLE
[ios] Updates build scripts and deployments so that .js.map are copied in debug build

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -11,5 +11,6 @@ samples/KMSample2/build
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanios.js
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanweb-osk.ttf
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/kmwosk.css
+engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyman.js.map
 Keyman 2*
 Carthage

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -141,7 +141,9 @@ update_bundle ( ) {
         cp resources/osk/kmwosk.css        "$base_dir/$BUNDLE_PATH/kmwosk.css"
         cp resources/osk/keymanweb-osk.ttf "$base_dir/$BUNDLE_PATH/keymanweb-osk.ttf"
         cp keyman.js                       "$base_dir/$BUNDLE_PATH/keymanios.js"
-
+        if [ "$CONFIG" == "Debug" ]; then
+          cp keyman.js.map "$base_dir/$BUNDLE_PATH/keyman.js.map"
+        fi
         cd $base_dir
     fi
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -127,6 +127,11 @@ extension Storage {
     try Storage.copy(from: bundle,
                      resourceName: "keymanios.js",
                      dstDir: baseDir)
+    if bundle.path(forResource: "keyman.js", ofType: ".map" ) != nil {
+      try Storage.copy(from: bundle,
+                       resourceName: "keyman.js.map",
+                       dstDir: baseDir)
+    }
     try Storage.copy(from: bundle,
                      resourceName: "kmwosk.css",
                      dstDir: baseDir)

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -253,6 +253,7 @@ while [[ $# -gt 0 ]] ; do
             BUILD_COREWEB=false
             BUILD_FULLWEB=false
             BUILD_DEBUG_EMBED=true
+            DO_MINIFY=false
             ;;
         -h|-?)
             display_usage
@@ -280,7 +281,7 @@ if [ $FULL_BUILD = true ]; then
 fi
 
 
-if [ $BUILD_EMBED = true ]; then
+if [ $BUILD_EMBED = true ] || [ $BUILD_DEBUG_EMBED = true ]; then
     echo Compile KMEI/KMEA build $BUILD
 
     $compilecmd -p $NODE_SOURCE/tsconfig.embedded.json
@@ -390,6 +391,7 @@ fi
 
 if [ $BUILD_DEBUG_EMBED = true ]; then
     # Copy the sourcemap.
+    cp $INTERMEDIATE/keyman.js $EMBED_OUTPUT/keyman.js
     cp $INTERMEDIATE/keyman.js.map $EMBED_OUTPUT/keyman.js.map
-    echo Uncompiled embedded application saved as keyman.js
+    echo Uncompiled embedded application saved as $EMBED_OUTPUT/keyman.js
 fi


### PR DESCRIPTION
This simplifies debugging KeymanWeb within the iOS environment because we can see full symbols and source maps. Seems that the `-debug -no-codesign` parameters did not cause a full build of KMW either, so updated the scripts accordingly.

Suggest merging this after release of 10.0 as it impacts only development and testing. Needs to be checked with Android as well as iOS.