### PR TITLE
[Web] Keystroke processing refactor

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMModifierCodes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMModifierCodes.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public final class KMModifierCodes {
 
-  // Note: Keep this table in sync with web/source/kmwosk.js osk.modifierCodes
+  // Note: Keep this table in sync with web/source/text/codes.ts, Codes.modifierCodes.
   final static HashMap<String, Integer> codes = new HashMap<String, Integer>() {{
     put("LCTRL", 0x0001);
     put("RCTRL", 0x0002);

--- a/android/Tests/KeyboardHarness/app/src/main/assets/cloud/chirality-1.0.js
+++ b/android/Tests/KeyboardHarness/app/src/main/assets/cloud/chirality-1.0.js
@@ -43,7 +43,7 @@ function Keyboard_chirality() {
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
     var osk = keyman.osk.vkbd;
-    var Constants = com.keyman.osk.VisualKeyboard;
+    var Constants = com.keyman.text.Codes;
     
     // Handwritten time!
     var kls = this.KV.KLS;

--- a/android/Tests/KeyboardHarness/app/src/main/assets/cloud/chirality-1.0.js
+++ b/android/Tests/KeyboardHarness/app/src/main/assets/cloud/chirality-1.0.js
@@ -42,7 +42,7 @@ function Keyboard_chirality() {
   };
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
-    var osk = keyman.osk.vkbd;
+    var Processor = keyman.textProcessor;
     var Constants = com.keyman.text.Codes;
     
     // Handwritten time!
@@ -54,7 +54,7 @@ function Keyboard_chirality() {
     for(var i = 0; i < layers.length; i++) {
       // Obtain the modifier code to match for the selected layer.
       // The following uses a non-public property potentially subject to change in the future.
-      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | osk.getModifierState(layers[i]);
+      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | Processor.getModifierState(layers[i]);
       var layer = layers[i];
       
       for(var key=0; key < kls[layer].length; key++) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,21 +21,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
+        "es6-promisify": "^5.0.0"
       }
     },
     "ansi-regex": {
@@ -231,9 +222,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "version": "1.6.40",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
+      "integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ==",
       "dev": true
     },
     "binary": {
@@ -328,12 +319,12 @@
       "dev": true
     },
     "browserstack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.0.tgz",
-      "integrity": "sha1-tWVCWtYu1ywQgqHrl51TE8fUdU8=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.2.tgz",
+      "integrity": "sha512-+6AFt9HzhKykcPF79W6yjEUJcdvZOV0lIXdkORXMJftGrDl0OKWqRF4GHqpDNkxiceDT/uB7Fb/aDwktvXX7dg==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "browserstacktunnel-wrapper": {
@@ -344,42 +335,6 @@
       "requires": {
         "https-proxy-agent": "^2.2.1",
         "unzipper": "^0.9.3"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
       }
     },
     "buffer-alloc": {
@@ -621,9 +576,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combine-lists": {
@@ -690,9 +645,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+      "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
       "dev": true
     },
     "core-util-is": {
@@ -1070,9 +1025,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -1229,10 +1184,16 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "dev": true,
       "requires": {
         "debug": "=3.1.0"
@@ -2017,24 +1978,29 @@
       }
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -2263,9 +2229,9 @@
       "dev": true
     },
     "karma": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz",
-      "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.4.tgz",
+      "integrity": "sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==",
       "dev": true,
       "requires": {
         "bluebird": "^3.3.0",
@@ -2278,11 +2244,12 @@
         "di": "^0.0.1",
         "dom-serialize": "^2.2.0",
         "expand-braces": "^0.1.1",
+        "flatted": "^2.0.0",
         "glob": "^7.1.1",
         "graceful-fs": "^4.1.2",
         "http-proxy": "^1.13.0",
         "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.5",
         "log4js": "^3.0.0",
         "mime": "^2.3.1",
         "minimatch": "^3.0.2",
@@ -2294,7 +2261,7 @@
         "socket.io": "2.1.1",
         "source-map": "^0.6.1",
         "tmp": "0.0.33",
-        "useragent": "2.2.1"
+        "useragent": "2.3.0"
       },
       "dependencies": {
         "source-map": {
@@ -2306,22 +2273,14 @@
       }
     },
     "karma-browserstack-launcher": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.3.0.tgz",
-      "integrity": "sha512-LrPf5sU/GISkEElWyoy06J8x0c8BcOjjOwf61Wqu6M0aWQu0Eoqm9yh3xON64/ByST/CEr0GsWiREQ/EIEMd4Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-1.4.0.tgz",
+      "integrity": "sha512-bUQK84U+euDfOUfEjcF4IareySMOBNRLrrl9q6cttIe8f011Ir6olLITTYMOJDcGY58wiFIdhPHSPd9Pi6+NfQ==",
       "dev": true,
       "requires": {
-        "browserstack": "1.5.0",
-        "browserstacktunnel-wrapper": "~2.0.1",
+        "browserstack": "~1.5.1",
+        "browserstacktunnel-wrapper": "~2.0.2",
         "q": "~1.5.0"
-      },
-      "dependencies": {
-        "q": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-          "dev": true
-        }
       }
     },
     "karma-chai": {
@@ -2585,10 +2544,14 @@
       }
     },
     "lru-cache": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-      "dev": true
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -2633,9 +2596,9 @@
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
       "dev": true
     },
     "mime-db": {
@@ -2780,9 +2743,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
       "dev": true,
       "optional": true
     },
@@ -3057,6 +3020,18 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
       "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "qjobs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
@@ -3221,12 +3196,28 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "safe-buffer": {
@@ -3752,9 +3743,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
     },
     "ultron": {
@@ -3857,9 +3848,9 @@
       }
     },
     "unzipper": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.4.tgz",
-      "integrity": "sha512-kGrkTaphmXE+0/A5Q7rwcm/xHlDkXDOGEh6wuiN3SUQsyVWd7V51rwqttlNTT91JrLkfn34MoBNf38unF0vhRw==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.9.7.tgz",
+      "integrity": "sha512-icFtME1RD648v+cjfcUWoky4bHbMTi8nk06nGxH77EPYyEeKaTgT3nRHM/dQ3znGXLi3+OlhYo86zQzNBRdNhw==",
       "dev": true,
       "requires": {
         "big-integer": "^1.6.17",
@@ -3930,12 +3921,12 @@
       "dev": true
     },
     "useragent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
-      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
+        "lru-cache": "4.1.x",
         "tmp": "0.0.x"
       }
     },
@@ -4054,6 +4045,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,8 +22,8 @@
     "google-closure-compiler": "^20171203.0.0",
     "google-closure-library": "^20171203.0.0",
     "html2canvas": "^1.0.0-alpha.12",
