### PR TITLE
[iOS] #1045,#1046 - Quick fix for OSK layout: disable animation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -983,7 +983,11 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   public func dismissKeyboardPicker(_ viewController: UIViewController) {
-    viewController.dismiss(animated: true)
+    // #1045 - Setting animated to false "fixes" the display problems and prevents the crash (on iPad 10.5"
+    // and 12.9"), but it makes the transition less smooth (obviously) and probably isn't the "right"
+    // way to fix the problem. Presumably there is some kind of underlying plumbing issue that is the
+    // true source of the problems.
+    viewController.dismiss(animated: false)
     if shouldReloadKeyboard {
       reloadKeyboard(in: keymanWeb)
     }

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2018-08-02 10.0.208 stable 
+* Fixed OSK layout problems (and possible crash) on iOS 11 on certain hardware (#1089) 
+
 ## 2018-07-06 10.0.203 stable
 * Fixes issue for Keyman for iPhone and iPad where a keyboard with varying row counts in different layers could crash (#1055)
 


### PR DESCRIPTION
Setting animated to false "fixes" the display problems and prevents the crash (on iPad 10.5" and 12.9"), but it makes the transition less smooth (obviously) and probably isn't the "right" way to fix the problem. Presumably there is some kind of underlying plumbing issue that is the true source of the problems. This should therefore be regarded as a stop-gap measure and not a permanent fix for #1045 and #1046.