### PR TITLE
[LMLayer] Implement Dummy language model + refactorings

### DIFF
--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -45,7 +45,8 @@ class LMLayer {
    */
   private _worker: Worker;
   /** Call this when the LMLayer has sent us the 'ready' message! */
-  private _declareLMLayerReady: (Configuration) => void;
+  private _declareLMLayerReady: (conf: Configuration) => void;
+  private _promises: PromiseStore<any>;
 
   /**
    * Construct the top-level LMLayer interface. This also starts the underlying Worker.
@@ -59,6 +60,7 @@ class LMLayer {
     this._worker = worker || new Worker(LMLayer.asBlobURI(LMLayerWorkerCode));
     this._worker.onmessage = this.onMessage.bind(this)
     this._declareLMLayerReady = null;
+    this._promises = new PromiseStore;
   }
 
   /**
@@ -84,7 +86,7 @@ class LMLayer {
       this._worker.postMessage({
         message: 'predict',
         transform: transform,
-        context: context
+        context: context,
         // TODO: tokens! implement the PromiseStore:
         // https://github.com/eddieantonio/keyman-lmlayer-prototype/blob/f8e6268b03190d08cf5d35f9428cf9150d6d219e/index.ts#L133-L186
       });
@@ -137,10 +139,6 @@ class LMLayer {
   }
 }
 
-/**
- * Shh! Tokens are just signed 31-bit integers!
- */
-type Token = number;
 type Resolve<T> = (value?: T | PromiseLike<T>) => void;
 type Reject = (reason?: any) => void;
 interface PromiseCallbacks<T> {

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -164,6 +164,13 @@ class PromiseStore<T> {
   }
 
   /**
+   * How many promises are currently being tracked?
+   */
+  get length(): number {
+    return this._promises.size;
+  }
+
+  /**
    * Associate a token with its respective resolve and reject callbacks.
    */
   make(token: Token, resolve: Resolve<T>, reject: Reject): void {

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -79,8 +79,17 @@ class LMLayer {
     });
   }
 
-  // TODO: asynchronous predict() method, based on 
-  //       https://github.com/eddieantonio/keyman-lmlayer-prototype/blob/f8e6268b03190d08cf5d35f9428cf9150d6d219e/index.ts#L64-L80
+  predict(transform: Transform, context: Context): Promise<Suggestion[]> {
+    return new Promise((resolve, _reject) => {
+      this._worker.postMessage({
+        message: 'predict',
+        transform: transform,
+        context: context
+        // TODO: tokens! implement the PromiseStore:
+        // https://github.com/eddieantonio/keyman-lmlayer-prototype/blob/f8e6268b03190d08cf5d35f9428cf9150d6d219e/index.ts#L133-L186
+      });
+    });
+  }
 
   // TODO: asynchronous close() method.
   //       Worker code must recognize message and call self.close().

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -90,3 +90,84 @@ interface Configuration {
    */
   rightContextCodeUnits: number;
 }
+
+/**
+ * Describes how to change a buffer at the cursor position.
+ * first, you delete the specified amount amount from the left
+ * and right, then you insert the provided text.
+ */
+interface Transform {
+  /**
+   * The Unicode scalar values (i.e., characters) to be inserted at the
+   * cursor position.
+   *
+   * Corresponds to `s` in com.keyman.KeyboardInterface.output.
+   */
+  insert: USVString;
+
+  /**
+   * The number of code units to delete to the left of the cursor.
+   *
+   * Corresponds to `dn` in com.keyman.KeyboardInterface.output.
+   */
+  deleteLeft: number;
+
+  /**
+   * The number of code units to delete to the right of the cursor.
+   * Not available on all platforms.
+   */
+  deleteRight?: number;
+}
+
+/**
+ * The text and environment surrounding the insertion point (text cursor).
+ */
+interface Context {
+  /**
+   * Up to maxLeftContextCodeUnits code units of Unicode scalar value
+   * (i. e., characters) to the left of the insertion point in the
+   * buffer. If there is nothing to the left of the buffer, this is
+   * an empty string.
+   */
+  left: USVString;
+
+  /**
+   * Up to maxRightContextCodeUnits code units of Unicode scalar value
+   * (i. e., characters) to the right of the insertion point in the
+   * buffer. If there is nothing to the right of the buffer, this is
+   * an empty string.
+   * 
+   * This property may be missing entirely.
+   */
+  right?: USVString;
+
+  /**
+   * Whether the insertion point is at the start of the buffer.
+   */
+  startOfBuffer: boolean;
+
+  /**
+   * Whether the insertion point is at the end of the buffer.
+   */
+  endOfBuffer: boolean;
+}
+
+/**
+ * A concrete suggestion
+ */
+interface Suggestion {
+  /**
+   * The suggested update to the buffer. Note that this transform should
+   * be applied AFTER the instigating transform, if any.
+   */
+  transform: Transform;
+
+  /**
+   * A string to display the suggestion to the typist.
+   * This should aid the typist understand what the transform
+   * will do to their text.
+   * 
+   * When suggesting a word, `displayAs` should be that entire word.
+   */
+  displayAs: string;
+}

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -39,6 +39,40 @@ type USVString = string;
 type Token = number;
 
 /**
+ * The valid outgoing message kinds.
+ */
+type OutgoingMessageKind = 'ready' | 'suggestions';
+type OutgoingMessage = ReadyMessage | SuggestionMessage;
+
+/**
+ * Tells the keyboard that the LMLayer is ready. Provides
+ * negotiated configuration.
+ */
+interface ReadyMessage {
+  message: 'ready';
+  configuration: Configuration;
+}
+
+/**
+ * Sends the keyboard an ordered list of suggestions.
+ */
+interface SuggestionMessage {
+  message: 'suggestions';
+
+  /**
+   * Opaque, unique token that pairs this suggestions message
+   * with the predict message that initiated it.
+   */
+  token: Token;
+
+  /**
+   * Ordered array of suggestions, most probable first, least
+   * probable last.
+   */
+  suggestions: Suggestion[];
+}
+
+/**
  * Describes the capabilities of the keyboard's platform.
  * This includes upper bounds for how much text will be sent on each
  * prediction, as well as what operations the keyboard is allowed to do on the

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -33,6 +33,10 @@
  */	
 type USVString = string;
 
+/**
+ * Tokens are signed 31-bit integers!
+ */
+type Token = number;
 
 /**
  * Describes the capabilities of the keyboard's platform.

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -61,8 +61,13 @@ interface Capabilities {
   supportsDeleteRight?: false,
 }
 
-// TODO: Define what a valid model description is!
-interface ModelDescription {}
+/**
+ * TODO: discriminated union of different model types.
+ */
+interface ModelDescription {
+  type: 'dummy';
+  futureSuggestions?: Suggestion[][];
+}
 
 /**
  * Configuration of the LMLayer, sent back to the keyboard.

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -85,7 +85,7 @@ interface Configuration {
    *
    * Affects the `context` property sent in `predict` messages.
    *
-   * While the left context MUST NOT bisect surrogate pairs, they MAY
+   * While the right context MUST NOT bisect surrogate pairs, they MAY
    * bisect graphical clusters.
    */
   rightContextCodeUnits: number;

--- a/common/predictive-text/promise-store.ts
+++ b/common/predictive-text/promise-store.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018 National Research Council Canada (author: Eddie A. Santos)
+ * Copyright (c) 2018 SIL International
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+type Resolve<T> = (value?: T | PromiseLike<T>) => void;
+type Reject = (reason?: any) => void;
+interface PromiseCallbacks<T> {
+  resolve: Resolve<T>;
+  reject: Reject;
+}
+
+/**
+ * Associate tokens with promises.
+ *
+ * First, .make() a promise -- associate a token with resolve/reject callbacks.
+ *
+ * You can either .keep() a promise -- resolve() and forget it;
+ * Or you may also .break() a promise -- reject() and forget it.
+ * 
+ * <T> is the type of resolved value (value yielded successfully by promise).
+ */
+class PromiseStore<T> {
+  private _promises: Map<Token, PromiseCallbacks<T>>;
+  constructor() {
+    this._promises = new Map();
+  }
+  /**
+   * How many promises are currently being tracked?
+   */
+  get length(): number {
+    return this._promises.size;
+  }
+  /**
+   * Associate a token with its respective resolve and reject callbacks.
+   */
+  make(token: Token, resolve: Resolve<T>, reject: Reject): void {
+    if (this._promises.has(token)) {
+      reject(`Existing request with token ${token}`);
+    }
+    this._promises.set(token, { reject, resolve });
+  }
+  /**
+   * Resolve the promise associated with a token (with a value!).
+   * Once the promise is resolved, the token is removed..
+   */
+  keep(token: Token, value: T) {
+    let callbacks = this._promises.get(token);
+    if (!callbacks) {
+      throw new Error(`No promise associated with token: ${token}`);
+    }
+    let accept = callbacks.resolve;
+    this._promises.delete(token);
+    return accept(value);
+  }
+  /**
+   * Instantly reject and forget a promise associated with the token.
+   */
+  break(token: Token, reason?: any): void {
+    let callbacks = this._promises.get(token);
+    if (!callbacks) {
+      throw new Error(`No promise associated with token: ${token}`);
+    }
+    this._promises.delete(token);
+    callbacks.reject(reason);
+  }
+}

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -32,9 +32,7 @@ describe('PromiseStore', function () {
       var randomPayload = randomToken();
       doLater(function () {
         assert.lengthOf(promises, 1);
-        // TODO: this API probably should not return a resolve function;
-        // it should call it immediately.
-        promises.keep(token)(randomPayload);
+        promises.keep(token, randomPayload);
       });
 
       return promise.then(function (actual) {

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -71,11 +71,6 @@ describe('PromiseStore', function () {
     });
   });
 
-  function randomToken() {
-    var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
-    return Math.random() * range + Number.MIN_SAFE_INTEGER;
-  }
-
   // Do something asynchronously.
   function doLater(callback) {
     return setTimeout(callback, 0);

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -44,6 +44,28 @@ describe('PromiseStore', function () {
     });
   });
 
+  describe('.break()', function () {
+    it('should call the reject() function', function () {
+      var promises = new PromiseStore();
+      var token = randomToken();
+      var promise = new Promise(function (resolve, reject) {
+        promises.make(token, resolve, reject);
+      });
+
+      // Resolve the promise asynchronously.
+      var error = new Error();
+      doLater(function () {
+        assert.lengthOf(promises, 1);
+        promises.break(token, error);
+      });
+
+      return promise.catch(function (actualError) {
+        assert.strictEqual(actualError, error);
+        assert.lengthOf(promises, 0);
+      });
+    });
+  });
+
   function randomToken() {
     var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
     return Math.random() * range + Number.MIN_SAFE_INTEGER;

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -59,10 +59,15 @@ describe('PromiseStore', function () {
         promises.break(token, error);
       });
 
-      return promise.catch(function (actualError) {
-        assert.strictEqual(actualError, error);
-        assert.lengthOf(promises, 0);
-      });
+      // inspired by:
+      // https://gist.github.com/haroldtreen/5f1055eee5fcf01da3e0e15b8ec86bf6#gistcomment-2623170
+      return promise.then(
+        function () { return Promise.reject('should not be called'); },
+        function (actualError) {
+          assert.strictEqual(actualError, error);
+          assert.lengthOf(promises, 0);
+        }
+      );
     });
   });
 

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -1,0 +1,14 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+let PromiseStore = require('../../build').PromiseStore;
+
+describe('PromiseStore', function () {
+  describe('.make()', function () {
+    it("should track a promise's callbacks", function () {
+      var promises = new PromiseStore();
+      
+      assert.lengthOf(promises, 0);
+    });
+  });
+});

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -7,8 +7,14 @@ describe('PromiseStore', function () {
   describe('.make()', function () {
     it("should track a promise's callbacks", function () {
       var promises = new PromiseStore();
-      
+      // There should be no tracked promises.
       assert.lengthOf(promises, 0);
+
+      // Add one promise.
+      new Promise(function (resolve, reject) {
+        promises.make(resolve, reject);
+      });
+      assert.lengthOf(promises, 1);
     });
   });
 });

