### PR TITLE
Use more generic preprocessor macro 64bit

### DIFF
--- a/common/engine/keyboardprocessor/src/kmx/kmx_base.h
+++ b/common/engine/keyboardprocessor/src/kmx/kmx_base.h
@@ -10,7 +10,7 @@
 #define strncasecmp _strnicmp 
 #endif
 
-#if __x86_64__
+#if defined(__LP64__) || defined(_LP64)
 /* 64-bit, g++ */
 #define KMX_64BIT
 #endif


### PR DESCRIPTION
__x86_64__ is only for Intel __LP64__ and _LP64 are for any arch that has 64bit `long int` and pointers, and 32bit `int` same as Intel.