### PR TITLE
feat(windows): left-only hotkeys

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1911,7 +1911,7 @@ var
   language: IKeymanLanguage;
   id: Integer;
 begin
-  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkeys) then Exit;
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkey) then Exit;
 
   TDebugLogClient.Instance.WriteMessage('Enter RegisterHotkeys', []);
 
@@ -1965,7 +1965,7 @@ procedure TfrmKeyman7Main.UnregisterHotkeys;
 var
   i, hk: Integer;
 begin
-  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkeys) then Exit;
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkey) then Exit;
 
   TDebugLogClient.Instance.WriteMessage('Enter UnregisterHotkeys', []);
 

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1284,6 +1284,22 @@ begin
 end;
 
 procedure TfrmKeyman7Main.ProcessProfileChange(CommandAndAtom: DWORD);   // I3933   // I3949
+
+  procedure ProcessHotkeyChange(hkl: DWORD; guidProfile: TGUID);
+  var
+    kbd: TLangSwitchKeyboard;
+  begin
+    kbd := FLangSwitchManager.FindKeyboard(hkl, guidProfile);
+    if Assigned(kbd) then
+    begin
+      // Handle toggle hotkey
+      if (kbd = FLangSwitchManager.ActiveKeyboard) and (kmcom.Options['koKeyboardHotkeysAreToggle'].Value) then
+          kbd := FLangSwitchManager.Languages[0].Keyboards[0];
+
+      ActivateKeyboard(kbd);
+    end;
+  end;
+
 var
   val, FLangID: Integer;
   param2, param3: string;
@@ -1293,7 +1309,6 @@ var
   FActiveKeyboard: TLangSwitchKeyboard;
   i: Integer;
   wCommand: Word;
-  kbd: TLangSwitchKeyboard;
 begin
   if GlobalGetAtomName(HiWord(CommandAndAtom), buftext, 128) = 0 then   // I3949
     Exit;   // I4286
@@ -1329,15 +1344,7 @@ begin
     end
     else if wCommand = PC_HOTKEYCHANGE then
     begin
-      kbd := FLangSwitchManager.FindKeyboard(val, GUID_NULL);
-      if Assigned(kbd) then
-      begin
-        // Handle toggle hotkey
-        if (kbd = FLangSwitchManager.ActiveKeyboard) and (kmcom.Options['koKeyboardHotkeysAreToggle'].Value) then
-            kbd := FLangSwitchManager.Languages[0].Keyboards[0];
-
-        ActivateKeyboard(kbd);
-      end;
+      ProcessHotkeyChange(val, GUID_NULL);
       Exit;
     end;
   end
@@ -1367,15 +1374,7 @@ begin
     end
     else if wCommand = PC_HOTKEYCHANGE then
     begin
-      kbd := FLangSwitchManager.FindKeyboard(0, FProfileGuid);
-      if Assigned(kbd) then
-      begin
-        // Handle toggle hotkey
-        if (kbd = FLangSwitchManager.ActiveKeyboard) and (kmcom.Options['koKeyboardHotkeysAreToggle'].Value) then
-            kbd := FLangSwitchManager.Languages[0].Keyboards[0];
-
-        ActivateKeyboard(kbd);
-      end;
+      ProcessHotkeyChange(0, FProfileGuid);
       Exit;
     end;
   end;

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -221,9 +221,11 @@ type
     FGlobalKeyboardChangeManager: TGlobalKeyboardChangeManager;   // I4271
     FActiveHKL: Integer;
     FTrayIcon: TIcon;   // I4359
+
     FHotkeyWindow: HWND;
     FHotkeys: TIntegerList;
-//TOUCH      FCurrentContext: string;
+
+    //TOUCH      FCurrentContext: string;
 
     function AddTaskbarIcon: Boolean;
 
