### PR TITLE
[LMLayer] Allow model authors to specify quotes for keep message, and what to insert after a word

### DIFF
--- a/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
+++ b/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
@@ -1,0 +1,61 @@
+/*
+ * Unit tests for the Dummy prediction model.
+ */
+
+var assert = require('chai').assert;
+var DummyModel = require('../../build/intermediate').models.DummyModel;
+var ModelCompositor = require('../../build/intermediate').ModelCompositor;
+
+describe('Custom Punctuation', function() {
+  it('appears in the keep suggestion', function () {
+    let dummySuggestions = [
+      {
+        transform: {
+          insert: 'Hrllo',
+          deleteLeft: 0,
+        },
+        tag: 'keep',
+        displayAs: 'Hrllo',
+      },
+      {
+        transform: {
+          insert: 'Hello',
+          deleteLeft: 0,
+        },
+        displayAs: 'Hello',
+      },
+      {
+        transform: {
+          insert: 'Jello',
+          deleteLeft: 0,
+        },
+        displayAs: 'Jello',
+      }
+    ];
+
+    var model = new DummyModel({futureSuggestions: [dummySuggestions] }, {
+      punctuation: {
+        quotesForKeepSuggestion: {
+          open: "«", close: "»"
+        }
+      }
+    });
+    // The model compositor is responsible for adding this to the display as
+    // string.
+    var composite = new ModelCompositor(model);
+    var suggestions =  composite.predict([{ sample: { insert: 'o', deleteLeft: 0 }, p: 1.00 }], {
+      left: 'Hrll', startOfBuffer: false, endOfBuffer: true
+    });
+    assert.lengthOf(suggestions, 3);
+
+    // We only care about the "keep" suggestion.
+    var keepSuggestions = suggestions.filter(suggestion => suggestion.tag === 'keep');
+    assert.lengthOf(keepSuggestions, 1,
+      `Expected exactly one "keep" suggestion, but found ${keepSuggestions.length}`
+    );
+
+    // The moment of truth: has our punctuation been applied?
+    var suggestion = keepSuggestions[0];
+    assert.equal(suggestion.displayAs, `«Hrllo»`);
+  });
+});

