### PR TITLE
[linux] fix majorversion which broke download window

### DIFF
--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -8,13 +8,6 @@
 
 set -e
 
-# maybe don't need dev any more
-# from git can determine whether to use current tagnum or next
-# and whether to use current.datetime
-# see ../test.sh for script to bring in
-# maybe make it a function to get the minor number?
-
-
 BASEDIR=`pwd`
 echo "basedir is $BASEDIR"
 autotool_projects="kmflcomp libkmfl ibus-kmfl ibus-keyman"
@@ -66,11 +59,10 @@ for proj in ${extra_projects}; do
         meson ../common/engine/keyboardprocessor keyboardprocessor
     fi
     if [ "${proj}" == "keyman-config" ]; then
-        majorvers=`cat ../resources/VERSION.md`
         cd keyman-config
         make clean
         cd keyman_config
-        sed -e "s/_VERSION_/${newvers}/g" -e "s/_MAJORVERSION_/${majorvers}/g" version.py.in > version.py
+        sed -e "s/_VERSION_/${newvers}/g" -e "s/_MAJORVERSION_/${oldvers}/g" version.py.in > version.py
     fi
     cd $BASEDIR
 done


### PR DESCRIPTION
`oldvers` is the version that comes from resources/VERSION.md before `newvers` is put into that file
the majorversion is used in the URL used by the download window

Closes: #1486

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1490)
<!-- Reviewable:end -->
