### PR TITLE
fix(ios): System keyboard popup-key positioning confinement

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
@@ -11,6 +11,7 @@ import  UIKit
 class SubKeysView: UIView {
   private let borderRadius: CGFloat = 5.0
   private let strokeWidth: CGFloat = 1.0
+  private var baseKeyYDelta: CGFloat = 0.0
 
   private var keyFrame = CGRect.zero
   private var adjX: CGFloat = 0.0
@@ -88,7 +89,14 @@ class SubKeysView: UIView {
     let baseHeight = keyFrame.size.height + marginY
     let viewHeight = baseHeight + containerHeight - marginY + strokeWidth
     var viewPosX = keyFrame.origin.x - (viewWidth - keyFrame.size.width) / 2.0
-    let viewPosY = keyFrame.origin.y - (viewHeight - keyFrame.size.height + strokeWidth)
+    var viewPosY = keyFrame.origin.y - (viewHeight - keyFrame.size.height + strokeWidth)
+
+    // Ensure that the system keyboard doesn't try to display off the top of the keyboard's view area.
+    if viewPosY < 0 && isSystemKeyboard {
+      baseKeyYDelta = viewPosY // We'll need this to adjust the visualization.
+      viewPosY = 0
+    }
+
     adjX = 0
     adjY = 0
 
@@ -173,6 +181,10 @@ class SubKeysView: UIView {
     let viewTop = strokeWidth
 
     var viewBottom = viewHeight - strokeWidth * 0.75 - (CGFloat(rows - 1) * 0.25)
+    viewBottom += baseKeyYDelta
+
+    let showBaseKeyPopup = (viewBottom > midY)
+
     if scale == 3.0 {
       viewBottom -= CGFloat(3 - rows) * 0.4
     } else if scale == 2.0 {
@@ -198,16 +210,21 @@ class SubKeysView: UIView {
     context.move(to: CGPoint(x: viewMid, y: viewTop))
     context.addArc(tangent1End: CGPoint(x: viewLeft, y: viewTop),
                    tangent2End: CGPoint(x: viewLeft, y: midY), radius: r1)
-    context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
-                   tangent2End: CGPoint(x: keyLeft, y: midY), radius: r1)
-    context.addArc(tangent1End: CGPoint(x: keyLeft, y: midY),
-                   tangent2End: CGPoint(x: keyLeft, y: viewBottom), radius: r2)
-    context.addArc(tangent1End: CGPoint(x: keyLeft, y: viewBottom),
-                   tangent2End: CGPoint(x: keyRight, y: viewBottom), radius: r0)
-    context.addArc(tangent1End: CGPoint(x: keyRight, y: viewBottom),
-                   tangent2End: CGPoint(x: keyRight, y: midY), radius: r0)
-    context.addArc(tangent1End: CGPoint(x: keyRight, y: midY),
-                   tangent2End: CGPoint(x: viewRight, y: midY), radius: r2)
+    if showBaseKeyPopup {
+      context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
+                     tangent2End: CGPoint(x: keyLeft, y: midY), radius: r1)
+      context.addArc(tangent1End: CGPoint(x: keyLeft, y: midY),
+                     tangent2End: CGPoint(x: keyLeft, y: viewBottom), radius: r2)
+      context.addArc(tangent1End: CGPoint(x: keyLeft, y: viewBottom),
+                     tangent2End: CGPoint(x: keyRight, y: viewBottom), radius: r0)
+      context.addArc(tangent1End: CGPoint(x: keyRight, y: viewBottom),
+                     tangent2End: CGPoint(x: keyRight, y: midY), radius: r0)
+      context.addArc(tangent1End: CGPoint(x: keyRight, y: midY),
+                     tangent2End: CGPoint(x: viewRight, y: midY), radius: r2)
+    } else {
+      context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
+                     tangent2End: CGPoint(x: viewRight, y: midY), radius: r0)
+    }
     context.addArc(tangent1End: CGPoint(x: viewRight, y: midY),
                    tangent2End: CGPoint(x: viewRight, y: viewTop), radius: r1)
     context.addArc(tangent1End: CGPoint(x: viewRight, y: viewTop),
@@ -219,16 +236,21 @@ class SubKeysView: UIView {
     context.move(to: CGPoint(x: viewMid, y: viewTop))
     context.addArc(tangent1End: CGPoint(x: viewLeft, y: viewTop),
                    tangent2End: CGPoint(x: viewLeft, y: midY), radius: r1)
-    context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
-                   tangent2End: CGPoint(x: keyLeft, y: midY), radius: r1)
-    context.addArc(tangent1End: CGPoint(x: keyLeft, y: midY),
-                   tangent2End: CGPoint(x: keyLeft, y: viewBottom), radius: r2)
-    context.addArc(tangent1End: CGPoint(x: keyLeft, y: viewBottom),
-                   tangent2End: CGPoint(x: keyRight, y: viewBottom), radius: r0)
-    context.addArc(tangent1End: CGPoint(x: keyRight, y: viewBottom),
-                   tangent2End: CGPoint(x: keyRight, y: midY), radius: r0)
-    context.addArc(tangent1End: CGPoint(x: keyRight, y: midY),
-                   tangent2End: CGPoint(x: viewRight, y: midY), radius: r2)
+    if showBaseKeyPopup {
+      context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
+                     tangent2End: CGPoint(x: keyLeft, y: midY), radius: r1)
+      context.addArc(tangent1End: CGPoint(x: keyLeft, y: midY),
+                     tangent2End: CGPoint(x: keyLeft, y: viewBottom), radius: r2)
+      context.addArc(tangent1End: CGPoint(x: keyLeft, y: viewBottom),
+                     tangent2End: CGPoint(x: keyRight, y: viewBottom), radius: r0)
+      context.addArc(tangent1End: CGPoint(x: keyRight, y: viewBottom),
+                     tangent2End: CGPoint(x: keyRight, y: midY), radius: r0)
+      context.addArc(tangent1End: CGPoint(x: keyRight, y: midY),
+                     tangent2End: CGPoint(x: viewRight, y: midY), radius: r2)
+    } else {
+      context.addArc(tangent1End: CGPoint(x: viewLeft, y: midY),
+                     tangent2End: CGPoint(x: viewRight, y: midY), radius: r0)
+    }
     context.addArc(tangent1End: CGPoint(x: viewRight, y: midY),
                    tangent2End: CGPoint(x: viewRight, y: viewTop), radius: r1)
     context.addArc(tangent1End: CGPoint(x: viewRight, y: viewTop),


### PR DESCRIPTION
Fixes #2299.

This PR ensures that the popup keys are always displayed within the keyboard's area for the system keyboard.  It turns out there was no bounds-checking for the vertical position, so this implements some logic to handle this.

Accordingly, a bit of adaptive styling is necessary to ensure that the displayed popup keys "look right."  For comparison, an example that doesn't need to be constrained:

<img width="410" alt="Screen Shot 2019-11-07 at 11 39 36 AM" src="https://user-images.githubusercontent.com/25213402/68360848-294cc880-0154-11ea-9bca-a701f9bf90b7.png">

For the 'i' key, constrainment is needed because there are two rows of popup keys.  I've managed to implement a reasonable UI adjustment for this:

<img width="412" alt="Screen Shot 2019-11-07 at 11 38 47 AM" src="https://user-images.githubusercontent.com/25213402/68360881-4da8a500-0154-11ea-8ce4-702870c32684.png">

The base y-coordinate of the "extension" of the base key for the popups is located identically.  Should the base key ever be entirely hidden behind popup keys, no "extension nub" will be displayed.

The positioning of the popup menu will only be adjusted when necessary - we can see this with the 'y' key:

<img width="411" alt="Screen Shot 2019-11-07 at 11 51 10 AM" src="https://user-images.githubusercontent.com/25213402/68361075-0d95f200-0155-11ea-9553-be24248f602b.png">


## User Testing

The screenshots above should speak fairly well to user testing, but here's a bit more detail.

- As suggested by the original issue report, testing with the SIL EuroLatin keyboard is advised.
- Note that the vowel keys tend to all have a _lot_ of popup options - be sure to check 'e', 'i', 'o', and 'u'.  (Note that even the semivowel 'y' is close to needing a second row!)
- 'a' will have a lot of popup keys as well, but is low enough on the keyboard that it will behave more similarly to the 'k' and 'y' images above.
- Single-row popup menus should behave like the 'y' and 'k' key images seen above.