### PR TITLE
[Android] Fix crash when displaying preview key

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -928,7 +928,9 @@ final class KMKeyboard extends WebView {
 
     dismissHelpBubble();
     //keyPreviewWindow.setAnimationStyle(R.style.KeyPreviewAnim);
-    keyPreviewWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX, posY);
+    if (keyPreviewWindow != null) {
+      keyPreviewWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX, posY);
+    }
   }
 
   protected void dismissKeyPreview(long delay) {

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2018-10-03 10.0.506 stable
+* Fix crash that can occur when displaying preview key (#1230)
+
 ## 2018-08-23 10.0.505 stable
 * Validate keyboard ID when downloading keyboard from Keyman cloud (#1121)
 


### PR DESCRIPTION
Fixes Crashlytics  [crash report](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/5b59a79f6007d59fcdced3c2)  that's caused by trying to display the preview key when the token is null.