### PR TITLE
[LMLayer] Upgrade to karma-browserstack-launcher@^1.4.0.

### DIFF
--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -247,9 +247,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "version": "1.6.40",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
+      "integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ==",
       "dev": true
     },
     "binary": {
@@ -355,50 +355,12 @@
       "dev": true
     },
     "browserstack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz",
-      "integrity": "sha1-tWVCWtYu1ywQgqHrl51TE8fUdU8=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.1.tgz",
+      "integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-          "dev": true,
-          "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-          "dev": true,
-          "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
-          }
-        },
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "browserstacktunnel-wrapper": {
@@ -2120,13 +2082,13 @@
       }
     },
     "karma-browserstack-launcher": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.3.0.tgz",
-      "integrity": "sha512-LrPf5sU/GISkEElWyoy06J8x0c8BcOjjOwf61Wqu6M0aWQu0Eoqm9yh3xON64/ByST/CEr0GsWiREQ/EIEMd4Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.4.0.tgz",
+      "integrity": "sha512-bUQK84U+euDfOUfEjcF4IareySMOBNRLrrl9q6cttIe8f011Ir6olLITTYMOJDcGY58wiFIdhPHSPd9Pi6+NfQ==",
       "dev": true,
       "requires": {
-        "browserstack": "1.5.0",
-        "browserstacktunnel-wrapper": "~2.0.1",
+        "browserstack": "~1.5.1",
+        "browserstacktunnel-wrapper": "~2.0.2",
         "q": "~1.5.0"
       }
     },
@@ -3450,9 +3412,9 @@
       }
     },
     "unzipper": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.4.tgz",
-      "integrity": "sha512-kGrkTaphmXE+0/A5Q7rwcm/xHlDkXDOGEh6wuiN3SUQsyVWd7V51rwqttlNTT91JrLkfn34MoBNf38unF0vhRw==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.7.tgz",
+      "integrity": "sha512-icFtME1RD648v+cjfcUWoky4bHbMTi8nk06nGxH77EPYyEeKaTgT3nRHM/dQ3znGXLi3+OlhYo86zQzNBRdNhw==",
       "dev": true,
       "requires": {
         "big-integer": "^1.6.17",

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^10.12.11",
     "chai": "^4.2.0",
     "karma": "^3.1.3",
-    "karma-browserstack-launcher": "^1.3.0",
+    "karma-browserstack-launcher": "^1.4.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-edge-launcher": "^0.4.2",


### PR DESCRIPTION
The `npm audit` was upset with a transitive dependency of `karma-browserstack-launcher`, so I updated it to the latest version.