### PR TITLE
[Developer] Tidy up row selection in web editor

### DIFF
--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -787,6 +787,7 @@ begin
   v := TJSONNumber.Create(ln);
   try
     ExecuteCommand('highlightError', v);
+    SetSelectedRow(ln);
   finally
     v.Free;
   end;

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -46,6 +46,7 @@ window.editorGlobalContext = {
 
   context.moveCursor = function (o) {
     editor.moveCursorTo(o.row, o.column);
+    editor.selection.clearSelection();
     editor.renderer.scrollCursorIntoView();
   };
   


### PR DESCRIPTION
This fixes two issues:
1. Double-clicking an error doesn't select the row with the error, just highlights it
2. Selecting a row from Delphi code causes the selection to extend to the row rather than just moving the cursor to the row

Arises from todo list in #1097