### PR TITLE
[ios] "Get Started" view / keyboard conflict fix

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -254,6 +254,9 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   func hideKeyboard(_ keymanWeb: KeymanWebViewController) {
+    // Is not implemented for this class, nor is resumeKeyboard().
+    // This class is used for System-level keyboards and would not have a
+    // practical way to be resumed after dismissal.
     dismissKeyboard()
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebDelegate.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebDelegate.swift
@@ -39,6 +39,9 @@ protocol KeymanWebDelegate: class {
   func menuKeyUp(_ keymanWeb: KeymanWebViewController)
   func menuKeyHeld(_ keymanWeb: KeymanWebViewController)
   func hideKeyboard(_ keymanWeb: KeymanWebViewController)
+  
+  func dismissKeyboard()
+  func resumeKeyboard()
 }
 
 extension KeymanWebDelegate {
@@ -55,4 +58,7 @@ extension KeymanWebDelegate {
   func menuKeyUp(_ keymanWeb: KeymanWebViewController) {}
   func menuKeyHeld(_ keymanWeb: KeymanWebViewController) {}
   func hideKeyboard(_ keymanWeb: KeymanWebViewController) {}
+  
+  func dismissKeyboard() {}
+  func resumeKeyboard() {}
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -1253,6 +1253,18 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
       userData.synchronize()
     }
   }
+  
+  public func showKeyboard() {
+    keymanWebDelegate?.resumeKeyboard()
+  }
+  
+  public func hideKeyboard() {
+    keymanWebDelegate?.dismissKeyboard()
+    
+    dismissHelpBubble()
+    dismissSubKeys()
+    dismissKeyboardMenu()
+  }
 
   func hideKeyboard(_ keymanWeb: KeymanWebViewController) {
     keymanWebDelegate?.hideKeyboard(keymanWeb)

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
@@ -106,6 +106,10 @@ public class TextField: UITextField {
     resignFirstResponder()
     Manager.shared.keymanWeb.view.endEditing(true)
   }
+  
+  public func resumeKeyboard() {
+    becomeFirstResponder()
+  }
 
   public override var text: String! {
     get {

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
@@ -103,6 +103,10 @@ public class TextView: UITextView {
     resignFirstResponder()
     Manager.shared.keymanWeb.view.endEditing(true)
   }
+  
+  public func resumeKeyboard() {
+    becomeFirstResponder()
+  }
 
   public override var text: String! {
     get {

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -949,6 +949,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     let doneButton = navBar?.topItem?.rightBarButtonItem
     doneButton?.target = self
     doneButton?.action = #selector(self.dismissGetStartedView)
+    
+    Manager.shared.hideKeyboard()
 
     containerView.frame = containerView.frame.insetBy(dx: 15, dy: 140)
     containerView.backgroundColor = UIColor.white
@@ -965,6 +967,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   @objc func dismissGetStartedView(_ sender: Any?) {
     overlayWindow.viewWithTag(getStartedViewTag)?.removeFromSuperview()
     overlayWindow.isHidden = true
+    
+    Manager.shared.showKeyboard()
   }
 
   private var shouldShowGetStarted: Bool {

--- a/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #1084.

This fix hides the in-app keyboard whenever the "Get Started" view is active, restoring it when that view is dismissed.  To accomplish this, it was necessary to add two new public API functions to KMEI's Manager.swift and extend a few related internal objects a bit.