### PR TITLE
[Web] BannerManager docs

### DIFF
--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -9,6 +9,30 @@ namespace com.keyman.osk {
 
   export type BannerType = "blank" | "image" | "suggestion";
 
+  /**
+   * The `BannerManager` module is designed to serve as a manager for the different `Banner` types. 
+   * To facilitate this, it will provide a root element property that serves as a container for any active `Banner`, 
+   * helping KMW to avoid needless DOM element shuffling.
+   *
+   * Goals for the `BannerManager`:
+   *
+   * * It will be exposed as `keyman.osk.banner` and will provide the following API:
+   *   * `getOptions`, `setOptions` - refer to the `BannerOptions` class for details.
+   *   * This provides a persistent point that the web page designers and our model apps can utilize and can communicate with.
+   *   * These API functions are designed for live use and will allow _hot-swapping_ the `Banner` instance; they're not initialization-only.
+   * * Disabling the `Banner` (even for suggestions) outright with `enablePredictions == false` will auto-unload any loaded predictive model 
+   *   from `ModelManager` and setting it to `true` will revert this.
+   *   * This should help to avoid wasting computational resources.
+   * * It will listen to ModelManager events and automatically swap Banner instances as appropriate:
+   *   * The option `persistentBanner == true` is designed to replicate current iOS system keyboard behavior.
+   *     * When true, an `ImageBanner` will be displayed.
+   *     * If false, it will be replaced with a `BlankBanner` of zero height, corresponding to our current default lack of banner.
+   *   * It will not automatically set `persistentBanner == true`; this must be set by the iOS app, and only under the following conditions:
+   *     * `keyman.isEmbedded == true`
+   *     * `device.OS == 'ios'`
+   *     * Keyman is being used as the system keyboard within an app that needs to reserve this space (i.e: Keyman for iOS),
+   *       rather than as its standalone app.
+   */
   export class BannerManager {
     private _options: BannerOptions = {};
     private bannerContainer: HTMLDivElement;


### PR DESCRIPTION
Noting @mcdurdin's recent comment on #1678, this adds that PR's notes on `BannerManager` design as documentation to the TS file.  It's been formatted to look nice with VS Code Intellisense.