### PR TITLE
[Windows] Fixup installer .wxs sources for use with WiX 3.11 (RegistryKey/@Action)

### DIFF
--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -192,7 +192,7 @@ TDS2DBG=$(ROOT)\bin\buildtools\tds2dbg
 
 MAKEJCLDBG=$(ROOT)\bin\buildtools\makejcldbg.exe -E
 
-WIXPATH="c:\program files (x86)\windows installer xml v3.5\bin"
+WIXPATH="c:\program files (x86)\wix toolset v3.11\bin"
 WIXCANDLE=$(WIXPATH)\candle.exe -wx
 
 !IFDEF LINT

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -105,12 +105,12 @@
               <Component Id="Reg_RootPath" Guid="*" Location="either">
                 <RegistryValue KeyPath="yes" Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop\10.0" Name="root path" Type="string" Value="[INSTALLDIR]" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop\10.0" Name="charmap source data" Type="string" Value="[INSTALLDIR]" />
-                <RegistryKey Action="createAndRemoveOnUninstall" Root="HKLM" Key="Software\Keyman\Keyman Desktop\10.0" />
+                <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKLM" Key="Software\Keyman\Keyman Desktop\10.0" />
               </Component>
               
               <Component Id="removeCU" Guid="*">
                 <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\Keyman\Keyman Desktop\10.0" Name="Install" Type="string" Value="1" />
-                <RegistryKey Action="createAndRemoveOnUninstall" Root="HKCU" Key="Software\Keyman\Keyman Desktop\10.0" />
+                <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\Keyman\Keyman Desktop\10.0" />
                 <RemoveFolder Id="ProgramMenuDir" Directory="ProgramMenuDir" On="uninstall" />
       
                 <RemoveFile Id="Version70ShortcutKeyman"   Name="Keyman Desktop Light 7.0.lnk"  Directory="ProgramMenuDirLight70" On="both" />

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -61,7 +61,7 @@
                 <File Id="kmcmpdll.dll" Name="kmcmpdll.dll" />
                 <File Id="debughost.kmx" Name="debughost.kmx" Source="..\..\developer\tike\redist\debughost.kmx" />
                 <RemoveFile Id="excmagic.log" On="uninstall" Name="excmagic.log" />
-                <RegistryKey Action="createAndRemoveOnUninstall" Root="HKLM" Key="Software\Keyman\Keyman Developer\10.0" />
+                <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKLM" Key="Software\Keyman\Keyman Developer\10.0" />
                 <Environment Id="environmentKeymanDeveloperPath" Action="set" Name="KeymanDeveloperPath" System="yes" Value="[INSTALLDIR]" />
 
                 <RemoveFile Id="CachedInstallDirFiles" Property="CachedInstallDir" On="uninstall" Name="*" />
@@ -267,7 +267,7 @@
           </Directory>
           <Component Id="AppDataRemovals" Guid="{780C99E9-E97E-4EB0-BBF5-D4591EEABA7C}">
             <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer\10.0" Name="root path" Type="string" Value="[INSTALLDIR]" />
-            <RegistryKey Action="createAndRemoveOnUninstall" Root="HKCU" Key="Software\Keyman\Keyman Developer\10.0" />
+            <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer\10.0" />
             <RemoveFolder Id="AD_ts_Uninstall" On="uninstall" />
             <RemoveFolder Id="AD_ts_KeymanDev_Uninstall" On="uninstall" Directory="App_TS_KeymanDev" />
             <RemoveFolder Id="AD_ts_KeymanDev_Databases_Uninstall" On="uninstall" Directory="App_TS_KeymanDev_Databases" />

--- a/windows/src/engine/inst/components.wxi
+++ b/windows/src/engine/inst/components.wxi
@@ -156,14 +156,14 @@
       <RegistryValue Name="Enable" Type="string" Value="1" />
       <RegistryKey Key="Category">
         <RegistryKey Key="Category">
-          <RegistryKey Action="create" Key="{34745C63-B2F0-4784-8B67-5E12C8701A31}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIP_KEYBOARD -->
-          <RegistryKey Action="create" Key="{364215D9-75BC-11D7-A6EF-00065B84435C}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_COMLESS -->
-          <RegistryKey Action="create" Key="{49D2F9CE-1F5E-11D7-A6D3-00065B84435C}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_SECUREMODE -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{34745C63-B2F0-4784-8B67-5E12C8701A31}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIP_KEYBOARD -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{364215D9-75BC-11D7-A6EF-00065B84435C}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_COMLESS -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{49D2F9CE-1F5E-11D7-A6D3-00065B84435C}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_SECUREMODE -->
         </RegistryKey>
         <RegistryKey Key="Item">
