### PR TITLE
[iOS] Settings notification bar refactor/prep

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -142,7 +142,6 @@
 		9AD4F53D229F85AC007992D3 /* LanguageSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AD4F53B229F85AC007992D3 /* LanguageSettingsViewController.xib */; };
 		9AD4F53E22A8A25B007992D3 /* LanguageSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD4F53A229F85AC007992D3 /* LanguageSettingsViewController.swift */; };
 		9AD4F53F22A8A286007992D3 /* LanguageSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AD4F53B229F85AC007992D3 /* LanguageSettingsViewController.xib */; };
-		9ADC459A22E186F5004C78C6 /* LanguageSpecificViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7EEFA122DCF64F00877C22 /* LanguageSpecificViewController.swift */; };
 		9ADC459D22E1895D004C78C6 /* LanguageLMDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC459B22E1895D004C78C6 /* LanguageLMDetailViewController.swift */; };
 		9ADC459E22E1895D004C78C6 /* LanguageLMDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC459B22E1895D004C78C6 /* LanguageLMDetailViewController.swift */; };
 		9ADC459F22E1895D004C78C6 /* LanguageLMDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9ADC459C22E1895D004C78C6 /* LanguageLMDetailViewController.xib */; };
@@ -213,6 +212,7 @@
 		C0D3F3601F9F3AD80055C7CF /* InstallableKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F35F1F9F3AD80055C7CF /* InstallableKeyboard.swift */; };
 		C0E30C8C1FC40D0400C80416 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E30C8B1FC40D0400C80416 /* Storage.swift */; };
 		C0EF3E7B1F95B65300CE9BD4 /* KeymanWebDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */; };
+		CE1E1EC12303C8CC001C7BE0 /* ResourceDownloadStatusToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1E1EC02303C8CC001C7BE0 /* ResourceDownloadStatusToolbar.swift */; };
 		CE24ECF021B763740052D291 /* KeymanResponder+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24ECEF21B763740052D291 /* KeymanResponder+Types.swift */; };
 		CE24ECF121B763740052D291 /* KeymanResponder+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24ECEF21B763740052D291 /* KeymanResponder+Types.swift */; };
 		CE24ECF221B763740052D291 /* KeymanResponder+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24ECEF21B763740052D291 /* KeymanResponder+Types.swift */; };
@@ -415,6 +415,7 @@
 		C0ED71B21F6BB0B1002A2FD6 /* HTTPDownloadRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPDownloadRequest.swift; sourceTree = "<group>"; };
 		C0ED71B41F6BBFAF002A2FD6 /* HTTPDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPDownloader.swift; sourceTree = "<group>"; };
 		C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanWebDelegate.swift; sourceTree = "<group>"; };
+		CE1E1EC02303C8CC001C7BE0 /* ResourceDownloadStatusToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadStatusToolbar.swift; sourceTree = "<group>"; };
 		CE24ECEF21B763740052D291 /* KeymanResponder+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeymanResponder+Types.swift"; sourceTree = "<group>"; };
 		CE2B1E4521B60E7C007D092E /* DeviceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DeviceKit.framework; path = ../../Carthage/Build/iOS/DeviceKit.framework; sourceTree = "<group>"; };
 		CE67D960228A6F190029F2B5 /* KeyboardCommandStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardCommandStructs.swift; sourceTree = "<group>"; };
@@ -640,6 +641,7 @@
 				9A3B14D1229370B20052A11F /* InstalledLanguagesViewController.swift */,
 				9AD4F53A229F85AC007992D3 /* LanguageSettingsViewController.swift */,
 				9AD4F53B229F85AC007992D3 /* LanguageSettingsViewController.xib */,
+				CE1E1EC02303C8CC001C7BE0 /* ResourceDownloadStatusToolbar.swift */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -1219,6 +1221,7 @@
 				C06D37341F81F5C300F61AE0 /* HTTPDownloader.swift in Sources */,
 				C0452BAF1F9F22A80064431A /* Font.swift in Sources */,
 				C0D3F3601F9F3AD80055C7CF /* InstallableKeyboard.swift in Sources */,
