### PR TITLE
fix(developer): ci alternate installer path

### DIFF
--- a/windows/src/developer/inst/Makefile
+++ b/windows/src/developer/inst/Makefile
@@ -23,6 +23,7 @@ setup:
     
     $(MAKE) -fcopydev.mak candle
     $(WIXLIGHT) -sice:ICE91 -sice:ICE60 -dWixUILicenseRtf=License.rtf -out keymandeveloper.msi -ext WixUIExtension $(DEVELOPER_FILES)
+    $(MAKE) -fcopydev.mak clean-heat
 
     #
     # Sign the installation archive

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -33,7 +33,10 @@ candle: heat-cef heat-xml heat-templates heat-model-compiler
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dXmlSourceDir=$(ROOT)\src\developer\TIKE\xml xml.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dTemplatesSourceDir=$(KEYMAN_DEVELOPER_TEMPLATES_ROOT) templates.wxs
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dModelCompilerSourceDir=$(KEYMAN_MODELCOMPILER_ROOT) kmlmc.wxs
+    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dModelCompilerSourceDir=$(KEYMAN_WIX_TEMP_MODELCOMPILER) kmlmc.wxs
+    $(MAKE) -fcopydev.mak clean-heat
+
+clean-heat: clean-heat-model-compiler
 
 heat-xml:
     # We copy the files to a temp folder in order to exclude thumbs.db, .vs, etc from harvesting
@@ -103,6 +106,8 @@ heat-model-compiler:
     cd $(ROOT)\src\developer\inst
     $(WIXHEAT) dir $(KEYMAN_WIX_TEMP_MODELCOMPILER) -o kmlmc.wxs -ag -cg ModelCompiler -dr INSTALLDIR -var var.ModelCompilerSourceDir -wx -nologo
 
+clean-heat-model-compiler:
+    # the production build generates files that are not in source, e.g. .ps1 scripts
     # When we candle/light build, we can grab the source files from the proper root so go ahead and delete the temp folder again
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)
 

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -34,7 +34,6 @@ candle: heat-cef heat-xml heat-templates heat-model-compiler
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dTemplatesSourceDir=$(KEYMAN_DEVELOPER_TEMPLATES_ROOT) templates.wxs
     $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dModelCompilerSourceDir=$(KEYMAN_WIX_TEMP_MODELCOMPILER) kmlmc.wxs
-    $(MAKE) -fcopydev.mak clean-heat
 
 clean-heat: clean-heat-model-compiler
 


### PR DESCRIPTION
CI needs to build the model compiler from an alternate path because the
production build from npm can have files not in the development build.

This was causing CI errors such as:
  kmlmc.wxs(170) : error LGHT0103 : The system cannot find the file
  'C:\...\node_modules\.bin\node.ps1'.