### PR TITLE
[Developer] Do not callback to UI handler when creating project file on http worker thread

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -480,7 +480,7 @@ begin
   if not Assigned(AProject) then   // I4720
     CheckGetFileParameters;
 
-  if Assigned(FDoCreateProjectFileUI) then   // I4702
+  if (GetCurrentThreadId = MainThreadID) and Assigned(FDoCreateProjectFileUI) then   // I4702
     FDoCreateProjectFileUI(Self);   // I4687
 
   UpdateID;


### PR DESCRIPTION
This was found by running through a profiler to catch calls to UI methods on threads other than the main thread.