### PR TITLE
[Developer] Creating a new project doesn't open it automatically.

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
@@ -16,7 +16,7 @@ uses
 
   Keyman.Developer.System.ImportWindowsKeyboard,
   Keyman.Developer.UI.Project.UfrmNewProjectParameters,
-  UfrmMain,
+  dmActionsMain,
   UfrmSelectSystemKeyboard;
 
 function ShowImportWindowsKeyboard(Owner: TComponent): Boolean;
@@ -81,7 +81,7 @@ begin
     f.Free;
   end;
 
-  frmKeymanDeveloper.OpenProject(ProjectFilename);
+  modActionsMain.OpenProject(ProjectFilename);
   Result := True;
 end;
 

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -366,7 +366,6 @@ type
     property ActiveChildIndex: Integer read GetActiveChildIndex write SetActiveChildIndex;
 
     function BeforeOpenProject: Boolean;
-    procedure OpenProject(const ProjectFilename: string);
     procedure ShowProject;
     function ProjectForm: TfrmProject;
     procedure ToggleProject;
@@ -1128,7 +1127,10 @@ begin
       ext := LowerCase(ExtractFileExt(FFileName));
 
       if ext = Ext_ProjectSource then
-        modActionsMain.OpenProject(FFileName)
+      begin
+        if BeforeOpenProject then
+          modActionsMain.OpenProject(FFileName);
+      end
       else
       begin
         if FCloseNewFile then
@@ -1183,22 +1185,6 @@ begin
       Exit(False);
 
   Result := True;
-end;
-
-procedure TfrmKeymanDeveloper.OpenProject(const ProjectFilename: string);
-var
-  i: Integer;
-begin
-  // Close child windows
-  for i := 0 to FChildWindows.Count - 1 do
-    FChildWindows[i].Close;
-
-  FGlobalProject.Save;
-  ProjectForm.Free;
-  FreeGlobalProjectUI;
-  LoadGlobalProjectUI('');
-  ShowProject;
-  UpdateCaption;
 end;
 
 function TfrmKeymanDeveloper.OpenEditor(FFileName: string; frmClass: TfrmTikeEditorClass): TfrmTikeEditor;
@@ -1385,7 +1371,10 @@ end;
 procedure TfrmKeymanDeveloper.mnuProjectRecentFileClick(Sender: TObject);
 begin
   with Sender as TMenuItem do
-    modActionsMain.OpenProject(Hint);
+  begin
+    if BeforeOpenProject then
+      modActionsMain.OpenProject(Hint);
+  end;
 end;
 
 procedure TfrmKeymanDeveloper.cbTextFileFormatItemClick(Sender: TObject);

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProject.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProject.pas
@@ -82,7 +82,7 @@ uses
   Keyman.Developer.UI.Project.ProjectUI,
   Keyman.Developer.UI.Project.UfrmNewProjectParameters,
   Keyman.Developer.UI.ImportWindowsKeyboardDialogManager,
-  UfrmMain,
+  dmActionsMain,
   utilsystem;
 
 function ShowNewProjectForm(Owner: TComponent): Boolean;
@@ -108,7 +108,7 @@ begin
       Result := ShowNewProjectParameters(Owner);
     kptBlank:
       begin
-        frmKeymanDeveloper.OpenProject('');
+        modActionsMain.OpenProject('');
         Result := True;
       end;
     kptImportWindowsKeyboard:

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -104,9 +104,9 @@ uses
 
   Keyman.System.LanguageCodeUtils,
   BCP47Tag,
-  UfrmMain,
   utilstr,
   utilsystem,
+  dmActionsMain,
   Keyman.Developer.System.HelpTopics,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.Project.ProjectFile,
@@ -143,9 +143,18 @@ begin
       kpt.Author := f.Author;
       kpt.Version := f.Version;
       kpt.BCP47Tags := f.BCP47Tags;
-      kpt.Generate;
 
-      frmKeymanDeveloper.OpenProject(kpt.ProjectFilename);
+      try
+        kpt.Generate;
+      except
+        on E:EFOpenError do
+        begin
+          ShowMessage('Unable to create project: '+E.Message);
+          Exit(False);
+        end;
+      end;
+
+      modActionsMain.OpenProject(kpt.ProjectFilename);
       Result := True;
 
     finally

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,11 +1,9 @@
 # Keyman Developer Version History
 
-## 2019-01-07 11.0.1302.0 beta
+## 2019-01-07 11.0.1301.0 beta
 * Bug fix: Developer does not open a new project after it is created (#1499)
 * Bug fix: Developer does not enable Install button in Package Editor after compile (#1498)
-
-## 2019-01-04 11.0.1301.0 beta
-* Bug Fix: Developer would sometimes ask for ethnologue.txt on upgrade (#1481)
+* Bug fix: Developer would sometimes ask for ethnologue.txt on upgrade (#1481)
 * Change: Options dialog Editor tab layout polished (#1482)
 
 ## 2019-01-02 11.0.1300.0 beta

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,9 @@
 # Keyman Developer Version History
 
+## 2019-01-07 11.0.1302.0 beta
+* Bug fix: Developer does not open a new project after it is created (#1499)
+* Bug fix: Developer does not enable Install button in Package Editor after compile (#1498)
+
 ## 2019-01-04 11.0.1301.0 beta
 * Bug Fix: Developer would sometimes ask for ethnologue.txt on upgrade (#1481)
 * Change: Options dialog Editor tab layout polished (#1482)


### PR DESCRIPTION
Fixes #1483. Also fixes a crash if project template files cannot be found (can usually only occur if running from source for debugging)