### PR TITLE
[Developer] Prevent keyboard files with many warnings clobbering build reports by stopping reports after 100 messages

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -2934,14 +2934,16 @@ begin
 
   KMXFileName2 := KMXFileName.Name;   // I4181
 
+  TProject.CompilerMessageFile := ProjectFile;
   frmMessages.Clear;
-  if CompileKeyboardFile(PChar(KMNFileName.Name), PChar(KMXFileName2), False, False, False, CompilerMessage) <= 0 then   // I4181   // I4865   // I4866
+  if CompileKeyboardFile(PChar(KMNFileName.Name), PChar(KMXFileName2), False, False, False, ProjectCompilerMessage) <= 0 then   // I4181   // I4865   // I4866
   begin
     frmMessages.DoShowForm;
     ShowMessage('There were errors compiling the keyboard to convert to the On Screen Keyboard.');
     FreeAndNil(KMXFileName);   // I4181
   end;
   FreeAndNil(KMNFileName);   // I4181
+  TProject.CompilerMessageFile := nil;
 end;
 
 procedure TfrmKeymanWizard.OSKImportKMXFinished(Sender: TObject; KMXFileName: TTempFile);   // I4181

--- a/windows/src/developer/TIKE/main/UfrmMessages.pas
+++ b/windows/src/developer/TIKE/main/UfrmMessages.pas
@@ -86,10 +86,6 @@ type
 var
   frmMessages: TfrmMessages;
 
-  FCompilingFile: string;
-
-function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;  // I3310
-
 implementation
 
 uses
@@ -138,6 +134,7 @@ procedure TfrmMessages.Clear;
 begin
   FMessageItems.Clear;
   memoMessage.Clear;
+  ProjectCompilerMessageClear;
 end;
 
 procedure TfrmMessages.memoMessageDblClick(Sender: TObject);
@@ -205,31 +202,6 @@ end;
 procedure TfrmMessages.cmdmPreviousMessageClick(Sender: TObject);
 begin
   PrevMessage;
-end;
-
-function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;  // I3310
-var
-  errtype: string;
-begin
-  (*subtext := text;
-  n := Pos('chr:', subtext);
-  if n > 0 then
-  begin
-    if TryStrToInt(Trim(Copy(subtext, n+4, MAXINT)), v) then
-    begin
-      Delete(subtext, n, MAXINT);
-    end;
-  end;*)
-
-  case msgcode and $F000 of
-    $1000: errtype := 'fatal';
-    $2000: errtype := 'warning';
-    $4000: errtype := 'error';
-    $8000: errtype := 'fatal';
-  end;
-
-  frmMessages.Add(FCompilingFile, Format('line %d  %s %x: %s', [line, errtype, msgcode, text]));
-  Result := 1;
 end;
 
 procedure TfrmMessages.NextMessage;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -95,8 +95,6 @@ function TkmnProjectFileUI.CompileKeyboard(FSilent: Boolean): Boolean;
 begin
   Result := False;
 
-  FCompilingFile := ProjectFile.FileName;
-
   if ProjectFile.Modified then
   begin
     if not FSilent then

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -63,6 +63,10 @@ uses
 var
   hOutfile: THandle;
   HasWarning: Boolean = False;
+  MessageCount: Integer = 0;
+
+const
+  MAX_MESSAGES = 100;
 
 function CompileKeyboard(FInFile, FOutFile: string; FDebug, FSilent, FWarnAsError: Boolean): Boolean; forward;   // I4706
 
@@ -79,7 +83,16 @@ begin
   else if (msgcode and CERR_FATAL) <> 0   then p := 'Fatal'
   else p := 'Memory';
 
-  str := System.AnsiStrings.Format('%s %d: %8.8X %s', [p, line, msgcode, text]);   // I3310
+  if(msgcode <> CWARN_Info) then
+  begin
+    Inc(MessageCount);
+    if MessageCount > MAX_MESSAGES then
+      Exit(1);
+
+    if MessageCount = MAX_MESSAGES
+      then str := System.AnsiStrings.Format('%s %d: 00000000 More than %d warnings or errors received; suppressing further messages', [p, line, MAX_MESSAGES])
+      else str := System.AnsiStrings.Format('%s %d: %8.8X %s', [p, line, msgcode, text]);   // I3310
+  end;
 
 	if hOutfile <> 0 then
   begin


### PR DESCRIPTION
Fixes #1919.

Note that the fix is in two places in kmcomp because there is a legacy pathway for the compiler that is outside the scope of this PR to refactor.