### PR TITLE
[Developer] Refactor merge keyboard info

### DIFF
--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -80,10 +80,14 @@ To deploy a development build of Keyman and Keyman Developer,
 
 ### Visual Studio 2017 Community Edition setup requirements
 
-In Visual Studio 2017, you need to have the following components installed:
-* Universal Windows Platform development
-    * Desktop development with C++ > Windows 8.1 SDK and UCRT SDK
+In Visual Studio 2017, you need to have the following installed:
+#### Workloads
 * Desktop development with C++
+* Universal Windows Platform development
+
+#### Individual components
+* Windows Universal CRT SDK
+* Windows 8.1 SDK
 
 Configure Visual Studio to use two-space tab stops:
 1. Open the options dialog: Tools > Options.

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -329,7 +329,7 @@ begin
         begin
           for i := 0 to High(Zip.FileNames) do
           begin
-            if IsKEyboardFile(Zip.FileName[i]) then
+            if IsKeyboardFile(Zip.FileName[i]) then
             begin
               SetLength(FPackageKMXFileInfos, Length(FPackageKMXFileInfos)+1);
               SaveMemberToFile(Zip.FileNames[i], FKMXTempFile.Name);

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -38,7 +38,8 @@ uses
   packageinfo,
   TempFileManager,
   kmxfile,
-  kmxfileconsts;
+  kmxfileconsts,
+  UKeymanTargets;
 
 type
   TKeyboardInfoMap = record
@@ -60,8 +61,9 @@ type
     FBaseName, FJsFile, FKmpFile, FJsonFile: string;
     FMergingValidateIds: Boolean;
     FKMPInfFile: TKMPInfFile;
-    FKMXFiles: array of TKeyboardInfoMap;
-    FJSFiles: array of TJSKeyboardInfoMap;
+    FPackageKMXFileInfos: array of TKeyboardInfoMap;
+    FPackageJSFileInfos: array of TKeyboardInfoMap;
+    FJSFileInfo: TJSKeyboardInfoMap;
     FVersion: string;
     FSourcePath: string;
     function Failed(message: string): Boolean;
@@ -84,10 +86,10 @@ type
     procedure AddPlatformSupport;
     procedure CheckOrAddVersion;
     function SaveJsonFile: Boolean;
-    procedure CheckKMXFilenames;
+    procedure CheckPackageKeyboardFilenames;
     procedure AddIsRTL;
     procedure AddSourcePath;
-    function AddJSFile(const Filename: string): Integer;
+    procedure AddJSFile(const Filename: string);
   public
     destructor Destroy; override;
     class function Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean; overload;
@@ -171,7 +173,7 @@ begin
     if not LoadJSFile then
       Exit(Failed('Could not load JS file '+FJsFile));
 
-    CheckKMXFileNames;
+    CheckPackageKeyboardFilenames;
 
     CheckOrAddID;
     AddName;
@@ -229,8 +231,8 @@ end;
 
 function TMergeKeyboardInfo.LoadKMPFile: Boolean;
 var
-  FKMXTempFile, FKMPInfTempFile: TTempFile;
-  i: Integer;
+  FKMXTempFile, FJSTempFile, FKMPInfTempFile: TTempFile;
+  i, j: Integer;
   LocalHeader: TZipHeader;
   Zip: TZipFile;
 
@@ -288,22 +290,39 @@ begin
         end;
       end;
 
-      FKMXTempFile := TTempFileManager.Get('.kmx');
-      try
-        for i := 0 to High(Zip.FileNames) do
-        begin
-          if SameText(ExtractFileExt(Zip.FileNames[i]), '.kmx') then
+
+      for i := 0 to FKMPInfFile.Keyboards.Count - 1 do
+      begin
+        FKMXTempFile := TTempFileManager.Get('.kmx');
+        FJSTempFile := TTempFileManager.Get('.js');
+        try
+          for j := 0 to High(Zip.FileNames) do
           begin
-            SetLength(FKMXFiles, Length(FKMXFiles)+1);
+            // Add the KMX to FPackageKMXFileinfos
+            if SameText(Zip.FileName[j], FKMPInfFile.Keyboards[i].ID + '.kmx') then
+            begin
+              SetLength(FPackageKMXFileInfos, Length(FPackageKMXFileInfos)+1);
+              SaveMemberToFile(Zip.FileNames[j], FKMXTempFile.Name);
+              FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Filename := Zip.FileNames[j];
+              GetKeyboardInfo(FKMXTempFile.Name, False, FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Info, False);
+            end;
 
