### PR TITLE
fix[android]: Fix UI problem during keyboard switch

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -468,7 +468,7 @@ final class KMKeyboard extends WebView {
    * @param languageName the language name
    * @return the result
    */
-  public boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID,  String keyboardName, String languageName)
+  public boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID,  String keyboardName)
   {
     if (packageID == null || keyboardID == null || languageID == null)
       return false;
@@ -492,7 +492,6 @@ final class KMKeyboard extends WebView {
 
     // Escape single-quoted names for javascript call
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
-    languageName = languageName.replaceAll("\'", "\\\\'");
 
     this.packageID = packageID;
     this.keyboardID = keyboardID;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -483,8 +483,6 @@ final class KMKeyboard extends WebView {
 
     setKeyboardRoot(packageID);
 
-    //TODO: check fonts?
-
     // Escape single-quoted names for javascript call
     keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -360,7 +360,7 @@ final class KMKeyboard extends WebView {
   /**
    * Return the full path to the special OSK font,
    * which is with all the keyboard assets at the root app_data folder
-   * @param String filename
+   * @param filename
    * @return String
    */
   public String specialOSKFontFilename(String filename) {
@@ -456,6 +456,51 @@ final class KMKeyboard extends WebView {
     }
 
     KeyboardEventHandler.notifyListeners(kbEventListeners, keyboardType, EventType.KEYBOARD_CHANGED, currentKeyboard);
+    return retVal;
+  }
+
+  /**
+   * preapre keyboard switch. The switch is executed in next reload.
+   * @param packageID the package id
+   * @param keyboardID the keyman keyboard id
+   * @param languageID the langauge id
+   * @param keyboardName the keyboard name
+   * @param languageName the language name
+   * @return the result
+   */
+  public boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID,  String keyboardName, String languageName)
+  {
+    if (packageID == null || keyboardID == null || languageID == null)
+      return false;
+
+    boolean retVal = true;
+    String keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
+    if (!KMManager.shouldAllowSetKeyboard() || keyboardVersion == null) {
+      Toast.makeText(context, "Can't set " + packageID + "::" + keyboardID + " for " +
+        languageID + " language. Loading default keyboard", Toast.LENGTH_LONG).show();
+      keyboardID = KMManager.KMDefault_KeyboardID;
+      languageID = KMManager.KMDefault_LanguageID;
+      retVal = false;
+    }
+    String kbKey = String.format("%s_%s", languageID, keyboardID);
+
+    keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
+
+    setKeyboardRoot(packageID);
+
+    //TODO: check fonts?
+
+    // Escape single-quoted names for javascript call
+    keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
+    languageName = languageName.replaceAll("\'", "\\\\'");
+
+    this.packageID = packageID;
+    this.keyboardID = keyboardID;
+    this.keyboardName = keyboardName;
+    this.keyboardVersion = keyboardVersion;
+    currentKeyboard = kbKey;
+    saveCurrentKeyboardIndex();
+
     return retVal;
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -12,7 +12,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
@@ -35,8 +34,6 @@ import android.util.Log;
 import android.view.GestureDetector;
 import android.view.Gravity;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,7 +45,6 @@ import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.GridLayout;
-import android.widget.PopupMenu;
 import android.widget.PopupWindow;
 import android.widget.PopupWindow.OnDismissListener;
 import android.widget.TextView;
@@ -465,7 +461,6 @@ final class KMKeyboard extends WebView {
    * @param keyboardID the keyman keyboard id
    * @param languageID the langauge id
    * @param keyboardName the keyboard name
-   * @param languageName the language name
    * @return the result
    */
   public boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID,  String keyboardName)

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1165,7 +1165,7 @@ public final class KMManager {
 
   public static int getBannerHeight(Context context) {
     int bannerHeight = 0;
-    if (currentBanner.equals("suggestion")) {
+    if (currentBanner.equals(BANNER_STATE_SUGGESTION)) {
       bannerHeight = (int) context.getResources().getDimension(R.dimen.banner_height);
     }
     return bannerHeight;
@@ -1836,7 +1836,7 @@ public final class KMManager {
       } else if (url.indexOf("refreshBannerHeight") >= 0) {
         int start = url.indexOf("change=") + 7;
         String change = url.substring(start);
-        currentBanner = (change.equals("loaded")) ? "suggestion" : "blank";
+        currentBanner = (change.equals("loaded")) ? BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         SystemKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -899,10 +899,9 @@ public final class KMManager {
    * @param keyboardID the keyboard id
    * @param languageID the language id
    * @param keyboardName keyboard name
-   * @param languageName language name
    * @return the success result
    */
-  public static boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID, String keyboardName, String languageName) {
+  public static boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID, String keyboardName) {
 
     //reset banner and layout params
     currentBanner = KMManager.KM_BANNER_STATE_BLANK;
@@ -912,14 +911,14 @@ public final class KMManager {
 
     if (InAppKeyboard != null && InAppKeyboardLoaded)
     {
-      result1 = InAppKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName,languageName);
+      result1 = InAppKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
       if(result1)
         InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
 
     if (SystemKeyboard != null && SystemKeyboardLoaded)
     {
-      result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName,languageName);
+      result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
       if(result2)
         SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -123,7 +123,7 @@ public final class KMManager {
   /**
    * Banner state value: "suggestion" - dictionary suggestions are shown.
    */
-  protected static final String BANNER_STATE_SUGGESTION = "suggestion";
+  protected static final String KM_BANNER_STATE_SUGGESTION = "suggestion";
 
   //TODO: should be part of kmkeyboard
   /**
@@ -903,8 +903,6 @@ public final class KMManager {
    */
   public static boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID, String keyboardName) {
 
-    //reset banner and layout params
-    currentBanner = KMManager.KM_BANNER_STATE_BLANK;
 
     boolean result1 = false;
     boolean result2 = false;
@@ -912,13 +910,21 @@ public final class KMManager {
     if (InAppKeyboard != null && InAppKeyboardLoaded)
     {
       result1 = InAppKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
-      if(result1)
-        InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
-
     if (SystemKeyboard != null && SystemKeyboardLoaded)
     {
       result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
+    }
+
+    if(result1 || result2)
+    {
+      //reset banner state if new language has no lexical model
+      if(currentBanner.equals(KMManager.KM_BANNER_STATE_SUGGESTION)
+        && getAssociatedLexicalModel(languageID)==null)
+        currentBanner = KMManager.KM_BANNER_STATE_BLANK;
+
+      if(result1)
+        InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
       if(result2)
         SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
@@ -1165,7 +1171,7 @@ public final class KMManager {
 
   public static int getBannerHeight(Context context) {
     int bannerHeight = 0;
-    if (currentBanner.equals(BANNER_STATE_SUGGESTION)) {
+    if (currentBanner.equals(KM_BANNER_STATE_SUGGESTION)) {
       bannerHeight = (int) context.getResources().getDimension(R.dimen.banner_height);
     }
     return bannerHeight;
@@ -1601,7 +1607,7 @@ public final class KMManager {
         int start = url.indexOf("change=") + 7;
         String change = url.substring(start);
         currentBanner = (change.equals("loaded")) ?
-          BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
+          KM_BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         InAppKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {
@@ -1836,7 +1842,7 @@ public final class KMManager {
       } else if (url.indexOf("refreshBannerHeight") >= 0) {
         int start = url.indexOf("change=") + 7;
         String change = url.substring(start);
-        currentBanner = (change.equals("loaded")) ? BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
+        currentBanner = (change.equals("loaded")) ? KM_BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
         RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         SystemKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -23,7 +23,6 @@ import com.tavultesoft.kmea.util.MapCompat;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Typeface;
@@ -37,7 +36,6 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.BaseAdapter;
 import android.widget.Button;
-import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.PopupMenu;
 import android.widget.TextView;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -144,7 +144,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        switchKeyboard(position);
+        switchKeyboard(position,dismissOnSelect);
         if (dismissOnSelect)
           finish();
       }
@@ -301,7 +301,12 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     selectedIndex = position;
   }
 
-  private static void switchKeyboard(int position) {
+  /**
+   * switch to the given keyboard.
+   * @param position the keyboard index in list
+   * @param aPrepareOnly prepare switch, it is executed on keyboard reload
+   */
+  private static void switchKeyboard(int position, boolean aPrepareOnly) {
     setSelection(position);
     int listPosition = (position >= keyboardsList.size()) ? keyboardsList.size()-1 : position;
     HashMap<String, String> kbInfo = keyboardsList.get(listPosition);
@@ -315,7 +320,10 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     String langName = kbInfo.get(KMManager.KMKey_LanguageName);
     String kFont = kbInfo.get(KMManager.KMKey_Font);
     String kOskFont = kbInfo.get(KMManager.KMKey_OskFont);
-    KMManager.setKeyboard(pkgId, kbId, langId, kbName, langName, kFont, kOskFont);
+    if(aPrepareOnly)
+      KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName, langName);
+    else
+      KMManager.setKeyboard(pkgId, kbId, langId, kbName, langName, kFont, kOskFont);
   }
 
   protected static boolean addKeyboard(Context context, HashMap<String, String> keyboardInfo) {
@@ -428,7 +436,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         adapter.notifyDataSetChanged();
       }
       if (position == curKbPos && listView != null) {
-        switchKeyboard(0);
+        switchKeyboard(0,false);
       } else if(listView != null) { // A bit of a hack, since LanguageSettingsActivity calls this method too.
         curKbPos = getCurrentKeyboardIndex();
         setSelection(curKbPos);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -321,7 +321,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     String kFont = kbInfo.get(KMManager.KMKey_Font);
     String kOskFont = kbInfo.get(KMManager.KMKey_OskFont);
     if(aPrepareOnly)
-      KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName, langName);
+      KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName);
     else
       KMManager.setKeyboard(pkgId, kbId, langId, kbName, langName, kFont, kOskFont);
   }


### PR DESCRIPTION
Fixes #2137

## Previous Behavior ##
Keyboard switch using the keyboard picker in keyman seems to swaps the keyboard more than once.

@jahorton already analyzed that this behavior is caused by two separate calls to the embedded page's `setKeymanLanguage` function. 
The first one is the language switch and the second one a reload of keyboard when keyboardpicker is closed.

## New Behavior ##
Keyboard switch using the keyboard picker swaps only once. 
Fixed the multiple call of `setKeymanLanguage` function.

## Work Done ##
- Remove the call  to the embedded page's `setKeymanLanguage` function in the original `switchKeyboard`-method of keyboardpicker.

The keyboardswitch is now executed in 2 phases: 
- first step only prepares the keyboard switch on android site.
- second step: reload the keyboard and execute `setKeymanLanguage` when closing the keyboard picker

## Testing 
- open Keyboard selection in keyman
- select switch keyboard
- test also switching between keyboard with a dictionary and without.
