### PR TITLE
[Web] Application of predictive Suggestions.

### DIFF
--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -217,6 +217,13 @@ interface Context {
  */
 interface Suggestion {
   /**
+   * Indicates the externally-supplied id of the Transform that prompted
+   * the Suggestion.  Automatically handled by the LMLayer; models should
+   * not handle this field.
+   */
+  transformId?: number;
+
+  /**
    * The suggested update to the buffer. Note that this transform should
    * be applied AFTER the instigating transform, if any.
    */

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -233,9 +233,17 @@ class LMLayerWorker {
         switch(payload.message) {
           case 'predict':
             let {transform, context} = payload;
+
+            // Let's not rely on the model to copy transform IDs.
+            let suggestions = model.predict(transform, context);
+            suggestions.forEach(function(s: Suggestion) {
+              s.transformId = transform.id;
+            });
+
+            // Now that the suggestions are ready, send them out!
             this.cast('suggestions', {
               token: payload.token,
-              suggestions: model.predict(transform, context)
+              suggestions: suggestions
             });
             break;
           case 'unload':

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -234,11 +234,15 @@ class LMLayerWorker {
           case 'predict':
             let {transform, context} = payload;
 
-            // Let's not rely on the model to copy transform IDs.
             let suggestions = model.predict(transform, context);
-            suggestions.forEach(function(s: Suggestion) {
-              s.transformId = transform.id;
-            });
+
+            // Let's not rely on the model to copy transform IDs.
+            // Only bother is there IS an ID to copy.
+            if(transform.id !== undefined) {
+              suggestions.forEach(function(s: Suggestion) {
+                s.transformId = transform.id;
+              });
+            }
 
             // Now that the suggestions are ready, send them out!
             this.cast('suggestions', {

--- a/web/source/dom/contentEditable.ts
+++ b/web/source/dom/contentEditable.ts
@@ -190,7 +190,7 @@ namespace com.keyman.dom {
         var n = start.node.ownerDocument.createTextNode(s);
 
         let range = this.root.ownerDocument.createRange();
-        range.setStart(start.node, s.length);
+        range.setStart(start.node, start.offset);
         range.collapse(true);
         range.insertNode(n);
       }
@@ -206,6 +206,36 @@ namespace com.keyman.dom {
         Lsel.addRange(finalCaret);
       }
       Lsel.collapseToEnd();
+    }
+
+    protected setTextAfterCaret(s: string) {
+      if(!this.hasSelection()) {
+        return;
+      }
+
+      let caret = this.getCarets().end;
+      let delta = s._kmwLength();
+      let Lsel = this.root.ownerDocument.getSelection();
+
+      if(delta == 0) {
+        return;
+      }
+
+      // This is designed explicitly for use in direct-setting operations; deadkeys
+      // will be handled after this method.
+
+      if(caret.node.nodeType == 3) {
+        let textStart = <Text> caret.node;
+        textStart.replaceData(caret.offset, textStart.length, s);
+      } else {
+        // Create a new text node - empty control
+        var n = caret.node.ownerDocument.createTextNode(s);
+
+        let range = this.root.ownerDocument.createRange();
+        range.setStart(caret.node, caret.offset);
+        range.collapse(true);
+        range.insertNode(n);
+      }
     }
   }
 }

--- a/web/source/dom/designIFrame.ts
+++ b/web/source/dom/designIFrame.ts
@@ -196,7 +196,7 @@ namespace com.keyman.dom {
         var n = this.doc.createTextNode(s);
 
         let range = this.doc.createRange();
-        range.setStart(start.node, s.length);
+        range.setStart(start.node, start.offset);
         range.collapse(true);
         range.insertNode(n);
       }
@@ -212,6 +212,36 @@ namespace com.keyman.dom {
         Lsel.addRange(finalCaret);
       }
       Lsel.collapseToEnd();
+    }
+
+    protected setTextAfterCaret(s: string) {
+      if(!this.hasSelection()) {
+        return;
+      }
+
+      let caret = this.getCarets().end;
+      let delta = s._kmwLength();
+      let Lsel = this.doc.getSelection();
+
+      if(delta == 0) {
+        return;
+      }
+
+      // This is designed explicitly for use in direct-setting operations; deadkeys
+      // will be handled after this method.
+
+      if(caret.node.nodeType == 3) {
+        let textStart = <Text> caret.node;
+        textStart.replaceData(caret.offset, textStart.length, s);
+      } else {
+        // Create a new text node - empty control
+        var n = caret.node.ownerDocument.createTextNode(s);
+
+        let range = this.root.ownerDocument.createRange();
+        range.setStart(caret.node, caret.offset);
+        range.collapse(true);
+        range.insertNode(n);
+      }
     }
 
     /**

--- a/web/source/dom/input.ts
+++ b/web/source/dom/input.ts
@@ -92,6 +92,13 @@ namespace com.keyman.dom {
       this.setCaret(newCaret);
     }
 
+    protected setTextAfterCaret(s: string) {
+      let c = this.getCaret();
+
+      this.root.value = this.getTextBeforeCaret() + s;
+      this.setCaret(c);
+    }
+
     getTextAfterCaret(): string {
       this.getCaret();
       return this.getText()._kmwSubstring(this.processedSelectionEnd);

--- a/web/source/dom/textarea.ts
+++ b/web/source/dom/textarea.ts
@@ -99,6 +99,13 @@ namespace com.keyman.dom {
       this.setCaret(newCaret);
     }
 
+    protected setTextAfterCaret(s: string) {
+      let c = this.getCaret();
+
+      this.root.value = this.getTextBeforeCaret() + s;
+      this.setCaret(c);
+    }
+
     getTextAfterCaret(): string {
       this.getCaret();
       return this.getText()._kmwSubstring(this.processedSelectionEnd);

--- a/web/source/dom/touchAlias.ts
+++ b/web/source/dom/touchAlias.ts
@@ -59,5 +59,9 @@ namespace com.keyman.dom {
       this.adjustDeadkeys(s._kmwLength());
       this.root.setTextBeforeCaret(this.root.getTextBeforeCaret() + s);
     }
+
+    protected setTextAfterCaret(s: string) {
+      this.root.setText(this.getTextBeforeCaret() + s, this.getTextBeforeCaret()._kmwLength());
+    }
   }
 }

--- a/web/source/dom/touchAliasElement.ts
+++ b/web/source/dom/touchAliasElement.ts
@@ -295,7 +295,7 @@ namespace com.keyman.dom {
       this.setText(textValue, null); 
     }
 
-    private setText(t?: string, cp?: number): void {
+    setText(t?: string, cp?: number): void {
       var tLen=0;
       var t1: string, t2: string;
       

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -168,14 +168,16 @@ namespace com.keyman.osk {
       div.id = BannerSuggestion.BASE_ID + this.index;
 
       let kbdDetails = keyman.keyboardManager.activeStub;
-      if (kbdDetails['KLC']) {
-        div.lang = kbdDetails['KLC'];
-      }
+      if(kbdDetails) {  
+        if (kbdDetails['KLC']) {
+          div.lang = kbdDetails['KLC'];
+        }
 
-      // Establish base font settings
-      let font = kbdDetails['KFont'];
-      if(font && font.family && font.family != '') {
-        ds.fontFamily = this.fontFamily = font.family;
+        // Establish base font settings
+        let font = kbdDetails['KFont'];
+        if(font && font.family && font.family != '') {
+          ds.fontFamily = this.fontFamily = font.family;
+        }
       }
 
       // Ensures that a reasonable width % is set.

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -135,32 +135,63 @@ namespace com.keyman.osk {
     }
   }
 
-  export class BannerSuggestionSpec {
-    id: string;
-    languageID: string;
-    text?: string;
-    width: number;
-    pad?: string;
-    widthpc?: number; // Added during OSK construction.
-    padpc?: number; // Added during OSK construction.
-
-    public DEFAULT_SUGGESTION_WIDTH: number = 50; // pixels
-
-    constructor(id: string, languageID: string, text?: string, width?: number, pad?: string) {
-      this.id = id;
-      this.languageID = languageID;
-      this.text = text;
-      this.width = width ? width : this.DEFAULT_SUGGESTION_WIDTH;
-      this.pad = pad;
-    }
-  }
-
   export class BannerSuggestion {
-    spec: BannerSuggestionSpec;
-    suggestion: Suggestion;
+    div: HTMLDivElement;
+    private display: HTMLSpanElement;
+    private fontFamily?: string;
 
-    constructor(spec: BannerSuggestionSpec) {
-      this.spec = spec;
+    private suggestion: Suggestion;
+
+    private index: number;
+    private width: number;
+
+    private static readonly BASE_ID = 'kmw-suggestion-';
+
+    constructor(index: number, widthpc?: number) {
+      let keyman = com.keyman.singleton;
+
+      this.index = index;
+      this.width = widthpc > 0 ? (widthpc <= 100 ? widthpc : 100) : 0;
+
+      this.constructRoot();
+
+      // Provides an empty, base SPAN for text display.  We'll swap these out regularly;
+      // `Suggestion`s will have varying length and may need different styling.
+      let display = this.display = keyman.util._CreateElement('span');
+      this.div.appendChild(display);
+    }
+
+    private constructRoot() {
+      let keyman = com.keyman.singleton;
+
+      // Add OSK suggestion labels
+      let div = this.div = keyman.util._CreateElement('div'), ds=div.style;
+      div.className = "kmw-suggest-option";
+      div.id = BannerSuggestion.BASE_ID + this.index;
+
+      let kbdDetails = keyman.keyboardManager.activeStub;
+      if (kbdDetails['KLC']) {
+        div.lang = kbdDetails['KLC'];
+      }
+
+      // Establish base font settings
+      let font = kbdDetails['KFont'];
+      if(font && font.family && font.family != '') {
+        ds.fontFamily = this.fontFamily = font.family;
+      }
+
+      // Ensures that a reasonable width % is set.
+      let oskManager = keyman.osk;
+      let widthpc = this.width;
+
+      ds.width = widthpc + '%';
+      // if (keyman.util.device.formFactor == 'desktop') {
+      //   // Desktop OSK widths are defined in %.
+      //   ds.width = widthpc + '%';
+      // } else {
+      //   // Touch-based OSK widths are defined in px.
+      //   ds.width = widthpc + '%'; //Math.floor(oskManager.getWidth() * widthpc / 100) + 'px';
+      // }
     }
 
     /**
@@ -169,10 +200,14 @@ namespace com.keyman.osk {
      * @param {Suggestion} suggestion   Suggestion from the lexical model
      * Description  Update the ID and text of the BannerSuggestionSpec
      */
-    public update(id: string, suggestion: Suggestion) {
-      this.spec.id = id;
-      this.spec.text = suggestion.displayAs;
+    public update(suggestion: Suggestion) {
       this.suggestion = suggestion;
+      this.updateText();
+    }
+
+    private updateText() {
+      let display = this.generateSuggestionText();
+      this.div.replaceChild(display, this.display);
     }
 
     /**
@@ -210,39 +245,23 @@ namespace com.keyman.osk {
      */
     //
     public generateSuggestionText(): HTMLSpanElement {
-      let util = (<KeymanBase>window['keyman']).util;
-      let spec = this.spec;
+      let keyman = com.keyman.singleton;
+      let util = keyman.util;
 
-      // Add OSK suggestion labels
+      let suggestion = this.suggestion;
       var suggestionText: string;
-      var t=util._CreateElement('span'), ts=t.style;
-      t.id = spec.id;
-      t.className = "kmw-suggestion-span";
-      if(spec.text == null || spec.text == '') {
+
+      var s=util._CreateElement('span');
+      s.className = 'kmw-suggestion-text';
+
+      if(suggestion == null) {
+        return s;
+      }
+
+      if(suggestion.displayAs == null || suggestion.displayAs == '') {
         suggestionText = '\xa0';  // default:  nbsp.
       } else {
-        suggestionText = spec.text;
-      }
-
-      if (this.spec.languageID) {
-        t.lang = this.spec.languageID;
-      }
-
-      //Override font spec if set for this key in the layout
-      if(typeof spec['font'] == 'string' && spec['font'] != '') {
-        ts.fontFamily=spec['font'];
-      }
-
-      if(typeof spec['fontsize'] == 'string' && spec['fontsize'] != 0) {
-        ts.fontSize=spec['fontsize'];
-      }
-
-      let device = util.device;
-      let oskManager = com.keyman.singleton.osk;
-      if (device.formFactor != 'desktop') {
-        ts.width = Math.floor(oskManager.getWidth() / SuggestionBanner.SUGGESTION_LIMIT) + 'px';
-      } else {
-        ts.width = Math.floor(oskManager.getWidthFromCookie() / SuggestionBanner.SUGGESTION_LIMIT) + 'px';
+        suggestionText = suggestion.displayAs;
       }
 
       let keyboardManager = (<KeymanBase>window['keyman']).keyboardManager;
@@ -251,13 +270,11 @@ namespace com.keyman.osk {
         suggestionText = '\u200f' + suggestionText;
       }
 
-      // Finalize the suggestion text
-      var d=util._CreateElement('div'), ds=d.style;
-      d.className = 'kmw-suggestion-text';
-      d.innerHTML = suggestionText;
-      t.appendChild(d);
+      // TODO:  Dynamic suggestion text resizing.  (Refer to OSKKey.getTextWidth in visualKeyboard.ts.)
 
-      return t;
+      // Finalize the suggestion text
+      s.innerHTML = suggestionText;
+      return s;
     }
   }
 
@@ -269,27 +286,17 @@ namespace com.keyman.osk {
   export class SuggestionBanner extends Banner {
     public static SUGGESTION_LIMIT: number = 3;
     private suggestionList : BannerSuggestion[];
+    private currentSuggestions: Suggestion[] = [];
 
     constructor() {
       super(SuggestionBanner.DEFAULT_HEIGHT);
       this.suggestionList = new Array();
       for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
-        let s = new BannerSuggestionSpec('kmw-suggestion-' + i, 'en', '', 33, ' ');
-        let d = new BannerSuggestion(s);
+        let d = new BannerSuggestion(i, 100 / SuggestionBanner.SUGGESTION_LIMIT);
         this.suggestionList[i] = d;
-        this.getDiv().appendChild(d.generateSuggestionText());
+        this.getDiv().appendChild(d.div);
       }
     }
-
-    public static BLANK_SUGGESTION(): Suggestion {
-      let s: Suggestion = {
-        displayAs: '',
-        transform: {
-          insert: '', deleteLeft: 0, deleteRight: 0
-        }
-      };
-      return s;
-    };
 
     /**
      * Function invalidateSuggestions
@@ -298,11 +305,8 @@ namespace com.keyman.osk {
      */
     public invalidateSuggestions: (this: SuggestionBanner) => boolean = 
         function(this: SuggestionBanner) {
-      this.suggestionList.forEach((suggestion, i) => {
-        this.suggestionList[i].update('kmw-suggestion-'+i, 
-          SuggestionBanner.BLANK_SUGGESTION());
-        this.getDiv().replaceChild(suggestion.generateSuggestionText(), 
-          this.getDiv().childNodes.item(i));
+      this.suggestionList.forEach((option: BannerSuggestion) => {
+        option.update(null);
       });
     }.bind(this);
 
@@ -314,10 +318,14 @@ namespace com.keyman.osk {
      */
     public updateSuggestions: (this: SuggestionBanner, suggestions: Suggestion[]) => boolean =
         function(this: SuggestionBanner, suggestions: Suggestion[]) {
-      this.suggestionList.forEach((suggestion, i) => {
-        this.suggestionList[i].update('kmw-suggestion-'+i, suggestions[i]);
-        this.getDiv().replaceChild(suggestion.generateSuggestionText(), 
-          this.getDiv().childNodes.item(i));
+      this.currentSuggestions = suggestions;
+      
+      this.suggestionList.forEach((option: BannerSuggestion, i: number) => {
+        if(i < suggestions.length) {
+          option.update(suggestions[i]);
+        } else {
+          option.update(null);
+        }
       });
     }.bind(this);
   }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -157,6 +157,7 @@ namespace com.keyman.osk {
 
   export class BannerSuggestion {
     spec: BannerSuggestionSpec;
+    suggestion: Suggestion;
 
     constructor(spec: BannerSuggestionSpec) {
       this.spec = spec;
@@ -171,6 +172,35 @@ namespace com.keyman.osk {
     public update(id: string, suggestion: Suggestion) {
       this.spec.id = id;
       this.spec.text = suggestion.displayAs;
+      this.suggestion = suggestion;
+    }
+
+    /**
+     * Function apply
+     * @param target (Optional) The OutputTarget to which the `Suggestion` ought be applied.
+     * Description  Applies the predictive `Suggestion` represented by this `BannerSuggestion`.
+     */
+    public apply(target?: text.OutputTarget) {
+      let keyman = com.keyman.singleton;
+      
+      // Find the state of the context at the time the prediction-triggering keystroke was applied.
+      let original = keyman.modelManager.getPredictionState(this.suggestion.transformId);
+      if(!original) {
+        console.warn("Could not apply the Suggestion!");
+        return;
+      } else {
+        if(!target) {
+          /* Assume it's the currently-active `OutputTarget`.  We should probably invalidate 
+           * everything if/when the active `OutputTarget` changes, though we haven't gotten that 
+           * far in implementation yet.
+           */
+          target = text.Processor.getOutputTarget();
+        }
+
+        // Apply the Suggestion!
+        target.restoreTo(original.preInput);
+        target.apply(this.suggestion.transform);
+      }
     }
 
     /**

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -143,15 +143,13 @@ namespace com.keyman.osk {
     private suggestion: Suggestion;
 
     private index: number;
-    private width: number;
 
     private static readonly BASE_ID = 'kmw-suggestion-';
 
-    constructor(index: number, widthpc?: number) {
+    constructor(index: number) {
       let keyman = com.keyman.singleton;
 
       this.index = index;
-      this.width = widthpc > 0 ? (widthpc <= 100 ? widthpc : 100) : 0;
 
       this.constructRoot();
 
@@ -181,17 +179,11 @@ namespace com.keyman.osk {
       }
 
       // Ensures that a reasonable width % is set.
-      let oskManager = keyman.osk;
-      let widthpc = this.width;
+      let usableWidth = 100 - SuggestionBanner.MARGIN * (SuggestionBanner.SUGGESTION_LIMIT + 1);
+      let widthpc = usableWidth / SuggestionBanner.SUGGESTION_LIMIT;
 
       ds.width = widthpc + '%';
-      // if (keyman.util.device.formFactor == 'desktop') {
-      //   // Desktop OSK widths are defined in %.
-      //   ds.width = widthpc + '%';
-      // } else {
-      //   // Touch-based OSK widths are defined in px.
-      //   ds.width = widthpc + '%'; //Math.floor(oskManager.getWidth() * widthpc / 100) + 'px';
-      // }
+      ds.marginLeft = SuggestionBanner.MARGIN + '%';
     }
 
     /**
@@ -284,7 +276,9 @@ namespace com.keyman.osk {
    * Description  Display lexical model suggestions in the banner
    */
   export class SuggestionBanner extends Banner {
-    public static SUGGESTION_LIMIT: number = 3;
+    public static readonly SUGGESTION_LIMIT: number = 3;
+    public static readonly MARGIN = 1;
+
     private suggestionList : BannerSuggestion[];
     private currentSuggestions: Suggestion[] = [];
 
@@ -292,11 +286,13 @@ namespace com.keyman.osk {
       super(SuggestionBanner.DEFAULT_HEIGHT);
       this.suggestionList = new Array();
       for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
-        let d = new BannerSuggestion(i, 100 / SuggestionBanner.SUGGESTION_LIMIT);
+        let d = new BannerSuggestion(i);
         this.suggestionList[i] = d;
         this.getDiv().appendChild(d.div);
       }
     }
+
+
 
     /**
      * Function invalidateSuggestions

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -84,7 +84,7 @@ namespace com.keyman.osk {
 
       let d = util._CreateElement('div');
       d.id = "keymanweb_banner_container";
-      d.className = "keymanweb-banner-container";
+      d.className = "kmw-banner-container";
       return this.bannerContainer = d;
     }
 

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -167,7 +167,7 @@ namespace com.keyman.osk {
 
       this._Visible = false;  // I3363 (Build 301)
       var s = this._Box.style;
-      s.zIndex='9999'; s.display='none'; s.width='auto';
+      s.zIndex='9999'; s.display='none'; s.width= device.touchable ? '100%' : 'auto';
       s.position = (device.formFactor == 'desktop' ? 'absolute' : 'fixed');
 
       // Use smaller base font size for mobile devices

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -50,8 +50,8 @@
 .phone.ios .kmw-key.kmw-key-touched {background-color:#88f;}
 
 .phone.ios .kmw-banner-bar {background-color: #cfd3d9; height: 40px; width: 100%;}
-.phone.ios .kmw-banner-bar span {background-color: #cfd3d9; display:inline-block; vertical-align: middle;}
-.phone.ios .kmw-suggestion-text {color:#000; background-color:#fdfdfe; text-align: center;}
+.phone.ios .kmw-banner-bar .kmw-suggest-option {background-color: #cfd3d9; display:inline-block; vertical-align: middle;}
+.phone.ios .kmw-suggestion-text {color:#000; background-color:#fdfdfe; width: 100%; text-align: center;}
 
 .phone.android .kmw-key-layer-group {background-color: #333;}  
 .phone.android .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 3px;}
@@ -66,7 +66,7 @@
 .phone.android .kmw-spacebar-caption {color: #aaa;}
 
 .phone.android .kmw-banner-bar {background-color: #222; height: 40px; width: 100%;}
-.phone.android .kmw-banner-bar span {background-color: #333; display:inline-block; vertical-align: middle;}
+.phone.android .kmw-banner-bar .kmw-suggest-option {background-color: #333; display:inline-block; vertical-align: middle;}
 .phone.android .kmw-suggestion-text {color:#ffff; background-color: #222; text-align: center;}
 
 .tablet.kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
@@ -95,7 +95,7 @@
 .tablet.ios .kmw-key.kmw-key-touched {background-color:#88f;}
 
 .tablet.ios .kmw-banner-bar {background-color: #cfd3d9}
-.tablet.ios .kmw-banner-bar span {background-color: #cfd3d9; display:inline-block; vertical-align:middle;}
+.tablet.ios .kmw-banner-bar .kmw-suggest-option {background-color: #cfd3d9; display:inline-block; vertical-align:middle;}
 .tablet.ios .kmw-suggestion-text {color:#000; background-color:#fdfdfe; text-align: center;}
 
 .tablet .kmw-key-row {-webkit-touch-callout:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);}
@@ -113,7 +113,7 @@
 .tablet.android .kmw-spacebar-caption {color: #888;}         
 
 .tablet.android .kmw-banner-bar {background-color: #b4b4b8; height: 40px; width: 100%;}
-.tablet.android .kmw-banner-bar span {background-color: #b4b4b8; display:inline-block; vertical-align: middle;}
+.tablet.android .kmw-banner-bar .kmw-suggest-option {background-color: #b4b4b8; display:inline-block; vertical-align: middle;}
 .tablet.android .kmw-suggestion-text {color:#77f; background-color: #b4b4b8; text-align: center;}
 
 /* Vertical centering of text labels on keys */ 
@@ -155,10 +155,10 @@
 .kmw-title-bar-actions{position: absolute; cursor: default; right:2px; top:0; width: 33px; height: 13px;}
 .kmw-footer-caption{color:#fff;font:0.7em Arial;margin:0 0 0 4px;}
 
-
+.kmw-banner-container{width:100%; margin:0;}
 .kmw-banner-bar{height:40px; width:100%; margin:0; background-color:darkorange;}
-.kmw-banner-bar span {background-color: orange; display:inline-block; vertical-align: middle;}
-.kmw-suggestion-text{color:#ffff; background-color: orange; text-align: center;}
+.kmw-banner-bar .kmw-suggest-option {background-color: orange; display:inline-block; vertical-align: middle; text-align: center}
+.kmw-suggestion-text{color:#ffff; background-color: orange; text-align: center; width: 95%}
 
 
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -50,8 +50,8 @@
 .phone.ios .kmw-key.kmw-key-touched {background-color:#88f;}
 
 .phone.ios .kmw-banner-bar {background-color: #cfd3d9; height: 40px; width: 100%;}
-.phone.ios .kmw-banner-bar .kmw-suggest-option {background-color: #cfd3d9; display:inline-block; vertical-align: middle;}
-.phone.ios .kmw-suggestion-text {color:#000; background-color:#fdfdfe; width: 100%; text-align: center;}
+.phone.ios .kmw-banner-bar .kmw-suggest-option {background-color: #fdfdfe; display:inline-block; vertical-align: middle; border-radius: 5px;}
+.phone.ios .kmw-suggestion-text {color:#000; width: 100%; text-align: center;}
 
 .phone.android .kmw-key-layer-group {background-color: #333;}  
 .phone.android .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 3px;}
@@ -66,7 +66,7 @@
 .phone.android .kmw-spacebar-caption {color: #aaa;}
 
 .phone.android .kmw-banner-bar {background-color: #222; height: 40px; width: 100%;}
-.phone.android .kmw-banner-bar .kmw-suggest-option {background-color: #333; display:inline-block; vertical-align: middle;}
+.phone.android .kmw-banner-bar .kmw-suggest-option {background-color: #333; display:inline-block; vertical-align: middle; border-radius: 5px}
 .phone.android .kmw-suggestion-text {color:#ffff; background-color: #222; text-align: center;}
 
 .tablet.kmw-osk-frame{position:fixed;left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
@@ -95,8 +95,8 @@
 .tablet.ios .kmw-key.kmw-key-touched {background-color:#88f;}
 
 .tablet.ios .kmw-banner-bar {background-color: #cfd3d9}
-.tablet.ios .kmw-banner-bar .kmw-suggest-option {background-color: #cfd3d9; display:inline-block; vertical-align:middle;}
-.tablet.ios .kmw-suggestion-text {color:#000; background-color:#fdfdfe; text-align: center;}
+.tablet.ios .kmw-banner-bar .kmw-suggest-option {background-color: #fdfdfe; display:inline-block; vertical-align:middle; border-radius: 5px;}
+.tablet.ios .kmw-suggestion-text {color:#000; text-align: center;}
 
 .tablet .kmw-key-row {-webkit-touch-callout:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 
@@ -113,7 +113,7 @@
 .tablet.android .kmw-spacebar-caption {color: #888;}         
 
 .tablet.android .kmw-banner-bar {background-color: #b4b4b8; height: 40px; width: 100%;}
-.tablet.android .kmw-banner-bar .kmw-suggest-option {background-color: #b4b4b8; display:inline-block; vertical-align: middle;}
+.tablet.android .kmw-banner-bar .kmw-suggest-option {background-color: #b4b4b8; display:inline-block; vertical-align: middle; border-radius: 5px}
 .tablet.android .kmw-suggestion-text {color:#77f; background-color: #b4b4b8; text-align: center;}
 
 /* Vertical centering of text labels on keys */ 
@@ -157,8 +157,8 @@
 
 .kmw-banner-container{width:100%; margin:0;}
 .kmw-banner-bar{height:40px; width:100%; margin:0; background-color:darkorange;}
-.kmw-banner-bar .kmw-suggest-option {background-color: orange; display:inline-block; vertical-align: middle; text-align: center}
-.kmw-suggestion-text{color:#ffff; background-color: orange; text-align: center; width: 95%}
+.kmw-banner-bar .kmw-suggest-option {background-color: orange; display:inline-block; vertical-align: middle; text-align: center; border-radius: 5px}
+.kmw-suggestion-text{color:#ffff; text-align: center; width: 95%}
 
 
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -175,6 +175,24 @@ namespace com.keyman.text {
       this._dks = original._dks.clone();
     }
 
+    apply(transform: Transform) {
+      if(transform.deleteRight) {
+        this.setTextAfterCaret(this.getTextAfterCaret()._kmwSubstr(transform.deleteRight));
+      }
+
+      if(transform.deleteLeft) {
+        this.deleteCharsBeforeCaret(transform.deleteLeft);
+      }
+
+      if(transform.insert) {
+        this.insertTextBeforeCaret(transform.insert);
+      }
+
+      // We assume that all deadkeys are invalidated after applying a Transform, since
+      // prediction implies we'll be completing a word, post-deadkeys.
+      this._dks.clear();
+    }
+
     /**
      * Helper to `restoreTo` - allows directly setting the 'before' context to that of another
      * `OutputTarget`.

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -163,6 +163,37 @@ namespace com.keyman.text {
     }
 
     /**
+     * Restores the `OutputTarget` to the indicated state.  Designed for use with `Transcription.preInput`.
+     * @param original An `OutputTarget` (usually a `Mock`).
+     */
+    restoreTo(original: OutputTarget) {
+      //
+      this.setTextBeforeCaret(original.getTextBeforeCaret());
+      this.setTextAfterCaret(original.getTextAfterCaret());
+
+      // Also, restore the deadkeys!
+      this._dks = original._dks.clone();
+    }
+
+    /**
+     * Helper to `restoreTo` - allows directly setting the 'before' context to that of another
+     * `OutputTarget`.
+     * @param s 
+     */
+    protected setTextBeforeCaret(s: string): void {
+      // This one's easy enough to provide a default implementation for.
+      this.deleteCharsBeforeCaret(this.getTextBeforeCaret()._kmwLength());
+      this.insertTextBeforeCaret(s);
+    }
+
+    /**
+     * Helper to `restoreTo` - allows directly setting the 'after' context to that of another
+     * `OutputTarget`.
+     * @param s 
+     */
+    protected abstract setTextAfterCaret(s: string): void;
+
+    /**
      * Returns the underlying element / document modeled by the wrapper.
      */
     abstract getElement(): HTMLElement;
@@ -316,6 +347,10 @@ namespace com.keyman.text {
     insertTextBeforeCaret(s: string): void {
       this.text = this.getTextBeforeCaret() + s + this.getTextAfterCaret();
       this.caretIndex += s.kmwLength();
+    }
+
+    protected setTextAfterCaret(s: string): void {
+      this.text = this.getTextBeforeCaret() + s;
     }
   }
 }

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -251,6 +251,21 @@ namespace com.keyman.text.prediction {
       }
     }
 
+    /**
+     * Retrieves the context and output state of KMW immediately before the prediction with 
+     * token `id` was generated.  Must correspond to a 'recent' one, as only so many are stored
+     * in `ModelManager`'s history buffer.
+     * @param id A unique identifier corresponding to a recent `Transcription`.
+     * @returns The matching `Transcription`, or `null` none is found.
+     */
+    public getPredictionState(id: number): Transcription {
+      let match = this.recentTranscriptions.filter(function(t: Transcription) {
+        return t.token == id;
+      })
+
+      return match.length == 0 ? null : match[0];
+    }
+
     public shutdown() {
       this.lmEngine.shutdown();
     }


### PR DESCRIPTION
When complete, this PR will allow active use of the `SuggestionBanner` UI, allowing a user to apply LMLayer-generated predictions.

Done:
- Restoring an `OutputTarget`'s context to the state that generated the prediction request
- Applying a `Suggestion`'s `Transcription` to a destination `OutputTarget`
- Some refactoring of the new `SuggestionBanner` and some enhanced styling.
  - Styling is likely not permanent, but will at least make the interactive area more clear than otherwise.

Note that #1714, which is based on this PR, implements touch interactivity.