### PR TITLE
[Android] Add HashMap.getOrDefault for older Android API levels

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardListActivity.java
@@ -14,6 +14,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
+import com.tavultesoft.kmea.util.MapCompat;
 
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -97,14 +98,14 @@ public final class KeyboardListActivity extends AppCompatActivity implements OnK
         @Override
         public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
           HashMap<String, String> kbInfo = LanguageListActivity.getKeyboardInfo(langIndex, position);
-          final String pkgID = kbInfo.getOrDefault(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
+          final String pkgID = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
           final String kbID = kbInfo.get(KMManager.KMKey_KeyboardID);
           final String langID = kbInfo.get(KMManager.KMKey_LanguageID);
           String kbName = kbInfo.get(KMManager.KMKey_KeyboardName);
           String langName = kbInfo.get(KMManager.KMKey_LanguageName);
-          String kFont = kbInfo.getOrDefault(KMManager.KMKey_Font, "");
-          String kOskFont = kbInfo.getOrDefault(KMManager.KMKey_OskFont, kFont);
-          String isCustom = kbInfo.getOrDefault(KMManager.KMKey_CustomKeyboard, "N");
+          String kFont = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_Font, "");
+          String kOskFont = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_OskFont, kFont);
+          String isCustom = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_CustomKeyboard, "N");
 
           if (!pkgID.equals(KMManager.KMDefault_UndefinedPackageID)) {
             // keyboard already exists in packages/ so just add the language association

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.BuildConfig;
+import com.tavultesoft.kmea.util.MapCompat;
 
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AlertDialog;
@@ -307,7 +308,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
 
   private static boolean hasKeyboardFromPackage() {
     for(HashMap<String, String> kbInfo: keyboardsList) {
-      String packageID = kbInfo.getOrDefault(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
+      String packageID = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
       if (!packageID.equals(KMManager.KMDefault_UndefinedPackageID)) {
         return true;
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -26,6 +26,7 @@ import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener
 import com.tavultesoft.kmea.BuildConfig;
 import com.tavultesoft.kmea.packages.JSONUtils;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.MapCompat;
 
 import android.annotation.SuppressLint;
 import android.content.DialogInterface;
@@ -575,9 +576,9 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
               final String pkgID = kbInfo.get(KMManager.KMKey_PackageID);
               final String kbID = kbInfo.get(KMManager.KMKey_KeyboardID);
               final String langID = kbInfo.get(KMManager.KMKey_LanguageID);
-              String kFont = kbInfo.getOrDefault(KMManager.KMKey_Font, "");
-              String kOskFont = kbInfo.getOrDefault(KMManager.KMKey_OskFont, "");
-              String isCustom = kbInfo.getOrDefault(KMManager.KMKey_CustomKeyboard, "N");
+              String kFont = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_Font, "");
+              String kOskFont = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_OskFont, "");
+              String isCustom = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_CustomKeyboard, "N");
 
               if (!pkgID.equals(KMManager.KMDefault_UndefinedPackageID)) {
                 // Custom keyboard already exists in packages/ so just add the language association

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
@@ -1,0 +1,23 @@
+package com.tavultesoft.kmea.util;
+
+import android.os.Build;
+
+import java.util.HashMap;
+
+/**
+ * HashMap.getOrDefault is only available for Android API 24+, so this method is an alternative
+ * for older devices.
+ * Reference: https://stackoverflow.com/questions/41211960/alternative-to-getordefault-for-devices-below-api-24-android
+ */
+public final class MapCompat {
+
+  public static <K, V> V getOrDefault(HashMap<K, V> map, K key, V defaultValue) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return map.getOrDefault(key, defaultValue);
+    }
+
+    V v;
+    return (((v = map.get(key)) != null) || map.containsKey(key)) ? v : defaultValue;
+  }
+
+}

--- a/android/history.md
+++ b/android/history.md
@@ -3,7 +3,7 @@
 ## 2019-01-21 10.0.2059 beta
 * Bug fix:
   * Change installation of ad-hoc keyboards via .kmp packages to only add the first language for each keyboard.
-    Additional languages can be added offline from the .kmp package. (#1550)
+    Additional languages can be added offline from the .kmp package. (#1550, 1554)
 
 ## 2019-01-18 10.0.2058 beta
 * No changes to Keyman for Android (updated Keyman Web Engine, #1537)

--- a/android/history.md
+++ b/android/history.md
@@ -3,7 +3,7 @@
 ## 2019-01-21 10.0.2059 beta
 * Bug fix:
   * Change installation of ad-hoc keyboards via .kmp packages to only add the first language for each keyboard.
-    Additional languages can be added offline from the .kmp package. (#1550, 1554)
+    Additional languages can be added offline from the .kmp package. (#1550, #1554)
 
 ## 2019-01-18 10.0.2058 beta
 * No changes to Keyman for Android (updated Keyman Web Engine, #1537)


### PR DESCRIPTION
During implementation of #1550, HashMap.getOrDefault() calls were used.
That method is only available for Android API levels 24+, so this PR provides an alternative for older API's.