-            SaveMemberToFile(Zip.FileNames[i], FKMXTempFile.Name);
+            // Add the JS to FPackageJSFileInfos
+            if SameText(Zip.FileNames[j], FKMPInfFile.Keyboards[i].ID + '.js') then
+            begin
+              SetLength(FPackageJSFileInfos, Length(FPackageJSFileInfos)+1);
+              SaveMemberToFile(Zip.FileNames[j], FJSTempFile.Name);
+              FPackageJSFileInfos[High(FPackageJSFileInfos)].Filename := Zip.FileNames[j];
 
-            FKMXFiles[High(FKMXFiles)].Filename := Zip.FileNames[i];
-            GetKeyboardInfo(FKMXTempFile.Name, False, FKMXFiles[High(FKMXFiles)].Info, False);
+              // For now, apply JS keyboard to all web and mobile targets
+              // Not using GetKeyboardInfo because that only handles kmx files
+              FPackageJSFileInfos[High(FPackageJSFileInfos)].Info.Targets := 'web mobile';
+            end;
           end;
+        finally
+          FKMXTempFile.Free;
+          FJSTempFile.Free;
         end;
-      finally
-        FKMXTempFile.Free;
       end;
     finally
       FreeAndNil(Zip);
@@ -321,23 +340,9 @@ begin
   if FJsFile = '' then
     Exit(True);
 
-  FJSFiles[AddJSFile(FJsFile)].Standalone := True;
+  AddJSFile(FJsFile);
+  FJSFileInfo.Standalone := True;
   Result := True;
-end;
-
-function TMergeKeyboardInfo.AddJSFile(const Filename: string): Integer;
-begin
-  with TStringStream.Create('', TEncoding.UTF8) do
-  try
-    LoadFromFile(FJsFile);
-    SetLength(FJSFiles, Length(FJSFiles)+1);
-    Result := High(FJSFiles);
-    FJSFiles[Result].Filename := Filename;
-    FJSFiles[Result].Data := DataString;
-    FJSFiles[Result].Standalone := False;
-  finally
-    Free;
-  end;
 end;
 
 function TMergeKeyboardInfo.SaveJsonFile: Boolean;
@@ -364,6 +369,19 @@ function TMergeKeyboardInfo.Failed(message: string): Boolean;
 begin
   FCallback(0, 0, PAnsiChar(AnsiString(Message)));
   Result := False;
+end;
+
+procedure TMergeKeyboardInfo.AddJSFile(const Filename: string);
+begin
+  with TStringStream.Create('', TEncoding.UTF8) do
+  try
+    LoadFromFile(FJsFile);
+    FJSFileInfo.Filename := Filename;
+    FJSFileInfo.Data := DataString;
+    FJSFileInfo.Standalone := False;
+  finally
+    Free;
+  end;
 end;
 
 //
@@ -397,12 +415,12 @@ begin
 
   if Assigned(FKMPInfFile) then
     FName := FKMPInfFile.Info.Desc[PackageInfo_Name]
-  else if Length(FJSFiles) > 0  then
+  else if (FJSFileInfo.Data <> '')  then
   begin
-    with TRegEx.Match(FJSFiles[0].Data, 'this\.KN="([^"]+)"') do
+    with TRegEx.Match(FJSFileInfo.Data, 'this\.KN="([^"]+)"') do
     begin
       if Success
-        then FName := TGroupHelperRSP19902.Create(Groups[1], FJsFiles[0].Data).FixedValue
+        then FName := TGroupHelperRSP19902.Create(Groups[1], FJSFileInfo.Data).FixedValue
         else Exit;
     end;
   end
@@ -419,9 +437,9 @@ procedure TMergeKeyboardInfo.AddIsRTL;
 begin
   if json.GetValue('isRTL') <> nil then Exit;
 
-  if Length(FJSFiles) > 0 then
+  if (FJSFileInfo.Data <> '') then
   begin
-    with TRegEx.Match(FJsFiles[0].Data, 'this\.KRTL=1') do
+    with TRegEx.Match(FJSFileInfo.Data, 'this\.KRTL=1') do
     begin
       if not Success then Exit;
     end;
