### PR TITLE
[Developer] First pass of managing code and char fonts in web text editor

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -266,7 +266,8 @@ uses
   Keyman.Developer.System.HttpServer.App in 'http\Keyman.Developer.System.HttpServer.App.pas',
   Keyman.Developer.System.HttpServer.Base in 'http\Keyman.Developer.System.HttpServer.Base.pas',
   UfrmProject in 'project\UfrmProject.pas' {frmProject},
-  Keyman.Developer.System.HttpServer.AppSource in 'http\Keyman.Developer.System.HttpServer.AppSource.pas';
+  Keyman.Developer.System.HttpServer.AppSource in 'http\Keyman.Developer.System.HttpServer.AppSource.pas',
+  Keyman.UI.FontUtils in '..\..\global\delphi\general\Keyman.UI.FontUtils.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -96,7 +96,6 @@
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
-        <DCC_Define>$(DCC_Define)</DCC_Define>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
@@ -104,7 +103,6 @@
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_Define>$(DCC_Define)</DCC_Define>
         <DCC_UnitSearchPath>C:\keyman\10.0\src\ext\jcl\jcl\source\common;C:\keyman\10.0\src\ext\jcl\jcl\source\vcl;C:\keyman\10.0\src\ext\jcl\jcl\source\windows;C:\keyman\10.0\src\ext\jcl\jvcl\run;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
         <Icon_MainIcon>KeymanDeveloper90.ico</Icon_MainIcon>
@@ -511,6 +509,7 @@
             <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="http\Keyman.Developer.System.HttpServer.AppSource.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.UI.FontUtils.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -552,6 +552,7 @@ uses
   System.Win.ComObj,
 
   Keyman.Developer.System.HelpTopics,
+  Keyman.UI.FontUtils,
 
   CharacterDragObject,
   CharacterInfo,
@@ -801,8 +802,6 @@ end;
 procedure TfrmKeymanWizard.CodeFontChanged;
 begin
   inherited;
-  if CodeFont.Size <> CharFont.Size then
-    CharFont.Size := CodeFont.Size;
   frameSource.CodeFont := CodeFont;
 end;
 
@@ -1787,27 +1786,6 @@ begin
   Result := 'Keyboard definitions (*.kmn)|*.kmn';
 end;
 
-function FontSizeToStr(const name: string; sz: Integer): string;   // I4872
-var
-  tm: TTextMetric;
-begin
-  if sz < 0 then
-  begin
-    with TBitmap.Create do
-    try
-      Canvas.Font.Name := name;
-      Canvas.Font.Size := sz;
-      Canvas.TextExtent('A');
-      GetTextMetrics(Canvas.Handle, tm);
-      Result := IntToStr((Canvas.Font.Height - tm.tmInternalLeading) * 72 div GetDeviceCaps(Canvas.Handle, LOGPIXELSY));
-    finally
-      Free;
-    end;
-  end
-  else
-    Result := IntToStr(sz);
-end;
-
 function TfrmKeymanWizard.GetFontInfo(Index: TKeyboardFont): TKeyboardFontInfo;   // I4057
 begin
   case Index of
@@ -1815,13 +1793,13 @@ begin
       begin
         Result.Enabled := True;
         Result.Name := CodeFont.Name;
-        Result.Size := FontSizeToStr(CodeFont.Name, CodeFont.Size);   // I4872
+        Result.Size := IntToStr(TFontUtils.FontSizeInPoints(CodeFont.Name, CodeFont.Size));   // I4872
       end;
     kfontChar:
       begin
         Result.Enabled := True;
         Result.Name := CharFont.Name;
-        Result.Size := FontSizeToStr(CharFont.Name, CharFont.Size);   // I4872
+        Result.Size := IntToStr(TFontUtils.FontSizeInPoints(CharFont.Name, CharFont.Size));   // I4872
       end;
     kfontOSK:
       begin
@@ -1829,7 +1807,7 @@ begin
         if Result.Enabled then
         begin
           Result.Name := frameOSK.KeyFont.Name;
