### PR TITLE
[Mac] fix out-of-date context buffer after keyboard commands

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -41,7 +41,7 @@ NSMutableArray *servers;
 }
 
 - (NSUInteger)recognizedEvents:(id)sender {
-    return (NSEventMaskKeyDown);
+    return NSEventMaskKeyDown | NSEventMaskFlagsChanged;
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -81,7 +81,7 @@ id _lastServerWithOSKShowing = nil;
                                                          forEventClass:kInternetEventClass
                                                             andEventID:kAEGetURL];
         
-        self.lowLevelEventTap = CGEventTapCreate(kCGAnnotatedSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly, NSFlagsChangedMask | NSLeftMouseDown | NSLeftMouseUp, (CGEventTapCallBack)eventTapFunction, nil);
+        self.lowLevelEventTap = CGEventTapCreate(kCGAnnotatedSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly, CGEventMaskBit(kCGEventFlagsChanged) | CGEventMaskBit(kCGEventLeftMouseDown) | CGEventMaskBit(kCGEventLeftMouseUp), (CGEventTapCallBack)eventTapFunction, nil);
         
         if (!self.lowLevelEventTap) {
             NSLog(@"Can't tap into low level events!");

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -489,6 +489,11 @@ NSRange _previousSelRange;
     /*if (event.type == NSKeyDown)
      [self.AppDelegate handleKeyEvent:event];*/
     
+    if (event.type == NSFlagsChanged) {
+        _contextOutOfDate = YES;
+        return NO;
+    }
+
     if ((event.modifierFlags & NSEventModifierFlagCommand) == NSEventModifierFlagCommand) {
         [self handleCommand:event];
         return NO; // We let the client app handle all Command-key events.


### PR DESCRIPTION
The current code for detecting keyboard commands in [KMInputMethodEventHandler.m](https://github.com/keymanapp/keyman/blob/master/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m) checks `keyDown` events for `event.modifierFlags` to detect keyboard commands that can change the contextBuffer (command-A to change selection, etc.). 

I've found that command-key combinations never trigger `keyDown` events. This can cause the context buffer to be out of date. The solution I've found is to handle `flagsChanged` events, as in the low-level event tap. This patch does so and sets `contextOutOfDate` for `flagsChanged` events. 

It also correctly passes event flags to `CGEventTapCreate` (per Apple's documentation).