### PR TITLE
[Android] Add wrappers to missing API methods

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -53,6 +53,7 @@ import android.widget.RelativeLayout;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.tavultesoft.kmea.KMKeyboardJSHandler;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
+import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.packages.JSONUtils;
@@ -198,6 +199,10 @@ public final class KMManager {
 
   public static String getCloudDir() {
     return getResourceRoot() + KMDefault_UndefinedPackageID + File.separator;
+  }
+
+  public static String getVersion() {
+    return com.tavultesoft.kmea.BuildConfig.VERSION_NAME;
   }
 
   // Check if a keyboard namespace is reserved
@@ -1046,9 +1051,17 @@ public final class KMManager {
     return kbFileVersion;
   }
 
+  public static void addKeyboardDownloadEventListener(OnKeyboardDownloadEventListener listener) {
+    KMKeyboardDownloaderActivity.addKeyboardDownloadEventListener(listener);
+  }
+
   public static void addKeyboardEventListener(OnKeyboardEventListener listener) {
     KMTextView.addOnKeyboardEventListener(listener);
     KMKeyboard.addOnKeyboardEventListener(listener);
+  }
+
+  public static void removeKeyboardDownloadEventListener(OnKeyboardDownloadEventListener listener) {
+    KMKeyboardDownloaderActivity.removeKeyboardDownloadEventListener(listener);
   }
 
   public static void removeKeyboardEventListener(OnKeyboardEventListener listener) {

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-10-04 12.0.4096 beta
+* Bug Fix:
+  * Add wrappers for missing API methods (#2167)
+
 ## 2019-10-01 12.0.4095 beta
 * Splits help into multiple pages for better usability (#2139)
 


### PR DESCRIPTION
Fixes #2166 by adding wrappers to missing API methods:
* addKeyboardDownloadEventListener
* getVersion
* removeKeyboardDownloadEventListener

Ignoring `setKeymanLicense`. (Shouldn't it be deprecated?)