### PR TITLE
[iOS] Fixes Carthage's link to the app for App Store submission.

### DIFF
--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -1045,11 +1045,13 @@
 				"$(SRCROOT)/../../Carthage/Build/iOS/Zip.framework",
 				"$(SRCROOT)/../../Carthage/Build/iOS/ObjcExceptionBridging.framework",
 				"$(SRCROOT)/../../Carthage/Build/iOS/XCGLogger.framework",
+				"$(SRCROOT)/../../Carthage/Build/iOS/DeviceKit.framework",
 			);
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Zip.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ObjcExceptionBridging.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/XCGLogger.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/DeviceKit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Fixes the iTunesConnect issue that arose with our recent iOS nightly submissions.

For reference, see https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos.  The procedure there was done for all but DeviceKit, which was just added in a recent PR.  Correcting this will fix the submission process.