### PR TITLE
fix(developer): Remove kps version when needed

### DIFF
--- a/windows/src/global/delphi/general/kpsfile.pas
+++ b/windows/src/global/delphi/general/kpsfile.pas
@@ -217,6 +217,9 @@ var
   i: Integer;
   ANode: IXMLNode;
 begin
+  if (Options as TKPSOptions).FollowKeyboardVersion then
+    Info.Desc[PackageInfo_Version] := '';
+
   Options.FileVersion := SKeymanVersion70;
 
   if FileName <> '' then


### PR DESCRIPTION
Fixes #2201. If the flag followKeyboardVersion is set, then this removes
the version number embedded in the package source file.