### PR TITLE
[linux] 'us' is the default us xkb keyboard not 'en'

### DIFF
--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -213,7 +213,7 @@ ibus_keyman_add_engines(GList * engines, GList * kmpdir_list)
                                         kbd_details->license, // license
                                         details->info.author_desc, // author name only, not email
                                         keyman_get_icon_file(abs_kmx), // icon full path
-                                        "en", // layout defaulting to en (en-US)
+                                        "us", // layout defaulting to us (en-US)
                                         keyboard->version));
                             g_free(lang);
                             g_free(id_with_lang);
@@ -233,7 +233,7 @@ ibus_keyman_add_engines(GList * engines, GList * kmpdir_list)
                                 kbd_details->license, // license
                                 details->info.author_desc, // author name only, not email
                                 keyman_get_icon_file(abs_kmx), // icon full path
-                                "en", // layout defaulting to en (en-US)
+                                "us", // layout defaulting to us (en-US)
                                 keyboard->version));
                 }
                 free_keyboard_details(kbd_details);


### PR DESCRIPTION
as it says on the tin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1425)
<!-- Reviewable:end -->
