### PR TITLE
[Windows] Fix thread safety for Chromium events

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.pas
@@ -34,9 +34,26 @@ const
   CEF_AFTERDESTROY = WM_USER + 301;
   CEF_AFTERCREATE = WM_USER + 302;
   CEF_SHOW = WM_USER + 303;
+  CEF_LOADEND = WM_USER + 304;
+  CEF_SETFOCUS = WM_USER + 305;
+  CEF_KEYEVENT = WM_USER + 306;
+  CEF_BEFOREBROWSE = WM_USER + 307;
 
 type
-  TCEFHostBeforeBrowseEvent = procedure(Sender: TObject; const Url: string; out Result: Boolean) of object;
+  TCEFHostKeyEventData = record
+    browserid: Integer;
+    frameid: Int64;
+    event: TCefKeyEvent;
+    osEvent: TMsg;
+  end;
+
+  PCEFHostKeyEventData = ^TCEFHostKeyEventData;
+
+  TCEFHostBeforeBrowseSyncEvent = procedure(Sender: TObject; const Url: string; out Handled: Boolean) of object;
+  TCEFHostBeforeBrowseEvent = procedure(Sender: TObject; const Url: string; params: TStringList; wasHandled: Boolean) of object;
+
+  TCEFHostPreKeySyncEvent = procedure(Sender: TObject; e: TCEFHostKeyEventData; out isShortcut, Handled: Boolean) of object;
+  TCEFHostKeyEvent = procedure(Sender: TObject; e: TCEFHostKeyEventData; wasShortcut, wasHandled: Boolean) of object;
 
   TframeCEFHost = class(TTikeForm, IKeymanCEFHost)
     tmrRefresh: TTimer;
@@ -82,21 +99,33 @@ type
                              var Result: Boolean);
     procedure cefWidgetCompMsg(var aMessage: TMessage; var aHandled: Boolean);
   private
+    FApplicationHandle: THandle;
     FNextURL: string;
     FOnLoadEnd: TNotifyEvent;
-    FOnBeforeBrowse: TCEFHostBeforeBrowseEvent;
+    FOnBeforeBrowseSync: TCEFHostBeforeBrowseSyncEvent;
     FOnAfterCreated: TNotifyEvent;
     FShutdownCompletionHandler: TShutdownCompletionHandlerEvent;
     FIsClosing: Boolean;
     FShouldShowContextMenu: Boolean;
-    FOnPreKeyEvent: TOnPreKeyEvent;
+
+    FCallbackWnd: THandle;
+    FOnPreKeySyncEvent: TCEFHostPreKeySyncEvent;
+    FOnKeyEvent: TCEFHostKeyEvent;
+    FOnBeforeBrowse: TCEFHostBeforeBrowseEvent;
+
+    procedure CallbackWndProc(var Message: TMessage);
 
     // IKeymanCEFHost
     procedure StartShutdown(CompletionHandler: TShutdownCompletionHandlerEvent);
 
-    procedure CEFDestroy(var Message: TMessage); message CEF_DESTROY;
-    procedure CEFAfterDestroy(var Message: TMessage); message CEF_AFTERDESTROY;
-    procedure CEFAfterCreate(var Message: TMessage); message CEF_AFTERCREATE;
+    procedure Handle_CEF_DESTROY(var Message: TMessage);
+    procedure Handle_CEF_AFTERDESTROY(var Message: TMessage);
+    procedure Handle_CEF_AFTERCREATE(var Message: TMessage);
+    procedure Handle_CEF_SHOW(var message: TMessage);
+    procedure Handle_CEF_LOADEND(var message: TMessage);
+    procedure Handle_CEF_SETFOCUS(var message: TMessage);
+    procedure Handle_CEF_KEYEVENT(var message: TMessage);
+    procedure Handle_CEF_BEFOREBROWSE(var message: TMessage);
 
     // CEF: You have to handle this two messages to call NotifyMoveOrResizeStarted or some page elements will be misaligned.
     procedure WMMove(var aMessage : TWMMove); message WM_MOVE;
@@ -107,7 +136,7 @@ type
 
     procedure CreateBrowser;
     procedure Navigate; overload;
