### PR TITLE
[Developer] Add option to check filename conventions

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -289,10 +289,6 @@ begin
     Free;
   end;
 
-  //FRunFolder := GetCurrentDir;
-
-  //raise Exception.Create('Error Message');
-
   KeyboardFileNames := TWideStringList.Create;
   try
     if not Init(FMode, KeyboardFileNames, FSilent, FForce, FNoWelcome, FLogFile, FQuery) then

--- a/windows/src/developer/TIKE/actions/dmActionsMain.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.dfm
@@ -53,6 +53,7 @@ object modActionsMain: TmodActionsMain
       Category = 'File'
       Caption = 'Save &As...'
       Dialog.Title = 'Save As'
+      Dialog.OnCanClose = actFileSaveAsSaveDialogCanClose
       Hint = 'Save As|Saves the active file with a new name'
       BeforeExecute = actFileSaveAsBeforeExecute
       OnAccept = actFileSaveAsAccept
@@ -255,6 +256,7 @@ object modActionsMain: TmodActionsMain
       Dialog.Filter = 'Keyman Developer Project Files (*.kpj)|*.kpj|All Files (*.*)|*.*'
       Dialog.Options = [ofOverwritePrompt, ofHideReadOnly, ofPathMustExist, ofEnableSizing]
       Dialog.Title = 'Save Project As'
+      Dialog.OnCanClose = actProjectSaveAsSaveDialogCanClose
       Hint = 'Save Project As|Saves the current project with a new name'
       BeforeExecute = actProjectSaveAsBeforeExecute
       OnAccept = actProjectSaveAsAccept
@@ -482,7 +484,7 @@ object modActionsMain: TmodActionsMain
     Left = 304
     Top = 236
     Bitmap = {
-      494C01010A000E00780010001000FFFFFFFFFF10FFFFFFFFFFFFFFFF424D3600
+      494C01010A000E007C0010001000FFFFFFFFFF10FFFFFFFFFFFFFFFF424D3600
       0000000000003600000028000000400000003000000001002000000000000030
       0000000000000000000000000000000000000000000000000000000000000000
       0000000000000000000000000000000000000000000000000000000000000000
@@ -891,7 +893,7 @@ object modActionsMain: TmodActionsMain
     Left = 124
     Top = 116
     Bitmap = {
-      494C0101110013008C0020002000FFFFFFFFFF10FFFFFFFFFFFFFFFF424D3600
+      494C010111001300900020002000FFFFFFFFFF10FFFFFFFFFFFFFFFF424D3600
       000000000000360000002800000080000000A000000001002000000000000040
       0100000000000000000000000000000000000000000000000000000000000000
       0000000000000000000000000000000000000000000000000000A8CAFF00A8CA

--- a/windows/src/developer/TIKE/actions/dmActionsMain.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.pas
@@ -202,7 +202,11 @@ type
     procedure actViewCodeUpdate(Sender: TObject);   // I4678
     procedure actViewCodeExecute(Sender: TObject);   // I4678
     procedure actViewCharacterIdentifierExecute(Sender: TObject);   // I4807
-    procedure actViewCharacterIdentifierUpdate(Sender: TObject);   // I4807
+    procedure actViewCharacterIdentifierUpdate(Sender: TObject);
+    procedure actFileSaveAsSaveDialogCanClose(Sender: TObject;
+      var CanClose: Boolean);
+    procedure actProjectSaveAsSaveDialogCanClose(Sender: TObject;
+      var CanClose: Boolean);   // I4807
   private
     procedure AboutShowStartup(Sender: TObject);
   public
@@ -354,6 +358,12 @@ begin
   end;
 end;
 
+procedure TmodActionsMain.actFileSaveAsSaveDialogCanClose(Sender: TObject;
+  var CanClose: Boolean);
+begin
+  CanClose := CheckFilenameConventions((Sender as TSaveDialog).FileName);
+end;
+
 procedure TmodActionsMain.actFileSaveAsUpdate(Sender: TObject);
 begin
   with frmKeymanDeveloper do
@@ -472,7 +482,8 @@ var
   i: Integer;
 begin
   for i := 0 to actProjectAddFiles.Dialog.Files.Count - 1 do
-    if FGlobalProject.Files.IndexOfFileName(actProjectAddFiles.Dialog.Files[i]) < 0 then
+    if (FGlobalProject.Files.IndexOfFileName(actProjectAddFiles.Dialog.Files[i]) < 0) and
+      CheckFilenameConventions(actProjectAddFiles.Dialog.Files[i]) then
       CreateProjectFile(FGlobalProject, actProjectAddFiles.Dialog.Files[i], nil);
   frmKeymanDeveloper.ShowProject;
 end;
@@ -517,6 +528,12 @@ end;
 procedure TmodActionsMain.actProjectSaveAsBeforeExecute(Sender: TObject);
 begin
   actProjectSaveAs.Dialog.FileName := FGlobalProject.FileName;
+end;
+
+procedure TmodActionsMain.actProjectSaveAsSaveDialogCanClose(Sender: TObject;
+  var CanClose: Boolean);
+begin
+  CanClose := CheckFilenameConventions((Sender as TSaveDialog).FileName);
 end;
 
 procedure TmodActionsMain.actProjectSaveExecute(Sender: TObject);

--- a/windows/src/developer/TIKE/actions/dmActionsMain.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.pas
@@ -209,6 +209,7 @@ type
       var CanClose: Boolean);   // I4807
   private
     procedure AboutShowStartup(Sender: TObject);
+    function CheckFilenameConventions(FileName: string): Boolean;
   public
     procedure OpenProject(FileName: WideString);
   end;
@@ -228,6 +229,7 @@ uses
   OnlineConstants,
   OnlineUpdateCheck,
   Printers,
+  Keyman.System.KeyboardUtils,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.Project.ProjectFile,
   Keyman.Developer.System.Project.ProjectFileType,
@@ -355,6 +357,29 @@ begin
     actFileSaveAs.Dialog.DefaultExt := ActiveEditor.DefaultExt;
     actFileSaveAs.Dialog.Filter := ActiveEditor.FileNameFilter;
     actFileSaveAs.Dialog.FileName := ActiveEditor.FileName;
+  end;
+end;
+
+function TmodActionsMain.CheckFilenameConventions(FileName: string): Boolean;
+begin
+  if not FGlobalProject.Options.CheckFilenameConventions then Exit(True);
+
+  if (GetFileTypeFromFileName(FileName) in [ftKeymanSource, ftPackageSource]) or
+    SameText(ExtractFileExt(FileName), Ext_ProjectSource) then
+  begin
+    if TKeyboardUtils.DoesKeyboardFilenameFollowConventions(FileName) then
+      Exit(True);
+
+    Result := MessageDlg(Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Prompt, [FileName]),
+      mtConfirmation, mbOkCancel, 0) = mrOk;
+  end
+  else
+  begin
+    if TKeyboardUtils.DoesFilenameFollowConventions(FileName) then
+      Exit(True);
+
+    Result := MessageDlg(Format(TKeyboardUtils.SFilenameDoesNotFollowConventions_Prompt, [FileName]),
+      mtConfirmation, mbOkCancel, 0) = mrOk;
   end;
 end;
 

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -588,6 +588,9 @@ var
 begin
   if pack.Files.FromFileNameEx(FileName) <> nil then Exit; // Already added
 
