### PR TITLE
[Android] Accommodate dimension for device banner

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -240,26 +240,6 @@
       window.location.hash = 'hideKeyboard' + fragmentToggle;
     }
 
-    function setBanner(bannerType) {
-    /*
-      var kmw = com.keyman.singleton;
-      var banner = kmw.osk.banner;
-      if (bannerType == 'blank') {
-        banner.setBanner('blank');
-      } else if (bannerType == 'suggestion') {
-        banner.setOptions({
-          'persistentBanner': false,
-          'enablePredictions': true
-        });
-        banner.setBanner('suggestion', bannerHeight);
-
-        // TODO: Remove for production. For testing integration of suggestion banner
-        window.console.log('Embedded setBanner to ' + bannerHeight);
-        // kmw.osk.banner.activeBanner.updateSuggestions([{displayAs: 'alpha'}, {displayAs: 'bravo'}, {displayAs: 'charlie'}]);
-      }
-      */
-    }
-
     function showHelpBubble() {
       fragmentToggle = (fragmentToggle + 1) % 100;
       var kmw = window['keyman'];

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -1,6 +1,6 @@
 <html>
 <!--
- Copyright (C) 2017-2018 SIL International. All rights reserved.
+ Copyright (C) 2017-2019 SIL International. All rights reserved.
 -->
 
 <head>
@@ -32,23 +32,32 @@
       var ta = document.getElementById('ta');
       kmw['setActiveElement'](ta);
 
-      setBanner('blank');
       ta.readOnly = false;
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
       kmw.addEventListener('keyboardchange', setIsChiral);
+      kmw.addEventListener('mm.modelchange', onModelChange);
     }
 
     function setOskHeight(h) {
       if(h > 0) {
         oskHeight = h;
+        bannerHeight = window.jsInterface.getBannerHeight();
+        window.console.log('Embedded setOskHeight: ' + bannerHeight + ', ' + oskHeight);
       }
       var kmw=window['keyman'];
       kmw['correctOSKTextSize']();
       window.console.log('Embedded done with correctOSKTextSize');
     }
 
+    function setBannerHeight(h) {
+      if (h > 0) {
+        bannerHeight = h;
+      }
+    }
+
     function getBannerHeight() {
+      window.console.log('Embedded getBannerHeight: '+bannerHeight);
       return bannerHeight;
     }
 
@@ -73,6 +82,12 @@
 
     function beepKeyboard() {
       window.jsInterface.beepKeyboard();
+    }
+
+    function onModelChange(change) {
+      var loaded = change == 'loaded' ? true : false;
+      window.console.log('onModelChange change: ' + change + ', loaded: ' + loaded);
+      window.jsInterface.onModelChange(loaded);
     }
 
     // Query KMW if a given keyboard uses chiral modifiers.
@@ -133,20 +148,20 @@
     function insertText(dn, s) {
       //window.console.log('insertText('+ dn +', ' + s +');');
       window.jsInterface.insertText(dn, s);
+    }
 
-      // TODO: Remove for production: Testing
-      var kmw=com.keyman.singleton;
-      if (s == 'b') {
-        setBanner('blank');
-      } else if (s == 's') {
-        setBanner('suggestion');
-        kmw.osk.banner.activeBanner.updateSuggestions([{displayAs: 'insertAlpha'}, {displayAs: 'insertBeta'}, {displayAs: 'insertCharlie'}]);
-      }
+    function enableSuggestions(model) {
+      bannerHeight = window.jsInterface.getBannerHeight();
+      //setOskHeight(oskHeight);
+
+      var kmw=window['keyman'];
+
+      registerModel(model);
     }
 
     function registerModel(model) {
       var kmw=window['keyman'];
-      window.console.log('model: ' + model);
+      window.console.log('registerModel: ' + model);
       kmw.registerModel(model);
     }
 
@@ -226,25 +241,23 @@
     }
 
     function setBanner(bannerType) {
+    /*
       var kmw = com.keyman.singleton;
       var banner = kmw.osk.banner;
       if (bannerType == 'blank') {
-        banner.setOptions({
-          'persistentBanner': false,
-          'enablePredictions': false
-        });
         banner.setBanner('blank');
       } else if (bannerType == 'suggestion') {
         banner.setOptions({
-          'persistentBanner': true,
+          'persistentBanner': false,
           'enablePredictions': true
         });
         banner.setBanner('suggestion', bannerHeight);
 
         // TODO: Remove for production. For testing integration of suggestion banner
         window.console.log('Embedded setBanner to ' + bannerHeight);
-        kmw.osk.banner.activeBanner.updateSuggestions([{displayAs: 'alpha'}, {displayAs: 'bravo'}, {displayAs: 'charlie'}]);
+        // kmw.osk.banner.activeBanner.updateSuggestions([{displayAs: 'alpha'}, {displayAs: 'bravo'}, {displayAs: 'charlie'}]);
       }
+      */
     }
 
     function showHelpBubble() {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -10,7 +10,8 @@
   <script src="keyman.js"></script>
   <script type="text/javascript">
     var device = window.jsInterface.getDeviceType();
-    var defaultBannerHeight = Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
+    var defaultBannerHeight =
+      Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
     var oskHeight = window.jsInterface.getKeyboardHeight();
     var oskWidth = 0;
     window.addEventListener('load', init, false);
@@ -33,6 +34,7 @@
 
       ta.readOnly = false;
 
+      // Tell KMW the default banner height to use
       com.keyman.osk.Banner.DEFAULT_HEIGHT = defaultBannerHeight;
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
@@ -46,7 +48,6 @@
       }
       var kmw=window['keyman'];
       kmw['correctOSKTextSize']();
