### PR TITLE
[common][linux] keyboardprocessor on xenial

### DIFF
--- a/common/engine/keyboardprocessor/tests/unit/kmx/meson.build
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/meson.build
@@ -86,8 +86,10 @@ if kmcomp.found()
   endforeach
 else
   foreach kbd : tests
-    kbd_src = files(kbd + '.kmn')
-    kbd_obj = files(kbd + '.kmx')
+    # meson 0.40 on xenial backports aborts if files used in args
+    # was e.g. kbd_src = files(kbd + '.kmn')
+    kbd_src = join_paths(meson.current_source_dir(),kbd) + '.kmn'
+    kbd_obj = join_paths(meson.current_source_dir(),kbd) + '.kmx'
 
     test(kbd, kmx, args: [kbd_src, kbd_obj])
   endforeach

--- a/common/engine/keyboardprocessor/tests/unit/kmx/meson.build
+++ b/common/engine/keyboardprocessor/tests/unit/kmx/meson.build
@@ -73,6 +73,8 @@ else
 endif
 
 if kmcomp.found()
+  # This is only expected to work in meson 0.48+
+  # so not on bionic or xenial without using pip
   foreach kbd : tests
     kbd_src = files(kbd + '.kmn')
     kbd_obj = join_paths(meson.current_source_dir(),kbd) + '.kmx'


### PR DESCRIPTION
xenial doesn't like files in args. This is meson 0.40 from xenial backports which the ppa can build with

Error message is:
"Command line arguments must be strings, files or targets"

even though the arguments are files()

This is kludgy so I hope there is a better way to fix this, but if not then there is this PR

Closes: #1476

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1477)
<!-- Reviewable:end -->
