### PR TITLE
[Web] Updates notifyKeyboard and uses of KNS

### DIFF
--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -220,7 +220,7 @@ namespace com.keyman {
       
       var isActivating = this.keyman.uiManager.isActivating;
       if(!isActivating) {
-        this.keyman.keyboardManager.notifyKeyboard(0, Ltarg, 0);  // I2187
+        this.keyman['interface'].notifyKeyboard(0, Ltarg, 0);  // I2187
       }
 
       //e = this.keyman._GetEventObject<FocusEvent>(e);   // I2404 - Manage IE events in IFRAMEs  //TODO: is this really needed again????
@@ -328,7 +328,7 @@ namespace com.keyman {
         if(target && text.Processor.getOutputTarget(target)) {
           text.Processor.getOutputTarget(target).deadkeys().clear();
         }
-        this.keyman.keyboardManager.notifyKeyboard(0, target, 1);  // I2187
+        this.keyman['interface'].notifyKeyboard(0, target, 1);  // I2187
       }
     
       if(!uiManager.justActivated && DOMEventHandlers.states._SelectionControl != target) {

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1514,23 +1514,6 @@ namespace com.keyman {
       return this.keymanweb.util.callEvent('kmw.keyboardchange', p);
     }
 
-        
-    /**
-     * Function     _NotifyKeyboard
-     * Scope        Private
-     * @param       {number}    _PCommand     event code (16,17,18) or 0
-     * @param       {Object}    _PTarget      target element
-     * @param       {number}    _PData        1 or 0    
-     * Description  Notifies keyboard of keystroke or other event
-     */    
-    notifyKeyboard = function(_PCommand: number, _PTarget: HTMLElement|Document, _PData: number) { // I2187
-      var activeKeyboard = this.activeKeyboard;
-
-      if(activeKeyboard != null && typeof(activeKeyboard['KNS']) == 'function') {
-        activeKeyboard['KNS'](_PCommand, _PTarget, _PData);
-      }
-    }
-
     shutdown() {
       for(let script of this.linkedScripts) {
         if(script.remove) {

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -204,6 +204,32 @@ namespace com.keyman.text {
         DOMEventHandlers.states._IgnoreNextSelChange = 1;
       }
     }
+
+            
+    /**
+     * Function     _NotifyKeyboard
+     * Scope        Private
+     * @param       {number}    _PCommand     event code (16,17,18) or 0
+     * @param       {Object}    _PTarget      target element
+     * @param       {number}    _PData        1 or 0    
+     * Description  Notifies keyboard of keystroke or other event
+     */    
+    notifyKeyboard(_PCommand: number, _PTarget: OutputTarget|HTMLElement|Document, _PData: number) { // I2187
+      let keyman = com.keyman.singleton;
+      var activeKeyboard = keyman.keyboardManager.activeKeyboard;
+
+      var target: OutputTarget;
+      if(_PTarget instanceof text.OutputTarget) {
+        target = _PTarget;
+      } else {
+        target = text.Processor.getOutputTarget(_PTarget as HTMLElement);
+      }
+
+      // Good example use case - the Japanese CJK-picker keyboard
+      if(activeKeyboard != null && typeof(activeKeyboard['KNS']) == 'function') {
+        activeKeyboard['KNS'](_PCommand, target, _PData);
+      }
+    }
       
     /**
      * Function     KT

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -955,7 +955,7 @@ namespace com.keyman.text {
         case 144:
         case 145:
           // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-          keyman.keyboardManager.notifyKeyboard(Levent.Lcode, Levent.Ltarg, 1); 
+          keyman['interface'].notifyKeyboard(Levent.Lcode, Levent.Ltarg, isKeyDown ? 1 : 0); 
           if(!keyman.util.device.touchable) {
             return this._UpdateVKShift(Levent, Levent.Lcode-15, 1); // I2187
           } else {
@@ -964,7 +964,7 @@ namespace com.keyman.text {
       }
 
       if(Levent.LmodifierChange) {
-        keyman.keyboardManager.notifyKeyboard(0, Levent.Ltarg, 1); 
+        keyman['interface'].notifyKeyboard(0, Levent.Ltarg, 1); 
         this._UpdateVKShift(Levent, 0, 1);
       }
 


### PR DESCRIPTION
While examining the old CJK picker keyboards towards updating their code, I noticed that the `notifyKeyboard` function, which connects to selectively-defined `KNS` functions within compiled keyboards, hadn't been properly updated to reflect the new 12.0 abstraction provided by `outputTarget`s.  This broke part of the Japanese keyboard's functionality - the ability to swap between hirigana and katakana with the SHIFT key.

Fortunately, it's nothing too hard to fix.  I also relocated `notifyKeyboard` to kbdInterface.ts, which is a much more 'proper' home for the function - it _is_ a part of the keyboard interface, after all.

Best tested with the legacy Japanese keyboard on desktop form factors.