### PR TITLE
[iOS] Fixes iOS predictive banner due to key-distribution calc breakage

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -72,7 +72,14 @@ class KeymanWebViewController: UIViewController {
 
   override func viewWillLayoutSubviews() {
     // This method is called automatically during layout correction by iOS.
-    /// It also has access to correct `view.bounds.size` values, unlike viewDidAppear.
+    // It also has access to correct `view.bounds.size` values, unlike viewDidAppear.
+    // As a result, it's the correct place to perform OSK size adjustments.
+    //
+    // Problem - this is ALSO called automatically upon any touch-based interaction with the OSK!  (Why!?)
+    // The `keyboardSize` property will filter out any such redundant size-change requests to prevent issues
+    // that would otherwise arise.  (Important event handlers can trigger for the original OSK instance
+    // after it has been replaced by KMW's OSK resizing operation.)
+
     keyboardSize = view.bounds.size
   }
   
@@ -817,9 +824,19 @@ extension KeymanWebViewController {
       return kbSize
     }
     set(size) {
-      kbSize = size
-      setOskWidth(Int(size.width))
-      setOskHeight(Int(size.height))
+      // Only perform set management code if the size values has actually changed.
+      // We tend to get a lot of noise on this, so filtering like this also helps increase
+      // stability and performance.
+      //
+      // Note that since viewWillLayoutSubviews is triggered by touch events (for some reason) as
+      // well as view transitions, this helps to prevent issues that arise from replacing the OSK
+      // on touch events that would otherwise occur - at present, a resize operation in KMW
+      // automatically replaces the OSK.
+      if kbSize != size {
+        kbSize = size
+        setOskWidth(Int(size.width))
+        setOskHeight(Int(size.height))
+      }
     }
   }
 

--- a/ios/history.md
+++ b/ios/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-11 12.0.35 beta
+* Fixes predictive text bug where the last input was always interpreted as the first available key (#2076)
+* Adds support for scrolling long suggestions in the predictive banner (#2071)
+
 ## 2019-09-09 12.0.32 beta
 * Fixes OSK scaling bug on app re-entry when using keyboards without dictionaries (#2067)
 


### PR DESCRIPTION
Fixes #2072.

Turns out there was an interesting unexpected interaction that occurred on the swap to using `viewWillLayoutSubviews` - the function is unexpectedly called whenever users interact with the WebView via touch.  This, in turn, was triggering keyboard resize requests that replaced the keyboard elements _during_ keystroke processing, causing loss of important data for necessary predictive calculations that in turn broke the context that was being sent to the LMLayer.

"Fun" stuff.  Fortunately, it's somewhat easy to filter out the cases; I've made sure to document the reasoning in the critical locations so that we don't accidentally re-introduce the bug later.