### PR TITLE
[ios] slimmed down keyboard picker

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -121,14 +121,17 @@
 		9A3B14CA228F5AF60052A11F /* KeyboardNameTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08C62121F67C31100268D03 /* KeyboardNameTableViewCell.swift */; };
 		9A3B14D2229370B20052A11F /* InstalledLanguagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3B14D1229370B20052A11F /* InstalledLanguagesViewController.swift */; };
 		9A3B14D3229370B20052A11F /* InstalledLanguagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3B14D1229370B20052A11F /* InstalledLanguagesViewController.swift */; };
+		9A3E832322EABBFE00D22D2A /* LanguageSpecificViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7EEFA122DCF64F00877C22 /* LanguageSpecificViewController.swift */; };
+		9A3E832522EAC14A00D22D2A /* KeyboardSwitcherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3E832422EAC14A00D22D2A /* KeyboardSwitcherViewController.swift */; };
+		9A3E832622EAC14A00D22D2A /* KeyboardSwitcherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3E832422EAC14A00D22D2A /* KeyboardSwitcherViewController.swift */; };
 		9A4609972241B39B00B0BFD1 /* LexicalModelInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4609962241B39B00B0BFD1 /* LexicalModelInfoViewController.swift */; };
 		9A4609992242047400B0BFD1 /* LexicalModelAPICall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4609982242047400B0BFD1 /* LexicalModelAPICall.swift */; };
-		9A60764422893A4E003BCFBA /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A60764322893A4E003BCFBA /* SettingsViewController.swift */; };
-		9A7EEFA222DCF64F00877C22 /* LanguageSpecificViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7EEFA122DCF64F00877C22 /* LanguageSpecificViewController.swift */; };
 		9A5091B122B418140094B99C /* KeyboardCommandStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE67D960228A6F190029F2B5 /* KeyboardCommandStructs.swift */; };
 		9A5091B222B418A90094B99C /* KeyboardPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08C62161F67CFB800268D03 /* KeyboardPickerViewController.swift */; };
 		9A5091B322B418CA0094B99C /* KeyboardInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08C62141F67C8D500268D03 /* KeyboardInfoViewController.swift */; };
 		9A5091B422B419B10094B99C /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04C2A6C1F6B7D9A00BA42B6 /* LanguageViewController.swift */; };
+		9A60764422893A4E003BCFBA /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A60764322893A4E003BCFBA /* SettingsViewController.swift */; };
+		9A7EEFA222DCF64F00877C22 /* LanguageSpecificViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7EEFA122DCF64F00877C22 /* LanguageSpecificViewController.swift */; };
 		9A862D2822B429FB005FE26D /* KeyboardNameTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08C62121F67C31100268D03 /* KeyboardNameTableViewCell.swift */; };
 		9A862D2922B42A0C005FE26D /* LanguageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C092D8381F6A70C8005C5485 /* LanguageDetailViewController.swift */; };
 		9A9CB08022416E5400231FB9 /* LexicalModelPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9CB07F22416E5400231FB9 /* LexicalModelPickerViewController.swift */; };
@@ -335,8 +338,9 @@
 		9A079E3F223B602B00581263 /* LexicalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexicalModel.swift; sourceTree = "<group>"; };
 		9A079E42223B61AE00581263 /* FullLexicalModelID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullLexicalModelID.swift; sourceTree = "<group>"; };
 		9A082558227589360051EBB0 /* Formatter+ISODateExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Formatter+ISODateExtension.swift"; sourceTree = "<group>"; };
-		9A3B14D1229370B20052A11F /* InstalledLanguagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstalledLanguagesViewController.swift; path = Settings/InstalledLanguagesViewController.swift; sourceTree = "<group>"; };
 		9A0FC9FC22D66D9E00D33F86 /* Reachability.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Reachability.framework; path = ../../Carthage/Build/iOS/Reachability.framework; sourceTree = "<group>"; };
+		9A3B14D1229370B20052A11F /* InstalledLanguagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstalledLanguagesViewController.swift; path = Settings/InstalledLanguagesViewController.swift; sourceTree = "<group>"; };
+		9A3E832422EAC14A00D22D2A /* KeyboardSwitcherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSwitcherViewController.swift; sourceTree = "<group>"; };
 		9A4609962241B39B00B0BFD1 /* LexicalModelInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexicalModelInfoViewController.swift; sourceTree = "<group>"; };
 		9A4609982242047400B0BFD1 /* LexicalModelAPICall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexicalModelAPICall.swift; sourceTree = "<group>"; };
 		9A60763C22892485003BCFBA /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Settings.storyboard; path = Settings/Settings.storyboard; sourceTree = "<group>"; };
@@ -799,6 +803,7 @@
 				C08C62141F67C8D500268D03 /* KeyboardInfoViewController.swift */,
 				9A4609962241B39B00B0BFD1 /* LexicalModelInfoViewController.swift */,
 				C08C62161F67CFB800268D03 /* KeyboardPickerViewController.swift */,
