### PR TITLE
[Android] Comments out hooks for rotation suggestion.

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -167,10 +167,11 @@ final class KMKeyboard extends WebView {
         if (subKeysList != null) {
           showSubKeys(context);
           return;
-        } else if(suggestionJSON != null) {
+        } /* For future implementation
+        else if(suggestionJSON != null) {
           showSuggestionLongpress(context);
           return;
-        }
+        }*/
       }
 
       @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1485,17 +1485,19 @@ public final class KMManager {
         JSONParser parser = new JSONParser();
         JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
 
+        /*  // For future implementation
         InAppKeyboard.suggestionWindowPos = new double[]{x, y};
         InAppKeyboard.suggestionJSON = suggestionJSON;
 
         try {
           Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
           Log.v("KMEA", "Suggestion's banner coords: " + x + ", " + y + ", " + width + ", " + height);
-          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom);
+          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom); // likely outdated now that tags exist.
         } catch (JSONException e) {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
+        */
       }
       return false;
     }
@@ -1713,14 +1715,19 @@ public final class KMManager {
         JSONParser parser = new JSONParser();
         JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
 
+        /*  // For future implementation
+        SystemKeyboard.suggestionWindowPos = new double[]{x, y};
+        SystemKeyboard.suggestionJSON = suggestionJSON;
+
         try {
           Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
           Log.v("KMEA", "Suggestion's banner coords: " + x + ", " + y + ", " + width + ", " + height);
-          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom);
+          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom); // likely outdated now that tags exist.
         } catch (JSONException e) {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
+        */
       }
 
       return false;


### PR DESCRIPTION
Fixes #1880.

The code triggering the error was never meant to be merged into master; it was from work toward a now-postponed feature.  As such, we can safely remove it for now - the key is to remove any calls to `showSuggestionLongpress`.

Compare vs #1773 (Intended) and #1778 (unintended), as noted by #1844.  While #1844 fixed a more notable bug, it failed to notice that there were actually active hooks into the incomplete feature.