### PR TITLE
[Common] Refactor options storage and lookup

### DIFF
--- a/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
@@ -44,7 +44,7 @@ km_kbp_state_option_lookup(km_kbp_state const *state,
 
   auto & processor = state->processor();
 
-  *value_out = processor.lookup_option(km_kbp_option_scope(scope), key).value;
+  *value_out = processor.lookup_option(km_kbp_option_scope(scope), key);
   if (!*value_out)  return KM_KBP_STATUS_KEY_ERROR;
 
   return KM_KBP_STATUS_OK;

--- a/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_options_api.cpp
@@ -42,9 +42,9 @@ km_kbp_state_option_lookup(km_kbp_state const *state,
   if (scope == KM_KBP_OPT_UNKNOWN || scope > KM_KBP_OPT_MAX_SCOPES)
     return KM_KBP_STATUS_INVALID_ARGUMENT;
 
-  auto & opts = state->options();
+  auto & processor = state->processor();
 
-  *value_out = opts.lookup(km_kbp_option_scope(scope), key);
+  *value_out = processor.lookup_option(km_kbp_option_scope(scope), key).value;
   if (!*value_out)  return KM_KBP_STATUS_KEY_ERROR;
 
   return KM_KBP_STATUS_OK;
@@ -57,7 +57,7 @@ km_kbp_state_options_update(km_kbp_state *state, km_kbp_option_item const *opt)
   assert(state); assert(opt);
   if (!state|| !opt)  return KM_KBP_STATUS_INVALID_ARGUMENT;
 
-  auto & opts = state->options();
+  auto & processor = state->processor();
 
   try
   {
@@ -66,7 +66,10 @@ km_kbp_state_options_update(km_kbp_state *state, km_kbp_option_item const *opt)
       if (opt->scope == KM_KBP_OPT_UNKNOWN || opt->scope > KM_KBP_OPT_MAX_SCOPES)
         return KM_KBP_STATUS_INVALID_ARGUMENT;
 
-      if (!opts.assign(state, km_kbp_option_scope(opt->scope), opt->key, opt->value))
+      if (processor.update_option(
+            km_kbp_option_scope(opt->scope),
+            opt->key,
+            opt->value).empty())
         return KM_KBP_STATUS_KEY_ERROR;
     }
   }
@@ -92,7 +95,8 @@ km_kbp_state_options_to_json(km_kbp_state const *state, char *buf, size_t *space
 
   try
   {
-    jo << state->options();
+// TODO: Fix
+//    jo << state->options();
   }
   catch (std::bad_alloc)
   {

--- a/common/engine/keyboardprocessor/src/km_kbp_state_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_state_api.cpp
@@ -176,7 +176,7 @@ km_kbp_status km_kbp_state_to_json(km_kbp_state const *state,
     jo << json::object
         << "$schema" << "keyman/keyboardprocessor/doc/introspection.schema"
         << "keyboard" << state->processor().keyboard()
-        << "options" << state->options()
+//        << "options" << state->options()  TODO: Fix
         << "context" << state->context()
         << "actions" << state->actions()
         << json::close;

--- a/common/engine/keyboardprocessor/src/kmx/kmx_actions.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_actions.cpp
@@ -4,7 +4,8 @@
 */
 #include <kmx/kmx_processor.h>
 
-using namespace km::kbp::kmx;
+using namespace km::kbp;
+using namespace kmx;
 
 void KMX_Actions::ResetQueue()
 {
@@ -31,7 +32,7 @@ KMX_BOOL KMX_Actions::QueueAction(int ItemType, KMX_DWORD dwData)
   QueueSize++;
 
   int result = TRUE;
-  
+
   switch(ItemType)
   {
   case QIT_VKEYDOWN:

--- a/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_environment.cpp
@@ -21,23 +21,41 @@ namespace {
 }
 
 KMX_Environment::KMX_Environment() {
+  Load(KM_KBP_KMX_ENV_PLATFORM, DEFAULT_PLATFORM);
+  Load(KM_KBP_KMX_ENV_BASELAYOUT, DEFAULT_BASELAYOUT);
+  Load(KM_KBP_KMX_ENV_BASELAYOUTALT, DEFAULT_BASELAYOUTALT);
+  Load(KM_KBP_KMX_ENV_SIMULATEALTGR, DEFAULT_SIMULATEALTGR);
+  Load(KM_KBP_KMX_ENV_CAPSLOCK, DEFAULT_CAPSLOCK);
+  Load(KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT, DEFAULT_BASELAYOUTGIVESCTRLRALTFORRALT);
 }
 
-void KMX_Environment::InitOption(std::vector<option> &default_env, km_kbp_cp const *key, km_kbp_cp const *default_value) {
-  default_env.emplace_back(KM_KBP_OPT_ENVIRONMENT, key, default_value);
-  Load(key, default_value);
-}
 
-void KMX_Environment::Init(std::vector<option> &default_env) {
-  InitOption(default_env, KM_KBP_KMX_ENV_PLATFORM, DEFAULT_PLATFORM);
-  InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUT, DEFAULT_BASELAYOUT);
-  InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUTALT, DEFAULT_BASELAYOUTALT);
-  InitOption(default_env, KM_KBP_KMX_ENV_SIMULATEALTGR, DEFAULT_SIMULATEALTGR);
-  InitOption(default_env, KM_KBP_KMX_ENV_CAPSLOCK, DEFAULT_CAPSLOCK);
-  InitOption(default_env, KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT, DEFAULT_BASELAYOUTGIVESCTRLRALTFORRALT);
+char16_t const * KMX_Environment::LookUp(std::u16string const & key) const {
+  assert(!key.empty());
+  if (!key.empty()) return nullptr;
 
-  // TODO refactor this and the keyboard option terminator into state.cpp and keyboard.cpp respectively
-  default_env.emplace_back();
+  if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_PLATFORM)) {
+    return _platform.c_str();
+  }
+  else if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_BASELAYOUT)) {
+    return _baseLayout.c_str();
+  }
+  else if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_BASELAYOUTALT)) {
+    return _baseLayoutAlt.c_str();
+  }
+  else if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_SIMULATEALTGR)) {
+    return _simulateAltGr ? u"1" : u"0";
+  }
+  else if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_CAPSLOCK)) {
+    return _capsLock ? u"1" : u"0";
+  }
+  else if (!u16icmp(key.c_str(), KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT)) {
+    return _baseLayoutGivesCtrlRAltForRAlt ? u"1" : u"0";
+  }
+  else {
+    // Unsupported key
+    return nullptr;
+  }
 }
 
 

