### PR TITLE
[windows] rename build alltags

### DIFF
--- a/windows/src/buildtools/build_standards_data/Keyman.Console.BuildStandardsData.pas
+++ b/windows/src/buildtools/build_standards_data/Keyman.Console.BuildStandardsData.pas
@@ -10,7 +10,7 @@ uses
   Keyman.System.BuildISO6393Registry,
   Keyman.System.BuildLanguageSubtagRegistry,
   Keyman.System.BuildLCIDToBCP47Registry,
-  Keyman.System.BuildLibPalasoAllTags;
+  Keyman.System.BuildNRSIAllTags;
 
 procedure Run;
 begin
@@ -54,7 +54,7 @@ begin
   else if ParamStr(1) = 'alltags' then
   begin
     writeln('Building '+ParamStr(3));
-    TBuildLibPalasoAllTags.Build(ParamStr(2), ParamStr(3));
+    TBuildNRSIAllTags.Build(ParamStr(2), ParamStr(3));
   end
   else
   begin

--- a/windows/src/buildtools/build_standards_data/Keyman.System.BuildNRSIAllTags.pas
+++ b/windows/src/buildtools/build_standards_data/Keyman.System.BuildNRSIAllTags.pas
@@ -1,9 +1,9 @@
-unit Keyman.System.BuildLibPalasoAllTags;
+unit Keyman.System.BuildNRSIAllTags;
 
 interface
 
 type
-  TBuildLibPalasoAllTags = class
+  TBuildNRSIAllTags = class
     class procedure Build(AllTagsFile, DestinationFile: string);
   end;
 
@@ -15,9 +15,9 @@ uses
   System.StrUtils,
   System.SysUtils;
 
-{ TBuildLibPalasoAllTags }
+{ TBuildNRSIAllTags }
 