-    "karma": "^3.1.1",
-    "karma-browserstack-launcher": "^1.3.0",
+    "karma": "^3.1.4",
+    "karma-browserstack-launcher": "^1.4.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-edge-launcher": "^0.4.2",
@@ -38,7 +38,7 @@
     "karma-teamcity-reporter": "^1.1.0",
     "mocha": "^5.2.0",
     "modernizr": "^3.6.0",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.2"
   },
   "scripts": {
     "tsc": "tsc",

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -4,8 +4,8 @@
 /// <reference path="../node_modules/promise-polyfill/lib/polyfill.js" />
 // Defines the web-page interface object.
 /// <reference path="singleton.ts" />
-// Defines key-code constants.
-/// <reference path="text/codes.ts" />
+// Defines the core text processor.
+/// <reference path="text/processor.ts" />
 // Defines the web-page interface object.
 /// <reference path="kmwdom.ts" />
 // Includes KMW-added property declaration extensions for HTML elements.
@@ -68,6 +68,7 @@ namespace com.keyman {
     hotkeyManager: HotkeyManager;
     uiManager: UIManager;
     keyMapManager: KeyMapManager;
+    textProcessor: text.Processor;
 
     touchAliasing: DOMEventHandlers;
 
@@ -114,6 +115,7 @@ namespace com.keyman {
       this.hotkeyManager = new HotkeyManager(this);
       this.uiManager = new UIManager(this);
       this.keyMapManager = new KeyMapManager();
+      this.textProcessor = new text.Processor();
 
       // Load properties from their static variants.
       this['build'] = KeymanBase.__BUILD__;

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -4,6 +4,8 @@
 /// <reference path="../node_modules/promise-polyfill/lib/polyfill.js" />
 // Defines the web-page interface object.
 /// <reference path="singleton.ts" />
+// Defines key-code constants.
+/// <reference path="text/codes.ts" />
 // Defines the web-page interface object.
 /// <reference path="kmwdom.ts" />
 // Includes KMW-added property declaration extensions for HTML elements.

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -566,8 +566,9 @@ namespace com.keyman {
       var keyCode = (e.Lcode == 173 ? 189 : e.Lcode);  //I3555 (Firefox hyphen issue)
 
       var bitmask = this.keymanweb.keyboardManager.getKeyboardModifierBitmask();
-      var modifierBitmask = bitmask & com.keyman.osk.VisualKeyboard.modifierBitmasks["ALL"];
-      var stateBitmask = bitmask & com.keyman.osk.VisualKeyboard.stateBitmasks["ALL"];
+      let Codes = com.keyman.text.Codes;
+      var modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
+      var stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
       if(e.vkCode > 255) {
         keyCode = e.vkCode; // added to support extended (touch-hold) keys for mnemonic layouts

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -8,6 +8,14 @@
 ***/
 
 namespace com.keyman {
+  type KeyEvent = com.keyman.text.KeyEvent;
+
+  export class KeyInformation {
+    vk: boolean;
+    code: number;
+    modifiers: number;
+  }
+
   /*
   * Type alias definitions to reflect the parameters of the fullContextMatch() callback (KMW 10+).
   * No constructors or methods since keyboards will not utilize the same backing prototype, and
@@ -1307,7 +1315,7 @@ namespace com.keyman {
      * Description  Encapsulates calls to keyboard input processing.
      * @returns     {number}        0 if no match is made, otherwise 1.
      */
-    processKeystroke(device, element: HTMLElement, keystroke:KeyEvent|LegacyKeyEvent) {
+    processKeystroke(device, element: HTMLElement, keystroke: KeyEvent|com.keyman.text.LegacyKeyEvent) {
       // Clear internal state tracking data from prior keystrokes.
       (<any>this.keymanweb)._CachedSelectionStart = null; // I3319     
       this._DeadkeyResetMatched();       // I3318    

--- a/web/source/kmwcallback.ts
+++ b/web/source/kmwcallback.ts
@@ -1413,9 +1413,10 @@ namespace com.keyman {
      * Reset OSK shift states when entering or exiting the active element
      **/    
     resetVKShift() {
+      let processor = com.keyman.singleton.textProcessor;
       if(!this.keymanweb.uiManager.isActivating && this.keymanweb.osk.vkbd) {
-        if(this.keymanweb.osk.vkbd._UpdateVKShift) {
-          this.keymanweb.osk.vkbd._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
+        if(processor._UpdateVKShift) {
+          processor._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
         }
       }
     }

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -474,7 +474,7 @@ namespace com.keyman {
      */    
     _GetKeyEventProperties(e: KeyboardEvent, keyState?: boolean) {
       var s = new KeyEvent();
-      let VisualKeyboard = osk.VisualKeyboard;
+      let Codes = text.Codes;
 
       e = this.keyman._GetEventObject(e);   // I2404 - Manage IE events in IFRAMEs
       s.Ltarg = this.keyman.util.eventTarget(e) as HTMLElement;
@@ -498,7 +498,7 @@ namespace com.keyman {
 
       if(activeKeyboard && activeKeyboard['KM']) {
         // K_SPACE is not handled by defaultKeyOutput for physical keystrokes unless using touch-aliased elements.
-        if(s.Lcode != VisualKeyboard.keyCodes['K_SPACE']) {
+        if(s.Lcode != Codes.keyCodes['K_SPACE']) {
           // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
           // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
           var mappedChar: string = com.keyman.singleton.osk.vkbd.defaultKeyOutput('K_xxxx', s.Lcode, (e.getModifierState("Shift") ? 0x10 : 0), false, null);
@@ -512,7 +512,7 @@ namespace com.keyman {
       var prevModState = DOMEventHandlers.states.modStateFlags, curModState = 0x0000;
       var ctrlEvent = false, altEvent = false;
       
-      let keyCodes = VisualKeyboard.keyCodes;
+      let keyCodes = Codes.keyCodes;
       switch(s.Lcode) {
         case keyCodes['K_CTRL']:      // The 3 shorter "K_*CTRL" entries exist in some legacy keyboards.
         case keyCodes['K_LCTRL']:
@@ -548,7 +548,7 @@ namespace com.keyman {
 
       curModState |= (e.getModifierState("Shift") ? 0x10 : 0);
 
-      let modifierCodes = VisualKeyboard.modifierCodes;
+      let modifierCodes = Codes.modifierCodes;
       if(e.getModifierState("Control")) {
         curModState |= ((e.location != 0 && ctrlEvent) ? 
           (e.location == 1 ? modifierCodes['LCTRL'] : modifierCodes['RCTRL']) : // Condition 1
@@ -608,7 +608,7 @@ namespace com.keyman {
         curModState &= ~modifierCodes['LCTRL'];
       }
 
-      let modifierBitmasks = VisualKeyboard.modifierBitmasks;
+      let modifierBitmasks = Codes.modifierBitmasks;
       // Stage 4 - map the modifier set to the appropriate keystroke's modifiers.
       if(this.keyman.keyboardManager.isChiral()) {
         s.Lmodifiers = curModState & modifierBitmasks.CHIRAL;

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -501,7 +501,7 @@ namespace com.keyman {
         if(s.Lcode != Codes.keyCodes['K_SPACE']) {
           // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
           // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
-          var mappedChar: string = com.keyman.singleton.osk.vkbd.defaultKeyOutput('K_xxxx', s.Lcode, (e.getModifierState("Shift") ? 0x10 : 0), false, null);
+          var mappedChar: string = com.keyman.singleton.textProcessor.defaultKeyOutput('K_xxxx', s.Lcode, (e.getModifierState("Shift") ? 0x10 : 0), false, null);
           if(mappedChar) {
             s.Lcode = mappedChar.charCodeAt(0);
           } // No 'else' - avoid blocking modifier keys, etc.
@@ -794,7 +794,7 @@ namespace com.keyman {
       if(typeof((Levent.Ltarg as HTMLElement).base) != 'undefined') {
         // Simulated touch elements have no default text-processing - we need to rely on a strategy similar to
         // that of the OSK here.
-        var ch = osk.vkbd.defaultKeyOutput('',Levent.Lcode,Levent.Lmodifiers,false,Levent.Ltarg);
+        var ch = this.keyman.textProcessor.defaultKeyOutput('',Levent.Lcode,Levent.Lmodifiers,false,Levent.Ltarg);
         if(ch) {
           kbdInterface.output(0, Levent.Ltarg, ch);
           return false;

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -646,6 +646,7 @@ namespace com.keyman {
     _KeyDown: (e: KeyboardEvent) => boolean = function(this: DOMEventHandlers, e: KeyboardEvent): boolean {
       var Ldv: Document, eClass='';
       var activeKeyboard = this.keyman.keyboardManager.activeKeyboard;
+      let processor = this.keyman.textProcessor;
       var osk = this.keyman.osk;
       var util = this.keyman.util;
       var kbdInterface = this.keyman['interface'];
@@ -689,7 +690,7 @@ namespace com.keyman {
           // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
           this.keyman.keyboardManager.notifyKeyboard(Levent.Lcode,Levent.Ltarg,1); 
           if(!util.device.touchable) {
-            return osk.vkbd._UpdateVKShift(Levent, Levent.Lcode-15, 1); // I2187
+            return processor._UpdateVKShift(Levent, Levent.Lcode-15, 1); // I2187
           } else {
             return true;
           }
@@ -697,7 +698,7 @@ namespace com.keyman {
 
       if(Levent.LmodifierChange) {
         this.keyman.keyboardManager.notifyKeyboard(0,Levent.Ltarg,1); 
-        osk.vkbd._UpdateVKShift(Levent, 0, 1);
+        processor._UpdateVKShift(Levent, 0, 1);
       }
 
       if(!window.event) {
@@ -877,6 +878,7 @@ namespace com.keyman {
      */       
     _KeyUp: (e: KeyboardEvent) => boolean = function(this: DOMEventHandlers, e: KeyboardEvent): boolean {
       var keyboardManager = this.keyman.keyboardManager;
+      let processor = this.keyman.textProcessor;
       var osk = this.keyman.osk;
 
       var Levent = this._GetKeyEventProperties(e, false);
@@ -913,7 +915,7 @@ namespace com.keyman {
         case 145:
           keyboardManager.notifyKeyboard(Levent.Lcode,Levent.Ltarg,0);
           if(!this.keyman.util.device.touchable) {
-            return osk.vkbd._UpdateVKShift(Levent, Levent.Lcode-15, 1);  // I2187
+            return processor._UpdateVKShift(Levent, Levent.Lcode-15, 1);  // I2187
           } else {
             return true;
           }
@@ -921,7 +923,7 @@ namespace com.keyman {
       
       if(Levent.LmodifierChange){
         keyboardManager.notifyKeyboard(0,Levent.Ltarg,0); 
-        osk.vkbd._UpdateVKShift(Levent, 0, 1);  // I2187
+        processor._UpdateVKShift(Levent, 0, 1);  // I2187
       }
       
       return false;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -616,12 +616,6 @@ namespace com.keyman.osk {
     if (code == Codes.keyCodes.K_SPACE) {
       kbdInterface.output(0, Lelem, ' ');
       return true;
-    } else if (code == Codes.keyCodes.K_ENTER) {
-      kbdInterface.output(0, Lelem, '\n');
-      return true;
-    } else if (code == Codes.keyCodes.K_TAB) {
-      kbdInterface.output(0, Lelem, '\t');
-      return true;
     } else if (code == Codes.keyCodes.K_BKSP) {
       kbdInterface.defaultBackspace();
       return true;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -487,11 +487,11 @@ namespace com.keyman.osk {
         return true;      
       }
 
-      let VisualKeyboard = com.keyman.osk.VisualKeyboard;
-      let modifierCodes = VisualKeyboard.modifierCodes;
+      let Codes = com.keyman.text.Codes;
+      let modifierCodes = Codes.modifierCodes;
       
       // Check the virtual key 
-      Lkc = {Ltarg:Lelem,Lmodifiers:0,Lstates:0, Lcode: VisualKeyboard.keyCodes[keyName],LisVirtualKey:true};
+      Lkc = {Ltarg:Lelem,Lmodifiers:0,Lstates:0, Lcode: Codes.keyCodes[keyName],LisVirtualKey:true};
 
       // Set the flags for the state keys.
       Lkc.Lstates |= osk.vkbd.stateKeys['K_CAPS']    ? modifierCodes['CAPS'] : modifierCodes['NO_CAPS'];
@@ -522,7 +522,7 @@ namespace com.keyman.osk {
 
       // Define modifiers value for sending to keyboard mapping function
       Lkc.Lmodifiers = keyShiftState;
-      let modifierBitmasks = VisualKeyboard.modifierBitmasks;
+      let modifierBitmasks = Codes.modifierBitmasks;
 
       // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
       if((Lkc.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM'] && Layouts.emulatesAltGr()) {
@@ -610,22 +610,22 @@ namespace com.keyman.osk {
    *  @return {boolean}         true if key code successfully processed
    */
   keymanweb.processDefaultMapping = function(code, shift, Lelem, keyName) {
-    let VisualKeyboard = com.keyman.osk.VisualKeyboard;
-    if (code == VisualKeyboard.keyCodes.K_SPACE) {
+    let Codes = com.keyman.text.Codes;
+    if (code == Codes.keyCodes.K_SPACE) {
       kbdInterface.output(0, Lelem, ' ');
       return true;
-    } else if (code == VisualKeyboard.keyCodes.K_ENTER) {
+    } else if (code == Codes.keyCodes.K_ENTER) {
       kbdInterface.output(0, Lelem, '\n');
       return true;
-    } else if (code == VisualKeyboard.keyCodes.K_TAB) {
+    } else if (code == Codes.keyCodes.K_TAB) {
       kbdInterface.output(0, Lelem, '\t');
       return true;
-    } else if (code == VisualKeyboard.keyCodes.K_BKSP) {
+    } else if (code == Codes.keyCodes.K_BKSP) {
       kbdInterface.defaultBackspace();
       return true;
-    } else if (code == VisualKeyboard.keyCodes.K_oE2) {
+    } else if (code == Codes.keyCodes.K_oE2) {
       // Using defaults of English US layout for the 102nd key
-      if (shift == VisualKeyboard.modifierCodes['SHIFT']) {
+      if (shift == Codes.modifierCodes['SHIFT']) {
         kbdInterface.output(0, Lelem, '|');
       } else {
         kbdInterface.output(0, Lelem, '\\');
@@ -633,7 +633,7 @@ namespace com.keyman.osk {
       return true;
     }
 
-    var ch = osk.vkbd.defaultKeyOutput(keyName, code, shift, false, undefined);
+    var ch = keymanweb.textProcessor.defaultKeyOutput(keyName, code, shift, false, undefined);
     if(ch) {
       kbdInterface.output(0, Lelem, ch);
       return true;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -578,7 +578,7 @@ namespace com.keyman.osk {
     keymanweb.domManager.initActiveElement(Lelem);
 
     // Check the virtual key 
-    var Lkc = {
+    var Lkc: com.keyman.text.KeyEvent = {
       Ltarg: keymanweb.domManager.getActiveElement(),
       Lmodifiers: shift,
       vkCode: code,

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -433,6 +433,8 @@ namespace com.keyman.osk {
    *  @param  {string}  keyName   key identifier
    **/            
   keymanweb['executePopupKey'] = function(keyName: string) {
+      let Processor = (<KeymanBase> keymanweb).textProcessor;
+
       var origArg = keyName;
       if(!keymanweb.keyboardManager.activeKeyboard || !osk.vkbd) {
         return false;
@@ -448,7 +450,7 @@ namespace com.keyman.osk {
       keyName=t[t.length-1];
       if(layer == 'undefined') layer=osk.vkbd.layerId;
               
-      var Lelem=keymanweb.domManager.getLastActiveElement(),Lkc,keyShiftState=osk.vkbd.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),Lkc,keyShiftState=Processor.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -483,7 +485,7 @@ namespace com.keyman.osk {
       }
       
       // Process modifier key action
-      if(osk.vkbd.selectLayer(keyName, undefined)) {
+      if(Processor.selectLayer(keyName)) {
         return true;      
       }
 
@@ -494,16 +496,16 @@ namespace com.keyman.osk {
       Lkc = {Ltarg:Lelem,Lmodifiers:0,Lstates:0, Lcode: Codes.keyCodes[keyName],LisVirtualKey:true};
 
       // Set the flags for the state keys.
-      Lkc.Lstates |= osk.vkbd.stateKeys['K_CAPS']    ? modifierCodes['CAPS'] : modifierCodes['NO_CAPS'];
-      Lkc.Lstates |= osk.vkbd.stateKeys['K_NUMLOCK'] ? modifierCodes['NUM_LOCK'] : modifierCodes['NO_NUM_LOCK'];
-      Lkc.Lstates |= osk.vkbd.stateKeys['K_SCROLL']  ? modifierCodes['SCROLL_LOCK'] : modifierCodes['NO_SCROLL_LOCK'];
+      Lkc.Lstates |= Processor.stateKeys['K_CAPS']    ? modifierCodes['CAPS'] : modifierCodes['NO_CAPS'];
+      Lkc.Lstates |= Processor.stateKeys['K_NUMLOCK'] ? modifierCodes['NUM_LOCK'] : modifierCodes['NO_NUM_LOCK'];
+      Lkc.Lstates |= Processor.stateKeys['K_SCROLL']  ? modifierCodes['SCROLL_LOCK'] : modifierCodes['NO_SCROLL_LOCK'];
 
       // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
       if(keyName.substr(0,2) == 'U_') Lkc.isVirtualKey=false;
 
       // Get code for non-physical keys
       if(typeof Lkc.Lcode == 'undefined') {
-          Lkc.Lcode = osk.vkbd.getVKDictionaryCode(keyName);
+          Lkc.Lcode = keymanweb.textProcessor.getVKDictionaryCode(keyName);
           if (!Lkc.Lcode) {
               // Special case for U_xxxx keys
               Lkc.Lcode = 1;
@@ -515,7 +517,7 @@ namespace com.keyman.osk {
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          osk.vkbd.selectLayer(keyName, nextLayer);
+          Processor.selectLayer(keyName, nextLayer);
         }
         return false;
       }
@@ -539,7 +541,7 @@ namespace com.keyman.osk {
       if(kbdInterface.processKeystroke(util.device, Lelem, Lkc)) {
         // Make sure we don't affect the current layer until the keystroke has been processed!
         if(nextLayer) {
-          osk.vkbd.selectLayer(keyName, nextLayer);
+          Processor.selectLayer(keyName, nextLayer);
         }
 
         return true;
@@ -549,7 +551,7 @@ namespace com.keyman.osk {
 
       if(nextLayer) {
         // Final nextLayer check.
-        osk.vkbd.selectLayer(keyName, nextLayer);
+        Processor.selectLayer(keyName, nextLayer);
       }
 
       return true;

--- a/web/source/kmwhotkeys.ts
+++ b/web/source/kmwhotkeys.ts
@@ -67,12 +67,12 @@ namespace com.keyman {
      * @param       {Event}       e       event
      * Description  Passes control to handlers according to the hotkey pressed
      */
-    _Process: (e: KeyboardEvent) => boolean = function(e: KeyboardEvent) {
+    _Process: (e: KeyboardEvent) => boolean = function(this: HotkeyManager, e: KeyboardEvent) {
       if(!e) {
         e = window.event as KeyboardEvent;
       }
 
-      var _Lcode = this.keyman.domManager.nonTouchHandlers._GetEventKeyCode(e);
+      var _Lcode = this.keyman.textProcessor._GetEventKeyCode(e);
       if(_Lcode == null) {
         return false;
       }
@@ -85,9 +85,11 @@ namespace com.keyman {
 
       for(var i=0; i<this.hotkeys.length; i++) {  
         if(this.hotkeys[i].matches(_Lcode, _Lmodifiers)) { 
-          this.hotkeys[i].Handler(); 
+          this.hotkeys[i].handler(); 
           e.returnValue = false; 
-          if(e && e.preventDefault) e.preventDefault(); 
+          if(e && e.preventDefault) {
+            e.preventDefault(); 
+          }
           e.cancelBubble = true; 
           return false; 
         }

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -819,7 +819,7 @@ namespace com.keyman {
         k0 = this.getKeyboardByID(k0);
       }
 
-      return !!(this.getKeyboardModifierBitmask(k0) & osk.VisualKeyboard.modifierBitmasks.IS_CHIRAL);
+      return !!(this.getKeyboardModifierBitmask(k0) & text.Codes.modifierBitmasks.IS_CHIRAL);
     }
 
     /**
@@ -844,7 +844,7 @@ namespace com.keyman {
         return k['KMBM'];
       }
 
-      return osk.VisualKeyboard.modifierBitmasks['NON_CHIRAL'];
+      return text.Codes.modifierBitmasks['NON_CHIRAL'];
     }
 
     getFont(k0?) {

--- a/web/source/kmwkeymaps.ts
+++ b/web/source/kmwkeymaps.ts
@@ -164,7 +164,7 @@ namespace com.keyman {
      * @return      {number}                Character code 
      * Description Translate keyboard codes to standard US layout codes
      */    
-    _USKeyCodeToCharCode(Levent: KeyEvent) {
+    _USKeyCodeToCharCode(Levent: com.keyman.text.KeyEvent) {
       return this._usCharCodes[Levent.Lmodifiers & 0x10 ? 1 : 0]['k'+Levent.Lcode];
     };
   }

--- a/web/source/kmwtypedefs.ts
+++ b/web/source/kmwtypedefs.ts
@@ -1,15 +1,4 @@
 namespace com.keyman {
-  export class KeyEvent {
-      Ltarg: HTMLElement;
-      Lcode: number;
-      Lstates: number;
-      LmodifierChange: boolean;
-      Lmodifiers: number;
-      LisVirtualKeyCode: boolean;
-      LisVirtualKey: boolean;
-      vkCode: number
-  };
-
   export class AttachmentInfo {
     /**
      * Tracks the control's independent keyboard selection, when applicable.
@@ -33,19 +22,6 @@ namespace com.keyman {
       this.keyboard = kbd;
       this.touchEnabled = touch;
     }
-  }
-
-  export class LegacyKeyEvent {
-    Ltarg: HTMLElement;
-    Lcode: number;
-    Lmodifiers: number;
-    LisVirtualKey: number;
-  }
-
-  export class KeyInformation {
-    vk: boolean;
-    code: number;
-    modifiers: number;
   }
 
   export class StyleCommand {

--- a/web/source/osk/defaultLayouts.ts
+++ b/web/source/osk/defaultLayouts.ts
@@ -4,6 +4,8 @@
 ***/
 
 namespace com.keyman.osk {
+  let Codes = com.keyman.text.Codes;
+
   export type KLS = {[layerName: string]: string[]};
 
   // The following types provide type definitions for the full JSON format we use for visual keyboard definitions.
@@ -126,7 +128,7 @@ namespace com.keyman.osk {
 
       var n,layers=layout['layer'], keyLabels: KLS=PVK['KLS'], key102=PVK['K102'];
       var i, j, k, m, row, rows: LayoutRow[], key: LayoutKey, keys: LayoutKey[];
-      var chiral: boolean = (kbdBitmask & VisualKeyboard.modifierBitmasks.IS_CHIRAL) != 0;
+      var chiral: boolean = (kbdBitmask & Codes.modifierBitmasks.IS_CHIRAL) != 0;
 
       var kmw10Plus = !(typeof keyLabels == 'undefined' || !keyLabels);
       if(!kmw10Plus) {
@@ -319,7 +321,7 @@ namespace com.keyman.osk {
      * Description  Get name of layer from code, where the modifer order is determined by ascending bit-flag value.
      */
     static getLayerId(m: number): string {
-      let modifierCodes = VisualKeyboard.modifierCodes;
+      let modifierCodes = Codes.modifierCodes;
 
       var s='';
       if(m == 0) {
@@ -358,7 +360,7 @@ namespace com.keyman.osk {
     static emulatesAltGr(keyLabels?: KLS): boolean { // TODO:  typing for keyLabels (corresponds to KLS)
       var layers;
       let keyman = <KeymanBase> window['keyman'];
-      let modifierCodes = VisualKeyboard.modifierCodes;
+      let modifierCodes = Codes.modifierCodes;
 
       // If we're not chiral, we're not emulating.
       if(!keyman.keyboardManager.isChiral()) {

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -61,6 +61,12 @@ namespace com.keyman.osk {
     _VPreviousCursor: string;
     _VPreviousMouseButton: number;
 
+    // Key code definition aliases for legacy keyboards  (They expect window['keyman']['osk'].___)
+    modifierCodes = text.Codes.modifierCodes;
+    modifierBitmasks = text.Codes.modifierBitmasks;
+    stateBitmasks = text.Codes.stateBitmasks;
+    keyCodes = text.Codes.keyCodes;
+
     // First time initialization of OSK
     prepare() {
       let keymanweb = com.keyman.singleton;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1,4 +1,8 @@
+// Defines key code constants
+/// <reference path="../text/codes.ts" />
+
 namespace com.keyman.osk {
+  let Codes = com.keyman.text.Codes;
   //#region Definition of the KeyElement merger type
   class KeyData {
     ['key']: OSKKey;
@@ -259,7 +263,7 @@ namespace com.keyman.osk {
     // Produces a small reference label for the corresponding physical key on a US keyboard.
     private generateKeyCapLabel(): HTMLDivElement {
       // Create the default key cap labels (letter keys, etc.)
-      var x = VisualKeyboard.keyCodes[this.spec.id];
+      var x = Codes.keyCodes[this.spec.id];
       switch(x) {
         // Converts the keyman key id code for common symbol keys into its representative ASCII code.
         // K_COLON -> K_BKQUOTE
@@ -463,73 +467,6 @@ namespace com.keyman.osk {
   //#endregion
 
   export class VisualKeyboard {
-    //#region Keyboard-related static constants
-    // Define Keyman Developer modifier bit-flags (exposed for use by other modules)
-    static modifierCodes = {
-      "LCTRL":0x0001,
-      "RCTRL":0x0002,
-      "LALT":0x0004,
-      "RALT":0x0008,
-      "SHIFT":0x0010,
-      "CTRL":0x0020,
-      "ALT":0x0040,
-      "CAPS":0x0100,
-      "NO_CAPS":0x0200,
-      "NUM_LOCK":0x0400,
-      "NO_NUM_LOCK":0x0800,
-      "SCROLL_LOCK":0x1000,
-      "NO_SCROLL_LOCK":0x2000,
-      "VIRTUAL_KEY":0x4000
-    };
-
-    static modifierBitmasks = {
-      "ALL":0x007F,
-      "ALT_GR_SIM": (VisualKeyboard.modifierCodes['LCTRL'] | VisualKeyboard.modifierCodes['LALT']),
-      "CHIRAL":0x001F,    // The base bitmask for chiral keyboards.  Includes SHIFT, which is non-chiral.
-      "IS_CHIRAL":0x000F, // Used to test if a bitmask uses a chiral modifier.
-      "NON_CHIRAL":0x0070 // The default bitmask, for non-chiral keyboards
-    };
-
-    static stateBitmasks = {
-      "ALL":0x3F00,
-      "CAPS":0x0300,
-      "NUM_LOCK":0x0C00,
-      "SCROLL_LOCK":0x3000
-    };
-
-    // Define standard keycode numbers (exposed for use by other modules)
-    static keyCodes = {
-      "K_BKSP":8,"K_TAB":9,"K_ENTER":13,
-      "K_SHIFT":16,"K_CONTROL":17,"K_ALT":18,"K_PAUSE":19,"K_CAPS":20,
-      "K_ESC":27,"K_SPACE":32,"K_PGUP":33,
-      "K_PGDN":34,"K_END":35,"K_HOME":36,"K_LEFT":37,"K_UP":38,
-      "K_RIGHT":39,"K_DOWN":40,"K_SEL":41,"K_PRINT":42,"K_EXEC":43,
-      "K_INS":45,"K_DEL":46,"K_HELP":47,"K_0":48,
-      "K_1":49,"K_2":50,"K_3":51,"K_4":52,"K_5":53,"K_6":54,"K_7":55,
-      "K_8":56,"K_9":57,"K_A":65,"K_B":66,"K_C":67,"K_D":68,"K_E":69,
-      "K_F":70,"K_G":71,"K_H":72,"K_I":73,"K_J":74,"K_K":75,"K_L":76,
-      "K_M":77,"K_N":78,"K_O":79,"K_P":80,"K_Q":81,"K_R":82,"K_S":83,
-      "K_T":84,"K_U":85,"K_V":86,"K_W":87,"K_X":88,"K_Y":89,"K_Z":90,
-      "K_NP0":96,"K_NP1":97,"K_NP2":98,
-      "K_NP3":99,"K_NP4":100,"K_NP5":101,"K_NP6":102,
-      "K_NP7":103,"K_NP8":104,"K_NP9":105,"K_NPSTAR":106,
-      "K_NPPLUS":107,"K_SEPARATOR":108,"K_NPMINUS":109,"K_NPDOT":110,
-      "K_NPSLASH":111,"K_F1":112,"K_F2":113,"K_F3":114,"K_F4":115,
-      "K_F5":116,"K_F6":117,"K_F7":118,"K_F8":119,"K_F9":120,
-      "K_F10":121,"K_F11":122,"K_F12":123,"K_NUMLOCK":144,"K_SCROLL":145,
-      "K_LSHIFT":160,"K_RSHIFT":161,"K_LCONTROL":162,"K_RCONTROL":163,
-      "K_LALT":164,"K_RALT":165,
-      "K_COLON":186,"K_EQUAL":187,"K_COMMA":188,"K_HYPHEN":189,
-      "K_PERIOD":190,"K_SLASH":191,"K_BKQUOTE":192,
-      "K_LBRKT":219,"K_BKSLASH":220,"K_RBRKT":221,
-      "K_QUOTE":222,"K_oE2":226,
-      "K_LOPT":50001,"K_ROPT":50002,
-      "K_NUMERALS":50003,"K_SYMBOLS":50004,"K_CURRENCIES":50005,
-      "K_UPPER":50006,"K_LOWER":50007,"K_ALPHA":50008,
-      "K_SHIFTED":50009,"K_ALTGR":50010,
-      "K_TABBACK":50011,"K_TABFWD":50012
-    };
-
     // Defines the PUA code mapping for the various 'special' modifier/control keys on keyboards.
     static specialCharacters = {
       '*Shift*':    8,
@@ -565,12 +502,6 @@ namespace com.keyman.osk {
       '*LCtrlShift*':     0x69,
       '*RCtrlShift*':     0x70
     };
-
-    static codesUS = [
-      ['0123456789',';=,-./`', '[\\]\''],
-      [')!@#$%^&*(',':+<_>?~', '{|}"']
-    ];
-    //#endregion
 
     // Tracks the OSK-based state of supported state keys.
     // Using the exact keyCode name from above allows for certain optimizations elsewhere in the code.
@@ -1388,14 +1319,14 @@ namespace com.keyman.osk {
           Ltarg:Lelem,
           Lmodifiers:0,
           Lstates:0,
-          Lcode:VisualKeyboard.keyCodes[keyName],
+          Lcode: Codes.keyCodes[keyName],
           LisVirtualKey:true
         };
 
         // Set the flags for the state keys.
-        Lkc.Lstates |= this.stateKeys['K_CAPS']    ? VisualKeyboard.modifierCodes['CAPS'] : VisualKeyboard.modifierCodes['NO_CAPS'];
-        Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? VisualKeyboard.modifierCodes['NUM_LOCK'] : VisualKeyboard.modifierCodes['NO_NUM_LOCK'];
-        Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? VisualKeyboard.modifierCodes['SCROLL_LOCK'] : VisualKeyboard.modifierCodes['NO_SCROLL_LOCK'];
+        Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
+        Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
+        Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
 
         // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
         if(keyName.substr(0,2) == 'U_') Lkc.LisVirtualKey=false;
@@ -1418,15 +1349,15 @@ namespace com.keyman.osk {
         Lkc.Lmodifiers = keyShiftState;
 
         // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
-        if((Lkc.Lmodifiers & VisualKeyboard.modifierBitmasks['ALT_GR_SIM']) == VisualKeyboard.modifierBitmasks['ALT_GR_SIM'] && Layouts.emulatesAltGr()) {
-          Lkc.Lmodifiers &= ~VisualKeyboard.modifierBitmasks['ALT_GR_SIM'];
-          Lkc.Lmodifiers |= VisualKeyboard.modifierCodes['RALT'];
+        if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && Layouts.emulatesAltGr()) {
+          Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
+          Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
         }
 
         // Include *limited* support for mnemonic keyboards (Sept 2012)
         // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
         if(activeKeyboard && activeKeyboard['KM'] && !(activeKeyboard['KVKL'] && formFactor != 'desktop')) {
-          if(Lkc.Lcode != VisualKeyboard.keyCodes['K_SPACE']) { // exception required, March 2013
+          if(Lkc.Lcode != Codes.keyCodes['K_SPACE']) { // exception required, March 2013
             Lkc.vkCode = Lkc.Lcode;
             // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
             // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
@@ -1620,25 +1551,25 @@ namespace com.keyman.osk {
           // Toggle the modifier represented by our input argument.
           switch(id) {
             case 'shift':
-              modifier ^= VisualKeyboard.modifierCodes['SHIFT'];
+              modifier ^= Codes.modifierCodes['SHIFT'];
               break;
             case 'leftctrl':
-              modifier ^= VisualKeyboard.modifierCodes['LCTRL'];
+              modifier ^= Codes.modifierCodes['LCTRL'];
               break;
             case 'rightctrl':
-              modifier ^= VisualKeyboard.modifierCodes['RCTRL'];
+              modifier ^= Codes.modifierCodes['RCTRL'];
               break;
             case 'ctrl':
-              modifier ^= VisualKeyboard.modifierCodes['CTRL'];
+              modifier ^= Codes.modifierCodes['CTRL'];
               break;
             case 'leftalt':
-              modifier ^= VisualKeyboard.modifierCodes['LALT'];
+              modifier ^= Codes.modifierCodes['LALT'];
               break;
             case 'rightalt':
-              modifier ^= VisualKeyboard.modifierCodes['RALT'];
+              modifier ^= Codes.modifierCodes['RALT'];
               break;
             case 'alt':
-              modifier ^= VisualKeyboard.modifierCodes['ALT'];
+              modifier ^= Codes.modifierCodes['ALT'];
               break;
             default:
               s = id;
@@ -1686,34 +1617,34 @@ namespace com.keyman.osk {
     getModifierState(layerId: string): number {
       var modifier=0;
       if(layerId.indexOf('shift') >= 0) {
-        modifier |= VisualKeyboard.modifierCodes['SHIFT'];
+        modifier |= Codes.modifierCodes['SHIFT'];
       }
 
       // The chiral checks must not be directly exclusive due each other to visual OSK feedback.
       var ctrlMatched=false;
       if(layerId.indexOf('leftctrl') >= 0) {
-        modifier |= VisualKeyboard.modifierCodes['LCTRL'];
+        modifier |= Codes.modifierCodes['LCTRL'];
         ctrlMatched=true;
       } 
       if(layerId.indexOf('rightctrl') >= 0) {
-        modifier |= VisualKeyboard.modifierCodes['RCTRL'];
+        modifier |= Codes.modifierCodes['RCTRL'];
         ctrlMatched=true;
       } 
       if(layerId.indexOf('ctrl')  >= 0 && !ctrlMatched) {
-        modifier |= VisualKeyboard.modifierCodes['CTRL'];
+        modifier |= Codes.modifierCodes['CTRL'];
       }
 
       var altMatched=false;
       if(layerId.indexOf('leftalt') >= 0) {
-        modifier |= VisualKeyboard.modifierCodes['LALT'];
+        modifier |= Codes.modifierCodes['LALT'];
         altMatched=true;
       } 
       if(layerId.indexOf('rightalt') >= 0) {
-        modifier |= VisualKeyboard.modifierCodes['RALT'];
+        modifier |= Codes.modifierCodes['RALT'];
         altMatched=true;
       } 
       if(layerId.indexOf('alt')  >= 0 && !altMatched) {
-        modifier |= VisualKeyboard.modifierCodes['ALT'];
+        modifier |= Codes.modifierCodes['ALT'];
       }
 
       return modifier;
@@ -1739,7 +1670,7 @@ namespace com.keyman.osk {
       // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
       if(keyShiftState == 0) {
         checkCodes = true;
-      } else if (keyShiftState == VisualKeyboard.modifierCodes['SHIFT']) {
+      } else if (keyShiftState == Codes.modifierCodes['SHIFT']) {
         checkCodes = true; 
         keyShiftState = 1; // It's used as an index.
       } else {
@@ -1748,25 +1679,25 @@ namespace com.keyman.osk {
 
       // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
       if(touchAlias || usingOSK) {
-        var code = VisualKeyboard.keyCodes[keyName];
+        var code = Codes.keyCodes[keyName];
         if(!code) {
           code = n;
         }
 
         switch(code) {
-          case VisualKeyboard.keyCodes['K_BKSP']:  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
+          case Codes.keyCodes['K_BKSP']:  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
             keyman.interface.defaultBackspace();
             break;
-          case VisualKeyboard.keyCodes['K_TAB']:
+          case Codes.keyCodes['K_TAB']:
             domManager.moveToNext(keyShiftState);
             break;
-          case VisualKeyboard.keyCodes['K_TABBACK']:
+          case Codes.keyCodes['K_TABBACK']:
             domManager.moveToNext(true);
             break;
-          case VisualKeyboard.keyCodes['K_TABFWD']:
+          case Codes.keyCodes['K_TABFWD']:
             domManager.moveToNext(false);
             break;
-          case VisualKeyboard.keyCodes['K_ENTER']:
+          case Codes.keyCodes['K_ENTER']:
             // Insert new line in text area fields
             if(Lelem.nodeName == 'TEXTAREA' || (typeof Lelem.base != 'undefined' && Lelem.base.nodeName == 'TEXTAREA')) {
               return '\n';
@@ -1787,7 +1718,7 @@ namespace com.keyman.osk {
               }
             }
             break;
-          case VisualKeyboard.keyCodes['K_SPACE']:
+          case Codes.keyCodes['K_SPACE']:
             return ' ';
           // break;
           //
@@ -1842,14 +1773,14 @@ namespace com.keyman.osk {
         // Hereafter, we refer to keyCodes.
       } else if(checkCodes) { // keyShiftState can only be '1' or '2'.
         try {
-          if(n >= VisualKeyboard.keyCodes['K_0'] && n <= VisualKeyboard.keyCodes['K_9']) { // The number keys.
-            ch = VisualKeyboard.codesUS[keyShiftState][0][n-VisualKeyboard.keyCodes['K_0']];
-          } else if(n >=VisualKeyboard.keyCodes['K_A'] && n <= VisualKeyboard.keyCodes['K_Z']) { // The base letter keys
+          if(n >= Codes.keyCodes['K_0'] && n <= Codes.keyCodes['K_9']) { // The number keys.
+            ch = Codes.codesUS[keyShiftState][0][n-Codes.keyCodes['K_0']];
+          } else if(n >= Codes.keyCodes['K_A'] && n <= Codes.keyCodes['K_Z']) { // The base letter keys
             ch = String.fromCharCode(n+(keyShiftState?0:32));  // 32 is the offset from uppercase to lowercase.
-          } else if(n >= VisualKeyboard.keyCodes['K_COLON'] && n <= VisualKeyboard.keyCodes['K_BKQUOTE']) {
-            ch = VisualKeyboard.codesUS[keyShiftState][1][n-VisualKeyboard.keyCodes['K_COLON']];
-          } else if(n >= VisualKeyboard.keyCodes['K_LBRKT'] && n <= VisualKeyboard.keyCodes['K_QUOTE']) {
-            ch = VisualKeyboard.codesUS[keyShiftState][2][n-VisualKeyboard.keyCodes['K_LBRKT']];
+          } else if(n >= Codes.keyCodes['K_COLON'] && n <= Codes.keyCodes['K_BKQUOTE']) {
+            ch = Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
+          } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
+            ch = Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
           }
         } catch (e) {
           console.error("Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default'));
@@ -1881,21 +1812,21 @@ namespace com.keyman.osk {
 
         // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
         if(keyman.keyboardManager.isChiral() && Layouts.emulatesAltGr() && 
-            (com.keyman.DOMEventHandlers.states.modStateFlags & VisualKeyboard.modifierBitmasks['ALT_GR_SIM']) == VisualKeyboard.modifierBitmasks['ALT_GR_SIM']) {
-          keyShiftState |= VisualKeyboard.modifierBitmasks['ALT_GR_SIM'];
-          keyShiftState &= ~VisualKeyboard.modifierCodes['RALT'];
+            (com.keyman.DOMEventHandlers.states.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
+          keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
+          keyShiftState &= ~Codes.modifierCodes['RALT'];
         }
 
         for(i=0; i < lockNames.length; i++) {
-          if(lockStates & VisualKeyboard.stateBitmasks[lockNames[i]]) {
-            this.stateKeys[lockKeys[i]] = lockStates & VisualKeyboard.modifierCodes[lockNames[i]];
+          if(lockStates & Codes.stateBitmasks[lockNames[i]]) {
+            this.stateKeys[lockKeys[i]] = lockStates & Codes.modifierCodes[lockNames[i]];
           }
         }
       } else if(d) {
         keyShiftState |= v;
 
         for(i=0; i < lockNames.length; i++) {
-          if(v & VisualKeyboard.stateBitmasks[lockNames[i]]) {
+          if(v & Codes.stateBitmasks[lockNames[i]]) {
             this.stateKeys[lockKeys[i]] = true;
           }
         }
@@ -1903,7 +1834,7 @@ namespace com.keyman.osk {
         keyShiftState &= ~v;
 
         for(i=0; i < lockNames.length; i++) {
-          if(v & VisualKeyboard.stateBitmasks[lockNames[i]]) {
+          if(v & Codes.stateBitmasks[lockNames[i]]) {
             this.stateKeys[lockKeys[i]] = false;
           }
         }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -500,14 +500,6 @@ namespace com.keyman.osk {
       '*RCtrlShift*':     0x70
     };
 
-    // Tracks the OSK-based state of supported state keys.
-    // Using the exact keyCode name from above allows for certain optimizations elsewhere in the code.
-    stateKeys = {
-      "K_CAPS":false,
-      "K_NUMLOCK":false,
-      "K_SCROLL":false
-    };
-
     private layout: LayoutFormFactor;
     layers: LayoutLayer[];
     layerId: string = "default";
@@ -872,6 +864,7 @@ namespace com.keyman.osk {
      *
      */
     touch: (e: TouchEvent) => void = function(this: VisualKeyboard, e: TouchEvent) {
+      let Processor = com.keyman.singleton.textProcessor;
       // Identify the key touched
       var t = <HTMLElement> e.changedTouches[0].target, key = this.keyTarget(t);
 
@@ -909,7 +902,7 @@ namespace com.keyman.osk {
       // Special function keys need immediate action
       if(keyName == 'K_LOPT' || keyName == 'K_ROPT')      {
         window.setTimeout(function(this: VisualKeyboard){
-          this.clickKey(key);
+          Processor.clickKey(key);
         }.bind(this),0);
         this.keyPending = null;
 
@@ -917,14 +910,14 @@ namespace com.keyman.osk {
       } else if(keyName == 'K_BKSP') {
         // While we could inline the execution of the delete key here, we lose the ability to
         // record the backspace key if we do so.
-        this.clickKey(key);
+        Processor.clickKey(key);
         this.deleteKey = key;
         this.deleting = window.setTimeout(this.repeatDelete,500);
         this.keyPending = null;
       } else {
         if(this.keyPending) {
           this.highlightKey(this.keyPending, false);
-          this.clickKey(this.keyPending);
+          Processor.clickKey(this.keyPending);
           this.clearPopup();
           // Decrement the number of unreleased touch points to prevent
           // sending the keystroke again when the key is actually released
@@ -945,6 +938,8 @@ namespace com.keyman.osk {
      *
      **/
     release: (e: TouchEvent) => void = function(this: VisualKeyboard, e: TouchEvent) {
+      let Processor = com.keyman.singleton.textProcessor;
+
       // Prevent incorrect multi-touch behaviour if native or device popup visible
       var sk = document.getElementById('kmw-popup-keys'), t = this.currentTarget;
 
@@ -984,7 +979,7 @@ namespace com.keyman.osk {
 
         // Output character unless moved off key
         if(this.keyPending.className.indexOf('hidden') < 0 && tc > 0 && !beyondEdge) {
-          this.clickKey(this.keyPending);
+          Processor.clickKey(this.keyPending);
         }
         this.clearPopup();
         this.keyPending = null;
@@ -1239,475 +1234,16 @@ namespace com.keyman.osk {
      *  Repeat backspace as long as the backspace key is held down
      **/
     repeatDelete: () => void = function(this: VisualKeyboard) {
+      let Processor = com.keyman.singleton.textProcessor;
+
       if(this.deleting) {
-        this.clickKey(this.deleteKey);
+        Processor.clickKey(this.deleteKey);
         this.deleting = window.setTimeout(this.repeatDelete,100);
       }
     }.bind(this);
     //#endregion
 
-    /**
-     * Simulate a keystroke according to the touched keyboard button element
-     *
-     * Note that the test-case oriented 'recorder' stubs this method to facilitate OSK-based input
-     * recording for use in test cases.  If changing this function, please ensure the recorder is
-     * not affected.
-     * 
-     * @param       {Object}      e      element touched (or clicked)
-     */
-    clickKey(e: KeyElement) {
-      let keyman = com.keyman.singleton;
-      var Lelem = keyman.domManager.getLastActiveElement(), Ls, Le, Lkc;
-
-      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
-      let kbdInterface = keyman.interface;
-      let formFactor = keyman.util.device.formFactor;
-
-      if(Lelem != null) {
-        // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
-        // Note - virtual keys should be treated case-insensitive, so we force uppercasing here.
-        var layer=e['key'].spec.layer || '', keyName=e['keyId'].toUpperCase(), keyShiftState=this.getModifierState(this.layerId);
-        var nextLayer: string = e['key'].spec['nextlayer'];
-
-        keyman.domManager.initActiveElement(Lelem);
-
-        // Exclude menu and OSK hide keys from normal click processing
-        if(keyName == 'K_LOPT' || keyName == 'K_ROPT') {
-          this.optionKey(e, keyName, true);
-          return true;
-        }
-
-        // Turn off key highlighting (or preview)
-        this.highlightKey(e,false);
-
-        // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
-        if(formFactor == 'desktop') {
-          if(this.selectLayer(keyName, nextLayer)) {
-            return true;
-          }
-        }
-
-        // Prevent any output from 'ghost' (unmapped) keys
-        if(keyName != 'K_SPACE') {
-          var keyText=(<HTMLElement> e.childNodes[0]).innerHTML;
-          //// if(keyText == '' || keyText == '&nbsp;') return true; --> why?
-        }
-
-        Ls=Lelem._KeymanWebSelectionStart;
-        Le=Lelem._KeymanWebSelectionEnd;
-        keyman.uiManager.setActivatingUI(true);
-        com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 100;
-        keyman.domManager.focusLastActiveElement();
-        if(keyman.domManager._IsMozillaEditableIframe(<HTMLIFrameElement> Lelem,0)) {
-          Lelem = (<HTMLIFrameElement> Lelem).contentDocument.documentElement;
-        }
-        Lelem._KeymanWebSelectionStart=Ls;
-        Lelem._KeymanWebSelectionEnd=Le;
-        com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 0;
-        // ...end I3363 (Build 301)
-        (<any>keyman)._CachedSelectionStart = null; // I3319
-        // Deadkey matching continues to be troublesome.
-        // Deleting matched deadkeys here seems to correct some of the issues.   (JD 6/6/14)
-        kbdInterface._DeadkeyDeleteMatched();      // Delete any matched deadkeys before continuing
-        //kbdInterface._DeadkeyResetMatched();       // I3318   (Not needed if deleted first?)
-
-        // First check the virtual key, and process shift, control, alt or function keys
-        Lkc = {
-          Ltarg:Lelem,
-          Lmodifiers:0,
-          Lstates:0,
-          Lcode: Codes.keyCodes[keyName],
-          LisVirtualKey:true
-        };
-
-        // Set the flags for the state keys.
-        Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
-        Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
-        Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
-
-        // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
-        if(keyName.substr(0,2) == 'U_') Lkc.LisVirtualKey=false;
-
-        // Get code for non-physical keys (T_KOKAI, U_05AB etc)
-        if(typeof Lkc.Lcode == 'undefined') {
-          Lkc.Lcode = this.getVKDictionaryCode(keyName);// Updated for Build 347
-          if(!Lkc.Lcode) {
-            // Special case for U_xxxx keys. This vk code will never be used
-            // in a keyboard, so we use this to ensure that keystroke processing
-            // occurs for the key.
-            Lkc.Lcode = 1; 
-          }
-        }
-
-        // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-        keyShiftState = this.getModifierState(e['key'].spec['layer'] || layer);
-
-        // Define modifiers value for sending to keyboard mapping function
-        Lkc.Lmodifiers = keyShiftState;
-
-        // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
-        if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && Layouts.emulatesAltGr()) {
-          Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
-          Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
-        }
-
-        // Include *limited* support for mnemonic keyboards (Sept 2012)
-        // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
-        if(activeKeyboard && activeKeyboard['KM'] && !(activeKeyboard['KVKL'] && formFactor != 'desktop')) {
-          if(Lkc.Lcode != Codes.keyCodes['K_SPACE']) { // exception required, March 2013
-            Lkc.vkCode = Lkc.Lcode;
-            // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
-            // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
-            var mappedChar: string = keyman.textProcessor.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
-            if(mappedChar) {
-              Lkc.Lcode = mappedChar.charCodeAt(0);
-            } // No 'else' - avoid remapping control + modifier keys!
-
-            if(this.stateKeys['K_CAPS']) {
-              if((Lkc.Lcode >= 65 && Lkc.Lcode <= 90) /* 'A' - 'Z' */ || (Lkc.Lcode >= 97 && Lkc.Lcode <= 122) /* 'a' - 'z' */) {
-                Lkc.Lmodifiers ^= 0x10; // Flip the 'shift' bit.
-                Lkc.Lcode ^= 0x20; // Flips the 'upper' vs 'lower' bit for the base 'a'-'z' ASCII alphabetics.
-              }
-            }
-          }
-        } else {
-          Lkc.vkCode=Lkc.Lcode;
-        }
-
-        // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
-        if(typeof activeKeyboard['KM'] == 'undefined') {
-          Lkc.Lcode=keyman.keyMapManager._USKeyCodeToCharCode(Lkc);
-          Lkc.LisVirtualKey=false;
-        }
-
-        // Pass this key code and state to the keyboard program
-        if(!activeKeyboard || (Lkc.Lcode != 0 && !kbdInterface.processKeystroke(keyman.util.device, Lelem, Lkc))) {
-          // Restore the virtual key code if a mnemonic keyboard is being used
-          Lkc.Lcode=Lkc.vkCode;
-
-          // Handle unmapped keys, including special keys
-          switch(keyName) {
-            case 'K_CAPS':
-            case 'K_NUMLOCK':
-            case 'K_SCROLL':
-              this.stateKeys[keyName] = ! this.stateKeys[keyName];
-              com.keyman.singleton.osk._Show();
-              break;
-            default:
-              // The following is physical layout dependent, so should be avoided if possible.  All keys should be mapped.
-              var ch = keyman.textProcessor.defaultKeyOutput(keyName,Lkc.Lcode,keyShiftState,true,Lelem);
-              if(ch) {
-                kbdInterface.output(0, Lelem, ch);
-              }
-          }
-        }
-
-        // Swap layer as appropriate.
-        this.nextLayer = nextLayer;
-        this.selectLayer(keyName, nextLayer);
-
-        /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
-        Lelem._KeymanWebSelectionStart=null;
-        Lelem._KeymanWebSelectionEnd=null;
-      }
-      
-      keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
-      return true;
-    }
-
     // cancel = function(e) {} //cancel event is never generated by iOS
-
-    /**
-     * Select the next keyboard layer for layer switching keys
-     * The next layer will be determined from the key name unless otherwise specifed
-     *
-     *  @param  {string}                    keyName     key identifier
-     *  @param  {number|string|undefined}   nextLayerIn optional next layer identifier
-     *  @return {boolean}                               return true if keyboard layer changed
-     */
-    selectLayer(keyName: string, nextLayerIn: number | string): boolean {
-      var nextLayer = arguments.length < 2 ? null : nextLayerIn;
-      let keyman = com.keyman.singleton;
-      var isChiral = keyman.keyboardManager.isChiral();
-
-      // Layer must be identified by name, not number (27/08/2015)
-      if(typeof nextLayer == 'number') {
-        nextLayer = Layouts.getLayerId(nextLayer * 0x10);
-      }
-
-      // Identify next layer, if required by key
-      if(!nextLayer) {
-        switch(keyName) {
-          case 'K_LSHIFT':
-          case 'K_RSHIFT':
-          case 'K_SHIFT':
-            nextLayer = 'shift'; break;
-          case 'K_LCONTROL':
-          case 'K_LCTRL':
-            if(isChiral) {
-              nextLayer = 'leftctrl';
-              break;
-            }
-          case 'K_RCONTROL':
-          case 'K_RCTRL':
-            if(isChiral) {
-              nextLayer = 'rightctrl';
-              break;
-            }
-          case 'K_CTRL':
-            nextLayer = 'ctrl'; break;
-          case 'K_LMENU':
-          case 'K_LALT':
-            if(isChiral) {
-              nextLayer = 'leftalt';
-              break;
-            }
-          case 'K_RMENU':
-          case 'K_RALT':
-            if(isChiral) {
-              nextLayer = 'rightalt';
-              break;
-            }
-          case 'K_ALT':
-            nextLayer = 'alt'; break;
-          case 'K_ALTGR':
-            if(isChiral) {
-              nextLayer = 'leftctrl-rightalt';
-            } else {
-              nextLayer = 'ctrl-alt';
-            }
-            break;
-          case 'K_CURRENCIES':
-          case 'K_NUMERALS':
-          case 'K_SHIFTED':
-          case 'K_UPPER':
-          case 'K_LOWER':
-          case 'K_SYMBOLS':
-            nextLayer = 'default'; break;
-        }
-      }
-
-      if(!nextLayer) {
-        return false;
-      }
-
-      // Do not change layer unless needed (27/08/2015)
-      if(nextLayer == this.layerId && keyman.util.device.formFactor != 'desktop') {
-        return false;
-      }
-
-      // Change layer and refresh OSK
-      this.updateLayer(nextLayer);
-      com.keyman.singleton.osk._Show();
-
-      return true;
-    }
-
-    /**
-     * Sets the new layer id, allowing for toggling shift/ctrl/alt while preserving the remainder
-     * of the modifiers represented by the current layer id (where applicable)
-     *
-     * @param       {string}      id      layer id (e.g. ctrlshift)
-     */
-    updateLayer(id: string) {
-      var s=this.layerId, idx=id;
-      var i;
-      let keyman = com.keyman.singleton;
-
-      if(keyman.util.device.formFactor == 'desktop') {
-        // Need to test if target layer is a standard layer (based on the plain 'default')
-        var replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
-
-        for(i=0; i < replacements.length; i++) {
-          // Don't forget to remove the kebab-case hyphens!
-          idx=idx.replace(replacements[i] + '-', '');
-          idx=idx.replace(replacements[i],'');
-        }
-
-        // If we are presently on the default layer, drop the 'default' and go straight to the shifted mode.
-        // If on a common symbolic layer, drop out of symbolic mode and go straight to the shifted mode.
-        if(this.layerId == 'default' || this.layerId == 'numeric' || this.layerId == 'symbol' || this.layerId == 'currency' || idx != '') {
-          s = id;
-        }
-        // Otherwise, we are based upon the a layer that accepts modifier variations.
-        // Modify the layer according to the current state and key pressed.
-        //
-        // TODO:  Consider:  should this ever be allowed for a base layer other than 'default'?  If not,
-        // if(idx == '') with accompanying if-else structural shift would be a far better test here.
-        else {
-          // Save our current modifier state.
-          var modifier=this.getModifierState(s);
-
-          // Strip down to the base modifiable layer.
-          for(i=0; i < replacements.length; i++) {
-            // Don't forget to remove the kebab-case hyphens!
-            s=s.replace(replacements[i] + '-', '');
-            s=s.replace(replacements[i],'');
-          }
-
-          // Toggle the modifier represented by our input argument.
-          switch(id) {
-            case 'shift':
-              modifier ^= Codes.modifierCodes['SHIFT'];
-              break;
-            case 'leftctrl':
-              modifier ^= Codes.modifierCodes['LCTRL'];
-              break;
-            case 'rightctrl':
-              modifier ^= Codes.modifierCodes['RCTRL'];
-              break;
-            case 'ctrl':
-              modifier ^= Codes.modifierCodes['CTRL'];
-              break;
-            case 'leftalt':
-              modifier ^= Codes.modifierCodes['LALT'];
-              break;
-            case 'rightalt':
-              modifier ^= Codes.modifierCodes['RALT'];
-              break;
-            case 'alt':
-              modifier ^= Codes.modifierCodes['ALT'];
-              break;
-            default:
-              s = id;
-          }
-
-          // Combine our base modifiable layer and attach the new modifier variation info to obtain our destination layer.
-          if(s != 'default') {
-            if(s == '') {
-              s = Layouts.getLayerId(modifier);
-            } else {
-              s = Layouts.getLayerId(modifier) + '-' + s;
-            }
-          }
-        }
-        
-        if(s == '') {
-          s = 'default';
-        }
-      } else {
-        // Mobile form-factor.  Either the layout is specified by a keyboard developer with direct layer name references
-        // or all layers are accessed via subkey of a single layer-shifting key - no need for modifier-combining logic.
-        s = id;
-      }
-
-      // Actually set the new layer id.
-      this.layerId = s;
-
-      // Check that requested layer is defined   (KMEA-1, but does not resolve issue)
-      for(i=0; i<this.layers.length; i++) {
-        if(this.layerId == this.layers[i].id) {
-          return;
-        }
-      }
-
-      // Show default layer if an undefined layer has been requested
-      this.layerId='default';
-    }
-
-    /**
-     * Get modifier key state from layer id
-     *
-     * @param       {string}      layerId       layer id (e.g. ctrlshift)
-     * @return      {number}                    modifier key state (desktop keyboards)
-     */
-    getModifierState(layerId: string): number {
-      var modifier=0;
-      if(layerId.indexOf('shift') >= 0) {
-        modifier |= Codes.modifierCodes['SHIFT'];
-      }
-
-      // The chiral checks must not be directly exclusive due each other to visual OSK feedback.
-      var ctrlMatched=false;
-      if(layerId.indexOf('leftctrl') >= 0) {
-        modifier |= Codes.modifierCodes['LCTRL'];
-        ctrlMatched=true;
-      } 
-      if(layerId.indexOf('rightctrl') >= 0) {
-        modifier |= Codes.modifierCodes['RCTRL'];
-        ctrlMatched=true;
-      } 
-      if(layerId.indexOf('ctrl')  >= 0 && !ctrlMatched) {
-        modifier |= Codes.modifierCodes['CTRL'];
-      }
-
-      var altMatched=false;
-      if(layerId.indexOf('leftalt') >= 0) {
-        modifier |= Codes.modifierCodes['LALT'];
-        altMatched=true;
-      } 
-      if(layerId.indexOf('rightalt') >= 0) {
-        modifier |= Codes.modifierCodes['RALT'];
-        altMatched=true;
-      } 
-      if(layerId.indexOf('alt')  >= 0 && !altMatched) {
-        modifier |= Codes.modifierCodes['ALT'];
-      }
-
-      return modifier;
-    }
-
-    /**
-     * Function     _UpdateVKShift
-     * Scope        Private
-     * @param       {Object}            e     OSK event
-     * @param       {number}            v     keyboard shift state
-     * @param       {(boolean|number)}  d     set (1) or clear(0) shift state bits
-     * @return      {boolean}                 Always true
-     * Description  Update the current shift state within KMW
-     */
-    _UpdateVKShift(e, v: number, d: boolean|number): boolean {
-      var keyShiftState=0, lockStates=0, i;
-      let keyman = com.keyman.singleton;
-
-      var lockNames  = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'];
-      var lockKeys   = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'];
-
-      if(e) {
-        // read shift states from Pevent
-        keyShiftState = e.Lmodifiers;
-        lockStates = e.Lstates;
-
-        // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
-        if(keyman.keyboardManager.isChiral() && Layouts.emulatesAltGr() && 
-            (com.keyman.DOMEventHandlers.states.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
-          keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
-          keyShiftState &= ~Codes.modifierCodes['RALT'];
-        }
-
-        for(i=0; i < lockNames.length; i++) {
-          if(lockStates & Codes.stateBitmasks[lockNames[i]]) {
-            this.stateKeys[lockKeys[i]] = lockStates & Codes.modifierCodes[lockNames[i]];
-          }
-        }
-      } else if(d) {
-        keyShiftState |= v;
-
-        for(i=0; i < lockNames.length; i++) {
-          if(v & Codes.stateBitmasks[lockNames[i]]) {
-            this.stateKeys[lockKeys[i]] = true;
-          }
-        }
-      } else {
-        keyShiftState &= ~v;
-
-        for(i=0; i < lockNames.length; i++) {
-          if(v & Codes.stateBitmasks[lockNames[i]]) {
-            this.stateKeys[lockKeys[i]] = false;
-          }
-        }
-      }
-
-      // Find and display the selected OSK layer
-      this.layerId=Layouts.getLayerId(keyShiftState);
-
-      // osk._UpdateVKShiftStyle will be called automatically upon the next _Show.
-      if(keyman.osk._Visible) {
-        keyman.osk._Show();
-      }
-
-      return true;
-    }
 
     /**
      * Function     _UpdateVKShiftStyle
@@ -1717,6 +1253,7 @@ namespace com.keyman.osk {
      */
     _UpdateVKShiftStyle(layerId?: string) {
       var i, n, layer=null, layerElement=null;
+      let Processor = com.keyman.singleton.textProcessor;
 
       if(layerId) {
         for(n=0; n<this.layers.length; n++) {
@@ -1743,7 +1280,7 @@ namespace com.keyman.osk {
           continue;
         }
 
-        keys[i]['sp'] = this.stateKeys[states[i]] ? Layouts.buttonClasses['SHIFT-ON'] : Layouts.buttonClasses['SHIFT'];
+        keys[i]['sp'] = Processor.stateKeys[states[i]] ? Layouts.buttonClasses['SHIFT-ON'] : Layouts.buttonClasses['SHIFT'];
         var btn = document.getElementById(layerId+'-'+states[i]);
 
         this.setButtonClass(keys[i], btn, this.layout);
@@ -1805,45 +1342,7 @@ namespace com.keyman.osk {
       }
       this.popupBaseKey = null;
     }
-
-    /**
-     * @summary Look up a custom virtual key code in the virtual key code dictionary KVKD.  On first run, will build the dictionary.
-     *
-     * `VKDictionary` is constructed from the keyboard's `KVKD` member. This list is constructed 
-     * at compile-time and is a list of 'additional' virtual key codes, starting at 256 (i.e. 
-     * outside the range of standard virtual key codes). These additional codes are both 
-     * `[T_xxx]` and `[U_xxxx]` custom key codes from the Keyman keyboard language. However, 
-     * `[U_xxxx]` keys only generate an entry in `KVKD` if there is a corresponding rule that 
-     * is associated with them in the keyboard rules. If the `[U_xxxx]` key code is only 
-     * referenced as the id of a key in the touch layout, then it does not get an entry in 
-     * the `KVKD` property.
-     *
-     * @private
-     * @param       {string}      keyName   custom virtual key code to lookup in the dictionary
-     * @return      {number}                key code > 255 on success, or 0 if not found
-     */
-    getVKDictionaryCode(keyName: string) {
-      let keyman = com.keyman.singleton;
-      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
-      if(!activeKeyboard['VKDictionary']) {
-        var a=[];
-        if(typeof activeKeyboard['KVKD'] == 'string') {
-          // Build the VK dictionary
-          // TODO: Move the dictionary build into the compiler -- so compiler generates code such as following.  
-          // Makes the VKDictionary member unnecessary.
-          //       this.KVKD={"K_ABC":256,"K_DEF":257,...};
-          var s=activeKeyboard['KVKD'].split(' ');
-          for(var i=0; i<s.length; i++) {
-            a[s[i].toUpperCase()]=i+256; // We force upper-case since virtual keys should be case-insensitive.
-          }
-        }
-        activeKeyboard['VKDictionary']=a;
-      }
-
-      var res=activeKeyboard['VKDictionary'][keyName.toUpperCase()];
-      return res ? res : 0;
-    }
-
+    
     //#region 'native'-mode subkey handling
     /**
      * Display touch-hold array of 'sub-keys' above the currently touched key
@@ -2122,7 +1621,7 @@ namespace com.keyman.osk {
       // Process as click if mouse button released anywhere over key
       if(util.eventType(e) == 'mouseup') {
         if(key.id == this.currentKey) {
-          this.clickKey(getKeyFrom(key));
+          keyman.textProcessor.clickKey(getKeyFrom(key));
         }
         this.currentKey='';
       }
@@ -2234,6 +1733,13 @@ namespace com.keyman.osk {
      */
     showLayer(id: string): boolean {
       let keyman = com.keyman.singleton;
+
+      // Do not change layer unless needed (27/08/2015)
+      if(id == this.layerId && keyman.util.device.formFactor != 'desktop') {
+        // The layer's already shown, so report success.
+        return true;
+      }
+
       if(keyman.keyboardManager.activeKeyboard) {
         for(var i=0; i<this.layers.length; i++) {
           if(this.layers[i].id == id) {
@@ -2243,6 +1749,7 @@ namespace com.keyman.osk {
           }
         }
       }
+      
       return false;
     }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1,6 +1,3 @@
-// Defines key code constants
-/// <reference path="../text/codes.ts" />
-
 namespace com.keyman.osk {
   let Codes = com.keyman.text.Codes;
   //#region Definition of the KeyElement merger type
@@ -1361,7 +1358,7 @@ namespace com.keyman.osk {
             Lkc.vkCode = Lkc.Lcode;
             // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
             // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
-            var mappedChar: string = this.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
+            var mappedChar: string = keyman.textProcessor.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
             if(mappedChar) {
               Lkc.Lcode = mappedChar.charCodeAt(0);
             } // No 'else' - avoid remapping control + modifier keys!
@@ -1398,7 +1395,7 @@ namespace com.keyman.osk {
               break;
             default:
               // The following is physical layout dependent, so should be avoided if possible.  All keys should be mapped.
-              var ch = this.defaultKeyOutput(keyName,Lkc.Lcode,keyShiftState,true,Lelem);
+              var ch = keyman.textProcessor.defaultKeyOutput(keyName,Lkc.Lcode,keyShiftState,true,Lelem);
               if(ch) {
                 kbdInterface.output(0, Lelem, ch);
               }
@@ -1648,145 +1645,6 @@ namespace com.keyman.osk {
       }
 
       return modifier;
-    }
-
-    /**
-     * Get the default key string. If keyName is U_xxxxxx, use that Unicode codepoint.
-     * Otherwise, lookup the  virtual key code (physical keyboard mapping)
-     *
-     * @param   {string}  keyName Name of the key
-     * @param   {number}  n
-     * @param   {number}  keyShiftState
-     * @param   {boolean} usingOSK
-     * @param   {Object=} Lelem
-     * @return  {string}
-     */
-    defaultKeyOutput(keyName: string, n: number, keyShiftState: number, usingOSK: boolean, Lelem?: HTMLElement): string {
-      let keyman = com.keyman.singleton;
-      let domManager = keyman.domManager;
-
-      var ch = '', checkCodes = false;
-      var touchAlias = (Lelem && typeof(Lelem.base) != 'undefined');
-      // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
-      if(keyShiftState == 0) {
-        checkCodes = true;
-      } else if (keyShiftState == Codes.modifierCodes['SHIFT']) {
-        checkCodes = true; 
-        keyShiftState = 1; // It's used as an index.
-      } else {
-        console.warn("KMW only defines default key output for the 'default' and 'shift' layers!");
-      }
-
-      // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
-      if(touchAlias || usingOSK) {
-        var code = Codes.keyCodes[keyName];
-        if(!code) {
-          code = n;
-        }
-
-        switch(code) {
-          case Codes.keyCodes['K_BKSP']:  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
-            keyman.interface.defaultBackspace();
-            break;
-          case Codes.keyCodes['K_TAB']:
-            domManager.moveToNext(keyShiftState);
-            break;
-          case Codes.keyCodes['K_TABBACK']:
-            domManager.moveToNext(true);
-            break;
-          case Codes.keyCodes['K_TABFWD']:
-            domManager.moveToNext(false);
-            break;
-          case Codes.keyCodes['K_ENTER']:
-            // Insert new line in text area fields
-            if(Lelem.nodeName == 'TEXTAREA' || (typeof Lelem.base != 'undefined' && Lelem.base.nodeName == 'TEXTAREA')) {
-              return '\n';
-            // Or move to next field from TEXT fields
-            } else if(usingOSK) {
-              var inputEle: HTMLInputElement;
-              if(com.keyman.Util.instanceof(Lelem, "HTMLInputElement")) {
-                inputEle = <HTMLInputElement> Lelem;
-              } else if(typeof(Lelem.base) != 'undefined' && com.keyman.Util.instanceof(Lelem.base, "HTMLInputElement")) {
-                inputEle = <HTMLInputElement> Lelem.base;
-              }
-
-              if (inputEle && (inputEle.type == 'search' || inputEle.type == 'submit')) {
-                inputEle.disabled=false;
-                inputEle.form.submit();
-              } else {
-                domManager.moveToNext(false);
-              }
-            }
-            break;
-          case Codes.keyCodes['K_SPACE']:
-            return ' ';
-          // break;
-          //
-          // // Problem:  clusters, and doing them right.
-          // // The commented-out code below should be a decent starting point, but clusters make it complex.
-          //
-          // case VisualKeyboard.keyCodes['K_LEFT']:
-          //   if(touchAlias) {
-          //     var caretPos = keymanweb.getTextCaret(Lelem);
-          //     keymanweb.setTextCaret(Lelem, caretPos - 1 >= 0 ? caretPos - 1 : 0);
-          //   }
-          //   break;
-          // case VisualKeyboard.keyCodes['K_RIGHT']:
-          //   if(touchAlias) {
-          //     var caretPos = keymanweb.getTextCaret(Lelem);
-          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
-          //   }
-          //   if(code == VisualKeyboard.keyCodes['K_RIGHT']) {
-          //     break;
-          //   }
-          // // Should we include this?  It could be tricky to do correctly...
-          // case VisualKeyboard.keyCodes['K_DEL']:
-          //   // Move caret right one unit, then backspace.
-          //   if(touchAlias) {
-          //     var caretPos = keymanweb.getTextCaret(Lelem);
-          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
-          //     if(caretPos == keymanweb.getTextCaret(Lelem)) {
-          //       // Failed to move right - there's nothing to delete.
-          //       break;
-          //     }
-          //     kbdInterface.defaultBackspace();
-          //   }
-        }
-      }
-
-      // TODO:  Refactor the overloading of the 'n' parameter here into separate methods.
-
-      // Test for fall back to U_xxxxxx key id
-      // For this first test, we ignore the keyCode and use the keyName
-      if((keyName.substr(0,2) == 'U_')) {
-        var codePoint = parseInt(keyName.substr(2,6), 16);
-        if (((0x0 <= codePoint) && (codePoint <= 0x1F)) || ((0x80 <= codePoint) && (codePoint <= 0x9F))) {
-          // Code points [U_0000 - U_001F] and [U_0080 - U_009F] refer to Unicode C0 and C1 control codes.
-          // Check the codePoint number and do not allow output of these codes via U_xxxxxx shortcuts.
-          console.log("Suppressing Unicode control code: U_00" + codePoint.toString(16));
-          return ch;
-        } else {
-          // String.fromCharCode() is inadequate to handle the entire range of Unicode
-          // Someday after upgrading to ES2015, can use String.fromCodePoint()
-          ch=String.kmwFromCharCode(codePoint);
-        }
-        // Hereafter, we refer to keyCodes.
-      } else if(checkCodes) { // keyShiftState can only be '1' or '2'.
-        try {
-          if(n >= Codes.keyCodes['K_0'] && n <= Codes.keyCodes['K_9']) { // The number keys.
-            ch = Codes.codesUS[keyShiftState][0][n-Codes.keyCodes['K_0']];
-          } else if(n >= Codes.keyCodes['K_A'] && n <= Codes.keyCodes['K_Z']) { // The base letter keys
-            ch = String.fromCharCode(n+(keyShiftState?0:32));  // 32 is the offset from uppercase to lowercase.
-          } else if(n >= Codes.keyCodes['K_COLON'] && n <= Codes.keyCodes['K_BKQUOTE']) {
-            ch = Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
-          } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
-            ch = Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
-          }
-        } catch (e) {
-          console.error("Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default'));
-        }
-      }
-      return ch;
     }
 
     /**

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1271,8 +1271,8 @@ namespace com.keyman.osk {
       layer=this.layers[n];
       
       // Set the on/off state of any visible state keys.
-      var states =['K_CAPS',      'K_NUMLOCK',  'K_SCROLL'];
-      var keys   =[layer.capsKey, layer.numKey, layer.scrollKey];
+      var states = ['K_CAPS',      'K_NUMLOCK',  'K_SCROLL'];
+      var keys   = [layer.capsKey, layer.numKey, layer.scrollKey];
 
       for(i=0; i < keys.length; i++) {
         // Skip any keys not in the OSK!

--- a/web/source/recorder_ui_and_stubs.js
+++ b/web/source/recorder_ui_and_stubs.js
@@ -127,15 +127,15 @@ copyTestDefinition = function() {
   alert("Unable to copy successfully.");
 }
 
-var _ock = com.keyman.osk.VisualKeyboard.prototype.clickKey; //.bind(keyman.osk);
-com.keyman.osk.VisualKeyboard.prototype.clickKey = function(e) {
+var _ock = com.keyman.text.Processor.prototype.clickKey; //.bind(keyman.osk);
+com.keyman.text.Processor.prototype.clickKey = function(e) {
   if(com.keyman.DOMEventHandlers.states.activeElement != in_output &&
     com.keyman.DOMEventHandlers.states.activeElement != in_output['kmw_ip']) {
-    return _ock.call(com.keyman.singleton.osk.vkbd, e);
+    return _ock.call(com.keyman.singleton.textProcessor, e);
   }
 
   var event = new KMWRecorder.OSKInputEvent(e);
-  var retVal = _ock.call(com.keyman.singleton.osk.vkbd, e);
+  var retVal = _ock.call(com.keyman.singleton.textProcessor, e);
 
   // Record the click/touch as part of a test sequence!
   addInputRecord(event);

--- a/web/source/text/codes.ts
+++ b/web/source/text/codes.ts
@@ -1,0 +1,74 @@
+namespace com.keyman.text {
+  export var Codes = {
+    // Define Keyman Developer modifier bit-flags (exposed for use by other modules)
+    modifierCodes: {
+      "LCTRL":0x0001,
+      "RCTRL":0x0002,
+      "LALT":0x0004,
+      "RALT":0x0008,
+      "SHIFT":0x0010,
+      "CTRL":0x0020,
+      "ALT":0x0040,
+      "CAPS":0x0100,
+      "NO_CAPS":0x0200,
+      "NUM_LOCK":0x0400,
+      "NO_NUM_LOCK":0x0800,
+      "SCROLL_LOCK":0x1000,
+      "NO_SCROLL_LOCK":0x2000,
+      "VIRTUAL_KEY":0x4000
+    },
+
+    modifierBitmasks: {
+      "ALL":0x007F,
+      "ALT_GR_SIM": (0x0001 | 0x0004),
+      "CHIRAL":0x001F,    // The base bitmask for chiral keyboards.  Includes SHIFT, which is non-chiral.
+      "IS_CHIRAL":0x000F, // Used to test if a bitmask uses a chiral modifier.
+      "NON_CHIRAL":0x0070 // The default bitmask, for non-chiral keyboards
+    },
+
+    stateBitmasks: {
+      "ALL":0x3F00,
+      "CAPS":0x0300,
+      "NUM_LOCK":0x0C00,
+      "SCROLL_LOCK":0x3000
+    },
+
+    // Define standard keycode numbers (exposed for use by other modules)
+    keyCodes: {
+      "K_BKSP":8,"K_TAB":9,"K_ENTER":13,
+      "K_SHIFT":16,"K_CONTROL":17,"K_ALT":18,"K_PAUSE":19,"K_CAPS":20,
+      "K_ESC":27,"K_SPACE":32,"K_PGUP":33,
+      "K_PGDN":34,"K_END":35,"K_HOME":36,"K_LEFT":37,"K_UP":38,
+      "K_RIGHT":39,"K_DOWN":40,"K_SEL":41,"K_PRINT":42,"K_EXEC":43,
+      "K_INS":45,"K_DEL":46,"K_HELP":47,"K_0":48,
+      "K_1":49,"K_2":50,"K_3":51,"K_4":52,"K_5":53,"K_6":54,"K_7":55,
+      "K_8":56,"K_9":57,"K_A":65,"K_B":66,"K_C":67,"K_D":68,"K_E":69,
+      "K_F":70,"K_G":71,"K_H":72,"K_I":73,"K_J":74,"K_K":75,"K_L":76,
+      "K_M":77,"K_N":78,"K_O":79,"K_P":80,"K_Q":81,"K_R":82,"K_S":83,
+      "K_T":84,"K_U":85,"K_V":86,"K_W":87,"K_X":88,"K_Y":89,"K_Z":90,
+      "K_NP0":96,"K_NP1":97,"K_NP2":98,
+      "K_NP3":99,"K_NP4":100,"K_NP5":101,"K_NP6":102,
+      "K_NP7":103,"K_NP8":104,"K_NP9":105,"K_NPSTAR":106,
+      "K_NPPLUS":107,"K_SEPARATOR":108,"K_NPMINUS":109,"K_NPDOT":110,
+      "K_NPSLASH":111,"K_F1":112,"K_F2":113,"K_F3":114,"K_F4":115,
+      "K_F5":116,"K_F6":117,"K_F7":118,"K_F8":119,"K_F9":120,
+      "K_F10":121,"K_F11":122,"K_F12":123,"K_NUMLOCK":144,"K_SCROLL":145,
+      "K_LSHIFT":160,"K_RSHIFT":161,"K_LCONTROL":162,"K_RCONTROL":163,
+      "K_LALT":164,"K_RALT":165,
+      "K_COLON":186,"K_EQUAL":187,"K_COMMA":188,"K_HYPHEN":189,
+      "K_PERIOD":190,"K_SLASH":191,"K_BKQUOTE":192,
+      "K_LBRKT":219,"K_BKSLASH":220,"K_RBRKT":221,
+      "K_QUOTE":222,"K_oE2":226,
+      "K_LOPT":50001,"K_ROPT":50002,
+      "K_NUMERALS":50003,"K_SYMBOLS":50004,"K_CURRENCIES":50005,
+      "K_UPPER":50006,"K_LOWER":50007,"K_ALPHA":50008,
+      "K_SHIFTED":50009,"K_ALTGR":50010,
+      "K_TABBACK":50011,"K_TABFWD":50012
+    },
+
+    codesUS: [
+      ['0123456789',';=,-./`', '[\\]\''],
+      [')!@#$%^&*(',':+<_>?~', '{|}"']
+    ]
+  }
+}

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -1,0 +1,146 @@
+// Establishes key-code definitions.
+/// <reference path="codes.ts" />
+
+namespace com.keyman.text {
+  export class Processor {
+
+    /**
+     * Get the default key string. If keyName is U_xxxxxx, use that Unicode codepoint.
+     * Otherwise, lookup the  virtual key code (physical keyboard mapping)
+     *
+     * @param   {string}  keyName Name of the key
+     * @param   {number}  n
+     * @param   {number}  keyShiftState
+     * @param   {boolean} usingOSK
+     * @param   {Object=} Lelem
+     * @return  {string}
+     */
+    defaultKeyOutput(keyName: string, n: number, keyShiftState: number, usingOSK: boolean, Lelem?: HTMLElement): string {
+      let keyman = com.keyman.singleton;
+      let domManager = keyman.domManager;
+
+      var ch = '', checkCodes = false;
+      var touchAlias = (Lelem && typeof(Lelem.base) != 'undefined');
+      // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
+      if(keyShiftState == 0) {
+        checkCodes = true;
+      } else if (keyShiftState == Codes.modifierCodes['SHIFT']) {
+        checkCodes = true; 
+        keyShiftState = 1; // It's used as an index.
+      } else {
+        console.warn("KMW only defines default key output for the 'default' and 'shift' layers!");
+      }
+
+      // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
+      if(touchAlias || usingOSK) {
+        var code = Codes.keyCodes[keyName];
+        if(!code) {
+          code = n;
+        }
+
+        switch(code) {
+          case Codes.keyCodes['K_BKSP']:  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
+            keyman.interface.defaultBackspace();
+            break;
+          case Codes.keyCodes['K_TAB']:
+            domManager.moveToNext(keyShiftState);
+            break;
+          case Codes.keyCodes['K_TABBACK']:
+            domManager.moveToNext(true);
+            break;
+          case Codes.keyCodes['K_TABFWD']:
+            domManager.moveToNext(false);
+            break;
+          case Codes.keyCodes['K_ENTER']:
+            // Insert new line in text area fields
+            if(Lelem.nodeName == 'TEXTAREA' || (typeof Lelem.base != 'undefined' && Lelem.base.nodeName == 'TEXTAREA')) {
+              return '\n';
+            // Or move to next field from TEXT fields
+            } else if(usingOSK) {
+              var inputEle: HTMLInputElement;
+              if(com.keyman.Util.instanceof(Lelem, "HTMLInputElement")) {
+                inputEle = <HTMLInputElement> Lelem;
+              } else if(typeof(Lelem.base) != 'undefined' && com.keyman.Util.instanceof(Lelem.base, "HTMLInputElement")) {
+                inputEle = <HTMLInputElement> Lelem.base;
+              }
+
+              if (inputEle && (inputEle.type == 'search' || inputEle.type == 'submit')) {
+                inputEle.disabled=false;
+                inputEle.form.submit();
+              } else {
+                domManager.moveToNext(false);
+              }
+            }
+            break;
+          case Codes.keyCodes['K_SPACE']:
+            return ' ';
+          // break;
+          //
+          // // Problem:  clusters, and doing them right.
+          // // The commented-out code below should be a decent starting point, but clusters make it complex.
+          //
+          // case VisualKeyboard.keyCodes['K_LEFT']:
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos - 1 >= 0 ? caretPos - 1 : 0);
+          //   }
+          //   break;
+          // case VisualKeyboard.keyCodes['K_RIGHT']:
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
+          //   }
+          //   if(code == VisualKeyboard.keyCodes['K_RIGHT']) {
+          //     break;
+          //   }
+          // // Should we include this?  It could be tricky to do correctly...
+          // case VisualKeyboard.keyCodes['K_DEL']:
+          //   // Move caret right one unit, then backspace.
+          //   if(touchAlias) {
+          //     var caretPos = keymanweb.getTextCaret(Lelem);
+          //     keymanweb.setTextCaret(Lelem, caretPos + 1);
+          //     if(caretPos == keymanweb.getTextCaret(Lelem)) {
+          //       // Failed to move right - there's nothing to delete.
+          //       break;
+          //     }
+          //     kbdInterface.defaultBackspace();
+          //   }
+        }
+      }
+
+      // TODO:  Refactor the overloading of the 'n' parameter here into separate methods.
+
+      // Test for fall back to U_xxxxxx key id
+      // For this first test, we ignore the keyCode and use the keyName
+      if((keyName.substr(0,2) == 'U_')) {
+        var codePoint = parseInt(keyName.substr(2,6), 16);
+        if (((0x0 <= codePoint) && (codePoint <= 0x1F)) || ((0x80 <= codePoint) && (codePoint <= 0x9F))) {
+          // Code points [U_0000 - U_001F] and [U_0080 - U_009F] refer to Unicode C0 and C1 control codes.
+          // Check the codePoint number and do not allow output of these codes via U_xxxxxx shortcuts.
+          console.log("Suppressing Unicode control code: U_00" + codePoint.toString(16));
+          return ch;
+        } else {
+          // String.fromCharCode() is inadequate to handle the entire range of Unicode
+          // Someday after upgrading to ES2015, can use String.fromCodePoint()
+          ch=String.kmwFromCharCode(codePoint);
+        }
+        // Hereafter, we refer to keyCodes.
+      } else if(checkCodes) { // keyShiftState can only be '1' or '2'.
+        try {
+          if(n >= Codes.keyCodes['K_0'] && n <= Codes.keyCodes['K_9']) { // The number keys.
+            ch = Codes.codesUS[keyShiftState][0][n-Codes.keyCodes['K_0']];
+          } else if(n >= Codes.keyCodes['K_A'] && n <= Codes.keyCodes['K_Z']) { // The base letter keys
+            ch = String.fromCharCode(n+(keyShiftState?0:32));  // 32 is the offset from uppercase to lowercase.
+          } else if(n >= Codes.keyCodes['K_COLON'] && n <= Codes.keyCodes['K_BKQUOTE']) {
+            ch = Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
+          } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
+            ch = Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
+          }
+        } catch (e) {
+          console.error("Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default'));
+        }
+      }
+      return ch;
+    }
+  }
+}

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -4,6 +4,14 @@
 namespace com.keyman.text {
   export class Processor {
 
+    // Tracks the simulated value for supported state keys, allowing the OSK to mirror a physical keyboard for them.
+    // Using the exact keyCode name from the Codes definitions will allow for certain optimizations elsewhere in the code.
+    stateKeys = {
+      "K_CAPS":false,
+      "K_NUMLOCK":false,
+      "K_SCROLL":false
+    };
+
     /**
      * Get the default key string. If keyName is U_xxxxxx, use that Unicode codepoint.
      * Otherwise, lookup the  virtual key code (physical keyboard mapping)
@@ -141,6 +149,520 @@ namespace com.keyman.text {
         }
       }
       return ch;
+    }
+
+    /**
+     * Simulate a keystroke according to the touched keyboard button element
+     *
+     * Note that the test-case oriented 'recorder' stubs this method to facilitate OSK-based input
+     * recording for use in test cases.  If changing this function, please ensure the recorder is
+     * not affected.
+     * 
+     * @param       {Object}      e      element touched (or clicked)
+     */
+    clickKey(e: osk.KeyElement) {
+      let keyman = com.keyman.singleton;
+      var Lelem = keyman.domManager.getLastActiveElement(), Ls, Le, Lkc;
+
+      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
+      let kbdInterface = keyman.interface;
+      let formFactor = keyman.util.device.formFactor;
+
+      if(Lelem != null) {
+        // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
+        // Note - virtual keys should be treated case-insensitive, so we force uppercasing here.
+        var layer=e['key'].spec.layer || '', keyName=e['keyId'].toUpperCase(), keyShiftState=this.getModifierState(keyman['osk'].vkbd.layerId);
+        var nextLayer: string = e['key'].spec['nextlayer'];
+
+        keyman.domManager.initActiveElement(Lelem);
+
+        // Exclude menu and OSK hide keys from normal click processing
+        if(keyName == 'K_LOPT' || keyName == 'K_ROPT') {
+          keyman['osk'].vkbd.optionKey(e, keyName, true);
+          return true;
+        }
+
+        // Turn off key highlighting (or preview)
+        keyman['osk'].vkbd.highlightKey(e,false);
+
+        // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
+        if(formFactor == 'desktop') {
+          if(this.selectLayer(keyName, nextLayer)) {
+            return true;
+          }
+        }
+
+        // Prevent any output from 'ghost' (unmapped) keys
+        if(keyName != 'K_SPACE') {
+          var keyText=(<HTMLElement> e.childNodes[0]).innerHTML;
+          //// if(keyText == '' || keyText == '&nbsp;') return true; --> why?
+        }
+
+        Ls=Lelem._KeymanWebSelectionStart;
+        Le=Lelem._KeymanWebSelectionEnd;
+        keyman.uiManager.setActivatingUI(true);
+        com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 100;
+        keyman.domManager.focusLastActiveElement();
+        if(keyman.domManager._IsMozillaEditableIframe(<HTMLIFrameElement> Lelem,0)) {
+          Lelem = (<HTMLIFrameElement> Lelem).contentDocument.documentElement;
+        }
+        Lelem._KeymanWebSelectionStart=Ls;
+        Lelem._KeymanWebSelectionEnd=Le;
+        com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 0;
+        // ...end I3363 (Build 301)
+        (<any>keyman)._CachedSelectionStart = null; // I3319
+        // Deadkey matching continues to be troublesome.
+        // Deleting matched deadkeys here seems to correct some of the issues.   (JD 6/6/14)
+        kbdInterface._DeadkeyDeleteMatched();      // Delete any matched deadkeys before continuing
+        //kbdInterface._DeadkeyResetMatched();       // I3318   (Not needed if deleted first?)
+
+        // First check the virtual key, and process shift, control, alt or function keys
+        Lkc = {
+          Ltarg:Lelem,
+          Lmodifiers:0,
+          Lstates:0,
+          Lcode: Codes.keyCodes[keyName],
+          LisVirtualKey:true
+        };
+
+        // Set the flags for the state keys.
+        Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
+        Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
+        Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
+
+        // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
+        if(keyName.substr(0,2) == 'U_') Lkc.LisVirtualKey=false;
+
+        // Get code for non-physical keys (T_KOKAI, U_05AB etc)
+        if(typeof Lkc.Lcode == 'undefined') {
+          Lkc.Lcode = this.getVKDictionaryCode(keyName);// Updated for Build 347
+          if(!Lkc.Lcode) {
+            // Special case for U_xxxx keys. This vk code will never be used
+            // in a keyboard, so we use this to ensure that keystroke processing
+            // occurs for the key.
+            Lkc.Lcode = 1; 
+          }
+        }
+
+        // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
+        keyShiftState = this.getModifierState(e['key'].spec['layer'] || layer);
+
+        // Define modifiers value for sending to keyboard mapping function
+        Lkc.Lmodifiers = keyShiftState;
+
+        // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
+        if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && osk.Layouts.emulatesAltGr()) {
+          Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
+          Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
+        }
+
+        // Include *limited* support for mnemonic keyboards (Sept 2012)
+        // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
+        if(activeKeyboard && activeKeyboard['KM'] && !(activeKeyboard['KVKL'] && formFactor != 'desktop')) {
+          if(Lkc.Lcode != Codes.keyCodes['K_SPACE']) { // exception required, March 2013
+            Lkc.vkCode = Lkc.Lcode;
+            // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
+            // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
+            var mappedChar: string = keyman.textProcessor.defaultKeyOutput('K_xxxx', Lkc.Lcode, (layer.indexOf('shift') != -1 ? 0x10 : 0), false, null);
+            if(mappedChar) {
+              Lkc.Lcode = mappedChar.charCodeAt(0);
+            } // No 'else' - avoid remapping control + modifier keys!
+
+            if(this.stateKeys['K_CAPS']) {
+              if((Lkc.Lcode >= 65 && Lkc.Lcode <= 90) /* 'A' - 'Z' */ || (Lkc.Lcode >= 97 && Lkc.Lcode <= 122) /* 'a' - 'z' */) {
+                Lkc.Lmodifiers ^= 0x10; // Flip the 'shift' bit.
+                Lkc.Lcode ^= 0x20; // Flips the 'upper' vs 'lower' bit for the base 'a'-'z' ASCII alphabetics.
+              }
+            }
+          }
+        } else {
+          Lkc.vkCode=Lkc.Lcode;
+        }
+
+        // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
+        if(typeof activeKeyboard['KM'] == 'undefined') {
+          Lkc.Lcode=keyman.keyMapManager._USKeyCodeToCharCode(Lkc);
+          Lkc.LisVirtualKey=false;
+        }
+
+        // Pass this key code and state to the keyboard program
+        if(!activeKeyboard || (Lkc.Lcode != 0 && !kbdInterface.processKeystroke(keyman.util.device, Lelem, Lkc))) {
+          // Restore the virtual key code if a mnemonic keyboard is being used
+          Lkc.Lcode=Lkc.vkCode;
+
+          // Handle unmapped keys, including special keys
+          switch(keyName) {
+            case 'K_CAPS':
+            case 'K_NUMLOCK':
+            case 'K_SCROLL':
+              this.stateKeys[keyName] = ! this.stateKeys[keyName];
+              com.keyman.singleton.osk._Show();
+              break;
+            default:
+              // The following is physical layout dependent, so should be avoided if possible.  All keys should be mapped.
+              var ch = keyman.textProcessor.defaultKeyOutput(keyName,Lkc.Lcode,keyShiftState,true,Lelem);
+              if(ch) {
+                kbdInterface.output(0, Lelem, ch);
+              }
+          }
+        }
+
+        // Swap layer as appropriate.
+        //this.nextLayer = nextLayer; // Is it safe to remove this?
+        this.selectLayer(keyName, nextLayer);
+
+        /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
+        Lelem._KeymanWebSelectionStart=null;
+        Lelem._KeymanWebSelectionEnd=null;
+      }
+      
+      keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
+      return true;
+    }
+
+    /**
+     * Get modifier key state from layer id
+     *
+     * @param       {string}      layerId       layer id (e.g. ctrlshift)
+     * @return      {number}                    modifier key state (desktop keyboards)
+     */
+    getModifierState(layerId: string): number {
+      var modifier=0;
+      if(layerId.indexOf('shift') >= 0) {
+        modifier |= Codes.modifierCodes['SHIFT'];
+      }
+
+      // The chiral checks must not be directly exclusive due each other to visual OSK feedback.
+      var ctrlMatched=false;
+      if(layerId.indexOf('leftctrl') >= 0) {
+        modifier |= Codes.modifierCodes['LCTRL'];
+        ctrlMatched=true;
+      } 
+      if(layerId.indexOf('rightctrl') >= 0) {
+        modifier |= Codes.modifierCodes['RCTRL'];
+        ctrlMatched=true;
+      } 
+      if(layerId.indexOf('ctrl')  >= 0 && !ctrlMatched) {
+        modifier |= Codes.modifierCodes['CTRL'];
+      }
+
+      var altMatched=false;
+      if(layerId.indexOf('leftalt') >= 0) {
+        modifier |= Codes.modifierCodes['LALT'];
+        altMatched=true;
+      } 
+      if(layerId.indexOf('rightalt') >= 0) {
+        modifier |= Codes.modifierCodes['RALT'];
+        altMatched=true;
+      } 
+      if(layerId.indexOf('alt')  >= 0 && !altMatched) {
+        modifier |= Codes.modifierCodes['ALT'];
+      }
+
+      return modifier;
+    }
+
+    /**
+     * @summary Look up a custom virtual key code in the virtual key code dictionary KVKD.  On first run, will build the dictionary.
+     *
+     * `VKDictionary` is constructed from the keyboard's `KVKD` member. This list is constructed 
+     * at compile-time and is a list of 'additional' virtual key codes, starting at 256 (i.e. 
+     * outside the range of standard virtual key codes). These additional codes are both 
+     * `[T_xxx]` and `[U_xxxx]` custom key codes from the Keyman keyboard language. However, 
+     * `[U_xxxx]` keys only generate an entry in `KVKD` if there is a corresponding rule that 
+     * is associated with them in the keyboard rules. If the `[U_xxxx]` key code is only 
+     * referenced as the id of a key in the touch layout, then it does not get an entry in 
+     * the `KVKD` property.
+     *
+     * @private
+     * @param       {string}      keyName   custom virtual key code to lookup in the dictionary
+     * @return      {number}                key code > 255 on success, or 0 if not found
+     */
+    getVKDictionaryCode(keyName: string) {
+      let keyman = com.keyman.singleton;
+      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
+      if(!activeKeyboard['VKDictionary']) {
+        var a=[];
+        if(typeof activeKeyboard['KVKD'] == 'string') {
+          // Build the VK dictionary
+          // TODO: Move the dictionary build into the compiler -- so compiler generates code such as following.  
+          // Makes the VKDictionary member unnecessary.
+          //       this.KVKD={"K_ABC":256,"K_DEF":257,...};
+          var s=activeKeyboard['KVKD'].split(' ');
+          for(var i=0; i<s.length; i++) {
+            a[s[i].toUpperCase()]=i+256; // We force upper-case since virtual keys should be case-insensitive.
+          }
+        }
+        activeKeyboard['VKDictionary']=a;
+      }
+
+      var res=activeKeyboard['VKDictionary'][keyName.toUpperCase()];
+      return res ? res : 0;
+    }
+
+    /**
+     * Function     _UpdateVKShift
+     * Scope        Private
+     * @param       {Object}            e     OSK event
+     * @param       {number}            v     keyboard shift state
+     * @param       {(boolean|number)}  d     set (1) or clear(0) shift state bits
+     * @return      {boolean}                 Always true
+     * Description  Update the current shift state within KMW
+     */
+    _UpdateVKShift(e, v: number, d: boolean|number): boolean {
+      var keyShiftState=0, lockStates=0, i;
+      let keyman = com.keyman.singleton;
+
+      var lockNames  = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'];
+      var lockKeys   = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'];
+
+      if(e) {
+        // read shift states from Pevent
+        keyShiftState = e.Lmodifiers;
+        lockStates = e.Lstates;
+
+        // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
+        if(keyman.keyboardManager.isChiral() && osk.Layouts.emulatesAltGr() && 
+            (com.keyman.DOMEventHandlers.states.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
+          keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
+          keyShiftState &= ~Codes.modifierCodes['RALT'];
+        }
+
+        for(i=0; i < lockNames.length; i++) {
+          if(lockStates & Codes.stateBitmasks[lockNames[i]]) {
+            this.stateKeys[lockKeys[i]] = lockStates & Codes.modifierCodes[lockNames[i]];
+          }
+        }
+      } else if(d) {
+        keyShiftState |= v;
+
+        for(i=0; i < lockNames.length; i++) {
+          if(v & Codes.stateBitmasks[lockNames[i]]) {
+            this.stateKeys[lockKeys[i]] = true;
+          }
+        }
+      } else {
+        keyShiftState &= ~v;
+
+        for(i=0; i < lockNames.length; i++) {
+          if(v & Codes.stateBitmasks[lockNames[i]]) {
+            this.stateKeys[lockKeys[i]] = false;
+          }
+        }
+      }
+
+      // Find and display the selected OSK layer
+      if(keyman['osk'].vkbd) {
+        keyman['osk'].vkbd.showLayer(this.getLayerId(keyShiftState));
+      }
+
+      // osk._UpdateVKShiftStyle will be called automatically upon the next _Show.
+      if(keyman.osk._Visible) {
+        keyman.osk._Show();
+      }
+
+      return true;
+    }
+
+    getLayerId(modifier: number): string {
+      return osk.Layouts.getLayerId(modifier);
+    }
+
+    /**
+     * Select the OSK's next keyboard layer based upon layer switching keys as a default
+     * The next layer will be determined from the key name unless otherwise specifed
+     *
+     *  @param  {string}                    keyName     key identifier
+     *  @param  {number|string|undefined}   nextLayerIn optional next layer identifier
+     *  @return {boolean}                               return true if keyboard layer changed
+     */
+    selectLayer(keyName: string, nextLayerIn?: number | string): boolean {
+      var nextLayer = arguments.length < 2 ? null : nextLayerIn;
+      let keyman = com.keyman.singleton;
+      var isChiral = keyman.keyboardManager.isChiral();
+
+      // Layer must be identified by name, not number (27/08/2015)
+      if(typeof nextLayer == 'number') {
+        nextLayer = this.getLayerId(nextLayer * 0x10);
+      }
+
+      // Identify next layer, if required by key
+      if(!nextLayer) {
+        switch(keyName) {
+          case 'K_LSHIFT':
+          case 'K_RSHIFT':
+          case 'K_SHIFT':
+            nextLayer = 'shift';
+            break;
+          case 'K_LCONTROL':
+          case 'K_LCTRL':
+            if(isChiral) {
+              nextLayer = 'leftctrl';
+              break;
+            }
+          case 'K_RCONTROL':
+          case 'K_RCTRL':
+            if(isChiral) {
+              nextLayer = 'rightctrl';
+              break;
+            }
+          case 'K_CTRL':
+            nextLayer = 'ctrl';
+            break;
+          case 'K_LMENU':
+          case 'K_LALT':
+            if(isChiral) {
+              nextLayer = 'leftalt';
+              break;
+            }
+          case 'K_RMENU':
+          case 'K_RALT':
+            if(isChiral) {
+              nextLayer = 'rightalt';
+              break;
+            }
+          case 'K_ALT':
+            nextLayer = 'alt';
+            break;
+          case 'K_ALTGR':
+            if(isChiral) {
+              nextLayer = 'leftctrl-rightalt';
+            } else {
+              nextLayer = 'ctrl-alt';
+            }
+            break;
+          case 'K_CURRENCIES':
+          case 'K_NUMERALS':
+          case 'K_SHIFTED':
+          case 'K_UPPER':
+          case 'K_LOWER':
+          case 'K_SYMBOLS':
+            nextLayer = 'default';
+            break;
+        }
+      }
+
+      // If no key corresponding to a layer transition is pressed, maintain the current layer.
+      if(!nextLayer) {
+        return false;
+      }
+
+      // Change layer and refresh OSK
+      this.updateLayer(nextLayer);
+      com.keyman.singleton.osk._Show();
+
+      return true;
+    }
+
+    /**
+     * Sets the new layer id, allowing for toggling shift/ctrl/alt while preserving the remainder
+     * of the modifiers represented by the current layer id (where applicable)
+     *
+     * @param       {string}      id      layer id (e.g. ctrlshift)
+     */
+    updateLayer(id: string) {
+      let keyman = com.keyman.singleton;
+      let processor = keyman.textProcessor;
+      let vkbd = keyman['osk'].vkbd;
+
+      if(!vkbd) {
+        return;
+      }
+
+      let activeLayer = vkbd.layerId;
+      var s = activeLayer;
+
+      // Do not change layer unless needed (27/08/2015)
+      if(id == activeLayer && keyman.util.device.formFactor != 'desktop') {
+        return false;
+      }
+
+      var idx=id;
+      var i;
+
+      if(keyman.util.device.formFactor == 'desktop') {
+        // Need to test if target layer is a standard layer (based on the plain 'default')
+        var replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
+
+        for(i=0; i < replacements.length; i++) {
+          // Don't forget to remove the kebab-case hyphens!
+          idx=idx.replace(replacements[i] + '-', '');
+          idx=idx.replace(replacements[i],'');
+        }
+
+        // If we are presently on the default layer, drop the 'default' and go straight to the shifted mode.
+        // If on a common symbolic layer, drop out of symbolic mode and go straight to the shifted mode.
+        if(activeLayer == 'default' || activeLayer == 'numeric' || activeLayer == 'symbol' || activeLayer == 'currency' || idx != '') {
+          s = id;
+        }
+        // Otherwise, we are based upon a layer that accepts modifier variations.
+        // Modify the layer according to the current state and key pressed.
+        //
+        // TODO:  Consider:  should this ever be allowed for a base layer other than 'default'?  If not,
+        // if(idx == '') with accompanying if-else structural shift would be a far better test here.
+        else {
+          // Save our current modifier state.
+          var modifier=processor.getModifierState(s);
+
+          // Strip down to the base modifiable layer.
+          for(i=0; i < replacements.length; i++) {
+            // Don't forget to remove the kebab-case hyphens!
+            s=s.replace(replacements[i] + '-', '');
+            s=s.replace(replacements[i],'');
+          }
+
+          // Toggle the modifier represented by our input argument.
+          switch(id) {
+            case 'shift':
+              modifier ^= Codes.modifierCodes['SHIFT'];
+              break;
+            case 'leftctrl':
+              modifier ^= Codes.modifierCodes['LCTRL'];
+              break;
+            case 'rightctrl':
+              modifier ^= Codes.modifierCodes['RCTRL'];
+              break;
+            case 'ctrl':
+              modifier ^= Codes.modifierCodes['CTRL'];
+              break;
+            case 'leftalt':
+              modifier ^= Codes.modifierCodes['LALT'];
+              break;
+            case 'rightalt':
+              modifier ^= Codes.modifierCodes['RALT'];
+              break;
+            case 'alt':
+              modifier ^= Codes.modifierCodes['ALT'];
+              break;
+            default:
+              s = id;
+          }
+
+          // Combine our base modifiable layer and attach the new modifier variation info to obtain our destination layer.
+          if(s != 'default') {
+            if(s == '') {
+              s = this.getLayerId(modifier);
+            } else {
+              s = this.getLayerId(modifier) + '-' + s;
+            }
+          }
+        }
+        
+        if(s == '') {
+          s = 'default';
+        }
+      } else {
+        // Mobile form-factor.  Either the layout is specified by a keyboard developer with direct layer name references
+        // or all layers are accessed via subkey of a single layer-shifting key - no need for modifier-combining logic.
+        s = id;
+      }
+
+      // Actually set the new layer id.
+      if(vkbd) {
+        if(!vkbd.showLayer(s)) {
+          vkbd.showLayer('default');
+        }
+      }
     }
   }
 }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -12,6 +12,14 @@ namespace com.keyman.text {
       "K_SCROLL":false
     };
 
+    // Tracks the most recent modifier state information in order to quickly detect changes
+    // in keyboard state not otherwise captured by the hosting page in the browser.
+    // Needed for AltGr simulation.
+    modStateFlags: number = 0;
+    // Denotes whether or not KMW needs to 'swallow' the next keypress.
+    swallowKeypress: boolean = false;
+
+
     /**
      * Get the default key string. If keyName is U_xxxxxx, use that Unicode codepoint.
      * Otherwise, lookup the  virtual key code (physical keyboard mapping)
@@ -186,6 +194,7 @@ namespace com.keyman.text {
         keyman['osk'].vkbd.highlightKey(e,false);
 
         // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
+        // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
         if(formFactor == 'desktop') {
           if(this.selectLayer(keyName, nextLayer)) {
             return true;
@@ -216,9 +225,10 @@ namespace com.keyman.text {
         kbdInterface._DeadkeyDeleteMatched();      // Delete any matched deadkeys before continuing
         //kbdInterface._DeadkeyResetMatched();       // I3318   (Not needed if deleted first?)
 
+        // Start:  mirrors _GetKeyEventProperties
         // First check the virtual key, and process shift, control, alt or function keys
         Lkc = {
-          Ltarg:Lelem,
+          Ltarg: Lelem,
           Lmodifiers:0,
           Lstates:0,
           Lcode: Codes.keyCodes[keyName],
@@ -255,6 +265,8 @@ namespace com.keyman.text {
           Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
           Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
         }
+
+        // End - mirrors _GetKeyEventProperties
 
         // Include *limited* support for mnemonic keyboards (Sept 2012)
         // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
@@ -423,7 +435,7 @@ namespace com.keyman.text {
 
         // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
         if(keyman.keyboardManager.isChiral() && osk.Layouts.emulatesAltGr() && 
-            (com.keyman.DOMEventHandlers.states.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
+            (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
           keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
           keyShiftState &= ~Codes.modifierCodes['RALT'];
         }
@@ -663,6 +675,418 @@ namespace com.keyman.text {
           vkbd.showLayer('default');
         }
       }
+    }
+
+    /**
+     * Function     _GetEventKeyCode
+     * Scope        Private
+     * @param       {Event}       e         Event object
+     * Description  Finds the key code represented by the event.
+     */
+    _GetEventKeyCode(e: KeyboardEvent) {
+      if (e.keyCode) {
+        return e.keyCode;
+      } else if (e.which) {
+        return e.which;
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * Function     _GetKeyEventProperties
+     * Scope        Private
+     * @param       {Event}       e         Event object
+     * @param       {boolean=}    keyState  true if call results from a keyDown event, false if keyUp, undefined if keyPress
+     * @return      {Object.<string,*>}     KMW keyboard event object: 
+     * Description  Get object with target element, key code, shift state, virtual key state 
+     *                Ltarg=target element
+     *                Lcode=keyCode
+     *                Lmodifiers=shiftState
+     *                LisVirtualKeyCode e.g. ctrl/alt key
+     *                LisVirtualKey     e.g. Virtual key or non-keypress event
+     */    
+    _GetKeyEventProperties(e: KeyboardEvent, keyState?: boolean) {
+      var s = new KeyEvent();
+      let keyman = com.keyman.singleton;
+
+      e = keyman._GetEventObject(e);   // I2404 - Manage IE events in IFRAMEs
+      s.Ltarg = keyman.util.eventTarget(e) as HTMLElement;
+      if (s.Ltarg == null) {
+        return null;
+      }
+      if(e.cancelBubble === true) {
+        return null; // I2457 - Facebook meta-event generation mess -- two events generated for a keydown in Facebook contentEditable divs
+      }      
+
+      if (s.Ltarg.nodeType == 3) {// defeat Safari bug
+        s.Ltarg = s.Ltarg.parentNode as HTMLElement;
+      }
+
+      s.Lcode = this._GetEventKeyCode(e);
+      if (s.Lcode == null) {
+        return null;
+      }
+
+      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
+
+      if(activeKeyboard && activeKeyboard['KM']) {
+        // K_SPACE is not handled by defaultKeyOutput for physical keystrokes unless using touch-aliased elements.
+        if(s.Lcode != Codes.keyCodes['K_SPACE']) {
+          // So long as the key name isn't prefixed with 'U_', we'll get a default mapping based on the Lcode value.
+          // We need to determine the mnemonic base character - for example, SHIFT + K_PERIOD needs to map to '>'.
+          var mappedChar: string = com.keyman.singleton.textProcessor.defaultKeyOutput('K_xxxx', s.Lcode, (e.getModifierState("Shift") ? 0x10 : 0), false, null);
+          if(mappedChar) {
+            s.Lcode = mappedChar.charCodeAt(0);
+          } // No 'else' - avoid blocking modifier keys, etc.
+        }
+      }
+
+      // Stage 1 - track the true state of the keyboard's modifiers.
+      var prevModState = this.modStateFlags, curModState = 0x0000;
+      var ctrlEvent = false, altEvent = false;
+      
+      let keyCodes = Codes.keyCodes;
+      switch(s.Lcode) {
+        case keyCodes['K_CTRL']:      // The 3 shorter "K_*CTRL" entries exist in some legacy keyboards.
+        case keyCodes['K_LCTRL']:
+        case keyCodes['K_RCTRL']:
+        case keyCodes['K_CONTROL']:
+        case keyCodes['K_LCONTROL']:
+        case keyCodes['K_RCONTROL']:
+          ctrlEvent = true;
+          break;
+        case keyCodes['K_LMENU']:     // The 2 "K_*MENU" entries exist in some legacy keyboards.
+        case keyCodes['K_RMENU']:
+        case keyCodes['K_ALT']:
+        case keyCodes['K_LALT']:
+        case keyCodes['K_RALT']:
+          altEvent = true;
+          break;
+      }
+
+      /**
+       * Two separate conditions exist that should trigger chiral modifier detection.  Examples below use CTRL but also work for ALT.
+       * 
+       * 1.  The user literally just pressed CTRL, so the event has a valid `location` property we can utilize.  
+       *     Problem: its layer isn't presently activated within the OSK.
+       * 
+       * 2.  CTRL has been held a while, so the OSK layer is valid, but the key event doesn't tell us the chirality of the active CTRL press.
+       *     Bonus issue:  RAlt simulation may cause erasure of this location property, but it should ONLY be empty if pressed in this case.
+       *     We default to the 'left' variants since they're more likely to exist and cause less issues with RAlt simulation handling.
+       * 
+       * In either case, `e.getModifierState("Control")` is set to true, but as a result does nothing to tell us which case is active.
+       * 
+       * `e.location != 0` if true matches condition 1 and matches condition 2 if false.
+       */
+
+      curModState |= (e.getModifierState("Shift") ? 0x10 : 0);
+
+      let modifierCodes = Codes.modifierCodes;
+      if(e.getModifierState("Control")) {
+        curModState |= ((e.location != 0 && ctrlEvent) ? 
+          (e.location == 1 ? modifierCodes['LCTRL'] : modifierCodes['RCTRL']) : // Condition 1
+          prevModState & 0x0003);                                                       // Condition 2
+      }
+      if(e.getModifierState("Alt")) {
+        curModState |= ((e.location != 0 && altEvent) ? 
+          (e.location == 1 ? modifierCodes['LALT'] : modifierCodes['RALT']) :   // Condition 1
+          prevModState & 0x000C);                                                       // Condition 2
+      }
+
+      // Stage 2 - detect state key information.  It can be looked up per keypress with no issue.
+      s.Lstates = 0;
+      
+      if(e.getModifierState("CapsLock")) {
+        s.Lstates = modifierCodes['CAPS'];
+      } else {
+        s.Lstates = modifierCodes['NO_CAPS'];
+      }
+
+      if(e.getModifierState("NumLock")) {
+        s.Lstates |= modifierCodes['NUM_LOCK'];
+      } else {
+        s.Lstates |= modifierCodes['NO_NUM_LOCK'];
+      }
+
+      if(e.getModifierState("ScrollLock") || e.getModifierState("Scroll")) {  // "Scroll" for IE9.
+        s.Lstates |= modifierCodes['SCROLL_LOCK'];
+      } else {
+        s.Lstates |= modifierCodes['NO_SCROLL_LOCK'];
+      }
+
+      // We need these states to be tracked as well for proper OSK updates.
+      curModState |= s.Lstates;
+
+      // Stage 3 - Set our modifier state tracking variable and perform basic AltGr-related management.
+      s.LmodifierChange = this.modStateFlags != curModState;
+      this.modStateFlags = curModState;
+
+      // Flip the shift bit if Caps Lock is active on mnemonic keyboards.
+      // Avoid signaling a change in the shift key's modifier state.  (The reason for this block's positioning.)
+      if(activeKeyboard && activeKeyboard['KM'] && e.getModifierState("CapsLock")) {
+        if((s.Lcode >= 65 && s.Lcode <= 90) /* 'A' - 'Z' */ || (s.Lcode >= 97 && s.Lcode <= 122) /* 'a' - 'z' */) {
+          curModState ^= 0x10; // Flip the 'shift' bit.
+          s.Lcode ^= 0x20; // Flips the 'upper' vs 'lower' bit for the base 'a'-'z' ASCII alphabetics.
+        }
+      }
+
+      // For European keyboards, not all browsers properly send both key-up events for the AltGr combo.
+      var altGrMask = modifierCodes['RALT'] | modifierCodes['LCTRL'];
+      if((prevModState & altGrMask) == altGrMask && (curModState & altGrMask) != altGrMask) {
+        // We just released AltGr - make sure it's all released.
+        curModState &= ~ altGrMask;
+      }
+      // Perform basic filtering for Windows-based ALT_GR emulation on European keyboards.
+      if(curModState & modifierCodes['RALT']) {
+        curModState &= ~modifierCodes['LCTRL'];
+      }
+
+      let modifierBitmasks = Codes.modifierBitmasks;
+      // Stage 4 - map the modifier set to the appropriate keystroke's modifiers.
+      if(keyman.keyboardManager.isChiral()) {
+        s.Lmodifiers = curModState & modifierBitmasks.CHIRAL;
+
+        // Note for future - embedding a kill switch here or in keymanweb.osk.emulatesAltGr would facilitate disabling
+        // AltGr / Right-alt simulation.
+        if(osk.Layouts.emulatesAltGr() && (s.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM']) {
+          s.Lmodifiers ^= modifierBitmasks['ALT_GR_SIM'];
+          s.Lmodifiers |= modifierCodes['RALT'];
+        }
+      } else {
+        // No need to sim AltGr here; we don't need chiral ALTs.
+        s.Lmodifiers = 
+          (curModState & 0x10) | // SHIFT
+          ((curModState & (modifierCodes['LCTRL'] | modifierCodes['RCTRL'])) ? 0x20 : 0) | 
+          ((curModState & (modifierCodes['LALT'] | modifierCodes['RALT']))   ? 0x40 : 0); 
+      }
+
+      // The 0x6F used to be 0x60 - this adjustment now includes the chiral alt and ctrl modifiers in that check.
+      s.LisVirtualKeyCode = (typeof e.charCode != 'undefined' && e.charCode != null  &&  (e.charCode == 0 || (s.Lmodifiers & 0x6F) != 0));
+      s.LisVirtualKey = s.LisVirtualKeyCode || e.type != 'keypress';
+      
+      return s;
+    }
+
+    // Returns true if the key event is a modifier press, allowing keyPress to return selectively
+    // in those cases.
+    private doModifierPress(Levent: KeyEvent, isKeyDown: boolean): boolean {
+      let keyman = com.keyman.singleton;
+
+      switch(Levent.Lcode) {
+        case 8: 
+          keyman.interface.clearDeadkeys();
+          break; // I3318 (always clear deadkeys after backspace) 
+        case 16: //"K_SHIFT":16,"K_CONTROL":17,"K_ALT":18
+        case 17: 
+        case 18: 
+        case 20: //"K_CAPS":20, "K_NUMLOCK":144,"K_SCROLL":145
+        case 144:
+        case 145:
+          // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
+          keyman.keyboardManager.notifyKeyboard(Levent.Lcode, Levent.Ltarg, 1); 
+          if(!keyman.util.device.touchable) {
+            return this._UpdateVKShift(Levent, Levent.Lcode-15, 1); // I2187
+          } else {
+            return true;
+          }
+      }
+
+      if(Levent.LmodifierChange) {
+        keyman.keyboardManager.notifyKeyboard(0, Levent.Ltarg, 1); 
+        this._UpdateVKShift(Levent, 0, 1);
+      }
+
+      // No modifier keypresses detected.
+      return false;
+    }
+
+    /**
+     * Function     keyDown
+     * Scope        Public
+     * Description  Processes keydown event and passes data to keyboard. 
+     * 
+     * Note that the test-case oriented 'recorder' stubs this method to facilitate keystroke
+     * recording for use in test cases.  If changing this function, please ensure the recorder is
+     * not affected.
+     */ 
+    keyDown(e: KeyboardEvent): boolean {
+      let keyman = com.keyman.singleton;
+      let activeKeyboard = keyman.keyboardManager.activeKeyboard;
+      let util = keyman.util;
+      let kbdInterface = keyman['interface'];
+      let keyMapManager = keyman.keyMapManager;
+
+      this.swallowKeypress = false;
+
+      // Get event properties  
+      var Levent = this._GetKeyEventProperties(e, true);
+      if(Levent == null) {
+        return true;
+      }
+
+      if(this.doModifierPress(Levent, true)) {
+        return true;
+      }
+
+      if(!window.event) {
+        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
+        // FireFox, Mozilla Suite
+        if(keyMapManager.browserMap.FF['k'+Levent.Lcode]) {
+          Levent.Lcode=keyMapManager.browserMap.FF['k'+Levent.Lcode];
+        }
+      } //else 
+      //{
+      // Safari, IE, Opera?
+      //}
+      
+      if(!activeKeyboard['KM']) {
+        // Positional Layout
+
+        var LeventMatched=0;
+        /* 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard */
+        var Lbase=keyMapManager.languageMap[com.keyman.osk.Layouts._BaseLayout];
+        if(Lbase && Lbase['k'+Levent.Lcode]) {
+          Levent.Lcode=Lbase['k'+Levent.Lcode];
+        }
+        /* 13/03/2007 MCD: Swedish: End mapping of keystroke to US keyboard */
+        
+        if(typeof(activeKeyboard['KM'])=='undefined'  &&  !(Levent.Lmodifiers & 0x60)) {
+          // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
+          var Levent2: com.keyman.LegacyKeyEvent = {
+            Lcode: keyMapManager._USKeyCodeToCharCode(Levent),
+            Ltarg: Levent.Ltarg,
+            Lmodifiers: 0,
+            LisVirtualKey: 0
+          };
+
+          if(kbdInterface.processKeystroke(util.physicalDevice, Levent2.Ltarg, Levent2)) {
+            LeventMatched=1;
+          }
+        }
+        
+        LeventMatched = LeventMatched || kbdInterface.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent);
+        
+        // Support backspace in simulated input DIV from physical keyboard where not matched in rule  I3363 (Build 301)
+        if(Levent.Lcode == 8 && !LeventMatched && Levent.Ltarg.className != null && Levent.Ltarg.className.indexOf('keymanweb-input') >= 0) {
+          kbdInterface.defaultBackspace();
+        }
+      } else {
+        // Mnemonic layout
+        if(Levent.Lcode == 8) { // I1595 - Backspace for mnemonic
+          this.swallowKeypress = true;
+          if(!kbdInterface.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent)) {
+            kbdInterface.defaultBackspace(); // I3363 (Build 301)
+          }
+          return false;  //added 16/3/13 to fix double backspace on mnemonic layouts on desktop
+        } else {
+          this.swallowKeypress = false;
+          LeventMatched = LeventMatched || kbdInterface.processKeystroke(util.physicalDevice,Levent.Ltarg,Levent);
+        }
+      }
+
+      // Translate numpad keystrokes into their non-numpad equivalents
+      if(!LeventMatched  &&  Levent.Lcode >= Codes.keyCodes["K_NP0"]  &&  Levent.Lcode <= Codes.keyCodes["K_NPSLASH"] && !activeKeyboard['KM']) {
+        // Number pad, numlock on
+        //      _Debug('KeyPress NumPad code='+Levent.Lcode+'; Ltarg='+Levent.Ltarg.tagName+'; LisVirtualKey='+Levent.LisVirtualKey+'; _KeyPressToSwallow='+keymanweb._KeyPressToSwallow+'; keyCode='+(e?e.keyCode:'nothing'));
+
+        if(Levent.Lcode < 106) {
+          var Lch = Levent.Lcode-48;
+        } else {
+          Lch = Levent.Lcode-64;
+        }
+        kbdInterface.output(0, Levent.Ltarg, String._kmwFromCharCode(Lch)); //I3319
+
+        LeventMatched = 1;
+      }
+
+      // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
+      if(LeventMatched) {
+        if(e  &&  e.preventDefault) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        
+        this.swallowKeypress = (e ? this._GetEventKeyCode(e) != 0 : false);
+        return false;
+      } else {
+        this.swallowKeypress = false;
+      }
+      
+      // Special backspace handling.
+      if(Levent.Lcode == 8) {
+        /* Backspace - delete deadkeys, also special rule if desired? */
+        // This is needed to prevent jumping to previous page, but why???  // I3363 (Build 301)
+        if(Levent.Ltarg.className != null && Levent.Ltarg.className.indexOf('keymanweb-input') >= 0) {
+          return false;
+        }
+      }
+
+      // Default text output emulation (for simulated touch elements)
+      if(typeof((Levent.Ltarg as HTMLElement).base) != 'undefined') {
+        // Simulated touch elements have no default text-processing - we need to rely on a strategy similar to
+        // that of the OSK here.
+        var ch = this.defaultKeyOutput('', Levent.Lcode, Levent.Lmodifiers, false, Levent.Ltarg);
+        if(ch) {
+          kbdInterface.output(0, Levent.Ltarg, ch);
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // KeyUp basically exists for two purposes:
+    // 1)  To detect browser form submissions (handled in kmwdomevents.ts)
+    // 2)  To detect modifier state changes.
+    keyUp(e: KeyboardEvent): boolean {
+      var Levent = this._GetKeyEventProperties(e, false);
+      if(Levent == null) {
+        return true;
+      }
+
+      return this.doModifierPress(Levent, false);
+    }
+
+    keyPress(e: KeyboardEvent): boolean {
+      let keyman = com.keyman.singleton;
+
+      var Levent = this._GetKeyEventProperties(e);
+      if(Levent == null || Levent.LisVirtualKey) {
+        return true;
+      }
+
+      // _Debug('KeyPress code='+Levent.Lcode+'; Ltarg='+Levent.Ltarg.tagName+'; LisVirtualKey='+Levent.LisVirtualKey+'; _KeyPressToSwallow='+keymanweb._KeyPressToSwallow+'; keyCode='+(e?e.keyCode:'nothing'));
+
+      /* I732 START - 13/03/2007 MCD: Swedish: Start positional keyboard layout code: prevent keystroke */
+      if(!keyman.keyboardManager.activeKeyboard['KM']) {
+        if(!this.swallowKeypress) {
+          return true;
+        }
+        if(Levent.Lcode < 0x20 || ((<any>keyman)._BrowserIsSafari  &&  (Levent.Lcode > 0xF700  &&  Levent.Lcode < 0xF900))) {
+          return true;
+        }
+
+        e = keyman._GetEventObject<KeyboardEvent>(e);   // I2404 - Manage IE events in IFRAMEs
+        if(e) {
+          e.returnValue = false;
+        }
+        return false;
+      }
+      /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
+      
+      // Only reached if it's a mnemonic keyboard.
+      if(this.swallowKeypress || keyman['interface'].processKeystroke(keyman.util.physicalDevice, Levent.Ltarg, Levent)) {
+        this.swallowKeypress = false;
+        if(e && e.preventDefault) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        return false;
+      }
+
+      this.swallowKeypress = false;
+      return true;
     }
   }
 }

--- a/web/testing/chirality/chirality.js
+++ b/web/testing/chirality/chirality.js
@@ -43,7 +43,7 @@ function Keyboard_chirality() {
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
     var osk = keyman.osk.vkbd;
-    var Constants = com.keyman.osk.VisualKeyboard;
+    var Constants = com.keyman.text.Codes;
     
     // Handwritten time!
     var kls = this.KV.KLS;

--- a/web/testing/chirality/chirality.js
+++ b/web/testing/chirality/chirality.js
@@ -42,7 +42,7 @@ function Keyboard_chirality() {
   };
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
-    var osk = keyman.osk.vkbd;
+    var Processor = keyman.textProcessor;
     var Constants = com.keyman.text.Codes;
     
     // Handwritten time!
@@ -54,7 +54,7 @@ function Keyboard_chirality() {
     for(var i = 0; i < layers.length; i++) {
       // Obtain the modifier code to match for the selected layer.
       // The following uses a non-public property potentially subject to change in the future.
-      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | osk.getModifierState(layers[i]);
+      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | Processor.getModifierState(layers[i]);
       var layer = layers[i];
       
       for(var key=0; key < kls[layer].length; key++) {

--- a/web/unit_tests/resources/keyboards/khmer_angkor.js
+++ b/web/unit_tests/resources/keyboards/khmer_angkor.js
@@ -6,8 +6,8 @@ KeymanWeb.KR(new Keyboard_khmer_angkor());
 }
 function Keyboard_khmer_angkor()
 {
-  var modCodes = com.keyman.osk.VisualKeyboard.modifierCodes;
-  var keyCodes = com.keyman.osk.VisualKeyboard.keyCodes;
+  var modCodes = com.keyman.text.Codes.modifierCodes;
+  var keyCodes = com.keyman.text.Codes.keyCodes;
 
   this.KI="Keyboard_khmer_angkor";
   this.KN="Khmer Angkor";

--- a/web/unit_tests/resources/keyboards/test_deadkeys.js
+++ b/web/unit_tests/resources/keyboards/test_deadkeys.js
@@ -6,8 +6,8 @@ KeymanWeb.KR(new Keyboard_test_deadkeys());
 }
 function Keyboard_test_deadkeys()
 {
-  var modCodes = com.keyman.osk.VisualKeyboard.modifierCodes;
-  var keyCodes = com.keyman.osk.VisualKeyboard.keyCodes;
+  var modCodes = com.keyman.text.Codes.modifierCodes;
+  var keyCodes = com.keyman.text.Codes.keyCodes;
 
   this.KI="Keyboard_test_deadkeys";
   this.KN="Keyman Deadkey Stress-Tester";


### PR DESCRIPTION
This PR refactor's KMW's keystroke mapping functionality into a common module.  With all the OSK reorganization work done to this point, it's now comparatively simple to extract its old `.clickKey` function and related helpers into a new `Processor` module and to refactor it alongside the hardware-based keystroke functions.  A few areas of commonality have been found and utilized to simplify future code maintenance in this area.

During work on this, some additional issues with mnemonic support have been noted.  While I have refactored the existing code, I have not addressed the issues themselves; they have been noted on https://github.com/keymanapp/keyman/issues/846.