### PR TITLE
[Windows] Change destruction order for Keyman to avoid error reloading.

### DIFF
--- a/windows/src/engine/keyman/main.pas
+++ b/windows/src/engine/keyman/main.pas
@@ -115,6 +115,9 @@ begin
           Application.CreateForm(TfrmKeyman7Main, frmKeyman7Main);
           if not Application.Terminated then
             Application.Run;
+
+          FreeAndNil(frmKeyman7Main);
+
           Finished := True;
         finally
           if hMutex <> 0 then CloseHandle(hMutex);

--- a/windows/src/engine/kmcomapi/util/keymanautoobject.pas
+++ b/windows/src/engine/kmcomapi/util/keymanautoobject.pas
@@ -168,10 +168,10 @@ end;
 function TKeymanAutoObject.SafeCallException(ExceptObject: TObject;
   ExceptAddr: Pointer): HResult;
 begin
-{$IFDEF KLOG}
+{.$IFDEF KLOG}
   if (ExceptObject is Exception) then //and not (ExceptObject is EOleException) { for some reason, we lose the class name EKeyman? } then
     LogException(ClassName, ExceptObject as Exception, ExceptAddr);
-{$ENDIF}
+{.$ENDIF}
   Result := inherited SafeCallException(ExceptObject, ExceptAddr);
 end;
 


### PR DESCRIPTION
Fixes #2147.

This may fix #2147. Despite having many reports, I have never been able to reproduce this on my computer. It appears to be related to destruction order because it looks like during Keyman shutdown, Keyman is trying to load keyman32.dll. That in itself is strange; in my debugging keyman32.dll is always already loaded at this point in the shutdown process.

Notes:
* It's not an upgrade scenario because it occurs on latest release versions of Keyman.
* It occurs across 10.0, 11.0 and 12.0
* The error is buried somewhere in C++ code called from the COM layer, which means our diagnostic call stacks don't show the detail we need.
* I'm enabling reporting of call stacks for kmcomapi. That may help trace the issue with additional .errlog files included in the attached .tsi, even if it doesn't necessarily get us the detail of the C++ issue yet.