### PR TITLE
Reachability crash alleviation

### DIFF
--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "DaveWoodCom/XCGLogger" "6.0.2"
+github "DaveWoodCom/XCGLogger" "6.1.0"
 github "marmelroy/Zip" "1.1.0"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -180,11 +180,12 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     hold.delegate = self
     keymanWeb.view.addGestureRecognizer(hold)
 
-    reachability = Reachability(hostName: keymanHostName)
-    NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
-                                           name: .reachabilityChanged, object: reachability)
-    reachability.startNotifier()
-
+    if(!Util.isSystemKeyboard) {
+      reachability = Reachability(hostName: keymanHostName)
+      NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
+                                             name: .reachabilityChanged, object: reachability)
+      reachability.startNotifier()
+    }
     /* HTTPDownloader only uses this for its delegate methods.  So long as we don't
      * set the queue running, this should be perfectly fine.
      */

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -180,8 +180,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     hold.delegate = self
     keymanWeb.view.addGestureRecognizer(hold)
 
+    reachability = Reachability(hostName: keymanHostName)
+    
     if(!Util.isSystemKeyboard) {
-      reachability = Reachability(hostName: keymanHostName)
       NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
                                              name: .reachabilityChanged, object: reachability)
       reachability.startNotifier()

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2018-11-14 10.0.211 stable
+* Added mitigation for reachability-related crashes (#1322)
+
 ## 2018-08-06 10.0.209 stable 
 * Removed unnecessary UIFileSharingEnabled flag (#1087)
 

--- a/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/keymanios.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Parallels #1301, cherry-picked for 10.0 stable.  A few environment and dependency updates were included out of necessity, since we're building on a newer version of Xcode that is incompatible with the old state.