### PR TITLE
[iOS] Slide-deletion for keyboards via Settings menu

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardPickerViewController.swift
@@ -110,33 +110,6 @@ class KeyboardPickerViewController: KeyboardSwitcherViewController {
   
   // MARK: - table view delegate UITableViewDelegate
 
-  // TODO: Refactor. Duplicated in KeyboardInfoViewController
-  override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-    if !Manager.shared.canRemoveKeyboards {
-      return false
-    }
-
-    if !Manager.shared.canRemoveDefaultKeyboard {
-      return indexPath.row != 0
-    }
-    if indexPath.row > 0 {
-      return true
-    }
-    return userKeyboards.count > 1
-  }
-
-  override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle,
-                          forRowAt indexPath: IndexPath) {
-    if editingStyle != .delete {
-      return
-    }
-
-    if Manager.shared.removeKeyboard(at: indexPath.row) {
-      loadUserKeyboards()
-    }
-    setIsDoneButtonEnabled(true)
-  }
-
   override func tableView(_ tableView: UITableView,
                           accessoryButtonTappedForRowWith indexPath: IndexPath) {
     showKeyboardInfoView(with: indexPath.row)

--- a/ios/history.md
+++ b/ios/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-08-11 12.0.13 beta
+* Enables swipe-deletion of installed keyboards in the language settings menu. (#1969)
+
 ## 2019-08-08 12.0.12 beta
 * Fixes toggle alignment issues in the Settings UI (#1947)
 


### PR DESCRIPTION
Fixes #1948.
Fixes #1949.

This removes swipe-deletion for keyboards from the old picker (currently only accessible via "Get Started") and moves it to the language-specific keyboard management menu.

There may be a bit of refinement needed with regard to detecting the default keyboard.