### PR TITLE
[iOS] Added entries to plist to say that Keyman is not document-based

### DIFF
--- a/ios/keyman/Keyman/Keyman-Info.plist
+++ b/ios/keyman/Keyman/Keyman-Info.plist
@@ -47,6 +47,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -75,6 +77,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportsDocumentBrowser</key>
+	<false/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This should prevent warning from AppStore. We probably don't need to cherry-pick this into stable unless we make some other change there that triggers the warning.