### PR TITLE
[Web] Disables Safari tests for KMW pending BrowserStack fix.

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -49,18 +49,21 @@ module.exports = function(config) {
       os: 'OS X',
       os_version: 'Mojave'
     },
-    bs_safari_mac_hs: {
-      browser: 'safari',
-      browser_version: '11.1',
-      os: 'OS X',
-      os_version: 'High Sierra'
-    },
-    bs_safari_mac_m: {
-      browser: 'safari',
-      browser_version: '12',
-      os: 'OS X',
-      os_version: 'Mojave'
-    },
+    // Unfortunately, BrowserStack's Safari test clients have been quite unstable recently,
+    // failing to even start running their tests.  We're disabling them until the issue goes away.
+
+    // bs_safari_mac_hs: {
+    //   browser: 'safari',
+    //   browser_version: '11.1',
+    //   os: 'OS X',
+    //   os_version: 'High Sierra'
+    // },
+    // bs_safari_mac_m: {
+    //   browser: 'safari',
+    //   browser_version: '12',
+    //   os: 'OS X',
+    //   os_version: 'Mojave'
+    // },
     bs_chrome_mac: {
       browser: 'chrome',
       browser_version: '70.0',

--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -49,18 +49,21 @@ module.exports = function(config) {
       os: 'OS X',
       os_version: 'Mojave'
     },
-    bs_safari_mac_hs: {
-      browser: 'safari',
-      browser_version: '11.1',
-      os: 'OS X',
-      os_version: 'High Sierra'
-    },
-    bs_safari_mac_m: {
-      browser: 'safari',
-      browser_version: '12',
-      os: 'OS X',
-      os_version: 'Mojave'
-    },
+    // Unfortunately, BrowserStack's Safari test clients have been quite unstable recently,
+    // failing to even start running their tests.  We're disabling them until the issue goes away.
+
+    // bs_safari_mac_hs: {
+    //   browser: 'safari',
+    //   browser_version: '11.1',
+    //   os: 'OS X',
+    //   os_version: 'High Sierra'
+    // },
+    // bs_safari_mac_m: {
+    //   browser: 'safari',
+    //   browser_version: '12',
+    //   os: 'OS X',
+    //   os_version: 'Mojave'
+    // },
     bs_chrome_mac: {
       browser: 'chrome',
       browser_version: '70.0',


### PR DESCRIPTION
It's obviously not ideal, but since the Safari checks have been causing CI to report failures due to not actually running (it's something with BrowserStack), this will disable them until that issue is resolved.