### PR TITLE
[linux] fix help2man on jenkins

### DIFF
--- a/linux/keyman-config/km-kvk2ldml
+++ b/linux/keyman-config/km-kvk2ldml
@@ -42,7 +42,7 @@ def main():
 
     kvkData = parse_kvk_file(args.kvkfile)
 
-    if args.print:
+    if args.p:
         print_kvk(kvkData, args.keys)
 
     if args.o:

--- a/linux/keyman-config/km-package-uninstall
+++ b/linux/keyman-config/km-package-uninstall
@@ -5,7 +5,6 @@ import logging
 import sys
 
 from keyman_config import __version__
-from keyman_config.uninstall_kmp import uninstall_kmp
 
 def main():
 	parser = argparse.ArgumentParser(description='Uninstall Keyman keyboard package.')
@@ -23,6 +22,7 @@ def main():
 	else:
 		logging.basicConfig(format='%(levelname)s:%(message)s')
 
+	from keyman_config.uninstall_kmp import uninstall_kmp
 	uninstall_kmp(args.id, args.s)
 
 if __name__ == "__main__":


### PR DESCRIPTION
the jenkins keyman-config build currently fails because it can't run km-package-uninstall -h with some dependent packages not installed.

This moves the import to after -h and -v are processed

print is a keyword on python2 so use the short form args.p in km-kvk2ldml (just allows running -h)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1214)
<!-- Reviewable:end -->
