### PR TITLE
[Android][Cherrypick] Also use the lexical model package version for generating Dataset

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -438,11 +438,11 @@ public class CloudRepository {
           langName = languageObj.getString("name");
         }
 
-        String modelID = model.getString("id");
-        String modelName = model.getString("name");
-        String modelVersion = model.getString("version");
+        String modelID = model.getString(KMManager.KMKey_ID);
+        String modelName = model.getString(KMManager.KMKey_Name);
+        String modelVersion = model.getString(KMManager.KMKey_LexicalModelVersion);
 
-        String isCustom = model.optString("CustomModel", "N");
+        String isCustom = model.optString(KMManager.KMKey_CustomModel, "N");
         String icon = "0";
 
         HashMap<String, String> hashMap = new HashMap<String, String>();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -208,6 +208,7 @@ public class JSONUtils {
           try {
             String packageID = pkg.getName();
             JSONObject kmp = parser.getJSONObjectFromFile(file);
+            String packageVersion = PackageProcessor.getPackageVersion(kmp);
             JSONArray kmpModels = kmp.getJSONArray("lexicalModels");
 
             // Determine if kmp contains welcome.htm help file
@@ -218,7 +219,6 @@ public class JSONUtils {
               JSONObject kmpModelObj = kmpModels.getJSONObject(i);
               String modelName = kmpModelObj.getString(KMManager.KMKey_Name);
               String modelID = kmpModelObj.getString(KMManager.KMKey_ID);
-              String modelVersion = kmpModelObj.getString("version");
               String modelFilename = pkg.getName() + "/" + modelID + FileUtils.LEXICALMODEL;
 
               // Merge languages
@@ -230,10 +230,10 @@ public class JSONUtils {
 
                 JSONObject modelObj = new JSONObject();
                 modelObj.put(KMManager.KMKey_PackageID, packageID);
-                modelObj.put("id", modelID);
+                modelObj.put(KMManager.KMKey_ID, modelID);
                 modelObj.put(KMManager.KMKey_Name, modelName);
                 modelObj.put("filename", modelFilename);
-                modelObj.put(KMManager.KMKey_KeyboardVersion, modelVersion);
+                modelObj.put(KMManager.KMKey_LexicalModelVersion, packageVersion);
                 modelObj.put(KMManager.KMKey_CustomModel, "Y");
                 if (containsHelp) {
                   File welcomeFile = new File(pkg, "welcome.htm");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -215,7 +215,7 @@ public class PackageProcessor {
    * @param json The metadata JSONObject for the package.
    * @return The version number (via String)
    */
-  public String getPackageVersion(JSONObject json) {
+  public static String getPackageVersion(JSONObject json) {
     try {
       return json.getJSONObject("info").getJSONObject("version").getString("description");
     } catch (Exception e) {

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,14 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-10-25 12.0.4205 stable
+* Bug fix:
+  * Use lexical model package version for dataset (#2242)
+  
+## 2019-10-14 12.0.4204 stable
+* Bug Fix:
+  * FirstVoices app may crash if analytics is not present (#2204)
+
 ## 2019-10-10 12.0.4201 stable
 * Bug Fix:
   * Use lexical model package version for lexical model version (#2195)


### PR DESCRIPTION
Cherrypick #2242 and fixes #2190 on master

## User Testing (Copied from original PR)
### Verify lexical model version from the cloud still works
- [ ] Install Keyman for Android
- [ ] From the "Settings" menu, install "Salish, Straights" --> "SENĆOŦEN" keyboard (this will automatically install the nrc.str.sencoten.model v. 1.0.3 from the cloud).
- [ ] From the "Settings" menu, navigate to the SENĆOŦEN model picker activity and verify the version displays

### Verify lexical model package version is used for lexical model version
- [ ] From the "Settings" menu, install "Malayalam" --> "Mozhi 5.1" keyboard
- [ ] Install custom Malayalam lexical model [package](https://darcywong00.github.io/examples/malar/malar.ml.malayalam.model.kmp) v 1.0
- [ ] From the "Settings" menu, navigate to the Malayalam model picker activity and verify the version displays
- [ ] Verify you can uninstall the Malyalam dictionary
