### PR TITLE
[LMLayer] Constructor takes a Worker instead of a URI

### DIFF
--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -62,8 +62,9 @@ class LMLayer {
    * @param uri URI of the underlying LMLayer worker code. This will usually be a blob:
    *            or file: URI. If uri is not provided, this will start the default Worker.
    */
-  constructor(uri?: string) {
-    this._worker = new Worker(uri || LMLayer.asBlobURI(LMLayerWorkerCode));
+  constructor(worker?: Worker) {
+    // Either use the given worker, or instantiate the default worker.
+    this._worker = worker || new Worker(LMLayer.asBlobURI(LMLayerWorkerCode));
   }
 
   // TODO: asynchronous initialize() method, based on 

--- a/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
@@ -7,8 +7,12 @@ let LMLayer = require('../../build');
 // Note: these tests can only be run after BOTH stages of compilation are completed.
 describe('LMLayer', function() {
   describe('[[constructor]]', function () {
-    it.skip('should be take a URI to instantiate', function () {
-      new LMLayer(uri);
+    it('should be take a Worker to instantiate', function () {
+      let fakeWorker = {
+        postMessage: sinon.fake(),
+        onmessage: null
+      };
+      new LMLayer(fakeWorker);
     });
   });
 


### PR DESCRIPTION
The constructors optional argument _was_ a URI, so that we could mock a Worker to test the LMLayer in headless mode; however I realized that involved stringifying code, and maybe creating a temporary file. Yuck! Instead, this PR mocks the Worker directly. There should only be a few of methods to mock: `postMessage()` and checking how `.onmessage` gets set. There may be more later.

Note that I don't assert whether `.onmessage` gets assigned to a function, as that's not relevant until the `.initialize()` method gets called (which will be implemented in a future PR).