### PR TITLE
[iOS] Banner Repair

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -283,6 +283,8 @@ extension KeymanWebViewController {
   
     log.debug("LexicalModel stub: \(stubString)")
     webView!.evaluateJavaScript("keyman.registerModel(\(stubString));", completionHandler: nil)
+    
+    setBannerHeight(to: InputViewController.topBarHeight)
   }
   
   func setBannerImage(to path: String) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -293,7 +293,7 @@ extension KeymanWebViewController {
   
   func setBannerHeight(to height: Int) {
     // TODO:
-    webView?.evaluateJavaScript("setBannerHeight(\(height);", completionHandler: nil)
+    webView?.evaluateJavaScript("setBannerHeight(\(height));", completionHandler: nil)
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -256,7 +256,7 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
       
       // Add lexicalModel.
       for lexicalModel in lexicalModels {
-        if lexicalModel.languageID == language.id {
+        if lexicalModel.languageID == language?.id {
           Manager.shared.addLexicalModel(lexicalModel)
           switchLexicalModel(lexicalModel)
         }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -256,10 +256,13 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
       
       // Add lexicalModel.
       for lexicalModel in lexicalModels {
-        Manager.shared.addLexicalModel(lexicalModel)
-        _ = Manager.shared.registerLexicalModel(lexicalModel)
+        if lexicalModel.languageID == language.id {
+          Manager.shared.addLexicalModel(lexicalModel)
+          switchLexicalModel(lexicalModel)
+        }
       }
       
+      // Wait, really?  That might not be the best idea...
       navigationController?.popToRootViewController(animated: true)
     }
   }
@@ -289,15 +292,22 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     self.present(alertController, animated: true, completion: nil)
   }
   
-  private func switchLexicalModel(_ index: Int) {
+  private func switchLexicalModel(_ model: InstallableLexicalModel) {
     // Switch lexicalModel and register to user defaults.
-    if Manager.shared.registerLexicalModel(userLexicalModels[index]) {
+    if Manager.shared.registerLexicalModel(model) {
       tableView.reloadData()
     }
+    
+    // Register the lexical model in defaults!
+    Storage.active.userDefaults.set(preferredLexicalModelID: model.id, forKey: model.languageID)
     
     if !_isDoneButtonEnabled {
       Manager.shared.dismissLexicalModelPicker(self)
     }
+  }
+  
+  private func switchLexicalModel(_ index: Int) {
+    switchLexicalModel(userLexicalModels[index])
   }
   
   // if we have a language set, filter models down to those of that language

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -262,7 +262,6 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
         }
       }
       
-      // Wait, really?  That might not be the best idea...
       navigationController?.popToRootViewController(animated: true)
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -264,7 +264,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   // returns lexical model id, given language id
   func preferredLexicalModel(_ ud: UserDefaults, forLanguage lgCode: String) -> InstallableLexicalModel? {
     if let preferredID = ud.preferredLexicalModelID(forLanguage: lgCode) {
-      return ud.userLexicalModels?.first { $0.id == preferredID }
+      // We need to match both the model id and the language code - registration fails
+      // when the language code mismatches the current keyboard's set code!
+      return ud.userLexicalModels?.first { $0.id == preferredID && $0.languageID == lgCode }
     }
     return nil
   }

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -25,6 +25,7 @@
             };
         
             var device = 'AppleMobile';
+            var bannerHeight = 0;
             var oskHeight = 0;
             var oskWidth = 0;
             
@@ -63,8 +64,17 @@
               var kmw = com.keyman.singleton;
               var osk = kmw.osk;
 
-              if(h >= 0 && osk.banner.activeType != 'blank') {
-                osk.banner.height = h;
+              if(h >= 0) {
+                // The banner itself may not be loaded yet.  This will preemptively help set
+                // its eventual display height.
+                com.keyman.osk.Banner.DEFAULT_HEIGHT = h;
+                
+                if(osk.banner.activeType != 'blank') {
+                  osk.banner.height = h;
+                  setOskHeight(bannerHeight + oskHeight - h);
+                }
+                
+                bannerHeight = h;
               }
               
               // Refresh KMW's OSK
@@ -79,7 +89,7 @@
             
             function setOskHeight(height) {
                 var kmw=window['keyman'];
-                oskHeight = height - kmw.osk.banner.height;
+                oskHeight = height - bannerHeight;
                 kmw.osk.show(true);
                 kmw['correctOSKTextSize']();
             }

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -25,7 +25,6 @@
             };
         
             var device = 'AppleMobile';
-            var bannerHeight = 0;
             var oskHeight = 0;
             var oskWidth = 0;
             
@@ -71,10 +70,7 @@
                 
                 if(osk.banner.activeType != 'blank') {
                   osk.banner.height = h;
-                  setOskHeight(bannerHeight + oskHeight - h);
                 }
-                
-                bannerHeight = h;
               }
               
               // Refresh KMW's OSK
@@ -89,7 +85,7 @@
             
             function setOskHeight(height) {
                 var kmw=window['keyman'];
-                oskHeight = height - bannerHeight;
+                oskHeight = height - kmw.osk.banner.height;
                 kmw.osk.show(true);
                 kmw['correctOSKTextSize']();
             }

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -181,6 +181,8 @@ namespace com.keyman.osk {
     public setBanner(type: BannerType, height?: number) {
       var banner: Banner;
 
+      console.log("Setting banner type to " + type + ".");
+
       switch(type) {
         case 'blank':
           banner = new BlankBanner();

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -181,8 +181,6 @@ namespace com.keyman.osk {
     public setBanner(type: BannerType, height?: number) {
       var banner: Banner;
 
-      console.log("Setting banner type to " + type + ".");
-
       switch(type) {
         case 'blank':
           banner = new BlankBanner();


### PR DESCRIPTION
This PR aims to fix most of the current iOS banner instability issues.  That said, there's one I've yet to fully fix: when swapping the keyboard in-app, the banner never shows at first.  Simply rotating the device will fix this, though.  It appears that there's some strange order of events for keyboard loading within the app which is making a full solution difficult for this aspect.

Fortunately, that in-app issue is not reflected in the system keyboard, which appears to work flawlessly with the fix in place.