### PR TITLE
[linux] 1189 other files and 1187 multiple keyboards

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -61,15 +61,6 @@ def get_infdata(tmpdirname):
 	kmpinf = os.path.join(tmpdirname, "kmp.inf")
 	if os.path.isfile(kmpinf):
 		info, system, options, keyboards, files =  parseinfdata(kmpinf, False)
-		if files and not keyboards:
-			id = "unknown"
-			for kbfile in files:
-				if kbfile['type'] == KMFileTypes.KM_KMX:
-					id = os.path.basename(os.path.splitext(kbfile['name'])[0])
-			#inf file may not have keyboards so generate it if needed
-			keyboards = [ { 'name' : info['name']['description'],
-				'id' : id,
-				'version' : info['version']['description'] } ]
 		return info, system, options, keyboards, files
 	else:
 		return None, None, None, None, None

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -108,7 +108,7 @@ def determine_filetype(filename):
 	name, ext = os.path.splitext(filename)
 	if ext.lower() == ".ico":
 		return KMFileTypes.KM_ICON
-	elif ext.lower() == ".kmn":
+	elif ext.lower() == ".kmn" or ext.lower() == ".kvks":
 		return KMFileTypes.KM_SOURCE
 	elif ext.lower() == ".kmx":
 		return KMFileTypes.KM_KMX
@@ -116,11 +116,17 @@ def determine_filetype(filename):
 		return KMFileTypes.KM_KVK
 	elif ext.lower() == ".ttf" or ext.lower() == ".otf":
 		return KMFileTypes.KM_FONT
-	elif ext.lower() == ".txt" or ext.lower() == ".pdf" or ext.lower() == ".htm" or ext.lower() == ".html":
+	elif ext.lower() == ".txt" or ext.lower() == ".pdf" or ext.lower() == ".htm" \
+			or ext.lower() == ".html" or ext.lower() == ".doc" or ext.lower() == ".docx" \
+			or ext.lower() == ".css" or ext.lower() == ".chm" or ext.lower() == "" \
+			or ext.lower() == ".md" or ext.lower() == ".odt" or ext.lower() == ".rtf" \
+			or ext.lower() == ".dot":
 		return KMFileTypes.KM_DOC
 	elif ext.lower() == ".inf" or ext.lower() == ".json":
 		return KMFileTypes.KM_META
-	elif ext.lower() == ".png" or ext.lower() == ".jpeg" or ext.lower() == ".jpg" or ext.lower() == ".gif":
+	elif ext.lower() == ".png" or ext.lower() == ".jpeg" \
+		or ext.lower() == ".jpg" or ext.lower() == ".gif" \
+		or ext.lower() == ".bmp":
 		return KMFileTypes.KM_IMAGE
 	else:
 		return KMFileTypes.KM_UNKNOWN

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -13,10 +13,14 @@ class KMFileTypes(Enum):
 	KM_SOURCE = auto()
 	KM_KMX = auto()
 	KM_KVK = auto()
+	KM_TOUCH = auto()
 	KM_FONT = auto()
 	KM_DOC = auto()
 	KM_META = auto()
 	KM_IMAGE = auto()
+	KM_TECKIT = auto()
+	KM_CC = auto()
+	KM_XML = auto()
 	KM_UNKNOWN = auto()
 
 
@@ -25,7 +29,8 @@ def print_info(info):
 		print("---- Info ----")
 		print("Name: ", info['name']['description'])
 		print("Copyright: ", info['copyright']['description'])
-		print("Version: ", info['version']['description'])
+		if 'version' in info:
+			print("Version: ", info['version']['description'])
 		if 'author' in info:
 			print("Author: ", info['author']['description'])
 			if 'url' in info['author']:
@@ -72,7 +77,8 @@ def print_keyboards(keyboards):
 		for kb in keyboards:
 			print("Keyboard Name: ", kb['name'])
 			print("Keyboard Id: ", kb['id'])
