### PR TITLE
[Android] Change keyboard version comparison from Float to strings

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -789,14 +789,12 @@ public final class KMManager {
         String kbKey = String.format("%s_%s", languageID, keyboardID);
         HashMap<String, String> kbInfo = keyboardsInfo.get(kbKey);
         String kbVersion = "1.0";
-        if (kbInfo != null)
+        if (kbInfo != null) {
           kbVersion = kbInfo.get(KMManager.KMKey_KeyboardVersion);
+        }
 
-        try {
-          if (kbVersion != null && compareVersions(kbVersion, latestVersion) > 0)
-            kbState = KeyboardState.KEYBOARD_STATE_NEEDS_UPDATE;
-        } catch (Exception e) {
-          Log.e("KMManager", "getKeyboardState Error: " + e);
+        if (kbVersion != null && (FileUtils.compareVersions(kbVersion, latestVersion) == FileUtils.VERSION_GREATER)) {
+          kbState = KeyboardState.KEYBOARD_STATE_NEEDS_UPDATE;
         }
       }
     }
@@ -848,10 +846,10 @@ public final class KMManager {
           int lastIndex = filename.toLowerCase().lastIndexOf(".js");
           String v = filename.substring(firstIndex, lastIndex);
           if (kbFileVersion != null) {
-            if (compareVersions(v, kbFileVersion) > 0) {
+            if (FileUtils.compareVersions(v, kbFileVersion) == FileUtils.VERSION_GREATER) {
               kbFileVersion = v;
             }
-          } else if (compareVersions(v, v) == 0) {
+          } else if (FileUtils.compareVersions(v, v) == FileUtils.VERSION_EQUAL) {
             kbFileVersion = v;
           }
         }
@@ -874,146 +872,6 @@ public final class KMManager {
     }
 
     return kbFileVersion;
-  }
-
-  /**
-   * Compare two version strings
-   * @param v1 String
-   * @param v2 String
-   * @return int
-   *   -2 if v1 or v2 is invalid
-   *    0 if v1 = v2
-   *   -1 if v1 < v2
-   *    1 if v1 > v2
-   */
-  public static int compareVersions(String v1, String v2) {
-    // returns;
-
-    if (v1 == null || v2 == null) {
-      return -2;
-    }
-
-    if (v1.isEmpty() || v2.isEmpty()) {
-      return -2;
-    }
-
-    String[] v1Values = v1.split("\\.");
-    String[] v2Values = v2.split("\\.");
-
-    int len = (v1Values.length >= v2Values.length ? v1Values.length : v2Values.length);
-    for (int i = 0; i < len; i++) {
-      String vStr1 = "0";
-      if (i < v1Values.length) {
-        vStr1 = v1Values[i];
-      }
-
-      String vStr2 = "0";
-      if (i < v2Values.length) {
-        vStr2 = v2Values[i];
-      }
-
-      Integer vInt1 = parseInteger(vStr1);
-      Integer vInt2 = parseInteger(vStr2);
-      int iV1, iV2, iV1_, iV2_;
-
-      if (vInt1 != null) {
-        iV1 = vInt1.intValue();
-        iV1_ = 0;
-      } else {
-        iV1 = 0;
-        iV1_ = 0;
-      }
-
-      if (vInt2 != null) {
-        iV2 = vInt2.intValue();
-        iV2_ = 0;
-      } else {
-        iV2 = 0;
-        iV2_ = 0;
-      }
-
-      if (vInt1 == null) {
-        if (i != (v1Values.length - 1)) {
-          return -2;
-        }
-
-        if (vStr1.toLowerCase().endsWith("b")) {
-          Integer vInt1_ = parseInteger(vStr1.substring(0, vStr1.length() - 1));
-          if (vInt1_ == null) {
-            return -2;
-          }
-
-          iV1 = vInt1_.intValue();
-          iV1_ = -100;
-        } else if (vStr1.toLowerCase().endsWith("a")) {
-          Integer vInt1_ = parseInteger(vStr1.substring(0, vStr1.length() - 1));
-          if (vInt1_ == null) {
-            return -2;
-          }
-
-          iV1 = vInt1_.intValue();
-          iV1_ = -200;
-        } else {
-          return -2;
-        }
-      }
-
-      if (vInt2 == null) {
-        if (i != (v2Values.length - 1)) {
-          return -2;
-        }
-
-        if (vStr2.toLowerCase().endsWith("b")) {
-          Integer vInt2_ = parseInteger(vStr2.substring(0, vStr2.length() - 1));
-          if (vInt2_ == null) {
-            return -2;
-          }
-
-          iV2 = vInt2_.intValue();
-          iV2_ = -100;
-        } else if (vStr2.toLowerCase().endsWith("a")) {
-          Integer vInt2_ = parseInteger(vStr2.substring(0, vStr2.length() - 1));
-          if (vInt2_ == null) {
-            return -2;
-          }
-
-          iV2 = vInt2_.intValue();
-          iV2_ = -200;
-        } else {
-          return -2;
-        }
-      }
-
-      if (iV1 == iV2) {
-        if (iV1_ == iV2_) {
-          continue;
-        }
-        if (iV1_ < iV2_) {
-          return -1;
-        }
-        if (iV1_ > iV2_) {
-          return 1;
-        }
-      } else if (iV1 < iV2) {
-        return -1;
-      } else if (iV1 > iV2) {
-        return 1;
-      }
-    }
-
-    return 0;
-  }
-
-  private static Integer parseInteger(String s) {
-    Integer retVal = null;
-    try {
-      int i = Integer.parseInt(s);
-      retVal = new Integer(i);
-    } catch (Exception e) {
-      retVal = null;
-    }
-
-    return retVal;
   }
 
   public static void addKeyboardEventListener(OnKeyboardEventListener listener) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -603,11 +603,12 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
                 keyboardVersions.put(kbKey, newKbVersion);
               }
 
