### PR TITLE
[Android] Predict vs correct options

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -48,6 +48,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     bannerPreference.setKey(KeymanSettingsActivity.showBannerKey);
     bannerPreference.setTitle(getString(R.string.show_banner));
     bannerPreference.setSummaryOn(getString(R.string.show_banner_on));
+    bannerPreference.setSummaryOff(getString(R.string.show_banner_off));
 
     SwitchPreference getStartedPreference = new SwitchPreference(context);
     getStartedPreference.setKey(GetStartedActivity.showGetStartedKey);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -38,6 +38,12 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     languagesIntent.putExtra(KMManager.KMKey_DisplayKeyboardSwitcher, false);
     languagesPreference.setIntent(languagesIntent);
 
+    /*
+      Automatically does the following:
+        SharedPreferences.Editor editor = prefs.edit();
+          editor.putBoolean(KeymanSettingsActivity.showBannerKey, isChecked);
+      as part of the default onClick() used by SwitchPreference.
+     */
     SwitchPreference bannerPreference = new SwitchPreference(context);
     bannerPreference.setKey(KeymanSettingsActivity.showBannerKey);
     bannerPreference.setTitle(getString(R.string.show_banner));

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -38,8 +38,9 @@
   <string name="keyman_settings" translatable="false">Settings</string>
   <string name="installed_languages_empty" translatable="false">Installed languages</string>
   <string name="installed_languages" translatable="false">Installed languages (%d)</string>
-  <string name="show_banner" translatable="false">Show banner</string>
-  <string name="show_banner_on" translatable="false">Cannot be switched off when predictive text is enabled</string>
+  <string name="show_banner" translatable="false">Always show banner</string>
+  <string name="show_banner_on" translatable="false">To be implemented</string>
+  <string name="show_banner_off" translatable="false">When off, only shown when predictive text is enabled</string>
   <!-- reuse show_get_started -->
 
   <!-- Web Browser strings -->

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -165,8 +165,13 @@
       kmw.modelManager.deregister(modelID);
     }
 
-    function enableSuggestions(model) {
+    function enableSuggestions(model, mayPredict, mayCorrect) {
       registerModel(model);
+
+      keyman.osk.banner.setOptions({
+        'mayPredict': mayPredict,
+        'mayCorrect': mayCorrect
+      });
     }
 
     function registerModel(model) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -166,12 +166,14 @@
     }
 
     function enableSuggestions(model, mayPredict, mayCorrect) {
-      registerModel(model);
-
+      // Set the options first so that KMW's ModelManager can properly handle model enablement states
+      // the moment we actually register the new model.
       keyman.osk.banner.setOptions({
         'mayPredict': mayPredict,
         'mayCorrect': mayCorrect
       });
+
+      registerModel(model);
     }
 
     function registerModel(model) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -706,14 +706,18 @@ public final class KMManager {
     model = model.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
     model = model.replaceAll("\"", "'");
 
+    SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    boolean mayPredict = prefs.getBoolean(LanguageSettingsActivity.getLanguagePredictionPreferenceKey(languageID), false);
+    boolean mayCorrect = prefs.getBoolean(LanguageSettingsActivity.getLanguageCorrectionPreferenceKey(languageID), false);
+
     RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
       InAppKeyboard.setLayoutParams(params);
-      InAppKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s)", model));
+      InAppKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
       SystemKeyboard.setLayoutParams(params);
-      SystemKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s)", model));
+      SystemKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     return true;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -707,8 +707,8 @@ public final class KMManager {
     model = model.replaceAll("\"", "'");
 
     SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-    boolean mayPredict = prefs.getBoolean(LanguageSettingsActivity.getLanguagePredictionPreferenceKey(languageID), false);
-    boolean mayCorrect = prefs.getBoolean(LanguageSettingsActivity.getLanguageCorrectionPreferenceKey(languageID), false);
+    boolean mayPredict = prefs.getBoolean(LanguageSettingsActivity.getLanguagePredictionPreferenceKey(languageID), true);
+    boolean mayCorrect = prefs.getBoolean(LanguageSettingsActivity.getLanguageCorrectionPreferenceKey(languageID), true);
 
     RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {


### PR DESCRIPTION
Following from #1857, this PR integrates its changes into the current version of the Android app.  This involves tracking new settings with `SharedPreferences` and some bug fixes necessary to make things work right.

Note that the "Always show banner" global option is not yet fully connected to anything, as Android currently lacks the resources needed to mirror iOS's image banner behavior.