--- a/common/predictive-text/unit_tests/headless/promise-store.js
+++ b/common/predictive-text/unit_tests/headless/promise-store.js
@@ -12,9 +12,45 @@ describe('PromiseStore', function () {
 
       // Add one promise.
       new Promise(function (resolve, reject) {
-        promises.make(resolve, reject);
+        promises.make(randomToken(), resolve, reject);
       });
       assert.lengthOf(promises, 1);
     });
+
+    // TODO: test existing token
   });
+
+  describe('.keep()', function () {
+    it('should call the resolve() function', function () {
+      var promises = new PromiseStore();
+      var token = randomToken();
+      var promise = new Promise(function (resolve, reject) {
+        promises.make(token, resolve, reject);
+      });
+
+      // Resolve the promise asynchronously.
+      var randomPayload = randomToken();
+      doLater(function () {
+        assert.lengthOf(promises, 1);
+        // TODO: this API probably should not return a resolve function;
+        // it should call it immediately.
+        promises.keep(token)(randomPayload);
+      });
+
+      return promise.then(function (actual) {
+        assert.strictEqual(actual, randomPayload);
+        assert.lengthOf(promises, 0);
+      });
+    });
+  });
+
+  function randomToken() {
+    var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
+    return Math.random() * range + Number.MIN_SAFE_INTEGER;
+  }
+
+  // Do something asynchronously.
+  function doLater(callback) {
+    return setTimeout(callback, 0);
+  }
 });

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -17,7 +17,7 @@ describe('LMLayerWorker', function() {
       // Sending it the initialize it should notify us that it's initialized!
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        model: dummyModelCode(),
+        model: dummyModel(),
         capabilities: defaultCapabilities()
       }));
       assert(fakePostMessage.calledOnce);
@@ -54,8 +54,8 @@ describe('LMLayerWorker', function() {
 
       // Send a message; we should get something back.
       worker.onMessage(createMessageEventWithData({
-       message: 'initialize',
-       model: dummyModelCode(),
+        message: 'initialize',
+        model: dummyModel(),
         capabilities: defaultCapabilities()
       }));
 
@@ -83,7 +83,7 @@ describe('LMLayerWorker', function() {
       var worker = new LMLayerWorker({ postMessage: fakePostMessage });
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        model: dummyModelCode(),
+        model: dummyModel(),
         capabilities: defaultCapabilities()
       }));
 
@@ -98,7 +98,7 @@ describe('LMLayerWorker', function() {
       var maxCodeUnits = 64;
       worker.onMessage(createMessageEventWithData({
         message: 'initialize',
-        model: dummyModelCode(),
+        model: dummyModel(),
         capabilities: {
           maxLeftContextCodeUnits: maxCodeUnits,
         }
@@ -111,54 +111,6 @@ describe('LMLayerWorker', function() {
           rightContextCodeUnits: 0,
         }
       })), lastMessageAsString(fakePostMessage));
-    });
-
-    // TODO: this should no longer worker in future versions
-    it.skip('should run the code for the model', function () {
-      var fakePostMessage;
-      var worker = new LMLayerWorker({
-        postMessage: fakePostMessage = sinon.fake(), // required, but ignored in this test case
-      });
-
-      // Create some values that the function can't fake:
-      var maxCodeUnit = 64;
-      var fakeLeft = Math.round(Math.random() * maxCodeUnit);
-      var fakeRight = Math.round(Math.random() * maxCodeUnit);
-
-      worker.onMessage(createMessageEventWithData({
-        message: 'initialize',
-        capabilities: {
-          maxLeftContextCodeUnits: maxCodeUnit,
-          maxRightContextCodeUnits: maxCodeUnit
-        },
-        // We can only send source code through the Structure Clones algorithm,
-        // (we can't send mocks :c) so, send something that cannot
-        // be easily faked, and we can determine if it's correct.
-        model: `
-          return {
-            model: {},
-            configuration: {
-              leftContextCodeUnits: ${fakeLeft},
-              rightContextCodeUnits: ${fakeRight}
-            }
-          };
-        `
-      }));
-
-      assert(fakePostMessage.calledOnceWith(sinon.match({
-        message: 'ready',
-        configuration: {
-          leftContextCodeUnits: fakeLeft,
-          rightContextCodeUnits: fakeRight,
-        }
-      })), lastMessageAsString(fakePostMessage));
-    });
-  });
-
-  // TODO: move these tests to a different file.
-  describe('Message: predict', function () {
-    it.skip('should predict from a local model', function () {
-      // will need import scripts figured out
     });
   });
 
@@ -175,7 +127,7 @@ describe('LMLayerWorker', function() {
    * when this happens, tests should refrain from sending source code for the model
    * parameter.
    */
-  function dummyModelCode() {
+  function dummyModel() {
     return 'return {model: {}, configuration: {}}';
   }
 

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -115,30 +115,13 @@ describe('LMLayerWorker', function() {
   });
 
   /**
-   * Creates a MessageEvent (for inter-worker communication), with the given data payload.
-   * @param {*} data 
-   */
-  function createMessageEventWithData(data) {
-    return { data };
-  }
-
-  /**
    * Deprecation warning: Soon, models will not be required to be passed as source code;
    * when this happens, tests should refrain from sending source code for the model
    * parameter.
    */
+  // TODO: Use dummyModel defined in unit_tests/helpers.js
   function dummyModel() {
     return 'return {model: {}, configuration: {}}';
-  }
-
-  /**
-   * Returns reasonable defaults for the default capabilities
-   * to initialize the LMLayer.
-   */
-  function defaultCapabilities() {
-    return {
-      maxLeftContextCodeUnits: 64
-    };
   }
 
   /**

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -104,13 +104,13 @@ describe('LMLayerWorker', function() {
         }
       }));
 
-      assert(fakePostMessage.calledOnceWith(sinon.match({
+      sinon.assert.calledWithMatch(fakePostMessage, {
         message: 'ready',
         configuration: {
           leftContextCodeUnits: maxCodeUnits,
           rightContextCodeUnits: 0,
         }
-      })), lastMessageAsString(fakePostMessage));
+      });
     });
   });
 
@@ -122,14 +122,5 @@ describe('LMLayerWorker', function() {
   // TODO: Use dummyModel defined in unit_tests/helpers.js
   function dummyModel() {
     return 'return {model: {}, configuration: {}}';
-  }
-
-  /**
-   * Returns the last message received in a pretty string format. 
-   * @param {sinon.SinonFake} fakePostMessage 
-   * @returns {string}
-   */
-  function lastMessageAsString(fakePostMessage) {
-    return JSON.stringify(fakePostMessage.lastCall.args[0], null, 2);
   }
 });

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -113,7 +113,8 @@ describe('LMLayerWorker', function() {
       })), lastMessageAsString(fakePostMessage));
     });
 
