### PR TITLE
fix(developer): Hotkeys in text editor regression

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2019-12-06 12.0.62 stable
+* Bug Fix: Shortcuts in text editors were not working after #2331 (#2424)
+
 ## 2019-11-18 12.0.55 stable
 * Bug Fix: Some keyboards were incorrectly marked as mobile-capable (#2334)
 


### PR DESCRIPTION
Fixes #2421. With fixes to the focus in text editors, this changed the
active control reported back through Delphi and we were then testing the
wrong control for availability.