### PR TITLE
[Android] Fix crashes when input connection or package name is null

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -134,7 +134,7 @@ public class PackageActivity extends Activity {
       webView.loadUrl("file:///" + files[0].getAbsolutePath());
     } else {
       // No welcome.htm so display minimal package information
-      String keyboardString = (pkgName.toLowerCase().endsWith("keyboard")) ? "" : " Keyboard ";
+      String keyboardString = (pkgName != null && pkgName.toLowerCase().endsWith("keyboard")) ? "" : " Keyboard ";
       String htmlString = String.format(
         "<body style=\"max-width:600px;\"><H1>The %s%s Package</H1></body>",
         pkgName, keyboardString);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1738,8 +1738,10 @@ public final class KMManager {
           }
 
           InputConnection ic = IMService.getCurrentInputConnection();
-          if ((ic == null) && isDebugMode()) {
-            Log.w("SWK: JS Handler", "insertText failed: InputConnection is null");
+          if (ic == null) {
+            if (isDebugMode()) {
+              Log.w("SWK: JS Handler", "insertText failed: InputConnection is null");
+            }
             return;
           }
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,7 +1,7 @@
 # Keyman for Android
 
 ## 2018-08-16 10.0.503 stable
-* Fixes crash for release configurations when InputConfiguration is null (#1103)
+* Fixes crashes for release configurations when InputConfiguration or package name is null (#1103)
 
 ## 2018-07-06 10.0.502 stable
 * Fixes issue for embedded Android, iOS apps where a keyboard with varying row counts in different layers could crash (#1055)

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-08-16 10.0.503 stable
+* Fixes crash for release configurations when InputConfiguration is null (#1103)
+
 ## 2018-07-06 10.0.502 stable
 * Fixes issue for embedded Android, iOS apps where a keyboard with varying row counts in different layers could crash (#1055)
 


### PR DESCRIPTION
This PR fixes 2 null-pointer crashes appearing on Crashlytics.

1. Cleaning up the console log in #837 introduced a bug when the InputConnection in KMManager is `null` and build variant is `release`.
2. PackageActivity is crashing when the package name is null.