### PR TITLE
[Web] Highlighting checks key instance, not key id

### DIFF
--- a/web/source/dom/uiTouchHandlerBase.ts
+++ b/web/source/dom/uiTouchHandlerBase.ts
@@ -395,7 +395,7 @@ namespace com.keyman.dom {
       this.currentTarget = key1;
 
       // Clear previous key highlighting
-      if(key0 && key1 && key1 != key0) {
+      if(key0 && key1 && key1 !== key0) {
         this.highlight(key0,false);
       }
 

--- a/web/source/dom/uiTouchHandlerBase.ts
+++ b/web/source/dom/uiTouchHandlerBase.ts
@@ -395,7 +395,7 @@ namespace com.keyman.dom {
       this.currentTarget = key1;
 
       // Clear previous key highlighting
-      if(key0 && key1 && (key1.id != key0.id)) {
+      if(key0 && key1 && key1 != key0) {
         this.highlight(key0,false);
       }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1097,7 +1097,7 @@ namespace com.keyman.osk {
       this.currentTarget = key1;
 
       // Clear previous key highlighting
-      if(key0 && key1 && (key1.id != key0.id)) {
+      if(key0 && key1 && key1 !== key0) {
         this.highlightKey(key0,false);
       }
 


### PR DESCRIPTION
Fixes #1733.

As best as I can tell, the original check simply neglected to compare the JS instances, preferring the id instead.

The `visualKeyboard.ts` edit is the important one, but the code in `uiTouchHandlerBase.ts` is an abstraction that will eventually replace `visualKeyboard.ts`'s code.  (At present, it only backs the predictive banner, but it was designed to back both.)