### PR TITLE
[Web] Fixes CSS issue affecting some Android devices

### DIFF
--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -123,7 +123,7 @@
 }
 
 .phone.android .kmw-suggestion-text {
-  color:#ffff;
+  color:#fff;
 }
 
 .phone.android .kmw-suggest-option.kmw-suggest-touched {background-color:#bbb;}


### PR DESCRIPTION
Fixes #1909.

Turns out that some versions of Android and/or Chrome were ignoring part of KMW's CSS due to an extra `f` in the color spec:

![Screen Shot 2019-09-03 at 10 16 51 AM](https://user-images.githubusercontent.com/25213402/64142148-fa089b00-ce34-11e9-96f8-f8a452759efa.png)

The warning indicator on the `color: #ffff` line basically indicated that it was rejected because it wasn't a proper color spec with either 3 or 6 hex digits.