### PR TITLE
[Android][stable] Swap TextView positions when end < start

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1635,6 +1635,15 @@ public final class KMManager {
 
           int start = textView.getSelectionStart();
           int end = textView.getSelectionEnd();
+          // Workaround for Android TextView bug where end < start
+          // Reference: https://issuetracker.google.com/issues/36911048
+          if (end < start) {
+            Log.d(TAG, "Swapping TextView selection end:" + end + " and start:" + start);
+            int temp = end;
+            end = start;
+            start = temp;
+          }
+
           if (dn <= 0) {
             if (start == end) {
               if (!s.isEmpty() && s.charAt(0) == '\n') {

--- a/android/history.md
+++ b/android/history.md
@@ -1,6 +1,9 @@
 # Keyman for Android
 
-## 2018-10-03 10.0.506 stable
+## 2018-11-14 10.0.508 stable
+* Fix crash that can occur when text selection ends before the starting position (#1313)
+
+## 2018-10-04 10.0.507 stable
 * Fix crash that can occur when displaying preview key (#1230)
 
 ## 2018-08-23 10.0.505 stable


### PR DESCRIPTION
Addresses #1312  for Keyman for Android 10.0 

Character replacement functions would crash when TextView selections had `end` positions before `start` positions. 

This PR adds a workaround to just swap positions.
Verified on ltr and rtl keyboards