### PR TITLE
[iOS] Subkey combining diacritic display fix

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -617,7 +617,7 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
       let textSize = subKeyText.size(withAttributes: [NSAttributedStringKey.font: button.titleLabel?.font! as Any])
       var displayText = subKeyText
       
-      if textSize.width <= 0 {
+      if textSize.width <= 0 && subKeyText.count > 0 {
         // It's probably a diacritic in need of a combining character!
         // Also check if the language is RTL!
         if Manager.shared.currentKeyboard?.isRTL ?? false {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -612,7 +612,22 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
       }
 
       button.addTarget(self, action: #selector(subKeyButtonClick), for: .touchUpInside)
-      button.setTitle(subKeyText, for: .normal)
+
+      // Detect the text width for subkeys.  The 'as Any' silences an inappropriate warning from Swift.
+      let textSize = subKeyText.size(withAttributes: [NSAttributedStringKey.font: button.titleLabel?.font! as Any])
+      var displayText = subKeyText
+      
+      if textSize.width <= 0 {
+        // It's probably a diacritic in need of a combining character!
+        // Also check if the language is RTL!
+        if Manager.shared.currentKeyboard?.isRTL ?? false {
+          displayText = "\u{200f}\u{25cc}" + subKeyText
+        } else {
+          displayText = "\u{25cc}" + subKeyText
+        }
+      }
+
+      button.setTitle(displayText, for: .normal)
       button.tintColor = UIColor(red: 181.0 / 255.0, green: 181.0 / 255.0, blue: 181.0 / 255.0, alpha: 1.0)
       button.isEnabled = false
       return button

--- a/ios/history.md
+++ b/ios/history.md
@@ -9,6 +9,7 @@
 * Added support for keypress error feedback (#257)
 * Fixed ongoing issues with keyboard rotation and sizing, including the iPhone X notch. (#444) (#1045)
 * Fixed keyboard display/overlap of "Getting Started" info panel, added keyboard hide/display API functions. (#1084)
+* Fixes issues with keyboard keycap scaling and diacritic display. (#1070)
 
 ## 2018-08-02 10.0.208 stable 
 * Fixed OSK layout problems (and possible crash) on iOS 11 on certain hardware (#1089, #1159) 


### PR DESCRIPTION
Addresses the iOS portion of #1070.

Fixes https://github.com/keymanapp/keyboards/issues/436.  I have directly tested against this keyboard to help verify the overall fix.
Also fixes #382.

Applies the strategy of #1421 to subkeys within the iOS app, which is (fortunately) a far more controlled and favorable environment.

Why WIP?  [Moved to issue #1449.]

It appears that something in the change from #1421 may have revealed a bug in how the iOS app is managing certain keyboards' fonts.  Android doesn't suffer from this while iOS does.  I need to figure out what's up with SIL EuroLatin's font changing from the current `master`'s.