### PR TITLE
[Windows] Serialized input: don't trigger on console windows

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,8 @@
 # Keyman Desktop Version History
 
+## 2018-10-05 11.0 alpha
+* Rework keyboard input to serialize input queue to resolve modifier key stickiness (#1229)
+
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,6 +1,6 @@
 # Keyman Desktop Version History
 
-## 2018-10-05 11.0 alpha
+## 11.0 alpha
 * Rework keyboard input to serialize input queue to resolve modifier key stickiness (#1229)
 
 ## 2018-06-28 10.0.1200 stable

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -4,8 +4,12 @@
 * Refactor how keyboard_info metadata is generated (#1158)
 * New Feature: New Project from template and Import Keyboard (#1210)
 * New Feature: kmconvert command line utility (#1207)
-* New code editor using open source Monaco component (#1153, #1154 and others)
+* New code editor using open source Monaco component (#1153, #1154, #1252)
 * Tidy up of installer to make future upgrades easier (#1175)
+* Support Linux targets (#1239)
+* Opening or creating a project now closes current editor files (#1242)
+* Projects can now include other related files such as history.md (#1243)
+* Keyman Developer now treats files as UTF-8 by default (#1244)
 
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release

--- a/windows/src/engine/keyman32/K32_DBG.CPP
+++ b/windows/src/engine/keyman32/K32_DBG.CPP
@@ -407,7 +407,10 @@ void DebugMessage(LPMSG msg, WPARAM wParam)  // I2908
 	else if(msg->message == wm_keymankeyup)
     wsprintf(ds, "DebugMessage(%x, wm_keymankeyup: %s lParam: %X) [message flags: %x time: %d]", msg->hwnd, 
       Debug_VirtualKey((WORD) msg->wParam), msg->lParam, wParam, msg->time);
-	else if(msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_SYSKEYDOWN || msg->message == WM_SYSKEYUP)
+  else if (msg->message == wm_keyman_keyevent)
+    wsprintf(ds, "DebugMessage(%x, wm_keyman_keyevent: %s lParam: %X) [message flags: %x time: %d]", msg->hwnd,
+      Debug_VirtualKey((WORD)msg->wParam), msg->lParam, wParam, msg->time);
+  else if(msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_SYSKEYDOWN || msg->message == WM_SYSKEYUP)
     wsprintf(ds, "DebugMessage(%x, %s, wParam: %s, lParam: %X) [message flags: %x time: %d extra: %x]", 
       msg->hwnd, 
       msgnames[msg->message-WM_KEYDOWN],

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -141,7 +141,9 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 		if(!InitialiseProcess(mp->hwnd)) return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
   }
 
-  if (mp->message >= WM_KEYFIRST && mp->message <= WM_KEYLAST && ShouldDebug(sdmMessage)) {
+  if (((mp->message >= WM_KEYFIRST && mp->message <= WM_KEYLAST) || mp->message == wm_keymankeydown || mp->message == wm_keymankeyup ||
+    mp->message == wm_keyman_keyevent) 
+    && ShouldDebug(sdmMessage)) {
     DebugMessage(mp, wParam);
   }
 


### PR DESCRIPTION
We don't attempt to serialize input to the console windows because they 
behave somewhat differently to normal windows. For now, this should be 
sufficient. In the future, we may want to find a way to interrogate the 
focused process to find out which window actually has focus for posting
messages, because we appear to post the messages to the wrong thread
for console windows.