### PR TITLE
[LMLayer] top-level initialize()

### DIFF
--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -32,6 +32,40 @@
  */	
 type USVString = string;
 
+
+/**
+ * Describes the capabilities of the keyboard's platform.
+ * This includes upper bounds for how much text will be sent on each
+ * prediction, as well as what operations the keyboard is allowed to do on the
+ * underlying buffer.
+ */
+interface Capabilities {
+  /**
+   * The maximum amount of UTF-16 code units that the keyboard will provide to
+   * the left of the cursor, as an integer.
+   */
+  maxLeftContextCodeUnits: number,
+
+  /**
+   * The maximum amount of code units that the keyboard will provide to the
+   * right of the cursor, as an integer. The value 0 or the absence of this
+   * rule implies that the right contexts are not supported.
+   */
+  maxRightContextCodeUnits?: number,
+
+  /**
+   * Whether the platform supports deleting to the right. The absence of this
+   * rule implies false.
+   */
+  supportsDeleteRight?: false,
+}
+
+// TODO: Define this!
+interface ModelDescription {}
+
+// TODO: Define this!
+interface Configuration {}
+
 /**
  * Top-level interface to the Language Modelling layer, or "LMLayer" for short.
  * 
@@ -65,16 +99,31 @@ class LMLayer {
   constructor(worker?: Worker) {
     // Either use the given worker, or instantiate the default worker.
     this._worker = worker || new Worker(LMLayer.asBlobURI(LMLayerWorkerCode));
+    this._worker.onmessage = this.onMessage.bind(this)
   }
 
-  // TODO: asynchronous initialize() method, based on 
-  //       https://github.com/eddieantonio/keyman-lmlayer-prototype/blob/f8e6268b03190d08cf5d35f9428cf9150d6d219e/index.ts#L42-L62
+  /**
+   * Initializes the LMLayer worker with the keyboard/platform's capabilities,
+   * as well as a description of the model required.
+   */
+  initialize(capabilities: Capabilities, model: ModelDescription): Promise<Configuration> {
+    this._worker.postMessage({
+      message: 'initialize',
+      // TODO: other arguments
+    })
+
+    return Promise.reject('Not implemented');
+  }
 
   // TODO: asynchronous predict() method, based on 
   //       https://github.com/eddieantonio/keyman-lmlayer-prototype/blob/f8e6268b03190d08cf5d35f9428cf9150d6d219e/index.ts#L64-L80
 
   // TODO: asynchronous close() method.
   //       Worker code must recognize message and call self.close().
+
+  private onMessage(event: MessageEvent): void {
+    throw new Error('Not implemented');
+  }
 
   /**
    * Given a function, this utility returns the source code within it, as a string.

--- a/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
@@ -28,7 +28,28 @@ describe('LMLayer', function() {
       );
 
       assert.isFunction(fakeWorker.onmessage, 'LMLayer failed to set a callback!');
+    });
+
+    it('should send the `initialize` message to the LMLayer', async function () {
+      let fakeWorker = createFakeWorker();
+      let lmLayer = new LMLayer(fakeWorker);
+      let configuration = await lmLayer.initialize(
+        {
+          maxLeftContextCodeUnits: 32,
+        },
+        {
+          kind: 'wordlist',
+          words: ['foo', 'bar', 'baz', 'quux']
+        }
+      );
+
       assert.propertyVal(fakeWorker.postMessage, 'callCount', 1);
+      assert(fakeWorker.postMessage.calledOnceWith(sinon.match({
+        message: 'initialize',
+        capabilities: sinon.match.any(),
+        model: sinon.match.any()
+      })));
+      assert.isObject(configuration);
     });
   });
 

--- a/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
@@ -51,12 +51,12 @@ describe('LMLayer', function() {
         assert.isObject(data.model);
       
         // send the message on setTimeout() to emulate "asynchronous" call.
-        setTimeout(() => fakeWorker.onmessage({
+        callAsynchronously(() => fakeWorker.onmessage({
           data: {
             message: 'ready',
             configuration: {}
           }
-        }), 0);
+        }));
       }
       assert.isObject(configuration);
     });
@@ -88,5 +88,22 @@ describe('LMLayer', function() {
         postMessage: postMessage ? sinon.fake(postMessage) : sinon.fake(),
         onmessage: null
       };
+  }
+
+  /**
+   * Call a function in the future, i.e., later in the event loop.  
+   * The call does NOT block the current execution.
+   * Use this to fake asynchronous callbacks. 
+   * 
+   * @param {Function} fn function to call
+   */
+  function callAsynchronously(fn) {
+    if (typeof process !== 'undefined' && process.nextTick) {
+      // Preferred way to do it in Node.JS
+      process.nextTick(fn);
+    } else {
+      // In all other JavaScript environments (e.g., the browser)
+      setTimeout(fn, 0)
+    }
   }
 });

