### PR TITLE
[Android] Check activity is not finishing before showing error dialog

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -640,7 +640,11 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
       });
 
     alertDialog = alertDialogBuilder.create();
-    alertDialog.show();
+    if (!((AppCompatActivity)context).isFinishing()) {
+      alertDialog.show();
+    } else {
+      alertDialog.dismiss();
+    }
   }
 
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -156,7 +156,7 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
         Toast.makeText(context, context.getString(R.string.font_failed_to_download), Toast.LENGTH_LONG).show();
       }
       finish();
-    } else {
+    } else if (!((AppCompatActivity)context).isFinishing()) {
       String title = String.format("%s: %s", languageName, keyboardName);
       showErrorDialog(context, title, context.getString(R.string.keyboard_failed_to_download));
     }
@@ -640,11 +640,7 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
       });
 
     alertDialog = alertDialogBuilder.create();
-    if (!((AppCompatActivity)context).isFinishing()) {
-      alertDialog.show();
-    } else {
-      alertDialog.dismiss();
-    }
+    alertDialog.show();
   }
 
 }

--- a/android/history.md
+++ b/android/history.md
@@ -1,8 +1,11 @@
 # Keyman for Android
 
-## 2019-02-26 11.0.2101 stable
+## 2019-02-27 11.0.2102 stable
 * Bug fix:
   * Fix crash from language picker trying to show error dialog (#1634)
+
+## 2019-02-26 11.0.2101 stable
+* No changes to Keyman for Android (updated Keyman Web Engine, #1629)
 
 ## 2019-02-25 11.0.2100 stable
 * 11.0 Stable release

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android
 
+## 2019-02-26 11.0.2101 stable
+* Bug fix:
+  * Fix crash from language picker trying to show error dialog (#1634)
+
 ## 2019-02-25 11.0.2100 stable
 * 11.0 Stable release
 


### PR DESCRIPTION
Fixes [crash report](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/5c73bebdf8b88c29630d9b7d?time=last-seven-days&sessionId=5C73FD0B01F50001606FDCD1E526D22F_DNE_0_v2) when the LanguageListActivity is attempting to show the error dialog after the Activity is finished.

References: 
* https://stackoverflow.com/questions/7811993/error-binderproxy45d459c0-is-not-valid-is-your-activity-running
* http://dimitar.me/android-displaying-dialogs-from-background-threads/