### PR TITLE
[LMLayer] Batch mode for CLI

### DIFF
--- a/common/test/predictive-text/README.md
+++ b/common/test/predictive-text/README.md
@@ -8,18 +8,29 @@ Install
 
 **NOTE**: Requires Node >= 10.0
 
-Install locally with `npm`:
+First, ensure that Keyman web and the LMLayer are built. You can run the
+build script in `/web/source` to do this for you:
+
+    cd ../../../web/source
+    ./build.sh
+
+Then, you can install locally with `npm`:
 
     npm install
 
-You can install globally like so:
+Or you can install globally like so:
 
     npm install -g .
+
+When installed globally, you can invoke the CLI using the `lmlayer-cli`
+command.
 
 Usage
 -----
 
-Start it like so:
+### Interactive mode
+
+Start it in interactive mode like so:
 
     $ ./index.js -f path/to/model.js  # local
     $ lmlayer-cli . -f path/to/model.js  # global
@@ -37,6 +48,30 @@ language.
 > He
 [Hello] [Hey] [He he]
 ```
+
+### Batch mode
+
+Instead of using `lmlayer-cli` interactively, you can give the model one
+or more phrases in batch mode. Either pass in a newline-separated file
+with `-i`, or one or more phrases with `-p`. You can also pipe input to
+`lmlayer-cli`, and it will read each line as a phrase.
+
+```sh
+$ lmlayer-cli author.bcp47.uniq -p "a test phrase" -p "another test phrase"
+$ lmlayer-cli author.bcp47.unq -i my-test-file.txt
+$ echo "anything from stdin" | lmlayer-cli author.bcp47.uniq
+```
+
+The output is tab-separated, with the first column being the input, and
+the remaining columns being the suggestions, e.g.,
+
+```sh
+$ lmlayer-cli example.en.wordlist -p "d"
+d      dinosaur        dumbo octopus
+$ echo "c" | "lmlayer-cli example.en.wordlist
+c      cat     cheetah
+```
+
 
 Defining the `LMPATH` environment variable
 ------------------------------------------

--- a/common/test/predictive-text/index.js
+++ b/common/test/predictive-text/index.js
@@ -49,12 +49,15 @@ function main() {
   program
     .name(require('./package.json').name)
     .version(require('./package.json').version)
-    .usage('[-i <test-file> | -s <string>] (-f <model-file> | <model-id>)')
+    .usage('[-i <test-file> | -p <phrase> [-p <phrase> ...]] (-f <model-file> | <model-id>)')
     .description('CLI for trying lexical models.')
     .arguments('[model-id]')
     .option('-f, --model-file <file>', 'path to model file')
-    .option('-i, --test-file <file>', 'path to test file')
-    .option('-s, --string <string>', 'string to test against the model')
+    .option('-i, --test-file <file>', 'path to file containing newline-delimited phrases')
+    .option('-p, --phrase <phrase>',
+      'phrase to test against the model. Can be provided multiple times.',
+      createArrayOfPhrases, []  // allow for one or more phrases
+    )
     .parse(process.argv);
 
   // Find the model.
@@ -376,6 +379,15 @@ function createAsyncWorker() {
 ///////////////////////////////// Utilities /////////////////////////////////
 
 /**
+ * Callback function for Commander.js to store multiple arguments for the
+ * --phrase argument.
+ */
+function createArrayOfPhrases(val, array) {
+  array.push(val);
+  return array;
+}
+
+/**
  * Return the context when the cursor is at the end of the given string.
  */
 function contextFromString(string) {
@@ -420,11 +432,11 @@ function determineModelFile(program) {
  * Determine which mode to run in. Reads in data, if necessary.
  */
 function determineMode(program) {
-  if (program.string) {
+  if (program.phrase) {
     return {
       mode: 'batch',
-      // The input is a single provided string.
-      data: [program.string]
+      // 'phrase' is an array of phrases!
+      data: program.phrase
     };
   }
 

--- a/common/test/predictive-text/index.js
+++ b/common/test/predictive-text/index.js
@@ -46,14 +46,21 @@ main();
 function main() {
   // Command line options:
   program
+    .name(require('./package.json').name)
     .version(require('./package.json').version)
-    .usage('(-f <model-file> | <model-id>)')
+    .usage('[-i <test-file> | -s <string>] (-f <model-file> | <model-id>)')
     .description('CLI for trying lexical models.')
     .arguments('[model-id]')
     .option('-f, --model-file <file>', 'path to model file')
+    .option('-i, --test-file <file>', 'path to test file')
+    .option('-s, --string <string>', 'string to test against the model')
     .parse(process.argv);
 
   let modelFile = determineModelFile(program);
+
+  if (program.testFile || program.string) {
+    throw new Error('Not implemented');
+  }
 
   // Ensure we're running in the terminal
   if (!process.stdin.isTTY) {

--- a/common/test/predictive-text/index.js
+++ b/common/test/predictive-text/index.js
@@ -423,22 +423,15 @@ function determineMode(program) {
   if (program.string) {
     return {
       mode: 'batch',
-      // test on the single provided string.
+      // The input is a single provided string.
       data: [program.string]
     };
   }
 
   if (program.testFile) {
-    let file = fs.readFileSync(program.testFile, 'UTF-8');
-    let lines = file.split('\n');
-
-    // Remove trailing empty line, caused be last newline.
-    if (file[file.length - 1] === '\n')
-      lines.pop();
-
     return {
       mode: 'batch',
-      data: lines
+      data: slurpLinesFromFile(program.testFile)
     };
   }
 
@@ -446,18 +439,29 @@ function determineMode(program) {
     return { mode: 'interactive' };
   } else {
     // Batch mode from stdin. Slurp all of stdin synchronously; fd 0 is stdin.
-    let file = fs.readFileSync(0, 'UTF-8');
-    let lines = file.split('\n');
-
-    // Remove trailing empty line, caused be last newline.
-    if (file[file.length - 1] === '\n')
-      lines.pop();
-
+    const STDIN_FD = 0;
     return {
       mode: 'batch',
-      data: lines
+      data: slurpLinesFromFile(STDIN_FD)
     };
   }
+}
+
+/**
+ * Given a file path as a string or a file descriptor as an integer,
+ * synchronously reads the file, and returns an Array of its lines, minus the
+ * trailing newline.
+ */
+function slurpLinesFromFile(input) {
+  let file = fs.readFileSync(input, 'UTF-8');
+  let lines = file.split('\n');
+
+  // Remove trailing empty line, caused be last newline.
+  if (file[file.length - 1] === '\n') {
+    lines.pop();
+  }
+
+  return lines;
 }
 
 /**

--- a/common/test/predictive-text/package.json
+++ b/common/test/predictive-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmlayer-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Command line interface to the predictive text engine.",
   "main": "index.js",
   "bin": "./index.js",


### PR DESCRIPTION
Adds batch mode, invokable three ways:

```sh
$ lmlayer-cli author.bcp47.uniq -p "a test phrase" -p "another test phrase"
$ lmlayer-cli author.bcp47.uniq -i my-test-file.txt
$ echo "anything from stdin" | lmlayer-cli author.bcp47.uniq
```

The output is tab-separated, with the first column being the input, and the remaining columns being the suggestions, e.g.,

```sh
$ lmlayer-cli example.en.wordlist -p "d"
d      dinosaur        dumbo octopus
$ echo "c" | lmlayer-cli example.en.wordlist
c      cat     cheetah
```

Resolves #1726.