### PR TITLE
[Developer] Package RTL keyboard metadata was being overwritten if .kmx was after .js in package file list

### DIFF
--- a/windows/src/global/delphi/general/kmxfile.pas
+++ b/windows/src/global/delphi/general/kmxfile.pas
@@ -77,6 +77,7 @@ type
     MemoryDump: TMemoryStream;
     ProductID: Integer;
     MnemonicLayout: Boolean;
+    KMW_RTL: Boolean;
     WindowsLanguages: WideString;
     ISO6393Languages: WideString;
     KeyboardVersion: WideString;   // I4136
@@ -201,7 +202,7 @@ var
   mem: TMemoryStream;
   ver: WideString;
   shver: string;
-  smnemonic: WideString;
+  srtl, smnemonic: WideString;
   signature: Integer;
   bmpsig: array[0..2] of ansichar;  // I3310
 begin
@@ -249,6 +250,8 @@ begin
         ki.KeyboardVersion := '1.0';
 
       ki.MnemonicLayout := GetSystemStore(Memory, TSS_MNEMONIC, smnemonic) and (smnemonic <> '0');
+
+      ki.KMW_RTL := GetSystemStore(Memory, TSS_KMW_RTL, srtl) and (srtl <> '0');
 
       ki.KeyboardID := kfh.KeyboardID;
       ki.DefaultHotKey := kfh.HotKey;

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -106,7 +106,7 @@ begin
     begin
       // If the keyboard already exists, don't change language information because
       // it may have been edited by the user. However, do refresh the fields we
-      // need to keep in sync: name and version
+      // need to keep in sync: name, version and rtl (js keyboards only)
 
       k := FindKeyboardByFileName(pack.Files[i].FileName);
       if not Assigned(k) then
@@ -121,7 +121,11 @@ begin
         k.Name := pki.Name;
         k.ID := pki.ID;
         k.Version := pki.Version;
-        k.RTL := pki.RTL;
+        if IsKeyboardFileByName(pack.Files[i]) = ftJavascript then
+          // RTL flag is currently only relevant for KMW so although the
+          // information can be read from .kmx we only copy it over for
+          // js keyboards.
+          k.RTL := pki.RTL;
       end;
     end;
   end;
@@ -307,6 +311,7 @@ begin
       GetKeyboardInfo(f.FileName, False, ki, False);
       pki.Name := ki.KeyboardName;
       pki.Version := ki.KeyboardVersion;
+      pki.RTL := ki.KMW_RTL;
     except
       on E:EKMXError do Result := False;
       on E:EFOpenError do Result := False;


### PR DESCRIPTION
Fixes #1219.

Note: history.md updates in #1575 (expecting both PRs to land on same day).