### PR TITLE
[linux] ibus install issues

### DIFF
--- a/linux/ibus-kmfl/src/kmfl.xml.in.in
+++ b/linux/ibus-kmfl/src/kmfl.xml.in.in
@@ -12,6 +12,8 @@
 	<observed-paths>
 		<path>/usr/share/kmfl/</path>
 		<path>~/.kmfl/</path>
+		<path>/usr/local/share/keyman/</path>
+		<path>~/.local/share/keyman/</path>
 	</observed-paths>
 	<engines exec=\"${libexecdir}/ibus-engine-kmfl --xml\" />
 </component>

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -110,7 +110,6 @@ def download_source(kbid, kbdir, sourcePath):
 			os.remove(kmn_file)
 			rmtree(kbdir)
 			raise InstallError(InstallStatus.Abort, message)
-		do_install_to_ibus = True
 	else:
 		message = "install_kmp.py: warning: no kmn source file for %s so not installing keyboard." % (kbid)
 		rmtree(kbdir)
@@ -186,6 +185,7 @@ def install_kmp_shared(inputfile, online=False):
 				for kb in keyboards:
 					if kb['id'] != kmpid:
 						process_keyboard_data(kb['id'], kmpdir)
+			do_install_to_ibus = True
 
 		for f in files:
 			fpath = os.path.join(kmpdir, f['name'])
@@ -245,6 +245,7 @@ def install_kmp_user(inputfile, online=False):
 				for kb in keyboards:
 					if kb['id'] != kmpid:
 						process_keyboard_data(kb['id'], kmpdir)
+			do_install_to_ibus = True
 
 		for f in files:
 			fpath = os.path.join(kmpdir, f['name'])
@@ -271,6 +272,7 @@ def install_kmp_user(inputfile, online=False):
 				#TODO for the moment just leave it for ibus-kmfl to ignore if it doesn't load
 				pass
 		if do_install_to_ibus:
+			kmn_file = os.path.join(kmpdir, kmpid + ".kmn")
 			install_to_ibus(kmn_file)
 	else:
 		logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -11,6 +11,7 @@ import zipfile
 from os import listdir, makedirs
 from shutil import copy2, rmtree
 from ast import literal_eval
+from enum import Enum
 
 import requests
 
@@ -28,6 +29,23 @@ from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
 #TODO optionally standardise throughout on variable names
 # packageID for kmps and keyboardID for keyboards
 # see https://docs.google.com/document/d/1sj7W6pCiN-_iRss5iRdib1aHaSTmYoLIueQSKJeNy8Q/edit#heading=h.mq0rc28mf031
+
+class InstallStatus(Enum):
+	Continue = 0
+	Warning = 1
+	Abort = 2
+
+class InstallError(Exception):
+    """Exception raised for errors in KMP installation.
+
+    Attributes:
+        status -- InstallStatus for what to do when the error occurrs
+        message -- explanation of the error
+    """
+
+    def __init__(self, status, message):
+        self.status = status
+        self.message = message
 
 def list_files(directory, extension):
 	return (f for f in listdir(directory) if f.endswith('.' + extension))
@@ -88,15 +106,15 @@ def download_source(kbid, kbdir, sourcePath):
 		subprocess.run(["kmflcomp", kmn_file], stdout=subprocess.PIPE, stderr= subprocess.STDOUT)
 		kmfl_file = os.path.join(kbdir, kbid + ".kmfl")
 		if not os.path.isfile(kmfl_file):
-			logging.warning("Could not compile %s to %s so not installing keyboard.", kmn_file, kmfl_file)
+			message = "Could not compile %s to %s so not installing keyboard." % (kmn_file, kmfl_file)
 			os.remove(kmn_file)
 			rmtree(kbdir)
-			return 1
+			raise InstallError(InstallStatus.Abort, message)
 		do_install_to_ibus = True
 	else:
-		logging.warning("install_kmp.py: warning: no kmn source file for %s so not installing keyboard.", kbid)
+		message = "install_kmp.py: warning: no kmn source file for %s so not installing keyboard." % (kbid)
 		rmtree(kbdir)
-		return 1
+		raise InstallError(InstallStatus.Abort, message)
 	icodownloadfile = os.path.join(kbdir, kbid + ".ico")
 	if not os.path.isfile(icodownloadfile):
 		ico_url = base_url + "/source/" + kbid + ".ico"
