### PR TITLE
fix(windows): focus is incorrect for CEF 🍒

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.UframeCEFHost.dfm
@@ -34,7 +34,6 @@ inherited frameCEFHost: TframeCEFHost
     Top = 208
   end
   object cef: TChromium
-    OnWidgetCompMsg = cefWidgetCompMsg
     OnLoadEnd = cefLoadEnd
     OnSetFocus = cefSetFocus
     OnRunContextMenu = cefRunContextMenu

--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -656,7 +656,6 @@ end;
 
 procedure TframeTextEditor.SetFocus;
 begin
-  inherited;
   cef.SetFocus;
 end;
 

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-11-15 12.0.54 stable
+* Bug Fix: Text editor and other controls did not receive focus correctly (#2331)
+
 ## 2019-10-07 12.0.50 stable
 * Release 12.0
 


### PR DESCRIPTION
Cherry pick of #2331 for stable-12.0.

The focus code paths for Chromium frames (CEF4Delphi) were incorrect. The
return value for preventing focus on navigation events was inverted, and
then other code was attempting to work around this inversion, wrongly.
Fixed the root issue of the inverted test (it would help if the parameter
cefSetFocus was known as `Handled` rather than
`Result`!) and then the remaining code pathways became far simpler.

Fixes #2314.