### PR TITLE
[Developer] Fixes for project templates and installer

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
@@ -13,9 +13,9 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   object lblFileName: TLabel
     Left = 12
     Top = 275
-    Width = 50
+    Width = 64
     Height = 13
-    Caption = '&File Name:'
+    Caption = '&Keyboard ID:'
     FocusControl = editFileName
   end
   object lblPath: TLabel
@@ -55,7 +55,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Top = 92
     Width = 37
     Height = 13
-    Caption = '&Author:'
+    Caption = 'A&uthor:'
     FocusControl = editAuthor
   end
   object lblTargets: TLabel
@@ -75,11 +75,12 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     FocusControl = gridKeyboardLanguages
   end
   object editFileName: TEdit
-    Left = 64
+    Left = 120
     Top = 272
-    Width = 205
+    Width = 149
     Height = 21
     TabOrder = 10
+    OnChange = editFileNameChange
   end
   object cmdBrowse: TButton
     Left = 275
@@ -88,13 +89,15 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Height = 21
     Caption = '&Browse...'
     TabOrder = 11
+    OnClick = cmdBrowseClick
   end
   object editPath: TEdit
-    Left = 64
+    Left = 120
     Top = 245
-    Width = 289
+    Width = 233
     Height = 21
     TabOrder = 9
+    OnChange = editPathChange
   end
   object editKeyboardName: TEdit
     Left = 120
@@ -111,6 +114,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Height = 21
     TabOrder = 1
     Text = #169
+    OnChange = editCopyrightChange
   end
   object editVersion: TEdit
     Left = 120
@@ -119,6 +123,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Height = 21
     TabOrder = 2
     Text = '1.0'
+    OnChange = editVersionChange
   end
   object editAuthor: TEdit
     Left = 120
@@ -126,6 +131,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Width = 205
     Height = 21
     TabOrder = 3
+    OnChange = editAuthorChange
   end
   object cmdOK: TButton
     Left = 463
@@ -152,6 +158,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Top = 116
     Width = 205
     Height = 97
+    OnClickCheck = clbTargetsClickCheck
     ItemHeight = 13
     TabOrder = 4
   end

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -56,6 +56,13 @@ type
     procedure cmdKeyboardEditLanguageClick(Sender: TObject);
     procedure cmdKeyboardRemoveLanguageClick(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
+    procedure editCopyrightChange(Sender: TObject);
+    procedure editVersionChange(Sender: TObject);
+    procedure editAuthorChange(Sender: TObject);
+    procedure clbTargetsClickCheck(Sender: TObject);
+    procedure editPathChange(Sender: TObject);
+    procedure editFileNameChange(Sender: TObject);
+    procedure cmdBrowseClick(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer; // Used temporarily for storing language list
@@ -178,6 +185,33 @@ begin
   FreeAndNil(pack);
 end;
 
+procedure TfrmNewProjectParameters.clbTargetsClickCheck(Sender: TObject);
+begin
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.cmdBrowseClick(Sender: TObject);
+var
+  FPathName, FFolderName, FProjectName: string;
+begin
+  inherited;
+  if dlgSave.Execute then
+  begin
+    FPathName := ExtractFilePath(ExtractFileDir(dlgSave.FileName));
+    FFolderName := ExtractFileName(ExtractFileDir(dlgSave.FileName));
+    FProjectName := ChangeFileExt(ExtractFileName(dlgSave.FileName), '');
+    if not SameText(FFolderName, FProjectName) then
+    begin
+      if MessageDlg('The project will be saved at "'+FPathName+FFolderName+'\'+FProjectName+'\'+FProjectName+'.kpj". Continue?',
+          mtConfirmation, mbOkCancel, 0) = mrCancel then
+        Exit;
+      FPathName := FPathName+FFolderName;
+    end;
+    editPath.Text := ExcludeTrailingPathDelimiter(FPathName);
+    editFileName.Text := FProjectName;
+  end;
+end;
+
 procedure TfrmNewProjectParameters.cmdKeyboardAddLanguageClick(
   Sender: TObject);
 var
@@ -257,11 +291,36 @@ begin
     ModalResult := mrOk;
 end;
 
+procedure TfrmNewProjectParameters.editAuthorChange(Sender: TObject);
+begin
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.editCopyrightChange(Sender: TObject);
+begin
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.editFileNameChange(Sender: TObject);
+begin
+  EnableControls;
+end;
+
 procedure TfrmNewProjectParameters.editKeyboardNameChange(Sender: TObject);
 begin
-  inherited;
   if not editFileName.Modified then
     editFileName.Text := TKeyboardUtils.CleanKeyboardID(Trim(editKeyboardName.Text));
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.editPathChange(Sender: TObject);
+begin
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.editVersionChange(Sender: TObject);
+begin
+  EnableControls;
 end;
 
 procedure TfrmNewProjectParameters.EnableControls;
@@ -270,7 +329,8 @@ var
 begin
   e := (Trim(editKeyboardName.Text) <> '') and
     (Trim(editPath.Text) <> '') and
-    (Trim(editFileName.Text) <> '');
+    TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text)) and
+    (GetTargets <> []);
   cmdOK.Enabled := e;
 
   e := gridKeyboardLanguages.RowCount > 1;