+  if not CheckFilenameConventions(FileName) then
+    Exit;
+
   f := TPackageContentFile.Create(pack);
   f.FileName := FileName;
 

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -266,6 +266,7 @@ type
       State: TProjectLogState);
     procedure RefreshTargetPanels;
     procedure EnableControls;
+    function CheckFilenameConventions(FileName: string): Boolean;
 
   protected
     function GetHelpTopic: string; override;
@@ -578,6 +579,18 @@ end;
 {-------------------------------------------------------------------------------
  - Files page                                                                  -
  -------------------------------------------------------------------------------}
+
+function TfrmPackageEditor.CheckFilenameConventions(FileName: string): Boolean;
+begin
+  if not FGlobalProject.Options.CheckFilenameConventions then
+    Exit(True);
+
+  if TKeyboardUtils.DoesFilenameFollowConventions(FileName) then
+    Exit(True);
+
+  Result := MessageDlg(Format(TKeyboardUtils.SFilenameDoesNotFollowConventions_Prompt, [FileName]),
+    mtConfirmation, mbOkCancel, 0) = mrOk;
+end;
 
 procedure TfrmPackageEditor.AddFile(FileName: WideString);
 var

--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -326,8 +326,6 @@ begin
     FTabStop := '';
   end;
 
-  CheckFilenameConventions;
-
   if Assigned(AOwnerProject) then   // I4865   // I4866
   begin
     FCompilerWarningsAsErrors := AOwnerProject.Options.CompilerWarningsAsErrors;

--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -326,6 +326,8 @@ begin
     FTabStop := '';
   end;
 
+  CheckFilenameConventions;
+
   if Assigned(AOwnerProject) then   // I4865   // I4866
   begin
     FCompilerWarningsAsErrors := AOwnerProject.Options.CompilerWarningsAsErrors;

--- a/windows/src/developer/TIKE/dialogs/UfrmNew.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNew.pas
@@ -72,6 +72,7 @@ type
     function GetAddToProject: Boolean;
     function GetFileName: string;
     function GetDefaultExt: string;
+    function CheckFilenameConventions: Boolean;
   protected
     function GetHelpTopic: string; override;
   public
@@ -84,8 +85,8 @@ implementation
 
 uses
   Keyman.Developer.System.HelpTopics,
