### PR TITLE
fix(windows): Keyman was not working with Skype

### DIFF
--- a/windows/src/engine/keyman/main.pas
+++ b/windows/src/engine/keyman/main.pas
@@ -181,6 +181,10 @@ begin
     if r.OpenKey(SRegKey_KeymanRoot_CU, True) then
     begin
       GrantPermissionToAllApplicationPackages(r.CurrentKey, KEY_READ);
+      // #1680 - on some systems, HKCU\Software\Keyman\Keyman Engine is not
+      // inheriting permissions from HKCU\Software\Keyman
+      if r.OpenKey('\' + SRegKey_KeymanEngineRoot_CU, True) then
+        GrantPermissionToAllApplicationPackages(r.CurrentKey, KEY_READ);
     end;
   finally
     r.Free;


### PR DESCRIPTION
Fixes #1680. This issue arose only on some systems where
permissions for Keyman registry keys were not being
set correctly.