### PR TITLE
[Web] Predictive text UX improvements

### DIFF
--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -296,6 +296,11 @@ namespace com.keyman {
       } else if(!blockGlobalChange) {
         this.keyman.keyboardManager.setActiveKeyboard(this.keyman.globalKeyboard, this.keyman.globalLanguageCode);
       }
+
+      // Now that we've fully entered the new context, we can generate initial predictions from it.
+      if(this.keyman.modelManager) {
+        this.keyman.modelManager.predict();
+      }
     }
 
     /**

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -345,7 +345,7 @@ namespace com.keyman.osk {
     static readonly TOUCHED_CLASS: string = 'kmw-suggest-touched';
 
     constructor(height?: number) {
-      super(height || SuggestionBanner.DEFAULT_HEIGHT);
+      super(height || Banner.DEFAULT_HEIGHT);
 
       this.options = new Array();
       for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -87,6 +87,24 @@ namespace com.keyman.osk {
     public getDiv(): HTMLElement {
       return this.div;
     }
+
+    /**
+     * Function     activate
+     * Scope        Public
+     * Description  Adds any relevant event listeners needed by this banner type.
+     */
+    public activate() {
+
+    }
+
+    /**
+     * Function     activate
+     * Scope        Public
+     * Description  Removes any relevant event listeners previously added by this banner.
+     */
+    public deactivate() {
+
+    }
   }
 
   /**
@@ -465,5 +483,17 @@ namespace com.keyman.osk {
         }
       });
     }.bind(this);
+
+    activate() {
+      let keyman = com.keyman.singleton;
+      keyman.modelManager['addEventListener']('invalidatesuggestions', this.invalidateSuggestions);
+      keyman.modelManager['addEventListener']('suggestionsready', this.updateSuggestions);
+    }
+
+    deactivate() {
+      let keyman = com.keyman.singleton;
+      keyman.modelManager['removeEventListener']('invalidatesuggestions', this.invalidateSuggestions);
+      keyman.modelManager['removeEventListener']('suggestionsready', this.updateSuggestions);
+    }
   }
 }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -94,7 +94,7 @@ namespace com.keyman.osk {
      * Description  Adds any relevant event listeners needed by this banner type.
      */
     public activate() {
-
+      // Default implementation - no listeners.
     }
 
     /**
@@ -103,7 +103,7 @@ namespace com.keyman.osk {
      * Description  Removes any relevant event listeners previously added by this banner.
      */
     public deactivate() {
-
+      // Default implementation - no listeners.
     }
   }
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -486,6 +486,8 @@ namespace com.keyman.osk {
 
     private options: BannerSuggestion[];
 
+    private initNewContext: boolean = true;
+
     private currentSuggestions: Suggestion[] = [];
     private currentTranscriptionID: number;
 
@@ -604,6 +606,7 @@ namespace com.keyman.osk {
 
         if(source == 'context') {
           this.swallowPrediction = false;
+          this.initNewContext = true;
         }
       }
 
@@ -618,7 +621,7 @@ namespace com.keyman.osk {
       let suggestions = [];
       // TODO:  Insert 'current text' if/when valid as the leading option.
       //        We need the LMLayer to tell us this somehow.
-      if(!this.recentAccept && !this.recentRevert) {
+      if(!this.recentAccept && !this.recentRevert && !this.initNewContext) {
         // In the meantime, a placeholder:
         // (generated from the 'true'/original transform)
         let original = keyman.modelManager.getPredictionState(this.currentTranscriptionID);
@@ -635,6 +638,8 @@ namespace com.keyman.osk {
           option.update(null);
         }
       });
+
+      this.initNewContext = false;
     }
 
     /**
@@ -643,13 +648,13 @@ namespace com.keyman.osk {
      * @param {Suggestion[]}  suggestions   Array of suggestions from the lexical model.
      * Description    Update the displayed suggestions in the SuggestionBanner
      */
-    public updateSuggestions: (this: SuggestionManager, suggestions: Suggestion[]) => boolean =
-        function(this: SuggestionManager, suggestions: Suggestion[]) {
+    public updateSuggestions: (this: SuggestionManager, prediction: text.prediction.ReadySuggestions) => boolean =
+        function(this: SuggestionManager, prediction: text.prediction.ReadySuggestions) {
       
+      let suggestions = prediction.suggestions;
+
       this.currentSuggestions = suggestions;
-      if(suggestions.length > 0) {
-        this.currentTranscriptionID = suggestions[0].transformId;
-      }
+      this.currentTranscriptionID = prediction.transcriptionID;
 
       // If we've gotten an update request like this, it's almost always user-triggered and means the context has shifted.
       if(!this.swallowPrediction) {

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -484,16 +484,38 @@ namespace com.keyman.osk {
       });
     }.bind(this);
 
+    /**
+     * Receives messages from the keyboard that the 'accept' keystroke has been entered.
+     * Should return 'false' if the current state allows accepting a suggestion and act accordingly.
+     * Otherwise, return true.
+     */
+    tryAccept() {
+      return true;  // Not yet implemented
+    }
+
+    /**
+     * Receives messages from the keyboard that the 'revert' keystroke has been entered.
+     * Should return 'false' if the current state allows reverting a recently-applied suggestion and act accordingly.
+     * Otherwise, return true.
+     */
+    tryRevert() {
+      return true;
+    }
+
     activate() {
       let keyman = com.keyman.singleton;
       keyman.modelManager['addEventListener']('invalidatesuggestions', this.invalidateSuggestions);
       keyman.modelManager['addEventListener']('suggestionsready', this.updateSuggestions);
+      keyman.modelManager['addEventListener']('tryaccept', this.tryAccept);
+      keyman.modelManager['addEventListener']('tryrevert', this.tryRevert);
     }
 
     deactivate() {
       let keyman = com.keyman.singleton;
       keyman.modelManager['removeEventListener']('invalidatesuggestions', this.invalidateSuggestions);
       keyman.modelManager['removeEventListener']('suggestionsready', this.updateSuggestions);
+      keyman.modelManager['removeEventListener']('tryaccept', this.tryAccept);
+      keyman.modelManager['removeEventListener']('tryrevert', this.tryRevert);
     }
   }
 }

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -175,22 +175,25 @@ namespace com.keyman.osk {
      * @param height - Optional banner height in pixels.
      */
     public setBanner(type: BannerType, height?: number) {
+      var banner: Banner;
+
       switch(type) {
         case 'blank':
-          this._setBanner(new BlankBanner());
+          banner = new BlankBanner();
           break;
         case 'image':
-          this._setBanner(new ImageBanner(this.imagePath, ImageBanner.DEFAULT_HEIGHT));
+          banner = new ImageBanner(this.imagePath, ImageBanner.DEFAULT_HEIGHT);
           break;
         case 'suggestion':
-          this._setBanner(new SuggestionBanner(height));
-          let keyman = com.keyman.singleton;
-          let banner = this.activeBanner as SuggestionBanner;
-          keyman.modelManager['addEventListener']('invalidatesuggestions', banner.invalidateSuggestions);
-          keyman.modelManager['addEventListener']('suggestionsready', banner.updateSuggestions);
+          banner = new SuggestionBanner(height);
           break;
         default:
           throw new Error("Invalid type specified for the banner!");
+      }
+
+      if(banner) {
+        this._setBanner(banner);
+        banner.activate();
       }
     }
 
@@ -226,13 +229,8 @@ namespace com.keyman.osk {
           return;
         } else {
           let prevBanner = this.activeBanner;
+          prevBanner.deactivate();
           this.bannerContainer.replaceChild(banner.getDiv(), prevBanner.getDiv());
-
-          if(prevBanner instanceof SuggestionBanner) {
-            let keyman = com.keyman.singleton;
-            keyman.modelManager['removeEventListener']('invalidatesuggestions', prevBanner.invalidateSuggestions);
-            keyman.modelManager['removeEventListener']('suggestionsready', prevBanner.updateSuggestions);
-          }
         }
       }
 

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -182,7 +182,7 @@ namespace com.keyman.osk {
           banner = new BlankBanner();
           break;
         case 'image':
-          banner = new ImageBanner(this.imagePath, ImageBanner.DEFAULT_HEIGHT);
+          banner = new ImageBanner(this.imagePath, Banner.DEFAULT_HEIGHT);
           break;
         case 'suggestion':
           banner = new SuggestionBanner(height);

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -1151,6 +1151,10 @@ namespace com.keyman.text {
       }
       this.resetContextCache();
       this.resetVKShift();
+      
+      if(keyman.modelManager) {
+        keyman.modelManager.invalidateContext();
+      }
 
       if(!keyman.isHeadless) {
         keyman.osk._Show();

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -8,7 +8,7 @@
 ///<reference path="keyEvent.ts" />
 
 namespace com.keyman.text {
-  class TextTransform implements Transform {
+  export class TextTransform implements Transform {
     readonly insert: string;
     readonly deleteLeft: number;
     readonly deleteRight?: number;
@@ -18,6 +18,8 @@ namespace com.keyman.text {
       this.deleteLeft = deleteLeft;
       this.deleteRight = deleteRight || 0;
     }
+
+    public static readonly nil = new TextTransform('', 0, 0);
   }
 
   export class Transcription {

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -63,7 +63,7 @@ namespace com.keyman.text.prediction {
    */
   export type ModelChangeHandler = (state: ModelChangeEnum) => boolean;
 
-  type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "modelchange";
+  type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "modelchange" | "tryaccept" | "tryrevert";
   type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | ModelChangeHandler;
 
   export class ModelManager {
@@ -290,6 +290,20 @@ namespace com.keyman.text.prediction {
         this.unloadModel();
         keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
       }
+    }
+
+    public tryAcceptSuggestion(): boolean {
+      let keyman = com.keyman.singleton;
+      
+      // Handlers of this event should return 'false' when the 'try' is successful.
+      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', null);
+    }
+
+    public tryRevertSuggestion(): boolean {
+      let keyman = com.keyman.singleton;
+      
+      // Handlers of this event should return 'false' when the 'try' is successful.
+      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryrevert', null);
     }
   }
 }

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -54,10 +54,20 @@ namespace com.keyman.text.prediction {
    */
   export type InvalidateSuggestionsHandler = (source: InvalidateSourceEnum) => boolean;
 
+  export class ReadySuggestions {
+    suggestions: Suggestion[];
+    transcriptionID: number;
+
+    constructor(suggestions: Suggestion[], id: number) {
+      this.suggestions = suggestions;
+      this.transcriptionID = id;
+    }
+  }
+
   /**
    * Corresponds to the 'suggestionsready' ModelManager event.
    */
-  export type ReadySuggestionsHandler = (suggestions: Suggestion[]) => boolean;
+  export type ReadySuggestionsHandler = (prediction: ReadySuggestions) => boolean;
 
   export type ModelChangeEnum = 'loaded'|'unloaded';
   /**
@@ -261,7 +271,8 @@ namespace com.keyman.text.prediction {
       let mm = this;
       promise.then(function(suggestions: Suggestion[]) {
         if(promise == mm.currentPromise) {
-          keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", suggestions);
+          let result = new ReadySuggestions(suggestions, transform.id);
+          keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", result);
           mm.currentPromise = null;
         }
       })

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -63,8 +63,13 @@ namespace com.keyman.text.prediction {
    */
   export type ModelChangeHandler = (state: ModelChangeEnum) => boolean;
 
+  /**
+   * Covers both 'tryaccept' and 'tryrevert' events.
+   */
+  export type TryUIHandler = (source: string) => boolean;
+
   type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "modelchange" | "tryaccept" | "tryrevert";
-  type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | ModelChangeHandler;
+  type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | ModelChangeHandler | TryUIHandler;
 
   export class ModelManager {
     private lmEngine: LMLayer;
@@ -292,11 +297,11 @@ namespace com.keyman.text.prediction {
       }
     }
 
-    public tryAcceptSuggestion(): boolean {
+    public tryAcceptSuggestion(source: string): boolean {
       let keyman = com.keyman.singleton;
       
       // Handlers of this event should return 'false' when the 'try' is successful.
-      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', null);
+      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', source);
     }
 
     public tryRevertSuggestion(): boolean {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -380,9 +380,9 @@ namespace com.keyman.text {
       // Safari, IE, Opera?
       //}
 
-      // TODO:  When predictive-text is active...
-      //          If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
-      //          If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
+      // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
+      // If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
+      // We check the first condition here, while the prediction UI handles the second through the try__() methods below.
       if(keyman.modelManager.enabled) {
         // The following code relies on JS's logical operator "short-circuit" properties to prevent unwanted triggering of the second condition.
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -390,7 +390,7 @@ namespace com.keyman.text {
         if((keyEvent.kName == "K_BKSP" || keyEvent.Lcode == Codes.keyCodes["K_BKSP"]) && keyman.modelManager.tryRevertSuggestion()) {
           return;
           // Can the suggestion UI accept an existing suggestion?  If so, do that and swallow the space character.
-        } else if((keyEvent.kName == "K_SPACE" || keyEvent.Lcode == Codes.keyCodes["K_SPACE"]) && keyman.modelManager.tryAcceptSuggestion()) {
+        } else if((keyEvent.kName == "K_SPACE" || keyEvent.Lcode == Codes.keyCodes["K_SPACE"]) && keyman.modelManager.tryAcceptSuggestion('space')) {
           return;
         }
       }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -380,6 +380,21 @@ namespace com.keyman.text {
       // Safari, IE, Opera?
       //}
 
+      // TODO:  When predictive-text is active...
+      //          If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
+      //          If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
+      if(keyman.modelManager.enabled) {
+        // The following code relies on JS's logical operator "short-circuit" properties to prevent unwanted triggering of the second condition.
+
+        // Can the suggestion UI revert a recent suggestion?  If so, do that and swallow the backspace.
+        if((keyEvent.kName == "K_BKSP" || keyEvent.Lcode == Codes.keyCodes["K_BKSP"]) && keyman.modelManager.tryRevertSuggestion()) {
+          return;
+          // Can the suggestion UI accept an existing suggestion?  If so, do that and swallow the space character.
+        } else if((keyEvent.kName == "K_SPACE" || keyEvent.Lcode == Codes.keyCodes["K_SPACE"]) && keyman.modelManager.tryAcceptSuggestion()) {
+          return;
+        }
+      }
+
       if(fromOSK && !keyman.isEmbedded) {
         keyman.uiManager.setActivatingUI(true);
         com.keyman.DOMEventHandlers.states._IgnoreNextSelChange = 100;

--- a/web/testing/prediction-ui/index.html
+++ b/web/testing/prediction-ui/index.html
@@ -42,9 +42,13 @@
       }).then(function() {
         kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
 
+        var pageRef = (window.location.protocol == 'file:')
+          ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)
+          : window.location.href;
+
         var modelStub = {'id': 'example.en.wordlist',
           languages: ['en'],
-          path: (window.location.href + "simple-en-wordlist.js")
+          path: (pageRef + "simple-en-wordlist.js")
         };
         kmw.modelManager.register(modelStub);
       });


### PR DESCRIPTION
New features:

- Upon initialization and change-of-context, new predictions will be generated.
  - These will be based on the caret position within the context, allowing the LMLayer to use context for these predictions.
- Hitting the spacebar with a highlighted suggestion will auto-accept it.
  - Outside of touch-interaction, nothing presently 'highlights'/selects a suggestion - **yet**.
    - Future work:  language modeling input is needed for automatic selection.
  - Acceptance will also auto-trigger new predictions.
- Hitting backspace immediately after accepting a prediction rejects it:
  - The 'accept' operation will be reverted.
  - The rejected suggestion will be removed from the stored suggestion buffer/list.
    - While we only ever have three at max presently, that can easily be altered - especially now that extra options may be useful. 
    - A "keep text" suggestion will never be permanently removed, however.
  - This may be repeated for multiple consecutive accept-reject sequences so long as no additional predictions are generated.
  - To do something more 'iOS' style, we'd need language modeling to get a good display string for the reversion.
- Adds a placeholder '`<keep>`' option during certain states.
  - Eventually, we should be able to request better display text from the LMLayer for this.