### PR TITLE
[linux] misc packaging

### DIFF
--- a/linux/kmflcomp/NEWS
+++ b/linux/kmflcomp/NEWS
@@ -1,1 +1,6 @@
-ChangeLog
+10.99
+-----
+
+kmflcomp now supports special stores added since Keyman version 6.0.
+However it does not support the newer syntax.
+Keyboards for Keyman > 6.0 which only use older syntax should compile

--- a/linux/kmflcomp/debian/changelog
+++ b/linux/kmflcomp/debian/changelog
@@ -1,12 +1,17 @@
-kmflcomp (10.99.1-1) UNRELEASED; urgency=medium
+kmflcomp (10.99.32-1) experimental; urgency=medium
 
   * Change license to MIT as kmflcomp is being moved into Keyman 11
   * Keyman is now owned by SIL
   * new upstream pre-release
     - add new symbols to d/libkmflcomp0.symbols
   * d/control remove build-dep on autotools-dev (compat 10)
+              update webpage 
+  * New upstream pre-release
+  * added symbols in libkmflcomp0 so will require transition
+  * I am now the maintainer as I am the one working
+      on Keyman for Linux upstream
 
- -- Daniel Glassey <wdg@debian.org>  Wed, 29 Aug 2018 16:37:58 +0700
+ -- Daniel Glassey <wdg@debian.org>  Tue, 16 Oct 2018 13:09:24 +0700
 
 kmflcomp (0.9.10-1) unstable; urgency=low
 

--- a/linux/kmflcomp/debian/changelog
+++ b/linux/kmflcomp/debian/changelog
@@ -5,7 +5,7 @@ kmflcomp (10.99.32-1) experimental; urgency=medium
   * new upstream pre-release
     - add new symbols to d/libkmflcomp0.symbols
   * d/control remove build-dep on autotools-dev (compat 10)
-              update webpage 
+              update webpage
   * New upstream pre-release
   * added symbols in libkmflcomp0 so will require transition
   * I am now the maintainer as I am the one working

--- a/linux/kmflcomp/kmfl_compiler/Makefile.am
+++ b/linux/kmflcomp/kmfl_compiler/Makefile.am
@@ -16,6 +16,4 @@ bin_PROGRAMS = kmflcomp
 kmflcomp_SOURCES = \
 	kmfl_compiler.c
 
-kmflcomp_LDFLAGS = -lX11 -L/usr/X11R6/lib -Wl,--no-as-needed
-
-kmflcomp_LDADD = ../src/.libs/libkmflcomp.a
+kmflcomp_LDADD = ../src/libkmflcomp.la

--- a/linux/kmflcomp/src/Makefile.am
+++ b/linux/kmflcomp/src/Makefile.am
@@ -22,8 +22,8 @@ libkmflcomp_la_SOURCES = \
 
 EXTRA_DIST = compiler.h memman.h
 
-libkmflcomp_la_LDFLAGS = -lX11 -L/usr/X11R6/lib -Wl,--no-as-needed -version-info 1:0:1
+libkmflcomp_la_LDFLAGS = -Wl,--no-as-needed -version-info 1:0:1
 
-libkmflcomp_la_LIBADD = 
+libkmflcomp_la_LIBADD = -L/usr/X11R6/lib -lX11
 
 AM_YFLAGS = -d

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -44,6 +44,7 @@ for proj in ${projects}; do
     cd ${proj}
     if [ "${proj}" == "keyman-config" ]; then
         tarname="keyman_config"
+        make clean
     else
         tarname="${proj}"
     fi


### PR DESCRIPTION
minor tweaks for packaging

fix longstanding build bug reported to Debian by Ubuntu about linking X11 lib in kmflcomp
clean keyman-config before launchpad build
make kmflcomp NEWS file different from Changelog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1266)
<!-- Reviewable:end -->
