### PR TITLE
[Windows] Keyman now handles backspace correctly again for SMP characters in TSF-aware apps

### DIFF
--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -281,6 +281,13 @@ BOOL ProcessGroup(LPGROUP gp)
               fOutputKeystroke = TRUE;   // I4933
               return FALSE;   // I4933
             }
+            if (Uni_IsSurrogate1(*pdeletecontext) && Uni_IsSurrogate2(*(pdeletecontext+1))) {
+              // 2 backspaces to delete both parts of surrogate pair
+              // This only needs to be done for non-legacy apps as legacy apps
+              // will receive a BKSP WM_KEYDOWN event which results in deleting
+              // both parts in one action
+              _td->app->QueueAction(QIT_BACK, BK_BACKSPACE);
+            }
           }
 				  _td->app->QueueAction(QIT_BACK, BK_BACKSPACE);   // I4933
         }

--- a/windows/src/engine/keyman32/message-analyzer/README.md
+++ b/windows/src/engine/keyman32/message-analyzer/README.md
@@ -4,4 +4,16 @@ keyman-debug-etw.man will be installed with Keyman Engine so that debug log file
 Microsoft Message Analyzer. You can import the layout file keyman-debug-etw.asset into Microsoft Message Analyzer 
 to provide a good default layout for Keyman log files.
 
+To manually install the provider, run:
+
+    wevtutil im keyman-debug-etw.man
+
+To uninstall it (a good idea often before installing):
+
+    wevtutil um keyman-debug-etw.man
+    
+You may need to manually edit the file to add the paths for keyman32.dll, e.g.:
+
+    <provider name="Keyman-Debug-ETWProvider" guid="{DA621615-E08B-4283-918E-D2502D3757AE}" symbol="ProviderGuid" message="$(string.Provider.Name)" messageFileName="C:\Program Files (x86)\Common Files\Keyman\Keyman Engine\keyman32.dll" resourceFileName="C:\Program Files (x86)\Common Files\Keyman\Keyman Engine\keyman32.dll">
+
 Debug log files are written to %LOCAL_APP_DATA%\Keyman\Diag.


### PR DESCRIPTION
Fixes #1600.