### PR TITLE
fix(android): Sanitize version for API query

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -128,7 +128,7 @@ public class CloudRepository {
     // Sanitize appVersion to #.#.# to match the API spec
     // Regex needs to match the entire string
     String appVersion = BuildConfig.VERSION_NAME;
-    Pattern pattern = Pattern.compile("(\\d+\\.\\d+\\.\\d+).*");
+    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+).*");
     Matcher matcher = pattern.matcher(appVersion);
     if (matcher.matches() && matcher.groupCount() >= 1) {
       appVersion = matcher.group(1);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 public class CloudRepository {
   static public final CloudRepository shared = new CloudRepository();
@@ -123,9 +125,18 @@ public class CloudRepository {
   {
     String deviceType = CloudDataJsonUtil.getDeviceTypeForCloudQuery(aContext);
 
+    // Sanitize appVersion to #.#.# to match the API spec
+    // Regex needs to match the entire string
+    String appVersion = BuildConfig.VERSION_NAME;
+    Pattern pattern = Pattern.compile("(\\d+\\.\\d+\\.\\d+).*");
+    Matcher matcher = pattern.matcher(appVersion);
+    if (matcher.matches() && matcher.groupCount() >= 1) {
+      appVersion = matcher.group(1);
+    }
+
     // Retrieves the cloud-based keyboard catalog in Android's preferred format.
     String keyboardURL = String.format("%s?version=%s&device=%s&languageidtype=bcp47",
-      KMKeyboardDownloaderActivity.kKeymanApiBaseURL, BuildConfig.VERSION_NAME, deviceType);
+      KMKeyboardDownloaderActivity.kKeymanApiBaseURL, appVersion, deviceType);
 
     //cloudQueries[cloudQueryEntries++] = new CloudApiParam(ApiTarget.Keyboards, keyboardURL, JSONType.Object);
    return new CloudApiTypes.CloudApiParam(

--- a/android/history.md
+++ b/android/history.md
@@ -7,6 +7,7 @@
   * Improve custom package installation: Show readme.htm before starting installation process (#2286)
   * Update target Android SDK version to 29 (#2279)
   * Add linting to Debug builds and resolve lint errors (#2305)
+  * Sanitize the app version to `#.#.#` for the API cloud query (#2319)
 
 ## 2019-10-30 12.0.4206 stable
 * Bug fix:


### PR DESCRIPTION
Fixes #2298

Sanitize the app version to `#.#.#` to match the API query spec

## User Testing
- [ ] Test for presence of fv_sencoten keyboard
1. Load the PR test build
2. start Keyman
3. Go "Settings" --> "Languages" to bring up the language picker
4. Search for "Salish, Straits" / "SENĆOŦEN" keyboard and install
5. Return to language picker
6. Search for "SENĆOŦEN" / "SENĆOŦEN" keyboard and install (this is fv_sencoten version 9.1)