--- a/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
+++ b/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
@@ -82,7 +82,8 @@ describe('Custom Punctuation', function () {
       var model = new DummyModel({
         futureSuggestions: [dummySuggestions],
         punctuation: {
-          // OGHAM SPACE: it's technically whitespace, but it don't look it!
+          // U+1680 OGHAM SPACE MARK:
+          // it's technically whitespace, but it don't look it!
           insertAfterWord: " ",
           quotesForKeepSuggestion: {
             open: "“", close: "”"
@@ -100,8 +101,7 @@ describe('Custom Punctuation', function () {
 
       // Check that it has been changed:
       for (var i = 0; i < dummySuggestions.length; i++) {
-        assert.equal(suggestions[i].transform.insert,
-                     dummySuggestions[i].transform.insert + " ");
+        assert.isTrue(suggestions[i].transform.insert.endsWith(' '));
       }
     });
   })

--- a/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
+++ b/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
@@ -33,13 +33,15 @@ describe('Custom Punctuation', function() {
       }
     ];
 
-    var model = new DummyModel({futureSuggestions: [dummySuggestions] }, {
+    var model = new DummyModel({
+      futureSuggestions: [dummySuggestions],
       punctuation: {
         quotesForKeepSuggestion: {
           open: "«", close: "»"
         }
       }
     });
+
     // The model compositor is responsible for adding this to the display as
     // string.
     var composite = new ModelCompositor(model);

--- a/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
+++ b/common/predictive-text/unit_tests/headless/worker-custom-punctuation.js
@@ -39,7 +39,6 @@ describe('Custom Punctuation', function () {
         quotesForKeepSuggestion: {
           open: "«", close: "»"
         },
-        insertAfterWord: " "
       }
     });
 
@@ -85,9 +84,6 @@ describe('Custom Punctuation', function () {
           // U+1680 OGHAM SPACE MARK:
           // it's technically whitespace, but it don't look it!
           insertAfterWord: " ",
-          quotesForKeepSuggestion: {
-            open: "“", close: "”"
-          },
         }
       });
 

--- a/common/predictive-text/unit_tests/headless/worker-predict-trie.js
+++ b/common/predictive-text/unit_tests/headless/worker-predict-trie.js
@@ -6,6 +6,27 @@ var assert = require('chai').assert;
 var TrieModel = require('../../build/intermediate').models.TrieModel;
 
 describe('LMLayerWorker trie model for word lists', function() {
+  describe('instantiation', function () {
+    it('should expose the punctuation object', function () {
+      var spaceMark = "👩🏻‍🚀";
+      var openQuote = "🌜";
+      var closeQuote = "🌛";
+
+      var model = new TrieModel(jsonFixture('tries/english-1000'), {
+        punctuation: {
+          insertAfterWord: spaceMark,
+          quotesForKeepSuggestion: {
+            open: openQuote, close: closeQuote
+          }
+        }
+      })
+      
+      assert.equal(model.punctuation.insertAfterWord, spaceMark);
+      assert.equal(model.punctuation.quotesForKeepSuggestion.open, openQuote);
+      assert.equal(model.punctuation.quotesForKeepSuggestion.close, closeQuote);
+    })
+  });
+
   describe('prediction', function () {
     var MIN_SUGGESTIONS = 3;
 

--- a/common/predictive-text/unit_tests/in_browser/json/future_suggestions/i_got_distracted_by_hazel.json
+++ b/common/predictive-text/unit_tests/in_browser/json/future_suggestions/i_got_distracted_by_hazel.json
@@ -19,7 +19,7 @@
         "insert": "Oh ",
         "deleteLeft": 0
       },
-      "displayAs": "Oh "
+      "displayAs": "Oh"
     }
   ],
   [

--- a/common/predictive-text/unit_tests/in_browser/resources/models/simple-dummy.js
+++ b/common/predictive-text/unit_tests/in_browser/resources/models/simple-dummy.js
@@ -8,7 +8,7 @@
     }
 
     Model.punctuation = {
-      quotesForKeepSuggestion: { open: `“`, close: `”`},
+      quotesForKeepSuggestion: { open: '“', close: '”'},
       // Important! Set this, or else the model compositor will
       // insert something for us!
       insertAfterWord: "",

--- a/common/predictive-text/unit_tests/in_browser/resources/models/simple-dummy.js
+++ b/common/predictive-text/unit_tests/in_browser/resources/models/simple-dummy.js
@@ -7,6 +7,13 @@
     function Model() { // implements Model
     }
 
+    Model.punctuation = {
+      quotesForKeepSuggestion: { open: `“`, close: `”`},
+      // Important! Set this, or else the model compositor will
+      // insert something for us!
+      insertAfterWord: "",
+    };
+
     // A direct import/copy from i_got_distracted_by_hazel.json.
     Model.futureSuggestions = [
       [
@@ -29,7 +36,7 @@
             "insert": "Oh ",
             "deleteLeft": 0
           },
-          "displayAs": "Oh "
+          "displayAs": "Oh"
         }
       ],
       [
@@ -107,5 +114,5 @@
   }());
 
   // It's a 'dummy' model, so there's no need for extra methods and such within the Model's class definition.
-  LMLayerWorker.loadModel(new models.DummyModel({futureSuggestions: Model.futureSuggestions}));
+  LMLayerWorker.loadModel(new models.DummyModel({futureSuggestions: Model.futureSuggestions, punctuation: Model.punctuation}));
 })();

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -49,7 +49,7 @@ class ModelCompositor {
     let postContext = models.applyTransform(inputTransform, context);
     let keepOptionText = this.lexicalModel.wordbreak(postContext);
     let keepOption: Suggestion = null;
-    let punctuation = this.determinePunctuationFromModel();
+    let punctuation = this.determinePunctuationFromModel(this.lexicalModel);
 
     for(let alt of transformDistribution) {
       let transform = alt.sample;
@@ -153,8 +153,30 @@ class ModelCompositor {
     return suggestions;
   }
 
-  private determinePunctuationFromModel() {
-    return this.lexicalModel.punctuation || DEFAULT_PUNCTUATION;
+  /**
+   * Returns the punctuation used for this model, filling out unspecified fields
+   */
+  private determinePunctuationFromModel(model: WorkerInternalModel): LexicalModelPunctuation {
+    let defaults = DEFAULT_PUNCTUATION;
+
+    // Use the defaults of the model does not provide any punctuation at all.
+    if (!model.punctuation)
+      return defaults;
+
+    let specifiedPunctuation = this.lexicalModel.punctuation;
+    let insertAfterWord = specifiedPunctuation.insertAfterWord;
+    if (insertAfterWord !== '' && !insertAfterWord) {
+      insertAfterWord = defaults.insertAfterWord;
+    }
+
+    let quotesForKeepSuggestion = specifiedPunctuation.quotesForKeepSuggestion;
+    if (!quotesForKeepSuggestion) {
+      quotesForKeepSuggestion = defaults.quotesForKeepSuggestion;
+    }
+
+    return {
+      insertAfterWord, quotesForKeepSuggestion
+    }
   }
 }
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -118,10 +118,10 @@ class ModelCompositor {
       };
     }
 
-    // TODO:  Customizable modeling for this formatting.  Different languages
-    //        use different quotation styles.  See https://github.com/keymanapp/keyman/issues/1883.
-    if(keepOption) {
-      keepOption.displayAs = '"' + keepOption.displayAs + '"';
+    if (keepOption) {
+      let punctuation = this.lexicalModel.punctuation || DEFAULT_PUNCTUATION;
+      let { open, close } = punctuation.quotesForKeepSuggestion;
+      keepOption.displayAs = open + keepOption.displayAs + close;
     }
 
     // Now that we've calculated a unique set of probability masses, time to make them into a proper
@@ -145,4 +145,12 @@ class ModelCompositor {
 
     return suggestions;
   }
+}
+
+/**
+ * The default punctuation and spacing produced by the model.
+ */
+const DEFAULT_PUNCTUATION = {
+  quotesForKeepSuggestion: { open: `“`, close: `”`},
+  insertAfterWord: " " ,
 }

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -185,7 +185,7 @@ class ModelCompositor {
 /**
  * The default punctuation and spacing produced by the model.
  */
-const DEFAULT_PUNCTUATION = {
+const DEFAULT_PUNCTUATION: LexicalModelPunctuation = {
   quotesForKeepSuggestion: { open: `“`, close: `”`},
   insertAfterWord: " " ,
 };

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -49,7 +49,7 @@ class ModelCompositor {
     let postContext = models.applyTransform(inputTransform, context);
     let keepOptionText = this.lexicalModel.wordbreak(postContext);
     let keepOption: Suggestion = null;
-    let punctuation = this.lexicalModel.punctuation || DEFAULT_PUNCTUATION;
+    let punctuation = this.determinePunctuationFromModel();
 
     for(let alt of transformDistribution) {
       let transform = alt.sample;
@@ -151,6 +151,10 @@ class ModelCompositor {
     }
 
     return suggestions;
+  }
+
+  private determinePunctuationFromModel() {
+    return this.lexicalModel.punctuation || DEFAULT_PUNCTUATION;
   }
 }
 

--- a/common/predictive-text/worker/models/dummy-model.ts
+++ b/common/predictive-text/worker/models/dummy-model.ts
@@ -33,6 +33,7 @@ namespace models {
    */
   export class DummyModel implements WorkerInternalModel {
     configuration: Configuration;
+    punctuation?: LexicalModelPunctuation;
     private _futureSuggestions: Suggestion[][];
 
     constructor(options?: any) {
@@ -41,6 +42,10 @@ namespace models {
       // this class mutates the array.
       this._futureSuggestions = options.futureSuggestions
         ? options.futureSuggestions.slice() : [];
+
+      if (options.punctuation) {
+        this.punctuation = options.punctuation;
+      }
     }
 
     configure(capabilities: Capabilities): Configuration {

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -48,6 +48,11 @@
      *  This should simplify a search term into a key.
      */
     searchTermToKey?: (searchTerm: string) => string;
+
+    /**
+     * Any punctuation to expose to the user.
+     */
+    punctuation?: LexicalModelPunctuation;
   }
 
   /**
@@ -72,6 +77,7 @@
     configuration: Configuration;
     private _trie: Trie;
     readonly breakWords: WordBreakingFunction;
+    readonly punctuation?: LexicalModelPunctuation;
 
     constructor(trieData: object, options: TrieModelOptions = {}) {
       this._trie = new Trie(
@@ -80,6 +86,7 @@
         options.searchTermToKey as Wordform2Key || defaultWordform2Key
       );
       this.breakWords = options.wordBreaker || wordBreakers.placeholder;
+      this.punctuation = options.punctuation;
     }
 
     configure(capabilities: Capabilities): Configuration {

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -94,7 +94,7 @@
       if (!transform.insert && context.startOfBuffer && context.endOfBuffer) {
         return makeDistribution(this._trie.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
           transform: {
-            insert: text + ' ', // TODO: do NOT add the space here!
+            insert: text,
             deleteLeft: 0
           },
           displayAs: text,

--- a/common/predictive-text/worker/worker-compiler-interfaces.d.ts
+++ b/common/predictive-text/worker/worker-compiler-interfaces.d.ts
@@ -1,0 +1,80 @@
+/**
+ * Types and interfaces that must be know both by the lexical model compiler,
+ * and by the runtime.
+ */
+
+/**
+ * A simple word breaking function takes a phrase, and splits it into "words",
+ * for whatever definition of "word" is usable for the language model.
+ *
+ * For example:
+ *
+ *   getText(breakWordsEnglish("Hello, world!")) == ["Hello", "world"]
+ *   getText(breakWordsCree("ᑕᐻ ᒥᔪ ᑮᓯᑲᐤ ᐊᓄᐦᐨ᙮")) == ["ᑕᐻ", "ᒥᔪ ᑮᓯᑲᐤ""", "ᐊᓄᐦᐨ"]
+ *   getText(breakWordsJapanese("英語を話せますか？")) == ["英語", "を", "話せます", "か"]
+ *
+ * Not all language models take in a configurable word breaking function.
+ *
+ * @returns an array of spans from the phrase, in order as they appear in the
+ *          phrase, each span which representing a word.
+ */
+interface WordBreakingFunction {
+  // invariant: span[i].end <= span[i + 1].start
+  // invariant: for all span[i] and span[i + 1], there does not exist a span[k]
+  //            where span[i].end <= span[k].start AND span[k].end <= span[i + 1].start
+  (phrase: string): Span[];
+}
+
+/**
+ * A span of text in a phrase. This is usually meant to reprent words from a
+ * pharse.
+ */
+interface Span {
+  // invariant: start < end (empty spans not allowed)
+  readonly start: number;
+  // invariant: end > end (empty spans not allowed)
+  readonly end: number;
+  // invariant: length === end - start
+  readonly length: number;
+  // invariant: text.length === length
+  // invariant: each character is BMP UTF-16 code unit, or is a high surrogate
+  // UTF-16 code unit followed by a low surrogate UTF-16 code unit.
+  readonly text: string;
+}
+/**
+ * Options for various punctuation to use in suggestions.
+ */
+interface LexicalModelPunctuation {
+  /**
+   * The quotes that appear in "keep" suggestions, e.g., keep what the user
+   * typed verbatim.
+   *
+   * The keep suggestion is often the leftmost one, when suggested.
+   *
+   * [ “Hrllo” ] [ Hello ] [ Heck ]
+   */
+  readonly quotesForKeepSuggestion: {
+    /**
+     * What will appear on the opening side of the quote.
+     * (left side for LTR scripts; right side for RTL scripts)
+     *
+     * Default: `“`
+     */
+    readonly open: string;
+    /**
+     * What will appear on the closing side of the quote.
+     * (right side for LTR scripts; left side for RTL scripts)
+     *
+     * Default: `”`
+     */
+    readonly close: string;
+  };
+  /**
+   * What punctuation or spacing to insert after every complete word
+   * prediction. This can be set to the empty string when the script does not
+   * use spaces to separate words.
+   *
+   * Default: ` `
+   */
+  readonly insertAfterWord: string;
+}

--- a/common/predictive-text/worker/worker-compiler-interfaces.d.ts
+++ b/common/predictive-text/worker/worker-compiler-interfaces.d.ts
@@ -26,7 +26,7 @@ interface WordBreakingFunction {
 }
 
 /**
- * A span of text in a phrase. This is usually meant to reprent words from a
+ * A span of text in a phrase. This is usually meant to represent words from a
  * pharse.
  */
 interface Span {

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -138,6 +138,14 @@ interface WorkerInternalModel {
   configure(capabilities: Capabilities): Configuration;
   predict(transform: Transform, context: Context): Distribution<Suggestion>;
   wordbreak(context: Context): USVString;
+
+  /**
+   * Punctuation and presentational settings that the underlying lexical model
+   * expects to be applied at higher levels. e.g., the ModelCompositor.
+   * 
+   * @see LexicalModelPunctuation
+   */
+  readonly punctuation?: LexicalModelPunctuation;
 }
 
 /**
@@ -188,4 +196,42 @@ interface Span {
   // invariant: each character is BMP UTF-16 code unit, or is a high surrogate
   // UTF-16 code unit followed by a low surrogate UTF-16 code unit.
   readonly text: string;
+}
+
+/**
+ * Options for various punctuation to use in suggestions.
+ */
+interface LexicalModelPunctuation {
+  /**
+   * The quotes that appear in "keep" suggestions, e.g., keep what the user
+   * typed verbatim.
+   * 
+   * The keep suggestion is often the leftmost one, when suggested.
+   * 
+   * [ “Hrllo” ] [ Hello ] [ Heck ]
+   */
+  readonly quotesForKeepSuggestion: {
+    /**
+     * What will appear on the opening side of the quote.
+     * (left side for LTR scripts; right side for RTL scripts)
+     *
+     * Default: `“`
+     */
+    readonly open: string;
+    /**
+     * What will appear on the closing side of the quote.
+     * (right side for LTR scripts; left side for RTL scripts)
+     *
+     * Default: `”`
+     */
+    readonly close: string;
+  };
+  /**
+   * What punctuation or spacing to insert after every complete word
+   * prediction. This can be set to the empty string when the script does not
+   * use spaces to separate words.
+   * 
+   * Default: ` `
+   */
+  readonly insertAfterWord: string;
 }

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -27,6 +27,7 @@
  */
 
 /// <reference path="../message.d.ts" />
+/// <reference path="./worker-compiler-interfaces.d.ts" />
 
 /**
  * The signature of self.postMessage(), so that unit tests can mock it.
@@ -203,81 +204,4 @@ interface WorkerInternalModelConstructor {
    * capabilities, plus any parameters they require.
    */
   new(...modelParameters: any[]): WorkerInternalModel;
-}
-
-/**
- * A simple word breaking function takes a phrase, and splits it into "words",
- * for whatever definition of "word" is usable for the language model.
- *
- * For example:
- *
- *   getText(breakWordsEnglish("Hello, world!")) == ["Hello", "world"]
- *   getText(breakWordsCree("ᑕᐻ ᒥᔪ ᑮᓯᑲᐤ ᐊᓄᐦᐨ᙮")) == ["ᑕᐻ", "ᒥᔪ ᑮᓯᑲᐤ""", "ᐊᓄᐦᐨ"]
- *   getText(breakWordsJapanese("英語を話せますか？")) == ["英語", "を", "話せます", "か"]
- *
- * Not all language models take in a configurable word breaking function.
- *
- * @returns an array of spans from the phrase, in order as they appear in the
- *          phrase, each span which representing a word.
- */
-interface WordBreakingFunction {
-  // invariant: span[i].end <= span[i + 1].start
-  // invariant: for all span[i] and span[i + 1], there does not exist a span[k]
-  //            where span[i].end <= span[k].start AND span[k].end <= span[i + 1].start
-  (phrase: USVString): Span[];
-}
-
-/**
- * A span of text in a phrase. This is usually meant to reprent words from a
- * pharse.
- */
-interface Span {
-  // invariant: start < end (empty spans not allowed)
-  readonly start: number;
-  // invariant: end > end (empty spans not allowed)
-  readonly end: number;
-  // invariant: length === end - start
-  readonly length: number;
-  // invariant: text.length === length
-  // invariant: each character is BMP UTF-16 code unit, or is a high surrogate
-  // UTF-16 code unit followed by a low surrogate UTF-16 code unit.
-  readonly text: string;
-}
-
-/**
- * Options for various punctuation to use in suggestions.
- */
-interface LexicalModelPunctuation {
-  /**
-   * The quotes that appear in "keep" suggestions, e.g., keep what the user
-   * typed verbatim.
-   * 
-   * The keep suggestion is often the leftmost one, when suggested.
-   * 
-   * [ “Hrllo” ] [ Hello ] [ Heck ]
-   */
-  readonly quotesForKeepSuggestion: {
-    /**
-     * What will appear on the opening side of the quote.
-     * (left side for LTR scripts; right side for RTL scripts)
-     *
-     * Default: `“`
-     */
-    readonly open: string;
-    /**
-     * What will appear on the closing side of the quote.
-     * (right side for LTR scripts; left side for RTL scripts)
-     *
-     * Default: `”`
-     */
-    readonly close: string;
-  };
-  /**
-   * What punctuation or spacing to insert after every complete word
-   * prediction. This can be set to the empty string when the script does not
-   * use spaces to separate words.
-   * 
-   * Default: ` `
-   */
-  readonly insertAfterWord: string;
 }

--- a/developer/js/index.ts
+++ b/developer/js/index.ts
@@ -15,6 +15,14 @@ import { createTrieDataStructure } from "./lexical-model-compiler/build-trie";
 //                         author           .bcp47            .uniq
 const MODEL_ID_PATTERN = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/;
 
+/**
+ * The default punctuation and spacing produced by the model.
+ */
+const DEFAULT_PUNCTUATION = {
+  quotesForKeepSuggestion: { open: `“`, close: `”`},
+  insertAfterWord: " " ,
+}
+
 export default class LexicalModelCompiler {
   compile(modelSource: LexicalModelSource) {
     //
@@ -221,6 +229,11 @@ export default class LexicalModelCompiler {
       }
     }
 
+    // Figure out the punctuation used in the model.
+    let punctuation: LexicalModelPunctuation = Object.assign(
+      {}, DEFAULT_PUNCTUATION, modelSource.punctuation
+    );
+
     //
     // Emit the model as code and data
     //
@@ -245,6 +258,7 @@ export default class LexicalModelCompiler {
         if (modelSource.searchTermToKey) {
           func += `  searchTermToKey: ${modelSource.searchTermToKey.toString()},\n`;
         }
+        func += `  punctuation: ${JSON.stringify(punctuation)},\n`;
         func += `}));\n`;
         break;
       default:

--- a/developer/js/index.ts
+++ b/developer/js/index.ts
@@ -258,7 +258,9 @@ export default class LexicalModelCompiler {
         if (modelSource.searchTermToKey) {
           func += `  searchTermToKey: ${modelSource.searchTermToKey.toString()},\n`;
         }
-        func += `  punctuation: ${JSON.stringify(punctuation)},\n`;
+        if (modelSource.punctuation) {
+          func += `  punctuation: ${JSON.stringify(punctuation)},\n`;
+        }
         func += `}));\n`;
         break;
       default:

--- a/developer/js/index.ts
+++ b/developer/js/index.ts
@@ -244,11 +244,9 @@ export default class LexicalModelCompiler {
         func += `LMLayerWorker.loadModel(new ${modelSource.rootClass}());\n`;
         break;
       case "fst-foma-1.0":
-        (oc as LexicalModelCompiledFst).fst = Buffer.from(sources.join('')).toString('base64');
-        this.logError('Unimplemented model format '+modelSource.format);
+        this.logError('Unimplemented model format ' + modelSource.format);
         return false;
-      case "trie-1.0": // TODO: in lexical-models, rollback all trie-2.0 models to use trie-1.0!
-      case 'trie-2.0':
+      case "trie-1.0":
         func += `LMLayerWorker.loadModel(new models.TrieModel(${
           createTrieDataStructure(sources, modelSource.searchTermToKey)
         }, {\n`;

--- a/developer/js/index.ts
+++ b/developer/js/index.ts
@@ -15,14 +15,6 @@ import { createTrieDataStructure } from "./lexical-model-compiler/build-trie";
 //                         author           .bcp47            .uniq
 const MODEL_ID_PATTERN = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/;
 
-/**
- * The default punctuation and spacing produced by the model.
- */
-const DEFAULT_PUNCTUATION = {
-  quotesForKeepSuggestion: { open: `“`, close: `”`},
-  insertAfterWord: " " ,
-}
-
 export default class LexicalModelCompiler {
   compile(modelSource: LexicalModelSource) {
     //
@@ -229,11 +221,6 @@ export default class LexicalModelCompiler {
       }
     }
 
-    // Figure out the punctuation used in the model.
-    let punctuation: LexicalModelPunctuation = Object.assign(
-      {}, DEFAULT_PUNCTUATION, modelSource.punctuation
-    );
-
     //
     // Emit the model as code and data
     //
@@ -257,7 +244,7 @@ export default class LexicalModelCompiler {
           func += `  searchTermToKey: ${modelSource.searchTermToKey.toString()},\n`;
         }
         if (modelSource.punctuation) {
-          func += `  punctuation: ${JSON.stringify(punctuation)},\n`;
+          func += `  punctuation: ${JSON.stringify(modelSource.punctuation)},\n`;
         }
         func += `}));\n`;
         break;

--- a/developer/js/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/lexical-model-compiler/lexical-model.ts
@@ -35,6 +35,13 @@ interface LexicalModelSource extends LexicalModel {
    * This often involves removing accents, lowercasing, etc.
    */
   readonly searchTermToKey?: (term: string) => string;
+
+  /**
+   * Punctuation and spacing suggested by the model.
+   *
+   * @see LexicalModelPunctuation
+   */
+  readonly punctuation?: LexicalModelPunctuation;
 }
 
 interface LexicalModelCompiled extends LexicalModel {
@@ -43,6 +50,44 @@ interface LexicalModelCompiled extends LexicalModel {
 
 interface LexicalModelCompiledTrie extends LexicalModelCompiled {
   trie: string;
+}
+
+/**
+ * Options for various punctuation to use in suggestions.
+ */
+interface LexicalModelPunctuation {
+  /**
+   * The quotes that appear in "keep" suggestions, e.g., keep what the user
+   * typed verbatim.
+   * 
+   * The keep suggestion is often the leftmost one, when suggested.
+   * 
+   * [ “Hrllo” ] [ Hello ] [ Heck ]
+   */
+  readonly quotesForKeepSuggestion: {
+    /**
+     * What will appear on the opening side of the quote.
+     * (left side for LTR scripts; right side for RTL scripts)
+     *
+     * Default: `“`
+     */
+    readonly open: string;
+    /**
+     * What will appear on the closing side of the quote.
+     * (right side for LTR scripts; left side for RTL scripts)
+     *
+     * Default: `”`
+     */
+    readonly close: string;
+  };
+  /**
+   * What punctuation or spacing to insert after every complete word
+   * prediction. This can be set to the empty string when the script does not
+   * use spaces to separate words.
+   * 
+   * Default: ` `
+   */
+  readonly insertAfterWord?: string;
 }
 
 interface LexicalModelCompiledFst extends LexicalModelCompiled {

--- a/developer/js/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/lexical-model-compiler/lexical-model.ts
@@ -64,7 +64,7 @@ interface LexicalModelPunctuation {
    * 
    * [ “Hrllo” ] [ Hello ] [ Heck ]
    */
-  readonly quotesForKeepSuggestion: {
+  readonly quotesForKeepSuggestion?: {
     /**
      * What will appear on the opening side of the quote.
      * (left side for LTR scripts; right side for RTL scripts)

--- a/developer/js/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/lexical-model-compiler/lexical-model.ts
@@ -15,15 +15,8 @@ interface ClassBasedWordBreaker {
 }
 
 interface LexicalModel {
-  // TODO: remove trie-2.0 when https://github.com/keymanapp/lexical-models/pull/39 is merged.
-  readonly format: 'trie-1.0'|'trie-2.0'|'fst-foma-1.0'|'custom-1.0',
+  readonly format: 'trie-1.0'|'fst-foma-1.0'|'custom-1.0',
   //... metadata ...
-}
-
-interface LexicalModelPrediction {
-  display?: string;
-  transform: string;
-  delete: number;
 }
 
 interface LexicalModelSource extends LexicalModel {
@@ -52,15 +45,4 @@ interface LexicalModelSource extends LexicalModel {
 
 interface LexicalModelCompiled extends LexicalModel {
   readonly id: string;
-}
-
-interface LexicalModelCompiledTrie extends LexicalModelCompiled {
-  trie: string;
-}
-
-interface LexicalModelCompiledFst extends LexicalModelCompiled {
-  fst: string;
-}
-
-interface LexicalModelCompiledCustom extends LexicalModelCompiled {
 }

--- a/developer/js/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/lexical-model-compiler/lexical-model.ts
@@ -1,3 +1,9 @@
+/**
+ * Interfaces and constants used by the lexical model compiler. These target
+ * the LMLayer's internal worker code, so we provide those definitions too.
+ */
+/// <reference path="../../../common/predictive-text/worker/worker-compiler-interfaces.d.ts" />
+
 interface ClassBasedWordBreaker {
   allowedCharacters?: { initials?: string, medials?: string, finals?: string } | string,
   defaultBreakCharacter?: string
@@ -50,44 +56,6 @@ interface LexicalModelCompiled extends LexicalModel {
 
 interface LexicalModelCompiledTrie extends LexicalModelCompiled {
   trie: string;
-}
-
-/**
- * Options for various punctuation to use in suggestions.
- */
-interface LexicalModelPunctuation {
-  /**
-   * The quotes that appear in "keep" suggestions, e.g., keep what the user
-   * typed verbatim.
-   * 
-   * The keep suggestion is often the leftmost one, when suggested.
-   * 
-   * [ “Hrllo” ] [ Hello ] [ Heck ]
-   */
-  readonly quotesForKeepSuggestion?: {
-    /**
-     * What will appear on the opening side of the quote.
-     * (left side for LTR scripts; right side for RTL scripts)
-     *
-     * Default: `“`
-     */
-    readonly open: string;
-    /**
-     * What will appear on the closing side of the quote.
-     * (right side for LTR scripts; left side for RTL scripts)
-     *
-     * Default: `”`
-     */
-    readonly close: string;
-  };
-  /**
-   * What punctuation or spacing to insert after every complete word
-   * prediction. This can be set to the empty string when the script does not
-   * use spaces to separate words.
-   * 
-   * Default: ` `
-   */
-  readonly insertAfterWord?: string;
 }
 
 interface LexicalModelCompiledFst extends LexicalModelCompiled {

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -2,7 +2,7 @@ import LexicalModelCompiler from '../';
 import {assert} from 'chai';
 import 'mocha';
 
-const path = require('path');
+import path = require('path');
 
 
 describe('LexicalModelCompiler', function () {
@@ -24,8 +24,9 @@ describe('LexicalModelCompiler', function () {
       // Check that the punctuation actually made into the code:
       assert.match(code, /«/);
       assert.match(code, /»/);
-      // TODO: more robust assertions?
+      // Ensure we inserted that OGHAM SPACE MARK!
       assert.match(code, /\u1680/);
+      // TODO: more robust assertions?
     });
   })
 });

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -7,7 +7,7 @@ const path = require('path');
 
 describe('LexicalModelCompiler', function () {
   describe('spefifying punctuation', function () {
-    const MODEL_ID = 'example.qaa.punctuation';
+    const MODEL_ID = 'example.qaa.trivial';
     const PATH = path.join(__dirname, 'fixtures', MODEL_ID)
 
     it('should compile a trivial word list', function () {
@@ -16,7 +16,7 @@ describe('LexicalModelCompiler', function () {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
         punctuation: {
-          quotesForKeepSuggestion: [`«`, `»`],
+          quotesForKeepSuggestion: { open: `«`, close: `»`},
           insertAfterWord: " " ,
         }
       }, PATH) as string;

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -17,7 +17,7 @@ describe('LexicalModelCompiler', function () {
         sources: ['wordlist.tsv'],
         punctuation: {
           quotesForKeepSuggestion: { open: `«`, close: `»`},
-          insertAfterWord: " " ,
+          insertAfterWord: " " , // OGHAM SPACE MARK
         }
       }, PATH) as string;
 
@@ -25,6 +25,7 @@ describe('LexicalModelCompiler', function () {
       assert.match(code, /«/);
       assert.match(code, /»/);
       // TODO: more robust assertions?
+      assert.match(code, /\u1680/);
     });
   })
 });

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -6,24 +6,25 @@ const path = require('path');
 
 
 describe('LexicalModelCompiler', function () {
-  describe('#generateLexicalModelCode', function () {
-    const MODEL_ID = 'example.qaa.trivial';
+  describe('spefifying punctuation', function () {
+    const MODEL_ID = 'example.qaa.punctuation';
     const PATH = path.join(__dirname, 'fixtures', MODEL_ID)
+
     it('should compile a trivial word list', function () {
       let compiler = new LexicalModelCompiler;
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
-        sources: ['wordlist.tsv']
+        sources: ['wordlist.tsv'],
+        punctuation: {
+          quotesForKeepSuggestion: [`«`, `»`],
+          insertAfterWord: " " ,
+        }
       }, PATH) as string;
 
-      assert.doesNotThrow(function evalModelCode() {
-        eval(code);
-      }, SyntaxError);
-      // TODO: Mock LMLayerWorker.loadModel()
-  
-      // Sanity check: the word list has three total unweighted words, with a
-      // total weight of 3!
-      assert.match(code, /\btotalWeight\b["']?:\s*3\b/);
+      // Check that the punctuation actually made into the code:
+      assert.match(code, /«/);
+      assert.match(code, /»/);
+      // TODO: more robust assertions?
     });
   })
 });

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -10,7 +10,7 @@ describe('LexicalModelCompiler', function () {
     const MODEL_ID = 'example.qaa.trivial';
     const PATH = path.join(__dirname, 'fixtures', MODEL_ID)
 
-    it('should compile a trivial word list', function () {
+    it('should compile punctuation into the generated code', function () {
       let compiler = new LexicalModelCompiler;
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
@@ -29,4 +29,3 @@ describe('LexicalModelCompiler', function () {
     });
   })
 });
-

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -1,0 +1,30 @@
+import LexicalModelCompiler from '../';
+import {assert} from 'chai';
+import 'mocha';
+
+const path = require('path');
+
+
+describe('LexicalModelCompiler', function () {
+  describe('#generateLexicalModelCode', function () {
+    const MODEL_ID = 'example.qaa.trivial';
+    const PATH = path.join(__dirname, 'fixtures', MODEL_ID)
+    it('should compile a trivial word list', function () {
+      let compiler = new LexicalModelCompiler;
+      let code = compiler.generateLexicalModelCode(MODEL_ID, {
+        format: 'trie-1.0',
+        sources: ['wordlist.tsv']
+      }, PATH) as string;
+
+      assert.doesNotThrow(function evalModelCode() {
+        eval(code);
+      }, SyntaxError);
+      // TODO: Mock LMLayerWorker.loadModel()
+  
+      // Sanity check: the word list has three total unweighted words, with a
+      // total weight of 3!
+      assert.match(code, /\btotalWeight\b["']?:\s*3\b/);
+    });
+  })
+});
+

--- a/developer/js/tests/tsconfig.json
+++ b/developer/js/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "sourceMap": true
+    },
+    "include": [
+        "**/test-*.ts"
+    ]
+}

--- a/developer/js/tsconfig.json
+++ b/developer/js/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
   },
   "include": [
     "lexical-model-compiler/**/*",


### PR DESCRIPTION
This PR introduces a `punctuation` object, when defining models.

This allows model authors to specify what quotes will go around the "keep" option.
It also allows model authors to specify what, if anything, should be inserted after a word .

The defaults to both of these options work well for... pretty much just English.

Fixes #1883.