### PR TITLE
[Developer] Don't overwrite a BCP 47 code that the user has chosen when writing project templates.

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFiles.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFiles.pas
@@ -66,6 +66,7 @@ initialization
   RegisterProjectFileType('.txt', TOpenableProjectFile);
   RegisterProjectFileType('.md', TOpenableProjectFile);
   RegisterProjectFileType('.keyboard_info', TOpenableProjectFile);
+  RegisterProjectFileType('.model_info', TOpenableProjectFile);
   RegisterProjectFileType('.htm', TOpenableProjectFile);   // I1769
   RegisterProjectFileType('.html', TOpenableProjectFile);  // I1769
   RegisterProjectFileType('.xml', TOpenableProjectFile);   // I1769

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-08 12.0.27 beta
+* Make sure New Project actually starts a new, blank project (#2059)
+* Don't overwrite a BCP 47 code that the user has chosen when writing project templates (#2060)
+
 ## 2019-09-02 12.0.23 beta
 * Add kmlmc, kmlmi and kmlmp command line tools for building lexical models (#2024)
 

--- a/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
@@ -23,6 +23,11 @@ uses
 // 3. finally, if no appropriate script is given, return '', because we'll need user
 //    to figure out the script themselves
 //
+// TODO: This code is not really 100% correct. We need to revisit how language tags
+//       are constructed and the point at which we do canonicalization. There are
+//       also competing requirements; for instance, Windows requires a script in
+//       some language tags where other operating systems might now.
+//
 class function TCanonicalLanguageCodeUtils.FindBestTag(const Tag: string): string;
 var
   t: TBCP47Tag;
@@ -34,6 +39,12 @@ var
   var
     i: Integer;
   begin
+    // If the tag is in the list of valid tags, use it. #2046.
+    for i := 0 to High(a) do
+      if SameText(a[i], Tag) then
+        Exit(a[i]);
+
+    // Otherwise, use the most complete tag
     for i := High(a) downto 0 do
     begin
       with TBCP47Tag.Create(a[i]) do


### PR DESCRIPTION
Fixes #2046.

Note: .model_info change in ProjectFiles.pas is to allow Developer to load .model_info files by default, rather than opening in external editor, which I encountered when testing.