### PR TITLE
[Android] Fix missing FileProvider authority for MainActivity

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -24,6 +24,7 @@ import com.tavultesoft.kmea.KMTextView;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
 
 import android.Manifest;
@@ -452,7 +453,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         File defaultDictionaryKMP = new File(
           new File(KMManager.getResourceRoot(), KMManager.KMDefault_DictionaryKMP).getAbsolutePath());
         Uri uri = FileProvider.getUriForFile(
-          context, "com.tavultesoft.kmea.fileProvider", defaultDictionaryKMP);
+          context, FileProviderUtils.getAuthority(context), defaultDictionaryKMP);
         useLocalKMP(context, uri, true);
       }
 


### PR DESCRIPTION
This fixes a regression that was missed from the combination of #2029 and #2053 

I missed updating the FileProvider `authority` in the MainActivity.