### PR TITLE
[iOS] #824 - remove blank buttons from alert screens

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardInfoViewController.swift
@@ -134,24 +134,21 @@ class KeyboardInfoViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func showDeleteKeyboard() {
-    let alert = UIAlertView(title: title ?? "",
-                            message: "Would you like to delete this keyboard?",
-                            delegate: self,
-                            cancelButtonTitle: "Cancel",
-                            otherButtonTitles: "Delete")
-    alert.tag = 1
-    alert.show()
+    let alertController = UIAlertController(title: title ?? "", message: "Would you like to delete this keyboard?",
+                                            preferredStyle: UIAlertControllerStyle.alert)
+    alertController.addAction(UIAlertAction(title: "Cancel",
+                                            style: UIAlertActionStyle.cancel,
+                                            handler: nil))
+    alertController.addAction(UIAlertAction(title: "Delete",
+                                            style: UIAlertActionStyle.default,
+                                            handler: deleteHandler))
+    
+    self.present(alertController, animated: true, completion: nil)
   }
 
-  func alertView(_ alertView: UIAlertView, clickedButtonAt buttonIndex: Int) {
-    if buttonIndex == alertView.cancelButtonIndex {
-      return
-    }
-
-    if alertView.tag == 1 {
-      if Manager.shared.removeKeyboard(at: keyboardIndex) {
+  func deleteHandler(withAction action: UIAlertAction) {
+    if Manager.shared.removeKeyboard(at: keyboardIndex) {
         navigationController?.popToRootViewController(animated: true)
-      }
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-private let errorAlertTag = -1
 private let toolbarButtonTag = 100
 private let toolbarLabelTag = 101
 private let toolbarActivityIndicatorTag = 102
@@ -254,11 +253,14 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
       title = "Keyboard Download Error"
     }
     navigationController?.setToolbarHidden(true, animated: true)
-
-    let alert = UIAlertView(title: title, message: notification.error.localizedDescription,
-                            delegate: self, cancelButtonTitle: "OK", otherButtonTitles: "")
-    alert.tag = errorAlertTag
-    alert.show()
+    
+    let alertController = UIAlertController(title: title, message: notification.error.localizedDescription,
+                                            preferredStyle: UIAlertControllerStyle.alert)
+    alertController.addAction(UIAlertAction(title: "OK",
+                                            style: UIAlertActionStyle.cancel,
+                                            handler: nil))
+    
+    self.present(alertController, animated: true, completion: nil)
   }
 
   private func switchKeyboard(_ index: Int) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -90,7 +90,8 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     tableView.cellForRow(at: indexPath)?.isSelected = false
-    let keyboard = language.keyboards![indexPath.section]
+    let keyboardIndex = indexPath.section
+    let keyboard = language.keyboards![keyboardIndex]
 
     let state = Manager.shared.stateForKeyboard(withID: keyboard.id)
     if state != .downloading {
@@ -99,23 +100,24 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
       } else {
         isUpdate = true
       }
-
-      let alert = UIAlertView(title: "\(language.name): \(keyboard.name)",
-                              message: "Would you like to download this keyboard?",
-                              delegate: self,
-                              cancelButtonTitle: "Cancel",
-                              otherButtonTitles: "Download")
-      alert.tag = indexPath.section
-      alert.show()
+    
+        let alertController = UIAlertController(title: "\(language.name): \(keyboard.name)",
+                                                message: "Would you like to download this keyboard?",
+                                                preferredStyle: UIAlertControllerStyle.alert)
+        alertController.addAction(UIAlertAction(title: "Cancel",
+                                                style: UIAlertActionStyle.cancel,
+                                                handler: nil))
+        alertController.addAction(UIAlertAction(title: "Download",
+                                                style: UIAlertActionStyle.default,
+                                                handler: {_ in self.downloadHandler(keyboardIndex)} ))
+        
+        self.present(alertController, animated: true, completion: nil)
     }
   }
 
