### PR TITLE
[Android] Update to Cloud API 4.0

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -44,7 +44,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   public static final String ARG_URL = "KMKeyboardActivity.url";
   public static final String ARG_FILENAME = "KMKeyboardActivity.filename";
 
-  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/3.0/languages";
+  public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
   public static final String kKeymanApiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url=";
 
   // Keyman public keys


### PR DESCRIPTION
Fixes #1129

Since Cloud API 5.0 won't be developed til 12.0, going ahead with updating to Cloud API 4.0 (in line with iOS platform)