### PR TITLE
[Windows] If a language was dynamically loaded by Windows, then the hotkey entry is never assigned when a keyboard is installed

### DIFF
--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -153,4 +153,4 @@ source the binary files from the https://github.com/keymanapp/CEF4Delphi_binary 
 The `KEYMAN_CEF4DELPHI_ROOT` environment variable should be set to the root of this
 repo on your local machine.
 
-Keyman Desktop does not depend on this component.
+Keyman Desktop does not currently depend on this component.

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,8 @@
 # Keyman Desktop Version History
 
+## 2019-01-04 11.0.1301.0 beta
+* Bug Fix: Hotkeys are now correctly assigned to keyboards when installed (#1485)
+
 ## 2019-01-02 11.0.1300.0 beta
 * Initial beta release of Keyman Desktop 11
 * [Pull Requests](https://github.com/keymanapp/keyman/pulls?utf8=%E2%9C%93&q=is%3Apr+merged%3A2018-07-01..2019-01-01+label%3Awindows+-label%3Acherry-pick+-label%3Astable)

--- a/windows/src/engine/kmcomapi/com/languages/keymanlanguages.pas
+++ b/windows/src/engine/kmcomapi/com/languages/keymanlanguages.pas
@@ -126,16 +126,16 @@ begin
         FWin8Language := nil;
         if FWin8Languages.IsSupported then
         begin
+          // Find the corresponding Win8 language registry entry
+          // If it is missing, it usually means the language is
+          // dynamically loaded, but even in that situation we can
+          // still provide information for hotkeys, etc
           for j := 0 to FWin8Languages.Count - 1 do
             if FWin8Languages[J].LangID = pLangID^ then
             begin
               FWin8Language := FWin8Languages[j];
               Break;
             end;
-
-          // Language is not installed, just loaded, so we ignore it
-          if FWin8Language = nil then
-            Continue;
         end;
 
         FProfileMgr.EnumProfiles(pLangID^, ppEnum);


### PR DESCRIPTION
Fixes #730