### PR TITLE
[wip] [Common] refactor processor init

### DIFF
--- a/common/engine/keyboardprocessor/include/keyman/keyboardprocessor.h.in
+++ b/common/engine/keyboardprocessor/include/keyman/keyboardprocessor.h.in
@@ -751,7 +751,7 @@ This must be disposed of by a call to `km_kbp_state_dispose`.
 */
 KMN_API
 km_kbp_status
-km_kbp_state_create(km_kbp_keyboard const *keyboard,
+km_kbp_state_create(km_kbp_keyboard *keyboard,
                     km_kbp_option_item const *env,
                     km_kbp_state **out);
 

--- a/common/engine/keyboardprocessor/src/keyboard.hpp
+++ b/common/engine/keyboardprocessor/src/keyboard.hpp
@@ -9,12 +9,11 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include <keyman/keyboardprocessor.h>
 
 #include "option.hpp"
-#include "processor.hpp"
-
 #include "path.hpp"
 
 // Forward declarations
@@ -23,30 +22,41 @@ class json;
 namespace km {
 namespace kbp
 {
-
-  class keyboard : public km_kbp_keyboard_attrs
+  class keyboard_attributes : public km_kbp_keyboard_attrs
   {
-    std::u16string const                      _keyboard_id;
-    std::u16string const                      _version_string;
-    km::kbp::path const                       _folder_path;
-    std::vector<km_kbp_option_item>           _default_opts;
-    abstract_processor                       *_processor;
+    std::u16string      _keyboard_id;
+    std::u16string      _version_string;
+    kbp::path           _folder_path;
+    std::vector<option> _default_opts;
+
+    void render();
+
   public:
-    keyboard(km::kbp::path const &);
-    ~keyboard() {
-      delete _processor;
-    }
+    using options_store = decltype(_default_opts);
+    using path_type = decltype(_folder_path);
 
-    friend json & operator << (json &, km::kbp::keyboard const &);
+    keyboard_attributes()
+    : km_kbp_keyboard_attrs {nullptr, nullptr, nullptr, nullptr} {}
+    keyboard_attributes(keyboard_attributes const &) = delete;
+    keyboard_attributes(keyboard_attributes &&);
 
-    std::vector<km_kbp_option_item> *default_opts() { return & _default_opts; }
+    keyboard_attributes(std::u16string const & id,
+             std::u16string const & version,
+             path_type const & path,
+             options_store const &opts);
 
-    kbp::abstract_processor const &  processor() const noexcept { return *_processor; }
+    keyboard_attributes & operator = (keyboard_attributes const &) = delete;
+    keyboard_attributes & operator = (keyboard_attributes &&);
+
+    friend json & operator << (json &, km::kbp::keyboard_attributes const &);
+
+    options_store const &   default_opts_store() const noexcept { return _default_opts; }
+    options_store &         default_opts_store() noexcept { return _default_opts; }
+
+    path_type const     &   path() const noexcept { return _folder_path; }
   };
 
-  json & operator << (json &, km::kbp::keyboard const &);
+  json & operator << (json &, km::kbp::keyboard_attributes const &);
 
 } // namespace kbp
 } // namespace km
-
-struct km_kbp_keyboard : public km::kbp::keyboard {};

--- a/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
@@ -14,7 +14,8 @@
 #include <sstream>
 #include <unordered_map>
 #include <vector>
-#include <keyman/keyboardprocessor.h>
+
+#include "processor.hpp"
 
 #include "option.hpp"
 #include "json.hpp"

--- a/common/engine/keyboardprocessor/src/km_kbp_processevent_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_processevent_api.cpp
@@ -16,14 +16,12 @@ km_kbp_status
 km_kbp_process_event(km_kbp_state *state,
                           km_kbp_virtual_key vk, uint16_t modifier_state)
 {
-  km::kbp::keyboard const & k = state->keyboard();
-  return const_cast<km::kbp::abstract_processor&>(k.processor()).process_event(state, vk, modifier_state);
+  return state->processor().process_event(state, vk, modifier_state);
 }
 
 
 km_kbp_attr const * 
 km_kbp_get_engine_attrs(km_kbp_state const *state)
 {
-  return state->keyboard().processor().get_attrs();
+  return &state->processor().attributes();
 }
-

--- a/common/engine/keyboardprocessor/src/km_kbp_state_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_state_api.cpp
@@ -21,13 +21,14 @@
 #include <json.hpp>
 
 #include "context.hpp"
-#include "option.hpp"
 #include "keyboard.hpp"
+#include "option.hpp"
+#include "processor.hpp"
 #include "state.hpp"
 
 using namespace km::kbp;
 
-km_kbp_status km_kbp_state_create(km_kbp_keyboard const * keyboard,
+km_kbp_status km_kbp_state_create(km_kbp_keyboard * keyboard,
                                   km_kbp_option_item const *env,
                                   km_kbp_state ** out)
 {
@@ -37,9 +38,7 @@ km_kbp_status km_kbp_state_create(km_kbp_keyboard const * keyboard,
 
   try
   {
-    *out = new km_kbp_state(static_cast<km::kbp::keyboard const &>(*keyboard),
-      env);
-
+    *out = new km_kbp_state(static_cast<abstract_processor&>(*keyboard), env);
   }
   catch (std::bad_alloc)
   {
@@ -192,7 +191,7 @@ km_kbp_status km_kbp_state_to_json(km_kbp_state const *state,
     // Pretty print the document.
     jo << json::object
         << "$schema" << "keyman/keyboardprocessor/doc/introspection.schema"
-        << "keyboard" << state->keyboard()
+        << "keyboard" << state->processor().keyboard()
         << "options" << state->options()
         << "context" << state->context()
         << "actions" << state->actions

--- a/common/engine/keyboardprocessor/src/kmx/kmx_capslock.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_capslock.cpp
@@ -4,7 +4,8 @@
 */
 #include <kmx/kmx_processor.h>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 void KMX_Processor::ResetCapsLock(void)
 {

--- a/common/engine/keyboardprocessor/src/kmx/kmx_context.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_context.cpp
@@ -4,7 +4,8 @@
 */
 #include <kmx/kmx_processor.h>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 /* KMX_Context */
 

--- a/common/engine/keyboardprocessor/src/kmx/kmx_debug.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_debug.cpp
@@ -6,7 +6,8 @@
 #include <stdarg.h>
 #include <iostream>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 #define TAB "\t"
 #define NL  "\n"

--- a/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
@@ -7,7 +7,8 @@
 #include <state.hpp>
 #include <option.hpp>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 namespace {
   km_kbp_cp const

--- a/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
@@ -22,13 +22,12 @@ namespace {
 KMX_Environment::KMX_Environment() {
 }
 
-void KMX_Environment::InitOption(std::vector<km_kbp_option_item> *default_env, km_kbp_cp const *key, km_kbp_cp const *default_value) {
-  km_kbp_option_item opt = { (km_kbp_cp*) key, (km_kbp_cp*) default_value, KM_KBP_OPT_ENVIRONMENT };
-  default_env->emplace_back(opt);
+void KMX_Environment::InitOption(std::vector<option> &default_env, km_kbp_cp const *key, km_kbp_cp const *default_value) {
+  default_env.emplace_back(KM_KBP_OPT_ENVIRONMENT, key, default_value);
   Load(key, default_value);
 }
 
-void KMX_Environment::Init(std::vector<km_kbp_option_item> *default_env) {
+void KMX_Environment::Init(std::vector<option> &default_env) {
   InitOption(default_env, KM_KBP_KMX_ENV_PLATFORM, DEFAULT_PLATFORM);
   InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUT, DEFAULT_BASELAYOUT);
   InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUTALT, DEFAULT_BASELAYOUTALT);
@@ -37,8 +36,7 @@ void KMX_Environment::Init(std::vector<km_kbp_option_item> *default_env) {
   InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT, DEFAULT_BASELAYOUTGIVESCTRLRALTFORRALT);
 
   // TODO refactor this and the keyboard option terminator into state.cpp and keyboard.cpp respectively
-  km_kbp_option_item opt = KM_KBP_OPTIONS_END;
-  default_env->emplace_back(opt);
+  default_env.emplace_back();
 }
 
 void KMX_Environment::Load(std::u16string const & key, std::u16string const & value) {

--- a/common/engine/keyboardprocessor/src/kmx/kmx_environment.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_environment.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "option.hpp"
 #include "kmx_base.h"
 
 namespace km {
@@ -14,13 +15,13 @@ private:
   KMX_BOOL _capsLock;
   std::u16string _platform;
   void InitOption(
-    std::vector<km_kbp_option_item> * default_env, 
-    km_kbp_cp const * key, 
+    std::vector<option> & default_env,
+    km_kbp_cp const * key,
     km_kbp_cp const * default_value);
 public:
   KMX_Environment();
   void Load(std::u16string const & key, std::u16string const & value);
-  void Init(std::vector<km_kbp_option_item> *default_env);
+  void Init(std::vector<option> &default_env);
 
   KMX_BOOL capsLock() const noexcept { return _capsLock; }
   KMX_BOOL simulateAltGr() const noexcept { return _simulateAltGr; }

--- a/common/engine/keyboardprocessor/src/kmx/kmx_file.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_file.cpp
@@ -4,7 +4,8 @@
 */
 #include "kmx_processor.h"
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 #if defined(_WIN32) || defined(_WIN64) 
 #include <share.h>

--- a/common/engine/keyboardprocessor/src/kmx/kmx_modifiers.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_modifiers.cpp
@@ -4,7 +4,8 @@
 */
 #include "kmx_processor.h"
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 #define MAX_RSHIFT 24
 #define MAX_KSHIFT 18

--- a/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
@@ -47,9 +47,9 @@ void KMX_Options::Load(km_kbp_options *options, std::u16string const &key) {
   assert(false);
 }
 
-void KMX_Options::Init(std::vector<km_kbp_option_item> *opts) {
+void KMX_Options::Init(std::vector<option> &opts) {
 
-  opts->clear();
+  opts.clear();
 
   _kp->KeyboardOptions = new INTKEYBOARDOPTIONS[_kp->Keyboard->cxStoreArray];
   memset(_kp->KeyboardOptions, 0, sizeof(INTKEYBOARDOPTIONS) * _kp->Keyboard->cxStoreArray);
@@ -77,8 +77,7 @@ void KMX_Options::Init(std::vector<km_kbp_option_item> *opts) {
   }
 
   if (n == 0) {
-    km_kbp_option_item opt = KM_KBP_OPTIONS_END;
-    opts->emplace_back(opt);
+    opts.emplace_back(); // Terminate the options array
     return;
   }
 
@@ -87,16 +86,11 @@ void KMX_Options::Init(std::vector<km_kbp_option_item> *opts) {
   LPSTORE sp;
   for (n = 0, i = 0, ko = _kp->KeyboardOptions, sp = _kp->Keyboard->dpStoreArray; i < _kp->Keyboard->cxStoreArray; i++, sp++, ko++) {
     if (ko->OriginalStore == NULL) continue;
-    km_kbp_option_item opt;
-    opt.key = sp->dpName;
-    opt.value = sp->dpString;
-    opt.scope = KM_KBP_OPT_KEYBOARD;
-    opts->emplace_back(opt);
+    opts.emplace_back(KM_KBP_OPT_KEYBOARD, sp->dpName, sp->dpString);
     n++;
   }
 
-  km_kbp_option_item opt = KM_KBP_OPTIONS_END;
-  opts->emplace_back(opt);
+  opts.emplace_back(); // Terminate the options array
 }
 
 KMX_Options::~KMX_Options()

--- a/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
@@ -6,7 +6,8 @@
 #include <option.hpp>
 #include <state.hpp>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 void KMX_Options::AddOptionsStoresFromXString(PKMX_WCHAR s) {
   int idx;
@@ -35,7 +36,7 @@ void KMX_Options::Load(km_kbp_options *options, std::u16string const &key) {
   assert(!key.empty());
 
   if (options == nullptr || key.empty()) return;
-  
+
   for (i = 0, sp = _kp->Keyboard->dpStoreArray; i < _kp->Keyboard->cxStoreArray; i++, sp++) {
     if (_kp->KeyboardOptions[i].OriginalStore != NULL && sp->dpName != NULL && u16icmp(sp->dpName, key.c_str()) == 0) {
       Reset(options, i);
@@ -123,7 +124,7 @@ void KMX_Options::Set(int nStoreToSet, int nStoreToRead)
   {
     delete _kp->KeyboardOptions[nStoreToSet].Value;
   }
-   
+
   _kp->KeyboardOptions[nStoreToSet].Value = new KMX_WCHAR[u16len(sp->dpString)+1];
   u16cpy(_kp->KeyboardOptions[nStoreToSet].Value, /*u16len(sp->dpString)+1,*/ sp->dpString);
   _kp->Keyboard->dpStoreArray[nStoreToSet].dpString = _kp->KeyboardOptions[nStoreToSet].Value;

--- a/common/engine/keyboardprocessor/src/kmx/kmx_options.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_options.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <keyman/keyboardprocessor.h>
+#include "option.hpp"
 #include "kmx_base.h"
 
 namespace km {
@@ -21,7 +22,7 @@ public:
   KMX_Options(LPINTKEYBOARDINFO kp) : _kp(kp) {}
   ~KMX_Options();
 
-  void Init(std::vector<km_kbp_option_item> *opts);
+  void Init(std::vector<option> &opts);
   void Load(km_kbp_options *options, std::u16string const &key);
   void Set(int nStoreToSet, int nStoreToRead);
   void Reset(km_kbp_options *options, int nStoreToReset);

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
@@ -1,0 +1,42 @@
+/*
+  Copyright:    © 2018 SIL International.
+  Description:  Internal keyboard class and adaptor class for the API.
+  Create Date:  2 Oct 2018
+  Authors:      Tim Eves (TSE)
+  History:      2 Oct 2018 - TSE - Refactored out of km_kbp_keyboard_api.cpp
+*/
+
+#pragma once
+
+#include <string>
+#include <keyman/keyboardprocessor.h>
+#include "kmx/kmx_processor.h"
+#include "keyboard.hpp"
+#include "processor.hpp"
+
+namespace km {
+namespace kbp
+{
+  class kmx_processor : public abstract_processor
+  {
+  private:
+    bool               _valid;
+    kmx::KMX_Processor _kmx;
+  public:
+    kmx_processor(path);
+    km_kbp_status process_event(km_kbp_state *state,
+                                km_kbp_virtual_key vk,
+                                uint16_t modifier_state) override;
+    km_kbp_attr const & attributes() const override;
+    km_kbp_status       validate() const override;
+
+    void    update_option(km_kbp_state *state,
+                          km_kbp_option_scope scope,
+                          std::u16string const & key,
+                          std::u16string const & value) override;
+
+    void init_state(std::vector<option> &) override;
+  };
+
+} // namespace kbp
+} // namespace km

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
@@ -4,7 +4,8 @@
 */
 #include "kmx_processor.h"
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 /* Globals */
 

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
@@ -637,7 +637,15 @@ KMX_Options *KMX_Processor::GetOptions() {
   return &m_options;
 }
 
+KMX_Options const *KMX_Processor::GetOptions() const {
+  return &m_options;
+}
+
 KMX_Environment *KMX_Processor::GetEnvironment() {
+  return &m_environment;
+}
+
+KMX_Environment const *KMX_Processor::GetEnvironment() const {
   return &m_environment;
 }
 

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processor.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processor.h
@@ -85,7 +85,9 @@ public:
   KMX_Actions *GetActions();
   KMX_Context *GetContext();
   KMX_Options *GetOptions();
+  KMX_Options const *GetOptions() const;
   KMX_Environment *GetEnvironment();
+  KMX_Environment const *GetEnvironment() const;
   LPINTKEYBOARDINFO GetKeyboard();
 };
 

--- a/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_xstring.cpp
@@ -11,7 +11,8 @@
 
 
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 const km_kbp_cp *km::kbp::kmx::u16chr(const km_kbp_cp *p, km_kbp_cp ch) {
   while (*p) {

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
@@ -11,7 +11,7 @@
 */
 
 #include <keyman/keyboardprocessor.h>
-#include "processor.hpp"
+#include "mock/mock_processor.hpp"
 #include "state.hpp"
 
 namespace
@@ -73,8 +73,22 @@ namespace
 namespace km {
   namespace kbp
   {
+    mock_processor::mock_processor(kbp::path const & path)
+    : abstract_processor(
+        keyboard_attributes(path.stem(), u"3.145", path.parent(), {
+          option{KM_KBP_OPT_KEYBOARD, u"__test_point", u"F2 pressed test save."},
+          option{KM_KBP_OPT_KEYBOARD, u"hello", u"-"}
+      }))
+    {
+    }
 
-    km_kbp_status mock_processor::process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state) {
+
+    km_kbp_status mock_processor::process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state)
+    {
+      assert(state);
+      if (!state)
+        return KM_KBP_STATUS_INVALID_ARGUMENT;
+
       try
       {
         state->actions.clear();
@@ -123,11 +137,23 @@ namespace km {
 
     }
 
-    km_kbp_attr const * mock_processor::get_attrs() const {
-      return &engine_attrs;
+    void mock_processor::update_option(km_kbp_state *,
+                                       km_kbp_option_scope,
+                                       std::u16string const &,
+                                       std::u16string const &)
+    {};
+
+    void mock_processor::init_state(std::vector<option> &default_env) {
+      default_env.emplace_back(KM_KBP_OPT_ENVIRONMENT, u"hello", u"-");
+      default_env.emplace_back();
+    };
+
+    km_kbp_attr const & mock_processor::attributes() const {
+      return engine_attrs;
     }
 
     km_kbp_status mock_processor::validate() const { return KM_KBP_STATUS_OK; }
+
     km_kbp_status null_processor::validate() const { return KM_KBP_STATUS_INVALID_ARGUMENT; }
   } // namespace kbp
 } // namespace km

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright:    © 2018 SIL International.
+  Description:  Internal keyboard class and adaptor class for the API.
+  Create Date:  2 Oct 2018
+  Authors:      Tim Eves (TSE)
+  History:      2 Oct 2018 - TSE - Refactored out of km_kbp_keyboard_api.cpp
+*/
+
+#pragma once
+
+//#include <string>
+//#include <keyman/keyboardprocessor.h>
+#include "keyboard.hpp"
+#include "processor.hpp"
+namespace km {
+namespace kbp
+{
+  class mock_processor : public abstract_processor
+  {
+    std::vector<option> _options;
+    option const * _find_option(km_kbp_option_scope scope,
+                                std::u16string const & key) const;
+  public:
+    mock_processor(km::kbp::path const &);
+//    ~mock_processor() override;
+
+    km_kbp_status process_event(km_kbp_state *state,
+                                km_kbp_virtual_key vk,
+                                uint16_t modifier_state) override;
+
+    virtual km_kbp_attr const & attributes() const override;
+    km_kbp_status validate() const override;
+
+
+    void    update_option(km_kbp_state *state,
+                          km_kbp_option_scope scope,
+                          std::u16string const & key,
+                          std::u16string const & value) override;
+
+    void init_state(std::vector<option> &) override;
+  };
+
+  class null_processor : public mock_processor {
+  public:
+    null_processor(): mock_processor(path())
+    {
+      _attributes = keyboard_attributes(u"null", u"0.0", path(), {});
+    }
+
+    km_kbp_status validate() const override;
+  };
+} // namespace kbp
+} // namespace km

--- a/common/engine/keyboardprocessor/src/option.cpp
+++ b/common/engine/keyboardprocessor/src/option.cpp
@@ -28,12 +28,22 @@ namespace
 // Forward declarations
 
 
-option::option(km_kbp_option_scope s, std::u16string const & k, std::u16string const & v)
-: km_kbp_option_item { new km_kbp_cp[k.size()+1], new km_kbp_cp[v.size()+1],
-                uint8_t(s) }
+option::option(km_kbp_option_scope s, char16_t const *k, char16_t const *v)
+: option()
 {
-  std::copy_n(k.c_str(), k.size()+1, const_cast<km_kbp_cp *>(key));
-  std::copy_n(v.c_str(), v.size()+1, const_cast<km_kbp_cp *>(value));
+  if (k && v)
+  {
+    auto n_k = std::char_traits<char16_t>::length(k)+1,
+         n_v = std::char_traits<char16_t>::length(v)+1;
+    auto _key = new km_kbp_cp[n_k],
+         _val = new km_kbp_cp[n_v];
+    std::copy_n(k, n_k, _key);
+    std::copy_n(v, n_v, _val);
+
+    key = _key;
+    value = _val;
+    scope = s;
+  }
 }
 
 

--- a/common/engine/keyboardprocessor/src/option.cpp
+++ b/common/engine/keyboardprocessor/src/option.cpp
@@ -9,11 +9,12 @@
 #include <algorithm>
 #include <memory>
 
+#include "json.hpp"
 #include "keyboard.hpp"
 #include "option.hpp"
-#include "json.hpp"
-#include "utfcodec.hpp"
+#include "processor.hpp"
 #include "state.hpp"
+#include "utfcodec.hpp"
 
 using namespace km::kbp;
 
@@ -76,9 +77,7 @@ km_kbp_option_item const * options::assign(km_kbp_state *state, km_kbp_option_sc
     if (save.key == key && save.scope == scope)
     {
       save = option(scope, key, value);
-
-      //((km::kbp::state *)state)->keyboard().
-      const_cast<km::kbp::abstract_processor &>(static_cast<km::kbp::state *>(state)->keyboard().processor()).update_option(state, scope, key, value);
+      state->processor().update_option(state, scope, key, value);
 
       return &save;
     }
@@ -86,7 +85,7 @@ km_kbp_option_item const * options::assign(km_kbp_state *state, km_kbp_option_sc
 
   _saved.emplace_back(scope, key, value);
 
-  const_cast<km::kbp::abstract_processor &>(static_cast<km::kbp::state *>(state)->keyboard().processor()).update_option(state, scope, key, value);
+  state->processor().update_option(state, scope, key, value);
 
   return &_saved.back();
 }

--- a/common/engine/keyboardprocessor/src/option.hpp
+++ b/common/engine/keyboardprocessor/src/option.hpp
@@ -26,25 +26,35 @@ namespace kbp
     option(): km_kbp_option_item KM_KBP_OPTIONS_END {}
     option(option const &);
     option(option &&);
+    option(km_kbp_option_scope, char16_t const *, char16_t const *);
     option(km_kbp_option_scope, std::u16string const &,
            std::u16string const &);
 
     ~option() noexcept;
 
     option & operator=(option && rhs);
+    option & operator=(option const &);
   };
+
+
+  inline
+  option::option(km_kbp_option_scope s,
+                 std::u16string const & k, std::u16string const & v)
+  : option(s, k.c_str(), v.c_str())
+  {}
+
 
   inline
   option::option(option const & rhs)
-  : option(km_kbp_option_scope(rhs.scope), rhs.key, rhs.value)
-  {}
+  : option(km_kbp_option_scope(rhs.scope), rhs.key, rhs.value) {}
+
 
   inline
-  option::option(option && rhs)
-  : km_kbp_option_item { rhs.key, rhs.value, rhs.scope }
+  option::option(option && rhs) : option()
   {
-    rhs.key = nullptr;
-    rhs.value = nullptr;
+    std::swap(key, rhs.key);
+    std::swap(value, rhs.value);
+    scope = rhs.scope;
   }
 
   inline
@@ -59,10 +69,15 @@ namespace kbp
   {
     delete [] key;
     delete [] value;
-    key = rhs.key;
-    value = rhs.value; rhs.key = nullptr;
-    scope = rhs.scope; rhs.value = nullptr;
-    return *this;
+    return *new (this) option(rhs);
+  }
+
+  inline
+  option & option::operator=(option const & rhs)
+  {
+    delete [] key;
+    delete [] value;
+    return *new (this) option(rhs);
   }
 
 

--- a/common/engine/keyboardprocessor/src/processor.hpp
+++ b/common/engine/keyboardprocessor/src/processor.hpp
@@ -9,73 +9,44 @@
 #pragma once
 
 #include <string>
+
 #include <keyman/keyboardprocessor.h>
-#include <kmx/kmx_processor.h>
+
+#include "keyboard.hpp"
 
 namespace km {
 namespace kbp
 {
-
   class abstract_processor
   {
-  private:
-    km_kbp_keyboard_attrs const *_kb;
   protected:
-    km_kbp_keyboard_attrs const * keyboard() const noexcept { return _kb; }
+    keyboard_attributes _attributes;
+
   public:
+    abstract_processor() {}
+    abstract_processor(keyboard_attributes && kb) : _attributes(std::move(kb)) {}
     virtual ~abstract_processor() { };
-    abstract_processor(km_kbp_keyboard_attrs const * kb) : _kb(kb)
-	{}
 
-
-    virtual km_kbp_status process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state) = 0;
-    virtual km_kbp_attr const * get_attrs() const = 0;
-    virtual km_kbp_status validate() const = 0;
-    virtual void update_option(km_kbp_state *state, km_kbp_option_scope scope, std::u16string const & key, std::u16string const & value) = 0;
-    virtual void init_state(std::vector<km_kbp_option_item> *default_env) = 0;
-  };
-
-  class kmx_processor : public abstract_processor
-  {
-  private:
-    bool _valid;
-    kmx::KMX_Processor _kmx;
-  public:
-    kmx_processor(km_kbp_keyboard_attrs const * kb_);
-    km_kbp_status process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state);
-    km_kbp_attr const * get_attrs() const;
-    km_kbp_status validate() const;
-    void update_option(km_kbp_state *state, km_kbp_option_scope scope, std::u16string const & key, std::u16string const & value);
-    void init_state(std::vector<km_kbp_option_item> *default_env);
-  };
-
-  class mock_processor : public abstract_processor
-  {
-  public:
-    mock_processor(km_kbp_keyboard_attrs const * kb) : abstract_processor(kb) {
+    keyboard_attributes const & keyboard() const noexcept {
+      return _attributes;
     }
-    km_kbp_status process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state);
-    km_kbp_attr const * get_attrs() const;
-    km_kbp_status validate() const;
-    void update_option(km_kbp_state *_kmn_unused(state), km_kbp_option_scope _kmn_unused(scope), std::u16string const & _kmn_unused(key), std::u16string const & _kmn_unused(value)) {};
-    void init_state(std::vector<km_kbp_option_item> *default_env) {
-      km_kbp_option_item opt = { u"hello", u"-", 0 };
-      default_env->emplace_back(opt);
-      opt = KM_KBP_OPTIONS_END;
-      default_env->emplace_back(opt);
-    };
-  };
 
-  class null_processor : public mock_processor {
-  public:
-    null_processor(km_kbp_keyboard_attrs const * kb) : mock_processor(kb) {
-    }
-    km_kbp_status validate() const;
-    void init_state(std::vector<km_kbp_option_item> *default_env) {
-      km_kbp_option_item opt = KM_KBP_OPTIONS_END;
-      default_env->emplace_back(opt);
-    }
+    virtual km_kbp_status process_event(km_kbp_state *,
+                                        km_kbp_virtual_key,
+                                        uint16_t modifier_state) = 0;
+
+    virtual km_kbp_attr const & attributes() const = 0;
+    virtual km_kbp_status       validate() const = 0;
+
+    virtual void    update_option(km_kbp_state *state,
+                                  km_kbp_option_scope,
+                                  std::u16string const & key,
+                                  std::u16string const & value) = 0;
+
+    virtual void init_state(std::vector<option> &default_env) = 0;
   };
 
 } // namespace kbp
 } // namespace km
+
+struct km_kbp_keyboard : public km::kbp::abstract_processor {};

--- a/common/engine/keyboardprocessor/src/state.cpp
+++ b/common/engine/keyboardprocessor/src/state.cpp
@@ -10,10 +10,11 @@
 
 using namespace km::kbp;
 
-state::state(km::kbp::keyboard const & kb, km_kbp_option_item const * env)
-  : _options(kb.default_options), _kb(kb)
+state::state(km::kbp::abstract_processor & ap, km_kbp_option_item const *env)
+  : _options(ap.keyboard().default_options),
+    _processor(ap)
 {
-  const_cast<km::kbp::abstract_processor&>(_kb.processor()).init_state(&_env);
+  ap.init_state(_env);
   _options.set_default_env(_env.data());
 
   for (; env && env->key != nullptr; env++) {

--- a/common/engine/keyboardprocessor/src/state.hpp
+++ b/common/engine/keyboardprocessor/src/state.hpp
@@ -7,6 +7,7 @@
 */
 
 #pragma once
+#include <cassert>
 #include <vector>
 
 #include <keyman/keyboardprocessor.h>
@@ -16,21 +17,26 @@
 #include "keyboard.hpp"
 
 
+
 namespace km {
 namespace kbp
 {
+//Forward declarations
+class abstract_processor;
+
 using action = km_kbp_action_item;
 
 class state
 {
 protected:
-    kbp::context          _ctxt;
-    kbp::options          _options;
-    kbp::keyboard const & _kb;
-    std::vector<km_kbp_option_item> _env;
+    kbp::context                    _ctxt;
+    kbp::options                    _options;
+    kbp::abstract_processor &       _processor;
+    std::vector<option> _env;
 
 public:
-    state(kbp::keyboard const & kb, km_kbp_option_item const * env);
+    state(kbp::abstract_processor & kb, km_kbp_option_item const *env);
+
     state(state const &) = default;
     state(state const &&) = delete;
 
@@ -40,7 +46,8 @@ public:
     kbp::options &          options() noexcept        { return _options; }
     kbp::options const &    options() const noexcept  { return _options; }
 
-    kbp::keyboard const &  keyboard() const noexcept      { return _kb; }
+    kbp::abstract_processor const & processor() const noexcept { return _processor; }
+    kbp::abstract_processor & processor() noexcept { return _processor; }
 };
 
 } // namespace kbp

--- a/common/engine/keyboardprocessor/tests/unit/kmnkbd/state_api.cpp
+++ b/common/engine/keyboardprocessor/tests/unit/kmnkbd/state_api.cpp
@@ -45,7 +45,10 @@ constexpr char const *doc1_expected = u8"\
         \"rules\" : []\n\
     },\n\
     \"options\" : {\n\
-        \"keyboard\" : {},\n\
+        \"keyboard\" : {\n\
+            \"__test_point\" : \"F2 pressed test save.\",\n\
+            \"hello\" : \"-\"\n\
+        },\n\
         \"environment\" : {\n\
             \"hello\" : \"-\"\n\
         },\n\
@@ -83,7 +86,10 @@ constexpr char const *doc2_expected = u8"\
         \"rules\" : []\n\
     },\n\
     \"options\" : {\n\
-        \"keyboard\" : {},\n\
+        \"keyboard\" : {\n\
+            \"__test_point\" : \"F2 pressed test save.\",\n\
+            \"hello\" : \"-\"\n\
+        },\n\
         \"environment\" : {\n\
             \"hello\" : \"-\"\n\
         },\n\

--- a/common/engine/keyboardprocessor/tests/unit/kmx/kmx.cpp
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/kmx.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <type_traits>
 
-#include <keyman/keyboardprocessor.h>
+#include <kmx/kmx_processor.h>
 
 #include "path.hpp"
 #include "state.hpp"


### PR DESCRIPTION
This refactors the underlying keyboard & abstract processor set and relationship. Moving the existing keyboard object down to a keyboard_attributes class as all it does it manage the memory and initialisation of the API km_kbp_keyboard_attrs object and makes this a member of the abstract_processor class.  Abstract_processor is now promoted to back the km_kbp_keyboard API object as performs that function anyway and this consolidates keyboard object creation and simplifies initialising the attributes and option stores.

This is in prepartion for delegating the API option store mangement to the processors.
This is branched off the common-refactor-path branch as it uses the path class and utf generic convert function work done there.