--- a/common/engine/keyboardprocessor/src/kmx/kmx_environment.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_environment.h
@@ -21,7 +21,7 @@ private:
 public:
   KMX_Environment();
   void Load(std::u16string const & key, std::u16string const & value);
-  void Init(std::vector<option> &default_env);
+  char16_t const * LookUp(std::u16string const & key) const;
 
   KMX_BOOL capsLock() const noexcept { return _capsLock; }
   KMX_BOOL simulateAltGr() const noexcept { return _simulateAltGr; }

--- a/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_options.cpp
@@ -16,7 +16,7 @@ int KMX_Options::_GetIndex(std::u16string const &key) const {
   for (auto sp = _kp->Keyboard->dpStoreArray;
        i != _kp->Keyboard->cxStoreArray; ++i, ++sp)
   {
-    if (sp->dpName && sp->dpName == key) break;
+    if (sp->dpName && sp->dpName == key) return i;
   }
 
   return -1;

--- a/common/engine/keyboardprocessor/src/kmx/kmx_options.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_options.h
@@ -11,6 +11,10 @@
 
 namespace km {
 namespace kbp {
+
+class abstract_processor;
+class state;
+
 namespace kmx {
 
 class KMX_Options
@@ -27,12 +31,13 @@ public:
   ~KMX_Options();
 
   void Init(std::vector<option> &opts);
-  void Load(options *options, std::u16string const &key);
+  void Load(abstract_processor &, std::u16string const &key);
+  char16_t const * LookUp(std::u16string const &key) const;
   void Set(int nStoreToSet, int nStoreToRead);
   void Set(int nStoreToSet, std::u16string const &value);
   void Set(std::u16string const &key, std::u16string const &value);
-  void Reset(options *options, int nStoreToReset);
-  void Save(km_kbp_state *state, int nStoreToSave);
+  void Reset(abstract_processor &, int nStoreToReset);
+  void Save(state & state, int nStoreToSave);
 
   STORE const * begin() const;
   STORE const * end() const;
@@ -41,7 +46,7 @@ public:
 inline
 void KMX_Options::Set(std::u16string const &key, std::u16string const &value) {
   auto i = _GetIndex(key);
-  if (i != signed(_kp->Keyboard->cxStoreArray))   Set(i, value);
+  if (i >= 0)   Set(i, value);
 }
 
 inline

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
@@ -56,6 +56,7 @@ namespace km {
       switch(scope) {
         case KM_KBP_OPT_KEYBOARD:
           _kmx.GetOptions()->Set(key, value);
+          persisted_store()[key] = value;
           break;
         case KM_KBP_OPT_ENVIRONMENT:
           _kmx.GetEnvironment()->Load(key, value);

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
@@ -33,7 +33,7 @@ namespace km {
     }
 
 
-    option kmx_processor::lookup_option(km_kbp_option_scope scope, std::u16string const & key) const
+    char16_t const * kmx_processor::lookup_option(km_kbp_option_scope scope, std::u16string const & key) const
     {
       char16_t const * pValue = nullptr;
       switch(scope)
@@ -48,7 +48,7 @@ namespace km {
           break;
       }
 
-      return pValue ? option(scope, key, pValue) : option();
+      return pValue ? pValue : nullptr;
     }
 
     option kmx_processor::update_option(km_kbp_option_scope scope, std::u16string const & key, std::u16string const & value)

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.cpp
@@ -19,6 +19,11 @@ namespace km {
       if (_valid)
         _kmx.GetOptions()->Init(defaults);
 
+      for (auto const & opt: defaults)
+      {
+        if (!opt.empty() && opt.scope == KM_KBP_OPT_KEYBOARD  )
+          persisted_store()[opt.key] = opt.value;
+      }
       // Fill out attributes
       auto v = _kmx.GetKeyboard()->Keyboard->version;
       auto vs = std::to_string(v >> 16) + "." + std::to_string(v & 0xffff);
@@ -27,21 +32,40 @@ namespace km {
                       std::u16string(vs.begin(), vs.end()), p.parent(), defaults);
     }
 
-    void kmx_processor::init_state(std::vector<option> &default_env) {
-      _kmx.GetEnvironment()->Init(default_env);
+
+    option kmx_processor::lookup_option(km_kbp_option_scope scope, std::u16string const & key) const
+    {
+      char16_t const * pValue = nullptr;
+      switch(scope)
+      {
+        case KM_KBP_OPT_KEYBOARD:
+          pValue = _kmx.GetOptions()->LookUp(key);
+          break;
+        case KM_KBP_OPT_ENVIRONMENT:
+          pValue = _kmx.GetEnvironment()->LookUp(key);
+          break;
+        default:
+          break;
+      }
+
+      return pValue ? option(scope, key, pValue) : option();
     }
 
-    void kmx_processor::update_option(km_kbp_state *state, km_kbp_option_scope scope, std::u16string const & key, std::u16string const & value) {
+    option kmx_processor::update_option(km_kbp_option_scope scope, std::u16string const & key, std::u16string const & value)
+    {
       switch(scope) {
         case KM_KBP_OPT_KEYBOARD:
-          _kmx.GetOptions()->Load(&state->options(), key);
+          _kmx.GetOptions()->Set(key, value);
           break;
         case KM_KBP_OPT_ENVIRONMENT:
           _kmx.GetEnvironment()->Load(key, value);
           break;
         default:
+          return option();
           break;
       }
+
+      return option(scope, key, value);
     }
 
     km_kbp_status kmx_processor::process_event(km_kbp_state *state, km_kbp_virtual_key vk, uint16_t modifier_state) {

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
@@ -30,12 +30,11 @@ namespace kbp
     km_kbp_attr const & attributes() const override;
     km_kbp_status       validate() const override;
 
-    void    update_option(km_kbp_state *state,
-                          km_kbp_option_scope scope,
+    option  lookup_option(km_kbp_option_scope,
+                          std::u16string const & key)  const override;
+    option  update_option(km_kbp_option_scope scope,
                           std::u16string const & key,
                           std::u16string const & value) override;
-
-    void init_state(std::vector<option> &) override;
   };
 
 } // namespace kbp

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processevent.hpp
@@ -30,7 +30,7 @@ namespace kbp
     km_kbp_attr const & attributes() const override;
     km_kbp_status       validate() const override;
 
-    option  lookup_option(km_kbp_option_scope,
+    char16_t const * lookup_option(km_kbp_option_scope,
                           std::u16string const & key)  const override;
     option  update_option(km_kbp_option_scope scope,
                           std::u16string const & key,

--- a/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_processor.cpp
@@ -403,12 +403,12 @@ int KMX_Processor::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR endstr
       case CODE_RESETOPT:
         p++;
         n1 = *p - 1;
-        GetOptions()->Reset(&m_kbp_state->options(), n1);
+        GetOptions()->Reset(m_kbp_state->processor(), n1);
         break;
       case CODE_SAVEOPT:
         p++;
         n1 = *p - 1;
-        GetOptions()->Save(m_kbp_state, n1);
+        GetOptions()->Save(*m_kbp_state, n1);
         break;
       case CODE_IFSYSTEMSTORE:
         p+=3;

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
@@ -84,11 +84,11 @@ namespace km {
     {
     }
 
-    option mock_processor::lookup_option(km_kbp_option_scope scope,
+    char16_t const * mock_processor::lookup_option(km_kbp_option_scope scope,
                                     std::u16string const & key) const
     {
       auto i = _options.find(char16_t(scope) + key);
-      return i != _options.end() ? option(scope, key, i->second) : option();
+      return i != _options.end() ? i->second.c_str() : nullptr;
     }
 
     option mock_processor::update_option(km_kbp_option_scope scope,

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
@@ -76,9 +76,30 @@ namespace km {
     : abstract_processor(
         keyboard_attributes(path.stem(), u"3.145", path.parent(), {
           option{KM_KBP_OPT_KEYBOARD, u"__test_point", u"not tiggered"},
-          option{KM_KBP_OPT_KEYBOARD, u"hello", u"-"}
-      }))
+        })),
+      _options({
+          {u"\x01__test_point", u"not tiggered"},
+          {u"\x02hello", u"-"}
+      })
     {
+    }
+
+    option mock_processor::lookup_option(km_kbp_option_scope scope,
+                                    std::u16string const & key) const
+    {
+      auto i = _options.find(char16_t(scope) + key);
+      return i != _options.end() ? option(scope, key, i->second) : option();
+    }
+
+    option mock_processor::update_option(km_kbp_option_scope scope,
+                       std::u16string const & key,
+                       std::u16string const & value)
+    {
+      auto i = _options.find(char16_t(scope) + key);
+      if (i == _options.end()) return option();
+
+      i->second = value;
+      return option(scope, key, i->second);
     }
 
 
@@ -102,12 +123,10 @@ namespace km {
 
         case KM_KBP_VKEY_F2:
         {
-          auto & opts = state->options();
-          auto opt = opts.assign(state,
-                                 KM_KBP_OPT_KEYBOARD,
-                                 u"__test_point",
-                                 u"F2 pressed test save.");
-          state->actions().push_persist(static_cast<option const &>(*opt));
+          state->actions().push_persist(
+            update_option(KM_KBP_OPT_KEYBOARD,
+                        u"__test_point",
+                        u"F2 pressed test save."));
           break;
         }
 
@@ -152,17 +171,6 @@ namespace km {
       return KM_KBP_STATUS_OK;
 
     }
-
-    void mock_processor::update_option(km_kbp_state *,
-                                       km_kbp_option_scope,
-                                       std::u16string const &,
-                                       std::u16string const &)
-    {};
-
-    void mock_processor::init_state(std::vector<option> &default_env) {
-      default_env.emplace_back(KM_KBP_OPT_ENVIRONMENT, u"hello", u"-");
-      default_env.emplace_back();
-    };
 
     km_kbp_attr const & mock_processor::attributes() const {
       return engine_attrs;

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.cpp
@@ -99,6 +99,7 @@ namespace km {
       if (i == _options.end()) return option();
 
       i->second = value;
+      persisted_store()[key] = value;
       return option(scope, key, i->second);
     }
 

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <unordered_map>
 #include <keyman/keyboardprocessor.h>
 
 #include "processor.hpp"
@@ -20,9 +20,8 @@ namespace kbp
 {
   class mock_processor : public abstract_processor
   {
-    std::vector<option> _options;
-    option const * _find_option(km_kbp_option_scope scope,
-                                std::u16string const & key) const;
+    std::unordered_map<std::u16string, std::u16string> _options;
+
   public:
     mock_processor(km::kbp::path const &);
 //    ~mock_processor() override;
@@ -35,12 +34,12 @@ namespace kbp
     km_kbp_status               validate() const override;
 
 
-    void    update_option(km_kbp_state *state,
-                          km_kbp_option_scope scope,
-                          std::u16string const & key,
-                          std::u16string const & value) override;
 
-    void init_state(std::vector<option> &) override;
+    option  lookup_option(km_kbp_option_scope,
+                  std::u16string const & key) const override;
+    option  update_option(km_kbp_option_scope,
+                  std::u16string const & key,
+                  std::u16string const & value) override;
   };
 
   class null_processor : public mock_processor {

--- a/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
+++ b/common/engine/keyboardprocessor/src/mock/mock_processor.hpp
@@ -35,7 +35,7 @@ namespace kbp
 
 
 
-    option  lookup_option(km_kbp_option_scope,
+    char16_t const * lookup_option(km_kbp_option_scope,
                   std::u16string const & key) const override;
     option  update_option(km_kbp_option_scope,
                   std::u16string const & key,

--- a/common/engine/keyboardprocessor/src/option.hpp
+++ b/common/engine/keyboardprocessor/src/option.hpp
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <vector>
 #include <string>
 
 #include <keyman/keyboardprocessor.h>
@@ -88,39 +87,6 @@ namespace kbp
     return key == nullptr;
   }
 
-
-
-  class options
-  {
-    //km_kbp_keyboard_attrs const &_kb;
-    km_kbp_option_item const * _scopes[KM_KBP_OPT_MAX_SCOPES-1];
-    std::vector<option>   _saved;
-
-  public:
-    options(km_kbp_option_item const * kb_default_options);
-
-    void set_default_env(km_kbp_option_item const *env);
-
-    char16_t const *      lookup(km_kbp_option_scope scope,
-                                 std::u16string const & key) const noexcept;
-    km_kbp_option_item const * assign(km_kbp_state *state, km_kbp_option_scope scope, std::u16string const & key,
-                                           std::u16string const & value);
-    void                  reset(km_kbp_option_scope scope,
-                                std::u16string const & key);
-
-    friend json & operator << (json &j, km::kbp::options const &opts);
-  };
-
-  json & operator << (json &j, km::kbp::options const &opts);
-
-  inline
-  options::options(km_kbp_option_item const * kb_default_options)
-  : _scopes {kb_default_options, nullptr}
-  {}
-
-  inline void options::set_default_env(km_kbp_option_item const *env) {
-    _scopes[KM_KBP_OPT_ENVIRONMENT - 1] = env;
-  }
 
 
 } // namespace kbp

--- a/common/engine/keyboardprocessor/src/processor.hpp
+++ b/common/engine/keyboardprocessor/src/processor.hpp
@@ -43,7 +43,7 @@ namespace kbp
     virtual km_kbp_attr const & attributes() const = 0;
     virtual km_kbp_status       validate() const = 0;
 
-    virtual option  lookup_option(km_kbp_option_scope,
+    virtual char16_t const * lookup_option(km_kbp_option_scope,
                                   std::u16string const & key) const = 0;
     virtual option  update_option(km_kbp_option_scope,
                                   std::u16string const & key,

--- a/common/engine/keyboardprocessor/src/processor.hpp
+++ b/common/engine/keyboardprocessor/src/processor.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 #include <keyman/keyboardprocessor.h>
 
@@ -19,8 +20,9 @@ namespace kbp
 {
   class abstract_processor
   {
+    std::unordered_map<std::u16string, std::u16string>  _persisted;
   protected:
-    keyboard_attributes _attributes;
+    keyboard_attributes                                 _attributes;
 
   public:
     abstract_processor() {}
@@ -31,6 +33,9 @@ namespace kbp
       return _attributes;
     }
 
+    auto & persisted_store() const noexcept { return _persisted; }
+    auto & persisted_store() noexcept { return _persisted; }
+
     virtual km_kbp_status process_event(km_kbp_state *,
                                         km_kbp_virtual_key,
                                         uint16_t modifier_state) = 0;
@@ -38,13 +43,16 @@ namespace kbp
     virtual km_kbp_attr const & attributes() const = 0;
     virtual km_kbp_status       validate() const = 0;
 
-    virtual void    update_option(km_kbp_state *state,
-                                  km_kbp_option_scope,
+    virtual option  lookup_option(km_kbp_option_scope,
+                                  std::u16string const & key) const = 0;
+    virtual option  update_option(km_kbp_option_scope,
                                   std::u16string const & key,
                                   std::u16string const & value) = 0;
 
-    virtual void init_state(std::vector<option> &default_env) = 0;
+    friend json & operator << (json &j, abstract_processor const &opts);
   };
+
+  json & operator << (json &j, abstract_processor const &opts);
 
 } // namespace kbp
 } // namespace km

--- a/common/engine/keyboardprocessor/src/state.cpp
+++ b/common/engine/keyboardprocessor/src/state.cpp
@@ -28,14 +28,14 @@ void actions::push_persist(option const &&opt) {
 
 
 state::state(km::kbp::abstract_processor & ap, km_kbp_option_item const *env)
-  : _options(ap.keyboard().default_options),
-    _processor(ap)
+  : _processor(ap)
 {
-  ap.init_state(_env);
-  _options.set_default_env(_env.data());
-
   for (; env && env->key != nullptr; env++) {
     //assert(env->scope == KM_KBP_OPT_ENVIRONMENT); // todo do we need scope? or can we find a way to eliminate it?
-    assert(_options.assign(static_cast<km_kbp_state *>(this), (km_kbp_option_scope) KM_KBP_OPT_ENVIRONMENT, env->key, env->value) != nullptr);
+    ap.update_option(env->scope
+                        ? km_kbp_option_scope(env->scope)
+                        : KM_KBP_OPT_ENVIRONMENT, 
+                     env->key,
+                     env->value);
   }
 }

--- a/common/engine/keyboardprocessor/src/state.hpp
+++ b/common/engine/keyboardprocessor/src/state.hpp
@@ -122,8 +122,6 @@ protected:
     kbp::context              _ctxt;
     kbp::abstract_processor & _processor;
     kbp::actions              _actions;
-    kbp::options              _options;
-    std::vector<option>       _env;
 
 public:
     state(kbp::abstract_processor & kb, km_kbp_option_item const *env);
@@ -133,9 +131,6 @@ public:
 
     kbp::context       &  context() noexcept            { return _ctxt; }
     kbp::context const &  context() const noexcept      { return _ctxt; }
-
-    kbp::options &          options() noexcept        { return _options; }
-    kbp::options const &    options() const noexcept  { return _options; }
 
     kbp::abstract_processor const & processor() const noexcept { return _processor; }
     kbp::abstract_processor &       processor() noexcept { return _processor; }

--- a/common/engine/keyboardprocessor/tests/unit/kmnkbd/state_api.cpp
+++ b/common/engine/keyboardprocessor/tests/unit/kmnkbd/state_api.cpp
@@ -44,23 +44,6 @@ constexpr char const *doc1_expected = u8"\
         \"version\" : \"3.145\",\n\
         \"rules\" : []\n\
     },\n\
-    \"options\" : {\n\
-        \"keyboard\" : {\n\
-            \"__test_point\" : \"not tiggered\",\n\
-            \"hello\" : \"-\"\n\
-        },\n\
-        \"environment\" : {\n\
-            \"hello\" : \"-\"\n\
-        },\n\
-        \"saved\" : {\n\
-            \"keyboard\" : {\n\
-                \"__test_point\" : \"F2 pressed test save.\"\n\
-            },\n\
-            \"environment\" : {\n\
-                \"hello\" : \"world\"\n\
-            }\n\
-        }\n\
-    },\n\
     \"context\" : [\n\
         \"H\",\n\
         \"e\",\n\
@@ -86,21 +69,6 @@ constexpr char const *doc2_expected = u8"\
         \"folder\" : \"\",\n\
         \"version\" : \"3.145\",\n\
         \"rules\" : []\n\
-    },\n\
-    \"options\" : {\n\
-        \"keyboard\" : {\n\
-            \"__test_point\" : \"not tiggered\",\n\
-            \"hello\" : \"-\"\n\
-        },\n\
-        \"environment\" : {\n\
-            \"hello\" : \"-\"\n\
-        },\n\
-        \"saved\" : {\n\
-            \"keyboard\" : {},\n\
-            \"environment\" : {\n\
-                \"hello\" : \"globe\"\n\
-            }\n\
-        }\n\
     },\n\
     \"context\" : [],\n\
     \"actions\" : []\n\

--- a/common/engine/keyboardprocessor/tests/unit/kmx/035 - options double set staged.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/035 - options double set staged.kmn
@@ -1,9 +1,9 @@
 c Description: Tests basic option rules with save reset+set+reset
 c keys: [K_A][K_B][K_C][K_B][K_A]
 c expected: foo.foo.
-c context: 
+c context:
 c option: foo=1
-c expected option: foo=1
+c expected option: foo=2
 
 store(&version) '10.0'
 

--- a/common/engine/keyboardprocessor/tests/unit/kmx/036 - options - double reset staged.kmn
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/036 - options - double reset staged.kmn
@@ -1,9 +1,9 @@
 c Description: Tests basic option rules with save reset+reset
 c keys: [K_A][K_B][K_B][K_A]
 c expected: foo.foo.
-c context: 
+c context:
 c option: foo=1
-c expected option: foo=1
+c expected option: foo=2
 
 store(&version) '10.0'
 


### PR DESCRIPTION
Refactor all options storage and management to be done by processor sub-classes and add a persistence cache to allow implementation save/reset.
