### PR TITLE
fix(web): displayUnderlying flag was ignored

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -617,7 +617,12 @@ namespace com.keyman.osk {
       }
 
       // Set flag to add default (US English) key label if specified by keyboard
-      layout.keyLabels = activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      if(typeof layout['displayUnderlying'] != 'undefined') {
+        layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+      } else {
+        layout.keyLabels = activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      }
+
       let divLayerContainer = this.deviceDependentLayout(layout, util.device.formFactor);
 
       this.ddOSK = true;
@@ -2126,7 +2131,11 @@ namespace com.keyman.osk {
 
       // Cannot create an OSK if no layout defined, just return empty DIV
       if(layout != null) {
-        layout.keyLabels=((typeof(PKbd['KDU']) != 'undefined') && PKbd['KDU']);
+        if(typeof layout['displayUnderlying'] != 'undefined') {
+          layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+        } else {
+          layout.keyLabels = typeof(PKbd['KDU']) != 'undefined' && PKbd['KDU'];
+        }        
       }
 
       // TODO:  Fix this method's link!


### PR DESCRIPTION
Fixes #2311.

The `displayUnderlying` flag introduced in #1539 was somehow missed from
the 12.0 work. This PR restores the behaviour from 11.0 by adding the
relevant changes from #1539.

Tested in Chrome Emulator.

# User Testing

@makarasok

- [ ] Test that when the OSK underlying layout is switched on, it does not impact touch keyboards
1. Create a basic keyboard project. Turn **on** 'display underlying layout characters' in the On-Screen editor.
2. Make sure that the 'display underlaying' switch is off for both Phone and Tablet in the Touch Layout editor.
3. Compile and test the keyboard in desktop configuration.  Make sure that the underlying characters **are** shown.
4. Test in phone and tablet configurations. Make sure that the underlying characters **are not** shown.

- [ ] Test that when the OSK underlying layout is switched off, it does not impact touch keyboards
1. Create a basic keyboard project. Turn **off** 'display underlying layout characters' in the On-Screen editor.
2. Make sure that the 'display underlaying' switch is **on** for both Phone and Tablet in the Touch Layout editor.
3. Compile and test the keyboard in desktop configuration.  Make sure that the underlying characters **are not** shown.
4. Test in phone and tablet configurations. Make sure that the underlying characters **are** shown.

- [ ] Test that the tablet and phone flags are independent
1. Create a basic keyboard project. Turn **off** 'display underlying layout characters' in the On-Screen editor.
2. Make sure that the 'display underlaying' switch is **on** for Phone and **off** for Tablet in the Touch Layout editor.
3. Compile and test the keyboard in desktop configuration.  Make sure that the underlying characters **are not** shown.
4. Test in phone configuration. Make sure that the underlying characters **are** shown.
5. Test in tablet configuration. Make sure that the underlying characters **are not** shown.