### PR TITLE
[Web] [Developer] displayUnderlying flag is now separate for different platforms.

### DIFF
--- a/web/source/kmwosk.ts
+++ b/web/source/kmwosk.ts
@@ -3622,7 +3622,12 @@ if(!window['keyman']['initialized']) {
       if('font' in layout) osk.fontFamily=layout['font']; else osk.fontFamily='';
 
       // Set flag to add default (US English) key label if specified by keyboard
-      layout.keyLabels=activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      if(typeof layout['displayUnderlying'] != 'undefined') {
+        layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+      } else {
+        layout.keyLabels = activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      }
+
       LdivC=osk.deviceDependentLayout(layout,device.formFactor);
 
       osk.ddOSK = true;
@@ -3701,8 +3706,13 @@ if(!window['keyman']['initialized']) {
         layout=osk.buildDefaultLayout(PVK,keymanweb.keyboardManager.getKeyboardModifierBitmask(PKbd),formFactor);
 
       // Cannot create an OSK if no layout defined, just return empty DIV
-      if(layout != null)
-        layout.keyLabels=((typeof(PKbd['KDU']) != 'undefined') && PKbd['KDU']);
+      if(layout != null) {
+        if(typeof layout['displayUnderlying'] != 'undefined') {
+          layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+        } else {
+          layout.keyLabels = typeof(PKbd['KDU']) != 'undefined' && PKbd['KDU'];
+        }
+      }
 
       kbd=osk.deviceDependentLayout(layout,formFactor);
       kbd.className=formFactor+'-static kmw-osk-inner-frame';

--- a/windows/src/developer/TIKE/oskbuilder/TouchLayoutDefinitions.pas
+++ b/windows/src/developer/TIKE/oskbuilder/TouchLayoutDefinitions.pas
@@ -73,9 +73,10 @@ const
     (Name: 'row'; ClassType: TJSONArray; Required: True; Value: @RowDef[0]; ValueSize: Length(RowDef))
   );
 
-  PlatformDef: array[0..2] of TJSONDef = (
+  PlatformDef: array[0..3] of TJSONDef = (
     (Name: 'font'; ClassType: TJSONString),
     (Name: 'fontsize'; ClassType: TJSONString),   // I4062
+    (Name: 'displayUnderlying'; ClassType: TJSONBool),
     (Name: 'layer'; ClassType: TJSONArray; Required: True; Value: @LayerDef[0]; ValueSize: Length(LayerDef))
   );
 

--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -77,7 +77,6 @@ type
     FLastError: string;   // I4083
     FLastErrorOffset: Integer;   // I4083
     FFilename: string;
-    FSourceWasRegistered: Boolean;
     function GetLayoutJS: string;
     procedure DoModified;
     procedure DoLoad;
@@ -92,7 +91,6 @@ type
     procedure cefBeforeBrowse(Sender: TObject; const Url: string; params: TStringList; wasHandled: Boolean);
     procedure cefLoadEnd(Sender: TObject);
     procedure RegisterSource;
-    procedure UnregisterSource;
     procedure CharMapDragDrop(Sender, Source: TObject; X, Y: Integer);
     procedure CharMapDragOver(Sender, Source: TObject; X, Y: Integer;
       State: TDragState; var Accept: Boolean);
@@ -227,23 +225,14 @@ end;
 procedure TframeTouchLayoutBuilder.FormDestroy(Sender: TObject);
 begin
   inherited;
-  UnregisterSource;
+  if (FFileName <> '') and modWebHttpServer.AppSource.IsSourceRegistered(FFilename) then
+    modWebHttpServer.AppSource.UnregisterSource(FFilename);
 end;
 
 procedure TframeTouchLayoutBuilder.RegisterSource;
 begin
   if FFilename <> '' then
     modWebHttpServer.AppSource.RegisterSource(FFilename, FSavedLayoutJS);
-
-  FSourceWasRegistered := True;
-end;
-
-procedure TframeTouchLayoutBuilder.UnregisterSource;
-begin
-  if (FFilename <> '') and FSourceWasRegistered then
-    modWebHttpServer.AppSource.UnregisterSource(FFilename);
-
-  FSourceWasRegistered := False;
 end;
 
 procedure TframeTouchLayoutBuilder.ImportFromKVK(const KVKFileName: string);   // I3945
@@ -324,11 +313,6 @@ begin
 
   if (FFileName <> '') and modWebHttpServer.AppSource.IsSourceRegistered(FFilename) then
     modWebHttpServer.AppSource.UnregisterSource(FFilename);
-
-//  FreeAndNil(FHTMLTempFilename);   // I4195
-//  FHTMLTempFilename := TTempFileManager.Get('.html');   // I4195
-
-  UnregisterSource;
 
   if ALoadFromString then
   begin

--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.css
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.css
@@ -120,6 +120,16 @@ body {
   cursor: pointer;
 }
 
+.key .underlying {
+  font-family: Tahoma;
+  font-size: 10px;
+  color: #666666;
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  text-align: left;
+}
+
 .key.key-modifier .id {
   color: #808080;
 }
@@ -199,10 +209,17 @@ br.clear {
 }
 
 #toolbar div {
-    background: #DCDCDD;
-    margin: -1px -1px -1px 0;
-    padding: 8px;
-    float: left;
+  background: #DCDCDD;
+  margin: -1px -1px -1px 0;
+  padding: 8px;
+  float: left;
+}
+
+#toolbar #layoutToolbar > div {
+  margin: 0;
+  padding: 0 8px;
+  border-left: 1px solid #444444;
+  line-height: 24px;
 }
 
 button, input, select {

--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -285,6 +285,278 @@ $(function () {
   'K_?FF'         // &HFF
   ];
 
+  this.standardKeyCaps = [
+  ['',''], // 'K_?00',      // &H0
+  ['',''], // 'K_LBUTTON',    // &H1
+  ['',''], // 'K_RBUTTON',    // &H2
+  ['',''], // 'K_CANCEL',       // &H3
+  ['',''], // 'K_MBUTTON',    // &H4
+  ['',''], // 'K_?05',      // &H5
+  ['',''], // 'K_?06',      // &H6
+  ['',''], // 'K_?07',      // &H7
+  ['',''], // 'K_BKSP',         // &H8
+  ['',''], // 'K_TAB',        // &H9
+  ['',''], // 'K_?0A',      // &HA
+  ['',''], // 'K_?0B',      // &HB
+  ['',''], // 'K_KP5',        // &HC
+  ['',''], // 'K_ENTER',      // &HD
+  ['',''], // 'K_?0E',      // &HE
+  ['',''], // 'K_?0F',      // &HF
+  ['',''], // 'K_SHIFT',      // &H10
+  ['',''], // 'K_CONTROL',    // &H11
+  ['',''], // 'K_ALT',      // &H12
+  ['',''], // 'K_PAUSE',      // &H13
+  ['',''], // 'K_CAPS',       // &H14
+  ['',''], // 'K_KANJI?15',     // &H15
+  ['',''], // 'K_KANJI?16',     // &H16
+  ['',''], // 'K_KANJI?17',     // &H17
+  ['',''], // 'K_KANJI?18',     // &H18
+  ['',''], // 'K_KANJI?19',     // &H19
+  ['',''], // 'K_?1A',      // &H1A
+  ['',''], // 'K_ESC',      // &H1B
+  ['',''], // 'K_KANJI?1C',     // &H1C
+  ['',''], // 'K_KANJI?1D',     // &H1D
+  ['',''], // 'K_KANJI?1E',     // &H1E
+  ['',''], // 'K_KANJI?1F',     // &H1F
+  [' ',' '], // 'K_SPACE',      // &H20
+  ['',''], // 'K_PGUP',       // &H21
+  ['',''], // 'K_PGDN',       // &H22
+  ['',''], // 'K_END',      // &H23
+  ['',''], // 'K_HOME',       // &H24
+  ['',''], // 'K_LEFT',       // &H25
+  ['',''], // 'K_UP',       // &H26
+  ['',''], // 'K_RIGHT',      // &H27
+  ['',''], // 'K_DOWN',       // &H28
+  ['',''], // 'K_SEL',      // &H29
+  ['',''], // 'K_PRINT',      // &H2A
+  ['',''], // 'K_EXEC',       // &H2B
+  ['',''], // 'K_PRTSCN',     // &H2C
+  ['',''], // 'K_INS',      // &H2D
+  ['',''], // 'K_DEL',      // &H2E
+  ['',''], // 'K_HELP',       // &H2F
+  ['0',')'], // 'K_0',        // &H30
+  ['1','!'], // 'K_1',        // &H31
+  ['2','@'], // 'K_2',        // &H32
+  ['3','#'], // 'K_3',        // &H33
+  ['4','$'], // 'K_4',        // &H34
+  ['5','%'], // 'K_5',        // &H35
+  ['6','^'], // 'K_6',        // &H36
+  ['7','&'], // 'K_7',        // &H37
+  ['8','*'], // 'K_8',        // &H38
+  ['9','('], // 'K_9',        // &H39
+  ['',''], // 'K_?3A',      // &H3A
+  ['',''], // 'K_?3B',      // &H3B
+  ['',''], // 'K_?3C',      // &H3C
+  ['',''], // 'K_?3D',      // &H3D
+  ['',''], // 'K_?3E',      // &H3E
+  ['',''], // 'K_?3F',      // &H3F
+  ['',''], // 'K_?40',      // &H40
+  
+  ['a','A'], // 'K_A',        // &H41
+  ['b','B'], // 'K_B',        // &H42
+  ['c','C'], // 'K_C',        // &H43
+  ['d','D'], // 'K_D',        // &H44
+  ['e','E'], // 'K_E',        // &H45
+  ['f','F'], // 'K_F',        // &H46
+  ['g','G'], // 'K_G',        // &H47
+  ['h','H'], // 'K_H',        // &H48
+  ['i','I'], // 'K_I',        // &H49
+  ['j','J'], // 'K_J',        // &H4A
+  ['k','K'], // 'K_K',        // &H4B
+  ['l','L'], // 'K_L',        // &H4C
+  ['m','M'], // 'K_M',        // &H4D
+  ['n','N'], // 'K_N',        // &H4E
+  ['o','O'], // 'K_O',        // &H4F
+  ['p','P'], // 'K_P',        // &H50
+  ['q','Q'], // 'K_Q',        // &H51
+  ['r','R'], // 'K_R',        // &H52
+  ['s','S'], // 'K_S',        // &H53
+  ['t','T'], // 'K_T',        // &H54
+  ['u','U'], // 'K_U',        // &H55
+  ['v','V'], // 'K_V',        // &H56
+  ['w','W'], // 'K_W',        // &H57
+  ['x','X'], // 'K_X',        // &H58
+  ['y','Y'], // 'K_Y',        // &H59
+  ['z','Z'], // 'K_Z',        // &H5A
+  ['',''], // 'K_?5B',      // &H5B
+  ['',''], // 'K_?5C',      // &H5C
+  ['',''], // 'K_?5D',      // &H5D
+  ['',''], // 'K_?5E',      // &H5E
+  ['',''], // 'K_?5F',      // &H5F
+  ['',''], // 'K_NP0',      // &H60
+  ['',''], // 'K_NP1',      // &H61
+  ['',''], // 'K_NP2',      // &H62
+  ['',''], // 'K_NP3',      // &H63
+  ['',''], // 'K_NP4',      // &H64
+  ['',''], // 'K_NP5',      // &H65
+  ['',''], // 'K_NP6',      // &H66
+  ['',''], // 'K_NP7',      // &H67
+  ['',''], // 'K_NP8',      // &H68
+  ['',''], // 'K_NP9',      // &H69
+  ['',''], // 'K_NPSTAR',     // &H6A
+  ['',''], // 'K_NPPLUS',     // &H6B
+  ['',''], // 'K_SEPARATOR',    // &H6C
+  ['',''], // 'K_NPMINUS',    // &H6D
+  ['',''], // 'K_NPDOT',      // &H6E
+  ['',''], // 'K_NPSLASH',    // &H6F
+  ['',''], // 'K_F1',       // &H70
+  ['',''], // 'K_F2',       // &H71
+  ['',''], // 'K_F3',       // &H72
+  ['',''], // 'K_F4',       // &H73
+  ['',''], // 'K_F5',       // &H74
+  ['',''], // 'K_F6',       // &H75
+  ['',''], // 'K_F7',       // &H76
+  ['',''], // 'K_F8',       // &H77
+  ['',''], // 'K_F9',       // &H78
+  ['',''], // 'K_F10',      // &H79
+  ['',''], // 'K_F11',      // &H7A
+  ['',''], // 'K_F12',      // &H7B
+  ['',''], // 'K_F13',      // &H7C
+  ['',''], // 'K_F14',      // &H7D
+  ['',''], // 'K_F15',      // &H7E
+  ['',''], // 'K_F16',      // &H7F
+  ['',''], // 'K_F17',      // &H80
+  ['',''], // 'K_F18',      // &H81
+  ['',''], // 'K_F19',      // &H82
+  ['',''], // 'K_F20',      // &H83
+  ['',''], // 'K_F21',      // &H84
+  ['',''], // 'K_F22',      // &H85
+  ['',''], // 'K_F23',      // &H86
+  ['',''], // 'K_F24',      // &H87
+
+  ['',''], // 'K_?88',      // &H88
+  ['',''], // 'K_?89',      // &H89
+  ['',''], // 'K_?8A',      // &H8A
+  ['',''], // 'K_?8B',      // &H8B
+  ['',''], // 'K_?8C',      // &H8C
+  ['',''], // 'K_?8D',      // &H8D
+  ['',''], // 'K_?8E',      // &H8E
+  ['',''], // 'K_?8F',      // &H8F
+
+  ['',''], // 'K_NUMLOCK',    // &H90
+  ['',''], // 'K_SCROLL',     // &H91
+
+  ['',''], // 'K_?92',      // &H92
+  ['',''], // 'K_?93',      // &H93
+  ['',''], // 'K_?94',      // &H94
+  ['',''], // 'K_?95',      // &H95
+  ['',''], // 'K_?96',      // &H96
+  ['',''], // 'K_?97',      // &H97
+  ['',''], // 'K_?98',      // &H98
+  ['',''], // 'K_?99',      // &H99
+  ['',''], // 'K_?9A',      // &H9A
+  ['',''], // 'K_?9B',      // &H9B
+  ['',''], // 'K_?9C',      // &H9C
+  ['',''], // 'K_?9D',      // &H9D
+  ['',''], // 'K_?9E',      // &H9E
+  ['',''], // 'K_?9F',      // &H9F
+  ['',''], // 'K_?A0',      // &HA0
+  ['',''], // 'K_?A1',      // &HA1
+  ['',''], // 'K_?A2',      // &HA2
+  ['',''], // 'K_?A3',      // &HA3
+  ['',''], // 'K_?A4',      // &HA4
+  ['',''], // 'K_?A5',      // &HA5
+  ['',''], // 'K_?A6',      // &HA6
+  ['',''], // 'K_?A7',      // &HA7
+  ['',''], // 'K_?A8',      // &HA8
+  ['',''], // 'K_?A9',      // &HA9
+  ['',''], // 'K_?AA',      // &HAA
+  ['',''], // 'K_?AB',      // &HAB
+  ['',''], // 'K_?AC',      // &HAC
+  ['',''], // 'K_?AD',      // &HAD
+  ['',''], // 'K_?AE',      // &HAE
+  ['',''], // 'K_?AF',      // &HAF
+  ['',''], // 'K_?B0',      // &HB0
+  ['',''], // 'K_?B1',      // &HB1
+  ['',''], // 'K_?B2',      // &HB2
+  ['',''], // 'K_?B3',      // &HB3
+  ['',''], // 'K_?B4',      // &HB4
+  ['',''], // 'K_?B5',      // &HB5
+  ['',''], // 'K_?B6',      // &HB6
+  ['',''], // 'K_?B7',      // &HB7
+  ['',''], // 'K_?B8',      // &HB8
+  ['',''], // 'K_?B9',      // &HB9
+
+  [';',':'], // 'K_COLON',      // &HBA
+  ['=','+'], // 'K_EQUAL',      // &HBB
+  [',','<'], // 'K_COMMA',      // &HBC
+  ['-','_'], // 'K_HYPHEN',     // &HBD
+  ['.','>'], // 'K_PERIOD',     // &HBE
+  ['/','?'], // 'K_SLASH',      // &HBF
+  ['`','~'], // 'K_BKQUOTE',    // &HC0
+
+  ['',''], // 'K_?C1',      // &HC1
+  ['',''], // 'K_?C2',      // &HC2
+  ['',''], // 'K_?C3',      // &HC3
+  ['',''], // 'K_?C4',      // &HC4
+  ['',''], // 'K_?C5',      // &HC5
+  ['',''], // 'K_?C6',      // &HC6
+  ['',''], // 'K_?C7',      // &HC7
+  ['',''], // 'K_?C8',      // &HC8
+  ['',''], // 'K_?C9',      // &HC9
+  ['',''], // 'K_?CA',      // &HCA
+  ['',''], // 'K_?CB',      // &HCB
+  ['',''], // 'K_?CC',      // &HCC
+  ['',''], // 'K_?CD',      // &HCD
+  ['',''], // 'K_?CE',      // &HCE
+  ['',''], // 'K_?CF',      // &HCF
+  ['',''], // 'K_?D0',      // &HD0
+  ['',''], // 'K_?D1',      // &HD1
+  ['',''], // 'K_?D2',      // &HD2
+  ['',''], // 'K_?D3',      // &HD3
+  ['',''], // 'K_?D4',      // &HD4
+  ['',''], // 'K_?D5',      // &HD5
+  ['',''], // 'K_?D6',      // &HD6
+  ['',''], // 'K_?D7',      // &HD7
+  ['',''], // 'K_?D8',      // &HD8
+  ['',''], // 'K_?D9',      // &HD9
+  ['',''], // 'K_?DA',      // &HDA
+
+  ['[','{'], // 'K_LBRKT',      // &HDB
+  ['\\','|'], // 'K_BKSLASH',    // &HDC
+  [']','}'], // 'K_RBRKT',      // &HDD
+  ['\'','"'], // 'K_QUOTE',      // &HDE
+  ['',''], // 'K_oDF',      // &HDF
+  ['',''], // 'K_oE0',      // &HE0
+  ['',''], // 'K_oE1',      // &HE1
+  ['\\','|'], // 'K_oE2',      // &HE2
+  ['',''], // 'K_oE3',      // &HE3
+  ['',''], // 'K_oE4',      // &HE4
+
+  ['',''], // 'K_?E5',      // &HE5
+
+  ['',''], // 'K_oE6',      // &HE6
+
+  ['',''], // 'K_?E7',      // &HE7
+  ['',''], // 'K_?E8',      // &HE8
+
+  ['',''], // 'K_oE9',      // &HE9
+  ['',''], // 'K_oEA',      // &HEA
+  ['',''], // 'K_oEB',      // &HEB
+  ['',''], // 'K_oEC',      // &HEC
+  ['',''], // 'K_oED',      // &HED
+  ['',''], // 'K_oEE',      // &HEE
+  ['',''], // 'K_oEF',      // &HEF
+  ['',''], // 'K_oF0',      // &HF0
+  ['',''], // 'K_oF1',      // &HF1
+  ['',''], // 'K_oF2',      // &HF2
+  ['',''], // 'K_oF3',      // &HF3
+  ['',''], // 'K_oF4',      // &HF4
+  ['',''], // 'K_oF5',      // &HF5
+
+  ['',''], // 'K_?F6',      // &HF6
+  ['',''], // 'K_?F7',      // &HF7
+  ['',''], // 'K_?F8',      // &HF8
+  ['',''], // 'K_?F9',      // &HF9
+  ['',''], // 'K_?FA',      // &HFA
+  ['',''], // 'K_?FB',      // &HFB
+  ['',''], // 'K_?FC',      // &HFC
+  ['',''], // 'K_?FD',      // &HFD
+  ['',''], // 'K_?FE',      // &HFE
+  ['',''], // 'K_?FF'       // &HFF
+  ];
+  
+  
   this.lookupKeyNames = [];
 
   for (var i = 0; i < this.standardKeyNames.length; i++) {
@@ -588,8 +860,23 @@ $(function () {
     }
   };
 
+  this.getModifierCombinationFromLayerId = function(id) {
+    for(var i = 0; i < this.validModifierCombinations.length; i++) {
+      if(this.getModifierCombinationName(this.validModifierCombinations[i]) == id) {
+        return this.validModifierCombinations[i];
+      }
+    }
+    return 0;
+  };
+  
+  this.isLayerIdShifted = function(id) {
+    return (builder.getModifierCombinationFromLayerId(id) & this.modifierCodes.SHIFT) != 0;
+  };
+  
   this.prepareLayer = function () {
     var layer = KVKL[builder.lastPlatform].layer[builder.lastLayerIndex];
+    
+    var isLayerShifted = builder.isLayerIdShifted(layer.id); 
 
     var width = 0;  // calculate the widest and rescale
     for (var i = 0; i < layer.row.length; i++) {
@@ -660,6 +947,7 @@ $(function () {
           .css('font-family', key.font)
           .css('font-size', key.fontsize);
         $('.text', nkey).text(this.renameSpecialKey(text));
+        if(KVKL[builder.lastPlatform].displayUnderlying) $('.underlying', nkey).text(this.getStandardKeyCap(key.id, key.layer ? builder.isLayerIdShifted(key.layer) : isLayerShifted));
 
         builder.updateKeyId(nkey);
       }
@@ -678,10 +966,16 @@ $(function () {
     $(div).css('clear', 'both');
     $('#kbd').append(div);
   };
+  
+  this.getStandardKeyCap = function (id, shifted) {
+    id = id ? id.toUpperCase() : '';
+    var i = this.standardKeyNames.findIndex(function(x) { return x.toUpperCase() == id });
+    return i >= 0 ? this.standardKeyCaps[i][shifted ? 1 : 0] : '';
+  };
 
   this.updateKeyId = function (nkey) {
     $('.id', nkey).text(($(nkey).data('layer') || '') + ' ' + $(nkey).data('id'));
-  }
+  };
 
   this.selectPlatform = function (val) {
     builder.lastPlatform = val || $('#selPlatform').val();
@@ -698,6 +992,8 @@ $(function () {
       listContainer.append(option);
     }
 
+    $('#chkDisplayUnderlying')[0].checked = KVKL[builder.lastPlatform].displayUnderlying;
+    
     builder.prepareLayers();
     builder.selectLayer(0);
   }
@@ -835,10 +1131,13 @@ $(function () {
     var key = document.createElement('div');
     var ktext = document.createElement('div');
     var kid = document.createElement('div');
+    var kunderlying = document.createElement('div');
     $(kid).addClass('id');
     $(ktext).addClass('text');
+    $(kunderlying).addClass('underlying');
     $(key).append(kid);
     $(key).append(ktext);
+    $(key).append(kunderlying);
     $(key).addClass('key');
     $(key).data('id', 'T_new_' + this.uniqId);
     builder.uniqId++;
@@ -1441,6 +1740,12 @@ $(function () {
 
   this.generate = function (display) {
     var json = JSON.stringify(KVKL, null, '  ');
+    
+    if(!display) {
+      // Save changed settings -- only when not saving undo
+      KVKL[builder.lastPlatform].displayUnderlying = $('#chkDisplayUnderlying')[0].checked;
+    }
+    
     var layer = KVKL[builder.lastPlatform].layer[builder.lastLayerIndex];
     layer.row = [];
 
@@ -1575,6 +1880,13 @@ $(function () {
     builder.lastPlatform = null;
     builder.preparePlatforms();
     builder.post();
+  });
+  
+  $('#chkDisplayUnderlying').click(function () {
+    builder.saveUndo();
+    var platform = $('#selPlatform').val();
+    builder.post();
+    builder.prepareLayer();
   });
 
   //

--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.xsl
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.xsl
@@ -31,15 +31,22 @@
                         <button id='btnImport'>Import from On Screen</button>
                     </div>
                     <div id='layoutToolbar'>
-                        Platform: <select id='selPlatform'></select>
-                        <button id='btnAddPlatform'>Add</button>
-                        <button id='btnDelPlatform'>Del</button>
-                        Layer: <select id='selLayer'></select>
-                        <button id='btnAddLayer'>Add</button>
-                        <button id='btnDelLayer'>Del</button>
-                        <button id='btnEditLayer'>Edit</button>
-                        Presentation: <select id='selPlatformPresentation'></select>
-                        <input type='checkbox' id='chkShowAllModifierOptions'/> <label for='chkShowAllModifierOptions'>Show all modifier options</label>
+                        <div>
+                          Platform: <select id='selPlatform'></select>
+                          <button id='btnAddPlatform'>Add</button>
+                          <button id='btnDelPlatform'>Del</button>
+                          <input type='checkbox' id='chkDisplayUnderlying'/> <label for='chkDisplayUnderlying'>Display underlying</label>
+                        </div>
+                        <div>
+                          Layer: <select id='selLayer'></select>
+                          <button id='btnAddLayer'>Add</button>
+                          <button id='btnDelLayer'>Del</button>
+                          <button id='btnEditLayer'>Edit</button>
+                        </div>
+                        <div>
+                          Presentation: <select id='selPlatformPresentation'></select>
+                          <input type='checkbox' id='chkShowAllModifierOptions'/> <label for='chkShowAllModifierOptions'>Show all modifier options</label>
+                        </div>
                     </div>
                     <br class='clear' />
                 </div>


### PR DESCRIPTION
Fixes #1117.

Also fixes:
* A crash switching between Code and Design tabs in Touch Layout Editor
* KDU flag is always filled by KMW compiler, even if no OSK is included in the compiled keyboard

However, currently KMW effectively ignores the KDU flag for desktop because of the `isDesktop` test 
in kmwosk:312, which is something we could improve!

There is a separate issue of blank keys getting a default character in the desktop OSK. Changing this
would require much care around testing existing keyboard layouts to ensure that what is displayed 
continues to make sense, particularly for latin-based layouts.