### PR TITLE
[Android] Add preference to ignore update notification

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -330,7 +330,8 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * @param id : keyboard or lexical model ID to ignore for MONTHS_TO_IGNORE_NOTIFICATION months
    */
   private void setPrefKeyIgnoreNotifications(String id) {
-    SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    SharedPreferences prefs = currentContext.getSharedPreferences(
+      currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();
     String ignoredNotificationsStr = prefs.getString(PREF_KEY_IGNORE_NOTIFICATIONS, null);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -313,7 +313,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           Calendar ignoreUntilTime = Calendar.getInstance();
           ignoreUntilTime.setTime(new Date(lastIgnoredTime));
           ignoreUntilTime.add(Calendar.MONTH, MONTHS_TO_IGNORE_NOTIFICATION);
-          Log.d(TAG,"now: " + now.getTime() + ", ignore til: " + ignoreUntilTime.getTime());
           if (now.compareTo(ignoreUntilTime) < 0) {
             return true;
           }
@@ -576,7 +575,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
   public void cancelLexicalModelUpdate(String aLangId, String aModelId)
   {
-    NotificationManagerCompat notificationManager = NotificationManagerCompat.from(currentContext);
     setPrefKeyIgnoreNotifications(aModelId);
     removeOpenUpdate(createLexicalModelId(aLangId,aModelId));
     if(openUpdates.isEmpty())

--- a/android/history.md
+++ b/android/history.md
@@ -9,10 +9,12 @@
   * Check for keyboard updates during keyman startup (#2335)
   * Show available keyboard updates as android system notifications (#2335)
   * Add update indicator icon to inform user about updates and install updates in keyman app (#2335)
+  * Add preference so update notifications can be ignored 3 months (#2412)
 * Changes:
   * Update target Android SDK version to 29 (#2279)
   * Add simple UI tests for keyboard picker and keyboard info screens (#2326)
   * Add example dictionary to KMSample1 project (#2369)
+  * Prevent lower-cased API returns from causing mismatches (#2404)
 * Bug fix:
   * Sanitize the app version to `#.#.#` for the API cloud query (#2319)
   * Add linting to Debug builds and resolve lint errors (#2305)


### PR DESCRIPTION
Starts to address #2367 

Adds a preference that tracks when an update notification for keyboard / lexical model ID is cancelled.
For 3 months, that notification won't appear again.
