### PR TITLE
[Android] Add notifications when font/keyboard fails to download

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -807,7 +807,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         }
       }
     } else {
-      Toast.makeText(this, "Keyboard " + keyboardID + " download failed", Toast.LENGTH_SHORT).show();
+      // Error notifications handled in LanguageListActivity
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -226,7 +226,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
     /**
      * Download a non-KMP Keyman keyboard from Keyman cloud via JSON
      * @param remoteUrl String
-     * @return ret int -1 for fail
+     * @return ret int -1 for fail; >0 for success; 2 for keyboard downloading but not font
      * @throws Exception
      */
     protected int downloadNonKMPKeyboard(String remoteUrl) throws Exception {
@@ -343,7 +343,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
         result = FileUtils.download(context, url, destination, filename);
         if (result < 0) {
           if (FileUtils.hasFontExtension(url)) {
-            // Propogate warning about font failing to download
+            // Propagate warning about font failing to download
             ret = 2;
           } else {
             ret = -1;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -222,6 +222,11 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       ((AppCompatActivity) context).finish();
       if (result > 0) {
         notifyListeners(KeyboardEventHandler.EventType.KEYBOARD_DOWNLOAD_FINISHED, result);
+
+        if (result == 2) {
+          Toast.makeText(context, "Warning: Font failed to download.",
+            Toast.LENGTH_LONG).show();
+        }
       }
     }
 
@@ -342,10 +347,20 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
           }
         }
 
+        if (FileUtils.hasJavaScriptExtension(url)) {
+          // TEST stub: DDW
+          url = "invalid-" + url;
+        }
+
         result = FileUtils.download(context, url, destination, filename);
         if (result < 0) {
-          ret = -1;
-          break;
+          if (FileUtils.hasFontExtension(url)) {
+            // Propogate warning about font failing to download
+            ret = 2;
+          } else {
+            ret = -1;
+            break;
+          }
         }
       }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -220,14 +220,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       }
 
       ((AppCompatActivity) context).finish();