@@ -562,8 +580,8 @@ var
 begin
   encodings := [];
   // For each .kmx, get encodings and add to the result
-  for i := 0 to High(FKMXFiles) do
-    encodings := encodings + FKMXFiles[i].Info.Encodings;
+  for i := 0 to High(FPackageKMXFileInfos) do
+    encodings := encodings + FPackageKMXFileInfos[i].Info.Encodings;
 
   if FJsFile <> '' then Include(encodings, keUnicode);
 
@@ -684,10 +702,10 @@ begin
   begin
     FVersion := FKMPInfFile.Info.Desc[PackageInfo_Version];
   end
-  else if Length(FJsFiles) > 0 then
+  else if (FJSFileInfo.Data <> '') then
   begin
-    with TRegEx.Match(FJsFiles[0].Data, 'this\.KBVER=([''"])([^''"]+)(\1)') do
-      if Success then FVersion := TGroupHelperRSP19902.Create(Groups[2], FJsFiles[0].Data).FixedValue;
+    with TRegEx.Match(FJSFileInfo.Data, 'this\.KBVER=([''"])([^''"]+)(\1)') do
+      if Success then FVersion := TGroupHelperRSP19902.Create(Groups[2], FJSFileInfo.Data).FixedValue;
   end;
 
   if FVersion = '' then
@@ -717,17 +735,16 @@ var
 begin
   MinVersion := $0500;
   // For each .kmx, get minimum version and add to the result
-  for i := 0 to High(FKMXFiles) do
-    if FKMXFiles[i].Info.FileVersion > MinVersion then
-      MinVersion := FKMXFiles[i].Info.FileVersion;
+  for i := 0 to High(FPackageKMXFileInfos) do
+    if FPackageKMXFileInfos[i].Info.FileVersion > MinVersion then
+      MinVersion := FPackageKMXFileInfos[i].Info.FileVersion;
 
   FJSMinVersionString := '';
-  for i := Low(FJSFiles) to High(FJSFiles) do
   begin
-    with TRegEx.Match(FJsFiles[i].Data, 'this\.KMINVER=([''"])([^''"]+)(\1)') do
+    with TRegEx.Match(FJSFileInfo.Data, 'this\.KMINVER=([''"])([^''"]+)(\1)') do
       if Success then
       begin
-        s := TGroupHelperRSP19902.Create(Groups[2], FJsFiles[i].Data).FixedValue;
+        s := TGroupHelperRSP19902.Create(Groups[2], FJSFileInfo.Data).FixedValue;
         if (FJSMinVersionString = '') or (CompareVersions(FJSMinVersionString, s) > 0) then
           FJSMinVersionString := s;
       end;
@@ -753,26 +770,159 @@ end;
 //
 procedure TMergeKeyboardInfo.AddPlatformSupport;
 var
-  v: TJSONObject;
-begin
-  if json.GetValue('platformSupport') <> nil then Exit;
+  keyboardFile: TKeyboardInfoMap;
+  target: TKeymanTarget;
+  targets: TKeymanTargets;
+  p, v: TJSONObject;
+  numberKMXFiles, numberJSFiles : Integer;
 
