### PR TITLE
[Developer] Add FindErrorByOffset support for future use by JSON, XML editors

### DIFF
--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -849,24 +849,31 @@ begin
 end;
 
 function TframeTextEditor.OffsetToLine(Offset: Integer): Integer;   // I4083
+var
+  line: Integer;
 begin
   Result := 0;
-//  while (Result < memo.ParagraphCount) and (Offset > memo.PargrphOffset[Result]) do
-//    Inc(Result);
+
+  with TStringList.Create do
+  try
+    Text := Self.GetText;
+    line := 0;
+    while offset > 0 do
+    begin
+      Dec(offset, Strings[line].Length + 2);
+      Inc(line);
+    end;
+  finally
+    Free;
+  end;
+
+  Result := line;
 end;
 
 procedure TframeTextEditor.FindErrorByOffset(offset: Integer);   // I4083
 begin
   ClearError;
-
-  {TODO: if offset <= 0 then Exit;
-
-  memo.SelStart := offset;
-  memo.SelCol := 0;
-  memo.ScrollInView;
-  FErrorPar := memo.SelLine;
-
-  UpdateParColour(FErrorPar, pcltError);}
+  FindError(OffsetToLine(offset));
 end;
 
 procedure TframeTextEditor.FireCommand(const commands: TStringList);

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -98,6 +98,14 @@ window.editorGlobalContext = {
     context.loading = false;
   };
 
+  context.setText = function (text) {
+    let range = editor.session.selection.getRange();
+    context.loading = true;
+    editor.session.setValue(text);
+    editor.session.selection.setSelectionRange(range);
+    context.loading = false;
+  };
+
   /* Printing */
 
   context.print = function () {


### PR DESCRIPTION
The JSON parser currently does not return the offset of the error in the file. This is a Delphi limitation.
However, the infrastructure is there if we need it.

Arises from todo in #1097