### PR TITLE
[Android] Settings UI enhancement

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -26,6 +26,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.widget.TextView;
 
 public class GetStartedActivity extends AppCompatActivity {
 
@@ -64,6 +65,14 @@ public class GetStartedActivity extends AppCompatActivity {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean(showGetStartedKey, isChecked);
         editor.commit();
+      }
+    });
+
+    final TextView getStartedText = findViewById(R.id.getStartedText);
+    getStartedText.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        checkBox.setChecked(!checkBox.isChecked());
       }
     });
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -155,7 +155,7 @@ public class GetStartedActivity extends AppCompatActivity {
         list.get(0).put(iconKey, one);
       }
 
-      if (isEnabledAsSystemKB(this)) {
+      if (SystemIMESettings.isEnabledAsSystemKB(this)) {
         list.get(1).put(iconKey, checkbox_on);
         list.get(2).put(isEnabledKey, "true");
       } else {
@@ -163,7 +163,7 @@ public class GetStartedActivity extends AppCompatActivity {
         list.get(2).put(isEnabledKey, "false");
       }
 
-      if (isDefaultKB(this)) {
+      if (SystemIMESettings.isDefaultKB(this)) {
         list.get(2).put(iconKey, checkbox_on);
       } else {
         list.get(2).put(iconKey, three);
@@ -176,25 +176,5 @@ public class GetStartedActivity extends AppCompatActivity {
       listAdapter = new KMListAdapter(this, list, R.layout.get_started_row_layout, from, to);
       listView.setAdapter(listAdapter);
     }
-  }
-
-  protected static boolean isEnabledAsSystemKB(Context context) {
-    InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-    List<InputMethodInfo> imList = imManager.getEnabledInputMethodList();
-    boolean isEnabled = false;
-    int size = imList.size();
-    for (int i = 0; i < size; i++) {
-      if (imList.get(i).getServiceName().equals("com.keyman.android.SystemKeyboard")) {
-        isEnabled = true;
-        break;
-      }
-    }
-
-    return isEnabled;
-  }
-
-  protected static boolean isDefaultKB(Context context) {
-    String inputMethod = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
-    return inputMethod.equals(context.getPackageName() + "/com.keyman.android.SystemKeyboard");
   }
 }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
@@ -9,6 +9,8 @@ public class KeymanSettingsActivity extends AppCompatActivity {
   protected static final String installedLanguagesKey = "InstalledLanguages";
   protected static final String showBannerKey = "ShowBanner";
 
+  protected KeymanSettingsFragment innerFragment;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -21,6 +23,17 @@ public class KeymanSettingsActivity extends AppCompatActivity {
       getSupportActionBar().setDisplayHomeAsUpEnabled(true);
       getSupportActionBar().setDisplayShowHomeEnabled(true);
       getSupportActionBar().setDisplayShowTitleEnabled(true);
+    }
+
+    innerFragment = (KeymanSettingsFragment) getSupportFragmentManager().findFragmentById(R.id.keyman_settings_fragment);
+  }
+
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+
+    if(hasFocus) {
+      innerFragment.update();
     }
   }
 }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -57,6 +57,15 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     getStartedPreference.setTitle(getString(R.string.show_get_started));
     getStartedPreference.setDefaultValue(true);
 
+    // Blocks the default checkmark interaction; we want to control the checkmark's state separately
+    // from within update() based on if the user has taken the appropriate actions with the OS.
+    final Preference.OnPreferenceChangeListener checkBlocker = new Preference.OnPreferenceChangeListener() {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue) {
+        return false;
+      }
+    };
+
     setSystemKeyboardPreference = new CheckBoxPreference(context);
     setSystemKeyboardPreference.setTitle(R.string.enable_system_keyboard);
     setSystemKeyboardPreference.setDefaultValue(GetStartedActivity.isEnabledAsSystemKB(context));
@@ -67,13 +76,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
         return false;
       }
     });
-    setSystemKeyboardPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-      @Override
-      public boolean onPreferenceChange(Preference preference, Object newValue) {
-        // Blocks the checkmark from changing from user interaction.
-        return false;
-      }
-    });
+    setSystemKeyboardPreference.setOnPreferenceChangeListener(checkBlocker);
 
     setDefaultKeyboardPreference = new CheckBoxPreference(context);
     setDefaultKeyboardPreference.setTitle(R.string.set_keyman_as_default);
@@ -86,13 +89,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
         return false;
       }
     });
-    setDefaultKeyboardPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-      @Override
-      public boolean onPreferenceChange(Preference preference, Object newValue) {
-        // Blocks the checkmark from changing from user interaction.
-        return false;
-      }
-    });
+    setDefaultKeyboardPreference.setOnPreferenceChangeListener(checkBlocker);
 
     screen.addPreference(languagesPreference);
     screen.addPreference(setSystemKeyboardPreference);
