### PR TITLE
[Linux] determine-filetype enum and website metadata

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -15,7 +15,7 @@ from ast import literal_eval
 import requests
 
 from keyman_config.get_kmp import get_keyboard_data, get_kmp
-from keyman_config.kmpmetadata import determine_filetype, parseinfdata, parsemetadata
+from keyman_config.kmpmetadata import parseinfdata, parsemetadata, KMFileTypes
 from keyman_config.uninstall_kmp import uninstall_kmp
 from keyman_config.convertico import checkandsaveico
 from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
@@ -64,7 +64,7 @@ def get_infdata(tmpdirname):
 		if files and not keyboards:
 			id = "unknown"
 			for kbfile in files:
-				if determine_filetype(kbfile['name']) == "Compiled keyboard":
+				if kbfile['type'] == KMFileTypes.KM_KVK:
 					id = os.path.basename(os.path.splitext(kbfile['name'])[0])
 			#inf file may not have keyboards so generate it if needed
 			keyboards = [ { 'name' : info['name']['description'],
@@ -157,23 +157,23 @@ def install_kmp(inputfile, online=False):
 
 			for f in files:
 				fpath = os.path.join(tmpdirname, f['name'])
-				ftype = determine_filetype(f['name'])
-				if ftype == "Documentation" or ftype == "Image":
+				ftype = f['type']
+				if ftype == KMFileTypes.KM_DOC or ftype == KMFileTypes.KM_IMAGE:
 					logging.info("Installing %s as documentation", f['name'])
 					if not os.path.isdir(kbdocdir):
 						os.makedirs(kbdocdir)
 					copy2(fpath, kbdocdir)
-				elif ftype == "Font":
+				elif ftype == KMFileTypes.KM_FONT:
 					logging.info("Installing %s as font", f['name'])
 					if not os.path.isdir(kbfontdir):
 						os.makedirs(kbfontdir)
 					copy2(fpath, kbfontdir)
-				elif ftype == "Metadata" or ftype == "Keyboard source" or ftype == "Compiled keyboard":
+				elif ftype == KMFileTypes.KM_META or ftype == KMFileTypes.KM_SOURCE or ftype == KMFileTypes.KM_KMX:
 					logging.info("Installing %s as keyman file", f['name'])
 					if not os.path.isdir(kbdir):
 						os.makedirs(kbdir)
 					copy2(fpath, kbdir)
-				elif ftype == "Compiled on screen keyboard":
+				elif ftype == KMFileTypes.KM_KVK:
 					logging.info("Converting %s to LDML and installing both as as keyman file", f['name'])
 					if not os.path.isdir(kbdir):
 						os.makedirs(kbdir)
@@ -182,7 +182,7 @@ def install_kmp(inputfile, online=False):
 					name, ext = os.path.splitext(f['name'])
 					ldmlfile = os.path.join(kbdir, name+".ldml")
 					output_ldml(ldmlfile, ldml)
-				elif ftype == "Keyboard icon":
+				elif ftype == KMFileTypes.KM_ICON:
 					logging.info("Converting %s to PNG and installing both as keyman files", f['name'])
 					if not os.path.isdir(kbdir):
 						os.makedirs(kbdir)

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -151,7 +151,6 @@ def print_files(files, extracted_dir):
 def get_fonts(files):
 	fonts = []
 	for kbfile in files:
-		#if determine_filetype(kbfile['name']) == KMFileTypes.KM_FONT:
 		if kbfile['type'] == KMFileTypes.KM_FONT:
 			fonts.append(kbfile)
 	return fonts

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -29,7 +29,10 @@ def print_info(info):
 		print("Author: ", info['author']['description'])
 		print("Author URL: ", info['author']['url'])
 		print("Website: ", info['website']['description'])
-	except Exception:
+	except Exception as e:
+		print(type(e))    # the exception instance
+		print(e.args)     # arguments stored in .args
+		print(e)          # __str__ allows args to be printed directly,		pass
 		pass
 
 def print_system(system):
@@ -37,7 +40,10 @@ def print_system(system):
 		print("---- System ----")
 		print("File Version: ", system['fileVersion'])
 		print("Keyman Developer Version: ", system['keymanDeveloperVersion'])
-	except Exception:
+	except Exception as e:
+		print(type(e))    # the exception instance
+		print(e.args)     # arguments stored in .args
+		print(e)          # __str__ allows args to be printed directly,		pass
 		pass
 
 def print_options(options):
@@ -45,7 +51,10 @@ def print_options(options):
 		print("---- Options ----")
 		print("Readme File: ", options['readmeFile'])
 		print("Graphic File: ", options['graphicFile'])
-	except Exception:
+	except Exception as e:
+		print(type(e))    # the exception instance
+		print(e.args)     # arguments stored in .args
+		print(e)          # __str__ allows args to be printed directly,		pass
 		pass
 
 def print_keyboards(keyboards):
@@ -62,7 +71,10 @@ def print_keyboards(keyboards):
 			print("Languages")
 			for lang in kb['languages']:
 				print("  Name: ", lang['name'], "Id: ", lang['id'])
-	except Exception:
+	except Exception as e:
+		print(type(e))    # the exception instance
+		print(e.args)     # arguments stored in .args
+		print(e)          # __str__ allows args to be printed directly,		pass
 		pass
 
 def determine_filetype(filename):
@@ -105,21 +117,27 @@ def determine_filetype(filename):
 		return KMFileTypes.KM_UNKNOWN
 
 def print_files(files, extracted_dir):
-	print("---- Files ----")
-	for kbfile in files:
-		print("* File name: ", kbfile['name'])
-		print("    Description: ", kbfile['description'])
-		print("    Type: ", kbfile['type'])
-		file = os.path.join(extracted_dir, kbfile['name'])
-		if os.path.isfile(file):
-			print("    File", file, "exists")
-			ms = magic.open(magic.MAGIC_NONE)
-			ms.load()
-			ftype =  ms.file(file)
-			print ("        Type: ", ftype)
-			ms.close()
-		else:
-			print("    File", file, "does not exist")
+	try:
+		print("---- Files ----")
+		for kbfile in files:
+			print("* File name: ", kbfile['name'])
+			print("    Description: ", kbfile['description'])
+			print("    Type: ", kbfile['type'])
+			file = os.path.join(extracted_dir, kbfile['name'])
+			if os.path.isfile(file):
+				print("    File", file, "exists")
+				ms = magic.open(magic.MAGIC_NONE)
+				ms.load()
+				ftype =  ms.file(file)
+				print ("        Type: ", ftype)
+				ms.close()
+			else:
+				print("    File", file, "does not exist")
+	except Exception as e:
+		print(type(e))    # the exception instance
+		print(e.args)     # arguments stored in .args
+		print(e)          # __str__ allows args to be printed directly,		pass
+		pass
 
 def get_fonts(files):
 	fonts = []

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -26,9 +26,14 @@ def print_info(info):
 		print("Name: ", info['name']['description'])
 		print("Copyright: ", info['copyright']['description'])
 		print("Version: ", info['version']['description'])
-		print("Author: ", info['author']['description'])
-		print("Author URL: ", info['author']['url'])
-		print("Website: ", info['website']['description'])
+		if 'author' in info:
+			print("Author: ", info['author']['description'])
+			if 'url' in info['author']:
+				print("Author URL: ", info['author']['url'])
+		if 'website' in info:
+			print("Website description: ", info['website']['description'])
+			if 'url' in info['website']:
+				print("Website URL: ", info['website']['url'])
 	except Exception as e:
 		print(type(e))    # the exception instance
 		print(e.args)     # arguments stored in .args
@@ -38,8 +43,10 @@ def print_info(info):
 def print_system(system):
 	try:
 		print("---- System ----")
-		print("File Version: ", system['fileVersion'])
-		print("Keyman Developer Version: ", system['keymanDeveloperVersion'])
+		if 'fileVersion' in system:
+			print("File Version: ", system['fileVersion'])
+		if 'keymanDeveloperVersion' in system:
+			print("Keyman Developer Version: ", system['keymanDeveloperVersion'])
 	except Exception as e:
 		print(type(e))    # the exception instance
 		print(e.args)     # arguments stored in .args
@@ -49,8 +56,10 @@ def print_system(system):
 def print_options(options):
 	try:
 		print("---- Options ----")
-		print("Readme File: ", options['readmeFile'])
-		print("Graphic File: ", options['graphicFile'])
+		if 'readmeFile' in options:
+			print("Readme File: ", options['readmeFile'])
+		if 'graphicFile' in options:
+			print("Graphic File: ", options['graphicFile'])
 	except Exception as e:
 		print(type(e))    # the exception instance
 		print(e.args)     # arguments stored in .args
@@ -212,7 +221,7 @@ def parseinfdata(inffile, verbose=False):
 					elif item[0] == 'Author':
 						info['author'] = { 'description' : item[1].split("\"")[1], 'url' : item[1].split("\"")[3] }
 					elif item[0] == "WebSite":
-						info['website'] = { 'description' : item[1].split("\"")[1] }
+						info['website'] = { 'description' : item[1].split("\"")[1], 'url' : item[1].split("\"")[3] }
 					else:
 						logging.warning("Unknown item in Info: %s", item[0])
 			if section == 'PackageInfo':
@@ -272,8 +281,11 @@ def parseinfdata(inffile, verbose=False):
 						keyboard['oskFont'] = item[1]
 					elif item[0] == 'DisplayFont':
 						keyboard['displayFont'] = item[1]
+					elif item[0] == 'RTL':
+						keyboard['RTL'] = item[1]
 					elif "Language" in item[0]:
-						langname, langid = item[1].split(",")
+						# only split on first ','
+						langid, langname = item[1].split(",", 1)
 						languages.append({ 'name' : langname, 'id' : langid })
 					else:
 						logging.warning("Unknown item in keyboard: %s", item[0])


### PR DESCRIPTION
Fixes #1188 and Fixes #1190 

uses an enum `KMFileType` for keyman file type and only calls determine-filetype in parsing metadata
adds website url to parsed and printed metadata
conditionally print optional metadata if it exists
show exceptions in printing
in parsing kmp.inf split language entry only on first ','

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1202)
<!-- Reviewable:end -->
