### PR TITLE
[Android] Get lexical model packages from API

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -147,11 +147,11 @@ public class PackageActivity extends AppCompatActivity {
       }
     });
 
-    // Determine if KMP contains welcome.htm (case-insensitive) to display
+    // Determine if ad-hoc distributed KMP contains welcome.htm (case-insensitive) to display
     FileFilter welcomeFilter = new FileFilter() {
       @Override
       public boolean accept(File pathname) {
-        if (pathname.isFile() && pathname.getName().equalsIgnoreCase("welcome.htm")) {
+        if (pathname.isFile() && FileUtils.isWelcomeFile(pathname.getName())) {
           return true;
         }
         return false;

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -85,7 +85,7 @@ fi
 PLATFORM=`uname -s`
 
 # Report JUnit test results to CI
-echo "##teamcity[importData type='junit' path='keyman\android\KMEA\app\build\test-results\testReleaseUnitTest\TEST-com.tavultesoft.kmea.packages.PackageProcessorTest.xml']"
+echo "##teamcity[importData type='junit' path='keyman\android\KMEA\app\build\test-results\testReleaseUnitTest\']"
 
 if [ "$DO_BUILD" = true ]; then
     echo "Building keyman web engine"


### PR DESCRIPTION
When downloading a keyboard from the cloud, also download associated lexical models.
(Currently limited to the first one)

* Refactor JSONParser to download JSONObject or JSONArray from a URL
* Also update TC reporter of unit tests