### PR TITLE
[Windows] Change the vk_prefix (zap) code from 0x07 to 0x0E to avoid Game Bar conflict and make it customisable via registry

### DIFF
--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -427,6 +427,11 @@ extern "C" BOOL _declspec(dllexport) WINAPI Keyman_Initialise(HWND Handle, BOOL 
 
 	InitDebugging();
 
+  if (!Globals::InitSettings()) {
+    SendDebugMessageFormat(Handle, sdmGlobal, 0, "Keyman_Initialise: Failed to initialise global settings.  GetLastError = %d", GetLastError());
+    return FALSE;
+  }
+
   if(!Globals::InitHandles())  // I3040
   {
     SendDebugMessageFormat(Handle, sdmGlobal, 0, "Keyman_Initialise: Failed to create global handles.  GetLastError = %d", GetLastError());
@@ -1031,6 +1036,6 @@ BOOL ShouldAttachToProcess()
 
 
 void PostDummyKeyEvent() {  // I3301 - Handle I3250 regression with inadvertent menu activation with Alt keys   // I3534   // I4844
-  keybd_event(_VK_PREFIX, SCAN_FLAG_KEYMAN_KEY_EVENT, 0, 0); // I3250 - is this unnecessary?
-  keybd_event(_VK_PREFIX, SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0); // I3250 - is this unnecessary?
+  keybd_event((BYTE) Globals::get_vk_prefix(), SCAN_FLAG_KEYMAN_KEY_EVENT, 0, 0); // I3250 - is this unnecessary?
+  keybd_event((BYTE) Globals::get_vk_prefix(), SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0); // I3250 - is this unnecessary?
 }

--- a/windows/src/engine/keyman32/appint/aiTIP.h
+++ b/windows/src/engine/keyman32/appint/aiTIP.h
@@ -32,7 +32,8 @@
 #define AIType_TIP	3
 
 // _VK_PREFIX is used to mask out ALT key seemingly pressed by itself when Keyman swallows the next key, which would activate a menu.   // I4844
-#define _VK_PREFIX    0x07
+// This can be customised with HKLM\Software\Keyman\Keyman Engine\zap virtual key code
+#define _VK_PREFIX_DEFAULT    0x0E
 
 struct AIDEBUGKEYINFO
 {

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -120,6 +120,9 @@ public:
 
   static BOOL get_MnemonicDeadkeyConversionMode();   // I4583   // I4552
 
+  static UINT get_vk_prefix();
+  static void set_vk_prefix(UINT value);
+
   static void SetBaseKeyboardName(wchar_t *baseKeyboardName, wchar_t *baseKeyboardNameAlt);   // I4583
 
 	static BOOL IsControllerWindow(HWND hwnd);
@@ -134,6 +137,7 @@ public:
   static BOOL IsControllerProcess();
 
   static BOOL InitHandles();
+  static BOOL InitSettings();
   static BOOL Lock();
   static BOOL Unlock();
   static BOOL CheckControllers();

--- a/windows/src/engine/keyman32/keybd_shift.cpp
+++ b/windows/src/engine/keyman32/keybd_shift.cpp
@@ -108,8 +108,8 @@ void do_keybd_event(LPINPUT pInputs, int *n, BYTE vk, BYTE scan, DWORD flags, UL
 void keybd_sendprefix(LPINPUT pInputs, int *n)
 {
   SendDebugMessageFormat(0, sdmAIDefault, 0, "keybd_sendprefix: sending prefix down+up");
-  do_keybd_event(pInputs, n, _VK_PREFIX, SCAN_FLAG_KEYMAN_KEY_EVENT, 0, 0);   // I4548   // I4844
-  do_keybd_event(pInputs, n, _VK_PREFIX, SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0);   // I4548   // I4844
+  do_keybd_event(pInputs, n, (BYTE) Globals::get_vk_prefix(), SCAN_FLAG_KEYMAN_KEY_EVENT, 0, 0);   // I4548   // I4844
+  do_keybd_event(pInputs, n, (BYTE) Globals::get_vk_prefix(), SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0);   // I4548   // I4844
 }
 
 /**

--- a/windows/src/global/inc/registry.h
+++ b/windows/src/global/inc/registry.h
@@ -106,7 +106,7 @@
 #define REGSZ_SimulateAltGr     "simulate altgr"
 #define REGSZ_KeyboardHotkeysAreToggle "hotkeys are toggles"
 #define REGSZ_DeadkeyConversionMode    "deadkey conversion mode"                // CU   // I4552
-
+#define REGSZ_ZapVirtualKeyCode        "zap virtual key code"   // LM, defaults to 0x0E (_VK_PREFIX_DEFAULT)
 /* 
   Debug flags
   These are all stored in HKCU\Software\Keyman\Debug


### PR DESCRIPTION
The Game Bar on Windows 10 registers a hotkey for virtual key code `0x07` (in Explorer, twice, once by 
`CImmersiveWindowMessageService (CImmersiveHotkeyNotification)` and once by `twinui_pcshell!PrivilegedHotkeyOperations::RequestPrivilegedHotkeys` 
(`BroadcastDVRComponent::RegisterHotkeys`), and handled by `twinui!BroadcastDVRComponent::HandleHolographicHotkey`. This virtual key code is not
documented in WinUser.h. It may well be generated by an Xbox One controller or some other hardware gaming device.

So the default zap code has been changed to 0x0E which is also 'unassigned'. In order to mitigate this in the future if this causes a conflict
anywhere, the setting can also be changed via the registry setting `zap virtual key code` in `HKLM\Software\Keyman\Keyman Engine`.