### PR TITLE
[linux] remove X11 dependency from ibus-keyman

### DIFF
--- a/linux/ibus-keyman/configure.ac
+++ b/linux/ibus-keyman/configure.ac
@@ -54,6 +54,12 @@ PKG_CHECK_MODULES(IBUS, [
 ])
 
 # check Json glib
+PKG_CHECK_MODULES(GTK, [
+    gtk+-3.0 >= 2.4
+])
+
+
+# check Json glib
 PKG_CHECK_MODULES(JSON_GLIB, [
     json-glib-1.0 >= 1.4.0
 ])

--- a/linux/ibus-keyman/debian/changelog
+++ b/linux/ibus-keyman/debian/changelog
@@ -1,5 +1,12 @@
+ibus-keyman (10.99.50-1) unstable; urgency=medium
+
+  * d/control replace dep on x11-dev with gtk-dev
+  * It theoretically will work on wayland as well now
+
+ -- Daniel Glassey <wdg@debian.org>  Fri, 14 Dec 2018 13:21:25 +0700
+
 ibus-keyman (10.99.0-1) unstable; urgency=low
 
-    * initial alpha release
+  * initial alpha release
 
  -- Daniel Glassey <wdg@debian.org>  Mon, 26 Nov 2018 11:09:40 +0700

--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Daniel Glassey <wdg@debian.org>
 Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, pkg-config,
  libkmnkbp-dev (>=0.0.0~), libibus-1.0-dev (>= 1.2), libjson-glib-dev (>= 1.4.0),
- x11proto-core-dev, libx11-dev
+ libgtk-3-dev
 Standards-Version: 3.9.8
 Homepage: http://www.keyman.com
 

--- a/linux/ibus-keyman/src/Makefile.am
+++ b/linux/ibus-keyman/src/Makefile.am
@@ -20,6 +20,7 @@
 
 AM_CFLAGS = \
 	@IBUS_CFLAGS@ \
+	@GTK_CFLAGS@ \
 	@JSON_GLIB_CFLAGS@ \
 	@KEYMAN_PROC_CFLAGS@ \
 	-DPKGDATADIR=\"$(pkgdatadir)\" \
@@ -27,9 +28,9 @@ AM_CFLAGS = \
 
 AM_LDFLAGS = \
 	@IBUS_LIBS@ \
+	@GTK_LIBS@ \
 	@JSON_GLIB_LIBS@ \
 	@KEYMAN_PROC_LIBS@ \
-	-lX11 \
 	$(NULL)
 
 check_PROGRAMS = \
@@ -71,16 +72,17 @@ ibus_engine_keyman_SOURCES = \
 
 ibus_engine_keyman_CFLAGS = \
 	@IBUS_CFLAGS@ \
+	@GTK_CFLAGS@ \
 	@JSON_GLIB_CFLAGS@ \
 	@KEYMAN_PROC_CFLAGS@ \
 	-DPKGDATADIR=\"$(pkgdatadir)\" \
 	$(NULL)
 
 ibus_engine_keyman_LDFLAGS = \
+	@GTK_LIBS@ \
 	@IBUS_LIBS@ \
 	@JSON_GLIB_LIBS@ \
 	@KEYMAN_PROC_LIBS@ \
-	-lX11 \
 	$(NULL)
 
 component_DATA = \


### PR DESCRIPTION
use gdk_display_beep instead of X11 beep (which is implemented in #1408 )
alternative strategy for detecting right mod keys instead of X11 calls to try and find current keypress state
forward keycode instead of keysym

N.B. this alternative strategy for detecting right mod keys effectively implements a form of compulsory sticky keys. Any Control or Alt key pressed in any order at any time before the next key is processed by keyman will be the modifier for that key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1429)
<!-- Reviewable:end -->
