### PR TITLE
[android] Add "cancel" button when downloading keyboard catalog

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
@@ -11,6 +11,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -44,6 +45,10 @@ public final class JSONParser {
       Log.e(logTag, (e.getMessage() == null) ? "UnsupportedEncodingException" : e.getMessage());
       jsonObj = null;
       System.err.println(e);
+    } catch (InterruptedIOException e) {
+      // Disregard from cancelling action
+      Log.e(logTag, (e.getMessage() == null)  ? "InterruptedIOException" : e.getMessage());
+      jsonObj = null;
     } catch (IOException e) {
       Log.e(logTag, (e.getMessage() == null) ? "IOException" : e.getMessage());
       jsonObj = null;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -74,6 +74,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   private static String filename;
 
   private static ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener> kbDownloadEventListeners = null;
+  private static DownloadTask downloadTask = null;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -154,7 +155,18 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       if (showProgressDialog) {
         progressDialog = new ProgressDialog(context);
         progressDialog.setMessage(context.getString(R.string.downloading_keyboard));
-        progressDialog.setCancelable(false);
+        progressDialog.setCancelable(true);
+        progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(R.string.label_cancel),
+          new DialogInterface.OnClickListener() {
+
+          @Override
+          public void onClick(DialogInterface dialogInterface, int which) {
+            if (downloadTask != null) {
+              downloadTask.cancel(true);
+            }
+            progressDialog.dismiss();
+          }
+        });
         if (!((AppCompatActivity) context).isFinishing()) {
           progressDialog.show();
         } else {
@@ -340,6 +352,10 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
         }
       }
 
+      boolean spin = true;
+      while (spin) {
+        wait(500);
+      }
       return ret;
     }
 
@@ -372,8 +388,8 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
    * @param showProgressDialog
    */
   public static void download(final Context context, final boolean showProgressDialog) {
-
-    new DownloadTask(context, showProgressDialog).execute();
+    downloadTask = new DownloadTask(context, showProgressDialog);
+    downloadTask.execute();
   }
 
   public static boolean isCustom(String u) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -74,8 +74,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   private static String filename;
 
   private static ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener> kbDownloadEventListeners = null;
-  private static DownloadTask downloadTask = null;
-
+  
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -155,18 +154,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       if (showProgressDialog) {
         progressDialog = new ProgressDialog(context);
         progressDialog.setMessage(context.getString(R.string.downloading_keyboard));
-        progressDialog.setCancelable(true);
-        progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(R.string.label_cancel),
-          new DialogInterface.OnClickListener() {
-
-          @Override
-          public void onClick(DialogInterface dialogInterface, int which) {
-            if (downloadTask != null) {
-              downloadTask.cancel(true);
-            }
-            progressDialog.dismiss();
-          }
-        });
+        progressDialog.setCancelable(false);
         if (!((AppCompatActivity) context).isFinishing()) {
           progressDialog.show();
         } else {
@@ -352,10 +340,6 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
         }
       }
 
-      boolean spin = true;
-      while (spin) {
-        wait(500);
-      }
       return ret;
     }
 
@@ -388,8 +372,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
    * @param showProgressDialog
    */
   public static void download(final Context context, final boolean showProgressDialog) {
-    downloadTask = new DownloadTask(context, showProgressDialog);
-    downloadTask.execute();
+    new DownloadTask(context, showProgressDialog).execute();
   }
 
   public static boolean isCustom(String u) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -338,7 +338,6 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
           loadFromCache = true;
       }
 
-      loadFromCache = false; // DDW don't commit
       if (hasConnection && !loadFromCache) {
         progressDialog = new ProgressDialog(context, R.style.ProgressDialog);
         progressDialog.setMessage(getString(R.string.getting_keyboard_catalog));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -26,6 +26,7 @@ import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener
 import com.tavultesoft.kmea.BuildConfig;
 
 import android.annotation.SuppressLint;
+import android.content.DialogInterface;
 import android.support.v7.app.AppCompatActivity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -337,10 +338,23 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
           loadFromCache = true;
       }
 
+      loadFromCache = false; // DDW don't commit
       if (hasConnection && !loadFromCache) {
-        progressDialog = new ProgressDialog(context);
-        progressDialog.setMessage(getString(R.string.loading));
-        progressDialog.setCancelable(false);
+        progressDialog = new ProgressDialog(context, R.style.ProgressDialog);
+        progressDialog.setMessage(getString(R.string.getting_keyboard_catalog));
+        progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(R.string.label_cancel),
+          new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialogInterface, int which) {
+              cancel(true);
+              progressDialog.dismiss();
+              progressDialog = null;
+              LanguageListActivity.this.finish();
+              return;
+            }
+          });
+        progressDialog.setCancelable(true);
         if (!((AppCompatActivity) context).isFinishing()) {
           progressDialog.show();
         } else {

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="custom_keyboard" translatable="false">Custom Keyboard</string>
     <string name="downloading_keyboard" translatable="false">Downloading keyboard&#8230;</string>
     <string name="keyboard_updates_available" translatable="false">Keyboard Updates Available</string>
-    <string name="loading" translatable="false">Loading&#8230;</string>
+    <string name="getting_keyboard_catalog" translatable="false">Getting keyboard catalog.\nThis may take a while&#8230;</string>
     <string name="updating_keyboards" translatable="false">Updating keyboards&#8230;</string>
 
     <!-- Keyboard Info -->

--- a/android/KMEA/app/src/main/res/values/styles.xml
+++ b/android/KMEA/app/src/main/res/values/styles.xml
@@ -21,6 +21,12 @@
         <item name="android:background">@android:color/white</item>
     </style-->
 
+    <style name="ProgressDialog">
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColorHint">@android:color/darker_gray</item>
+        <item name="android:textColorPrimary">@android:color/black</item>
+    </style>
+
     <style name="PopupAnim">
         <item name="android:windowEnterAnimation">@anim/fade_in</item>
         <item name="android:windowExitAnimation">@anim/fade_out</item>


### PR DESCRIPTION
Fixes #575 adding the option to cancel downloading the keyboard catalog. (This action can take many seconds depending on user's network connection)

For now, we won't add this to other alert dialogs because #1316 will move all that activity to background tasks/notifications.

Screenshot shows the updated dialog
![loading catalog](https://user-images.githubusercontent.com/7358010/50596615-6e222600-0ed7-11e9-8c5b-21e74215f529.png)
