### PR TITLE
[Android] Fix globe button when pausing WebBrowser

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -332,8 +332,6 @@ public class WebBrowserActivity extends AppCompatActivity {
   protected void onResume() {
     super.onResume();
     if (webView != null) {
-      webView.resumeTimers();
-
       if (didFinishLoading) {
         String fontFilename = KMManager.getKeyboardTextFontFilename();
         if (!loadedFont.equals(fontFilename)) {
@@ -346,9 +344,6 @@ public class WebBrowserActivity extends AppCompatActivity {
   @Override
   protected void onPause() {
     super.onPause();
-    if (webView != null) {
-      webView.pauseTimers();
-    }
   }
 
   @Override

--- a/android/history.md
+++ b/android/history.md
@@ -8,6 +8,7 @@
 * Remove deprecated ad-hoc distribution of keyboards via `keyman://` protocol (#1109)
 * Add splash screen (#1151)
 * Update app to use Material Design theme
+* Fix globe button when pausing WebBrowser (#1213)
 
 ## 2018-08-23 10.0.505 stable
 * Validate keyboard ID when downloading keyboard from keman cloud (#1121)


### PR DESCRIPTION
This is a follow-on fix of #913

`webView.pauseTimers()` disables Javascript in all WebViews (including Keyman as a system keyboard).

The bug is when the WebBrowserActivity is paused, the globe button in system keyboards is disabled.

Reference: https://developer.android.com/reference/android/webkit/WebView#pauseTimers()