### PR TITLE
fix(mac): osk shouldn't show base letters

### DIFF
--- a/mac/history.md
+++ b/mac/history.md
@@ -2,6 +2,8 @@
 
 ## 13.0 alpha
 * Start version 13.0
+* Fix: On Screen Keyboard should not show base letters for blank keycaps (#2414)
+* Fix: On Screen Keyboard would sometimes show unexpectedly (#2413)
 
 ## 2019-08-12 12.0.7 beta
 * Fix compatibility issues with macOS 10.14.5 (#1889)


### PR DESCRIPTION
Fixes #2345.

The OSK shouldn't show base letters when a Keyman keyboard is active that includes a visual keyboard.

Fixed keyboard:
<img width="618" alt="Screen Shot 2019-12-04 at 12 15 24 pm" src="https://user-images.githubusercontent.com/4498365/70138160-f254ce80-168f-11ea-82b3-ab256c6dddec.png">
