### PR TITLE
[Android] Guard against condition when `language.keyboards` entries don't exist

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -117,8 +117,7 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
           int offsetY = (v == null) ? 0 : v.getTop();
           i.putExtra("offsetY", offsetY);
           startActivityForResult(i, 1);
-        } else {
-          // language.keyboards.size() == 1
+        } else if (language.keyboards.size() == 1) {
           Keyboard kbd = language.keyboards.iterator().next();
           String kbName = kbd.map.get(KMManager.KMKey_KeyboardName);
 
@@ -148,6 +147,10 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
             i.putExtras(bundle);
             startActivity(i);
           }
+        } else {
+          // language.keyboards.size() == 0
+          // No language.keyboards entries exist because of previous failure in downloading keyboard catalog
+          Toast.makeText(context, "One or more resources failed to update!", Toast.LENGTH_SHORT).show();
         }
       }
     });

--- a/android/history.md
+++ b/android/history.md
@@ -4,8 +4,10 @@
 * Start version 13.0
 
 ## 2019-09-26 12.0.4094 beta
-* Bug Fix:
+* Bug Fixes:
+  * Fix crash when Language picker doesn't contain keyboard catalog info (#2138)
   * Fix crashes involving dismissing keyboard and selecting the last keyboard (#2135)
+  * Improve keyboard swap stability (#2136)
 
 ## 2019-09-26 12.0.4093 beta
 * No change to Keyman for Android (updated Keyman Web Engine, #2126)


### PR DESCRIPTION
This fixes the numerous crashes reported in Crashlytics in [LanguageListActivity](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/1f8ec181433fccb0f7f135f5737d53e2?time=last-seven-days&sessionId=5D8BBF2303090001482B99A421C3910B_DNE_0_v2)

where the user attempts to download a keyboard, but the catalog info doesn't exist.

Steps to replicate scenario:
1. Clean install of app
2. Close the "Get Started" page and let the in-app load the English model
3. Re-open "Get Started" and click "Add a keyboard for your language"
4. Cancel the dialog 
![Screenshot_1569467864](https://user-images.githubusercontent.com/7358010/65655934-2a181800-e048-11e9-909f-d7ff63e4efc9.png)
5. The resulting Language screen has default English keyboard entries, but no catalog info backing it.
![Screenshot_1569467789](https://user-images.githubusercontent.com/7358010/65655950-3ef4ab80-e048-11e9-9f4a-983f6c8c4e8e.png)
6. Now, attempting to click on them gives a notification at the bottom 
![Screenshot_1569468508](https://user-images.githubusercontent.com/7358010/65655998-69deff80-e048-11e9-9aaa-912afba8690c.png)


