### PR TITLE
[Windows] [11.0] Fix FieldWorks LT-19402, buffer overrun in GetDefaultKeyboardID for 64 bit

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,20 @@
 # Keyman Desktop Version History
 
+## 2019-04-29 11.0.1355.0 stable
+* Bug Fix: Error in initialization of Keyman Engine causes FieldWorks to crash if Keyman Developer installed but not Keyman Desktop. (#1739)
+
+## 2019-04-06 11.0.1354.0 stable
+* No changes
+
+## 2019-04-06 11.0.1353.0 stable
+* No changes
+
+## 2019-02-27 11.0.1352.0 stable
+* No changes
+
+## 2019-02-26 11.0.1351.0 stable
+* Not released
+
 ## 2019-02-25 11.0.1350.0 stable
 * 11.0 Stable release
 

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 2019-04-29 11.0.1355.0 stable
+* No changes
+
 ## 2019-04-24 11.0.1354.0 stable
 * Bug fix: Keyman Developer touch layout editor would not save key caps for subkeys (#1731)
 * Bug fix: Compiler could occasionally fail with undefined results when using Unicode store names (#1736)

--- a/windows/src/engine/kmcomapi/util/utilkeyman.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeyman.pas
@@ -57,7 +57,7 @@ function GetKeyboardIconFileName(const KeyboardFileName: string): string;   // I
 function GetKeymanInstallPath: string;
 
 function GetDefaultHKL: HKL;   // I3581   // I3619   // I3619
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 
 var
   FInstallingKeyman: Boolean = False;
@@ -306,7 +306,7 @@ begin
     Result := 0;
 end;
 
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 const
   BaseKeyboardID_USEnglish: Integer = $00000409;
 begin

--- a/windows/src/global/delphi/general/klog.pas
+++ b/windows/src/global/delphi/general/klog.pas
@@ -60,7 +60,7 @@ implementation
 
 {$IFDEF KLOGGING}
 uses
-  Variants, Windows, SysUtils, ErrorControlledRegistry, SystemDebugPath, VersionInfo, Unicode;
+  Variants, Windows, SysUtils, ErrorControlledRegistry, ErrLogPath, VersionInfo, Unicode;
 
 {$ENDIF}
 
@@ -91,7 +91,7 @@ var
   FRootPath: string;
 begin
   inherited Create;
-  FRootPath := GetSystemDebugPath;
+  FRootPath := GetErrLogPath;
 
   FMethodStack := TStringList.Create;
   GetModuleFileName(hInstance, buf, 260); FAppName := buf;


### PR DESCRIPTION
See #1739