### PR TITLE
fix: Temporarily disable dictionary when entering password field

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -9,8 +9,11 @@ import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KMHardwareKeyboardInterpreter;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
+import com.tavultesoft.kmea.LanguageSettingsActivity;
+import com.tavultesoft.kmea.R;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Point;
 import android.inputmethodservice.InputMethodService;
@@ -23,6 +26,8 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+
+import java.util.HashMap;
 
 public class SystemKeyboard extends InputMethodService implements OnKeyboardEventListener {
 
@@ -110,6 +115,21 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     if (((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_NUMBER) ||
         ((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_PHONE)) {
       KMManager.setNumericLayer(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    }
+
+    // Temporarily disable predictions if entering a hidden password field
+    if (KMManager.isHiddenPasswordInputType(inputType)) {
+      KMManager.setBannerOptions(false);
+    } else {
+      // Check if predictions needs to be re-enabled per Settings preference
+      Context appContext = getApplicationContext();
+      HashMap<String, String> kbInfo = KMManager.getCurrentKeyboardInfo(appContext);
+      if (kbInfo != null) {
+        String langId = kbInfo.get(KMManager.KMKey_LanguageID);
+        SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+        boolean mayPredict = prefs.getBoolean(LanguageSettingsActivity.getLanguagePredictionPreferenceKey(langId), true);
+        KMManager.setBannerOptions(mayPredict);
+      }
     }
 
     InputConnection ic = getCurrentInputConnection();

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -118,7 +118,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     }
 
     // Temporarily disable predictions if entering a hidden password field
-    if (KMManager.isHiddenPasswordInputType(inputType)) {
+    KMManager.setMayPredictOverride(inputType);
+    if (KMManager.getMayPredictOverride()) {
       KMManager.setBannerOptions(false);
     } else {
       // Check if predictions needs to be re-enabled per Settings preference

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -189,6 +189,12 @@
       registerModel(model);
     }
 
+    function setBannerOptions(mayPredict) {
+      keyman.osk.banner.setOptions({
+        'mayPredict': mayPredict
+      });
+    }
+
     function registerModel(model) {
       var kmw=window['keyman'];
       //window.console.log('registerModel: ' + model);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -338,8 +338,10 @@ public final class KMManager {
     } else if (currentLexicalModel == null) {
       // Check if lm-layer needs to be re-enabled
       HashMap<String, String> kbInfo = getCurrentKeyboardInfo(appContext);
-      String langId = kbInfo.get(KMKey_LanguageID);
-      registerAssociatedLexicalModel(langId);
+      if (kbInfo != null) {
+        String langId = kbInfo.get(KMKey_LanguageID);
+        registerAssociatedLexicalModel(langId);
+      }
     }
 
     if (!restarting) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -120,9 +120,9 @@ public final class KMManager {
   protected static String currentBanner = "blank";
 
   // Special override for when keyboard is entering a password text field.
-  // When shouldOverrideMayProtect is true, the option {'mayProtect' = false} is set in the lm-layer
+  // When mayPredictOverride is true, the option {'mayPredict' = false} is set in the lm-layer
   // regardless what the Settings preference is.
-  private static boolean shouldOverrideMayProtect = false;
+  private static boolean mayPredictOverride = false;
 
   // Keyman public keys
   public static final String KMKey_ID = "id";
@@ -677,18 +677,23 @@ public final class KMManager {
   }
 
   /**
-   * Determine if the InputType field is a hidden password text field
+   * Sets mayPredictOverride true if the InputType field is a hidden password text field
+   * (either TYPE_TEXT_VARIATION_PASSWORD or TYPE_TEXT_VARIATION_WEB_PASSWORD
+   * but not TYPE_TEXT_VARIATION_VISIBLE_PASSWORD)
    * @param inputType android.text.InputType
-   * @return true if inputType is a text field of either
-   * TYPE_TEXT_VARIATION_PASSWORD or TYPE_TEXT_VARIATION_WEB_PASSWORD
-   * but not TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
    */
-  public static boolean isHiddenPasswordInputType(int inputType) {
-    shouldOverrideMayProtect =
+  public static void setMayPredictOverride(int inputType) {
+    mayPredictOverride =
       ((inputType == (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD)) ||
        (inputType == (InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD)));
+  }
 
-    return shouldOverrideMayProtect;
+  /**
+   * Get the value of mayPredictOverride
+   * @return boolean
+   */
+  public static boolean getMayPredictOverride() {
+    return mayPredictOverride;
   }
 
   /**
@@ -751,7 +756,7 @@ public final class KMManager {
 
     // When entering password field, mayPredict should override to false
     SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-    boolean mayPredict = (shouldOverrideMayProtect) ? false :
+    boolean mayPredict = (mayPredictOverride) ? false :
       prefs.getBoolean(LanguageSettingsActivity.getLanguagePredictionPreferenceKey(languageID), true);
     boolean mayCorrect = prefs.getBoolean(LanguageSettingsActivity.getLanguageCorrectionPreferenceKey(languageID), true);
 

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,10 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-10-30 12.0.4206 stable
+* Bug fix:
+  * Disable suggestions when system keyboard entering password field (#2255)
+
 ## 2019-10-25 12.0.4205 stable
 * Bug fix:
   * Use lexical model package version for dataset (#2242)


### PR DESCRIPTION
Fixes #2251 
On entering a hidden password field, disable the dictionary so the password won't appear as the left suggestion.

On entering a non-password field, re-enable the dictionary

