### PR TITLE
[Developer] Add "-add-help-link" parameter to kmcomp

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -11,6 +11,21 @@
 * Projects can now include other related files such as history.md (#1243)
 * Keyman Developer now treats files as UTF-8 by default (#1244)
 
+## 2018-11-28 10.0.1206 stable
+* Add parameter `-add-help-link` to kmcomp (#1346)
+
+## 2018-11-07 10.0.1205 stable
+* Mitigation for issues with installation under certain languages in Windows 10 1803 or later (#1299)
+
+## 2018-09-28 10.0.1204 stable
+* Fix crash in Keyman Developer package editor when a compiled .js keyboard is missing (#1224)
+
+## 2018-09-12 10.0.1202 stable
+* Refactor how keyboard_info metadata is generated (#1174)
+
+## 2018-07-06 10.0.1201 stable
+* No changes to Keyman Developer (update to KeymanWeb script)
+
 ## 2018-06-28 10.0.1200 stable
 * 10.0 stable release
 

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -112,6 +112,7 @@ var
   FMergingValidateIds: Boolean;
   FJsonSchemaPath: string;
   FParamSourcePath: string;
+  FParamHelpLink: string;
 begin
   FSilent := False;
   FFullySilent := False;
@@ -176,6 +177,11 @@ begin
       Inc(i);
       FParamSourcePath := ParamStr(i);
     end
+    else if s = '-add-help-link' then
+    begin
+      Inc(i);
+      FParamHelpLink := ParamStr(i);
+    end
     else if s = '-schema-path' then
     begin
       Inc(i);
@@ -213,6 +219,7 @@ begin
     writeln('');
     writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-schema-path path] ');
     writeln('              [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
+    writeln('              [-add-help-link path]');
     writeln('              [-extract-keyboard-info field[,field...]]');
     writeln('          infile        can be a .kmn file (Keyboard Source, .kps file (Package Source), or .kpj (project)');   // I4699   // I4825
     writeln('                        if -v specified, can also be a .keyboard_info file');
@@ -227,6 +234,7 @@ begin
     writeln('          -d       include debug information');
     writeln('          -w       treat warnings as errors');
     writeln('          -t       build only the target file from the project (only for .kpj)');   // I4699
+    writeln('          -add-help-link path to help file on https://help.keyman.com/keyboards');
     writeln;
     writeln(' JSON .keyboard_info compile targets:');
     writeln('          -v[s]    validate infile against source schema');
@@ -254,7 +262,7 @@ begin
       hOutfile := 0;
 
     if FMerging then
-      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FMergingValidateIds, FSilent, @CompilerMessage)
+      FError := not TMergeKeyboardInfo.Execute(FParamSourcePath, FParamInfile, FParamInfile2, FParamOutfile, FParamHelpLink, FMergingValidateIds, FSilent, @CompilerMessage)
     else if FValidating then
       FError := not TValidateKeyboardInfo.Execute(FParamInfile, FJsonSchemaPath, FParamDistribution, FSilent, @CompilerMessage)
     else if FJsonExtract then

--- a/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
+++ b/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
@@ -29,6 +29,7 @@
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
         "version": { "type": "string" },
         "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
         "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
         "legacyId": { "type": "number" },
         "sourcePath": { "type": "string", "pattern": "^(release|legacy|experimental)/.+/.+$" },

--- a/windows/src/global/inst/data/keyboard_info/readme.MD
+++ b/windows/src/global/inst/data/keyboard_info/readme.MD
@@ -1,4 +1,4 @@
-# .keyboard_info
+# keyboard_info
 
 * **keyboard_info.source.json**
 * **keyboard_info.distribution.json**
@@ -8,6 +8,19 @@ Documentation at https://help.keyman.com/developer/cloud/keyboard_info
 New versions should be deployed to **keymanapp/keyman/windows/src/global/inst/keyboard_info** and **keymanapp/keyboards/tools**
 
 # .keyboard_info version history
+
+## 2018-11-26 1.0.4 stable
+* Add helpLink field - a link to a keyboard's help page on help.keyman.com if it exists.
+
+## 2018-02-12 1.0.3 stable
+* Renamed minKeymanDesktopVersion to minKeymanVersion to clarify that this version information applies to all platforms.
+
+## 2018-02-10 1.0.2 stable
+* Add dictionary to platform support choices. Fixed default for platform to 'none'.
+
+## 2018-01-31 1.0.1 stable
+* Add file sizes, isRTL, sourcePath fields so we can supply these to the legacy KeymanWeb Cloud API endpoints.
+* Remove references to .kmx being a valid package format.
 
 ## 2017-09-14 1.0 stable
 * Initial version


### PR DESCRIPTION
Cherrypick of #1346

* Add `-add-help-link` parameter to kmcomp to generate `helpLink` field
* Update keyboard_info.source.json schema to v1.0.4 from api.keyman.com