### PR TITLE
fix(windows): focus is incorrect for CEF

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
@@ -34,7 +34,6 @@ inherited frameCEFHost: TframeCEFHost
     Top = 208
   end
   object cef: TChromium
-    OnWidgetCompMsg = cefWidgetCompMsg
     OnLoadEnd = cefLoadEnd
     OnSetFocus = cefSetFocus
     OnRunContextMenu = cefRunContextMenu

--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -656,7 +656,6 @@ end;
 
 procedure TframeTextEditor.SetFocus;
 begin
-  inherited;
   cef.SetFocus;
 end;
 


### PR DESCRIPTION
The focus code paths for Chromium frames (CEF4Delphi) were incorrect.
The return value for preventing focus on navigation events was
inverted, and then other code was attempting to work around this
inversion, wrongly. Fixed the root issue of the inverted test (it would
help if the parameter cefSetFocus was known as `Handled` rather than
`Result`!) and then the remaining code pathways became far simpler.

Fixes #2314.