### PR TITLE
[linux] more on restarting ibus

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -2,7 +2,7 @@
 
 ## 2019-01-10 11.0.105 beta
 * add icons for km-config and .kmp files (#1495)
-* restart ibus as user (#1510)
+* restart ibus as user and on gnome-shell (#1510,#1521)
 * build on xenial (#1518,#1477)
 
 ## 2019-01-02 11.0.100 beta

--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -6,18 +6,18 @@ case "$1" in
 
   configure)
     # Restart IBus if it is running
-    ! ibuspid=`ps -C ibus-daemon -o pid=`
+    ! ibuspid=`ps -C ibus-daemon -o pid=|head -n 1`
 
     if [ "x$ibuspid" != "x" ]; then
       # check for gnome-shell as it works differently
-      ! gspid=`ps -C gnome-shell -o pid=`
-      if [ "x$gspid" == "x" ]; then
-        ibususer=`ps -C ibus-daemon -o user=`
-        sudo -H -u "$ibususer" ibus restart
-      else
+      ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
+      if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
         sudo -H -u "$ibususer" ibus exit
+      else
+        ibususer=`ps -C ibus-daemon -o user=`
+        sudo -H -u "$ibususer" ibus restart
       fi
     fi
   ;;

--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -9,8 +9,16 @@ case "$1" in
     ! ibuspid=`ps -C ibus-daemon -o pid=`
 
     if [ "x$ibuspid" != "x" ]; then
-      ibususer=`ps -C ibus-daemon -o user=`
-      sudo -u "$ibususer" ibus restart
+      # check for gnome-shell as it works differently
+      ! gspid=`ps -C gnome-shell -o pid=`
+      if [ "x$gspid" == "x" ]; then
+        ibususer=`ps -C ibus-daemon -o user=`
+        sudo -H -u "$ibususer" ibus restart
+      else
+        # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
+        ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
+        sudo -H -u "$ibususer" ibus exit
+      fi
     fi
   ;;
 

--- a/linux/ibus-keyman/debian/postrm
+++ b/linux/ibus-keyman/debian/postrm
@@ -6,18 +6,18 @@ case "$1" in
 
   remove)
     # Restart IBus if it is running
-    ! ibuspid=`ps -C ibus-daemon -o pid=`
+    ! ibuspid=`ps -C ibus-daemon -o pid=|head -n 1`
 
     if [ "x$ibuspid" != "x" ]; then
       # check for gnome-shell as it works differently
-      ! gspid=`ps -C gnome-shell -o pid=`
-      if [ "x$gspid" == "x" ]; then
-        ibususer=`ps -C ibus-daemon -o user=`
-        sudo -H -u "$ibususer" ibus restart
-      else
+      ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
+      if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
         sudo -H -u "$ibususer" ibus exit
+      else
+        ibususer=`ps -C ibus-daemon -o user=`
+        sudo -H -u "$ibususer" ibus restart
       fi
     fi
   ;;

--- a/linux/ibus-keyman/debian/postrm
+++ b/linux/ibus-keyman/debian/postrm
@@ -9,8 +9,16 @@ case "$1" in
     ! ibuspid=`ps -C ibus-daemon -o pid=`
 
     if [ "x$ibuspid" != "x" ]; then
-      ibususer=`ps -C ibus-daemon -o user=`
-      sudo -u "$ibususer" ibus restart
+      # check for gnome-shell as it works differently
+      ! gspid=`ps -C gnome-shell -o pid=`
+      if [ "x$gspid" == "x" ]; then
+        ibususer=`ps -C ibus-daemon -o user=`
+        sudo -H -u "$ibususer" ibus restart
+      else
+        # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
+        ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
+        sudo -H -u "$ibususer" ibus exit
+      fi
     fi
   ;;
 


### PR DESCRIPTION
This time do things differently on gnome-shell
It needs to run `ibus exit` instead of `ibus restart`
check just 1 pid
sudo -H to get the right user environment for running ibus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/1521)
<!-- Reviewable:end -->