-
   Keyman.Developer.System.Project.Project,
+  Keyman.System.KeyboardUtils,
   shlobj,
   utilsystem;
 
@@ -109,6 +110,29 @@ begin
   begin
     editPath.Text := ExtractFileDir(dlgSave.FileName);   // I4798
     editFileName.Text := ExtractFileName(dlgSave.FileName);   // I4798
+  end;
+end;
+
+function TfrmNew.CheckFilenameConventions: Boolean;
+begin
+  if not FGlobalProject.Options.CheckFilenameConventions then
+    Exit(True);
+
+  if FileType in [ftKeymanSource, ftPackageSource] then
+  begin
+    if TKeyboardUtils.DoesKeyboardFilenameFollowConventions(FileName) then
+      Exit(True);
+
+    Result := MessageDlg(Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Prompt, [editFileName.Text]),
+      mtConfirmation, mbOkCancel, 0) = mrOk;
+  end
+  else
+  begin
+    if TKeyboardUtils.DoesFilenameFollowConventions(FileName) then
+      Exit(True);
+
+    Result := MessageDlg(Format(TKeyboardUtils.SFilenameDoesNotFollowConventions_Prompt, [editFileName.Text]),
+      mtConfirmation, mbOkCancel, 0) = mrOk;
   end;
 end;
 
@@ -223,7 +247,7 @@ begin
     Exit('');
 
   if Pos('\', editFileName.Text) > 0 then   // I4798
-    Exit;
+    Exit('');
 
   s := ExtractFileExt(editFileName.Text);
   if (CompareText(GetDefaultExt, '.html') = 0) or (CompareText(GetDefaultExt, '.htm') = 0) then

--- a/windows/src/developer/TIKE/dialogs/UfrmNew.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNew.pas
@@ -114,6 +114,9 @@ end;
 
 procedure TfrmNew.cmdOKClick(Sender: TObject);
 begin
+  if not CheckFilenameConventions then
+    Exit;
+
   if FileExists(FileName) then
   begin
     if MessageDlg('The file '+FileName+' already exists.  Overwrite it and create a new file?',

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -294,11 +294,13 @@ type
     FBuildPath: string;
     FWarnDeprecatedCode: Boolean;   // I4866
     FCompilerWarningsAsErrors: Boolean;   // I4865
+    FCheckFilenameConventions: Boolean;
   public
     constructor Create;
     property BuildPath: string read FBuildPath write FBuildPath;
     property WarnDeprecatedCode: Boolean read FWarnDeprecatedCode write FWarnDeprecatedCode;   // I4866
     property CompilerWarningsAsErrors: Boolean read FCompilerWarningsAsErrors write FCompilerWarningsAsErrors;   // I4865
+    property CheckFilenameConventions: Boolean read FCheckFilenameConventions write FCheckFilenameConventions;
   end;
 
 const
@@ -1175,6 +1177,7 @@ constructor TProjectOptions.Create;
 begin
   WarnDeprecatedCode := True;   // I4866
   CompilerWarningsAsErrors := False;   // I4865
+  CheckFilenameConventions := True; // default to TRUE for new projects
 end;
 
 type

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLoader.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLoader.pas
@@ -105,6 +105,10 @@ begin
     if VarIsNull(node.ChildValues['WarnDeprecatedCode'])   // I4866
       then FProject.Options.WarnDeprecatedCode := True
       else FProject.Options.WarnDeprecatedCode := node.ChildValues['WarnDeprecatedCode'];
+
+    if VarIsNull(node.ChildValues['CheckFilenameConventions'])
+      then FProject.Options.CheckFilenameConventions := False // existing projects default to FALSE (new projects default to TRUE)
+      else FProject.Options.CheckFilenameConventions := node.ChildValues['CheckFilenameConventions'];
   end;
 
   { Load root nodes first - I708 }

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectSaver.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectSaver.pas
@@ -95,6 +95,7 @@ begin
   node.AddChild('BuildPath').NodeValue := FProject.Options.BuildPath;
   node.AddChild('CompilerWarningsAsErrors').NodeValue := FProject.Options.CompilerWarningsAsErrors;   // I4866
   node.AddChild('WarnDeprecatedCode').NodeValue := FProject.Options.WarnDeprecatedCode;   // I4865
+  node.AddChild('CheckFilenameConventions').NodeValue := FProject.Options.CheckFilenameConventions;   // I4866
 
   // files
 

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
@@ -119,6 +119,8 @@ begin
           Result := CompileVisualKeyboard(FKVKSourceFile, FKVKTargetFile);
       end;
 
+      CheckFilenameConventions;
+
       if HasCompileWarning and (WarnAsError or OwnerProject.Options.CompilerWarningsAsErrors) then Result := False;   // I4706
 
       if Result

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
@@ -15,6 +15,7 @@ type
   TkmnProjectFileAction = class(TkmnProjectFile)
   private
     function CompileVisualKeyboard(const AKVKSourceFile, AKVKTargetFile: string): Boolean;
+    procedure CheckFilenameConventions;
   public
     function CompileKeyboard: Boolean;
     function Clean: Boolean;
@@ -84,6 +85,27 @@ begin
   Result := True;
 end;
 
+procedure TkmnProjectFileAction.CheckFilenameConventions;
+begin
+  if not OwnerProject.Options.CheckFilenameConventions then
+    Exit;
+
+  if not TKeyboardUtils.DoesKeyboardFilenameFollowConventions(FileName) then
+  begin
+    HasCompileWarning := True;
+    Log(plsWarning, Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Message, [ExtractFileName(FileName)]));
+  end;
+
+  if KVKFileName <> '' then
+  begin
+    if not TKeyboardUtils.DoesKeyboardFilenameFollowConventions(KVKFileName) then
+    begin
+      HasCompileWarning := True;
+      Log(plsWarning, Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Message, [ExtractFileName(KVKFileName)]));
+    end;
+  end;
+end;
+
 function TkmnProjectFileAction.CompileKeyboard: Boolean;
 var
   KMXFileName: String;
