### PR TITLE
[LMLayer] Adds promise polyfill for IE.

### DIFF
--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -20,6 +20,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/// <reference path="node_modules/promise-polyfill/lib/polyfill.js" />
+
 /**
  * Top-level interface to the Language Modelling layer, or "LMLayer" for short.
  * 

--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.1.tgz",
-      "integrity": "sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==",
+      "version": "10.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.11.tgz",
+      "integrity": "sha512-3iIOhNiPGTdcUNVCv9e5G7GotfvJJe2pc9w2UgDXlUwnxSZ3RgcUocIU+xYm+rTU54jIKih998QE4dMOyMN1NQ==",
       "dev": true
     },
     "accepts": {
@@ -1144,10 +1144,16 @@
         }
       }
     },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "dev": true,
       "requires": {
         "debug": "=3.1.0"
@@ -2078,9 +2084,9 @@
       "dev": true
     },
     "karma": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz",
-      "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.3.tgz",
+      "integrity": "sha512-JU4FYUtFEGsLZd6ZJzLrivcPj0TkteBiIRDcXWFsltPMGgZMDtby/MIzNOzgyZv/9dahs9vHpSxerC/ZfeX9Qw==",
       "dev": true,
       "requires": {
         "bluebird": "^3.3.0",
@@ -2093,11 +2099,12 @@
         "di": "^0.0.1",
         "dom-serialize": "^2.2.0",
         "expand-braces": "^0.1.1",
+        "flatted": "^2.0.0",
         "glob": "^7.1.1",
         "graceful-fs": "^4.1.2",
         "http-proxy": "^1.13.0",
         "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.5",
         "log4js": "^3.0.0",
         "mime": "^2.3.1",
         "minimatch": "^3.0.2",
@@ -2109,7 +2116,7 @@
         "socket.io": "2.1.1",
         "source-map": "^0.6.1",
         "tmp": "0.0.33",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       }
     },
     "karma-browserstack-launcher": {
@@ -2339,10 +2346,14 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-      "dev": true
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "make-error": {
       "version": "1.3.5",
@@ -2393,9 +2404,9 @@
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
       "dev": true
     },
     "mime-db": {
@@ -2724,6 +2735,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
+      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "q": {
@@ -3335,9 +3357,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.4.tgz",
-      "integrity": "sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
       "dev": true
     },
     "ultron": {
@@ -3471,12 +3493,12 @@
       "dev": true
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
+        "lru-cache": "4.1.x",
         "tmp": "0.0.x"
       }
     },
@@ -3534,6 +3556,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yeast": {

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/eddieantonio/keyman-lmlayer-prototype#readme",
   "devDependencies": {
-    "@types/node": "^10.11.7",
+    "@types/node": "^10.12.11",
     "chai": "^4.2.0",
-    "karma": "^3.1.1",
+    "karma": "^3.1.3",
     "karma-browserstack-launcher": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -39,6 +39,9 @@
     "mocha-teamcity-reporter": "^2.5.1",
     "sinon": "^7.1.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.1.4"
+    "typescript": "^3.2.1"
+  },
+  "dependencies": {
+    "promise-polyfill": "8.1.0"
   }
 }


### PR DESCRIPTION
Targets #1365 to help fix a CI test failure related to IE missing `Promise`.

Since our goal is to eventually support LMLayer code across all our platforms, we'd like to keep support for LMLayer code in IE.  (I mean, we'd rather not, but there is that ~2.5% global user base that we do care about.)  So, to facilitate this, a polyfill for the ES6 `Promise` can be used to help bridge the gap while allowing usage of nice, newer JS features.