### PR TITLE
fix(web): iOS-Safari user agent spoof detection

### DIFF
--- a/web/source/utils/version.ts
+++ b/web/source/utils/version.ts
@@ -9,6 +9,8 @@ namespace com.keyman.utils {
     // as it results in unexpected, bug-like behavior for keyboard designers when it is unwanted.
     public static readonly NO_DEFAULT_KEYCAPS = new Version([12, 0]);
 
+    public static readonly MAC_POSSIBLE_IPAD_ALIAS = new Version([10, 15]);
+
     private readonly components: number[]
 
     /**


### PR DESCRIPTION
Fixes #2267.

This aims to provide a very directed fix for iOS user-agent spoofing as seen in its recently-released offerings.  By testing against specific versions of macOS, we establish a pattern that can be used to adjust device detection accordingly in future versions is the `TouchEvent` check becomes invalid.  Regarding that check itself... https://stackoverflow.com/questions/56578799/tell-ipados-from-macos-on-the-web

Noting the standard aspect ratio of iPad screens to be 4:3 (https://www.lifewire.com/what-is-ipads-screen-resolution-ips-display-1994325) and that iPhones have slimmer form factors, we rely on this ratio to detect the difference betwen iPhones and iPads.

---

Note that without any additional changes, this also fixes in-app and system keyboard behavior for the iOS app on tablets.