-			print("Keyboard Version: ", kb['version'])
+			if 'version' in kb:
+				print("Keyboard Version: ", kb['version'])
 			if 'oskFont' in kb:
 				print("Keyboard On screen keyboard Font: ", kb['oskFont'])
 			if 'oskFont' in kb:
@@ -86,11 +92,12 @@ def print_keyboards(keyboards):
 		print(e)          # __str__ allows args to be printed directly,		pass
 		pass
 
-def determine_filetype(filename):
+def determine_filetype(kblist, filename):
 	"""
 	Determine file type of a filename in a kmp from the extension
 
 	Args:
+		kblist (list): list of keyboard ids
 		filename (str): File name
 
 	Returns:
@@ -99,10 +106,14 @@ def determine_filetype(filename):
 			KM_SOURCE: Keyboard source
 			KM_KMX: Compiled keyboard
 			KM_KVK: Compiled on screen keyboard
+			KM_TOUCH: JS touch keyboard
 			KM_FONT: Font
 			KM_DOC: Documentation
 			KM_META: Metadata
 			KM_IMAGE: Image
+			KM_TECKIT: Files to use with teckit
+			KM_CC: Consistent changes tables
+			KM_XML: unspecified xml files
 			KM_UNKNOWN: Unknown
 	"""
 	name, ext = os.path.splitext(filename)
@@ -116,11 +127,22 @@ def determine_filetype(filename):
 		return KMFileTypes.KM_KVK
 	elif ext.lower() == ".ttf" or ext.lower() == ".otf":
 		return KMFileTypes.KM_FONT
+	elif ext.lower() == ".js":
+		if kblist is None:
+			return KMFileTypes.KM_UNKNOWN
+		if name in kblist:
+			return KMFileTypes.KM_TOUCH
+		else:
+			if name == "keyrenderer": # currently 2018-09-21 this is the own known non touch js file
+				return KMFileTypes.KM_DOC
+			else:
+				return KMFileTypes.KM_UNKNOWN
 	elif ext.lower() == ".txt" or ext.lower() == ".pdf" or ext.lower() == ".htm" \
 			or ext.lower() == ".html" or ext.lower() == ".doc" or ext.lower() == ".docx" \
 			or ext.lower() == ".css" or ext.lower() == ".chm" or ext.lower() == "" \
 			or ext.lower() == ".md" or ext.lower() == ".odt" or ext.lower() == ".rtf" \
-			or ext.lower() == ".dot":
+			or ext.lower() == ".dot" or ext.lower() == ".mht"  or ext.lower() == ".woff" \
+			or ext.lower() == ".php":
 		return KMFileTypes.KM_DOC
 	elif ext.lower() == ".inf" or ext.lower() == ".json":
 		return KMFileTypes.KM_META
@@ -128,6 +150,12 @@ def determine_filetype(filename):
 		or ext.lower() == ".jpg" or ext.lower() == ".gif" \
 		or ext.lower() == ".bmp":
 		return KMFileTypes.KM_IMAGE
+	elif ext.lower() == ".tec" or ext.lower() == ".map":
+		return KMFileTypes.KM_TECKIT
+	elif ext.lower() == ".cct":
+		return KMFileTypes.KM_CC
+	elif ext.lower() == ".xml":
+		return KMFileTypes.KM_XML
 	else:
 		return KMFileTypes.KM_UNKNOWN
 
@@ -206,7 +234,7 @@ def parseinfdata(inffile, verbose=False):
 	if os.path.isfile(inffile):
 		config = configparser.ConfigParser()
 		config.optionxform = str
-		logging.info("parseinfdata: reading file:%s dir:%s", inffile, extracted_dir)
+		logging.debug("parseinfdata: reading file:%s dir:%s", inffile, extracted_dir)
 
 		with open(inffile, 'r', encoding='latin_1') as f:
 			config.read_file(f)
@@ -266,6 +294,10 @@ def parseinfdata(inffile, verbose=False):
 						options['readmeFile'] = item[1]
 					elif item[0] == 'GraphicFile':
 						options['graphicFile'] = item[1]
