### PR TITLE
[Developer] Enable stricter type checks

### DIFF
--- a/developer/js/package-lock.json
+++ b/developer/js/package-lock.json
@@ -19,12 +19,14 @@
     "@types/node": {
       "version": "10.14.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
-      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q=="
+      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
+      "dev": true
     },
     "@types/xml2js": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
       "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -444,6 +446,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
       "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
+      "dev": true,
       "requires": {
         "pako": "~0.2.5"
       }
@@ -574,14 +577,6 @@
         "semver": "^5.7.0"
       }
     },
-    "node-zip": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
-      "integrity": "sha1-lNGtZ0o81GoViN1zb0qaeMdX62I=",
-      "requires": {
-        "jszip": "2.5.0"
-      }
-    },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -649,7 +644,8 @@
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",

--- a/developer/js/package-lock.json
+++ b/developer/js/package-lock.json
@@ -19,8 +19,15 @@
     "@types/node": {
       "version": "10.14.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
-      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q==",
-      "dev": true
+      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q=="
+    },
+    "@types/xml2js": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
+      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "ansi-colors": {
       "version": "3.2.3",

--- a/developer/js/package.json
+++ b/developer/js/package.json
@@ -35,10 +35,8 @@
     "kmlmi": "dist/kmlmi.js"
   },
   "dependencies": {
-    "@types/xml2js": "^0.4.5",
     "commander": "^3.0.0",
     "node": "^11.7.0",
-    "node-zip": "^1.1.1",
     "typescript": "^3.2.4",
     "xml2js": "^0.4.19"
   },
@@ -46,8 +44,10 @@
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.6",
+    "@types/xml2js": "^0.4.5",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
+    "jszip": "^2.5.0",
     "mocha": "^6.1.4",
     "ts-node": "^8.3.0"
   },

