### PR TITLE
[Developer] Rename default to '(current layer)' to reduce ambiguity.

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -532,8 +532,8 @@ $(function () {
     $('#selSubKeyLayerOverride option').remove();
     $('#addLayerList option').remove();
 
-    add($selKeyLayerOverride, '', '(layer default)');
-    add($selSubKeyLayerOverride, '', '(layer default)');
+    add($selKeyLayerOverride, '', '(current layer)');
+    add($selSubKeyLayerOverride, '', '(current layer)');
     add($addLayerList, '', '(custom)');
     
         


### PR DESCRIPTION
Fixes #1035.