### PR TITLE
[iOS] Deregisters deleted registered models.

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -399,6 +399,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     keymanWeb.registerLexicalModel(lm)
   }
   
+  func deregisterLexicalModel(_ lm: InstallableLexicalModel) {
+    keymanWeb.deregisterLexicalModel(lm)
+  }
+  
   func showHelpBubble() {
     keymanWeb.showHelpBubble()
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -261,10 +261,14 @@ extension KeymanWebViewController {
     log.debug("Keyboard stub: \(stubString)")
     webView!.evaluateJavaScript("setKeymanLanguage(\(stubString));", completionHandler: nil)
   }
+  
+  func deregisterLexicalModel(_ lexicalModel: InstallableLexicalModel) {
+    webView!.evaluateJavaScript("keyman.modelManager.deregister(\"\(lexicalModel.id)\")")
+  }
 
   func registerLexicalModel(_ lexicalModel: InstallableLexicalModel) {
     let stub: [String: Any] = [
-      "id": "LexicalModel_\(lexicalModel.id)",
+      "id": lexicalModel.id,
       "languages": [lexicalModel.languageID], // Change when InstallableLexicalModel is updated to store an array
       "path": storage.lexicalModelURL(for: lexicalModel).absoluteString
     ]

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -507,8 +507,9 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
     guard let lm = removeLexicalModelFromUserList(userDefs: userData, at: index) else {
       return false
     }
-    
+
     removeLexicalModelFromLanguagePreference(userDefs: userData, lm)
+    inputViewController.deregisterLexicalModel(lm);
     // Set a new lexical model if deleting the current one
     let userLexicalModels = userData.userLexicalModels! //removeLexicalModelFromUserList fails above if this is not present
 


### PR DESCRIPTION
Fills in functionality missing from #1923.  As a result:
Fixes #1921.

This will automatically deactivate and deregister a newly-deleted lexical model if it is active.