-      if (result > 0) {
-        notifyListeners(KeyboardEventHandler.EventType.KEYBOARD_DOWNLOAD_FINISHED, result);
-
-        if (result == 2) {
-          Toast.makeText(context, "Warning: Font failed to download.",
-            Toast.LENGTH_LONG).show();
-        }
-      }
+      notifyListeners(KeyboardEventHandler.EventType.KEYBOARD_DOWNLOAD_FINISHED, result);
     }
 
     /**

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -340,11 +340,6 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
           }
         }
 
-        if (FileUtils.hasJavaScriptExtension(url)) {
-          // TEST stub: DDW
-          url = "invalid-" + url;
-        }
-
         result = FileUtils.download(context, url, destination, filename);
         if (result < 0) {
           if (FileUtils.hasFontExtension(url)) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardListActivity.java
@@ -179,10 +179,8 @@ public final class KeyboardListActivity extends AppCompatActivity implements OnK
 
       KeyboardPickerActivity.addKeyboard(this, keyboardInfo);
       KMManager.setKeyboard(packageID, keyboardID, languageID, keyboardName, languageName, kFont, kOskFont);
-      finish();
-    } else {
-      Toast.makeText(this, "Keyboard download failed", Toast.LENGTH_SHORT).show();
     }
+    finish();
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -31,6 +31,7 @@ import com.tavultesoft.kmea.util.MapCompat;
 import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.os.Build;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -74,6 +75,7 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
   private static HashMap<String, String> keyboardModifiedDates = null;
 
   private int selectedIndex = 0;
+  private static AlertDialog alertDialog;
   //protected static int selectedIndex() { return selectedIndex; }
 
   @Override
@@ -138,20 +140,25 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
 
   @Override
   public void onKeyboardDownloadFinished(HashMap<String, String> keyboardInfo, int result) {
+    String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
+    String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
     if (result > 0) {
       String packageID = keyboardInfo.get(KMManager.KMKey_PackageID);
       String keyboardID = keyboardInfo.get(KMManager.KMKey_KeyboardID);
       String languageID = keyboardInfo.get(KMManager.KMKey_LanguageID);
-      String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
-      String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
       String kFont = keyboardInfo.get(KMManager.KMKey_Font);
       String kOskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
 
       KeyboardPickerActivity.addKeyboard(this, keyboardInfo);
       KMManager.setKeyboard(packageID, keyboardID, languageID, keyboardName, languageName, kFont, kOskFont);
+
+      if (result == 2) {
+        Toast.makeText(context, context.getString(R.string.font_failed_to_download), Toast.LENGTH_LONG).show();
+      }
       finish();
     } else {
-      Toast.makeText(this, "Keyboard download failed", Toast.LENGTH_SHORT).show();
+      String title = String.format("%s: %s", languageName, keyboardName);
+      showErrorDialog(context, title, context.getString(R.string.keyboard_failed_to_download));
     }
   }
 
@@ -616,4 +623,24 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
       }
     }
   }
+
+  private static void showErrorDialog(Context context, String title, String message) {
+    AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
+
+    alertDialogBuilder.setTitle(title);
+    alertDialogBuilder
+      .setMessage(message)
+      .setCancelable(false)
+      .setPositiveButton(context.getString(R.string.label_close),new DialogInterface.OnClickListener() {
+        public void onClick(DialogInterface dialog,int id) {
+        if (dialog != null) {
+          dialog.dismiss();
+        }
+        }
+      });
+
+    alertDialog = alertDialogBuilder.create();
+    alertDialog.show();
+  }
+
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -119,13 +119,13 @@ public final class FileUtils {
           ret = DOWNLOAD_ERROR;
         }
       } else {
-        if (file.exists()) {
+        if (file != null && file.exists()) {
           file.delete();
         }
-        if (tmpFile.exists()) {
+        if (tmpFile != null && tmpFile.exists()) {
           tmpFile.delete();
         }
-        Log.e("FileUtils", "Could not download filename " + file.toString());
+        Log.e("FileUtils", "Could not download filename " + filename);
       }
 
       Connection.disconnect();

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="confirm_update" translatable="false">Would you like to update keyboards now?</string>
     <string name="custom_keyboard" translatable="false">Custom Keyboard</string>
     <string name="downloading_keyboard" translatable="false">Downloading keyboard&#8230;</string>
+    <string name="font_failed_to_download" translatable="false">Warning: Font failed to download</string>
+    <string name="keyboard_failed_to_download" translatable="false">Error: Keyboard failed to download</string>
     <string name="keyboard_updates_available" translatable="false">Keyboard Updates Available</string>
     <string name="getting_keyboard_catalog" translatable="false">Getting keyboard catalog.\nThis may take a while&#8230;</string>
     <string name="updating_keyboards" translatable="false">Updating keyboards&#8230;</string>

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -1,5 +1,6 @@
 package com.tavultesoft.kmea.util;
 
+import android.content.Context;
 import android.os.Build;
 import android.support.v4.widget.TextViewCompat;
 
@@ -7,9 +8,29 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.shadows.ShadowLog;
+
+import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class FileUtilsTest {
+
+  @Test
+  public void test_download() {
+    // Test invalid download doesn't throw exception
+    int ret = FileUtils.download(RuntimeEnvironment.application, "invalidURL", "", "");
+    Assert.assertEquals(-1, ret);
+
+    List<ShadowLog.LogItem> logs = ShadowLog.getLogs();
+    Assert.assertEquals(2, logs.size());
+
+    Assert.assertEquals("Connection", logs.get(0).tag);
+    Assert.assertEquals("Initialization failed:java.net.MalformedURLException: no protocol: invalidURL", logs.get(0).msg);
+
+    Assert.assertEquals("FileUtils", logs.get(1).tag);
+    Assert.assertEquals("Could not download filename ", logs.get(1).msg);
+  }
 
   @Test
   public void test_compareVersions() {

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android
 
+## 2019-02-08 10.0.2061 beta
+* Bug fix:
+  * Add notifications when keyboard or font fails to download from Keyman cloud (#1570)
+
 ## 2019-01-27 10.0.2060 beta
 * Bug fixes:
   * Clean up styling of dialogs when downloading keyboards


### PR DESCRIPTION
Fixes #1552 

Currently when downloading a keyboard from the cloud, the download activity silently fails if the font or keyboard fails to download.
 
* This PR add a toast warning when font fails to download. (Keyboard is still installed)
![keyboard font warning](https://user-images.githubusercontent.com/7358010/52355969-f9239e00-29f8-11e9-8cf5-2c5871c61903.png)

* Also adds an error dialog if the keyboard fails to download
From the LanguageListActivity
![language list error](https://user-images.githubusercontent.com/7358010/52355999-0b054100-29f9-11e9-81e6-961f6cb729ec.png)

* From the KeyboardListActivity
![keyboard list error](https://user-images.githubusercontent.com/7358010/52356012-122c4f00-29f9-11e9-9516-c68c22831a48.png)

(test code used to induce the above scenarios)

* The toast notifications in MainActivity and KeyboardListActivity also removed since they're handled in LanguageListActivity

* Finally, fixed null string exception when FileUtils.download() fails