### PR TITLE
[Android] Fix "Get Started" status for default keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -188,6 +188,6 @@ public class GetStartedActivity extends AppCompatActivity {
 
   protected static boolean isDefaultKB(Context context) {
     String inputMethod = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
-    return inputMethod.equals("com.tavultesoft.kmapro/com.keyman.android.SystemKeyboard");
+    return inputMethod.equals(context.getPackageName() + "/com.keyman.android.SystemKeyboard");
   }
 }


### PR DESCRIPTION
Fixes #1511 

Engineering builds of the app append `.debug` to the package name.
This caused the "Get Started" --> Default keyboard status not to update.

Screenshot with the fix
![get started](https://user-images.githubusercontent.com/7358010/50884412-699cc680-141d-11e9-9c1c-8497b1ca7ee1.png)
