### PR TITLE
[Developer] Include index.ts in tsconfig.json for Lexical Model compiler

### DIFF
--- a/developer/js/tsconfig.json
+++ b/developer/js/tsconfig.json
@@ -11,7 +11,8 @@
   },
   "include": [
     "lexical-model-compiler/**/*",
-    "package-compiler/**/*"
+    "package-compiler/**/*",
+    "index.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This fixes a regression from #1861. It may not have been visible on developer machines because the build doesn't wipe dist/ by default; however build agents start with a clean tree when doing lexical model builds, so it fell over there.