### PR TITLE
In-app acceptance of predictive suggestions

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -145,8 +145,14 @@
       kmw['osk']['show'](true);
     }
 
+    /**
+     * Inserts the selected string <i>s</i>
+     * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+     * @param s   Text to insert
+     * @param dr  Number of post-caret code points to delete.  (optional)
+     */
     function insertText(dn, s, dr) {
-      dr = dr || 0; // Sets a default value.
+      dr = dr || 0; // Sets a default value of zero when dr is undefined
       //window.console.log('insertText('+ dn +', ' + s +', ' + dr + ');');
       window.jsInterface.insertText(dn, s, dr);
     }

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -145,9 +145,10 @@
       kmw['osk']['show'](true);
     }
 
-    function insertText(dn, s) {
-      //window.console.log('insertText('+ dn +', ' + s +');');
-      window.jsInterface.insertText(dn, s);
+    function insertText(dn, s, dr) {
+      dr = dr || 0; // Sets a default value.
+      //window.console.log('insertText('+ dn +', ' + s +', ' + dr + ');');
+      window.jsInterface.insertText(dn, s, dr);
     }
 
     function enableSuggestions(model) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -91,7 +91,12 @@ public abstract class KMKeyboardJSHandler {
   @JavascriptInterface
   public  abstract boolean dispatchKey(final int code, final int eventModifiers);
 
-  // Insert the selected string s
+  /**
+   * Inserts the selected string <i>s</i>
+   * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+   * @param s   Text to insert
+   * @param dr  Number of post-caret code points to delete.
+   */
   @JavascriptInterface
   public abstract void insertText(final int dn, final String s, final int dr);
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -93,5 +93,5 @@ public abstract class KMKeyboardJSHandler {
 
   // Insert the selected string s
   @JavascriptInterface
-  public abstract void insertText(final int dn, final String s);
+  public abstract void insertText(final int dn, final String s, final int dr);
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1576,6 +1576,10 @@ public final class KMManager {
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
     public void insertText(final int dn, final String s, final int dr) {
+      if(dr != 0) {
+        Log.d(TAG, "Right deletions requested but are not presently supported by the in-app keyboard.");
+      }
+
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
         public void run() {
@@ -1720,6 +1724,7 @@ public final class KMManager {
 
           ic.beginBatchEdit();
 
+          // Delete any existing selected text.
           ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
           if (icText != null) { // This can be null if the input connection becomes invalid.
             int start = icText.startOffset + icText.selectionStart;
@@ -1744,6 +1749,7 @@ public final class KMManager {
             return;
           }
 
+          // Perform left-deletions
           for (int i = 0; i < dn; i++) {
             CharSequence chars = ic.getTextBeforeCursor(1, 0);
             if (chars != null && chars.length() > 0) {
@@ -1753,6 +1759,20 @@ public final class KMManager {
                 ic.deleteSurroundingText(2, 0);
               } else {
                 ic.deleteSurroundingText(1, 0);
+              }
+            }
+          }
+
+          // Perform right-deletions
+          for (int i = 0; i < dr; i++) {
+            CharSequence chars = ic.getTextAfterCursor(1, 0);
+            if (chars != null && chars.length() > 0) {
+              char c = chars.charAt(0);
+              SystemKeyboardShouldIgnoreSelectionChange = true;
+              if (Character.isHighSurrogate(c)) {
+                ic.deleteSurroundingText(0, 2);
+              } else {
+                ic.deleteSurroundingText(0, 1);
               }
             }
           }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1575,7 +1575,7 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s) {
+    public void insertText(final int dn, final String s, final int dr) {
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
         public void run() {
@@ -1700,7 +1700,7 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s) {
+    public void insertText(final int dn, final String s, final int dr) {
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
         public void run() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -260,9 +260,14 @@ extension KeymanWebViewController: WKScriptMessageHandler {
     if fragment.hasPrefix("#insertText-") {
       let dnRange = fragment.range(of: "+dn=")!
       let sRange = fragment.range(of: "+s=")!
+      let drRange = fragment.range(of: "+dr=")!
 
       let dn = Int(fragment[dnRange.upperBound..<sRange.lowerBound])!
-      let s = fragment[sRange.upperBound...]
+      let s = fragment[sRange.upperBound..<drRange.lowerBound]
+      // This computes the number of requested right-deletion characters.
+      // Use it when we're ready to implement that.
+      // Our .insertText will need to be adjusted accordingly.
+      _ = Int(fragment[drRange.upperBound...])!
 
       // KMW uses dn == -1 to perform special processing of deadkeys.
       // This is handled outside of Swift so we don't delete any characters.

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -83,10 +83,16 @@
             }
             
             var fragmentToggle = 0;
-            function insertText(dn, s) {
+            /**
+             * Inserts the selected string <i>s</i>
+             * @param dn  Number of pre-caret code points (UTF+8 characters) to delete
+             * @param s   Text to insert
+             * @param dr  Number of post-caret code points to delete.  (optional)
+             */
+            function insertText(dn, s, dr) {
+                dr = dr || 0;  // Sets a default value of zero when dr is undefined
                 fragmentToggle = (fragmentToggle + 1) % 100;
-                var insertHash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
-                //window.location.hash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s);
+                var insertHash = 'insertText-'+ fragmentToggle + '+dn=' + dn + '+s=' + toHex(s) + '+dr=' + dr;
                 if (typeof(window.webkit) != 'undefined')
                     window.webkit.messageHandlers.keyman.postMessage('#' + insertHash);
             }

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -578,6 +578,11 @@ namespace com.keyman {
 
     // Functions that might be added later
     ['beepKeyboard']: () => void;
+    /**
+     * @param {number}  dn  Number of pre-caret characters to delete
+     * @param {string}  s   Text to insert
+     * @param {number=}  dr  Number of post-caret characters to delete
+     */
     ['oninserttext']: (dn: number, s: string, dr?: number) => void;
 
     /**

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -578,7 +578,7 @@ namespace com.keyman {
 
     // Functions that might be added later
     ['beepKeyboard']: () => void;
-    ['oninserttext']: (dn: number, s: string) => void;
+    ['oninserttext']: (dn: number, s: string, dr?: number) => void;
 
     /**
      * Create copy of the OSK that can be used for embedding in documentation or help

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -238,8 +238,16 @@ namespace com.keyman.osk {
         }
 
         // Apply the Suggestion!
-        target.restoreTo(original.preInput);
-        target.apply(this.suggestion.transform);
+
+        // Step 1:  determine the final output text
+        let final = text.Mock.from(original.preInput);
+        final.apply(this.suggestion.transform);
+
+        // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
+        // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
+        // values as needed for use with their IME interfaces.
+        let transform = final.buildTransformFrom(target);
+        target.apply(transform);
       }
     }
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -248,6 +248,11 @@ namespace com.keyman.osk {
         // values as needed for use with their IME interfaces.
         let transform = final.buildTransformFrom(target);
         target.apply(transform);
+
+        // Signal the necessary text changes to the embedding app, if it exists.
+        if(keyman['oninserttext'] && keyman.isEmbedded) {
+          keyman['oninserttext'](transform.deleteLeft, transform.insert, transform.deleteRight);
+        }
       }
     }
 

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -92,7 +92,7 @@ namespace com.keyman.text {
      * As such, it assumes that the caret is immediately after any inserted text.
      * @param from An output target (preferably a Mock) representing the prior state of the input/output system.
      */
-    private buildTransformFrom(original: Mock): Transform {
+    buildTransformFrom(original: OutputTarget): Transform {
       let to = this.getText();
       let from = original.getText();
 
@@ -120,7 +120,7 @@ namespace com.keyman.text {
       return new TextTransform(delta, deletedLeft, originalRight - undeletedRight);
     }
 
-    buildTranscriptionFrom(original: Mock, keyEvent: KeyEvent): Transcription {
+    buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent): Transcription {
       let transform = this.buildTransformFrom(original);
 
       // While not presently needed, there's a chance we'll want to have Deadkey mutation tracked

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -90,7 +90,9 @@ namespace com.keyman.text.prediction {
       // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer
       // model may expect.
       let capabilities: Capabilities = {
-        maxLeftContextCodeUnits: 64
+        maxLeftContextCodeUnits: 64,
+        // Since the apps don't yet support right-deletions.
+        maxRightContextCodeUnits: keyman.isEmbedded ? 0 : 64
       }
       this.lmEngine = new LMLayer(capabilities);
       


### PR DESCRIPTION
This PR allows embedded-KMW to properly output predictive suggestions to the apps' IME interfaces.

Already implemented:
* [x] Basic integration for Android (since it's based on #1729)
  - With this change in place, basic interaction is now fully possible within the Android app!
* [x] Integration of new hooks for iOS
  - Basically, just enough to mirror this PR's Android changes.

Yet to implement:
* Right-deletions
  - As per Slack conversations with @eddieantonio and @mcdurdin, supporting these is not a priority at this point.