### PR TITLE
fix(web):  Fixes bug in version hotkey combo

### DIFF
--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -467,7 +467,7 @@ namespace com.keyman.osk {
           this.showBuild();
         }
         return false;
-      },false);
+      }.bind(this),false);
 
       // Prevent selection of caption (IE - set by class for other browsers)
       if('onselectstart' in Ltitle) Ltitle.onselectstart= util.selectStartHandler; //IE (Build 360)


### PR DESCRIPTION
Fixes #2289.

The cause:  a tale as old as Javascript-time. (`this` handling in events)

Note that the combo doesn't seem to work on Macs, as CTRL+click usually launches a context menu, blocking the hotkey from being processed properly.  That's probably a conversation for later, though.

