### PR TITLE
cherry(web): iOS-Safari user agent spoof detection

### DIFF
--- a/web/source/utils/version.ts
+++ b/web/source/utils/version.ts
@@ -9,6 +9,8 @@ namespace com.keyman.utils {
     // as it results in unexpected, bug-like behavior for keyboard designers when it is unwanted.
     public static readonly NO_DEFAULT_KEYCAPS = new Version([12, 0]);
 
+    public static readonly MAC_POSSIBLE_IPAD_ALIAS = new Version([10, 15]);
+
     private readonly components: number[]
 
     /**


### PR DESCRIPTION
This is a cherrypick of #2268 for 12.0 stable.  As iOS 13.1 is already out and causing issues with Keyman on updated iPads, it's pretty important that we get this out soon.

Since we're early in the 13.0 development cycle, a simple `git rebase -i` was all that was needed for this cherrypick.