+  procedure AddNewPair(PairName: string; value: string);
+  begin
+    try
+      if (v.GetValue(PairName) = nil) then
+        v.AddPair(PairName, value);
+    finally
+    end;
+  end;
+
+begin
+  try
+    // Validate pre-existing platformSupport
+    p := json.GetValue('platformSupport') as TJSONObject;
+    if p <> nil then
+    begin
+      numberKMXFiles := Length(FPackageKMXFileInfos);
+      if FJsFile <> '' then
+      begin
+        numberJSFiles := 1;
+      end
+      else
+      begin
+        numberJSFiles := Length(FPackageJSFileInfos);
+      end;
+
+      // Validate any target
+      if (p.GetValue('any') <> nil) and ((numberKMXFiles = 0) or (numberJSFiles = 0)) then
+        raise EInvalidKeyboardInfo.Create(
+          '"Any" target should have at least 1 .kmx and 1 .js keyboard file in the package');
+
+      // Validate desktop targets
+      if ((p.GetValue('windows') <> nil) or (p.GetValue('macos') <> nil) or
+          (p.GetValue('linux') <> nil) or (p.GetValue('desktop') <> nil)) and
+          (numberKMXFiles = 0) then
+        raise EInvalidKeyboardInfo.Create(
+          'Desktop targets should have at least 1 .kmx keyboard file in the package');
+
+      // Validate web/mobile targets. No kmx implies web/mobile targets
+      if ((numberKMXFiles = 0) or (p.GetValue('web') <> nil) or
+          (p.GetValue('iphone') <> nil) or (p.GetValue('ipad') <> nil) or
+          (p.GetValue('androidphone') <> nil) or (p.GetValue('androidtablet') <> nil) or
+          (p.GetValue('mobile') <> nil) or (p.GetValue('tablet') <> nil)) and
+          (numberJSFiles = 0) then
+        raise EInvalidKeyboardInfo.Create(
+          'Web/mobile targets should have at least 1 .js keyboard file in the package');
+
+      Exit;
+    end;
+  finally
+  end;
+
+  // Parse targets to populate platformSuppport
   v := TJSONObject.Create;
 
-  if Assigned(FKMPInfFile) then
+  for keyboardFile in FPackageKMXFileInfos do
   begin
-    v.AddPair('windows', 'full');
-    v.AddPair('macos', 'full');
-  end
-  else if Length(FKMXFiles) > 0 then
-    v.AddPair('windows', 'full');
+    targets := StringToKeymanTargets(keyboardFile.Info.Targets);
+    if ktAny in targets then
+    begin
+      AddNewPair('windows', 'full');
+      AddNewPair('macos', 'full');
+      AddNewPair('linux', 'full');
+      AddNewPair('desktopWeb', 'full');
+      AddNewPair('mobileWeb', 'full');
+      AddNewPair('android', 'full');
+      AddNewPair('ios', 'full');
+    end
+    else
+    begin
+      // If targets empty, then include all desktop targets
+      if (targets = []) then
+      begin
+        AddNewPair('windows', 'full');
+        AddNewPair('macos', 'full');
+        AddNewPair('linux', 'full');
+      end;
 
+      for target in targets do
+      begin
+        if target = ktDesktop then
+        begin
+          AddNewPair('windows', 'full');
+          AddNewPair('macos', 'full');
+          AddNewPair('linux', 'full');
+        end;
+        if target = ktWindows then
+          AddNewPair('windows', 'full');
+        if target = ktMacosx then
+          AddNewPair('macos', 'full');
+        if target = ktLinux then
+          AddNewPair('linux', 'full');
+
+        // FPackageKMXFileInfos can contain target information for web/mobile targets.
+        // This is a current limitation of FPackageJSFileInfos if there's no kmx files
+        if target = ktWeb then
+        begin
+          AddNewPair('desktopWeb', 'full');
+          AddNewPair('mobileWeb', 'full');
+        end;
+        if (target = ktMobile) then
+        begin
+          AddNewPair('android', 'full');
+          AddNewPair('ios', 'full');
+        end;
+        if (target = ktIphone) or (target = ktIpad) then
+        begin
+          AddNewPair('ios', 'full');
+        end;
+        if (target = ktAndroidphone) or (target = ktAndroidtablet) then
+        begin
+          AddNewPair('android', 'full');
+        end;
+      end;
+    end;
+  end;
+
+  for keyboardFile in FPackageJSFileInfos do
+  begin
+    targets := StringToKeymanTargets(keyboardFile.Info.Targets);
+    for target in targets do
+    begin
+      if (target = ktWeb) then
+      begin
+        AddNewPair('desktopWeb', 'full');
+        AddNewPair('mobileWeb', 'full');
+      end;
+      if (target = ktMobile) then
+      begin
+        AddNewPair('android', 'full');
+        AddNewPair('ios', 'full');
+      end;
+      if (target = ktIphone) or (target = ktIpad) then
+      begin
+        AddNewPair('ios', 'full');
+      end;
+      if (target = ktAndroidphone) or (target = ktAndroidtablet) then
+      begin
+        AddNewPair('android', 'full');
+      end;
+    end;
+  end;
+
+  // Handle JS file not in kmp
   if FJsFile <> '' then
   begin
