### PR TITLE
[iOS] Language-specific keyboard download regression fix.

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -43,12 +43,14 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
   override func loadView() {
     super.loadView()
     
-    if let languageDict = keyboardRepository?.languages {
-      self.postLanguageLoad(languageDict: languageDict)
-    } else {
-      log.info("Fetching repository from API for keyboard download (LanguageDetailViewController)")
-      pendingFetch = true
-      keyboardRepository?.fetch()
+    if keyboardRepository != nil {
+      if let languageDict = keyboardRepository?.languages {
+        self.postLanguageLoad(languageDict: languageDict)
+      } else {
+        log.info("Fetching repository from API for keyboard download (LanguageDetailViewController)")
+        pendingFetch = true
+        keyboardRepository?.fetch()
+      }
     }
     
     loadUserKeyboards()

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -42,7 +42,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     } else {
       self.installedLanguages = givenLanguages!
     }
-    self.keyboardRepository = nil
+    self.keyboardRepository = Manager.shared.apiKeyboardRepository //nil
     self.lexicalModelRepository = nil
     super.init(nibName: nil, bundle: nil)
 //    keyboardRepository.delegate = self

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -42,7 +42,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     } else {
       self.installedLanguages = givenLanguages!
     }
-    self.keyboardRepository = Manager.shared.apiKeyboardRepository //nil
+    self.keyboardRepository = Manager.shared.apiKeyboardRepository
     self.lexicalModelRepository = nil
     super.init(nibName: nil, bundle: nil)
 //    keyboardRepository.delegate = self


### PR DESCRIPTION
Fixes regressions related to mistakes in merging other recent PRs with #1991's work.

The language-specific keyboard list view was locking up; this restores it.