### PR TITLE
[Developer] Prevent package metadata preprocessor from treating .model.js files as keyboard files when they don't exist.

### DIFF
--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -25,6 +25,7 @@ type
     function IsKeyboardFileByContent(f: TPackageContentFile): Boolean;
     function CheckKeyboardLanguages: Boolean;
     function CheckKeyboardTargetVersions: Boolean;
+    function IsModelFileByName(f: TPackageContentFile): Boolean;
   public
     type TPackageKeyboardInfo = record
       Name, ID, Version: string;
@@ -222,6 +223,11 @@ begin
   end;
 end;
 
+function TPackageInfoRefreshKeyboards.IsModelFileByName(f: TPackageContentFile): Boolean;
+begin
+  Result := TRegEx.IsMatch(f.FileName, '\.model\.js$', [roIgnoreCase]);
+end;
+
 function TPackageInfoRefreshKeyboards.IsKeyboardFileByName(f: TPackageContentFile): TKMFileType;
 begin
   if f.FileType = ftKeymanFile then
@@ -230,6 +236,12 @@ begin
   end;
 
   if f.FileType <> ftJavascript then
+    Exit(ftOther);
+
+  // A lexical model file will typicaly have the extension .model.js. This prevents the
+  // package editor from treating a lexical model as a keyboard when refreshing the list
+  // of included keyboards
+  if IsModelFileByName(f) then
     Exit(ftOther);
 
   // Need to test if the JS is a valid keyboard file.


### PR DESCRIPTION
Fixes #2081.

This issue would typically only surface if the target .js file did not exist, but then in some circumstances the package source file would contain a spurious `<Keyboard>` entry.

To reproduce:

1. Create a new model from template.
2. Open the package file, switch to source tab.
3. You'll see a blank `<Keyboard>` entry listed under `<Keyboards>`. This should not be present.