--- a/windows/src/developer/inst/Makefile
+++ b/windows/src/developer/inst/Makefile
@@ -6,7 +6,7 @@
 
 # ----------------------------------------------------------------------
 
-DEVELOPER_FILES=kmdev.wixobj xml.wixobj cef.wixobj
+DEVELOPER_FILES=kmdev.wixobj xml.wixobj cef.wixobj templates.wixobj
 
 setup:
 
@@ -60,6 +60,7 @@ clean:
     -del /Q *.wixpdb
     -del /Q xml.wxs
     -del /Q cef.wxs
+    -del /Q templates.wxs
 
 test-releaseexists:
     cd $(ROOT)\src\developer\inst

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -2,9 +2,9 @@
 
 # We use different directories so that heat generates
 # different identifiers for the various folders
-KEYMAN_WIX_TEMP_XML=$(TEMP)\keyman_wix_build_xml
-KEYMAN_WIX_TEMP_CEF=$(TEMP)\keyman_wix_build_cef
-KEYMAN_WIX_TEMP_TEMPLATES=$(TEMP)\keyman_wix_build_templates
+KEYMAN_WIX_TEMP_XML=$(TEMP)\keyman_wix_build\xml
+KEYMAN_WIX_TEMP_CEF=$(TEMP)\keyman_wix_build\cef
+KEYMAN_WIX_TEMP_TEMPLATES=$(TEMP)\keyman_wix_build\templates
 
 KEYMAN_DEVELOPER_TEMPLATES_ROOT=$(ROOT)\src\developer\kmconvert\data
 
@@ -38,7 +38,7 @@ heat-templates:
     -rmdir /s/q $(KEYMAN_WIX_TEMP_TEMPLATES)
     mkdir $(KEYMAN_WIX_TEMP_TEMPLATES)
     xcopy $(KEYMAN_DEVELOPER_TEMPLATES_ROOT)\* $(KEYMAN_WIX_TEMP_TEMPLATES)\ /s
-    $(WIXHEAT) dir $(KEYMAN_WIX_TEMP_TEMPLATES) -o templates.wxs -ag -cg Templates -dr dirProjectsTemplates -var var.TemplatesSourceDir -wx -nologo
+    $(WIXHEAT) dir $(KEYMAN_WIX_TEMP_TEMPLATES) -o templates.wxs -ag -cg Templates -dr dirProjects -var var.TemplatesSourceDir -wx -nologo
     # When we candle/light build, we can grab the source files from the proper root so go ahead and delete the temp folder again
     -rmdir /s/q $(KEYMAN_WIX_TEMP_TEMPLATES)
 

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -61,9 +61,7 @@
               <Directory Id="dirRedist" Name="Redist">
                 <Directory Id="dirRedistSetup" Name="Setup" />
               </Directory>