-      window.console.log('Embedded done with correctOSKTextSize');
     }
 
     function setOskWidth(w) {
@@ -56,7 +57,6 @@
     }
 
     function getOskHeight() {
-      window.console.log('Embedded getOskHeight: '+oskHeight);
       return oskHeight;
     }
 

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -10,7 +10,7 @@
   <script src="keyman.js"></script>
   <script type="text/javascript">
     var device = window.jsInterface.getDeviceType();
-    var bannerHeight = window.jsInterface.getBannerHeight();
+    var defaultBannerHeight = Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
     var oskHeight = window.jsInterface.getKeyboardHeight();
     var oskWidth = 0;
     window.addEventListener('load', init, false);
@@ -25,7 +25,6 @@
       kmw['oninserttext'] = insertText;
       kmw['showKeyboardList'] = showMenu;
       kmw['hideKeyboard'] = hideKeyboard;
-      kmw['getBannerHeight'] = getBannerHeight;
       kmw['getOskHeight'] = getOskHeight;
       kmw['getOskWidth'] = getOskWidth;
       kmw['beepKeyboard'] = beepKeyboard;
@@ -33,6 +32,8 @@
       kmw['setActiveElement'](ta);
 
       ta.readOnly = false;
+
+      com.keyman.osk.Banner.DEFAULT_HEIGHT = defaultBannerHeight;
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
       kmw.addEventListener('keyboardchange', setIsChiral);
@@ -42,23 +43,10 @@
     function setOskHeight(h) {
       if(h > 0) {
         oskHeight = h;
-        bannerHeight = window.jsInterface.getBannerHeight();
-        window.console.log('Embedded setOskHeight: ' + bannerHeight + ', ' + oskHeight);
       }
       var kmw=window['keyman'];
       kmw['correctOSKTextSize']();
       window.console.log('Embedded done with correctOSKTextSize');
-    }
-
-    function setBannerHeight(h) {
-      if (h > 0) {
-        bannerHeight = h;
-      }
-    }
-
-    function getBannerHeight() {
-      window.console.log('Embedded getBannerHeight: '+bannerHeight);
-      return bannerHeight;
     }
 
     function setOskWidth(w) {
@@ -87,6 +75,10 @@
     function onModelChange(change) {
       var loaded = change == 'loaded' ? true : false;
       window.console.log('onModelChange change: ' + change + ', loaded: ' + loaded);
+
+      var kmw=window['keyman'];
+      kmw['correctOSKTextSize']();
+
       window.jsInterface.onModelChange(loaded);
     }
 
@@ -151,11 +143,6 @@
     }
 
     function enableSuggestions(model) {
-      bannerHeight = window.jsInterface.getBannerHeight();
-      //setOskHeight(oskHeight);
-
-      var kmw=window['keyman'];
-
       registerModel(model);
     }
 

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -73,13 +73,14 @@
     }
 
     function onModelChange(change) {
-      var loaded = change == 'loaded' ? true : false;
-      window.console.log('onModelChange change: ' + change + ', loaded: ' + loaded);
+      //window.console.log('onModelChange change: ' + change);
 
+      // Refresh KMW OSK
       var kmw=window['keyman'];
       kmw['correctOSKTextSize']();
 
-      window.jsInterface.onModelChange(loaded);
+      fragmentToggle = (fragmentToggle + 1) % 100;
+      window.location.hash = 'refreshBannerHeight-'+fragmentToggle+'+change='+change;
     }
 
     // Query KMW if a given keyboard uses chiral modifiers.

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -138,9 +138,16 @@
       kmw['osk']['show'](true);
     }
 
-    function insertText(dn, s) {
-      //window.console.log('insertText('+ dn +', ' + s +');');
-      window.jsInterface.insertText(dn, s);
+    /**
+     * Inserts the selected string <i>s</i>
+     * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+     * @param s   Text to insert
+     * @param dr  Number of post-caret code points to delete.  (optional)
+     */
+    function insertText(dn, s, dr) {
+      dr = dr || 0; // Sets a default value of zero when dr is undefined
+      //window.console.log('insertText('+ dn +', ' + s +', ' + dr + ');');
+      window.jsInterface.insertText(dn, s, dr);
     }
 
     function enableSuggestions(model) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -10,8 +10,6 @@
   <script src="keyman.js"></script>
   <script type="text/javascript">
     var device = window.jsInterface.getDeviceType();
-    var defaultBannerHeight =
-      Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
     var oskHeight = window.jsInterface.getKeyboardHeight();
     var oskWidth = 0;
     window.addEventListener('load', init, false);
@@ -35,11 +33,23 @@
       ta.readOnly = false;
 
       // Tell KMW the default banner height to use
-      com.keyman.osk.Banner.DEFAULT_HEIGHT = defaultBannerHeight;
+      com.keyman.osk.Banner.DEFAULT_HEIGHT = 
+        Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
       kmw.addEventListener('keyboardchange', setIsChiral);
       kmw.addEventListener('mm.modelchange', onModelChange);
+    }
+
+    // Update the KMW banner height
+    function setBannerHeight(h) {
+      if (h > 0) {
+        var kmw=com.keyman.singleton;
+        var osk = kmw.osk;
+        osk.banner.height = Math.ceil(h / window.devicePixelRatio);
+      }
+      // Refresh KMW OSK
+      kmw.correctOSKTextSize();
     }
 
     function setOskHeight(h) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -232,6 +232,8 @@ final class KMKeyboard extends WebView {
     super.onConfigurationChanged(newConfig);
     dismissKeyPreview(0);
     dismissSubKeysWindow();
+    int bannerHeight = KMManager.getBannerHeight(context);
+    loadUrl(String.format("javascript:setBannerHeight(%d)", bannerHeight));
     loadUrl(String.format("javascript:setOskWidth(%d)", newConfig.screenWidthDp));
     loadUrl("javascript:setOskHeight(0)");
     if (dismissHelpBubble()) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -70,21 +70,6 @@ public abstract class KMKeyboardJSHandler {
     }
   }
 