+				9A3E832422EAC14A00D22D2A /* KeyboardSwitcherViewController.swift */,
 				9A9CB07F22416E5400231FB9 /* LexicalModelPickerViewController.swift */,
 				C092D8381F6A70C8005C5485 /* LanguageDetailViewController.swift */,
 				C04C2A6C1F6B7D9A00BA42B6 /* LanguageViewController.swift */,
@@ -1170,9 +1175,10 @@
 				9A5091B222B418A90094B99C /* KeyboardPickerViewController.swift in Sources */,
 				9A31E2C2224AAD9A00D9A491 /* Notifications.swift in Sources */,
 				9A079DDD2231A11C00581263 /* InstallableKeyboard.swift in Sources */,
-				9A7EEFA222DCF64F00877C22 /* LanguageSpecificViewController.swift in Sources */,
+				9A3E832322EABBFE00D22D2A /* LanguageSpecificViewController.swift in Sources */,
 				9A079DD2223194B100581263 /* KeymanEngineTests.swift in Sources */,
 				9A079E41223B602B00581263 /* LexicalModel.swift in Sources */,
+				9A3E832622EAC14A00D22D2A /* KeyboardSwitcherViewController.swift in Sources */,
 				9A3B14C0228F59490052A11F /* SettingsViewController.swift in Sources */,
 				9A3B14BB228F592F0052A11F /* LanguageViewController.swift in Sources */,
 				9A31E2CE224AE8B100D9A491 /* LexicalModelRepository.swift in Sources */,
@@ -1245,6 +1251,7 @@
 				C0B901AA1FA1AFC200764EB8 /* UserDefaults+Types.swift in Sources */,
 				9A079E372238680700581263 /* KMPLexicalModel.swift in Sources */,
 				C06D373F1F81F5C400F61AE0 /* KeyboardPickerViewController.swift in Sources */,
