### PR TITLE
Fixes iOS Get Started

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
@@ -134,20 +134,20 @@ open class SettingsViewController: UITableViewController {
         }
       case "showgetstarted":
         cell.accessoryType = .none
-        let dontShowAgainSwitch = UISwitch()
-        dontShowAgainSwitch.translatesAutoresizingMaskIntoConstraints = false
+        let showAgainSwitch = UISwitch()
+        showAgainSwitch.translatesAutoresizingMaskIntoConstraints = false
         
-        let switchFrame = frameAtRightOfCell(cell: cell.frame, controlSize: dontShowAgainSwitch.frame.size)
-        dontShowAgainSwitch.frame = switchFrame
+        let switchFrame = frameAtRightOfCell(cell: cell.frame, controlSize: showAgainSwitch.frame.size)
+        showAgainSwitch.frame = switchFrame
         
-        dontShowAgainSwitch.isOn = dontShowGetStarted
-        dontShowAgainSwitch.addTarget(self, action: #selector(self.showGetStartedSwitchValueChanged),
+        showAgainSwitch.isOn = showGetStarted
+        showAgainSwitch.addTarget(self, action: #selector(self.showGetStartedSwitchValueChanged),
                                       for: .valueChanged)
-        cell.addSubview(dontShowAgainSwitch)
+        cell.addSubview(showAgainSwitch)
         
         if #available(iOSApplicationExtension 9.0, *) {
-          dontShowAgainSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-          dontShowAgainSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
+          showAgainSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+          showAgainSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
         }
       default:
         log.error("unknown cellIdentifier(\"\(cellIdentifier ?? "EMPTY")\")")
@@ -174,9 +174,9 @@ open class SettingsViewController: UITableViewController {
     }
   }
   
-  private var dontShowGetStarted: Bool {
+  private var showGetStarted: Bool {
     let userData = Storage.active.userDefaults
-    return !userData.bool(forKey: "ShouldShowGetStarted")
+    return userData.bool(forKey: "ShouldShowGetStarted")
   }
 
   override open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/ios/history.md
+++ b/ios/history.md
@@ -3,10 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
-## 2019-08-11 12.0.13 beta
-* Enables swipe-deletion of installed keyboards in the language settings menu. (#1969)
 
-## 2019-08-08 12.0.12 beta
+## 2019-08-22 12.0.12 beta
+* Fixes Get Started display logic (#1988)
+* Enables swipe-deletion of installed keyboards in the language settings menu. (#1969)
 * Fixes toggle alignment issues in the Settings UI (#1947)
 
 ## 2019-07-29 12.0.11 beta

--- a/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
@@ -179,7 +179,7 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
   @objc func switchValueChanged(_ sender: Any) {
     let userData = AppDelegate.activeUserDefaults()
     if let toggle = sender as? UISwitch {
-      userData.set(toggle.isOn, forKey: dontShowGetStartedKey)
+      userData.set(!toggle.isOn, forKey: shouldShowGetStartedKey)
       userData.synchronize()
     }
   }


### PR DESCRIPTION
Fixes #1935.

Somehow the Get Started menu's settings handling got broken with some of the recent Settings UI work; this PR should correct that.