-  func alertView(_ alertView: UIAlertView, clickedButtonAt buttonIndex: Int) {
-    // Keyboard download confirmation alert (tag is used for keyboard index).
-    if buttonIndex != alertView.cancelButtonIndex {
-      Manager.shared.downloadKeyboard(withID: language.keyboards![alertView.tag].id,
+  func downloadHandler(_ keyboardIndex: Int) {
+    Manager.shared.downloadKeyboard(withID: language.keyboards![keyboardIndex].id,
                                       languageID: language.id, isUpdate: isUpdate)
-    }
   }
 
   private func keyboardDownloadStarted() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -184,6 +184,7 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
       alertController.addAction(UIAlertAction(title: "Download",
                                                 style: UIAlertActionStyle.default,
                                                 handler: {_ in self.downloadHandler(keyboardIndex)} ))
+      self.present(alertController, animated: true, completion: nil)
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
+++ b/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
@@ -276,8 +276,12 @@ class MainViewController: UIViewController, UIAlertViewDelegate, TextViewDelegat
   }
 
   @objc func showAlert(_ message: String) {
-    let alert = UIAlertView(title: "Keyboard Download Error", message: message, delegate: self,
-                            cancelButtonTitle: "OK", otherButtonTitles: "")
-    alert.show()
+    let alertController = UIAlertController(title: "Keyboard Download Error",
+                                            message: message,
+                                            preferredStyle: UIAlertControllerStyle.alert)
+    alertController.addAction(UIAlertAction(title: "OK",
+                                            style: UIAlertActionStyle.default,
+                                            handler: nil))
+    self.present(alertController, animated: true, completion: nil)
   }
 }

