### PR TITLE
[Developer] Update documentation on UTF-8 BOM handling; write test.

### DIFF
--- a/developer/js/lexical-model-compiler/build-trie.ts
+++ b/developer/js/lexical-model-compiler/build-trie.ts
@@ -47,13 +47,17 @@ export function parseWordList(contents: string): WordList {
 
   let result: WordList = [];
   for (let line of lines) {
+    // Remove the byte-order mark (BOM) from the beginning of the string.
+    // Because `contents` can be the concatenation of several files, we have to remove
+    // the BOM from every possible start of file -- i.e., beginning of every line.
+    line = line.replace(/^\uFEFF/, '');
+
     if (line.startsWith('#') || line === "") {
       continue; // skip comments and empty lines
     }
     let [wordform, countText, _comment] = line.split(TAB);
     // Clean the word form.
     // TODO: what happens if we get duplicate forms?
-    // NOTE: String.prototype.trim() removes the byte-order mark (BOM), if present!
     wordform = wordform.normalize('NFC').trim();
     countText = (countText || '').trim();
     let count = parseInt(countText, 10);

--- a/developer/js/lexical-model-compiler/build-trie.ts
+++ b/developer/js/lexical-model-compiler/build-trie.ts
@@ -23,16 +23,19 @@ export function createTrieDataStructure(sourceFiles: string[], searchTermToKey?:
  *
  * Format specification:
  *
- *  - the file is a UTF-8 encoded text file
- *  - new lines are either LF or CRLF
- *  - the file either consists of a comment or an entry
- *  - comment lines MUST start with the '#' character on the very first column
+ *  - the file is a UTF-8 encoded text file.
+ *  - new lines are either LF or CRLF.
+ *  - the file MAY start with the UTF-8 byte-order mark (BOM); that is, if the
+ *    first three bytes of the file are EF BB BF, these will be interepreted as
+ *    the BOM and will be ignored.
+ *  - the file either consists of a comment or an entry.
+ *  - comment lines MUST start with the '#' character on the very first column.
  *  - entries are one to three columns, separated by the (horizontal) tab
- *    character
+ *    character.
  *  - column 1 (REQUIRED): the wordform: can have any character except tab, CR,
  *    LF. Surrounding whitespace characters are trimmed.
  *  - column 2 (optional): the count: a non-negative integer specifying how many
- *    times this entry has appeared in the corpus. Blank means 'indeterminate'
+ *    times this entry has appeared in the corpus. Blank means 'indeterminate'.
  *  - column 3 (optional): comment: an informative comment, ignored by the tool.
  */
 export function parseWordList(contents: string): WordList {
@@ -50,6 +53,7 @@ export function parseWordList(contents: string): WordList {
     let [wordform, countText, _comment] = line.split(TAB);
     // Clean the word form.
     // TODO: what happens if we get duplicate forms?
+    // NOTE: String.prototype.trim() removes the byte-order mark (BOM), if present!
     wordform = wordform.normalize('NFC').trim();
     countText = (countText || '').trim();
     let count = parseInt(countText, 10);

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -1,0 +1,22 @@
+import {parseWordList} from '../lexical-model-compiler/build-trie';
+import {assert} from 'chai';
+import 'mocha';
+
+import path = require('path');
+
+const BOM = '\ufeff';
+
+describe('parseWordList', function () {
+  it('should remove the UTF-8 byte order mark from files', function () {
+    let word = 'hello';
+    let count = 1;
+    let expected = [
+      [word, count]
+    ];
+    let withoutBOM = parseWordList(`${word}\t${count}\n`);
+    assert.deepEqual(withoutBOM, expected);
+    let withBOM = parseWordList(`${BOM}${word}\t${count}\n`)
+    assert.deepEqual(withBOM, expected);
+  });
+});
+

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -13,10 +13,11 @@ describe('parseWordList', function () {
     let expected = [
       [word, count]
     ];
-    let withoutBOM = parseWordList(`${word}\t${count}\n`);
-    assert.deepEqual(withoutBOM, expected);
-    let withBOM = parseWordList(`${BOM}${word}\t${count}\n`)
-    assert.deepEqual(withBOM, expected);
+    let file = `# this is a comment\n${word}\t${count}`;
+    let withoutBOM = parseWordList(file);
+    assert.deepEqual(withoutBOM, expected, "expected regular file to parse properly");
+    let withBOM = parseWordList(`${BOM}${file}`)
+    assert.deepEqual(withBOM, expected, "expected BOM to be ignored");
   });
 });
 


### PR DESCRIPTION
I've added documentation that the byte-order mark is a-okay at the beginning of a word list TSV file. I wrote the test first, and was surprised that it passed already without me writing any code.

It turns out that `String.prototype.trim()` removes the BOM, a.ka. U+FEFF from either side of a string. This is used to trim whitespace when parsing a line. Check out the polyfill!

> ```javascript
> if (!String.prototype.trim) {
>  String.prototype.trim = function () {
>    return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
>  };
> }
> ```
>
> Source: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill)

**EDIT**: I explicitly remove the BOM from the beginning of each line anyway!

Closes #1916.