-    procedure CEFShow(var message: TMessage); message CEF_SHOW;
+    procedure DoBeforeBrowse(const url: string; out Handled: Boolean; ShouldOpenUrlIfNotHandled: Boolean);
   public
     procedure SetFocus; override;
     procedure StartClose;
@@ -115,10 +144,18 @@ type
     function HasFocus: Boolean;
     property ShouldShowContextMenu: Boolean read FShouldShowContextMenu write FShouldShowContextMenu;
     property OnAfterCreated: TNotifyEvent read FOnAfterCreated write FOnAfterCreated;
+    property OnBeforeBrowseSync: TCEFHostBeforeBrowseSyncEvent read FOnBeforeBrowseSync write FOnBeforeBrowseSync;
     property OnBeforeBrowse: TCEFHostBeforeBrowseEvent read FOnBeforeBrowse write FOnBeforeBrowse;
     property OnLoadEnd: TNotifyEvent read FOnLoadEnd write FOnLoadEnd;
-    property OnPreKeyEvent: TOnPreKeyEvent read FOnPreKeyEvent write FOnPreKeyEvent;
+
+    property OnPreKeySyncEvent: TCEFHostPreKeySyncEvent read FOnPreKeySyncEvent write FOnPreKeySyncEvent;
+    property OnKeyEvent: TCEFHostKeyEvent read FOnKeyEvent write FOnKeyEvent;
   end;
+
+// Helpers to make sure we don't accidentally code
+// VCL references into non-VCL-thread functions
+procedure AssertVclThread;
+procedure AssertCefThread;
 
 implementation
 
@@ -131,6 +168,7 @@ uses
   ErrorControlledRegistry,
   ExternalExceptionHandler,
   UfrmMain,
+  utilhttp,
   uCEFApplication,
   VersionInfo;
 
@@ -144,8 +182,19 @@ uses
 // 2. The TChromiumWindow.OnClose event calls TChromiumWindow.DestroyChildWindow which triggers the TChromiumWindow.OnBeforeClose event.
 // 3. TChromiumWindow.OnBeforeClose sets FCanClose to True and closes the form.
 
+procedure AssertVclThread;
+begin
+  Assert(GetCurrentThreadId = MainThreadID);
+end;
+
+procedure AssertCefThread;
+begin
+  Assert(GetCurrentThreadId <> MainThreadID);
+end;
+
 procedure TframeCEFHost.StartClose;
 begin
+  AssertVclThread;
   Visible := False;
   FIsClosing := True;
   cef.CloseBrowser(True);
@@ -153,6 +202,7 @@ end;
 
 procedure TframeCEFHost.StartShutdown(CompletionHandler: TShutdownCompletionHandlerEvent);
 begin
+  AssertVclThread;
   OutputDebugString(PChar('TframeCEFHost.StartShutdown'));
   FIsClosing := True;
   FShutdownCompletionHandler := CompletionHandler;
@@ -161,60 +211,75 @@ begin
   // post it to occur on next idle.
   if cef.Initialized
     then cef.CloseBrowser(False)
-    else PostMessage(Handle, CEF_AFTERDESTROY, 0, 0);
+    else PostMessage(FCallbackWnd, CEF_AFTERDESTROY, 0, 0);
 end;
 
 procedure TframeCEFHost.FormCreate(Sender: TObject);
 begin
+  AssertVclThread;
   inherited;
+  FApplicationHandle := Application.Handle; // take a copy to avoid Vcl thread mismatches in cef callbacks
+
+  // We need our own window handle for events, because VCL windows can be destroyed
+  // and recreated at any time. With our own handle, we can guarantee the lifetime
+  // of it across threads.
+  FCallbackWnd := AllocateHWnd(CallbackWndProc);
   FInitializeCEF.RegisterWindow(Self);
 //  CreateBrowser;
 end;
 
 procedure TframeCEFHost.FormDestroy(Sender: TObject);
 begin
+  AssertVclThread;
 //  OutputDebugString(PChar('TframeCEFHost.FormDestroy'));
   inherited;
   FInitializeCEF.UnregisterWindow(Self);
+  DeallocateHWnd(FCallbackWnd);
 end;
 
 procedure TframeCEFHost.FormShow(Sender: TObject);
 begin
+  AssertVclThread;
   inherited;
