### PR TITLE
[iOS] Fixes the in-app banner issue.

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -179,8 +179,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   open override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
     // Necessary for existing infrastructure to resend info for the keyboard after reloading
-    // as system keyboard.
-    Manager.shared.shouldReloadKeyboard = true
+    // as system keyboard.  Do NOT perform if in-app, as this unnecessarily resets the WebView.
+    if(Manager.shared.isSystemKeyboard) {
+      Manager.shared.shouldReloadKeyboard = true
+    }
   }
 
   open override func textDidChange(_ textInput: UITextInput?) {


### PR DESCRIPTION
... sometimes it's just a matter of knowing where to look.

So a while back, I refactored the iOS app and the root of the system keyboard to also function in-app, as opposed to the scheme previously used.  It turns out at the time that I forgot one small detail - and that detail is part of why the banner hasn't been able to display in-app after a keyboard swap.

Note the old comment about that line there - _as system keyboard_.  We were doing this in-app too, which triggers a keyboard.html reset.  The problem is that the reloading process that occurs has a little issue with the order of events in which the OSK height won't be set after the banner is initialized, thus hiding the banner.

But we don't actually need to reload in-app, or even in the system keyboard, except for in one case.  The comments just out of view for the function below indicate that this function was only ever intended to operate when the system keyboard is swapped out; iOS will reuse the same keyboard extension instance but requires a resource reload when swapped back in.