--- a/developer/js/package.json
+++ b/developer/js/package.json
@@ -35,6 +35,7 @@
     "kmlmi": "dist/kmlmi.js"
   },
   "dependencies": {
+    "@types/xml2js": "^0.4.5",
     "commander": "^3.0.0",
     "node": "^11.7.0",
     "node-zip": "^1.1.1",

--- a/developer/js/source/jszip.d.ts
+++ b/developer/js/source/jszip.d.ts
@@ -1,0 +1,262 @@
+// Definitions by: mzeiher <https://github.com/mzeiher>, forabi <https://github.com/forabi>, eddieantonio <https://github.com/eddieantonio>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+interface JSZipSupport {
+    arraybuffer: boolean;
+    uint8array: boolean;
+    blob: boolean;
+    nodebuffer: boolean;
+}
+
+type Compression = 'STORE' | 'DEFLATE';
+
+interface Metadata  {
+    percent: number;
+    currentFile: string;
+}
+
+type OnUpdateCallback = (metadata: Metadata) => void;
+
+interface InputByType {
+    base64: string;
+    string: string;
+    text: string;
+    binarystring: string;
+    array: number[];
+    uint8array: Uint8Array;
+    arraybuffer: ArrayBuffer;
+    blob: Blob;
+    stream: NodeJS.ReadableStream;
+}
+
+interface OutputByType {
+    base64: string;
+    text: string;
+    binarystring: string;
+    array: number[];
+    uint8array: Uint8Array;
+    arraybuffer: ArrayBuffer;
+    blob: Blob;
+    nodebuffer: Buffer;
+}
+
+type InputFileFormat = InputByType[keyof InputByType];
+
+type InputType = keyof InputByType;
+
+type OutputType = keyof OutputByType;
+
+interface JSZipObject {
+    name: string;
+    dir: boolean;
+    date: Date;
+    comment: string;
+    /** The UNIX permissions of the file, if any. */
+    unixPermissions: number | string | null;
+    /** The UNIX permissions of the file, if any. */
+    dosPermissions: number | null;
+    options: JSZipObjectOptions;
+
+    /**
+     * Prepare the content in the asked type.
+     * @param type the type of the result.
+     * @param onUpdate a function to call on each internal update.
+     * @return Promise the promise of the result.
+     */
+    async<T extends OutputType>(type: T, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
+    nodeStream(type?: 'nodestream', onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
+}
+
+interface JSZipFileOptions {
+    /** Set to `true` if the data is `base64` encoded. For example image data from a `<canvas>` element. Plain text and HTML do not need this option. */
+    base64?: boolean;
+    /**
+     * Set to `true` if the data should be treated as raw content, `false` if this is a text. If `base64` is used,
+     * this defaults to `true`, if the data is not a `string`, this will be set to `true`.
+     */
+    binary?: boolean;
+    /**
+     * The last modification date, defaults to the current date.
+     */
+    date?: Date;
+    compression?: string;
+    comment?: string;
+    /** Set to `true` if (and only if) the input is a "binary string" and has already been prepared with a `0xFF` mask. */
+    optimizedBinaryString?: boolean;
+    /** Set to `true` if folders in the file path should be automatically created, otherwise there will only be virtual folders that represent the path to the file. */
+    createFolders?: boolean;
+    /** Set to `true` if this is a directory and content should be ignored. */
+    dir?: boolean;
+
+    /** 6 bits number. The DOS permissions of the file, if any. */
+    dosPermissions?: number | null;
+    /**
+     * 16 bits number. The UNIX permissions of the file, if any.
+     * Also accepts a `string` representing the octal value: `"644"`, `"755"`, etc.
+     */
+    unixPermissions?: number | string | null;
+}
+
+interface JSZipObjectOptions {
+    compression: Compression;
+}
+
+interface JSZipGeneratorOptions<T extends OutputType = OutputType> {
+    /**
+     * @deprecated https://github.com/Stuk/jszip/blob/9ab3ed85da96700f32f50e01b87f2a4bde010390/lib/object.js#L738
+     */
+    base64?: boolean;
+    compression?: Compression;
+    compressionOptions?: null | {
+        level: number;
+    };
+    type?: T;
+    comment?: string;
+    /**
+     * mime-type for the generated file.
+     * Useful when you need to generate a file with a different extension, ie: “.ods”.
+     * @default 'application/zip'
+     */
+    mimeType?: string;
+    encodeFileName?(filename: string): string;
+    /** Stream the files and create file descriptors */
+    streamFiles?: boolean;
+    /** DOS (default) or UNIX */
+    platform?: 'DOS' | 'UNIX';
+}
+
+interface JSZipLoadOptions {
+    base64?: boolean;
+    checkCRC32?: boolean;
+    optimizedBinaryString?: boolean;
+    createFolders?: boolean;
+    decodeFileName?(filenameBytes: Uint8Array): string;
+}
+
+interface JSZip {
+    files: {[key: string]: JSZipObject};
+
+    /**
+     * Get a file from the archive
+     *
+     * @param Path relative path to file
+     * @return File matching path, null if no file found
+     */
+    file(path: string): JSZipObject;
+
+    /**
+     * Get files matching a RegExp from archive
+     *
+     * @param path RegExp to match
+     * @return Return all matching files or an empty array
+     */
+    file(path: RegExp): JSZipObject[];
+
+    /**
+     * Add a file to the archive
+     *
+     * @param path Relative path to file
+     * @param data Content of the file
+     * @param options Optional information about the file
+     * @return JSZip object
+     */
+    file<T extends InputType>(path: string, data: InputByType[T] | Promise<InputByType[T]>, options?: JSZipFileOptions): this;
+    file<T extends InputType>(path: string, data: null, options?: JSZipFileOptions & { dir: true }): this;
+
+    /**
+     * Returns an new JSZip instance with the given folder as root
+     *
+     * @param name Name of the folder
+     * @return New JSZip object with the given folder as root or null
+     */
+    folder(name: string): JSZip;
+
+    /**
+     * Returns new JSZip instances with the matching folders as root
+     *
+     * @param name RegExp to match
+     * @return New array of JSZipFile objects which match the RegExp
+     */
+    folder(name: RegExp): JSZipObject[];
+
+    /**
+     * Call a callback function for each entry at this folder level.
+     *
+     * @param callback function
+     */
+    forEach(callback: (relativePath: string, file: JSZipObject) => void): void;
+
+    /**
+     * Get all files which match the given filter function
+     *
+     * @param predicate Filter function
+     * @return Array of matched elements
+     */
+    filter(predicate: (relativePath: string, file: JSZipObject) => boolean): JSZipObject[];
+
+    /**
+     * Removes the file or folder from the archive
+     *
+     * @param path Relative path of file or folder
+     * @return Returns the JSZip instance
+     */
+    remove(path: string): JSZip;
+
+    /**
+     * Generate the complete zip file
+     * @param {Object} options the options to generate the zip file :
+     * - base64, (deprecated, use type instead) true to generate base64.
+     * - compression, "STORE" by default.
+     * - type, "base64" by default. Values are : string, base64, uint8array, arraybuffer, blob.
+     * @return {String|Uint8Array|ArrayBuffer|Buffer|Blob} the zip file
+     */
+    generate<T extends OutputType>(options?: JSZipGeneratorOptions<T>, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
+
+    /**
+     * Generates a new archive asynchronously
+     *
+     * @param options Optional options for the generator
+     * @param onUpdate The optional function called on each internal update with the metadata.
+     * @return A Node.js `ReadableStream`
+     */
+    generateNodeStream(options?: JSZipGeneratorOptions<'nodebuffer'>, onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
+
+    /**
+     * Deserialize zip file asynchronously
+     *
+     * @param data Serialized zip file
+     * @param options Options for deserializing
+     * @return Returns promise
+     */
+    loadAsync(data: InputFileFormat, options?: JSZipLoadOptions): Promise<JSZip>;
+
+    support: JSZipSupport;
+    external: {
+        Promise: PromiseConstructorLike;
+    };
+    version: string;
+}
+
+interface JSZipStatic extends JSZip {
+    /**
+     * Create JSZip instance
+     */
+    (): JSZip;
+
+    /**
+     * Create JSZip instance
+     * If no parameters given an empty zip archive will be created
+     *
+     * @param data Serialized zip archive
+     * @param options Description of the serialized zip archive
+     */
+    new (data?: InputFileFormat, options?: JSZipLoadOptions): this;
+}
+
+declare let JSZipModuleObject: JSZipStatic;
+declare module "jszip" {
+    export = JSZipModuleObject;
+}

--- a/developer/js/source/lexical-model-compiler/stub.ts
+++ b/developer/js/source/lexical-model-compiler/stub.ts
@@ -1,7 +1,0 @@
-
-// This file defines stub callbacks so that dev-time work on wordbreaker and predictors don't give
-// errors.
-
-// TODO: Turn into a .d.ts?
-// TODO: jsdoc function comments and parameter names
-let com = {keyman: {lexicalModel: { registerWordBreaker(a,b) {}, registerPredictor(a,b) {} } } };

--- a/developer/js/source/model-info-compiler/model-info-compiler.ts
+++ b/developer/js/source/model-info-compiler/model-info-compiler.ts
@@ -69,12 +69,15 @@ export function writeMergedModelMetadataFile(
   // https://help.keyman.com/developer/cloud/model_info/1.0
   //
 
-  function setModelMetadata(field: string, expected: any, warn: boolean = true) {
-    if(model_info[field] && model_info[field] !== expected) {
-      if(warn || typeof warn === 'undefined')
+  function setModelMetadata(field: keyof ModelInfoFile, expected: unknown, warn: boolean = true) {
+    if (model_info[field] && model_info[field] !== expected) {
+      if (warn || typeof warn === 'undefined')
         console.warn(`Warning: source ${sourceModelInfoFileName} field ${field} value "${model_info[field]}" does not match "${expected}" found in source file metadata.`);
     }
-    model_info[field] = model_info[field] || expected;
+    // TypeScript gets upset with this assignment, because it cannot deduce
+    // the exact type of model_info[field] -- there are many possibilities!
+    // So we assert that it's unknown so that TypeScript can chill.
+    (<unknown> model_info[field]) = model_info[field] || expected;
   }
 
   //

--- a/developer/js/source/package-compiler/kmp-compiler.ts
+++ b/developer/js/source/package-compiler/kmp-compiler.ts
@@ -2,9 +2,9 @@
 /// <reference path="kps-file.ts" />
 /// <reference path="kmp-json-file.ts" />
 
-let fs = require('fs');
-let path = require('path');
-let xml2js = require('xml2js');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as xml2js from 'xml2js';
 let zip = require('node-zip')();
 
 export default class KmpCompiler {

--- a/developer/js/source/package-compiler/kmp-compiler.ts
+++ b/developer/js/source/package-compiler/kmp-compiler.ts
@@ -1,4 +1,3 @@
-// <reference path="lexical-model.ts" />
 /// <reference path="kps-file.ts" />
 /// <reference path="kmp-json-file.ts" />
 

--- a/developer/js/source/package-compiler/kmp-compiler.ts
+++ b/developer/js/source/package-compiler/kmp-compiler.ts
@@ -76,10 +76,10 @@ export default class KmpCompiler {
     let keys: (keyof KpsFileOptions & keyof KmpJsonFileOptions)[] = ['executeProgram', 'graphicFile', 'msiFilename', 'msiOptions', 'readmeFile'];
     for (let element of keys) {
       if (kps.options[element]) {
-        if (element === "followKeyboardVersion") {
-          throw new Error('Should never get here')
-        }
-        kmp.options[element] = kps.options[element];
+        // TypeScript thinks it's possible to assign to followKeyboardVersion (a
+        // boolean), but in reality, all of the other keys are strings.
+        // Politely inform TypeScript that it's okay to do this assignment:
+        (<string> kmp.options[element]) = kps.options[element];
       }
     }
 

--- a/developer/js/source/package-compiler/kmp-compiler.ts
+++ b/developer/js/source/package-compiler/kmp-compiler.ts
@@ -5,7 +5,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as xml2js from 'xml2js';
-let zip = require('node-zip')();
+import * as JSZip from 'jszip';
+
+let zip = JSZip();
 
 export default class KmpCompiler {
 

--- a/developer/js/source/package-compiler/kmp-compiler.ts
+++ b/developer/js/source/package-compiler/kmp-compiler.ts
@@ -75,9 +75,12 @@ export default class KmpCompiler {
 
     let keys: (keyof KpsFileOptions & keyof KmpJsonFileOptions)[] = ['executeProgram', 'graphicFile', 'msiFilename', 'msiOptions', 'readmeFile'];
     for (let element of keys) {
-      if (kps.options[element])
-        // Not sure why the TypeScript compiler is so upset about this assignment...
-        (<string>kmp.options[element]) = kps.options[element];
+      if (kps.options[element]) {
+        if (element === "followKeyboardVersion") {
+          throw new Error('Should never get here')
+        }
+        kmp.options[element] = kps.options[element];
+      }
     }
 
     if(kps.info) {

--- a/developer/js/source/package-compiler/kps-file.ts
+++ b/developer/js/source/package-compiler/kps-file.ts
@@ -13,6 +13,13 @@
 // * Strings element is not yet checked to be correct
 //
 
+interface KpsPackage {
+  /**
+   * <Package> -- the root element.
+   */
+  package: KpsFile;
+}
+
 interface KpsFile {
   system: KpsFileSystem;
   options: KpsFileOptions;

--- a/developer/js/source/util/util.ts
+++ b/developer/js/source/util/util.ts
@@ -22,6 +22,15 @@ export function compileModel(filename: string): string {
 }
 
 /**
+ * An ECMAScript module as emitted by the TypeScript compiler.
+ */
+interface ES2015Module {
+  /** This is always true. */
+  __esModule: boolean;
+  'default'?: unknown;
+}
+
+/**
  * Loads a lexical model's source module from the given filename.
  *
  * @param filename path to the model source file.
@@ -38,14 +47,17 @@ export function loadFromFilename(filename: string): LexicalModelSource {
   });
   // Turn the module into a function in which we can inject a global.
   let moduleCode = '(function(exports){' + compilationOutput + '})';
+
   // Run the module; its exports will be assigned to `moduleExports`.
-  let moduleExports = {};
+  let moduleExports: Partial<ES2015Module> = {};
   let module = eval(moduleCode);
   module(moduleExports);
+
   if (!moduleExports['__esModule'] || !moduleExports['default']) {
     console.error(`Model source '${filename}' does have a default export. Did you remember to write \`export default source;\`?`);
     // TODO: throw an Error instead.
     process.exit(SysExits.EX_DATAERR);
   }
+
   return moduleExports['default'] as LexicalModelSource;
 }

--- a/developer/js/tsconfig.json
+++ b/developer/js/tsconfig.json
@@ -9,6 +9,7 @@
     "alwaysStrict": true,
     "noImplicitThis": true,
     "noImplicitReturns": true,
+    "noImplicitAny": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "noUnusedLocals": true

--- a/developer/js/tsconfig.json
+++ b/developer/js/tsconfig.json
@@ -7,8 +7,10 @@
     "outDir": "dist",
     "declaration": true,
     "alwaysStrict": true,
-    "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
     "noUnusedLocals": true
   },
   "include": [


### PR DESCRIPTION
I made sure `kmlmc`/`kmlmp`/`kmlmi` all type check under compiler options  `--noImplicitAny`, `--noImplicitThis`, `--alwaysStrict`, `--strictBindCallApply`, and `--strictFunctionTypes`. 

`--strictNullChecks`, `--strictPropertyInitialization` (which depends on the former) are simply too dificult to implement. Also, the typechecker is too dump to realize that an `if(foo === undefined) { process.exit()}` means that `foo` cannot be undefined after this block :/

Fixes #2387