### PR TITLE
[iOS] Disabled predictions - settings UI enhancement

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -92,7 +92,7 @@ class LanguageSettingsViewController: UITableViewController {
     userDefaults.set(predictSetting: value, forLanguageID: self.language.id)
 
     // Reactively set the corrections switch interactivity state.
-    self.doCorrectionsSwitch?.isEnabled = value
+    self.doCorrectionsSwitch?.isHidden = !value
     self.doCorrectionsLabel?.isEnabled = value
     self.correctionsCell?.isUserInteractionEnabled = value
     
@@ -163,7 +163,7 @@ class LanguageSettingsViewController: UITableViewController {
           }
 
           // Disable interactivity if the prediction toggle is set to 'off'.
-          doCorrectionsSwitch!.isEnabled = userDefaults.predictSettingForLanguage(languageID: self.language.id)
+          doCorrectionsSwitch!.isHidden = !userDefaults.predictSettingForLanguage(languageID: self.language.id)
           cell.isUserInteractionEnabled = userDefaults.predictSettingForLanguage(languageID: self.language.id)
         } else { // rows 3 and 4
           cell.accessoryType = .disclosureIndicator
@@ -229,7 +229,7 @@ class LanguageSettingsViewController: UITableViewController {
         case 1:
           doCorrectionsLabel = cell.textLabel
           cell.textLabel?.text = "Enable corrections"
-          cell.textLabel?.isEnabled = doCorrectionsSwitch?.isEnabled ?? false
+          cell.textLabel?.isEnabled = !(doCorrectionsSwitch?.isHidden ?? false)
         case 2:
           cell.textLabel?.text = "Dictionaries"
           cell.accessoryType = .disclosureIndicator


### PR DESCRIPTION
Mirroring an enhancement in #2119 for Android, this PR's changes hide the "Enable corrections" toggle when manipulating it is not a valid option instead of leaving it disabled but visible.

Predictions enabled:

![Visible toggle](https://user-images.githubusercontent.com/25213402/65402878-5f7bf600-ddfb-11e9-99f7-e237f9ed13ee.png)

Predictions disabled:

![Invisible toggle](https://user-images.githubusercontent.com/25213402/65402889-6d317b80-ddfb-11e9-86d3-012eb698b915.png)
