### PR TITLE
[Windows] kmshell now only checks for damaged profiles when starting Configuration or Keyman itself

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,8 @@
 # Keyman Desktop Version History
 
+## 2019-01-09 11.0.1302.0 beta
+* Bug Fix: Keyman can no longer show a "Damaged Profile" dialog box during silent installs (#1508)
+
 ## 2019-01-07 11.0.1301.0 beta
 * Bug Fix: Hotkeys are now correctly assigned to keyboards when installed (#1485)
 * Change: Removed legacy API: Keyman_BuildKeyboardList, Keyman_GetAPIVersion, GetKeymanKeyboardInfo, GetKeymanInfo, GetSystemStore (#1503)

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -356,7 +356,7 @@ begin
       Exit;
   end;
 
-  if not FSilent and (FMode <> fmRepair) then   // I4773
+  if not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout]) then   // I4773
   begin
     if not TKeyboardTIPCheck.CheckKeyboardTIPInstallStatus then
     begin


### PR DESCRIPTION
Fixes #187