### PR TITLE
fix(android): Grant WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/android/history.md
+++ b/android/history.md
@@ -3,7 +3,7 @@
 ## 13.0 alpha
 * Start version 13.0
 * New Features:
-  * Adding a download manager to execute downloads in background and cleanup the existing implementation (#2247, #2275, #2308)
+  * Adding a download manager to execute downloads in background and cleanup the existing implementation (#2247, #2275, #2308, #2365)
   * Show spinner (without blocking UI), if user wants to add a language/keyboard and catalog download is in progress (#2313)
   * Improve custom package installation: Show readme.htm before starting installation process (#2286)
   * Sanitize the app version to `#.#.#` for the API cloud query (#2319)


### PR DESCRIPTION
On API level 19, the DownloadManager was throwing an exception because it needed WRITE_EXTERNAL_STORAGE permission to download the cloud catalog info.

Reference: https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationUri(android.net.Uri)