### PR TITLE
[LMLayer] The ModelCompositor

### DIFF
--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -111,7 +111,7 @@ namespace com.keyman.text.prediction {
       });
     }
 
-    predict(transform: Transform, context: Context): Promise<Suggestion[]> {
+    predict(transform: Transform | Distribution<Transform>, context: Context): Promise<Suggestion[]> {
       let token = this._nextToken++;
       return new Promise((resolve, reject) => {
         this._promises.make(token, resolve, reject);

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -180,6 +180,26 @@ interface Transform {
 }
 
 /**
+ * Represents members of a probability distribution over potential outputs
+ * from ambiguous text sequences.  Designed for use with fat-finger correction
+ * and similar typing ambiguities.
+ */
+interface ProbabilityMass<T> {
+  /**
+   * A potentially-valid Transform usable to produce the next state of input.
+   */
+  sample: T;
+
+  /**
+   * The probability mass for this member of the distribution,
+   * calculated devoid of any language-modeling influences.
+   */
+  p: number;
+}
+
+type Distribution<T> = ProbabilityMass<T>[];
+
+/**
  * The text and environment surrounding the insertion point (text cursor).
  */
 interface Context {

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -186,7 +186,7 @@ interface Transform {
  */
 interface ProbabilityMass<T> {
   /**
-   * A potentially-valid Transform usable to produce the next state of input.
+   * An individual sample from a Distribution over the same type.
    */
   sample: T;
 

--- a/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-dummy.js
@@ -60,7 +60,9 @@ describe('LMLayerWorker dummy model', function() {
         left: "I'm a little ",
         startOfBuffer: true,
         endOfBuffer: true,
-      }, expectedSuggestions);
+      }, expectedSuggestions).map(function(value) {
+        return value.sample;
+      });
      assert.deepEqual(suggestions, expectedSuggestions);
     });
 
@@ -77,13 +79,13 @@ describe('LMLayerWorker dummy model', function() {
 
       // The dummy model should give suggestions in order,
       // regardless of the provided transform and context.
-      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample }),
                        futureSuggestions[0]);
-      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample }),
                        futureSuggestions[1]);
-      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample }),
                        futureSuggestions[2]);
-      assert.deepEqual(model.predict(zeroTransform(), emptyContext()),
+      assert.deepEqual(model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample }),
                        futureSuggestions[3]);
     });
   });

--- a/common/predictive-text/unit_tests/headless/worker-predict-trie.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-trie.js
@@ -21,7 +21,7 @@ describe('LMLayerWorker trie model for word lists', function() {
       var suggestions = model.predict({
         insert: 't',
         deleteLeft: 0,
-      }, emptyContext());
+      }, emptyContext()).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions actually start with 't'
@@ -54,7 +54,7 @@ describe('LMLayerWorker trie model for word lists', function() {
       var suggestions = model.predict({
         insert: insertedLetter,
         deleteLeft: 0,
-      }, context);
+      }, context).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions actually start with 'th'
@@ -77,7 +77,7 @@ describe('LMLayerWorker trie model for word lists', function() {
         jsonFixture('tries/english-1000')
       );
 
-      var suggestions = model.predict(zeroTransform(), emptyContext());
+      var suggestions = model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions seem okay.
@@ -107,7 +107,7 @@ describe('LMLayerWorker trie model for word lists', function() {
         left: 'I ',
         startOfBuffer: false,
         endOfBuffer: true,
-      });
+      }).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions seem valid.

