### PR TITLE
chore(common): Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/linux/scripts/.editorconfig
+++ b/linux/scripts/.editorconfig
@@ -1,0 +1,4 @@
+# Editor configuration, see https://editorconfig.org
+[*]
+indent_style = space
+indent_size = 4

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -15,18 +15,18 @@ extra_projects="keyboardprocessor keyman-config"
 
 if [ "$1" != "" ]; then
     if [ "$1" == "keyboardprocessor" ]; then
-    echo "reconfiguring only keyboardprocessor"
+        echo "reconfiguring only keyboardprocessor"
         extra_projects="keyboardprocessor"
         autotool_projects=""
     elif [ ! -d "$1" ]; then
         echo "project $1 does not exist"
         exit 1
     elif [ "$1" == "keyman-config" ]; then
-    echo "reconfiguring only keyman-config"
+        echo "reconfiguring only keyman-config"
         extra_projects="keyman-config"
         autotool_projects=""
     else
-    echo "reconfiguring only $1"
+        echo "reconfiguring only $1"
         autotool_projects="$1"
         extra_projects=""
     fi


### PR DESCRIPTION
This allows IDEs to automatically pick up the preferred coding style and might help with a more consistent use of spaces/tabs for indentation. This might need some fine-tuning for certain files or platforms, but it is a start...

The motivation for this change is that I'm tired of telling VS Code every time I open this project to use spaces for the files I edit. There are other ways how this could be achieved, but an `.editorconfig` is a pretty standard way of achieving this across different machines, users and IDEs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2327)
<!-- Reviewable:end -->
