### PR TITLE
[Web] Toolchain update + dev-resource compilation fix

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2314,9 +2314,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "uc.micro": {

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
     "karma-teamcity-reporter": "^1.1.0",
     "mocha": "^5.2.0",
     "modernizr": "^3.7.1",
-    "typescript": "^3.2.2"
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "tsc": "tsc",

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -1,3 +1,6 @@
+// Includes version-related functionality
+///<reference path="utils/version.ts"/>
+
 // The Device object definition -------------------------------------------------
 
 namespace com.keyman {

--- a/web/source/kmwexthtml.ts
+++ b/web/source/kmwexthtml.ts
@@ -23,8 +23,6 @@ interface Element {
     kmwInput: boolean,
     _kmwResizeHandler: (e: any) => void,
 
-    onselectstart: any,
-
     // Used by our util.wait / util.alert system
     dismiss: () => void
 }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -204,7 +204,7 @@ namespace com.keyman.osk {
         ts.fontFamily=spec['font'];
       }
 
-      if(typeof spec['fontsize'] == 'string' && spec['fontsize'] != 0) {
+      if(typeof spec['fontsize'] == 'string' && spec['fontsize'] != '') {
         ts.fontSize=spec['fontsize'];
       }
 
@@ -564,12 +564,12 @@ namespace com.keyman.osk {
     // Function fields (fleshed out by kmwnative.ts and/or kmwembedded.ts)
     touchHold: (key: KeyElement) => void;
     optionKey: (e: KeyElement, keyName: string, keyDown: boolean) => void;
-    highlightSubKeys: (key: KeyElement, x: number, y: number) => void = this.highlightSubKeys || function(k,x,y) {};
+    highlightSubKeys: (key: KeyElement, x: number, y: number) => void;
     showKeyTip: (key: KeyElement, on: boolean) => void;
-    drawPreview: (canvas: HTMLCanvasElement, w: number, h: number, edge: number) => void = this.drawPreview || function(c,w,h,e) {};
+    drawPreview: (canvas: HTMLCanvasElement, w: number, h: number, edge: number) => void;
     createKeyTip: () => void;
-    addCallout: (key: KeyElement) => HTMLDivElement = this.addCallout || function(key) {return null};
-    waitForFonts: (kfd,ofd) => boolean = this.waitForFonts || function(kfd,ofd){return true;}; // Default is used by embedded.
+    addCallout: (key: KeyElement) => HTMLDivElement;
+    waitForFonts: (kfd,ofd) => boolean;
 
     //#region OSK constructor and helpers
 
@@ -581,6 +581,14 @@ namespace com.keyman.osk {
      * Description  Generates the base visual keyboard element, prepping for attachment to KMW
      */
     constructor(PVK, Lhelp, layout0: LayoutFormFactor, kbdBitmask: number) {
+      // Add handler stubs if not otherwise defined.  (We can no longer in-line default-define with the declaration.)
+      this.highlightSubKeys = this.highlightSubKeys || function(k,x,y) {};
+      this.drawPreview = this.drawPreview || function(c,w,h,e) {};
+      this.addCallout = this.addCallout || function(key) {return null};
+      this.waitForFonts = this.waitForFonts || function(kfd,ofd){return true;}; // Default is used by embedded.
+      
+      // Do normal constructor stuff.
+
       let keyman = com.keyman.singleton;
 
       let util = keyman.util;

--- a/web/source/utils/version.ts
+++ b/web/source/utils/version.ts
@@ -1,3 +1,6 @@
+// Ensure that this class contains no reference into core KMW code - it is referenced
+// by components intended to be modular and possible to separate from core KMW.
+
 namespace com.keyman.utils {
   // Dotted-decimal version
   export class Version {


### PR DESCRIPTION
Fixes #2322.
Fixes #2328.

TypeScript has gotten a little more restrictive than before, causing the initialization style used for some function stubs to generate errors now.  On the other hand, it now properly defines `onselectstart` now, allowing for us to drop our crude manual definition from before.