### PR TITLE
[Android] Fix exception when setting banner height 0

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -43,8 +43,8 @@
 
     // Update the KMW banner height
     function setBannerHeight(h) {
+      var kmw=com.keyman.singleton;
       if (h > 0) {
-        var kmw=com.keyman.singleton;
         var osk = kmw.osk;
         osk.banner.height = Math.ceil(h / window.devicePixelRatio);
       }


### PR DESCRIPTION
After #1770 , KMW deregisters and sets the banner height to 0.
This revealed a bug in the Android JS `setBannerHeight()` function where `kmw` wasn't defined and attempted to call `kmw.correctOSKTextSize();`

Expand line 52 when viewing the change