### PR TITLE
[LMLayer] Disable Firefox and Edge in unit tests

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -73,12 +73,14 @@ module.exports = function(config) {
   };
 
   var CURRENT_WIN_LAUNCHERS = {
-    bs_firefox_win: {
-      os: 'Windows',
-      os_version: '10',
-      browser: 'firefox',
-      browser_version: '62.0'
-    },
+    // Currently, Firefox launcher is unstable; see https://github.com/karma-runner/karma-firefox-launcher/issues/93
+    // (in particular "not maintained" commentary). 
+    //bs_firefox_win: {
+    //  os: 'Windows',
+    //  os_version: '10',
+    //  browser: 'firefox',
+    //  browser_version: '62.0'
+    //},
     bs_chrome_win: {
       os: 'Windows',
       os_version: '10',
@@ -91,12 +93,13 @@ module.exports = function(config) {
       browser: 'ie',
       browser_version: '11.0'
     },
-    bs_edge_win: {
-      os: 'Windows',
-      os_version: '10',
-      browser: 'edge',
-      browser_version: '17.0'
-    }
+    // On recent versions of Edge, launcher fails to start and/or stop Edge successfully
+    //bs_edge_win: {
+    //  os: 'Windows',
+    //  os_version: '10',
+    //  browser: 'edge',
+    //  browser_version: '17.0'
+    //}
   }
 
   var CURRENT_ANDROID_LAUNCHERS = {

--- a/common/predictive-text/unit_tests/in_browser/browser-test.sh
+++ b/common/predictive-text/unit_tests/in_browser/browser-test.sh
@@ -32,7 +32,7 @@ get_browser_set_for_OS ( ) {
     if [ $os_id = "mac" ]; then
         BROWSERS="--browsers Firefox,Chrome,Safari"
     elif [ $os_id = "win" ]; then
-        BROWSERS="--browsers Firefox,Chrome,IE,Edge"
+        BROWSERS="--browsers Chrome,IE"
     else
         BROWSERS="--browsers Firefox,Chrome"
     fi

--- a/common/predictive-text/unit_tests/in_browser/manual.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/manual.conf.js
@@ -9,7 +9,8 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Firefox', 'IE', 'Chrome', 'Edge'], // Can be specified at run-time instead!
+    browsers: ['IE', 'Chrome'], // Can be specified at run-time instead!
+      // Note: disabled Firefox, Edge due to instability
 	  // Future note for us:  https://www.npmjs.com/package/karma-browserstack-launcher
 
     // Concurrency level


### PR DESCRIPTION
Both Firefox and Edge test runners are proving flaky, so disabling them at this time. Not removing refs from package.json, just disabling the runners in hope that stability improves.

It appears that both runners are not being maintained (no updates in 2 years) so this is a bit of a concern.