### PR TITLE
[iOS] Fixes banner display misalignments.

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -301,6 +301,11 @@ extension KeymanWebViewController {
     setBannerHeight(to: InputViewController.topBarHeight)
   }
   
+  func showBanner(_ display: Bool) {
+    log.debug("Changing banner's alwaysShow property to \(display).")
+    webView?.evaluateJavaScript("showBanner(\(display ? "true" : "false"))", completionHandler: nil)
+  }
+  
   func setBannerImage(to path: String) {
     bannerImgPath = path // Save the path in case delayed initializaiton is needed.
     log.debug("Banner image path: '\(path).'")
@@ -512,12 +517,9 @@ extension KeymanWebViewController: KeymanWebDelegate {
 
     log.info("Loaded keyboard.")
     
-    // Now that we've loaded the keyboard page fully, perform any in-page needed init.
-    setBannerImage(to: bannerImgPath)
-    
     resizeKeyboard()
     setDeviceType(UIDevice.current.userInterfaceIdiom)
-
+    
     let shouldReloadKeyboard = Manager.shared.shouldReloadKeyboard
     var newKb = Defaults.keyboard
     if Manager.shared.currentKeyboardID == nil && !shouldReloadKeyboard {
@@ -532,6 +534,17 @@ extension KeymanWebViewController: KeymanWebDelegate {
       log.info("Setting initial keyboard.")
       _ = Manager.shared.setKeyboard(newKb)
     }
+    
+    if Manager.shared.isSystemKeyboard {
+      showBanner(true)
+    } else {
+      // TODO:  Set banner to visible / not visible based on the toggle in Settings.
+      //        Problem:  we need access to the banner image path there.  It's only set for the system keyboard variant!
+      showBanner(false)
+    }
+    setBannerImage(to: bannerImgPath)
+    // Reset the keyboard's size.
+    keyboardSize = kbSize
     
     fixLayout()
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -308,6 +308,8 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
       _ = Manager.shared.registerLexicalModel(first_model)
     }
     
+    inputViewController.fixLayout()
+    
     return true
   }
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -28,11 +28,6 @@
             var oskHeight = 0;
             var oskWidth = 0;
             
-            var bannerOptions = {
-                'alwaysShow': true,
-                'imagePath': '' // Need to route the actual banner image here.
-            };
-            
             window.addEventListener('load', init, false);
             
             function init() {
@@ -49,14 +44,17 @@
                     kmw['beepKeyboard'] = beepKeyboard;
                     kmw['setActiveElement']('ta');
                     
-                    kmw.osk.banner.setOptions(bannerOptions);
                 //});
             }
         
+            function showBanner(flag) {
+              console.log("Setting banner display for dictionaryless keyboards to " + flag);
+              keyman.osk.banner.setOptions({'alwaysShow': flag});
+            }
+        
             function setBannerImage(path) {
-              bannerOptions['imagePath'] = path;
               var kmw=window['keyman'];
-              kmw.osk.banner.setOptions(bannerOptions);
+              kmw.osk.banner.setOptions({"imagePath": path});
             }
         
             function setBannerHeight(h) {
@@ -85,7 +83,7 @@
             
             function setOskHeight(height) {
                 var kmw=window['keyman'];
-                oskHeight = height - kmw.osk.banner.height;
+                oskHeight = height;
                 kmw.osk.show(true);
                 kmw['correctOSKTextSize']();
             }
@@ -105,7 +103,11 @@
             }
             
             function getOskHeight() {
-                return oskHeight;
+                var height = oskHeight;
+                if(keyman.osk.banner._activeType != 'blank') {
+                  height = height - keyman.osk.banner.height;
+                }
+                return height;
             }
             
             var keyboardOffset = 0;


### PR DESCRIPTION
Fixes #1911. 

While this doesn't yet enact image settings for the in-app version of the banner or manage the "always show" option, this fixes the core layout issues that would make a terrible first impression.

Regarding the "Always show" option, it looks like the in-app and system keyboards are managed quite separately.  We may require a slight redesign to get that part working correctly - a small interface that can be passed into both versions of the keyboard would be useful, since we can't rely on the app's subclass for in-app keyboard use.