### PR TITLE
[linux] install kmx to ibus when installing kmp

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -388,8 +388,8 @@ ibus_keyman_engine_constructor (GType                   type,
         g_warning("problem creating km_kbp_state");
     }
     for (int i =0; i < 3; i++) {
-        km_kbp_cp_dispose(keyboard_opts[i].key);
-        km_kbp_cp_dispose(keyboard_opts[i].value);
+        g_free((km_kbp_cp *)keyboard_opts[i].key);
+        g_free((km_kbp_cp *)keyboard_opts[i].value);
     }
     g_free(keyboard_opts);
 

--- a/linux/keyman-config/experiments/osk/ibus_dbus.py
+++ b/linux/keyman-config/experiments/osk/ibus_dbus.py
@@ -1,24 +1,52 @@
 #!/usr/bin/python3
+
+def try_ibus():
+  try:
+    bus = IBus.Bus()
+    if not bus.is_connected():
+      print("x", end='')
+      #print("Can not connect to ibus-daemon")
+    else:
+      print(".", end='')
+      if bus.is_global_engine_enabled():
+        print("+", end='')
+      #print("Is global engine enabled:", bus.is_global_engine_enabled())
+      #print("Is global engine used:", bus.get_use_global_engine())
+      #for e in bus.list_active_engines():
+      #  print("Active engine:", e.get_name())
+      #print("Global engine name:", bus.get_global_engine().get_name())
+      #for e in bus.list_engines():
+      #    print(e.get_name())
+    bus.destroy()
+    print("-", end='')
+  except Exception as e:
+    print("Failed to connect to iBus")
+    print(e)
+
+
 try:
   import gi
   gi.require_version('IBus', '1.0')
   gi.require_version('DBus', '1.0')
   from gi.repository import IBus
   from gi.repository import DBus
+
+  for i in range(10000):
+      try_ibus()
   #import dbus #,vim
-  bus = IBus.Bus()
-  if not bus.is_connected():
-    print("Can not connect to ibus-daemon")
-  else:
-    print("Is global engine enabled:", bus.is_global_engine_enabled())
-    print("Is global engine used:", bus.get_use_global_engine())
-    for e in bus.list_active_engines():
-        print("Active engine:", e.get_name())
-    print("Global engine name:", bus.get_global_engine().get_name())
-    #for e in bus.list_engines():
-    #    print(e.get_name())
+#  bus = IBus.Bus()
+#  if not bus.is_connected():
+#    print("Can not connect to ibus-daemon")
+#  else:
+#    print("Is global engine enabled:", bus.is_global_engine_enabled())
+#    print("Is global engine used:", bus.get_use_global_engine())
+#    for e in bus.list_active_engines():
+#        print("Active engine:", e.get_name())
+#    print("Global engine name:", bus.get_global_engine().get_name())
+#    #for e in bus.list_engines():
+#    #    print(e.get_name())
 except Exception as e:
-  print("Failed to connect to iBus")
+  print("Failed to run test")
   print(e)
 
 #  dbusconn = bus.get_connection()

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -459,6 +459,51 @@ def parsemetadata(jsonfile, verbose=False):
 				print_files(files, extracted_dir)
 	return info, system, options, keyboards, files
 
+def get_metadata(tmpdirname):
+	"""
+	Get metadata from kmp.json if it exists.
+	If it does not exist then will return get_and_convert_infdata
+
+	Args:
+		inputfile (str): path to kmp file
+		tmpdirname(str): temp directory to extract kmp
+
+	Returns:
+		list[5]: info, system, options, keyboards, files
+			see kmpmetadata.parsemetadata for details
+	"""
+	kmpjson = os.path.join(tmpdirname, "kmp.json")
+	if os.path.isfile(kmpjson):
+		return parsemetadata(kmpjson, False)
+	else:
+		return get_and_convert_infdata(tmpdirname)
+
+def get_and_convert_infdata(tmpdirname):
+	"""
+	Get metadata from kmp.inf if it exists.
+	Convert it to kmp.json if possible
+
+	Args:
+		inputfile (str): path to kmp file
+		tmpdirname(str): temp directory to extract kmp
+
+	Returns:
+		list[5]: info, system, options, keyboards, files
+			see kmpmetadata.parseinfdata for details
+	"""
+	kmpinf = os.path.join(tmpdirname, "kmp.inf")
+	if os.path.isfile(kmpinf):
+		info, system, options, keyboards, files =  parseinfdata(kmpinf, False)
+		j = infmetadata_to_json(info, system, options, keyboards, files)
+		kmpjson = os.path.join(tmpdirname, "kmp.json")
+		with open(kmpjson, "w") as write_file:
+			print(j, file=write_file)
+		return info, system, options, keyboards, files
+	else:
+		return None, None, None, None, None
+
+
+
 def infmetadata_to_json(info, system, options, keyboards, files):
 	jsonfiles = []
 	for entry in files:

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -9,6 +9,9 @@ from shutil import rmtree
 from keyman_config.get_kmp import user_keyboard_dir, user_keyman_font_dir
 
 def uninstall_from_ibus(kmnfile):
