### PR TITLE
[Developer] Avoid a crash in package editor when compiled keyboard file is missing

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 2018-09-28 10.0.1204 stable
+* Fix crash in Keyman Developer package editor when a compiled .js keyboard is missing (#1224)
+
 ## 2018-09-12 10.0.1202 stable
 * Refactor how keyboard_info metadata is generated (#1174)
 

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -207,6 +207,9 @@ function TPackageInfoRefreshKeyboards.IsKeyboardFileByContent(f: TPackageContent
 var
   id: string;
 begin
+  if not FileExists(f.FileName) then
+    Exit(True);
+
   id := TKeyboardUtils.GetKeymanWebCompiledNameFromFileName(f.FileName);
   // Look for Keyboard_<id>
   with TStringStream.Create('', TEncoding.UTF8) do

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -233,7 +233,7 @@ begin
 
   // Need to test if the JS is a valid keyboard file.
   // This is a bit of a pain... but we have to stick with .js for compat
-  if IsKeyboardFileByContent(f) then
+  if not FileExists(f.FileName) or IsKeyboardFileByContent(f) then
     Exit(ftJavascript);
 
   Exit(ftOther);
@@ -297,6 +297,9 @@ class function TPackageInfoRefreshKeyboards.FillKeyboardDetails(f: TPackageConte
 var
   ki: TKeyboardInfo;
 begin
+  if not FileExists(f.FileName) then
+    Exit(False);
+
   Result := True;
   pki.ID := TKeyboardUtils.KeyboardFileNameToID(f.FileName);
   pki.RTL := False;


### PR DESCRIPTION
This was fixed in alpha with the bigger set of changes in the Import and Project Template work