@@ -100,6 +122,8 @@ begin
   FKVKTargetFile := OwnerProject.GetTargetFileName(ChangeFileExt(FKVKSourceFile, '.kvk'), FileName, FileVersion);
 
   try
+    CheckFilenameConventions;
+
     if Targets * KMXKeymanTargets <> [] then
     begin
       TargetNames := KeymanTargetsToNames(Targets * KMXKeymanTargets);
@@ -118,8 +142,6 @@ begin
         if KVKFileName <> '' then
           Result := CompileVisualKeyboard(FKVKSourceFile, FKVKTargetFile);
       end;
-
-      CheckFilenameConventions;
 
       if HasCompileWarning and (WarnAsError or OwnerProject.Options.CompilerWarningsAsErrors) then Result := False;   // I4706
 

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kpsProjectFileAction.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kpsProjectFileAction.pas
@@ -47,7 +47,7 @@ begin
 
   try
     try
-      Result := DoCompilePackage(pack, SelfMessage, FSilent, TargetFilename);
+      Result := DoCompilePackage(pack, SelfMessage, FSilent, OwnerProject.Options.CheckFilenameConventions, TargetFilename);
       if HasCompileWarning and (WarnAsError or OwnerProject.Options.CompilerWarningsAsErrors) then   // I4706
         Result := False;
 

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -336,8 +336,7 @@ var
 begin
   e := (Trim(editKeyboardName.Text) <> '') and
     (Trim(editPath.Text) <> '') and
-    TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text)) and
-    (LowerCase(editFileName.Text) = editFileName.Text) and
+    TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text), True) and
     (GetTargets <> []);
   cmdOK.Enabled := e;
 
@@ -423,8 +422,7 @@ function TfrmNewProjectParameters.Validate: Boolean;
 var
   ProjectFolder: string;
 begin
-  Result := TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text)) and
-    (LowerCase(editFileName.Text) = editFileName.Text);
+  Result := TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text), True);
 
   if Result then
   begin

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -337,6 +337,7 @@ begin
   e := (Trim(editKeyboardName.Text) <> '') and
     (Trim(editPath.Text) <> '') and
     TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text)) and
+    (LowerCase(editFileName.Text) = editFileName.Text) and
     (GetTargets <> []);
   cmdOK.Enabled := e;
 
@@ -422,7 +423,8 @@ function TfrmNewProjectParameters.Validate: Boolean;
 var
   ProjectFolder: string;
 begin
-  Result := TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text));
+  Result := TKeyboardUtils.IsValidKeyboardID(Trim(editFileName.Text)) and
+    (LowerCase(editFileName.Text) = editFileName.Text);
 
   if Result then
   begin

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProjectSettings.dfm
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProjectSettings.dfm
@@ -3,7 +3,7 @@ object frmProjectSettings: TfrmProjectSettings
   Top = 0
   BorderStyle = bsDialog
   Caption = 'Project Settings'
-  ClientHeight = 213
+  ClientHeight = 219
   ClientWidth = 418
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -82,23 +82,23 @@ object frmProjectSettings: TfrmProjectSettings
   end
   object cmdOK: TButton
     Left = 131
-    Top = 180
+    Top = 186
     Width = 75
     Height = 25
     Caption = 'OK'
     Default = True
-    TabOrder = 3
+    TabOrder = 4
     OnClick = cmdOKClick
   end
   object cmdCancel: TButton
     Left = 212
-    Top = 180
+    Top = 186
     Width = 75
     Height = 25
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 4
+    TabOrder = 5
   end
   object chkCompilerWarningsAsErrors: TCheckBox
     Left = 81
