### PR TITLE
[linux] Sanitize packageID, keyboardID, and kmx filenames

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -6,8 +6,8 @@
 ## 2019-02-20 11.0.110 beta
 * update readme about launchpad (#1574)
 
-## 2019-02-18  11.0.109 beta
-* add appstream appdata file for km-config (#1543)
+## 2019-02-18 11.0.109 beta
+* add appstream appdata file for keyman-config (#1543)
 
 ## 2019-02-15 11.0.108 beta
 * handle keyboard package install/uninstall when languages aren't defined (#1585)

--- a/linux/history.md
+++ b/linux/history.md
@@ -7,7 +7,7 @@
 * update readme about launchpad (#1574)
 
 ## 2019-02-18 11.0.109 beta
-* add appstream appdata file for keyman-config (#1543)
+* create appstream appdata for keyman-config (#1543)
 
 ## 2019-02-15 11.0.108 beta
 * handle keyboard package install/uninstall when languages aren't defined (#1585)

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,14 @@
 # Keyman for Linux Version History
 
+## 2019-02-22 11.0.111 beta
+* use lowercase ID and kmx filenames when installing .kmp packages (#1601)
+
+## 2019-02-20 11.0.110 beta
+* update readme about launchpad (#1574)
+
+## 2019-02-18  11.0.109 beta
+* add appstream appdata file for km-config (#1543)
+
 ## 2019-02-15 11.0.108 beta
 * handle keyboard package install/uninstall when languages aren't defined (#1585)
 

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -30,6 +30,7 @@ def install_to_ibus(bus, keyboard_id):
         preload_engines = ibus_settings.get_strv("preload-engines")
         logging.debug(preload_engines)
         if keyboard_id not in preload_engines:
+            # TODO: in the event preload_engines contains upper-case keyboards, we'll need to uninstall_from_ibus #1601
             preload_engines.append(keyboard_id)
         logging.debug(preload_engines)
         ibus_settings.set_strv("preload-engines", preload_engines)

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -27,7 +27,7 @@ def install_to_ibus(bus, keyboard_id):
         # bus = IBus.Bus()
         logging.debug("installing to ibus")
         ibus_settings = Gio.Settings.new("org.freedesktop.ibus.general")
-        preload_engines = ibus_settings.getr_strv("preload-engines")
+        preload_engines = ibus_settings.get_strv("preload-engines")
         logging.debug(preload_engines)
         if keyboard_id not in preload_engines:
             preload_engines.clear()

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -30,7 +30,6 @@ def install_to_ibus(bus, keyboard_id):
         preload_engines = ibus_settings.get_strv("preload-engines")
         logging.debug(preload_engines)
         if keyboard_id not in preload_engines:
-            preload_engines.clear()
             preload_engines.append(keyboard_id)
         logging.debug(preload_engines)
         ibus_settings.set_strv("preload-engines", preload_engines)

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -27,9 +27,10 @@ def install_to_ibus(bus, keyboard_id):
         # bus = IBus.Bus()
         logging.debug("installing to ibus")
         ibus_settings = Gio.Settings.new("org.freedesktop.ibus.general")
-        preload_engines = ibus_settings.get_strv("preload-engines")
+        preload_engines = ibus_settings.getr_strv("preload-engines")
         logging.debug(preload_engines)
         if keyboard_id not in preload_engines:
+            preload_engines.clear()
             preload_engines.append(keyboard_id)
         logging.debug(preload_engines)
         ibus_settings.set_strv("preload-engines", preload_engines)

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import logging
 import os.path
-import re
 import subprocess
 import sys
 import tempfile
@@ -118,7 +117,7 @@ def check_keyman_dir(basedir, error_message):
 
 def extract_package_id(inputfile):
 	packageID, ext = os.path.splitext(os.path.basename(inputfile))
-	return packageID.lower(), ext
+	return packageID.lower()
 
 def install_kmp_shared(inputfile, online=False):
 	"""
@@ -132,7 +131,7 @@ def install_kmp_shared(inputfile, online=False):
 	check_keyman_dir('/usr/local/share/doc', "You do not have permissions to install the documentation to the shared documentation area /usr/local/share/doc/keyman")
 	check_keyman_dir('/usr/local/share/fonts', "You do not have permissions to install the font files to the shared font area /usr/local/share/fonts")
 
-	packageID, ext = extract_package_id(inputfile)
+	packageID = extract_package_id(inputfile)
 	packageDir = os.path.join('/usr/local/share/keyman', packageID)
 	kmpdocdir = os.path.join('/usr/local/share/doc/keyman', packageID)
 	kmpfontdir = os.path.join('/usr/local/share/fonts/keyman', packageID)
@@ -196,7 +195,7 @@ def install_kmp_shared(inputfile, online=False):
 		raise InstallError(InstallStatus.Abort, message)
 
 def install_kmp_user(inputfile, online=False):
-	packageID, ext = extract_package_id(inputfile)
+	packageID = extract_package_id(inputfile)
 	packageDir=user_keyboard_dir(packageID)
 	if not os.path.isdir(packageDir):
 		os.makedirs(packageDir)
@@ -241,8 +240,8 @@ def install_kmp_user(inputfile, online=False):
 				pass
 			elif ftype == KMFileTypes.KM_KMX:
 				# Sanitize keyboard filename if not lower case
-				kmx_id = re.sub('.kmx', '', f['name'])
-				for index, kb in enumerate(keyboards):
+				kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
+				for kb in keyboards:
 					if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
 						os.rename(os.path.join(packageDir, f['name']), os.path.join(packageDir, kb['id']+'.kmx'))
 

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -177,10 +177,17 @@ def install_kmp_shared(inputfile, online=False):
 				name, ext = os.path.splitext(f['name'])
 				ldmlfile = os.path.join(packageDir, name+".ldml")
 				output_ldml(ldmlfile, ldml)
-				# Special handling of icon to convert to PNG
 			elif ftype == KMFileTypes.KM_ICON:
+				# Special handling of icon to convert to PNG
 				logging.info("Converting %s to PNG and installing both as keyman files", f['name'])
 				checkandsaveico(fpath)
+			elif ftype == KMFileTypes.KM_KMX:
+				# Sanitize keyboard filename if not lower case
+				kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
+				for kb in keyboards:
+					if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
+						os.rename(os.path.join(packageDir, f['name']), os.path.join(packageDir, kb['id']+'.kmx'))
+
 		for kb in keyboards:
 			# install all kmx for first lang not just packageID
 			kmx_file = os.path.join(packageDir, kb['id'] + ".kmx")


### PR DESCRIPTION
This addresses the issue in legacy KMFL keyboard packages that used to install but fail in Keyman for Linux because of filecasing.
e.g. the .kmp filename or .kmx files are upper-case so when the ID's in kmp.json are parsed, things don't align.

Example: https://darcywong00.github.io/examples/invalid/BDH.kmp

Changes:
* Lower-case the folder (packageID) when extracting the .kmp file.
* Lower-case the .kmx files that match the keyboards list.