### PR TITLE
[Android] Disable version and copyright text from flashing on splash screen

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SplashScreenActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SplashScreenActivity.java
@@ -29,12 +29,13 @@ public class SplashScreenActivity extends Activity {
     } catch (PackageManager.NameNotFoundException e) {
       // Could not get version number
     }
-    version.setText(ver);
+    // TODO: Add version and copyright info when Android supports TextViews in the splash screen
+    //version.setText(ver);
 
     TextView copyright = (TextView)findViewById(R.id.splash_copyright);
     int year = Calendar.getInstance().get(Calendar.YEAR);
     String date = String.format("%s%s", copyright.getText(), year);
-    copyright.setText(date);
+    //copyright.setText(date);
 
     new Handler().postDelayed(new Runnable() {
       @Override

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_splash_screen.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_splash_screen.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:text="@string/title_version"
+        android:text="@string/splash_blank"
         android:textSize="@dimen/activity_splash_textsize" />
 
     <TextView
@@ -21,7 +21,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:text="@string/splash_copyright"
+        android:text="@string/splash_blank"
         android:textSize="@dimen/activity_splash_textsize" />
 
 </LinearLayout>

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
   <string name="textview_hint" translatable="false">Start typing here&#8230;</string>
 
   <!-- Splash screen (version/copyright info currently disabled -->
+  <string name="splash_blank" translatable="false"></string>
   <string name="splash_copyright" translatable="false">Copyright &#169; 1992-</string>
 
   <!-- Text Size dialog -->

--- a/android/KMAPro/kMAPro/src/main/res/values/styles.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/styles.xml
@@ -25,7 +25,7 @@
 
     </style>
 
-    <style name="AppTheme.BrandedLaunch" parent="@style/android:Theme.Light.NoTitleBar">
+    <style name="AppTheme.BrandedLaunch" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/branded_logo</item>
     </style>
 

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,15 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-08-23 12.0.4079 beta
+* Disable version and copyright text on splash screen
+
+## 2019-08-16 12.0.4078 beta
+* No changes to Keyman for Android
+
+## 2019-08-12 12.0.4077 beta
+* No changes to Keyman for Android
+
 ## 2019-08-06 12.0.4076 beta
 * Adjustments to Settings UI (#1931)
 

--- a/android/history.md
+++ b/android/history.md
@@ -4,7 +4,7 @@
 * Start version 13.0
 
 ## 2019-08-23 12.0.4079 beta
-* Disable version and copyright text on splash screen
+* Disable version and copyright text on splash screen (#1989)
 
 ## 2019-08-16 12.0.4078 beta
 * No changes to Keyman for Android


### PR DESCRIPTION
In #1511, it was decided to avoid a startup delay and not display version/copyright info on the splash screen. The current timeout of 0ms doesn't work, as the splash screen still flickers with version/copyright text.

This addresses #1964 by blanking the version and copyright text fields.