### PR TITLE
[Android] Check getTextBeforeCursor() doesn't return null

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2096,7 +2096,7 @@ public final class KMManager {
       // subSequence indices are start(inclusive) to end(exclusive)
       CharSequence expectedChars = charsBackup.subSequence(0, charsBackup.length() - (dn + numPairs));
       ic.deleteSurroundingText(dn + numPairs, 0);
-      CharSequence newContext = getCharacterSequence(ic, originalBufferLength - dn);
+      CharSequence newContext = getCharacterSequence(ic, originalBufferLength - 2*dn);
 
       CharSequence charsToRestore = CharSequenceUtil.restoreChars(expectedChars, newContext);
       if (charsToRestore.length() > 0) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2120,7 +2120,7 @@ public final class KMManager {
       }
 
       CharSequence sequence = ic.getTextBeforeCursor(length, 0);
-      if (sequence.length() <= 0) {
+      if (sequence == null || sequence.length() <= 0) {
         return "";
       }
 
@@ -2131,7 +2131,7 @@ public final class KMManager {
         sequence = ic.getTextBeforeCursor(length, 0);
       }
 
-      if (Character.isLowSurrogate(sequence.charAt(0))) {
+      if (sequence != null && Character.isLowSurrogate(sequence.charAt(0))) {
         // Adjust if the first char is also a split surrogate pair
         // subSequence indices are start(inclusive) to end(exclusive)
         sequence = sequence.subSequence(1, sequence.length());

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,16 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-11-27 12.0.4211 stable
+* Bug fix:
+  * Fix crashes involving context manipulation of invalid context (#2377)
+
+## 2019-11-26 12.0.4210 stable
+* No change to Keyman for Android (updated Keyman Web Engine, #2322)
+
+## 2019-11-25 12.0.4209 stable
+* No change to Keyman for Android (updated Keyman Web Engine, #2372)
+
 ## 2019-11-22 12.0.4208 stable
 * Bug fix:
   * Fix context manipulation to work around Chromium issue (#2281)


### PR DESCRIPTION
Follow-on to #2281

This fixes Crashlytics [issue](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/054f29f4c0601121ea1102c0eadf7cb6?time=last-seven-days&sessionId=5DDAD1AB0156000132ECCEAF30E92E2B_DNE_0_v2)

by adding additional checks for when `getTextBeforeCursor()` returns null context. The length in determining `newContext` was also fixed to handle the test scenario involving steps 5 below.

### User Testing
1. Load the apk
2. Install either the custom "[moo](https://darcywong00.github.io/examples/moo/moo.kmp)" keyboard or **xinaliq** from the cloud.

- [x] Verify no crashes in empty context
3. As a system keyboard, repeatedly hit backspace when the context is empty.
4. Verify keyboard doesn't crash

- [x] Verify backspace doesn't delete an entire grapheme
5. Enter a context of 6 emojis (s or w key), followed by p^p^ (p key 4 times)
6. Hit backspace
7. Verify only ^ is removed