### PR TITLE
[Windows] [11.0] Keyman32/keyman64 should detach without cleanup on process termination

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,5 +1,8 @@
 # Keyman Desktop Version History
 
+## 2019-04-30 11.0.1357.0 stable
+* Bug Fix: Error in shutdown of Keyman Engine can cause other applications to crash (#1820)
+
 ## 2019-04-29 11.0.1355.0 stable
 * Bug Fix: Error in initialization of Keyman Engine causes FieldWorks to crash if Keyman Developer installed but not Keyman Desktop. (#1739)
 

--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -1,6 +1,6 @@
 # Keyman Desktop Version History
 
-## 2019-04-30 11.0.1357.0 stable
+## 2019-06-05 11.0.1357.0 stable
 * Bug Fix: Error in shutdown of Keyman Engine can cause other applications to crash (#1820)
 
 ## 2019-04-29 11.0.1355.0 stable

--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -161,8 +161,26 @@ BOOL __stdcall DllMain(HINSTANCE hinstDll, DWORD fdwReason, LPVOID reserved)
 		break;
 	case DLL_PROCESS_DETACH:
     //if(!TestDebugProcess()) return FALSE;
-		UninitialiseProcess(FALSE);
-    Globals_UninitProcess();
+    if (reserved == NULL) {
+      // If reserved == NULL, that means the library is being unloaded, but
+      // the process is not terminating.
+      //
+      // We only cleanup after ourselves if the process is not terminating
+      // because of an issue with the order of DLL detach: if msctf.dll is
+      // detached first, then we end up causing an exception in msctf when
+      // we try to do our cleanup in CloseTSF.
+      //
+      // https://devblogs.microsoft.com/oldnewthing/20120105-00/?p=8683
+      //
+      // See https://github.com/keymanapp/keyman/issues/1723 for details
+      // relating to SumatraPDF. Note that this is hard to reproduce; I
+      // have been unable to reproduce the issue on my test machines.
+      //
+      // Note: Keyman may be violating a loader lock rule by calling 
+      // CloseTSF from here. This needs further investigation...
+      UninitialiseProcess(FALSE);
+      Globals_UninitProcess();
+    }
 		break;
 	case DLL_THREAD_ATTACH:
     //if(!TestDebugProcess()) return FALSE;


### PR DESCRIPTION
Fixes #1723. Stable cherry-pick for 11.0 from #1813.