-          <RegistryKey Action="create" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{34745C63-B2F0-4784-8B67-5E12C8701A31}" /><!-- TFCAT_KEYBOARD -->
-          <RegistryKey Action="create" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{364215D9-75BC-11D7-A6EF-00065B84435C}" /><!-- TFCAT_TIPCAP_COMLESS -->
-          <RegistryKey Action="create" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{49D2F9CE-1F5E-11D7-A6D3-00065B84435C}" /><!-- TFCAT_TIPCAP_SECUREMODE -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{34745C63-B2F0-4784-8B67-5E12C8701A31}" /><!-- TFCAT_KEYBOARD -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{364215D9-75BC-11D7-A6EF-00065B84435C}" /><!-- TFCAT_TIPCAP_COMLESS -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{49D2F9CE-1F5E-11D7-A6D3-00065B84435C}" /><!-- TFCAT_TIPCAP_SECUREMODE -->
         </RegistryKey>
       </RegistryKey>
     </RegistryKey>
@@ -177,12 +177,12 @@
     <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\CTF\TIP\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}">
       <RegistryKey Key="Category">
         <RegistryKey Key="Category">
-          <RegistryKey Action="create" Key="{13A016DF-560B-46CD-947A-4C3AF1E0E35D}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_IMMERSIVESUPPORT -->
-          <RegistryKey Action="create" Key="{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_SYSTRAYSUPPORT -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{13A016DF-560B-46CD-947A-4C3AF1E0E35D}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_IMMERSIVESUPPORT -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_SYSTRAYSUPPORT -->
         </RegistryKey>
         <RegistryKey Key="Item">
-          <RegistryKey Action="create" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{13A016DF-560B-46CD-947A-4C3AF1E0E35D}" /><!-- TFCAT_TIPCAP_IMMERSIVESUPPORT -->
-          <RegistryKey Action="create" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}" /><!-- TFCAT_TIPCAP_SYSTRAYSUPPORT -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{13A016DF-560B-46CD-947A-4C3AF1E0E35D}" /><!-- TFCAT_TIPCAP_IMMERSIVESUPPORT -->
+          <RegistryKey ForceCreateOnInstall="yes" Key="{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}\{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}" /><!-- TFCAT_TIPCAP_SYSTRAYSUPPORT -->
         </RegistryKey>
       </RegistryKey>
     </RegistryKey>

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -46,7 +46,7 @@
           </Directory>
           <Component Id="CommonAppDataRemovals" Guid="{B8AA53CB-E32E-47E6-88E6-C704B89A7108}">
             <RegistryValue KeyPath="yes" Root="HKLM" Key="Software\Keyman\Keyman Engine\10.0" Name="root path" Type="string" Value="[INSTALLDIR]" />
-            <RegistryKey Action="createAndRemoveOnUninstall" Root="HKLM" Key="Software\Keyman\Keyman Engine\10.0" />
+            <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKLM" Key="Software\Keyman\Keyman Engine\10.0" />
             <RemoveFolder Id="CAD_ts_Uninstall" On="uninstall" />
             <RemoveFolder Id="CAD_ts_Keyman_Uninstall" On="uninstall" Directory="CommonApp_TS_Keyman" />
             <RemoveFolder Id="CAD_ts_Keyman_Kbd_Uninstall" On="uninstall" Directory="CommonApp_TS_Keyman_Kbd" />
@@ -65,7 +65,7 @@
           </Directory>
           <Component Id="AppDataRemovals" Guid="{95D0FCEE-F1B7-45B1-B263-B80A96D0AA92}">
             <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\Keyman\Keyman Engine\10.0" Name="root path" Type="string" Value="[INSTALLDIR]" />
-            <RegistryKey Action="createAndRemoveOnUninstall" Root="HKCU" Key="Software\Keyman\Keyman Engine\10.0" />
+            <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\Keyman\Keyman Engine\10.0" />
             <RemoveFolder Id="AD_ts_Uninstall" On="uninstall" />
             <RemoveFolder Id="AD_ts_Keyman_Uninstall" On="uninstall" Directory="App_TS_Keyman" />
             <RemoveFolder Id="AD_ts_Keyman_Keyboard_Uninstall" On="uninstall" Directory="App_TS_Keyman_Keyboard" />


### PR DESCRIPTION
We moved to WiX 3.11 for Keyman 11 as 3.5 is no longer available for download.

As we cannot have two versions of WiX installed on the build agents, it's easier to update the 
.wxs source files to meet the requirements of WiX 3.11 than it is to maintain a separate 
build agent infrastructure. This is not necessarily always the case -- we may in the future
find a situation where we want separate stable and alpha build agents, but not in this case.