### PR TITLE
[iOS] #1045 - cherry-pick: Quick (temp?) fix for OSK layout: disable animation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -983,7 +983,11 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   }
 
   public func dismissKeyboardPicker(_ viewController: UIViewController) {
-    viewController.dismiss(animated: true)
+    // #1045 - Setting animated to false "fixes" the display problems and prevents the crash (on iPad 10.5"
+    // and 12.9"), but it makes the transition less smooth (obviously) and probably isn't the "right"
+    // way to fix the problem. Presumably there is some kind of underlying plumbing issue that is the
+    // true source of the problems.
+    viewController.dismiss(animated: false)
     if shouldReloadKeyboard {
       reloadKeyboard(in: keymanWeb)
     }

--- a/ios/history.md
+++ b/ios/history.md
@@ -4,8 +4,11 @@
 * Replaced deprecated calls to UIAlertView and cleaned up extraneous blank buttons (#1002)
 * Bookmark add button is enabled only when title/url fields have text (#1073)
 
+## 2018-08-02 10.0.208 stable 
+* Fixed OSK layout problems (and possible crash) on iOS 11 on certain hardware (#1089, #1159) 
+
 ## 2018-07-06 10.0.203 stable
-* Fixes an issue where a keyboard with varying row counts in different layers could crash (#1055)
+* Fixes an issue where a keyboard with varying row counts in different layers could crash (#1056, #1057)
 
 ## 2018-06-28 10.0.200 stable
 * 10.0 stable release


### PR DESCRIPTION
This fix was made on stable 10 branch. Unless/until we come up with something better, I think we need to go ahead and put it into master also.