### PR TITLE
fix(web): displayUnderlying flag was ignored 🍒

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-11-18 12.0.103 stable
+* Fix for 'display underlying' flag not working (#2353)
+
 ## 2019-10-10 12.0.101 stable
 * Fixes issue with keyboards requiring special state notifications, such as the CJK picker keyboards (#2194)
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -617,7 +617,12 @@ namespace com.keyman.osk {
       }
 
       // Set flag to add default (US English) key label if specified by keyboard
-      layout.keyLabels = activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      if(typeof layout['displayUnderlying'] != 'undefined') {
+        layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+      } else {
+        layout.keyLabels = activeKeyboard && ((typeof(activeKeyboard['KDU']) != 'undefined') && activeKeyboard['KDU']);
+      }
+
       let divLayerContainer = this.deviceDependentLayout(layout, util.device.formFactor);
 
       this.ddOSK = true;
@@ -2126,7 +2131,11 @@ namespace com.keyman.osk {
 
       // Cannot create an OSK if no layout defined, just return empty DIV
       if(layout != null) {
-        layout.keyLabels=((typeof(PKbd['KDU']) != 'undefined') && PKbd['KDU']);
+        if(typeof layout['displayUnderlying'] != 'undefined') {
+          layout.keyLabels = layout['displayUnderlying'] == true; // force bool
+        } else {
+          layout.keyLabels = typeof(PKbd['KDU']) != 'undefined' && PKbd['KDU'];
+        }        
       }
 
       // TODO:  Fix this method's link!


### PR DESCRIPTION
Fixes #2311.

Cherry-pick of #2353 for stable-12.0

The `displayUnderlying` flag introduced in #1539 was somehow missed from 
the 12.0 work. This PR restores the behaviour from 11.0 by adding the 
relevant changes from #1539.

Tested in Chrome Emulator.