### PR TITLE
[Mac] add support for if(), set(), reset(), save()

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -223,6 +223,7 @@ NSMutableArray *servers;
         [self.AppDelegate setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
         [self.AppDelegate setContextBuffer:nil];
         [self.AppDelegate setSelectedKeyboard:path];
+        [self.AppDelegate loadSavedStores];
         if (kvk != nil && self.AppDelegate.alwaysShowOSK)
             [self.AppDelegate showOSK];
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -89,6 +89,8 @@ extern NSString *const kWebSite;
 
 - (NSMenu *)menu;
 - (void)saveActiveKeyboards;
+- (void)loadSavedStores;
+- (void)saveStore:(NSNumber *)storeKey withValue:(NSString* )value;
 - (void)showAboutWindow;
 - (void)showOSK;
 - (void)showConfigurationWindow;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -24,6 +24,7 @@
 
 NSString *const kKMSelectedKeyboardKey = @"KMSelectedKeyboardKey";
 NSString *const kKMActiveKeyboardsKey = @"KMActiveKeyboardsKey";
+NSString *const kKMSavedStoresKey = @"KMSavedStoresKey";
 NSString *const kKMAlwaysShowOSKKey = @"KMAlwaysShowOSKKey";
 NSString *const kKMUseVerboseLogging = @"KMUseVerboseLogging";
 NSString *const kKeymanKeyboardDownloadCompletedNotification = @"kKeymanKeyboardDownloadCompletedNotification";
@@ -306,6 +307,53 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     _keyboardName = keyboardName;
     if (_oskWindow != nil)
         [_oskWindow.window setTitle:self.oskWindowTitle];
+}
+
+- (void)loadSavedStores {
+    NSUserDefaults *userData = [NSUserDefaults standardUserDefaults];
+    NSDictionary *allSavedStores = [userData dictionaryForKey:kKMSavedStoresKey];
+    if (!allSavedStores) return;
+    NSDictionary *savedStores = [allSavedStores objectForKey:_selectedKeyboard];
+    if (!savedStores) return;
+
+    NSNumberFormatter *fmt = [[NSNumberFormatter alloc] init];
+    fmt.numberStyle = NSNumberFormatterDecimalStyle;
+
+    for (NSString *key in savedStores) {
+        NSString *value = [savedStores objectForKey:key];
+        NSUInteger storeID = [[fmt numberFromString:key] unsignedIntegerValue];
+        [self.kme setStore:(DWORD)storeID withValue:value];
+    }
+}
+
+- (void)saveStore:(NSNumber *)storeKey withValue:(NSString* )value {
+    NSString *storeKeyStr = [storeKey stringValue];
+    NSUserDefaults *userData = [NSUserDefaults standardUserDefaults];
+    NSDictionary *allSavedStores = [userData dictionaryForKey:kKMSavedStoresKey];
+    NSDictionary *savedStores;
+
+    if (allSavedStores) {
+        savedStores = [allSavedStores objectForKey:_selectedKeyboard];
+    }
+
+    if (savedStores) {
+        NSMutableDictionary *newSavedStores = [savedStores mutableCopy];
+        [newSavedStores setObject:value forKey:storeKeyStr];
+        savedStores = newSavedStores;
+    } else {
+        savedStores = [[NSDictionary alloc] initWithObjectsAndKeys:value, storeKeyStr, nil];
+    }
+
+    if (allSavedStores) {
+        NSMutableDictionary *newAllSavedStores = [allSavedStores mutableCopy];
+        [newAllSavedStores setObject:savedStores forKey:_selectedKeyboard];
+        allSavedStores = newAllSavedStores;
+    } else {
+        allSavedStores = [[NSDictionary alloc] initWithObjectsAndKeys:savedStores, _selectedKeyboard, nil];
+    }
+
+    [userData setObject:allSavedStores forKey:kKMSavedStoresKey];
+    [userData synchronize];
 }
 
 - (NSString *)oskWindowTitle {
@@ -765,6 +813,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
                 [self setKvk:kvk];
                 [self setKeyboardName:[kmxInfo objectForKey:kKMKeyboardNameKey]];
                 [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
+                [self loadSavedStores];
 
                 didSetKeyboard = YES;
             }
@@ -800,6 +849,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
             [self setKeyboardName:[kmxInfo objectForKey:kKMKeyboardNameKey]];
             [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
             [self setContextBuffer:nil];
+            [self loadSavedStores];
             [self setSelectedKeyboard:path];
         }
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -425,6 +425,12 @@ NSRange _previousSelRange;
         else if ([actionType isEqualToString:Q_BEEP]) {
             [[NSSound soundNamed:@"Tink"] play];
         }
+        else if ([actionType isEqualToString:Q_SAVEOPT]) {
+            NSDictionary *save = [action objectForKey:actionType];
+            NSNumber *storeKey = [save allKeys][0];
+            NSString *value = [save objectForKey:storeKey];
+            [self.AppDelegate saveStore:storeKey withValue:value];
+        }
     }
     return YES;
 }

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
@@ -36,6 +36,9 @@
                 [self removeLastObject];
                 [self addObject:mAction];
             }
