### PR TITLE
[Web, iOS, Android] Base for predictive text longpress

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -235,6 +235,23 @@
       }
     }
 
+    function suggestionPopup(obj,custom,x,y,w,h) {
+      if(obj != null) {
+        var i;
+        var s = JSON.stringify(obj);
+        var shift = false;
+        var pos = x.toString() + ',' + y.toString();
+        var size = w.toString() + ',' + h.toString();
+
+
+        fragmentToggle=(fragmentToggle+1) % 100;
+        var hash = 'suggestPopup-' + fragmentToggle + '+pos=' + pos + '+size=' + size + '+suggestion=' + s;
+        hash = hash + '+custom=' + custom;
+
+        window.location.hash = hash;
+      }
+    }
+
     function showMenu() {
       fragmentToggle = (fragmentToggle + 1) % 100;
       window.location.hash = 'globeKeyAction' + fragmentToggle;

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -242,11 +242,14 @@
         var shift = false;
         var pos = x.toString() + ',' + y.toString();
         var size = w.toString() + ',' + h.toString();
+        var frame = pos + ',' + size;
 
 
         fragmentToggle=(fragmentToggle+1) % 100;
-        var hash = 'suggestPopup-' + fragmentToggle + '+pos=' + pos + '+size=' + size + '+suggestion=' + s;
-        hash = hash + '+custom=' + custom;
+        var hash = 'suggestPopup-' + fragmentToggle;
+        hash = hash + '&x=' + encodeURIComponent(x) + '&y=' + encodeURIComponent(y);
+        hash = hash + '&w=' + encodeURIComponent(w) + '&h=' + encodeURIComponent(h);
+        hash = hash + '&suggestion=' + encodeURIComponent(s) + '&custom=' + encodeURIComponent(custom);
 
         window.location.hash = hash;
       }

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -237,16 +237,11 @@
 
     function suggestionPopup(obj,custom,x,y,w,h) {
       if(obj != null) {
-        var i;
-        var s = JSON.stringify(obj);
-        var shift = false;
-        var pos = x.toString() + ',' + y.toString();
-        var size = w.toString() + ',' + h.toString();
-        var frame = pos + ',' + size;
-
+        let s = JSON.stringify(obj);
 
         fragmentToggle=(fragmentToggle+1) % 100;
-        var hash = 'suggestPopup-' + fragmentToggle;
+        let hash = 'suggestPopup-' + fragmentToggle;
+
         hash = hash + '&x=' + encodeURIComponent(x) + '&y=' + encodeURIComponent(y);
         hash = hash + '&w=' + encodeURIComponent(w) + '&h=' + encodeURIComponent(h);
         hash = hash + '&suggestion=' + encodeURIComponent(s) + '&custom=' + encodeURIComponent(custom);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -161,5 +162,17 @@ public final class JSONParser {
 
   public JSONObject getJSONObjectFromUrl(String urlStr) {
     return getJSONObjectFromUrl(urlStr, JSONObject.class);
+  }
+
+  public JSONObject getJSONObjectFromString(String str) {
+    return getJSONObjectFromReader(new BufferedReader(new StringReader(str)));
+  }
+
+  public JSONObject getJSONObjectFromURIString(String str) {
+    try {
+      return getJSONObjectFromString(java.net.URLDecoder.decode(str, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1371,6 +1371,36 @@ public final class KMManager {
         currentBanner = (change.equals("loaded")) ? "suggestion" : "blank";
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         InAppKeyboard.setLayoutParams(params);
+      } else if (url.indexOf("suggestPopup") >= 0) {
+        int start = url.indexOf("pos=") + 4;
+        int end = url.indexOf("size=");
+
+        String posData[] = url.substring(start, end).split("\\,");
+
+        start = end + 5;
+        end = url.indexOf("suggestion=");
+
+        String sizeData[] = url.substring(start, end).split("\\,");
+
+        start = end + 11;
+        end = url.indexOf("custom=");
+
+        String suggestionJSON = url.substring(start, end);
+
+        start = end + 7;
+
+        String isCustomStr = url.substring(start);
+
+        JSONParser parser = new JSONParser();
+        JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
+
+        try {
+          Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
+        } catch (JSONException e) {
+          //e.printStackTrace();
+          Log.v("KMEA", "JSON parsing error: " + e.getMessage());
+        }
+
       }
       return false;
     }
@@ -1547,8 +1577,37 @@ public final class KMManager {
         currentBanner = (change.equals("loaded")) ? "suggestion" : "blank";
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         SystemKeyboard.setLayoutParams(params);
-      }
-      return false;
+      } else if (url.indexOf("suggestPopup") >= 0) {
+        int start = url.indexOf("pos=") + 4;
+        int end = url.indexOf("size=");
+
+        String posData[] = url.substring(start, end).split("\\,");
+
+        start = end + 5;
+        end = url.indexOf("suggestion=");
+
+        String sizeData[] = url.substring(start, end).split("\\,");
+
+        start = end + 11;
+        end = url.indexOf("custom=");
+
+        String suggestionJSON = url.substring(start, end);
+
+        start = end + 7;
+
+        String isCustomStr = url.substring(start);
+
+        JSONParser parser = new JSONParser();
+        JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
+
+        try {
+          Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
+        } catch (JSONException e) {
+          //e.printStackTrace();
+          Log.v("KMEA", "JSON parsing error: " + e.getMessage());
+        }
+
+        return false;
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1399,7 +1399,6 @@ public final class KMManager {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
-
       }
       return false;
     }
@@ -1577,37 +1576,28 @@ public final class KMManager {
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         SystemKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {
-        int start = url.indexOf("pos=") + 4;
-        int end = url.indexOf("size=");
+        // URL has actual path to the keyboard.html file as a prefix!  We need to replace
+        // just the first intended '#' to get URI-based query param processing.
 
-        String posData[] = url.substring(start, end).split("\\,");
+        // At some point, other parts of the function should be redone to allow use of ? instead
+        // of # in our WebView command "queries" entirely.
+        String cmd = url.replace("keyboard.html#", "keyboard.html?");
+        Uri urlCommand = Uri.parse(cmd);
 
-        start = end + 5;
-        end = url.indexOf("suggestion=");
-
-        String sizeData[] = url.substring(start, end).split("\\,");
-
-        start = end + 11;
-        end = url.indexOf("custom=");
-
-        String suggestionJSON = url.substring(start, end);
-
-        start = end + 7;
-
-        String isCustomStr = url.substring(start);
+        double x = Float.parseFloat(urlCommand.getQueryParameter("x"));
+        double y = Float.parseFloat(urlCommand.getQueryParameter("y"));
+        double width = Float.parseFloat(urlCommand.getQueryParameter("w"));
+        double height = Float.parseFloat(urlCommand.getQueryParameter("h"));
+        String suggestionJSON = urlCommand.getQueryParameter("suggestion");
+        boolean isCustom = Boolean.parseBoolean(urlCommand.getQueryParameter("custom"));
 
         JSONParser parser = new JSONParser();
         JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
 
         try {
           Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
-
-          Uri.Builder builder = new Uri.Builder();
-          builder.fragment(url);
-
-          Uri uri = builder.build();
-
-          Log.v("KMEA", "Using Uri object: " + uri.getQueryParameter("custom"));
+          Log.v("KMEA", "Suggestion's banner coords: " + x + ", " + y + ", " + width + ", " + height);
+          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom);
         } catch (JSONException e) {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1606,8 +1606,9 @@ public final class KMManager {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
-
-        return false;
+      }
+      
+      return false;
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		CE2B1E4721B60E89007D092E /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2B1E4521B60E7C007D092E /* DeviceKit.framework */; };
 		CE2B1E4821B60E8A007D092E /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2B1E4521B60E7C007D092E /* DeviceKit.framework */; };
 		CE2B1E4A21B60FB1007D092E /* DeviceKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE2B1E4521B60E7C007D092E /* DeviceKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CE67D961228A6F190029F2B5 /* KeyboardCommandStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE67D960228A6F190029F2B5 /* KeyboardCommandStructs.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -351,6 +352,7 @@
 		C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanWebDelegate.swift; sourceTree = "<group>"; };
 		CE24ECEF21B763740052D291 /* KeymanResponder+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeymanResponder+Types.swift"; sourceTree = "<group>"; };
 		CE2B1E4521B60E7C007D092E /* DeviceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DeviceKit.framework; path = ../../Carthage/Build/iOS/DeviceKit.framework; sourceTree = "<group>"; };
+		CE67D960228A6F190029F2B5 /* KeyboardCommandStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardCommandStructs.swift; sourceTree = "<group>"; };
 		CECB38931F2199BC0098882F /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reachability.h; path = KeymanEngine/lib/Reachability/Reachability.h; sourceTree = SOURCE_ROOT; };
 		CECB38941F2199BC0098882F /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Reachability.m; path = KeymanEngine/lib/Reachability/Reachability.m; sourceTree = SOURCE_ROOT; };
 		F243887E14BBD43000A3E055 /* KeymanEngineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeymanEngineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -649,6 +651,15 @@
 			name = HTTPRequest;
 			sourceTree = "<group>";
 		};
+		CE67D95F228A6ECF0029F2B5 /* KeymanWebView */ = {
+			isa = PBXGroup;
+			children = (
+				C0C16A881FA8146300F090BA /* KeymanWebViewController.swift */,
+				CE67D960228A6F190029F2B5 /* KeyboardCommandStructs.swift */,
+			);
+			name = KeymanWebView;
+			sourceTree = "<group>";
+		};
 		F243887314BBD43000A3E055 = {
 			isa = PBXGroup;
 			children = (
@@ -743,6 +754,7 @@
 				987F00041AB8FCB700998116 /* KeyboardMenuView */,
 				980CC8E119D51EF00089BB57 /* URLProtocol */,
 				98411308199D9ACD005BD609 /* SubKeysView */,
+				CE67D95F228A6ECF0029F2B5 /* KeymanWebView */,
 				98F9D6ED19545A620087AA43 /* InputViewController */,
 				989FDF8C193C1B0C00EECAF9 /* KeyPreviewView */,
 				F2607212158FBCB500F37184 /* KeyboardPicker */,
@@ -750,7 +762,6 @@
 				F273AB9E156440CD00A47CEE /* UITextField */,
 				F273AB9D156440BA00A47CEE /* UITextView */,
 				C0959CD31F99C44E00B616BC /* Constants.swift */,
-				C0C16A881FA8146300F090BA /* KeymanWebViewController.swift */,
 				C0B09EAD1FCFD10F002F39AF /* FontManager.swift */,
 				C0E30C8B1FC40D0400C80416 /* Storage.swift */,
 				C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */,
@@ -1105,6 +1116,7 @@
 				C07A9D8C1FD176AB00828ADD /* KeyboardRepositoryDelegate.swift in Sources */,
 				C024C9961FA6EC650060583B /* NotificationCenter+Typed.swift in Sources */,
 				C06D37361F81F5C300F61AE0 /* KeyboardMenuView.swift in Sources */,
+				CE67D961228A6F190029F2B5 /* KeyboardCommandStructs.swift in Sources */,
 				9A4609972241B39B00B0BFD1 /* LexicalModelInfoViewController.swift in Sources */,
 				9A9CB08022416E5400231FB9 /* LexicalModelPickerViewController.swift in Sources */,
 				9A079E3D223B5FAF00581263 /* InstallableLexicalModel.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardCommandStructs.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardCommandStructs.swift
@@ -1,0 +1,31 @@
+//
+//  KeyboardCommandStructs.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 5/14/19.
+//  Copyright © 2019 SIL International. All rights reserved.
+//
+
+import Foundation
+
+struct Transform: Codable {
+  var id: Int?
+  var insert: String
+  var deleteLeft: Int?
+  var deleteRight: Int?
+}
+
+struct Suggestion: Codable {
+  var transformId: Int
+  var displayAs: String
+  var transform: Transform
+}
+
+struct SuggestionPopup: Codable {
+  var suggestion: Suggestion
+  var x: Float
+  var y: Float
+  var width: Float
+  var height: Float
+  var isCustom: Bool
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -27,19 +27,6 @@ private let phoneLandscapeSystemKeyboardHeight: CGFloat = 162.0
 private let padPortraitSystemKeyboardHeight: CGFloat = 264.0
 private let padLandscapeSystemKeyboardHeight: CGFloat = 352.0
 
-struct Transform: Codable {
-  var id: Int?
-  var insert: String
-  var deleteLeft: Int?
-  var deleteRight: Int?
-}
-
-struct Suggestion: Codable {
-  var transformId: Int
-  var displayAs: String
-  var transform: Transform
-}
-
 // MARK: - UIViewController
 class KeymanWebViewController: UIViewController {
   let storage: Storage
@@ -413,29 +400,26 @@ extension KeymanWebViewController: WKScriptMessageHandler {
       beep(self)
       delegate?.beep(self)
     } else if fragment.hasPrefix("#suggestPopup"){
-      let baseFrameKey = fragment.range(of: "+baseFrame=")!
-      let suggestKey = fragment.range(of: "+suggestion=")!
-      let customKey = fragment.range(of: "+custom=")!
-      let baseFrame = fragment[baseFrameKey.upperBound..<suggestKey.lowerBound]
-      let suggestionJSON = String(fragment[suggestKey.upperBound..<customKey.lowerBound])
-      let customStr = fragment[customKey.upperBound..<fragment.endIndex]
-
-      let frameComponents = baseFrame.components(separatedBy: ",")
-      let x = CGFloat(Float(frameComponents[0])!)
-      let y = CGFloat(Float(frameComponents[1])!)
-      let w = CGFloat(Float(frameComponents[2])!)
-      let h = CGFloat(Float(frameComponents[3])!)
-      let frame = KeymanWebViewController.keyFrame(x: x, y: y, w: w, h: h)
+      let cmdKey = fragment.range(of: "+cmd=")!
+      let cmdStr = fragment[cmdKey.upperBound..<fragment.endIndex]
       
-      let suggestionData = suggestionJSON.data(using: .utf16)
+      let cmdData = cmdStr.data(using: .utf16)
       let decoder = JSONDecoder()
       
       do {
-        let suggestion = try decoder.decode(Suggestion.self, from: suggestionData!)
-        log.verbose("Longpress detected on suggestion: \"\(suggestion.displayAs)\".")
+        let cmd = try decoder.decode(SuggestionPopup.self, from: cmdData!)
+        log.verbose("Longpress detected on suggestion: \"\(cmd.suggestion.displayAs)\".")
       } catch {
         log.error("Unexpected JSON parse error: \(error).")
       }
+      
+      // Will need processing upon extraction from the resulting object.
+//      let frameComponents = baseFrame.components(separatedBy: ",")
+//      let x = CGFloat(Float(frameComponents[0])!)
+//      let y = CGFloat(Float(frameComponents[1])!)
+//      let w = CGFloat(Float(frameComponents[2])!)
+//      let h = CGFloat(Float(frameComponents[3])!)
+//      let frame = KeymanWebViewController.keyFrame(x: x, y: y, w: w, h: h)
       
     } else {
       log.error("Unexpected KMW event: \(fragment)")

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -27,6 +27,19 @@ private let phoneLandscapeSystemKeyboardHeight: CGFloat = 162.0
 private let padPortraitSystemKeyboardHeight: CGFloat = 264.0
 private let padLandscapeSystemKeyboardHeight: CGFloat = 352.0
 
+struct Transform: Codable {
+  var id: Int?
+  var insert: String
+  var deleteLeft: Int?
+  var deleteRight: Int?
+}
+
+struct Suggestion: Codable {
+  var transformId: Int
+  var displayAs: String
+  var transform: Transform
+}
+
 // MARK: - UIViewController
 class KeymanWebViewController: UIViewController {
   let storage: Storage
@@ -399,6 +412,31 @@ extension KeymanWebViewController: WKScriptMessageHandler {
     } else if fragment.hasPrefix("#beep-") {
       beep(self)
       delegate?.beep(self)
+    } else if fragment.hasPrefix("#suggestPopup"){
+      let baseFrameKey = fragment.range(of: "+baseFrame=")!
+      let suggestKey = fragment.range(of: "+suggestion=")!
+      let customKey = fragment.range(of: "+custom=")!
+      let baseFrame = fragment[baseFrameKey.upperBound..<suggestKey.lowerBound]
+      let suggestionJSON = String(fragment[suggestKey.upperBound..<customKey.lowerBound])
+      let customStr = fragment[customKey.upperBound..<fragment.endIndex]
+
+      let frameComponents = baseFrame.components(separatedBy: ",")
+      let x = CGFloat(Float(frameComponents[0])!)
+      let y = CGFloat(Float(frameComponents[1])!)
+      let w = CGFloat(Float(frameComponents[2])!)
+      let h = CGFloat(Float(frameComponents[3])!)
+      let frame = KeymanWebViewController.keyFrame(x: x, y: y, w: w, h: h)
+      
+      let suggestionData = suggestionJSON.data(using: .utf16)
+      let decoder = JSONDecoder()
+      
+      do {
+        let suggestion = try decoder.decode(Suggestion.self, from: suggestionData!)
+        log.verbose("Longpress detected on suggestion: \"\(suggestion.displayAs)\".")
+      } catch {
+        log.error("Unexpected JSON parse error: \(error).")
+      }
+      
     } else {
       log.error("Unexpected KMW event: \(fragment)")
     }

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -180,6 +180,25 @@
                 }
             }
         
+            function suggestionPopup(obj,custom,x,y,w,h) {
+              if(obj != null) {
+                var i;
+                var s = JSON.stringify(obj);
+                var shift = false;
+                var pos = x.toString() + ',' + y.toString();
+                var size = w.toString() + ',' + h.toString();
+                var frame = pos + ',' + size;
+
+                fragmentToggle=(fragmentToggle+1) % 100;
+                var hash = 'suggestPopup-' + fragmentToggle + '+baseFrame=' + frame + '+suggestion=' + s;
+                hash = hash + '+custom=' + custom;
+
+                if (typeof(window.webkit) != 'undefined') {
+                  window.webkit.messageHandlers.keyman.postMessage('#' + hash);
+                }
+              }
+            }
+        
             function menuKeyDown() {
                 fragmentToggle = (fragmentToggle + 1) % 100;
                 var keyDownHash = 'menuKeyDown-' + fragmentToggle;

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -182,16 +182,18 @@
         
             function suggestionPopup(obj,custom,x,y,w,h) {
               if(obj != null) {
-                var i;
-                var s = JSON.stringify(obj);
-                var shift = false;
-                var pos = x.toString() + ',' + y.toString();
-                var size = w.toString() + ',' + h.toString();
-                var frame = pos + ',' + size;
-
                 fragmentToggle=(fragmentToggle+1) % 100;
-                var hash = 'suggestPopup-' + fragmentToggle + '+baseFrame=' + frame + '+suggestion=' + s;
-                hash = hash + '+custom=' + custom;
+                
+                var cmd = {
+                  'suggestion': obj,
+                  'isCustom': custom,
+                  'x': x,
+                  'y': y,
+                  'width': w,
+                  'height': h
+                };
+                
+                var hash = 'suggestPopup-' + fragmentToggle + '+cmd=' + JSON.stringify(cmd);
 
                 if (typeof(window.webkit) != 'undefined') {
                   window.webkit.messageHandlers.keyman.postMessage('#' + hash);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -373,7 +373,7 @@ namespace com.keyman.text {
   };
 
   /**
-   * Function called by iOS when a device-implemented keyboard popup is displayed or hidden
+   * Function called by Android and iOS when a device-implemented keyboard popup is displayed or hidden
    * 
    *  @param  {boolean}  isVisible
    *     

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -186,6 +186,18 @@ namespace com.keyman.osk {
 
     return true;
   };
+
+  SuggestionManager.prototype.platformHold = function(this: SuggestionManager, suggestionObj: BannerSuggestion, isCustom: boolean) {
+    // Parallels VisualKeyboard.prototype.touchHold, but for predictive suggestions instead of keystrokes.
+    let suggestionEle = suggestionObj.div;
+
+    // Need to know if it's a <keep> option or not!
+
+    var xBase = dom.Utils.getAbsoluteX(suggestionEle) - dom.Utils.getAbsoluteX(suggestionEle.parentElement) + suggestionEle.offsetWidth/2,
+        yBase = dom.Utils.getAbsoluteY(suggestionEle) - dom.Utils.getAbsoluteY(suggestionEle.parentElement);
+
+    window['suggestionPopup'](suggestionObj.suggestion, isCustom, xBase, yBase, suggestionEle.offsetWidth, suggestionEle.offsetHeight);
+  }
 }
 
 namespace com.keyman.text {

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -407,8 +407,10 @@ namespace com.keyman.osk {
     }
   }
 
-  class SuggestionManager extends dom.UITouchHandlerBase<HTMLDivElement> {
+  export class SuggestionManager extends dom.UITouchHandlerBase<HTMLDivElement> {
     private selected: BannerSuggestion;
+
+    platformHold: (suggestion: BannerSuggestion, isCustom: boolean) => void;
 
     //#region Touch handling implementation
     findTargetFrom(e: HTMLElement): HTMLDivElement {
@@ -459,11 +461,16 @@ namespace com.keyman.osk {
 
     //#region Long-press support
     protected hold(t: HTMLDivElement): void {
-      // Temp, pending implementation of suggestion longpress submenus
-      // - nothing worth doing with a hold yet -
+      let suggestionObj = t['suggestion'] as BannerSuggestion;
 
-      // Should have separate native + embedded mode branches.
-      // Embedded mode should pass any info needed to show a submenu IMMEDIATELY.
+      // Is this the <keep> suggestion?  It's never in this.currentSuggestions, so check against that.
+      let isCustom = this.currentSuggestions.indexOf(suggestionObj.suggestion) == -1;
+
+      if(this.platformHold) {
+        // Implemented separately for native + embedded mode branches.
+        // Embedded mode should pass any info needed to show a submenu IMMEDIATELY.
+        this.platformHold(suggestionObj, isCustom); // No implementation yet for native.
+      }
     }
     protected clearHolds(): void {
       // Temp, pending implementation of suggestion longpress submenus
@@ -471,12 +478,12 @@ namespace com.keyman.osk {
 
       // only really used in native-KMW
     }
+    
     protected hasModalPopup(): boolean {
-      // Temp, pending implementation of suggestion longpress submenus
-
       // Utilized by the mobile apps; allows them to 'take over' touch handling,
       // blocking it within KMW when the apps are already managing an ongoing touch-hold.
-      return false;
+      let keyman = com.keyman.singleton;
+      return keyman['osk'].vkbd.popupVisible;
     }
 
     protected dealiasSubTarget(target: HTMLDivElement): HTMLDivElement {

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -461,27 +461,44 @@ namespace com.keyman.osk {
     protected hold(t: HTMLDivElement): void {
       // Temp, pending implementation of suggestion longpress submenus
       // - nothing worth doing with a hold yet -
+
+      // Should have separate native + embedded mode branches.
+      // Embedded mode should pass any info needed to show a submenu IMMEDIATELY.
     }
     protected clearHolds(): void {
       // Temp, pending implementation of suggestion longpress submenus
       // - nothing to clear without them -
+
+      // only really used in native-KMW
     }
     protected hasModalPopup(): boolean {
       // Temp, pending implementation of suggestion longpress submenus
+
+      // Utilized by the mobile apps; allows them to 'take over' touch handling,
+      // blocking it within KMW when the apps are already managing an ongoing touch-hold.
       return false;
     }
+
     protected dealiasSubTarget(target: HTMLDivElement): HTMLDivElement {
       return target;
     }
+
     protected hasSubmenu(t: HTMLDivElement): boolean {
-      // Temp, pending implementation of suggestion longpress submenus:
+      // Temp, pending implementation of suggestion longpress submenus
+
+      // Only really used by native-KMW - see kmwnative's highlightSubKeys func.
       return false;
     }
+
     protected isSubmenuActive(): boolean {
-      // Temp, pending implementation of suggestion longpress submenus:
+      // Temp, pending implementation of suggestion longpress submenus
+
+      // Utilized only by native-KMW - it parallels hasModalPopup() in purpose.
       return false;
     }
+
     protected displaySubmenuFor(target: HTMLDivElement) {
+      // Utilized only by native-KMW to show submenus.
       throw new Error("Method not implemented.");
     }
     //#endregion


### PR DESCRIPTION
Provides hooks for KMW to notify the apps of an ongoing longpress on a predictive text option, ensuring any relevant data reaches each app's native code.  Nothing of use is done with this data yet (just logging), but the transfer of data has been tested and verified, providing a useful starting point to add options for predictive text suggestions.