### PR TITLE
[Android] Misc UI cleanup

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -16,6 +16,10 @@
 # Gradle generated files
 **/.gradle/
 build_file_checksums.ser
+gradle_models.ser
+
+# Layout Inspector files
+**/captures/*.li
 
 # OS-specific files
 **/.DS_Store

--- a/android/KMAPro/kMAPro/src/main/res/layout/get_started_list_layout.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/get_started_list_layout.xml
@@ -23,17 +23,31 @@
             android:layout_alignParentTop="true"
             android:background="@color/keyman_orange" />
 
-        <CheckBox
-            android:id="@+id/checkBox"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width = "wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/checkbox_margin_left"
-            android:layout_marginStart="@dimen/checkbox_margin_left"
-            android:layout_marginTop="@dimen/checkbox_padding"
-            android:layout_marginBottom="@dimen/checkbox_padding"
-            android:paddingTop="@dimen/checkbox_padding"
-            android:paddingBottom="@dimen/checkbox_padding"
-            android:text="@string/dont_show_again" />
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/checkBox"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/checkbox_margin_left"
+                android:layout_marginStart="@dimen/checkbox_margin_left"
+                android:layout_marginTop="@dimen/checkbox_padding"
+                android:layout_marginBottom="@dimen/checkbox_padding"
+                android:paddingTop="@dimen/checkbox_padding"
+                android:paddingBottom="@dimen/checkbox_padding" />
+
+            <TextView
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginLeft="@dimen/checkbox_margin_left"
+              android:layout_marginStart="@dimen/checkbox_margin_left"
+              android:layout_gravity="center_vertical"
+              android:text="@string/dont_show_again" />
+
+        </LinearLayout>
 
     </RelativeLayout>
 </LinearLayout>

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="com.tavultesoft.kmea.KMKeyboardDownloaderActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+            android:label=""
             android:theme="@style/Theme.AppCompat.Light.Dialog">
         </activity>
     </application>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -6,22 +6,35 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.view.Window;
 import android.widget.Toast;
 
 /**
  * Confirmation dialog for downloading a Keyman keyboard
  */
 public class ConfirmDialogFragment extends DialogFragment {
-  public static String ARG_TITLE = "ConfirmDialogFragment.title";
+  public static final String ARG_TITLE = "ConfirmDialogFragment.title";
+  public static final String ARG_MESSAGE = "ConfirmationDialogFragment.message";
+
+  public static ConfirmDialogFragment newInstance(String title, String message) {
+    ConfirmDialogFragment frag = new ConfirmDialogFragment();
+    Bundle args = new Bundle();
+    args.putString(ARG_TITLE, title);
+    args.putString(ARG_MESSAGE, message);
+    frag.setArguments(args);
+    return frag;
+  }
 
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
-    Bundle args = getArguments();
-    final String title = args.getString(ARG_TITLE);
+    Dialog dialog = super.onCreateDialog(savedInstanceState);
+
+    final String title = getArguments().getString(ARG_TITLE);
+    final String message = getArguments().getString(ARG_MESSAGE);
 
     return new AlertDialog.Builder(getActivity())
       .setTitle(title)
-      .setMessage(getString(R.string.confirm_download))
+      .setMessage(message)
       .setPositiveButton(getString(R.string.label_download), new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {
@@ -31,12 +44,17 @@ public class ConfirmDialogFragment extends DialogFragment {
           } else {
             Toast.makeText(getActivity(), "No internet connection", Toast.LENGTH_SHORT).show();
           }
+          if (dialog != null) {
+            dialog.dismiss();
+          }
         }
       })
       .setNegativeButton(getString(R.string.label_cancel),  new DialogInterface.OnClickListener() {
        public void onClick(DialogInterface dialog, int which) {
          // Cancel
-         dialog.dismiss();
+         if (dialog != null) {
+           dialog.dismiss();
+         }
          getActivity().finish();
        }
       })

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -14,7 +14,7 @@ import android.widget.Toast;
  */
 public class ConfirmDialogFragment extends DialogFragment {
   public static final String ARG_TITLE = "ConfirmDialogFragment.title";
-  public static final String ARG_MESSAGE = "ConfirmationDialogFragment.message";
+  public static final String ARG_MESSAGE = "ConfirmDialogFragment.message";
 
   public static ConfirmDialogFragment newInstance(String title, String message) {
     ConfirmDialogFragment frag = new ConfirmDialogFragment();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -126,10 +126,8 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       title = String.format("%s: %s", langName, kbName);
     }
 
-    DialogFragment dialog = new ConfirmDialogFragment();
-      args.putString(ConfirmDialogFragment.ARG_TITLE, title);
-      dialog.setArguments(args);
-      dialog.show(getFragmentManager(), "dialog");
+    DialogFragment dialog = ConfirmDialogFragment.newInstance(title, getString(R.string.confirm_download));
+    dialog.show(getFragmentManager(), "dialog");
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -30,6 +30,7 @@ import com.tavultesoft.kmea.util.MapCompat;
 
 import android.annotation.SuppressLint;
 import android.content.DialogInterface;
+import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -350,7 +351,11 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
       }
 
       if (hasConnection && !loadFromCache) {
-        progressDialog = new ProgressDialog(context, R.style.ProgressDialog);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+          progressDialog = new ProgressDialog(context, R.style.AppTheme_Dialog_Progress);
+        } else {
+          progressDialog = new ProgressDialog(context);
+        }
         progressDialog.setMessage(getString(R.string.getting_keyboard_catalog));
         progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(R.string.label_cancel),
           new DialogInterface.OnClickListener() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -83,7 +83,7 @@ public class JSONUtils {
 
                 File jsFile = new File(pkg, kbdID + ".js");
                 if (jsFile.exists()) {
-                  SimpleDateFormat sdf = new SimpleDateFormat("YYYY-MM-DD");
+                  SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-DD");
                   kbdObj.put("lastModified", sdf.format(jsFile.lastModified()));
                 } else {
                   Log.d(TAG, "getLanguages() can't generate modified date for " + jsFile);

--- a/android/KMEA/app/src/main/res/values/styles.xml
+++ b/android/KMEA/app/src/main/res/values/styles.xml
@@ -13,18 +13,14 @@
         -->
     </style>
 
-    <!--style name="ToolbarStyle">
-        <item name="theme">@style/ToolbarTheme</item>
+  <style name="AppTheme.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
+      <item name="android:textColor">@android:color/black</item>
+      <item name="android:textColorHint">@android:color/darker_gray</item>
+      <item name="android:textColorPrimary">@android:color/black</item>
     </style>
 
-    <style name="ToolbarTheme">
-        <item name="android:background">@android:color/white</item>
-    </style-->
-
-    <style name="ProgressDialog">
-        <item name="android:textColor">@android:color/black</item>
-        <item name="android:textColorHint">@android:color/darker_gray</item>
-        <item name="android:textColorPrimary">@android:color/black</item>
+    <style name="AppTheme.Dialog.Progress" parent="AppTheme.Dialog.Alert">
+        <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
     <style name="PopupAnim">

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,10 @@
 # Keyman for Android
 
+## 2019-01-27 10.0.2060 beta
+* Bug fixes:
+  * Clean up styling of dialogs when downloading keyboards
+  * Fix "Get Started" checkbox label to display on older Android versions
+
 ## 2019-01-21 10.0.2059 beta
 * Bug fix:
   * Change installation of ad-hoc keyboards via .kmp packages to only add the first language for each keyboard.


### PR DESCRIPTION
This PR adds some polish to the UI to clean up some nuisances.

1. Fix "Get Started" checkbox label
For lower versions of Android API levels, the "Get Started" checkbox label doesn't appear. I suspect it's vertically aligned, and off  the screen. These screenshots are with the Nexus S emulator on Android API 16.

### Before fix
![nexus s - api 16 before fix](https://user-images.githubusercontent.com/7358010/51457280-5d046080-1d83-11e9-8a9b-f35ddcb91560.png)

### After fix
![nexus s - api 16 after fix](https://user-images.githubusercontent.com/7358010/51457303-760d1180-1d83-11e9-80ff-46e1161612bf.png)

2. Currently, a "Keyman" label flickers after downloading keyboards and ConfirmDIalogFragment finishes.
These changes make the flicker less noticeable:
* Set the app name blank in the Manifest
* Dismiss the dialog fragment and finish the activity
* Updated ConfirmDialogFragment to have a flexible message body (second parameter)
* Updated gitignore to ignore artifacts from Android Studio's "Layout Inspector" tool

3. Fix pattern used in SimpleDateFormat found while testing this PR. Add sil_cameroon_qwerty for Afade (Latin) from the cloud, then add the same keyboard package from keyman.com/keyboard/sil_cameroon_qwerty. Then bring up language picker again.

4. Fix background of ProgressDialog for older Android API < 21.

### Before fix
![before progress dialog](https://user-images.githubusercontent.com/7358010/51594015-1dc24500-1f26-11e9-8534-c2dfc5918bcd.png)


### After fix
![after progress dialog](https://user-images.githubusercontent.com/7358010/51594027-2286f900-1f26-11e9-903c-cd30e0d731b4.png)

