### PR TITLE
[iOS] #1166-Use try-catch block to trap and ignore reachability error

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/lib/Reachability/Reachability.m
+++ b/ios/engine/KMEI/KeymanEngine/lib/Reachability/Reachability.m
@@ -134,10 +134,15 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 
 	if (SCNetworkReachabilitySetCallback(_reachabilityRef, ReachabilityCallback, &context))
 	{
-		if (SCNetworkReachabilityScheduleWithRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode))
-		{
-			returnValue = YES;
-		}
+        @try
+        {
+            returnValue = SCNetworkReachabilityScheduleWithRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        }
+        @catch (NSException *exception)
+        {
+            NSLog(@"%@ ",exception.name);
+            NSLog(@"Reason: %@ ",exception.reason);
+        }
 	}
     
 	return returnValue;


### PR DESCRIPTION
Since I can't reproduce the crash, I can't see whether this fixes it (or causes other problems). Not sure if we want to try to put this into master (alpha) first or apply it directly to stable.