### PR TITLE
fix: commit-msg requires bash and +x

### DIFF
--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # This commit-msg hook validates commit messages


### PR DESCRIPTION
Make commit-msg hook executable. Also use bash - Ubuntu has `dash`
linked as `/bin/sh` which doesn't support some of the features we use
in the hook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2262)
<!-- Reviewable:end -->
