### PR TITLE
fix(developer): crash when deleting selected platform in code view

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -2186,15 +2186,15 @@ $(function () {
       function(data) {
         builder.loadingState = false;
         if(typeof data === 'object') {
-          if(data.platform) {
+          if(data.platform && KVKL[data.platform]) {
             $('#selPlatform').val(data.platform);
-            builder.selectPlatform();
           }
-          if(data.presentation) {
+          builder.selectPlatform();
+          if(data.presentation && builder.presentations[data.presentation]) {
             $('#selPlatformPresentation').val(data.presentation);
             builder.prepareLayer();
           }
-          if(data.layer) {
+          if(data.layer && KVKL[builder.lastPlatform][data.layer]) {
             $('#selLayer').val(data.layer);
             builder.selectLayer();
           }


### PR DESCRIPTION
Fixes #2256.

## User testing

This one can be a little tricky to reproduce. Recommend trying these steps in 12.0.52 version to reproduce the error before testing the fix.

1. Create a touch layout with `phone` and `tablet` platforms. Ensure the first platform is selected.
2. Then, go to code view, and delete the entire first platform block in the JSON file.
3. Switch back to design view. The app should no longer crash; the view will be a little funny, because no presentation is selected, but that's acceptable (just select a presentation to resolve).