-    it('should run the code for the model', function () {
+    // TODO: this should no longer worker in future versions
+    it.skip('should run the code for the model', function () {
       var fakePostMessage;
       var worker = new LMLayerWorker({
         postMessage: fakePostMessage = sinon.fake(), // required, but ignored in this test case

--- a/common/predictive-text/unit_tests/headless/worker-initialization.js
+++ b/common/predictive-text/unit_tests/headless/worker-initialization.js
@@ -113,14 +113,4 @@ describe('LMLayerWorker', function() {
       });
     });
   });
-
-  /**
-   * Deprecation warning: Soon, models will not be required to be passed as source code;
-   * when this happens, tests should refrain from sending source code for the model
-   * parameter.
-   */
-  // TODO: Use dummyModel defined in unit_tests/helpers.js
-  function dummyModel() {
-    return 'return {model: {}, configuration: {}}';
-  }
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -43,27 +43,24 @@ describe('LMLayerWorker dummy model', function() {
       //   «I'm a little teapot|      » [Send]
 
       var expectedSuggestions = [
-        // The transforms are a bit redundant, but slightly
-        // easier to program; they undo the 't' input, only to
-        // type suggestions with that all start with 't'.
         {
           transform: {
             insert: 'teapot',
-            deleteLeft: 1,
+            deleteLeft: 0,
           },
           displayAs: '🍵',
         },
         {
           transform: {
             insert: 'too',
-            deleteLeft: 1,
+            deleteLeft: 0,
           },
           displayAs: 'too',
         },
         {
           transform: {
             insert: 'tired',
-            deleteLeft: 1,
+            deleteLeft: 0,
           },
           displayAs: '😪',
         },

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -206,41 +206,4 @@ describe('LMLayerWorker dummy model', function() {
                        futureSuggestions[3]);
     });
   });
-
-  /**
-   * Capabilities of a keyboard that will ONLY send left-sided capabilities.
-   * The keyboard does not support deleting to the right.
-   * 
-   * @returns Capabilities
-   */
-  function defaultCapabilities() {
-    return {
-      maxLeftContextCodeUnits: 64,
-    };
-  }
-
-  /**
-   * Returns a transform that does nothing.
-   *
-   * @returns Transform
-   */
-  function zeroTransform() {
-    return {
-      insert: '',
-      deleteLeft: 0,
-    };
-  }
-
-  /**
-   * Returns a context of an empty buffer.
-   *
-   * @returns Context
-   */
-  function emptyContext() {
-    return {
-      left: '',
-      startOfBuffer: true,
-      endOfBuffer: true
-    };
-  }
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -82,105 +82,13 @@ describe('LMLayerWorker dummy model', function() {
     });
 
     it('can be injected with multiple suggestions to send back', function () {
-      // Based on suggestions produced my phone's personal language model.
-      var futureSuggestions = [
-        // Initial suggestions
-        [
-          {
-            transform: {
-              insert: 'I ',
-              deleteLeft: 0
-            },
-            displayAs: 'I',
-          },
-          {
-            transform: {
-              insert: "I'm ",
-            deleteLeft: 0
-            },
-            displayAs: "I'm",
-          },
-          {
-            transform: {
-              insert: "Oh ",
-              deleteLeft: 0
-            },
-            displayAs: "Oh ",
-          }
-        ],
-        // Second set of suggestions, after choosing "I"
-        [
-          {
-            transform: {
-              insert: 'love ',
-              deleteLeft: 0
-            },
-            displayAs: 'love',
-          },
-          {
-            transform: {
-              insert: "am ",
-              deleteLeft: 0
-            },
-            displayAs: "am",
-          },
-          {
-            transform: {
-              insert: "got ",
-              deleteLeft: 0
-            },
-            displayAs: "got",
-          }
-        ],
-        // Third set of suggestions, after choosing "got"
-        [
-          {
-            transform: {
-              insert: 'distracted ',
-              deleteLeft: 0
-            },
-            displayAs: 'distracted by',
-          },
-          {
-            transform: {
-              insert: "distracted ",
-              deleteLeft: 0
-            },
-            displayAs: "distracted",
-          },
-          {
-            transform: {
-              insert: "a ",
-              deleteLeft: 0
-            },
-            displayAs: "a",
-          }
-        ],
-        // Last set of suggestions, after choosing "distracted by"
-        [
-          {
-            transform: {
-              insert: 'Hazel ',
-              deleteLeft: 0
-            },
-            displayAs: 'Hazel',
-          },
-          {
-            transform: {
-              insert: 'the ',
-              deleteLeft: 0
-            },
-            displayAs: 'the',
-          },
-          {
-            transform: {
-              insert: 'a ',
-              deleteLeft: 0
-            },
-            displayAs: 'a',
-          },
-        ],
-      ];
+      // See the fixture. It's based on suggestions produced my phone's personal
+      // language model.
+      var futureSuggestions = iGotDistractedByHazel();
+      assert.isDefined(futureSuggestions[0]);
+      assert.isDefined(futureSuggestions[1]);
+      assert.isDefined(futureSuggestions[2]);
+      assert.isDefined(futureSuggestions[3]);
 
       var model = new DummyModel(defaultCapabilities, {
         futureSuggestions: futureSuggestions

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -19,14 +19,12 @@ describe('LMLayerWorker dummy model', function() {
         rightContextCodeUnits: 0
       };
 
-      var model = new DummyModel(
-        {
-          maxLeftContextCodeUnits: 64,
-        },
-        {
-          configuration: configuration,
-        }
-      );
+      var model = new DummyModel({
+        maxLeftContextCodeUnits: 64,
+      },
+      {
+        configuration: configuration,
+      });
 
       assert.deepEqual(model.configuration, configuration);
     });
@@ -73,19 +71,16 @@ describe('LMLayerWorker dummy model', function() {
 
       var model = new DummyModel(defaultCapabilities());
 
-      var suggestions = model.predict(
-        // Type a 't'
-        {
-          insert: 't',
-          deleteLeft: 0,
-        },
-        {
-          left: "I'm a little ",
-          startOfBuffer: true,
-          endOfBuffer: true,
-        },
-        expectedSuggestions
-     );
+      // Type a 't'
+      var suggestions = model.predict({
+        insert: 't',
+        deleteLeft: 0,
+      },
+      {
+        left: "I'm a little ",
+        startOfBuffer: true,
+        endOfBuffer: true,
+      }, expectedSuggestions);
      assert.deepEqual(suggestions, expectedSuggestions);
     });
 

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -8,8 +8,10 @@ var sinon = require('sinon');
 var DummyModel = require('../../build/intermediate').models.DummyModel;
 
 describe('LMLayerWorker dummy model', function() {
-  it('can be instantiated with no arguments', function () {
-    var model = new DummyModel;
+  it('can be instantiated with capabilities', function () {
+    var model = new DummyModel({
+      maxLeftContextCodeUnits: 64,
+    });
     assert.isObject(model);
   });
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -1,0 +1,16 @@
+/*
+ * Unit tests for the Dummy prediction model.
+ */
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+var DummyModel = require('../../build/intermediate').DummyModel;
+
+describe('LMLayerWorker dummy model', function() {
+  it('can be instantiated with no arguments', function () {
+    var model = new DummyModel;
+    assert.isObject(model);
+    assert.isFunction(model.suggest)
+  });
+});

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -204,7 +204,7 @@ describe('LMLayerWorker dummy model', function() {
       assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
                        futureSuggestions[2]);
       assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
-                       futureSuggestions[4]);
+                       futureSuggestions[3]);
     });
   });
 

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -14,4 +14,22 @@ describe('LMLayerWorker dummy model', function() {
     });
     assert.isObject(model);
   });
+
+  it('supports dependency-injected configuration', function () {
+    let configuration = {
+      leftContextCodeUnits: 64,
+      rightContextCodeUnits: 0
+    };
+
+    var model = new DummyModel(
+      {
+        maxLeftContextCodeUnits: 64,
+      },
+      {
+        configuration: configuration,
+      }
+    );
+
+    assert.deepEqual(model.configuration, configuration);
+  });
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -75,21 +75,136 @@ describe('LMLayerWorker dummy model', function() {
       var model = new DummyModel(defaultCapabilities());
 
       var suggestions = model.predict(
+        // Type a 't'
         {
-          // Type a 't'
-          transform: {
-            insert: 't',
-            deleteLeft: 0,
-          },
-          context: {
-            left: "I'm a little ",
-            startOfBuffer: true,
-            endOfBuffer: true,
-          }
+          insert: 't',
+          deleteLeft: 0,
+        },
+        {
+          left: "I'm a little ",
+          startOfBuffer: true,
+          endOfBuffer: true,
         },
         expectedSuggestions
      );
      assert.deepEqual(suggestions, expectedSuggestions);
+    });
+
+    it('can be injected with multiple suggestions to send back', function () {
+      // Based on suggestions produced my phone's personal language model.
+      var futureSuggestions = [
+        // Initial suggestions
+        [
+          {
+            transform: {
+              insert: 'I ',
+              deleteLeft: 0
+            },
+            displayAs: 'I',
+          },
+          {
+            transform: {
+              insert: "I'm ",
+            deleteLeft: 0
+            },
+            displayAs: "I'm",
+          },
+          {
+            transform: {
+              insert: "Oh ",
+              deleteLeft: 0
+            },
+            displayAs: "Oh ",
+          }
+        ],
+        // Second set of suggestions, after choosing "I"
+        [
+          {
+            transform: {
+              insert: 'love ',
+              deleteLeft: 0
+            },
+            displayAs: 'love',
+          },
+          {
+            transform: {
+              insert: "am ",
+              deleteLeft: 0
+            },
+            displayAs: "am",
+          },
+          {
+            transform: {
+              insert: "got ",
+              deleteLeft: 0
+            },
+            displayAs: "got",
+          }
+        ],
+        // Third set of suggestions, after choosing "got"
+        [
+          {
+            transform: {
+              insert: 'distracted ',
+              deleteLeft: 0
+            },
+            displayAs: 'distracted by',
+          },
+          {
+            transform: {
+              insert: "distracted ",
+              deleteLeft: 0
+            },
+            displayAs: "distracted",
+          },
+          {
+            transform: {
+              insert: "a ",
+              deleteLeft: 0
+            },
+            displayAs: "a",
+          }
+        ],
+        // Last set of suggestions, after choosing "distracted by"
+        [
+          {
+            transform: {
+              insert: 'Hazel ',
+              deleteLeft: 0
+            },
+            displayAs: 'Hazel',
+          },
+          {
+            transform: {
+              insert: 'the ',
+              deleteLeft: 0
+            },
+            displayAs: 'the',
+          },
+          {
+            transform: {
+              insert: 'a ',
+              deleteLeft: 0
+            },
+            displayAs: 'the',
+          },
+        ],
+      ];
+
+      var model = new DummyModel(defaultCapabilities, {
+        futureSuggestions: futureSuggestions
+      });
+
+      // The dummy model should give suggestions in order,
+      // regardless of the provided transform and context.
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+                       futureSuggestions[0]);
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+                       futureSuggestions[1]);
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+                       futureSuggestions[2]);
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+                       futureSuggestions[4]);
     });
   });
 
