### PR TITLE
[Android] Add "Language Settings" menu stub

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -35,6 +35,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     languagesPreference.setWidgetLayoutResource(R.layout.preference_icon_layout);
     Intent languagesIntent = new Intent();
     languagesIntent.setClassName(context.getPackageName(), "com.tavultesoft.kmea.LanguagesSettingsActivity");
+    languagesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
     languagesIntent.putExtra(KMManager.KMKey_DisplayKeyboardSwitcher, false);
     languagesPreference.setIntent(languagesIntent);
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -23,6 +23,8 @@ import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KMTextView;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
+import com.tavultesoft.kmea.KeyboardPickerActivity;
+import com.tavultesoft.kmea.LanguagesSettingsActivity;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
 
@@ -725,6 +727,20 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
   private void showGetStarted() {
     Intent getStartedIntent = new Intent(this, GetStartedActivity.class);
+
+    String langId = "en";
+    ArrayList<HashMap<String, String>> associatedKeyboardsList = KeyboardPickerActivity.getAssociatedKeyboards(langId);
+    HashMap<String, String> associatedLexicalModel = KeyboardPickerActivity.getAssociatedLexicalModel(this, langId);
+    Bundle args = new Bundle();
+    args.putString(KMManager.KMKey_LanguageID, langId);
+    args.putString(KMManager.KMKey_LanguageName, "English");
+    args.putSerializable("associatedKeyboards", associatedKeyboardsList);
+    if (associatedLexicalModel != null) {
+      args.putString(KMManager.KMKey_LexicalModelName, associatedLexicalModel.get(KMManager.KMKey_LexicalModelName));
+    }
+    getStartedIntent = new Intent(this, com.tavultesoft.kmea.LanguageSettingsActivity.class);
+    getStartedIntent.putExtras(args);
+
     startActivity(getStartedIntent);
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -23,8 +23,6 @@ import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KMTextView;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
-import com.tavultesoft.kmea.KeyboardPickerActivity;
-import com.tavultesoft.kmea.LanguagesSettingsActivity;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
 
@@ -727,20 +725,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
   private void showGetStarted() {
     Intent getStartedIntent = new Intent(this, GetStartedActivity.class);
-
-    String langId = "en";
-    ArrayList<HashMap<String, String>> associatedKeyboardsList = KeyboardPickerActivity.getAssociatedKeyboards(langId);
-    HashMap<String, String> associatedLexicalModel = KeyboardPickerActivity.getAssociatedLexicalModel(this, langId);
-    Bundle args = new Bundle();
-    args.putString(KMManager.KMKey_LanguageID, langId);
-    args.putString(KMManager.KMKey_LanguageName, "English");
-    args.putSerializable("associatedKeyboards", associatedKeyboardsList);
-    if (associatedLexicalModel != null) {
-      args.putString(KMManager.KMKey_LexicalModelName, associatedLexicalModel.get(KMManager.KMKey_LexicalModelName));
-    }
-    getStartedIntent = new Intent(this, com.tavultesoft.kmea.LanguageSettingsActivity.class);
-    getStartedIntent.putExtras(args);
-
     startActivity(getStartedIntent);
   }
 

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -41,10 +41,6 @@
   <string name="show_banner_on" translatable="false">Cannot be switched off when predictive text is enabled</string>
   <!-- reuse show_get_started -->
 
-  <!-- Language Settings menu strings -->
-  <string name="enable_corrections" translatable="false">Enable corrections</string>
-  <string name="enable_predictions" translatable="false">Enable predictions</string>
-  <string name="model" translatable="false">Model</string>
   <!-- Web Browser strings -->
   <string name="hint_text" translatable="false">Search or type URL</string>
   <string name="title_bookmarks" translatable="false">Bookmarks</string>

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -50,6 +50,12 @@
             android:theme="@style/Theme.AppCompat.Light.Dialog">
         </activity>
         <activity
+            android:name="com.tavultesoft.kmea.KeyboardSettingsActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AppCompat.Light.Dialog" >
+        </activity>
+        <activity
             android:name="com.tavultesoft.kmea.ModelsPickerActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -44,6 +44,12 @@
             android:theme="@style/Theme.AppCompat.Light.Dialog">
         </activity>
         <activity
+            android:name="com.tavultesoft.kmea.LanguageSettingsActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AppCompat.Light.Dialog">
+        </activity>
+        <activity
             android:name="com.tavultesoft.kmea.ModelsPickerActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -160,6 +160,12 @@
       window.jsInterface.insertText(dn, s, dr);
     }
 
+    function unloadModel() {
+      var kmw=window['keyman'];
+      window.console.log('unloadModel');
+      kmw.modelManager.unloadModel();
+    }
+
     function enableSuggestions(model) {
       registerModel(model);
     }

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -160,10 +160,9 @@
       window.jsInterface.insertText(dn, s, dr);
     }
 
