### PR TITLE
[Android] Improves keyboard swap stability

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -207,7 +207,9 @@ final class KMKeyboard extends WebView {
     if((keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP && KMManager.InAppKeyboardLoaded) ||
       (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && KMManager.SystemKeyboardLoaded)) {
 
-      if(this.javascriptAfterLoad.size() == 1)
+      // If !this.keyboardSet, then pageLoaded hasn't fired yet.
+      // When pageLoaded fires, it'll call `callJavascriptAfterLoad` safely.
+      if(this.javascriptAfterLoad.size() == 1 && this.keyboardSet)
         callJavascriptAfterLoad();
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -190,6 +190,7 @@ final class KMKeyboard extends WebView {
 
   public void loadKeyboard() {
     keyboardSet = false;
+    this.javascriptAfterLoad.clear();
 
     if(keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP)
       KMManager.InAppKeyboardLoaded = false;
@@ -209,7 +210,7 @@ final class KMKeyboard extends WebView {
 
       // If !this.keyboardSet, then pageLoaded hasn't fired yet.
       // When pageLoaded fires, it'll call `callJavascriptAfterLoad` safely.
-      if(this.javascriptAfterLoad.size() == 1 && this.keyboardSet)
+      if(this.javascriptAfterLoad.size() == 1 && keyboardSet)
         callJavascriptAfterLoad();
     }
   }
@@ -223,8 +224,11 @@ final class KMKeyboard extends WebView {
           if(javascriptAfterLoad.size() > 0) {
             loadUrl("javascript:" + javascriptAfterLoad.get(0));
             javascriptAfterLoad.remove(0);
-            if (javascriptAfterLoad.size() > 0) {
-              callJavascriptAfterLoad();
+            // Make sure we didn't reset the page in the middle of the queue!
+            if(keyboardSet) {
+              if (javascriptAfterLoad.size() > 0) {
+                callJavascriptAfterLoad();
+              }
             }
           }
         }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -600,7 +600,7 @@ namespace com.keyman.osk {
         if(activeKeyboard) {
           kbdDevVersion = new utils.Version(activeKeyboard['KVER']);
         } else {
-          kbdDevVersion = utils.Version.CURRENT;
+          kbdDevVersion = new utils.Version(keyman['version']);
         }
         layout=Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, formFactor);
       }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -592,7 +592,16 @@ namespace com.keyman.osk {
 
       // Build a layout using the default for the device
       if(typeof layout != 'object' || layout == null) {
-        let kbdDevVersion = new utils.Version(activeKeyboard['KVER']);
+        var kbdDevVersion: utils.Version;
+
+        // This CAN be called with no backing keyboard; KMW will try to force-show
+        // the OSK even without a backing keyboard on mobile, using the default
+        // layout as the OSK's base.
+        if(activeKeyboard) {
+          kbdDevVersion = new utils.Version(activeKeyboard['KVER']);
+        } else {
+          kbdDevVersion = utils.Version.CURRENT;
+        }
         layout=Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, formFactor);
       }
 

--- a/web/source/utils/version.ts
+++ b/web/source/utils/version.ts
@@ -9,9 +9,6 @@ namespace com.keyman.utils {
     // as it results in unexpected, bug-like behavior for keyboard designers when it is unwanted.
     public static readonly NO_DEFAULT_KEYCAPS = new Version([12, 0]);
 
-    // Corresponds to the most recent known version of KMW and Keyman Developer.
-    public static readonly CURRENT = new Version([12, 0]);
-
     private readonly components: number[]
 
     /**

--- a/web/source/utils/version.ts
+++ b/web/source/utils/version.ts
@@ -9,6 +9,9 @@ namespace com.keyman.utils {
     // as it results in unexpected, bug-like behavior for keyboard designers when it is unwanted.
     public static readonly NO_DEFAULT_KEYCAPS = new Version([12, 0]);
 
+    // Corresponds to the most recent known version of KMW and Keyman Developer.
+    public static readonly CURRENT = new Version([12, 0]);
+
     private readonly components: number[]
 
     /**


### PR DESCRIPTION
This handles two things:

1. It's possible to instantiate a `VisualKeyboard` instance without an `activeKeyboard`.  KMW is currently set to provide a default interactive OSK on mobile devices when no keyboards are available, since something must be available to interact with the touch-alias elements.  The KMW edits handle this case.

2. The `loadJavascript` function doesn't wait for the page to actually load before executing the first JS command after page load, as the `.javascriptAfterLoad` array does not include the `loadURL` call that resets the page.  Fortunately, the `pageLoaded` event handler already calls `callJavascriptAfterLoad`, so we can simply condition on `this.keyboardSet`, which is set at the end of that handler.  