-class procedure TBuildLibPalasoAllTags.Build(AllTagsFile,
+class procedure TBuildNRSIAllTags.Build(AllTagsFile,
   DestinationFile: string);
 var
   FAllTags: TStringList;
@@ -37,7 +37,7 @@ begin
     FResult := TStringList.Create;
     try
 
-      FResult.Add('unit Keyman.System.Standards.LibPalasoAllTagsRegistry;');
+      FResult.Add('unit Keyman.System.Standards.NRSIAllTagsRegistry;');
       FResult.Add('');
       FResult.Add('interface');
       FResult.Add('');
@@ -49,16 +49,16 @@ begin
       FResult.Add('  System.Generics.Collections;');
       FResult.Add('');
       FResult.Add('type');
-      FResult.Add('  TLibPalasoAllTagsMap = class');
+      FResult.Add('  TNRSIAllTagsMap = class');
       FResult.Add('  public');
       FResult.Add('    class procedure Fill(dict: TDictionary<string,TArray<string>>);');
       FResult.Add('  end;');
       FResult.Add('');
       FResult.Add('implementation');
       FResult.Add('');
-      FResult.Add('{ TLibPalasoAllTagsMap }');
+      FResult.Add('{ TNRSIAllTagsMap }');
       FResult.Add('');
-      FResult.Add('class procedure TLibPalasoAllTagsMap.Fill(dict: TDictionary<string,TArray<string>>);');
+      FResult.Add('class procedure TNRSIAllTagsMap.Fill(dict: TDictionary<string,TArray<string>>);');
       FResult.Add('begin');
 
       dict := TStringList.Create; //' TArray<string,TArray<string>>.Create;

--- a/windows/src/buildtools/build_standards_data/Makefile
+++ b/windows/src/buildtools/build_standards_data/Makefile
@@ -22,7 +22,7 @@ LCID_DATA=$(STANDARDS_DATA_PATH)\windows-lcid-to-bcp-47\map_clean_win.txt
 LCID_PAS=$(STANDARDS_OUT_PATH)\Keyman.System.Standards.LCIDToBCP47Registry.pas
 
 ALLTAGS_DATA=$(STANDARDS_DATA_PATH)\alltags\alltags.txt
-ALLTAGS_PAS=$(STANDARDS_OUT_PATH)\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas
+ALLTAGS_PAS=$(STANDARDS_OUT_PATH)\Keyman.System.Standards.NRSIAllTagsRegistry.pas
 
 build: 
     $(DELPHI_MSBUILD) build_standards_data.dproj

--- a/windows/src/buildtools/build_standards_data/build_standards_data.dpr
+++ b/windows/src/buildtools/build_standards_data/build_standards_data.dpr
@@ -10,7 +10,7 @@ uses
   Keyman.System.BuildISO6393Registry in 'Keyman.System.BuildISO6393Registry.pas',
   Keyman.Console.BuildStandardsData in 'Keyman.Console.BuildStandardsData.pas',
   Keyman.System.BuildLCIDToBCP47Registry in 'Keyman.System.BuildLCIDToBCP47Registry.pas',
-  Keyman.System.BuildLibPalasoAllTags in 'Keyman.System.BuildLibPalasoAllTags.pas';
+  Keyman.System.BuildNRSIAllTags in 'Keyman.System.BuildNRSIAllTags.pas';
 
 begin
   try

--- a/windows/src/buildtools/build_standards_data/build_standards_data.dproj
+++ b/windows/src/buildtools/build_standards_data/build_standards_data.dproj
@@ -92,7 +92,7 @@
         <DCCReference Include="Keyman.System.BuildISO6393Registry.pas"/>
         <DCCReference Include="Keyman.Console.BuildStandardsData.pas"/>
         <DCCReference Include="Keyman.System.BuildLCIDToBCP47Registry.pas"/>
-        <DCCReference Include="Keyman.System.BuildLibPalasoAllTags.pas"/>
+        <DCCReference Include="Keyman.System.BuildNRSIAllTags.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/buildtools/buildpkg/buildpkg.dpr
+++ b/windows/src/buildtools/buildpkg/buildpkg.dpr
@@ -70,7 +70,7 @@ uses
   BCP47Tag in '..\..\global\delphi\general\BCP47Tag.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas';
 
 begin

--- a/windows/src/buildtools/buildpkg/buildpkg.dproj
+++ b/windows/src/buildtools/buildpkg/buildpkg.dproj
@@ -157,7 +157,7 @@
         <DCCReference Include="..\..\global\delphi\general\BCP47Tag.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -152,7 +152,7 @@ uses
   kmxfileconsts in '..\..\global\delphi\general\kmxfileconsts.pas',
   Keyman.System.UpdateCheckResponse in '..\..\global\delphi\general\Keyman.System.UpdateCheckResponse.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
   UImportOlderVersionKeyboards9 in 'main\UImportOlderVersionKeyboards9.pas',

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -294,7 +294,7 @@
         <DCCReference Include="..\..\global\delphi\general\kmxfileconsts.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.UpdateCheckResponse.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="main\UImportOlderVersionKeyboards9.pas"/>

--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -258,7 +258,7 @@ uses
   Keyman.Developer.System.HelpTopics in 'help\Keyman.Developer.System.HelpTopics.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   Keyman.Developer.System.CEFManager in 'main\Keyman.Developer.System.CEFManager.pas',
   Keyman.Developer.System.HttpServer.Debugger in 'http\Keyman.Developer.System.HttpServer.Debugger.pas',

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -499,7 +499,7 @@
         <DCCReference Include="help\Keyman.Developer.System.HelpTopics.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="main\Keyman.Developer.System.CEFManager.pas"/>
         <DCCReference Include="http\Keyman.Developer.System.HttpServer.Debugger.pas"/>

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -101,7 +101,7 @@ uses
   Keyman.System.RegExGroupHelperRSP19902 in '..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   TextFileFormat in '..\TIKE\main\TextFileFormat.pas',
   Keyman.Developer.System.Project.kmnProjectFileAction in '..\TIKE\project\Keyman.Developer.System.Project.kmnProjectFileAction.pas',

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -203,7 +203,7 @@
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\TIKE\main\TextFileFormat.pas"/>
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.kmnProjectFileAction.pas"/>

--- a/windows/src/developer/kmconvert/kmconvert.dpr
+++ b/windows/src/developer/kmconvert/kmconvert.dpr
@@ -44,7 +44,7 @@ uses
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
   Keyman.System.Standards.ISO6393ToBCP47Registry in '..\..\global\delphi\standards\Keyman.System.Standards.ISO6393ToBCP47Registry.pas',
   Keyman.System.Standards.LCIDToBCP47Registry in '..\..\global\delphi\standards\Keyman.System.Standards.LCIDToBCP47Registry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.RegExGroupHelperRSP19902 in '..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas',
   Keyman.System.PackageInfoRefreshKeyboards in '..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshKeyboards.pas',
   Keyman.Developer.System.Project.ProjectFile in '..\TIKE\project\Keyman.Developer.System.Project.ProjectFile.pas',

--- a/windows/src/developer/kmconvert/kmconvert.dproj
+++ b/windows/src/developer/kmconvert/kmconvert.dproj
@@ -143,7 +143,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.ISO6393ToBCP47Registry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LCIDToBCP47Registry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas"/>
         <DCCReference Include="..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshKeyboards.pas"/>
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.ProjectFile.pas"/>

--- a/windows/src/engine/keyman/keyman.dpr
+++ b/windows/src/engine/keyman/keyman.dpr
@@ -136,7 +136,7 @@ uses
   kmxfileconsts in '..\..\global\delphi\general\kmxfileconsts.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   Keyman.System.DebugLogClient in '..\..\global\delphi\debug\Keyman.System.DebugLogClient.pas',
   Keyman.System.DebugLogCommon in '..\..\global\delphi\debug\Keyman.System.DebugLogCommon.pas',

--- a/windows/src/engine/keyman/keyman.dproj
+++ b/windows/src/engine/keyman/keyman.dproj
@@ -258,7 +258,7 @@
         <DCCReference Include="..\..\global\delphi\general\kmxfileconsts.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\debug\Keyman.System.DebugLogClient.pas"/>
         <DCCReference Include="..\..\global\delphi\debug\Keyman.System.DebugLogCommon.pas"/>

--- a/windows/src/engine/kmcomapi/kmcomapi.dpr
+++ b/windows/src/engine/kmcomapi/kmcomapi.dpr
@@ -151,7 +151,7 @@ uses
   keymankeyboardlanguagefile in 'com\keyboardlanguages\keymankeyboardlanguagefile.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   utilicon in '..\..\global\delphi\general\utilicon.pas',
   Keyman.System.MitigateWin10_1803LanguageInstall in 'processes\keyboard\Keyman.System.MitigateWin10_1803LanguageInstall.pas';

--- a/windows/src/engine/kmcomapi/kmcomapi.dproj
+++ b/windows/src/engine/kmcomapi/kmcomapi.dproj
@@ -290,7 +290,7 @@
         <DCCReference Include="com\keyboardlanguages\keymankeyboardlanguagefile.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\general\utilicon.pas"/>
         <DCCReference Include="processes\keyboard\Keyman.System.MitigateWin10_1803LanguageInstall.pas"/>

--- a/windows/src/global/delphi/general/Keyman.System.LanguageCodeUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.System.LanguageCodeUtils.pas
@@ -57,7 +57,7 @@ uses
   Keyman.System.Standards.BCP47SuppressScriptRegistry,
   Keyman.System.Standards.ISO6393ToBCP47Registry,
   Keyman.System.Standards.LCIDToBCP47Registry,
-  Keyman.System.Standards.LibPalasoAllTagsRegistry,
+  Keyman.System.Standards.NRSIAllTagsRegistry,
 
   utilstr;
 
@@ -117,7 +117,7 @@ begin
   if not Assigned(FAllTags) then
   begin
     FAllTags := TDictionary<string,TArray<string>>.Create;
-    TLibPalasoAllTagsMap.Fill(FAllTags);
+    TNRSIAllTagsMap.Fill(FAllTags);
   end;
 end;
 

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
@@ -93,7 +93,7 @@ uses
   BCP47Tag in '..\..\global\delphi\general\BCP47Tag.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas',
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   TextFileFormat in '..\..\developer\TIKE\main\TextFileFormat.pas';
 

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
@@ -180,7 +180,7 @@
         <DCCReference Include="..\..\global\delphi\general\BCP47Tag.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\developer\TIKE\main\TextFileFormat.pas"/>
         <BuildConfiguration Include="Release">

--- a/windows/src/unit-tests/kmx-file-languages/KMXFileLanguagesTestSuite.dpr
+++ b/windows/src/unit-tests/kmx-file-languages/KMXFileLanguagesTestSuite.dpr
@@ -30,7 +30,7 @@ uses
   kmxfileconsts in '..\..\global\delphi\general\kmxfileconsts.pas',
   Keyman.System.Standards.BCP47SubtagRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas',
   Keyman.System.Standards.BCP47SuppressScriptRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas',
-  Keyman.System.Standards.LibPalasoAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas';
+  Keyman.System.Standards.NRSIAllTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/unit-tests/kmx-file-languages/KMXFileLanguagesTestSuite.dproj
+++ b/windows/src/unit-tests/kmx-file-languages/KMXFileLanguagesTestSuite.dproj
@@ -108,7 +108,7 @@
         <DCCReference Include="..\..\global\delphi\general\kmxfileconsts.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SubtagRegistry.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.BCP47SuppressScriptRegistry.pas"/>
-        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LibPalasoAllTagsRegistry.pas"/>
+        <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.NRSIAllTagsRegistry.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
rename build alltags from Keyman.System.BuildLibPalasoAllTags.pas to Keyman.System.BuildNRSIAllTags.pas

to make explicit that this is from the NRSI repo and nothing to do with libpalaso

Tom made me aware of the alltags use in Keyman and I thought this looked confusing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1302)
<!-- Reviewable:end -->
