### PR TITLE
[Developer] Disable canonicalization when building keyboard and model projects from template because it's inadequate.

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-19 12.0.33 beta
+* Disable canonicalization of BCP 47 codes when building keyboard and model projects from template because it's inadequate (#2084)
+* Prevent package metadata preprocessor from treating .model.js files as keyboard files when they don't exist (#2085)
+
 ## 2019-09-11 12.0.30 beta
 * Clarify the project filename that will be created and simplify how the Browse button works in Project Template dialogs (#2073)
 

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
@@ -136,7 +136,7 @@ begin
 
     bcp47tag := TBCP47Tag.Create(tag);
     try
-      bcp47tag.Canonicalize;
+      //bcp47tag.Canonicalize; #2080
       pkl.ID := bcp47tag.Tag;
 
       if not TLanguageCodeUtils.BCP47Languages.TryGetValue(bcp47tag.Language, pkl.Name) then


### PR DESCRIPTION
Fixes #2080.

The primary problem here is that the canonicalization process depends on alltags.txt, and only allows tags in that list. This overrides the wishes of the keyboard developer, and in some cases, such as `hre`, gives us a code which is too descriptive.