### PR TITLE
[Windows] Fix docbook links (stable)

### DIFF
--- a/windows/src/desktop/help/common/linux.xml
+++ b/windows/src/desktop/help/common/linux.xml
@@ -2,5 +2,5 @@
 
 <section id="common_linux">
   <title>Does Keyman Desktop run on Linux?</title>
-  <para>While Keyman Desktop is a Windows product, we have an input method manager for Linux called <ulink href="https://help.keyman.com/kb/58">KMFL</ulink>.</para>
+  <para>While Keyman Desktop is a Windows product, we have an input method manager for Linux called <ulink url="https://help.keyman.com/kb/58">KMFL</ulink>.</para>
 </section>

--- a/windows/src/desktop/help/common/mac.xml
+++ b/windows/src/desktop/help/common/mac.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="common_mac">
   <title>Does Keyman Desktop run on a Mac?</title>
-  <para>Yes. Please visit <ulink href="https://keyman.com/macos/">Keyman for macOS</ulink> for more information. Also note that there are two other ways you can use Keyman keyboards on a Mac:</para>
+  <para>Yes. Please visit <ulink url="https://keyman.com/macos/">Keyman for macOS</ulink> for more information. Also note that there are two other ways you can use Keyman keyboards on a Mac:</para>
   <orderedlist>
     <listitem><para>If you are running Windows on your Mac (through a program like Fusion, Parallels or BootCamp) you can use Keyman Desktop through Windows.</para></listitem>
     <listitem>

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,11 @@
 # Keyman Desktop Version History
 
+## 2018-09-12 10.0.1202 stable
+* Fix links to Keyman for macOS in help files (#1067)
+
+## 2018-07-06 10.0.1201 stable
+* No changes to Keyman Desktop (update to KeymanWeb script)
+
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,11 @@
 # Keyman Developer Version History
 
+## 2018-09-12 10.0.1202 stable
+* Fix docbook links (#1067)
+
+## 2018-07-06 10.0.1201 stable
+* No changes to Keyman Developer (update to KeymanWeb script)
+
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,11 +1,5 @@
 # Keyman Developer Version History
 
-## 2018-09-12 10.0.1202 stable
-* Fix docbook links (#1067)
-
-## 2018-07-06 10.0.1201 stable
-* No changes to Keyman Developer (update to KeymanWeb script)
-
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 


### PR DESCRIPTION
This fixes the links on the help pages for
* https://help.keyman.com/products/desktop/10.0/docs/common_mac.php
* https://help.keyman.com/products/desktop/10.0/docs/common_linux.php

I propose holding off on this merge to coincide with whenever a Windows bugfix gets merged to 10.0 stable.