### PR TITLE
[Windows] Add meta x-ua-compatible to all remaining XSL templates

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman.xsl
@@ -19,6 +19,7 @@
   <xsl:template match="/">
     <html xmlns="http://www.w3.org/1999/xhtml">
       <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
         <title><xsl:value-of select="$locale/String[@Id='S_ConfigurationTitle']"/></title>
         <link rel="stylesheet" type="text/css"><xsl:attribute name="href"><xsl:value-of select="/Keyman/templatepath"/>config.css</xsl:attribute></link>

--- a/windows/src/desktop/kmshell/xml/onlineupdate.xsl
+++ b/windows/src/desktop/kmshell/xml/onlineupdate.xsl
@@ -10,6 +10,7 @@
 
 <html>
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 <title><xsl:value-of select="$locale/String[@Id='S_Update_Title']"/></title>
 <style type="text/css">
 

--- a/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
+++ b/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
@@ -10,6 +10,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 <title><xsl:value-of select="$locale/String[@Id='S_ProxyConfiguration_Title']"/></title>
 <style type="text/css">
   * { font-family: <xsl:value-of select="($locale/String[@Id='SK_UIFontName'])[1]" />; }

--- a/windows/src/desktop/kmshell/xml/usage_keyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/usage_keyboard.xsl
@@ -10,6 +10,7 @@
 
 		<html>
 			<head>
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 				<title>
 					<xsl:value-of select="$locale/String[@Id='Usage_Title']" />
 				</title>

--- a/windows/src/desktop/kmshell/xml/vkhints.xsl
+++ b/windows/src/desktop/kmshell/xml/vkhints.xsl
@@ -8,7 +8,7 @@
 
 		<html>
 			<head>
-				<!--<META http-equiv="Page-Enter" CONTENT="progid:DXImageTransform.Microsoft.Pixelate(Duration=1)" />-->
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 
 				<title>hintbar</title>
 				<style type="text/css">

--- a/windows/src/desktop/kmshell/xml/welcome_fonts.xsl
+++ b/windows/src/desktop/kmshell/xml/welcome_fonts.xsl
@@ -8,7 +8,7 @@
 
 		<html>
 			<head>
-				<!-- META http-equiv="Page-Enter" CONTENT="progid:DXImageTransform.Microsoft.Pixelate(Duration=1)" / -->
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 
 				<title>fonts</title>
 				<style type="text/css">


### PR DESCRIPTION
This fixes compatibility issues on some systems where IE runs in a legacy mode and results in errors such as reported at https://community.software.sil.org/t/object-doesnt-support-property-or-method-addeventlistener/2207