### PR TITLE
[Windows] Update build scripts, compiler conditionals, and address hints arising with move to Delphi 10.3.2

### DIFF
--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -87,11 +87,11 @@ INSTALLPATH_KEYMANENGINE=%CommonProgramFiles(X86)%\Keyman\Keyman Engine
 # Delphi Compiler Configuration - Delphi 10.3.2
 #
 
-!IFDEF DELPHI_VERSION
-DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\$(DELPHI_VERSION)\bin
-!ELSE
-DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\20.0\bin
+!IFNDEF DELPHI_VERSION
+DELPHI_VERSION=20.0
 !ENDIF
+
+DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\$(DELPHI_VERSION)\bin
 
 #
 # Pass local configuration through to sub-instances of MAKE
@@ -135,7 +135,8 @@ DCC64="$(DCC32PATH)\dcc64.exe" $(DELPHIDPRPARAMS64) -N0x64\ -Ex64\
 # Delphi MSBuild related commands and macros
 #
 
-DELPHI_MSBUILD=$(ROOT)\src\buildtools\msbuild-wrapper.bat $(DELPHI_MSBUILD_FLAG_DEBUG)
+# Warning: whitespace is horribly significant in the following macro -- particularly lack of space before &&
+DELPHI_MSBUILD=set DCC32PATH=$(DCC32PATH)&& $(ROOT)\src\buildtools\msbuild-wrapper.bat $(DELPHI_MSBUILD_FLAG_DEBUG)
 
 !IFDEF DEBUG
 TARGET_PATH=Debug

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -1,6 +1,18 @@
 # DEBUG=1
 
+# TODO: Eliminate this hard coded version; used only in windows/src/desktop/help/Makefile
+#       so convert to .in with mkver transform
 KEYMAN_VERSION=13.0
+
+#
+# Delphi Compiler Configuration - Delphi 10.3.2
+#
+
+DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\20.0\bin
+
+#
+# Paths
+#
 
 !IFNDEF KEYMAN_ROOT
 KEYMAN_ROOT=c:\keyman
@@ -68,7 +80,7 @@ INSTALLPATH_KEYMANENGINE=%CommonProgramFiles(X86)%\Keyman\Keyman Engine
   MAKEFLAG_RELEASE_OEM=-DRELEASE_OEM
 !ENDIF
 
-MAKE=$(MAKE) -l $(MAKEFLAG_USERDEFINES) $(MAKEFLAG_DEBUG) $(MAKEFLAG_BUILDHELP) $(MAKEFLAG_BUILDRTF) $(MAKEFLAG_SC_TIMESTAMP) $(MAKEFLAG_LINT) $(MAKEFLAG_QUIET) $(MAKEFLAG_RELEASE_OEM)
+MAKE="$(DCC32PATH)\make" -l $(MAKEFLAG_USERDEFINES) $(MAKEFLAG_DEBUG) $(MAKEFLAG_BUILDHELP) $(MAKEFLAG_BUILDRTF) $(MAKEFLAG_SC_TIMESTAMP) $(MAKEFLAG_LINT) $(MAKEFLAG_QUIET) $(MAKEFLAG_RELEASE_OEM)
 
 #
 # Delphi build commands
@@ -88,8 +100,8 @@ DELPHIDPRPARAMS64=-Q -B -GD -H -VT -$C+ -$D+ -$L+ -$O+ -$Q- -$R- -$W+ -$Y+ -E. $
 DELPHIDPKPARAMS=-Q -B -GD -VT -$C+ -$D+ -$L+ -$O+ -$Q- -$R- -$W+ -$Y+ -E. $(DELPHIWARNINGS) -I$(DELPHIINCLUDES) -U$(DELPHIINCLUDES) -R$(DELPHIINCLUDES) -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win -LE$(OUTLIB) -LN$(OUTLIB) -NSData
 
 !IFDEF NOUI