+				9A3E832522EAC14A00D22D2A /* KeyboardSwitcherViewController.swift in Sources */,
 				C0324B911F8763E100AF3785 /* TextViewDelegateProxy.swift in Sources */,
 				C0B09EAE1FCFD10F002F39AF /* FontManager.swift in Sources */,
 				C040E50E1F85FF8A00901EE4 /* KeyPreviewView.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -12,7 +12,7 @@ private let toolbarButtonTag = 100
 private let toolbarLabelTag = 101
 private let toolbarActivityIndicatorTag = 102
 
-class KeyboardPickerViewController: KeyboardPickerViewController {
+class KeyboardPickerViewController: KeyboardSwitcherViewController {
   private var updateQueue: [InstallableKeyboard]?
   private var _isDoneButtonEnabled = false
   private var isDidUpdateCheck = false
@@ -23,7 +23,7 @@ class KeyboardPickerViewController: KeyboardPickerViewController {
   private var lexicalModelDownloadStartedObserver: NotificationObserver?
   private var lexicalModelDownloadCompletedObserver: NotificationObserver?
   private var lexicalModelDownloadFailedObserver: NotificationObserver?
-
+  
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -382,7 +382,7 @@ class KeyboardPickerViewController: KeyboardPickerViewController {
     navigationController?.setToolbarHidden(true, animated: true)
   }
 
-  func showAddKeyboard() {
+  override func showAddKeyboard() {
     let button: UIButton? = (navigationController?.toolbar?.viewWithTag(toolbarButtonTag) as? UIButton)
     button?.isEnabled = false
     let vc = LanguageViewController(Manager.shared.apiKeyboardRepository)

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -387,7 +387,8 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     updateKeyboards()
   }
 
-  private func checkUpdates() -> Bool {
+  // so KeyboardSwitcherViewController can override this to do nothing
+  public func checkUpdates() -> Bool {
     if Manager.shared.apiKeyboardRepository.languages == nil {
       return false
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -12,8 +12,7 @@ private let toolbarButtonTag = 100
 private let toolbarLabelTag = 101
 private let toolbarActivityIndicatorTag = 102
 
-class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
-  private var userKeyboards: [InstallableKeyboard] = [InstallableKeyboard]()
+class KeyboardPickerViewController: KeyboardPickerViewController {
   private var updateQueue: [InstallableKeyboard]?
   private var _isDoneButtonEnabled = false
   private var isDidUpdateCheck = false
@@ -28,7 +27,9 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = "Keyboards"
+    self.accessoryType = .detailDisclosureButton
+
+    // adding keyboards is unique to this subclass, so is updating them
     setIsDoneButtonEnabled(false)
     isDidUpdateCheck = false
     updateQueue = nil
@@ -70,13 +71,6 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     log.info("didLoad: KeyboardPickerViewController (registered lexicalModelDownloadCompleted et al)")
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    loadUserKeyboards()
-    scroll(toSelectedKeyboard: false)
-  }
-
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     if isDidUpdateCheck || !checkUpdates() {
@@ -102,27 +96,19 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     scroll(toSelectedKeyboard: false)
     log.info("didAppear: KeyboardPickerViewController")
   }
-
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return userKeyboards.count
-  }
-
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cellIdentifier = "Cell"
-    if let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier) {
-      return cell
+  
+  override func switchKeyboard(_ index: Int) {
+    // Switch keyboard and register to user defaults.
+    if Manager.shared.setKeyboard(userKeyboards[index]) {
+      tableView.reloadData()
     }
-
-    let cell = UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
-    let selectionColor = UIView()
-    selectionColor.backgroundColor = UIColor(red: 204.0 / 255.0, green: 136.0 / 255.0, blue: 34.0 / 255.0, alpha: 1.0)
-    cell.selectedBackgroundView = selectionColor
-    return cell
+    
+    if !_isDoneButtonEnabled {
+      Manager.shared.dismissKeyboardPicker(self)
+    }
   }
+  
+  // MARK: - table view delegate UITableViewDelegate
 
   // TODO: Refactor. Duplicated in KeyboardInfoViewController
   override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -171,31 +157,8 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     infoView.isCustomKeyboard = kb.isCustom
     navigationController?.pushViewController(infoView, animated: true)
   }
-
-  override func tableView(_ tableView: UITableView,
-                          willDisplay cell: UITableViewCell,
-                          forRowAt indexPath: IndexPath) {
-    cell.selectionStyle = .none
-    let kb = userKeyboards[indexPath.row]
-
-    cell.textLabel?.text = kb.languageName
-    cell.detailTextLabel?.text = kb.name
-    cell.tag = indexPath.row
-
-    if Manager.shared.currentKeyboardID == kb.fullID {
-      cell.selectionStyle = .blue
-      cell.isSelected = true
-      cell.accessoryType = .detailDisclosureButton
-    } else {
-      cell.selectionStyle = .none
-      cell.isSelected = false
-      cell.accessoryType = .detailDisclosureButton
-    }
-  }
-
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    switchKeyboard(indexPath.row)
-  }
+  
+  // MARK: - keyboard and lexical model downloading
 
   private func keyboardDownloadStarted(_ keyboards: [InstallableKeyboard]) {
     log.info("keyboardDownloadStarted")
@@ -325,26 +288,8 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
     
     self.present(alertController, animated: true, completion: nil)
   }
-
-  private func switchKeyboard(_ index: Int) {
-    // Switch keyboard and register to user defaults.
-    if Manager.shared.setKeyboard(userKeyboards[index]) {
-      tableView.reloadData()
-    }
-
-    if !_isDoneButtonEnabled {
-      Manager.shared.dismissKeyboardPicker(self)
-    }
-  }
-
-  private func loadUserKeyboards() {
-    userKeyboards = Storage.active.userDefaults.userKeyboards ?? []
-    tableView.reloadData()
-  }
-
-  private func isAdded(languageID langID: String, keyboardID kbID: String) -> Bool {
-    return userKeyboards.contains { kb in kb.languageID == langID && kb.id == kbID }
-  }
+  
+  // MARK: - keyboard adding
 
   @objc func doneClicked(_ sender: Any) {
     Manager.shared.dismissKeyboardPicker(self)
@@ -417,18 +362,6 @@ class KeyboardPickerViewController: UITableViewController, UIAlertViewDelegate {
       let langID = updateQueue![0].languageID
       let kbID = updateQueue![0].id
       Manager.shared.downloadKeyboard(withID: kbID, languageID: langID, isUpdate: true)
-    }
-  }
-
-  private func scroll(toSelectedKeyboard animated: Bool) {
-    let index = userKeyboards.index { kb in
-      return Manager.shared.currentKeyboardID == kb.fullID
-    }
-
-    if let index = index {
-      let indexPath = IndexPath(row: index, section: 0)
-      tableView.scrollToRow(at: indexPath, at: .middle, animated: animated)
-
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
@@ -13,7 +13,7 @@ import UIKit
 private let toolbarButtonTag = 100
 
 class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate {
-  private var userKeyboards: [InstallableKeyboard] = [InstallableKeyboard]()
+  public var userKeyboards: [InstallableKeyboard] = [InstallableKeyboard]()
   public var accessoryType: UITableViewCellAccessoryType = .none
 
   override func viewDidLoad() {
@@ -37,7 +37,7 @@ class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate
     scroll(toSelectedKeyboard: false)
   }
   
-  private func scroll(toSelectedKeyboard animated: Bool) {
+  public func scroll(toSelectedKeyboard animated: Bool) {
     let index = userKeyboards.index { kb in
       return Manager.shared.currentKeyboardID == kb.fullID
     }
@@ -110,7 +110,12 @@ class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate
     Manager.shared.dismissKeyboardPicker(self)
   }
   
-  private func loadUserKeyboards() {
+  // never called but on the subclass
+  public func showAddKeyboard() {
+  }
+
+  
+  public func loadUserKeyboards() {
     userKeyboards = Storage.active.userDefaults.userKeyboards ?? []
     tableView.reloadData()
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
@@ -1,0 +1,60 @@
+//
+//  KeyboardSwitcherViewControllerTableViewController.swift
+//  KeymanEngine
+//
+//  Created by Randy Boring on 7/26/19.
+//  Copyright © 2019 SIL International. All rights reserved.
+//
+// This subclass is slimmed down to *just* picking (switching to) an existing keyboard.
+// It replaces the original in every case but one.
+
+import UIKit
+
+private let toolbarButtonTag = 100
+
+class KeyboardSwitcherViewController: KeyboardPickerViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // remove UI that adds keyboards
+    navigationItem.rightBarButtonItem = nil
+    
+    // maybe remove, but for now, distinguish this picker via color
+    navigationController?.toolbar?.barTintColor = UIColor(red: 0.8, green: 0.25,
+                                                          blue: 0.5, alpha: 0.4)
+    // I don't think we need to remove the download observers
+    //  they just won't be used if we never start a download
+    //keyboardDownloadStartedObserver = nil
+
+    log.info("didLoad: KeyboardSwitcherViewController")
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    // remove the update button, if any
+    navigationController?.toolbar?.viewWithTag(toolbarButtonTag)?.removeFromSuperview()
+
+    log.info("didAppear: KeyboardSwitcherViewController")
+  }
+  
+  
+  // override to make it never try to update
+  //NOTE: might we want it to check?
+  override func checkUpdates() -> Bool {
+    return false
+  }
+  
+  override func tableView(_ tableView: UITableView,
+                          accessoryButtonTappedForRowWith indexPath: IndexPath) {
+    // do not show keyboard info, as it has the ability to delete it
+    //NOTE: we may wish to show info without that ability, but for now, this is easier
+    return
+  }
+
+  override func tableView(_ tableView: UITableView,
+                          willDisplay cell: UITableViewCell,
+                          forRowAt indexPath: IndexPath) {
+    super.tableView(tableView, willDisplay: cell, forRowAt: indexPath)
+    cell.accessoryType = .none
+  }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -319,9 +319,7 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     tableView.reloadData()
   }
   
-  private func isAdded(languageID langID: String, lexicalModelID lmID: String) -> Bool {
-    return userLexicalModels.contains { lm in lm.languageID == langID && lm.id == lmID }
-  }
+  // MARK: - lexical model adding functionaliry
   
   @objc func doneClicked(_ sender: Any) {
     Manager.shared.dismissLexicalModelPicker(self)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -1522,7 +1522,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   /// TextView/TextField to enable/disable the keyboard picker
   public func showKeyboardPicker(in viewController: UIViewController, shouldAddKeyboard: Bool) {
     hideKeyboard()
-    let vc = KeyboardPickerViewController()
+    let vc = shouldAddKeyboard ? KeyboardPickerViewController() :
+      KeyboardSwitcherViewController()
     let nc = UINavigationController(rootViewController: vc)
     nc.modalTransitionStyle = .coverVertical
     nc.modalPresentationStyle = .pageSheet

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -360,13 +360,6 @@ class InstalledLanguagesViewController: UITableViewController, UIAlertViewDelega
     tableView.reloadData()
  }
   
-  private func isAdded(languageID: String?, keyboardID: String?) -> Bool {
-    guard let languageID = languageID, let keyboardID = keyboardID else {
-      return false
-    }
-    return userKeyboards["\(languageID)_\(keyboardID)"] != nil
-  }
-  
   private func showConnectionErrorAlert() {
     dismissActivityView()
     let alertController = UIAlertController(title: "Connection Error",


### PR DESCRIPTION
A first pass at a slimmed down keyboard picker launched from the globe icon.

I haven't tested the case where we call the KeyboardPickerViewController with true for shouldAddKeyboard (which immediately launched the add view). But that should still work as before. (See the minor change in Manager).