### PR TITLE
fix(windows): OSK restores to wrong monitor 🍒

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-11-15 12.0.54 stable
+* Bug Fix: On Screen Keyboard restored to wrong screen and position when reloading (#2330)
+
 ## 2019-11-12 12.0.53 stable
 * Bug Fix: Address instability when exiting Keyman on some systems (#2324)
 * Bug Fix: Keyman was not working with Skype, Windows Search on some systems (#2324)


### PR DESCRIPTION
Cherry-pick of #2330.

If the On Screen Keyboard was closed when on a monitor other than the 
primary monitor, it would restore to the primary monitor in the top- left
corner instead of the previous location.

This fix allows the OSK to be restored to another monitor, but still avoids
positioning the window off screen if the monitor has been disconnected.

Fixes #2270.