### PR TITLE
[linux] set GTK_CFLAGS and GTK_LIBS for make dist on jenkins

### DIFF
--- a/linux/ibus-keyman/configure.ac
+++ b/linux/ibus-keyman/configure.ac
@@ -53,7 +53,7 @@ PKG_CHECK_MODULES(IBUS, [
     ibus-1.0 >= 1.2.0
 ])
 
-# check Json glib
+# check Gtk
 PKG_CHECK_MODULES(GTK, [
     gtk+-3.0 >= 2.4
 ])

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -59,7 +59,7 @@ for proj in ${autotool_projects}; do
     rm -rf ../build-$proj
     mkdir -p ../build-$proj
     cd ../build-$proj
-    JSON_GLIB_CFLAGS="-I/usr/include/json-glib-1.0" JSON_GLIB_LIBS="-ljson-glib-1.0" KEYMAN_PROC_CFLAGS="-I/usr/include/keyman" KEYMAN_PROC_LIBS="-lkmnkbp" ../$proj/configure
+    GTK_CFLAGS="-I/usr/include/gtk-3.0" GTK_LIBS="-lgtk-3 -lgdk-3" JSON_GLIB_CFLAGS="-I/usr/include/json-glib-1.0" JSON_GLIB_LIBS="-ljson-glib-1.0" KEYMAN_PROC_CFLAGS="-I/usr/include/keyman" KEYMAN_PROC_LIBS="-lkmnkbp" ../$proj/configure
     make dist
     mv *.tar.gz ../dist
     cd $BASEDIR


### PR DESCRIPTION
set GTK_CFLAGS and GTK_LIBS for make dist on jenkins because of new dependency for ibus-keyman on gdk for the alert bell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1441)
<!-- Reviewable:end -->
