### PR TITLE
[Windows] Tweak vertical scaling for characters that may overflow OSK key boxes (e.g. Tai Dam)

### DIFF
--- a/windows/src/global/delphi/comp/OnScreenKeyboard.pas
+++ b/windows/src/global/delphi/comp/OnScreenKeyboard.pas
@@ -1386,7 +1386,11 @@ var
           if FTextExtent.cx > (RText.Right - RText.Left) * FKeyboard.FScale then
           begin
             Font.Height := Trunc(Font.Height * (RText.Right - RText.Left) * FKeyboard.FScale / FTextExtent.cx);
-          end;
+          end
+          else if FTextExtent.cy > (RText.Bottom - RText.Top) * FKeyboard.FScale then
+          begin
+            Font.Height := Trunc(Font.Height * (RText.Bottom - RText.Top) * FKeyboard.FScale / FTextExtent.cy);
+          end
         end;
 
 


### PR DESCRIPTION
This PR adds checks for the vertical text extent for each key cap as well as the horizontal text extent.

This results in most OSKs having a slightly reduced font size, which does not impact them very adversely. 
I have checked against the keyboards in keyboards/release repo folder.

The sil_tai_dam keyboard is most impacted by this but currently has whitespace on each key for a manual workaround of the overflow,
so the improvement won't really be visible until whitespace is reduced. See screenshot below for sample before-and-after. While I 
am not 100% satisfied with this improvement for Tai Dam, it does at least make the characters visible on the key cap.

[Note base on windows-osk-renderer-tool currently, will rebase once PR is merged]