### PR TITLE
[Android] Lexical model swapping + management

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -843,14 +843,22 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
   @Override
   public void onLexicalModelInstalled(List<Map<String, String>> lexicalModelsInstalled) {
+    String langId = KMManager.getCurrentKeyboardInfo(this).get(KMManager.KMKey_LanguageID);
+    boolean matchingModel = false;
+
     for(int i=0; i<lexicalModelsInstalled.size(); i++) {
       HashMap<String, String>lexicalModelInfo = new HashMap<>(lexicalModelsInstalled.get(i));
+      if(lexicalModelInfo.get(KMManager.KMKey_LanguageID).equals(langId)) {
+        matchingModel = true;
+      }
       KMManager.addLexicalModel(this, lexicalModelInfo);
     }
 
-    // TODO:  It would be nice to register associated lexical models; this is no longer called
-    //        from the async task, so it may be possible to modify the WebView.
-    //        (banner heights get adjusted during model registration)
+    // We're on the main thread, so if the active keyboard's language code matches,
+    // let's register the associated lexical model.
+    if(matchingModel) {
+      KMManager.registerAssociatedLexicalModel(langId);
+    }
   }
 
   private void copyFile(FileInputStream inStream, File dstFile) throws IOException {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -76,7 +76,7 @@ public class ConfirmDialogFragment extends DialogFragment {
             case DIALOG_TYPE_DELETE_KEYBOARD :
               // Confirmation to delete keyboard
               int keyboardIndex = KeyboardPickerActivity.getKeyboardIndex(getActivity(), itemKey);
-              KeyboardPickerActivity.deleteKeyboard(getContext(), keyboardIndex);
+              KeyboardPickerActivity.deleteKeyboard(getActivity(), keyboardIndex);
               dismissOnSelect = true;
               break;
             case DIALOG_TYPE_DOWNLOAD_MODEL :
@@ -90,7 +90,7 @@ public class ConfirmDialogFragment extends DialogFragment {
             case DIALOG_TYPE_DELETE_MODEL :
               // Confirmation to delete model
               int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(getActivity(), itemKey);
-              KeyboardPickerActivity.deleteLexicalModel(getContext(), modelIndex);
+              KeyboardPickerActivity.deleteLexicalModel(getActivity(), modelIndex, false);
               dismissOnSelect = true;
               break;
             default :

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -486,18 +486,21 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
    * @param context
    * @param position - int position in the models list
    */
-  protected static void deleteLexicalModel(Context context, int position) {
+  protected static void deleteLexicalModel(Context context, int position, boolean silenceNotification) {
     String modelID = getModelIDFromPosition(context, position);
     boolean result = removeLexicalModel(context, position);
 
     if (result) {
-      Toast.makeText(context, "Model deleted", Toast.LENGTH_SHORT).show();
+      if(!silenceNotification) {
+        Toast.makeText(context, "" + "Model deleted", Toast.LENGTH_SHORT).show();
+      }
       KMManager.deregisterLexicalModel(modelID);
     }
 
     notifyLexicalModelsUpdate(context);
   }
 
+  // Gets a raw list of installed lexical models.
   @SuppressWarnings("unchecked")
   private static ArrayList<HashMap<String, String>> getList(Context context, String filename) {
     ArrayList<HashMap<String, String>> list = null;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -69,7 +69,12 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
       // Should never actually happen.
       Log.e(TAG, "Language data not specified for LanguageSettingsActivity!");
       finish();
-      return;  // We could throw NullPointerException, but this is more graceful in case it slips into production.
+
+      if(KMManager.isDebugMode()) {
+        throw new NullPointerException("Language data not specified for LanguageSettingsActivity!");
+      } else {
+        return;
+      }
     }
 
     associatedLexicalModel = bundle.getString(KMManager.KMKey_LexicalModelName, "");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -40,6 +40,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
   private Context context;
   private static Toolbar toolbar = null;
   private static ListView listView = null;
+  private static TextView lexicalModelTextView = null;
   private ImageButton addButton = null;
   private String associatedLexicalModel = "";
   private String lgCode;
@@ -77,7 +78,6 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
       }
     }
 
-    associatedLexicalModel = bundle.getString(KMManager.KMKey_LexicalModelName, "");
     lgCode = bundle.getString(KMManager.KMKey_LanguageID);
     lgName = bundle.getString(KMManager.KMKey_LanguageName);
 
@@ -98,11 +98,11 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     layout = (RelativeLayout)findViewById(R.id.model_picker);
     textView = (TextView) layout.findViewById(R.id.text1);
     textView.setText(getString(R.string.model));
-    if (!associatedLexicalModel.isEmpty()) {
-      textView = (TextView) layout.findViewById(R.id.text2);
-      textView.setText(associatedLexicalModel);
-      textView.setEnabled(true);
-    }
+
+    lexicalModelTextView = layout.findViewById(R.id.text2);
+
+    updateActiveLexicalModel();
+
     ImageView imageView = (ImageView) layout.findViewById(R.id.image1);
     imageView.setImageResource(R.drawable.ic_arrow_forward);
     layout.setEnabled(true);
@@ -197,6 +197,19 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
       // Despite the fact that updates should have been auto-triggered anyway, it seems that we
       // need a manual call here for things to happen in a timely fashion.
       adapter.notifyDataSetChanged();
+    }
+
+    updateActiveLexicalModel();
+  }
+
+  public void updateActiveLexicalModel() {
+    associatedLexicalModel = KMManager.getAssociatedLexicalModel(lgCode).get(KMManager.KMKey_LexicalModelName);
+    if (!associatedLexicalModel.isEmpty()) {
+      lexicalModelTextView.setText(associatedLexicalModel);
+      lexicalModelTextView.setEnabled(true);
+    } else {
+      lexicalModelTextView.setText("");
+      lexicalModelTextView.setEnabled(false);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -270,9 +270,10 @@ public final class LanguagesSettingsActivity extends AppCompatActivity
       holder.img.setImageResource(R.drawable.ic_arrow_forward);
 
       if(data.keyboards.size() == 1) {
-        holder.textCount.setText("(1 keyboard)");
+        holder.textCount.setText(this.getContext().getString(R.string.single_keyboard_count));
       } else {
-        holder.textCount.setText("(" + data.keyboards.size() + " keyboards)");
+        String msg = String.format(this.getContext().getString(R.string.multiple_keyboard_count), data.keyboards.size());
+        holder.textCount.setText(msg);
       }
 
       return convertView;
@@ -287,7 +288,7 @@ public final class LanguagesSettingsActivity extends AppCompatActivity
           return;
         }
 
-        Toast.makeText(context, "All resources are up to date!", Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, context.getString(R.string.update_check_current), Toast.LENGTH_SHORT).show();
         lastUpdateCheck = Calendar.getInstance();
         SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
@@ -303,7 +304,7 @@ public final class LanguagesSettingsActivity extends AppCompatActivity
           return;
         }
 
