### PR TITLE
[linux] fix glitch in versioning local builds

### DIFF
--- a/linux/scripts/version.sh
+++ b/linux/scripts/version.sh
@@ -4,7 +4,7 @@ version()
 {
     local catvers=`cat VERSION`
     local datevers=`TZ=UTC git log -1 --pretty=format:%cd --date=format-local:%Y%m%d%H%M`
-    local num=`git describe --abbrev=0| cut -d '.' -f3`
+    local num=`git describe --abbrev=0 --match=linux-release-*| cut -d '.' -f3`
     echo "current tag number ${num}"
     local next=$((num+1))
     echo "next tag number ${next}"


### PR DESCRIPTION
only get latest linux tag for calculating current tag number - fixes glitch in versioning local builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1233)
<!-- Reviewable:end -->
