### PR TITLE
[Web] Embedded-mode processing refactor

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -476,30 +476,8 @@ namespace com.keyman.osk {
 
       Lkc.vkCode=Lkc.Lcode;
 
-      // Pass this key code and state to the keyboard program
-      if(!keymanweb.keyboardManager.activeKeyboard ||  Lkc.Lcode == 0) return false;
-      
-      let Processor = com.keyman.text.Processor;
-      let outputTarget = Processor.getOutputTarget(Lelem);
-
-      // If key is mapped, return true
-      if(kbdInterface.processKeystroke(util.device, outputTarget, Lkc)) {
-        // Make sure we don't affect the current layer until the keystroke has been processed!
-        if(nextLayer) {
-          processor.selectLayer(keyName, nextLayer);
-        }
-
-        return true;
-      }
-
-      keymanweb.processDefaultMapping(Lkc, outputTarget);
-
-      if(nextLayer) {
-        // Final nextLayer check.
-        processor.selectLayer(keyName, nextLayer);
-      }
-
-      return true;
+      // Now that we have a valid key event, hand it off to the Processor for execution.
+      return processor.processKeyEvent(Lkc);
   };
 
   /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -188,22 +188,19 @@ namespace com.keyman.text {
     let Codes = com.keyman.text.Codes;
     let code = Lkc.Lcode;
 
-    // Default handling for external keys.
     // Intentionally not assigning K_TAB or K_ENTER so KMW will pass them back
     // to the mobile apps to handle (insert characters or navigate forms).
-    if(!usingOSK) { // If hardware-sourced.
-      if (code == Codes.keyCodes.K_SPACE) {
-        return ' ';
-      } else if (code == Codes.keyCodes.K_BKSP) {
-        keyman['interface'].defaultBackspace();
-        return '';
-      } else if (code == Codes.keyCodes.K_oE2) {
-        // Using defaults of English US layout for the 102nd key
-        if (Lkc.Lmodifiers == Codes.modifierCodes['SHIFT']) {
-          return '|';
-        } else {
-          return '\\';
-        }
+    if (code == Codes.keyCodes.K_SPACE) {
+      return ' ';
+    } else if (code == Codes.keyCodes.K_BKSP) {
+      keyman['interface'].defaultBackspace();
+      return '';
+    } else if (code == Codes.keyCodes.K_oE2) {
+      // Using defaults of English US layout for the 102nd key
+      if (Lkc.Lmodifiers == Codes.modifierCodes['SHIFT']) {
+        return '|';
+      } else {
+        return '\\';
       }
     }
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -319,11 +319,16 @@ namespace com.keyman.text {
      * 
      * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
      */
-    processKeyEvent(keyEvent: KeyEvent, e?: osk.KeyElement): boolean {
+    processKeyEvent(keyEvent: KeyEvent, e?: osk.KeyElement | boolean): boolean {
       let keyman = com.keyman.singleton;
       //var Lelem = keyman.domManager.getLastActiveElement();
 
       let fromOSK = !!e; // If specified, it's from the OSK.
+
+      // Enables embedded-path OSK sourcing detection.
+      if(typeof e == 'boolean') {
+        e = null as osk.KeyElement; // Cast is necessary for TS type-checking later in the method.
+      }
 
       var activeKeyboard = keyman.keyboardManager.activeKeyboard;
       let kbdInterface = keyman.interface;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -367,7 +367,7 @@ namespace com.keyman.text {
       }
 
 
-      if(!fromOSK && !window.event) {
+      if(!keyman.isEmbedded && !fromOSK && !window.event) {
         // I1466 - Convert the - keycode on mnemonic as well as positional layouts
         // FireFox, Mozilla Suite
         if(keyMapManager.browserMap.FF['k'+keyEvent.Lcode]) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -329,7 +329,7 @@ namespace com.keyman.text {
 
       this.swallowKeypress = false;
 
-      if(fromOSK) {
+      if(fromOSK && !keyman.isEmbedded) {
         keyman.domManager.initActiveElement(keyEvent.Ltarg);
 
         // Turn off key highlighting (or preview)
@@ -370,7 +370,7 @@ namespace com.keyman.text {
       // Safari, IE, Opera?
       //}
 
-      if(fromOSK) {
+      if(fromOSK && !keyman.isEmbedded) {
         keyman.uiManager.setActivatingUI(true);
         com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 100;
         keyman.domManager.focusLastActiveElement();
@@ -421,7 +421,7 @@ namespace com.keyman.text {
 
       /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
       
-      if(fromOSK) {
+      if(fromOSK && !keyman.isEmbedded) {
         keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
       }
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -232,10 +232,14 @@ namespace com.keyman.text {
       outputTarget.deadkeys().deleteMatched();      // Delete any matched deadkeys before continuing
 
       // Start:  mirrors _GetKeyEventProperties
+
+      // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
+      keyShiftState = this.getModifierState(e['key'].spec['layer'] || layer);
+
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: KeyEvent = {
         Ltarg: Lelem,
-        Lmodifiers: 0,
+        Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],
         LisVirtualKey: true,
@@ -253,38 +257,8 @@ namespace com.keyman.text {
           this.stateKeys[keyName] = ! this.stateKeys[keyName];
       }
 
-      // Set the flags for the state keys.
-      Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
-      Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
-      Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
-
-      // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
-      if(keyName.substr(0,2) == 'U_') {
-        Lkc.LisVirtualKey=false;
-      }
-
-      // Get code for non-physical keys (T_KOKAI, U_05AB etc)
-      if(typeof Lkc.Lcode == 'undefined') {
-        Lkc.Lcode = this.getVKDictionaryCode(keyName);// Updated for Build 347
-        if(!Lkc.Lcode) {
-          // Special case for U_xxxx keys. This vk code will never be used
-          // in a keyboard, so we use this to ensure that keystroke processing
-          // occurs for the key.
-          Lkc.Lcode = 1; 
-        }
-      }
-
-      // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-      keyShiftState = this.getModifierState(e['key'].spec['layer'] || layer);
-
-      // Define modifiers value for sending to keyboard mapping function
-      Lkc.Lmodifiers = keyShiftState;
-
-      // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
-      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && osk.Layouts.emulatesAltGr()) {
-        Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
-        Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
-      }
+      // Performs common pre-analysis for both 'native' and 'embedded' OSK key & subkey input events.
+      this.commonClickEventPreprocessing(Lkc);
 
       // End - mirrors _GetKeyEventProperties
 
@@ -307,6 +281,35 @@ namespace com.keyman.text {
       }
 
       return Lkc;
+    }
+
+    commonClickEventPreprocessing(Lkc: KeyEvent) {
+      // Set the flags for the state keys.
+      Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
+      Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
+      Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
+
+      // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
+      if(Lkc.kName.substr(0,2) == 'U_') {
+        Lkc.LisVirtualKey=false;
+      }
+
+      // Get code for non-physical keys (T_KOKAI, U_05AB etc)
+      if(typeof Lkc.Lcode == 'undefined') {
+        Lkc.Lcode = this.getVKDictionaryCode(Lkc.kName);// Updated for Build 347
+        if(!Lkc.Lcode) {
+          // Special case for U_xxxx keys. This vk code will never be used
+          // in a keyboard, so we use this to ensure that keystroke processing
+          // occurs for the key.
+          Lkc.Lcode = 1; 
+        }
+      }
+
+      // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
+      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && osk.Layouts.emulatesAltGr()) {
+        Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
+        Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
+      }
     }
 
     /**


### PR DESCRIPTION
This PR aims to centralize text processing even further, finding common aspects between 'embedded' and 'native' modes so that the `Processor` can handle the central aspects of text processing and coordinate with our in-development predictive text module.

Fortunately, much of embedded mode's `executePopupKey` was a pre-existing copy-paste of its corresponding native-mode control path.  While some of the `KeyEvent` generation code is necessarily unique (there's no DOM element corresponding to mobile in-app popup keys), much of the rest can easily be handled by existing `Processor` code.

More troublesome - handling external keyboard keystrokes, as many of the existing 'default' keystroke handling is designed from the perspective of _browser_ defaults.  Fortunately, we're using TS, which is based on JS - we can simply save the 'native' version of the method and then replace the original appropriately, reusing the old version where appropriate to create an 'extended' version.