### PR TITLE
[Developer] Context help screen was not showing on startup in 12.0.39 (regression).

### DIFF
--- a/windows/src/developer/TIKE/main/UfrmHelp.pas
+++ b/windows/src/developer/TIKE/main/UfrmHelp.pas
@@ -22,7 +22,6 @@ type
     procedure actHelpContextRefreshUpdate(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
-    procedure FormShow(Sender: TObject);
   private
     FRefreshQueued: Boolean;
     FHelpControl: TWinControl;
@@ -39,6 +38,7 @@ type
     procedure cefBeforeBrowseSync(Sender: TObject; const Url: string; out Handled: Boolean);
   protected
     function GetHelpTopic: string; override;
+    procedure FormShown; override;
   public
     procedure LoadHelp(ControlName, FormName: string);
     procedure QueueRefresh;
@@ -201,7 +201,7 @@ begin
   FreeAndNil(FTempFile);
 end;
 
-procedure TfrmHelp.FormShow(Sender: TObject);
+procedure TfrmHelp.FormShown;
 begin
   inherited;
   cef := TframeCEFHost.Create(Self);

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,10 +3,13 @@
 ## 13.0 alpha
 * Start version 13.0
 
-## 2019-9-27 12.0.39 beta
-* General: Introduces a Welcome screen and improves workflow for starting use of Keyman Developer (#2134)
-* General: Fix version numbers for kmlmc, kmlmp and kmlmi (#2129)
-* General: .js files now open in Keyman Developer for editing (#2140)
+## 2019-09-29 12.0.40 beta
+* General: Context help was not showing correctly on startup. (#2145)
+
+## 2019-09-27 12.0.39 beta
+* General: Introduces a Welcome screen and improves workflow for starting use of Keyman Developer. (#2134)
+* General: Fix version numbers for kmlmc, kmlmp and kmlmi. (#2129)
+* General: .js files now open in Keyman Developer for editing. (#2140)
 
 ## 2019-09-25 12.0.37 beta
 * Compiler: Add -lexical-model command line option for building lexical model template projects to kmconvert. (#2120)


### PR DESCRIPTION
Fixes #2144.

This arose because around the removal of the splash screen which changed the timing of the display of the help. Moving the instantiation of the web control to FormShown avoids the window being recreated and other side-effects.