+            else {
+                [self addObject:newAction];
+            }
         }
         else if ([preActionType isEqualToString:Q_STR] && [newActionType isEqualToString:Q_BACK]) {
             NSString *preStr = [preAction objectForKey:preActionType];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMCompStore.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMCompStore.h
@@ -20,6 +20,7 @@
 @property (strong, nonatomic) NSString *string;
 
 - (void)setDwSystemID:(DWORD)dwID;
+- (id)copyWithZone:(NSZone *)zone;
 
 @end
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMCompStore.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMCompStore.m
@@ -21,6 +21,18 @@
     return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+    KMCompStore *newStore = [[[self class] allocWithZone:zone] init];
+
+    if (newStore) {
+        [newStore setDwSystemID:[self dwSystemID]];
+        if ([self name]) newStore.name = [[NSString alloc] initWithString:[self name]];
+        if ([self string]) newStore.string = [[NSString alloc] initWithString:[self string]];
+    }
+
+    return newStore;
+}
+
 - (NSString *)description {
     NSString *format = @"<%@:%p ID:0x%X DN:%@ N:%@ S:%@>";
     NSString *str = [NSString stringWithFormat:format,

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
@@ -20,6 +20,7 @@ extern NSString *const Q_DEADKEY;
 extern NSString *const Q_NUL;
 extern NSString *const Q_BEEP;
 extern NSString *const Q_RETURN;
+extern NSString *const Q_SAVEOPT;
 
 extern DWORD VKMap[0x80];
 
@@ -31,6 +32,7 @@ extern DWORD VKMap[0x80];
 - (id)initWithKMX:(KMXFile *)kmx contextBuffer:(NSString *)ctxBuf;
 - (void)setContextBuffer:(NSString *)ctxBuf;
 - (NSString *)contextBuffer;
+- (void)setStore:(DWORD)storeID withValue:(NSString *)value;
 - (NSArray *)processEvent:(NSEvent *)event;
 - (void)setUseVerboseLogging:(BOOL)useVerboseLogging;
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -408,6 +408,8 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
     if (!outKey || !outKey.length)
         return nil;
     
+    BOOL handled = NO;
+
     for (int i = 0; i < outKey.length;) {
         unichar c = [outKey characterAtIndex:i];
         if (c == UC_SENTINEL) {
@@ -523,6 +525,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     KMCompStore *store1 = [self.kmx.store objectAtIndex:x1];
                     KMCompStore *store2 = [self.kmx.store objectAtIndex:x2];
                     store1.string = [[NSString alloc] initWithString:store2.string];
+                    handled = YES;
 
                     i+=4;
                     break;
@@ -531,8 +534,8 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     DWORD x1 = [outKey characterAtIndex:i+2]-1;
                     KMCompStore *store = [self.kmx.store objectAtIndex:x1];
                     KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:x1];
-
                     store.string = [[NSString alloc] initWithString:storeSaved.string];
+                    handled = YES;
                     i+=3;
                     break;
                 }
@@ -541,6 +544,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     KMCompStore *store = [self.kmx.store objectAtIndex:x1];
                     KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:x1];
                     storeSaved.string = [[NSString alloc] initWithString:store.string];
+                    handled = YES;
                     i+=3;
                     break;
                 }
@@ -565,6 +569,11 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
             NSLog(@"tmpCtxBuf = \"%@\"", [self.tmpCtxBuf codeString]);
     }
     
+    if (!actions && handled) {
+        NSDictionary *action = [[NSDictionary alloc] initWithObjectsAndKeys:@"", Q_NUL, nil];
+        actions = [[NSMutableArray alloc] initWithObjects:action, nil];
+    }
+
     return actions;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -550,7 +550,6 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     KMCompStore *store = [self.kmx.store objectAtIndex:x1];
                     KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:x1];
                     storeSaved.string = [[NSString alloc] initWithString:store.string];