@@ -108,7 +126,6 @@ def download_source(kbid, kbdir, sourcePath):
 			checkandsaveico(icodownloadfile)
 		else:
 			logging.warning("install_kmp.py: warning: no ico source file for %s", kbid)
-	return 0
 
 def process_keyboard_data(kbid, kbdir):
 	kbdata = get_keyboard_data(kbid)
@@ -116,17 +133,15 @@ def process_keyboard_data(kbid, kbdir):
 		if not os.path.isdir(kbdir):
 			os.makedirs(kbdir)
 		if 'sourcePath' in kbdata:
-			ret = download_source(kbid, kbdir, kbdata['sourcePath'])
-			if ret > 0:
-				return ret
+			download_source(kbid, kbdir, kbdata['sourcePath'])
+
 		with open(os.path.join(kbdir, kbid + '.json'), 'w') as outfile:
 			json.dump(kbdata, outfile)
 			logging.info("Installing api data file %s.json as keyman file", kbid)
 	else:
-		logging.error("install_kmp.py: error: cannot download keyboard data so not installing.")
+		message = "install_kmp.py: error: cannot download keyboard data so not installing."
 		rmtree(kbdir)
-		return 1
-	return 0
+		raise InstallError(InstallStatus.Abort, message)
 
 def check_keyman_dir(basedir, error_message):
 	# check if keyman subdir exists
@@ -134,13 +149,11 @@ def check_keyman_dir(basedir, error_message):
 	if os.path.isdir(keyman_dir):
 		# Check for write access of keyman dir to be able to create subdir
 		if not os.access(keyman_dir, os.X_OK | os.W_OK):
-			logging.error(error_message)
-			exit(3)
+			raise InstallError(InstallStatus.Abort, error_message)
 	else:
 		# Check for write access of basedir and create keyman subdir if we can
 		if not os.access(basedir, os.X_OK | os.W_OK):
-			logging.error(error_message)
-			exit(3)
+			raise InstallError(InstallStatus.Abort, error_message)
 		os.mkdir(keyman_dir)
 
 def install_kmp_shared(inputfile, online=False):
@@ -168,15 +181,11 @@ def install_kmp_shared(inputfile, online=False):
 	if keyboards:
 		logging.info("Installing %s", info['name']['description'])
 		if online:
-			ret = process_keyboard_data(kmpid, kmpdir)
-			if ret > 0:
-				return
+			process_keyboard_data(kmpid, kmpdir)
 			if len(keyboards) > 1:
 				for kb in keyboards:
 					if kb['id'] != kmpid:
-						ret = process_keyboard_data(kb['id'], kmpdir)
-						if ret > 0:
-							return
+						process_keyboard_data(kb['id'], kmpdir)
 
 		for f in files:
 			fpath = os.path.join(kmpdir, f['name'])
@@ -215,6 +224,8 @@ def install_kmp_shared(inputfile, online=False):
 		for o in os.listdir(kmpdir):
 			logging.info(o)
 		rmtree(kmpdir)
+		message = "install_kmp.py: error: No kmp.json or kmp.inf found in %s" % (inputfile)
+		raise InstallError(InstallStatus.Abort, message)
 
 def install_kmp_user(inputfile, online=False):
 	do_install_to_ibus = False
@@ -229,15 +240,11 @@ def install_kmp_user(inputfile, online=False):
 	if keyboards:
 		logging.info("Installing %s", info['name']['description'])
 		if online:
-			ret = process_keyboard_data(kmpid, kmpdir)
-			if ret > 0:
-				return
+			process_keyboard_data(kmpid, kmpdir)
 			if len(keyboards) > 1:
 				for kb in keyboards:
 					if kb['id'] != kmpid:
-						ret = process_keyboard_data(kb['id'], kmpdir)
-						if ret > 0:
-							return
+						process_keyboard_data(kb['id'], kmpdir)
 
 		for f in files:
 			fpath = os.path.join(kmpdir, f['name'])
@@ -271,6 +278,8 @@ def install_kmp_user(inputfile, online=False):
 		for o in os.listdir(kmpdir):
 			logging.info(o)
 		rmtree(kmpdir)
+		message = "install_kmp.py: error: No kmp.json or kmp.inf found in %s" % (inputfile)
+		raise InstallError(InstallStatus.Abort, message)
 
 
 
@@ -293,6 +302,18 @@ def install_to_ibus(kmn_file):
 		else:
 			dconfwriteresult = subprocess.run(["dconf", "write", "/desktop/ibus/general/preload-engines", str(preload_engines)],
 				stdout=subprocess.PIPE, stderr= subprocess.STDOUT, encoding="UTF8")
