### PR TITLE
[Web] Unintended use of goog.DebugLoader fix

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1845,12 +1845,6 @@
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
-    "google-closure-library": {
-      "version": "20171203.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20171203.0.0.tgz",
-      "integrity": "sha1-50ZFFT4w8Wl/nRmbxbLMmYhPkuo=",
-      "dev": true
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "google-closure-compiler": "^20171203.0.0",
-    "google-closure-library": "^20171203.0.0",
     "html2canvas": "^1.0.0-alpha.12",
     "karma": "^3.1.4",
     "karma-browserstack-launcher": "^1.4.0",

--- a/web/source/kmwapi.ts
+++ b/web/source/kmwapi.ts
@@ -3,87 +3,56 @@
 /// <reference path="kmwutils.ts" />
 /// <reference path="kmwcallback.ts" />
 
-// Allows proper minification handling.
-/// <reference path="../node_modules/google-closure-library/closure/goog/base.js" />
-
 /**
- * This file provides calls needed to export our established API elements when performing minification.
- * Closure can work with these instructions to prevent it from eliminating these names.
- * 
- * Note that in general, class fields in need of exposure cannot have their minification blocked;
- * maintenance of those must be performed manually, hence certain setters and this['propertyName']
- * code lines.
- * 
- * Format:  goog.exportSymbol("<API name>", <actual function name>);
- *     - <API name> - not minified, must match published API.
- *     - <actual function name> - may be renamed by Closure, no need to directly match the API name.  
- *       It should be a method of the same object, however, due to how 'this' works in JS.
+ * This file generates aliases linking renamed functions to some of our published developer API for KMW.
+ * This won't enable Closure to do "advanced minification", but it's useful for ensuring we don't break
+ * things people depended on in legacy versions.
  */
 
 // Util.ts
-
-// goog.exportSymbol("Device", Device);
-// goog.exportSymbol("Util", Util);
-goog.exportSymbol("com.keyman.Util.prototype.attachDOMEvent", com.keyman.Util.prototype.attachDOMEvent);
-goog.exportSymbol("com.keyman.Util.prototype.detachDOMEvent", com.keyman.Util.prototype.detachDOMEvent);
-goog.exportSymbol("com.keyman.Util.prototype.getOption", com.keyman.Util.prototype.getOption);
-goog.exportSymbol("com.keyman.Util.prototype.setOption", com.keyman.Util.prototype.setOption);
-goog.exportSymbol("com.keyman.Util.prototype.getAbsoluteX", com.keyman.Util.prototype._GetAbsoluteX);
-goog.exportSymbol("com.keyman.Util.prototype.getAbsoluteY", com.keyman.Util.prototype._GetAbsoluteY);
-goog.exportSymbol("com.keyman.Util.prototype.getAbsolute", com.keyman.Util.prototype._GetAbsolute);
-goog.exportSymbol("com.keyman.Util.prototype.createElement", com.keyman.Util.prototype.createElement);
-goog.exportSymbol("com.keyman.Util.prototype.getIEVersion", com.keyman.Util.prototype.getIEVersion);
-goog.exportSymbol("com.keyman.Util.prototype.isTouchDevice", com.keyman.Util.prototype.isTouchDevice);
-goog.exportSymbol("com.keyman.Util.prototype.createShim", com.keyman.Util.prototype.createShim);
-goog.exportSymbol("com.keyman.Util.prototype.showShim", com.keyman.Util.prototype.showShim);
-goog.exportSymbol("com.keyman.Util.prototype.hideShim", com.keyman.Util.prototype.hideShim);
-goog.exportSymbol("com.keyman.Util.prototype.rgba", com.keyman.Util.prototype.rgba);
-goog.exportSymbol("com.keyman.Util.prototype.addStyleSheet", com.keyman.Util.prototype.addStyleSheet);
-goog.exportSymbol("com.keyman.Util.prototype.removeStyleSheet", com.keyman.Util.prototype.removeStyleSheet);
-goog.exportSymbol("com.keyman.Util.prototype.linkStyleSheet", com.keyman.Util.prototype.linkStyleSheet);
-goog.exportSymbol("com.keyman.Util.prototype.addFontFaceStyleSheet", com.keyman.Util.prototype.addFontFaceStyleSheet);
-goog.exportSymbol("com.keyman.Util.prototype.loadCookie", com.keyman.Util.prototype.loadCookie);
-goog.exportSymbol("com.keyman.Util.prototype.saveCookie", com.keyman.Util.prototype.saveCookie);
-goog.exportSymbol("com.keyman.Util.prototype.toNumber", com.keyman.Util.prototype.toNumber);
-goog.exportSymbol("com.keyman.Util.prototype.toFloat", com.keyman.Util.prototype.toFloat);
-goog.exportSymbol("com.keyman.Util.prototype.toNzString", com.keyman.Util.prototype.nzString);
-goog.exportSymbol("com.keyman.Util.prototype.alert", com.keyman.Util.prototype.alert);
-
-// kmwcallback.ts
 (function() {
-  var exportKBCallback = function(miniName: string, longName: string, func:() => any) {
-    goog.exportSymbol("com.keyman.KeyboardInterface.prototype." + longName, func);
-    goog.exportSymbol("com.keyman.KeyboardInterface.prototype." + miniName, func);
+  let prototype = com.keyman.Util.prototype;
+
+  var publishAPI = function(miniName: string, longName: string) {
+    prototype[miniName] = prototype[longName];
   }
 
-  var exportKBCallbackWithArgs = function(miniName: string, longName: string, func:(...args: any[]) => any) {
-    goog.exportSymbol("com.keyman.KeyboardInterface.prototype." + longName, func);
-    goog.exportSymbol("com.keyman.KeyboardInterface.prototype." + miniName, func);
+  publishAPI('getAbsoluteX', "_GetAbsoluteX");
+  publishAPI("getAbsoluteY", "_GetAbsoluteY");
+  publishAPI("getAbsolute", "_GetAbsolute");
+  publishAPI("toNzString", "nzString");
+}());
+
+// Keyboard callbacks
+(function() {
+  let prototype = com.keyman.KeyboardInterface.prototype;
+
+  var exportKBCallback = function(miniName: string, longName: string) {
+    prototype[miniName] = prototype[longName];
   }
 
-  exportKBCallback('KSF', 'saveFocus', com.keyman.KeyboardInterface.prototype.saveFocus);
-  exportKBCallback('KBR', 'beepReset', com.keyman.KeyboardInterface.prototype.beepReset);
-
-  exportKBCallbackWithArgs('KT', 'insertText', com.keyman.KeyboardInterface.prototype.insertText);
-  exportKBCallbackWithArgs('KR', 'registerKeyboard', com.keyman.KeyboardInterface.prototype.registerKeyboard);
-  exportKBCallbackWithArgs('KRS', 'registerStub', com.keyman.KeyboardInterface.prototype.registerStub);
-  exportKBCallbackWithArgs('KC', 'context', com.keyman.KeyboardInterface.prototype.context);
-  exportKBCallbackWithArgs('KN', 'nul', com.keyman.KeyboardInterface.prototype.nul);
-  exportKBCallbackWithArgs('KCM', 'contextMatch', com.keyman.KeyboardInterface.prototype.contextMatch);
-  exportKBCallbackWithArgs('KFCM', 'fullContextMatch', com.keyman.KeyboardInterface.prototype.fullContextMatch);
-  exportKBCallbackWithArgs('KIK', 'isKeypress', com.keyman.KeyboardInterface.prototype.isKeypress);
-  exportKBCallbackWithArgs('KKM', 'keyMatch', com.keyman.KeyboardInterface.prototype.keyMatch);
-  exportKBCallbackWithArgs('KSM', 'stateMatch', com.keyman.KeyboardInterface.prototype.stateMatch);
-  exportKBCallbackWithArgs('KKI', 'keyInformation', com.keyman.KeyboardInterface.prototype.keyInformation);
-  exportKBCallbackWithArgs('KDM', 'deadkeyMatch', com.keyman.KeyboardInterface.prototype.deadkeyMatch);
-  exportKBCallbackWithArgs('KB', 'beep', com.keyman.KeyboardInterface.prototype.beep);
-  exportKBCallbackWithArgs('KA', 'any', com.keyman.KeyboardInterface.prototype.any);
-  exportKBCallbackWithArgs('KDC', 'deleteContext', com.keyman.KeyboardInterface.prototype.deleteContext);
-  exportKBCallbackWithArgs('KO', 'output', com.keyman.KeyboardInterface.prototype.output);
-  exportKBCallbackWithArgs('KDO', 'deadkeyOutput', com.keyman.KeyboardInterface.prototype.deadkeyOutput);
-  exportKBCallbackWithArgs('KIO', 'indexOutput', com.keyman.KeyboardInterface.prototype.indexOutput);
-  exportKBCallbackWithArgs('KIFS', 'ifStore', com.keyman.KeyboardInterface.prototype.ifStore);
-  exportKBCallbackWithArgs('KSETS', 'setStore', com.keyman.KeyboardInterface.prototype.setStore);
-  exportKBCallbackWithArgs('KLOAD', 'loadStore', com.keyman.KeyboardInterface.prototype.loadStore);
-  exportKBCallbackWithArgs('KSAVE', 'saveStore', com.keyman.KeyboardInterface.prototype.saveStore);
+  exportKBCallback('KSF', 'saveFocus');
+  exportKBCallback('KBR', 'beepReset');
+  exportKBCallback('KT', 'insertText');
+  exportKBCallback('KR', 'registerKeyboard');
+  exportKBCallback('KRS', 'registerStub');
+  exportKBCallback('KC', 'context');
+  exportKBCallback('KN', 'nul');
+  exportKBCallback('KCM', 'contextMatch');
+  exportKBCallback('KFCM', 'fullContextMatch');
+  exportKBCallback('KIK', 'isKeypress');
+  exportKBCallback('KKM', 'keyMatch');
+  exportKBCallback('KSM', 'stateMatch');
+  exportKBCallback('KKI', 'keyInformation');
+  exportKBCallback('KDM', 'deadkeyMatch');
+  exportKBCallback('KB', 'beep');
+  exportKBCallback('KA', 'any');
+  exportKBCallback('KDC', 'deleteContext');
+  exportKBCallback('KO', 'output');
+  exportKBCallback('KDO', 'deadkeyOutput');
+  exportKBCallback('KIO', 'indexOutput');
+  exportKBCallback('KIFS', 'ifStore');
+  exportKBCallback('KSETS', 'setStore');
+  exportKBCallback('KLOAD', 'loadStore');
+  exportKBCallback('KSAVE', 'saveStore');
 }());


### PR DESCRIPTION
Fixes #1516.

Removes a dependency on the Google Closure library (separate from the compiler) that was intended to facilitate better minification, but was causing issues on some devices.  Said 'advanced-level' minification is no longer a priority and is nowhere on our roadmap at this point, so little is lost here.

Note that this fix will need a tweak when it reaches 'master' / the alpha to reflect some of its recent refactorings.