### PR TITLE
[iOS] KMEI:  Reinstates pre-refactor API endpoints w helpers

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -60,7 +60,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     return Storage.active.userDefaults.userKeyboards?.count ?? 0
   }
 
-  private var expandedHeight: CGFloat {
+  var expandedHeight: CGFloat {
     return keymanWeb.keyboardHeight + activeTopBarHeight
   }
   

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -963,4 +963,64 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     shouldReloadKeyboard = true
     inputViewController.reload()
   }
+
+  /*-----------------------------
+   *    Legacy API endpoints    -
+   *-----------------------------
+   *
+   * Some functionality has been refactored into separate classes for 12.0.
+   * No reason we can't add a couple of helper functions to help forward
+   * the data for apps built on older versions of KMEI, though.
+   */
+
+  public func downloadKeyboard(from url: URL) {
+    ResourceDownloadManager.shared.downloadKeyboard(from: url)
+  }
+
+  public func downloadKeyboard(withID: String, languageID: String, isUpdate: Bool, fetchRepositoryIfNeeded: Bool = true) {
+    ResourceDownloadManager.shared.downloadKeyboard(withID: withID,
+                                                    languageID: languageID,
+                                                    isUpdate: isUpdate,
+                                                    fetchRepositoryIfNeeded: fetchRepositoryIfNeeded)
+  }
+
+  // A new API, but it so closely parallels downloadKeyboard that we should add a 'helper' handler here.
+  public func downloadLexicalModel(from url: URL) {
+    ResourceDownloadManager.shared.downloadLexicalModel(from: url)
+  }
+
+  // A new API, but it so closely parallels downloadKeyboard that we should add a 'helper' handler here.
+  public func downloadLexicalModel(withID: String, languageID: String, isUpdate: Bool, fetchRepositoryIfNeeded: Bool = true) {
+    ResourceDownloadManager.shared.downloadLexicalModel(withID: withID,
+                                                        languageID: languageID,
+                                                        isUpdate: isUpdate,
+                                                        fetchRepositoryIfNeeded: fetchRepositoryIfNeeded)
+  }
+
+  public func stateForKeyboard(withID keyboardID: String) -> KeyboardState {
+    return ResourceDownloadManager.shared.stateForKeyboard(withID: keyboardID)
+  }
+
+  // Technically new, but it does closely parallel an old API point.
+  public func stateForLexicalModel(withID modelID: String) -> KeyboardState {
+    return ResourceDownloadManager.shared.stateForLexicalModel(withID: modelID)
+  }
+
+  public func parseKMP(_ folder: URL, type: LanguageResourceType = .keyboard) throws -> Void {
+    switch type {
+      case .keyboard:
+        try! parseKbdKMP(folder)
+        break
+      case .lexicalModel:
+        // Yep.  Unlike the original, THIS one is static.
+        try! Manager.parseLMKMP(folder)
+        break
+    }
+  }
+
+  // To re-implement the old API (missing from v11!) we need to pick one version of height.
+  // For library users, the total height of the InputViewController should be most useful.
+  public func keyboardHeight() -> CGFloat {
+    return inputViewController?.expandedHeight ?? 0
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public enum LanguageResourceType {
+  case keyboard, lexicalModel
+}
+
 public protocol LanguageResource {
   var id: String { get }
   var languageID: String { get }


### PR DESCRIPTION
While working on https://github.com/keymanapp/help.keyman.com/pull/58, we became aware that a few published API endpoints were missing due to refactoring in v11 and the work toward v12.  This PR recreates those originally-published endpoints as closely as possible, along with a few closely-paralleling new endpoints for lexical models.

In the long term, we'll want a more complete API overhaul, but that's been placed further down the line on our road map.