### PR TITLE
[Android] Suggestion text misalignment on tablets

### DIFF
--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-08-05 12.0.4075 beta
+* Fixes issue with suggestion text misalignment (#1932)
+
 ## 2019-07-29 12.0.4074 beta
 * Initial beta release of Keyman for Android 12
 * [Pull Requests](https://github.com/keymanapp/keyman/pulls?utf8=%E2%9C%93&q=is%3Apr+merged%3A2019-02-25..2019-08-04+label%3Aandroid+base%3Amaster)

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -181,7 +181,8 @@
   background-color: #b4b4b8; 
   display:inline-block; 
   text-align: center; 
-  border-radius: 5px
+  border-radius: 5px;
+  vertical-align: top;
 }
 
 .tablet.android .kmw-suggestion-text {


### PR DESCRIPTION
Looks like a `vertical-align` got missed in some of the recent CSS work; the other permutations all had that line, which fixes the Android tablet issue.

Fixes #1908.