### PR TITLE
[Developer] Add Word Breaking API

### DIFF
--- a/developer/js/source/index.ts
+++ b/developer/js/source/index.ts
@@ -218,6 +218,12 @@ export default class LexicalModelCompiler {
       if (typeof modelSource.wordBreaking === "string") {
         // It must be a builtin word breaker, so just instantiate it.
         wordBreakingSource = `wordBreakers['${modelSource.wordBreaking}']`;
+      } else if (typeof modelSource.wordBreaking === "function") {
+        // The word breaker was passed as a literal function; use its source code.
+        wordBreakingSource = modelSource.wordBreaking.toString()
+        // Note: the .toString() might just be the property name, but we want a
+        // plain function:
+          .replace(/^wordBreaking\b/, 'function');
       } else if (modelSource.wordBreaking.sources) {
         let wordBreakingSources: string[] = modelSource.wordBreaking.sources.map(function(source) {
           return fs.readFileSync(path.join(sourcePath, source), 'utf8');
@@ -251,7 +257,7 @@ export default class LexicalModelCompiler {
           createTrieDataStructure(filenames, modelSource.searchTermToKey)
         }, {\n`;
         if (wordBreakingSource) {
-          func += `  wordBreaking: ${wordBreakingSource},\n`;
+          func += `  wordBreaker: ${wordBreakingSource},\n`;
         }
         if (modelSource.searchTermToKey) {
           func += `  searchTermToKey: ${modelSource.searchTermToKey.toString()},\n`;

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -28,7 +28,7 @@ interface LexicalModelSource extends LexicalModel {
   /**
    * What kind of word breaking to use, if any.
    */
-  readonly wordBreaking?: 'default' | 'ascii' | 'placeholder' | ClassBasedWordBreaker;
+  readonly wordBreaking?: 'default' | 'ascii' | 'placeholder' | WordBreakingFunction | ClassBasedWordBreaker;
   /**
    * How to simplify words, to convert them into simplifired search keys
    * This often involves removing accents, lowercasing, etc.

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -46,5 +46,27 @@ describe('LexicalModelCompiler', function () {
       // total weight of 44,103!
       assert.match(code, /\btotalWeight\b["']?:\s*44103\b/);
     });
-  })
+  });
+
+  it('should compile a word list with a custom word breaking function', function () {
+    const MODEL_ID = 'example.qaa.trivial';
+    const PATH = makePathToFixture(MODEL_ID);
+
+    let compiler = new LexicalModelCompiler;
+    let code = compiler.generateLexicalModelCode(MODEL_ID, {
+      format: 'trie-1.0',
+      sources: ['wordlist.txt'],
+      wordBreaking(phrase: string): Span[] {
+        return [];
+      }
+    }, PATH) as string;
+
+    let result = compileModelSourceCode(code);
+    assert.isFalse(result.hasSyntaxError);
+    assert.isNotNull(result.exportedModel);
+    assert.equal(result.modelConstructorName, 'TrieModel');
+
+    // Sanity check: the word breaker is a property of the object.
+    assert.match(code, /\bwordBreaker\b["']?:\s+function\b/);
+  });
 });

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -55,7 +55,8 @@ describe('LexicalModelCompiler', function () {
     let compiler = new LexicalModelCompiler;
     let code = compiler.generateLexicalModelCode(MODEL_ID, {
       format: 'trie-1.0',
-      sources: ['wordlist.txt'],
+      sources: ['wordlist.tsv'],
+      // This is a possible word breaking function:
       wordBreaking(phrase: string): Span[] {
         return [];
       }


### PR DESCRIPTION
Allows model authors to specify a word breaker as a function that returns an array of [`Span` objects](https://github.com/keymanapp/keyman/blob/master/common/predictive-text/worker/worker-compiler-interfaces.d.ts#L28-L43).