### PR TITLE
[Android] Improve font handling

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -301,6 +301,9 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       if (jsonFont != null) {
         findTTF(jsonFont);
       }
+      if (jsonOskFont != null) {
+        findTTF(jsonOskFont);
+      }
       ArrayList<String> fontUrls = fontUrls(jsonFont, fontBaseUri, true);
       ArrayList<String> oskFontUrls = fontUrls(jsonOskFont, fontBaseUri, true);
       if (fontUrls != null)

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -613,17 +613,16 @@ public final class KMManager {
   public static Typeface getFontTypeface(Context context, String fontFilename) {
     Typeface font = null;
 
-    if (fontFilename != null) {
-      if (FileUtils.hasFontExtension(fontFilename)) {
+    try {
+      if ((fontFilename != null) && FileUtils.hasFontExtension(fontFilename)) {
         File file = new File(fontFilename);
         if (file.exists()) {
           font = Typeface.createFromFile(file);
-        } else {
-          font = null;
         }
       }
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to create Typeface: " + fontFilename);
     }
-
     return font;
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -242,6 +242,11 @@ public final class FileUtils {
     return f.endsWith(KEYBOARDPACKAGE);
   }
 
+  public static boolean isTTFFont(String filename) {
+    String f = filename.toLowerCase();
+    return f.endsWith(TRUETYPEFONT);
+  }
+
   public static boolean isWelcomeFile(String filename) {
     String f = getFilename(filename);
     return f.equalsIgnoreCase(WELCOME_HTM);

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -108,6 +108,21 @@ public class FileUtilsTest {
   }
 
   @Test
+  public void test_isTTFFont() {
+    String filename = "test/abc.ttf";
+    Assert.assertTrue(FileUtils.isTTFFont(filename));
+
+    filename = "test/abc.TTF";
+    Assert.assertTrue(FileUtils.isTTFFont(filename));
+
+    filename = "test/abc.ttfo";
+    Assert.assertFalse(FileUtils.isTTFFont(filename));
+
+    filename = "";
+    Assert.assertFalse(FileUtils.isTTFFont(filename));
+  }
+
+  @Test
   public void test_isWelcomeFile() {
     String filename = "test/welcome.htm";
     Assert.assertTrue(FileUtils.isWelcomeFile(filename));

--- a/android/history.md
+++ b/android/history.md
@@ -1,9 +1,10 @@
 # Keyman for Android
 
-## 2019-01-05 11.0.2053 beta
-* Fix default handling of 102nd key found on European hardware keyboards (#1491)
+## 2019-01-09 11.0.2053 beta
+* Fix crash involving certain fonts. Prioritize using .ttf font in keyboards (#1507)
 
 ## 2019-01-04 11.0.2052 beta
+* Fix default handling of 102nd key found on European hardware keyboards (#1491)
 * Fixed external keyboard keys "tab" and "backspace" for embedded platforms (#1474)
 
 ## 2019-01-03 11.0.2051 beta


### PR DESCRIPTION
This PR addresses two issues in how Keyman for Android handles fonts:
gff_amharic keyboard lists associated fonts in this order:
```
          "wookianos.woff",
          "wookianos.ttf",
          "wookianos.mobileconfig",
          "ETHIOPI0.eot"
```
and the current Android app just grabs the first one (.woff) when making the Typeface in the WebView.

1. Fixes #1478 where certain Android SDK levels crash when attempting to create a Typeface from a .woff font
This could be replicated in an emulator of SDK level 15 and attempting to download the Amharic keyboard.

2. When downloading keyboard that lists multiple fonts, choose the .ttf if available