### PR TITLE
fix(developer): keyboard id should be clean in import

### DIFF
--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,7 @@
 ## 13.0 alpha
 * Start version 13.0
 * Feature: Add unsupported kmdecomp decompiler utility (#2419)
+* Bug Fix: Keyboard ID was not clean by default with Import Windows Keyboard (#2431)
 
 ## 2019-11-18 12.0.55 stable
 * Bug Fix: Some keyboards were incorrectly marked as mobile-capable (#2334)

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -73,6 +73,7 @@ uses
   Keyman.Developer.System.ImportKeyboardDLL,
   Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter,
   Keyman.System.Util.RenderLanguageIcon,
+  Keyman.System.KeyboardUtils,
   KeymanVersion,
   KeyboardParser,
   kmxfileconsts,
@@ -107,7 +108,7 @@ begin
         r.ValueExists(SRegValue_KeyboardLayoutText) then
       Exit(False);
 
-    KeyboardID := ChangeFileExt(r.ReadString(SRegValue_KeyboardLayoutFile), '');
+    KeyboardID := TKeyboardUtils.CleanKeyboardID(ChangeFileExt(r.ReadString(SRegValue_KeyboardLayoutFile), ''));
     Name := r.ReadString(SRegValue_KeyboardLayoutText);
   finally
     r.Free;


### PR DESCRIPTION
When importing a Windows keyboard, the default keyboard id would not necessarily be lower case, which could be confusing as it wasn't clear why the OK button was not enabled.