### PR TITLE
[Android] If the keyboard view is not ready, calling javascript functions will crash

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -12,6 +12,7 @@
     var device = window.jsInterface.getDeviceType();
     var oskHeight = window.jsInterface.getKeyboardHeight();
     var oskWidth = 0;
+    var fragmentToggle = 0;
     window.addEventListener('load', init, false);
 
     function init() {
@@ -39,6 +40,18 @@
       kmw.addEventListener('keyboardloaded', setIsChiral);
       kmw.addEventListener('keyboardchange', setIsChiral);
       kmw.addEventListener('mm.modelchange', onModelChange);
+
+      notifyHost('pageLoaded');
+    }
+
+    function notifyHost(event, params) {
+      // TODO: Update all other host notifications to use notifyHost instead of directly setting window.location.hash
+      window.setTimeout(function() {
+        // We use a timeout so that the navigation doesn't cause the calling function to abort after the call
+        fragmentToggle = (fragmentToggle + 1) % 100;
+        params = params ? '+'+params : '';
+        window.location.hash = event+'-'+fragmentToggle+params;
+      }, 10);
     }
 
     // Update the KMW banner height
@@ -211,7 +224,6 @@
       kmw['setActiveElement'](ta);
     }
 
-    var fragmentToggle = 0;
     function oskCreateKeyPreview(x,y,w,h,t) {
       fragmentToggle = (fragmentToggle + 1) % 100;
       var div = document.createElement('div');

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -62,6 +62,8 @@ final class KMKeyboard extends WebView {
   private String keyboardName;
   private String keyboardVersion;
 
+  protected ArrayList<String> javascriptAfterLoad = new ArrayList<String>();
+
   private static String currentKeyboard = null;
   private static String txtFont = "";
   private static String oskFont = null;
@@ -136,12 +138,16 @@ final class KMKeyboard extends WebView {
       public boolean onConsoleMessage(ConsoleMessage cm) {
         if (KMManager.isDebugMode()) {
           Log.d("KMEA", "Keyman JS Log: Line " + cm.lineNumber() + ", " + cm.sourceId() + ":" + cm.message());
+          if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
+            Log.e("KMEA", "Keyman JS Log: ERROR");
+          }
         }
 
         // Send console errors to Firebase Analytics.
         // (Ignoring spurious message "No keyboard stubs exist = ...")
         // TODO: Analyze if this error warrants reverting to default keyboard
         // TODO: Fix base error rather than trying to ignore it "No keyboard stubs exist"
+
         if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
           sendKMWError(cm.lineNumber(), cm.sourceId(), cm.message());
           Toast.makeText(context, "Fatal Error with " + currentKeyboard +
@@ -151,6 +157,7 @@ final class KMKeyboard extends WebView {
             KMManager.KMDefault_LanguageID, KMManager.KMDefault_KeyboardName,
             KMManager.KMDefault_LanguageName, KMManager.KMDefault_KeyboardFont, null);
         }
+
         return true;
       }
     });
@@ -188,15 +195,44 @@ final class KMKeyboard extends WebView {
     setBackgroundColor(0);
   }
 
+  public void loadJavascript(String func) {
+    this.javascriptAfterLoad.add(func);
+
+    if((keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP && KMManager.InAppKeyboardLoaded) ||
+      (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && KMManager.SystemKeyboardLoaded)) {
+
+      if(this.javascriptAfterLoad.size() == 1)
+        callJavascriptAfterLoad();
+    }
+  }
+
+  public void callJavascriptAfterLoad() {
+    if(this.javascriptAfterLoad.size() > 0) {
+      Handler handler = new Handler();
+      handler.postDelayed(new Runnable() {
+        @Override
+        public void run() {
+          if(javascriptAfterLoad.size() > 0) {
+            loadUrl("javascript:" + javascriptAfterLoad.get(0));
+            javascriptAfterLoad.remove(0);
+            if (javascriptAfterLoad.size() > 0) {
+              callJavascriptAfterLoad();
+            }
+          }
+        }
+      }, 1);
+    }
+  }
+
   public void hideKeyboard() {
-    String jsString = "javascript:hideKeyboard()";
-    loadUrl(jsString);
+    String jsString = "hideKeyboard()";
+    loadJavascript(jsString);
   }
 
   public void executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
