### PR TITLE
fix(web): Fixes mnemonic code handling issues

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -2,6 +2,10 @@
 
 ## 13.0 alpha
 * Start version 13.0
+* Testing for upcoming patch to stable:
+  * Fixes issue with mnemonic keyboard handling of backspace and delete keys (#2288)
+  * Fix for iOS Safari's "Request Desktop Website" option disabling touch interactivity (#2283)
+  * Fix for keyboards using rules with the `nul` statement that replace the full context (#2284)
 
 ## 2019-10-04 12.0.90 beta
 * Fixes next-layer management complications with predictive correction data computation (#2172)

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -149,9 +149,21 @@ namespace com.keyman.text {
           //     kbdInterface.defaultBackspace();
           //   }
         }
-      } else if(Lkc.Lcode == 8) {  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
-        keyman.interface.defaultBackspace();
-        return '';
+
+        // Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
+        //
+        // Can easily occur from mnemonic keyboards, which create synthetic events without
+        // the appropriate kName value.
+        //
+        // Not strictly if `Lkc.vkCode` is properly maintained, but it's good to have an
+        // extra safety; this would have blocked the backspace bug as well.
+      } else if(Lkc.Lcode == 8) {
+        if(disableDOM) {
+          return '\b'; // the escape sequence for backspace.
+        } else {
+          keyman.interface.defaultBackspace();
+          return '';
+        }
       }
 
       // Translate numpad keystrokes into their non-numpad equivalents
@@ -560,13 +572,26 @@ namespace com.keyman.text {
           mappingEvent[key] = Lkc[key];
         }
         
+        // To facilitate storing relevant commands, we should probably reverse-lookup
+        // the actual keyname instead.
         mappingEvent.kName = 'K_xxxx';
         mappingEvent.Ltarg = null;
-        var mappedChar: string = this.defaultKeyOutput(Lkc, (shifted ? 0x10 : 0), false, true);
+        var mappedChar: string = this.defaultKeyOutput(mappingEvent, (shifted ? 0x10 : 0), false, true);
+        
+        /* First, save a backup of the original code.  This one won't needlessly trigger keyboard
+         * rules, but allows us to replicate/emulate commands after rule processing if needed.
+         * (Like backspaces)
+         */
+        Lkc.vkCode = Lkc.Lcode;
         if(mappedChar) {
-          // FIXME;  Warning - will return 96 for 'a', which is a keycode corresponding to Codes.keyCodes('K_NP1') - a numpad key.
+          // Will return 96 for 'a', which is a keycode corresponding to Codes.keyCodes('K_NP1') - a numpad key.
+          // That stated, we're in mnemonic mode - this keyboard's rules are based on the char codes.
           Lkc.Lcode = mappedChar.charCodeAt(0);
-        } // No 'else' - avoid blocking modifier keys, etc.
+        } else {
+          // Don't let command-type keys (like K_DEL, which will output '.' otherwise!)
+          // trigger keyboard rules.
+          delete Lkc.Lcode;
+        }
       }
 
       if(capsActive) {


### PR DESCRIPTION
Fixes #2209.

OK, this one was a bit fun.

We had a similar error before with non-mnemonic layouts that was fixed, but I forgot about the "other" backspace handler in `defaultKeyOutput`.  Easy enough to fix... though it turns out that this was triggered in combination with another bug.  (It took two things going wrong to occur.)

In v12, `defaultKeyOutput` gained an extra purpose when compared to prior versions - it's now used to lookup mnemonic keystroke codes _in addition to_ handling default output.  The "disableDOM" bit indicates that it's functioning in "lookup" mode, so no change should happen to the DOM when `true`.

That "another bug"?  Try hitting the "Delete" key with the sil_ipa keyboard active on the current version of KeymanWeb - it outputs periods instead!  The code we use for Delete is the same as the ASCII code for period... turns out that mnemonic's use of `.vkCode` as a backup (to avoid triggering rules exactly here) was been forgotten during the v12 refactor and placed within `.lCode` instead, which erroneously triggers the output mentioned above.  I had the mnemonic `.lCode` logic all wrong.

Fixing this `.lCode`/`.vkCode` bug is _also_ enough to correct the originally-reported bug while also fixing a highly-related secondary bug, so it's the main fix that should be added.  Never hurts to have a failsafe though, especially for high-impact backspace issues, so I added fixes to both places for robustness.

## Testing

* Clone this repo if you haven't already
* Build this branch
  * Go to /web/source
  * Run .build.sh
* Go to web/testing/unminified.html.
* "Add a keyboard by keyboard name" > `sil_ipa` > Add
* Select the sil_ipa keyboard, test with a standard desktop form factor (not touch)
  * In particular, ensure that Backspace behaves normally.
  * The Delete key should also behave normally, now that it's not erroneously triggering any keyboard rules.
* Feel free to reload the page in touch mode (Chrome emulation) and ensure that backspace still works correctly.
* It wouldn't hurt to test a "normal" keyboard like sil_eurolatin or one of the EuroLatin 2 variants.