-    v.AddPair('desktopWeb', 'full');
-    v.AddPair('mobileWeb', 'full');
-    v.AddPair('android', 'full');
-    v.AddPair('ios', 'full');
+    AddNewPair('desktopWeb', 'full');
+    AddNewPair('mobileWeb', 'full');
   end;
 
   json.AddPair('platformSupport', v);
@@ -792,19 +942,43 @@ begin
   json.AddPair('sourcePath', FSourcePath);
 end;
 
-procedure TMergeKeyboardInfo.CheckKMXFilenames;
+procedure TMergeKeyboardInfo.CheckPackageKeyboardFilenames;
+var
+  numberKMXFiles, numberJSFiles : Integer;
 begin
-  // Check that the id of the kmx files matches the filename; used only for release/ keyboards
-  // in the keyboards repository. This implies there should be only 1 kmx in release/ keyboard
+  if (FJsFile <> '') then
+    Exit;
+
+  numberKMXFiles := Length(FPackageKMXFileInfos);
+  numberJSFiles := Length(FPackageJSFileInfos);
+  if (numberKMXFiles = 0) and (numberJSFiles = 0) then
+    raise EInvalidKeyboardInfo.Create('There should be at least 1 .kmx or .js keyboard file in the package.');
+
+  // Check that the id of the kmx/js files matches the base filename; used only for release/ keyboards
+  // in the keyboards repository. This implies there should be only 1 kmx and/or 1 js in release/ keyboard
   // packages; this check would not be done in the packages folder.
   if FMergingValidateIds and Assigned(FKMPInfFile) then
   begin
-    if Length(FKMXFiles) <> 1 then
-      raise EInvalidKeyboardInfo.Create('There should be exactly 1 .kmx file in the package.');
-
-    if ChangeFileExt(FKMXFiles[0].Filename, '') <> FBaseName then
+    if numberKMXFiles > 1 then
+    begin
+      raise EInvalidKeyboardInfo.Create('There should be at most 1 .kmx keyboard file in the packge.');
+    end
+    else if (numberKMXFiles = 1) and (ChangeFileExt(FPackageKMXFileInfos[0].Filename, '') <> FBaseName) then
+    begin
       raise EInvalidKeyboardInfo.CreateFmt('The file "%s" file in the package has the wrong filename. It should be "%s.kmx"',
-        [FKMXFiles[0].Filename, FBaseName]);
+        [FPackageKMXFileInfos[0].Filename, FBaseName]);
+    end;
+
+    if numberJSFiles > 1 then
+    begin
+      raise EInvalidKeyboardInfo.Create('There should be at most 1 .js keyboard file in the package.');
+    end
+    else if (numberJSFiles = 1) and (ChangeFileExt(FPackageJSFileInfos[0].Filename, '') <> FBaseName) then
+    begin
+      raise EInvalidKeyboardInfo.CreateFmt('The file "%s" file in the package has the wrong filename. It should be "%s.js"',
+        [FPackageJSFileInfos[0].Filename, FBaseName]);
+    end;
+
   end;
 end;
 

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -290,39 +290,58 @@ begin
         end;
       end;
 
+      FKMXTempFile := TTempFileManager.Get('.kmx');
+      FJSTempFile := TTempFileManager.Get('.js');
 
-      for i := 0 to FKMPInfFile.Keyboards.Count - 1 do
-      begin
-        FKMXTempFile := TTempFileManager.Get('.kmx');
-        FJSTempFile := TTempFileManager.Get('.js');
-        try
-          for j := 0 to High(Zip.FileNames) do
+      try
+        if FMergingValidateIds then
+        begin
+          for i := 0 to FKMPInfFile.Keyboards.Count - 1 do
           begin
-            // Add the KMX to FPackageKMXFileinfos
-            if SameText(Zip.FileName[j], FKMPInfFile.Keyboards[i].ID + '.kmx') then
+            for j := 0 to High(Zip.FileNames) do
             begin
