### PR TITLE
fix(developer): project menu obscured sometimes

### DIFF
--- a/windows/src/developer/TIKE/xml/project/common.js
+++ b/windows/src/developer/TIKE/xml/project/common.js
@@ -204,7 +204,12 @@ function ShowMenu(name,align) {
   menudiv.style.visibility='visible';
   if(align=='right') menudiv.style.left = (pb.x+button.offsetWidth-menudiv.offsetWidth) + 'px';
   else menudiv.style.left = pb.x + 'px';
-  menudiv.style.top = (pb.y+button.offsetHeight) + 'px';
+
+  if(pb.y + button.offsetHeight + menudiv.offsetHeight > window.innerHeight - 4) {
+    menudiv.style.top = (pb.y - menudiv.offsetHeight) + 'px';
+  } else {
+    menudiv.style.top = (pb.y + button.offsetHeight) + 'px';
+  }
 
   document.getElementById('menubackground').className = 'show';
 }


### PR DESCRIPTION
Fixes #2395. The popup menus in the project window would sometimes
be obscured because they would pop below the height of the window. This
PR changes the menu to pop up instead in those situations.