### PR TITLE
[Android] Change system keyboard to "numeric" layer for numeric text fields

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -14,6 +14,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Point;
 import android.inputmethodservice.InputMethodService;
+import android.text.InputType;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -103,6 +104,13 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     super.onStartInput(attribute, restarting);
     KMManager.onStartInput(attribute, restarting);
     KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+
+    // Select numeric layer if applicable
+    int inputType = attribute.inputType;
+    if (((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_NUMBER) ||
+        ((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_PHONE)) {
+      KMManager.setNumericLayer(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    }
 
     InputConnection ic = getCurrentInputConnection();
     if (ic != null) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -126,6 +126,12 @@
       kmw.resetContext();
     }
 
+    // Tell KMW to switch to "numeric" layer
+    function setNumericLayer() {
+      var kmw=window['keyman'];
+      kmw.setNumericLayer();
+    }
+
     function updateKMText(text) {
       if(text == undefined) {
           text = '';

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1061,6 +1061,18 @@ public final class KMManager {
     KeyboardPickerActivity.showLanguageList(context);
   }
 
+  public static void setNumericLayer(KeyboardType kbType) {
+    if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+      if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
+        InAppKeyboard.loadUrl("javascript:setNumericLayer()");
+      }
+    } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
+      if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
+        SystemKeyboard.loadUrl("javascript:setNumericLayer()");
+      }
+    }
+  }
+
   public static boolean updateText(KeyboardType kbType, String text) {
     boolean result = false;
     String kmText = "";

--- a/android/history.md
+++ b/android/history.md
@@ -9,6 +9,7 @@
 * Add splash screen (#1151)
 * Update app to use Material Design theme
 * Fix globe button when pausing WebBrowser (#1213)
+* Change system keyboard to "numeric" layer for digit/phone number text fields (#1218)
 
 ## 2018-08-23 10.0.505 stable
 * Validate keyboard ID when downloading keyboard from keman cloud (#1121)

--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 11.0 alpha
+* Add `setNumericLayer()` for embedded platforms to change OSK to numeric layer.
+
 ## 2018-07-06 10.0.103 stable
 * Fixes issue for embedded Android, iOS apps where a keyboard with varying row counts in different layers could crash (#1055)
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -16,8 +16,8 @@
 /// <reference path="kmwuimanager.ts" />
 
 /***
-   KeymanWeb 10.0
-   Copyright 2017 SIL International
+   KeymanWeb 11.0
+   Copyright 2017-2018 SIL International
 ***/
 namespace com.keyman {
   export class KeymanBase {
@@ -402,6 +402,15 @@ namespace com.keyman {
      */
     ['resetContext']() {
       this.interface.resetContext();
+    };
+
+    /**
+     * Function     setNumericLayer
+     * Scope        Public
+     * Description  Set OSK to numeric layer if it exists
+     */
+    ['setNumericLayer']() {
+      this.interface.setNumericLayer();
     };
 
     /**

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -3,8 +3,8 @@
 /// <reference path="kmwbase.ts" />
 
 /***
-   KeymanWeb 10.0
-   Copyright 2017 SIL International
+   KeymanWeb 11.0
+   Copyright 2017-2018 SIL International
 ***/
 
 namespace com.keyman {
@@ -1355,6 +1355,16 @@ namespace com.keyman {
       this.resetVKShift();
 
       this.keymanweb.osk._Show();
+    };
+
+    setNumericLayer() {
+      var i;
+      for(i=0; i<this.keymanweb.osk.layers.length; i++) {
+        if (this.keymanweb.osk.layers[i].id == 'numeric') {
+          this.keymanweb.osk.layerId = 'numeric';
+          this.keymanweb.osk._Show();
+        }
+      }
     };
 
     /**


### PR DESCRIPTION
Fixes #289

When changing to a digit/phone number text field, set the OSK to "numeric" layer if it exists. 

This will occur after `resetContext()`.