### PR TITLE
[Mac] #1090 - Fixed follow-on bug (when Shift is pressed)

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -175,7 +175,8 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
         return nil; // Engine should NEVER attempt to process characters when the Command key is pressed.
     
     // REVIEW: Might need to use charactersIgnoringModifiers instead of characters to avoid
-    // getting Mac predefined subsitutions for Option + ??? keystrokes
+    // getting Mac predefined subsitutions for Option + ??? keystrokes. But at least for the normal
+    // case of shifted characters, what we have is what we want.
     NSString *characters = [event characters];
     //NSString *characters = [event charactersIgnoringModifiers];
     if (self.debugMode) {
@@ -308,7 +309,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     }
                 }
             }
-            else if (!(mask & K_MODIFIERFLAG)) {
+            else if (!(mask & K_MODIFIERFLAG) || mask == K_SHIFTFLAG) {
                 //if (self.debugMode)
                 //NSLog(@"No shift flags!");
                 if (!key.context.length) {

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -129,6 +129,21 @@ NSString * names[nCombinations];
     }
 }
 
+- (void)testprocessEvent_eventsForOpenCurlyBraceWithCipherMusicKmx_ReturnsQstrActionForStartSlide {
+    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
+    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@""];
+    UTF32Char expectedUtf32Char = 0x1D177;
+    NSString * expectedStartSlideSurrogatePair = [[NSString alloc] initWithBytes:&expectedUtf32Char length:4 encoding:NSUTF32LittleEndianStringEncoding];
+    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:NSEventModifierFlagShift timestamp:0 windowNumber:0 context:nil characters:@"{" charactersIgnoringModifiers:@"[" isARepeat:NO keyCode:kVK_ANSI_LeftBracket];
+    NSArray *actions = [engine processEvent:event];
+    XCTAssert(actions.count == 1, @"Expected 1 action");
+    NSDictionary *action = actions[0];
+    NSString *actionType = [[action allKeys] objectAtIndex:0];
+    XCTAssert([actionType isEqualToString:Q_STR], @"Expected Q_STR action");
+    NSString *output = [action objectForKey:actionType];
+    XCTAssert([output isEqualToString:expectedStartSlideSurrogatePair], @"Output incorrect");
+}
+
 - (void)testprocessEvent_eventForUnshiftedNumeralWithCipherMusicKmx_ReturnsQstrActionToInsertNumeral {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@""];

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,7 +1,7 @@
 # Keyman for macOS Version History
 
-## 2018-08-10 10.0.105 stable
-* Fixed bug in engine that caused incorrect rule to be used (#1091)
+## 2018-08-10 10.0.111 stable
+* Fixed bug in engine that caused incorrect rules to be used (#1091, 1098)
 
 ## 2018-07-12 10.0.104 stable
 * Removed help button from OSK for versions of macOS < 10.10 to prevent crash (#1080)

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,7 +1,10 @@
 # Keyman for macOS Version History
 
 ## 2018-08-14 10.0.111 stable
-* Fixed bug in engine that caused incorrect rules to be used (#1091, 1099)
+* CORRECLTY fixed bug in engine that caused incorrect rules to be used (#1099)
+
+## 2018-08-10 10.0.105 stable
+* DO NOT USE - Faulty attempt at bug fix in engine (#1091)
 
 ## 2018-07-12 10.0.104 stable
 * Removed help button from OSK for versions of macOS < 10.10 to prevent crash (#1080)

--- a/mac/history.md
+++ b/mac/history.md
@@ -3,7 +3,10 @@
 ## 2018-08-14 10.0.111 stable
 * CORRECLTY fixed bug in engine that caused incorrect rules to be used (#1099)
 
-## 2018-08-10 10.0.105 stable
+## 2018-08-10 10.0.110 stable
+* No change
+
+## 2018-08-10 10.0.109 stable
 * DO NOT USE - Faulty attempt at bug fix in engine (#1091)
 
 ## 2018-07-12 10.0.104 stable

--- a/mac/history.md
+++ b/mac/history.md
@@ -1,7 +1,7 @@
 # Keyman for macOS Version History
 
-## 2018-08-10 10.0.111 stable
-* Fixed bug in engine that caused incorrect rules to be used (#1091, 1098)
+## 2018-08-14 10.0.111 stable
+* Fixed bug in engine that caused incorrect rules to be used (#1091, 1099)
 
 ## 2018-07-12 10.0.104 stable
 * Removed help button from OSK for versions of macOS < 10.10 to prevent crash (#1080)


### PR DESCRIPTION
Previous fix over-corrected by preventing a non-virtual rule from being used for normal shifted characters. For example, if a rule was supposed to fire for a left curly brace, it would not fire if the rule contained '{' instead of [SHIFT K_LBRKT].