### PR TITLE
[Developer] Support CSS, JS and JSON formats in text editor

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmEditor.pas
@@ -200,6 +200,9 @@ begin
   else if Pos('htm', s) > 0 then EditorFormat := efHTML
   else if Copy(s,1,4) = '.php' then EditorFormat := efHTML
   else if Pos('xml', s) > 0 then EditorFormat := efXML
+  else if s = '.json' then EditorFormat := efJSON
+  else if s = '.js' then EditorFormat := efJS
+  else if s = '.css' then EditorFormat := efCSS
   else EditorFormat := efText;
 end;
 

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -1700,6 +1700,7 @@ begin
   if Assigned(c) and not Assigned(FFeature[ID].Frame) then
   begin
     FFeature[ID].Frame := TframeTextEditor.Create(Self);
+    FFeature[ID].Frame.EditorFormat := KeyboardFeatureEditorFormat[ID];
     FFeature[ID].Frame.TextFileFormat := tffUTF8;
     FFeature[ID].Frame.Parent := c;
     FFeature[ID].Frame.Align := alClient;
@@ -3080,6 +3081,7 @@ begin
   frameTouchLayout.Visible := True;
 
   frameTouchLayoutSource := TframeTextEditor.Create(Self);   // I4034
+  frameTouchLayoutSource.EditorFormat := efJSON;
   frameTouchLayoutSource.TextFileFormat := tffUTF8;
   frameTouchLayoutSource.Parent := pageTouchLayoutCode;
   frameTouchLayoutSource.Align := alClient;

--- a/windows/src/developer/TIKE/main/KeyboardParser.pas
+++ b/windows/src/developer/TIKE/main/KeyboardParser.pas
@@ -1,8 +1,8 @@
 (*
   Name:             KeyboardParser
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      23 Aug 2006
 
   Modified Date:    23 Feb 2016
@@ -44,6 +44,7 @@ uses
   ExtShiftState,
   kmxfile,
   kmxfileconsts,
+  TextFileFormat,
   UKeymanTargets,
   utilfiletypes;
 
@@ -320,6 +321,10 @@ const
   KeyboardFeatureFilename: array[TKeyboardParser_FeatureID] of string = (
     '%s.ico', '%s'+Ext_VisualKeyboardSource, '%s'+Ext_KeymanTouchLayout,
     '%s-code.js', '%s.css', '%s-help.htm', '%s-codes.txt');   // I4369
+  KeyboardFeatureEditorFormat: array[TKeyboardParser_FeatureID] of TEditorFormat = (
+    efText, efXML, efJSON,
+    efJS, efCSS, efHTML, efText
+  );
   KeyboardFeatureTargets: array[TKeyboardParser_FeatureID] of TKeymanTargets = (   // I4504
     // Due to Delphi compiler limitation, need to copy the target values, can't
     // use the defined constants.

--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
@@ -197,7 +197,7 @@ procedure TframeCEFHost.cefWidgetCompMsg(var aMessage: TMessage;
   var aHandled: Boolean);
 begin
   if aMessage.Msg = WM_SETFOCUS then
-    if cefwp.Visible and cefwp.CanFocus then
+    if Assigned(cefwp) and cefwp.Visible and cefwp.CanFocus then
       GetParentForm(cefwp).ActiveControl := cefwp;
 end;
 

--- a/windows/src/developer/TIKE/main/TextFileFormat.pas
+++ b/windows/src/developer/TIKE/main/TextFileFormat.pas
@@ -26,7 +26,7 @@ uses
 
 type
   TTextFileFormat = (tffANSI, tffUTF8, tffUTF16);
-  TEditorFormat = (efKMN, efXML, efText, efHTML);
+  TEditorFormat = (efKMN, efXML, efText, efHTML, efJSON, efJS, efCSS);
 
 function TextFileFormatToEncoding(AFormat: TTextFileFormat): TEncoding;   // I3502   // I3637
 

--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -391,7 +391,7 @@ procedure TframeTextEditor.LoadFileInBrowser(const AData: string);
   end;
 const
   mode: array[TEditorFormat] of string = (
-    'keyman', 'xml', 'text', 'html'
+    'keyman', 'xml', 'text', 'html', 'json', 'javascript', 'css'
   );
 begin
   if FFilename = '' then

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -103,7 +103,8 @@ uses
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
   Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
-  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
+  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
+  TextFileFormat in '..\TIKE\main\TextFileFormat.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -206,6 +206,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
+        <DCCReference Include="..\TIKE\main\TextFileFormat.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
@@ -92,7 +92,8 @@ uses
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
   Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
-  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
+  Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
+  TextFileFormat in '..\..\developer\TIKE\main\TextFileFormat.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
@@ -180,6 +180,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
+        <DCCReference Include="..\..\developer\TIKE\main\TextFileFormat.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
Arises from todo list in #1097

(Also fixes an access violation in shutdown in rare circumstances when focus changes, in UframeCEFHost: `if Assigned(cefwp) and ...`)