+		if (dconfwriteresult.returncode == 0):
+			# restart IBus to be sure the keyboard is installed
+			ibusrestartresult = subprocess.run(["ibus", "restart"])
+			if (ibusrestartresult.returncode != 0):
+				message = "install_kmp.py: error %d: Could not restart IBus." % (ibusrestartresult.returncode)
+				raise InstallError(InstallStatus.Continue, message)
+		else:
+			message = "install_kmp.py: error %d: Could not install the keyboad to IBus." % (dconfwriteresult.returncode)
+			raise InstallError(InstallStatus.Continue, message)
+	else:
+		message = "install_kmp.py: error %d: Could not read dconf preload-engines entry so cannot install to IBus" % (dconfreadresult.returncode)
+		raise InstallError(InstallStatus.Continue, message)
 
 
 

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -23,9 +23,6 @@ from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
 
 #TODO userdir install
 # special processing for kmn if needed
-#TODO gui review
-# review what errors need abort and uninstall and
-#    where there should be user feedback to gui
 #TODO optionally standardise throughout on variable names
 # packageID for kmps and keyboardID for keyboards
 # see https://docs.google.com/document/d/1sj7W6pCiN-_iRss5iRdib1aHaSTmYoLIueQSKJeNy8Q/edit#heading=h.mq0rc28mf031

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -14,7 +14,7 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit', '3.0')
 from gi.repository import Gtk, WebKit
 from distutils.version import StrictVersion
-from keyman_config.install_kmp import install_kmp, extract_kmp, get_metadata
+from keyman_config.install_kmp import install_kmp, extract_kmp, get_metadata, InstallError, InstallStatus
 from keyman_config.list_installed_kmp import get_kmp_version
 from keyman_config.kmpmetadata import get_fonts
 from keyman_config.welcome import WelcomeView
@@ -262,26 +262,33 @@ class InstallKmpWindow(Gtk.Window):
 
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
-        if install_kmp(self.kmpfile, self.online):
-            if self.viewwindow:
-                self.viewwindow.refresh_installed_kmp()
-            keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
-            welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
-            if os.path.isfile(welcome_file):
-                uri_path = pathlib.Path(welcome_file).as_uri()
-                logging.debug(uri_path)
-                w = WelcomeView(uri_path, self.kbname)
-                w.resize(800, 600)
-                w.show_all()
+        try:
+            install_kmp(self.kmpfile, self.online):
+        except InstallError as e:
+            if e.status == InstallStatus.Abort:
+                message = "Keyboard " + self.kbname + " could not be installed"
+                logging.error(message)
             else:
-                dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
-                    Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
-                dialog.run()
-                logging.debug("INFO dialog closed")
-                dialog.destroy()
+                message = "Keyboard " + self.kbname + " could not be installed"
+                logging.warning(message)
+            dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
+                Gtk.ButtonsType.OK, message)
+            dialog.run()
+            logging.debug("INFO dialog closed")
+            dialog.destroy()
+        if self.viewwindow:
+            self.viewwindow.refresh_installed_kmp()
+        keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
+        welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
+        if os.path.isfile(welcome_file):
+            uri_path = pathlib.Path(welcome_file).as_uri()
+            logging.debug(uri_path)
+            w = WelcomeView(uri_path, self.kbname)
+            w.resize(800, 600)
+            w.show_all()
         else:
             dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
-                Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " could not be installed")
+                Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
             dialog.run()
             logging.debug("INFO dialog closed")
             dialog.destroy()

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -262,20 +262,26 @@ class InstallKmpWindow(Gtk.Window):
 
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
-        install_kmp(self.kmpfile, self.online)
-        if self.viewwindow:
-            self.viewwindow.refresh_installed_kmp()
-        keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
-        welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
-        if os.path.isfile(welcome_file):
-            uri_path = pathlib.Path(welcome_file).as_uri()
-            logging.debug(uri_path)
-            w = WelcomeView(uri_path, self.kbname)
-            w.resize(800, 600)
-            w.show_all()
+        if install_kmp(self.kmpfile, self.online):
+            if self.viewwindow:
+                self.viewwindow.refresh_installed_kmp()
+            keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
+            welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
+            if os.path.isfile(welcome_file):
+                uri_path = pathlib.Path(welcome_file).as_uri()
+                logging.debug(uri_path)
+                w = WelcomeView(uri_path, self.kbname)
+                w.resize(800, 600)
+                w.show_all()
+            else:
+                dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
+                    Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
+                dialog.run()
+                logging.debug("INFO dialog closed")
+                dialog.destroy()
         else:
             dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
