### PR TITLE
[Web, Android, iOS] Null suggestion banner bug

### DIFF
--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -511,7 +511,14 @@ namespace com.keyman.osk {
     }
 
     private doAccept(suggestion: BannerSuggestion) {
-      this.preAccept = suggestion.apply();
+      let revert = suggestion.apply();
+      
+      if(revert) {
+        this.preAccept = revert;
+      } else {
+        // If null, it's a blank option; we should effectively never 'accept' it.
+        return;
+      }
       
       this.selected = null;
       this.recentAccept = true;

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -442,6 +442,7 @@ namespace com.keyman.osk {
         let suggestion = this.selected = t['suggestion'] as BannerSuggestion;
         if(suggestion.isEmpty()) {
           on = false;
+          this.selected = null;
         }
       }
 

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -239,6 +239,7 @@ namespace com.keyman.text.prediction {
 
       // Signal to any predictive text UI that the context has changed, invalidating recent predictions.
       keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'context');
+      this.predict();
     }
 
     public predict(transcription?: Transcription) {


### PR DESCRIPTION
Fixes the following issue:

- Selecting a 'blank' suggestion element was erroneously triggering predictive state management.
  - Most significantly, this tended to temporarily break the BKSP key.