### PR TITLE
[Developer] Remove Alt+letter/digit and function key bindings from editor

### DIFF
--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -148,6 +148,16 @@ window.editorGlobalContext = {
   */
   $(function initialize() {
     editor = ace.edit("editor");
+
+    // Remove Alt+ key bindings which may conflict with environment shortcuts, e.g. Alt+E, function keys
+
+    var reAltKeyBindings = /(^alt-[a-z0-9]|f[0-9]+)$/;
+    for (var key in editor.keyBinding.$defaultHandler.commandKeyBinding) {
+      if (key.match(reAltKeyBindings)) {
+        delete editor.keyBinding.$defaultHandler.commandKeyBinding[key];
+      }
+    }
+
     editor.setTheme("ace/theme/xcode");
     
     editor.session.selection.on('changeCursor', updateState);    


### PR DESCRIPTION
Arising from todo list in #1097

Wait on: #1134 (rebase)

The Alt+letter/digit bindings conflict with Windows menu and command shortcuts. Function keys also have predefined meanings in Keyman Developer. Hence remove them all from the editor bindings. If we find that we need a specific binding we can always remap it in the future, however none of the mapped bindings were significant for Keyman Developer use.