### PR TITLE
[ios] Capitalize the heading for Keyboards and Language settings

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -153,9 +153,9 @@ class LanguageSettingsViewController: UITableViewController {
     var title: String
     switch (section) {
     case 0:
-      title = "keyboards"
+      title = "Keyboards"
     case 1:
-      title = "language settings"
+      title = "Language settings"
     default:
       title = "unknown header"
     }


### PR DESCRIPTION
Capitalize the heading for Keyboards and Language settings in LanguageSettingsViewController