### PR TITLE
[mac] Where available, call showPreferences, otherwise, call our workaround

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -874,6 +874,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"{$PROJECT_DIR}/Keyman4MacIM/KMAboutWindow",
 					"{$PROJECT_DIR}/Keyman4MacIM",
 				);
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
@@ -904,6 +905,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"{$PROJECT_DIR}/Keyman4MacIM/KMAboutWindow",
 					"{$PROJECT_DIR}/Keyman4MacIM",
 				);
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		98FE105E1B4DE8F400525F54 /* NSWindow+SuppMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 98FE105D1B4DE8F400525F54 /* NSWindow+SuppMethods.m */; };
 		98FE10631B4DEE5600525F54 /* KMInfoWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 98FE10611B4DEE5600525F54 /* KMInfoWindowController.m */; };
 		98FE10641B4DEE5600525F54 /* KMInfoWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98FE10621B4DEE5600525F54 /* KMInfoWindowController.xib */; };
+		9A3D6C5D221531B0008785A3 /* KMOSVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3D6C5C221531B0008785A3 /* KMOSVersion.m */; };
 		E211769D20E182DD00F8065D /* NoContextTestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E211769C20E182DD00F8065D /* NoContextTestClient.m */; };
 		E21176A020E18C5200F8065D /* AppleCompliantTestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E211769F20E18C5200F8065D /* AppleCompliantTestClient.m */; };
 		E211CCF620B600A500505C36 /* KeymanEngine4Mac.framework.dSYM in CopyFiles */ = {isa = PBXBuildFile; fileRef = E211CCF520B600A500505C36 /* KeymanEngine4Mac.framework.dSYM */; };
@@ -193,6 +194,8 @@
 		98FE10601B4DEE5600525F54 /* KMInfoWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KMInfoWindowController.h; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.h; sourceTree = "<group>"; };
 		98FE10611B4DEE5600525F54 /* KMInfoWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KMInfoWindowController.m; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m; sourceTree = "<group>"; };
 		98FE10621B4DEE5600525F54 /* KMInfoWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = KMInfoWindowController.xib; path = Keyman4MacIM/KMInfoWindow/KMInfoWindowController.xib; sourceTree = "<group>"; };
+		9A3D6C5B221531B0008785A3 /* KMOSVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KMOSVersion.h; sourceTree = "<group>"; };
+		9A3D6C5C221531B0008785A3 /* KMOSVersion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KMOSVersion.m; sourceTree = "<group>"; };
 		9E7FB3417C46A01721AD32D0 /* libPods-KeymanTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KeymanTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E211769B20E1826800F8065D /* NoContextTestClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NoContextTestClient.h; sourceTree = "<group>"; };
 		E211769C20E182DD00F8065D /* NoContextTestClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoContextTestClient.m; sourceTree = "<group>"; };
@@ -400,6 +403,8 @@
 				9836B3631AE5F11D00780482 /* ZipArchive */,
 				E240F597202DED300000067D /* KMPackage.h */,
 				E240F598202DED740000067D /* KMPackage.m */,
+				9A3D6C5B221531B0008785A3 /* KMOSVersion.h */,
+				9A3D6C5C221531B0008785A3 /* KMOSVersion.m */,
 			);
 			path = Keyman4MacIM;
 			sourceTree = "<group>";