+				CE1E1EC12303C8CC001C7BE0 /* ResourceDownloadStatusToolbar.swift in Sources */,
 				C042ED5D1FC6A65A001D82F4 /* Version.swift in Sources */,
 				C0D3F35E1F9F33490055C7CF /* Options.swift in Sources */,
 				C06D37351F81F5C300F61AE0 /* HTTPDownloadRequest.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -133,33 +133,6 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
     log.info("keyboardDownloadStarted: LanguageDetailViewController")
     view.isUserInteractionEnabled = false
     navigationItem.setHidesBackButton(true, animated: true)
-
-    let toolbarFrame = navigationController!.toolbar.frame
-    let labelFrame = CGRect(origin: toolbarFrame.origin,
-                            size: CGSize(width: toolbarFrame.width * 0.95, height: toolbarFrame.height * 0.7))
-    let label = UILabel(frame: labelFrame)
-    label.backgroundColor = UIColor.clear
-    label.textColor = UIColor.white
-    label.textAlignment = .center
-    label.center = CGPoint(x: toolbarFrame.width * 0.5, y: toolbarFrame.height * 0.5)
-    label.text = "Downloading\u{2026}"
-    label.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin,
-                              .flexibleBottomMargin, .flexibleWidth, .flexibleHeight]
-    label.tag = toolbarLabelTag
-
-    let indicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-    indicatorView.center = CGPoint(x: toolbarFrame.width - indicatorView.frame.width,
-                                   y: toolbarFrame.height * 0.5)
-    indicatorView.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin, .flexibleBottomMargin]
-    indicatorView.tag = toolbarActivityIndicatorTag
-    indicatorView.startAnimating()
-
-    navigationController?.toolbar.viewWithTag(toolbarButtonTag)?.removeFromSuperview()
-    navigationController?.toolbar.viewWithTag(toolbarLabelTag)?.removeFromSuperview()
-    navigationController?.toolbar.viewWithTag(toolbarActivityIndicatorTag)?.removeFromSuperview()
-    navigationController?.toolbar.addSubview(label)
-    navigationController?.toolbar.addSubview(indicatorView)
-    navigationController?.setToolbarHidden(false, animated: true)
   }
 
   private func keyboardDownloadFailed() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -250,36 +250,6 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
   private func keyboardDownloadStarted() {
     view.isUserInteractionEnabled = false
     navigationItem.setHidesBackButton(true, animated: true)
-
-    guard let toolbar = navigationController?.toolbar else {
-      return
-    }
-
-    let labelFrame = CGRect(origin: toolbar.frame.origin,
-                            size: CGSize(width: toolbar.frame.width * 0.95,
-                                         height: toolbar.frame.height * 0.7))
-    let label = UILabel(frame: labelFrame)
-    label.backgroundColor = UIColor.clear
-    label.textColor = UIColor.white
-    label.textAlignment = .center
-    label.center = CGPoint(x: toolbar.frame.width * 0.5, y: toolbar.frame.height * 0.5)
-    label.text = "Downloading\u{2026}"
-    label.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin,
-                              .flexibleBottomMargin, .flexibleWidth, .flexibleHeight]
-    label.tag = toolbarLabelTag
-
-    let indicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-    indicatorView.center = CGPoint(x: toolbar.frame.width - indicatorView.frame.width,
-                                   y: toolbar.frame.height * 0.5)
-    indicatorView.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin, .flexibleBottomMargin]
-    indicatorView.tag = toolbarActivityIndicatorTag
-    indicatorView.startAnimating()
-    toolbar.viewWithTag(toolbarButtonTag)?.removeFromSuperview()
-    toolbar.viewWithTag(toolbarLabelTag)?.removeFromSuperview()
-    toolbar.viewWithTag(toolbarActivityIndicatorTag)?.removeFromSuperview()
-    toolbar.addSubview(label)
-    toolbar.addSubview(indicatorView)
-    navigationController?.setToolbarHidden(false, animated: true)
   }
 
   private func keyboardDownloadFailed() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -233,19 +233,8 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
           navigationItem.rightBarButtonItem?.isEnabled = true
         }
         updateQueue = nil
-        let label = navigationController?.toolbar?.viewWithTag(toolbarLabelTag) as? UILabel
-        label?.text = "Dictionaries successfully updated!"
-        navigationController?.toolbar?.viewWithTag(toolbarActivityIndicatorTag)?.removeFromSuperview()
-        Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(self.hideToolbarDelayed),
-                             userInfo: nil, repeats: false)
       }
     } else {
-      let label = navigationController?.toolbar?.viewWithTag(toolbarLabelTag) as? UILabel
-      label?.text = "Dictionary successfully downloaded!"
-      navigationController?.toolbar?.viewWithTag(toolbarActivityIndicatorTag)?.removeFromSuperview()
-      Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(self.hideToolbarDelayed),
-                           userInfo: nil, repeats: false)
-      
       view.isUserInteractionEnabled = true
       navigationItem.leftBarButtonItem?.isEnabled = true
       if navigationItem.rightBarButtonItem != nil {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -229,8 +229,18 @@ public class Manager: NSObject, HTTPDownloadDelegate, UIGestureRecognizerDelegat
   
   public func showKeymanEngineSettings(inVC: UIViewController) -> Void {
     hideKeyboard()
+    
+    // Allows us to set a custom UIToolbar for download/update status displays.
+    let nc = UINavigationController(navigationBarClass: nil, toolbarClass: ResourceDownloadStatusToolbar.self)
+    
+    // Grab our newly-generated toolbar instance and inform it of its parent NavigationController.
+    // This will help streamline use of the 'toolbar' as a status/update bar.
+    let toolbar = nc.toolbar as? ResourceDownloadStatusToolbar
+    toolbar?.navigationController = nc
+    
+    // As it's the first added view controller, settingsVC will function as root automatically.
     let settingsVC = SettingsViewController()
-    let nc = UINavigationController(rootViewController: settingsVC)
+    nc.pushViewController(settingsVC, animated: false)
     nc.modalTransitionStyle = .coverVertical
     nc.modalPresentationStyle = .pageSheet
     inVC.present(nc, animated: true)

--- a/ios/engine/KMEI/KeymanEngine/Classes/ResourceDownloadStatusToolbar.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/ResourceDownloadStatusToolbar.swift
@@ -1,0 +1,146 @@
+//
+//  ResourceDownloadStatusToolbar.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 8/14/19.
+//  Copyright © 2019 SIL International. All rights reserved.
+//
+
+import Foundation
+
+class ResourceDownloadStatusToolbar: UIToolbar {
+  private var statusLabel: UILabel?
+  private var activityIndicator: UIActivityIndicatorView?
+  private var actionButton: UIButton?
+  
+  private var _navigationController: UINavigationController?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    
+    setup()
+  }
+  
+  // Only here because it's required by Swift.
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+  
+  var navigationController: UINavigationController? {
+    get {
+      return _navigationController
+    }
+    
+    set {
+      _navigationController = newValue
+    }
+  }
+  
+  private func setup() {
+    barTintColor = UIColor(red: 0.5, green: 0.75, blue: 0.25, alpha: 0.9)
+  }
+  
+  /**
+   * Creates a simple text label for indicating current status without allowing interactivity.
+   */
+  private func setupStatusLabel() -> UILabel {
+    let labelFrame = CGRect(origin: frame.origin,
+                            size: CGSize(width: frame.width * 0.95,
+                            height: frame.height * 0.7))
+    let label = UILabel(frame: labelFrame)
+    label.backgroundColor = UIColor.clear
+    label.textColor = UIColor.white
+    label.textAlignment = .center
+    label.center = CGPoint(x: frame.width * 0.5, y: frame.height * 0.5)
+    label.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin,
+                              .flexibleBottomMargin, .flexibleWidth, .flexibleHeight]
+    
+    return label
+  }
+  
+  /**
+   * Creates the classic spinning-wheel 'activity in progress' indicator.
+   */
+  private func setupActivityIndicator() -> UIActivityIndicatorView {
+    let indicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    indicatorView.center = CGPoint(x: frame.width - indicatorView.frame.width,
+                                   y: frame.height * 0.5)
+    indicatorView.autoresizingMask = [.flexibleLeftMargin, .flexibleTopMargin, .flexibleBottomMargin]
+    indicatorView.startAnimating()
+    
+    return indicatorView
+  }
+  
+  private func setupActionButton(_ text: String, for handler: Any?, onClick: Selector) -> UIButton {
+    let button = UIButton(type: .roundedRect)
+    button.addTarget(handler, action: onClick, for: .touchUpInside)
+
+    button.frame = CGRect(x: frame.origin.x, y: frame.origin.y,
+                          width: frame.width * 0.95, height: frame.height * 0.7)
+    button.center = CGPoint(x: frame.width / 2, y: frame.height / 2)
+    button.tintColor = UIColor(red: 0.75, green: 1.0, blue: 0.5, alpha: 1.0)
+    button.setTitleColor(UIColor.white, for: .normal)
+    button.setTitle(text, for: .normal)
+    button.autoresizingMask =  [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin,
+                                .flexibleBottomMargin, .flexibleWidth, .flexibleHeight]
+
+    return button
+  }
+  
+  private func clearSubviews() {
+    statusLabel?.removeFromSuperview()
+    activityIndicator?.removeFromSuperview()
+    actionButton?.removeFromSuperview()
+  }
+  
+  public func displayStatus(_ text: String, withIndicator: Bool, duration: TimeInterval? = nil) {
+    clearSubviews()
+    
+    statusLabel = setupStatusLabel()
+    statusLabel!.text = text
+    addSubview(statusLabel!)
+    if withIndicator {
+      activityIndicator = setupActivityIndicator()
+      addSubview(activityIndicator!)
+    }
+    
+    // Automatically display if we're hidden and have access to our owning UINavigationController.
+    if navigationController?.isToolbarHidden ?? false {
+      navigationController!.setToolbarHidden(false, animated: true)
+    }
+    
+    if let timeout = duration {
+      hideAfterDelay(timeout: timeout)
+    }
+  }
+  
+  public func displayButton(_ text: String, with target: Any?, callback: Selector) {
+    clearSubviews()
+    
+    // This forces iOS to create any intervening default UIToolbar subviews that may exist by default.
+    // Anything added afterward will be placed on top of those, enabling interactivity.
+    layoutIfNeeded()
+    
+    actionButton = setupActionButton(text, for: target, onClick: callback)
+    addSubview(actionButton!)
+    bringSubview(toFront: actionButton!)
+    
+    // Automatically display if we're hidden and have access to our owning UINavigationController.
+    if navigationController?.isToolbarHidden ?? false {
+      navigationController!.setToolbarHidden(false, animated: true)
+    }
+  }
+  
+  private func hideAfterDelay(timeout: TimeInterval) {
+    Timer.scheduledTimer(timeInterval: timeout, target: self, selector: #selector(self.delayedHide),
+                         userInfo: nil, repeats: false)
+  }
+  
+  @objc private func delayedHide() {
+    // If the navigation controller exists and the toolbar is not hidden.  The ! + true literal together
+    // give false for the condition when the navigation controller does not exist.
+    if !(navigationController?.isToolbarHidden ?? true) {
+      navigationController!.setToolbarHidden(true, animated: true)
+    }
+  }
+}


