### PR TITLE
[iOS] System keyboard + Reachability crash fix

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		C0A5FF391F6684DE00BE740C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -181,9 +181,12 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     keymanWeb.view.addGestureRecognizer(hold)
 
     reachability = Reachability(hostName: keymanHostName)
-    NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
+
+    if(!Util.isSystemKeyboard) {
+      NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
                                            name: .reachabilityChanged, object: reachability)
-    reachability.startNotifier()
+      reachability.startNotifier()
+    }
 
     /* HTTPDownloader only uses this for its delegate methods.  So long as we don't
      * set the queue running, this should be perfectly fine.

--- a/ios/history.md
+++ b/ios/history.md
@@ -5,6 +5,7 @@
 * Bookmark add button is enabled only when title/url fields have text (#1073)
 * Removed deprecated code to to support keyman:// scheme for ad-hoc distribution (#1160)
 * Updated the default keyboard to SIL EuroLatin (#1101)
+* Fixed bug behind some crashes of system keyboard (#1166)
 
 ## 2018-08-02 10.0.208 stable 
 * Fixed OSK layout problems (and possible crash) on iOS 11 on certain hardware (#1089, #1159) 

--- a/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #1166.

Due to some unfortunate mis-organization of code, we had internet "reachability" checks running from the system keyboard.  This makes sense in the app, which can check for keyboard updates and has event handlers designed toward that end, but little sense for the system keyboard - and since the handlers weren't intended for the system keyboard, the latter has been causing crashes.

Easiest solution?  Just disable reachability checks for system-keyboard contexts.

Also, Xcode 10's been causing some issues with IDE-based builds that are resolved by using the legacy/"original" build system.  Since it's pretty helpful to use the Simulator for testing through Xcode, the workspace settings change is being included.