### PR TITLE
[LMLayer] Word breaking

### DIFF
--- a/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
@@ -1,0 +1,13 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+let LMLayer = require('../../build');
+var breakASCIIWords = require('../../build/intermediate').wordBreakers['ascii'];
+
+describe('The ASCIIWordBreaker', function() {
+    it('breaks simple English sentences', function () {
+        let breaks = breakASCIIWords('Look! -- The quick brown fox jumps... over the lazy dog!');
+        let words = breaks.map(span => span.text);
+        assert.deepEqual(words, ['Look', 'the', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog']);
+    });
+});

--- a/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
@@ -1,13 +1,11 @@
 var assert = require('chai').assert;
-var sinon = require('sinon');
 
-let LMLayer = require('../../build');
 var breakASCIIWords = require('../../build/intermediate').wordBreakers['ascii'];
 
-describe('The ASCIIWordBreaker', function() {
-    it('breaks simple English sentences', function () {
-        let breaks = breakASCIIWords('Look! -- The quick brown fox jumps... over the lazy dog!');
-        let words = breaks.map(span => span.text);
-        assert.deepEqual(words, ['Look', 'The', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog']);
-    });
+describe('The ASCII word breaker', function () {
+  it('should break simple English sentences', function () {
+    let breaks = breakASCIIWords('Look! -- The quick brown fox jumps... over the lazy dog!');
+    let words = breaks.map(span => span.text);
+    assert.deepEqual(words, ['Look', 'The', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog']);
+  });
 });

--- a/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/ascii-word-breaker.js
@@ -8,6 +8,6 @@ describe('The ASCIIWordBreaker', function() {
     it('breaks simple English sentences', function () {
         let breaks = breakASCIIWords('Look! -- The quick brown fox jumps... over the lazy dog!');
         let words = breaks.map(span => span.text);
-        assert.deepEqual(words, ['Look', 'the', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog']);
+        assert.deepEqual(words, ['Look', 'The', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog']);
     });
 });

--- a/common/predictive-text/worker/defaultWordBreaker.ts
+++ b/common/predictive-text/worker/defaultWordBreaker.ts
@@ -1,9 +1,0 @@
-class DefaultWordBreaker implements WorkerInternalWordBreaker {
-  // TODO:  Specify the data needed to implement a 'default' word breaker.
-  constructor(obj) {
-  }
-
-  break(text: string): string[] {
-    throw "Not yet implemented.";
-  }
-}

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -32,6 +32,7 @@
 /// <reference path="../message.d.ts" />
 /// <reference path="models/dummy-model.ts" />
 /// <reference path="models/wordlist-model.ts" />
+/// <reference path="word_breaking/ascii-word-breaker.ts" />
 
 /**
  * Encapsulates all the state required for the LMLayer's worker thread.
@@ -282,6 +283,7 @@ class LMLayerWorker {
     // Assists unit-testing.
     scope['LMLayerWorker'] = worker;
     scope['models'] = models;
+    scope['wordBreakers'] = wordBreakers;
 
     return worker;
   }
@@ -291,6 +293,7 @@ class LMLayerWorker {
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = LMLayerWorker;
   module.exports['models'] = models;
+  module.exports['wordBreakers'] = wordBreakers;
 } else if (typeof self !== 'undefined' && 'postMessage' in self) {
   // Automatically install if we're in a Web Worker.
   LMLayerWorker.install(self as DedicatedWorkerGlobalScope);

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -194,10 +194,6 @@ class LMLayerWorker {
     }
   }
   
-  public loadWordBreaker(breaker: WorkerInternalWordBreaker) {
-    // TODO:  Actually store it somewhere for future use.  Make sure we can forget it with `unloadModel` as well.
-  }
-
   /**
    * Sets the model-loading state, i.e., `modelless`.
    * This state only handles `load` messages, and will

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -22,6 +22,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/// <reference path="../word_breaking/placeholder-word-breaker.ts" />
+
 /**
  * @file trie-model.ts
  * 
@@ -60,7 +62,7 @@
 
     constructor(trieData: object, options: TrieModelOptions = {}) {
       this._trie = new Trie(trieData as Node);
-      this.breakWords = options.wordBreaker || defaultWordBreaker;
+      this.breakWords = options.wordBreaker || wordBreakers.placeholderWordBreaker;
     }
 
     configure(capabilities: Capabilities): Configuration {
@@ -344,28 +346,6 @@
       this._storage.sort((a, b) => b.weight - a.weight);
       return this._storage.shift();
     }
-  }
-
-  /**
-   * A **VERY** dumb word breaker that simply splits at words. Do not use this
-   * word breaker!
-   *
-   * @param phrase The phrase in which to break words.
-   * @deprecated Please use a word breaker tailored to your language instead.
-   */
-  function defaultWordBreaker(phrase: string): Span[] {
-    let nextStart = 0;
-    return phrase.split(/\s+/).map(utterance => {
-      // XXX: The indices are NOT accurate to the original phrase!
-      let span = {
-        start: nextStart,
-        end: nextStart + utterance.length,
-        text: utterance,
-        length: utterance.length
-      };
-      nextStart = span.end;
-      return span;
-    });
   }
 
   /**

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -109,8 +109,13 @@
      * Get the last word of the phrase, or nothing.
      * @param fullLeftContext the entire left context of the string.
      */
-    private getLastWord(fullLeftContext: string) {
-      return this.breakWords(fullLeftContext).pop().text || '';
+    private getLastWord(fullLeftContext: string): string {
+      let words = this.breakWords(fullLeftContext)
+      if (words.length > 0) {
+        return words.pop().text;
+      }
+
+      return '';
     }
   };
 

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -108,7 +108,7 @@
      * @param fullLeftContext the entire left context of the string.
      */
     private getLastWord(fullLeftContext: string) {
-      return fullLeftContext.split(/\s+/).pop() || '';
+      return this.breakWords(fullLeftContext).pop().text || '';
     }
   };
 
@@ -346,8 +346,26 @@
     }
   }
 
+  /**
+   * A **VERY** dumb word breaker that simply splits at words. Do not use this
+   * word breaker!
+   *
+   * @param phrase The phrase in which to break words.
+   * @deprecated Please use a word breaker tailored to your language instead.
+   */
   function defaultWordBreaker(phrase: string): Span[] {
-    throw new Error;
+    let nextStart = 0;
+    return phrase.split(/\s+/).map(utterance => {
+      // XXX: The indices are NOT accurate to the original phrase!
+      let span = {
+        start: nextStart,
+        end: nextStart + utterance.length,
+        text: utterance,
+        length: utterance.length
+      };
+      nextStart = span.end;
+      return span;
+    });
   }
 
   /**

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -62,7 +62,7 @@
 
     constructor(trieData: object, options: TrieModelOptions = {}) {
       this._trie = new Trie(trieData as Node);
-      this.breakWords = options.wordBreaker || wordBreakers.placeholderWordBreaker;
+      this.breakWords = options.wordBreaker || wordBreakers.placeholder;
     }
 
     configure(capabilities: Capabilities): Configuration {

--- a/common/predictive-text/worker/models/wordlist-model.ts
+++ b/common/predictive-text/worker/models/wordlist-model.ts
@@ -61,7 +61,7 @@
       // [wordform, count] pairs. Since this model does not
       // support weighting, discard the count.
       this._wordlist = wordlist.map(([word, _count]) => word);
-      this.breakWords = options.wordBreaker || wordBreakers.placeholderWordBreaker;
+      this.breakWords = options.wordBreaker || wordBreakers.placeholder;
     }
 
     configure(capabilities: Capabilities): Configuration {

--- a/common/predictive-text/worker/models/wordlist-model.ts
+++ b/common/predictive-text/worker/models/wordlist-model.ts
@@ -40,15 +40,28 @@
   /** Upper bound on the amount of suggestions to generate. */
   const MAX_SUGGESTIONS = 3;
 
+  /**
+   * Additional arguments to pass into the model, in addition to the model
+   * parameters themselves.
+   */
+  interface WordListModelOptions {
+    /**
+     * How to break words in a phrase.
+     */
+    wordBreaker?: WordBreakingFunction;
+  }
+
   export class WordListModel implements WorkerInternalModel {
     configuration: Configuration;
     private _wordlist: string[];
+    readonly breakWords: WordBreakingFunction;
 
-    constructor(wordlist: [string, number][]) {
+    constructor(wordlist: [string, number][], options: WordListModelOptions = {}) {
       // The wordlist is always given as an array of
       // [wordform, count] pairs. Since this model does not
       // support weighting, discard the count.
       this._wordlist = wordlist.map(([word, _count]) => word);
+      this.breakWords = options.wordBreaker || wordBreakers.placeholderWordBreaker;
     }
 
     configure(capabilities: Capabilities): Configuration {
@@ -62,7 +75,8 @@
       // EVERYTHING to the left of the cursor: 
       let fullLeftContext = context.left || '';
       // Stuff to the left of the cursor in the current word.
-      let leftContext = fullLeftContext.split(/\s+/).pop() || '';
+      let words = this.breakWords(fullLeftContext);
+      let leftContext = words.length > 0 ? words.pop().text : '';
       // All text to the left of the cursor INCLUDING anything that has
       // just been typed.
       let prefix = leftContext + (transform.insert || '');

--- a/common/predictive-text/worker/word_breaking/ascii-word-breaker.ts
+++ b/common/predictive-text/worker/word_breaking/ascii-word-breaker.ts
@@ -1,0 +1,39 @@
+namespace wordBreakers {
+  /**
+   * A concrete span class that derives its properties from the result of
+   * RegExp.exec() array.
+   */
+  class RegExpDerivedSpan implements Span {
+    readonly text: string;
+    readonly start: number;
+
+    constructor(text: string, start: number) {
+      this.text = text;
+      this.start = start;
+    }
+
+    get length(): number {
+      return this.text.length;
+    }
+
+    get end(): number {
+      return this.start + this.text.length;
+    }
+  }
+
+  /**
+   * Splits ASCII words.
+   * 
+   * @param phrase 
+   */
+  export function ascii(phrase: string): Span[] {
+    let matchWord = /[A-Za-z0-9']+/g;
+    let words: Span[] = [];
+    let match: RegExpExecArray;
+    while ((match = matchWord.exec(phrase)) !== null) {
+      words.push(new RegExpDerivedSpan(match[0], match.index));
+    }
+
+    return words;
+  }
+}

--- a/common/predictive-text/worker/word_breaking/placeholder-word-breaker.ts
+++ b/common/predictive-text/worker/word_breaking/placeholder-word-breaker.ts
@@ -7,7 +7,7 @@ namespace wordBreakers {
    * @param phrase The phrase in which to break words.
    * @deprecated Use a word breaker tailored to your language instead!
    */
-  export function placeholderWordBreaker(phrase: string): Span[] {
+  export function placeholder(phrase: string): Span[] {
     let nextStart = 0;
     return phrase.split(/\s+/).map(utterance => {
       // XXX: The indices are NOT accurate to the original phrase!

--- a/common/predictive-text/worker/word_breaking/placeholder-word-breaker.ts
+++ b/common/predictive-text/worker/word_breaking/placeholder-word-breaker.ts
@@ -1,0 +1,24 @@
+namespace wordBreakers {
+
+  /**
+   * A **VERY** dumb word breaker that simply splits at words. Do not use this
+   * word breaker!
+   *
+   * @param phrase The phrase in which to break words.
+   * @deprecated Use a word breaker tailored to your language instead!
+   */
+  export function placeholderWordBreaker(phrase: string): Span[] {
+    let nextStart = 0;
+    return phrase.split(/\s+/).map(utterance => {
+      // XXX: The indices are NOT accurate to the original phrase!
+      let span = {
+        start: nextStart,
+        end: nextStart + utterance.length,
+        text: utterance,
+        length: utterance.length
+      };
+      nextStart = span.end;
+      return span;
+    });
+  }
+}

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -131,7 +131,3 @@ interface WorkerInternalModelConstructor {
    */
   new(...modelParameters: any[]): WorkerInternalModel;
 }
-
-interface WorkerInternalWordBreaker {
-  break(text: string): string[]; // 
-}

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -160,13 +160,13 @@ interface WordBreakingFunction {
  */
 interface Span {
   // invariant: start < end (empty spans not allowed)
-  start: number;
+  readonly start: number;
   // invariant: end > end (empty spans not allowed)
-  end: number;
+  readonly end: number;
   // invariant: length === end - start
-  length: number;
+  readonly length: number;
   // invariant: text.length === length
   // invariant: each character is BMP UTF-16 code unit, or is a high surrogate
   // UTF-16 code unit followed by a low surrogate UTF-16 code unit.
-  text: number;
+  readonly text: string;
 }

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -22,7 +22,7 @@
 
 /**
  * @file worker-interfaces.ts
- * 
+ *
  * Interfaces and types required internally in the worker code.
  */
 
@@ -83,7 +83,7 @@ interface PredictMessage {
    * If this is not provided, then the prediction is not
    * assumed to be associated with an input event (for example,
    * when a user starts typing on an empty text field).
-   * 
+   *
    * TODO: test for absent transform!
    */
   transform?: Transform;
@@ -130,4 +130,43 @@ interface WorkerInternalModelConstructor {
    * capabilities, plus any parameters they require.
    */
   new(...modelParameters: any[]): WorkerInternalModel;
+}
+
+/**
+ * A simple word breaking function takes a phrase, and splits it into "words",
+ * for whatever definition of "word" is usable for the language model.
+ *
+ * For example:
+ *
+ *   getText(breakWordsEnglish("Hello, world!")) == ["Hello", "world"]
+ *   getText(breakWordsCree("ᑕᐻ ᒥᔪ ᑮᓯᑲᐤ ᐊᓄᐦᐨ᙮")) == ["ᑕᐻ", "ᒥᔪ ᑮᓯᑲᐤ""", "ᐊᓄᐦᐨ"]
+ *   getText(breakWordsJapanese("英語を話せますか？")) == ["英語", "を", "話せます", "か"]
+ *
+ * Not all language models take in a configurable word breaking function.
+ *
+ * @returns an array of spans from the phrase, in order as they appear in the
+ *          phrase, each span which representing a word.
+ */
+interface WordBreakingFunction {
+  // invariant: span[i].end <= span[i + 1].start
+  // invariant: for all span[i] and span[i + 1], there does not exist a span[k]
+  //            where span[i].end <= span[k].start AND span[k].end <= span[i + 1].start
+  (phrase: USVString): Span[];
+}
+
+/**
+ * A span of text in a phrase. This is usually meant to reprent words from a
+ * pharse.
+ */
+interface Span {
+  // invariant: start < end (empty spans not allowed)
+  start: number;
+  // invariant: end > end (empty spans not allowed)
+  end: number;
+  // invariant: length === end - start
+  length: number;
+  // invariant: text.length === length
+  // invariant: each character is BMP UTF-16 code unit, or is a high surrogate
+  // UTF-16 code unit followed by a low surrogate UTF-16 code unit.
+  text: number;
 }


### PR DESCRIPTION
This pull request introduces the basic word breaking API. At its simplest, the word breaker is simply a function that returns words.

```ts
interface WordBreakingFunction {
  (phrase: USVString): Span[];
}
```

A `Span` is the word, plus data like what index it started on, and what index it ended on.

```ts
interface Span {
  readonly start: number;
  readonly end: number;
  readonly length: number;
  readonly text: string;
}
```

---

A model may explicitly require a word breaking function in its options; the compiler will generate the appropriate code:

```ts
var parameters = {/* ... */};
LMLayer.loadModel(new MyCoolModel(parameters, { wordBreaker: function (phrase) { return []; }));
```