### PR DESCRIPTION
Yeah, I know.  It's technically an enhancement rather than a bug fix.  This is an extracted part of my current work toward fixing the following issues:

* #1967
* #1968 
* Eventually, #1975

I realized that this part was very reasonable to `git rebase -i` out of everything else.  Since smaller, segmented code reviews are far easier to do, I figured this would be wise.

So, what brought this 'enhancement' about?  All of the keyboard updating code tends to generate notifications that display things in a similar manner to the newly refactored code.  Since we have yet to fully complete lexical model updating, this will only become worse as as that's completed.  Tracking all of the random sites of UI code was creating a lot of unnecessary mental overhead and slowing my progress.

This PR seeks to eliminate that problem so that it will be easier to proceed with a comprehensive solution for the issues listed above.  It does break the status info generated within the old Picker, so it probably shouldn't be merged in until the next PR in the chain is ready.

---

Overall plans:

* This PR's new class will be relocated within the "Keyman" (app) project instead of remaining in the library later in the PR chain.  It's completely safe to move when that time comes.
* The next PR in the chain (#1979) adds a new class called `ResourceDownloadManager`  that will be a permanent resident of the KeymanEngine library (KMEI).
  * It will track all resource download events together, generating events that feed this PR's newly-centralized status toolbar, possibly through an intermediary callback `protocol`.
  * It will also provide update-detection functionality usable by UI.
    * For now, this will assume use of our keyboard + lexical model catalog for any such operations in the engine.  (Any further abstraction would be a v13/v14 task.)
  * In short, it will aim to resolve the first two issues listed above (#1967 and #1968) in a manner that sets up for resolution of the third.
* After that, the plan is to resolve #1975 by refactoring the `InstalledLanguagesViewController` as necessary to respect the distinction between the generality intended for the KeymanEngine and functionality specific to our app.
  * A new `ResourceSettingsManager` will expose any needed APIs from the KMEI side that correpond to UI settings manipulation.
    * At this time, only APIs necessary for the relocation to succeed will be created.  Anything after that would be v13/v14 work.
  * The resulting `InstalledLanguagesViewController`, all of its settings UI subviews, and this PR's `ResourceDownloadStatusToolbar` will be relocated into the "Keyman" (app) project.

Note that I'm still working on the next PRs - I wanted to split this off before things got too entangled.