@@ -115,5 +115,13 @@ object frmProjectSettings: TfrmProjectSettings
     Height = 17
     Caption = 'Warn on &deprecated code'
     TabOrder = 2
+  end
+  object chkCheckFilenameConventions: TCheckBox
+    Left = 81
+    Top = 160
+    Width = 160
+    Height = 17
+    Caption = '&Check filename conventions'
+    TabOrder = 3
   end
 end

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProjectSettings.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProjectSettings.pas
@@ -41,6 +41,7 @@ type
     Label7: TLabel;
     chkCompilerWarningsAsErrors: TCheckBox;
     chkWarnDeprecatedCode: TCheckBox;
+    chkCheckFilenameConventions: TCheckBox;
     procedure FormCreate(Sender: TObject);
     procedure cmdOKClick(Sender: TObject);
   private
@@ -61,6 +62,7 @@ begin
   FGlobalProject.Options.BuildPath := Trim(editOutputPath.Text);
   FGlobalProject.Options.CompilerWarningsAsErrors := chkCompilerWarningsAsErrors.Checked;   // I4865
   FGlobalProject.Options.WarnDeprecatedCode := chkWarnDeprecatedCode.Checked;   // I4866
+  FGlobalProject.Options.CheckFilenameConventions := chkCheckFilenameConventions.Checked;
   FGlobalProject.Save;
   ModalResult := mrOk;
 end;
@@ -70,6 +72,7 @@ begin
   editOutputPath.Text := FGlobalProject.Options.BuildPath;
   chkCompilerWarningsAsErrors.Checked := FGlobalProject.Options.CompilerWarningsAsErrors;   // I4865
   chkWarnDeprecatedCode.Checked := FGlobalProject.Options.WarnDeprecatedCode;   // I4866
+  chkCheckFilenameConventions.Checked := FGlobalProject.Options.CheckFilenameConventions;
   if editOutputPath.Text = '' then editOutputPath.Text := '$SOURCEPATH';
 end;
 

--- a/windows/src/developer/kmcomp/kccompilepackage.pas
+++ b/windows/src/developer/kmcomp/kccompilepackage.pas
@@ -32,7 +32,7 @@ uses
   PackageInfo,
   kpsfile;
 
