### PR TITLE
[Developer] Manage focus correctly for setting breakpoints and more

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
@@ -34,6 +34,7 @@ inherited frameCEFHost: TframeCEFHost
     Top = 208
   end
   object cef: TChromium
+    OnWidgetCompMsg = cefWidgetCompMsg
     OnLoadEnd = cefLoadEnd
     OnRunContextMenu = cefRunContextMenu
     OnPreKeyEvent = cefPreKeyEvent

--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
@@ -80,6 +80,7 @@ type
                              var settings: TCefBrowserSettings;
                              var noJavascriptAccess: Boolean;
                              var Result: Boolean);
+    procedure cefWidgetCompMsg(var aMessage: TMessage; var aHandled: Boolean);
   private
     FNextURL: string;
     FOnLoadEnd: TNotifyEvent;
@@ -190,6 +191,14 @@ end;
 procedure TframeCEFHost.CEFShow(var message: TMessage);
 begin
   CreateBrowser;
+end;
+
+procedure TframeCEFHost.cefWidgetCompMsg(var aMessage: TMessage;
+  var aHandled: Boolean);
+begin
+  if aMessage.Msg = WM_SETFOCUS then
+    if cefwp.Visible and cefwp.CanFocus then
+      GetParentForm(cefwp).ActiveControl := cefwp;
 end;
 
 procedure TframeCEFHost.CreateBrowser;

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -67,6 +67,7 @@ window.editorGlobalContext = {
       });
     }
     editor.moveCursorTo(o.row, 0);
+    editor.selection.clearSelection();
     editor.renderer.scrollCursorIntoView();
   };
   


### PR DESCRIPTION
The focus management in the CEF component is slightly flawed. This patch fixes the ActiveControl state for the component when focus is set to a child window of the web control, which helps track the focus per Delphi's expectations.