### PR TITLE
[Android] Fix gradle scripts for CI build using build.sh instead of gradle runner

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -12,23 +12,28 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
 
-        println "===DUMPING PROPERTIES==="
-        dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
-        println "===END DUMP==="
+        //println "===DUMPING PROPERTIES==="
+        //dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
+        //println "===END DUMP==="
 
-        if (project.hasProperty("services_json_file")) {
+        String env_services_json_file = System.getenv('services_json_file')
+
+        if (env_services_json_file != null) {
+            env_services_json_file = String.valueOf(env_services_json_file)
             println "Copying production google-services.json and using at kMAPro/"
             copy {
-                from project.ext.services_json_file
+                from env_services_json_file
                 include '*.json'
                 into './'
             }
         }
 
-        if (project.hasProperty("build.number")) {
-            versionCode project.ext['build_counter'] as Integer
+        String env_build_number = System.getenv("build_number")
+        String env_build_counter = System.getenv("build_counter")
+        if (env_build_number != null) {
+            versionCode env_build_counter as Integer
             // Because TeamCity does not bubble build.counter into system properties...
-            versionName "${project.ext['build.number']}"
+            versionName env_build_number
         } else {
             String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
             versionCode 100
@@ -36,13 +41,17 @@ android {
         }
     }
 
-    if (project.hasProperty("release_store_file")) {
+    String env_release_store_file = System.getenv("release_store_file")
+    String env_release_store_password = System.getenv("release_store_password")
+    String env_release_key_alias = System.getenv("release_key_alias")
+    String env_release_key_password = System.getenv("release_key_password")
+    if (env_release_store_file != null) {
         signingConfigs {
             release {
-                storeFile file(project.ext.release_store_file)
-                storePassword project.ext.release_store_password
-                keyAlias project.ext.release_key_alias
-                keyPassword project.ext.release_key_password
+                storeFile file(String.valueof(env_release_store_file))
+                storePassword env_release_store_password
+                keyAlias env_release_key_alias
+                keyPassword env_release_key_password
             }
         }
     }

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -13,7 +13,7 @@ android {
         targetSdkVersion 28
 
         println "===DUMPING PROPERTIES==="
-        dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
+        dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
         println "===END DUMP==="
 
         if (project.hasProperty("services_json_file")) {

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -31,6 +31,7 @@ android {
         String env_build_number = System.getenv("build_number")
         String env_build_counter = System.getenv("build_counter")
         if (env_build_number != null) {
+            println "Using build number $env_build_number and counter $env_build_counter from environment"
             versionCode env_build_counter as Integer
             // Because TeamCity does not bubble build.counter into system properties...
             versionName env_build_number
@@ -38,6 +39,7 @@ android {
             String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
             versionCode 100
             versionName majorMinorVersion + '.0.0'
+            println "Using build $majorMinorVersion from project VERSION.md"
         }
     }
 
@@ -48,6 +50,7 @@ android {
     if (env_release_store_file != null) {
         signingConfigs {
             release {
+                println "Using signing from environment"
                 storeFile file(String.valueOf(env_release_store_file))
                 storePassword env_release_store_password
                 keyAlias env_release_key_alias

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -12,7 +12,9 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
 
-        //dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
+        println "===DUMPING PROPERTIES==="
+        dumpProperties(project.ext) // Use this to dump all external properties for debugging TeamCity integration
+        println "===END DUMP==="
 
         if (project.hasProperty("services_json_file")) {
             println "Copying production google-services.json and using at kMAPro/"

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -48,7 +48,7 @@ android {
     if (env_release_store_file != null) {
         signingConfigs {
             release {
-                storeFile file(String.valueof(env_release_store_file))
+                storeFile file(String.valueOf(env_release_store_file))
                 storePassword env_release_store_password
                 keyAlias env_release_key_alias
                 keyPassword env_release_key_password

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -28,7 +28,7 @@ android {
             }
         }
 
-        String env_build_number = System.getenv("build_number")
+        String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity?
         String env_build_counter = System.getenv("build_counter")
         if (env_build_number != null) {
             println "Using build number $env_build_number and counter $env_build_counter from environment"

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -114,7 +114,6 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.0-alpha04'
 }
 
-/*
 def void dumpProperties(it){
     //println "Examining $it.name:"
     //println "Meta:"
@@ -127,6 +126,5 @@ def void dumpProperties(it){
     println it.properties.entrySet()*.toString()
             .sort().toString().replaceAll(", ","\n")
 }
-*/
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -28,12 +28,11 @@ android {
             }
         }
 
-        String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity?
+        String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity, so all caps
         String env_build_counter = System.getenv("build_counter")
         if (env_build_number != null) {
             println "Using build number $env_build_number and counter $env_build_counter from environment"
             versionCode env_build_counter as Integer
-            // Because TeamCity does not bubble build.counter into system properties...
             versionName env_build_number
         } else {
             String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
@@ -66,7 +65,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            if (project.hasProperty("release_store_file")) {
+            if (env_release_store_file != null) {
                 signingConfig signingConfigs.release
             }
         }
@@ -79,11 +78,12 @@ android {
     }
 }
 
-if (project.hasProperty("keys_json_file")) {
+String env_keys_json_file = System.getenv("keys_json_file")
+if (env_keys_json_file != null) {
     apply plugin: 'com.github.triplet.play'
 
     play {
-        serviceAccountCredentials = file(project.ext.keys_json_file)
+        serviceAccountCredentials = file(String.valueOf(env_keys_json_file))
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy = "ignore"
@@ -126,7 +126,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.0-alpha04'
 }
 
-def void dumpProperties(it){
+/*def void dumpProperties(it){
     //println "Examining $it.name:"
     //println "Meta:"
     //println it.metaClass.metaMethods*.name.sort().unique()
@@ -137,6 +137,6 @@ def void dumpProperties(it){
     println "Properties:"
     println it.properties.entrySet()*.toString()
             .sort().toString().replaceAll(", ","\n")
-}
+}*/
 
 apply plugin: 'com.google.gms.google-services'

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -8,13 +8,17 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
 
-        if (project.hasProperty("build.number")) {
-            versionCode project.ext['build_counter'] as Integer // Because TeamCity does not bubble build.counter into system properties...
-            versionName "${project.ext['build.number']}"
+        String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity, so all caps
+        String env_build_counter = System.getenv("build_counter")
+        if (env_build_number != null) {
+            println "Using build number $env_build_number and counter $env_build_counter from environment"
+            versionCode env_build_counter as Integer
+            versionName env_build_number
         } else {
             String majorMinorVersion = file('$projectDir/../../../../resources/VERSION.md').text.trim()
             versionCode 100
             versionName majorMinorVersion + '.0.0'
+            println "Using build $majorMinorVersion from project VERSION.md"
         }
     }
 

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -12,33 +12,44 @@ android {
         minSdkVersion 17
         targetSdkVersion 28
 
-        if (project.hasProperty("services_json_file")) {
-            println "Copying production google-services.json and using at FirstVoices/"
+        String env_services_json_file = System.getenv('oem_firstvoices_services_json_file')
+
+        if (env_services_json_file != null) {
+            env_services_json_file = String.valueOf(env_services_json_file)
+            println "Copying production google-services.json and using for firstvoices"
             copy {
-                from project.ext.services_json_file
+                from env_services_json_file
                 include '*.json'
                 into './'
             }
         }
 
-        if (project.hasProperty("build.number")) {
-            versionCode project.ext['build_counter'] as Integer
-            // Because TeamCity does not bubble build.counter into system properties...
-            versionName "${project.ext['build.number']}"
+        String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity, so all caps
+        String env_build_counter = System.getenv("build_counter")
+        if (env_build_number != null) {
+            println "Using build number $env_build_number and counter $env_build_counter from environment"
+            versionCode env_build_counter as Integer
+            versionName env_build_number
         } else {
             String majorMinorVersion = file('$projectDir/../../../../../resources/VERSION.md').text.trim()
             versionCode 999
             versionName majorMinorVersion + '.0.0'
+            println "Using build $majorMinorVersion from project VERSION.md"
         }
     }
 
-    if (project.hasProperty("release_store_file")) {
+    String env_release_store_file = System.getenv("oem_firstvoices_release_store_file")
+    String env_release_store_password = System.getenv("oem_firstvoices_release_store_password")
+    String env_release_key_alias = System.getenv("oem_firstvoices_release_key_alias")
+    String env_release_key_password = System.getenv("oem_firstvoices_release_key_password")
+    if (env_release_store_file != null) {
         signingConfigs {
             release {
-                storeFile file(project.ext.release_store_file)
-                storePassword project.ext.release_store_password
-                keyAlias project.ext.release_key_alias
-                keyPassword project.ext.release_key_password
+                println "Using signing from environment"
+                storeFile file(String.valueOf(env_release_store_file))
+                storePassword env_release_store_password
+                keyAlias env_release_key_alias
+                keyPassword env_release_key_password
             }
         }
     }
@@ -50,7 +61,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (project.hasProperty("release_store_file")) {
+            if (env_release_store_file != null) {
                 signingConfig signingConfigs.release
             }
         }
@@ -63,11 +74,12 @@ android {
     }
 }
 
-if (project.hasProperty("keys_json_file")) {
+String env_keys_json_file = System.getenv("oem_firstvoices_keys_json_file")
+if (env_keys_json_file != null) {
     apply plugin: 'com.github.triplet.play'
 
     play {
-        serviceAccountCredentials = file(project.ext.keys_json_file)
+        serviceAccountCredentials = file(String.valueOf(env_keys_json_file))
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy = "ignore"


### PR DESCRIPTION
Instead of using system properties, we use environment variables. This has the added
benefit of being easily testable externally.