-                    handledWithoutActions = YES;
 
                     NSDictionary *actionObj = [[NSDictionary alloc] initWithObjectsAndKeys:[[NSString alloc] initWithString:store.string], [NSNumber numberWithUnsignedInteger:x1], nil];
                     NSDictionary *action = [[NSDictionary alloc] initWithObjectsAndKeys:actionObj, Q_SAVEOPT, nil];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -106,7 +106,9 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
 
 - (void)setStore:(DWORD)storeID withValue:(NSString *)value {
     KMCompStore *store = [self.kmx.store objectAtIndex:storeID];
+    KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:storeID];
     store.string = [[NSString alloc] initWithString:value];
+    storeSaved.string = [[NSString alloc] initWithString:value];
 }
 
 - (NSArray *)processEvent:(NSEvent *)event {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -517,6 +517,33 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     i+=2;
                     break;
                 }
+                case CODE_SETOPT: {
+                    DWORD x1 = [outKey characterAtIndex:i+2]-1;
+                    DWORD x2 = [outKey characterAtIndex:i+3]-1;
+                    KMCompStore *store1 = [self.kmx.store objectAtIndex:x1];
+                    KMCompStore *store2 = [self.kmx.store objectAtIndex:x2];
+                    store1.string = [[NSString alloc] initWithString:store2.string];
+
+                    i+=4;
+                    break;
+                }
+                case CODE_RESETOPT: {
+                    DWORD x1 = [outKey characterAtIndex:i+2]-1;
+                    KMCompStore *store = [self.kmx.store objectAtIndex:x1];
+                    KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:x1];
+
+                    store.string = [[NSString alloc] initWithString:storeSaved.string];
+                    i+=3;
+                    break;
+                }
+                case CODE_SAVEOPT: {
+                    DWORD x1 = [outKey characterAtIndex:i+2]-1;
+                    KMCompStore *store = [self.kmx.store objectAtIndex:x1];
+                    KMCompStore *storeSaved = [self.kmx.storeSaved objectAtIndex:x1];
+                    storeSaved.string = [[NSString alloc] initWithString:store.string];
+                    i+=3;
+                    break;
+                }
                 default:
                     i+=2;
                     break;
@@ -784,13 +811,21 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     break;
                 }
                 case CODE_IFOPT: {
-                    //DWORD x1 = [keyCtx characterAtIndex:i+2]-1;
-                    //DWORD x2 = [keyCtx characterAtIndex:i+3]-1;
-                    //DWORD x3 = [keyCtx characterAtIndex:i+4]-1;
-                    //KMCompStore *store = [self.kmx.store objectAtIndex:x3];
-                    //i+=5;
+                    DWORD x1 = [keyCtx characterAtIndex:i+2]-1;
+                    DWORD x2 = [keyCtx characterAtIndex:i+3]-1;
+                    DWORD x3 = [keyCtx characterAtIndex:i+4]-1;
+                    KMCompStore *store1 = [self.kmx.store objectAtIndex:x1];
+                    KMCompStore *store2 = [self.kmx.store objectAtIndex:x3];
+
+                    BOOL match = [store1.string isEqualToString:store2.string];
+                    if ((match && x2 == EQUAL) || (!match && x2 == NOT_EQUAL)) {
+                        cx+=1000;
+                    }
+                    else {
+                        return 0;
+                    }
                     
-                    return 0; // CODE_IFOPT is not supported
+                    i+=5;
                     break;
                 }
                 case CODE_IFSYSTEMSTORE: {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.h
@@ -29,6 +29,7 @@ extern NSString *const kKMVisualKeyboardKey;
 @property (assign, nonatomic, readonly) BOOL isMnemonic;
 @property (assign, nonatomic, readonly) DWORD version;
 @property (strong, nonatomic, readonly) NSArray *store;
+@property (strong, nonatomic, readonly) NSArray *storeSaved;
 @property (strong, nonatomic, readonly) NSArray *group;
 @property (strong, nonatomic, readonly) NSArray *startGroup;
 @property (assign, nonatomic, readonly) DWORD flags;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
@@ -95,6 +95,7 @@ NSString *const kKMVisualKeyboardKey = @"KMVisualKeyboardKey";
         }
         
         _store = [[NSArray alloc] initWithArray:mStore];
+        _storeSaved = [[NSArray alloc] initWithArray:mStore copyItems:YES];
         
         struct COMP_GROUP cmp_grp[cmp_kb.cxGroupArray];
         [file seekToFileOffset:cmp_kb.dpGroupArray];


### PR DESCRIPTION
This addresses #1832 by implementing support for `if()`, `set()`, `reset()`, and `save()` on macOS. These now behave as expected and there is no more garbage output.

In order to support `reset()` and `save()`, I had to add another array of stores to `KMXFile` (with saved values) and implement `copyWithZone` on `KMCompStore`, so that it's easy to duplicate the initial array of stores.