### PR TITLE
[Web] Fixes Web UI controller alignment

### DIFF
--- a/web/source/kmwapi.ts
+++ b/web/source/kmwapi.ts
@@ -12,13 +12,14 @@
 (function() {
   let prototype = com.keyman.Util.prototype;
 
-  var publishAPI = function(miniName: string, longName: string) {
-    prototype[miniName] = prototype[longName];
+  var publishAPI = function(legacyName: string, name: string) {
+    prototype[legacyName] = prototype[name];
   }
 
-  publishAPI('getAbsoluteX', "_GetAbsoluteX");
-  publishAPI("getAbsoluteY", "_GetAbsoluteY");
-  publishAPI("getAbsolute", "_GetAbsolute");
+  // These four were renamed, but we need to maintain their legacy names.
+  publishAPI("_GetAbsoluteX", 'getAbsoluteX');
+  publishAPI("_GetAbsoluteY", "getAbsoluteY");
+  publishAPI("_GetAbsolute", "getAbsolute");
   publishAPI("toNzString", "nzString");
 }());
 

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -281,7 +281,7 @@ namespace com.keyman {
      * @return      {Object.<string,number>}               
      * Description  Returns absolute position of Pobj element with respect to page
      */  
-    _GetAbsolute(Pobj: HTMLElement) {
+    getAbsolute(Pobj: HTMLElement) {
       var p={
         /* @ export */
         x: this.getAbsoluteX(Pobj),
@@ -292,7 +292,7 @@ namespace com.keyman {
     }
 
     //  Unofficial API used by our desktop UIs.
-    getAbsolute = this._GetAbsolute;
+    _GetAbsolute = this.getAbsolute;
     
     /**
      * Select start handler (to replace multiple inline handlers) (Build 360)  


### PR DESCRIPTION
Fixes #1638.

Certain UI related methods were accidentally being overwritten, as the `publishAPI` calls related to them had the parameters in the incorrect order.  This fixes that and makes one other related method more consistent with the others to prevent confusion.