### PR TITLE
[Developer] Add "-add-help-link" parameter to kmcomp

### DIFF
--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -785,7 +785,6 @@ end;
 procedure TMergeKeyboardInfo.AddHelpLink;
 var
   v: TJSONValue;
-
 begin
   // Validate pre-existing helpLink
   v := json.GetValue('helpLink');

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -1,7 +1,7 @@
 {  Merges a source .keyboard_info file with data programatically extracted from a .kmp file and a keyboard .js file
 
   - Command line parameters:
-     kmcomp -m <keyboard.kmp> <keyboard.js> [-addHelpPath <help path>] <keyboard.keyboard_info>
+     kmcomp -m <keyboard.kmp> <keyboard.js> [-add-help-link <help path>] <keyboard.keyboard_info>
 
   Note: if keyboard.kmp or keyboard.js do not exist, merge_compiled_keyboard_info will continue to work, just will
         not attempt to pull data from them
@@ -66,13 +66,13 @@ type
     FJSFileInfo: TJSKeyboardInfoMap;
     FVersion: string;
     FSourcePath: string;
-    FHelpPath: string;
+    FHelpLink: string;
     function Failed(message: string): Boolean;
     function Execute: Boolean; overload;
     function LoadJsonFile: Boolean;
     function LoadKMPFile: Boolean;
     function LoadJSFile: Boolean;
-    constructor Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
+    constructor Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpLink: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
     procedure AddAuthor;
     procedure AddAuthorEmail;
     procedure CheckOrAddEncodings;
@@ -84,7 +84,7 @@ type
     procedure AddName;
     procedure CheckOrAddPackageFilename;
     procedure AddPackageIncludes;
-    procedure AddHelpPath;
+    procedure AddHelpLink;
     procedure AddPlatformSupport;
     procedure CheckOrAddVersion;
     function SaveJsonFile: Boolean;
@@ -93,7 +93,7 @@ type
     procedure AddSourcePath;
   public
     destructor Destroy; override;
-    class function Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean; overload;
+    class function Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpLink: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean; overload;
   end;
 
 implementation
@@ -118,10 +118,10 @@ type
 
 { TMergeKeyboardInfo }
 
-class function TMergeKeyboardInfo.Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string;
+class function TMergeKeyboardInfo.Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpLink: string;
   AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean;
 begin
-  with TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath, AMergingValidateIds, ASilent, ACallback) do
+  with TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpLink, AMergingValidateIds, ASilent, ACallback) do
   try
     Result := Execute;
   finally
@@ -129,14 +129,14 @@ begin
   end;
 end;
 
-constructor TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string;
+constructor TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpLink: string;
   AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
 begin
   inherited Create;
 
   FSourcePath := ASourcePath;
   FMergingValidateIds := AMergingValidateIds;
-  FHelpPath := AHelpPath;
+  FHelpLink := AHelpLink;
   FSilent := ASilent;
   FCallback := ACallback;
 
@@ -193,7 +193,7 @@ begin
     CheckOrAddFileSizes;
     AddPackageIncludes;
     CheckOrAddMinKeymanVersion;
-    AddHelpPath;
+    AddHelpLink;
     AddPlatformSupport;
 
     if not SaveJsonFile then
@@ -780,15 +780,27 @@ begin
 end;
 
 //
-// Add helpPath, from commandline parameter
+// Add helpLink, from commandline parameter
 //
-procedure TMergeKeyboardInfo.AddHelpPath;
+procedure TMergeKeyboardInfo.AddHelpLink;
+var
+  v: TJSONValue;
 
 begin
-    if FHelpPath = '' then
-    Exit;
+  // Validate pre-existing helpLink
+  v := json.GetValue('helpLink');
+  if v <> nil then
+  begin
+    if v.Value.IndexOf('https://help.keyman.com/keyboard/') < 0 then
+      raise EInvalidKeyboardInfo.Create('helpLink should be on https://help.keyman.com/keyboard/');
+  end
+  else
+  begin
+    if FHelpLink = '' then
+      Exit;
 
