### PR TITLE
[Web] Test bug squashing

### DIFF
--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -340,7 +340,6 @@ namespace com.keyman {
       var lastElem = this.getLastActiveElement();
       if(lastElem == Pelem || lastElem == Pelem['kmw_ip']) {
         this.clearLastActiveElement();
-        this.keyman.keyboardManager.setActiveKeyboard(this.keyman.globalKeyboard, this.keyman.globalLanguageCode);
         this.keyman.osk._Hide(false);
       }
       


### PR DESCRIPTION
Turns out that a bug went unnoticed in #2045 that breaks KMW tests.  It wasn't directly caused, either - there was an interesting chain of events causing the problem.

As it turns out, for quite a while now the testing-oriented `shutdown` method has inadvertently been calling `setKeyboard` and such *during* the shutdown process - in particular, when element attachment is removed by the `disableInputElement` method.  During `shutdown`, there should be no active keyboard - and the new version checks the erroneous calls trigger result in the visible errors.

After a bit of investigation... there's no reason for `disableInputElement` to call `setKeyboard` here.  The keyboard's about to be hidden, and there are other handlers that will automatically set the keyboard appropriately when focusing other input elements during non-shutdown cases.  It's simply the case of an extraneous method call somehow surviving far longer than it should, only to be discovered when it makes a visible bug.