+					elif item[0] == 'DisableKeepFonts':
+						options['disableKeepFonts'] = item[1]
+					elif item[0] == 'BothVersionsIncluded':
+						options['bothVersionsIncluded'] = item[1]
 					elif item[0] == 'ExecuteProgram':
 						pass
 					else:
@@ -300,12 +332,12 @@ def parseinfdata(inffile, verbose=False):
 				files = []
 				for item in config.items(section):
 					splititem = item[1].split("\"")
-					kbfile = { 'name' : splititem[3], 'description' : splititem[1], 'type' : determine_filetype(splititem[3]) }
+					kbfile = { 'name' : splititem[3], 'description' : splititem[1], 'type' : determine_filetype(None, splititem[3]) }
 					files.append(kbfile)
 			elif section == "InstallFiles":
 				files = []
 				for item in config.items(section):
-					kbfile = { 'name' : item[0], 'description' : item[1], 'type' : determine_filetype(item[0]) }
+					kbfile = { 'name' : item[0], 'description' : item[1], 'type' : determine_filetype(None, item[0]) }
 					files.append(kbfile)
 			elif section == 'Install':
 				if not options:
@@ -313,6 +345,31 @@ def parseinfdata(inffile, verbose=False):
 				for item in config.items('Install'):
 					if item[0] == 'ReadmeFile':
 						options['readmeFile'] = item[1]
+		kblist = []
+
+		if not info:
+			info = {}
+		if not 'version' in info:
+			info['version'] = { 'description' : "1.0" }
+		# inf file may not have keyboards in legacy kmps so generate it if needed
+		if files and not keyboards:
+			id = "unknown"
+			keyboards = []
+			for kbfile in files:
+				if kbfile['type'] == KMFileTypes.KM_KMX:
+					id = os.path.basename(os.path.splitext(kbfile['name'])[0])
+					keyboards = [ { 'name' : id,
+						'id' : id,
+						'version' : info['version']['description'] } ]
+
+		kblist = []
+		if files:
+			for k in keyboards:
+				kblist.append(k['id'])
+			for kbfile in files:
+				if kbfile['type'] == KMFileTypes.KM_UNKNOWN:
+					kbfile['type'] = determine_filetype(kblist, kbfile['name'])
+		logging.debug("finished parsing %s", inffile)
 
 		if verbose:
 			print_info(info)
@@ -364,6 +421,8 @@ def parsemetadata(jsonfile, verbose=False):
 	info = system = keyboards = files = options = nonexistent = None
 	extracted_dir = os.path.dirname(jsonfile)
 
+	logging.debug("parsemetadata: reading file:%s dir:%s", jsonfile, extracted_dir)
+
 	if os.path.isfile(jsonfile):
 		with open(jsonfile, "r") as read_file:
 			data = json.load(read_file)
@@ -376,12 +435,15 @@ def parsemetadata(jsonfile, verbose=False):
 					keyboards = data[x]
 				elif x == 'files':
 					files = data[x]
-					for kbfile in files:
-						kbfile['type'] = determine_filetype(kbfile['name'])
 				elif x == 'options':
 					options = data[x]
 				elif x == 'nonexistent':
 					nonexistent = data[x]
+			kblist = []
+			for k in keyboards:
+				kblist.append(k['id'])
+			for kbfile in files:
+				kbfile['type'] = determine_filetype(kblist, kbfile['name'])
 			if nonexistent != None:
 				logging.warning("This should not happen")
 			if verbose:


### PR DESCRIPTION
Fixes #1189  
Fixes #1187 

1189: Detects more files as doc files and detect teckit, cc and also xml
.js files with same name as a keyboard id are assumed to be touch keyboard files. keymanrender is recongnised, others are marked KM_UNKNOWN

Remaining windows binary file extensions ignored:
cfx
dll
exe
thmx

1187: moves the generation of keyboard data to parsing instead of in install_kmp
generate keyboard info for all legacy kmx in a kmp

#1177 will also changed shared installs to put all files into /usr/local/share/keyman/<kbid> and then link them to /usr/local/share/doc/... and /usr/local/share/font/... which will bring in the remaining windows only files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1206)
<!-- Reviewable:end -->