@@ -128,12 +125,15 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
   public void onResume() {
     super.onResume();
 
-    update();
+    // The onResume() function isn't called after the default-keyboard selection and cannot fix that
+    // option, though it is sufficient for handling the system-keyboard enablement option.
+    //
+    // As a result, we rely on KeymanSettingsActivity.onWindowFocusChanged to call
+    // .update() on our behalf.
   }
 
   public void update() {
     setSystemKeyboardPreference.setChecked(GetStartedActivity.isEnabledAsSystemKB(context));
-    // This function isn't called after the default-keyboard selection and cannot fix the option.
     setDefaultKeyboardPreference.setChecked(GetStartedActivity.isDefaultKB(context));
 
     // Update the language / keyboard count when we return to this menu from deeper levels.

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -3,7 +3,10 @@ package com.tavultesoft.kmapro;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
+import android.view.inputmethod.InputMethodManager;
 
+import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
@@ -12,14 +15,13 @@ import androidx.preference.SwitchPreference;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.data.Dataset;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
 public class KeymanSettingsFragment extends PreferenceFragmentCompat {
   private static final String TAG = "SettingsFragment";
   private static Context context;
 
   private Preference languagesPreference;
+  private CheckBoxPreference setSystemKeyboardPreference;
+  private CheckBoxPreference setDefaultKeyboardPreference;
 
   @Override
   public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -55,7 +57,47 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     getStartedPreference.setTitle(getString(R.string.show_get_started));
     getStartedPreference.setDefaultValue(true);
 
+    setSystemKeyboardPreference = new CheckBoxPreference(context);
+    setSystemKeyboardPreference.setTitle(R.string.enable_system_keyboard);
+    setSystemKeyboardPreference.setDefaultValue(GetStartedActivity.isEnabledAsSystemKB(context));
+    setSystemKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+      @Override
+      public boolean onPreferenceClick(Preference preference) {
+        startActivity(new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS));
+        return false;
+      }
+    });
+    setSystemKeyboardPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue) {
+        // Blocks the checkmark from changing from user interaction.
+        return false;
+      }
+    });
+
+    setDefaultKeyboardPreference = new CheckBoxPreference(context);
+    setDefaultKeyboardPreference.setTitle(R.string.set_keyman_as_default);
+    setDefaultKeyboardPreference.setDefaultValue(GetStartedActivity.isDefaultKB(context));
+    setDefaultKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+      @Override
+      public boolean onPreferenceClick(Preference preference) {
+        InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        imManager.showInputMethodPicker();
+        return false;
+      }
+    });
+    setDefaultKeyboardPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue) {
+        // Blocks the checkmark from changing from user interaction.
+        return false;
+      }
+    });
+
     screen.addPreference(languagesPreference);
+    screen.addPreference(setSystemKeyboardPreference);
+    screen.addPreference(setDefaultKeyboardPreference);
+
     screen.addPreference(bannerPreference);
     screen.addPreference(getStartedPreference);
 
