### PR TITLE
[linux] build ibus-keyman on xenial

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -3,6 +3,7 @@
 ## 2019-01-10 11.0.105 beta
 * add icons for km-config and .kmp files (#1495)
 * restart ibus as user (#1510)
+* build on xenial (#1518,#1477)
 
 ## 2019-01-02 11.0.100 beta
 * Initial beta release of Keyman for Linux

--- a/linux/ibus-keyman/configure.ac
+++ b/linux/ibus-keyman/configure.ac
@@ -58,10 +58,15 @@ PKG_CHECK_MODULES(GTK, [
     gtk+-3.0 >= 2.4
 ])
 
+# check atkspi 2.0
+#PKG_CHECK_MODULES(ATSPI, [
+#    atspi-2 >= 2.0
+#])
+
 
 # check Json glib
 PKG_CHECK_MODULES(JSON_GLIB, [
-    json-glib-1.0 >= 1.4.0
+    json-glib-1.0 >= 1.0
 ])
 
 # check Keyman keyboard processor


### PR DESCRIPTION
reduce the version dependency on json-glib-1.0 to 1.0 so that it will build with the version in xenial

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1518)
<!-- Reviewable:end -->
