### PR TITLE
[Windows] Switching between Keyman keyboards in same language using TSF interface could fail

### DIFF
--- a/windows/src/engine/kmtip/keys.cpp
+++ b/windows/src/engine/kmtip/keys.cpp
@@ -57,12 +57,18 @@ BOOL CKMTipTextService::_InitKeystrokeSink()
     return FALSE;   // I3714 -> app hangs when switching kmtip off when keyman32 not loaded, due to not init.   // I3714
   }
 
+  if (_keystrokeSinkInitialized) {
+    _UninitKeystrokeSink();
+  }
+
+  _keystrokeSinkInitialized = FALSE;
+
   hr = _pThreadMgr->QueryInterface(IID_ITfKeystrokeMgr, (void **)&pKeystrokeMgr);
   if(hr!= S_OK) {
     DebugLastError0(L"QueryInterface(ITfKeystrokeMgr)", hr);
     return FALSE;
   }
-
+  
   hr = pKeystrokeMgr->AdviseKeyEventSink(_tfClientId, (ITfKeyEventSink *)this, TRUE);
   if (hr != S_OK) {
     DebugLastError0(L"AdviseKeyEventSink", hr);
@@ -72,7 +78,7 @@ BOOL CKMTipTextService::_InitKeystrokeSink()
 
 	memset(fEatenBuf, 0, sizeof(fEatenBuf));
 
-  return (hr == S_OK);
+  return _keystrokeSinkInitialized = (hr == S_OK);
 }
 
 BOOL CKMTipTextService::_InitPreservedKeys() {   // I4274

--- a/windows/src/engine/kmtip/kmtip.h
+++ b/windows/src/engine/kmtip/kmtip.h
@@ -119,6 +119,7 @@ private:
 
     GUID guidActiveProfile;   // I4274
 
+    BOOL _keystrokeSinkInitialized;
     BOOL fEatenBuf[256];
 
     HMODULE _hKeyman;


### PR DESCRIPTION
The switch could fail when attempting to initialize the keystroke sink, because it is already initialized,
because TSF does not deactivate the TIP when switching between different registered profiles with the same
TIP CLSID.