### PR TITLE
[ios] reload table data so deletion or addition shows immediately

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
@@ -310,6 +310,7 @@ open class SettingsViewController: UITableViewController {
     } else {
       itemsArray[0]["subtitle"] = "\(userLanguages.count) languages installed"
     }
+    tableView.reloadData()
   }
   
   public func setIsDoneButtonEnabled(_ nc: UINavigationController, _ value: Bool) {


### PR DESCRIPTION
SettingsViewController now reloads table data in loadUserLanguages so deletion or addition shows right away when we come back to it.
Fixes #1952 