### PR TITLE
[Android] Fix two crashes reported in Crashyltics

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
@@ -286,15 +286,11 @@ public final class KMTextView extends AppCompatEditText {
   }
 
   public void dismissKeyboard() {
-    AppCompatActivity activity;
-    if (context instanceof ContextThemeWrapper) {
-      activity = (AppCompatActivity)(((ContextThemeWrapper)context).getBaseContext());
-    } else {
-      activity = (AppCompatActivity)context;
-    }
+    AppCompatActivity activity = (AppCompatActivity) context;
 
     Window mainWindow = activity.getWindow();
     FrameLayout mainLayout = (FrameLayout) mainWindow.getDecorView().findViewById(android.R.id.content);
+
     //mainWindow.clearFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
     ((InputMethodManager) activity.getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE)).hideSoftInputFromWindow(mainLayout.getWindowToken(), 0);
     //keyboardLayout.setAnimation(AnimationUtils.loadAnimation(context, R.anim.slide_out));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -302,7 +302,8 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
 
   private static void switchKeyboard(int position) {
     setSelection(position);
-    HashMap<String, String> kbInfo = keyboardsList.get(position);
+    int listPosition = (position >= keyboardsList.size()) ? keyboardsList.size()-1 : position;
+    HashMap<String, String> kbInfo = keyboardsList.get(listPosition);
     String pkgId = kbInfo.get(KMManager.KMKey_PackageID);
     if (pkgId == null || pkgId.isEmpty()) {
       pkgId = KMManager.KMDefault_UndefinedPackageID;

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,13 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-09-26 12.0.4094 beta
+* Bug Fix:
+  * Fix crashes involving dismissing keyboard and selecting the last keyboard (#2135)
+
+## 2019-09-26 12.0.4093 beta
+* No change to Keyman for Android (updated Keyman Web Engine, #2126)
+
 ## 2019-09-23 12.0.4092 beta
 * Disable corrections toggle when predictions are disabled (#2119)
 


### PR DESCRIPTION
1. Fixes crashlytics issue in KMTextView of a [ClassCastException](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/5c48b419f8b88c2963468341?time=last-seven-days&sessionId=5D8A6E990027000120BCBEDF388131A9_DNE_0_v2) being thrown.

This follows the pattern of getting `AppCompatActivity` from the context as done in `showKeyboard()` l. 260

```
  private void showKeyboard() {
    AppCompatActivity activity = (AppCompatActivity)context;
    Window mainWindow = activity.getWindow();
```

2. Fixes out of bounds [crash](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/164399637b92bc6efe61f84f7fc2523c?time=last-seven-days&sessionId=5D88C9C303BA000134F638CB49122030_DNE_0_v2) in KMKeyboardPickerActivity.
There's two lists: listView and keyboardsList