### PR TITLE
[Common] Update VS version checks to 19.16 for latest release of VS2017 (bug in VS workaround)

### DIFF
--- a/common/engine/keyboardprocessor/src/keyboard.cpp
+++ b/common/engine/keyboardprocessor/src/keyboard.cpp
@@ -56,7 +56,7 @@ json & km::kbp::operator << (json & j, km::kbp::keyboard const & kb)
   https://stackoverflow.com/a/35103224/1836776
 */
 
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 19.16 */
 
 std::string utf16_to_utf8(std::u16string utf16_string)
 {

--- a/common/engine/keyboardprocessor/src/keyboard.cpp
+++ b/common/engine/keyboardprocessor/src/keyboard.cpp
@@ -56,7 +56,7 @@ json & km::kbp::operator << (json & j, km::kbp::keyboard const & kb)
   https://stackoverflow.com/a/35103224/1836776
 */
 
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1915 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
 
 std::string utf16_to_utf8(std::u16string utf16_string)
 {

--- a/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
@@ -229,14 +229,14 @@ PKMX_WCHAR km::kbp::kmx::strtowstr(PKMX_CHAR in)
 {
   km_kbp_cp *result;
 
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 19.16 */
   std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
 #else 
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
 #endif
   auto s = convert.from_bytes(in, strchr(in, 0));
   result = new KMX_WCHAR[s.length() + 1];
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 19.16 */
   s.copy(reinterpret_cast<int16_t *>(result), s.length());
 #else
   s.copy(result, s.length());

--- a/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
@@ -229,14 +229,14 @@ PKMX_WCHAR km::kbp::kmx::strtowstr(PKMX_CHAR in)
 {
   km_kbp_cp *result;
 
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1915 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
   std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
 #else 
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
 #endif
   auto s = convert.from_bytes(in, strchr(in, 0));
   result = new KMX_WCHAR[s.length() + 1];
-#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1915 /* VS 2017 */
+#if _MSC_VER >= 1900 /* VS 2015 */ && _MSC_VER <= 1916 /* VS 2017 */
   s.copy(reinterpret_cast<int16_t *>(result), s.length());
 #else
   s.copy(result, s.length());


### PR DESCRIPTION
Build agents had a later version of VS installed. The version check is intentionally very
specific because it is working around a bug in the standard library included with VS so we
don't want to apply it unless we have to.