### PR TITLE
[Android] Ensure keyboards list has an entry

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -91,10 +91,8 @@ public final class KeyboardPickerActivity extends Activity implements OnKeyboard
     setContentView(R.layout.list_layout);
     listView = (ListView) findViewById(R.id.listView);
 
-    File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), KMManager.KMFilename_KeyboardsList);
-    if (file.exists()) {
-      keyboardsList = getKeyboardsList(context);
-    } else {
+    keyboardsList = getKeyboardsList(context);
+    if (keyboardsList == null) {
       keyboardsList = new ArrayList<HashMap<String, String>>();
       HashMap<String, String> kbInfo = new HashMap<String, String>();
       kbInfo.put(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
@@ -107,7 +105,12 @@ public final class KeyboardPickerActivity extends Activity implements OnKeyboard
       kbInfo.put(KMManager.KMKey_CustomKeyboard, "N");
       kbInfo.put(KMManager.KMKey_Font, KMManager.KMDefault_KeyboardFont);
       keyboardsList.add(kbInfo);
-      saveKeyboardsList(context);
+
+      // We'd prefer not to overwrite a file if it exists
+      File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), KMManager.KMFilename_KeyboardsList);
+      if (!file.exists()) {
+        saveKeyboardsList(context);
+      }
     }
 
     String[] from = new String[]{KMManager.KMKey_LanguageName, KMManager.KMKey_KeyboardName};

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-08-23 10.0.504 stable
+* Fixes crash when installed keyboards list is invalid (#1119)
+
 ## 2018-08-16 10.0.503 stable
 * Fixes crashes for release configurations when InputConfiguration or package name is null (#1103)
 


### PR DESCRIPTION
There are some crash reports coming from `KeyboardPickerActivity.java` because the keyboards list is null (file access error). When the app tries to display the installed keyboards list, this results in the crash.

`getKeyboardsList()` already checks the existence of the `keyboards_list.dat` file, so some of that code is also redundant.

With this PR, if `keyboardsList` is null, we'll populate the list with the default keyboard.
atm, I'm deciding not to overwrite the `keyboards_list.dat` file so we don't lose the info of previously installed keyboards.