### PR TITLE
[linux] install from kmp.json in directory

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -45,12 +45,20 @@ class InstallKmpWindow(Gtk.Window):
         self.viewwindow = viewkmp
         self.download = downloadwindow
         self.accelerators = None
-        keyboardid = os.path.basename(os.path.splitext(kmpfile)[0])
-        installed_kmp_ver = get_kmp_version(keyboardid)
+
+        kmpfilebase = os.path.basename(kmpfile)
+        if kmpfilebase == "kmp.json":
+            # use name of directory that kmp.json was found in
+            packageID = os.path.basename(os.path.dirname(kmpfile))
+        else:
+            # use name of kmpfile
+            packageID = os.path.basename(os.path.splitext(kmpfile)[0])
+        logging.debug("Thinking about installing packageID %s", packageID)
+        installed_kmp_ver = get_kmp_version(packageID)
         if installed_kmp_ver:
             logging.info("installed kmp version %s", installed_kmp_ver)
 
-        windowtitle = "Installing keyboard/package " + keyboardid
+        windowtitle = "Installing keyboard/package " + packageID
         Gtk.Window.__init__(self, title=windowtitle)
         init_accel(self)
 
@@ -77,7 +85,7 @@ class InstallKmpWindow(Gtk.Window):
                     dialog.destroy()
                     if response == Gtk.ResponseType.YES:
                         logging.debug("QUESTION dialog closed by clicking YES button")
-                        uninstall_kmp(keyboardid)
+                        uninstall_kmp(packageID)
                     elif response == Gtk.ResponseType.NO:
                         logging.debug("QUESTION dialog closed by clicking NO button")
                         self.checkcontinue = False
@@ -95,7 +103,7 @@ class InstallKmpWindow(Gtk.Window):
                             dialog.destroy()
                             if response == Gtk.ResponseType.YES:
                                 logging.debug("QUESTION dialog closed by clicking YES button")
-                                uninstall_kmp(keyboardid)
+                                uninstall_kmp(packageID)
                             elif response == Gtk.ResponseType.NO:
                                 logging.debug("QUESTION dialog closed by clicking NO button")
                                 self.checkcontinue = False
@@ -279,8 +287,15 @@ class InstallKmpWindow(Gtk.Window):
                 self.viewwindow.refresh_installed_kmp()
             if self.download:
                 self.download.close()
-            keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
-            welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
+            kmpfilebase = os.path.basename(self.kmpfile)
+            if kmpfilebase == "kmp.json":
+                # use name of directory that kmp.json was found in
+                packageID = os.path.basename(os.path.dirname(self.kmpfile))
+            else:
+                # use name of kmpfile
+                packageID = os.path.basename(os.path.splitext(self.kmpfile)[0])
+
+            welcome_file = os.path.join(user_keyboard_dir(packageID), "welcome.htm")
             if os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.debug(uri_path)
@@ -322,18 +337,18 @@ class InstallKmpWindow(Gtk.Window):
 
 def main(argv):
     if len(sys.argv) != 2:
-        logging.error("install_window.py <kmpfile>")
+        logging.error("install_window.py <kmpfile or kmp.json>")
         sys.exit(2)
 
     name, ext = os.path.splitext(sys.argv[1])
-    if ext != ".kmp":
-        logging.error("install_window.py Input file", sys.argv[1], "is not a kmp file.")
-        logging.error("install_window.py <kmpfile>")
+    if ext != ".kmp" and (os.path.basename(sys.argv[1]) != "kmp.json"):
+        logging.error("install_window.py Input file", sys.argv[1], "is not a kmp file or kmp.json.")
+        logging.error("install_window.py <kmpfile or kmp.json>>")
         sys.exit(2)
 
     if not os.path.isfile(sys.argv[1]):
-        logging.error("install_window.py Keyman kmp file", sys.argv[1], "not found.")
-        logging.error("install_window.py <kmpfile>")
+        logging.error("install_window.py Keyman kmp file or kmp.json", sys.argv[1], "not found.")
+        logging.error("install_window.py <kmpfile or kmp.json>")
         sys.exit(2)
 
     w = InstallKmpWindow(sys.argv[1])

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -79,6 +79,7 @@ def get_installed_kmp_paths(check_paths):
                         with open(kbjson, "r") as read_file:
                             kbdata = json.load(read_file)
                     if kbdata:
+                        logging.debug("kbdata from %s", kbjson)
                         if 'description' in kbdata:
                             description = kbdata['description']
                         version = kbdata['version']

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -49,7 +49,11 @@ class ViewInstalledWindowBase(Gtk.Window):
         filter_text = Gtk.FileFilter()
         filter_text.set_name("KMP files")
         filter_text.add_pattern("*.kmp")
+        jsonfilter_text = Gtk.FileFilter()
+        jsonfilter_text.set_name("KMP json")
+        jsonfilter_text.add_pattern("kmp.json")
         dlg.add_filter(filter_text)
+        dlg.add_filter(jsonfilter_text)
         response = dlg.run()
         if response == Gtk.ResponseType.OK:
             kmpfile = dlg.get_filename()


### PR DESCRIPTION
allows you to install from shared drive or usb stick or SD card
by selecting a kmp.json

It wasn't obvious how to select a directory, but I can try that if you think selecting a kmp.json will be too confusing for users.

The alternative of just copying a directory into ~/.local/share/keyman or /usr/local/share/keyman should just work.

Closes: #1250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1398)
<!-- Reviewable:end -->