--- a/common/predictive-text/unit_tests/headless/worker-predict-wordlist.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-wordlist.js
@@ -36,7 +36,7 @@ describe('LMLayerWorker word list model', function() {
       var suggestions = model.predict({
         insert: 't',
         deleteLeft: 0,
-      }, emptyContext());
+      }, emptyContext()).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions actually start with 't'
@@ -68,7 +68,7 @@ describe('LMLayerWorker word list model', function() {
         left: initialPrefix,
         startOfBuffer: false,
         endOfBuffer: true
-      });
+      }).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions actually start with 'th'
@@ -98,7 +98,7 @@ describe('LMLayerWorker word list model', function() {
         jsonFixture('wordlists/english-1000')
       );
 
-      var suggestions = model.predict(zeroTransform(), emptyContext());
+      var suggestions = model.predict(zeroTransform(), emptyContext()).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions seem valid.
@@ -128,7 +128,7 @@ describe('LMLayerWorker word list model', function() {
         left: 'I ',
         startOfBuffer: false,
         endOfBuffer: true,
-      });
+      }).map(function(value) { return value.sample });
       assert.isAtLeast(suggestions.length, MIN_SUGGESTIONS);
 
       // Ensure all of the suggestions seem valid.

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -33,6 +33,7 @@
 /// <reference path="models/dummy-model.ts" />
 /// <reference path="models/wordlist-model.ts" />
 /// <reference path="word_breaking/ascii-word-breaker.ts" />
