### PR TITLE
[LMLayer, Android] Adds workaround for Android duplicate load msg bug.

### DIFF
--- a/web/testing/prediction-ui/index.html
+++ b/web/testing/prediction-ui/index.html
@@ -41,6 +41,7 @@
 		    attachType:'auto'
       }).then(function() {
         kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
+        kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic.js'});
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)


### PR DESCRIPTION
A strange error has been arising in the Android app when swapping from a keyboard with no predictive model to a different one with a predictive model - in these cases, despite a single `postMessage` being sent to the LMLayer to load the model, the `LMLayerWorker` is receiving that message **twice**.  So far, this only happens within the Android app; no such errors occur in the 'native' web test page.  (The prediction-ui test page has been updated to match my attempts to repro the error there.)  This error triggers a detector in the Android app which then assumes that the keyboard has crashed and is in need of a reset, which is less-than-ideal _here_, but is otherwise reasonable.

Attempted workarounds:
* I can tell that it's not due to our use of a `Promise` polyfill.
* I tried moving the `importScripts` call into a `setTimeout` block to free up the message queue early (in case that somehow was related); the error still occurred.

Fortunately, since it's a literally-duplicated message, a simple enough approach is just to check if a newly-received message matches the last one - or even just the load from the currently-active model.  Once a model has been unloaded, we clear any state information so that a request to reload that model will then be successful.