-                Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
+                Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " could not be installed")
             dialog.run()
             logging.debug("INFO dialog closed")
             dialog.destroy()

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -263,34 +263,34 @@ class InstallKmpWindow(Gtk.Window):
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
         try:
-            install_kmp(self.kmpfile, self.online):
+            install_kmp(self.kmpfile, self.online)
+            if self.viewwindow:
+                self.viewwindow.refresh_installed_kmp()
+            keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
+            welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
+            if os.path.isfile(welcome_file):
+                uri_path = pathlib.Path(welcome_file).as_uri()
+                logging.debug(uri_path)
+                w = WelcomeView(uri_path, self.kbname)
+                w.resize(800, 600)
+                w.show_all()
+            else:
+                dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
+                    Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
+                dialog.run()
+                dialog.destroy()
         except InstallError as e:
             if e.status == InstallStatus.Abort:
-                message = "Keyboard " + self.kbname + " could not be installed"
+                message = "Keyboard " + self.kbname + " could not be installed.\n\nError Message:\n%s" % (e.message)
                 logging.error(message)
+                message_type = Gtk.MessageType.ERROR
             else:
-                message = "Keyboard " + self.kbname + " could not be installed"
+                message = "Keyboard " + self.kbname + " could not be installed fully.\n\nWarning Message:\n%s" % (e.message)
                 logging.warning(message)
-            dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
+                message_type = Gtk.MessageType.WARNING
+            dialog = Gtk.MessageDialog(self, 0, message_type,
                 Gtk.ButtonsType.OK, message)
             dialog.run()
-            logging.debug("INFO dialog closed")
-            dialog.destroy()
-        if self.viewwindow:
-            self.viewwindow.refresh_installed_kmp()
-        keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
-        welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
-        if os.path.isfile(welcome_file):
-            uri_path = pathlib.Path(welcome_file).as_uri()
-            logging.debug(uri_path)
-            w = WelcomeView(uri_path, self.kbname)
-            w.resize(800, 600)
-            w.show_all()
-        else:
-            dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
-                Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")
-            dialog.run()
-            logging.debug("INFO dialog closed")
             dialog.destroy()
         if not self.endonclose:
             self.close()

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -6,23 +6,23 @@ import logging
 import sys
 import os.path
 import magic
-from enum import Enum, auto
+from enum import Enum
 
 class KMFileTypes(Enum):
-	KM_ICON = auto()
-	KM_SOURCE = auto()
-	KM_OSK_SOURCE = auto()
-	KM_KMX = auto()
-	KM_OSK = auto()
-	KM_TOUCH = auto()
-	KM_FONT = auto()
-	KM_DOC = auto()
-	KM_META = auto()
-	KM_IMAGE = auto()
-	KM_TECKIT = auto()
-	KM_CC = auto()
-	KM_XML = auto()
-	KM_UNKNOWN = auto()
+	KM_ICON = 1
+	KM_SOURCE = 2
+	KM_OSK_SOURCE = 3
+	KM_KMX = 4
+	KM_OSK = 5
+	KM_TOUCH = 6
+	KM_FONT = 7
+	KM_DOC = 8
+	KM_META = 9
+	KM_IMAGE = 10
+	KM_TECKIT = 11
+	KM_CC = 12
+	KM_XML = 13
+	KM_UNKNOWN = 99
 
 
 def print_info(info):

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -127,7 +127,7 @@ def get_kmp_version(keyboardid):
             if version < user_version:
                 version = user_version
         else:
-            version = shared_version
+            version = user_version
 
     return version
 

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -4,15 +4,15 @@ import argparse
 import logging
 import os
 import json
-from enum import Enum, auto
+from enum import Enum
 from keyman_config.kmpmetadata import parsemetadata, parseinfdata
 from keyman_config.get_kmp import user_keyman_dir
 
 class InstallArea(Enum):
