### PR TITLE
[iOS] System keyboard launching efficiency

### DIFF
--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "DaveWoodCom/XCGLogger" "6.1.0"
-github "dennisweissmann/DeviceKit" "1.10.0"
+github "dennisweissmann/DeviceKit" "1.11.0"
 github "marmelroy/Zip" "1.1.0"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -49,7 +49,8 @@ public enum Defaults {
 public enum Resources {
   /// Keyman Web resources
   public static let bundle: Bundle = {
-    let frameworkBundle =  Bundle(identifier: "org.sil.Keyman.ios.Engine")!
+    // If we're executing this code, KMEI's framework should already be loaded.  Just use that.
+    let frameworkBundle = Bundle(for: Manager.self) //Bundle(identifier: "org.sil.Keyman.ios.Engine")!
     return Bundle(path: frameworkBundle.path(forResource: "Keyman", ofType: "bundle")!)!
   }()
 

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2019 01-04 11.0.302 beta
+* Improves loading efficiency of system keyboard, helping prevent related crashes (#1169, #1170, #1172)
+
 ## 2019-01-02 11.0.300 beta
 * Initial beta release of Keyman for iPhone and iPad 11
 * [Pull Requests](https://github.com/keymanapp/keyman/pulls?utf8=%E2%9C%93&q=is%3Apr+merged%3A2018-07-01..2019-01-01+label%3Aios+-label%3Acherry-pick+-label%3Astable)

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,7 +1,7 @@
 # Keyman for iPhone and iPad Version History
 
 ## 2019 01-04 11.0.302 beta
-* Improves loading efficiency of system keyboard, helping prevent related crashes (#1169, #1170, #1172)
+* Improves loading efficiency of system keyboard, helping prevent related crashes (#1475)
 
 ## 2019-01-02 11.0.300 beta
 * Initial beta release of Keyman for iPhone and iPad 11


### PR DESCRIPTION
Addresses #1169, #1170, #1172.

One interesting detail I found while investigating #1169 was in regard to how KMEI loads data from its own bundle.  It was using its unique bundle identifier, corresponding to the following link's documentation:  https://developer.apple.com/documentation/foundation/bundle/1411929-init

Of particular note, under "Discussion":
> However, if the initial lookup of an already loaded and cached bundle with the specified identifier fails, this method uses potentially time-consuming heuristics to attempt to locate the bundle. 

Surely the framework's bundle is already loaded if we're executing `Manager` code?  `Manager` only exists within the bundle, after all.  Why search the system (what that API does) when we can retrieve it through the `Manager` type?  Hence the transition to the following API method:  https://developer.apple.com/documentation/foundation/bundle/1417717-init

Current results:

![image](https://user-images.githubusercontent.com/25213402/50628535-0e755a80-0f6b-11e9-84a4-7ad43c72aa39.png)

This is on the same testing device as this image on beta 11.0.200:

![image](https://user-images.githubusercontent.com/25213402/50624094-2a6b0300-0f4f-11e9-8a99-0d1acad83f05.png)

Note `[UIViewController loadViewIfRequired]` in particular - this portion of execution time was nearly halved!  

In all, this change appears to neuter the time required to retrieve KMEI's bundle, which appeared to be the single-largest time consumer for loading the system keyboard on live devices.  As best as I can tell, this also seems to have near-eliminated the time previously needed to retrieve the core KMW resources as well, though not the time necessary to copy them into app-extension space.  While I doubt this will end all related crashes, this should at least reduce their number and improve stability.