-  PostMessage(Handle, CEF_SHOW, 0, 0);
+  PostMessage(FCallbackWnd, CEF_SHOW, 0, 0);
 end;
 
 function TframeCEFHost.HasFocus: Boolean;
 begin
+  AssertVclThread;
   Result := cefwp.HandleAllocated and IsChild(cefwp.Handle, GetFocus);
 end;
 
-procedure TframeCEFHost.CEFShow(var message: TMessage);
+procedure TframeCEFHost.Handle_CEF_SHOW(var message: TMessage);
 begin
+  AssertVclThread;
   CreateBrowser;
 end;
 
 procedure TframeCEFHost.cefWidgetCompMsg(var aMessage: TMessage;
   var aHandled: Boolean);
 begin
+  AssertCefThread;
   if aMessage.Msg = WM_SETFOCUS then
-    if Assigned(cefwp) and cefwp.Visible and cefwp.CanFocus then
-      GetParentForm(cefwp).ActiveControl := cefwp;
+    PostMessage(FCallbackWnd, CEF_SETFOCUS, 0, 0);
 end;
 
 procedure TframeCEFHost.CreateBrowser;
 begin
+  AssertVclThread;
   tmrCreateBrowser.Enabled := not cef.CreateBrowser(cefwp);
 end;
 
 procedure TframeCEFHost.Navigate(const url: string);
 begin
+  AssertVclThread;
   FNextURL := url;
   Navigate;
 end;
 
 procedure TframeCEFHost.Navigate;
 begin
+  AssertVclThread;
   if FNextURL = '' then
     Exit;
 
@@ -230,24 +295,48 @@ end;
 
 procedure TframeCEFHost.SetFocus;
 begin
+  AssertVclThread;
   inherited;
   if not FIsClosing and cefwp.CanFocus then
     cefwp.SetFocus;
 end;
 
-procedure TframeCEFHost.CEFAfterCreate(var Message: TMessage);
+procedure TframeCEFHost.CallbackWndProc(var Message: TMessage);
 begin
+  AssertVclThread;
+  case Message.Msg of
+    CEF_DESTROY: Handle_CEF_DESTROY(Message);
+    CEF_AFTERDESTROY: Handle_CEF_AFTERDESTROY(Message);
+    CEF_AFTERCREATE: Handle_CEF_AFTERCREATE(Message);
+    CEF_SHOW: Handle_CEF_SHOW(Message);
+    CEF_LOADEND: Handle_CEF_LOADEND(Message);
+    CEF_SETFOCUS: Handle_CEF_SETFOCUS(Message);
+    CEF_KEYEVENT: Handle_CEF_KEYEVENT(Message);
+    CEF_BEFOREBROWSE: Handle_CEF_BEFOREBROWSE(Message);
+  end;
+
+  if Self <> nil then
+    Message.Result := DefWindowProc(FCallbackWnd, Message.Msg, Message.WParam, Message.LParam);
+end;
+
+procedure TframeCEFHost.Handle_CEF_AFTERCREATE(var Message: TMessage);
+begin
+  AssertVclThread;
   Navigate;
+  if Assigned(FOnAfterCreated) then
+    FOnAfterCreated(Self);
 end;
 
 procedure TframeCEFHost.cefAfterCreated(Sender: TObject;
   const browser: ICefBrowser);
 begin
-  PostMessage(Handle, CEF_AFTERCREATE, 0, 0);
+  AssertCefThread;
+  PostMessage(FCallbackWnd, CEF_AFTERCREATE, 0, 0);
 end;
 
-procedure TframeCEFHost.CEFAfterDestroy(var Message: TMessage);
+procedure TframeCEFHost.Handle_CEF_AFTERDESTROY(var Message: TMessage);
 begin
+  AssertVclThread;
   if Assigned(FShutdownCompletionHandler) then
   begin
     FShutdownCompletionHandler(Self);
@@ -255,34 +344,78 @@ begin
   end;
 end;
 