-DCC32=dcc32.exe $(DELPHIDPRPARAMS)
-DCC32DPK=dcc32.exe $(DELPHIDPKPARAMS)
+DCC32="$(DCC32PATH)\dcc32.exe" $(DELPHIDPRPARAMS)
+DCC32DPK="$(DCC32PATH)\dcc32.exe" $(DELPHIDPKPARAMS)
 !ELSE
 !IFDEF QUIET
 DCC32=@$(DEVTOOLS) -dccq  $(DELPHIDPRPARAMS)
@@ -100,7 +112,7 @@ DCC32DPK=@$(DEVTOOLS) -dcc $(DELPHIDPKPARAMS)
 !ENDIF
 !ENDIF
 
-DCC64=dcc64.exe $(DELPHIDPRPARAMS64) -N0x64\ -Ex64\
+DCC64="$(DCC32PATH)\dcc64.exe" $(DELPHIDPRPARAMS64) -N0x64\ -Ex64\
 
 #
 # Delphi MSBuild related commands and macros

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -5,12 +5,6 @@
 KEYMAN_VERSION=13.0
 
 #
-# Delphi Compiler Configuration - Delphi 10.3.2
-#
-
-DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\20.0\bin
-
-#
 # Paths
 #
 
@@ -79,6 +73,29 @@ INSTALLPATH_KEYMANENGINE=%CommonProgramFiles(X86)%\Keyman\Keyman Engine
 !IFDEF RELEASE_OEM
   MAKEFLAG_RELEASE_OEM=-DRELEASE_OEM
 !ENDIF
+
+#
+# USERDEFINES allows the developer to specify overrides for various settings. We need a variable
+# because Makefiles cannot test for file existence
+#
+
+!ifdef USERDEFINES
+!include $(ROOT)\src\UserDefines.mak
+!endif
+
+#
+# Delphi Compiler Configuration - Delphi 10.3.2
+#
+
+!IFDEF DELPHI_VERSION
+DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\$(DELPHI_VERSION)\bin
+!ELSE
+DCC32PATH=C:\Program Files (x86)\Embarcadero\Studio\20.0\bin
+!ENDIF
+
+#
+# Pass local configuration through to sub-instances of MAKE
+#
 
 MAKE="$(DCC32PATH)\make" -l $(MAKEFLAG_USERDEFINES) $(MAKEFLAG_DEBUG) $(MAKEFLAG_BUILDHELP) $(MAKEFLAG_BUILDRTF) $(MAKEFLAG_SC_TIMESTAMP) $(MAKEFLAG_LINT) $(MAKEFLAG_QUIET) $(MAKEFLAG_RELEASE_OEM)
 
@@ -202,16 +219,23 @@ MAKE=$(MAKE)
 # To get a .pfx from a .spc and .pvk, run pvk2pfx.exe
 #
 
-SC_URL="https://keyman.com/"
-SC_PFX_SHA256="$(ROOT)\src\buildtools\certificates\keymantest-sha256.pfx"
+!IFNDEF SC_PFX_SHA1
 SC_PFX_SHA1="$(ROOT)\src\buildtools\certificates\keymantest-sha1.pfx"
+!ENDIF
+
+!IFNDEF SC_PFX_SHA256
+SC_PFX_SHA256="$(ROOT)\src\buildtools\certificates\keymantest-sha256.pfx"
+!ENDIF
+
+!IFNDEF SC_URL
+SC_URL="https://keyman.com/"
+!ENDIF
+
+!IFNDEF SC_PWD
 SC_PWD=""
+!ENDIF
 
 SIGNCODE=@$(ROOT)\src\buildtools\signtime.bat signtool.exe $(SC_PFX_SHA1) $(SC_PFX_SHA256) $(SC_URL) $(SC_PWD)
