### PR TITLE
[Android] Disables correct toggle when predict disabled

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -43,6 +43,8 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
   private static Toolbar toolbar = null;
   private static ListView listView = null;
   private static TextView lexicalModelTextView = null;
+  private static TextView correctionsTextView = null;
+  private static SwitchCompat correctionsToggle = null;
   private ImageButton addButton = null;
   private String associatedLexicalModel = "";
   private String lgCode;
@@ -66,12 +68,25 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
     @Override
     public void onClick(View v) {
-      SwitchCompat correctToggle = (SwitchCompat) v;
+      // For predictions/corrections toggle
+      SwitchCompat toggle = (SwitchCompat) v;
+
+      SharedPreferences.Editor prefEditor = prefs.edit();
+
+      // predictionToggle overrides whether correction toggle and text are enabled
+      if (prefsKey.endsWith(predictionPrefSuffix)) {
+        boolean override = toggle.isChecked();
+        if (correctionsTextView != null) {
+          correctionsTextView.setEnabled(override);
+        }
+        if (correctionsToggle != null) {
+          correctionsToggle.setEnabled(override);
+        }
+      }
 
       // This will allow preemptively making settings for languages without models.
       // Seems more trouble than it's worth to block this.
-      SharedPreferences.Editor prefEditor = prefs.edit();
-      prefEditor.putBoolean(prefsKey, correctToggle.isChecked());
+      prefEditor.putBoolean(prefsKey, toggle.isChecked());
       prefEditor.apply();
 
       // Don't use/apply language modeling settings for languages without models.
@@ -136,21 +151,25 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
     RelativeLayout layout = (RelativeLayout)findViewById(R.id.corrections_toggle);
 
-    textView = (TextView) layout.findViewById(R.id.text1);
-    textView.setText(getString(R.string.enable_corrections));
-    SwitchCompat toggle = layout.findViewById(R.id.toggle);
-    toggle.setChecked(mayCorrect); // Link to persistent option storage!  Also needs handler.
+    correctionsTextView = (TextView) layout.findViewById(R.id.text1);
+    correctionsTextView.setText(getString(R.string.enable_corrections));
+    correctionsToggle = layout.findViewById(R.id.toggle);
+    correctionsToggle.setChecked(mayCorrect); // Link to persistent option storage!  Also needs handler.
     String prefsKey = getLanguageCorrectionPreferenceKey(lgCode);
-    toggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
+    correctionsToggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
 
     layout = (RelativeLayout)findViewById(R.id.predictions_toggle);
 
     textView = (TextView) layout.findViewById(R.id.text1);
     textView.setText(getString(R.string.enable_predictions));
-    toggle = layout.findViewById(R.id.toggle);
-    toggle.setChecked(mayPredict); // Link to persistent option storage!  Also needs handler.
+    SwitchCompat predictionsToggle = layout.findViewById(R.id.toggle);
+    predictionsToggle.setChecked(mayPredict); // Link to persistent option storage!  Also needs handler.
     prefsKey = getLanguagePredictionPreferenceKey(lgCode);
-    toggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
+    predictionsToggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
+
+    // Corrections toggle and text are enabled only when predictions toggle is also enabled
+    correctionsTextView.setEnabled(mayPredict);
+    correctionsToggle.setEnabled(mayPredict);
 
     layout = (RelativeLayout)findViewById(R.id.model_picker);
     textView = (TextView) layout.findViewById(R.id.text1);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -73,15 +73,10 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
       SharedPreferences.Editor prefEditor = prefs.edit();
 
-      // predictionToggle overrides whether correction toggle and text are enabled
+      // predictionsToggle overrides correctionToggle and correctionsTextView
       if (prefsKey.endsWith(predictionPrefSuffix)) {
         boolean override = toggle.isChecked();
-        if (correctionsTextView != null) {
-          correctionsTextView.setEnabled(override);
-        }
-        if (correctionsToggle != null) {
-          correctionsToggle.setEnabled(override);
-        }
+        overrideCorrectionsToggle(override);
       }
 
       // This will allow preemptively making settings for languages without models.
@@ -167,9 +162,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     prefsKey = getLanguagePredictionPreferenceKey(lgCode);
     predictionsToggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
 
-    // Corrections toggle and text are enabled only when predictions toggle is also enabled
-    correctionsTextView.setEnabled(mayPredict);
-    correctionsToggle.setEnabled(mayPredict);
+    overrideCorrectionsToggle(mayPredict);
 
     layout = (RelativeLayout)findViewById(R.id.model_picker);
     textView = (TextView) layout.findViewById(R.id.text1);
@@ -322,6 +315,25 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
   public static String getLanguageCorrectionPreferenceKey(String langID) {
     return langID + correctionPrefSuffix;
+  }
+
+  /**
+   * Overrides the enable and visibility of corrections toggle,
+   * and overrides the enable of the corrections text view.
+   * Does not change the corrections toggle value.
+   * @param override boolean - Value from predictions toggle
+   *     When true, enables corrections toggle and text field, and makes corrections toggle visible
+   *     When false, disables corrections toggle and text field, and makes corrections toggle invisible
+   */
+  private void overrideCorrectionsToggle(boolean override) {
+    if (correctionsTextView != null) {
+      correctionsTextView.setEnabled(override);
+    }
+    if (correctionsToggle != null) {
+      correctionsToggle.setEnabled(override);
+      int visibility = override ? View.VISIBLE : View.INVISIBLE;
+      correctionsToggle.setVisibility(visibility);
+    }
   }
 
   // Fully details the building of this Activity's list view items.

--- a/android/KMEA/app/src/main/res/drawable/textview_item.xml
+++ b/android/KMEA/app/src/main/res/drawable/textview_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@android:color/darker_gray" />
+    <item android:color="@android:color/black"/>
+</selector>

--- a/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
@@ -14,7 +14,7 @@
 
         <TextView
           android:id="@+id/text1"
-          android:textColor="@android:color/black"
+          android:textColor="@drawable/textview_item"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="15dp"

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-23 12.0.4092 beta
+* Disable corrections toggle when predictions are disabled (#2119)
+
 ## 2019-09-20 12.0.4091 beta
 * Update offline help content (#2104)
 


### PR DESCRIPTION
This mirrors the iOS PR #2098 so the user can't toggle corrections when predictions are disabled.

When predictions toggle is set
* Enables corrections toggle (doesn't change the value)
* Makes corrections toggle visible
* Enables corrections text view

When predictions toggle is not set
* Disables corrections toggle (doesn't change the value)
* Hides the corrections toggle
* Disables corrections text view

(screenshots updated from review comments)
**Corrections toggle disabled (because predictions toggle disabled)**
![Screenshot_1569212679](https://user-images.githubusercontent.com/7358010/65401954-8e8f6900-ddf5-11e9-887b-8f8a704a6d96.png)

**Corrections toggle enabled (because predictions toggle enabled)**
![Screenshot_1569209326](https://user-images.githubusercontent.com/7358010/65400639-90552e80-dded-11e9-9a4b-cb54ed318d67.png)
