### PR TITLE
[LMLayer] Allow LMLayer to be imported as a Node module

### DIFF
--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -2,6 +2,7 @@
   "name": "keyman-lmlayer-prototype",
   "version": "0.20181001.0",
   "description": "Keyman/Predictive Text integration layer",
+  "main": "build/index.js",
   "scripts": {
     "karma": "karma",
     "mocha": "mocha",


### PR DESCRIPTION
Small PR:

Allow the LMLayer to be used as from node, outside of the `predictive-text` directory. E.g., from the keyman root dir:

```
$ node
> const LMLayer = require('./common/predictive-text');
undefined
> let lm = LMLayer({}, new Worker);
```