@@ -102,6 +217,31 @@ describe('LMLayerWorker dummy model', function() {
   function defaultCapabilities() {
     return {
       maxLeftContextCodeUnits: 64,
+    };
+  }
+
+  /**
+   * Returns a transform that does nothing.
+   *
+   * @returns Transform
+   */
+  function zeroTransform() {
+    return {
+      insert: '',
+      deleteLeft: 0,
+    };
+  }
+
+  /**
+   * Returns a context of an empty buffer.
+   *
+   * @returns Context
+   */
+  function emptyContext() {
+    return {
+      left: '',
+      startOfBuffer: true,
+      endOfBuffer: true
     };
   }
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -5,12 +5,11 @@
 var assert = require('chai').assert;
 var sinon = require('sinon');
 
-var DummyModel = require('../../build/intermediate').DummyModel;
+var DummyModel = require('../../build/intermediate').models.DummyModel;
 
 describe('LMLayerWorker dummy model', function() {
   it('can be instantiated with no arguments', function () {
     var model = new DummyModel;
     assert.isObject(model);
-    assert.isFunction(model.suggest)
   });
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -3,7 +3,6 @@
  */
 
 var assert = require('chai').assert;
-var sinon = require('sinon');
 
 var DummyModel = require('../../build/intermediate').models.DummyModel;
 
@@ -186,7 +185,7 @@ describe('LMLayerWorker dummy model', function() {
               insert: 'a ',
               deleteLeft: 0
             },
-            displayAs: 'the',
+            displayAs: 'a',
           },
         ],
       ];

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -36,11 +36,16 @@ describe('LMLayerWorker', function () {
         transform: zeroTransform(),
         context: emptyContext()
       }));
-      assert(fakePostMessage.calledOnceWith(sinon.match({
+      sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
         message: 'suggestions',
         // TODO: token
-        suggestions: [suggestion]
-      })));
+        suggestions: sinon.match.array.deepEquals([suggestion])
+      });
+    });
+
+    afterEach(function () {
+      // Restore all fakes.
+      sinon.restore();
     });
   });
 

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -1,0 +1,87 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+let LMLayerWorker = require('../../build/intermediate');
+
+
+describe('LMLayerWorker', function () {
+  describe('#predict()', function () {
+    it('should send back a "ready" message', function () {
+      var suggestion = {
+        transform: {
+          insert: 'I ',
+          deleteLeft: 0
+        },
+        displayAs: 'I'
+      };
+
+      // Initialize the worker with a model that will produce one suggestion.
+      var fakePostMessage = sinon.fake();
+      var worker = new LMLayerWorker({ postMessage: fakePostMessage });
+      worker.onMessage(createMessageEventWithData({
+        message: 'initialize',
+        model: dummyModel([
+          [suggestion]
+        ]),
+        capabilities: defaultCapabilities()
+      }));
+      assert(fakePostMessage.calledOnceWith(sinon.match({
+        message: 'ready'
+      })));
+
+      // Now predict! We should get the suggestions back.
+      worker.onMessage(createMessageEventWithData({
+        message: 'predict',
+        transform: zeroTransform(),
+        context: emptyContext()
+      }));
+      assert(fakePostMessage.calledOnceWith(sinon.match({
+        message: 'suggestions',
+        suggestions: [suggestion]
+      })));
+    });
+  });
+
+  // Helpers (TODO: factor out!)
+
+  /**
+   * Creates a MessageEvent (for inter-worker communication), with the given data payload.
+   * @param {*} data 
+   */
+  function createMessageEventWithData(data) {
+    return { data };
+  }
+
+  /**
+   * A valid model that suggests exactly what you want it to suggest.
+   */
+  function dummyModel(futureSuggestions) {
+    return {
+      model: 'dummy',
+      futureSuggestions: futureSuggestions || []
+    };
+  }
+  /**
+   * Returns reasonable defaults for the default capabilities
+   * to initialize the LMLayer.
+   */
+  function defaultCapabilities() {
+    return {
+      maxLeftContextCodeUnits: 64
+    };
+  }
+
+  /**
+   * Context of an empty buffer; no text, at both the start and end of the buffer.
+   */
+  function emptyContext() {
+    return { left: '', startOfBuffer: true, endOfBuffer: true };
+  }
+
+  /**
+   * This transform, when applied, makes no changes to the buffer.
+   */
+  function zeroTransform() {
+    return { insert: '', deleteLeft: 0 };
+  }
+});

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -48,47 +48,4 @@ describe('LMLayerWorker', function () {
       sinon.restore();
     });
   });
