### PR TITLE
[iOS] Utilization of correction/prediction settings

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -26,6 +26,10 @@ public enum Key {
   
   /// Dictionary of lexical model ids keyed by language id in UserDefaults
   static let userPreferredLexicalModels = "UserPreferredLexicalModels"
+  
+  /// Dictionary of prediction/correction toggle settings keyed by language id in UserDefaults
+  static let userPredictSettings = "UserPredictionEnablementSettings"
+  static let userCorrectSettings = "UserCorrectionEnablementSettings"
 
   // Internal user defaults keys
   static let engineVersion = "KeymanEngineVersion"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -207,4 +207,62 @@ public extension UserDefaults {
       set(level, forKey: Key.migrationLevel)
     }
   }
+  
+  // stores a dictionary of predict-enablement settings keyed to language ids, i.e., [langID: Bool]
+  var predictionEnablements: [String: Bool]? {
+    get {
+      return dictionary(forKey: Key.userPredictSettings) as? [String : Bool]
+    }
+    
+    set(prefs) {
+      set(prefs, forKey: Key.userPredictSettings)
+    }
+  }
+  
+  // stores a dictionary of correction-enablement settings keyed to language ids, i.e., [langID: Bool]
+  var correctionEnablements: [String: Bool]? {
+    get {
+      return dictionary(forKey: Key.userCorrectSettings) as? [String : Bool]
+    }
+    
+    set(prefs) {
+      set(prefs, forKey: Key.userCorrectSettings)
+    }
+  }
+  
+  func predictSettingForLanguage(languageID: String) -> Bool {
+    if let dict = predictionEnablements {
+      return dict[languageID] ?? true
+    } else {
+      return true
+    }
+  }
+  
+  func set(predictSetting: Bool, forLanguageID: String) {
+    var prefs: [String: Bool]?
+    prefs = predictionEnablements
+    if prefs == nil {
+      prefs = [String: Bool]()
+    }
+    prefs?[forLanguageID] = predictSetting
+    predictionEnablements = prefs
+  }
+  
+  func correctSettingForLanguage(languageID: String) -> Bool {
+    if let dict = correctionEnablements {
+      return dict[languageID] ?? true
+    } else {
+      return true
+    }
+  }
+  
+  func set(correctSetting: Bool, forLanguageID: String) {
+    var prefs: [String: Bool]?
+    prefs = correctionEnablements
+    if prefs == nil {
+      prefs = [String: Bool]()
+    }
+    prefs?[forLanguageID] = correctSetting
+    correctionEnablements = prefs
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -282,7 +282,21 @@ extension KeymanWebViewController {
     }
   
     log.debug("LexicalModel stub: \(stubString)")
-    webView!.evaluateJavaScript("keyman.registerModel(\(stubString));", completionHandler: nil)
+    if lexicalModel.languageID == Manager.shared.currentKeyboardID?.languageID {
+      // We're registering a lexical model for the now-current keyboard.
+      // Enact any appropriate language-modeling settings!
+      
+      let userDefaults = Storage.active.userDefaults
+      
+      let predict = userDefaults.predictSettingForLanguage(languageID: lexicalModel.languageID)
+      let correct = userDefaults.correctSettingForLanguage(languageID: lexicalModel.languageID)
+      
+      // Pass these off to KMW!
+      // We do these first so that they're automatically set for the to-be-registered model in advance.
+      webView!.evaluateJavaScript("enableSuggestions(\(stubString), \(predict), \(correct))")
+    } else {  // We're registering a model in the background - don't change settings.
+      webView!.evaluateJavaScript("keyman.registerModel(\(stubString));", completionHandler: nil)
+    }
     
     setBannerHeight(to: InputViewController.topBarHeight)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -85,7 +85,12 @@ class LanguageSettingsViewController: UITableViewController {
     let userDefaults = Storage.active.userDefaults
     userDefaults.set(predictSetting: value, forLanguageID: self.language.id)
     
-    // If for the active language, apply the setting now.
+    if let lm = Manager.shared.preferredLexicalModel(userDefaults, forLanguage: self.language.id) {
+      if Manager.shared.currentKeyboardID?.languageID == self.language.id {
+        // re-register the model - that'll enact the settings.
+        _ = Manager.shared.registerLexicalModel(lm)
+      }
+    }
   }
   
   @objc
@@ -94,7 +99,12 @@ class LanguageSettingsViewController: UITableViewController {
     let userDefaults = Storage.active.userDefaults
     userDefaults.set(correctSetting: value, forLanguageID: self.language.id)
     
-    // If for the active language, apply the setting now.
+    if let lm = Manager.shared.preferredLexicalModel(userDefaults, forLanguage: self.language.id) {
+      if Manager.shared.currentKeyboardID?.languageID == self.language.id {
+        // re-register the model - that'll enact the settings.
+        _ = Manager.shared.registerLexicalModel(lm)
+      }
+    }
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -185,9 +195,9 @@ class LanguageSettingsViewController: UITableViewController {
       cell.accessoryType = .none
       switch indexPath.row {
         case 0:
-          cell.textLabel?.text = "Enable corrections"
-        case 1:
           cell.textLabel?.text = "Enable predictions"
+        case 1:
+          cell.textLabel?.text = "Enable corrections"
         case 2:
           cell.textLabel?.text = "Model"
           cell.accessoryType = .disclosureIndicator

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -78,8 +78,28 @@ class LanguageSettingsViewController: UITableViewController {
                              height: cellFrame.size.height)
     return switchFrame
   }
+  
+  @objc
+  func predictionSwitchValueChanged(source: UISwitch) {
+    let value = source.isOn;
+    let userDefaults = Storage.active.userDefaults
+    userDefaults.set(predictSetting: value, forLanguageID: self.language.id)
+    
+    // If for the active language, apply the setting now.
+  }
+  
+  @objc
+  func correctionSwitchValueChanged(source: UISwitch) {
+    let value = source.isOn;
+    let userDefaults = Storage.active.userDefaults
+    userDefaults.set(correctSetting: value, forLanguageID: self.language.id)
+    
+    // If for the active language, apply the setting now.
+  }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let userDefaults = Storage.active.userDefaults
+    
     let cellIdentifier = 0 == indexPath.section ?  "KeyboardInLanguageSettingsCell" : "LanguageSettingsCell"
     
     let reusableCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)
@@ -89,22 +109,21 @@ class LanguageSettingsViewController: UITableViewController {
     
     let cell = UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
     if 1 == indexPath.section {
-        //TODO: find the settings these are to show
         if 0 == indexPath.row {
           cell.accessoryType = .none
           let doPredictionsSwitch = UISwitch()
           let switchFrame = frameAtRightOfCell(cell: cell.frame, controlSize: doPredictionsSwitch.frame.size)
           doPredictionsSwitch.frame = switchFrame
-          doPredictionsSwitch.isOn = false
-          //            showBannerSwitch.addTarget(self, action: #selector(self.predictionSwitchValueChanged), for: .valueChanged)
+          doPredictionsSwitch.isOn = userDefaults.predictSettingForLanguage(languageID: self.language.id)
+          doPredictionsSwitch.addTarget(self, action: #selector(self.predictionSwitchValueChanged), for: .valueChanged)
           cell.addSubview(doPredictionsSwitch)
         } else if 1 == indexPath.row {
           cell.accessoryType = .none
           let doCorrectionsSwitch = UISwitch()
           let switchFrame = frameAtRightOfCell(cell: cell.frame, controlSize: doCorrectionsSwitch.frame.size)
           doCorrectionsSwitch.frame = switchFrame
-          doCorrectionsSwitch.isOn = false
-          //            showBannerSwitch.addTarget(self, action: #selector(self.correctionSwitchValueChanged), for: .valueChanged)
+          doCorrectionsSwitch.isOn = userDefaults.correctSettingForLanguage(languageID: self.language.id)
+          doCorrectionsSwitch.addTarget(self, action: #selector(self.correctionSwitchValueChanged), for: .valueChanged)
           cell.addSubview(doCorrectionsSwitch)
         } else { // rows 3 and 4
           cell.accessoryType = .disclosureIndicator
@@ -222,6 +241,7 @@ class LanguageSettingsViewController: UITableViewController {
       showKeyboardInfoView(kb: (language.keyboards?[safe: indexPath.row])!)
     case 1:
       switch indexPath.row  {
+        // case 0, 1:  the toggles - but a general 'click' not on the toggle itself.
         case 2:
           showLexicalModelsView()
         default:

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -279,6 +279,17 @@
                 return hexString.substr(0, hexString.length-1);
             }
         
+            function enableSuggestions(model, mayPredict, mayCorrect) {
+              // Set the options first so that KMW's ModelManager can properly handle model enablement states
+              // the moment we actually register the new model.
+              keyman.osk.banner.setOptions({
+                'mayPredict': mayPredict,
+                'mayCorrect': mayCorrect
+              });
+
+              keyman.modelManager.register(model);
+            }
+        
             </script>
         <style type="text/css">
             body {background-color: rgb(210,214,220);}


### PR DESCRIPTION
This connects the in-app predict/correct settings to KMW and its predictive engine.  Accordingly, it also establishes permanent storage for these settings within the `UserDefaults` class, attempting to follow the paradigms already established there.