### PR TITLE
[Developer] Removes final references to old wordBreaking property

### DIFF
--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -55,9 +55,6 @@ export default class LexicalModelCompiler {
     function getWordBreakerSpec() {
       if (modelSource.wordBreaker) {
         return modelSource.wordBreaker;
-      } else if (modelSource.wordBreaking) {
-        compiler.logError('`wordBreaking` will be deleted; please use `wordBreaker` instead!');
-        return modelSource.wordBreaking;
       } else {
         return null;
       }

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -39,18 +39,10 @@ interface LexicalModelSource extends LexicalModel {
    *    Boundary Specification, which works well for *most* languages.
    *  - 'ascii' -- a very simple word breaker, for demonstration purposes only.
    *  - word breaking function -- provide your own function that breaks words.
+   *  - class-based word-breaker - may be supported in the future.
    */
-  readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction;
+  readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction | ClassBasedWordBreaker;
 
-  /**
-   * ****** TODO: DELETE ME******
-   *
-   * This used to be the way that word breaking was specified, but
-   * this should be deleted once keymanapp/lexical-models#54 is merged.
-   *
-   * https://github.com/keymanapp/lexical-models/pull/54
-   */
-  readonly wordBreaking?: 'default' | 'ascii' | 'placeholder' | WordBreakingFunction | ClassBasedWordBreaker;
   /**
    * How to simplify words, to convert them into simplifired search keys
    * This often involves removing accents, lowercasing, etc.


### PR DESCRIPTION
As noted in #2014, we've moved from using a `wordBreaking` parameter to `wordBreaker` instead.  Now that the appropriate changes to mirror this have been carried out with https://github.com/keymanapp/lexical-models/pull/54, it's time to finalize removal of the old property.

While moving the `ClassBasedWordBreaker` to the newer parameter at this time may be ideal, this results in less code changes for now.  There's also the pending work on #2048 - this PR will trust that one to finalize any decisions regarding this potential argument type.