-              SetLength(FPackageKMXFileInfos, Length(FPackageKMXFileInfos)+1);
-              SaveMemberToFile(Zip.FileNames[j], FKMXTempFile.Name);
-              FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Filename := Zip.FileNames[j];
-              GetKeyboardInfo(FKMXTempFile.Name, False, FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Info, False);
-            end;
+              // Add the KMX to FPackageKMXFileinfos
+              if SameText(Zip.FileName[j], FKMPInfFile.Keyboards[i].ID + '.kmx') then
+              begin
+                SetLength(FPackageKMXFileInfos, Length(FPackageKMXFileInfos)+1);
+                SaveMemberToFile(Zip.FileNames[j], FKMXTempFile.Name);
+                FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Filename := Zip.FileNames[j];
+                GetKeyboardInfo(FKMXTempFile.Name, False, FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Info, False);
+              end;
 
-            // Add the JS to FPackageJSFileInfos
-            if SameText(Zip.FileNames[j], FKMPInfFile.Keyboards[i].ID + '.js') then
-            begin
-              SetLength(FPackageJSFileInfos, Length(FPackageJSFileInfos)+1);
-              SaveMemberToFile(Zip.FileNames[j], FJSTempFile.Name);
-              FPackageJSFileInfos[High(FPackageJSFileInfos)].Filename := Zip.FileNames[j];
+              // Add the JS to FPackageJSFileInfos
+              if SameText(Zip.FileNames[j], FKMPInfFile.Keyboards[i].ID + '.js') then
+              begin
+                SetLength(FPackageJSFileInfos, Length(FPackageJSFileInfos)+1);
+                SaveMemberToFile(Zip.FileNames[j], FJSTempFile.Name);
+                FPackageJSFileInfos[High(FPackageJSFileInfos)].Filename := Zip.FileNames[j];
 
-              // For now, apply JS keyboard to all web and mobile targets
-              // Not using GetKeyboardInfo because that only handles kmx files
-              FPackageJSFileInfos[High(FPackageJSFileInfos)].Info.Targets := 'web mobile';
+                // For now, apply JS keyboard to all web and mobile targets
+                // Not using GetKeyboardInfo because that only handles kmx files
+                FPackageJSFileInfos[High(FPackageJSFileInfos)].Info.Targets := 'web mobile';
+              end;
             end;
           end;
-        finally
+        end
+
+        // Handle legacy keyboards which may not have keyboards defined in kmp.inf
+        else
+        begin
+          for i := 0 to High(Zip.FileNames) do
+          begin
+            if IsKEyboardFile(Zip.FileName[i]) then
+            begin
+              SetLength(FPackageKMXFileInfos, Length(FPackageKMXFileInfos)+1);
+              SaveMemberToFile(Zip.FileNames[i], FKMXTempFile.Name);
+              FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Filename := Zip.FileNames[i];
+              GetKeyboardInfo(FKMXTempFile.Name, False, FPackageKMXFileInfos[High(FPackageKMXFileInfos)].Info, False);
+            end;
+          end;
+        end;
+
+      finally
           FKMXTempFile.Free;
           FJSTempFile.Free;
-        end;
       end;
     finally
       FreeAndNil(Zip);

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -946,19 +946,16 @@ procedure TMergeKeyboardInfo.CheckPackageKeyboardFilenames;
 var
   numberKMXFiles, numberJSFiles : Integer;
 begin
-  if (FJsFile <> '') then
-    Exit;
-
-  numberKMXFiles := Length(FPackageKMXFileInfos);
-  numberJSFiles := Length(FPackageJSFileInfos);
-  if (numberKMXFiles = 0) and (numberJSFiles = 0) then
-    raise EInvalidKeyboardInfo.Create('There should be at least 1 .kmx or .js keyboard file in the package.');
-
   // Check that the id of the kmx/js files matches the base filename; used only for release/ keyboards
   // in the keyboards repository. This implies there should be only 1 kmx and/or 1 js in release/ keyboard
   // packages; this check would not be done in the packages folder.
   if FMergingValidateIds and Assigned(FKMPInfFile) then
   begin
+    numberKMXFiles := Length(FPackageKMXFileInfos);
+    numberJSFiles := Length(FPackageJSFileInfos);
+    if (numberKMXFiles = 0) and (numberJSFiles = 0) then
+      raise EInvalidKeyboardInfo.Create('There should be at least 1 .kmx or .js keyboard file in the package.');
+
     if numberKMXFiles > 1 then
     begin
       raise EInvalidKeyboardInfo.Create('There should be at most 1 .kmx keyboard file in the packge.');

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -360,7 +360,6 @@ begin
     LoadFromFile(FJsFile);
     FJSFileInfo.Filename := FJsFile;
     FJSFileInfo.Data := DataString;