-    String jsFormat = "javascript:executeHardwareKeystroke(%d,%d, %d, %d)";
+    String jsFormat = "executeHardwareKeystroke(%d,%d, %d, %d)";
     String jsString = String.format(jsFormat, code, shift, lstates, eventModifiers);
-    loadUrl(jsString);
+    loadJavascript(jsString);
   }
 
   @SuppressLint("ClickableViewAccessibility")
@@ -226,8 +262,8 @@ final class KMKeyboard extends WebView {
     DisplayMetrics dms = context.getResources().getDisplayMetrics();
     int kbWidth = (int) (dms.widthPixels / dms.density);
     // Ensure window is loaded for javascript functions
-    loadUrl(String.format(
-      "javascript:window.onload = function(){ setOskWidth(\"%d\");"+
+    loadJavascript(String.format(
+      "window.onload = function(){ setOskWidth(\"%d\");"+
       "setOskHeight(\"0\"); };", kbWidth));
     if (ShouldShowHelpBubble) {
       ShouldShowHelpBubble = false;
@@ -235,7 +271,7 @@ final class KMKeyboard extends WebView {
       handler.postDelayed(new Runnable() {
         @Override
         public void run() {
-          loadUrl("javascript:showHelpBubble()");
+          loadJavascript("showHelpBubble()");
         }
       }, 2000);
     }
@@ -258,15 +294,15 @@ final class KMKeyboard extends WebView {
     dismissKeyPreview(0);
     dismissSubKeysWindow();
     int bannerHeight = KMManager.getBannerHeight(context);
-    loadUrl(String.format("javascript:setBannerHeight(%d)", bannerHeight));
-    loadUrl(String.format("javascript:setOskWidth(%d)", newConfig.screenWidthDp));
-    loadUrl("javascript:setOskHeight(0)");
+    loadJavascript(String.format("setBannerHeight(%d)", bannerHeight));
+    loadJavascript(String.format("setOskWidth(%d)", newConfig.screenWidthDp));
+    loadJavascript("setOskHeight(0)");
     if (dismissHelpBubble()) {
       Handler handler = new Handler();
       handler.postDelayed(new Runnable() {
         @Override
         public void run() {
-          loadUrl("javascript:showHelpBubble()");
+          loadJavascript("showHelpBubble()");
         }
       }, 2000);
     }
@@ -386,9 +422,9 @@ final class KMKeyboard extends WebView {
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
     languageName = languageName.replaceAll("\'", "\\\\'");
 
-    String jsFormat = "javascript:setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
+    String jsFormat = "setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
     String jsString = String.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
-    loadUrl(jsString);
+    loadJavascript(jsString);
 
     this.packageID = packageID;
     this.keyboardID = keyboardID;
@@ -402,7 +438,7 @@ final class KMKeyboard extends WebView {
       handler.postDelayed(new Runnable() {
         @Override
         public void run() {
-          loadUrl("javascript:showHelpBubble()");
+          loadJavascript("showHelpBubble()");
         }
       }, 2000);
     }
@@ -487,9 +523,9 @@ final class KMKeyboard extends WebView {
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
     languageName = languageName.replaceAll("\'", "\\\\'");
 
-    String jsFormat = "javascript:setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
+    String jsFormat = "setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
     String jsString = String.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
-    loadUrl(jsString);
+    loadJavascript(jsString);
 
     this.packageID = packageID;
     this.keyboardID = keyboardID;
@@ -503,7 +539,7 @@ final class KMKeyboard extends WebView {
       handler.postDelayed(new Runnable() {
         @Override
         public void run() {
-          loadUrl("javascript:showHelpBubble()");
+          loadJavascript("showHelpBubble()");
         }
       }, 2000);
     }
@@ -713,14 +749,14 @@ final class KMKeyboard extends WebView {
       public void onDismiss() {
         suggestionJSON = null;
         suggestionMenuWindow = null;
-        String jsString = "javascript:popupVisible(0)";
-        loadUrl(jsString);
+        String jsString = "popupVisible(0)";
+        loadJavascript(jsString);
       }
     });
 
     suggestionMenuWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX , posY);
-    String jsString = "javascript:popupVisible(1)";
-    loadUrl(jsString);
+    String jsString = "popupVisible(1)";
+    loadJavascript(jsString);
 
     return;
   }
@@ -823,9 +859,9 @@ final class KMKeyboard extends WebView {
           int index = v.getId() - 1;
           String keyId = subkeyList.get(index).get("keyId");
           String keyText = getSubkeyText(keyId, subkeyList.get(index).get("keyText"));
-          String jsFormat = "javascript:executePopupKey('%s','%s')";
+          String jsFormat = "executePopupKey('%s','%s')";
           String jsString = String.format(jsFormat, keyId, keyText);
-          loadUrl(jsString);
+          loadJavascript(jsString);
         }
       });
       button.setClickable(false);
@@ -910,8 +946,8 @@ final class KMKeyboard extends WebView {
       public void onDismiss() {
         subKeysList = null;
         subKeysWindow = null;
-        String jsString = "javascript:popupVisible(0)";
-        loadUrl(jsString);
+        String jsString = "popupVisible(0)";
+        loadJavascript(jsString);
       }
     });
 
@@ -934,8 +970,8 @@ final class KMKeyboard extends WebView {
 
     // And now to actually display it.
     subKeysWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX, posY);
-    String jsString = "javascript:popupVisible(1)";
-    loadUrl(jsString);
+    String jsString = "popupVisible(1)";
+    loadJavascript(jsString);
   }
 
   // Attempt to get the subkey text.

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -190,6 +190,12 @@ final class KMKeyboard extends WebView {
 
   public void loadKeyboard() {
     keyboardSet = false;
+
+    if(keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP)
+      KMManager.InAppKeyboardLoaded = false;
+    else
+      KMManager.SystemKeyboardLoaded = false;
+
     String htmlPath = "file://" + getContext().getDir("data", Context.MODE_PRIVATE) + "/" + KMManager.KMFilename_KeyboardHtml;
     loadUrl(htmlPath);
     setBackgroundColor(0);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1301,9 +1301,9 @@ public final class KMManager {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
-      if (url.startsWith("file")) { // endsWith(KMFilename_KeyboardHtml)) {
+      /*if (url.startsWith("file")) { // endsWith(KMFilename_KeyboardHtml)) {
         InAppKeyboardLoaded = false;
-      }
+      }*/
     }
 
     @Override
@@ -1519,9 +1519,9 @@ public final class KMManager {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
-      if (url.endsWith(KMFilename_KeyboardHtml)) {
+      /*if (url.endsWith(KMFilename_KeyboardHtml)) {
         SystemKeyboardLoaded = false;
-      }
+      }*/
     }
 
     @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1575,6 +1575,8 @@ public final class KMManager {
         }, 2000);
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_SYSTEM, EventType.KEYBOARD_LOADED, null);
+
+        SystemKeyboard.callJavascriptAfterLoad();
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -718,11 +718,11 @@ public final class KMManager {
     RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
       InAppKeyboard.setLayoutParams(params);
-      InAppKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      InAppKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
       SystemKeyboard.setLayoutParams(params);
-      SystemKeyboard.loadUrl(String.format("javascript:enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      SystemKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     return true;
   }
@@ -733,13 +733,13 @@ public final class KMManager {
       currentLexicalModel = null;
     }
 
-    String url = String.format("javascript:deregisterModel('%s')", modelID);
-    if (InAppKeyboard != null && InAppKeyboardLoaded) {
-      InAppKeyboard.loadUrl(url);
+    String url = String.format("deregisterModel('%s')", modelID);
+    if (InAppKeyboard != null) { // && InAppKeyboardLoaded) {
+      InAppKeyboard.loadJavascript(url);
     }
 
-    if (SystemKeyboard != null && SystemKeyboardLoaded) {
-      SystemKeyboard.loadUrl(url);
+    if (SystemKeyboard != null) { // && SystemKeyboardLoaded) {
+      SystemKeyboard.loadJavascript(url);
     }
     return true;
   }
@@ -1103,11 +1103,11 @@ public final class KMManager {
   public static void setNumericLayer(KeyboardType kbType) {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
-        InAppKeyboard.loadUrl("javascript:setNumericLayer()");
+        InAppKeyboard.loadJavascript("setNumericLayer()");
       }
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
-        SystemKeyboard.loadUrl("javascript:setNumericLayer()");
+        SystemKeyboard.loadJavascript("setNumericLayer()");
       }
     }
   }
@@ -1121,14 +1121,14 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
-        InAppKeyboard.loadUrl(String.format("javascript:updateKMText('%s')", kmText));
+        InAppKeyboard.loadJavascript(String.format("updateKMText('%s')", kmText));
         result = true;
       }
 
       InAppKeyboardShouldIgnoreTextChange = false;
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
-        SystemKeyboard.loadUrl(String.format("javascript:updateKMText('%s')", kmText));
+        SystemKeyboard.loadJavascript(String.format("updateKMText('%s')", kmText));
         result = true;
       }
 
@@ -1142,7 +1142,7 @@ public final class KMManager {
     boolean result = false;
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreSelectionChange) {
-        InAppKeyboard.loadUrl(String.format("javascript:updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        InAppKeyboard.loadJavascript(String.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
 
@@ -1157,7 +1157,7 @@ public final class KMManager {
           }
         }
 
-        SystemKeyboard.loadUrl(String.format("javascript:updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        SystemKeyboard.loadJavascript(String.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
 
@@ -1170,11 +1170,11 @@ public final class KMManager {
   public static void resetContext(KeyboardType kbType) {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded) {
-        InAppKeyboard.loadUrl("javascript:resetContext()");
+        InAppKeyboard.loadJavascript("resetContext()");
       }
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (SystemKeyboard != null && SystemKeyboardLoaded) {
-        SystemKeyboard.loadUrl("javascript:resetContext()");
+        SystemKeyboard.loadJavascript("resetContext()");
       }
     }
   }
@@ -1301,7 +1301,7 @@ public final class KMManager {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
-      if (url.endsWith(KMFilename_KeyboardHtml)) {
+      if (url.startsWith("file")) { // endsWith(KMFilename_KeyboardHtml)) {
         InAppKeyboardLoaded = false;
       }
     }
@@ -1309,7 +1309,7 @@ public final class KMManager {
     @Override
     public void onPageFinished(WebView view, String url) {
       String langId = KMManager.KMKey_LanguageID;
-      if (url.endsWith(KMFilename_KeyboardHtml)) {
+      if (url.startsWith("file")) { //endsWith(KMFilename_KeyboardHtml)) {
         InAppKeyboardLoaded = true;
 
         if (!InAppKeyboard.keyboardSet) {
@@ -1342,10 +1342,12 @@ public final class KMManager {
           public void run() {
             SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
             if (prefs.getBoolean(KMManager.KMKey_ShouldShowHelpBubble, true)) {
-              InAppKeyboard.loadUrl("javascript:showHelpBubble()");
+              InAppKeyboard.loadJavascript("showHelpBubble()");
             }
           }
         }, 2000);
+
+        InAppKeyboard.callJavascriptAfterLoad();
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_INAPP, EventType.KEYBOARD_LOADED, null);
       }
@@ -1557,7 +1559,7 @@ public final class KMManager {
           public void run() {
             SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
             if (prefs.getBoolean(KMManager.KMKey_ShouldShowHelpBubble, true)) {
-              SystemKeyboard.loadUrl("javascript:showHelpBubble()");
+              SystemKeyboard.loadJavascript("showHelpBubble()");
             }
           }
         }, 2000);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1301,9 +1301,6 @@ public final class KMManager {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
-      /*if (url.startsWith("file")) { // endsWith(KMFilename_KeyboardHtml)) {
-        InAppKeyboardLoaded = false;
-      }*/
     }
 
     @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1308,7 +1308,13 @@ public final class KMManager {
 
     @Override
     public void onPageFinished(WebView view, String url) {
+      Log.d("KMEA", "onPageFinished: [inapp] " + url);
+      shouldOverrideUrlLoading(view, url);
+    }
+
+    private void pageLoaded(WebView view, String url) {
       String langId = KMManager.KMKey_LanguageID;
+      Log.d("KMEA", "pageLoaded: [inapp] " + url);
       if (url.startsWith("file")) { //endsWith(KMFilename_KeyboardHtml)) {
         InAppKeyboardLoaded = true;
 
@@ -1351,13 +1357,14 @@ public final class KMManager {
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_INAPP, EventType.KEYBOARD_LOADED, null);
       }
-
-      shouldOverrideUrlLoading(view, url);
     }
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-      if (url.indexOf("hideKeyboard") >= 0) {
+      Log.d("KMEA", "shouldOverrideUrlLoading [inapp]: "+url);
+      if(url.indexOf("pageLoaded") >= 0) {
+        pageLoaded(view, url);
+      } else if (url.indexOf("hideKeyboard") >= 0) {
         if (KMTextView.activeView != null && KMTextView.activeView.getClass() == KMTextView.class) {
           InAppKeyboard.dismissHelpBubble();
           KMTextView textView = (KMTextView) KMTextView.activeView;
@@ -1519,15 +1526,18 @@ public final class KMManager {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
-      /*if (url.endsWith(KMFilename_KeyboardHtml)) {
-        SystemKeyboardLoaded = false;
-      }*/
     }
 
     @Override
     public void onPageFinished(WebView view, String url) {
+      Log.d("KMEA", "onPageFinished: [system] " + url);
+      shouldOverrideUrlLoading(view, url);
+    }
+
+    private void pageLoaded(WebView view, String url) {
       String langId = KMManager.KMKey_LanguageID;
-      if (url.endsWith(KMFilename_KeyboardHtml)) {
+      Log.d("KMEA", "pageLoaded: [system] " + url);
+      if (url.startsWith("file:")) {
         SystemKeyboardLoaded = true;
         if (!SystemKeyboard.keyboardSet) {
           SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
@@ -1566,13 +1576,13 @@ public final class KMManager {
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_SYSTEM, EventType.KEYBOARD_LOADED, null);
       }
-
-      shouldOverrideUrlLoading(view, url);
     }
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-      if (url.indexOf("hideKeyboard") >= 0) {
+      if(url.indexOf("pageLoaded") >= 0) {
+        pageLoaded(view, url);
+      } else if (url.indexOf("hideKeyboard") >= 0) {
         SystemKeyboard.dismissHelpBubble();
         IMService.requestHideSelf(0);
       } else if (url.indexOf("globeKeyAction") >= 0) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -73,13 +73,13 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "async": {
@@ -94,7 +94,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
     "backo2": {
@@ -367,7 +367,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "^1.1.1"
@@ -424,7 +424,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "cookie": {
@@ -484,7 +484,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -872,7 +872,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1217,7 +1217,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -1242,7 +1242,7 @@
     "karma-chrome-launcher": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
+      "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
       "dev": true,
       "requires": {
         "fs-access": "^1.0.0",
@@ -1252,7 +1252,7 @@
     "karma-edge-launcher": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
-      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
+      "integrity": "sha1-PZUpsJsTyQnF887uEtAOf5qYmz0=",
       "dev": true,
       "requires": {
         "edge-launcher": "1.2.2"
@@ -1261,7 +1261,7 @@
     "karma-firefox-launcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
-      "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
+      "integrity": "sha1-LEcDBFLwRTHrfRPU/HZpYwu5Mzk=",
       "dev": true
     },
     "karma-fixture": {
@@ -1328,7 +1328,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -1374,7 +1374,7 @@
     "karma-teamcity-reporter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-teamcity-reporter/-/karma-teamcity-reporter-1.1.0.tgz",
-      "integrity": "sha512-Ca1uhHGtNqUuzsnW3I+QykNuS/jF9vdxnIrkbLCVJRunCc6yWJq+ai1UobQT13j0e3JVUOf0mKo3QHZ6A6mG9Q==",
+      "integrity": "sha1-eYD33JHmqwhH4SKt4Ls0x8b0KBY=",
       "dev": true
     },
     "linkify-it": {
@@ -1405,7 +1405,7 @@
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
@@ -1414,7 +1414,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -1548,7 +1548,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1863,7 +1863,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1954,7 +1954,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "safer-buffer": {
@@ -2198,7 +2198,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -2258,7 +2258,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -2328,7 +2328,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
       "dev": true
     },
     "universalify": {
@@ -2418,7 +2418,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2482,7 +2482,7 @@
     "ws": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",


### PR DESCRIPTION
Fixes #1884. 

This is not reproducible on all devices, but on some devices it seems that Javascript functions are called even when the page hasn't finished loading. So this fix is multi-part:

1. If any Javascript call is made from the engine to the web frame before the page finishes loading, we cache it and issue it after the load completes.
2. The `WebView.onPageFinished` event occurs too soon after the page load, and script has not necessarily finished executing. This can cause the Javascript calls to fail. So we now issue `'pageLoaded'` event when the web page calls its own `window.onloaded` event, and only mark the page as ready then.