### PR TITLE
[Web] Suggestion banner overflow-x support

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-10 12.0.83 beta
+* Enables scrolling for long suggestions in the mobile-only predictive text banner (#2071)
+
 ## 2019-09-09 12.0.82 beta
 * Fixes output of the 102nd key for touch keyboards using desktop layouts (#2064)
 

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -230,7 +230,7 @@
 .kmw-footer-caption{color:#fff;font:0.7em Arial;margin:0 0 0 4px;}
 
 .kmw-banner-bar{height:100%; width:100%; margin:0; background-color:darkorange; display: inline-block;}
-.kmw-banner-bar .kmw-suggest-option {background-color: orange; display:inline-block; text-align: center; height: 85%; border-radius: 5px;}
+.kmw-banner-bar .kmw-suggest-option {background-color: orange; display:inline-block; text-align: center; height: 85%; border-radius: 5px;overflow-x:scroll}
 .kmw-suggestion-text{color:#fff; line-height: normal; position: relative; vertical-align: middle;}
 
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;


### PR DESCRIPTION
Fixes #1980.

Due to some of the requirements of the OSK, we can't rely upon native scroll handling for `overflow-x` elements, but we can still apply that styling toward the same goals if we just implement the scroll behavior ourselves.

I've tried to aim for a "natural" feel with the scroll implementation and its interactions with our normal banner-bar event handling.  **Please** live-test these changes and give feedback on the resulting UX.  I advise following the repro instructions in #1980 when testing; a great testing model is provided there.

---

Expected behaviors:

If the user's touch started within an "overflowing" suggestion:

- subsequent `touchmove` events will only scroll the suggestion
- if the user scrolls the suggestion significantly, moving a total of over 10 units, releasing the touch will _not_ select the suggestion.
  - However, if the total is under 10 units, the suggestion _will_ be selected.
  - While the exact number (10 units) could be tweaked, the core idea is that a bit of robustness against noise will be needed to allow overflowing suggestions to "feel right" and be selectable when intended.

In testing, it personally "felt wrong" to have the suggestion accepted after a long scroll.  So, I've implemented scrolling and selection as two separate states / UX "commands."

If the user's touch started outside of an overflowing suggestion:

- As before, `touchmove`s to the left or right will highlight the closest suggestion.
- if the newly-closest suggestion is overflowing, it *will not be scrolled*.
  - Basically,  the banner will automatically be in "selection" mode, not "scroll" mode, when started in this manner.

---

Correspondingly, we could say that "scroll" mode is formally activated when a user starts a touch within an overflow element and `touchmove`s at least 10 units total; before that, we interpret the command as a "selection" instead.