-    FJSFileInfo.Standalone := False;
   finally
     Free;
   end;

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 11.0 alpha
+* Refactor how keyboard_info metdata is generated (#1158)
+
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 

--- a/windows/src/global/delphi/general/kmxfile.pas
+++ b/windows/src/global/delphi/general/kmxfile.pas
@@ -80,6 +80,7 @@ type
     WindowsLanguages: WideString;
     ISO6393Languages: WideString;
     KeyboardVersion: WideString;   // I4136
+    Targets: WideString;
   end;
 
   PKeyboardInfo = ^TKeyboardInfo;
@@ -242,6 +243,7 @@ begin
 
       GetSystemStore(Memory, TSS_WINDOWSLANGUAGES, ki.WindowsLanguages);
       GetSystemStore(Memory, TSS_ETHNOLOGUECODE, ki.ISO6393Languages);
+      GetSystemStore(Memory, TSS_TARGETS, ki.Targets);
 
       if not GetSystemStore(Memory, TSS_KEYBOARDVERSION, ki.KeyboardVersion) then   // I4136
         ki.KeyboardVersion := '1.0';

--- a/windows/src/global/delphi/general/utilfiletypes.pas
+++ b/windows/src/global/delphi/general/utilfiletypes.pas
@@ -26,13 +26,13 @@ type
     ftFont, ftReadme, ftTextFile,
     ftKeymanWizard, ftOther, ftBitmap,
     ftVisualKeyboard, ftXMLFile, ftHTMLFile, ftJavascript,
-    ftTouchLayout, ftVisualKeyboardSource, ftKeymanEncryptedFile);
+    ftTouchLayout, ftVisualKeyboardSource);
 const
   FileTypeNames: array[TKMFileType] of string = ('Keyman Source File', 'Package Source File',
     'Keyman Keyboard File', 'Keyman Package File', 'Font', 'Readme File', 'Text File',
     'Keyman Wizard File', 'Other File', 'Bitmap File',
     'Keyman Visual Keyboard File', 'XML File', 'HTML File', 'Javascript File',
-    'Keyman Touch Layout Source File', 'Keyman Visual Keyboard Source File', 'Keyman Encrpyted File');
+    'Keyman Touch Layout Source File', 'Keyman Visual Keyboard Source File');
 
 
 type
@@ -43,14 +43,13 @@ type
 
 const
   Ext_KeymanFile = '.kmx';
-  Ext_KeymanEncryptedFile = '.kxx';
   Ext_PackageFile = '.kmp';
   Ext_KeymanTouchLayout = '.keyman-touch-layout';
   Ext_VisualKeyboard = '.kvk';
   Ext_VisualKeyboardSource = '.kvks';
 
 
-const ExtFileTypes: array[0..13] of TKMFileTypeInfo = (
+const ExtFileTypes: array[0..12] of TKMFileTypeInfo = (
   (Ext: '.kmn'; FileType: ftKeymanSource),
   (Ext: '.kps'; FileType: ftPackageSource),
   (Ext: Ext_KeymanFile; FileType: ftKeymanFile),
@@ -63,7 +62,6 @@ const ExtFileTypes: array[0..13] of TKMFileTypeInfo = (
   (Ext: Ext_VisualKeyboardSource; FileType: ftVisualKeyboardSource),
   (Ext: '.js'; FileType: ftJavascript),
   (Ext: Ext_KeymanTouchLayout; FileType: ftTouchLayout),
-  (Ext: Ext_KeymanEncryptedFile; FileType: ftKeymanEncryptedFile),
   (Ext: ''; FileType: ftOther));
 
 function GetFileTypeFromFileName(const FileName: string): TKMFileType;
@@ -140,7 +138,7 @@ var
   t : TKMFileType;
 begin
   t := GetFileTypeFromFileName(FileName);
-  Result := (t = ftKeymanFile) or (t = ftKeymanEncryptedFile);
+  Result := t = ftKeymanFile;
 end;
 
 function RemoveFileExtension(Filename, Extension: string): string;

--- a/windows/src/global/delphi/general/utilfiletypes.pas
+++ b/windows/src/global/delphi/general/utilfiletypes.pas
@@ -26,13 +26,13 @@ type
     ftFont, ftReadme, ftTextFile,
     ftKeymanWizard, ftOther, ftBitmap,
     ftVisualKeyboard, ftXMLFile, ftHTMLFile, ftJavascript,
-    ftTouchLayout, ftVisualKeyboardSource);
+    ftTouchLayout, ftVisualKeyboardSource, ftKeymanEncryptedFile);
 const
   FileTypeNames: array[TKMFileType] of string = ('Keyman Source File', 'Package Source File',
     'Keyman Keyboard File', 'Keyman Package File', 'Font', 'Readme File', 'Text File',
     'Keyman Wizard File', 'Other File', 'Bitmap File',
     'Keyman Visual Keyboard File', 'XML File', 'HTML File', 'Javascript File',
-    'Keyman Touch Layout Source File', 'Keyman Visual Keyboard Source File');
+    'Keyman Touch Layout Source File', 'Keyman Visual Keyboard Source File', 'Keyman Encrpyted File');
 
 
 type