-              <Directory Id="dirProjects" Name="Projects">
-                <Directory Id="dirProjectsTemplates" Name="Templates" />
-              </Directory>
+              <Directory Id="dirProjects" Name="Projects" />
             </Directory>
           </Directory>
         </Directory>
@@ -326,6 +324,7 @@
       <ComponentGroupRef Id="AppData" />
       <ComponentGroupRef Id="XML" />
       <ComponentGroupRef Id="CEF" />
+      <ComponentGroupRef Id="Templates" />
       
       <MergeRef Id='keymanengine' />
     </Feature>

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -43,6 +43,7 @@ type
     procedure WriteRepositoryMetadata;
     procedure WriteDocumentation;
     procedure WriteKeyboardInfo;
+    function HasKMX: Boolean;
     function HasIcon: Boolean;
     procedure Transform(const SourceFile: string; DestFile: string = '');
     function DataPath: string;
@@ -164,19 +165,24 @@ begin
   Result := GetFilename(FTouchLayoutFilename);
 end;
 
+function TKeyboardProjectTemplate.HasKMX: Boolean;
+begin
+  Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
+end;
+
 function TKeyboardProjectTemplate.HasKVKS: Boolean;
 begin
-  Result := KeymanTargetsUsingKVK * FTargets <> [];
+  Result := (KeymanTargetsUsingKVK+[ktAny]) * FTargets <> [];
 end;
 
 function TKeyboardProjectTemplate.HasTouchLayout: Boolean;
 begin
-  Result := TouchKeymanTargets * FTargets <> [];
+  Result := (TouchKeymanTargets+[ktAny]) * FTargets <> [];
 end;
 
 function TKeyboardProjectTemplate.HasIcon: Boolean;
 begin
-  Result := KMXKeymanTargets * FTargets <> [];
+  Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
 end;
 
 procedure TKeyboardProjectTemplate.WriteDocumentation;
@@ -276,9 +282,12 @@ begin
     kps.FileName := GetPackageFilename;
 
     // Add .kmx
-    f := TPackageContentFile.Create(kps);
-    f.FileName := FBasePath + FKeyboardID + '\build\' + FKeyboardID + Ext_KeymanFile;
-    kps.Files.Add(f);
+    if HasKMX then
+    begin
+      f := TPackageContentFile.Create(kps);
+      f.FileName := FBasePath + FKeyboardID + '\build\' + FKeyboardID + Ext_KeymanFile;
+      kps.Files.Add(f);
+    end;
 
     // Add .js
     if HasTouchLayout then

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -32,8 +32,10 @@ type
     function GetProjectFilename: string;
     function GetTouchLayoutFilename: string;
 
-    function HasTouchLayout: Boolean;
+    function HasIcon: Boolean;
+    function HasKMX: Boolean;
     function HasKVKS: Boolean;
+    function HasTouchLayout: Boolean;
 
     procedure WriteKMN;
     procedure WriteKPS;
@@ -43,8 +45,6 @@ type
     procedure WriteRepositoryMetadata;
     procedure WriteDocumentation;
     procedure WriteKeyboardInfo;
-    function HasKMX: Boolean;
-    function HasIcon: Boolean;
     procedure Transform(const SourceFile: string; DestFile: string = '');
     function DataPath: string;
     procedure SetKeyboardLanguages(kps: TkpsFile);
@@ -165,6 +165,11 @@ begin
   Result := GetFilename(FTouchLayoutFilename);
 end;
 
+function TKeyboardProjectTemplate.HasIcon: Boolean;
+begin
+  Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
+end;
+
 function TKeyboardProjectTemplate.HasKMX: Boolean;
 begin
   Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
@@ -178,11 +183,6 @@ end;
 function TKeyboardProjectTemplate.HasTouchLayout: Boolean;
 begin
   Result := (TouchKeymanTargets+[ktAny]) * FTargets <> [];
-end;
-
-function TKeyboardProjectTemplate.HasIcon: Boolean;
-begin
-  Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
 end;
 
 procedure TKeyboardProjectTemplate.WriteDocumentation;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -34,7 +34,15 @@ end;
 function DoImportWindowsKeyboard(FParameters: TKMConvertParameters): Boolean;
 var
   iwk: TImportWindowsKeyboard;
