### PR TITLE
[Android] ES6 & API 19-23 compatibility changes

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -267,10 +267,10 @@
 
     function suggestionPopup(obj,custom,x,y,w,h) {
       if(obj != null) {
-        let s = JSON.stringify(obj);
+        var s = JSON.stringify(obj);
 
         fragmentToggle=(fragmentToggle+1) % 100;
-        let hash = 'suggestPopup-' + fragmentToggle;
+        var hash = 'suggestPopup-' + fragmentToggle;
 
         hash = hash + '&x=' + encodeURIComponent(x) + '&y=' + encodeURIComponent(y);
         hash = hash + '&w=' + encodeURIComponent(w) + '&h=' + encodeURIComponent(h);

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/// <reference path="node_modules/promise-polyfill/lib/polyfill.js" />
+/// <reference path="node_modules/es6-shim/es6-shim.min.js" />
 /// <reference path="promise-store.ts" />
 
 /**

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -143,8 +143,15 @@ namespace com.keyman.text.prediction {
 
     private onMessage(event: MessageEvent): void {
       let payload: OutgoingMessage = event.data;
-      if (payload.message === 'ready') {
+      if (payload.message === 'error') {
+        console.error(payload.log);
+        if(payload.error) {
+          console.error(payload.error);
+        }
+      }
+      else if (payload.message === 'ready') {
         this._declareLMLayerReady(event.data.configuration);
+        console.log("LMLayer ready!");
       } else if (payload.message === 'suggestions') {
         this._predictPromises.keep(payload.token, payload.suggestions);
       } else if (payload.message === 'currentword') {

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -151,7 +151,6 @@ namespace com.keyman.text.prediction {
       }
       else if (payload.message === 'ready') {
         this._declareLMLayerReady(event.data.configuration);
-        console.log("LMLayer ready!");
       } else if (payload.message === 'suggestions') {
         this._predictPromises.keep(payload.token, payload.suggestions);
       } else if (payload.message === 'currentword') {

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -30,8 +30,14 @@ type Token = number;
 /**
  * The valid outgoing message kinds.
  */
-type OutgoingMessageKind = 'ready' | 'suggestions' | 'currentword';
-type OutgoingMessage = ReadyMessage | SuggestionMessage | CurrentWordMessage;
+type OutgoingMessageKind = 'error' | 'ready' | 'suggestions' | 'currentword';
+type OutgoingMessage = ErrorMessage | ReadyMessage | SuggestionMessage | CurrentWordMessage;
+
+interface ErrorMessage {
+  message: 'error';
+  error?: any;
+  log: string;
+}
 
 /**
  * Tells the keyboard that the LMLayer is ready. Provides

--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -625,6 +625,11 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "es6-shim": {
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.5.tgz",
+      "integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1599,11 +1604,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
       "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
       "dev": true
-    },
-    "promise-polyfill": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
     },
     "ps-tree": {
       "version": "1.1.1",

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -44,6 +44,6 @@
     "typescript": "^3.2.1"
   },
   "dependencies": {
-    "promise-polyfill": "8.1.0"
+    "es6-shim": "^0.35.5"
   }
 }

--- a/common/predictive-text/promise-store.ts
+++ b/common/predictive-text/promise-store.ts
@@ -1,3 +1,5 @@
+/// <reference path="node_modules/es6-shim/es6-shim.min.js" />
+
 /*
  * Copyright (c) 2018 National Research Council Canada (author: Eddie A. Santos)
  * Copyright (c) 2018 SIL International

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -131,9 +131,10 @@ class LMLayerWorker {
     if(im.message == 'load') {
       let data = im as LoadMessage;
       if(data.model == this._currentModelSource) {
-        // if(console) {
-        //   console.warn("Duplicate model load message detected - squashing!");
-        // }
+        // Some JS implementations don't allow web workers access to the console.
+        if(console) {
+          console.warn("Duplicate model load message detected - squashing!");
+        }
         return;
       } else {
         this._currentModelSource = data.model;

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -95,6 +95,14 @@ class LMLayerWorker {
     this.setupConfigState();
   }
 
+  public error(message: string, error?: any) {
+    // error isn't a fan of being cloned across the worker boundary.
+    this.cast('error', {
+      log: message,
+      error: (error && error.stack) ? error.stack : undefined
+    });
+  }
+
   /**
    * A function that can be set as self.onmessage (the Worker
    * message handler).
@@ -165,24 +173,37 @@ class LMLayerWorker {
   public loadModel(model: LexicalModel) {
     // TODO:  pass _platformConfig to model so that it can self-configure to the platform,
     // returning a Configuration.
-    let configuration = model.configure(this._platformCapabilities);
 
-    // Set reasonable defaults for the configuration.
-    if (!configuration.leftContextCodeUnits) {
-      configuration.leftContextCodeUnits = this._platformCapabilities.maxLeftContextCodeUnits;
-    }
-    if (!configuration.rightContextCodeUnits) {
-      configuration.rightContextCodeUnits = this._platformCapabilities.maxRightContextCodeUnits || 0;
-    }
+    /* Note that this function is typically called from within an `importScripts` call.
+     * For meaningful error messages to be successfully logged, we must catch what we can here
+     * and pass a message to outside the worker - otherwise a generic "Script error" occurs.
+     */
+    try {
+      let configuration = model.configure(this._platformCapabilities);
 
-    this.transitionToReadyState(model);
-    this.cast('ready', { configuration });
+      // Set reasonable defaults for the configuration.
+      if (!configuration.leftContextCodeUnits) {
+        configuration.leftContextCodeUnits = this._platformCapabilities.maxLeftContextCodeUnits;
+      }
+      if (!configuration.rightContextCodeUnits) {
+        configuration.rightContextCodeUnits = this._platformCapabilities.maxRightContextCodeUnits || 0;
+      }
+
+      this.transitionToReadyState(model);
+      this.cast('ready', { configuration });
+    } catch (err) {
+      this.error("loadModel failed!", err);
+    }
   }
 
   private loadModelFile(url: string) {
     // The self/global WebWorker method, allowing us to directly import another script file into WebWorker scope.
     // If built correctly, the model's script file will auto-register the model with loadModel() above.
-    this._importScripts(url);
+    try {
+      this._importScripts(url);
+    } catch (err) {
+      this.error("Error occurred when attempting to load dictionary", err);
+    }
   }
 
   public unloadModel() {

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -123,7 +123,9 @@ class LMLayerWorker {
     if(im.message == 'load') {
       let data = im as LoadMessage;
       if(data.model == this._currentModelSource) {
-        console.warn("Duplicate model load message detected - squashing!");
+        // if(console) {
+        //   console.warn("Duplicate model load message detected - squashing!");
+        // }
         return;
       } else {
         this._currentModelSource = data.model;

--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -3,7 +3,7 @@
 // Needed for OSK rendering to image files.
 /// <reference path="../node_modules/html2canvas/dist/html2canvas.js" />
 // Ensure that Promises are within scope.
-/// <reference path="../node_modules/promise-polyfill/lib/polyfill.js" />
+/// <reference path="../node_modules/es6-shim/es6-shim.min.js" />
 
 type KeyboardMap = {[id: string]: any};
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -687,6 +687,11 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "es6-shim": {
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.5.tgz",
+      "integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1803,11 +1808,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
-    },
-    "promise-polyfill": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
     },
     "ps-tree": {
       "version": "1.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@types/node": "^11.9.4",
-    "promise-polyfill": "^8.1.0",
+    "es6-shim": "^0.35.5",
     "ts-node": "^8.0.2"
   }
 }

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -82,7 +82,7 @@ minifier="$CLOSURECOMPILERPATH/compiler.jar"
 #
 # `jsDocMissingType` prevents errors on type documentation Closure thinks is missing.  TypeScript may not
 # have the same requirements, and we trust TypeScript over Closure.
-minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType"
+minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode"
 minifycmd="$JAVA -jar $minifier --compilation_level WHITESPACE_ONLY $minifier_warnings --generate_exports"
 
 if ! [ -f $minifier ];

--- a/web/source/dom/utils.ts
+++ b/web/source/dom/utils.ts
@@ -26,8 +26,8 @@ namespace com.keyman.dom {
         }
 
         // On mobile devices, the OSK uses 'fixed' - this requires some extra offset work to handle.
-        if(Lobj.style.position == 'fixed') {
-          let Ldoc = Lobj.ownerDocument;
+        let Ldoc = Lobj.ownerDocument;
+        if(Lobj.style.position == 'fixed' && Ldoc && Ldoc.scrollingElement) {
           Lcurleft += Ldoc.scrollingElement.scrollLeft;
         }
       }

--- a/web/source/dom/utils.ts
+++ b/web/source/dom/utils.ts
@@ -66,8 +66,8 @@ namespace com.keyman.dom {
         }
 
         // On mobile devices, the OSK uses 'fixed' - this requires some extra offset work to handle.
-        if(Lobj.style.position == 'fixed') {
-          let Ldoc = Lobj.ownerDocument;
+        let Ldoc = Lobj.ownerDocument;
+        if(Lobj.style.position == 'fixed' && Ldoc && Ldoc.scrollingElement) {
           Lcurtop += Ldoc.scrollingElement.scrollTop;
         }
       }

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -1,7 +1,7 @@
 // Includes KMW-added property declaration extensions for HTML elements.
 /// <reference path="kmwexthtml.ts" />
 // Includes a promise polyfill (needed for IE)
-/// <reference path="../node_modules/promise-polyfill/lib/polyfill.js" />
+/// <reference path="../node_modules/es6-shim/es6-shim.min.js" />
 // Defines build-environment includes, since `tsc` doesn't provide a compile-time define.
 /// <reference path="environment.inc.ts" />
 // Defines the web-page interface object.


### PR DESCRIPTION
This will need a 🍒-pick to the `master` branch.

Addresses #2323.

----

Everything's in a pretty "rough-draft" state, as I'm still working on a baseline compat fix that will also handle APIs below 23.

Among other things, referencing the JS `console` from the WebWorker was also generating errors that could crash KMW.