### PR TITLE
fix(windows): smp characters could break context 🍒

### DIFF
--- a/windows/src/desktop/history.md
+++ b/windows/src/desktop/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-12-01 12.0.59 stable
+* Bug Fix: Using supplementary plane characters could cause rules to fail to match (#2398) 
+
 ## 2019-11-15 12.0.54 stable
 * Bug Fix: On Screen Keyboard restored to wrong screen and position when reloading (#2330)
 

--- a/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
+++ b/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
@@ -267,7 +267,6 @@ BOOL AIWin2000Unicode::PostKeys()
 		  break;
 	  case QIT_BACK:
 		  if(Queue[n].dwData == BK_DEADKEY) break;
-      if(Queue[n].dwData == BK_SUPP2) break;  // I1389 - supp chars on vista default to single backspace //TODO: eliminate BK_SUPP2
 		  if(Addin_ProcessBackspace(hwnd)) break;
 
       pInputs[i].type = INPUT_KEYBOARD;

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -415,8 +415,6 @@ BOOL ProcessGroup(LPGROUP gp)
       else 
 			{
 				_td->app->QueueAction(QIT_BACK, 0);
-				if(*p >= 0xD800 && *p <= 0xDBFF)
-          _td->app->QueueAction(QIT_BACK, BK_SUPP2);  // I1389 - supp chars on vista default to single backspace - use BK_SUPP2 flag
 			}
 		}
         p = kkp->dpOutput;

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -108,7 +108,6 @@
 
 #define BK_DEADKEY		1
 #define BK_BACKSPACE	2
-#define BK_SUPP2      3 // I1389 - Second backspace for supplementary pairs - so we can ignore it on Vista, etc
 /*
  A blank key (in a group without "using keys") cannot be '0' as that is
  used for error testing and blanking out unused keys and you don't really


### PR DESCRIPTION
Fixes #2398. Cherry-pick of #2399.