### PR TITLE
[Developer] Use the term "wordBreaker" instead of "wordBreaking"

### DIFF
--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -4,6 +4,12 @@
  */
 /// <reference path="../../../../common/predictive-text/worker/worker-compiler-interfaces.d.ts" />
 
+/**
+ * ******DELETE ME******
+ *
+ * This form of specifying word breakers is not implemented.
+ *
+ */
 interface ClassBasedWordBreaker {
   allowedCharacters?: { initials?: string, medials?: string, finals?: string } | string,
   defaultBreakCharacter?: string
@@ -25,8 +31,24 @@ interface LexicalModelSource extends LexicalModel {
    * The name of the type to instantiate (without parameters) as the base object for a custom predictive model.
    */
   readonly rootClass?: string
+
   /**
-   * What kind of word breaking to use, if any.
+   * Which word breaker to use. Choose from:
+   *
+   *  - 'default' -- breaks according to Unicode UAX #29 §4.1 Default Word
+   *    Boundary Specification, which works well for *most* languages.
+   *  - 'ascii' -- a very simple word breaker, for demonstration purposes only.
+   *  - word breaking function -- provide your own function that breaks words.
+   */
+  readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction;
+
+  /**
+   * ******DELETE ME******
+   *
+   * This used to be the way that word breaking was specified, but
+   * this should be deleted once keymanapp/lexical-models#54 is merged.
+   *
+   * https://github.com/keymanapp/lexical-models/pull/54
    */
   readonly wordBreaking?: 'default' | 'ascii' | 'placeholder' | WordBreakingFunction | ClassBasedWordBreaker;
   /**

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -5,7 +5,7 @@
 /// <reference path="../../../../common/predictive-text/worker/worker-compiler-interfaces.d.ts" />
 
 /**
- * ******DELETE ME******
+ * ****** TODO: DELETE ME******
  *
  * This form of specifying word breakers is not implemented.
  *
@@ -43,7 +43,7 @@ interface LexicalModelSource extends LexicalModel {
   readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction;
 
   /**
-   * ******DELETE ME******
+   * ****** TODO: DELETE ME******
    *
    * This used to be the way that word breaking was specified, but
    * this should be deleted once keymanapp/lexical-models#54 is merged.

--- a/developer/js/tests/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.ts
+++ b/developer/js/tests/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.ts
@@ -1,5 +1,6 @@
 const source: LexicalModelSource = {
   format: 'trie-1.0',
   sources: ['wordlist.tsv'],
+  wordBreaker: 'default',
 };
 export default source;

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -43,7 +43,7 @@ export function compileModelSourceCode(code: string) {
 
   let module: ModuleType | null = null;
   try {
-    module = new Function('LMLayerWorker', 'models', code) as ModuleType;
+    module = new Function('LMLayerWorker', 'models', 'wordBreakers', code) as ModuleType;
   } catch (err) {
     if (err instanceof SyntaxError) {
       hasSyntaxError = true;
@@ -88,7 +88,7 @@ export function compileModelSourceCode(code: string) {
   });
 
   try {
-    module(fakeLMLayerWorker, modelsNamespace);
+    module(fakeLMLayerWorker, modelsNamespace, {});
   } catch (err) {
     error = err;
   }
@@ -98,8 +98,9 @@ export function compileModelSourceCode(code: string) {
   };
 }
 
-type ModuleType = (a: LMLayerWorker, b: ModelsNamespace) => any;
+type ModuleType = (a: LMLayerWorker, b: ModelsNamespace, c: WordBreakersNamespace) => any;
 interface LMLayerWorker {
   loadModel(model: object): void;
 }
 type ModelsNamespace = object;
+type WordBreakersNamespace = object;

--- a/developer/js/tests/test-compile-model.ts
+++ b/developer/js/tests/test-compile-model.ts
@@ -24,6 +24,7 @@ describe('compileModel', function () {
       let compilation = r as CompilationResult;
 
       assert.isFalse(compilation.hasSyntaxError);
+      assert.isNull(compilation.error);
       assert.equal(compilation.modelConstructorName, 'TrieModel');
     });
   }

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -57,7 +57,7 @@ describe('LexicalModelCompiler', function () {
       format: 'trie-1.0',
       sources: ['wordlist.tsv'],
       // This is a possible word breaking function:
-      wordBreaking(phrase: string): Span[] {
+      wordBreaker(phrase: string): Span[] {
         return [];
       }
     }, PATH) as string;

--- a/developer/js/tests/test-compile-trie.ts
+++ b/developer/js/tests/test-compile-trie.ts
@@ -63,7 +63,7 @@ describe('LexicalModelCompiler', function () {
     }, PATH) as string;
 
     let result = compileModelSourceCode(code);
-    assert.isFalse(result.hasSyntaxError);
+    assert.isFalse(result.hasSyntaxError, `Syntax error in ${code}`);
     assert.isNotNull(result.exportedModel);
     assert.equal(result.modelConstructorName, 'TrieModel');
 


### PR DESCRIPTION
This changes the name of the `wordBreaking` model specification property to `wordBreaker`. `wordBreaking` is still kept so nothing in the lexical-models repo breaks (😏). I also added documentation for the `wordBreak` property inline.

Fixes #2012.

After keymanapp/lexical-models#54 is merged, we can remove all mention of `wordBreaking` altogether!