### PR TITLE
[Android] [iOS] Use Canadian Multilingual keyboard for French for FV Keyboards, rather than Eurolatin

### DIFF
--- a/oem/firstvoices/keyboards.csv
+++ b/oem/firstvoices/keyboards.csv
@@ -51,7 +51,7 @@ fv,fv_severn_ojibwa,ᐊᓂᔑᓂᓂᒧᐎᐣ (Severn Ojibwa),Eastern Subarctic,f
 fv,fv_ojibwa,ᐊᓂᔑᓇᐯᒧᐎᓐ (Ojibwa),Eastern Subarctic,fv_ojibwa_kmw-9.0.js
 fv,fv_naskapi,ᓇᔅᑲᐱ (Naskapi),Eastern Subarctic,fv_naskapi_kmw-9.0.js
 sil,sil_euro_latin,English,European,european2-1.6.js
-sil,sil_euro_latin,Français,European,canadian_french-1.0.js
+basic,basic_kbdcan,Français,European,canadian_french-1.0.js
 fv,fv_anishinaabemowin,Anishinaabemowin,Great Lakes - St. Lawrence,fv_anishinaabemowin_kmw-9.0.js
 fv,fv_bodewadminwen,Bodéwadminwen-Nishnabémwen,Great Lakes - St. Lawrence,fv_bodewadminwen_kmw-9.0.js
 fv,fv_goyogohono,Goyogo̱hó:nǫ',Great Lakes - St. Lawrence,fv_goyogohono_kmw-9.0.js


### PR DESCRIPTION
Right now, the FV Keyboards app does not support having two languages with the same keyboard. The Canadian Multilingual keyboard is a very good alternative for French because it is optimised for it anyway.

Support for multiple languages using the same base keyboard should be available when the app includes BCP 47 codes in keyboards.csv, but this isn't really required for 12.0 stable, as far as I can tell.