### PR TITLE
[Developer] Project - List other files, such as .keyboard_info, in Distribution tab

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFiles.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFiles.pas
@@ -62,7 +62,10 @@ end;
 initialization
   RegisterProjectFileType('*', TShellProjectFile);
   RegisterProjectFileType('.bmp', TOpenableProjectFile);
+  RegisterProjectFileType('.ico', TOpenableProjectFile);
   RegisterProjectFileType('.txt', TOpenableProjectFile);
+  RegisterProjectFileType('.md', TOpenableProjectFile);
+  RegisterProjectFileType('.keyboard_info', TOpenableProjectFile);
   RegisterProjectFileType('.htm', TOpenableProjectFile);   // I1769
   RegisterProjectFileType('.html', TOpenableProjectFile);  // I1769
   RegisterProjectFileType('.xml', TOpenableProjectFile);   // I1769

--- a/windows/src/developer/TIKE/xml/project/distribution.xsl
+++ b/windows/src/developer/TIKE/xml/project/distribution.xsl
@@ -45,8 +45,84 @@
       </div>
    
       <div class='filelist' id="distributionlist">
-        <p>&#160;</p>
+        <xsl:call-template name="button">
+          <xsl:with-param name="caption">New file...</xsl:with-param>
+          <xsl:with-param name="command">keyman:fileaddnew?type=text</xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="button">
+          <xsl:with-param name="caption">Add existing file...</xsl:with-param>
+          <xsl:with-param name="command">keyman:fileaddexisting?type=text</xsl:with-param>
+        </xsl:call-template>
+        |
+        <xsl:call-template name="button">
+          <xsl:with-param name="caption">Build all</xsl:with-param>
+          <xsl:with-param name="command">keyman:compileall</xsl:with-param>
+          <xsl:with-param name="enabled">
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+          </xsl:with-param>
+        </xsl:call-template>
+        <xsl:call-template name="button">
+          <xsl:with-param name="caption">Clean all</xsl:with-param>
+          <xsl:with-param name="command">keyman:cleanall</xsl:with-param>
+          <xsl:with-param name="enabled">
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+          </xsl:with-param>
+          <xsl:with-param name="width">auto</xsl:with-param>
+        </xsl:call-template>
+        
+        <br />
+        <br />
+
+        <div>
+          <xsl:for-each select="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and not(ParentFileID)]">
+            <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
+            <xsl:call-template name="file">
+              <xsl:with-param name="file_description"></xsl:with-param>
+              <xsl:with-param name="file_has_details">false</xsl:with-param>
+            </xsl:call-template>
+          </xsl:for-each>
+        </div>
       </div>
+    </div>
+  </xsl:template>
+
+  <xsl:template mode="options_menu" match="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn']" >
+    <div class="menu">
+      <xsl:attribute name="id">menu_options_<xsl:value-of select="ID"/></xsl:attribute>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open</xsl:with-param>
+        <xsl:with-param name="command">keyman:openfile?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Build</xsl:with-param>
+        <xsl:with-param name="command">keyman:compilefile?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:if test="/KeymanDeveloperProject/Modules/Module[ID='BrandingPack']">
+        <xsl:call-template name="menuitem">
+          <xsl:with-param name="caption">Build installer</xsl:with-param>
+          <xsl:with-param name="command">keyman:package_compileinstaller?id=<xsl:value-of select="ID" /></xsl:with-param>
+        </xsl:call-template>
+      </xsl:if>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Clean</xsl:with-param>
+        <xsl:with-param name="command">keyman:cleanfile?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">View Source</xsl:with-param>
+        <xsl:with-param name="command">keyman:viewfilesource?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open in External Editor</xsl:with-param>
+        <xsl:with-param name="command">keyman:editfileexternal?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open Containing Folder</xsl:with-param>
+        <xsl:with-param name="command">keyman:opencontainingfolder?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Remove from Project</xsl:with-param>
+        <xsl:with-param name="command">keyman:removefile?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
     </div>
   </xsl:template>
   

--- a/windows/src/developer/TIKE/xml/project/packages.xsl
+++ b/windows/src/developer/TIKE/xml/project/packages.xsl
@@ -91,17 +91,6 @@
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>
         
-        <xsl:if test="/KeymanDeveloperProject/Modules/Module[ID='BrandingPack']">
-          |
-          <xsl:call-template name="button">
-            <xsl:with-param name="caption">Build package installers</xsl:with-param>
-            <xsl:with-param name="command">keyman:package_compileallinstallers</xsl:with-param>
-            <xsl:with-param name="enabled">
-              <xsl:if test="not(KeymanDeveloperProject/Files/File[FileType='.kps' and not (ParentFileID)])">false</xsl:if>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:if>
-
         <br />
         <br />
 


### PR DESCRIPTION
The Distribution tab now lists any other files you add to the project (that is, files that are not .kmn or .kps), so that you can more easily track .keyboard_info, readme.md, license.md, history.md etc.

Fixes #1220