### PR TITLE
fix(ios): Fixes bad initialization of system keyboard width

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -142,6 +142,10 @@ class KeymanWebViewController: UIViewController {
   // Very useful for immediately adjusting the WebView's properties upon loading.
   override func viewDidAppear(_ animated: Bool) {
     fixLayout()
+
+    // Initialize the keyboard's size/scale.  In iOS 13 (at least), the system
+    // keyboard's width will be set at this stage, but not in viewWillAppear.
+    keyboardSize = view.bounds.size
   }
 }
 
@@ -530,7 +534,7 @@ extension KeymanWebViewController: KeymanWebDelegate {
     delegate?.keyboardLoaded(keymanWeb)
 
     log.info("Loaded keyboard.")
-    
+
     resizeKeyboard()
     setDeviceType(UIDevice.current.userInterfaceIdiom)
     
@@ -852,9 +856,10 @@ extension KeymanWebViewController {
   func resizeKeyboard() {
     fixLayout()
 
-    // Ensures the height is properly updated.
+     // Ensures the width and height are properly updated.
     // Note:  System Keyboard init currently requires this for the keyboard to display properly
     // the first time.
+    setOskWidth(Int(kbSize.width))
     setOskHeight(Int(kbSize.height))
   }
   

--- a/ios/history.md
+++ b/ios/history.md
@@ -3,6 +3,13 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-11-14 12.0.54 stable
+* Confine system keyboard popup-key positioning (#2317)
+* Fix initialization of system keyboard width (#2318)
+
+## 2019-10-10 12.0.53 stable
+* No actual code changes affecting iOS (KeymanWeb #2194)
+
 ## 2019-10-08 12.0.52 stable
 * Fixes issue when installing dictionaries (#2193)
 


### PR DESCRIPTION
Fixes #2260 and cherry-pick of #2301 for stable-12.0

These changes ensure that the Swift side of the keyboard can provided the KMW side with an initial width, bypassing the need for the failing `window.orientation` check (which was used to produce said initial width).