### PR TITLE
[Windows] Ensure locale files are copied to bin folder during build

### DIFF
--- a/windows/src/desktop/kmshell/Makefile
+++ b/windows/src/desktop/kmshell/Makefile
@@ -21,7 +21,9 @@ xml:
     -del /q $(ROOT)\bin\desktop\xml\*
     copy * $(ROOT)\bin\desktop\xml\   #
     cd $(ROOT)\src\desktop\kmshell
-
+    -rmdir /S /Q $(ROOT)\bin\desktop\locale
+    mkdir $(ROOT)\bin\desktop\locale
+    xcopy /S /I $(ROOT)\src\desktop\kmshell\locale $(ROOT)\bin\desktop\locale\
 
 clean: def-clean
     if exist MessageIdentifiers.pas del MessageIdentifiers.pas


### PR DESCRIPTION
This has no impact on the release build but ensures that the locale files are available during debug sessions.