### PR TITLE
[Android] Update minSdkVersion from 16 to 19

### DIFF
--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
 
         String env_build_number = System.getenv("BUILD_NUMBER") //assigned by TeamCity, so all caps

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample1"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample2"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.keyman.android.tests.keycode"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.firstvoices.keyboards"
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion 28
 
         String env_services_json_file = System.getenv('oem_firstvoices_services_json_file')


### PR DESCRIPTION
Since the Keyman app has a minimum SDK version of 19, this updates KMEA and dependent projects to use the same minimum SDK version.