### PR TITLE
[Developer] Better compilation assertions

### DIFF
--- a/developer/js/package.json
+++ b/developer/js/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "mocha -r ts-node/register tests/**/test-*.ts"
+    "test": "mocha"
   },
   "author": "Marc Durdin (SIL)",
   "license": "MIT",
@@ -28,5 +28,9 @@
     "mocha": "^6.1.4",
     "ts-node": "^8.3.0",
     "xml2js": "^0.4.19"
+  },
+  "mocha": {
+    "require": "ts-node/register",
+    "spec": "tests/**/test-*.ts"
   }
 }

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -2,7 +2,89 @@
  * Helpers and utilities for the Mocha tests.
  */
 import * as path from 'path';
+import {assert} from 'chai';
 
 export function makePathToFixture(name: string): string {
   return path.join(__dirname, '..', 'fixtures', name)
 }
+
+/**
+ * Given source code of a model (as produced by the compiler), this evaluates
+ * it!
+ *
+ * That way, you can determine if the source code was syntactically-valid,
+ * whether it raise an exception during construction, and you can even inspect
+ * the resultant WorkerInternalModel for yourself!
+ *
+ * @param code
+ */
+export function compileModelSourceCode(code: string) {
+  assert.typeOf(code, 'string');
+
+  let error: Error | null = null;
+  let exportedModel: object | null = null;
+  let hasSyntaxError = false;
+  let modelConstructorName: string | null = null;
+
+  let module: ModuleType | null = null;
+  try {
+    module = new Function('LMLayerWorker', 'models', code) as ModuleType;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      hasSyntaxError = true;
+    } else {
+      throw err;
+    }
+  }
+
+  // Module had some sort of syntax error:
+  if (module === null) {
+    return {
+      error, exportedModel, hasSyntaxError, modelConstructorName
+    };
+  }
+
+  let fakeLMLayerWorker = {
+    loadModel(model: object) {
+      exportedModel = model;
+    }
+  };
+  // We expect the compiled model to reach into the `models` namespace,
+  // and get some sort of model constructor. Problem is, we don't know
+  // what model constructors are defined!
+  // This proxy allows us to intercept
+  //    models.*
+  // meaning that when the compiled code tries to do this:
+  //
+  //    new models.WhateverModel('foo', 'bar')
+  //
+  // ...we can intercept the name "WhateverModel" and assign it to
+  // `modelConstructorName`.
+  let modelsNamespace = new Proxy({}, {
+    get(_target, property)  {
+      if (typeof property !== 'string')
+        throw new Error(`Don't know how to handle non-string property: ${String(property)}`);
+      return class DummyModel {
+        constructor() {
+          modelConstructorName = property as string;
+        }
+      }
+    }
+  });
+
+  try {
+    module(fakeLMLayerWorker, modelsNamespace);
+  } catch (err) {
+    error = err;
+  }
+
+  return {
+    error, exportedModel, hasSyntaxError, modelConstructorName
+  };
+}
+
+type ModuleType = (a: LMLayerWorker, b: ModelsNamespace) => any;
+interface LMLayerWorker {
+  loadModel(model: object): void;
+}
+type ModelsNamespace = object;

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Helpers and utilities for the Mocha tests.
+ */
+import * as path from 'path';
+
+export function makePathToFixture(name: string): string {
+  return path.join(__dirname, '..', 'fixtures', name)
+}

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -2,7 +2,7 @@ import LexicalModelCompiler from '../';
 import {assert} from 'chai';
 import 'mocha';
 
-import {makePathToFixture} from './helpers';
+import {makePathToFixture, compileModelSourceCode} from './helpers';
 
 
 describe('LexicalModelCompiler', function () {
@@ -16,11 +16,11 @@ describe('LexicalModelCompiler', function () {
         sources: ['wordlist.tsv']
       }, PATH) as string;
 
-      assert.doesNotThrow(function evalModelCode() {
-        eval(code);
-      }, SyntaxError);
-      // TODO: Mock LMLayerWorker.loadModel()
-  
+      let result = compileModelSourceCode(code);
+      assert.isFalse(result.hasSyntaxError);
+      assert.isNotNull(result.exportedModel);
+      assert.equal(result.modelConstructorName, 'TrieModel');
+
       // Sanity check: the word list has three total unweighted words, with a
       // total weight of 3!
       assert.match(code, /\btotalWeight\b["']?:\s*3\b/);

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -2,13 +2,13 @@ import LexicalModelCompiler from '../';
 import {assert} from 'chai';
 import 'mocha';
 
-const path = require('path');
+import {makePathToFixture} from './helpers';
 
 
 describe('LexicalModelCompiler', function () {
   describe('#generateLexicalModelCode', function () {
     const MODEL_ID = 'example.qaa.trivial';
-    const PATH = path.join(__dirname, 'fixtures', MODEL_ID)
+    const PATH = makePathToFixture(MODEL_ID);
     it('should compile a trivial word list', function () {
       let compiler = new LexicalModelCompiler;
       let code = compiler.generateLexicalModelCode(MODEL_ID, {

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -1,8 +1,6 @@
-import {parseWordList} from '../lexical-model-compiler/build-trie';
+import {parseWordList} from '../dist/lexical-model-compiler/build-trie';
 import {assert} from 'chai';
 import 'mocha';
-
-import path = require('path');
 
 const BOM = '\ufeff';
 

--- a/developer/js/tests/test-punctuation.ts
+++ b/developer/js/tests/test-punctuation.ts
@@ -3,6 +3,7 @@ import {assert} from 'chai';
 import 'mocha';
 
 import path = require('path');
+import { compileModelSourceCode } from './helpers';
 
 
 describe('LexicalModelCompiler', function () {
@@ -26,7 +27,11 @@ describe('LexicalModelCompiler', function () {
       assert.match(code, /»/);
       // Ensure we inserted that OGHAM SPACE MARK!
       assert.match(code, /\u1680/);
-      // TODO: more robust assertions?
+
+      // Make sure it compiles!
+      let compilation = compileModelSourceCode(code);
+      assert.isFalse(compilation.hasSyntaxError);
+      assert.isNotNull(compilation.exportedModel);
     });
   })
 });


### PR DESCRIPTION
This addresses some todos in `developer/js`; namely, the tests `eval` the model source code, but apart from checking for the absence of a syntax error, they didn't assert much. Through some effort, we can now:

 1. compile model source code in the tests
 2. determine the name of the constructor of the last model instantiated (i.e., `new models.SomeModel()` is `SomeModel`).
 3. Actually figure out what the compiled code passed to `LMLayerWorker.loadModel()`.

Assertions are a little bit more assert-y now!

**EDIT**: Also, I added a helper that returns the path to fixtures!