+# need to uninstall for all installed langs
+
+
 	if sys.version_info.major == 3 and sys.version_info.minor < 6:
 		result = subprocess.run(["dconf", "read", "/desktop/ibus/general/preload-engines"],
 			stdout=subprocess.PIPE, stderr= subprocess.STDOUT)
@@ -67,6 +70,7 @@ def uninstall_kmp_shared(keyboardid):
 		logging.info("Removed font directory: %s", kbfontdir)
 	else:
 		logging.info("No font directory")
+	# need to uninstall from ibus for all lang and all kmx in kmp
 	kmnfile = os.path.join(kbdir, keyboardid+".kmn")
 	uninstall_from_ibus(kmnfile)
 	rmtree(kbdir)
@@ -85,6 +89,7 @@ def uninstall_kmp_user(keyboardid):
 		logging.error("Keyboard directory for %s does not exist. Aborting", keyboardid)
 		exit(3)
 	logging.info("Uninstalling local keyboard: %s", keyboardid)
+	# need to uninstall from ibus for all lang and all kmx in kmp
 	kmnfile = os.path.join(kbdir, keyboardid+".kmn")
 	uninstall_from_ibus(kmnfile)
 	rmtree(kbdir)

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -1,56 +1,31 @@
 #!/usr/bin/python3
 
-import ast
 import logging
 import subprocess
 import sys
 import os.path
 from shutil import rmtree
+
 from keyman_config.get_kmp import user_keyboard_dir, user_keyman_font_dir
+from keyman_config.kmpmetadata import get_metadata
+from keyman_config.ibus_util import uninstall_from_ibus, get_ibus_bus, restart_ibus
 
-def uninstall_from_ibus(kmnfile):
-# need to uninstall for all installed langs
-
-
-	if sys.version_info.major == 3 and sys.version_info.minor < 6:
-		result = subprocess.run(["dconf", "read", "/desktop/ibus/general/preload-engines"],
-			stdout=subprocess.PIPE, stderr= subprocess.STDOUT)
-		logging.debug(result.stdout.decode("utf-8", "strict"))
-		dconfread = result.stdout.decode("utf-8", "strict")
-	else:
-		result = subprocess.run(["dconf", "read", "/desktop/ibus/general/preload-engines"],
-			stdout=subprocess.PIPE, stderr= subprocess.STDOUT, encoding="UTF8")
-		dconfread = result.stdout
-	if (result.returncode == 0) and dconfread:
-		preload_engines = ast.literal_eval(dconfread)
-		if kmnfile not in preload_engines:
-			logging.info("%s is not installed in IBus", kmnfile)
-			return
-		preload_engines.remove(kmnfile)
-		logging.info("Uninstalling %s from IBus", kmnfile)
-		if sys.version_info.major == 3 and sys.version_info.minor < 6:
-			result2 = subprocess.run(["dconf", "write", "/desktop/ibus/general/preload-engines", str(preload_engines)],
-				stdout=subprocess.PIPE, stderr= subprocess.STDOUT)
-		else:
-			result2 = subprocess.run(["dconf", "write", "/desktop/ibus/general/preload-engines", str(preload_engines)],
-				stdout=subprocess.PIPE, stderr= subprocess.STDOUT, encoding="UTF8")
-
-def uninstall_kmp_shared(keyboardid):
+def uninstall_kmp_shared(packageID):
 	"""
 	Uninstall a kmp from /usr/local/share/keyman
 
 	Args:
-		keyboardid (str): Keyboard ID
+		packageID (str): Keyboard package ID
 	"""
-	kbdir = os.path.join('/usr/local/share/keyman', keyboardid)
+	kbdir = os.path.join('/usr/local/share/keyman', packageID)
 	if not os.path.isdir(kbdir):
-		logging.error("Keyboard directory for %s does not exist. Aborting", keyboardid)
+		logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
 		exit(3)
 
-	kbdocdir = os.path.join('/usr/local/share/doc/keyman', keyboardid)
-	kbfontdir = os.path.join('/usr/local/share/fonts/keyman', keyboardid)
+	kbdocdir = os.path.join('/usr/local/share/doc/keyman', packageID)
+	kbfontdir = os.path.join('/usr/local/share/fonts/keyman', packageID)
 
