### PR TITLE
[LMLayer] Treat flakiness in 'empty buffer' test.

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/cases/worker-wordlist-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-wordlist-integration.js
@@ -10,6 +10,11 @@ describe('LMLayer using the word list model', function () {
     it('will predict an empty buffer', function () {
       var lmLayer = new LMLayer(helpers.defaultCapabilities);
 
+      // N.B.: This test can OCCASIONALLY Mocha's default 2
+      // seconds expected execution time, causing sporadic build
+      // failures. So just double the default timeout value! 🙃
+      this.timeout(4000);
+
       // We're testing many as asynchronous messages in a row.
       // this would be cleaner using async/await syntax, but
       // alas some of our browsers don't support it.


### PR DESCRIPTION
The in-browser test `LMLayer using the word list model » Prediction » will predict an empty buffer` fails sporadically in builds. I initially just thought it was the build server, then noticed it happening once on my machine. It turns out that this test is just a slow boi, and exceeds Mocha's 2000 ms timeout value for asynchronous tests. Mocha assumes that tests that have exceeded this timeout have crashed, which is not the case here! So I simply doubled this particular test's timeout value. Hopefully, this gets rid of all of the test flakiness.