### PR TITLE
[Developer] Set the package version when building kmlmx during Developer build.

### DIFF
--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -16,38 +16,97 @@ build () {
   npm run build || fail "Could not build top-level JavaScript file."
 }
 
+set_version () {
+  local version=$1
+  npm --no-git-tag-version --allow-same-version version "$version" || fail "Could not set package version to $version."
+}
+
 display_usage ( ) {
-  echo "Usage: $0 [-test]"
+  echo "Usage: $0 [-test] [-version version] [-tier tier]"
   echo "       $0 -help"
   echo
   echo "  -help               displays this screen and exits"
   echo "  -test               runs unit tests after building"
+  echo "  -version version    sets the package version before building"
+  echo "  -tier tier          also sets the package version tier (alpha, beta, stable) before building"
+  echo "                      If version has 4 components, only first three are used."
 }
 
 ################################ Main script ################################
 
 run_tests=0
 install_dependencies=1
+publish_version=
+publish_tier=
+lastkey=
 
 # Process command-line arguments
 while [[ $# -gt 0 ]] ; do
   key="$1"
-  case $key in
-    -help|-h)
-      display_usage
-      exit
-      ;;
-    -test)
-      run_tests=1
-      install_dependencies=0
-      ;;
-    *)
-      echo "$0: invalid option: $key"
-      display_usage
-      exit $EX_USAGE
-  esac
+  if [[ -z "$lastkey" ]]; then
+    case $key in
+      -help|-h)
+        display_usage
+        exit
+        ;;
+      -test)
+        run_tests=1
+        install_dependencies=0
+        ;;
+      -version)
+        lastkey=$key
+        ;;
+      -tier)
+        lastkey=$key
+        ;;
+      *)
+        echo "$0: invalid option: $key"
+        display_usage
+        exit $EX_USAGE
+    esac
+  else
+    case $lastkey in
+      -version)
+        publish_version=$key
+        ;;
+      -tier)
+        publish_tier=$key
+        ;;
+      *)
+        # Should be impossible to reach ;-)
+        echo "$0: invalid option: $lastkey"
+        display_usage
+        exit $EX_USAGE
+    esac
+    lastkey=
+  fi
   shift # past the processed argument
 done
+
+# Validate the publish_version
+if [ ! -z "$publish_version" ]; then
+  # Remove final component if more than 3 components passed
+  publish_version=` echo "$publish_version" | cut -d "." -f1,2,3 -`
+  [[ $publish_version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || fail "-version must be dotted numeric string, e.g. 1.2.3."
+fi
+
+if [ ! -z "$publish_tier" ]; then
+  [ -z "$publish_version" ] && fail "-tier cannot be specified without -version"
+  case "$publish_tier" in
+    alpha)
+      publish_tier=-alpha
+      ;;
+    beta)
+      publish_tier=-beta
+      ;;
+    stable)
+      publish_tier=
+      ;;
+    *)
+      fail "-tier must be one of alpha, beta or stable"
+  esac
+  publish_version=$publish_version$publish_tier
+fi
 
 # Check if Node.JS/npm is installed.
 type npm >/dev/null ||\
@@ -55,6 +114,10 @@ type npm >/dev/null ||\
 
 if (( install_dependencies )) ; then
   npm install || fail "Could not download dependencies."
+fi
+
+if [ ! -z "$publish_version" ]; then
+  set_version "$publish_version" || fail "Setting version failed."
 fi
 
 build || fail "Compilation failed."

--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -18,6 +18,11 @@ build () {
 
 set_version () {
   local version=$1
+  # We use --no-git-tag-version because our CI system controls version numbering and
+  # already tags releases. We also want to have the version of this match the
+  # release of Keyman Developer -- these two versions should be in sync. Because this
+  # is a large repo with multiple projects and build systems, it's better for us that
+  # individual build systems don't take too much ownership of git tagging. :)
   npm --no-git-tag-version --allow-same-version version "$version" || fail "Could not set package version to $version."
 }
 
@@ -100,6 +105,7 @@ if [ ! -z "$publish_tier" ]; then
       publish_tier=-beta
       ;;
     stable)
+      # Stable releases intentionally have a blank publish tier:
       publish_tier=
       ;;
     *)

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -59,6 +59,11 @@ heat-model-compiler:
     # Build kmlmc
     cd $(KEYMAN_MODELCOMPILER_ROOT)
 
+!ifndef TIER
+    # In dev environments, we'll hack the tier to stable; CI sets this for us.
+    TIER=alpha
+!endif
+
 !ifdef GIT_BASH_FOR_KEYMAN
     $(GIT_BASH_FOR_KEYMAN) build.sh -version "$(VERSION)" -tier "$(TIER)"
 !else

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -19,24 +19,24 @@ test-releaseexists:
     if exist $(ROOT)\release\$VERSION\keymandeveloper*.msi echo. & echo Release $VERSION already exists. Delete it or update src\version.txt and try again & exit 1
 
 candle: heat-cef heat-xml heat-templates heat-model-compiler
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE kmdev.wxs 
+    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE kmdev.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dXmlSourceDir=$(ROOT)\src\developer\TIKE\xml xml.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dTemplatesSourceDir=$(KEYMAN_DEVELOPER_TEMPLATES_ROOT) templates.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dModelCompilerSourceDir=$(KEYMAN_MODELCOMPILER_ROOT) kmlmc.wxs
-    
+
 heat-xml:
     # We copy the files to a temp folder in order to exclude thumbs.db, .vs, etc from harvesting
     -rmdir /s/q $(KEYMAN_WIX_TEMP_XML)
     mkdir $(KEYMAN_WIX_TEMP_XML)
     xcopy $(ROOT)\src\developer\TIKE\xml\* $(KEYMAN_WIX_TEMP_XML)\ /s
     -del /f /s /q $(KEYMAN_WIX_TEMP_XML)\Thumbs.db