-
-!ifdef USERDEFINES
-!include $(ROOT)\src\UserDefines.mak
-!endif
 
 #
 # On some computers, the PLATFORM environment variable is set to x86. This can break msbuild

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -8,7 +8,7 @@
 4. Install [nodejs](https://nodejs.org/en/download/).
 5. Follow steps in /web/README.md to install prerequisites for building KeymanWeb (included in Keyman Developer)
 6. Add the Keyman root folder to antivirus exclusions for performance and file lock reasons (optional - but highly recommended).
-7. Start Delphi 10.2 IDE once after installation to create default environment files and ensure registration is complete.
+7. Start Delphi IDE once after installation to create default environment files and ensure registration is complete.
 8. Set environment variables per [notes below](#environment-variables): `KEYMAN_ROOT`, `USERDEFINES`,
    `GIT_BASH_FOR_KEYMAN`.
 9. Add the **windows/lib** folder in the Keyman repository to your `PATH` environment variable (required for packages in Delphi).

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -3,17 +3,17 @@
 ## Build Prerequisites
 
 1. Install [VS2017 Community Edition](#visual-studio-2017-community-edition-setup-requirements).
-2. Install [Delphi 10.2](#delphi-setup-requirements).
+2. Install [Delphi 10.2 or Delphi 10.3](#delphi-setup-requirements).
 3. Install [git](https://git-scm.com/download/win).
 4. Install [nodejs](https://nodejs.org/en/download/).
 5. Follow steps in /web/README.md to install prerequisites for building KeymanWeb (included in Keyman Developer)
 6. Add the Keyman root folder to antivirus exclusions for performance and file lock reasons (optional - but highly recommended).
 7. Start Delphi 10.2 IDE once after installation to create default environment files and ensure registration is complete.
-8. Set environment variables per [notes below](#environment-variables): `KEYMAN_ROOT`, `USERDEFINES`, 
+8. Set environment variables per [notes below](#environment-variables): `KEYMAN_ROOT`, `USERDEFINES`,
    `GIT_BASH_FOR_KEYMAN`.
 9. Add the **windows/lib** folder in the Keyman repository to your `PATH` environment variable (required for packages in Delphi).
-10. In order to run Keyman Developer in the development build, you need to specify where the 
-   https://github.com/keymanapp/CEF4Delphi_binary repo is on your system, with the registry setting `HKCU\Software\Keyman\Debug`, 
+10. In order to run Keyman Developer in the development build, you need to specify where the
+   https://github.com/keymanapp/CEF4Delphi_binary repo is on your system, with the registry setting `HKCU\Software\Keyman\Debug`,
    `Debug_CEFPath`.
 
 ### Release build prerequisites
@@ -31,7 +31,7 @@ For local development you do not need to perform a release build so these are op
 2. Run `make build` from the **windows/src** folder.
 3. Artifacts from a successful build will be placed in **windows/bin** folder.
 
-*Note*: running `make build` will currently reset the packages and path settings in your Delphi environment. If you use Delphi for other projects, 
+*Note*: running `make build` will currently reset the packages and path settings in your Delphi environment. If you use Delphi for other projects,
 you should consider building Keyman under a login user dedicated to it, or in a VM.
 
 Type `make` to see build targets. Common build targets are:
@@ -52,11 +52,11 @@ environment.
 2. Run `make release` from the **windows/src** folder.
 3. Artifacts from a successful build will be placed in **windows/release** folder.
 4. **buildtools/help-keyman-com.sh** will push updated documentation to help.keyman.com.
-   Environment variable `HELP_KEYMAN_COM` needs to be set to the root of the local 
+   Environment variable `HELP_KEYMAN_COM` needs to be set to the root of the local
    help.keyman.com git repository.
 
-Note: by default, the version number generated may vary from the current release version. 
-You will not be able to install it over a later version of Keyman, and will need to 
+Note: by default, the version number generated may vary from the current release version.
+You will not be able to install it over a later version of Keyman, and will need to
 uninstall and reinstall.
 
 ## Installing Keyman
@@ -108,6 +108,9 @@ Install Delphi using the following options:
 * No other 3rd party components required
 * No Interbase components required
 
+Delphi 10.3 is supported by default. For Delphi 10.2, set the environment variable
+`DELPHI_VERSION=19.0`. This variable can also be added to your `UserDefines.mak`.
+
 ## Environment Variables
 
 To check whether these variables are set, run `SET NAME_OF_VAR` in command prompt.
@@ -125,7 +128,7 @@ SET KEYMAN_ROOT=c:\projects\keyman
 ### GIT_BASH_FOR_KEYMAN
 
 This environment variable is optional: the build will run bash in a separate window
-in order to build KeymanWeb if it isn't present, but you'll lose logging and have 
+in order to build KeymanWeb if it isn't present, but you'll lose logging and have
 the annoyance of a window popping up halfway through the build. To resolve both of
 those issues, set the environment variable to:
 
@@ -138,7 +141,7 @@ You should verify the install location of Git on your computer as it may vary.
 ### USERDEFINES - User Defines
 
 You can specify defines that will not be added to the git repository and will be used in
-the build in the UserDefines.mak file in the root folder. This is used mostly for 
+the build in the UserDefines.mak file in the root folder. This is used mostly for
 code signing certificates. If not specified, a test certificate will be used to sign
 executables when you build a release.
 

--- a/windows/src/buildtools/delphiprojectmanager/Makefile
+++ b/windows/src/buildtools/delphiprojectmanager/Makefile
@@ -6,7 +6,7 @@
 
 build: dirs
     # build with DCC32 as $DCC32 command uses devtools.exe, and devtools uses this package...
-    $(MAKEDIR)\dcc32 -B -E. -I$(DELPHIINCLUDES) -U$(DELPHIINCLUDES) -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win -LE$(OUTLIB) -LN$(OUTLIB) delphiprojectmanager.dpk
+    "$(DCC32PATH)\dcc32.exe" -B -E. -I$(DELPHIINCLUDES) -U$(DELPHIINCLUDES) -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win -LE$(OUTLIB) -LN$(OUTLIB) delphiprojectmanager.dpk
     $(DEVTOOLS) -ip $(OUTLIB)\delphiprojectmanager.bpl
 
 clean: def-clean

--- a/windows/src/buildtools/devtools/DevDelphiCompileWrapper.pas
+++ b/windows/src/buildtools/devtools/DevDelphiCompileWrapper.pas
@@ -31,6 +31,10 @@ const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\18.0\bin\DCC32.EXE';
 {$ELSE}
 {$IFDEF VER320}
 const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\DCC32.EXE';
+{$ELSE}
+{$IFDEF VER330}
+const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\DCC32.EXE';
+{$ENDIF}
 {$ENDIF}
 {$ENDIF}
 

--- a/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
+++ b/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
@@ -21,6 +21,13 @@ type
 {$IFDEF VER320}
 const
   SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\BDS.EXE';
+{$ELSE}
+{$IFDEF VER330}
+const
+  SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\BDS.EXE';
+{$ELSE}
+ERROR: SBDSExe is not defined
+{$ENDIF}
 {$ENDIF}
 
 implementation

--- a/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
+++ b/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
@@ -24,7 +24,7 @@ const
 {$ELSE}
 {$IFDEF VER330}
 const
-  SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\BDS.EXE';
+  SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\BDS.EXE';
 {$ELSE}
 ERROR: SBDSExe is not defined
 {$ENDIF}

--- a/windows/src/buildtools/devtools/DevIncludePaths.pas
+++ b/windows/src/buildtools/devtools/DevIncludePaths.pas
@@ -64,6 +64,14 @@ const
   SKey_DelphiLibrary = 'Software\Embarcadero\BDS\19.0\Library\Win32';
   SKey_DelphiLibrary64 = 'Software\Embarcadero\BDS\19.0\Library\Win64';
   SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\19.0\EnvOptions.proj';
+{$ELSE}
+{$IFDEF VER330}
+  SKey_DelphiLibrary = 'Software\Embarcadero\BDS\20.0\Library\Win32';
+  SKey_DelphiLibrary64 = 'Software\Embarcadero\BDS\20.0\Library\Win64';
+  SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\20.0\EnvOptions.proj';
+{$ELSE}
+  ERROR: New version of compiler needs new defines
+{$ENDIF VER330}
 {$ENDIF VER320}
 {$ENDIF VER310}
 

--- a/windows/src/buildtools/devtools/DevInstallPackages.pas
+++ b/windows/src/buildtools/devtools/DevInstallPackages.pas
@@ -52,6 +52,14 @@ const
   SKey_Delphi = 'Software\Embarcadero\BDS\19.0';
   SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\19.0\bpl\';
   SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\19.0\dcp\';
+{$ELSE}
+{$IFDEF VER330}
+  SKey_Delphi = 'Software\Embarcadero\BDS\20.0';
+  SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\20.0\bpl\';
+  SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\20.0\dcp\';
+{$ELSE}
+  ERROR: New version of compiler needs new defines
+{$ENDIF VER330}
 {$ENDIF VER320}
 {$ENDIF VER310}
 

--- a/windows/src/buildtools/devtools/Makefile
+++ b/windows/src/buildtools/devtools/Makefile
@@ -4,9 +4,9 @@
 
 #
 # Devtools is used to create PathDefines.mak, so
-# it may not be present when we build. So as we 
+# it may not be present when we build. So as we
 # don't need it for the build, let's go ahead and
-# delete it (Devtools has all dependencies 
+# delete it (Devtools has all dependencies
 # referenced explictly to avoid chicken-and-egg
 # here).
 #
@@ -15,9 +15,9 @@ EXCLUDEPATHDEFINES=1
 !include ..\..\Defines.mak
 
 build: dirs
-    # build with DCC32 as $DCC32 command uses devtools.exe...
+    # build with DCC32PATH as $DCC32 command uses devtools.exe...
     # $(DCC32) devtools.dpr
-    $(MAKEDIR)\dcc32 -Q -B -E. -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win devtools.dpr
+    "$(DCC32PATH)\dcc32.exe" -Q -B -E. -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win devtools.dpr
     $(COPY) devtools.exe $(PROGRAM)\buildtools
 
 test-releasebuildcheck: build

--- a/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
+++ b/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
@@ -113,6 +113,12 @@ const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\18.0\bin\bds.EXE';
 {$ELSE}
 {$IFDEF VER320}
 const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\bds.EXE';
+{$ELSE}
+{$IFDEF VER330}
+const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\bds.EXE';
+{$ELSE}
+ERROR: BDSPath is not defined
+{$ENDIF}
 {$ENDIF}
 {$ENDIF}
 
@@ -290,7 +296,7 @@ begin
   e := gridErrors.Objects[0, gridErrors.Row] as TCompilerError;
   if e.FileName = '' then Exit;
 
-  CommandLine := ' -np -ns -ni -pDelphi "'+FProjectFileName+'"'; // "'+e.FileName+'"';
+  CommandLine := ' -np -ns -p Delphi "'+FProjectFileName+'"'; // "'+e.FileName+'"';
 
   with TRegistry.Create do
   try

--- a/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
+++ b/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
@@ -296,7 +296,12 @@ begin
   e := gridErrors.Objects[0, gridErrors.Row] as TCompilerError;
   if e.FileName = '' then Exit;
 
-  CommandLine := ' -np -ns -p Delphi "'+FProjectFileName+'"'; // "'+e.FileName+'"';
+{$IFDEF VER320}
+  CommandLine := ' -np -ns -ni -pDelphi "'+FProjectFileName+'"';
+{$ELSE}
+  // Assume this works for Delphi compiler version 330 (10.3.2 Rio / 20.0) and above
+  CommandLine := ' -np -ns -p Delphi "'+FProjectFileName+'"';
+{$ENDIF}
 
   with TRegistry.Create do
   try

--- a/windows/src/buildtools/mkver/Makefile
+++ b/windows/src/buildtools/mkver/Makefile
@@ -7,9 +7,9 @@ EXCLUDEPATHDEFINES=1
 !include ..\..\Defines.mak
 
 build: dirs
-    # build with DCC32 as $DCC32 command uses devtools.exe...
+    # build with DCC32PATH as $DCC32 command uses devtools.exe...
     # $(DCC32) mkver.dpr
-    $(MAKEDIR)\dcc32 -Q -B -E. -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win mkver.dpr
+    "$(DCC32PATH)\dcc32.exe" -Q -B -E. -NSVcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Web;Soap;Winapi;System.Win mkver.dpr
     $(COPY) mkver.exe $(PROGRAM)\buildtools
 
 clean: def-clean

--- a/windows/src/buildtools/msbuild-wrapper.bat
+++ b/windows/src/buildtools/msbuild-wrapper.bat
@@ -7,6 +7,8 @@ rem
 rem Do not use this for VS builds.
 rem
 
-call rsvars.bat
+if not exist "%DCC32PATH%\rsvars.bat" echo Batch file %DCC32PATH%\rsvars.bat does not exist && exit /b 1
+
+call "%DCC32PATH%\rsvars.bat"
 msbuild.exe %*
 exit /b %errorlevel%

--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -108,6 +108,7 @@ uses
   Soap.XsBuiltIns,
 
   System.Classes,
+  System.Generics.Collections,
   System.RegularExpressions,
   System.SysUtils,
   System.Zip,

--- a/windows/src/developer/TIKE/compile/ValidateKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/ValidateKeyboardInfo.pas
@@ -24,6 +24,7 @@ implementation
 
 uses
   System.Classes,
+  System.Generics.Collections,
   System.SysUtils,
   Winapi.Windows,
 

--- a/windows/src/ext/mbcolor/mxs.inc
+++ b/windows/src/ext/mbcolor/mxs.inc
@@ -1,3 +1,12 @@
+    {$ifdef VER330}
+     {$define DELPHI_5_UP}
+     {$define DELPHI_6_UP}
+     {$define DELPHI_7_UP}
+     {$define DELPHI_8_UP}
+     {$define DELPHI_9_UP}
+     {$define DELPHI_10_UP}
+    {$endif}
+
     {$ifdef VER320}
      {$define DELPHI_5_UP}
      {$define DELPHI_6_UP}

--- a/windows/src/global/delphi/comp/FixedTrackbar.pas
+++ b/windows/src/global/delphi/comp/FixedTrackbar.pas
@@ -63,7 +63,8 @@ end;
   so it should be checked if we upgrade to new version of Delphi.
 }
 
-{$IFNDEF VER320}
+{$IFNDEF VER330}
+// TODO: Actually check this (after Delphi 10.3 code changes are done)
 {$MESSAGE ERROR 'Check that this fix is still applicable for a new version of Delphi. Checked against Delphi 10.2' }
 {$ENDIF}
 

--- a/windows/src/global/delphi/comp/FixedTrackbar.pas
+++ b/windows/src/global/delphi/comp/FixedTrackbar.pas
@@ -61,12 +61,14 @@ end;
 
   This code is pretty dependent on the implementation in Vcl.Grids.pas,
   so it should be checked if we upgrade to new version of Delphi.
+
+  Tested on VER320 (10.2)
+  Tested on VER330 (10.3) - 29 Oct 2019 - mcdurdin
 }
 
 {$IFNDEF VER330}
 {$IFNDEF VER320}
-// TODO: Actually check this (after Delphi 10.3 code changes are done)
-{$MESSAGE ERROR 'Check that this fix is still applicable for a new version of Delphi. Checked against Delphi 10.2' }
+{$MESSAGE ERROR 'Check that this fix is still applicable for a new version of Delphi. Checked against Delphi 10.2, 10.3' }
 {$ENDIF}
 {$ENDIF}
 

--- a/windows/src/global/delphi/comp/FixedTrackbar.pas
+++ b/windows/src/global/delphi/comp/FixedTrackbar.pas
@@ -64,8 +64,10 @@ end;
 }
 
 {$IFNDEF VER330}
+{$IFNDEF VER320}
 // TODO: Actually check this (after Delphi 10.3 code changes are done)
 {$MESSAGE ERROR 'Check that this fix is still applicable for a new version of Delphi. Checked against Delphi 10.2' }
+{$ENDIF}
 {$ENDIF}
 
 procedure TTntFixedDrawGrid.MouseDown(Button: TMouseButton;

--- a/windows/src/global/delphi/general/JsonUtil.pas
+++ b/windows/src/global/delphi/general/JsonUtil.pas
@@ -22,7 +22,8 @@ interface
 
 uses
   System.JSON,
-  System.Classes;
+  System.Classes,
+  System.Generics.Collections;
 
 function JSONToString(obj: TJSONAncestor; ReplaceSlashes: Boolean = False): string;
 

--- a/windows/src/global/delphi/general/Keyman.System.RegExGroupHelperRSP19902.pas
+++ b/windows/src/global/delphi/general/Keyman.System.RegExGroupHelperRSP19902.pas
@@ -16,6 +16,7 @@ interface
 // the library, then this workaround will fail. See the corresponding unit test
 // to make sure that we pick up when this happens.
 //
+// Fixed in VER330 (Delphi 10.3 Rio, 20.0)
 
 uses
   System.Character,
@@ -26,8 +27,10 @@ uses
 type
   TGroupHelperRSP19902 = record
   private
+{$IFDEF VER320}
     FInput: string;
     FSourceGroup: TGroup;
+{$ENDIF}
     FFixedIndex, FFixedLength: Integer;
     FFixedValue: string;
   public
@@ -42,6 +45,7 @@ implementation
 { TGroupHelperRSP19902 }
 
 constructor TGroupHelperRSP19902.Create(SourceGroup: TGroup; const Input: string);
+{$IFDEF VER320}
 var
   i: Integer;
 begin
@@ -65,6 +69,13 @@ begin
   end;
 
   FFixedValue := Copy(input, FFixedIndex, FFixedLength);
+{$ELSE}
+begin
+  // This was fixed in VER320 so
+  FFixedIndex := SourceGroup.Index;
+  FFixedLength := SourceGroup.Length;
+  FFixedValue := SourceGroup.Value;
+{$ENDIF}
 end;
 
 end.

--- a/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
+++ b/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
@@ -49,6 +49,7 @@ type
 implementation
 
 uses
+  System.Generics.Collections,
   versioninfo;
 
 { TUpdateCheckResponse }

--- a/windows/src/global/delphi/general/kpsfile.pas
+++ b/windows/src/global/delphi/general/kpsfile.pas
@@ -28,6 +28,7 @@ interface
 
 uses
   System.Classes,
+  System.Generics.Collections,
   System.IniFiles,
   System.JSON,
   System.SysUtils,

--- a/windows/src/test/unit-tests/group-helper-rsp19902/Keyman.Test.RegExGroupHelperRSP19902Test.pas
+++ b/windows/src/test/unit-tests/group-helper-rsp19902/Keyman.Test.RegExGroupHelperRSP19902Test.pas
@@ -9,6 +9,7 @@ interface
 // in the Embarcadero libraries, that the unit test will fail, so we will be able
 // to proactively resolve it without sending out an accidentally broken version.
 //
+// Fixed in VER330 (Delphi 10.3 Rio, 20.0)
 
 uses
   DUnitX.TestFramework,
@@ -76,9 +77,14 @@ begin
   m := TRegEx.Match(s, r);
   Assert.IsTrue(m.Success);
   writeln(Format('FAILED:(%s) at position %d (length %d): %s', ['x', m.Groups[1].Index, m.Groups[1].Length, m.Groups[1].Value]));
+{$IFDEF VER320}
   if ShouldPassBuiltinTest
     then Assert.AreEqual(x, m.Groups[1].Value)
     else Assert.AreNotEqual(x, m.Groups[1].Value);
+{$ELSE}
+  // Fixed in VER330
+  Assert.AreEqual(x, m.Groups[1].Value);
+{$ENDIF}
 
   g := TGroupHelperRSP19902.Create(m.Groups[1], s);
   writeln(Format('PASSED:(%s) at position %d (length %d): %s [expected %s]', ['x', g.FixedIndex, g.FixedLength, g.FixedValue, x]));


### PR DESCRIPTION
This allows the build to work with either Delphi 10.2 or Delphi 10.3 by setting the DELPHI_VERSION variable. If not set, then assumes Delphi 10.3.