### PR TITLE
[common] tweak kmx tests for ibus-keyman test

### DIFF
--- a/common/engine/keyboardprocessor/tests/unit/kmx/000 - null keyboard.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/000 - null keyboard.kmn
@@ -1,5 +1,5 @@
 c Description: Tests null keyboard 
-c keys: [K_A][RALT K_B][SHIFT K_C]
+c keys: [K_A][LALT K_B][SHIFT K_C]
 c expected: aC
 c context: 
 

--- a/common/engine/keyboardprocessor/tests/unit/kmx/000 - null keyboard.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/000 - null keyboard.kmn
@@ -1,5 +1,5 @@
 c Description: Tests null keyboard 
-c keys: [K_A][LALT K_B][SHIFT K_C]
+c keys: [K_A][RALT K_B][SHIFT K_C]
 c expected: aC
 c context: 
 

--- a/common/engine/keyboardprocessor/tests/unit/kmx/015 - ralt 2.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/015 - ralt 2.kmn
@@ -1,5 +1,5 @@
 c Description: Tests Right Alt processing with non-US kbds.
-c keys: abc[RALT K_A]
+c keys: [K_A][K_B][K_C][RALT K_A]
 c expected: abcd
 
 store(&VERSION) '9.0'

--- a/common/engine/keyboardprocessor/tests/unit/kmx/017 - space mnemonic kbd.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/017 - space mnemonic kbd.kmn
@@ -1,5 +1,5 @@
 c Description: Tests Space handling in mnemonic keyboards (failed with Win 98)
-c keys: ab c d de
+c keys: [K_A][K_B][K_SPACE][K_C][K_SPACE][K_D][K_SPACE][K_D][K_E]
 c expected: XYZ
 
 store(&VERSION) '9.0'

--- a/common/engine/keyboardprocessor/tests/unit/kmx/028 - smp.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/028 - smp.kmn
@@ -1,6 +1,6 @@
 c Description: Tests SMP characters
 c keys: [K_1][K_2]
-c expected: \u1F642hi\u1F600
+c expected: \U0001F642hi\U0001F600
 c context: 
 
 store(&version) '10.0'

--- a/common/engine/keyboardprocessor/tests/unit/kmx/kmx.cpp
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/kmx.cpp
@@ -356,11 +356,11 @@ std::u16string parse_source_string(std::string const & s) {
       p++;
       km_kbp_usv v;
       assert(p != s.end());
-      if (*p == 'u') {
+      if (*p == 'u' || *p == 'U') {
         // Unicode value
         p++;
         size_t n;
-        std::string s1 = s.substr(p - s.begin(), 6);
+        std::string s1 = s.substr(p - s.begin(), 8);
         v = std::stoul(s1, &n, 16);
         assert(v >= 0x20 && v <= 0x10FFFF);
         p += n-1;


### PR DESCRIPTION
handle python compatible /Uxxxxxxxx format for smp
use e.g. [K_A] instead of a in keys:
RALT K_B is ” on an Alt-Gr keyboard so use LALT instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1423)
<!-- Reviewable:end -->