--- a/ios/history.md
+++ b/ios/history.md
@@ -24,6 +24,9 @@
 ## 2018-06-13 10.0.158 beta
 * Bug fix installing a keyboard with missing metadata (#982)
 
+## 2018-06-19 10.0.162 beta
+* Replaced deprecated calls to UIAlertView and cleaned up extraneous blank buttons (#1002)
+
 ## 2018-06-13 10.0.157 beta
 * Improvements to device rotation (#981)
 

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,6 +1,6 @@
 # Keyman for iPhone and iPad Version History
 
-## 2018-07-09 11.0.??? alpha
+## 2018-07-09 11.0.16 alpha
 * Replaced deprecated calls to UIAlertView and cleaned up extraneous blank buttons (#1002)
 
 ## 11.0 alpha

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2018-07-09 11.0.??? alpha
+* Replaced deprecated calls to UIAlertView and cleaned up extraneous blank buttons (#1002)
+
 ## 11.0 alpha
 * Move to 11.0
 
@@ -23,9 +26,6 @@
 
 ## 2018-06-13 10.0.158 beta
 * Bug fix installing a keyboard with missing metadata (#982)
-
-## 2018-06-19 10.0.162 beta
-* Replaced deprecated calls to UIAlertView and cleaned up extraneous blank buttons (#1002)
 
 ## 2018-06-13 10.0.157 beta
 * Improvements to device rotation (#981)

--- a/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/KMWebBrowser/WebBrowserViewController.swift
@@ -209,12 +209,13 @@ class WebBrowserViewController: UIViewController, UIWebViewDelegate, UIAlertView
   func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = false
     updateButtons()
-    let alert = UIAlertView(title: "Cannot Open Page",
-                            message: error.localizedDescription,
-                            delegate: self,
-                            cancelButtonTitle: "OK",
-                            otherButtonTitles: "")
-    alert.show()
+    let alertController = UIAlertController(title: "Cannot Open Page",
+                                            message: error.localizedDescription,
+                                            preferredStyle: UIAlertControllerStyle.alert)
+    alertController.addAction(UIAlertAction(title: "OK",
+                                            style: UIAlertActionStyle.default,
+                                            handler: nil))
+    self.present(alertController, animated: true, completion: nil)
   }
 
   private func updateButtons() {

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -795,7 +795,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if let urlString = params["url"] {
       // Download and set custom keyboard
       guard let url = URL(string: urlString) else {
-        appDelegate.showSimpleAlert(title: "Custom Keyboard", message: "The keyboard could not be installed: Invalid Url")
+        appDelegate.showSimpleAlert(title: "Custom Keyboard",
+                                    message: "The keyboard could not be installed: Invalid Url")
         launchUrl = nil
         return
       }
@@ -906,28 +907,28 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       Manager.shared.downloadKeyboard(withID: keyboard.id, languageID: keyboard.languageID, isUpdate: false)
     }
   }
-  
+
   private func handleUserDecisionAboutInstallingProfile(withAction action: UIAlertAction) {
     if let profileName = profileName {
       checkedProfiles.append(profileName)
       let userData = AppDelegate.activeUserDefaults()
       userData.set(checkedProfiles, forKey: checkedProfilesKey)
       userData.synchronize()
-      
-      if (action.style == .default) {
+
+      if action.style == .default {
         UIApplication.shared.openURL(URL(string: "\(baseUri)\(profileName)")!)
       }
       self.profileName = nil
     }
   }
-  
+
   private func proceedWithCustomKeyboardDownload(withAction action: UIAlertAction) {
     if let url = customKeyboardToDownload {
       Manager.shared.downloadKeyboard(from: url)
     }
     showGetStartedIfNeeded(withAction: action)
   }
-  
+
   private func showGetStartedIfNeeded(withAction action: UIAlertAction) {
     if shouldShowGetStarted {
       showGetStartedView(nil)

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -22,7 +22,7 @@ let dontShowGetStartedKey = "DontShowGetStarted"
 let launchedFromUrlNotification = NSNotification.Name("LaunchedFromUrlNotification")
 let urlKey = "url"
 
-class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDelegate, UIAlertViewDelegate {
+class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDelegate {
   private let minTextSize: CGFloat = 9.0
   private let maxTextSize: CGFloat = 72.0
   private let getStartedViewTag = 7183
@@ -451,8 +451,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if launchUrl != nil {
       perform(#selector(self.dismissActivityIndicator), with: nil, afterDelay: 1.0)
       let error = notification.error
-      showAlert(withTitle: "Keyboard Download Error", message: error.localizedDescription,
-                cancelButtonTitle: "OK", otherButtonTitles: nil, tag: -1)
+      appDelegate.showSimpleAlert(title: "Keyboard Download Error", message: error.localizedDescription)
       launchUrl = nil
     }
   }
@@ -796,8 +795,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if let urlString = params["url"] {
       // Download and set custom keyboard
       guard let url = URL(string: urlString) else {
-        showAlert(withTitle: "Custom Keyboard", message: "The keyboard could not be installed: Invalid Url",
-                  cancelButtonTitle: "OK", otherButtonTitles: nil, tag: -1)
+        appDelegate.showSimpleAlert(title: "Custom Keyboard", message: "The keyboard could not be installed: Invalid Url")
         launchUrl = nil
         return
       }
@@ -809,8 +807,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
 
       customKeyboardToDownload = url
       let title = "Custom Keyboard: \(url.lastPathComponent)"
-      showAlert(withTitle: title, message: "Would you like to install this keyboard?",
-                cancelButtonTitle: "Cancel", otherButtonTitles: "Install", tag: 2)
+      confirmInstall(withTitle: title, message: "Would you like to install this keyboard?",
+                cancelButtonHandler: showGetStartedIfNeeded,
+                installButtonHandler: proceedWithCustomKeyboardDownload)
     } else if let kbID = params["keyboard"], let langID = params["language"] {
       // Query should include keyboard and language IDs to set the keyboard (first download if not available)
       guard let keyboard = Manager.shared.apiKeyboardRepository.installableKeyboard(withID: kbID,
@@ -820,9 +819,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
 
       if Manager.shared.stateForKeyboard(withID: kbID) == .needsDownload {
         keyboardToDownload = keyboard
-        showAlert(withTitle: "\(keyboard.languageName): \(keyboard.name)",
+        confirmInstall(withTitle: "\(keyboard.languageName): \(keyboard.name)",
           message: "Would you like to install this keyboard?",
-                  cancelButtonTitle: "Cancel", otherButtonTitles: "Install", tag: 0)
+          installButtonHandler: proceedWithKeyboardDownload)
       } else {
         Manager.shared.addKeyboard(keyboard)
         _ = Manager.shared.setKeyboard(keyboard)
@@ -873,7 +872,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       let languageName = keyboard.languageName
       let title = "\(languageName) Font"
       let msg = "Touch Install to make \(languageName) display correctly in all your apps"
-      showAlert(withTitle: title, message: msg, cancelButtonTitle: "Cancel", otherButtonTitles: "Install", tag: 1)
+      confirmInstall(withTitle: title, message: msg,
+                cancelButtonHandler: handleUserDecisionAboutInstallingProfile,
+                installButtonHandler: handleUserDecisionAboutInstallingProfile)
     } else {
       profileName = nil
     }
@@ -883,55 +884,53 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     textView.becomeFirstResponder()
   }
 
-  private func showAlert(withTitle title: String, message msg: String, cancelButtonTitle cbTitle: String?,
-                         otherButtonTitles obTitles: String?, tag: Int) {
+  private func confirmInstall(withTitle title: String, message msg: String,
+                         cancelButtonHandler cbHandler: ((UIAlertAction) -> Swift.Void)? = nil,
+                         installButtonHandler installHandler: ((UIAlertAction) -> Swift.Void)?) {
     dismissGetStartedView(nil)
-    let alertView = UIAlertView(title: title, message: msg, delegate: self, cancelButtonTitle: cbTitle,
-                                otherButtonTitles: obTitles ?? "")
-    alertView.tag = tag
-    alertView.show()
+    
+    let alertController = UIAlertController(title: title, message: msg,
+                                            preferredStyle: UIAlertControllerStyle.alert)
+    alertController.addAction(UIAlertAction(title: "Cancel",
+                                            style: UIAlertActionStyle.cancel,
+                                            handler: cbHandler))
+    alertController.addAction(UIAlertAction(title: "Install",
+                                              style: UIAlertActionStyle.default,
+                                              handler: installHandler))
+    
+    self.present(alertController, animated: true, completion: nil)
   }
-
-  private func performAlertButtonClick(withTag tag: Int) {
-    switch tag {
-    case 0:
-      if let keyboard = keyboardToDownload {
-        Manager.shared.downloadKeyboard(withID: keyboard.id, languageID: keyboard.languageID, isUpdate: false)
-      }
-    case 1:
-      if let profileName = profileName {
-        checkedProfiles.append(profileName)
-        let userData = AppDelegate.activeUserDefaults()
-        userData.set(checkedProfiles, forKey: checkedProfilesKey)
-        userData.synchronize()
-
-        UIApplication.shared.openURL(URL(string: "\(baseUri)\(profileName)")!)
-        self.profileName = nil
-      }
-    case 2:
-      if let url = customKeyboardToDownload {
-        Manager.shared.downloadKeyboard(from: url)
-      }
-    default:
-      break
+  
+  private func proceedWithKeyboardDownload(withAction action: UIAlertAction) {
+    if let keyboard = keyboardToDownload {
+      Manager.shared.downloadKeyboard(withID: keyboard.id, languageID: keyboard.languageID, isUpdate: false)
     }
   }
-
-  func alertView(_ alertView: UIAlertView, clickedButtonAt buttonIndex: Int) {
-    if buttonIndex != alertView.cancelButtonIndex {
-      performAlertButtonClick(withTag: alertView.tag)
-    }
-
-    if let profileName = profileName, alertView.tag == 1 {
+  
+  private func handleUserDecisionAboutInstallingProfile(withAction action: UIAlertAction) {
+    if let profileName = profileName {
       checkedProfiles.append(profileName)
       let userData = AppDelegate.activeUserDefaults()
       userData.set(checkedProfiles, forKey: checkedProfilesKey)
       userData.synchronize()
-      self.profileName = nil
-    } else if alertView.tag == 2 {
-      if shouldShowGetStarted {
-        showGetStartedView(nil)
+      
+      if (action.style == .default) {
+        UIApplication.shared.openURL(URL(string: "\(baseUri)\(profileName)")!)
       }
+      self.profileName = nil
+    }
+  }
+  
+  private func proceedWithCustomKeyboardDownload(withAction action: UIAlertAction) {
+    if let url = customKeyboardToDownload {
+      Manager.shared.downloadKeyboard(from: url)
+    }
+    showGetStartedIfNeeded(withAction: action)
+  }
+  
+  private func showGetStartedIfNeeded(withAction action: UIAlertAction) {
+    if shouldShowGetStarted {
+      showGetStartedView(nil)
     }
   }
 


### PR DESCRIPTION
As part of this work, I'm replacing all (deprecated) usages of UIAlertView with UIAlertController and UIAlertAction buttons.