### PR TITLE
[LMLayer] Fix linking step

### DIFF
--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -10,7 +10,7 @@ set -eu
 # Include some helper functions from resources
 . ../../resources/shellHelperFunctions.sh
 
-# Exit status on invalid usage. 
+# Exit status on invalid usage.
 EX_USAGE=64
 
 LMLAYER_OUTPUT=build

--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -10,6 +10,9 @@ set -eu
 # Include some helper functions from resources
 . ../../resources/shellHelperFunctions.sh
 
+# Exit status on invalid usage. 
+EX_USAGE=64
+
 LMLAYER_OUTPUT=build
 WORKER_OUTPUT=build/intermediate
 INCLUDES_OUTPUT=build/includes
@@ -21,9 +24,6 @@ LEXICAL_MODELS_TYPES=../lexical-model-types
 
 # Build the worker and the main script.
 build ( ) {
-  # Ensure that the local npm package we need can be require()'d.
-  (cd $LEXICAL_MODELS_TYPES && npm link .) || fail "Could not link lexical-model-types"
-
   # Ensure that the build-product destination for any generated include .d.ts files exists.
   if ! [ -d $INCLUDES_OUTPUT ]; then
     mkdir -p "$INCLUDES_OUTPUT"
@@ -71,7 +71,7 @@ clean ( ) {
   if [ -d $WORKER_OUTPUT ]; then
     rm -rf "$WORKER_OUTPUT" || fail "Failed to erase the prior build."
   fi
-  
+
   if [ -d $LMLAYER_OUTPUT ]; then
     rm -rf "$LMLAYER_OUTPUT" || fail "Failed to erase the prior build."
   fi
@@ -135,7 +135,7 @@ while [[ $# -gt 0 ]] ; do
     *)
       echo "$0: invalid option: $key"
       display_usage
-      exit -1
+      exit $EX_USAGE
   esac
   shift # past the processed argument
 done
@@ -145,6 +145,9 @@ type npm >/dev/null ||\
     fail "Build environment setup error detected!  Please ensure Node.js is installed!"
 
 if (( fetch_deps )); then
+  # Before installing, ensure that the local npm package we need can be require()'d.
+  (cd $LEXICAL_MODELS_TYPES && npm link .) || fail "Could not link lexical-model-types"
+
   echo "Dependencies check"
   npm install --no-optional
 fi

--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -16,9 +16,6 @@ LEXICAL_MODELS_TYPES=../../common/lexical-model-types
 
 # Build the main script.
 build () {
-  # Ensure that the local npm package can be require()'d.
-  (cd $LEXICAL_MODELS_TYPES && npm link .) || fail "Could not link lexical-model-types"
-
   npm run build || fail "Could not build top-level JavaScript file."
 }
 
@@ -128,6 +125,9 @@ type npm >/dev/null ||\
     fail "Build environment setup error detected!  Please ensure Node.js is installed!"
 
 if (( install_dependencies )) ; then
+  # Ensure that the local npm package can be require()'d.
+  (cd $LEXICAL_MODELS_TYPES && npm link .) || fail "Could not link lexical-model-types"
+
   npm install || fail "Could not download dependencies."
 fi
 

--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -26,6 +26,7 @@ display_usage ( ) {
   echo "  -help               displays this screen and exits"
   echo "  -version version    sets the package version before building"
   echo "  -test               runs unit tests after building"
+  echo "  -tdd                runs unit tests WITHOUT building"
   echo "  -publish-to-npm     publishes the current version to the npm package index"
   echo "  -tier tier          also sets the package version tier and npm tag (alpha, beta, stable) before building or publishing"
   echo "                      If version has 4 components, only first three are used."
@@ -51,6 +52,10 @@ while [[ $# -gt 0 ]] ; do
         exit
         ;;
       -test)
+        run_tests=1
+        install_dependencies=1
+        ;;
+      -tdd)
         run_tests=1
         install_dependencies=0
         ;;

--- a/windows/src/test/unit-tests/Makefile
+++ b/windows/src/test/unit-tests/Makefile
@@ -6,9 +6,9 @@
 
 TARGETS=group-helper-rsp19902 kmcomp shared-data lexical-model-compiler
 
-test: 
+test:
     $(MAKE) -DTARGET=test $(TARGETS)
-    
+
 !include ..\..\Header.mak
 
 # ----------------------------------------------------------------------
@@ -20,21 +20,25 @@ group-helper-rsp19902:
 kmcomp:
     cd $(ROOT)\src\test\unit-tests\kmcomp
     $(MAKE) $(TARGET)
-    
+
 shared-data:
     cd $(ROOT)\src\test\unit-tests\shared-data
     $(MAKE) $(TARGET)
 
 lexical-model-compiler:
     cd $(KEYMAN_ROOT)\developer\js
-    npm install
-    npm run build
-    npm test
+
+!ifdef GIT_BASH_FOR_KEYMAN
+    $(GIT_BASH_FOR_KEYMAN) build.sh -test
+!else
+    start /wait ./build.sh -test
+!endif
+
 
 # ----------------------------------------------------------------------
 
 !include ..\..\Target.mak
-    
+
 # ----------------------------------------------------------------------
 # EOF
 # ----------------------------------------------------------------------


### PR DESCRIPTION
The `npm link` command must run directly before `npm install` to succeed. This PR moves this step from the `build` phase to the `install` phase, to prevent build failures.