### PR TITLE
Build worker, then build main.

### DIFF
--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -54,7 +54,8 @@ while [[ $# -gt 0 ]] ; do
   shift # past the processed argument
 done
 
-npm run tsc
+# Build worker first; main file depends on it.
+npm run tsc -- -p ./worker/tsconfig.json && npm run tsc 
 
 if [ $? -ne 0 ]; then
   fail "Compilation failed."


### PR DESCRIPTION
Small PR to add building of worker, followed by the main script (outside-worker).

A few questions:

 - Should we use `npx` instead of `npm run <blah>`?
 - These seem to be tasks nicely suited for Makefiles. Is there a reason for using these custom shell scripts instead of `make`?