### PR TITLE
[WIP][Android] Allow system "globe button" to change keyboards

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/xml/method.xml
+++ b/android/KMAPro/kMAPro/src/main/res/xml/method.xml
@@ -20,4 +20,6 @@
 <!-- The attributes in this XML file provide configuration information -->
 <!-- for the Search Manager. -->
 
-<input-method xmlns:android="http://schemas.android.com/apk/res/android" />
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_action_language"
+    android:supportsSwitchingToNextInputMethod="true" />

--- a/android/Samples/KMSample2/app/src/main/res/xml/method.xml
+++ b/android/Samples/KMSample2/app/src/main/res/xml/method.xml
@@ -20,4 +20,6 @@
 <!-- The attributes in this XML file provide configuration information -->
 <!-- for the Search Manager. -->
 
-<input-method xmlns:android="http://schemas.android.com/apk/res/android" />
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_action_language"
+    android:supportsSwitchingToNextInputMethod="true" />


### PR DESCRIPTION
Fixes #943 

KMEA currently allows the globe button action to:
1. show language picker menu
2. switch to next keyboard
3. do nothing

where both in-app and system keyboards default the globe button to (1). 

This PR investigates and changes the system keyboard globe button to switch to the next IME.
