### PR TITLE
fix(ios): prevents lowercased API returns from causing mismatches

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -10,15 +10,32 @@ import Foundation
 
 /// Mainly differs from the API `Keyboard` by having an associated language.
 public struct InstallableKeyboard: Codable, LanguageResource {
+  // Details what properties are coded and decoded re: serialization.
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case lgCode = "languageID" // The original name of the property, which we maintain for serialization.
+    case languageName
+    case version
+    case isRTL
+    case font
+    case oskFont
+    case isCustom
+  }
+
   public private(set) var id: String
   public var name: String
-  public private(set) var languageID: String
+  public private(set) var lgCode: String
   public var languageName: String
   public var version: String
   public var isRTL: Bool
   public var font: Font?
   public var oskFont: Font?
   public var isCustom: Bool
+
+  public var languageID: String {
+    return lgCode.lowercased()
+  }
 
   public var fullID: FullKeyboardID {
     return FullKeyboardID(keyboardID: id, languageID: languageID)
@@ -35,7 +52,7 @@ public struct InstallableKeyboard: Codable, LanguageResource {
               isCustom: Bool) {
     self.id = id
     self.name = name
-    self.languageID = languageID
+    self.lgCode = languageID
     self.languageName = languageName
     self.version = version
     self.isRTL = isRTL
@@ -47,7 +64,7 @@ public struct InstallableKeyboard: Codable, LanguageResource {
   public init(keyboard: Keyboard, language: Language, isCustom: Bool) {
     self.id = keyboard.id
     self.name = keyboard.name
-    self.languageID = language.id
+    self.lgCode = language.id
     self.languageName = language.name
     self.version = keyboard.version
     self.isRTL = keyboard.isRTL

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
@@ -14,11 +14,24 @@ struct InstallableConstants {
 
 /// Mainly differs from the API `LexicalModel` by having an associated language.
 public struct InstallableLexicalModel: Codable, LanguageResource {
+  // Details what properties are coded and decoded re: serialization.
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case lgCode = "languageID"  // Redirects the old plain-property to something we can wrap with accessors.
+    case version
+    case isCustom
+  }
+
   public private(set) var id: String
   public var name: String
-  public private(set) var languageID: String
+  private var lgCode: String
   public var version: String
   public var isCustom: Bool
+
+  public var languageID: String {
+    return lgCode.lowercased()
+  }
   
   public var fullID: FullLexicalModelID {
     return FullLexicalModelID(lexicalModelID: id, languageID: languageID)
@@ -31,8 +44,7 @@ public struct InstallableLexicalModel: Codable, LanguageResource {
               isCustom: Bool) {
     self.id = id
     self.name = name
-    self.languageID = languageID
-//    self.languageName = languageName
+    self.lgCode = languageID
     self.version = version
     self.isCustom = isCustom
   }
@@ -40,8 +52,7 @@ public struct InstallableLexicalModel: Codable, LanguageResource {
   public init(lexicalModel: LexicalModel, languageID: String, isCustom: Bool) {
     self.id = lexicalModel.id
     self.name = lexicalModel.name
-    self.languageID = languageID
-//    self.languageName = language.name
+    self.lgCode = languageID
     self.version = lexicalModel.version ?? InstallableConstants.defaultVersion
     self.isCustom = isCustom
   }


### PR DESCRIPTION
Useful reference:  https://www.swiftbysundell.com/articles/customizing-codable-types-in-swift/

Since we had some issues with our Cloud API when language IDs weren't consistently lowercased, that's been changed for consistency with infrastructure (for keyboards).  Of course, users with language resources already installed may have local keyboards and/or lexical models with non-lowercased language IDs - this PR will prevent potential resulting language-code matching from being an issue.

Designed to address the same issues as #2404, just for iOS.