### PR TITLE
[Web] Generation of prediction requests

### DIFF
--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -149,6 +149,15 @@ interface Configuration {
  */
 interface Transform {
   /**
+   * Facilitates use of unique identifiers for tracking the Transform and
+   * any related data from its original source, as the reference cannot be
+   * preserved across WebWorker boundaries.
+   * 
+   * This is *separate* from any LMLayer-internal identification values.
+   */
+  id?: number;
+
+  /**
    * The Unicode scalar values (i.e., characters) to be inserted at the
    * cursor position.
    *

--- a/web/source/includes/lmMsgs.d.ts
+++ b/web/source/includes/lmMsgs.d.ts
@@ -1,1 +1,1 @@
-///<reference path="../../../common/predictive-text/build/includes/message.d.ts" />
+///<reference path="../../../common/predictive-text/message.d.ts" />

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -1092,10 +1092,6 @@ namespace com.keyman.text {
       var matched = keyman.keyboardManager.activeKeyboard['gs'](outputTarget, keystroke);
       this.activeTargetOutput = null;
 
-      if(matched && outputTarget.getElement()) {
-        this.doInputEvent(outputTarget.getElement());
-      }
-
       return matched;
     }
     

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -41,6 +41,8 @@ namespace com.keyman.text {
       this.preInput = preInput;
       this.removedDks = removedDks;
       this.insertedDks = insertedDks;
+
+      this.transform.id = this.token;
     }
   }
 

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -24,6 +24,29 @@ namespace com.keyman.text.prediction {
     path: string;
   }
 
+  class TranscriptionContext implements Context {
+    left: string;
+    right?: string;
+
+    startOfBuffer: boolean;
+    endOfBuffer: boolean;
+
+    constructor(mock: Mock, config: Configuration) {
+      this.left = mock.getTextBeforeCaret();
+      this.startOfBuffer = this.left._kmwLength() > config.leftContextCodeUnits;
+      if(!this.startOfBuffer) {
+        // Our custom substring version will return the last n characters if param #1 is given -n.
+        this.left = this.left._kmwSubstr(-config.leftContextCodeUnits);
+      }
+
+      this.right = mock.getTextAfterCaret();
+      this.endOfBuffer = this.right._kmwLength() > config.rightContextCodeUnits;
+      if(!this.endOfBuffer) {
+        this.right = this.right._kmwSubstr(0, config.rightContextCodeUnits);
+      }
+    }
+  }
+
   /**
    * Corresponds to the 'invalidatesuggestions' ModelManager event.
    */
@@ -43,7 +66,10 @@ namespace com.keyman.text.prediction {
   export class ModelManager {
     private lmEngine: LMLayer;
     private currentModel?: ModelSpec;
-    private currentPromise: Promise<Suggestion[]>;
+    private configuration?: Configuration;
+    private currentPromise?: Promise<Suggestion[]>;
+
+    private recentTranscriptions: Transcription[] = [];
 
     // Tracks registered models by ID.
     private registeredModels: {[id: string]: ModelSpec} = {};
@@ -52,6 +78,7 @@ namespace com.keyman.text.prediction {
     private languageModelMap: {[language:string]: ModelSpec} = {};
 
     private static EVENT_PREFIX: string = "kmw.mm.";
+    private static readonly TRANSCRIPTION_BUFFER: 10;
 
     init() {
       let keyman = com.keyman.singleton;
@@ -69,22 +96,28 @@ namespace com.keyman.text.prediction {
     private unloadModel() {
       this.lmEngine.unloadModel();
       delete this.currentModel;
+      delete this.configuration;
     }
 
-    private loadModel(model: ModelSpec) {
+    private loadModel(model: ModelSpec): Promise<void> {
       if(!model) {
         throw new Error("Null reference not allowed.");
       }
 
       let file = model.path;
-      this.lmEngine.loadModel(file);
-      this.currentModel = model;
+      let mm = this;
+
+      // We should wait until the model is successfully loaded before setting our state values.
+      return this.lmEngine.loadModel(file).then(function(config: Configuration) { 
+        mm.currentModel = model;
+        mm.configuration = config;
+      });
     }
 
     onKeyboardChange(kbdInfo: KeyboardChangeData) {
-      let keyman = com.keyman.singleton;
       let lgCode = kbdInfo['languageCode'];
       let model = this.languageModelMap[lgCode];
+      var loadPromise: Promise<number>;
 
       if(this.currentModel !== model) {
         let stateChange = 0; // Base value; will not remain the same 
@@ -95,8 +128,10 @@ namespace com.keyman.text.prediction {
         }
 
         if(model) {
-          this.loadModel(model);
-          stateChange += 1;
+          loadPromise = this.loadModel(model).then(function() {
+            // Track the state bit flags appropriately.
+            return stateChange + 1;
+          });
         }
 
         if(stateChange == 0) {
@@ -104,9 +139,27 @@ namespace com.keyman.text.prediction {
           return;
         }
 
-        let changeParam: ModelChangeEnum = stateChange == 1 ? 'loaded' : (stateChange == 2 ? 'unloaded' : 'changed');
-        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', changeParam);
+        // If we're loading a model, we need to defer until its completion before we report a change of state.
+        if(loadPromise) {
+          let mm = this;
+          loadPromise.then(function(stateBitFlags: number) {
+            mm.doModelChange(stateBitFlags);
+          }).catch(function(failReason: any) {
+            // Does this provide enough logging information?
+            console.error("Could not load model '" + model.id + "': " + failReason);
+          });
+        } else {
+          // No promises?  Just directly trigger the event, then!
+          this.doModelChange(stateChange);
+        }
       }
+    }
+
+    private doModelChange(stateBitFlags: number) {
+      let keyman = com.keyman.singleton;
+
+      let changeParam: ModelChangeEnum = stateBitFlags == 1 ? 'loaded' : (stateBitFlags == 2 ? 'unloaded' : 'changed');
+      keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', changeParam);
     }
 
     // Accessible publicly as keyman.modelManager.register(model: ModelSpec)
@@ -150,12 +203,18 @@ namespace com.keyman.text.prediction {
       return keyman.util.addEventListener(ModelManager.EVENT_PREFIX + event, func);
     }
 
-    public predict(transform: Transform, context: Context) {
+    public predict(transcription: Transcription) {
       // If there's no active model, there can be no predictions.
-      if(!this.currentModel) {
+      // We'll also be missing important data needed to even properly REQUEST the predictions.
+      if(!this.currentModel || !this.configuration) {
         return;
       }
+      let context = new TranscriptionContext(transcription.preInput, this.configuration);
+      this.recordTranscription(transcription);
+      this.predict_internal(transcription.transform, context);
+    }
 
+    private predict_internal(transform: Transform, context: Context) {
       let keyman = com.keyman.singleton;
       var promise = this.currentPromise = this.lmEngine.predict(transform, context);
 
@@ -167,8 +226,17 @@ namespace com.keyman.text.prediction {
       promise.then(function(suggestions: Suggestion[]) {
         if(promise == mm.currentPromise) {
           keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", suggestions);
+          mm.currentPromise = null;
         }
       })
+    }
+
+    private recordTranscription(transcription: Transcription) {
+      this.recentTranscriptions.push(transcription);
+
+      if(this.recentTranscriptions.length > ModelManager.TRANSCRIPTION_BUFFER) {
+        this.recentTranscriptions.splice(0, 1);
+      }
     }
 
     public shutdown() {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -384,9 +384,13 @@ namespace com.keyman.text {
         keyman.domManager.focusLastActiveElement();
         com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 0;
       }
-
       // // ...end I3363 (Build 301)
+
+      // Determine the current target for text output and create a "mock" backup
+      // of its current, pre-input state.
       let outputTarget = Processor.getOutputTarget(keyEvent.Ltarg);
+      let preInputMock = Mock.from(outputTarget);
+
       var LeventMatched = 0;
       this.swallowKeypress = false;
 
@@ -418,6 +422,16 @@ namespace com.keyman.text {
       
       // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
       if(LeventMatched) {
+        let transcription = outputTarget.buildTranscriptionFrom(preInputMock, keyEvent);
+        // Notify the ModelManager of new input
+        keyman.modelManager.predict(transcription);
+
+        // Since this method now performs changes for 'default' keystrokes, synthetic 'change' event generation
+        // belongs here, rather than only in interface.processKeystroke() as in versions pre-12.
+        if(outputTarget.getElement()) {
+          keyman['interface'].doInputEvent(outputTarget.getElement());
+        }
+
         this.swallowKeypress = (e && keyEvent.Lcode != 8 ? keyEvent.Lcode != 0 : false);
         if(keyEvent.Lcode == 8) {
           this.swallowKeypress = false;


### PR DESCRIPTION
This PR will allow KMW to start making prediction requests on the LMLayer for keyboards with supported lexical models, providing the necessary values to initiate such requests.

At this time, no effort is made to supply any layout or timing data which could be used to enhance the accuracy of predictions in cases of potential fat-fingering or typos - this will require further design and implementation work to achieve.