### PR TITLE
fix(developer): application title was confusing

### DIFF
--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -1482,8 +1482,6 @@ begin
   else if FGlobalProject.Untitled
     then Caption := '(Untitled project) - Keyman Developer'
     else Caption := ChangeFileExt(ExtractFileName(FGlobalProject.FileName), '') + ' - Keyman Developer';
-
-  Application.Title := Caption;
 end;
 
 procedure TfrmKeymanDeveloper.UpdateChildCaption(Window: TfrmTikeChild);

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -6,6 +6,7 @@
 * Feature: Show QRCode for web debugger URLs in Keyboard and Package editors (#2433)
 * Feature: Hotkeys defined in .kmn no longer need to be quoted (#2432)
 * Bug Fix: Keyboard ID was not clean by default with Import Windows Keyboard (#2431)
+* Change: Application title no longer shows active project, only main window (#2441)
 
 ## 2019-11-18 12.0.55 stable
 * Bug Fix: Some keyboards were incorrectly marked as mobile-capable (#2334)


### PR DESCRIPTION
The application title for Developer should always be
'Keyman Developer' and not show the active project. Only
the title of the main window should show the active project.