+/// <reference path="./model-compositor.ts" />
 
 /**
  * Encapsulates all the state required for the LMLayer's worker thread.
@@ -230,16 +231,9 @@ class LMLayerWorker {
         switch(payload.message) {
           case 'predict':
             let {transform, context} = payload;
+            let compositor = new ModelCompositor(model); // Yeah, should probably use a persistent one eventually.
 
-            let suggestions = model.predict(transform, context);
-
-            // Let's not rely on the model to copy transform IDs.
-            // Only bother is there IS an ID to copy.
-            if(transform.id !== undefined) {
-              suggestions.forEach(function(s: Suggestion) {
-                s.transformId = transform.id;
-              });
-            }
+            let suggestions = compositor.predict(transform, context);
 
             // Now that the suggestions are ready, send them out!
             this.cast('suggestions', {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -35,7 +35,7 @@ class ModelCompositor {
     // TODO:  What if the model emits duplicate samples, each with their own mass?
 
     suggestionDistribution = suggestionDistribution.sort(function(a, b) {
-      return a.p - b.p;
+      return b.p - a.p; // Use descending order - we want the largest probabilty suggestions first!
     });
 
     let suggestions = suggestionDistribution.splice(0, ModelCompositor.MAX_SUGGESTIONS).map(function(value) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -1,0 +1,47 @@
+class ModelCompositor {
+  private lexicalModel: WorkerInternalModel;
+  private static readonly MAX_SUGGESTIONS = 12;
+
+  constructor(lexicalModel: WorkerInternalModel) {
+    this.lexicalModel = lexicalModel;
+  }
+
+  predict(transformDistribution: Transform | Distribution<Transform>, context: Context): Suggestion[] {
+    let suggestionDistribution: Distribution<Suggestion> = [];
+
+    if(!(transformDistribution instanceof Array)) {
+      transformDistribution = [ {sample: transformDistribution, p: 1.0} ];
+    }
+
+    for(let alt of transformDistribution) {
+      let transform = alt.sample;
+      let distribution = this.lexicalModel.predict(transform, context);
+
+      distribution.forEach(function(pair: ProbabilityMass<Suggestion>) {
+        // Let's not rely on the model to copy transform IDs.
+        // Only bother is there IS an ID to copy.
+        if(transform.id !== undefined) {
+          pair.sample.transformId = transform.id;
+        }
+
+        let compositedPair = {sample: pair.sample, p: pair.p * alt.p};
+        suggestionDistribution.push(compositedPair);
+      });
+    }
+
+    // Now that we've calculated the set of probability masses, time to join 'em together
+    // and return the most likely candidates.
+    
+    // TODO:  What if the model emits duplicate samples, each with their own mass?
+
+    suggestionDistribution = suggestionDistribution.sort(function(a, b) {
+      return a.p - b.p;
+    });
+
+    let suggestions = suggestionDistribution.splice(0, ModelCompositor.MAX_SUGGESTIONS).map(function(value) {
+      return value.sample;
+    });
+
+    return suggestions;
+  }
+}

--- a/common/predictive-text/worker/models/dummy-model.ts
+++ b/common/predictive-text/worker/models/dummy-model.ts
@@ -71,7 +71,7 @@ namespace models {
       let currentSet = this._futureSuggestions.shift();
       
       if(!currentSet) {
-        return null;
+        return [];
       } else {
         return makeUniformDistribution(currentSet);
       }

--- a/common/predictive-text/worker/models/dummy-model.ts
+++ b/common/predictive-text/worker/models/dummy-model.ts
@@ -58,7 +58,7 @@ namespace models {
         let n = suggestions.length;
 
         for(let s of suggestions) {
-          distribution.push({sample: s, p: 1.0/n});
+          distribution.push({sample: s, p: 1});  // For a dummy model, this is sufficient.  The uniformness is all that matters.
         }
 
         return distribution;

--- a/common/predictive-text/worker/models/dummy-model.ts
+++ b/common/predictive-text/worker/models/dummy-model.ts
@@ -52,11 +52,29 @@ namespace models {
       return this.configuration;
     }
 
-    predict(transform: Transform, context: Context, injectedSuggestions?: Suggestion[]): Suggestion[] {
-      if (injectedSuggestions) {
-        return injectedSuggestions;
+    predict(transform: Transform, context: Context, injectedSuggestions?: Suggestion[]): Distribution<Suggestion> {
+      let makeUniformDistribution = function(suggestions: Suggestion[]): Distribution<Suggestion> {
+        let distribution: Distribution<Suggestion> = [];
+        let n = suggestions.length;
+
+        for(let s of suggestions) {
+          distribution.push({sample: s, p: 1.0/n});
+        }
+
+        return distribution;
       }
-      return this._futureSuggestions.shift();
+
+      if (injectedSuggestions) {
+        return makeUniformDistribution(injectedSuggestions);
+      }
+
+      let currentSet = this._futureSuggestions.shift();
+      
+      if(!currentSet) {
+        return null;
+      } else {
+        return makeUniformDistribution(currentSet);
+      }
     }
   };
 }

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -73,12 +73,13 @@
     }
 
     predict(transform: Transform, context: Context): Distribution<Suggestion> {
+      // TODO:  Get a better distribution!  Our words do have frequency weighting, right?
       let makeUniformDistribution = function(suggestions: Suggestion[]): Distribution<Suggestion> {
         let distribution: Distribution<Suggestion> = [];
         let n = suggestions.length;
 
         for(let s of suggestions) {
-          distribution.push({sample: s, p: 1.0/n});
+          distribution.push({sample: s, p: 1});
         }
 
         return distribution;

--- a/common/predictive-text/worker/models/wordlist-model.ts
+++ b/common/predictive-text/worker/models/wordlist-model.ts
@@ -71,7 +71,18 @@
       };
     }
 
-    predict(transform: Transform, context: Context): Suggestion[] {
+    predict(transform: Transform, context: Context): Distribution<Suggestion> {
+      let makeUniformDistribution = function(suggestions: Suggestion[]): Distribution<Suggestion> {
+        let distribution: Distribution<Suggestion> = [];
+        let n = suggestions.length;
+
+        for(let s of suggestions) {
+          distribution.push({sample: s, p: 1.0/n});
+        }
+
+        return distribution;
+      }
+
       // EVERYTHING to the left of the cursor: 
       let fullLeftContext = context.left || '';
       // Stuff to the left of the cursor in the current word.
@@ -84,13 +95,13 @@
 
       // Special-case the empty buffer/transform: return the top suggestions.
       if (!transform.insert && context.startOfBuffer && context.endOfBuffer) {
-        return this._wordlist.slice(0, MAX_SUGGESTIONS).map(word => ({
+        return makeUniformDistribution(this._wordlist.slice(0, MAX_SUGGESTIONS).map(word => ({
           transform: {
             insert: word + ' ',
             deleteLeft: 0
           },
           displayAs: word
-        }));
+        })));
       }
 
       // Naïve O(n) exhaustive search through the entire word
@@ -116,7 +127,7 @@
         }
       }
 
-      return suggestions;
+      return makeUniformDistribution(suggestions);
     }
   };
 }

--- a/common/predictive-text/worker/models/wordlist-model.ts
+++ b/common/predictive-text/worker/models/wordlist-model.ts
@@ -72,12 +72,13 @@
     }
 
     predict(transform: Transform, context: Context): Distribution<Suggestion> {
+      let wordCount = this._wordlist.length;
       let makeUniformDistribution = function(suggestions: Suggestion[]): Distribution<Suggestion> {
         let distribution: Distribution<Suggestion> = [];
         let n = suggestions.length;
 
         for(let s of suggestions) {
-          distribution.push({sample: s, p: 1.0/n});
+          distribution.push({sample: s, p: 1.0 / wordCount});
         }
 
         return distribution;

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -86,7 +86,7 @@ interface PredictMessage {
    *
    * TODO: test for absent transform!
    */
