### PR TITLE
[Windows] Fix FieldWorks LT-19402, buffer overrun in GetDefaultKeyboardID for 64 bit

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -3,6 +3,9 @@
 ## 12.0 alpha
 * Started work on Keyman Desktop 12.
 
+## 2019-04-29 11.0.1355.0 stable
+* Bug Fix: Error in initialization of Keyman Engine causes FieldWorks to crash if Keyman Developer installed but not Keyman Desktop. (#1739)
+
 ## 2019-02-25 11.0.1350.0 stable
 * 11.0 Stable release
 

--- a/windows/src/engine/kmcomapi/util/utilkeyman.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeyman.pas
@@ -57,7 +57,7 @@ function GetKeyboardIconFileName(const KeyboardFileName: string): string;   // I
 function GetKeymanInstallPath: string;
 
 function GetDefaultHKL: HKL;   // I3581   // I3619   // I3619
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 
 var
   FInstallingKeyman: Boolean = False;
@@ -306,7 +306,7 @@ begin
     Result := 0;
 end;
 
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 const
   BaseKeyboardID_USEnglish: Integer = $00000409;
 begin

--- a/windows/src/global/delphi/general/klog.pas
+++ b/windows/src/global/delphi/general/klog.pas
@@ -60,7 +60,7 @@ implementation
 
 {$IFDEF KLOGGING}
 uses
-  Variants, Windows, SysUtils, ErrorControlledRegistry, SystemDebugPath, VersionInfo, Unicode;
+  Variants, Windows, SysUtils, ErrorControlledRegistry, ErrLogPath, VersionInfo, Unicode;
 
 {$ENDIF}
 
@@ -91,7 +91,7 @@ var
   FRootPath: string;
 begin
   inherited Create;
-  FRootPath := GetSystemDebugPath;
+  FRootPath := GetErrLogPath;
 
   FMethodStack := TStringList.Create;
   GetModuleFileName(hInstance, buf, 260); FAppName := buf;


### PR DESCRIPTION
The buffer size for the return of SPI_GETDEFAULTINPUTLANG is 8 bytes (HKL, or UINT_PTR) on Win64 but we were only allocating 4 bytes (Cardinal). This led to memory corruption, which was messy enough that when the inevitable access violation occurred, our error handling was unable to log it.

Ref https://jira.sil.org/browse/LT-19402

This will be backported to 11.0 stable, 10.0 stable.