### PR TITLE
[Mac] keyboard download page error

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Info.plist
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Keyman $(PRODUCT_VERSION) for macOS</string>
+	<string>$(PRODUCT_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/mac/Keyman4MacIM/Keyman4MacIM/InfoPlist.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/InfoPlist.strings
@@ -14,8 +14,14 @@ CFBundleDisplayName = "Keyman";
     go out of date easily.
  */
 
+// NOTE: Do not put version-related strings in here. The following are now computed based
+//  on User-Defined Build Setting variables such as PRODUCT_VERSION and COPYRIGHT_STRING_RIGHTS
+//
 //NSHumanReadableCopyright = "Copyright © 2018 SIL International. All rights reserved.";
 //CFBundleShortVersionString = "10.0";
 //CFBundleVersion = "10.0";
 //CFBundleGetInfoString = "Keyman 10.0 for macOS, Copyright 2018, SIL International";
 
+// The PRODUCT_VERSION only needs to be changed once per version.  It should be in sync with
+//  ../resources/VERSION.md
+//  There is a Run Script that checks to be sure

--- a/mac/Keyman4MacIM/Keyman4MacIM/InfoPlist.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/InfoPlist.strings
@@ -15,6 +15,7 @@ CFBundleDisplayName = "Keyman";
  */
 
 //NSHumanReadableCopyright = "Copyright © 2018 SIL International. All rights reserved.";
-//CFBundleShortVersionString = "Keyman 10.0 for macOS";
+//CFBundleShortVersionString = "10.0";
+//CFBundleVersion = "10.0";
 //CFBundleGetInfoString = "Keyman 10.0 for macOS, Copyright 2018, SIL International";
 

--- a/mac/Keyman4MacIM/Podfile.lock
+++ b/mac/Keyman4MacIM/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Crashlytics (3.12.0):
-    - Fabric (~> 1.9.0)
-  - Fabric (1.9.0)
+  - Crashlytics (3.13.1):
+    - Fabric (~> 1.10.1)
+  - Fabric (1.10.1)
 
 DEPENDENCIES:
   - Crashlytics
@@ -13,8 +13,8 @@ SPEC REPOS:
     - Fabric
 
 SPEC CHECKSUMS:
-  Crashlytics: 07fb167b1694128c1c9a5a5cc319b0e9c3ca0933
-  Fabric: f988e33c97f08930a413e08123064d2e5f68d655
+  Crashlytics: 5aa8e90dcbf2f34898b4f5a0037787531246cca0
+  Fabric: f6f21452846788bb44595d73e9909d79d328e617
 
 PODFILE CHECKSUM: f97fe7081827fd61ed7a61b5a0820d4e0df01dee
 


### PR DESCRIPTION
Replaces PR#1809 which had the wrong base. Darcy cherry picked my changes to mac-kbdl-error2. These fixes are for issue#1808 (client side).
The client side fix is to put just the version number in the API call.