### PR TITLE
[Mac] #894 - Added try/catch to prevent crash from key event Timer

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -237,7 +237,12 @@ const NSTimeInterval repeatInterval = 0.05f;
 
 - (void)startTimerWithTimeInterval:(NSTimeInterval)interval {
     @synchronized(self.target) {
-        //NSLog(@"KeyView TIMER - starting");
+//        @try {
+//            NSLog(@"KeyView TIMER - starting for key %lu", [self keyCode]);
+//        }
+//        @catch (NSException *exception) {
+//            NSLog(@"KeyView TIMER - crash getting keyCode.");
+//        }
         if (_keyEventTimer == nil) {
             // The TimerTarget class and the following two lines allow the timer to hold a *weak*
             // reference to this KeyView object, so it can be disposed even if there is a timer waiting
@@ -265,7 +270,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 
 - (void)timerAction:(NSTimer *)timer {
     @synchronized(self.target) {
-        //NSLog(@"KeyView TIMER - Fired");
+        //NSLog(@"KeyView TIMER - Fired for key %lu", [self keyCode]);
         [self processKeyClick];
         
         if ([timer timeInterval] == delayBeforeRepeating) {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -359,7 +359,14 @@
 
 - (void)keyAction:(id)sender {
     KeyView *keyView = (KeyView *)sender;
-    NSUInteger keyCode = [keyView.key keyCode];
+    NSUInteger keyCode;
+    @try {
+        keyCode = [keyView.key keyCode];
+    }
+    @catch (NSException *exception) {
+        NSLog(@"Exception in keyAction:sender - %@", exception);
+        return;
+    }
     if (keyCode < 0x100) {
         ProcessSerialNumber psn;
         GetFrontProcess(&psn);


### PR DESCRIPTION
I am not able to reproduce #894, but I think this change will prevent the crash. But of course, it will also make it so we can't very easily figure out what was causing it. I think this will be safe, but it might cause some confusion for the user, depending on what exactly is going on.