### PR TITLE
[Android] Add check for `KMKey_CustomKeyboard`

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
@@ -113,7 +113,10 @@ final class KMKeyboardPickerAdapter extends NestedAdapter<Keyboard, Dataset.Keyb
     i.putExtra(KMManager.KMKey_KeyboardName, kbInfo.get(KMManager.KMKey_KeyboardName));
     String keyboardVersion = KMManager.getLatestKeyboardFileVersion(this.getContext(), packageID, keyboardID);
     i.putExtra(KMManager.KMKey_KeyboardVersion, keyboardVersion);
-    boolean isCustom = kbInfo.get(KMManager.KMKey_CustomKeyboard).equals("Y") ? true : false;
+    boolean isCustom = false;
+    if (kbInfo.get(KMManager.KMKey_CustomKeyboard) != null || kbInfo.containsKey(KMManager.KMKey_CustomKeyboard)) {
+      isCustom = kbInfo.get(KMManager.KMKey_CustomKeyboard).equals("Y") ? true : false;
+    }
     i.putExtra(KMManager.KMKey_CustomKeyboard, isCustom);
     String customHelpLink = kbInfo.get(KMManager.KMKey_CustomHelpLink);
     if (customHelpLink != null) {

--- a/android/history.md
+++ b/android/history.md
@@ -6,6 +6,7 @@
 ## 2019-09-09 12.0.4086 beta
 * Bug Fix:
   * Fix exception handling while parsing JSON info from cloud (#2065)
+  * Fix crash involving undefined key for custom keyboard (#2066)
 
 ## 2019-09-06 12.0.4085 beta
 * New Feature


### PR DESCRIPTION
Fixes crashlytics [issue](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/ae3e98fa5c6cd16e57f3140cc1949fd6?time=last-seven-days&sessionId=5D72B3F3033400016E434EDE02CAAA49_DNE_0_v2) where a keyboard map didn't contain `KMKey_CustomKeyboard`.