-   json.AddPair('helpPath', FHelpPath);
+    json.AddPair('helpLink', FHelpLink);
+  end;
 end;
 
 //

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -1,7 +1,7 @@
 {  Merges a source .keyboard_info file with data programatically extracted from a .kmp file and a keyboard .js file
 
   - Command line parameters:
-     kmcomp -m <keyboard.kmp> <keyboard.js> <keyboard.keyboard_info>
+     kmcomp -m <keyboard.kmp> <keyboard.js> [-addHelpPath <help path>] <keyboard.keyboard_info>
 
   Note: if keyboard.kmp or keyboard.js do not exist, merge_compiled_keyboard_info will continue to work, just will
         not attempt to pull data from them
@@ -66,12 +66,13 @@ type
     FJSFileInfo: TJSKeyboardInfoMap;
     FVersion: string;
     FSourcePath: string;
+    FHelpPath: string;
     function Failed(message: string): Boolean;
     function Execute: Boolean; overload;
     function LoadJsonFile: Boolean;
     function LoadKMPFile: Boolean;
     function LoadJSFile: Boolean;
-    constructor Create(ASourcePath, AJsFile, AKmpFile, AJsonFile: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
+    constructor Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
     procedure AddAuthor;
     procedure AddAuthorEmail;
     procedure CheckOrAddEncodings;
@@ -83,6 +84,7 @@ type
     procedure AddName;
     procedure CheckOrAddPackageFilename;
     procedure AddPackageIncludes;
+    procedure AddHelpPath;
     procedure AddPlatformSupport;
     procedure CheckOrAddVersion;
     function SaveJsonFile: Boolean;
@@ -91,7 +93,7 @@ type
     procedure AddSourcePath;
   public
     destructor Destroy; override;
-    class function Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean; overload;
+    class function Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string; AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean; overload;
   end;
 
 implementation
@@ -116,10 +118,10 @@ type
 
 { TMergeKeyboardInfo }
 
-class function TMergeKeyboardInfo.Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile: string;
+class function TMergeKeyboardInfo.Execute(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string;
   AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback): Boolean;
 begin
-  with TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AMergingValidateIds, ASilent, ACallback) do
+  with TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath, AMergingValidateIds, ASilent, ACallback) do
   try
     Result := Execute;
   finally
@@ -127,13 +129,14 @@ begin
   end;
 end;
 
-constructor TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile: string;
+constructor TMergeKeyboardInfo.Create(ASourcePath, AJsFile, AKmpFile, AJsonFile, AHelpPath: string;
   AMergingValidateIds, ASilent: Boolean; ACallback: TCompilerCallback);
 begin
   inherited Create;
 
   FSourcePath := ASourcePath;
   FMergingValidateIds := AMergingValidateIds;
+  FHelpPath := AHelpPath;
   FSilent := ASilent;
   FCallback := ACallback;
 
@@ -190,6 +193,7 @@ begin
     CheckOrAddFileSizes;
     AddPackageIncludes;
     CheckOrAddMinKeymanVersion;
+    AddHelpPath;
     AddPlatformSupport;
 
     if not SaveJsonFile then
@@ -773,6 +777,18 @@ begin
   end
   else
     json.AddPair('minKeymanVersion', MinVersionString);
+end;
+
+//
+// Add helpPath, from commandline parameter
+//
+procedure TMergeKeyboardInfo.AddHelpPath;
+
+begin
+    if FHelpPath = '' then
+    Exit;
+
+   json.AddPair('helpPath', FHelpPath);
 end;
 
 //

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,11 @@
 # Keyman Developer Version History
 
