### PR TITLE
[Developer] Reduce installer size for Keyman Developer

### DIFF
--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -295,7 +295,7 @@
       <Custom Action='SaveARPInstallLocation' After='InstallValidate'><![CDATA[Not Installed Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Media Id="1" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
+    <Media Id="1" CompressionLevel="high" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
 
     <Property Id="ALLUSERS">1</Property>
 

--- a/windows/src/developer/TIKE/main/Keyman.Developer.System.CEFManager.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.System.CEFManager.pas
@@ -75,6 +75,8 @@ begin
   // Read this https://www.briskbard.com/index.php?lang=en&pageid=cef
   GlobalCEFApp := TCefApplication.Create;
 
+  GlobalCEFApp.CheckCEFFiles := False;
+
   // We run in debug mode when TIKE debug mode flag is set, so that we can
   // debug the CEF interactions more easily
 //  GlobalCEFApp.SingleProcess        := TikeDebugMode;

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -334,7 +334,7 @@
       <ComponentGroupRef Id="Samples" />
     </Feature>
 
-    <Media Id="1" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
+    <Media Id="1" EmbedCab="yes" CompressionLevel="high" Cabinet="Data1.cab" VolumeLabel="DISK1" />
 
     <UIRef Id="WixUI_FeatureTree"/>
 


### PR DESCRIPTION
1. Use compression="high" instead of "mszip" for better compression of msi
2. Remove unneeded CEF files