### PR TITLE
feat[android]: change readme page handling for custom package install

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -154,7 +154,7 @@ public class PackageActivity extends AppCompatActivity {
       }
     });
 
-    // Determine if ad-hoc distributed KMP contains welcome.htm (case-insensitive) to display
+     // Determine if ad-hoc distributed KMP contains readme.htm (case-insensitive) to display
     FileFilter _readmeFilter = new FileFilter() {
       @Override
       public boolean accept(File pathname) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -88,7 +88,7 @@ public class PackageActivity extends AppCompatActivity {
 
     // Silent installation (skip displaying welcome.htm and user confirmation)
     if (silentInstall) {
-      installPackage(context, pkgTarget, pkgId);
+      installPackage(context, pkgTarget, pkgId,true);
       return;
     }
 
@@ -198,7 +198,7 @@ public class PackageActivity extends AppCompatActivity {
     installButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        installPackage(context, pkgTarget, pkgId);
+        installPackage(context, pkgTarget, pkgId,false);
       }
     });
 
@@ -311,7 +311,7 @@ public class PackageActivity extends AppCompatActivity {
    * @param pkgTarget String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
    * @param pkgId String      The Keyman package ID
    */
-  private void installPackage(Context context, String pkgTarget, String pkgId) {
+  private void installPackage(Context context, String pkgTarget, String pkgId, boolean anSilentInstall) {
     try {
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
         // processKMP will remove currently installed package and install
@@ -321,7 +321,8 @@ public class PackageActivity extends AppCompatActivity {
         boolean success = installedPackageKeyboards.size() != 0;
         boolean _cleanup = true;
         if (success) {
-          _cleanup = !loadWelcomePage(installedPackageKeyboards);
+          if(!anSilentInstall)
+            _cleanup = !loadWelcomePage(installedPackageKeyboards);
           notifyPackageInstallListeners(KeyboardEventHandler.EventType.PACKAGE_INSTALLED,
             installedPackageKeyboards, 1);
           if (installedPackageKeyboards != null) {
@@ -340,7 +341,8 @@ public class PackageActivity extends AppCompatActivity {
         boolean success = installedLexicalModels.size() != 0;
         boolean _cleanup = true;
         if (success) {
-          _cleanup = !loadWelcomePage(installedLexicalModels);
+          if(!anSilentInstall)
+            _cleanup = !loadWelcomePage(installedLexicalModels);
           notifyLexicalModelInstallListeners(KeyboardEventHandler.EventType.LEXICAL_MODEL_INSTALLED,
             installedLexicalModels, 1);
           if (installedLexicalModels != null) {

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
@@ -29,6 +29,19 @@
             android:layout_height="0dp"
             android:layout_weight="1" />
 
+      <Button
+        android:id="@+id/finishButton"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="15dp"
+        android:text="@string/label_ok"
+        android:textColor="@color/keyman_blue"
+        android:elevation="1dp"
+        android:singleLine="true"
+        android:layout_marginStart="10dp" android:layout_marginEnd="15dp" />
+
         <Button
             android:id="@+id/cancelButton"
             style="@style/Widget.AppCompat.Button.Borderless.Colored"

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -43,6 +43,7 @@ public final class FileUtils {
   public static final String MODELPACKAGE = ".model.kmp";
   public static final String KEYMANPACKAGE = ".kmp";
   public static final String WELCOME_HTM = "welcome.htm";
+  public static final String README_HTM = "readme.htm";
 
   /**
    * Utility to download a file from urlStr and store it at destinationDir/destinationFilename.
@@ -403,6 +404,11 @@ public final class FileUtils {
   public static boolean isWelcomeFile(String filename) {
     String f = getFilename(filename);
     return f.equalsIgnoreCase(WELCOME_HTM);
+  }
+
+  public static boolean isReadmeFile(String filename) {
+    String f = getFilename(filename);
+    return f.equalsIgnoreCase(README_HTM);
   }
 
   /**

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -1,5 +1,7 @@
 package com.tavultesoft.kmea.util;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,8 +9,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowLog;
 
 import java.util.List;
-
-import androidx.test.core.app.ApplicationProvider;
 
 @RunWith(RobolectricTestRunner.class)
 public class FileUtilsTest {
@@ -248,5 +248,15 @@ public class FileUtilsTest {
     filename = "test/abc.svg";
     Assert.assertEquals("", FileUtils.getSVGFilename(filename));
 
+  }
+
+  @Test
+  public void test_isReadmeFile() {
+
+    Assert.assertTrue(FileUtils.isReadmeFile("test/readme.htm"));
+
+    Assert.assertTrue(FileUtils.isReadmeFile("test/README.HTM"));
+
+    Assert.assertFalse(FileUtils.isReadmeFile("test/WELCOME.HTM"));
   }
 }


### PR DESCRIPTION
Addresses #1855

## Previous Behavior ##
Custom keyboard installtion on android shows welcome page before installation.
On other platforms before installation a readme.htm is shown and the welcome.htm is displayed after installation.

## New Behavior ##
On android custom keyboard installation behaves the same as on other platforms.
After selection a Custom package the readme-file is shown
![Screenshot_1572851164](https://user-images.githubusercontent.com/52272980/68104416-8440ae80-ff0d-11e9-88dc-6e665594b8ce.png)

After finishing the installation the welcome-file is display
![Screenshot_1572851234](https://user-images.githubusercontent.com/52272980/68104433-9884ab80-ff0d-11e9-8fc1-c9d43998ece8.png)

Goto keyboard details and show welcome.htm from info link
![Screenshot_1572852049](https://user-images.githubusercontent.com/52272980/68104661-88b99700-ff0e-11e9-941c-5b6b5752f476.png)

![Screenshot_1572852056](https://user-images.githubusercontent.com/52272980/68104665-8bb48780-ff0e-11e9-8272-468ef2e8b752.png)


## Work Done ##
- add Readme-Page-Helper-Method to FileUtils
-  Change PackageAcitivity to show Readme before starting installation
- Change PackageAcitivity to show Welcome page after finishing installation

## Testing 
- Goto Settings/ Add Keyboard from Device
- Select a downloaded custom keyboard package
- Select a keyboard from the list
- See the readme file from package
- Start keyboard installation
- See welcome page from package
- Press OK to close the welcome page

- Goto Settings/Installed languages
- Select the new language
- Select the new keyboard
- Open Help link
- See welcome page from package

