### PR TITLE
[LMLayer] Trie model: Replace the prefix with the suggestion

### DIFF
--- a/common/predictive-text/unit_tests/headless/worker-predict-trie.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-trie.js
@@ -156,6 +156,31 @@ describe('LMLayerWorker trie model for word lists', function() {
     });
   })
 
+  it('replaces the entire typed word when a suggestion is accepted', function () {
+      // Ensure that all input is lower-cased when we try to look it up.
+      var model = new TrieModel(jsonFixture('tries/english-1000'), {
+        searchTermToKey: function (searchTerm) {
+          let result = searchTerm.toLowerCase();
+          return result;
+        }
+      });
+
+      // Note: the input is **UPPERCASE**
+      var context = { left: 'T', startOfBuffer: false, endOfBuffer: true };
+      var transform = { insert: "H", deleteLeft: 0 };
+
+      // Predict upon typing
+      //   «TH|                        » [Send]
+      //   [  there ] [   the   ] [   they    ]
+      var [suggestion] = model.predict(transform, context);
+      // I'm assuming the top word in English is "the".
+      assert.strictEqual(suggestion.displayAs, 'the');
+
+      var newBuffer = applyTransform(context, suggestion.transform);
+      // The suggestion should change it to lowercase.
+      assert.strictEqual(newBuffer, 'the ');
+  });
+
   function applyTransform(context, transform) {
     assert.isTrue(context.endOfBuffer, "cannot only apply transform to end of buffer");
     var buffer = context.left;

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -101,9 +101,12 @@
       return this._trie.lookup(prefix).map(word => {
         return {
           transform: {
-            // The left part of the word has already been entered.
-            insert: word.substr(leftContext.length) + ' ',
-            deleteLeft: 0,
+            // Insert the suggestion from the Trie, verbatim
+            insert: word + ' ',
+            // Delete whatever the prefix that the user wrote.
+            // Note: a separate capitalization/orthography engine can take this
+            // result and transform it as needed.
+            deleteLeft: leftContext.length,
           },
           displayAs: word,
         }


### PR DESCRIPTION
Say you wanted to write the name of the FPCC conference: "HELISET TŦE SḰÁL".

Previously , if you started off by writing:

    > helis|
    [HELIS] [HELISE] [HEL¸ISET] [HELISET] [HELISETNOṈET]

Then you'd accept [HELISET], it would result in this buffer:

    > helisET |
    [TŦE] [E] [SEN] [Ȼ] [SW̱] [NIȽ] [U¸] [I¸] [ȻSE] [I] [YÁ¸] [ȻE]

Now that the model _replaces_ the prefix you wrote with what's in the model, it does the following:

    > HELISET |
    [TŦE] [E] [SEN] [Ȼ] [SW̱] [NIȽ] [U¸] [I¸] [ȻSE] [I] [YÁ¸] [ȻE]

The replacement is probably what you want!

---

By the way, using the predictions with the `lmlayer-cli` and the SENĆOŦEN model, makes it actually possible to type the name of this conference on a regular old ANSI keyboard! 👌 