-  transform?: Transform;
+  transform?: Transform | Distribution<Transform>;
 
   /**
    * The context (text to the left and text to right) at the
@@ -118,7 +118,7 @@ interface LMLayerWorkerState {
  */
 interface WorkerInternalModel {
   configure(capabilities: Capabilities): Configuration;
-  predict(transform: Transform, context: Context): Suggestion[];
+  predict(transform: Transform, context: Context): Distribution<Suggestion>;
 }
 
 /**

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -37,7 +37,7 @@ namespace com.keyman.text {
     private static tokenSeed: number = 0;
 
     constructor(keystroke: KeyEvent, transform: Transform, preInput: Mock, alternates: Alternate[]/*, removedDks: Deadkey[], insertedDks: Deadkey[]*/) {
-      this.token = Transcription.tokenSeed++;
+      let token = this.token = Transcription.tokenSeed++;
 
       this.keystroke = keystroke;
       this.transform = transform;
@@ -47,13 +47,17 @@ namespace com.keyman.text {
       // this.insertedDks = insertedDks;
 
       this.transform.id = this.token;
+
+      // Assign the ID to each alternate, as well.
+      if(alternates) {
+        alternates.forEach(function(alt) {
+          alt.sample.id = token;
+        });
+      }
     }
   }
 
-  export interface Alternate {
-    t: Transform;
-    p: number;
-  }
+  export type Alternate = ProbabilityMass<Transform>;
 
   export abstract class OutputTarget {
     private _dks: text.DeadkeyTracker;

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -313,9 +313,7 @@ namespace com.keyman.text.prediction {
       this.recordTranscription(transcription);
 
       let transform = transcription.transform;
-      // TODO:  Use this instead of the single Transform; requires LMLayer work.
-      let alternates = transcription.alternates;
-      var promise = this.currentPromise = this.lmEngine.predict(transform, context);
+      var promise = this.currentPromise = this.lmEngine.predict(transcription.alternates || transcription.transform, context);
 
       let mm = this;
       promise.then(function(suggestions: Suggestion[]) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -481,7 +481,7 @@ namespace com.keyman.text {
 
             let altEvent = this._GetClickEventProperties(altKey, keyEvent.Ltarg);
             if(this.processKeystroke(altEvent, mock, fromOSK, true)) {
-              alternates.push({t: mock.buildTransformFrom(preInputMock), 'p': pair.p});
+              alternates.push({sample: mock.buildTransformFrom(preInputMock), 'p': pair.p});
             }
           }
         }


### PR DESCRIPTION
This PR implements the rest of #1802, adding a new middle layer to the LMLayer called the `ModelCompositor`.  This layer will allow the LMLayer to combine probabilities from KMW's fat-finger analysis code with those from the lexical model (once they are made available), allowing us to, for the first time, support predictive suggestions.

Of course, there are some pretty significant limitations at this stage:

- Corrections will only consider the most recently-typed keystroke as erroneous - it doesn't model correction for multiple typos at this time.
- The probability combination code doesn't yet consider the (hopefully) edge-case where two different keystrokes produce the same resulting output in a manner that allows merging their probability masses.
- The existing model templates were forced into compliance with the new structure, but they don't all yet return meaningful / proper probability masses.
    - Further investigation is needed to return proper probability masses based on word weights for the weighted wordlist model.
- The composited probability distribution may need tweaking.
    - Is `p(word | language) * p(keystroke)` ideal?  Mathematically speaking, they're not independent probabilities... but we are getting these from two very different, independent sources with necessary factorization.

Those caveats aside, fat-finger use is now testable!

One more TODO:  this will break the 'custom' model in our `lexical-models` repo, as we now need models to return `Distribution<Suggestion>` rather than `Suggestion[]`.