### PR TITLE
[LMLayer] Basic WebWorker testing

### DIFF
--- a/common/predictive-text/testing/index.html
+++ b/common/predictive-text/testing/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    
+    <!-- Set the viewport width to match iOS device widths -->                         
+    <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
+      
+    <title>LMLayer Testing</title>
+    <style type='text/css'>   
+      body {padding-left:20px;margin-left:12px; font-family:Tahoma,Helvetica}
+      h1 {color: #800;margin-left:10px;}
+      h2 {color: #008;margin-left:20px;}
+    </style>
+  </head>
+  <body>
+  <h1>Language-Modeling Layer module testing</h1>
+  <h2><a href="./simple-webworker">A simple basic WebWorker.</a></h2>  Designed as a baseline functionality test we can run against various platforms as a first-stage canary of sorts.
+  </body>
+</html>

--- a/common/predictive-text/testing/simple-webworker/canaryWorker.js
+++ b/common/predictive-text/testing/simple-webworker/canaryWorker.js
@@ -1,0 +1,9 @@
+var counter = 0;
+
+onmessage = function(e) {
+  counter++;
+  
+  console.log("Message received from main page: ", e.data);
+  
+  postMessage(counter);
+}

--- a/common/predictive-text/testing/simple-webworker/index.html
+++ b/common/predictive-text/testing/simple-webworker/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    
+    <!-- Set the viewport width to match phone and tablet device widths -->                         
+    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
+      
+    <title>Basic WebWorker test</title>
+
+    <!-- Your page CSS --> 
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}       
+    </style>
+  
+	<script>
+    if(window.Worker) {
+      var canaryWorker = new Worker('canaryWorker.js');
+      
+      canaryWorker.onmessage = function(e) {
+        var counter = e.data; // Number of times the WebWorker has been messaged.
+        console.log("Received message from the WebWorker: " + e.data);
+        
+        var txtFeedback = document.getElementById("txtFeedback");
+        txtFeedback.value = counter + " click(s)";
+      }
+    } else {
+      console.error("WebWorkers are not supported in this browser!");
+    }
+	</script>
+  </head>
+
+<!-- Sample page HTML -->  
+  <body>
+    <h2>LM Layer Testing - basic WebWorker canary</h2>
+	<p>This page uses a simple WebWorker useful for ensuring functionality on various platforms.</p>
+  <input type='text' id='txtFeedback' value="No clicks yet." readonly></input> <br>
+  <script>
+    var txtFeedback = document.getElementById("txtFeedback");
+    txtFeedback.value = "No clicks yet.";
+  </script>
+	<input type='button' id='btnInput' onclick='canaryWorker.postMessage("Hello.");' value='Message the WebWorker.' />
+
+   <h3><a href="../index.html">Return to testing home page</a></h3>
+  </body> 
+</html>


### PR DESCRIPTION
Adds a small, extremely light-weight WebWorker testing page as a basic, first-stage test for LMLayer viability on various platforms.

In doing so, also adds the start of a 'testing' section to the common/predictive-text subproject.