### PR TITLE
[Windows] Fix docbook links (alpha)

### DIFF
--- a/windows/src/desktop/help/common/linux.xml
+++ b/windows/src/desktop/help/common/linux.xml
@@ -2,5 +2,5 @@
 
 <section id="common_linux">
   <title>Does Keyman Desktop run on Linux?</title>
-  <para>While Keyman Desktop is a Windows product, we have an input method manager for Linux called <ulink href="https://help.keyman.com/kb/58">KMFL</ulink>.</para>
+  <para>While Keyman Desktop is a Windows product, we have an input method manager for Linux called <ulink url="https://help.keyman.com/kb/58">KMFL</ulink>.</para>
 </section>

--- a/windows/src/desktop/help/common/mac.xml
+++ b/windows/src/desktop/help/common/mac.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="common_mac">
   <title>Does Keyman Desktop run on a Mac?</title>
-  <para>Yes. Please visit <ulink href="https://keyman.com/macos/">Keyman for macOS</ulink> for more information. Also note that there are two other ways you can use Keyman keyboards on a Mac:</para>
+  <para>Yes. Please visit <ulink url="https://keyman.com/macos/">Keyman for macOS</ulink> for more information. Also note that there are two other ways you can use Keyman keyboards on a Mac:</para>
   <orderedlist>
     <listitem><para>If you are running Windows on your Mac (through a program like Fusion, Parallels or BootCamp) you can use Keyman Desktop through Windows.</para></listitem>
     <listitem>


### PR DESCRIPTION
Corresponding fix to 11.0 alpha for #1067 

This fixes the links on the help pages for
* https://help.keyman.com/products/desktop/11.0/docs/common_mac.php
* https://help.keyman.com/products/desktop/11.0/docs/common_linux.php