### PR TITLE
[Developer] Touch Layout importer from KVK used incorrect layer names for some modifiers

### DIFF
--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -209,10 +209,8 @@ procedure TframeTouchLayoutBuilder.ImportFromKVK(const KVKFileName: string);   /
 var
   converter: TTouchLayoutToVisualKeyboardConverter;
   FVK: TVisualKeyboard;
-  FOldLayoutJS: string;
+  FJS: string;
 begin
-  FOldLayoutJS := FSavedLayoutJS;
-
   if not FileExists(KVKFileName) then
   begin
     ShowMessage('This keyboard does not include an On Screen Keyboard file named '+KVKFileName);
@@ -233,9 +231,8 @@ begin
 
     converter := TTouchLayoutToVisualKeyboardConverter.Create(FVK);
     try
-      if not converter.Execute(FSavedLayoutJS) then
+      if not converter.Execute(FJS) then
       begin
-        FSavedLayoutJS := FOldLayoutJS;
         ShowMessage('The converter failed to run.');
         Exit;
       end;
@@ -247,11 +244,10 @@ begin
   end;
 
   try
-    DoLoad;
+    Load(FJS, False, True);
   except
     on E:Exception do
     begin
-      FSavedLayoutJS := FOldLayoutJS;
       ShowMessage(E.Message);
       Exit;
     end;
@@ -284,6 +280,9 @@ var
 begin
   FLastErrorOffset := -1;
   FLastError := '';
+
+  if (FFileName <> '') and modWebHttpServer.AppSource.IsSourceRegistered(FFilename) then
+    modWebHttpServer.AppSource.UnregisterSource(FFilename);
 
 //  FreeAndNil(FHTMLTempFilename);   // I4195
 //  FHTMLTempFilename := TTempFileManager.Get('.html');   // I4195

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas
@@ -159,6 +159,7 @@ var
 type
   TLayoutShiftState = record Shift: Word; id: ansistring end;
 const
+  // These layer names match those in KeymanWeb, kmwosk.ts osk.modifierSpecials
   ShiftStates: array[0..21] of TLayoutShiftState = (
     (Shift: KVKS_NORMAL; id: 'default'),
     (Shift: KVKS_SHIFT; id: 'shift'),
@@ -177,12 +178,12 @@ const
     (Shift: KVKS_RALT; id: 'rightalt'),
     (Shift: KVKS_RCTRL or KVKS_RALT; id: 'rightctrl-rightalt'),
     (Shift: KVKS_SHIFT; id: 'shift'),
-    (Shift: KVKS_SHIFT or KVKS_LCTRL; id: 'shift-lctrl'),
-    (Shift: KVKS_SHIFT or KVKS_RCTRL; id: 'shift-rctrl'),
-    (Shift: KVKS_SHIFT or KVKS_LALT; id: 'shift-lalt'),
-    (Shift: KVKS_SHIFT or KVKS_RALT; id: 'shift-ralt'),
-    (Shift: KVKS_SHIFT or KVKS_LCTRL or KVKS_LALT; id: 'shift-lctrl-lalt'),
-    (Shift: KVKS_SHIFT or KVKS_RCTRL or KVKS_RALT; id: 'shift-rctrl-ralt')
+    (Shift: KVKS_SHIFT or KVKS_LCTRL; id: 'leftctrl-shift'),
+    (Shift: KVKS_SHIFT or KVKS_RCTRL; id: 'rightctrl-shift'),
+    (Shift: KVKS_SHIFT or KVKS_LALT; id: 'leftalt-shift'),
+    (Shift: KVKS_SHIFT or KVKS_RALT; id: 'rightalt-shift'),
+    (Shift: KVKS_SHIFT or KVKS_LCTRL or KVKS_LALT; id: 'leftctrl-leftalt-shift'),
+    (Shift: KVKS_SHIFT or KVKS_RCTRL or KVKS_RALT; id: 'rightctrl-rightalt-shift')
   );
 const
   NFirstChiralShiftState = 8;


### PR DESCRIPTION
Shift + chiral ctrl and alt modifier layer names were incorrect. Now matches that found in kmwosk.ts. Existing
keyboards that have the wrong layer names need to have those fixed manually.