### PR TITLE
[Windows] Fixes #5780. Crash when upgrading and TSF TIP enumeration fails

### DIFF
--- a/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
+++ b/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
@@ -68,7 +68,9 @@ begin
     begin
       Found := False;
 
-      ippm.EnumProfiles(k.Languages[j].LangID, ppe);
+      if not Succeeded(ippm.EnumProfiles(k.Languages[j].LangID, ppe)) then
+        Exit(False);
+
       while ppe.Next(1, profile, n) = S_OK do
       begin
         if IsEqualGUID(k.Languages[j].ProfileGUID, profile.guidProfile) then


### PR DESCRIPTION
Also:
* Fixes sillsdev/keyman-issues#5754
* Fixes sillsdev/keyman-issues#5763