@@ -43,13 +43,14 @@ type
 
 const
   Ext_KeymanFile = '.kmx';
+  Ext_KeymanEncryptedFile = '.kxx';
   Ext_PackageFile = '.kmp';
   Ext_KeymanTouchLayout = '.keyman-touch-layout';
   Ext_VisualKeyboard = '.kvk';
   Ext_VisualKeyboardSource = '.kvks';
 
 
-const ExtFileTypes: array[0..12] of TKMFileTypeInfo = (
+const ExtFileTypes: array[0..13] of TKMFileTypeInfo = (
   (Ext: '.kmn'; FileType: ftKeymanSource),
   (Ext: '.kps'; FileType: ftPackageSource),
   (Ext: Ext_KeymanFile; FileType: ftKeymanFile),
@@ -62,6 +63,7 @@ const ExtFileTypes: array[0..12] of TKMFileTypeInfo = (
   (Ext: Ext_VisualKeyboardSource; FileType: ftVisualKeyboardSource),
   (Ext: '.js'; FileType: ftJavascript),
   (Ext: Ext_KeymanTouchLayout; FileType: ftTouchLayout),
+  (Ext: Ext_KeymanEncryptedFile; FileType: ftKeymanEncryptedFile),
   (Ext: ''; FileType: ftOther));
 
 function GetFileTypeFromFileName(const FileName: string): TKMFileType;
@@ -134,10 +136,11 @@ begin
 end;
 
 function IsKeyboardFile(const FileName: string): Boolean;
+var
+  t : TKMFileType;
 begin
-    if Length(FileName) < 5 then Result := False
-    else Result := (LowerCase(Copy(FileName, Length(FileName)-3, 4)) = '.kmx') or
-        (LowerCase(Copy(FileName, Length(FileName)-3, 4)) = '.kxx');
+  t := GetFileTypeFromFileName(FileName);
+  Result := (t = ftKeymanFile) or (t = ftKeymanEncryptedFile);
 end;
 
 function RemoveFileExtension(Filename, Extension: string): string;


### PR DESCRIPTION
This is an initial cut at refactoring MergeKeyboardInfo to address issue #1110 
Eventually, it will need to be cherry-picked to 10.0

Refactor MergeKeyboardInfo to handle these keyboard scenarios:
1. JS file not in package (web only)
2. KMP package with kmx files (desktop only)
3. KMP package with JS files (mobile only)
4. KMP package with kmx and JS files (desktop, android, ios)

TODO
1. Rename `FKMXFiles` to `FPackageKMXFileInfos`
2. Create private var `FPackageJSFileInfos`
3. Update `TMergeKeyboardInfo.LoadKMPFile` to populate `FPackageJSFileInfos`
4. Rename `FJSFiles` to `FJSFileInfo`, change it from array to scalar, and apply only to js files outside package
5. Update `LoadKMPFile` to use the Keyboards structure in `FKMPInfFile` to determine which files inside the package are keyboards (`FKMPInfFile.Keyboards`)
6. Rename `CheckKMXFilenames` to `CheckPackageKetyboardFilenames` and update to report on .js and .kmx file inside the .kmp
7. Update `kmxfile.GetKeyboardInfo` to read targets store and persist in KeyboardInfo
8. Update `AddPlatformSupport` to account for targets