### PR TITLE
[Mac] fix two deadkey issues

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
@@ -36,9 +36,6 @@
                 [self removeLastObject];
                 [self addObject:mAction];
             }
-            else if ([preActionType isEqualToString:Q_DEADKEY]) {
-                [self addObject:newAction];
-            }
         }
         else if ([preActionType isEqualToString:Q_STR] && [newActionType isEqualToString:Q_BACK]) {
             NSString *preStr = [preAction objectForKey:preActionType];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSArray+Action.m
@@ -36,6 +36,9 @@
                 [self removeLastObject];
                 [self addObject:mAction];
             }
+            else if ([preActionType isEqualToString:Q_DEADKEY]) {
+                [self addObject:newAction];
+            }
         }
         else if ([preActionType isEqualToString:Q_STR] && [newActionType isEqualToString:Q_BACK]) {
             NSString *preStr = [preAction objectForKey:preActionType];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSString+XString.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/Categories/NSString+XString.m
@@ -356,7 +356,7 @@
 @implementation NSMutableString (XString)
 
 - (void)appendDeadkey:(NSUInteger)index {
-    NSString *dk = [NSString stringWithFormat:@"%C%C%lu", UC_SENTINEL, CODE_DEADKEY, index];
+    NSString *dk = [NSString stringWithFormat:@"%C%C%C", UC_SENTINEL, CODE_DEADKEY, index];
     [self appendString:dk];
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -770,7 +770,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
                     DWORD index = [keyCtx characterAtIndex:i+2];
                     if ([ctx characterAtIndex:px] == UC_SENTINEL && [ctx characterAtIndex:px+1] == CODE_DEADKEY) {
                         px+=2;
-                        c = [[NSString stringWithFormat:@"%d", index] characterAtIndex:0];
+                        c = [[NSString stringWithFormat:@"%C", index] characterAtIndex:0];
                         unichar c2 = [ctx characterAtIndex:px];
                         if (c != c2)
                             return 0;


### PR DESCRIPTION
This fixes two unrelated deadkey issues on macOS:

* Multiple deadkeys in a rule did not work, as in [019 - multiple deadkeys](https://github.com/keymanapp/keyman/blob/master/common/engine/keyboardprocessor/tests/unit/kmx/019%20-%20multiple%20deadkeys.kmn) cases "4" through "8". This was because `addAction` was skipping any deadkey actions following another deadkey action. I modified it to append in such cases.

* Keyboards with more than 9 deadkeys would fail when the 10th or higher deadkey was used. This was because the deadkey ID was being appended to the context buffer as a decimal string. Any ID above 9 therefore appended two characters, but the code reading the buffer expected only one. I fixed this by instead encoding it as a single UTF-16 character whose codepoint is the deadkey ID, and reading it back that way as well.

I have tested these changes with the full range of KMX unit tests.