-    function unloadModel() {
+    function deregisterModel(modelID) {
       var kmw=window['keyman'];
-      window.console.log('unloadModel');
-      kmw.modelManager.unloadModel();
+      kmw.modelManager.deregister(modelID);
     }
 
     function enableSuggestions(model) {
@@ -172,7 +171,7 @@
 
     function registerModel(model) {
       var kmw=window['keyman'];
-      window.console.log('registerModel: ' + model);
+      //window.console.log('registerModel: ' + model);
       kmw.registerModel(model);
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -9,11 +9,12 @@ import android.os.Bundle;
 import android.widget.Toast;
 
 /**
- * Confirmation dialog for downloading a Keyman keyboard
+ * Confirmation dialog for downloading or deleting a Keyman keyboard/model
  */
 public class ConfirmDialogFragment extends DialogFragment {
   public static final String ARG_TITLE = "ConfirmDialogFragment.title";
   public static final String ARG_MESSAGE = "ConfirmDialogFragment.message";
+  public static final String ARG_KEYBOARD_KEY = "confirmDialogFragment.keyboardKey";
 
   public static ConfirmDialogFragment newInstance(String title, String message) {
     ConfirmDialogFragment frag = new ConfirmDialogFragment();
@@ -24,24 +25,45 @@ public class ConfirmDialogFragment extends DialogFragment {
     return frag;
   }
 
+  public static ConfirmDialogFragment newInstance(String title, String message, String keyboardKey) {
+    ConfirmDialogFragment frag = new ConfirmDialogFragment();
+    Bundle args = new Bundle();
+    args.putString(ARG_TITLE, title);
+    args.putString(ARG_MESSAGE, message);
+    args.putString(ARG_KEYBOARD_KEY, keyboardKey);
+    frag.setArguments(args);
+    return frag;
+  }
+
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     Dialog dialog = super.onCreateDialog(savedInstanceState);
 
     final String title = getArguments().getString(ARG_TITLE);
     final String message = getArguments().getString(ARG_MESSAGE);
+    final String keyboardKey = getArguments().getString(ARG_KEYBOARD_KEY);
+    String positiveLabel = (keyboardKey == null) ? getString(R.string.label_download) : getString(R.string.label_delete);
 
     return new AlertDialog.Builder(getActivity())
       .setTitle(title)
       .setMessage(message)
-      .setPositiveButton(getString(R.string.label_download), new DialogInterface.OnClickListener() {
+      .setPositiveButton(positiveLabel, new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {
-          // Download keyboard
-          if (KMManager.hasConnection(getActivity())) {
-            KMKeyboardDownloaderActivity.download(getActivity(), true);
-          } else {
+          if (keyboardKey == null) {
+            // Confirmation to download keyboard
+            if (KMManager.hasConnection(getActivity())) {
+              KMKeyboardDownloaderActivity.download(getActivity(), true);
+            } else {
             Toast.makeText(getActivity(), "No internet connection", Toast.LENGTH_SHORT).show();
+          }
+          } else {
+            // Confirmation to delete item
+            int keyboardIndex = KeyboardPickerActivity.getKeyboardIndex(getActivity(), keyboardKey);
+            boolean result = KeyboardPickerActivity.removeKeyboard(getActivity(), keyboardIndex);
+            if (result) {
+              Toast.makeText(getActivity(), "Keyboard deleted", Toast.LENGTH_SHORT).show();
+            }
           }
           if (dialog != null) {
             dialog.dismiss();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -68,6 +68,7 @@ public class ConfirmDialogFragment extends DialogFragment {
           if (dialog != null) {
             dialog.dismiss();
           }
+          getActivity().finish();
         }
       })
       .setNegativeButton(getString(R.string.label_cancel),  new DialogInterface.OnClickListener() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -15,6 +15,7 @@ public class ConfirmDialogFragment extends DialogFragment {
   public static final String ARG_TITLE = "ConfirmDialogFragment.title";
   public static final String ARG_MESSAGE = "ConfirmDialogFragment.message";
   public static final String ARG_KEYBOARD_KEY = "confirmDialogFragment.keyboardKey";
+  private boolean dismissOnSelect = false;
 
   public static ConfirmDialogFragment newInstance(String title, String message) {
     ConfirmDialogFragment frag = new ConfirmDialogFragment();
@@ -56,7 +57,7 @@ public class ConfirmDialogFragment extends DialogFragment {
               KMKeyboardDownloaderActivity.download(getActivity(), true);
             } else {
             Toast.makeText(getActivity(), "No internet connection", Toast.LENGTH_SHORT).show();
-          }
+            }
           } else {
             // Confirmation to delete item
             int keyboardIndex = KeyboardPickerActivity.getKeyboardIndex(getActivity(), keyboardKey);
@@ -64,11 +65,15 @@ public class ConfirmDialogFragment extends DialogFragment {
             if (result) {
               Toast.makeText(getActivity(), "Keyboard deleted", Toast.LENGTH_SHORT).show();
             }
+            dismissOnSelect = true;
           }
           if (dialog != null) {
             dialog.dismiss();
           }
-          getActivity().finish();
+
+          if (dismissOnSelect && !getActivity().isFinishing()) {
+            getActivity().finish();
+          }
         }
       })
       .setNegativeButton(getString(R.string.label_cancel),  new DialogInterface.OnClickListener() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -15,12 +15,14 @@ public class ConfirmDialogFragment extends DialogFragment {
   public static final String ARG_DIALOG_TYPE = "ConfirmDialogFragment.dialogType";
   public static final String ARG_TITLE = "ConfirmDialogFragment.title";
   public static final String ARG_MESSAGE = "ConfirmDialogFragment.message";
-  public static final String ARG_KEYBOARD_KEY = "confirmDialogFragment.keyboardKey";
+  public static final String ARG_ITEM_KEY = "confirmDialogFragment.itemKey";
   private boolean dismissOnSelect = false;
 
   public enum DialogType {
     DIALOG_TYPE_DOWNLOAD_KEYBOARD,
-    DIALOG_TYPE_DELETE_KEYBOARD
+    DIALOG_TYPE_DELETE_KEYBOARD,
+    DIALOG_TYPE_DOWNLOAD_MODEL,
+    DIALOG_TYPE_DELETE_MODEL
   }
 
   public static ConfirmDialogFragment newInstance(DialogType dialogType, String title, String message) {
@@ -33,13 +35,13 @@ public class ConfirmDialogFragment extends DialogFragment {
     return frag;
   }
 
-  public static ConfirmDialogFragment newInstance(DialogType dialogType, String title, String message, String keyboardKey) {
+  public static ConfirmDialogFragment newInstance(DialogType dialogType, String title, String message, String itemKey) {
     ConfirmDialogFragment frag = new ConfirmDialogFragment();
     Bundle args = new Bundle();
     args.putSerializable(ARG_DIALOG_TYPE, dialogType);
     args.putString(ARG_TITLE, title);
     args.putString(ARG_MESSAGE, message);
-    args.putString(ARG_KEYBOARD_KEY, keyboardKey);
+    args.putString(ARG_ITEM_KEY, itemKey);
     frag.setArguments(args);
     return frag;
   }
@@ -51,8 +53,10 @@ public class ConfirmDialogFragment extends DialogFragment {
     final DialogType dialogType = (DialogType)getArguments().getSerializable(ARG_DIALOG_TYPE);
     final String title = getArguments().getString(ARG_TITLE);
     final String message = getArguments().getString(ARG_MESSAGE);
-    final String keyboardKey = getArguments().getString(ARG_KEYBOARD_KEY);
-    String positiveLabel = (keyboardKey == null) ? getString(R.string.label_download) : getString(R.string.label_delete);
+    final String itemKey = getArguments().getString(ARG_ITEM_KEY);
+    String positiveLabel = (dialogType == DialogType.DIALOG_TYPE_DOWNLOAD_KEYBOARD ||
+      dialogType == DialogType.DIALOG_TYPE_DOWNLOAD_MODEL) ?
+      getString(R.string.label_download) : getString(R.string.label_delete);
 
     return new AlertDialog.Builder(getActivity())
       .setTitle(title)
@@ -70,9 +74,15 @@ public class ConfirmDialogFragment extends DialogFragment {
               }
               break;
             case DIALOG_TYPE_DELETE_KEYBOARD :
-              // Confirmation to delete item
-              int keyboardIndex = KeyboardPickerActivity.getKeyboardIndex(getActivity(), keyboardKey);
+              // Confirmation to delete keyboard
+              int keyboardIndex = KeyboardPickerActivity.getKeyboardIndex(getActivity(), itemKey);
               KeyboardPickerActivity.deleteKeyboard(getContext(), keyboardIndex);
+              dismissOnSelect = true;
+              break;
+            case DIALOG_TYPE_DELETE_MODEL :
+              // Confirmation to delete model
+              int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(getActivity(), itemKey);
+              KeyboardPickerActivity.deleteLexicalModel(getContext(), modelIndex);
               dismissOnSelect = true;
               break;
             default :

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -82,7 +82,7 @@ public class ConfirmDialogFragment extends DialogFragment {
             case DIALOG_TYPE_DELETE_MODEL :
               // Confirmation to delete model
               int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(getActivity(), itemKey);
-              KeyboardPickerActivity.deleteLexicalModel(getContext(), modelIndex);
+              KeyboardPickerActivity.deleteLexicalModel(getContext(), modelIndex, itemKey);
               dismissOnSelect = true;
               break;
             default :

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -125,7 +125,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
     }
 
     DialogFragment dialog = ConfirmDialogFragment.newInstance(
-      DIALOG_TYPE_DOWNLOAD_KEYBOARD, title, getString(R.string.confirm_download));
+      DIALOG_TYPE_DOWNLOAD_KEYBOARD, title, getString(R.string.confirm_download_keyboard));
     dialog.show(getFragmentManager(), "dialog");
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -23,6 +23,7 @@ import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
 
+import static com.tavultesoft.kmea.ConfirmDialogFragment.DialogType.DIALOG_TYPE_DOWNLOAD_KEYBOARD;
 import static com.tavultesoft.kmea.KMManager.KMDefault_UndefinedPackageID;
 
 public class KMKeyboardDownloaderActivity extends AppCompatActivity {
@@ -123,7 +124,8 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       title = String.format("%s: %s", langName, kbName);
     }
 
-    DialogFragment dialog = ConfirmDialogFragment.newInstance(title, getString(R.string.confirm_download));
+    DialogFragment dialog = ConfirmDialogFragment.newInstance(
+      DIALOG_TYPE_DOWNLOAD_KEYBOARD, title, getString(R.string.confirm_download));
     dialog.show(getFragmentManager(), "dialog");
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -323,6 +323,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
         try {
           JSONObject modelInfo = lmData.getJSONObject(0);
           if (modelInfo.has("packageFilename")) {
+            // TODO: Confirm if user wants to overwrite exisiting model version
             urls.add(modelInfo.getString("packageFilename"));
           }
         } catch (JSONException e) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -708,13 +708,14 @@ public final class KMManager {
     return true;
   }
 
-  public static boolean unloadLexicalModel() {
+  public static boolean deregisterLexicalModel(String modelID) {
+    String url = String.format("javascript:deregisterModel('%s')", modelID);
     if (InAppKeyboard != null && InAppKeyboardLoaded) {
-      InAppKeyboard.loadUrl("javascript:unloadModel()");
+      InAppKeyboard.loadUrl(url);
     }
 
     if (SystemKeyboard != null && SystemKeyboardLoaded) {
-      SystemKeyboard.loadUrl("javascript:unloadModel()");
+      SystemKeyboard.loadUrl(url);
     }
     return true;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -708,6 +708,17 @@ public final class KMManager {
     return true;
   }
 
+  public static boolean unloadLexicalModel() {
+    if (InAppKeyboard != null && InAppKeyboardLoaded) {
+      InAppKeyboard.loadUrl("javascript:unloadModel()");
+    }
+
+    if (SystemKeyboard != null && SystemKeyboardLoaded) {
+      SystemKeyboard.loadUrl("javascript:unloadModel()");
+    }
+    return true;
+  }
+
   public static boolean addLexicalModel(Context context, HashMap<String, String> lexicalModelInfo) {
     return KeyboardPickerActivity.addLexicalModel(context, lexicalModelInfo);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -389,7 +389,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
     KMManager.setKeyboard(pkgId, kbId, langId, kbName, langName, kFont, kOskFont);
 
     // Register associated lexical model
-    HashMap<String, String> lmInfo = getAssociatedLexicalModel(langId);
+    HashMap<String, String> lmInfo = getAssociatedLexicalModel(this, langId);
     if (lmInfo != null) {
       KMManager.registerLexicalModel(lmInfo);
     }
@@ -601,16 +601,18 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
   }
 
   /**
-   * Get the list of associated keyboard names for a given language ID
+   * Get the list of associated keyboards for a given language ID
    * @param langId
-   * @return ArrayList of keyboard names
+   * @return ArrayList of keyboard
    */
-  protected static ArrayList<String> getAssociatedKeyboards(String langId) {
+  public static ArrayList<HashMap<String, String>> getAssociatedKeyboards(String langId) {
     if (keyboardsList != null) {
-      ArrayList<String> associatedKeyboards = new ArrayList<String>();
+      ArrayList<HashMap<String, String>> associatedKeyboards = new ArrayList<HashMap<String, String>>();
       for (HashMap<String, String> keyboardInfo: keyboardsList) {
         if (keyboardInfo.get(KMManager.KMKey_LanguageID).equalsIgnoreCase(langId)) {
-          associatedKeyboards.add(keyboardInfo.get(KMManager.KMKey_KeyboardName));
+          keyboardInfo.put(KMManager.KMKey_Icon, String.valueOf(R.drawable.ic_arrow_forward));
+          keyboardInfo.put("isEnabled", "true");
+          associatedKeyboards.add(keyboardInfo);
         }
       }
       return associatedKeyboards;
@@ -644,7 +646,10 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
     return index;
   }
 
-  protected static HashMap<String, String> getAssociatedLexicalModel(String langId) {
+  public static HashMap<String, String> getAssociatedLexicalModel(Context context, String langId) {
+    if (lexicalModelsList == null) {
+     lexicalModelsList = getLexicalModelsList(context);
+    }
     if (lexicalModelsList != null) {
       int length = lexicalModelsList.size();
       for (int i = 0; i < length; i++) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -172,7 +172,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
           popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
               if (item.getItemId() == R.id.popup_delete) {
-                deleteKeyboard(position);
+                deleteKeyboard(context, position);
                 return true;
               } else {
                 return false;
@@ -367,13 +367,13 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
     return result;
   }
 
-  private void setSelection(int position) {
+  private static void setSelection(int position) {
     listView.setItemChecked(position, true);
     listView.setSelection(position);
     selectedIndex = position;
   }
 
-  private void switchKeyboard(int position) {
+  private static void switchKeyboard(int position) {
     setSelection(position);
     HashMap<String, String> kbInfo = keyboardsList.get(position);
     String pkgId = kbInfo.get(KMManager.KMKey_PackageID);
@@ -472,13 +472,13 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
     return result;
   }
 
-  protected void deleteKeyboard(int position) {
+  protected static void deleteKeyboard(Context context, int position) {
     int curKbPos = getCurrentKeyboardIndex();
-    boolean result = removeKeyboard(this, position);
+    boolean result = removeKeyboard(context, position);
     ;
 
     if (result) {
-      Toast.makeText(this, "Keyboard deleted", Toast.LENGTH_SHORT).show();
+      Toast.makeText(context, "Keyboard deleted", Toast.LENGTH_SHORT).show();
       BaseAdapter adapter = (BaseAdapter) listAdapter;
       adapter.notifyDataSetChanged();
       if (position == curKbPos) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -439,7 +439,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
 
       if (pkgID != null && modelID != null && langID != null) {
         String lmKey = String.format("%s_%s_%s", langID, pkgID, modelID);
-        if (lmKey.length() >= 3) {
+        if (lmKey.length() >= 5) {
           int x = getLexicalModelIndex(context, lmKey);
           if (x >= 0) {
             lexicalModelsList.set(x, lexicalModelInfo);
@@ -487,6 +487,29 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
         curKbPos = getCurrentKeyboardIndex();
         setSelection(curKbPos);
       }
+    }
+  }
+
+  protected static boolean removeLexicalModel(Context context, int position) {
+    boolean result = false;
+    if (lexicalModelsList == null) {
+      lexicalModelsList = getLexicalModelsList(context);
+    }
+
+    if (lexicalModelsList != null && position >= 0 && position < lexicalModelsList.size()) {
+      lexicalModelsList.remove(position);
+      result = saveList(context, KMManager.KMFilename_LexicalModelsList);
+    }
+
+    return result;
+  }
+
+  protected static void deleteLexicalModel(Context context, int position) {
+    boolean result = removeLexicalModel(context, position);
+
+    if (result) {
+      Toast.makeText(context, "Model deleted", Toast.LENGTH_SHORT).show();
+      KMManager.unloadLexicalModel();
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -504,12 +504,17 @@ public final class KeyboardPickerActivity extends AppCompatActivity implements O
     return result;
   }
 
-  protected static void deleteLexicalModel(Context context, int position) {
+  protected static void deleteLexicalModel(Context context, int position, String modelKey) {
     boolean result = removeLexicalModel(context, position);
 
     if (result) {
       Toast.makeText(context, "Model deleted", Toast.LENGTH_SHORT).show();
-      KMManager.unloadLexicalModel();
+
+      // Extract [language ID, package ID, model ID] and deregister Lexical model
+      String idArray[] = modelKey.split("_");
+      if (idArray.length == 3) {
+        KMManager.deregisterLexicalModel(idArray[2]);
+      }
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -28,6 +28,8 @@ import android.widget.TextView;
 
 import com.tavultesoft.kmea.util.FileUtils;
 
+import static com.tavultesoft.kmea.ConfirmDialogFragment.DialogType.DIALOG_TYPE_DELETE_KEYBOARD;
+
 // Public access is necessary to avoid IllegalAccessException
 public final class KeyboardSettingsActivity extends AppCompatActivity {
 
@@ -133,7 +135,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
           // Uninstall selected keyboard
           String title = String.format("%s: %s", languageName, kbName);
           String keyboardKey = String.format("%s_%s", languageID, kbID);
-          DialogFragment dialog = ConfirmDialogFragment.newInstance(title, getString(R.string.confirm_delete), keyboardKey);
+          DialogFragment dialog = ConfirmDialogFragment.newInstance(
+            DIALOG_TYPE_DELETE_KEYBOARD, title, getString(R.string.confirm_delete), keyboardKey);
           dialog.show(getFragmentManager(), "dialog");
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -1,0 +1,161 @@
+
+package com.tavultesoft.kmea;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import android.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.graphics.Typeface;
+import android.net.Uri;
+import android.os.Bundle;
+import androidx.core.content.FileProvider;
+import android.util.Log;
+import android.view.View;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.SimpleAdapter;
+import android.widget.TextView;
+
+import com.tavultesoft.kmea.util.FileUtils;
+
+// Public access is necessary to avoid IllegalAccessException
+public final class KeyboardSettingsActivity extends AppCompatActivity {
+
+  private static Toolbar toolbar = null;
+  private static ListView listView = null;
+  private DialogFragment dialog;
+  private static ArrayList<HashMap<String, String>> infoList = null;
+  protected static Typeface titleFont = null;
+  private final String titleKey = "title";
+  private final String subtitleKey = "subtitle";
+  private final String iconKey = "icon";
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    final Context context = this;
+    setContentView(R.layout.activity_list_layout);
+    toolbar = (Toolbar) findViewById(R.id.list_toolbar);
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setDisplayShowHomeEnabled(true);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+    listView = (ListView) findViewById(R.id.listView);
+
+    final String packageID = getIntent().getStringExtra(KMManager.KMKey_PackageID);
+    final String languageID = getIntent().getStringExtra(KMManager.KMKey_LanguageID);
+    final String languageName = getIntent().getStringExtra(KMManager.KMKey_LanguageName);
+    final String kbID = getIntent().getStringExtra(KMManager.KMKey_KeyboardID);
+    final String kbName = getIntent().getStringExtra(KMManager.KMKey_KeyboardName);
+    final String kbVersion = getIntent().getStringExtra(KMManager.KMKey_KeyboardVersion);
+
+    final TextView textView = (TextView) findViewById(R.id.bar_title);
+    textView.setText(kbName);
+    if (titleFont != null)
+      textView.setTypeface(titleFont, Typeface.BOLD);
+
+    boolean isCustomKeyboard = getIntent().getBooleanExtra(KMManager.KMKey_CustomKeyboard, false);
+
+    infoList = new ArrayList<HashMap<String, String>>();
+    String icon = "0";
+    HashMap<String, String> hashMap = new HashMap<String, String>();
+    hashMap.put(titleKey, getString(R.string.keyboard_version));
+    hashMap.put(subtitleKey, kbVersion);
+    hashMap.put(iconKey, icon);
+    infoList.add(hashMap);
+
+    final String customHelpLink = getIntent().getStringExtra(KMManager.KMKey_CustomHelpLink);
+    if (!isCustomKeyboard || customHelpLink != null) {
+      icon = String.valueOf(R.drawable.ic_arrow_forward);
+      hashMap = new HashMap<String, String>();
+      hashMap.put(titleKey, getString(R.string.help_link));
+      hashMap.put(subtitleKey, "");
+      hashMap.put(iconKey, icon);
+      infoList.add(hashMap);
+    }
+
+    if (!packageID.equalsIgnoreCase(KMManager.KMDefault_UndefinedPackageID) ||
+        !kbID.equalsIgnoreCase(KMManager.KMDefault_KeyboardID)) {
+      icon = "0";
+      hashMap = new HashMap<String, String>();
+      hashMap.put(titleKey, getString(R.string.uninstall_keyboard));
+      hashMap.put(subtitleKey, "");
+      hashMap.put(iconKey, icon);
+      infoList.add(hashMap);
+    }
+
+    String[] from = new String[]{titleKey, subtitleKey, iconKey};
+    int[] to = new int[]{R.id.text1, R.id.text2, R.id.image1};
+    ListAdapter adapter = new SimpleAdapter(context, infoList, R.layout.list_row_layout2, from, to);
+    listView.setAdapter(adapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        if (position == 1) {
+          Intent i = new Intent(Intent.ACTION_VIEW);
+
+          if (customHelpLink != null) {
+            if (FileUtils.isWelcomeFile(customHelpLink)) {
+              File customHelp = new File(new File(customHelpLink).getAbsolutePath());
+              i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+              // Starting with Android N, you can't pass file:// to intents, so we use FileProvider
+              try {
+                Uri contentUri = FileProvider.getUriForFile(
+                  context, getApplication().getPackageName() + ".fileProvider", customHelp);
+                i.setDataAndType(contentUri, "text/html");
+              } catch (Exception e) {
+                Log.e("KeyboardInfoActivity", "Failed to access " + customHelp.toString());
+              }
+            }
+            else {
+              i.setData(Uri.parse(customHelpLink));
+            }
+            startActivity(i);
+          } else {
+            String helpUrlStr = String.format("http://help.keyman.com/keyboard/%s/%s/", kbID, kbVersion);
+            i.setData(Uri.parse(helpUrlStr));
+            startActivity(i);
+          }
+        } else if (position == 2) {
+          // Uninstall selected keyboard
+          String title = String.format("%s: %s", languageName, kbName);
+          String keyboardKey = String.format("%s_%s", languageID, kbID);
+          DialogFragment dialog = ConfirmDialogFragment.newInstance(title, getString(R.string.confirm_delete), keyboardKey);
+          dialog.show(getFragmentManager(), "dialog");
+        }
+      }
+
+
+    });
+
+
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    super.onBackPressed();
+    return true;
+  }
+
+  @Override
+  public void onDestroy(){
+    super.onDestroy();
+    if ( dialog !=null ){
+      dialog.dismiss();
+    }
+  }
+
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -136,7 +136,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
           String title = String.format("%s: %s", languageName, kbName);
           String keyboardKey = String.format("%s_%s", languageID, kbID);
           DialogFragment dialog = ConfirmDialogFragment.newInstance(
-            DIALOG_TYPE_DELETE_KEYBOARD, title, getString(R.string.confirm_delete), keyboardKey);
+            DIALOG_TYPE_DELETE_KEYBOARD, title, getString(R.string.confirm_delete_keyboard), keyboardKey);
           dialog.show(getFragmentManager(), "dialog");
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -88,6 +88,21 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     ImageView imageView = (ImageView) layout.findViewById(R.id.image1);
     imageView.setImageResource(R.drawable.ic_arrow_forward);
     layout.setEnabled(true);
+    layout.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        // Start Model Picker Activity.
+        // Use the language ID and nmae from the first associated keyboard (they should all be the same)
+        HashMap<String, String> kbInfo = associatedKeyboardList.get(0);
+        Bundle bundle = new Bundle();
+        bundle.putString(KMManager.KMKey_LanguageID, kbInfo.get(KMManager.KMKey_LanguageID));
+        bundle.putString(KMManager.KMKey_LanguageName, kbInfo.get(KMManager.KMKey_LanguageName));
+        Intent i = new Intent(context, ModelsPickerActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        i.putExtras(bundle);
+        startActivity(i);
+      }
+    });
 
     /**
      * This is a placeholder for "Manage dictionary" settings

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -103,6 +103,26 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         listView.setItemChecked(position, true);
         listView.setSelection(position);
+        HashMap<String, String> kbInfo = associatedKeyboardList.get(position);
+        String packageID = kbInfo.get(KMManager.KMKey_PackageID);
+        String keyboardID = kbInfo.get(KMManager.KMKey_KeyboardID);
+        if (packageID == null || packageID.isEmpty()) {
+          packageID = KMManager.KMDefault_UndefinedPackageID;
+        }
+        Intent intent = new Intent(context, KeyboardSettingsActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        intent.putExtra(KMManager.KMKey_PackageID, packageID);
+        intent.putExtra(KMManager.KMKey_KeyboardID, keyboardID);
+        intent.putExtra(KMManager.KMKey_LanguageID, kbInfo.get(KMManager.KMKey_LanguageID));
+        intent.putExtra(KMManager.KMKey_LanguageName, kbInfo.get(KMManager.KMKey_LanguageName));
+        intent.putExtra(KMManager.KMKey_KeyboardName, kbInfo.get(KMManager.KMKey_KeyboardName));
+        intent.putExtra(KMManager.KMKey_KeyboardVersion, KMManager.getLatestKeyboardFileVersion(context, packageID, keyboardID));
+        boolean isCustom = kbInfo.get(KMManager.KMKey_CustomKeyboard).equals("Y") ? true : false;
+        intent.putExtra(KMManager.KMKey_CustomKeyboard, isCustom);
+        String customHelpLink = kbInfo.get(KMManager.KMKey_CustomHelpLink);
+        if (customHelpLink != null)
+          intent.putExtra(KMManager.KMKey_CustomHelpLink, customHelpLink);
+        startActivity(intent);
       }
     });
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2019 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmea;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Typeface;
+import android.inputmethodservice.Keyboard;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Keyman Settings --> Languages Settings --> Language Settings
+ * Displays a list of installed keyboards and some lexical model switches.
+ */
+public final class LanguageSettingsActivity extends AppCompatActivity {
+  private Context context;
+  private static Toolbar toolbar = null;
+  private static ListView listView = null;
+  private static ArrayList<HashMap<String, String>> associatedKeyboardList = null;
+  private final String titleKey = "title";
+  private final String subtitleKey = "subtitle";
+  private final String iconKey = "icon";
+  private String associatedLexicalModel = "";
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    context = this;
+    setContentView(R.layout.language_settings_list_layout);
+
+    toolbar = (Toolbar) findViewById(R.id.list_toolbar);
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setDisplayShowHomeEnabled(true);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+    TextView textView = (TextView) findViewById(R.id.bar_title);
+    textView.setText(getString(R.string.title_language_settings));
+
+    listView = (ListView) findViewById(R.id.listView);
+    listView.setFastScrollEnabled(true);
+
+    Bundle bundle = getIntent().getExtras();
+    if (bundle != null) {
+      associatedKeyboardList = (ArrayList<HashMap<String, String>>) bundle.getSerializable("associatedKeyboards");
+      associatedLexicalModel = bundle.getString(KMManager.KMKey_LexicalModelName, "");
+    } else {
+      associatedKeyboardList = new ArrayList<HashMap<String, String>>();
+    }
+
+    RelativeLayout layout = (RelativeLayout)findViewById(R.id.corrections_toggle);
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.enable_corrections));
+
+    layout = (RelativeLayout)findViewById(R.id.predictions_toggle);
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.enable_predictions));
+
+    layout = (RelativeLayout)findViewById(R.id.model_picker);
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.model));
+    if (!associatedLexicalModel.isEmpty()) {
+      textView = (TextView) layout.findViewById(R.id.text2);
+      textView.setText(associatedLexicalModel);
+      textView.setEnabled(true);
+    }
+    ImageView imageView = (ImageView) layout.findViewById(R.id.image1);
+    imageView.setImageResource(R.drawable.ic_arrow_forward);
+    layout.setEnabled(true);
+
+    layout = (RelativeLayout)findViewById(R.id.manage_dictionary);
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.manage_dictionary));
+    imageView = (ImageView) layout.findViewById(R.id.image1);
+    imageView.setImageResource(R.drawable.ic_arrow_forward);
+
+    String[] from = new String[]{KMManager.KMKey_KeyboardName, KMManager.KMKey_Icon};
+    int[] to = new int[]{R.id.text1, R.id.image1};
+    ListAdapter listAdapter = new KMListAdapter(context, associatedKeyboardList, R.layout.list_row_layout1, from, to);
+
+    listView.setAdapter(listAdapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        listView.setItemChecked(position, true);
+        listView.setSelection(position);
+      }
+    });
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    onBackPressed();
+    return true;
+  }
+
+  @Override
+  public void onBackPressed() {
+    finish();
+  }
+
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -87,11 +87,15 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     imageView.setImageResource(R.drawable.ic_arrow_forward);
     layout.setEnabled(true);
 
-    layout = (RelativeLayout)findViewById(R.id.manage_dictionary);
-    textView = (TextView) layout.findViewById(R.id.text1);
-    textView.setText(getString(R.string.manage_dictionary));
-    imageView = (ImageView) layout.findViewById(R.id.image1);
-    imageView.setImageResource(R.drawable.ic_arrow_forward);
+    /**
+     * This is a placeholder for "Manage dictionary" settings
+     *
+     * layout = (RelativeLayout)findViewById(R.id.manage_dictionary);
+     * textView = (TextView) layout.findViewById(R.id.text1);
+     * textView.setText(getString(R.string.manage_dictionary));
+     * imageView = (ImageView) layout.findViewById(R.id.image1);
+     * imageView.setImageResource(R.drawable.ic_arrow_forward);
+     */
 
     String[] from = new String[]{KMManager.KMKey_KeyboardName, KMManager.KMKey_Icon};
     int[] to = new int[]{R.id.text1, R.id.image1};

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -35,11 +35,13 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
   private Context context;
   private static Toolbar toolbar = null;
   private static ListView listView = null;
+  private ImageButton addButton = null;
   private static ArrayList<HashMap<String, String>> associatedKeyboardList = null;
   private final String titleKey = "title";
   private final String subtitleKey = "subtitle";
   private final String iconKey = "icon";
   private String associatedLexicalModel = "";
+  private boolean dismissOnSelect = false;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -127,6 +129,30 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
         if (customHelpLink != null)
           intent.putExtra(KMManager.KMKey_CustomHelpLink, customHelpLink);
         startActivity(intent);
+      }
+    });
+
+    addButton = (ImageButton) findViewById(R.id.add_button);
+    addButton.setOnClickListener(new View.OnClickListener() {
+      public void onClick(View v) {
+        // Check that available keyboard information can be obtained via:
+        // 1. connection to cloud catalog
+        // 2. cached file
+        // 3. local kmp.json files in packages/
+        if (KMManager.hasConnection(context) || LanguageListActivity.getCacheFile(context).exists() ||
+          KeyboardPickerActivity.hasKeyboardFromPackage()){
+          dismissOnSelect = false;
+          Intent i = new Intent(context, LanguageListActivity.class);
+          i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+          context.startActivity(i);
+        } else {
+          AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
+          dialogBuilder.setTitle(getString(R.string.title_add_keyboard));
+          dialogBuilder.setMessage(String.format("\n%s\n", getString(R.string.cannot_connect)));
+          dialogBuilder.setPositiveButton(getString(R.string.label_ok), null);
+          AlertDialog dialog = dialogBuilder.create();
+          dialog.show();
+        }
       }
     });
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -37,7 +37,7 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
   private static ArrayList<HashMap<String, String>> languagesList = null;
   private static ArrayList<HashMap<String, String>> associatedKeyboardsList = null;
 
-  private boolean dismissOnSelect = true;
+  private boolean dismissOnSelect = false;
   protected static boolean canAddNewKeyboard = true;
 
   @Override
@@ -84,9 +84,9 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
           args.putString(KMManager.KMKey_LexicalModelName, associatedLexicalModel.get(KMManager.KMKey_LexicalModelName));
         }
         args.putSerializable("associatedKeyboards", associatedKeyboardsList);
-        // TODO: Start intent for "Language Settings" activity with the selected languageID
-        //Intent intent = new Intent(context, LanguageSettingsActivity.class);
-        // intent.putExtra(args);
+        Intent intent = new Intent(context, LanguageSettingsActivity.class);
+        intent.putExtras(args);
+        startActivity(intent);
 
         if (dismissOnSelect)
           finish();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -85,6 +85,7 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
         }
         args.putSerializable("associatedKeyboards", associatedKeyboardsList);
         Intent intent = new Intent(context, LanguageSettingsActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         intent.putExtras(args);
         startActivity(intent);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -35,7 +35,7 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
   private static ListView listView = null;
   private static ImageButton addButton = null;
   private static ArrayList<HashMap<String, String>> languagesList = null;
-  private static ArrayList<String> associatedKeyboardsList = null;
+  private static ArrayList<HashMap<String, String>> associatedKeyboardsList = null;
 
   private boolean dismissOnSelect = true;
   protected static boolean canAddNewKeyboard = true;
@@ -74,9 +74,15 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
         String langId = languageInfo.get(KMManager.KMKey_LanguageID);
         String langName = languageInfo.get(KMManager.KMKey_LanguageName);
         associatedKeyboardsList = KeyboardPickerActivity.getAssociatedKeyboards(langId);
+
+        HashMap<String, String> associatedLexicalModel = KeyboardPickerActivity.getAssociatedLexicalModel(context, langId);
+
         Bundle args = new Bundle();
         args.putString(KMManager.KMKey_LanguageID, langId);
         args.putString(KMManager.KMKey_LanguageName, langName);
+        if (associatedLexicalModel != null) {
+          args.putString(KMManager.KMKey_LexicalModelName, associatedLexicalModel.get(KMManager.KMKey_LexicalModelName));
+        }
         args.putSerializable("associatedKeyboards", associatedKeyboardsList);
         // TODO: Start intent for "Language Settings" activity with the selected languageID
         //Intent intent = new Intent(context, LanguageSettingsActivity.class);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import android.app.DialogFragment;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Typeface;
@@ -30,6 +31,8 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.util.FileUtils;
+
+import static com.tavultesoft.kmea.ConfirmDialogFragment.DialogType.DIALOG_TYPE_DELETE_MODEL;
 
 // Public access is necessary to avoid IllegalAccessException
 public final class ModelInfoActivity extends AppCompatActivity {
@@ -57,10 +60,12 @@ public final class ModelInfoActivity extends AppCompatActivity {
 
     listView = (ListView) findViewById(R.id.listView);
 
+    final String packageID = getIntent().getStringExtra(KMManager.KMKey_PackageID);
+    final String languageID = getIntent().getStringExtra(KMManager.KMKey_LanguageID);
     final String modelID = getIntent().getStringExtra(KMManager.KMKey_LexicalModelID);
 
     final TextView textView = (TextView) findViewById(R.id.bar_title);
-    String modelName = getIntent().getStringExtra(KMManager.KMKey_LexicalModelName);
+    final String modelName = getIntent().getStringExtra(KMManager.KMKey_LexicalModelName);
     textView.setText(String.format("%s model", modelName));
     if (titleFont != null)
       textView.setTypeface(titleFont, Typeface.BOLD);
@@ -101,6 +106,7 @@ public final class ModelInfoActivity extends AppCompatActivity {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         if (position == 1) {
+          // Help link to model
           Intent i = new Intent(Intent.ACTION_VIEW);
 
           if (customHelpLink != null) {
@@ -122,25 +128,17 @@ public final class ModelInfoActivity extends AppCompatActivity {
             startActivity(i);
           } else {
             // TODO: open browser to Keyman site on lexical models
-            //String helpUrlStr = String.format("http://help.keyman.com/keyboard/%s/%s/", modelID, modelVersion);
+            //String helpUrlStr = String.format("http://help.keyman.com/models/%s/%s/", modelID, modelVersion);
             //i.setData(Uri.parse(helpUrlStr));
             //startActivity(i);
           }
         } else if (position == 2) {
-          PopupMenu popup = new PopupMenu(context, view);
-          popup.getMenuInflater().inflate(R.menu.popup, popup.getMenu());
-          popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
-            public boolean onMenuItemClick(MenuItem item) {
-              if (item.getItemId() == R.id.popup_delete) {
-                deleteModel(modelID);
-                return true;
-              } else {
-                return false;
-              }
-            }
-          });
-          popup.show();
-          return;
+          // Confirmation to delete model
+          String lexicalModelKey = String.format("%s_%s_%s", languageID, packageID, modelID);
+          DialogFragment dialog = ConfirmDialogFragment.newInstance(
+            DIALOG_TYPE_DELETE_MODEL, modelName, getString(R.string.confirm_delete_model), lexicalModelKey);
+          dialog.show(getFragmentManager(), "dialog");
+
         } else {
           return;
         }
@@ -157,15 +155,5 @@ public final class ModelInfoActivity extends AppCompatActivity {
   public boolean onSupportNavigateUp() {
     super.onBackPressed();
     return true;
-  }
-
-  // TODO: Uninstall model
-  protected void deleteModel(String modelID) {
-    boolean result = true;
-
-    if (result) {
-      Toast.makeText(this, "Model deleted", Toast.LENGTH_SHORT).show();
-    }
-    finish();
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.graphics.Typeface;
 import android.inputmethodservice.Keyboard;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.widget.AdapterView;
@@ -33,6 +34,7 @@ public final class ModelsPickerActivity extends AppCompatActivity {
   private static Toolbar toolbar = null;
   private static ListView listView = null;
   private static ArrayList<HashMap<String, String>> lexicalModelsList = null;
+  private final static String TAG = "ModelsPickerActivity";
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -49,11 +51,8 @@ public final class ModelsPickerActivity extends AppCompatActivity {
     TextView textView = (TextView) findViewById(R.id.bar_title);
 
     Bundle bundle = getIntent().getExtras();
-    String languageID = "", languageName = "";
-    if (bundle != null) {
-      languageID = bundle.getString(KMManager.KMKey_LanguageID);
-      languageName = bundle.getString(KMManager.KMKey_LanguageName);
-    }
+    final String languageID = bundle.getString(KMManager.KMKey_LanguageID);
+    final String languageName = bundle.getString(KMManager.KMKey_LanguageName);
     textView.setText(String.format("%s model", languageName));
 
     listView = (ListView) findViewById(R.id.listView);
@@ -73,7 +72,14 @@ public final class ModelsPickerActivity extends AppCompatActivity {
 
         // Start intent for selected Predictive Text Model screen
         HashMap<String, String> modelInfo = lexicalModelsList.get(position);
+        if (!languageID.equalsIgnoreCase(modelInfo.get(KMManager.KMKey_LanguageID))) {
+          Log.d(TAG, "Language ID " + languageID + " doesn't match model language ID: " + modelInfo.get(KMManager.KMKey_LanguageID));
+        }
         Bundle bundle = new Bundle();
+        // Note: package ID of a model is different from package ID for a keyboard.
+        // Language ID can be re-used
+        bundle.putString(KMManager.KMKey_PackageID, modelInfo.get(KMManager.KMKey_PackageID));
+        bundle.putString(KMManager.KMKey_LanguageID, languageID);
         bundle.putString(KMManager.KMKey_LexicalModelID, modelInfo.get(KMManager.KMKey_LexicalModelID));
         bundle.putString(KMManager.KMKey_LexicalModelName, modelInfo.get(KMManager.KMKey_LexicalModelName));
         bundle.putString(KMManager.KMKey_LexicalModelVersion, modelInfo.get(KMManager.KMKey_LexicalModelVersion));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
@@ -18,6 +18,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.tavultesoft.kmea.util.MapCompat;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -69,7 +71,17 @@ public final class ModelsPickerActivity extends AppCompatActivity {
         listView.setItemChecked(position, true);
         listView.setSelection(position);
 
-        // TODO: Start intent for selected Predictive Text Model screen
+        // Start intent for selected Predictive Text Model screen
+        HashMap<String, String> modelInfo = lexicalModelsList.get(position);
+        Bundle bundle = new Bundle();
+        bundle.putString(KMManager.KMKey_LexicalModelID, modelInfo.get(KMManager.KMKey_LexicalModelID));
+        bundle.putString(KMManager.KMKey_LexicalModelName, modelInfo.get(KMManager.KMKey_LexicalModelName));
+        bundle.putString(KMManager.KMKey_LexicalModelVersion, modelInfo.get(KMManager.KMKey_LexicalModelVersion));
+        String isCustom = MapCompat.getOrDefault(modelInfo, KMManager.KMKey_CustomModel, "N");
+        bundle.putBoolean(KMManager.KMKey_CustomModel, isCustom.toUpperCase().equals("Y"));
+        Intent i = new Intent(context, ModelInfoActivity.class);
+        i.putExtras(bundle);
+        startActivity(i);
       }
     });
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelsPickerActivity.java
@@ -47,14 +47,10 @@ public final class ModelsPickerActivity extends AppCompatActivity {
     TextView textView = (TextView) findViewById(R.id.bar_title);
 
     Bundle bundle = getIntent().getExtras();
-    String languageID, languageName;
+    String languageID = "", languageName = "";
     if (bundle != null) {
       languageID = bundle.getString(KMManager.KMKey_LanguageID);
       languageName = bundle.getString(KMManager.KMKey_LanguageName);
-    } else {
-      // TODO: remove test code from production
-      languageID = "km";
-      languageName = "Khmer";
     }
     textView.setText(String.format("%s model", languageName));
 

--- a/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
@@ -75,10 +75,11 @@
         android:layout_below="@id/predictions_toggle"/>
 
     <!-- Model dictionary -->
+    <!-- Currently a placeholder
     <include layout="@layout/list_row_layout1"
         android:id="@+id/manage_dictionary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/model_picker"/>
+        android:layout_below="@id/model_picker"/> -->
 
 </RelativeLayout>

--- a/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <include layout="@layout/list_toolbar" />
+
+    <!-- ListView of installed keyboards. TODO: calculate height -->
+    <include layout="@layout/list_layout"
+        android:id="@+id/keyboard_list_layout"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:layout_below="@id/list_appbar"
+        android:layout_alignParentBottom="false" />
+
+    <LinearLayout
+        android:id="@+id/keyboard_linear_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_below="@id/keyboard_list_layout">
+
+        <Space
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="10"
+            android:layout_gravity="center"/>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_button"
+            style="?android:attr/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="end|center_vertical"
+            android:layout_marginTop="@dimen/fab_margin"
+            android:layout_marginBottom="@dimen/fab_margin"
+            android:contentDescription="@string/image_button"
+            android:src="@drawable/ic_add_white"
+            app:fabSize="normal" />
+
+    </LinearLayout>
+
+    <View
+        android:id="@+id/separator"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:background="?attr/colorAccent"
+        android:layout_below="@+id/keyboard_linear_layout"/>
+
+  <!-- Enable corrections toggle -->
+  <include
+    android:id="@+id/corrections_toggle"
+    layout="@layout/list_row_layout4"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_below="@id/separator" />
+
+    <!-- Enable predictions toggle -->
+    <include layout="@layout/list_row_layout4"
+        android:id="@+id/predictions_toggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/corrections_toggle"/>
+
+    <!-- Model picker -->
+    <include layout="@layout/list_row_layout2"
+        android:id="@+id/model_picker"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/predictions_toggle"/>
+
+    <!-- Model dictionary -->
+    <include layout="@layout/list_row_layout1"
+        android:id="@+id/manage_dictionary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/model_picker"/>
+
+</RelativeLayout>

--- a/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/list_item" >
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:orientation="vertical" >
+
+        <TextView
+          android:id="@+id/text1"
+          android:textColor="@android:color/black"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="15dp"
+          android:layout_marginBottom="15dp"
+          android:textSize="16sp"
+          android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_marginRight="12dp"
+        android:contentDescription="@string/image_view" />
+
+</RelativeLayout>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -48,6 +48,12 @@
     <string name="model_version" translatable="false">Model version</string>
     <string name="uninstall_model" translatable="false">Uninstall model</string>
 
+    <!-- Language Settings menu strings -->
+    <string name="enable_corrections" translatable="false">Enable corrections</string>
+    <string name="enable_predictions" translatable="false">Enable predictions</string>
+    <string name="model" translatable="false">Model</string>
+    <string name="manage_dictionary" translatable="false">Manage dictionary</string>
+
     <!-- Content descriptions -->
     <string name="image_button" translatable="false">Image Button</string>
     <string name="image_view" translatable="false">Image View</string>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="label_cancel" translatable="false">Cancel</string>
     <string name="label_close" translatable="false">Close</string>
     <string name="label_close_keyman" translatable="false">Close Keyman</string>
+
     <string name="label_download" translatable="false">Download</string>
     <string name="label_install" translatable="false">Install</string>
     <string name="label_later" translatable="false">Later</string>
@@ -30,6 +31,7 @@
     <!-- Keyboard Updates -->
     <string name="cannot_connect" translatable="false">Cannot connect to Keyman server!</string>
     <string name="checking_keyboard_updates" translatable="false">Checking keyboard updates&#8230;</string>
+    <string name="confirm_delete" translatable="false">Would you like to delete this keyboard?</string>
     <string name="confirm_download" translatable="false">Would you like to download this keyboard?</string>
     <string name="confirm_update" translatable="false">Would you like to update keyboards now?</string>
     <string name="custom_keyboard" translatable="false">Custom Keyboard</string>
@@ -40,9 +42,10 @@
     <string name="getting_keyboard_catalog" translatable="false">Getting keyboard catalog.\nThis may take a while&#8230;</string>
     <string name="updating_keyboards" translatable="false">Updating keyboards&#8230;</string>
 
-    <!-- Keyboard Info -->
+    <!-- Keyboard Info and Keyboard Settings -->
     <string name="keyboard_version" translatable="false">Keyboard version</string>
     <string name="help_link" translatable="false">Help link</string>
+    <string name="uninstall_keyboard" translatable="false">Uninstall keyboard</string>
 
     <!-- Model Info -->
     <string name="model_version" translatable="false">Model version</string>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -31,8 +31,8 @@
     <!-- Keyboard Updates -->
     <string name="cannot_connect" translatable="false">Cannot connect to Keyman server!</string>
     <string name="checking_keyboard_updates" translatable="false">Checking keyboard updates&#8230;</string>
-    <string name="confirm_delete" translatable="false">Would you like to delete this keyboard?</string>
-    <string name="confirm_download" translatable="false">Would you like to download this keyboard?</string>
+    <string name="confirm_delete_keyboard" translatable="false">Would you like to delete this keyboard?</string>
+    <string name="confirm_download_keyboard" translatable="false">Would you like to download this keyboard?</string>
     <string name="confirm_update" translatable="false">Would you like to update keyboards now?</string>
     <string name="custom_keyboard" translatable="false">Custom Keyboard</string>
     <string name="downloading_keyboard" translatable="false">Downloading keyboard&#8230;</string>
@@ -50,6 +50,7 @@
     <!-- Model Info -->
     <string name="model_version" translatable="false">Model version</string>
     <string name="uninstall_model" translatable="false">Uninstall model</string>
+    <string name="confirm_delete_model" translatable="false">Would you like to delete this model?</string>
 
     <!-- Language Settings menu strings -->
     <string name="enable_corrections" translatable="false">Enable corrections</string>

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -121,7 +121,7 @@ namespace com.keyman.text.prediction {
       return this.currentModel;
     }
 
-    private unloadModel() {
+    public unloadModel() {
       this.lmEngine.unloadModel();
       delete this.currentModel;
       delete this.configuration;


### PR DESCRIPTION
This PR connects the menu settings hierarchy:
Keyman Settings --> Languages Settings --> Language Settings

### Language Settings
Language Settings displays associated keyboards that are installed for a language ID.
There's also some toggles for configuring lexical models later.

Preliminary screenshot accessed by clicking through "Keyman Settings"
(screenshot updated to remove "Manage dictionary" setting)

![language settings](https://user-images.githubusercontent.com/7358010/57679646-0da9af00-7656-11e9-9154-1a719ea7a614.png)

### Keyboard Setting (US keyboard)
Note: Entry to "Uninstall keyboard" is not available on the default SIL Euro Latin keyboard
![us keyboard setting](https://user-images.githubusercontent.com/7358010/57679685-274af680-7656-11e9-823d-e2dd9355152d.png)

Language Settings --> can select Models Picker (bottom line)

### Models Picker (currently shows 0-1 installed model)
![model picker](https://user-images.githubusercontent.com/7358010/57744373-2fa53f00-76f3-11e9-93c6-c4f31d7bd8de.png)

Models Picker --> Model Info

### Model Info
![model info](https://user-images.githubusercontent.com/7358010/57744388-3633b680-76f3-11e9-9697-242c0bbd4a18.png)

longpress to delete model doesn't do anything

### ConfirmDialogFragment
Originally, this only confirmed downloading keyboards. Dialog now expanded for more uses:
* Delete keyboard
![delete keyboard confirmation](https://user-images.githubusercontent.com/7358010/57834250-13ce9580-77e6-11e9-8387-8587f6ae76bb.png)

* Download model (future PR)
* Delete model

![delete model confirmation](https://user-images.githubusercontent.com/7358010/57834137-cfdb9080-77e5-11e9-82ff-919f6ae00a58.png)
