### PR TITLE
[iOS] Settings menu tablet access

### DIFF
--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -285,8 +285,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if UIDevice.current.userInterfaceIdiom == .phone {
       navigationItem.rightBarButtonItems = [moreButton, fixedSpace, browserButton, fixedSpace, actionButton]
     } else {
-      navigationItem.rightBarButtonItems = [infoButton, fixedSpace, getStartedButton, fixedSpace, trashButton,
-          fixedSpace, textSizeButton, fixedSpace, browserButton, fixedSpace, actionButton]
+      navigationItem.rightBarButtonItems = [settingsButton, fixedSpace, infoButton, fixedSpace, getStartedButton,
+      fixedSpace, trashButton, fixedSpace, textSizeButton, fixedSpace, browserButton, fixedSpace, actionButton]
     }
   }
 


### PR DESCRIPTION
Fixes #1913.

Turns out the settings button simply didn't get added to the tablet navbar, while it had been added to the `dropdownItems` list.