### PR TITLE
[web] Fix default mapping of external keyboard keys for "tab" and "backspace" in mobile apps

### DIFF
--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2019-01-04 11.0.2052 beta
+* Fixed external keyboard keys "tab" and "backspace" for embedded platforms (#1474)
+
 ## 2019-01-03 11.0.2051 beta
 * Add option to cancel when downloading the keyboard catalog (#1470)
 

--- a/web/history.md
+++ b/web/history.md
@@ -1,7 +1,15 @@
 # KeymanWeb Version History
 
 ## 2019-01-04 11.0.202 beta
-* Fixed external keyboard keys "tab" and "backspace" for embedded platforms (#1474)
+* Bug Fix:
+  * Fixed external keyboard keys "tab" and "backspace" for embedded platforms (#1474)
+
+## 2019-01-03 11.0.201 beta
+* New Feature:
+  * Adds the alignInputs() API function to facilitate touch-alias element work-arounds in case of future issues. (#69)
+
+* Bug Fix:
+  * Fix keyboard layer transition bug on mobile devices. (#978)
 
 ## 2019-01-02 11.0.200 beta
 * Initial beta release of KeymanWeb 11

--- a/web/history.md
+++ b/web/history.md
@@ -9,7 +9,7 @@
   * Adds the alignInputs() API function to facilitate touch-alias element work-arounds in case of future issues. (#69)
 
 * Bug Fix:
-  * Fix keyboard layer transition bug on mobile devices. (#978)
+  * Fixed keyboard layer transition bug on mobile devices. (#978)
 
 ## 2019-01-02 11.0.200 beta
 * Initial beta release of KeymanWeb 11

--- a/web/history.md
+++ b/web/history.md
@@ -1,11 +1,7 @@
 # KeymanWeb Version History
 
-## 2019-01-03 11.0.201 beta
-* New Feature:
-  * Adds the alignInputs() API function to facilitate touch-alias element work-arounds in case of future issues. (#69)
-  
-* Bug Fix:
-  * Fixed keyboard layer transition bug on mobile devices. (#978)
+## 2019-01-04 11.0.202 beta
+* Fixed external keyboard keys "tab" and "backspace" for embedded platforms (#1474)
 
 ## 2019-01-02 11.0.200 beta
 * Initial beta release of KeymanWeb 11

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -582,12 +582,17 @@
     if (code == osk.keyCodes.K_SPACE) {
         kbdInterface.output(0, Lelem, ' ');
         return true;
-    }
-    else if (code == osk.keyCodes.K_ENTER) {
+    } else if (code == osk.keyCodes.K_ENTER) {
         kbdInterface.output(0, Lelem, '\n');
         return true;
+    } else if (code == osk.keyCodes.K_TAB) {
+        kbdInterface.output(0, Lelem, '\t');
+        return true;
+    } else if (code == osk.keyCodes.K_BKSP) {
+        kbdInterface.defaultBackspace();
+        return true;
     }
-    var ch = osk.defaultKeyOutput(keyName, code, shift, false);
+    var ch = osk.defaultKeyOutput(keyName, code, shift, false, null);
     if(ch) {
         kbdInterface.output(0, Lelem, ch);
         return true;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -592,7 +592,7 @@
         kbdInterface.defaultBackspace();
         return true;
     }
-    var ch = osk.defaultKeyOutput(keyName, code, shift, false, null);
+    var ch = osk.defaultKeyOutput(keyName, code, shift, false, undefined);
     if(ch) {
         kbdInterface.output(0, Lelem, ch);
         return true;


### PR DESCRIPTION
Fixes #1473 by adding default handling of "tab" and "backspace" keys.

If there's keyboard rules for `K_TAB` or `K_BKSP`, they'll continue to be handled by KMW.

Otherwise, the default mapping inserts `\t` and default backspace respectively.