### PR TITLE
[linux] for manually uploading selected nightlies to launchpad

### DIFF
--- a/linux/ibus-kmfl/debian/watch
+++ b/linux/ibus-kmfl/debian/watch
@@ -1,2 +1,2 @@
-version=3
-http://sf.net/kmfl/ibus-kmfl-(.+)\.tar\.gz debian uupdate
+version=4
+https://downloads.keyman.com/linux/alpha/10\.99\.(.+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/keyman-config/debian/watch
+++ b/linux/keyman-config/debian/watch
@@ -1,4 +1,2 @@
-# please also check http://pypi.debian.net/keyman-config/watch
-version=3
-opts=uversionmangle=s/(rc|a|b|c)/~$1/ \
-http://pypi.debian.net/keyman/keyman-config--(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))
+version=4
+https://downloads.keyman.com/linux/alpha/10\.99\.(.+)/keyman_config-(.+)\.tar\.gz debian uupdate

--- a/linux/kmflcomp/debian/watch
+++ b/linux/kmflcomp/debian/watch
@@ -1,2 +1,2 @@
-version=3
-http://sf.net/kmfl/kmflcomp-(.+)\.tar\.gz debian uupdate
+version=4
+https://downloads.keyman.com/linux/alpha/10\.99\.(.+)/kmflcomp-(.+)\.tar\.gz debian uupdate

--- a/linux/libkmfl/debian/watch
+++ b/linux/libkmfl/debian/watch
@@ -1,2 +1,2 @@
-version=3
-http://sf.net/kmfl/libkmfl-(.+)\.tar\.gz debian uupdate
+version=4
+https://downloads.keyman.com/linux/alpha/10\.99\.(.+)/libkmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -47,14 +47,19 @@ mkdir -p dist
 
 # configure and make dist for autotool projects
 for proj in ${autotool_projects}; do
-	cd $proj
+    echo "configure $proj"
+    cd $proj
+    oldvers=`cat VERSION`
+    vers=`./configure -version|grep kmfl|grep -Po "${proj} configure \K[^a-z]*"`
+    echo "$vers" > VERSION
     rm -rf ../build-$proj
     mkdir -p ../build-$proj
     cd ../build-$proj
     ../$proj/configure
     make dist
     mv *.tar.gz ../dist
-	cd $BASEDIR
+    cd $BASEDIR
+    echo "$oldvers" > VERSION
 done
 
 

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -15,7 +15,7 @@ set -e
 if [ "${UPLOAD}" == "yes" ]; then
     SIM=""
 else
-    SIM="-s -u"
+    SIM="-s"
 fi
 
 if [ ! `which xmllint` ]; then
@@ -61,7 +61,7 @@ for proj in ${projects}; do
         cp ../${proj}-changelog debian/changelog
         dch -v ${version}-1~${dist} "source package for PPA"
         dch -D ${dist} -r ""
-        debuild -d -S -sa -Zxz -us -uc
+        debuild -d -S -sa -Zxz
     done
     cd ..
     for dist in ${distributions}; do

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Build source packages from nightly builds and upload to PPA
+
+# must be run from linux dir
+
+# parameters: [LAUNCHPAD_ID="<me>"] [PROJECT="<project>"] ./scripts/launchpad.sh
+# LAUNCHPAD_ID="<me>" to set the launchpad id to dput to
+# PROJECT="<project>" only upload this project
+
+
+set -e
+
+if [ "${LAUNCHPAD_ID}" == "" ]; then
+    echo "you must set your LAUNCHPAD_ID in the enviroment for dputting"
+    exit 1
+fi
+
+if [ ! `which xmllint` ]; then
+    echo "you must install xmllint (libxml2-utils package) to use this script"
+    exit 1
+fi
+
+if [ "${PROJECT}" != "" ]; then
+    projects="$PROJECT"
+else
+    projects="kmflcomp libkmfl ibus-kmfl keyman-config"
+fi
+
+
+BASEDIR=`pwd`
+dists="xenial bionic cosmic"
+
+rm -rf launchpad
+mkdir -p launchpad
+
+for proj in ${projects}; do
+    cd ${proj}
+    version=`uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -`
+    echo "${proj} version is ${version}"
+    uscan
+    mv ../${proj}-${version} ../launchpad
+    mv ../${proj}_${version}.orig.tar.gz ../launchpad
+    if [ "${proj}" == "keyman-config" ]; then
+        mv ../keyman_config-${version}.tar.gz ../launchpad
+    else
+        mv ../${proj}-${version}.tar.gz ../launchpad
+    fi
+    rm ../${proj}*.debian.tar.xz
+    cd ../launchpad/${proj}-${version}
+    echo `pwd`
+    dch -v ${version}-1 "source package for PPA"
+    #TODO separate source builds and dputs for each of $dists?
+    dch -r ""
+    debuild -d -S -sa -Zxz -us -uc
+    cd ..
+    dput -s -u ppa:${LAUNCHPAD_ID}/keyman-daily ${proj}_${version}-1_source.changes
+    cd ${BASEDIR}
+done

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -4,9 +4,8 @@
 
 # must be run from linux dir
 
-# parameters: [UPLOAD="yes"] [LAUNCHPAD_ID="<me>"] [PROJECT="<project>"] [DIST="<dist>"] ./scripts/launchpad.sh
+# parameters: [UPLOAD="yes"] [PROJECT="<project>"] [DIST="<dist>"] ./scripts/launchpad.sh
 # UPLOAD="yes" do the dput for real
-# LAUNCHPAD_ID="<me>" to set the launchpad id to dput to
 # PROJECT="<project>" only upload this project
 # DIST="<dist>" only upload for this distribution
 
@@ -14,14 +13,9 @@
 set -e
 
 if [ "${UPLOAD}" == "yes" ]; then
-    SIM=
+    SIM=""
 else
     SIM="-s -u"
-fi
-
-if [ "${LAUNCHPAD_ID}" == "" ]; then
-    echo "you must set your LAUNCHPAD_ID in the enviroment for dputting"
-    exit 1
 fi
 
 if [ ! `which xmllint` ]; then
@@ -71,7 +65,7 @@ for proj in ${projects}; do
     done
     cd ..
     for dist in ${distributions}; do
-        dput ${SIM} ppa:${LAUNCHPAD_ID}/keyman-daily ${proj}_${version}-1~${dist}_source.changes
+        dput ${SIM} ppa:keymanapp/keyman-daily ${proj}_${version}-1~${dist}_source.changes
     done
     cd ${BASEDIR}
 done


### PR DESCRIPTION
changes debian/watch files to look for new sources in https://downloads.keyman.com/linux/alpha
launchpad.sh gets the latest of those, makes a Debian source package from it, and optionally uploads to the launchpad keyman-daily ppa

This is preparation for an alpha announcement of the PPA on the LinuxUser list at some point

Try the ppa at https://launchpad.net/~keymanapp/+archive/ubuntu/keyman-daily which now has the 10.99.24 nightlies