-    IA_OS = auto()
-    IA_SHARED = auto()
-    IA_USER = auto()
-    IA_UNKNOWN = auto()
+    IA_OS = 1
+    IA_SHARED = 2
+    IA_USER = 3
+    IA_UNKNOWN = 99
 
 def get_installed_kmp(area):
     """

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -31,6 +31,17 @@ def main():
 	from keyman_config.list_installed_kmp import get_kmp_version
 	from keyman_config.get_kmp import get_keyboard_data, get_kmp
 
+	def try_install_kmp(inputfile, arg, online=False, sharedarea=False):
+		try:
+			install_kmp(inputfile, online, sharedarea)
+		except InstallError as e:
+			if e.status == InstallStatus.Abort:
+				logging.error("km-package-install: error: Failed to install %s", arg)
+				logging.error(e.message)
+				sys.exit(3)
+			else:
+				logging.warning(e.message)
+
 	if args.f:
 		name, ext = os.path.splitext(args.f)
 		if ext != ".kmp":
@@ -42,14 +53,7 @@ def main():
 			logging.error("km-package-install: Keyman kmp file %s not found.", args.f)
 			logging.error("km-package-install -f <kmpfile>")
 			sys.exit(2)
-		try:
-			install_kmp(args.f, False, args.s)
-		except InstallError as e:
-			if e.status == InstallStatus.Abort:
-				logging.error("km-package-install: error: Failed to install file %s", args.f)
-				logging.error(e.message)
-			else:
-				logging.warning(e.message)
+		try_install_kmp(args.f, "file " + args.f, False, args.s)
 	elif args.k:
 		installed_kmp_ver = get_kmp_version(args.k)
 		kbdata = get_keyboard_data(args.k)
@@ -66,21 +70,15 @@ def main():
 
 		kmpfile = get_kmp(args.k)
 		if kmpfile:
-			try:
-				install_kmp(kmpfile, True, args.s)
-			except InstallError as e:
-				if e.status == InstallStatus.Abort:
-					logging.error("km-package-install: error: Failed to install keyboard %s", args.k)
-					logging.error(e.message)
-					sys.exit(3)
-				else:
-					logging.warning(e.message)
+			try_install_kmp(kmpfile, "keyboard " + args.k, True, args.s)
 		else:
 			logging.error("km-package-install: error: Could not download keyboard package %s", args.k)
 			sys.exit(2)
 	else:
 		logging.error("km-package-install: error: no arguments: either install a local kmp file or specify a keyboard id to download and install.")
 		sys.exit(2)
+
+
 
 if __name__ == "__main__":
 	main()

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -27,7 +27,7 @@ def main():
 		logging.error("km-package-install: error: too many arguments: either install a local kmp file or specify a keyboard id to download and install.")
 		sys.exit(2)
 
-	from keyman_config.install_kmp import install_kmp
+	from keyman_config.install_kmp import install_kmp, InstallError, InstallStatus
 	from keyman_config.list_installed_kmp import get_kmp_version
 	from keyman_config.get_kmp import get_keyboard_data, get_kmp
 
@@ -42,8 +42,14 @@ def main():
 			logging.error("km-package-install: Keyman kmp file %s not found.", args.f)
 			logging.error("km-package-install -f <kmpfile>")
 			sys.exit(2)
-
-		install_kmp(args.f, False, args.s)
+		try:
+			install_kmp(args.f, False, args.s)
+		except InstallError as e:
+			if e.status == InstallStatus.Abort:
+				logging.error("km-package-install: error: Failed to install file %s", args.f)
+				logging.error(e.message)
+			else:
+				logging.warning(e.message)
 	elif args.k:
 		installed_kmp_ver = get_kmp_version(args.k)
 		kbdata = get_keyboard_data(args.k)
@@ -60,7 +66,15 @@ def main():
 
 		kmpfile = get_kmp(args.k)
 		if kmpfile:
-			install_kmp(kmpfile, True, args.s)
+			try:
+				install_kmp(kmpfile, True, args.s)
+			except InstallError as e:
+				if e.status == InstallStatus.Abort:
+					logging.error("km-package-install: error: Failed to install keyboard %s", args.k)
+					logging.error(e.message)
+					sys.exit(3)
+				else:
+					logging.warning(e.message)
 		else:
 			logging.error("km-package-install: error: Could not download keyboard package %s", args.k)
 			sys.exit(2)


### PR DESCRIPTION
Fixes #1222 : raises InstallError exceptions for install errors and warnings and handles them to present messages to the user where install_kmp is called

Fixes #1184 : restarts ibus after installing the keyboard to ibus
adds /usr/local/share/keyman/ and ~/.local/share/keyman/ to ibus-kmfl observed paths which appears to help ibus-kmfl to find the keyboards more reliably

Fix running on xenial which doesn't have enum.auto()

This appears to work on wasta xenial, wasta bionic and mate bionic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1235)
<!-- Reviewable:end -->