-	logging.info("Uninstalling shared keyboard: %s", keyboardid)
+	logging.info("Uninstalling shared keyboard: %s", packageID)
 	if not os.access(kbdir, os.X_OK | os.W_OK): # Check for write access of keyman dir
 		logging.error("You do not have permissions to uninstall the keyboard files. You need to run this with `sudo`")
 		exit(3)
@@ -70,47 +45,70 @@ def uninstall_kmp_shared(keyboardid):
 		logging.info("Removed font directory: %s", kbfontdir)
 	else:
 		logging.info("No font directory")
+
 	# need to uninstall from ibus for all lang and all kmx in kmp
-	kmnfile = os.path.join(kbdir, keyboardid+".kmn")
-	uninstall_from_ibus(kmnfile)
+	info, system, options, keyboards, files = get_metadata(kbdir)
+	if keyboards:
+		uninstall_keyboards_from_ibus(keyboards, kbdir)
+	else:
+		logging.warning("could not uninstall keyboards from IBus")
+
 	rmtree(kbdir)
 	logging.info("Removed keyman directory: %s", kbdir)
-	logging.info("Finished uninstalling shared keyboard: %s", keyboardid)
+	logging.info("Finished uninstalling shared keyboard: %s", packageID)
 
-def uninstall_kmp_user(keyboardid):
+def uninstall_keyboards_from_ibus(keyboards, packageDir):
+		bus = get_ibus_bus()
+		if bus:
+			# install all kmx for first lang not just packageID
+			for kb in keyboards:
+				kmx_file = os.path.join(packageDir, kb['id'] + ".kmx")
+				if "languages" in kb:
+					logging.debug(kb["languages"][0])
+					keyboard_id = "%s:%s" % (kb["languages"][0]['id'], kmx_file)
+				else:
+					keyboard_id = kmx_file
+				uninstall_from_ibus(bus, keyboard_id)
+			restart_ibus(bus)
+		else:
+			logging.warning("could not uninstall keyboards from IBus")
+
+def uninstall_kmp_user(packageID):
 	"""
 	Uninstall a kmp from ~/.local/share/keyman
 
 	Args:
-		keyboardid (str): Keyboard ID
+		packageID (str): Keyboard package ID
 	"""
-	kbdir=user_keyboard_dir(keyboardid)
+	kbdir=user_keyboard_dir(packageID)
 	if not os.path.isdir(kbdir):
-		logging.error("Keyboard directory for %s does not exist. Aborting", keyboardid)
+		logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
 		exit(3)
-	logging.info("Uninstalling local keyboard: %s", keyboardid)
-	# need to uninstall from ibus for all lang and all kmx in kmp
-	kmnfile = os.path.join(kbdir, keyboardid+".kmn")
-	uninstall_from_ibus(kmnfile)
+	logging.info("Uninstalling local keyboard: %s", packageID)
+	info, system, options, keyboards, files = get_metadata(kbdir)
+	if keyboards:
+		uninstall_keyboards_from_ibus(keyboards, kbdir)
+	else:
+		logging.warning("could not uninstall keyboards from IBus")
 	rmtree(kbdir)
 	logging.info("Removed user keyman directory: %s", kbdir)
-	fontdir=os.path.join(user_keyman_font_dir(), keyboardid)
+	fontdir=os.path.join(user_keyman_font_dir(), packageID)
 	if os.path.isdir(fontdir):
 		rmtree(fontdir)
 		logging.info("Removed user keyman font directory: %s", fontdir)
-	logging.info("Finished uninstalling local keyboard: %s", keyboardid)
+	logging.info("Finished uninstalling local keyboard: %s", packageID)
 
 
 
-def uninstall_kmp(keyboardid, sharedarea=False):
+def uninstall_kmp(packageID, sharedarea=False):
 	"""
 	Uninstall a kmp
 
 	Args:
-		keyboardid (str): Keyboard ID
+		packageID (str): Keyboard package ID
 		sharedarea (str): whether to uninstall from shared /usr/local or ~/.local
 	"""
 	if sharedarea:
-		uninstall_kmp_shared(keyboardid)
+		uninstall_kmp_shared(packageID)
 	else:
-		uninstall_kmp_user(keyboardid)
+		uninstall_kmp_user(packageID)


### PR DESCRIPTION
All the kmx in a kmp will be installed to ibus (if it is already running) for the first language of the keyboard so that users should be able to use them straight away.

using the IBus gi API rather than subprocess

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1453)
<!-- Reviewable:end -->