-        Toast.makeText(context, "Failed to access Keyman server!", Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, context.getString(R.string.update_check_unavailable), Toast.LENGTH_SHORT).show();
         lastUpdateCheck = Calendar.getInstance();
         updateCheckFailed = true;
         checkingUpdates = false;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -101,6 +101,9 @@ public final class ModelPickerActivity extends AppCompatActivity {
 
           String modelKey = String.format("%s_%s_%s", packageID, languageID, modelID);
           boolean modelInstalled = KeyboardPickerActivity.containsLexicalModel(context, modelKey);
+          boolean immediateRegister = false;
+          Map<String, String> preInstalledModelMap = KMManager.getAssociatedLexicalModel(languageID);
+
           if (modelInstalled) {
             // Show Model Info
             listView.setItemChecked(position, true);
@@ -135,13 +138,34 @@ public final class ModelPickerActivity extends AppCompatActivity {
               Toast.makeText(context, "Model installed", Toast.LENGTH_SHORT).show();
             }
 
-            // Don't register associated lexical model because this is not a UI view
+            immediateRegister = true;
           } else {
             // Model isn't installed so prompt to download it
             Bundle args = model.buildDownloadBundle();
             Intent i = new Intent(getApplicationContext(), KMKeyboardDownloaderActivity.class);
             i.putExtras(args);
             startActivity(i);
+          }
+
+          // If we had a previously-installed lexical model, we should 'deinstall' it so that only
+          // one model is actively linked to any given language.
+          if(!modelInstalled) {
+            // While awkward, we must obtain the preInstalledModelMap before any installations occur.
+            // We don't want to remove the model we just installed, after all!
+            LexicalModel preInstalled = new LexicalModel(preInstalledModelMap);
+            String itemKey = String.format("%s_%s_%s",
+                preInstalled.map.get(KMManager.KMKey_PackageID), preInstalled.getLanguageCode(), preInstalled.getResourceId());
+            int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(context, itemKey);
+            KeyboardPickerActivity.deleteLexicalModel(context, modelIndex, true);
+          }
+
+          if(immediateRegister) {
+            // Register associated lexical model if it matches the active keyboard's language code;
+            // it's safe since we're on the same thread.  Needs to be called AFTER deinstalling the old one.
+            String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).get(KMManager.KMKey_LanguageID);
+            if(kbdLgCode.equals(languageID)) {
+              KMManager.registerAssociatedLexicalModel(languageID);
+            }
           }
 
           // Force a display refresh.

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -152,11 +152,13 @@ public final class ModelPickerActivity extends AppCompatActivity {
           if(!modelInstalled) {
             // While awkward, we must obtain the preInstalledModelMap before any installations occur.
             // We don't want to remove the model we just installed, after all!
-            LexicalModel preInstalled = new LexicalModel(preInstalledModelMap);
-            String itemKey = String.format("%s_%s_%s",
-                preInstalled.map.get(KMManager.KMKey_PackageID), preInstalled.getLanguageCode(), preInstalled.getResourceId());
-            int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(context, itemKey);
-            KeyboardPickerActivity.deleteLexicalModel(context, modelIndex, true);
+            if(preInstalledModelMap != null) {
+              LexicalModel preInstalled = new LexicalModel(preInstalledModelMap);
+              String itemKey = String.format("%s_%s_%s",
+                  preInstalled.map.get(KMManager.KMKey_PackageID), preInstalled.getLanguageCode(), preInstalled.getResourceId());
+              int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(context, itemKey);
+              KeyboardPickerActivity.deleteLexicalModel(context, modelIndex, true);
+            }
           }
 
           if(immediateRegister) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -421,7 +421,8 @@ public class CloudRepository {
           // Determine package ID from packageFilename
           modelURL = model.optString("packageFilename", "");
           packageID = FileUtils.getFilename(modelURL);
-          packageID = packageID.replace(".model.kmp", "");
+          // Android keeps the .model part of the file extension as part of the package ID.
+          packageID = packageID.replace(".kmp", "");
         }
 
         // api.keyman.com query returns an array of language IDs Strings while

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -535,6 +535,25 @@ public class CloudRepository {
       this.keyboardJSON = keyboardJSON;
       this.lexicalModelJSON = lexicalModelJSON;
     }
+
+    public boolean isEmpty() {
+      boolean emptyKbd = false;
+      boolean emptyLex = false;
+
+      if (keyboardJSON == null) {
+        emptyKbd = true;
+      } else if (keyboardJSON.length() == 0) {
+        emptyKbd = true;
+      }
+
+      if(lexicalModelJSON == null) {
+        emptyLex = true;
+      } else if(lexicalModelJSON.length() == 0) {
+        emptyLex = true;
+      }
+
+      return emptyKbd && emptyLex;
+    }
   }
 
   // This is copied from LanguageListActivity to download a catalog from the cloud.