+## 2018-11-28 10.0.1206 stable
+* Add parameter `-add-help-link` to kmcomp (#1346)
+
+## 2018-11-07 10.0.1205 stable
+* Mitigation for issues with installation under certain languages in Windows 10 1803 or later (#1299)
+
 ## 2018-09-28 10.0.1204 stable
 * Fix crash in Keyman Developer package editor when a compiled .js keyboard is missing (#1224)
 

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -177,6 +177,11 @@ begin
       Inc(i);
       FParamSourcePath := ParamStr(i);
     end
+    else if s = '-addhelppath' then
+    begin
+      Inc(i);
+      FParamHelpPath := ParamStr(i);
+    end
     else if s = '-schema-path' then
     begin
       Inc(i);
@@ -189,11 +194,6 @@ begin
       FJsonExtract := True;
       Inc(i);
       FParamJsonFields := ParamStr(i);
-    end
-    else if s = '-addHelpPath' then
-    begin
-      Inc(i);
-      FParamHelpPath := ParamStr(i);
     end
     else if FParamInfile = '' then FParamInfile := ParamStr(i)
     else if FParamOutfile = '' then FParamOutfile := ParamStr(i)

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -112,7 +112,7 @@ var
   FMergingValidateIds: Boolean;
   FJsonSchemaPath: string;
   FParamSourcePath: string;
-  FParamHelpPath: string;
+  FParamHelpLink: string;
 begin
   FSilent := False;
   FFullySilent := False;
@@ -177,10 +177,10 @@ begin
       Inc(i);
       FParamSourcePath := ParamStr(i);
     end
-    else if s = '-addhelppath' then
+    else if s = '-add-help-link' then
     begin
       Inc(i);
-      FParamHelpPath := ParamStr(i);
+      FParamHelpLink := ParamStr(i);
     end
     else if s = '-schema-path' then
     begin
@@ -219,7 +219,7 @@ begin
     writeln('');
     writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-schema-path path] ');
     writeln('              [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
-    writeln('              [-addHelpPath path]');
+    writeln('              [-add-help-link path]');
     writeln('              [-extract-keyboard-info field[,field...]]');
     writeln('          infile        can be a .kmn file (Keyboard Source, .kps file (Package Source), or .kpj (project)');   // I4699   // I4825
     writeln('                        if -v specified, can also be a .keyboard_info file');
@@ -234,7 +234,7 @@ begin
     writeln('          -d       include debug information');
     writeln('          -w       treat warnings as errors');
     writeln('          -t       build only the target file from the project (only for .kpj)');   // I4699
-    writeln('          -addHelpPath path to help file on https://help.keyman.com/keyboards');
+    writeln('          -add-help-link path to help file on https://help.keyman.com/keyboards');
     writeln;
     writeln(' JSON .keyboard_info compile targets:');
     writeln('          -v[s]    validate infile against source schema');
@@ -262,7 +262,7 @@ begin
       hOutfile := 0;
 
     if FMerging then
-      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FParamHelpPath, FMergingValidateIds, FSilent, @CompilerMessage)
+      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FParamHelpLink, FMergingValidateIds, FSilent, @CompilerMessage)
     else if FValidating then
       FError := not TValidateKeyboardInfo.Execute(FParamInfile, FJsonSchemaPath, FParamDistribution, FSilent, @CompilerMessage)
     else if FJsonExtract then

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -112,6 +112,7 @@ var
   FMergingValidateIds: Boolean;
   FJsonSchemaPath: string;
   FParamSourcePath: string;
+  FParamHelpPath: string;
 begin
   FSilent := False;
   FFullySilent := False;
@@ -189,6 +190,11 @@ begin
       Inc(i);
       FParamJsonFields := ParamStr(i);
     end
+    else if s = '-addHelpPath' then
+    begin
+      Inc(i);
+      FParamHelpPath := ParamStr(i);
+    end
     else if FParamInfile = '' then FParamInfile := ParamStr(i)
     else if FParamOutfile = '' then FParamOutfile := ParamStr(i)
     else if FParamDebugfile = '' then FParamDebugfile := ParamStr(i)
@@ -213,6 +219,7 @@ begin
     writeln('');
     writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-schema-path path] ');
     writeln('              [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
+    writeln('              [-addHelpPath path]');
     writeln('              [-extract-keyboard-info field[,field...]]');
     writeln('          infile        can be a .kmn file (Keyboard Source, .kps file (Package Source), or .kpj (project)');   // I4699   // I4825
     writeln('                        if -v specified, can also be a .keyboard_info file');
@@ -227,6 +234,7 @@ begin
     writeln('          -d       include debug information');
     writeln('          -w       treat warnings as errors');
     writeln('          -t       build only the target file from the project (only for .kpj)');   // I4699
+    writeln('          -addHelpPath path to help file on https://help.keyman.com/keyboards');
     writeln;
     writeln(' JSON .keyboard_info compile targets:');
     writeln('          -v[s]    validate infile against source schema');
@@ -254,7 +262,7 @@ begin
       hOutfile := 0;
 
     if FMerging then
-      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FMergingValidateIds, FSilent, @CompilerMessage)
+      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FParamHelpPath, FMergingValidateIds, FSilent, @CompilerMessage)
     else if FValidating then
       FError := not TValidateKeyboardInfo.Execute(FParamInfile, FJsonSchemaPath, FParamDistribution, FSilent, @CompilerMessage)
     else if FJsonExtract then

--- a/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
+++ b/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
@@ -29,6 +29,7 @@
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
         "version": { "type": "string" },
         "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
         "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
         "legacyId": { "type": "number" },
         "sourcePath": { "type": "string", "pattern": "^(release|legacy|experimental)/.+/.+$" },

--- a/windows/src/global/inst/data/keyboard_info/readme.MD
+++ b/windows/src/global/inst/data/keyboard_info/readme.MD
@@ -1,4 +1,4 @@
-# .keyboard_info
+# keyboard_info
 
 * **keyboard_info.source.json**
 * **keyboard_info.distribution.json**
@@ -8,6 +8,19 @@ Documentation at https://help.keyman.com/developer/cloud/keyboard_info
 New versions should be deployed to **keymanapp/keyman/windows/src/global/inst/keyboard_info** and **keymanapp/keyboards/tools**
 
 # .keyboard_info version history
+
+## 2018-11-26 1.0.4 stable
+* Add helpLink field - a link to a keyboard's help page on help.keyman.com if it exists.
+
+## 2018-02-12 1.0.3 stable
+* Renamed minKeymanDesktopVersion to minKeymanVersion to clarify that this version information applies to all platforms.
+
+## 2018-02-10 1.0.2 stable
+* Add dictionary to platform support choices. Fixed default for platform to 'none'.
+
+## 2018-01-31 1.0.1 stable
+* Add file sizes, isRTL, sourcePath fields so we can supply these to the legacy KeymanWeb Cloud API endpoints.
+* Remove references to .kmx being a valid package format.
 
 ## 2017-09-14 1.0 stable
 * Initial version


### PR DESCRIPTION
From review of sillsdev/keyman-keyman.com#220

kmcomp needs to handle a parameter ~`-addHelpPath`~ `-add-help-link` which populates .keyboard_info with a link to a keyboard's help page on https://help.keyman.com/keyboard/