### PR TITLE
[linux] Update km-config to handle packages with empty "languages"

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,14 @@
 # Keyman for Linux Version History
 
+## 2019-02-17 11.0.108 beta
+* handle keyboard package install/uninstall when languages aren't defined
+
+## 2019-02-08 11.0.107 beta
+* add disco distribution information (#1572)
+
+## 2019-02-05 11.0.106 beta
+* update readme about packaging and fix build.sh script (#1565)
+
 ## 2019-01-10 11.0.105 beta
 * add icons for km-config and .kmp files (#1495)
 * restart ibus as user and on gnome-shell (#1510,#1521)

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,7 +1,7 @@
 # Keyman for Linux Version History
 
-## 2019-02-17 11.0.108 beta
-* handle keyboard package install/uninstall when languages aren't defined
+## 2019-02-15 11.0.108 beta
+* handle keyboard package install/uninstall when languages aren't defined (#1585)
 
 ## 2019-02-08 11.0.107 beta
 * add disco distribution information (#1572)

--- a/linux/ibus-keyman/src/kmpdetails.c
+++ b/linux/ibus-keyman/src/kmpdetails.c
@@ -133,11 +133,14 @@ void kmp_languages_foreach (JsonArray *array,
                      gpointer user_data)
 {
     JsonObject *lang_object;
-    kmp_keyboard *keyboard = (kmp_keyboard *) user_data;
-    kmp_language *language = g_new0(kmp_language, 1);
+    kmp_keyboard *keyboard;
+    kmp_language *language;
 
     if (JSON_NODE_HOLDS_OBJECT(element_node)){
         lang_object = json_node_get_object(element_node);
+        keyboard = (kmp_keyboard *) user_data;
+        language = g_new0(kmp_language, 1);
+
         get_detail_from_object(lang_object, "name",
             &(language->name));
         get_detail_from_object(lang_object, "id",
@@ -157,11 +160,14 @@ void kmp_keyboards_foreach (JsonArray *array,
     GList *l;
     gchar *l_kmx_file, *l_kvk_file;
     kmp_fileinfo *fileinfo;
-    kmp_details *details = (kmp_details *) user_data;
-    kmp_keyboard *keyboard = g_new0(kmp_keyboard, 1);
+    kmp_details *details;
+    kmp_keyboard *keyboard;
 
     if (JSON_NODE_HOLDS_OBJECT(element_node)){
         keyboard_object = json_node_get_object(element_node);
+        details = (kmp_details *) user_data;
+        keyboard = g_new0(kmp_keyboard, 1);
+
         get_detail_from_object(keyboard_object, "name",
             &(keyboard->name));
         get_detail_from_object(keyboard_object, "id",
@@ -208,11 +214,14 @@ void kmp_files_foreach (JsonArray *array,
                      gpointer user_data)
 {
     JsonObject *file_object;
-    kmp_details *details = (kmp_details *) user_data;
-    kmp_fileinfo *fileinfo = g_new0(kmp_fileinfo, 1);
+    kmp_details *details;
+    kmp_fileinfo *fileinfo;
 
     if (JSON_NODE_HOLDS_OBJECT(element_node)){
         file_object = json_node_get_object(element_node);
+        details = (kmp_details *) user_data;
+        fileinfo = g_new0(kmp_fileinfo, 1);
+
         get_detail_from_object(file_object, "name",
             &(fileinfo->name));
         get_detail_from_object(file_object, "description",

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -250,7 +250,7 @@ def install_keyboards_to_ibus(keyboards, packageDir):
 			# install all kmx for first lang not just packageID
 			for kb in keyboards:
 				kmx_file = os.path.join(packageDir, kb['id'] + ".kmx")
-				if "languages" in kb:
+				if "languages" in kb and len(kb["languages"]) > 0:
 					logging.debug(kb["languages"][0])
 					keyboard_id = "%s:%s" % (kb["languages"][0]['id'], kmx_file)
 				else:

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -63,7 +63,7 @@ def uninstall_keyboards_from_ibus(keyboards, packageDir):
 			# install all kmx for first lang not just packageID
 			for kb in keyboards:
 				kmx_file = os.path.join(packageDir, kb['id'] + ".kmx")
-				if "languages" in kb:
+				if "languages" in kb and len(kb["languages"]) > 0:
 					logging.debug(kb["languages"][0])
 					keyboard_id = "%s:%s" % (kb["languages"][0]['id'], kmx_file)
 				else:


### PR DESCRIPTION
When km-config parses kmp.json to install keyboard packages, the languages array can be empty. e.g.
```
  "keyboards": [
    {
      "name": "General",
      "id": "ge",
      "version": "9.0",
      "languages": [
      ]
    }
  ]
```
This causes install/uninstall to throw index out of bounds exception.

Tested with https://darcywong00.github.io/examples/invalid/ge.kmp