### PR TITLE
fix(developer): nul in context caused incorrect deletion for 10.0 keyboards

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -974,15 +974,14 @@ begin
       n := len;
       pwszContext := fkp.dpContext;
 
-      //CODE_IFOPT:    // I3429
-      //CODE_IFSYSTEMSTORE:     // I3430
       for i := 1 to n do
       begin
         rec := ExpandSentinel(pwszContext);
-        if rec.IsSentinel and (rec.Code in [CODE_IFOPT, CODE_IFSYSTEMSTORE]) then
+        if rec.IsSentinel and (rec.Code in [CODE_NUL, CODE_IFOPT, CODE_IFSYSTEMSTORE]) then
           Dec(len);
         pwszContext := incxstr(pwszContext);
       end;
+
     end
     // KMW < 10.0 exclude all sentinel-based characters, including deadkeys, from direct context deletion.
     // Deadkeys have alternative special handling.
@@ -992,10 +991,10 @@ begin
     len := -1;
 
   if IsKeyboardVersion10OrLater() and (pwsz^ <> #0) then
-    begin
-      Result := Result + nlt+Format('k.KDC(%d,t);', [ len ] );   // I3681
-      len := -1;
-    end;
+  begin
+    Result := Result + nlt+Format('k.KDC(%d,t);', [ len ] );   // I3681
+    len := -1;
+  end;
 
 	while pwsz^ <> #0 do
   begin


### PR DESCRIPTION
This issue arises only in keyboards with `store(&version) '10.0'`.

Fixes #2272.
Relates to #2261.

## User Testing

Follow the steps described in #2261 before and after this fix to see the improved behaviour. For the test keyboard, paste the following code:

```
store(&VERSION) '10.0'
store(&TARGETS) 'web'

begin Unicode > use(main)

group(main) using keys

store(consonants_ra_key)  [K_N] [K_B] [K_Y]
store(consonants_ra_code) U+0CA3 U+0CAD U+0CAF

nul U+0CB0 U+0CCD + any(consonants_ra_key) > U+0CB0 U+200D U+0CCD index(consonants_ra_code,4)
```