-          Result.Size := FontSizeToStr(frameOSK.KeyFont.Name, frameOSK.KeyFont.Size);   // I4872
+          Result.Size := IntToStr(TFontUtils.FontSizeInPoints(frameOSK.KeyFont.Name, frameOSK.KeyFont.Size));   // I4872
         end;
       end;
     kfontTouchLayoutPhone, kfontTouchLayoutTablet, kfontTouchLayoutDesktop:
@@ -2470,9 +2448,6 @@ end;
 procedure TfrmKeymanWizard.CharFontChanged;
 begin
   inherited;
-  if CodeFont.Size <> CharFont.Size then
-    CodeFont.Size := CharFont.Size;
-
   UpdateKeyFont;
   //VK_UpdateKeyFont;
   frameSource.CharFont := CharFont;

--- a/windows/src/developer/TIKE/main/KeymanDeveloperUtils.pas
+++ b/windows/src/developer/TIKE/main/KeymanDeveloperUtils.pas
@@ -281,10 +281,10 @@ var
 begin
   if s = '' then
   begin
-    // We set to Courier New, 12pt
-    f.Name := 'Courier New';
-    f.Charset := ANSI_CHARSET;    // 02/02/2003 MCD: Added, charset not set when resetting to default font 
-    f.Size := 12;
+    // We set to Consolas, 12px as default
+    f.Name := 'Consolas';
+    f.Charset := ANSI_CHARSET;    // 02/02/2003 MCD: Added, charset not set when resetting to default font
+    f.Height := 12;
     f.Style := [];
     f.Color := clWindowText;
     Exit;

--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -428,7 +428,7 @@ procedure TframeTextEditor.LoadFileInBrowser(const AData: string);
   end;
   function EncodeFont(const prefix: string; f: TFont): string;
   begin
