### PR TITLE
[linux] bump lib version number of libkmflcomp

### DIFF
--- a/linux/kmflcomp/src/Makefile.am
+++ b/linux/kmflcomp/src/Makefile.am
@@ -22,7 +22,7 @@ libkmflcomp_la_SOURCES = \
 
 EXTRA_DIST = compiler.h memman.h
 
-libkmflcomp_la_LDFLAGS = -lX11 -L/usr/X11R6/lib -Wl,--no-as-needed
+libkmflcomp_la_LDFLAGS = -lX11 -L/usr/X11R6/lib -Wl,--no-as-needed -version-info 1:0:1
 
 libkmflcomp_la_LIBADD = 
 


### PR DESCRIPTION
because APIs were added since last release (0.9.10)
ref https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
scenario 2 so set to 1:0:1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1259)
<!-- Reviewable:end -->