@@ -627,7 +646,9 @@ public class CloudRepository {
       }
 
       List<CloudApiReturns> retrievedJSON = new ArrayList<>(params.length);
-      progressDialog.setMax(params.length);
+      if(progressDialog != null) {
+        progressDialog.setMax(params.length);
+      }
 
       for(CloudApiParam param:params) {
         JSONParser jsonParser = new JSONParser();
@@ -647,17 +668,20 @@ public class CloudRepository {
             Log.d(TAG, e.getMessage());
           }
         } else {
+          // Offline trouble!  That said, we can't get anything, so we simply shouldn't add anything.
         }
 
         if(param.type == JSONType.Array) {
-          retrievedJSON.add(new CloudApiReturns(param.target, dataArray));
+          retrievedJSON.add(new CloudApiReturns(param.target, dataArray));  // Null if offline.
         } else {
-          retrievedJSON.add(new CloudApiReturns(param.target, dataObject));
+          retrievedJSON.add(new CloudApiReturns(param.target, dataObject)); // Null if offline.
         }
-        progressDialog.setProgress(progressDialog.getProgress());
+        if(progressDialog != null) {
+          progressDialog.setProgress(progressDialog.getProgress());
+        }
       }
 
-      return new CloudDownloadReturns(retrievedJSON);
+      return new CloudDownloadReturns(retrievedJSON); // Will report empty arrays/objects if offline.
     }
 
     protected JSONArray ensureInit(JSONArray json) {
@@ -733,7 +757,16 @@ public class CloudRepository {
     }
 
     public void processCloudReturns(CloudDownloadReturns jsonTuple, boolean executeCallbacks) {
-      // TODO:  Need proper offline check again.
+      // Only empty if no queries returned data - we're offline.
+      if(jsonTuple.isEmpty()) {
+        if(this.updateHandler == null) {
+          String msg = context.getString(R.string.catalog_unavailable);
+          Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+        }
+        this.failure.run(); // Signal failure to download to our failure callback.
+        return;
+      }
+
       List<Keyboard> keyboardsArrayList = processKeyboardJSON(jsonTuple.keyboardJSON, false);
       List<LexicalModel> lexicalModelsArrayList = processLexicalModelJSON(jsonTuple.lexicalModelJSON);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -167,7 +167,7 @@ public class CloudRepository {
       languageCodes.add(installedSet.getItem(i).code);
     }
 
-    // Get kmp.json info from installed models.
+    // Get kmp.json info from installed (adhoc and cloud) models.
     // Consolidate kmp.json info from packages/
     JSONObject kmpLanguagesArray = wrapKmpKeyboardJSON(JSONUtils.getLanguages());
     JSONArray kmpLexicalModelsArray = JSONUtils.getLexicalModels();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -195,7 +195,7 @@ public class JSONUtils {
   }
 
   /**
-   * Iterate through each model folder and parse kmp.json
+   * Iterate through each model's folder and parse kmp.json, whether installed or not.
    */
   public static JSONArray getLexicalModels() {
     File[] packages = new File(KMManager.getLexicalModelsDir()).listFiles();

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -56,6 +56,11 @@
     <string name="confirm_download_model" translatable="false">Would you like to download this model?</string>
     <string name="checking_model_download" translatable="false">Checking to download model&#8230;</string>
     <string name="downloading_model" translatable="false">Downloading model&#8230;</string>
+    <string name="catalog_unavailable" translatable="false">The resource catalog is unavailable\n</string>
+
+    <!-- General Updates -->
+    <string name="update_check_unavailable" translatable="false">Failed to access server!\n</string>
+    <string name="update_check_current" translatable="false">"All resources are up to date!"</string>
 
     <!-- Model Info -->
     <string name="model_version" translatable="false">Model version</string>
@@ -67,6 +72,8 @@
     <string name="enable_predictions" translatable="false">Enable predictions</string>
     <string name="model" translatable="false">Model</string>
     <string name="manage_dictionary" translatable="false">Manage dictionary</string>
+    <string name="single_keyboard_count" translatable="false">(1 keyboard)</string>
+    <string name="multiple_keyboard_count" translatable="false">(%d keyboards)</string>
 
     <!-- Content descriptions -->
     <string name="image_button" translatable="false">Image Button</string>

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -223,7 +223,7 @@ namespace com.keyman.text.prediction {
       }
 
       // Is it the active model?
-      if(this.currentModel.id == modelId) {
+      if(this.currentModel && this.currentModel.id == modelId) {
         this.unloadModel();
         keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
       }


### PR DESCRIPTION
In the case that a user has two more more lexical models downloaded for the same language code, this PR allows proper management of their installation states.  Whenever the active model is changed, the previously-installed model will be de-installed automatically.  Afterward, the new model will be registered in the background and will be automatically activated once the Settings menus are closed.

This PR relies on #1836 at a minimum, though I've based it off of #1842 for ease of testing (and to facilitate a potential imminent demo).  The recent longpress PR's changes (#1844) also appear here since the longpress changes haven't yet been merged into the base.  (Basically - ignore KMKeyboard.java's changes.)