### PR TITLE
[Android] Fix a few CloudRepository issues

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -40,8 +40,7 @@ public class CloudDataJsonUtil {
                                                    String aFont, String aOskFont)
   {
     HashMap<String, String> keyboardInfo = new HashMap<String, String>();
-    if(aPackageId!=null)
-      keyboardInfo.put(KMManager.KMKey_PackageID, aPackageId);
+    keyboardInfo.put(KMManager.KMKey_PackageID, aPackageId);
     keyboardInfo.put(KMManager.KMKey_KeyboardID, aKeyboardId);
     keyboardInfo.put(KMManager.KMKey_LanguageID, aLanguageId);
     keyboardInfo.put(KMManager.KMKey_KeyboardName, aKeyboardName);
@@ -57,7 +56,9 @@ public class CloudDataJsonUtil {
 
   public static List<Keyboard> processKeyboardJSON(JSONObject query, boolean fromKMP) {
     List<Keyboard> keyboardsList = new ArrayList<>();
-    //keyboardModifiedDates = new HashMap<String, String>();
+    if (query.length() == 0) {
+      return keyboardsList;
+    }
 
     String isCustom = fromKMP ? "Y" : "N";
 
@@ -75,13 +76,14 @@ public class CloudDataJsonUtil {
         int kbLength = langKeyboards.length();
         for (int j = 0; j < kbLength; j++) {
           JSONObject keyboardJSON = langKeyboards.getJSONObject(j);
+          String pkgID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
           String kbID = keyboardJSON.getString(KMManager.KMKey_ID);
           String kbName = keyboardJSON.getString(KMManager.KMKey_Name);
           String kbVersion = keyboardJSON.optString(KMManager.KMKey_KeyboardVersion, "1.0");
           String kbFont = keyboardJSON.optString(KMManager.KMKey_Font, "");
 
           //String kbKey = String.format("%s_%s", langID, kbID);
-          HashMap<String, String> hashMap = createKeyboardInfoMap(null,langID,langName,kbID,kbName,kbVersion,isCustom,kbFont,null);
+          HashMap<String, String> hashMap = createKeyboardInfoMap(pkgID,langID,langName,kbID,kbName,kbVersion,isCustom,kbFont,null);
 
 
 //          if (keyboardModifiedDates.get(kbID) == null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -33,6 +33,9 @@ public class JSONUtils {
    * Will need to swap kmp.json (keyboards : languages) to cloud order (languages : keyboards)
    */
   public static JSONArray getLanguages() {
+    if (resourceRoot == null) {
+      return new JSONArray();
+    }
     File[] packages = resourceRoot.listFiles();
     JSONArray languagesArray = new JSONArray();
     JSONParser parser = new JSONParser();

--- a/android/history.md
+++ b/android/history.md
@@ -20,6 +20,8 @@
 ## 2019-11-27 12.0.4211 stable
 * Bug fix:
   * Fix crashes involving context manipulation of invalid context (#2377)
+  * Fix Package ID so other languages from a keyboard .kmp package can be installed (#2378)
+  * Fix crashes when accessing the Cloud for downloading keyboards (#2378)
 
 ## 2019-11-26 12.0.4210 stable
 * No change to Keyman for Android (updated Keyman Web Engine, #2322)


### PR DESCRIPTION
This PR cherrypicks #2378 to master
This fixes a few issues involving the Cloud Repository

1. Add some null checking to prevent crashes
2. This addresses an issue where a custom .kmp package is installed (which currently associates the first language listed in kmp.json). Trying to install additional languages listed in the kmp.json failed because the package ID info wasn't being propagated.