### PR TITLE
change(lmlayer): 'default' word breaker issues

### DIFF
--- a/common/predictive-text/unit_tests/headless/default-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/default-word-breaker.js
@@ -24,7 +24,9 @@ describe('The default word breaker', function () {
   // The following tests are performed with model integration as an internal
   // test for the wordbreaking API.
   it('recognizes a word at end of complete lefthand context', function () {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords // wordBreakers['default'] when fully integrated.
+    });
 
     // Standard case - wordbreaking at the end of a word.
     var context = { 
@@ -40,7 +42,9 @@ describe('The default word breaker', function () {
   // Same test as before, but we want to be sure the start/end of buffer flags
   // don't affect our results.
   it('recognizes a word at end of incomplete lefthand context', function () {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // Standard case - wordbreaking at the end of a word.
     var context = { 
@@ -54,7 +58,9 @@ describe('The default word breaker', function () {
   });
 
   it('returns text for a word in-progress', function() {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // Standard case - midword (xylophone) call
     var context = { 
@@ -68,7 +74,9 @@ describe('The default word breaker', function () {
   });
     
   it('returns empty string when called without word text', function() {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // Wordbreaking on a empty space => no word.
     context = { 
@@ -82,7 +90,9 @@ describe('The default word breaker', function () {
   });
 
   it('returns empty string when called with empty context', function() {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // Wordbreaking on a empty space => no word.
     context = { 
@@ -96,7 +106,9 @@ describe('The default word breaker', function () {
   });
 
   it('returns empty string when called with nil context', function() {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // Wordbreaking on a empty space => no word.
     context = { 
@@ -110,7 +122,9 @@ describe('The default word breaker', function () {
   });
 
   it.skip('correctly breaks a word when the caret is placed within it', function() {
-    var model = new TrieModel(jsonFixture('tries/english-1000'));
+    var model = new TrieModel(jsonFixture('tries/english-1000'), {
+      wordBreaker: breakWords
+    });
 
     // A limitation of the current implementation; we should fix this before release.
     // Then again, when typing this is probably fine; just not when not typing.

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.js
@@ -50,7 +50,7 @@ describe('LMLayer using dummy model', function () {
       if(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > -1) {
         // Our wordbreaking uses the IE-unsupported .codePointAt() function.
         console.warn("Bypassing wordbreak test on IE.");
-        return;
+        this.skip();
       }
 
       this.timeout(config.timeouts.standard * 3); // This one makes multiple subsequent calls across

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -18,7 +18,7 @@ describe('LMLayer using the trie model', function () {
       if(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > -1) {
         // Our wordbreaking uses the IE-unsupported .codePointAt() function.
         console.warn("Bypassing wordbreak test on IE.");
-        return;
+        this.skip();
       }
 
       // We're testing many as asynchronous messages in a row.

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -14,6 +14,13 @@ describe('LMLayer using the trie model', function () {
                                                   // the WebWorker boundary, so we should be generous here.
       var lmLayer = new LMLayer(helpers.defaultCapabilities);
 
+      // As noted in worker-dummy-integration as well.
+      if(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > -1) {
+        // Our wordbreaking uses the IE-unsupported .codePointAt() function.
+        console.warn("Bypassing wordbreak test on IE.");
+        return;
+      }
+
       // We're testing many as asynchronous messages in a row.
       // this would be cleaner using async/await syntax, but
       // alas some of our browsers don't support it.

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -85,7 +85,7 @@
         trieData['totalWeight'],
         options.searchTermToKey as Wordform2Key || defaultWordform2Key
       );
-      this.breakWords = options.wordBreaker || wordBreakers.placeholder;
+      this.breakWords = options.wordBreaker || wordBreakers['default'];
       this.punctuation = options.punctuation;
     }
 

--- a/common/predictive-text/worker/word_breaking/default-word-breaking/index.ts
+++ b/common/predictive-text/worker/word_breaking/default-word-breaking/index.ts
@@ -21,7 +21,13 @@ namespace wordBreakers {
       let start = boundaries[i];
       let end = boundaries[i + 1];
       let span = new LazySpan(text, start, end);
+
       if (isNonSpace(span.text)) {
+        spans.push(span);
+        // Preserve a sequence-final space if it exists.  Needed to signal "end of word".
+      } else if (i == boundaries.length - 2) { // if "we just checked the final boundary"...
+        // We don't want to return the whitespace itself; the correct token is simply ''.
+        span = new LazySpan(text, end, end);
         spans.push(span);
       }
     }


### PR DESCRIPTION
Note:  we'll probably want to 🍒-pick this to stable once it's ready.

... so, it turns out that our "default" word breaker wasn't the actual default.  That honor goes to the "placeholder" wordbreaker... which probably should have been removed a while back.

That said, it turns out that there's a problem this was masking.  The `default` wordbreaker doesn't honor context-final spaces that should trigger suggestions for new words instead of modification of pre-space text; this is what is currently breaking MTNT 0.1.3.  (0.1.2 relies on the "placeholder" instead.)

For proof, note the test results of this PR's first commit.  In it, I've corrected the "default" issue so that the tests we thought were running against the default wordbreaker _actually do_.  One failure should result - the one that's breaking MTNT 0.1.3.