### PR TITLE
[Web] Spacebar captioning fix

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-08-07 12.0.75 beta
+* Fixes issue where keyboard name / language caption was missing from spacebar (#1937)
+
 ## 2019-08-06 12.0.74 beta
 * Fixes issue with an extra space being added after accepted predictive suggestions (#1936)
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1539,7 +1539,7 @@ namespace com.keyman.osk {
       }
 
       try {
-        var t=<HTMLElement> this.spaceBar.firstChild; //.firstChild;
+        var t=<HTMLElement> this.spaceBar.firstChild;
         let tParent = <HTMLElement> t.parentNode;
         if(typeof(tParent.className) == 'undefined' || tParent.className == '') {
           tParent.className='kmw-spacebar';

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1539,11 +1539,11 @@ namespace com.keyman.osk {
       }
 
       try {
-        var t=<HTMLElement> this.spaceBar.firstChild.firstChild;
+        var t=<HTMLElement> this.spaceBar.firstChild; //.firstChild;
         let tParent = <HTMLElement> t.parentNode;
         if(typeof(tParent.className) == 'undefined' || tParent.className == '') {
           tParent.className='kmw-spacebar';
-        } else {
+        } else if(tParent.className.indexOf('kmw-spacebar') == -1) {
           tParent.className +=' kmw-spacebar';
         }
 


### PR DESCRIPTION
Fixes the lack of spacebar captions in KMW 12.0.  Turns out that the split of kmwosk.ts into two separate classes and files missed a small detail that caused this.

Apparently `#text` elements don't play nice with CSS or `.innerHTML` - who knew?