### PR TITLE
[Android] Add styling to show current selection in list

### DIFF
--- a/android/KMEA/app/src/main/res/drawable/list_item.xml
+++ b/android/KMEA/app/src/main/res/drawable/list_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:state_activated="false" android:state_pressed="true" android:drawable="@color/activated_bg" />
+    <item android:state_activated="false" android:state_selected="true" android:drawable="@color/selected_bg" />
 	<item android:state_activated="true" android:drawable="@color/activated_bg" />
 	<item android:drawable="@android:color/white" />
 </selector>

--- a/android/KMEA/app/src/main/res/layout/list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/list_layout.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingBottom="@dimen/fab_padding"
+        android:choiceMode="singleChoice"
         android:clipToPadding="false" />
     
 </RelativeLayout>

--- a/android/KMEA/app/src/main/res/values/colors.xml
+++ b/android/KMEA/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <color name="activated_bg">@android:color/holo_orange_light</color>
+    <color name="selected_bg">#EEEEEEEE</color>
     <color name="popup_bg">#ff282828</color>
     <color name="popup_bg2">#ff000000</color>
     <color name="popup_border">#ff282828</color>


### PR DESCRIPTION
Fixes #1304 

This PR adds a light gray background to the selected list item.
(currently set/active keyboard remains in a light orange/salmon color)

### Keyboard picker

![keyboards picker](https://user-images.githubusercontent.com/7358010/48120764-a75a6300-e2a5-11e8-938e-e6e432978348.png)

### Add new keyboard

![add new keyboard](https://user-images.githubusercontent.com/7358010/48120736-90b40c00-e2a5-11e8-93dd-e520a827968c.png)


Note: in KM 10, the initial focus was on the back button in the toolbar. and the user could jump between the back button <--> first list item.  So far in KM 11, the navigation is restricted to the list items.