### PR TITLE
[Android] Use lexical model package version for lexical model version

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
@@ -58,7 +58,7 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
     return false;
   }
 
-  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId) throws JSONException {
+  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray("languages");
 
     String modelId = jsonEntry.getString("id");
@@ -70,7 +70,8 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
         models[i].put(KMManager.KMKey_PackageID, packageId);
         models[i].put(KMManager.KMKey_LexicalModelName, jsonEntry.getString("name"));
         models[i].put(KMManager.KMKey_LexicalModelID, jsonEntry.getString("id"));
-        models[i].put(KMManager.KMKey_LexicalModelVersion, jsonEntry.getString("version"));
+        // Use package version for the lexical model version
+        models[i].put(KMManager.KMKey_LexicalModelVersion, packageVersion);
         models[i].put(KMManager.KMKey_LanguageID, languages.getJSONObject(i).getString("id"));
         models[i].put(KMManager.KMKey_LanguageName, languages.getJSONObject(i).getString("name"));
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -139,10 +139,12 @@ public class PackageProcessor {
    * Generates a list of keyboard data maps designed to mirror the `download` method output of
    * KMKeyboardDownloader as closely as practical.
    * @param jsonEntry  One entry of the master JSONArray of the top-level "keyboards" property.
+   * @param packageId  Package ID
+   * @param packageVersion Package version (used for lexical model version)
    * @return A list of maps defining one keyboard-language pairing each.
    * @throws JSONException
    */
-  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId) throws JSONException {
+  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray("languages");
 
     String keyboardId = jsonEntry.getString("id");
@@ -420,6 +422,10 @@ public class PackageProcessor {
     JSONObject newInfoJSON = loadPackageInfo(tempPath);
     String packageId = getPackageID(path);
 
+    // For lexical model packages, lexical model version is determined by the package version
+    // (Default to "1.0")
+    String packageVersion = getPackageVersion(newInfoJSON);
+
     File permPath = constructPath(path, false);
     if (permPath.exists()) {
       // Out with the old.  "In with the new" is identical to a new package installation.
@@ -440,7 +446,7 @@ public class PackageProcessor {
       JSONArray entries = newInfoJSON.getJSONArray(key);
 
       for (int i = 0; i < entries.length(); i++) {
-        Map<String, String>[] maps = processEntry(entries.getJSONObject(i), packageId);
+        Map<String, String>[] maps = processEntry(entries.getJSONObject(i), packageId, packageVersion);
         if (maps != null) {
           specs.addAll(Arrays.asList(maps));
         }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
@@ -63,14 +63,15 @@ public class LexicalModelPackageProcessorTest {
     FileUtils.moveDirectory(tempPkg, TEST_EN_CUSTOM_MODEL_KMP_TARGET);
 
     Assert.assertNotNull(json);
+    String pkgVersion = lmPP.getPackageVersion(json);
 
-    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom");
+    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom", pkgVersion);
 
     HashMap<String, String> en_custom = new HashMap<String, String>();
     en_custom.put(KMManager.KMKey_PackageID, "example.en.custom");
     en_custom.put(KMManager.KMKey_LexicalModelName, "Example (English) Template Custom Model");
     en_custom.put(KMManager.KMKey_LexicalModelID, "example.en.custom");
-    en_custom.put(KMManager.KMKey_LexicalModelVersion, "1.0.0");
+    en_custom.put(KMManager.KMKey_LexicalModelVersion, "1.0");
     en_custom.put(KMManager.KMKey_LanguageID, "en");
     en_custom.put(KMManager.KMKey_LanguageName, "English");
     en_custom.put(KMManager.KMKey_CustomHelpLink, "");

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -131,8 +131,9 @@ public class PackageProcessorTest {
     FileUtils.moveDirectory(tempPkg, TEST_GFF_KMP_TARGET);
 
     Assert.assertNotNull(json);
+    String pkgVersion = PP.getPackageVersion(json);
 
-    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json");
+    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion);
     // Only the first language is installed with the keyboard
     Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
 

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-10-10 12.0.4201 stable
+* Bug Fix:
+  * Use lexical model package version for lexical model version (#2195)
+
 ## 2019-10-07 12.0.4200 stable
 * Release 12.0
 


### PR DESCRIPTION
Fixes #2190

For lexical model packages, use the package version for the lexical model version.

Keyboard packages will continue to use the keyboard versions in kmp.json.

Screenshot showing the installed lexical model
![Screenshot_1570692301](https://user-images.githubusercontent.com/7358010/66547640-dc340180-eb69-11e9-9f4d-2da0b8dc9065.png)
