### PR TITLE
[Web] Toolbar UI minification fix

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 2019-02-26 11.0.221 stable
+* Fixes bug with the Toolbar UI (#1629)
+
 ## 2019-02-25 11.0.220 stable
 * 11.0 Stable release
 

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -337,7 +337,7 @@ if(!window['keyman']['ui']['name']) {
           if(Keyboards[j]['RegionCode'] != i) continue;              // Not this region
 
           // Get JUST the language code for this section.  BCP-47 codes can include more!
-          var bcpSubtags: string[] = keymanweb['util'].getLanguageCodes(Keyboards[j]['LanguageCode']);
+          var bcpSubtags: string[] = keymanweb['util']['getLanguageCodes'](Keyboards[j]['LanguageCode']);
           if(bcpSubtags[0] == languageCode) continue; // Same language as previous keyboard
           languageCode = bcpSubtags[0];
 
@@ -351,7 +351,7 @@ if(!window['keyman']['ui']['name']) {
         {           
           if(Keyboards[j]['RegionCode'] != i) continue;      // Not this region
 
-          var bcpSubtags: string[] = keymanweb['util'].getLanguageCodes(Keyboards[j]['LanguageCode']);
+          var bcpSubtags: string[] = keymanweb['util']['getLanguageCodes'](Keyboards[j]['LanguageCode']);
           if(bcpSubtags[0] == languageCode) {  // Same language as previous keyboard, so add it to that entry
             var x = ui.languages[languageCode].keyboards;
 


### PR DESCRIPTION
Context:  We've long had Closure's "advanced" minification in place on most of KMW's UI modules, which can get rather... aggressive... about renaming methods.  Accessing KMW methods through an "associative array" style bypasses this tendency.

Fixes the underlying issue of https://github.com/keymanapp/keymanweb.com/pull/2.