@@ -238,8 +240,6 @@ type
     procedure TrayIconUnresponsive(Sender: TObject; RetryCount: Integer; var ShouldCancel: Boolean);
     procedure TrayIconMouseDown(Sender: TObject; Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
     procedure ShowBalloon(Value: Integer);
-
-    procedure DoInterfaceHotkey(Target: Integer);
 
     procedure WMUserStart(var Message: TMessage); message WM_USER_Start;
     procedure WMUserParameterPass(var Message: TMessage); message WM_USER_ParameterPass;
@@ -290,12 +290,15 @@ type
     procedure UnregisterControllerWindows;   // I4731
     function IsSysTrayWindow(AHandle: THandle): Boolean;
     procedure GetTrayIconHandle;   // I4731
+
     procedure RegisterHotkeys;
     procedure UnregisterHotkeys;
     procedure HotkeyWndProc(var Message: TMessage);
-    procedure DoLanguageHotkey(Index: Integer);
-  protected
 
+    procedure DoLanguageHotkey(Index: Integer);
+    procedure DoInterfaceHotkey(Target: Integer);
+
+  protected
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
     procedure WndProc(var Message: TMessage); override;
   public
@@ -382,6 +385,7 @@ const
 implementation
 
 uses
+  DebugPaths,
   UfrmHelp,
   UILanguages,
   UfrmOSKCharacterMap,
@@ -794,8 +798,9 @@ begin
     KMC_SETFOCUSINFO:
       begin
         UpdateFocusInfo;   // I4731
-        RequestCurrentActiveKeyboard(0);   // I3961
+        RequestCurrentActiveKeyboard(PC_UPDATE);   // I3961
       end;
+
     KMC_INTERFACEHOTKEY:
       begin
         DoInterfaceHotkey(wParam);
@@ -884,7 +889,7 @@ begin
     khCharacterMap: MnuCharacterMap(nil);
     khTextEditor: MnuOpenTextEditor(nil);
     khLanguageSwitch:
-      RequestCurrentActiveKeyboard(1);   // I4124
+      RequestCurrentActiveKeyboard(PC_UPDATE_LANGUAGESWITCH);   // I4124
 
   end;
 end;
@@ -1287,14 +1292,18 @@ var
   buf: string;
   FActiveKeyboard: TLangSwitchKeyboard;
   i: Integer;
+  wCommand: Word;
+  kbd: TLangSwitchKeyboard;
 begin
   if GlobalGetAtomName(HiWord(CommandAndAtom), buftext, 128) = 0 then   // I3949
     Exit;   // I4286
 
+  wCommand := LoWord(CommandAndAtom);
+
   GlobalDeleteAtom(HiWord(CommandAndAtom));   // I3949
   buf := buftext;
 
-  OutputDebugString(PChar('ProcessProfileChange("'+buf+'")'#13#10));
+  //OutputDebugString(PChar('ProcessProfileChange("'+buf+'")'#13#10));
 
   {debug := } StrToken(buf, '|');   // I4285
 
@@ -1307,13 +1316,30 @@ begin
       OutputDebugString(PChar('Could not process profile change'#13#10));
       Exit;
     end;
-    FLangSwitchManager.UpdateActive(FLangID, lsitWinKeyboard, val);   // I3949
-    if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
+
+    if (wCommand = PC_UPDATE) or (wCommand = PC_UPDATE_LANGUAGESWITCH) then
     begin
-      FLangSwitchManager.Refresh;
       FLangSwitchManager.UpdateActive(FLangID, lsitWinKeyboard, val);   // I3949
+      if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
+      begin
+        FLangSwitchManager.Refresh;
+        FLangSwitchManager.UpdateActive(FLangID, lsitWinKeyboard, val);   // I3949
+      end;
+      FActiveHKL := val;   // I4359
+    end
+    else if wCommand = PC_HOTKEYCHANGE then
+    begin
+      kbd := FLangSwitchManager.FindKeyboard(val, GUID_NULL);
+      if Assigned(kbd) then
+      begin
+        // Handle toggle hotkey
+        if (kbd = FLangSwitchManager.ActiveKeyboard) and (kmcom.Options['koKeyboardHotkeysAreToggle'].Value) then
+            kbd := FLangSwitchManager.Languages[0].Keyboards[0];
+
+        ActivateKeyboard(kbd);
+      end;
+      Exit;
     end;
-    FActiveHKL := val;   // I4359
   end
   else
   begin
@@ -1328,12 +1354,29 @@ begin
         Exit;
       end;
     end;
-    FLangSwitchManager.UpdateActive(FLangID, lsitTIP, FClsid, FProfileGuid);
 
-    if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
+    if (wCommand = PC_UPDATE) or (wCommand = PC_UPDATE_LANGUAGESWITCH) then
     begin
-      FLangSwitchManager.Refresh;
       FLangSwitchManager.UpdateActive(FLangID, lsitTIP, FClsid, FProfileGuid);
+
+      if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
+      begin
+        FLangSwitchManager.Refresh;
+        FLangSwitchManager.UpdateActive(FLangID, lsitTIP, FClsid, FProfileGuid);
+      end;
+    end
+    else if wCommand = PC_HOTKEYCHANGE then
+    begin
+      kbd := FLangSwitchManager.FindKeyboard(0, FProfileGuid);
+      if Assigned(kbd) then
+      begin
+        // Handle toggle hotkey
+        if (kbd = FLangSwitchManager.ActiveKeyboard) and (kmcom.Options['koKeyboardHotkeysAreToggle'].Value) then
+            kbd := FLangSwitchManager.Languages[0].Keyboards[0];
+
+        ActivateKeyboard(kbd);
+      end;
+      Exit;
     end;
   end;
 
@@ -1367,9 +1410,9 @@ begin
 //TOUCH      frmTouchKeyboard.RefreshSelectedKeyboard;
 //TOUCH    end;
 
-  if LoWord(CommandAndAtom) = 1 then   // I4124
+  if wCommand = PC_UPDATE_LANGUAGESWITCH then   // I4124
   begin                                                           // TODO fixup product id
-    OutputDebugString(PChar('Showing language switch form'#13#10));
+    //OutputDebugString(PChar('Showing language switch form'#13#10));
     ShowLanguageSwitchForm;
   end;
 end;
@@ -1869,6 +1912,8 @@ var
   language: IKeymanLanguage;
   id: Integer;
 begin
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkeys) then Exit;
+
   TDebugLogClient.Instance.WriteMessage('Enter RegisterHotkeys', []);
 
   if FHotkeyWindow = 0 then
@@ -1921,6 +1966,8 @@ procedure TfrmKeyman7Main.UnregisterHotkeys;
 var
   i, hk: Integer;
 begin
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseRegisterHotkeys) then Exit;
+
   TDebugLogClient.Instance.WriteMessage('Enter UnregisterHotkeys', []);
 
   if not Assigned(FHotkeys) then

--- a/windows/src/engine/keyman/keyman.dproj
+++ b/windows/src/engine/keyman/keyman.dproj
@@ -7,7 +7,7 @@
         <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Console</AppType>
         <FrameworkType>VCL</FrameworkType>
-        <ProjectVersion>18.7</ProjectVersion>
+        <ProjectVersion>18.4</ProjectVersion>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -327,9 +327,9 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
+                <DeployFile LocalName="keyman.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
-                        <RemoteDir>.\</RemoteDir>
+                        <RemoteName>keyman.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -339,9 +339,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="keyman.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
-                        <RemoteName>keyman.exe</RemoteName>
+                        <RemoteDir>.\</RemoteDir>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -350,18 +350,13 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidClassesDexFile">
                     <Platform Name="Android">
                         <RemoteDir>classes</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="AndroidFileProvider">
-                    <Platform Name="Android">
-                        <RemoteDir>res\xml</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
@@ -396,18 +391,6 @@
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidSplashStyles">
-                    <Platform Name="Android">
-                        <RemoteDir>res\values</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="AndroidSplashStylesV21">
-                    <Platform Name="Android">
-                        <RemoteDir>res\values-v21</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="Android_Colors">
                     <Platform Name="Android">
                         <RemoteDir>res\values</RemoteDir>
                         <Operation>1</Operation>
@@ -449,36 +432,6 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="Android_NotificationIcon24">
-                    <Platform Name="Android">
-                        <RemoteDir>res\drawable-mdpi</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="Android_NotificationIcon36">
-                    <Platform Name="Android">
-                        <RemoteDir>res\drawable-hdpi</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="Android_NotificationIcon48">
-                    <Platform Name="Android">
-                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="Android_NotificationIcon72">
-                    <Platform Name="Android">
-                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="Android_NotificationIcon96">
-                    <Platform Name="Android">
-                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
                 <DeployClass Name="Android_SplashImage426">
                     <Platform Name="Android">
                         <RemoteDir>res\drawable-small</RemoteDir>
@@ -503,12 +456,6 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="Android_Strings">
-                    <Platform Name="Android">
-                        <RemoteDir>res\values</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
                 <DeployClass Name="DebugSymbols">
                     <Platform Name="iOSSimulator">
                         <Operation>1</Operation>
@@ -525,20 +472,12 @@
                         <Operation>1</Operation>
                         <Extensions>.framework</Extensions>
                     </Platform>
-                    <Platform Name="OSX64">
-                        <Operation>1</Operation>
-                        <Extensions>.framework</Extensions>
-                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="DependencyModule">
                     <Platform Name="OSX32">
-                        <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
-                    </Platform>
-                    <Platform Name="OSX64">
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
@@ -564,10 +503,6 @@
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
-                    <Platform Name="OSX64">
-                        <Operation>1</Operation>
-                        <Extensions>.dylib</Extensions>
-                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                         <Extensions>.bpl</Extensions>
@@ -589,25 +524,11 @@
                     <Platform Name="OSX32">
                         <Operation>0</Operation>
                     </Platform>
-                    <Platform Name="OSX64">
-                        <Operation>0</Operation>
-                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="iPad_Launch1024">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch1024x768">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
                     </Platform>
@@ -629,39 +550,6 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="iPad_Launch1536x2048">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch1668">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch1668x2388">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
                 <DeployClass Name="iPad_Launch2048">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
@@ -673,172 +561,7 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="iPad_Launch2048x1536">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch2048x2732">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch2224">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch2388x1668">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch2732x2048">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
                 <DeployClass Name="iPad_Launch768">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPad_Launch768x1024">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1125">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1136x640">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1242">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1242x2688">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1334">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch1792">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch2208">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch2436">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch2688x1242">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
                     </Platform>
@@ -882,28 +605,6 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="iPhone_Launch750">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
-                <DeployClass Name="iPhone_Launch828">
-                    <Platform Name="iOSDevice32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSDevice64">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="iOSSimulator">
-                        <Operation>1</Operation>
-                    </Platform>
-                </DeployClass>
                 <DeployClass Name="ProjectAndroidManifest">
                     <Platform Name="Android">
                         <Operation>1</Operation>
@@ -933,15 +634,10 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <DeployClass Name="ProjectOSXDebug"/>
                 <DeployClass Name="ProjectOSXEntitlements"/>
                 <DeployClass Name="ProjectOSXInfoPList"/>
                 <DeployClass Name="ProjectOSXResource">
                     <Platform Name="OSX32">
-                        <RemoteDir>Contents\Resources</RemoteDir>
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="OSX64">
                         <RemoteDir>Contents\Resources</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -964,9 +660,6 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX32">
-                        <Operation>1</Operation>
-                    </Platform>
-                    <Platform Name="OSX64">
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -1008,7 +701,6 @@
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
         </BorlandProject>

--- a/windows/src/engine/keyman/keyman.dproj
+++ b/windows/src/engine/keyman/keyman.dproj
@@ -7,7 +7,7 @@
         <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Console</AppType>
         <FrameworkType>VCL</FrameworkType>
-        <ProjectVersion>18.4</ProjectVersion>
+        <ProjectVersion>18.7</ProjectVersion>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -327,9 +327,9 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="keyman.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
-                        <RemoteName>keyman.exe</RemoteName>
+                        <RemoteDir>.\</RemoteDir>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -339,9 +339,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
+                <DeployFile LocalName="keyman.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
-                        <RemoteDir>.\</RemoteDir>
+                        <RemoteName>keyman.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -350,13 +350,18 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
-                        <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidClassesDexFile">
                     <Platform Name="Android">
                         <RemoteDir>classes</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidFileProvider">
+                    <Platform Name="Android">
+                        <RemoteDir>res\xml</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
@@ -391,6 +396,18 @@
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="AndroidSplashStyles">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV21">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_Colors">
                     <Platform Name="Android">
                         <RemoteDir>res\values</RemoteDir>
                         <Operation>1</Operation>
@@ -432,6 +449,36 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="Android_NotificationIcon24">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="Android_SplashImage426">
                     <Platform Name="Android">
                         <RemoteDir>res\drawable-small</RemoteDir>
@@ -456,6 +503,12 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="Android_Strings">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="DebugSymbols">
                     <Platform Name="iOSSimulator">
                         <Operation>1</Operation>
@@ -472,12 +525,20 @@
                         <Operation>1</Operation>
                         <Extensions>.framework</Extensions>
                     </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="DependencyModule">
                     <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
@@ -503,6 +564,10 @@
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                         <Extensions>.bpl</Extensions>
@@ -524,11 +589,25 @@
                     <Platform Name="OSX32">
                         <Operation>0</Operation>
                     </Platform>
+                    <Platform Name="OSX64">
+                        <Operation>0</Operation>
+                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                     </Platform>
                 </DeployClass>
                 <DeployClass Name="iPad_Launch1024">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1024x768">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
                     </Platform>
@@ -550,6 +629,39 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="iPad_Launch1536x2048">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1668">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch1668x2388">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="iPad_Launch2048">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
@@ -561,7 +673,172 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="iPad_Launch2048x1536">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2048x2732">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2224">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2388x1668">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2732x2048">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="iPad_Launch768">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch768x1024">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1125">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1136x640">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1242">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1242x2688">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1334">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch1792">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch2208">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch2436">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch2688x1242">
                     <Platform Name="iOSDevice32">
                         <Operation>1</Operation>
                     </Platform>
@@ -605,6 +882,28 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="iPhone_Launch750">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch828">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
                 <DeployClass Name="ProjectAndroidManifest">
                     <Platform Name="Android">
                         <Operation>1</Operation>
@@ -634,10 +933,15 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
+                <DeployClass Name="ProjectOSXDebug"/>
                 <DeployClass Name="ProjectOSXEntitlements"/>
                 <DeployClass Name="ProjectOSXInfoPList"/>
                 <DeployClass Name="ProjectOSXResource">
                     <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
                         <RemoteDir>Contents\Resources</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -660,6 +964,9 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win32">
@@ -701,6 +1008,7 @@
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
         </BorlandProject>

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -76,7 +76,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateKeyboard(GUID *profile) 
     SelectKeyboard(KEYMANID_NONKEYMAN);   // I3594
   }
   
-  ReportActiveKeyboard(_td, 0);   // I3961
+  ReportActiveKeyboard(_td, PC_UPDATE);   // I3961
   return TRUE;
 }
 

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -195,7 +195,7 @@ typedef struct tagKEYMAN64THREADDATA
   LPMSG msgbuf;						// Message buffer (alloc at runtime)
 
   int nKeyboards;						// nLoadedKeyboards
-  int nLanguages;           // I1087
+  int nLanguages;           // I1087 //TODO UNUSED
 
   LPWORD IndexStack;
   LPWSTR miniContext;

--- a/windows/src/engine/keyman32/hotkeys.h
+++ b/windows/src/engine/keyman32/hotkeys.h
@@ -20,6 +20,7 @@
                     25 Oct 2016 - mcdurdin - I5136 - Remove additional product references from Keyman Engine
 */
 
+// TODO fix this yuk: dynamic alloc plz
 #define MAX_HOTKEYS 1000
 
 typedef enum { hktInterface, hktLanguage } HotkeyType;

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -24,6 +24,7 @@
 // I4326
 #include "pch.h"
 #include "serialkeyeventserver.h"
+#include "kbd.h"	/* DDK kbdlayout */
 
 #ifdef _WIN64
 #error k32_lowlevelkeyboardhook.cpp is not required for win64.
@@ -93,6 +94,19 @@ BOOL IsConsoleWindow(HWND hwnd) {
   return last_isConsoleWindow;
 }
 
+/*
+  Cache UseRegisterHotkey debug flag for this session
+*/
+BOOL UseRegisterHotkey() {
+  static BOOL flag_UseRegisterHotkey = FALSE;
+  static BOOL loaded = FALSE;
+  if (!loaded) {
+    loaded = TRUE;
+    flag_UseRegisterHotkey = Reg_GetDebugFlag(REGSZ_Flag_UseRegisterHotkey, FALSE);
+  }
+  return flag_UseRegisterHotkey;
+}
+
 LRESULT _kmnLowLevelKeyboardProc(
   _In_  int nCode, 
   _In_  WPARAM wParam, 
@@ -118,18 +132,32 @@ LRESULT _kmnLowLevelKeyboardProc(
     return CallNextHookEx(Globals::get_hhookLowLevelKeyboardProc(), nCode, wParam, lParam);
   }
 
-  // Track shift state
   DWORD Flag = 0;
-  switch(hs->vkCode) {
-    case VK_LCONTROL: Flag = HK_CTRL; break;
-    case VK_RCONTROL: Flag = 0; break;
-    case VK_CONTROL:  Flag = extended ? HK_CTRL : 0; break;
-    case VK_LMENU:    Flag = HK_ALT; break;
-    case VK_RMENU:    Flag = 0; break;
-    case VK_MENU:     Flag = extended ? HK_ALT : 0; break;
-    case VK_LSHIFT:   Flag = HK_SHIFT; break;
-    case VK_RSHIFT:   Flag = 0; break;
-    case VK_SHIFT:    Flag = hs->scanCode == 0x36 /*SCAN_RIGHT_SHIFT*/ ? 0 : HK_SHIFT; break;
+  if (UseRegisterHotkey()) {
+    switch (hs->vkCode) {
+      case VK_LCONTROL:
+      case VK_RCONTROL:
+      case VK_CONTROL:  Flag = HK_CTRL; break;
+      case VK_LMENU:
+      case VK_RMENU:
+      case VK_MENU:     Flag = HK_ALT; break;
+      case VK_LSHIFT:
+      case VK_RSHIFT:
+      case VK_SHIFT:    Flag = HK_SHIFT; break;
+    }
+  }
+  else {
+    switch (hs->vkCode) {
+      case VK_LCONTROL: Flag = HK_CTRL; break;
+      case VK_RCONTROL: Flag = 0; break;
+      case VK_CONTROL:  Flag = extended ? HK_CTRL : 0; break;
+      case VK_LMENU:    Flag = HK_ALT; break;
+      case VK_RMENU:    Flag = 0; break;
+      case VK_MENU:     Flag = extended ? HK_ALT : 0; break;
+      case VK_LSHIFT:   Flag = HK_SHIFT; break;
+      case VK_RSHIFT:   Flag = 0; break;
+      case VK_SHIFT:    Flag = hs->scanCode == SCANCODE_RSHIFT ? 0 : HK_SHIFT; break;
+    }
   }
 
   if(Flag != 0) {
@@ -178,10 +206,8 @@ LRESULT _kmnLowLevelKeyboardProc(
   return CallNextHookEx(Globals::get_hhookLowLevelKeyboardProc(), nCode, wParam, lParam);
 }
 
-BOOL SendKeyboardSelectionToHost(HKL hkl, GUID profileGUID);
-
 BOOL ProcessHotkey(UINT vkCode, BOOL isUp, DWORD ShiftState) {
-  if (Reg_GetDebugFlag(REGSZ_Flag_UseRegisterHotkey, FALSE)) {
+  if (UseRegisterHotkey()) {
     return FALSE;
   }
 
@@ -203,7 +229,7 @@ BOOL ProcessHotkey(UINT vkCode, BOOL isUp, DWORD ShiftState) {
     Globals::PostMasterController(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
   }
   else {
-    SendKeyboardSelectionToHost(hotkey->hkl, hotkey->profileGUID);
+    ReportKeyboardChanged(PC_HOTKEYCHANGE, hotkey->hkl == 0 ? TF_PROFILETYPE_INPUTPROCESSOR : TF_PROFILETYPE_KEYBOARDLAYOUT, 0, hotkey->hkl, GUID_NULL, hotkey->profileGUID);
   }
   
   /* Generate a dummy keystroke to block menu activations, etc but let the shift key through */

--- a/windows/src/engine/keyman32/keybd_shift.cpp
+++ b/windows/src/engine/keyman32/keybd_shift.cpp
@@ -20,6 +20,7 @@
                     09 Aug 2015 - mcdurdin - I4844 - Tidy up PostDummyKeyEvent calls
 */
 #include "pch.h"
+#include "kbd.h"
 
 /**
   do_keybd_event adds a keyboard event into the keyboard event queue.
@@ -77,7 +78,7 @@ void do_keybd_event(LPINPUT pInputs, int *n, BYTE vk, BYTE scan, DWORD flags, UL
     break;
 
   case VK_RSHIFT:
-    scan = 0x36;
+    scan = SCANCODE_RSHIFT; // from kbd.h
   case VK_LSHIFT:
     vk = VK_SHIFT;
     break;

--- a/windows/src/engine/keyman32/kmhook_callwndproc.cpp
+++ b/windows/src/engine/keyman32/kmhook_callwndproc.cpp
@@ -198,7 +198,7 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         break;
 		  case WM_INPUTLANGCHANGE:
         SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_INPUTLANGCHANGE %x %x Hwnd=%x Parent=%x Focus=%x Active=%x", cp->wParam, cp->lParam, cp->hwnd, GetParent(cp->hwnd), GetFocus(), GetActiveWindow());
-          ReportActiveKeyboard(_td, 0);   // I4288
+          ReportActiveKeyboard(_td, PC_UPDATE);   // I4288
 
           // The input language has changed, so tell Keyman window about it
         break;

--- a/windows/src/engine/keyman32/kmhook_keyboard.cpp
+++ b/windows/src/engine/keyman32/kmhook_keyboard.cpp
@@ -138,7 +138,7 @@ BOOL KeyLanguageSwitchPress(WPARAM wParam, BOOL extended, BOOL isUp, DWORD Shift
       if(isUp)
       {
         InLanguageSwitchKeySequence = FALSE;
-        //ReportActiveKeyboard(_td, 0);
+        //ReportActiveKeyboard(_td, PC_UPDATE);
         Globals::PostControllers(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
         PostDummyKeyEvent();   // I4124   // I4844
         keybd_event(VK_SHIFT, SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0);    // I4203

--- a/windows/src/engine/keyman32/serialkeyeventserver.cpp
+++ b/windows/src/engine/keyman32/serialkeyeventserver.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "serialkeyeventserver.h"
 #include "security.h"
+#include "kbd.h"
 
 #ifndef _WIN64
 
@@ -523,7 +524,7 @@ private:
       break;
     case VK_SHIFT:
       // Left and right shift are distinguished by scan code alone
-      bVk = bScan == 0x36 ? VK_RSHIFT : VK_LSHIFT;
+      bVk = bScan == SCANCODE_RSHIFT ? VK_RSHIFT : VK_LSHIFT;
       break;
     case VK_LCONTROL:
     case VK_RCONTROL:

--- a/windows/src/global/delphi/general/DebugPaths.pas
+++ b/windows/src/global/delphi/general/DebugPaths.pas
@@ -23,6 +23,7 @@ unit DebugPaths;  // I3306
 interface
 
 function GetDebugPath(const RegValue, Default: WideString; TerminateInSlash: Boolean = True): WideString;
+function Reg_GetDebugFlag(const RegValue: string; Default: Boolean = False): Boolean;
 
 implementation
 
@@ -41,6 +42,18 @@ begin
   end;
   if TerminateInSlash and (Result <> '') then
     Result := IncludeTrailingPathDelimiter(Result);
+end;
+
+function Reg_GetDebugFlag(const RegValue: string; Default: Boolean): Boolean;
+begin
+  with TRegistryErrorControlled.Create do  // I2890
+  try
+    if OpenKeyReadOnly(SRegKey_KeymanEngineDebug_CU) and ValueExists(RegValue)
+      then Result := ReadInteger(RegValue) <> 0
+      else Result := Default;
+  finally
+    Free;
+  end;
 end;
 
 end.

--- a/windows/src/global/delphi/general/KeymanControlMessages.pas
+++ b/windows/src/global/delphi/general/KeymanControlMessages.pas
@@ -52,8 +52,12 @@ const
 
   KMC_PROFILECHANGED = 18;  // 9.0.426.0   // I3933
 
+  PC_UPDATE = 0;
+  PC_UPDATE_LANGUAGESWITCH = 1;
+  PC_HOTKEYCHANGE = 2;
+
   // KMC_KEYBOARDHOTKEY = 19;  // 9.0.459.0   // I4326 Deprecated in favour of language hotkeys
-  // KMC_LANGUAGEHOTKEY = 20;  // 9.0.471.0   // I4451 Now using keyman.exe RegisterHotkey
+  //KMC_LANGUAGEHOTKEY = 20;
 
 //TOUCH    KMC_CONTEXT = 19;
 

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -424,7 +424,11 @@ const
   SRegKey_Keyman_Exception_CU = SRegKey_KeymanRoot_CU + '\Exception';
   SRegValue_SymbolPath = 'SymbolPath';
 
+  { Debug Flags - Reg_GetDebugFlag in DebugPaths.pas }
 
+  SRegKey_KeymanEngineDebug_CU = SRegKey_KeymanEngineRoot_CU + '\Debug';
+
+  SRegValue_Flag_UseRegisterHotkeys = 'Flag_UseRegisterHotkey';
 // Fixed path names
 const
   // PF = CSIDL_PROGRAM_FILES

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -428,7 +428,7 @@ const
 
   SRegKey_KeymanEngineDebug_CU = SRegKey_KeymanEngineRoot_CU + '\Debug';
 
-  SRegValue_Flag_UseRegisterHotkeys = 'Flag_UseRegisterHotkey';
+  SRegValue_Flag_UseRegisterHotkey = 'Flag_UseRegisterHotkey';
 // Fixed path names
 const
   // PF = CSIDL_PROGRAM_FILES

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -422,6 +422,7 @@ void keybd_shift(LPINPUT pInputs, int *n, BOOL isReset, LPBYTE const kbd);
 void ReportActiveKeyboard(PKEYMAN64THREADDATA _td, WORD wCommand);   // I3933   // I3949
 void SelectKeyboardHKL(PKEYMAN64THREADDATA _td, DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4271
 BOOL SelectKeyboardTSF(PKEYMAN64THREADDATA _td, DWORD KeymanID, BOOL foreground);   // I3933   // I3949   // I4271
+BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL hkl, GUID clsid, GUID guidProfile);
 
 #endif
 

--- a/windows/src/global/inc/keymancontrol.h
+++ b/windows/src/global/inc/keymancontrol.h
@@ -47,8 +47,12 @@
 
 #define KMC_PROFILECHANGED  18  // 9.0.426.0   // I3933
 
+#define PC_UPDATE 0                   // Tell Keyman to update its display of active keyboard
+#define PC_UPDATE_LANGUAGESWITCH 1    // Tell Keyman to update its display of active keyboard and then open language switch form
+#define PC_HOTKEYCHANGE 2             // Tell Keyman that a hotkey was pressed to switch keyboard
+
 //#define KMC_KEYBOARDHOTKEY  19  // 9.0.459.0   // I4326 Deprecated in favour of language hotkeys
-//#define KMC_LANGUAGEHOTKEY  20  // 9.0.460.0    // I4451 Now using keyman.exe RegisterHotkey
+#define KMC_LANGUAGEHOTKEY  20
 //TOUCH  #define KMC_CONTEXT 19  // 9.0.450.0
 
 #define RWM_KEYMAN_CONTROL "WM_KEYMAN_CONTROL"

--- a/windows/src/global/inc/registry.h
+++ b/windows/src/global/inc/registry.h
@@ -114,9 +114,13 @@
 
 #define REGSZ_Keyman_Debug  REGSZ_KeymanCU "\\Debug"
 
-/* DWORD: Enable/disable serialized input, default 1 */
+/* REGSZ_Keyman_Debug DWORD: Enable/disable serialized input, default 1 */
 
 #define REGSZ_Flag_ShouldSerializeInput "Flag_ShouldSerializeInput"
+
+/* REGSZ_Keyman_Debug DWORD: Use old non-chiral Win32 API RegisterHotkey instead of left-only hotkeys */
+
+#define REGSZ_Flag_UseRegisterHotkey  "Flag_UseRegisterHotkey"
 
 /* DWORD: Enable/disable deep TSF integration, default enabled; 0 = disabled, 1 = enabled, 2 = default */
 


### PR DESCRIPTION
Fixes #364.

Hotkeys in Windows are currently implemented using RegisterHotkey.
However RegisterHotkey does not distinguish between left and right
modifier keys, which means that they override some keyboards' RAlt
combinations.

This feature reimplements hotkey support in the low level keyboard hook,
and adds a feature flag / debug flag Flag_UseRegisterHotkey to return
to the RegisterHotkey model if that is so needed.

I have made minimal refactoring changes to this code, although there
are certainly functions here which could be improved.

I have flagged a couple of potential future improvements with TODO.

I will not cherry-pick this to 12.0; it's a new feature that can wait for 13.0 release.

**note to reviewer**: Use 'ignore whitespace' to see code changes more clearly.