+  FTargetFolder: string;
+  v: Integer;
 begin
+  if not TryStrToInt('$'+FParameters.KLID, v) then
+  begin
+    writeln('ERROR: The format of the input parameter -klid '+FParameters.KLID+' is incorrect');
+    Exit(False);
+  end;
+
   iwk := TImportWindowsKeyboard.Create;
   try
     iwk.SourceKLID := FParameters.KLID;
@@ -45,6 +53,14 @@ begin
     iwk.Version := FParameters.Version;
     iwk.BCP47Tags := FParameters.BCP47Tags;
     iwk.Author := FParameters.Author;
+
+    FTargetFolder := ExtractFileDir(iwk.ProjectFilename);
+    if DirectoryExists(FTargetFolder) then
+    begin
+      writeln('ERROR: The directory "'+FTargetFolder+'" already exists.');
+      Exit(False);
+    end;
+
     Result := iwk.Execute;
   finally
     iwk.Free;
@@ -54,6 +70,7 @@ end;
 function DoCreateKeyboardTemplate(FParameters: TKMConvertParameters): Boolean;
 var
   kpt: TKeyboardProjectTemplate;
+  FTargetFolder: string;
 begin
   kpt := TKeyboardProjectTemplate.Create(FParameters.Destination, FParameters.KeyboardID, FParameters.Targets);
   try
@@ -62,6 +79,14 @@ begin
     kpt.Version := FParameters.Version;
     kpt.BCP47Tags := FParameters.BCP47Tags;
     kpt.Author := FParameters.Author;
+
+    FTargetFolder := ExtractFileDir(kpt.ProjectFilename);
+    if DirectoryExists(FTargetFolder) then
+    begin
+      writeln('ERROR: The directory "'+FTargetFolder+'" already exists.');
+      Exit(False);
+    end;
+
     try
       kpt.Generate;
     except

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -8,6 +8,7 @@ implementation
 
 uses
   System.SysUtils,
+  Winapi.ActiveX,
 
   Keyman.Developer.System.KMConvertParameters,
   Keyman.Developer.System.ImportWindowsKeyboard,
@@ -19,10 +20,15 @@ function DoRun: Boolean; forward;
 
 procedure Run;
 begin
-  if DoRun then
-    ExitCode := 0
-  else
-    ExitCode := 1;
+  CoInitializeEx(nil, COINIT_APARTMENTTHREADED);
+  try
+    if DoRun then
+      ExitCode := 0
+    else
+      ExitCode := 1;
+  finally
+    CoUninitialize;
+  end;
 end;
 
 function DoImportWindowsKeyboard(FParameters: TKMConvertParameters): Boolean;

--- a/windows/src/global/delphi/general/BCP47Tag.pas
+++ b/windows/src/global/delphi/general/BCP47Tag.pas
@@ -77,8 +77,12 @@ uses
 { TBCP47Tag }
 
 procedure TBCP47Tag.Canonicalize;
+var
+  newTag: string;
 begin
-  SetTag(TCanonicalLanguageCodeUtils.FindBestTag(Tag));
+  newTag := TCanonicalLanguageCodeUtils.FindBestTag(Tag);
+  if newTag <> '' then
+    SetTag(newTag);
 end;
 
 procedure TBCP47Tag.Clear;


### PR DESCRIPTION
This PR:

* Fixes a breaking issue with the installer for Keyman Developer [5ed4af8a]
  1. Target folder names were incorrect
  2. kmconvert template files were missing from build

* Fixes up a bug kmconvert command line tool [b64e1b48]
  1. kmconvert crashes because COM was not initialized

* Tidies up various small bugs in the New Basic Project dialog and kmconvert [a70efed0]
  1. Don't require language id?
  2. &A on two controls
  3. Does not enablecontrols on Name field change
  4. Browse button does nothing
  5. .js file was not added to .kps when building from a template with ktAny as target
  6. baz language code was not added to package or .keyboard_info when creating from a template
  7. kmconvert should fail if folder already exists