### PR TITLE
[Developer] Remove legacy 'Install keyboard' link in web test and cleanup look somewhat.

### DIFF
--- a/windows/src/developer/TIKE/web/UmodWebHttpServer.pas
+++ b/windows/src/developer/TIKE/web/UmodWebHttpServer.pas
@@ -260,7 +260,8 @@ begin
       Exit;
     end;
 
-    FDebugger.ProcessRequest(AContext, ARequestInfo, AResponseInfo);
+    if Assigned(FDebugger) then
+      FDebugger.ProcessRequest(AContext, ARequestInfo, AResponseInfo);
   finally
     CoUninitialize;
   end;

--- a/windows/src/developer/TIKE/xml/kmw/index.html
+++ b/windows/src/developer/TIKE/xml/kmw/index.html
@@ -14,14 +14,7 @@
     <title>Keyman Developer Keyboard Test Site</title>
 
     <style type='text/css'>
-      body {
-          padding-left: 10px;
-          margin-left: 12px;
-      }
-
-      h2 {
-          font-family: sans-serif
-      }
+      @import url('test.css');
 
       .test {
         font-size: 1.5em;
@@ -55,12 +48,12 @@
 
       /** Mobile, Tablet **/
 
-      #install-link {
-        font-weight: bold;
-      }
-
       .install-link .ios,
       .install-link .android {
+        display: none;
+      }
+
+      .touch-device #top-toolbar {
         display: none;
       }
 
@@ -161,19 +154,17 @@
   </head>
 
   <body class='osk-always-visible'>
-    <h2>Keyboard Test Host</h2>
+    <div class='header'>
+      <div><h2>Keyboard Test</h2></div>
+      <div class='float-right'><a href='/packages.html' class='install-link' id='install-link-packages'>Install packages</a></div>
+      <div class='clear'></div>
+    </div>
 
-    <div>
+    <div id='content'>
       <!-- The following DIV is only needed as a UI placeholder for the Button and Toolbar User Interfaces -->
       <div id='top-toolbar'>
         <div class='control' id='keymanweb-control-host'>
           <div id='KeymanWebControl'></div>
-        </div>
-        <div class='control' id='controls'>
-          <a href='https://keyman.com/go/developer/10.0/ios-app' target='_blank' class='install-link' id='install-link-ios'>Install Keyman for iOS</a>
-          <a href='https://keyman.com/go/developer/10.0/android-app' target='_blank' class='install-link' id='install-link-android'>Install Keyman for Android</a>
-          <a href='' class='install-link' id='install-link'>Add keyboard to Keyman for <span class='android'>Android</span><span class='ios'>iOS</span></a>
-          <a href='packages.html' class='install-link' id='install-link-packages'>Install packages</a>
         </div>
         <div style='clear:left'></div>
       </div>
@@ -193,13 +184,6 @@
         fonts:'/font/',
         attachType:'auto'
       });
-
-      keyman.addEventListener('keyboardchange',
-        function (p) {
-          //alert(p.internalName);
-          var nm = p.internalName.substr('Keyboard_'.length);
-          document.getElementById('install-link').href='keyman://localhost/open?direct=true&url='+location.protocol+'//'+location.host+'/kbinstall/'+nm+'-'+debugKeyboards[nm].version+'.json';
-        });
 
       var ta1 = document.getElementById('ta1');
       var charGrid = document.getElementById('character-grid');

--- a/windows/src/developer/TIKE/xml/kmw/packages.html
+++ b/windows/src/developer/TIKE/xml/kmw/packages.html
@@ -2,81 +2,51 @@
 <html>
 <head>
   <meta charset='utf-8'>
-  
-  <!-- Set the viewport width to match iOS device widths                         
+
+  <!-- Set the viewport width to match iOS device widths
   <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" />   -->
-  <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+  <meta name="viewport" content="width=device-width,user-scalable=no" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  
+
   <!-- Enable IE9 Standards mode -->
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-    
-  <title>Keyman Developer Keyboard Package Installation Site</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
-  <style type='text/css'>   
-    body {
-        padding-left: 10px;
-        margin-left: 12px;
-    }
+  <title>Keyman Developer Package Installation</title>
 
-    h2 { 
-        font-family: sans-serif 
-    }
+  <style type='text/css'>
+    @import url('test.css');
 
-    .install-link { 
-      background: none repeat scroll 0 0 #CCCCCC;
-      border: 1px solid #444444;
-      border-radius: 4px;
-      box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.25);
-      color: #444444;
-      display: none;
-      font-family: Sans-serif;
-      font-size: 10pt;
-      margin: 0;
-      padding: 6px;
-      margin: 2px;
-      text-decoration: none;
-    }
-    
-    /** Mobile, Tablet **/
-    
-    #install-link {
-      font-weight: bold;
-    }
-    
-    .install-link .ios,
-    .install-link .android {
-      display: none;
-    }
-
-    .touch-device #install-link,
-    .touch-device-ios #install-link-ios,
-    .touch-device-android #install-link-android {
-      display: inline-block;
-    }
-
-    .touch-device-android .install-link .android,
-    .touch-device-ios .install-link .ios {
-      display: inline;
-    }
-  </style> 
+  </style>
 </head>