-
-  // Helpers (TODO: factor out!)
-
-  /**
-   * Creates a MessageEvent (for inter-worker communication), with the given data payload.
-   * @param {*} data 
-   */
-  function createMessageEventWithData(data) {
-    return { data };
-  }
-
-  /**
-   * A valid model that suggests exactly what you want it to suggest.
-   */
-  function dummyModel(futureSuggestions) {
-    return {
-      type: 'dummy',
-      futureSuggestions: futureSuggestions || []
-    };
-  }
-  /**
-   * Returns reasonable defaults for the default capabilities
-   * to initialize the LMLayer.
-   */
-  function defaultCapabilities() {
-    return {
-      maxLeftContextCodeUnits: 64
-    };
-  }
-
-  /**
-   * Context of an empty buffer; no text, at both the start and end of the buffer.
-   */
-  function emptyContext() {
-    return { left: '', startOfBuffer: true, endOfBuffer: true };
-  }
-
-  /**
-   * This transform, when applied, makes no changes to the buffer.
-   */
-  function zeroTransform() {
-    return { insert: '', deleteLeft: 0 };
-  }
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -6,7 +6,7 @@ let LMLayerWorker = require('../../build/intermediate');
 
 describe('LMLayerWorker', function () {
   describe('#predict()', function () {
-    it('should send back a "ready" message', function () {
+    it('should send back suggestions', function () {
       var suggestion = {
         transform: {
           insert: 'I ',

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -32,11 +32,13 @@ describe('LMLayerWorker', function () {
       // Now predict! We should get the suggestions back.
       worker.onMessage(createMessageEventWithData({
         message: 'predict',
+        // TODO: token
         transform: zeroTransform(),
         context: emptyContext()
       }));
       assert(fakePostMessage.calledOnceWith(sinon.match({
         message: 'suggestions',
+        // TODO: token
         suggestions: [suggestion]
       })));
     });
@@ -57,7 +59,7 @@ describe('LMLayerWorker', function () {
    */
   function dummyModel(futureSuggestions) {
     return {
-      model: 'dummy',
+      type: 'dummy',
       futureSuggestions: futureSuggestions || []
     };
   }

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -50,11 +50,4 @@ describe('LMLayerWorker', function () {
       sinon.restore();
     });
   });
-
-  // TODO: factor into helpers.
-  function randomToken() {
-    var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
-    return Math.random() * range + Number.MIN_SAFE_INTEGER;
-  }
-
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -28,17 +28,19 @@ describe('LMLayerWorker', function () {
       sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
         message: 'ready',
       });
+      
+      var token = randomToken();
 
       // Now predict! We should get the suggestions back.
       worker.onMessage(createMessageEventWithData({
         message: 'predict',
-        // TODO: token
+        token: token,
         transform: zeroTransform(),
         context: emptyContext()
       }));
       sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
         message: 'suggestions',
-        // TODO: token
+        token: token,
         suggestions: sinon.match.array.deepEquals([suggestion])
       });
     });
@@ -48,4 +50,11 @@ describe('LMLayerWorker', function () {
       sinon.restore();
     });
   });
+
+  // TODO: factor into helpers.
+  function randomToken() {
+    var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
+    return Math.random() * range + Number.MIN_SAFE_INTEGER;
+  }
+
 });

--- a/common/predictive-text/unit_tests/headless/worker-predict.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict.js
@@ -25,9 +25,9 @@ describe('LMLayerWorker', function () {
         ]),
         capabilities: defaultCapabilities()
       }));
