### PR TITLE
[Developer] Remove class based word breaker

### DIFF
--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -22,8 +22,6 @@ export default class LexicalModelCompiler {
    * @param sourcePath    Where to find auxilary sources files
    */
   generateLexicalModelCode(model_id: string, modelSource: LexicalModelSource, sourcePath: string) {
-    let compiler = this;
-
     // TODO: add metadata in comment
     const filePrefix: string = `(function() {\n'use strict';\n`;
     const fileSuffix: string = `})();`;
@@ -42,13 +40,6 @@ export default class LexicalModelCompiler {
         // Note: the .toString() might just be the property name, but we want a
         // plain function:
           .replace(/^wordBreak(ing|er)\b/, 'function');
-      } else if (wordBreakerSpec.sources) {
-        compiler.logError('class-based word breaker is not officially supported :/');
-        let wordBreakerSources: string[] = wordBreakerSpec.sources.map(function(source) {
-          return fs.readFileSync(path.join(sourcePath, source), 'utf8');
-        });
-
-        wordBreakerSourceCode = this.transpileSources(wordBreakerSources).join('\n');
       }
     }
 

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -4,22 +4,6 @@
  */
 /// <reference path="../../../../common/predictive-text/worker/worker-compiler-interfaces.d.ts" />
 
-/**
- * ****** TODO: DELETE ME******
- *
- * This form of specifying word breakers is not implemented.
- *
- */
-interface ClassBasedWordBreaker {
-  allowedCharacters?: { initials?: string, medials?: string, finals?: string } | string,
-  defaultBreakCharacter?: string
-  sources?: Array<string>;
-  /**
-   * The name of the type to instantiate (without parameters) as the base object for a custom word-breaking model.
-   */
-  rootClass?: string
-}
-
 interface LexicalModel {
   readonly format: 'trie-1.0'|'fst-foma-1.0'|'custom-1.0',
   //... metadata ...
@@ -41,7 +25,7 @@ interface LexicalModelSource extends LexicalModel {
    *  - word breaking function -- provide your own function that breaks words.
    *  - class-based word-breaker - may be supported in the future.
    */
-  readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction | ClassBasedWordBreaker;
+  readonly wordBreaker?: 'default' | 'ascii' | WordBreakingFunction;
 
   /**
    * How to simplify words, to convert them into simplifired search keys


### PR DESCRIPTION
This removes the undocumented, and unimplemented class-based word breaker. Less code to maintain, at least for now!

Note: if we want to continue with #2048, simply revert this pull request:

    git revert 65a0e9d