### PR TITLE
fix(Android, ci): Resolve linting errors

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -49,10 +49,12 @@ else
 fi
 
 if [ "$ONLY_DEBUG" = true ]; then
-  BUILD_FLAG=assembleDebug
+  BUILD_FLAGS="assembleDebug lintDebug"
 else
-  BUILD_FLAG=build
+  # build = assemble + check; check = test + lint
+  BUILD_FLAGS=build
 fi
 
-./gradlew $DAEMON_FLAG clean $BUILD_FLAG
+echo "BUILD_FLAGS $BUILD_FLAGS"
+./gradlew $DAEMON_FLAG clean $BUILD_FLAGS
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -186,6 +186,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent returnIntent) {
+    super.onActivityResult(requestCode, resultCode, returnIntent);
+
     if (resultCode != RESULT_OK) {
       checkGetStarted();
       return;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -352,6 +352,8 @@ public class WebBrowserActivity extends AppCompatActivity {
 
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
     if (webView != null) {
       if (resultCode == RESULT_OK && data != null) {
         String url = data.getStringExtra("url");

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -32,6 +32,11 @@ android {
         }
     }
 
+    // TODO: Remove this when SDK > 17
+    lintOptions {
+        disable 'ResourceType'
+    }
+
     testOptions {
         unitTests {
             // Allows use of a simulated Android API for tests.  (Thanks, roboelectric!)
@@ -63,7 +68,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'org.apache.commons:commons-text:1.8'
 
     // Robolectric
     testImplementation 'androidx.test:core:1.2.0'

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -38,7 +38,8 @@ import static com.tavultesoft.kmea.ConfirmDialogFragment.DialogType.DIALOG_TYPE_
 
 // Public access is necessary to avoid IllegalAccessException
 public final class KeyboardSettingsActivity extends AppCompatActivity {
-
+  private static final String TAG = "KbSettingsActivity";
+  
   private static Toolbar toolbar = null;
   private static ListView listView = null;
   private DialogFragment dialog;
@@ -155,7 +156,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
               } catch (NullPointerException e) {
                 String message = "FileProvider undefined in app to load" + customHelp.toString();
                 Toast.makeText(context, message, Toast.LENGTH_LONG).show();
-                Log.e("KeyboardSettingsActivity", message);
+                Log.e("TAG", message);
               }
             }
             else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -192,6 +192,8 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
 
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
     if (resultCode == 1) {
       finish();
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListActivity.java
@@ -191,15 +191,6 @@ public final class LanguageListActivity extends AppCompatActivity implements OnK
   }
 
   @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    super.onActivityResult(requestCode, resultCode, data);
-
-    if (resultCode == 1) {
-      finish();
-    }
-  }
-
-  @Override
   public void onKeyboardDownloadStarted(HashMap<String, String> keyboardInfo) {
     // Do nothing
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -205,6 +205,8 @@ public final class ModelPickerActivity extends AppCompatActivity {
 
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
     if (resultCode == 1) {
       finish();
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -203,15 +203,6 @@ public final class ModelPickerActivity extends AppCompatActivity {
     finish();
   }
 
-  @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    super.onActivityResult(requestCode, resultCode, data);
-
-    if (resultCode == 1) {
-      finish();
-    }
-  }
-
   // Uses the repo dataset's master lexical model list to create a filtered adapter for use here.
   // As this one is specific to this class, we can implement Activity-specific functionality within it.
   static private class FilteredLexicalModelAdapter extends NestedAdapter<LexicalModel, Dataset.LexicalModels, String> {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudCatalogDownloadTask.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudCatalogDownloadTask.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 class CloudCatalogDownloadTask extends AsyncTask<CloudApiTypes.CloudApiParam, Integer, CloudCatalogDownloadReturns> {
 
-  private static final String TAG = "CloudCatalogDownloadTask";
+  private static final String TAG = "CloudCatDownloadTask";
 
   private final boolean hasConnection;
   private ProgressDialog progressDialog;

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -126,8 +126,7 @@ fi
 
 echo "Gradle Build of KMEA"
 cd $KMA_ROOT/KMEA
-./gradlew $DAEMON_FLAG clean
-./gradlew $DAEMON_FLAG aR
+./gradlew $DAEMON_FLAG clean aR lint
 if [ $? -ne 0 ]; then
     die "ERROR: Build of KMEA failed"
 fi

--- a/android/history.md
+++ b/android/history.md
@@ -5,6 +5,8 @@
 * New Features:
   * Adding a download manager to execute downloads in background (#2247)
   * Improve custom package installation: Show readme.htm before starting installation process (#2286)
+  * Update target Android SDK version to 29 (#2279)
+  * Add linting to Debug builds and resolve lint errors (#2305)
 
 ## 2019-10-30 12.0.4206 stable
 * Bug fix:


### PR DESCRIPTION
Follow-on to #2279 
Linting apparently was only being done on release builds, so the master alpha build failed.
(I still don't understand why it wasn't an issue on the PR builds done on the same build agent)

This PR adds linting flag to the `./build.sh` scripts.

Also fixes these lint errors:
* Add `super.onActivityResult()`
* Fix `TAG` strings to be <= 23 characters
* Suppress `ResourceType` lint error (TODO to address when our SDK > 17)
* Remove unused `org.apache.commons:commons-text` (gave a packaging lint error)

Lint reports will now be generated in:
android/KMEA/app/build/reports/lint-results(-debug).html
android/KMAPro/kMAPro/build/reports/lint-results(-debug).html

## User Testing
1. Check the CI artifacts for the lint-result reports
2. Verify no errors in red
