### PR TITLE
fix(developer): character map drops chars reliably

### DIFF
--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -1116,7 +1116,15 @@ begin
   try
     j.AddPair('x', TJSONNumber.Create(X));
     j.AddPair('y', TJSONNumber.Create(Y));
-    j.AddPair('text', cdo.Text[cdo.InsertType]);
+
+    // The character map insert format actually only
+    // makes sense for the .kmn source editor. For all
+    // other contexts, we currently only support cmimCharacter.
+    // It would be possible to do \uxxxx for JS/JSON etc but
+    // for now that is low priority.
+    if FEditorFormat = efKMN
+      then j.AddPair('text', cdo.Text[cdo.InsertType])
+      else j.AddPair('text', cdo.Text[cmimCharacter]);
     ExecuteCommand('charmapDragDrop', j);
   finally
     j.Free;

--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -677,7 +677,7 @@ begin
   try
     j.AddPair('x', TJSONNumber.Create(X));
     j.AddPair('y', TJSONNumber.Create(Y));
-    j.AddPair('text', cdo.Text[cdo.InsertType]);
+    j.AddPair('text', cdo.Text[cmimCharacter]); // It never makes sense to drop anything other than char
     BuilderCommand('charmapDragDrop', j);
   finally
     j.Free;


### PR DESCRIPTION
For all editors other than kmn, it only makes sense
to drop characters, not character codes.

Fixes #2125.