### PR TITLE
[Android][Cherrypick] Check getTextBeforeCursor() doesn't return null

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2194,7 +2194,7 @@ public final class KMManager {
       // subSequence indices are start(inclusive) to end(exclusive)
       CharSequence expectedChars = charsBackup.subSequence(0, charsBackup.length() - (dn + numPairs));
       ic.deleteSurroundingText(dn + numPairs, 0);
-      CharSequence newContext = getCharacterSequence(ic, originalBufferLength - dn);
+      CharSequence newContext = getCharacterSequence(ic, originalBufferLength - 2*dn);
 
       CharSequence charsToRestore = CharSequenceUtil.restoreChars(expectedChars, newContext);
       if (charsToRestore.length() > 0) {
@@ -2218,7 +2218,7 @@ public final class KMManager {
       }
 
       CharSequence sequence = ic.getTextBeforeCursor(length, 0);
-      if (sequence.length() <= 0) {
+      if (sequence == null || sequence.length() <= 0) {
         return "";
       }
 
@@ -2229,7 +2229,7 @@ public final class KMManager {
         sequence = ic.getTextBeforeCursor(length, 0);
       }
 
-      if (Character.isLowSurrogate(sequence.charAt(0))) {
+      if (sequence != null && Character.isLowSurrogate(sequence.charAt(0))) {
         // Adjust if the first char is also a split surrogate pair
         // subSequence indices are start(inclusive) to end(exclusive)
         sequence = sequence.subSequence(1, sequence.length());

--- a/android/history.md
+++ b/android/history.md
@@ -17,6 +17,16 @@
   * Add simple UI tests for keyboard picker and keyboard info screens (#2326)
   * Add example dictionary to KMSample1 project (#2369)
 
+## 2019-11-27 12.0.4211 stable
+* Bug fix:
+  * Fix crashes involving context manipulation of invalid context (#2377)
+
+## 2019-11-26 12.0.4210 stable
+* No change to Keyman for Android (updated Keyman Web Engine, #2322)
+
+## 2019-11-25 12.0.4209 stable
+* No change to Keyman for Android (updated Keyman Web Engine, #2372)
+
 ## 2019-11-22 12.0.4208 stable
 * Bug fix:
   * Fix context manipulation to work around Chromium issue (#2281)


### PR DESCRIPTION
Follow-on to #2376, cherrypick of #2377 for master

This fixes Crashlytics [issue](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/054f29f4c0601121ea1102c0eadf7cb6?time=last-seven-days&sessionId=5DDAD1AB0156000132ECCEAF30E92E2B_DNE_0_v2)

by adding additional checks for when `getTextBeforeCursor()` returns null context. The length in determining `newContext` was also fixed to handle the test scenario involving 6 emojis (SMP chars) followed by `p̂p̂`