+procedure TframeCEFHost.Handle_CEF_BEFOREBROWSE(var message: TMessage);
+var
+  params: TStringList;
+  url: string;
+  wasHandled,
+  shouldOpenUrlIfNotHandled: Boolean;
+begin
+  AssertVclThread;
+  params := TStringList(message.LParam);
+  url := params[0];
+  params.Delete(0);
+
+  wasHandled := Boolean(message.WParamLo);
+  shouldOpenUrlIfNotHandled := Boolean(message.WParamHi);
+
+  if wasHandled then
+  begin
+    if Assigned(FOnBeforeBrowse) then
+      FOnBeforeBrowse(Self, url, params, Boolean(message.WParam));
+  end
+  else if shouldOpenUrlIfNotHandled then
+    cef.LoadURL(url);
+
+  params.Free;
+end;
+
 procedure TframeCEFHost.cefBeforeBrowse(Sender: TObject;
   const browser: ICefBrowser; const frame: ICefFrame;
   const request: ICefRequest; user_gesture, isRedirect: Boolean;
   out Result: Boolean);
 begin
-  if Assigned(FOnBeforeBrowse) then
-    FOnBeforeBrowse(Self, request.Url, Result);
+  AssertCefThread;
+
+  DoBeforeBrowse(request.Url, Result, False);
 end;
 
-procedure TframeCEFHost.cefBeforeClose(Sender: TObject;
-  const browser: ICefBrowser);
+procedure TframeCEFHost.DoBeforeBrowse(const url: string; out Handled: Boolean; ShouldOpenUrlIfNotHandled: Boolean);
 var
-  m: TMessage;
+  params: TStringList;
 begin
-//  OutputDebugString(PChar('TframeCEFHost.cefBeforeClose'));
-  if HandleAllocated
-    then PostMessage(Handle, CEF_AFTERDESTROY, 0, 0)
-    else CEFAfterDestroy(m);
+  AssertCefThread;
+
+  Handled := False;
+  if Assigned(FOnBeforeBrowseSync) then
+  begin
+    FOnBeforeBrowseSync(Self, url, Handled);
+  end;
+
+  params := nil;
+  if not Handled then
+    Handled := GetParamsFromURL(Url, params);
+
+  if not Assigned(params) then
+    params := TStringList.Create;
+
+  params.Insert(0, Url);
+
+  PostMessage(FCallbackWnd, CEF_BEFOREBROWSE, MAKELONG(WORD(Handled), WORD(ShouldOpenUrlIfNotHandled)), LPARAM(params));
+end;
+
+procedure TframeCEFHost.cefBeforeClose(Sender: TObject; const browser: ICefBrowser);
+begin
+  AssertCefThread;
+  PostMessage(FCallbackWnd, CEF_AFTERDESTROY, 0, 0);
 end;
 
 procedure TframeCEFHost.cefClose(Sender: TObject; const browser: ICefBrowser;
   out Result: Boolean);
 begin
-  PostMessage(Handle, CEF_DESTROY, 0, 0);
+  AssertCefThread;
+  PostMessage(FCallbackWnd, CEF_DESTROY, 0, 0);
   Result := True;
