### PR TITLE
[Web] Keyboard text auto-scaling

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -4,6 +4,7 @@
 * Add `setNumericLayer()` for embedded platforms to change OSK to numeric layer.
 * Fixes issue where file extensions are upper-case, e.g. ".TTF"
 * Fixes keyboard layout issues after mobile device rotations. (#248) (#970)
+* Fixes issue with oversized key text on some keyboards. (#382)
 
 ## 2018-07-06 10.0.103 stable
 * Fixes issue for embedded Android, iOS apps where a keyboard with varying row counts in different layers could crash (#1055)

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -285,7 +285,7 @@ if(!window['keyman']['initialized']) {
             ktls = ktLabel.style,
             edge = 0,
             canvas = tip.firstChild, 
-            previewFontScale = 1.6;
+            previewFontScale = 1.8;
             
         // Find key text element
         for(var i=0; i<key.childNodes.length; i++)
@@ -311,6 +311,7 @@ if(!window['keyman']['initialized']) {
           kts.fontSize = popupFS + 'px';
 
           let textWidth = com.keyman.OSKKey.getTextWidth(ktLabel.textContent, kts);
+          // We use a factor of 0.9 to serve as a buffer in case of mild measurement error.
           let proportion = canvas.width * 0.9 / (textWidth);
 
           // Prevent the preview from overrunning its display area.

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -377,10 +377,10 @@ if(!window['keyman']['initialized']) {
       switch(edge)
       {
         case -1:
-          w1 -= dx; w2 -= dx; //w3 += dx;
+          w1 -= dx; w2 -= dx;
           break;
         case 1:
-          /*w0 += dx;*/ w1 += dx; w2 += dx;
+          w1 += dx; w2 += dx;
           break;
       }
       

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -285,7 +285,7 @@ if(!window['keyman']['initialized']) {
             ktls = ktLabel.style,
             edge = 0,
             canvas = tip.firstChild, 
-            previewFontScale = 1.8;
+            previewFontScale = 1.6;
             
         // Find key text element
         for(var i=0; i<key.childNodes.length; i++)
@@ -306,7 +306,18 @@ if(!window['keyman']['initialized']) {
         kts.height = canvas.height+'px';
 
         var px=util.getStyleInt(kc,'font-size');
-        if(px != 0) kts.fontSize = (previewFontScale * px)+'px';
+        if(px != 0) {
+          let popupFS = previewFontScale * px;
+          kts.fontSize = popupFS + 'px';
+
+          let textWidth = com.keyman.OSKKey.getTextWidth(ktLabel.textContent, kts);
+          let proportion = canvas.width * 0.9 / (textWidth);
+
+          // Prevent the preview from overrunning its display area.
+          if(proportion < 1) {
+            kts.fontSize = (popupFS * proportion) + 'px';
+          }
+        }
         
         ktLabel.textContent = kc.textContent;
         ktls.display = 'block';
@@ -365,10 +376,10 @@ if(!window['keyman']['initialized']) {
       switch(edge)
       {
         case -1:
-          w1 -= dx; w2 -= dx; w3 -= dx;
+          w1 -= dx; w2 -= dx; //w3 += dx;
           break;
         case 1:
-          w0 += dx; w1 += dx; w2 += dx;
+          /*w0 += dx;*/ w1 += dx; w2 += dx;
           break;
       }
       

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -386,6 +386,31 @@ namespace com.keyman {
       return Device._GetIEVersion();
     }
 
+    getFontSizeStyle(e: HTMLElement|string): {val: number, absolute: boolean} {
+      var val: number;
+      var fs: string;
+
+      if(typeof e == 'string') {
+        fs = e;
+      } else {
+        fs = e.style.fontSize;
+      }
+
+      if(fs.indexOf('em') != -1) {
+        val = parseFloat(fs.substr(0, fs.indexOf('em')));
+        return {val: val, absolute: false};
+      } else if(fs.indexOf('px') != -1) {
+        val = parseFloat(fs.substr(0, fs.indexOf('px')));
+        return {val: val, absolute: true};
+      } else if(fs.indexOf('%') != -1) {
+        val = parseFloat(fs.substr(0, fs.indexOf('%')));
+        return {val: val/100, absolute: false};
+      } else {
+        // Cannot parse.
+        return null;
+      }
+    }
+
     /**
      * Get browser-independent computed style value for element
      * 


### PR DESCRIPTION
Fixes #382.

It took a little longer than I would have liked to address, as it turns out that determining the relative font size of text in an element detached from the DOM isn't exactly straightforward.  This is exacerbated by the keyboard construction sequence, as we need much of the information before it has actually been otherwise made available within KeymanWeb.  A few in-code adjustments have been made to facilitate the necessary calculations with minimal adjustments to the actual keyboard construction process.

The main thing left to do:  draft up a proper test keyboard that can showcase this across various devices/form-factors.  Khmer Angkor is a good example... for phone layouts only.