### PR TITLE
[Web] Support for 'rotation' of predictive suggestions

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -599,6 +599,7 @@ final class KMKeyboard extends WebView {
 
   @SuppressLint("InflateParams")
   private void showSubKeys(Context context) {
+    // This is also called for banner longpresses!  Need a way to differentiate the sources.
     if (subKeysList == null || subKeysWindow != null) {
       return;
     }

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -32,7 +32,7 @@
 
  namespace models {
   /** Upper bound on the amount of suggestions to generate. */
-  const MAX_SUGGESTIONS = 3;
+  const MAX_SUGGESTIONS = 12;
 
   /**
    * Additional arguments to pass into the model, in addition to the model

--- a/common/predictive-text/worker/models/wordlist-model.ts
+++ b/common/predictive-text/worker/models/wordlist-model.ts
@@ -38,7 +38,7 @@
    */
 
   /** Upper bound on the amount of suggestions to generate. */
-  const MAX_SUGGESTIONS = 3;
+  const MAX_SUGGESTIONS = 12;
 
   /**
    * Additional arguments to pass into the model, in addition to the model

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -11,5 +11,6 @@ samples/KMSample2/build
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanios.js
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanweb-osk.ttf
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/kmwosk.css
+engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyman.js.map
 Keyman 2*
 Carthage

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -142,6 +142,12 @@ update_bundle ( ) {
         cp resources/osk/keymanweb-osk.ttf "$base_dir/$BUNDLE_PATH/keymanweb-osk.ttf"
         cp keyman.js                       "$base_dir/$BUNDLE_PATH/keymanios.js"
 
+        if [ "$CONFIG" == "Debug" ]; then
+          cp keyman.js.map                 "$base_dir/$BUNDLE_PATH/keyman.js.map"
+        elif [ -f "$base_dir/$BUNDLE_PATH/keyman.js.map" ]; then
+          rm                               "$base_dir/$BUNDLE_PATH/keyman.js.map"
+        fi
+
         cd $base_dir
     fi
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -655,6 +655,7 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
   }
 
   private func touchHoldBegan() {
+    // Is also called for banner longpresses.  Will need a way to properly differentiate.
     let isPad = UIDevice.current.userInterfaceIdiom == .pad
     let fontSize = isPad ? UIFont.buttonFontSize * 2 : UIFont.buttonFontSize
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -142,6 +142,12 @@ extension Storage {
     try Storage.copy(from: bundle,
                      resourceName: "keymanios.js",
                      dstDir: baseDir)
+    // For debug compilations - IF we have a sourcemap file, copy that over too.
+    if bundle.url(forResource: "keyman.js.map", withExtension: nil) != nil {
+      try Storage.copy(from: bundle,
+                       resourceName: "keyman.js.map",
+                       dstDir: baseDir)
+    }
     try Storage.copy(from: bundle,
                      resourceName: "kmwosk.css",
                      dstDir: baseDir)

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -420,7 +420,11 @@ if [ $BUILD_UI = true ]; then
 fi
 
 if [ $BUILD_DEBUG_EMBED = true ]; then
+    # We currently have an issue with sourcemaps for minified versions.
+    # We should use the unminified one instead for now.
+    cp $EMBED_OUTPUT_NO_MINI/keyman.js $EMBED_OUTPUT/keyman.js
     # Copy the sourcemap.
-    cp $INTERMEDIATE/keyman.js.map $EMBED_OUTPUT/keyman.js.map
+    cp $EMBED_OUTPUT_NO_MINI/keyman.js.map $EMBED_OUTPUT/keyman.js.map
     echo Uncompiled embedded application saved as keyman.js
 fi
+

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -297,7 +297,7 @@ namespace com.keyman {
         this.keyman.keyboardManager.setActiveKeyboard(this.keyman.globalKeyboard, this.keyman.globalLanguageCode);
       }
 
-      // Now that we've fully entered the new context, we can generate initial predictions from it.
+       // Now that we've fully entered the new context, invalidate the context so we can generate initial predictions from it.
       if(this.keyman.modelManager) {
         this.keyman.modelManager.invalidateContext();
       }

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -299,7 +299,7 @@ namespace com.keyman {
 
       // Now that we've fully entered the new context, we can generate initial predictions from it.
       if(this.keyman.modelManager) {
-        this.keyman.modelManager.predict();
+        this.keyman.modelManager.invalidateContext();
       }
     }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -389,8 +389,7 @@ namespace com.keyman.text {
 
     if(keyman['osk'].banner['activeBanner'] instanceof com.keyman.osk.SuggestionBanner) {
       let banner = keyman['osk'].banner['activeBanner'];
-
-      //
+      banner.rotateSuggestions();
     }
   }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -384,6 +384,16 @@ namespace com.keyman.text {
     keymanweb.modelManager.register(model);
   };
 
+  keymanweb['showNewSuggestions'] = function() {
+    let keyman = com.keyman.singleton;
+
+    if(keyman['osk'].banner['activeBanner'] instanceof com.keyman.osk.SuggestionBanner) {
+      let banner = keyman['osk'].banner['activeBanner'];
+
+      //
+    }
+  }
+
   /**
    * Function called by Android and iOS when a device-implemented keyboard popup is displayed or hidden
    * 

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -239,6 +239,13 @@ namespace com.keyman.text.prediction {
 
       // Signal to any predictive text UI that the context has changed, invalidating recent predictions.
       keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'context');
+
+      // If there's no active model, there can be no predictions.
+      // We'll also be missing important data needed to even properly REQUEST the predictions.
+      if(!this.currentModel || !this.configuration) {
+        return;
+      }
+      
       this.predict_internal();
     }
 
@@ -268,7 +275,11 @@ namespace com.keyman.text.prediction {
 
       if(!transcription) {
         let t = text.Processor.getOutputTarget();
-        transcription = t.buildTranscriptionFrom(t, null);
+        if(t) {
+          transcription = t.buildTranscriptionFrom(t, null);
+        } else {
+          return;
+        }
       }
 
       let context = new TranscriptionContext(transcription.preInput, this.configuration);


### PR DESCRIPTION
This PR does not provide any UI for rotating suggestions; just the underlying functionality that any such UI might connect to.  It also provides an API endpoint for use by the Android and iOS apps, designed to be called by yet-to-be-implemented longpress menus on the SuggestionBanner's options.

To test, call the following within the Dev Console within Chrome when testing a mobile form factor: `keyman.osk.banner.activeBanner.rotateSuggestions()`.  Make sure the banner is visible when entering this console command, as the suggestions will reset whenever the OSK reappears (as KMW [rightly] thinks a context change has occurred.)

I've noticed that the apps' initial state for the SuggestionBanner is a bit off with this in place, so I do need to chase down what's causing that.