-//  OutputDebugString(PChar('TframeCEFHost.cefClose'));
-  // DestroyChildWindow will destroy the child window created by CEF at the top of the Z order.
-  cefwp.DestroyChildWindow;
 end;
 
 procedure TframeCEFHost.cefConsoleMessage(Sender: TObject;
@@ -292,6 +425,7 @@ var
   id: string;
   I: Integer;
 begin
+  AssertVclThread;
   id := LowerCase(ExtractFileName(ParamStr(0)))+'_'+GetVersionString+'_script_';
   if Assigned(Owner)
     then id := id + Owner.ClassName
@@ -305,13 +439,16 @@ begin
   Result := True;
 end;
 
-procedure TframeCEFHost.CEFDestroy(var Message: TMessage);
+procedure TframeCEFHost.Handle_CEF_DESTROY(var Message: TMessage);
 begin
+  AssertVclThread;
+  cefwp.DestroyChildWindow;
   FreeAndNil(cefwp);
 end;
 
 procedure TframeCEFHost.tmrCreateBrowserTimer(Sender: TObject);
 begin
+  AssertVclThread;
   tmrCreateBrowser.Enabled := False;
   CreateBrowser;
 end;
@@ -319,44 +456,96 @@ end;
 procedure TframeCEFHost.cefLoadEnd(Sender: TObject; const browser: ICefBrowser;
   const frame: ICefFrame; httpStatusCode: Integer);
 begin
+  AssertCefThread;
+  PostMessage(FCallbackWnd, CEF_LOADEND, httpStatusCode, 0);
+end;
+
+procedure TframeCEFHost.Handle_CEF_KEYEVENT(var message: TMessage);
+var
+  p: PCEFHostKeyEventData;
+  wasHandled: Boolean;
+  wasShortcut: Boolean;
+begin
+  p := PCEFHostKeyEventData(message.LParam);
+
+  if p.event.windows_key_code = VK_F1 then
+  begin
+    frmKeymanDeveloper.HelpTopic(Self)
+  end
+  else if p.event.windows_key_code = VK_F12 then
+  begin
+    cef.ShowDevTools(Point(Low(Integer),Low(Integer)), nil);
+  end
+  else if Assigned(FOnKeyEvent) then
+  begin
+    wasHandled := message.WParamLo <> 0;
+    wasShortcut := message.WParamHi <> 0;
+    FOnKeyEvent(Self, p^, wasShortcut, wasHandled);
+  end;
+  FreeMem(p);
+end;
+
+procedure TframeCEFHost.Handle_CEF_LOADEND(var message: TMessage);
+begin
   if csDestroying in ComponentState then
     Exit;
   if Assigned(FOnLoadEnd) then
     FOnLoadEnd(Self);
 end;
 
+procedure TframeCEFHost.Handle_CEF_SETFOCUS(var message: TMessage);
+begin
+  AssertVclThread;
+  if Assigned(cefwp) and cefwp.Visible and cefwp.CanFocus then
+    GetParentForm(cefwp).ActiveControl := cefwp;
+end;
+
 procedure TframeCEFHost.cefPreKeyEvent(Sender: TObject;
   const browser: ICefBrowser; const event: PCefKeyEvent; osEvent: PMsg;
   out isKeyboardShortcut, Result: Boolean);
+var
+  p: PCEFHostKeyEventData;
 begin
+  AssertCefThread;
   Result := False;
 
-  if Assigned(FOnPreKeyEvent) and
-    (event.kind in [TCefKeyEventType.KEYEVENT_KEYDOWN, TCefKeyEventType.KEYEVENT_RAWKEYDOWN]) then
+  p := AllocMem(Sizeof(TCEFHostKeyEventData));
+  p.event := event^;
+  if Assigned(osEvent) then
+    p.osEvent := osEvent^;
+
+  if event.kind in [TCefKeyEventType.KEYEVENT_KEYDOWN, TCefKeyEventType.KEYEVENT_RAWKEYDOWN] then
   begin
-    FOnPreKeyEvent(Self, browser, event, osEvent, isKeyboardShortcut, Result);
-    if Result then
-      Exit;
+    if Assigned(FOnPreKeySyncEvent) then
+    begin
+      FOnPreKeySyncEvent(Self, p^, isKeyboardShortcut, Result);
+    end;
+
+    if not Result then  // only run this if the prekeysyncevent didn't swallow the keystroke
+    begin
+      if event.windows_key_code = VK_F1 then
+      begin
+        isKeyboardShortcut := True;
+        Result := True;
+      end
+      else if event.windows_key_code = VK_F12 then
+      begin
+        isKeyboardShortcut := True;
+        Result := True;
+      end
+      else if event.windows_key_code <> VK_CONTROL then
+      begin
+        if SendMessage(FApplicationHandle, CM_APPKEYDOWN, event.windows_key_code, 0) = 1 then
+        begin
+          isKeyboardShortcut := True;
+          Result := True;
+        end;
+      end;
+    end;
+
+    PostMessage(FCallbackWnd, CEF_KEYEVENT, MAKELONG(WORD(Result), WORD(isKeyboardShortcut)), LPARAM(p));
   end;
 
-  if (event.windows_key_code <> VK_CONTROL) and (event.kind in [TCefKeyEventType.KEYEVENT_KEYDOWN, TCefKeyEventType.KEYEVENT_RAWKEYDOWN]) then
-  begin
-    if event.windows_key_code = VK_F1 then
-    begin
-      isKeyboardShortcut := True;
-      Result := True;
-      frmKeymanDeveloper.HelpTopic(Self);
-    end
-    else if event.windows_key_code = VK_F12 then
-    begin
-      cef.ShowDevTools(Point(Low(Integer),Low(Integer)), nil);
-    end
-    else if SendMessage(Application.Handle, CM_APPKEYDOWN, event.windows_key_code, 0) = 1 then
-    begin
-      isKeyboardShortcut := True;
-      Result := True;
-    end;
-  end;
 end;
 
 procedure TframeCEFHost.cefBeforePopup(Sender: TObject;
@@ -366,16 +555,8 @@ procedure TframeCEFHost.cefBeforePopup(Sender: TObject;
   var windowInfo: TCefWindowInfo; var client: ICefClient;
   var settings: TCefBrowserSettings; var noJavascriptAccess, Result: Boolean);
 begin
-  Result := True;
-  if Assigned(FOnBeforeBrowse) then
-  begin
-    FOnBeforeBrowse(Self, targetUrl, Result);
-    if not Result then
-    begin
-      cef.LoadURL(targetUrl);
-      Result := True;
-    end;
-  end;
+  AssertCefThread;
+  DoBeforeBrowse(targetUrl, Result, True);
 end;
 
 procedure TframeCEFHost.cefRunContextMenu(Sender: TObject;
@@ -383,30 +564,35 @@ procedure TframeCEFHost.cefRunContextMenu(Sender: TObject;
   const params: ICefContextMenuParams; const model: ICefMenuModel;
   const callback: ICefRunContextMenuCallback; var aResult: Boolean);
 begin
+  AssertCefThread;
   // Return FALSE to show default context menu
   aResult := not FShouldShowContextMenu and (GetKeyState(VK_SHIFT) >= 0);
 end;
 
 procedure TframeCEFHost.WMEnterMenuLoop(var aMessage: TMessage);
 begin
+  AssertVclThread;
   inherited;
   if (aMessage.wParam = 0) and (GlobalCEFApp <> nil) then GlobalCEFApp.OsmodalLoop := True;
 end;
 
 procedure TframeCEFHost.WMExitMenuLoop(var aMessage: TMessage);
 begin
+  AssertVclThread;
   inherited;
   if (aMessage.wParam = 0) and (GlobalCEFApp <> nil) then GlobalCEFApp.OsmodalLoop := False;
 end;
 
 procedure TframeCEFHost.WMMove(var aMessage: TWMMove);
 begin
+  AssertVclThread;
   inherited;
   if cef <> nil then cef.NotifyMoveOrResizeStarted;
 end;
 
 procedure TframeCEFHost.WMMoving(var aMessage: TMessage);
 begin
+  AssertVclThread;
   inherited;
   if cef <> nil then cef.NotifyMoveOrResizeStarted;
 end;

--- a/windows/src/global/delphi/general/UserMessages.pas
+++ b/windows/src/global/delphi/general/UserMessages.pas
@@ -36,7 +36,6 @@ const
 
 const
   // UfrmKeymanBase
-  WM_USER_FireCommand = WM_USER + 111;
   WM_USER_FormShown = WM_USER + 112;
   WM_USER_ContentRender = WM_USER + 113;
   WM_USER_Step = WM_USER + 114;
@@ -46,8 +45,6 @@ const
   // KeymanDeveloperUtils
   WM_USER_LOADREGFILES = WM_USER+120;
   //WM_USER_FORMSHOWN = WM_USER+100;
-
-  WM_USER_WEBCOMMAND = WM_USER+122;
 
   WC_COMMAND = 0;
   WC_HELP = 1;


### PR DESCRIPTION
Chromium events tend to be fired on a thread other than the VCL thread. That means it is not
safe to call any VCL functions from those events. Now we marshall the events through to the
VCL thread and provide "sync" access for events where an instantaneous response is required
(e.g. `out result: boolean`). Those 'sync' event handlers in forms that consume the CEF host
frame must also be thread safe (suggest using `AssertCefThread` to remind maintainers that
they should not do any VCL calls -- not even to `Self.Handle` -- from those 
CEF event handlers).

Non-sync events are marshalled to the main thread and can safely call VCL. But that also
means they are asynchronous: keep in mind when working with them.

Some callbacks, such as BeforeBrowse, have a synchronous and an asynchronous version. The
sync version is called on a CEF thread and should be used to tell Chromium if the event is
handled (don't do any actual work there). The CEF host frame then calls the asynchronous
version to allow for the work to be done.