### PR TITLE
chore(linux): Allow to skip calculation of version number

### DIFF
--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -32,15 +32,20 @@ if [ "$1" != "" ]; then
     fi
 fi
 
-JENKINS=${JENKINS:="no"}
-oldvers=`cat VERSION`
+if [ -n $SKIPVERSION ]; then
+    oldvers=$(cat OLDVERSION)
+    newvers=$(cat VERSION)
+else
+    JENKINS=${JENKINS:="no"}
+    oldvers=`cat VERSION`
 
-. $(dirname "$0")/version.sh
+    . $(dirname "$0")/version.sh
 
-version
+    version
 
-echo "version: ${newvers}"
-echo "${newvers}" > VERSION
+    echo "version: ${newvers}"
+    echo "${newvers}" > VERSION
+fi
 
 # autoreconf the projects
 for proj in ${autotool_projects}; do

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -15,18 +15,18 @@ extra_projects="keyboardprocessor keyman-config"
 
 if [ "$1" != "" ]; then
     if [ "$1" == "keyboardprocessor" ]; then
-	echo "reconfiguring only keyboardprocessor"
+    echo "reconfiguring only keyboardprocessor"
         extra_projects="keyboardprocessor"
         autotool_projects=""
     elif [ ! -d "$1" ]; then
         echo "project $1 does not exist"
         exit 1
     elif [ "$1" == "keyman-config" ]; then
-	echo "reconfiguring only keyman-config"
+    echo "reconfiguring only keyman-config"
         extra_projects="keyman-config"
         autotool_projects=""
     else
-	echo "reconfiguring only $1"
+    echo "reconfiguring only $1"
         autotool_projects="$1"
         extra_projects=""
     fi


### PR DESCRIPTION
This change allows to calculate the version number once at the
beginning and then skip the calculation when we create the source
packages for the various packages. This allows to set the version
number in Jenkins early on.

Also fix some whitespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2321)
<!-- Reviewable:end -->
