### PR TITLE
[Windows] [10.0] Fix FieldWorks LT-19402, buffer overrun in GetDefaultKeyboardID for 64 bit

### DIFF
--- a/windows/src/engine/kmcomapi/util/utilkeyman.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeyman.pas
@@ -57,7 +57,7 @@ function GetKeyboardIconFileName(const KeyboardFileName: string): string;   // I
 function GetKeymanInstallPath: string;
 
 function GetDefaultHKL: HKL;   // I3581   // I3619   // I3619
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 
 var
   FInstallingKeyman: Boolean = False;
@@ -306,7 +306,7 @@ begin
     Result := 0;
 end;
 
-function GetDefaultKeyboardID: Cardinal;   // I4169
+function GetDefaultKeyboardID: HKL;   // I4169
 const
   BaseKeyboardID_USEnglish: Integer = $00000409;
 begin

--- a/windows/src/global/delphi/general/klog.pas
+++ b/windows/src/global/delphi/general/klog.pas
@@ -60,7 +60,7 @@ implementation
 
 {$IFDEF KLOGGING}
 uses
-  Variants, Windows, SysUtils, ErrorControlledRegistry, SystemDebugPath, VersionInfo, Unicode;
+  Variants, Windows, SysUtils, ErrorControlledRegistry, ErrLogPath, VersionInfo, Unicode;
 
 {$ENDIF}
 
@@ -91,7 +91,7 @@ var
   FRootPath: string;
 begin
   inherited Create;
-  FRootPath := GetSystemDebugPath;
+  FRootPath := GetErrLogPath;
 
   FMethodStack := TStringList.Create;
   GetModuleFileName(hInstance, buf, 260); FAppName := buf;


### PR DESCRIPTION
See #1739