### PR TITLE
[LMLayer] Deselect suggestions when one is selected.

### DIFF
--- a/common/test/predictive-text/index.js
+++ b/common/test/predictive-text/index.js
@@ -190,6 +190,8 @@ async function asyncRepl(modelFile) {
 
       // Ask for suggestions.
       suggestions = await askForPredictions();
+      // Since we chose a selection, it's best to UNSELECT the new suggestions
+      selectedSuggestionIndex = null;
       renderSuggestions();
 
     } else if (keypress.name === 'backspace') {

--- a/common/test/predictive-text/package-lock.json
+++ b/common/test/predictive-text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lmlayer-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Small PR that deselects the current suggestion when you have just accepted a suggestion. It doesn't make sense to select the same index of the suggestion again!