-    -rmdir /s/q $(KEYMAN_WIX_TEMP_XML)\app\node_modules 
+    -rmdir /s/q $(KEYMAN_WIX_TEMP_XML)\app\node_modules
     -for /f %i in ('dir /a:d /s /b $(KEYMAN_WIX_TEMP_XML)\.vs') do rd /s /q %i
     $(WIXHEAT) dir $(KEYMAN_WIX_TEMP_XML) -o xml.wxs -ag -cg XML -dr INSTALLDIR -var var.XmlSourceDir -wx -nologo
     # When we candle/light build, we can grab the source files from the proper root so go ahead and delete the temp folder again
     -rmdir /s/q $(KEYMAN_WIX_TEMP_XML)
-    
+
 heat-templates:
     # We copy the files to a temp folder in order to exclude .git and README.md from harvesting
     -rmdir /s/q $(KEYMAN_WIX_TEMP_TEMPLATES)
@@ -60,10 +60,10 @@ heat-model-compiler:
     cd $(KEYMAN_MODELCOMPILER_ROOT)
 
 !ifdef GIT_BASH_FOR_KEYMAN
-    $(GIT_BASH_FOR_KEYMAN) build.sh
+    $(GIT_BASH_FOR_KEYMAN) build.sh -version "$(VERSION)" -tier "$(TIER)"
 !else
-    start /wait .\build.sh
-!endif    
+    start /wait .\build.sh -version "$(VERSION)" -tier "$(TIER)"
+!endif
     # While we could use npm-bundle or similar, this gives us more control on the set of
     # files  we want to distribute with the Keyman Developer installer. For users on other
     # operating systems, node.js is a dependency and the compiler can be installed with
@@ -73,7 +73,7 @@ heat-model-compiler:
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)
     mkdir $(KEYMAN_WIX_TEMP_MODELCOMPILER)
     xcopy $(KEYMAN_MODELCOMPILER_ROOT)\* $(KEYMAN_WIX_TEMP_MODELCOMPILER)\ /s
-    
+
     # Remove files we don't want to harvest; build a product node_modules folder
     cd $(KEYMAN_WIX_TEMP_MODELCOMPILER)
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\node_modules
@@ -82,10 +82,10 @@ heat-model-compiler:
     # We don't need source for the compiler or the unit tests
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\source
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\tests
-    
+
     # We don't need another binary copy of node
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\node_modules\node
-    
+
     # We don't need the build script
     -del $(KEYMAN_WIX_TEMP_MODELCOMPILER)\build.sh
 

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -1,5 +1,10 @@
 !include ..\..\Defines.mak
 
+!ifndef TIER
+    # In dev environments, we'll hack the tier to stable; CI sets this for us.
+TIER=alpha
+!endif
+
 # We use different directories so that heat generates
 # different identifiers for the various folders
 KEYMAN_WIX_TEMP_XML=$(TEMP)\keyman_wix_build\xml
@@ -58,11 +63,6 @@ heat-cef:
 heat-model-compiler:
     # Build kmlmc
     cd $(KEYMAN_MODELCOMPILER_ROOT)
-
-!ifndef TIER
-    # In dev environments, we'll hack the tier to stable; CI sets this for us.
-    TIER=alpha
-!endif
 
 !ifdef GIT_BASH_FOR_KEYMAN
     $(GIT_BASH_FOR_KEYMAN) build.sh -version "$(VERSION)" -tier "$(TIER)"

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -1,7 +1,12 @@
 !include ..\..\Defines.mak
 
+##
+## In this file, $VERSION and $RELEASE will be replaced by mkver. These are not
+## Make variables, but mkver variables.
+##
+
+# In dev environments, we'll hack the tier to alpha; CI sets this for us in real builds.
 !ifndef TIER
-    # In dev environments, we'll hack the tier to stable; CI sets this for us.
 TIER=alpha
 !endif
 
@@ -65,12 +70,12 @@ heat-model-compiler:
     cd $(KEYMAN_MODELCOMPILER_ROOT)
 
 !ifdef GIT_BASH_FOR_KEYMAN
-    $(GIT_BASH_FOR_KEYMAN) build.sh -version "$(VERSION)" -tier "$(TIER)"
+    $(GIT_BASH_FOR_KEYMAN) build.sh -version "$VERSION" -tier "$(TIER)"
 !else
-    start /wait .\build.sh -version "$(VERSION)" -tier "$(TIER)"
+    start /wait .\build.sh -version "$VERSION" -tier "$(TIER)"
 !endif
     # While we could use npm-bundle or similar, this gives us more control on the set of
-    # files  we want to distribute with the Keyman Developer installer. For users on other
+    # files we want to distribute with the Keyman Developer installer. For users on other
     # operating systems, node.js is a dependency and the compiler can be installed with
     # `npm install @keymanapp/lexical-model-compiler`.
 


### PR DESCRIPTION
Fixes #2124.

Took the design decision to append -tier to the version number for npm packages. Happy to be corrected.

Windows version numbers have 4 components; the script will trim any more than 3 components as we only use the first three anyway.