-  // This annotation is required in Jelly Bean and later:
-  @JavascriptInterface
-  public void onModelChange(boolean loaded) {
-    Log.d(TAG, "onModelChange");
-    if (loaded) {
-      KMManager.setCurrentBanner("suggestion");
-    } else {
-      KMManager.setCurrentBanner("blank");
-    }
-
-    // TODO: Implement any updates when lexical model is loaded
-    //RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
-    //k.setLayoutParams(params);
-  }
-
   // Store the current keyboard chirality status from KMW in the Keyboard
   @JavascriptInterface
   public void setIsChiral(boolean isChiral) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -81,7 +81,12 @@ public abstract class KMKeyboardJSHandler {
   @JavascriptInterface
   public  abstract boolean dispatchKey(final int code, final int eventModifiers);
 
-  // Insert the selected string s
+  /**
+   * Inserts the selected string <i>s</i>
+   * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+   * @param s   Text to insert
+   * @param dr  Number of post-caret code points to delete.
+   */
   @JavascriptInterface
-  public abstract void insertText(final int dn, final String s);
+  public abstract void insertText(final int dn, final String s, final int dr);
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -5,7 +5,9 @@ import android.os.Build;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.webkit.JavascriptInterface;
+import android.widget.RelativeLayout;
 
 import static android.content.Context.VIBRATOR_SERVICE;
 
@@ -13,6 +15,7 @@ public abstract class KMKeyboardJSHandler {
   private Context context;
   private KMKeyboard k = null;
   private static int KM_VIBRATE_DURATION = 100; // milliseconds
+  private static String TAG = "KMKeyboardJSHandler";
 
   KMKeyboardJSHandler(Context context, KMKeyboard k) {
     this.context = context;
@@ -28,15 +31,14 @@ public abstract class KMKeyboardJSHandler {
   // This annotation is required in Jelly Bean and later:
   @JavascriptInterface
   public int getBannerHeight() {
-    int bannerHeight = context.getResources().getDimensionPixelSize(R.dimen.banner_height);
-    //bannerHeight -= bannerHeight % 20;
-    return bannerHeight;
+    return KMManager.getBannerHeight(context);
   }
 
+  // Get the keyboard height
   // This annotation is required in Jelly Bean and later:
   @JavascriptInterface
   public int getKeyboardHeight() {
-    int kbHeight = context.getResources().getDimensionPixelSize(R.dimen.keyboard_height);
+    int kbHeight = KMManager.getKeyboardHeight(context);
     kbHeight -= kbHeight % 20;
     return kbHeight;
   }
@@ -61,6 +63,21 @@ public abstract class KMKeyboardJSHandler {
         v.vibrate(KM_VIBRATE_DURATION);
       }
     }
+  }
+
+  // This annotation is required in Jelly Bean and later:
+  @JavascriptInterface
+  public void onModelChange(boolean loaded) {
+    Log.d(TAG, "onModelChange");
+    if (loaded) {
+      KMManager.setCurrentBanner("suggestion");
+    } else {
+      KMManager.setCurrentBanner("blank");
+    }
+
+    // TODO: Implement any updates when lexical model is loaded
+    //RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
+    //k.setLayoutParams(params);
   }
 
   // Store the current keyboard chirality status from KMW in the Keyboard

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -34,6 +34,11 @@ public abstract class KMKeyboardJSHandler {
     return KMManager.getBannerHeight(context);
   }
 
+  @JavascriptInterface
+  public int getDefaultBannerHeight() {
+    return (int) context.getResources().getDimension(R.dimen.banner_height);
+  }
+
   // Get the keyboard height
   // This annotation is required in Jelly Bean and later:
   @JavascriptInterface

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -30,11 +30,6 @@ public abstract class KMKeyboardJSHandler {
 
   // This annotation is required in Jelly Bean and later:
   @JavascriptInterface
-  public int getBannerHeight() {
-    return KMManager.getBannerHeight(context);
-  }
-
-  @JavascriptInterface
   public int getDefaultBannerHeight() {
     return (int) context.getResources().getDimension(R.dimen.banner_height);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -241,7 +241,7 @@ public final class KMManager {
    * @return RelativeLayout.LayoutParams
    */
   private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
-    int bannerHeight = currentBanner.equals("suggestion") ? getBannerHeight(appContext) : 0;
+    int bannerHeight = getBannerHeight(appContext);
     int kbHeight = getKeyboardHeight(appContext);
     RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
       RelativeLayout.LayoutParams.MATCH_PARENT, bannerHeight + kbHeight);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -688,7 +688,6 @@ public final class KMManager {
     model = model.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
     model = model.replaceAll("\"", "'");
 
-    currentBanner = "suggestion";
     RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
       InAppKeyboard.setLayoutParams(params);
@@ -1364,6 +1363,12 @@ public final class KMManager {
           hashMap.put("keyText", keyText);
           InAppKeyboard.subKeysList.add(hashMap);
         }
+      } else if (url.indexOf("refreshBannerHeight") >= 0) {
+        int start = url.indexOf("change=") + 7;
+        String change = url.substring(start);
+        currentBanner = (change.equals("loaded")) ? "suggestion" : "blank";
+        RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
+        InAppKeyboard.setLayoutParams(params);
       }
       return false;
     }
@@ -1534,8 +1539,13 @@ public final class KMManager {
           hashMap.put("keyText", keyText);
           SystemKeyboard.subKeysList.add(hashMap);
         }
+      } else if (url.indexOf("refreshBannerHeight") >= 0) {
+        int start = url.indexOf("change=") + 7;
+        String change = url.substring(start);
+        currentBanner = (change.equals("loaded")) ? "suggestion" : "blank";
+        RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
+        SystemKeyboard.setLayoutParams(params);
       }
-
       return false;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1580,7 +1580,11 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s) {
+    public void insertText(final int dn, final String s, final int dr) {
+      if(dr != 0) {
+        Log.d(TAG, "Right deletions requested but are not presently supported by the in-app keyboard.");
+      }
+
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
         public void run() {
@@ -1705,7 +1709,7 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s) {
+    public void insertText(final int dn, final String s, final int dr) {
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
         public void run() {
@@ -1725,6 +1729,7 @@ public final class KMManager {
 
           ic.beginBatchEdit();
 
+          // Delete any existing selected text.
           ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
           if (icText != null) { // This can be null if the input connection becomes invalid.
             int start = icText.startOffset + icText.selectionStart;
@@ -1749,6 +1754,7 @@ public final class KMManager {
             return;
           }
 
+          // Perform left-deletions
           for (int i = 0; i < dn; i++) {
             CharSequence chars = ic.getTextBeforeCursor(1, 0);
             if (chars != null && chars.length() > 0) {
@@ -1758,6 +1764,20 @@ public final class KMManager {
                 ic.deleteSurroundingText(2, 0);
               } else {
                 ic.deleteSurroundingText(1, 0);
+              }
+            }
+          }
+
+          // Perform right-deletions
+          for (int i = 0; i < dr; i++) {
+            CharSequence chars = ic.getTextAfterCursor(1, 0);
+            if (chars != null && chars.length() > 0) {
+              char c = chars.charAt(0);
+              SystemKeyboardShouldIgnoreSelectionChange = true;
+              if (Character.isHighSurrogate(c)) {
+                ic.deleteSurroundingText(0, 2);
+              } else {
+                ic.deleteSurroundingText(0, 1);
               }
             }
           }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -235,10 +235,16 @@ public final class KMManager {
     return false;
   }
 
+  /**
+   * Adjust the keyboard dimensions. If the suggestion banner is active, use the
+   * combined banner height and keyboard height
+   * @return RelativeLayout.LayoutParams
+   */
   private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
     int bannerHeight = currentBanner.equals("suggestion") ? getBannerHeight(appContext) : 0;
     int kbHeight = getKeyboardHeight(appContext);
-    RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, bannerHeight + kbHeight);
+    RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
+      RelativeLayout.LayoutParams.MATCH_PARENT, bannerHeight + kbHeight);
     params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
    return params;
   }
@@ -655,6 +661,10 @@ public final class KMManager {
     return KeyboardPickerActivity.getKeyboardsList(context);
   }
 
+  public static void setCurrentBanner(String banner) {
+    currentBanner = banner;
+  }
+
   public static boolean registerLexicalModel(HashMap<String, String> lexicalModelInfo) {
     String pkgID = lexicalModelInfo.get(KMKey_PackageID);
     String modelID = lexicalModelInfo.get(KMKey_LexicalModelID);
@@ -682,11 +692,11 @@ public final class KMManager {
     RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
       InAppKeyboard.setLayoutParams(params);
-      InAppKeyboard.loadUrl(String.format("javascript:registerModel(%s)", model));
+      InAppKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s)", model));
     }
     if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
       SystemKeyboard.setLayoutParams(params);
-      SystemKeyboard.loadUrl(String.format("javascript:registerModel(%s)", model));
+      SystemKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s)", model));
     }
     return true;
   }
@@ -950,11 +960,16 @@ public final class KMManager {
   }
 
   public static int getBannerHeight(Context context) {
-    return (int) context.getResources().getDimension(R.dimen.banner_height);
+    int bannerHeight = 0;
+    if (currentBanner.equals("suggestion")) {
+      bannerHeight = (int) context.getResources().getDimension(R.dimen.banner_height);
+    }
+    return bannerHeight;
   }
 
   public static int getKeyboardHeight(Context context) {
-    return (int) context.getResources().getDimension(R.dimen.keyboard_height);
+    int kbHeight = (int) context.getResources().getDimension(R.dimen.keyboard_height);
+    return kbHeight;
   }
 
   public static void setDebugMode(boolean value) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -661,10 +661,6 @@ public final class KMManager {
     return KeyboardPickerActivity.getKeyboardsList(context);
   }
 
-  public static void setCurrentBanner(String banner) {
-    currentBanner = banner;
-  }
-
   public static boolean registerLexicalModel(HashMap<String, String> lexicalModelInfo) {
     String pkgID = lexicalModelInfo.get(KMKey_PackageID);
     String modelID = lexicalModelInfo.get(KMKey_LexicalModelID);
@@ -967,8 +963,7 @@ public final class KMManager {
   }
 
   public static int getKeyboardHeight(Context context) {
-    int kbHeight = (int) context.getResources().getDimension(R.dimen.keyboard_height);
-    return kbHeight;
+    return (int) context.getResources().getDimension(R.dimen.keyboard_height);
   }
 
   public static void setDebugMode(boolean value) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -345,9 +345,13 @@ public final class KMManager {
   public static void onConfigurationChanged(Configuration newConfig) {
     // KMKeyboard
     if (InAppKeyboard != null) {
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
+      InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.onConfigurationChanged(newConfig);
     }
     if (SystemKeyboard != null) {
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
+      SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.onConfigurationChanged(newConfig);
     }
   }

--- a/android/KMEA/app/src/main/res/values-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Landscape (Phone) -->
 <resources>
-    <dimen name="banner_height">60dp</dimen>
+    <dimen name="banner_height">50dp</dimen>
     <dimen name="keyboard_height">205dp</dimen>
     <dimen name="key_width">49.25dp</dimen>
     <dimen name="key_height">49.25dp</dimen>

--- a/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Landscape (Tablet 7") -->
 <resources>
-    <dimen name="banner_height">80dp</dimen>
+    <dimen name="banner_height">60dp</dimen>
     <dimen name="keyboard_height">305dp</dimen>
     <dimen name="key_width">73.5dp</dimen>
     <dimen name="key_height">58.5dp</dimen>

--- a/android/KMEA/app/src/main/res/values-sw600dp/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Default or Portrait (Tablet 7") -->
 <resources>
+    <dimen name="banner_height">60dp</dimen>
     <dimen name="keyboard_height">305dp</dimen>
     <dimen name="key_width">58.5dp</dimen>
     <dimen name="key_height">73.5dp</dimen>

--- a/android/KMEA/app/src/main/res/values/dimens.xml
+++ b/android/KMEA/app/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Default or Portrait (Phone) -->
 <resources>
-    <dimen name="banner_height">60dp</dimen>
+    <dimen name="banner_height">50dp</dimen>
     <dimen name="keyboard_height">205dp</dimen>
     <dimen name="key_width">34.25dp</dimen>
     <dimen name="key_height">49.25dp</dimen>

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -45,6 +45,8 @@ die ( ) {
 DO_BUILD=true
 DO_COPY=true
 NO_DAEMON=false
+EMBED_BUILD=-embed
+KMW_PATH=
 
 # Parse args
 while [[ $# -gt 0 ]] ; do
@@ -61,6 +63,11 @@ while [[ $# -gt 0 ]] ; do
         -no-daemon)
             NO_DAEMON=true
             ;;
+        -debug)
+            DEBUG_BUILD=true
+            EMBED_BUILD=-debug_embedded
+            KMW_PATH=unminified
+            ;;
         -h|-?)
             display_usage
             ;;
@@ -72,6 +79,9 @@ echo
 echo "DO_BUILD: $DO_BUILD"
 echo "DO_COPY: $DO_COPY"
 echo "NO_DAEMON: $NO_DAEMON"
+echo "DEBUG_BUILD: $DEBUG_BUILD"
+echo "EMBED_BUILD: $EMBED_BUILD"
+echo "KMW_PATH: $KMW_PATH"
 echo
 
 if [ "$NO_DAEMON" = true ]; then
@@ -91,7 +101,7 @@ if [ "$DO_BUILD" = true ]; then
     echo "Building keyman web engine"
     cd $KMW_SOURCE
 
-    ./build.sh -embed
+    ./build.sh $EMBED_BUILD
 	
     if [ $? -ne 0 ]; then
         die "ERROR: keymanweb build failed. Exiting"
@@ -99,14 +109,18 @@ if [ "$DO_BUILD" = true ]; then
 fi
 if [ "$DO_COPY" = true ]; then
     echo "Copying KMW artifacts"
-    cp $KMW_ROOT/release/embedded/resources/osk/ajax-loader.gif $KMEA_ASSETS/ajax-loader.gif
-    cp $KMW_ROOT/release/embedded/keyman.js $KMEA_ASSETS/keyman.js
-    cp $KMW_ROOT/release/embedded/resources/osk/kmwosk.css $KMEA_ASSETS/kmwosk.css
-    cp $KMW_ROOT/release/embedded/resources/osk/keymanweb-osk.eot $KMEA_ASSETS/keymanweb-osk.eot
-    cp $KMW_ROOT/release/embedded/resources/osk/keymanweb-osk.ttf $KMEA_ASSETS/keymanweb-osk.ttf
-    cp $KMW_ROOT/release/embedded/resources/osk/keymanweb-osk.woff $KMEA_ASSETS/keymanweb-osk.woff
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/resources/osk/ajax-loader.gif $KMEA_ASSETS/ajax-loader.gif
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/keyman.js $KMEA_ASSETS/keyman.js
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/resources/osk/kmwosk.css $KMEA_ASSETS/kmwosk.css
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/resources/osk/keymanweb-osk.eot $KMEA_ASSETS/keymanweb-osk.eot
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/resources/osk/keymanweb-osk.ttf $KMEA_ASSETS/keymanweb-osk.ttf
+    cp $KMW_ROOT/release/$KMW_PATH/embedded/resources/osk/keymanweb-osk.woff $KMEA_ASSETS/keymanweb-osk.woff
     if [ $? -ne 0 ]; then
         die "ERROR: copying artifacts failed"
+    fi
+    if [ "$DEBUG_BUILD" = true ]; then
+      echo "Copying debug artifacts"
+      cp -R $KMW_ROOT/release/$KMW_PATH/embedded/* $KMEA_ASSETS/
     fi
 fi
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -260,9 +260,14 @@ extension KeymanWebViewController: WKScriptMessageHandler {
     if fragment.hasPrefix("#insertText-") {
       let dnRange = fragment.range(of: "+dn=")!
       let sRange = fragment.range(of: "+s=")!
+      let drRange = fragment.range(of: "+dr=")!
 
       let dn = Int(fragment[dnRange.upperBound..<sRange.lowerBound])!
-      let s = fragment[sRange.upperBound...]
+      let s = fragment[sRange.upperBound..<drRange.lowerBound]
+      // This computes the number of requested right-deletion characters.
+      // Use it when we're ready to implement that.
+      // Our .insertText will need to be adjusted accordingly.
+      _ = Int(fragment[drRange.upperBound...])!
 
       // KMW uses dn == -1 to perform special processing of deadkeys.
       // This is handled outside of Swift so we don't delete any characters.

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -83,10 +83,16 @@
             }
             
             var fragmentToggle = 0;
-            function insertText(dn, s) {
+            /**
+             * Inserts the selected string <i>s</i>
+             * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+             * @param s   Text to insert
+             * @param dr  Number of post-caret code points to delete.  (optional)
+             */
+            function insertText(dn, s, dr) {
+                dr = dr || 0;  // Sets a default value of zero when dr is undefined
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                var insertHash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
-                //window.location.hash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
+                var insertHash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s) + '+dr=' + dr;
                 if (typeof(window.webkit) != 'undefined')
                     window.webkit.messageHandlers.keyman.postMessage('#' + insertHash);
             }

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -264,7 +264,7 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -debug_embedded)
             set_default_vars
-            BUILD_EMBED=false
+            BUILD_EMBED=true
             BUILD_UI=false
             BUILD_COREWEB=false
             BUILD_FULLWEB=false

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -578,7 +578,12 @@ namespace com.keyman {
 
     // Functions that might be added later
     ['beepKeyboard']: () => void;
-    ['oninserttext']: (dn: number, s: string) => void;
+    /**
+     * @param {number}  dn  Number of pre-caret characters to delete
+     * @param {string}  s   Text to insert
+     * @param {number=}  dr  Number of post-caret characters to delete
+     */
+    ['oninserttext']: (dn: number, s: string, dr?: number) => void;
 
     /**
      * Create copy of the OSK that can be used for embedding in documentation or help

--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -378,7 +378,7 @@ namespace com.keyman {
 
       if(this.isKMWInput(Pelem)) {
         if(!this.isKMWDisabled(Pelem)) {
-          if(touchable) {
+          if(touchable && !this.keyman.isEmbedded) {
             this.enableTouchElement(Pelem);
           } else {
             this.enableInputElement(Pelem);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -134,7 +134,7 @@ namespace com.keyman.osk {
     let oskHeight : number = nRows*rowHeight;
 
     var b: HTMLElement = _Box, bs=b.style;
-    console.log("adjustHeights: bannerHeight " + bannerHeight + ", oskHeight " + oskHeight);
+    console.warn("adjustHeights: bannerHeight " + bannerHeight + ", oskHeight " + oskHeight);
     bs.height=bs.maxHeight=(bannerHeight + oskHeight+3)+'px';
     b = <HTMLElement> b.childNodes.item(1).firstChild;
     bs=b.style;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -217,7 +217,7 @@ namespace com.keyman.text {
     }
 
     // Use 'native'-mode defaults, determining the character from the OSK
-    return nativeDefaultKeyOutput.call(this, Lkc, keyShiftState, false);
+    return nativeDefaultKeyOutput.call(this, Lkc, keyShiftState, usingOSK);
   }
 }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -137,7 +137,6 @@ namespace com.keyman.osk {
     let oskHeight : number = nRows*rowHeight;
 
     var b: HTMLElement = _Box, bs=b.style;
-    console.warn("adjustHeights: bannerHeight " + bannerHeight + ", oskHeight " + oskHeight);
     bs.height=bs.maxHeight=(bannerHeight + oskHeight+3)+'px';
     b = <HTMLElement> b.childNodes.item(1).firstChild;
     bs=b.style;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -20,18 +20,19 @@ namespace com.keyman.osk {
    * 
    * @param {Object}  key   base key element
    */            
-  VisualKeyboard.prototype.touchHold = function(this: VisualKeyboard, key: KeyElement) { 
-    let util = com.keyman.singleton.util;       
+  VisualKeyboard.prototype.touchHold = function(this: VisualKeyboard, key: KeyElement) {
+    let util = com.keyman.singleton.util;
     if(key['subKeys'] && (typeof(window['oskCreatePopup']) == 'function')) {
-      var xBase=dom.Utils.getAbsoluteX(key)-dom.Utils.getAbsoluteX(this.kbdDiv)+key.offsetWidth/2,
-          yBase=dom.Utils.getAbsoluteY(key)-dom.Utils.getAbsoluteY(this.kbdDiv);      
+      let bannerHeight : number = com.keyman.singleton.osk.getBannerHeight();
+      var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
+          yBase = dom.Utils.getAbsoluteY(key) - dom.Utils.getAbsoluteY(this.kbdDiv) + bannerHeight;
       
       if(util.device.formFactor == 'phone') {
         this.prependBaseKey(key);
       }
 
       this.popupBaseKey = key;
-      this.popupPending=true;      
+      this.popupPending=true;
       window['oskCreatePopup'](key['subKeys'], xBase, yBase, key.offsetWidth, key.offsetHeight);
     }
   };
@@ -76,8 +77,10 @@ namespace com.keyman.osk {
     }
 
     if(on && (typeof showPreview == 'function')) {
-      var xBase=dom.Utils.getAbsoluteX(key)-dom.Utils.getAbsoluteX(this.kbdDiv)+key.offsetWidth/2,
-          yBase=dom.Utils.getAbsoluteY(key)-dom.Utils.getAbsoluteY(this.kbdDiv), kc;
+      let bannerHeight : number = com.keyman.singleton.osk.getBannerHeight();
+      var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
+          yBase = dom.Utils.getAbsoluteY(key) - dom.Utils.getAbsoluteY(this.kbdDiv) + bannerHeight,
+          kc;
 
       // Find key text element
       for(var i=0; i<key.childNodes.length; i++) {
@@ -88,7 +91,7 @@ namespace com.keyman.osk {
       }
         
       if(key.className.indexOf('kmw-key-default') >= 0 && key.id.indexOf('K_SPACE') < 0) {
-        showPreview(xBase,yBase,key.offsetWidth,key.offsetHeight,kc.innerHTML);
+        showPreview(xBase, yBase, key.offsetWidth, key.offsetHeight, kc.innerHTML);
       }
     } else if(!on && (typeof clearPreview == 'function')) {
       if(this.touchCount == 0 || key == null) {

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -134,12 +134,21 @@ namespace com.keyman.osk {
     let oskHeight : number = nRows*rowHeight;
 
     var b: HTMLElement = _Box, bs=b.style;
-    bs.height=bs.maxHeight=(bannerHeight+oskHeight+3)+'px';
+    console.log("adjustHeights: bannerHeight " + bannerHeight + ", oskHeight " + oskHeight);
+    bs.height=bs.maxHeight=(bannerHeight + oskHeight+3)+'px';
     b = <HTMLElement> b.childNodes.item(1).firstChild;
     bs=b.style;
+    // Sets the layer group to the correct height.
     bs.height=bs.maxHeight=(oskHeight+3)+'px';
+    if(device.OS == 'Android' && 'devicePixelRatio' in window) {
+      b.childNodes.forEach(function(layer: HTMLElement) {
+        layer.style.height = layer.style.maxHeight = (oskHeight+3)+'px';
+      });
+    }
+    // Sets the layers to the correct height 
     pad = Math.round(0.15*rowHeight);
 
+    bs.fontSize=fs+'em';
     var resizeLabels=(device.OS == 'iOS' && device.formFactor == 'phone' && util.landscapeView());
 
     for(nLayer=0;nLayer<layers.length; nLayer++) {
@@ -155,7 +164,7 @@ namespace com.keyman.osk {
         nKeys=keys.length;
         for(nKey=0;nKey<nKeys;nKey++) {
           key=keys[nKey];
-          // Must set the height of the text DIV, not the label (if any)
+          // Must set the height of the btn DIV, not the label (if any)
           for(j=0; j<key.childNodes.length; j++) {
             if(util.hasClass(key.childNodes[j],'kmw-key')) {
               break;

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -669,17 +669,6 @@ if(!window['keyman']['initialized']) {
     }
 
     /**
-     * Test code to set suggestion banner
-     * TODO: Remove from production
-     */
-    keymanweb['setBanner']=function() {
-      let keyman = com.keyman.singleton;
-      let osk = keyman.osk;
-      osk.banner.setBanner('suggestion');
-      osk.banner.setSuggestions();
-    };
-
-    /**
      * Possible way to detect the start of a rotation and hide the OSK before it is adjusted in size
      * 
      *  @param  {Object}    e   accelerometer rotation event      

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -8,7 +8,7 @@ namespace com.keyman.osk {
     private _height: number; // pixels
     private div: HTMLDivElement;
 
-    public static readonly DEFAULT_HEIGHT: number = 40; // pixels
+    public static DEFAULT_HEIGHT: number = 40; // pixels
     public static readonly BANNER_CLASS: string = 'kmw-banner-bar';
     public static readonly BANNER_ID: string = 'kmw-banner-bar';
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -239,8 +239,21 @@ namespace com.keyman.osk {
         }
 
         // Apply the Suggestion!
-        target.restoreTo(original.preInput);
-        target.apply(this.suggestion.transform);
+
+        // Step 1:  determine the final output text
+        let final = text.Mock.from(original.preInput);
+        final.apply(this.suggestion.transform);
+
+        // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
+        // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
+        // values as needed for use with their IME interfaces.
+        let transform = final.buildTransformFrom(target);
+        target.apply(transform);
+
+        // Signal the necessary text changes to the embedding app, if it exists.
+        if(keyman['oninserttext'] && keyman.isEmbedded) {
+          keyman['oninserttext'](transform.deleteLeft, transform.insert, transform.deleteRight);
+        }
       }
     }
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -281,14 +281,6 @@ namespace com.keyman.osk {
 
       // TODO:  Dynamic suggestion text resizing.  (Refer to OSKKey.getTextWidth in visualKeyboard.ts.)
 
-      if(keyman.isEmbedded && keyman.util.device.OS == 'Android') {
-        // TODO: Investigate the factor of "48"
-
-        let ss = s.style;
-        let oskManager = keyman.osk;
-        ss.top = oskManager.getBannerHeight() - 48 + 'px';
-      }
-
       // Finalize the suggestion text
       s.innerHTML = suggestionText;
       return s;

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -8,7 +8,8 @@ namespace com.keyman.osk {
     private _height: number; // pixels
     private div: HTMLDivElement;
 
-    public static DEFAULT_HEIGHT: number = 40; // pixels
+    public static DEFAULT_HEIGHT: number = 40; // pixels; embedded apps can modify
+
     public static readonly BANNER_CLASS: string = 'kmw-banner-bar';
     public static readonly BANNER_ID: string = 'kmw-banner-bar';
 

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -81,10 +81,17 @@ namespace com.keyman.osk {
     private constructContainer(): HTMLDivElement {
       let keymanweb = com.keyman.singleton;
       let util = keymanweb.util;
-
       let d = util._CreateElement('div');
       d.id = "keymanweb_banner_container";
       d.className = "kmw-banner-container";
+
+      /*
+      let oskManager = keymanweb.osk;
+      let bannerHeight : number = oskManager.getBannerHeight();
+      console.warn("constructContainer: bannerHeight " + bannerHeight);
+      let ds = d.style;
+      ds.height = ds.maxHeight = bannerHeight + 'px';
+      */
       return this.bannerContainer = d;
     }
 
@@ -193,17 +200,6 @@ namespace com.keyman.osk {
         default:
           throw new Error("Invalid type specified for the banner!");
       }
-    }
-
-    // TODO: test code not to keep in production
-    public setSuggestions() {
-      let blank : Suggestion = {displayAs: 'blank'} as Suggestion;
-      let s:Array<Suggestion> = Array(blank, blank, blank);
-      s[0].displayAs = 'choco';
-      s[1].displayAs = 'taco';
-      s[2].displayAs = 'last';
-      let suggestionBanner = this.activeBanner as SuggestionBanner;
-      suggestionBanner.updateSuggestions(s);
     }
 
     /**

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -244,7 +244,6 @@ namespace com.keyman.osk {
      * Gets the height (in pixels) of the active `Banner` instance.
      */
     public get height(): number {
-      console.warn("bannerManager.height activeBanner: " + this.activeBanner);
       if(this.activeBanner) {
         return this.activeBanner.height;
       } else {
@@ -257,7 +256,6 @@ namespace com.keyman.osk {
      */
     public set height(h: number) {
       if (this.activeBanner) {
-        console.warn("bannerManager.height set to " + h);
         this.activeBanner.height = h;
       }
     }

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -84,14 +84,6 @@ namespace com.keyman.osk {
       let d = util._CreateElement('div');
       d.id = "keymanweb_banner_container";
       d.className = "kmw-banner-container";
-
-      /*
-      let oskManager = keymanweb.osk;
-      let bannerHeight : number = oskManager.getBannerHeight();
-      console.warn("constructContainer: bannerHeight " + bannerHeight);
-      let ds = d.style;
-      ds.height = ds.maxHeight = bannerHeight + 'px';
-      */
       return this.bannerContainer = d;
     }
 
@@ -252,10 +244,21 @@ namespace com.keyman.osk {
      * Gets the height (in pixels) of the active `Banner` instance.
      */
     public get height(): number {
+      console.warn("bannerManager.height activeBanner: " + this.activeBanner);
       if(this.activeBanner) {
         return this.activeBanner.height;
       } else {
         return 0;
+      }
+    }
+
+    /**
+     * Sets the height (in pixels) of the active 'Banner' instance.
+     */
+    public set height(h: number) {
+      if (this.activeBanner) {
+        console.warn("bannerManager.height set to " + h);
+        this.activeBanner.height = h;
       }
     }
   }

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -1001,7 +1001,21 @@ namespace com.keyman.osk {
      *  @return   {number}    height in pixels
      */
     getBannerHeight(): number {
-      return this.banner.height;
+      let keymanweb = com.keyman.singleton;
+      let util = keymanweb.util;
+
+      // KeymanTouch - get OSK height from device
+      if (typeof(keymanweb['getBannerHeight']) == 'function') {
+        let bannerHeight : number = keymanweb['getBannerHeight']();
+        console.log("oskManager getBannerHeight: " + bannerHeight);
+        if(util.device.OS == 'Android' && 'devicePixelRatio' in window) {
+          bannerHeight = bannerHeight / window.devicePixelRatio;
+        }
+
+        return bannerHeight;
+      }
+
+      return (this.banner != null) ? this.banner.height : 0;
     }
 
     /**

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -1001,20 +1001,6 @@ namespace com.keyman.osk {
      *  @return   {number}    height in pixels
      */
     getBannerHeight(): number {
-      let keymanweb = com.keyman.singleton;
-      let util = keymanweb.util;
-
-      // KeymanTouch - get OSK height from device
-      if (typeof(keymanweb['getBannerHeight']) == 'function') {
-        let bannerHeight : number = keymanweb['getBannerHeight']();
-        console.log("oskManager getBannerHeight: " + bannerHeight);
-        if(util.device.OS == 'Android' && 'devicePixelRatio' in window) {
-          bannerHeight = bannerHeight / window.devicePixelRatio;
-        }
-
-        return bannerHeight;
-      }
-
       return (this.banner != null) ? this.banner.height : 0;
     }
 

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -92,7 +92,7 @@ namespace com.keyman.text {
      * As such, it assumes that the caret is immediately after any inserted text.
      * @param from An output target (preferably a Mock) representing the prior state of the input/output system.
      */
-    private buildTransformFrom(original: Mock): Transform {
+    buildTransformFrom(original: OutputTarget): Transform {
       let to = this.getText();
       let from = original.getText();
 
@@ -120,7 +120,7 @@ namespace com.keyman.text {
       return new TextTransform(delta, deletedLeft, originalRight - undeletedRight);
     }
 
-    buildTranscriptionFrom(original: Mock, keyEvent: KeyEvent): Transcription {
+    buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent): Transcription {
       let transform = this.buildTransformFrom(original);
 
       // While not presently needed, there's a chance we'll want to have Deadkey mutation tracked

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -90,7 +90,9 @@ namespace com.keyman.text.prediction {
       // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer
       // model may expect.
       let capabilities: Capabilities = {
-        maxLeftContextCodeUnits: 64
+        maxLeftContextCodeUnits: 64,
+        // Since the apps don't yet support right-deletions.
+        maxRightContextCodeUnits: keyman.isEmbedded ? 0 : 64
       }
       this.lmEngine = new LMLayer(capabilities);
       

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -88,7 +88,9 @@ namespace com.keyman.text {
             // Or move to next field from TEXT fields
             } else if(usingOSK) {
               var inputEle: HTMLInputElement;
-              if(dom.Utils.instanceof(Lelem, "HTMLInputElement")) {
+              if(keyman.isEmbedded) { // In embedded mode, the OutputTarget may not meet other conditions.
+                return '\n';
+              } else if(dom.Utils.instanceof(Lelem, "HTMLInputElement")) {
                 inputEle = <HTMLInputElement> Lelem;
               } else if(typeof(Lelem.base) != 'undefined' && dom.Utils.instanceof(Lelem.base, "HTMLInputElement")) {
                 inputEle = <HTMLInputElement> Lelem.base;


### PR DESCRIPTION
This PR does some cleanup and integrates suggestions with the Android app

* Per @jahorton , allow the apps to specify `Banner.DEFAULT_HEIGHT`.
* Add listener for `mm.modelchange` event to detect model changes "unload" and "load"
* Have Android app track the banner (suggestion vs blank) on lexical model change
* Pass the banner height to KMW on device rotations (portrait vs landscape)
* Update build scripts so `-debug` variant uses unminified KMW

### Testing Steps ###
1. Install Joshua's en wordlist `/web/testing/prediction-ui/simple-en-wordlist.js`
2. Add another English (US) keyboard
3. On the device, delete the en.custom model that gets installed (it currently generates exceptions)
4. The suggestion banner should appear when switching to an English keyboard. Accepting suggestions will have the same functionality as the KMW test page
5. The suggestion banner should disappear when switching to a non-English keyboard