-              if (Float.valueOf(newKbVersion) > Float.valueOf(kbVersion)) {
+              if (FileUtils.compareVersions(newKbVersion, kbVersion) == FileUtils.VERSION_GREATER) {
                 ret++;
               }
             }
           } catch (Exception e) {
+            Log.e("KeyboardPickerActivity", "Failed to compare keyboard version. Error: " + e);
             keyboardVersions = null;
             ret = -1;
           }
@@ -654,7 +655,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
                   String newKbVersion = keyboardVersions.get(kbKey);
                   if (newKbVersion != null) {
                     keyboardVersions.put(kbKey, newKbVersion);
-                    if (Float.valueOf(newKbVersion) > Float.valueOf(kbVersion)) {
+                    if (FileUtils.compareVersions(newKbVersion, kbVersion) == FileUtils.VERSION_GREATER) {
                       if (updateProgress == null || !updateProgress.isShowing()) {
                         updateProgress = new ProgressDialog(context);
                         updateProgress.setMessage(context.getString(R.string.updating_keyboards));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -244,9 +244,9 @@ public class PackageProcessor {
       JSONObject oldInfoJSON = loadPackageInfo(oldPath);
       String originalVersion = getPackageVersion(oldInfoJSON);
 
-      if(KMManager.compareVersions(newVersion, originalVersion) == 1) {
+      if(FileUtils.compareVersions(newVersion, originalVersion) == FileUtils.VERSION_GREATER) {
         return 1;
-      } else if(KMManager.compareVersions(newVersion, originalVersion) == 0){
+      } else if(FileUtils.compareVersions(newVersion, originalVersion) == FileUtils.VERSION_EQUAL){
         return 0;
       } else {
         return -1;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -25,6 +25,11 @@ public final class FileUtils {
   public static final int DOWNLOAD_ERROR = -1;
   public static final int DOWNLOAD_SUCCESS = 1;
 
+  public static final int VERSION_INVALID = -2;
+  public static final int VERSION_EQUAL = 0;
+  public static final int VERSION_LOWER = -1;
+  public static final int VERSION_GREATER = 1;
+
   // File extensions and file types
   public static final String JAVASCRIPT = ".js";
   public static final String TRUETYPEFONT = ".ttf";
@@ -214,6 +219,147 @@ public final class FileUtils {
       filename = urlStr.substring(urlStr.lastIndexOf('/') + 1);
     }
     return filename;
+  }
+
+  /**
+   * Utility to compare two version strings
+   * @param v1 String
+   * @param v2 String
+   * @return int
+   *   -2 if v1 or v2 is invalid
+   *    0 if v1 = v2
+   *   -1 if v1 < v2
+   *    1 if v1 > v2
+   */
+  public static int compareVersions(String v1, String v2) {
+    // returns;
+
+    if (v1 == null || v2 == null) {
+      return VERSION_INVALID;
+    }
+
+    if (v1.isEmpty() || v2.isEmpty()) {
+      return VERSION_INVALID;
+    }
+
+    String[] v1Values = v1.split("\\.");
+    String[] v2Values = v2.split("\\.");
+
+    int len = (v1Values.length >= v2Values.length ? v1Values.length : v2Values.length);
+    for (int i = 0; i < len; i++) {
+      String vStr1 = "0";
+      if (i < v1Values.length) {
+        vStr1 = v1Values[i];
+      }
+
+      String vStr2 = "0";
+      if (i < v2Values.length) {
+        vStr2 = v2Values[i];
+      }
+
+      Integer vInt1 = parseInteger(vStr1);
+      Integer vInt2 = parseInteger(vStr2);
+      int iV1, iV2, iV1_, iV2_;
+
+      if (vInt1 != null) {
+        iV1 = vInt1.intValue();
+        iV1_ = 0;
+      } else {
+        iV1 = 0;
+        iV1_ = 0;
+      }
+
+      if (vInt2 != null) {
+        iV2 = vInt2.intValue();
+        iV2_ = 0;
+      } else {
+        iV2 = 0;
+        iV2_ = 0;
+      }
+
+      if (vInt1 == null) {
+        if (i != (v1Values.length - 1)) {
+          return VERSION_INVALID;
+        }
+
+        if (vStr1.toLowerCase().endsWith("b")) {
+          Integer vInt1_ = parseInteger(vStr1.substring(0, vStr1.length() - 1));
+          if (vInt1_ == null) {
+            return VERSION_INVALID;
+          }
+
+          iV1 = vInt1_.intValue();
+          iV1_ = -100;
+        } else if (vStr1.toLowerCase().endsWith("a")) {
+          Integer vInt1_ = parseInteger(vStr1.substring(0, vStr1.length() - 1));
+          if (vInt1_ == null) {
+            return VERSION_INVALID;
+          }
+
+          iV1 = vInt1_.intValue();
+          iV1_ = -200;
+        } else {
+          return VERSION_INVALID;
+        }
+      }
+
+      if (vInt2 == null) {
+        if (i != (v2Values.length - 1)) {
+          return VERSION_INVALID;
+        }
+
+        if (vStr2.toLowerCase().endsWith("b")) {
+          Integer vInt2_ = parseInteger(vStr2.substring(0, vStr2.length() - 1));
+          if (vInt2_ == null) {
+            return VERSION_INVALID;
+          }
+
+          iV2 = vInt2_.intValue();
+          iV2_ = -100;
+        } else if (vStr2.toLowerCase().endsWith("a")) {
+          Integer vInt2_ = parseInteger(vStr2.substring(0, vStr2.length() - 1));
+          if (vInt2_ == null) {
+            return VERSION_INVALID;
+          }
+
+          iV2 = vInt2_.intValue();
+          iV2_ = -200;
+        } else {
+          return VERSION_INVALID;
+        }
+      }
+
+      if (iV1 == iV2) {
+        if (iV1_ == iV2_) {
+          continue;
+        }
+        if (iV1_ < iV2_) {
+          return VERSION_LOWER;
+        }
+        if (iV1_ > iV2_) {
+          return VERSION_GREATER;
+        }
+      } else if (iV1 < iV2) {
+        return VERSION_LOWER;
+      } else if (iV1 > iV2) {
+        return VERSION_GREATER;
+      }
+    }
+
+    return VERSION_EQUAL;
+  }
+
+  private static Integer parseInteger(String s) {
+    Integer retVal = null;
+    try {
+      int i = Integer.parseInt(s);
+      retVal = new Integer(i);
+    } catch (Exception e) {
+      Log.e("FileUtils", "parseInteger Error: " + e);
+      retVal = null;
+    }
+
+    return retVal;
   }
 
   /**

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -12,6 +12,41 @@ import org.robolectric.RobolectricTestRunner;
 public class FileUtilsTest {
 
   @Test
+  public void test_compareVersions() {
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions(null, "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("" , "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("1.0", null));
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("1.0", ""));
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions(null, null));
+    Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("", ""));
+
+    Assert.assertEquals(FileUtils.VERSION_EQUAL, FileUtils.compareVersions("0.1", "0.1"));
+    Assert.assertEquals(FileUtils.VERSION_EQUAL, FileUtils.compareVersions("1.0", "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_EQUAL, FileUtils.compareVersions("1.0a", "1.0a"));
+    Assert.assertEquals(FileUtils.VERSION_EQUAL, FileUtils.compareVersions("1.0.1", "1.0.1"));
+
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("-1.0", "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("0", "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("0.1", "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("1.0", "1.0.1"));
+
+    // 1.0 alpha < 1.0 beta < 1.0
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("1.0a", "1.0b"));
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("1.0a", "1.0"));
+    Assert.assertEquals(FileUtils.VERSION_LOWER, FileUtils.compareVersions("1.0b", "1.0"));
+
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0", "-1.0"));
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0", "0"));
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0", "0.1"));
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0.1", "1.0"));
+
+    // 1.0 > 1.0 beta > 1.0 alpha
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0", "1.0b"));
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0", "1.0a"));
+    Assert.assertEquals(FileUtils.VERSION_GREATER, FileUtils.compareVersions("1.0b", "1.0a"));
+  }
+
+  @Test
   public void test_hasFontExtension() {
     String filename = "test/abc.ttf";
     Assert.assertTrue(FileUtils.hasFontExtension(filename));

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,8 @@
 # Keyman for Android
 
+## 2019-01-11 11.0.2055 beta
+* Fix keyboard version comparison that was causing "Unable to contact Keyman server" notifications (#1520)
+
 ## 2019-01-10 11.0.2054 beta
 * Fix "Get Started" default keyboard status on engineering builds (#1515)
 


### PR DESCRIPTION
Fixes #1512 

Currently, keyboard versions as floats are compared for determining when to update the keyboard.
This doesn't work for the current default keyboard sil_euro_latin version 1.8.1

* Move compareVersions() from KMManager to FileUtils