--- a/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
@@ -7,7 +7,7 @@ let LMLayer = require('../../build');
 // Note: these tests can only be run after BOTH stages of compilation are completed.
 describe('LMLayer', function() {
   describe('[[constructor]]', function () {
-    it('should be take a Worker to instantiate', function () {
+    it('should accept a Worker to instantiate', function () {
       let fakeWorker = {
         postMessage: sinon.fake(),
         onmessage: null
@@ -16,8 +16,31 @@ describe('LMLayer', function() {
     });
   });
 
-  // Since the Blob API is browser-specific, look for those tests
-  // for .asBlobURI() in the in_browser tests.
+  describe('#initialize()', function () {
+    it('should accept capabilities and model description', function () {
+      let fakeWorker = {
+        postMessage: sinon.fake(),
+        onmessage: null
+      };
+
+      let lmLayer = new LMLayer(fakeWorker);
+      lmLayer.initialize(
+        {
+          maxLeftContextCodeUnits: 32,
+        },
+        {
+          kind: 'wordlist',
+          words: ['foo', 'bar', 'baz', 'quux']
+        }
+      );
+
+      assert.isFunction(fakeWorker.onmessage, 'LMLayer failed to set a callback!');
+      assert.propertyVal(fakeWorker.postMessage, 'callCount', 1);
+    });
+  });
+
+  // Since the Blob API is limited to browsers, look for those
+  // tests for .asBlobURI() in the in_browser tests.
   describe('.unwrap', function () {
     it('should return the inner code of a function', function () {
       // Create a multi-line function body we can match in a RegExp.

--- a/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/headless/top-level-lmlayer.js
@@ -8,20 +8,13 @@ let LMLayer = require('../../build');
 describe('LMLayer', function() {
   describe('[[constructor]]', function () {
     it('should accept a Worker to instantiate', function () {
-      let fakeWorker = {
-        postMessage: sinon.fake(),
-        onmessage: null
-      };
-      new LMLayer(fakeWorker);
+      new LMLayer(createFakeWorker());
     });
   });
 
   describe('#initialize()', function () {
     it('should accept capabilities and model description', function () {
-      let fakeWorker = {
-        postMessage: sinon.fake(),
-        onmessage: null
-      };
+      let fakeWorker = createFakeWorker();
 
       let lmLayer = new LMLayer(fakeWorker);
       lmLayer.initialize(
@@ -52,4 +45,19 @@ describe('LMLayer', function() {
       assert.match(text, /^\s*var\s+hello;\s*var\s+world;\s*$/);
     });
   });
+
+  /**
+   * Returns an object implementing *enough* of the Worker
+   * interface to fool the LMLayer into thinking it's
+   * communicating with a bona fide Web Worker.
+   * 
+   * @returns {Worker} an object with sinon.fake() instances.
+   */
+  function createFakeWorker() {
+    return {
+        // TODO: this should reply
+        postMessage: sinon.fake(),
+        onmessage: null
+      };
+  }
 });

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -17,7 +17,8 @@ describe('LMLayerWorker', function() {
       // Sending it the initialize it should notify us that it's initialized!
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        model: dummyModelCode()
+        model: dummyModelCode(),
+        capabilities: defaultCapabilities()
       }));
       assert(fakePostMessage.calledOnce);
     });
@@ -54,7 +55,8 @@ describe('LMLayerWorker', function() {
       // Send a message; we should get something back.
       worker.onMessage(createMessageEventWithData({
        message: 'initialize',
-       model: dummyModelCode()
+       model: dummyModelCode(),
+        capabilities: defaultCapabilities()
       }));
 
       // It called the postMessage() in its global scope. 
@@ -81,7 +83,8 @@ describe('LMLayerWorker', function() {
       var worker = new LMLayerWorker({ postMessage: fakePostMessage });
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        model: dummyModelCode()
+        model: dummyModelCode(),
+        capabilities: defaultCapabilities()
       }));
 
       assert(fakePostMessage.calledOnceWith(sinon.match({
@@ -96,7 +99,7 @@ describe('LMLayerWorker', function() {
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
         model: dummyModelCode(),
-        configuration: {
+        capabilities: {
           maxLeftContextCodeUnits: maxCodeUnits,
         }
       }));
@@ -123,8 +126,8 @@ describe('LMLayerWorker', function() {
 
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        configuration: {
-          supportsRightContexts: true,
+        capabilities: {
+          maxLeftContextCodeUnits: maxCodeUnit,
           maxRightContextCodeUnits: maxCodeUnit
         },
         // We can only send source code through the Structure Clones algorithm,
@@ -167,12 +170,22 @@ describe('LMLayerWorker', function() {
   }
 
   /**
-   * Deprecation warning: Soon, models will not be requierd to be passed as source code;
+   * Deprecation warning: Soon, models will not be required to be passed as source code;
    * when this happens, tests should refrain from sending source code for the model
    * parameter.
    */
   function dummyModelCode() {
     return 'return {model: {}, configuration: {}}';
+  }
+
+  /**
+   * Returns reasonable defaults for the default capabilities
+   * to initialize the LMLayer.
+   */
+  function defaultCapabilities() {
+    return {
+      maxLeftContextCodeUnits: 64
+    };
   }
 
   /**

--- a/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
@@ -2,10 +2,24 @@ var assert = chai.assert;
 
 describe('LMLayer', function () {
   describe('[[constructor]]', function () {
-      it('should construct with zero arguments', function () {
-        let lmlayer = new LMLayer();
-        assert.instanceOf(lmlayer, LMLayer);
+    it('should construct with zero arguments', function () {
+      let lmLayer = new LMLayer();
+      assert.instanceOf(lmLayer, LMLayer);
+    });
+  });
+
+  describe('#initialize()', function () {
+    it('should yield a reasonable configuration', function () {
+      let maxLeftContext = 64;
+      let lmLayer = new LMLayer();
+      return lmLayer.initialize(
+        { maxLeftContextCodeUnits: maxLeftContext },
+        { model: { kind: 'wordlist', words: ['foo', 'bar']} }
+      ).then(function (configuration) {
+        assert.isAtMost(configuration.leftContextCodeUnits, maxLeftContext);
+        assert.propertyVal(configuration, 'rightContextCodeUnits', 0);
       });
+    });
   });
 
   describe('#asBlobURI()', function () {

--- a/common/predictive-text/unit_tests/in_browser/cases/worker.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker.js
@@ -18,7 +18,8 @@ describe('LMLayerWorker', function () {
       };
       worker.postMessage({
         message: 'initialize',
-        model: "return {model: {}, configuration: {}}"
+        model: "return {model: {}, configuration: {}}",
+        capabilities: { maxLeftContextCodeUnits: 64 }
       });
     });
   });


### PR DESCRIPTION
Highlights:

 - unit tests for calling `LMLayer#initialize()` with mocked `Worker`
 - integration test for calling `LMLayer` with true worker
 - "configuration" sent from keyboard to LMLayer is now called "capabilities"
 - refactored all interfaces in common in both the worker and top-level to its own file