-  
+
 <body>
-  <h2>Available Packages for Installation</h2>
+  <div class='header'>
+    <div><h2>Install Packages</h2></div>
+    <div class='float-right'><a href='/' class='install-link'>Test keyboards online</a></div>
+    <div class='clear'></div>
+  </div>
 
-  <p>Clicking the package links below will download and install the package into the Keyman app on this device.</p>
-  
-  <ul id='packages'>
-  </ul>
-  
-  <p>You can add more packages to this list by opening the package source in the Package Editor and clicking
-  [Test Online].</p>
+  <div id='content'>
+    <div id='top-toolbar'>
+      <div class='control' id='controls'>
+        <a href='https://keyman.com/go/developer/10.0/ios-app' target='_blank' class='install-link'>Install Keyman for iOS</a>
+        <a href='https://keyman.com/go/developer/10.0/android-app' target='_blank' class='install-link'>Install Keyman for Android</a>
+      </div>
+    </div>
 
+    <p>Clicking the package links below will download and install the package into the Keyman app on this device.</p>
+
+    <ul id='packages'>
+    </ul>
+
+    <p>You can add more packages to this list by opening the package source in the Package Editor and clicking
+    [Test Online].</p>
+
+  </div>
   <!-- The following dynamic script will register each of the additional packages -->
 <script>
   var packages = null, packagesJSON = '';
-  
+
   function ajaxRequest(){
     var activexmodes=["Msxml2.XMLHTTP", "Microsoft.XMLHTTP"] //activeX versions to check for in IE
     if (window.ActiveXObject) { //Test for support for ActiveXObject in IE first (as XMLHttpRequest in IE7 is broken)
@@ -92,7 +62,7 @@
     }
    return false;
   }
-  
+
   function updatePackages(data) {
     var dataJSON = JSON.stringify(data);
     if(packagesJSON !== dataJSON) {
@@ -101,7 +71,7 @@
       if(!data.packages) {
         return false;
       }
-      
+
       var ul = document.getElementById('packages');
       ul.innerHTML = '';
       if(data.packages.length == 0) {
@@ -110,7 +80,7 @@
         ul.appendChild(li);
         return true;
       }
-      
+
       for(var i = 0; i < data.packages.length; i++) {
         var li = document.createElement('li');
         var a = document.createElement('a');
@@ -134,9 +104,9 @@
     req.open("GET", "/inc/packages.json", true);
     req.send(null);
   }
-  
+
   checkPackages();
-  
+
   window.setInterval(checkPackages, 2000);
 </script>
 </body>

--- a/windows/src/developer/TIKE/xml/kmw/test.css
+++ b/windows/src/developer/TIKE/xml/kmw/test.css
@@ -1,0 +1,55 @@
+    html, body {
+      margin: 0;
+      padding: 0;
+    }
+
+    h2 {
+        font-family: sans-serif
+    }
+
+    .install-link {
+      background: none repeat scroll 0 0 #CCCCCC;
+      border: 1px solid #444444;
+      border-radius: 4px;
+      box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.25);
+      display: inline-block;
+      color: #444444;
+      font-family: Sans-serif;
+      font-size: 10pt;
+      padding: 6px;
+      margin: 12px 2px 0 2px;
+      text-decoration: none;
+    }
+
+    .header {
+      padding: 4px 8px;
+      background: #424248;
+      color: #f0f0ff;
+    }
+
+    .header div {
+      display: inline-block;
+    }
+
+    .header div h2 {
+      margin: 4px;
+    }
+
+    .header div.float-right {
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    .float-right a.install-link {
+      margin: 8px 8px 0 0 ;
+    }
+
+    .clear {
+      clear: both;
+    }
+
+    #content {
+      margin: 8px 16px;
+    }


### PR DESCRIPTION
Fixes #1771. New look.

Keyboard test view, mobile mode:

![image](https://user-images.githubusercontent.com/4498365/65456591-f80e8680-de8c-11e9-808b-ad0bdc33c4a5.png)

Keyboard test view, desktop mode:

![image](https://user-images.githubusercontent.com/4498365/65456751-5cc9e100-de8d-11e9-9756-c4f8c858ae5c.png)

Package install view:

![image](https://user-images.githubusercontent.com/4498365/65456445-ad8d0a00-de8c-11e9-9294-e9e8437ac175.png)