@@ -85,6 +127,14 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
   @Override
   public void onResume() {
     super.onResume();
+
+    update();
+  }
+
+  public void update() {
+    setSystemKeyboardPreference.setChecked(GetStartedActivity.isEnabledAsSystemKB(context));
+    // This function isn't called after the default-keyboard selection and cannot fix the option.
+    setDefaultKeyboardPreference.setChecked(GetStartedActivity.isDefaultKB(context));
 
     // Update the language / keyboard count when we return to this menu from deeper levels.
     languagesPreference.setTitle(getInstalledLanguagesText());

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -35,7 +35,6 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     languagesPreference.setWidgetLayoutResource(R.layout.preference_icon_layout);
     Intent languagesIntent = new Intent();
     languagesIntent.setClassName(context.getPackageName(), "com.tavultesoft.kmea.LanguagesSettingsActivity");
-    languagesIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
     languagesIntent.putExtra(KMManager.KMKey_DisplayKeyboardSwitcher, false);
     languagesPreference.setIntent(languagesIntent);
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -68,7 +68,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
 
     setSystemKeyboardPreference = new CheckBoxPreference(context);
     setSystemKeyboardPreference.setTitle(R.string.enable_system_keyboard);
-    setSystemKeyboardPreference.setDefaultValue(GetStartedActivity.isEnabledAsSystemKB(context));
+    setSystemKeyboardPreference.setDefaultValue(SystemIMESettings.isEnabledAsSystemKB(context));
     setSystemKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
       @Override
       public boolean onPreferenceClick(Preference preference) {
@@ -80,7 +80,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
 
     setDefaultKeyboardPreference = new CheckBoxPreference(context);
     setDefaultKeyboardPreference.setTitle(R.string.set_keyman_as_default);
-    setDefaultKeyboardPreference.setDefaultValue(GetStartedActivity.isDefaultKB(context));
+    setDefaultKeyboardPreference.setDefaultValue(SystemIMESettings.isDefaultKB(context));
     setDefaultKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
       @Override
       public boolean onPreferenceClick(Preference preference) {
@@ -133,8 +133,8 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
   }
 
   public void update() {
-    setSystemKeyboardPreference.setChecked(GetStartedActivity.isEnabledAsSystemKB(context));
-    setDefaultKeyboardPreference.setChecked(GetStartedActivity.isDefaultKB(context));
+    setSystemKeyboardPreference.setChecked(SystemIMESettings.isEnabledAsSystemKB(context));
+    setDefaultKeyboardPreference.setChecked(SystemIMESettings.isDefaultKB(context));
 
     // Update the language / keyboard count when we return to this menu from deeper levels.
     languagesPreference.setTitle(getInstalledLanguagesText());

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -602,10 +602,10 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       if (kbList != null && kbList.size() < 2)
         shouldShowGetStarted = true;
 
-      if (!GetStartedActivity.isEnabledAsSystemKB(this))
+      if (!SystemIMESettings.isEnabledAsSystemKB(this))
         shouldShowGetStarted = true;
 
-      if (!GetStartedActivity.isDefaultKB(this))
+      if (!SystemIMESettings.isDefaultKB(this))
         shouldShowGetStarted = true;
 
       if (shouldShowGetStarted)

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SystemIMESettings.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SystemIMESettings.java
@@ -1,0 +1,30 @@
+package com.tavultesoft.kmapro;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.view.inputmethod.InputMethodInfo;
+import android.view.inputmethod.InputMethodManager;
+
+import java.util.List;
+
+public class SystemIMESettings {
+  static boolean isEnabledAsSystemKB(Context context) {
+    InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    List<InputMethodInfo> imList = imManager.getEnabledInputMethodList();
+    boolean isEnabled = false;
+    int size = imList.size();
+    for (int i = 0; i < size; i++) {
+      if (imList.get(i).getServiceName().equals("com.keyman.android.SystemKeyboard")) {
+        isEnabled = true;
+        break;
+      }
+    }
+
+    return isEnabled;
+  }
+
+  static boolean isDefaultKB(Context context) {
+    String inputMethod = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
+    return inputMethod.equals(context.getPackageName() + "/com.keyman.android.SystemKeyboard");
+  }
+}

--- a/android/KMAPro/kMAPro/src/main/res/layout/get_started_list_layout.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/get_started_list_layout.xml
@@ -40,12 +40,13 @@
                 android:paddingBottom="@dimen/checkbox_padding" />
 
             <TextView
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginLeft="@dimen/checkbox_margin_left"
-              android:layout_marginStart="@dimen/checkbox_margin_left"
-              android:layout_gravity="center_vertical"
-              android:text="@string/show_get_started" />
+                android:id="@+id/getStartedText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/checkbox_margin_left"
+                android:layout_marginLeft="@dimen/checkbox_margin_left"
+                android:text="@string/show_get_started" />
 
         </LinearLayout>
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -110,7 +110,6 @@ public final class LanguagesSettingsActivity extends AppCompatActivity
         }
 
         Intent intent = new Intent(context, LanguageSettingsActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         intent.putExtras(args);
         startActivity(intent);
 

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-08-05 12.0.4075 beta
+* Adjustments to Settings UI
+
 ## 2019-07-29 12.0.4074 beta
 * Initial beta release of Keyman for Android 12
 * [Pull Requests](https://github.com/keymanapp/keyman/pulls?utf8=%E2%9C%93&q=is%3Apr+merged%3A2019-02-25..2019-08-04+label%3Aandroid+base%3Amaster)

--- a/android/history.md
+++ b/android/history.md
@@ -4,7 +4,7 @@
 * Start version 13.0
 
 ## 2019-08-06 12.0.4076 beta
-* Adjustments to Settings UI
+* Adjustments to Settings UI (#1931)
 
 ## 2019-08-05 12.0.4075 beta
 * Fixes issue with suggestion text misalignment (#1932)


### PR DESCRIPTION
Addresses the following concerns from #1904:

> 1. [Settings] Back from Settings/Installed Languages/Installed Language takes you to Settings instead of Settings/Installed Languages

> 3. [Get Started] The "Show Get Started" checkbox is only touchable on the checkbox, not the label, unlike the items above it

> 6. Default keyboard and Enable System Keyboard should really be available from Settings