### PR TITLE
[Android] Fix gradle syntax for account credentials

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -69,7 +69,7 @@ if (project.hasProperty("keys_json_file")) {
     apply plugin: 'com.github.triplet.play'
 
     play {
-        jsonFile = file(project.ext.keys_json_file)
+        serviceAccountCredentials = file(project.ext.keys_json_file)
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy = "ignore"


### PR DESCRIPTION
The newer gradle-play-publisher changed from `jsonFile` to `serviceAccountCredentials`