### PR TITLE
[Linux] Change watch to only follow stable

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-10-10 12.0.52 stable
+* Change Debian watch files to only watch stable (#2188)
+
 ## 2019-10-07 12.0.50 stable
 * Release 12.0
 

--- a/linux/ibus-keyman/debian/watch
+++ b/linux/ibus-keyman/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:stable)/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-kmfl/debian/watch
+++ b/linux/ibus-kmfl/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:stable)/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/keyman-config/debian/watch
+++ b/linux/keyman-config/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:stable)/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate

--- a/linux/kmflcomp/debian/watch
+++ b/linux/kmflcomp/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:stable)/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate

--- a/linux/libkmfl/debian/watch
+++ b/linux/libkmfl/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:stable)/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate


### PR DESCRIPTION
The current Debian watch files matches  `beta|stable` (in order). Trying to run launchpad.sh means the latest beta build 12.0.18 matches as the the latest build when it should be 12.0.51 stable