### PR TITLE
[Web] Updates Firefox-check for keymapping.

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-23 12.0.86 beta
+* Fixes issue in Toolbar UI for some keyboards with language ids that include subtags (#2116)
+* Fixes issue with '=' key use on certain platforms in Firefox (#2118)
+
 ## 2019-09-20 12.0.85 beta
 * Adds failsafe in case of sticky backspace scenarios, making it simpler to cancel. (#2107)
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -320,7 +320,7 @@ namespace com.keyman.text {
       let kbdInterface = keyman.interface;
       let keyMapManager = keyman.keyMapManager;
 
-      if(!keyman.isEmbedded && !fromOSK && !window.event) {
+      if(!keyman.isEmbedded && !fromOSK && keyman.util.device.browser == 'firefox') {
         // I1466 - Convert the - keycode on mnemonic as well as positional layouts
         // FireFox, Mozilla Suite
         if(keyMapManager.browserMap.FF['k'+keyEvent.Lcode]) {
@@ -411,8 +411,7 @@ namespace com.keyman.text {
         return true;
       }
 
-
-      if(!keyman.isEmbedded && !fromOSK && !window.event) {
+      if(!keyman.isEmbedded && !fromOSK && keyman.util.device.browser == 'firefox') {
         // I1466 - Convert the - keycode on mnemonic as well as positional layouts
         // FireFox, Mozilla Suite
         if(keyMapManager.browserMap.FF['k'+keyEvent.Lcode]) {


### PR DESCRIPTION
Turns out that there's an interesting difference in Firefox for Windows vs for Mac and Linux - the existence of `window.event`, which was a key part of our keymap-checking code.

Firefox's keycodes are the same for `K_EQUAL` on all platforms; the issue was that the keymap-check was failing.