### PR TITLE
[Windows] If Keyman Desktop 11 and Keyman Developer 12 are installed together, Keyman Desktop will crash on startup.

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-07-30 12.0.41 beta
+* General: Keyman Desktop 11 would crash if installed together with Keyman Developer 12. (#2148)
+
 ## 2019-09-29 12.0.40 beta
 * General: Context help was not showing correctly on startup. (#2145)
 

--- a/windows/src/engine/keyman/UfrmKeymanMenu.pas
+++ b/windows/src/engine/keyman/UfrmKeymanMenu.pas
@@ -515,9 +515,13 @@ begin
 end;
 
 procedure TfrmKeymanMenu.TntFormCreate(Sender: TObject);
+var
+  FImagePath: string;
 begin
   SetWindowLong(Handle, GWL_EXSTYLE, GetWindowLong(Handle, GWL_EXSTYLE) or WS_EX_LAYERED);
-  imgTitle.Picture.LoadFromFile(TKeymanPaths.KeymanDesktopInstallPath(TKeymanPaths.S_KeymanMenuTitleImage));
+  FImagePath := TKeymanPaths.KeymanDesktopInstallPath(TKeymanPaths.S_KeymanMenuTitleImage);
+  if FileExists(FImagePath) then
+    imgTitle.Picture.LoadFromFile(TKeymanPaths.KeymanDesktopInstallPath(TKeymanPaths.S_KeymanMenuTitleImage));
   imgTitle.AutoSize := True;
   //SetLayeredWindowAttributes(Handle, 0, 255, LWA_ALPHA);
   //UpdateLayeredWindow(Handle, 0, nil, nil, 0,


### PR DESCRIPTION
Fixes #2146.

This fixes a crash scenario for what is technically an unsupported configuration -- running different versions of Desktop and Developer. It's unsupported because they both use the same engine and we do not currently have a way to have multiple versions of the engine installed, so there may be api conflicts.

In this case, the problem was that a new file, menutitle.png, was expected by Keyman Engine 12, but was missing for Keyman Desktop. The mitigation is to only load the file if it exists, which leaves a blank bar in the Keyman menu, which is an acceptable compromise.

Long term, this issue will be resolved in a more elegant way as Keyman Developer will not use Keyman Engine directly (used only for debugging keyboards) as it will instead embed Keyman Core for debugging.