-    Result := Format('&%sName=%s&%sSize=%dpt', [prefix, URLEncode(f.Name), prefix, TFontUtils.FontSizeInPoints(f)]);
+    Result := Format('&%sName=%s&%sSize=%d', [prefix, URLEncode(f.Name), prefix, TFontUtils.FontSizeInPixels(f)]);
   end;
 const
   mode: array[TEditorFormat] of string = (
@@ -591,7 +591,7 @@ procedure TframeTextEditor.UpdateEditorFonts;
   begin
     Result := TJSONObject.Create;
     Result.AddPair('name', f.Name);
-    Result.AddPair('size', IntToStr(TFontUtils.FontSizeInPoints(f))+'pt');
+    Result.AddPair('size', TJSONNumber.Create(TFontUtils.FontSizeInPixels(f)));
   end;
 var
   j: TJSONObject;

--- a/windows/src/developer/TIKE/xml/app/editor/editor.css
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.css
@@ -1,6 +1,9 @@
 html, body {
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
 }
 
 #editor { 

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -15,10 +15,11 @@ window.editorGlobalContext = {
   var errorRange = null;
   var executionPoint = [];
   var breakpoints = [];
+  var fontCss = null;
   let params = (new URL(location)).searchParams;
   let filename = params.get('filename');
   let mode = params.get('mode');
-  
+
   if(!mode) {
     mode = 'keyman';
   }
@@ -187,6 +188,25 @@ window.editorGlobalContext = {
     editor.setValue(text);
     editor.setSelection(range);
     context.loading = false;
+  };
+
+  //
+  // Set character and code fonts
+  //
+
+  context.setFonts = function (fonts) {
+    if (fonts == null) {
+      return false;
+    }
+
+    if (!fontCss) {
+      fontCss = document.createElement('style');
+      document.head.appendChild(fontCss);
+    }
+
+    fontCss.innerHTML =
+      ".monaco-editor .view-lines { font-size: " + fonts.codeFont.size + "; font-family: \"" + fonts.codeFont.name + "\"; }" +
+      ".mtk20, .mtk8 { font-size: " + fonts.charFont.size + "; font-family: \"" + fonts.charFont.name + "\"; }";
   };
 
   //

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -32,8 +32,11 @@ window.editorGlobalContext = {
   require.config({ paths: { 'vs': '../lib/monaco/min/vs' } });
   require(['vs/editor/editor.main','language.keyman'], function (_editor, _language) {
     
+    //
     // Register Keyman .kmn tokens provider and language formatter
     // https://github.com/Microsoft/monaco-editor/blob/master/test/playground.generated/extending-language-services-custom-languages.html
+    //
+    
     monaco.languages.register({ id: 'keyman' });
     monaco.languages.setMonarchTokensProvider('keyman', _language.language);
     
@@ -47,6 +50,7 @@ window.editorGlobalContext = {
         enabled: false
       },
       glyphMargin: true,
+      lineNumbersMinChars: 2,
       disableMonospaceOptimizations: true
     });
 
@@ -61,6 +65,15 @@ window.editorGlobalContext = {
       },
       "text"
     );
+    
+    //
+    // Set initial fonts
+    //
+    
+    context.setFonts({
+      codeFont: { name: params.get('codeFontName'), size: params.get('codeFontSize') },
+      charFont: { name: params.get('charFontName'), size: params.get('charFontSize') }
+    });
     
     //
     // Setup callbacks
@@ -204,9 +217,26 @@ window.editorGlobalContext = {
       document.head.appendChild(fontCss);
     }
 
-    fontCss.innerHTML =
-      ".monaco-editor .view-lines { font-size: " + fonts.codeFont.size + "; font-family: \"" + fonts.codeFont.name + "\"; }" +
-      ".mtk20, .mtk8 { font-size: " + fonts.charFont.size + "; font-family: \"" + fonts.charFont.name + "\"; }";
+    fontCss.innerHTML = ".mtk20, .mtk8 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+      
+    // Calculate the appropriate line height based on the maximum from the two fonts set
+      
+    var eChar = document.createElement('div');
+    eChar.innerHTML = '?';
+    eChar.style = "position:absolute; top: -50000px; left: 0; font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\";";
+    document.body.appendChild(eChar);
+    var lineHeight = eChar.offsetHeight;
+
+    eChar.style = "position:absolute; top: -50000px; left: 0; font-size: " + fonts.codeFont.size + "px; font-family: \"" + fonts.codeFont.name + "\";";
+    lineHeight = Math.max(lineHeight, eChar.offsetHeight);
+    
+    document.body.removeChild(eChar);
+      
+    editor.updateOptions({
+      fontFamily: fonts.codeFont.name,
+      fontSize: fonts.codeFont.size,
+      lineHeight: lineHeight
+    });
   };
 
   //

--- a/windows/src/developer/TIKE/xml/app/editor/language.keyman.js
+++ b/windows/src/developer/TIKE/xml/app/editor/language.keyman.js
@@ -67,7 +67,7 @@ define("language.keyman", ["require", "exports"], function (require, exports) {
           [/\b(ctrl|shift|alt|caps|ncaps|nnumlock|numlock|ralt|lalt|rctrl|lctrl)\b/, 'tag'],
 
           // virtual key
-          [/\b[ktu]_([A-Z0-9]+)\b/, 'tag'],
+          [/\b[ktu]_([A-Z0-9_]+)\b/, 'tag'],
 
           // closing bracket
           [/\]/, { token: 'tag', bracket: '@close', next: '@pop' }],
@@ -89,11 +89,13 @@ define("language.keyman", ["require", "exports"], function (require, exports) {
         ],
 
         stringDouble: [
-          [/"/,        { token: 'string.quote', bracket: '@close', next: '@pop' } ]
+          [/"/,        { token: 'string.quote', bracket: '@close', next: '@pop' } ],
+          [/./,        'string' ]
         ],
 
         stringSingle: [
-          [/'/,        { token: 'string.quote', bracket: '@close', next: '@pop' } ]
+          [/'/,        { token: 'string.quote', bracket: '@close', next: '@pop' } ],
+          [/./,        'string' ]
         ],
 
         whitespace: [

--- a/windows/src/global/delphi/general/Keyman.UI.FontUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.UI.FontUtils.pas
@@ -1,0 +1,46 @@
+unit Keyman.UI.FontUtils;
+
+interface
+
+uses
+  System.SysUtils,
+  Vcl.Graphics,
+  Winapi.Windows;
+
+type
+  TFontUtils = class
+    class function FontSizeInPoints(const name: string; size: Integer): Integer; overload;
+    class function FontSizeInPoints(f: TFont): Integer; overload;
+  end;
+
+implementation
+
+class function TFontUtils.FontSizeInPoints(const name: string; size: Integer): Integer;
+var
+  tm: TTextMetric;
+begin
+  // The TFont.Size value may or may not include internal leading
+  // so we ask the Windows API for the value including internal leading
+  if size < 0 then
+  begin
+    with Vcl.Graphics.TBitmap.Create do
+    try
+      Canvas.Font.Name := name;
+      Canvas.Font.Size := size;
+      Canvas.TextExtent('A'); // Without this, the font may not be selected in.
+      GetTextMetrics(Canvas.Handle, tm);
+      Result := (Canvas.Font.Height) * 72 div GetDeviceCaps(Canvas.Handle, LOGPIXELSY);
+    finally
+      Free;
+    end;
+  end
+  else
+    Result := size;
+end;
+
+class function TFontUtils.FontSizeInPoints(f: TFont): Integer;
+begin
+  Result := FontSizeInPoints(f.Name, f.Size);
+end;
+
+end.

--- a/windows/src/global/delphi/general/Keyman.UI.FontUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.UI.FontUtils.pas
@@ -11,6 +11,7 @@ type
   TFontUtils = class
     class function FontSizeInPoints(const name: string; size: Integer): Integer; overload;
     class function FontSizeInPoints(f: TFont): Integer; overload;
+    class function FontSizeInPixels(f: TFont): Integer;
   end;
 
 implementation
@@ -36,6 +37,24 @@ begin
   end
   else
     Result := size;
+end;
+
+class function TFontUtils.FontSizeInPixels(f: TFont): Integer;
+var
+  tm: TTextMetric;
+begin
+  // The TFont.Size value may or may not include internal leading
+  // so we ask the Windows API for the value including internal leading
+  with Vcl.Graphics.TBitmap.Create do
+  try
+    Canvas.Font.Name := f.Name;
+    Canvas.Font.Size := f.Size;
+    Canvas.TextExtent('A'); // Without this, the font may not be selected in.
+    GetTextMetrics(Canvas.Handle, tm);
+    Result := tm.tmHeight;
+  finally
+    Free;
+  end;
 end;
 
 class function TFontUtils.FontSizeInPoints(f: TFont): Integer;


### PR DESCRIPTION
This PR adds support for differing code and char fonts in the Monaco text editor. It also fixes a few minor display issues in the editor (e.g. document scrollbars were wrong).



------

NOTE: Old comments below regarding ACE kept for posterity.

This PR is WIP because of a limitation in ACE -- [turns](https://github.com/ajaxorg/ace/issues?q=is%3Aopen+is%3Aissue+label%3Amonospace) [out](https://github.com/ajaxorg/ace/issues/460) it doesn't support variable width fonts, 
which is a total deal breaker for us with complex script requirements. Most of the code in this PR will still
apply if we replace with another editor, but I will wait on merging until we have come to a conclusion on way forward to
resolve the variable width font issues.

Options for resolution to the problem:

* Finish and apply WIP PR from ACE editor to our fork of ACE (see stalled WIP PRs on the ACE editor: 
https://github.com/ajaxorg/ace/pull/2002 and https://github.com/ajaxorg/ace/pull/1608)

* Swap to another editor -- e.g. Monaco (https://github.com/Microsoft/monaco-editor). I have tested 
Monaco and it will fill requirements for variable width fonts. Notes:

For font support, Monaco setup would need to include:

```
monaco.editor.create(document.getElementById("container"), {
  fontFamily: "Consolas",
  fontSize: "24px",
	//language: "javascript",
  disableMonospaceOptimizations: true
});
```

CSS rules will need reviewing any time Monaco is updated because the class names may change (they 
are dynamically generated), e.g., on the current build, mtk20 is strings and mtk8 is comments (at 
least in JavaScript):

```
.mtk20, .mtk8 {
	font-family: DaunPenh;
    font-size: 24px;
}
```