-function DoKCCompilePackage(FileName: string; AFullySilent, ASilent, AWarnAsError, AInstaller: Boolean; const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
+function DoKCCompilePackage(FileName: string; AFullySilent, ASilent, AWarnAsError, ACheckFilenameConventions, AInstaller: Boolean; const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
 
 implementation
 
@@ -58,7 +58,7 @@ begin
   end;
 end;
 
-function DoKCCompilePackage(FileName: string; AFullySilent, ASilent, AWarnAsError, AInstaller: Boolean; const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
+function DoKCCompilePackage(FileName: string; AFullySilent, ASilent, AWarnAsError, ACheckFilenameConventions, AInstaller: Boolean; const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
 var
   tcp: TKCCompilePackage;
   pack: TKPSFile;
@@ -82,7 +82,7 @@ begin
       tcp.FFullySilent := AFullySilent;
       tcp.FSilent := ASilent;
       tcp.pack := pack;
-      Result := DoCompilePackage(pack, tcp.SelfMessage, ASilent, ChangeFileExt(pack.FileName, '.kmp'));   // I4694
+      Result := DoCompilePackage(pack, tcp.SelfMessage, ASilent, ACheckFilenameConventions, ChangeFileExt(pack.FileName, '.kmp'));   // I4694
       if AWarnAsError and tcp.FHasWarning then Result := False;
 
       if AInstaller and Result then

--- a/windows/src/developer/kmcomp/kccompileproject.pas
+++ b/windows/src/developer/kmcomp/kccompileproject.pas
@@ -21,7 +21,7 @@ unit kccompileproject;   // I4699
 
 interface
 
-function DoKCCompileProject(AProjectFilename: string; AFullySilent, ASilent, ADebug, AClean, AWarnAsError: Boolean; ATarget: string): Boolean;   // I4706
+function DoKCCompileProject(AProjectFilename: string; AFullySilent, ASilent, ADebug, AClean, AWarnAsError, ACheckFilenameConventions: Boolean; ATarget: string): Boolean;   // I4706
 
 implementation
 
@@ -46,7 +46,7 @@ type
     property FullySilent: Boolean read FFullySilent write FFullySilent;
   end;
 
-function DoKCCompileProject(AProjectFilename: string; AFullySilent, ASilent, ADebug, AClean, AWarnAsError: Boolean; ATarget: string): Boolean;   // I4706
+function DoKCCompileProject(AProjectFilename: string; AFullySilent, ASilent, ADebug, AClean, AWarnAsError, ACheckFilenameConventions: Boolean; ATarget: string): Boolean;   // I4706
 var
   i: Integer;
   Found: Boolean;
@@ -66,6 +66,7 @@ begin
   Found := False;
   with TProjectConsole.Create(AProjectFilename, False) do
   try
+    Options.CheckFilenameConventions := Options.CheckFilenameConventions or ACheckFilenameConventions; // never downgrade this option
     FullySilent := AFullySilent;
     Silent := ASilent;
     for i := 0 to Files.Count - 1 do

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -103,6 +103,7 @@ var
   FClean: Boolean;
   FFullySilent: Boolean;
   FWarnAsError: Boolean;
+  FCheckFilenameConventions: Boolean;
   FValidating: Boolean;
   FMerging: Boolean;
   FParamInfile2: string;
@@ -123,6 +124,7 @@ begin
   FClean := False;
   FNologo := False;
   FWarnAsError := False;
+  FCheckFilenameConventions := False;
   FValidating := False;
   FJsonExtract := False;
   FMerging := False;
@@ -153,6 +155,7 @@ begin
     else if s = '-u' then FUpdateInstaller := True
     else if s = '-d' then FDebug := True
     else if s = '-w' then FWarnAsError := True   // I4706
+    else if s = '-cfc' then FCheckFilenameConventions := True
     else if s = '-t' then   // I4699
     begin
       Inc(i);
@@ -217,7 +220,7 @@ begin
   if FError or (FParamInfile = '') then
   begin
     writeln('');
-    writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-v[s|d]] [-source-path path] [-schema-path path] ');
+    writeln('Usage: kmcomp [-s[s]] [-nologo] [-c] [-d] [-w] [-cfc] [-v[s|d]] [-source-path path] [-schema-path path] ');
     writeln('              [-m] infile [-m infile] [-t target] [outfile.kmx|outfile.js [error.log]]');   // I4699
     writeln('              [-add-help-link path]');
     writeln('              [-extract-keyboard-info field[,field...]]');
@@ -233,6 +236,7 @@ begin
     writeln('          -c       clean target (only for .kpj)');
     writeln('          -d       include debug information');
     writeln('          -w       treat warnings as errors');
+    writeln('          -cfc     check filename conventions');
     writeln('          -t       build only the target file from the project (only for .kpj)');   // I4699
     writeln('          -add-help-link path to help file on https://help.keyman.com/keyboards');
     writeln;
@@ -268,9 +272,9 @@ begin
     else if FJsonExtract then
       FError := not TJsonExtractKeyboardInfo.Execute(FParamInfile, FParamJsonFields, FSilent, @CompilerMessage)
     else if LowerCase(ExtractFileExt(FParamInfile)) = '.kpj' then   // I4699
-      Ferror := not DoKCCompileProject(FParamInfile, FFullySilent, FSilent, FDebug, FClean, FWarnAsError, FParamTarget)   // I4706   // I4707
+      Ferror := not DoKCCompileProject(FParamInfile, FFullySilent, FSilent, FDebug, FClean, FWarnAsError, FCheckFilenameConventions, FParamTarget)   // I4706   // I4707
     else if LowerCase(ExtractFileExt(FParamInfile)) = '.kps' then
-      FError := not DoKCCompilePackage(FParamInfile, FFullySilent, FSilent, FWarnAsError, FInstaller, FInstallerMSI, FUpdateInstaller)   // I4706
+      FError := not DoKCCompilePackage(FParamInfile, FFullySilent, FSilent, FWarnAsError, FInstaller, FCheckFilenameConventions, FInstallerMSI, FUpdateInstaller)   // I4706
     else
       FError := not CompileKeyboard(FParamInfile, FParamOutfile, FDebug, FSilent, FWarnAsError);   // I4706
 

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -260,6 +260,7 @@ begin
     kpj.Options.BuildPath := '$PROJECTPATH\build';
     kpj.Options.WarnDeprecatedCode := True;
     kpj.Options.CompilerWarningsAsErrors := True;
+    kpj.Options.CheckFilenameConventions := True;
 
     kpj.Files.Add(TkmnProjectFile.Create(kpj, GetKeyboardFilename, nil));
     kpj.Files.Add(TkpsProjectFile.Create(kpj, GetPackageFilename, nil));

--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -30,7 +30,7 @@ uses
   kpsfile, kmpinffile, PackageInfo,
   Keyman.Developer.System.Project.ProjectLog;
 
-function DoCompilePackage(pack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent: Boolean; const AOutputFileName: string): Boolean;   // I4688
+function DoCompilePackage(pack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent, ACheckFilenameConventions: Boolean; const AOutputFileName: string): Boolean;   // I4688
 
 implementation
 
@@ -50,6 +50,7 @@ uses
   kmxfile,
   KeymanDeveloperOptions,
 
+  Keyman.System.KeyboardUtils,
   Keyman.System.CanonicalLanguageCodeUtils,
   Keyman.System.PackageInfoRefreshKeyboards,
 
@@ -67,23 +68,25 @@ type
 
     FOutputFileName: string;
     FTempFiles: TTempFiles;
+    FCheckFilenameConventions: Boolean;
 
     procedure FatalMessage(const msg: string);
     procedure WriteMessage(AState: TProjectLogState; const msg: string);   // I4706
 
     function BuildKMP: Boolean;
 
-    constructor Create(APack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent: Boolean; const AOutputFileName: string);   // I4688
+    constructor Create(APack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent, ACheckFilenameConventions: Boolean; const AOutputFileName: string);   // I4688
     destructor Destroy; override;
     function Compile: Boolean;
     procedure CheckForDangerousFiles;
     procedure CheckKeyboardVersions;
     procedure CheckKeyboardLanguages;
+    procedure CheckFilenameConventions;
   end;
 
-function DoCompilePackage(pack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent: Boolean; const AOutputFileName: string): Boolean;   // I4688
+function DoCompilePackage(pack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent, ACheckFilenameConventions: Boolean; const AOutputFileName: string): Boolean;   // I4688
 begin
-  with TCompilePackage.Create(pack, AMessageEvent, ASilent, AOutputFileName) do   // I4688
+  with TCompilePackage.Create(pack, AMessageEvent, ASilent, ACheckFilenameConventions, AOutputFileName) do   // I4688
   try
     Result := Compile;
   finally
@@ -92,7 +95,7 @@ begin
 end;
 
 
-constructor TCompilePackage.Create(APack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent: Boolean; const AOutputFileName: string);   // I4688
+constructor TCompilePackage.Create(APack: TKPSFile; AMessageEvent: TCompilePackageMessageEvent; ASilent, ACheckFilenameConventions: Boolean; const AOutputFileName: string);   // I4688
 begin
   inherited Create;
   pack := APack;
@@ -100,12 +103,30 @@ begin
   FSilent := ASilent;
   FOutputFileName := AOutputFileName;
   FTempFiles := TTempFiles.Create;
+  FCheckFilenameConventions := ACheckFilenameConventions;
 end;
 
 destructor TCompilePackage.Destroy;
 begin
   FreeAndNil(FTempFiles);
   inherited Destroy;
+end;
+
+procedure TCompilePackage.CheckFilenameConventions;
+var
+  i: Integer;
+begin
+  if not FCheckFilenameConventions then
+    Exit;
+
+  if not TKeyboardUtils.DoesKeyboardFilenameFollowConventions(pack.FileName) then
+    WriteMessage(plsWarning, Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Message, [ExtractFileName(pack.FileName)]));
+
+  for i := 0 to pack.Files.Count - 1 do
+  begin
+    if not TKeyboardUtils.DoesFilenameFollowConventions(pack.Files[i].FileName) then
+      WriteMessage(plsWarning, Format(TKeyboardUtils.SFilenameDoesNotFollowConventions_Message, [ExtractFileName(pack.Files[i].FileName)]));
+  end;
 end;
 
 function TCompilePackage.Compile: Boolean;

--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -130,6 +130,7 @@ begin
     Exit;
   end;
 
+  CheckFilenameConventions;
   CheckForDangerousFiles;
   CheckKeyboardVersions;
   CheckKeyboardLanguages;

--- a/windows/src/global/delphi/general/CompilePackageInstaller.pas
+++ b/windows/src/global/delphi/general/CompilePackageInstaller.pas
@@ -281,7 +281,7 @@ begin
         FPackageOutputFileName := ExtractFilePath(FOutputFilename) + ChangeFileExt(ExtractFileName(FPack.FileName), '.kmp');   // I4741
         if FBuildPackage then
         begin
-          if not DoCompilePackage(FPack, FOnMessage, True, FPackageOutputFileName) then Exit;
+          if not DoCompilePackage(FPack, FOnMessage, True, False, FPackageOutputFileName) then Exit;
         end
         else if not FileExists(FPackageOutputFileName) then
         begin

--- a/windows/src/global/delphi/keyboards/Keyman.System.KeyboardUtils.pas
+++ b/windows/src/global/delphi/keyboards/Keyman.System.KeyboardUtils.pas
@@ -4,12 +4,34 @@ interface
 
 type
   TKeyboardUtils = class
+  private
+    class function CleanComponent(e: string): string; static;
   public
+    const SKeyboardNameDoesNotFollowConventions_Message: string =
+      'The keyboard file %0:s does not follow the recommended filename conventions. The name should be all lower case, '+
+      'include only alphanumeric characters and underscore (_), and should not start with a digit.';
+    const SKeyboardNameDoesNotFollowConventions_Prompt: string =
+      'The keyboard file %0:s does not follow the recommended filename conventions. The name should be all lower case, '+
+      'include only alphanumeric characters and underscore (_), and should not start with a digit.'+
+      #13#10#13#10 +
+      'Do you wish to continue?';
+
+    const SFilenameDoesNotFollowConventions_Message: string =
+      'The file %0:s does not follow the recommended filename conventions. The extension should be all lower case, '+
+      'and the filename should include only alphanumeric characters, -, _, + and .';
+    const SFilenameDoesNotFollowConventions_Prompt: string =
+      'The file %0:s does not follow the recommended filename conventions. The extension should be all lower case, '+
+      'and the filename should include only alphanumeric characters, -, _, + and .'+
+      #13#10#13#10 +
+      'Do you wish to continue?';
+
     class function KeyboardFileNameToID(filename: string): string;
     class function CleanKeyboardID(const Name: WideString): WideString; static;
-    class function IsValidKeyboardID(const Name: string): Boolean; static;
+    class function IsValidKeyboardID(const Name: string; EnforceCaseAndWhitespace: Boolean): Boolean; static;
     class function GetKeymanWebCompiledFileName(const FileName: WideString): WideString; static;
     class function GetKeymanWebCompiledNameFromFileName(const FileName: WideString): WideString; static;
+    class function DoesFilenameFollowConventions(const Name: string): Boolean; static;
+    class function DoesKeyboardFilenameFollowConventions(const Name: string): Boolean; static;
   end;
 
 implementation
@@ -38,9 +60,46 @@ begin
   Result := CleanKeyboardID(ChangeFileExt(ExtractFileName(FileName), ''));
 end;
 
-class function TKeyboardUtils.IsValidKeyboardID(const Name: string): Boolean;
+class function TKeyboardUtils.CleanComponent(e: string): string;
+var
+  i: Integer;
+const
+  ValidChars: WideString = 'abcdefghijklmnopqrstuvwxyz0123456789_.-+';
 begin
-  Result := CleanKeyboardID(Name.Trim) = LowerCase(Name.Trim);
+  Result := e;
+  if Length(Result) = 0 then Exit;
+  for i := 1 to Length(Result) do
+    if Pos(Result[i], ValidChars) = 0 then Result[i] := '_';
+end;
+
+class function TKeyboardUtils.DoesFilenameFollowConventions(const Name: string): Boolean;
+var
+  e, n: string;
+begin
+  e := ExtractFileExt(Name);
+  n := LowerCase(ChangeFileExt(ExtractFileName(Name), ''));
+
+  // The extension must be lowercase and not
+  // use punctuation apart from ., _, -, and +.
+  // The filename does not need to be lowercase
+  Result := (CleanComponent(e) = e) and (CleanComponent(n) = n);
+end;
+
+class function TKeyboardUtils.DoesKeyboardFilenameFollowConventions(
+  const Name: string): Boolean;
+var
+  e, n: string;
+begin
+  e := ExtractFileExt(Name);
+  n := ChangeFileExt(ExtractFileName(Name), '');
+  Result := (CleanComponent(e) = e) and IsValidKeyboardID(n, True);
+end;
+
+class function TKeyboardUtils.IsValidKeyboardID(const Name: string; EnforceCaseAndWhitespace: Boolean): Boolean;
+begin
+  if EnforceCaseAndWhitespace
+    then Result := CleanKeyboardID(Name) = Name
+    else Result := CleanKeyboardID(Name.Trim) = LowerCase(Name.Trim);
 end;
 
 class function TKeyboardUtils.GetKeymanWebCompiledFileName(const FileName: WideString): WideString;   // I4140

--- a/windows/src/unit-tests/keyboard-package-versions/Keyman.Test.System.CompilePackageVersioningTest.pas
+++ b/windows/src/unit-tests/keyboard-package-versions/Keyman.Test.System.CompilePackageVersioningTest.pas
@@ -107,7 +107,7 @@ begin
   try
     pack.FileName := FRoot+'\'+Path;
     pack.LoadXML;
-    res := DoCompilePackage(pack, PackageMessage, False, FRoot+'\'+ChangeFileExt(Path,'.kmp'));
+    res := DoCompilePackage(pack, PackageMessage, False, False, FRoot+'\'+ChangeFileExt(Path,'.kmp'));
     Assert.AreEqual(not ExpectError, res);
   finally
     pack.Free;


### PR DESCRIPTION
Fixes #984.

While I would not normally include this in beta, it has been outstanding since v10 and 
really is needed for keyboard quality and cross-platform stability.

# Filename conventions

* A 'clean' component consists of only alphanumeric, `_`, `-` and `.` characters.

## kmn, kps, kpj, kvks (and corresponding kvk, kmp, kvk) files

* Filename component must be lowercase, not start with a digit, and contain only alphanumeric and underscore.
* Extension component must be lowercase and 'clean'

## Other files included in packages and projects

* Filename component must be 'clean'.
* Extension component must be lowercase and 'clean'