@@ -698,6 +703,7 @@
 			files = (
 				9836B3731AE5F11D00780482 /* zip.c in Sources */,
 				98F3C8931A8D739500F675E3 /* KMConfigurationWindowController.m in Sources */,
+				9A3D6C5D221531B0008785A3 /* KMOSVersion.m in Sources */,
 				989C9C111A7876DE00A20425 /* main.m in Sources */,
 				98BF924F1BF02DC20002126A /* KMBarView.m in Sources */,
 				E240F599202DED740000067D /* KMPackage.m in Sources */,

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
@@ -50,9 +50,9 @@
 - (IBAction)configAction:(id)sender {
     // Using `showConfigurationWindow` instead of `showPreferences:` because `showPreferences:` is missing in
     // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
-    // rrb: where available (everywhere but 10.13.1-10.13.3) call showPreferences, otherwise, call our workaround
+    // rrb: where Apple's API is broken (10.13.1-10.13.3) call our workaround, otherwise, call showPreferences
     u_int16_t systemVersion = [KMOSVersion SystemVersion];
-    if (0x0AD1 <= systemVersion && systemVersion <= 0x0AD3) // between 10.13.1 and 10.13.3 inclusive
+    if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
     {
         NSLog(@"About Box: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
         [self.AppDelegate showConfigurationWindow]; // call our workaround

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
@@ -51,7 +51,11 @@
     // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
     // TODO: This bug should be fixed in 10.13.4, so after that has been available for a few weeks, we
     // can create a PR for branch mac-revert-high-sierra-showPreferences-workaround and merge it.
-    [self.AppDelegate showConfigurationWindow];
+    // rrb: where available (everywhere but 10.13.1-10.13.3?) call showPreferences, otherwise, call our workaround
+    if ([self.AppDelegate.inputController respondsToSelector:@selector(showPreferences:)])
+        [self.AppDelegate.inputController showPreferences:sender];
+    else
+        [self.AppDelegate showConfigurationWindow];
     [self close];
 }
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
@@ -8,6 +8,7 @@
 
 #import "KMAboutWindowController.h"
 #import "KMInputMethodAppDelegate.h"
+#import "KMOSVersion.h"
 
 @interface KMAboutWindowController ()
 @property (nonatomic, weak) IBOutlet NSTextField *versionLabel;
@@ -49,13 +50,18 @@
 - (IBAction)configAction:(id)sender {
     // Using `showConfigurationWindow` instead of `showPreferences:` because `showPreferences:` is missing in
     // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
-    // TODO: This bug should be fixed in 10.13.4, so after that has been available for a few weeks, we
-    // can create a PR for branch mac-revert-high-sierra-showPreferences-workaround and merge it.
-    // rrb: where available (everywhere but 10.13.1-10.13.3?) call showPreferences, otherwise, call our workaround
-    if ([self.AppDelegate.inputController respondsToSelector:@selector(showPreferences:)])
-        [self.AppDelegate.inputController showPreferences:sender];
+    // rrb: where available (everywhere but 10.13.1-10.13.3) call showPreferences, otherwise, call our workaround
+    u_int16_t systemVersion = [KMOSVersion SystemVersion];
+    if (0x0AD1 <= systemVersion && systemVersion <= 0x0AD3) // between 10.13.1 and 10.13.3 inclusive
+    {
+        NSLog(@"About Box: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
+        [self.AppDelegate showConfigurationWindow]; // call our workaround
+    }
     else
-        [self.AppDelegate showConfigurationWindow];
+    {
+        NSLog(@"About Box: calling Apple's showPreferences (sys ver %x)", systemVersion);
+        [self.AppDelegate.inputController showPreferences:sender]; // call Apple API
+    }
     [self close];
 }
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -176,7 +176,11 @@ NSMutableArray *servers;
         // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
         // TODO: This bug should be fixed in 10.13.4, so after that has been available for a few weeks, we
         // can create a PR for branch mac-revert-high-sierra-showPreferences-workaround and merge it.
-        [self.AppDelegate showConfigurationWindow];
+        // rrb: where available (everywhere but 10.13.1-10.13.3?) call showPreferences, otherwise, call our workaround
+        if ([self respondsToSelector:@selector(showPreferences:)])
+            [self showPreferences:sender];
+        else
+            [self.AppDelegate showConfigurationWindow];
     }
     else if (itag == 3) {
         [self.AppDelegate showOSK];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -167,6 +167,7 @@ NSMutableArray *servers;
     return self.AppDelegate.kmx;
 }
 
+
 - (void)menuAction:(id)sender {
     NSMenuItem *mItem = [sender objectForKey:kIMKCommandMenuItemName];
     NSInteger itag = mItem.tag;
@@ -175,9 +176,9 @@ NSMutableArray *servers;
     if (itag == 2) {
         // Using `showConfigurationWindow` instead of `showPreferences:` because `showPreferences:` is missing in
         // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
-        // rrb: where available (everywhere but 10.13.1-10.13.3) call showPreferences, otherwise, call our workaround
+        // rrb: where Apple's API is broken (10.13.1-10.13.3) call our workaround, otherwise, call showPreferences
         u_int16_t systemVersion = [KMOSVersion SystemVersion];
-        if (0x0AD1 <= systemVersion && systemVersion <= 0x0AD3) // between 10.13.1 and 10.13.3 inclusive
+        if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
         {
             NSLog(@"Input Menu: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
             [self.AppDelegate showConfigurationWindow]; // call our workaround

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.h
@@ -1,0 +1,19 @@
+//
+//  KMOSVersion.h
+//  Keyman
+//
+//  Created by Randy Boring on 2/13/19.
+//  Copyright © 2019 SIL International. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface KMOSVersion : NSObject
+
++(u_int16_t)SystemVersion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface KMOSVersion : NSObject
 
 +(u_int16_t)SystemVersion;
++(u_int16_t)Version_10_13_1; // 0x0AD1 but don't depend on this
++(u_int16_t)Version_10_13_3; // 0x0AD3
 
 @end
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
@@ -1,0 +1,51 @@
+//
+//  KMOSVersion.m
+//  Keyman
+//
+//  Created by Randy Boring on 2/13/19.
+//  Copyright © 2019 SIL International. All rights reserved.
+//
+
+#import "KMOSVersion.h"
+
+static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/SystemVersion.plist");
+
+@implementation KMOSVersion
++(u_int16_t)SystemVersion
+{
+    NSDictionary *systemVersionDict = [NSDictionary dictionaryWithContentsOfFile:(__bridge NSString*)sSystemVersionPath];
+    if (NULL ==systemVersionDict)
+    {
+        NSLog(@"could not read system version dictionary file: %@", sSystemVersionPath);
+        return 0;
+    }
+    NSString *systemVersionString = [systemVersionDict objectForKey:@"ProductVersion"];
+    if (NULL ==systemVersionString)
+    {
+        NSLog(@"could not retrieve system version from dictionary at %@ with %d keys", sSystemVersionPath, (int)systemVersionDict.count);
+        return 0;
+    }
+    NSArray *systemVersionStringParts = [systemVersionString componentsSeparatedByString:@"."];
+    if (systemVersionStringParts.count < 2)
+    {
+        NSLog(@"Too few parts to the system version (probably): %@", systemVersionString);
+        return [systemVersionString intValue]; // hopefully this will at least be the major OS version, e.g., 10 (all versino so far!)
+    }
+
+    NSString *majVersionStr = systemVersionStringParts[0];
+    u_int16_t systemVersion = majVersionStr.intValue << 8;
+    NSString *minVersionStr = systemVersionStringParts[1];
+    systemVersion |= minVersionStr.intValue << 4;
+    if (systemVersionStringParts.count > 2)
+    {
+        NSString *bugVersionStr = systemVersionStringParts[2];
+        systemVersion |= bugVersionStr.intValue;
+    }
+    if (systemVersionStringParts.count > 3)
+    {
+        NSLog(@"Portions of System Version string after third part unused: %@", systemVersionString);
+    }
+    return systemVersion;
+}
+
+@end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
@@ -48,4 +48,14 @@ static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/Syst
     return systemVersion;
 }
 
++(u_int16_t)Version_10_13_1
+{
+    return 0x0AD1; // 10.13.1 in hex by nibbles, the way the old Gestalt call used to do it
+}
+
++(u_int16_t)Version_10_13_3
+{
+    return 0x0AD3; // 10.13.3 in hex by nibbles, the way the old Gestalt call used to do it
+}
+
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
@@ -29,7 +29,7 @@ static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/Syst
     if (systemVersionStringParts.count < 2)
     {
         NSLog(@"Too few parts to the system version (probably): %@", systemVersionString);
-        return [systemVersionString intValue]; // hopefully this will at least be the major OS version, e.g., 10 (all versino so far!)
+        return [systemVersionString intValue]; // hopefully this will at least be the major OS version, e.g., 10 (all versions so far!)
     }
 
     NSString *majVersionStr = systemVersionStringParts[0];


### PR DESCRIPTION
This should obviate PR #686 by improving the code to run on all versions, including the buggy ones, but only call the workaround on those (or future) buggy versions.