-      assert(fakePostMessage.calledOnceWith(sinon.match({
-        message: 'ready'
-      })));
+      sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
+        message: 'ready',
+      });
 
       // Now predict! We should get the suggestions back.
       worker.onMessage(createMessageEventWithData({

--- a/common/predictive-text/unit_tests/helpers.js
+++ b/common/predictive-text/unit_tests/helpers.js
@@ -75,3 +75,17 @@ _.randomToken = function randomToken() {
   var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
   return Math.random() * range + Number.MIN_SAFE_INTEGER;
 }
+
+// Use fixtures used in browser tests IN NODE!
+if (typeof require === 'function') {
+  // Assuming this file structure:
+  //     . common/predictive-text/unit_tests/
+  //     > in_browser/
+  //     | > json/
+  //     |   > future_suggestions/
+  //     |     > i_got_distracted_by_hazel.json
+  //     > helpers.js
+  _.iGotDistractedByHazel = function () {
+    return require('./in_browser/json/future_suggestions/i_got_distracted_by_hazel');
+  }
+}

--- a/common/predictive-text/unit_tests/helpers.js
+++ b/common/predictive-text/unit_tests/helpers.js
@@ -65,3 +65,13 @@ _.zeroTransform = function zeroTransform() {
     deleteLeft: 0,
   };
 }
+
+/**
+ * Returns a random token. NOT guaranteed to be unique.
+ *
+ * @returns {Token}
+ */
+_.randomToken = function randomToken() {
+  var range =  Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER;
+  return Math.random() * range + Number.MIN_SAFE_INTEGER;
+}

--- a/common/predictive-text/unit_tests/helpers.js
+++ b/common/predictive-text/unit_tests/helpers.js
@@ -1,0 +1,67 @@
+/**
+ * @file helpers
+ * 
+ * Globally-defined helper functions for use in in Mocha tests.
+ */
+
+// Choose the appropriate global object. Either `global` in
+// Node, or `window` in browsers.
+var _ = global || window;
+
+/**
+ * Creates a MessageEvent (for inter-worker communication), with the given data payload.
+ *
+ * @param {*} data 
+ */
+_.createMessageEventWithData = function createMessageEventWithData(data) {
+  return { data };
+}
+
+/**
+ * A valid model that suggests exactly what you want it to suggest.
+ * 
+ * @returns {ModelDescription}
+ */
+_.dummyModel = function dummyModel(futureSuggestions) {
+  return {
+    type: 'dummy',
+    futureSuggestions: futureSuggestions || []
+  };
+}
+/**
+ * Capabilities of a keyboard that will ONLY send left-sided capabilities.
+ * The keyboard does not support deleting to the right.
+ *
+ * @returns {Capabilities}
+ */
+_.defaultCapabilities = function defaultCapabilities() {
+  return {
+    maxLeftContextCodeUnits: 64
+  };
+}
+
+/**
+ * Returns the Context of an empty buffer; no text, at both the start and
+ * end of the buffer.
+ * 
+ * @returns {Context}
+ */
+_.emptyContext = function emptyContext() {
+  return {
+    left: '',
+    startOfBuffer: true,
+    endOfBuffer: true
+  };
+}
+
+/**
+ * Returns a Transform that, when applied, makes no changes to the buffer.
+ *
+ * @returns {Transform}
+ */
+_.zeroTransform = function zeroTransform() {
+  return {
+    insert: '',
+    deleteLeft: 0,
+  };
+}

--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -100,7 +100,7 @@ module.exports = function(config) {
     bs_native_android: {
       os: 'android',
       os_version: '7.1',
-      browser: 'android',
+      browser: 'firefox',
       real_mobile: true,
       device: 'Samsung Galaxy Note 8'
     },

--- a/common/predictive-text/unit_tests/in_browser/base.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/base.conf.js
@@ -55,7 +55,7 @@ module.exports = {
 
   // Settings to properly configure how JSON fixtures are automatically loaded by Karma.
   jsonFixturesPreprocessor: {
-    stripPrefix: 'json',
+    stripPrefix: 'json/',
     variableName: '__json__'
   },
 

--- a/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
@@ -8,21 +8,6 @@ describe('LMLayer', function () {
     });
   });
 
-  describe('#initialize()', function () {
-    // TODO: implement configuration negotiation?
-    it.skip('should yield a reasonable configuration', function () {
-      let maxLeftContext = 64;
-      let lmLayer = new LMLayer();
-      return lmLayer.initialize(
-        { maxLeftContextCodeUnits: maxLeftContext },
-        { model: { type: 'dummy' } }
-      ).then(function (configuration) {
-        assert.isAtMost(configuration.leftContextCodeUnits, maxLeftContext);
-        assert.propertyVal(configuration, 'rightContextCodeUnits', 0);
-      });
-    });
-  });
-
   describe('#asBlobURI()', function () {
     // #asBlobURI() requires browser APIs, hence why it cannot be tested headless in Node.
     it('should take a function and convert it into a blob function', function (done) {

--- a/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
@@ -9,12 +9,12 @@ describe('LMLayer', function () {
   });
 
   describe('#initialize()', function () {
-    it('should yield a reasonable configuration', function () {
+    it.skip('should yield a reasonable configuration', function () {
       let maxLeftContext = 64;
       let lmLayer = new LMLayer();
       return lmLayer.initialize(
         { maxLeftContextCodeUnits: maxLeftContext },
-        { model: { kind: 'wordlist', words: ['foo', 'bar']} }
+        { model: { type: 'dummy' } }
       ).then(function (configuration) {
         assert.isAtMost(configuration.leftContextCodeUnits, maxLeftContext);
         assert.propertyVal(configuration, 'rightContextCodeUnits', 0);

--- a/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/top-level-lmlayer.js
@@ -9,6 +9,7 @@ describe('LMLayer', function () {
   });
 
   describe('#initialize()', function () {
+    // TODO: implement configuration negotiation?
     it.skip('should yield a reasonable configuration', function () {
       let maxLeftContext = 64;
       let lmLayer = new LMLayer();

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
@@ -54,6 +54,6 @@ describe('LMLayer using dummy model', function () {
   }
 
   function iGotDistractedByHazel() {
-    return __json__['future_suggestions/i_got_distracted_by_hazel']
+    return __json__['future_suggestions/i_got_distracted_by_hazel'];
   }
 });

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
@@ -16,7 +16,9 @@ describe('LMLayer using dummy model', function () {
         maxLefContextCodeUnits: 32 + ~~Math.random() * 32
       };
 
-      // Tower of promises!
+      // We're testing many as asynchronous messages in a row.
+      // this would be cleaner using async/await syntax, but
+      // alas some of our browsers don't support it.
       return lmLayer.initialize(
         capabilities,
         {
@@ -52,103 +54,6 @@ describe('LMLayer using dummy model', function () {
   }
 
   function iGotDistractedByHazel() {
-    return [
-      [
-        {
-          transform: {
-            insert: 'I ',
-            deleteLeft: 0
-          },
-          displayAs: 'I',
-        },
-        {
-          transform: {
-            insert: "I'm ",
-            deleteLeft: 0
-          },
-          displayAs: "I'm",
-        },
-        {
-          transform: {
-            insert: "Oh ",
-            deleteLeft: 0
-          },
-          displayAs: "Oh ",
-        }
-      ],
-      // Second set of suggestions, after choosing "I"
-      [
-        {
-          transform: {
-            insert: 'love ',
-            deleteLeft: 0
-          },
-          displayAs: 'love',
-        },
-        {
-          transform: {
-            insert: "am ",
-            deleteLeft: 0
-          },
-          displayAs: "am",
-        },
-        {
-          transform: {
-            insert: "got ",
-            deleteLeft: 0
-          },
-          displayAs: "got",
-        }
-      ],
-      // Third set of suggestions, after choosing "got"
-      [
-        {
-          transform: {
-            insert: 'distracted ',
-            deleteLeft: 0
-          },
-          displayAs: 'distracted by',
-        },
-        {
-          transform: {
-            insert: "distracted ",
-            deleteLeft: 0
-          },
-          displayAs: "distracted",
-        },
-        {
-          transform: {
-            insert: "a ",
-            deleteLeft: 0
-          },
-          displayAs: "a",
-        }
-      ],
-      // Last set of suggestions, after choosing "distracted by"
-      [
-        {
-          transform: {
-            insert: 'Hazel ',
-            deleteLeft: 0
-          },
-          displayAs: 'Hazel',
-        },
-        {
-          transform: {
-            insert: 'the ',
-            deleteLeft: 0
-          },
-          displayAs: 'the',
-        },
-        {
-          transform: {
-            insert: 'a ',
-            deleteLeft: 0
-          },
-          displayAs: 'a',
-        },
-      ],
-
-    ]
+    return __json__['future_suggestions/i_got_distracted_by_hazel']
   }
 });

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
@@ -1,0 +1,154 @@
+var assert = chai.assert;
+
+/*
+ * Shows off the LMLayer API, using the full prediction interface.
+ * The dummy model (or mock model) is a language model which has 
+ * **injectable** suggestions: that is, you, as the tester, have
+ * to provide the predictions. The dummy model does not create any
+ * suggestions on its own. The dummy model can take in a series
+ * of suggestions when initialized and return them sequentially.
+ */
+describe('LMLayer using dummy model', function () {
+  describe('Prediction', function () {
+    it('will predict future suggestions', function () {
+      var lmLayer = new LMLayer();
+      var capabilities = {
+        maxLefContextCodeUnits: 32 + ~~Math.random() * 32
+      };
+
+      // Tower of promises!
+      return lmLayer.initialize(
+        capabilities,
+        { model: {
+            type: 'dummy',
+            futureSuggestions: iGotDistractedByHazel()
+        }}
+      ).then(function (actualConfiguration) {
+        return Promise.resolve();
+      }).then(function () {
+        return lmLayer.predict(zeroTransform(), emptyContext());
+      }).then(function (suggestions) {
+        assert.deepEqual(suggestions, iGotDistractedByHazel()[0]);
+        return lmLayer.predict(zeroTransform(), emptyContext());
+      }).then(function (suggestions) {
+        assert.deepEqual(suggestions, iGotDistractedByHazel()[1]);
+        return lmLayer.predict(zeroTransform(), emptyContext());
+      }).then(function (suggestions) {
+        assert.deepEqual(suggestions, iGotDistractedByHazel()[2]);
+        return lmLayer.predict(zeroTransform(), emptyContext());
+      }).then(function (suggestions) {
+        assert.deepEqual(suggestions, iGotDistractedByHazel()[3]);
+        return Promise.resolve();
+      });
+    });
+  });
+
+  function emptyContext() {
+    return { left: '', startOfBuffer: true, endOfBuffer: true };
+  }
+
+  function zeroTransform() {
+    return { insert: '', deleteLeft: 0 };
+  }
+
+  function iGotDistractedByHazel() {
+    return [
+      [
+        {
+          transform: {
+            insert: 'I ',
+            deleteLeft: 0
+          },
+          displayAs: 'I',
+        },
+        {
+          transform: {
+            insert: "I'm ",
+            deleteLeft: 0
+          },
+          displayAs: "I'm",
+        },
+        {
+          transform: {
+            insert: "Oh ",
+            deleteLeft: 0
+          },
+          displayAs: "Oh ",
+        }
+      ],
+      // Second set of suggestions, after choosing "I"
+      [
+        {
+          transform: {
+            insert: 'love ',
+            deleteLeft: 0
+          },
+          displayAs: 'love',
+        },
+        {
+          transform: {
+            insert: "am ",
+            deleteLeft: 0
+          },
+          displayAs: "am",
+        },
+        {
+          transform: {
+            insert: "got ",
+            deleteLeft: 0
+          },
+          displayAs: "got",
+        }
+      ],
+      // Third set of suggestions, after choosing "got"
+      [
+        {
+          transform: {
+            insert: 'distracted ',
+            deleteLeft: 0
+          },
+          displayAs: 'distracted by',
+        },
+        {
+          transform: {
+            insert: "distracted ",
+            deleteLeft: 0
+          },
+          displayAs: "distracted",
+        },
+        {
+          transform: {
+            insert: "a ",
+            deleteLeft: 0
+          },
+          displayAs: "a",
+        }
+      ],
+      // Last set of suggestions, after choosing "distracted by"
+      [
+        {
+          transform: {
+            insert: 'Hazel ',
+            deleteLeft: 0
+          },
+          displayAs: 'Hazel',
+        },
+        {
+          transform: {
+            insert: 'the ',
+            deleteLeft: 0
+          },
+          displayAs: 'the',
+        },
+        {
+          transform: {
+            insert: 'a ',
+            deleteLeft: 0
+          },
+          displayAs: 'a',
+        },
+      ],
+
+    ]
+  }
+});

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
@@ -19,10 +19,10 @@ describe('LMLayer using dummy model', function () {
       // Tower of promises!
       return lmLayer.initialize(
         capabilities,
-        { model: {
+        {
             type: 'dummy',
             futureSuggestions: iGotDistractedByHazel()
-        }}
+        }
       ).then(function (actualConfiguration) {
         return Promise.resolve();
       }).then(function () {

--- a/common/predictive-text/unit_tests/in_browser/json/future_suggestions/i_got_distracted_by_hazel.json
+++ b/common/predictive-text/unit_tests/in_browser/json/future_suggestions/i_got_distracted_by_hazel.json
@@ -1,0 +1,94 @@
+[
+  [
+    {
+      "transform": {
+        "insert": "I ",
+        "deleteLeft": 0
+      },
+      "displayAs": "I"
+    },
+    {
+      "transform": {
+        "insert": "I'm ",
+        "deleteLeft": 0
+      },
+      "displayAs": "I'm"
+    },
+    {
+      "transform": {
+        "insert": "Oh ",
+        "deleteLeft": 0
+      },
+      "displayAs": "Oh "
+    }
+  ],
+  [
+    {
+      "transform": {
+        "insert": "love ",
+        "deleteLeft": 0
+      },
+      "displayAs": "love"
+    },
+    {
+      "transform": {
+        "insert": "am ",
+        "deleteLeft": 0
+      },
+      "displayAs": "am"
+    },
+    {
+      "transform": {
+        "insert": "got ",
+        "deleteLeft": 0
+      },
+      "displayAs": "got"
+    }
+  ],
+  [
+    {
+      "transform": {
+        "insert": "distracted ",
+        "deleteLeft": 0
+      },
+      "displayAs": "distracted by"
+    },
+    {
+      "transform": {
+        "insert": "distracted ",
+        "deleteLeft": 0
+      },
+      "displayAs": "distracted"
+    },
+    {
+      "transform": {
+        "insert": "a ",
+        "deleteLeft": 0
+      },
+      "displayAs": "a"
+    }
+  ],
+  [
+    {
+      "transform": {
+        "insert": "Hazel ",
+        "deleteLeft": 0
+      },
+      "displayAs": "Hazel"
+    },
+    {
+      "transform": {
+        "insert": "the ",
+        "deleteLeft": 0
+      },
+      "displayAs": "the"
+    },
+    {
+      "transform": {
+        "insert": "a ",
+        "deleteLeft": 0
+      },
+      "displayAs": "a"
+    }
+  ]
+]

--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -45,7 +45,7 @@ test-browsers ( ) {
 # Defaults
 get_builder_OS  # return:  os_id="linux"|"mac"|"win" 
 
-FLAGS=
+FLAGS="--require ./unit_tests/helpers"
 CI_REPORTING=0
 RUN_HEADLESS=1
 RUN_BROWSERS=1

--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -39,7 +39,7 @@ test-browsers ( ) {
     _FLAGS="$_FLAGS -CI -reporter teamcity"
   fi
 
-  in_browser/browser-test.sh $_FLAGS $os_id
+  in_browser/browser-test.sh $os_id $_FLAGS
 }
 
 # Defaults

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -33,6 +33,6 @@
  * The Dummy Model that returns nonsensical, but predictable results. 
  */
 LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
-  constructor() {
+  constructor(capabilities: Capabilities) {
   }
 };

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -34,15 +34,21 @@
  */
 LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
   configuration: Configuration;
+  private _futureSuggestions: Suggestion[][];
 
   constructor(capabilities: Capabilities, options?: any) {
     options = options || {};
     this.configuration = options.configuration || {};
+    // Create a shallow copy of the suggestions;
+    // this class mutates the array.
+    this._futureSuggestions = options.futureSuggestions
+      ? options.futureSuggestions.slice() : [];
   }
 
   predict(transform: Transform, context: Context, injectedSuggestions?: Suggestion[]): Suggestion[] {
     if (injectedSuggestions) {
       return injectedSuggestions;
     }
+    return this._futureSuggestions.shift();
   }
 };

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -40,7 +40,9 @@ LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalMode
     this.configuration = options.configuration || {};
   }
 
-  predict(transform: Transform, context: Context): Suggestion[] {
-    return [];
+  predict(transform: Transform, context: Context, injectedSuggestions?: Suggestion[]): Suggestion[] {
+    if (injectedSuggestions) {
+      return injectedSuggestions;
+    }
   }
 };

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -33,6 +33,10 @@
  * The Dummy Model that returns nonsensical, but predictable results. 
  */
 LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
-  constructor(capabilities: Capabilities) {
+  configuration: Configuration;
+
+  constructor(capabilities: Capabilities, options?: any) {
+    options = options || {};
+    this.configuration = options.configuration || {};
   }
 };

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -1,4 +1,33 @@
+/*
+ * Copyright (c) 2018 National Research Council Canada (author: Eddie A. Santos)
+ * Copyright (c) 2018 SIL International
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 /// <reference path="./index.ts" />
+
+/**
+ * @file dummy-model.ts
+ * 
+ * Defines the Dummy model, which is used for testing the
+ * prediction API exclusively.
+ */
 
 /**
  * The Dummy Model that returns nonsensical, but predictable results. 

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -1,0 +1,9 @@
+/// <reference path="./index.ts" />
+
+/**
+ * The Dummy Model that returns nonsensical, but predictable results. 
+ */
+LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
+  constructor() {
+  }
+};

--- a/common/predictive-text/worker/dummy-model.ts
+++ b/common/predictive-text/worker/dummy-model.ts
@@ -39,4 +39,8 @@ LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalMode
     options = options || {};
     this.configuration = options.configuration || {};
   }
+
+  predict(transform: Transform, context: Context): Suggestion[] {
+    return [];
+  }
 };

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -86,7 +86,6 @@ class LMLayerWorker {
     if (!message) {
       throw new Error(`Missing required 'message' property: ${event.data}`)
     }
-    // TODO: update worker-communication-protocol document.
 
     // We got a message! Delegate to the current state.
     this.state.handleMessage(event.data as IncomingMessage);

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -35,7 +35,14 @@
   * Encapsulates all the state required for the LMLayer's worker thread.
   */
 class LMLayerWorker {
-  // All
+  /**
+   * All of the bundled model implementations will add themselves here:
+   * Note: the models will add themselves by including this
+   * file using a triple-slash directive:
+   * /// <reference path="path/to/this/file.ts" />
+   * then adding the constructor to this static object:
+   * LMLayerWorker.models.MyModelImplementation = class {}
+   */
   static models: {[key: string]: WorkerInternalModelConstructor} = {};
 
   /**

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -84,7 +84,7 @@ class LMLayerWorker {
     // TODO: state pattern
     // TODO: update worker-communication-protocol document.
     if (message === 'predict' && this.model) {
-      let {transform, context} = message.data;
+      let {transform, context} = event.data;
       this.cast('suggestions', {
         suggestions: this.model.predict(transform, context)
       })
@@ -138,6 +138,8 @@ class LMLayerWorker {
       leftContextCodeUnits: 0,
       rightContextCodeUnits: 0
     };
+
+    console.log({ modelCode })
 
     if (typeof modelCode === 'string') {
       console.warn("Deprecated: model defined as a string.")

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -194,6 +194,7 @@ class LMLayerWorker {
 
         let {transform, context} = payload;
         this.cast('suggestions', {
+          token: payload.token,
           suggestions: model.predict(transform, context)
         });
       }

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -19,63 +19,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+/**
+ * @file index.ts
+ * 
+ * The main LMLayerWorker class, the top-level class within the Web Worker.
+ * The LMLayerWorker handles the keyboard/worker communication
+ * protocol, delegating prediction requests to the language
+ * model implementations.
+ */
+
 /// <reference path="../message.d.ts" />
-
-/**
- * The signature of self.postMessage(), so that unit tests can mock it.
- */
-type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
-
-/**
- * The valid outgoing message types.
- */
-type OutgoingMessageKind = 'ready' | 'suggestions';
-
-/**
- * The structure of an initialization message. It should include the model (either in
- * source code or parameter form), as well as the keyboard's capabilities.
- */
-interface InitializeMessage {
-  /**
-   * The model, and its configuration.
-   * TODO: write a description of what this actually is!
-   */
-  model: any;
-
-  /**
-   * The configuration that the keyboard can offer to the model.
-   */
-  capabilities: Capabilities;
-}
-
-/**
- * The structure of the message back to the keyboard.
- */
-interface ReadyMessage {
-  configuration: Configuration;
-}
-
-interface PredictMessage {
-  // TODO:
-  // token: Token;
-  // context: Context;
-  // transform: Transform;
-}
-
-/**
- * The model implementation, within the Worker.
- */
-interface WorkerInternalModel {
-  // TODO: configuration
-}
-
-/**
- * Constructors that return worker internal models. 
- */
-interface WorkerInternalModelConstructor {
-  // TODO: new should take (cap: Capabilities)
-  new (): WorkerInternalModel;
-}
 
  /**
   * Encapsulates all the state required for the LMLayer's worker thread.

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -33,6 +33,25 @@
 
 /**
  * Encapsulates all the state required for the LMLayer's worker thread.
+ * 
+ * Implements the state pattern. There are two states:
+ * 
+ *  - `uninitialized` (initial state)
+ *  - `ready`         (accepting state)
+ * 
+ * Transitions are initiated by valid messages. Invalid
+ * messages are errors, and do not lead to transitions.
+ * 
+ *         +-----------------+            +---------+
+ *         |                 | initialize |         |
+ *  +------>  uninitialized  +----------->+  ready  +---+
+ *         |                 |            |         |   |
+ *         +-----------------+            +----^----+   | predict
+ *                                             |        |
+ *                                             +--------+
+ * 
+ * The model and the configuration are ONLY relevant in the `ready` state;
+ * as such, they are NOT direct properties of the LMLayerWorker.
  */
 class LMLayerWorker {
   /**

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -211,11 +211,6 @@ class LMLayerWorker {
   }
 }
 
-LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
-  constructor() {
-  }
-}
-
 // Let LMLayerWorker be available both in the browser and in Node.
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = LMLayerWorker;

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -139,8 +139,6 @@ class LMLayerWorker {
       rightContextCodeUnits: 0
     };
 
-    console.log({ modelCode })
-
     if (typeof modelCode === 'string') {
       console.warn("Deprecated: model defined as a string.")
       // Deprecated! The model should not be source code.

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -62,10 +62,28 @@ interface PredictMessage {
   // transform: Transform;
 }
 
+/**
+ * The model implementation, within the Worker.
+ */
+interface WorkerInternalModel {
+  // TODO: configuration
+}
+
+/**
+ * Constructors that return worker internal models. 
+ */
+interface WorkerInternalModelConstructor {
+  // TODO: new should take (cap: Capabilities)
+  new (): WorkerInternalModel;
+}
+
  /**
   * Encapsulates all the state required for the LMLayer's worker thread.
   */
 class LMLayerWorker {
+  // All
+  static models: {[key: string]: WorkerInternalModelConstructor} = {};
+
   /**
    * By default, it's self.postMessage(), but can be overridden
    * so that this can be tested **outside of a Worker**.
@@ -190,6 +208,11 @@ class LMLayerWorker {
     scope.onmessage = worker.onMessage.bind(worker);
 
     return worker;
+  }
+}
+
+LMLayerWorker.models.DummyModel = class DummyModel implements WorkerInternalModel {
+  constructor() {
   }
 }
 

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -38,16 +38,16 @@ type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
  */
 type OutgoingMessageKind = 'ready' | 'suggestions';
 
+
 /**
  * The structure of an initialization message. It should include the model (either in
  * source code or parameter form), as well as the keyboard's capabilities.
  */
 interface InitializeMessage {
   /**
-   * The model, and its configuration.
-   * TODO: write a description of what this actually is!
+   * The model type, and all of its parameters.
    */
-  model: any;
+  model: ModelDescription;
   /**
    * The configuration that the keyboard can offer to the model.
    */
@@ -76,7 +76,7 @@ interface WorkerInternalModel {
 interface WorkerInternalModelConstructor {
   /**
    * WorkerInternalModel instances are all given the keyboard's
-   * capabilities.
+   * capabilities, plus any parameters they require.
    */
-  new(capabilities: Capabilities): WorkerInternalModel;
+  new(capabilities: Capabilities, ...modelParameters: any[]): WorkerInternalModel;
 }

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -67,6 +67,7 @@ interface PredictMessage {
  * The model implementation, within the Worker.
  */
 interface WorkerInternalModel {
+  predict(transform: Transform, context: Context): Suggestion[];
 }
 
 /**

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 National Research Council Canada (author: Eddie A. Santos)
+ * Copyright (c) 2018 SIL International
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file worker-interfaces.ts
+ * 
+ * Interfaces and types required internally in the worker code.
+ */
+
+/// <reference path="../message.d.ts" />
+
+/**
+ * The signature of self.postMessage(), so that unit tests can mock it.
+ */
+type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
+/**
+ * The valid outgoing message types.
+ */
+type OutgoingMessageKind = 'ready' | 'suggestions';
+/**
+ * The structure of an initialization message. It should include the model (either in
+ * source code or parameter form), as well as the keyboard's capabilities.
+ */
+interface InitializeMessage {
+  /**
+   * The model, and its configuration.
+   * TODO: write a description of what this actually is!
+   */
+  model: any;
+  /**
+   * The configuration that the keyboard can offer to the model.
+   */
+  capabilities: Capabilities;
+}
+/**
+ * The structure of the message back to the keyboard.
+ */
+interface ReadyMessage {
+  configuration: Configuration;
+}
+interface PredictMessage {
+}
+/**
+ * The model implementation, within the Worker.
+ */
+interface WorkerInternalModel {
+}
+/**
+ * Constructors that return worker internal models.
+ */
+interface WorkerInternalModelConstructor {
+  // TODO: new should take (cap: Capabilities)
+  new(): WorkerInternalModel;
+}

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -86,33 +86,6 @@ interface PredictMessage {
   context: Context;
 }
 
-/**
- * The valid outgoing message kinds.
- */
-type OutgoingMessageKind = 'ready' | 'suggestions';
-type OutgoingMessage = ReadyMessage | SuggestionMessage;
-
-/**
- * Tells the keyboard that the LMLayer is ready. Provides
- * negotiated configuration.
- */
-interface ReadyMessage {
-  message: 'ready';
-  configuration: Configuration;
-}
-
-/**
- * Sends the keyboard an ordered list of suggestions.
- */
-interface SuggestionMessage {
-  message: 'suggestions';
-
-  /**
-   * Opaque, unique token that pairs this suggestions message
-   * with the predict message that initiated it.
-   */
-  token: Token;
-}
 
 
 /**

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -61,7 +61,21 @@ interface InitializeMessage {
  */
 interface PredictMessage {
   message: 'predict';
-  transform: Transform;
+  /**
+   * How the input event will transform the buffer.
+   * If this is not provided, then the prediction is not
+   * assumed to be associated with an input event (for example,
+   * when a user starts typing on an empty text field).
+   * 
+   * TODO: test for absent transform!
+   */
+  transform?: Transform;
+
+  /**
+   * The context (text to the left and text to right) at the
+   * insertion point/text cursor, at the moment before the
+   * transform is applied to the buffer.
+   */
   context: Context;
 }
 

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -73,6 +73,9 @@ interface WorkerInternalModel {
  * Constructors that return worker internal models.
  */
 interface WorkerInternalModelConstructor {
-  // TODO: new should take (cap: Capabilities)
-  new(): WorkerInternalModel;
+  /**
+   * WorkerInternalModel instances are all given the keyboard's
+   * capabilities.
+   */
+  new(capabilities: Capabilities): WorkerInternalModel;
 }

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -32,10 +32,12 @@
  * The signature of self.postMessage(), so that unit tests can mock it.
  */
 type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
+
 /**
  * The valid outgoing message types.
  */
 type OutgoingMessageKind = 'ready' | 'suggestions';
+
 /**
  * The structure of an initialization message. It should include the model (either in
  * source code or parameter form), as well as the keyboard's capabilities.
@@ -51,6 +53,7 @@ interface InitializeMessage {
    */
   capabilities: Capabilities;
 }
+
 /**
  * The structure of the message back to the keyboard.
  */
@@ -59,11 +62,13 @@ interface ReadyMessage {
 }
 interface PredictMessage {
 }
+
 /**
  * The model implementation, within the Worker.
  */
 interface WorkerInternalModel {
 }
+
 /**
  * Constructors that return worker internal models.
  */

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -38,6 +38,7 @@ type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
  * The valid incoming message kinds.
  */
 type IncomingMessageKind = 'initialize' | 'predict';
+type IncomingMessage = InitializeMessage | PredictMessage;
 
 /**
  * The structure of an initialization message. It should include the model (either in
@@ -61,6 +62,12 @@ interface InitializeMessage {
  */
 interface PredictMessage {
   message: 'predict';
+
+  /**
+   * Opaque, unique token that pairs this predict message with its suggestions.
+   */
+  token: Token;
+
   /**
    * How the input event will transform the buffer.
    * If this is not provided, then the prediction is not
@@ -83,16 +90,30 @@ interface PredictMessage {
  * The valid outgoing message kinds.
  */
 type OutgoingMessageKind = 'ready' | 'suggestions';
+type OutgoingMessage = ReadyMessage | SuggestionMessage;
 
 /**
- * The structure of the message back to the keyboard.
+ * Tells the keyboard that the LMLayer is ready. Provides
+ * negotiated configuration.
  */
 interface ReadyMessage {
   message: 'ready';
   configuration: Configuration;
 }
 
-type IncomingMessage = InitializeMessage | PredictMessage;
+/**
+ * Sends the keyboard an ordered list of suggestions.
+ */
+interface SuggestionMessage {
+  message: 'suggestions';
+
+  /**
+   * Opaque, unique token that pairs this suggestions message
+   * with the predict message that initiated it.
+   */
+  token: Token;
+}
+
 
 /**
  * Represents a state in the LMLayer.

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -33,18 +33,11 @@
  */
 type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
 
+
 /**
  * The valid incoming message kinds.
  */
 type IncomingMessageKind = 'initialize' | 'predict';
-
-/**
- * The valid outgoing message kinds.
- */
-type OutgoingMessageKind = 'ready' | 'suggestions';
-
-
-
 
 /**
  * The structure of an initialization message. It should include the model (either in
@@ -73,9 +66,15 @@ interface PredictMessage {
 }
 
 /**
+ * The valid outgoing message kinds.
+ */
+type OutgoingMessageKind = 'ready' | 'suggestions';
+
+/**
  * The structure of the message back to the keyboard.
  */
 interface ReadyMessage {
+  message: 'ready';
   configuration: Configuration;
 }
 

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -34,9 +34,16 @@
 type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
 
 /**
- * The valid outgoing message types.
+ * The valid incoming message kinds.
+ */
+type IncomingMessageKind = 'initialize' | 'predict';
+
+/**
+ * The valid outgoing message kinds.
  */
 type OutgoingMessageKind = 'ready' | 'suggestions';
+
+
 
 
 /**
@@ -44,6 +51,8 @@ type OutgoingMessageKind = 'ready' | 'suggestions';
  * source code or parameter form), as well as the keyboard's capabilities.
  */
 interface InitializeMessage {
+  message: 'initialize';
+
   /**
    * The model type, and all of its parameters.
    */
@@ -55,12 +64,33 @@ interface InitializeMessage {
 }
 
 /**
+ * Message to suggestion text.
+ */
+interface PredictMessage {
+  message: 'predict';
+  transform: Transform;
+  context: Context;
+}
+
+/**
  * The structure of the message back to the keyboard.
  */
 interface ReadyMessage {
   configuration: Configuration;
 }
-interface PredictMessage {
+
+type IncomingMessage = InitializeMessage | PredictMessage;
+
+/**
+ * Represents a state in the LMLayer.
+ */
+interface LMLayerWorkerState {
+  /**
+   * Informative property. Name of the state. Currently, the LMLayerWorker can only
+   * be the following states:
+   */
+  name: 'uninitialized' | 'ready';
+  handleMessage(payload: IncomingMessage): void;
 }
 
 /**


### PR DESCRIPTION
~~**NOTE**: still a work in progress; do not merge!~~ Please review!

This creates a new language model that suggests exactly what you tell it to suggest! It's instantiated with a list of `futureSuggestions`, which it will return sequentially on each call to `.predict()`.

This is looking to be a bigger PR than I thought, so please review what's there right now as I tackle the remaining TODOs:

 - [x] test and implement `PromiseStore`
 - [x] associate `suggestion` messages with pending promise
 - [x] update worker communication protocol document