### PR TITLE
fix(developer): F7 to compile all in project view

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -146,6 +146,7 @@ uses
   Keyman.Developer.System.Project.kpsProjectFile,
   Keyman.Developer.System.Project.ProjectFile,
   Keyman.Developer.UI.Project.ProjectFileUI,
+  Keyman.Developer.UI.Project.UfrmProject,
   UframeTextEditor,
   UfrmKeymanWizard,
   UfrmDebug,
@@ -441,13 +442,18 @@ begin
   else if ActivePackageEditor <> nil then
   begin
     (ActivePackageProjectFile.UI as TProjectFileUI).DoAction(pfaCompile, False);
-  end;
+  end
+  else if frmKeymanDeveloper.ActiveChild is TfrmProject then
+    (frmKeymanDeveloper.ActiveChild as TfrmProject).CompileAll;
 end;
 
 procedure TmodActionsKeyboardEditor.actKeyboardCompileUpdate(Sender: TObject);
 begin
   // TODO: Split Keyboard menu and package editor functions
-  actKeyboardCompile.Enabled := (ActiveEditor <> nil) or (ActivePackageEditor <> nil);
+  actKeyboardCompile.Enabled :=
+    (ActiveEditor <> nil) or
+    (ActivePackageEditor <> nil) or
+    (frmKeymanDeveloper.ActiveChild is TfrmProject);
   frmKeymanDeveloper.mnuKeyboard.Visible := actKeyboardCompile.Enabled;
   frmKeymanDeveloper.mnuDebug.Visible := ActiveEditor <> nil;
 end;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -93,6 +93,7 @@ type
     procedure SetFocus; override;
     procedure SetGlobalProject;
     procedure StartClose; override;
+    procedure CompileAll;
   end;
 
 implementation
@@ -263,6 +264,26 @@ end;
 procedure TfrmProject.ClearMessages;
 begin
   frmMessages.Clear;
+end;
+
+procedure TfrmProject.CompileAll;
+var
+  i: Integer;
+begin
+  ClearMessages;
+  for i := 0 to FGlobalProject.Files.Count - 1 do
+  begin
+    if (FGlobalProject.Files[i] is TkmnProjectFile) or
+      (FGlobalProject.Files[i] is TmodelTsProjectFile) then
+    begin
+      if not (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False) then Exit;   // I4687
+    end;
+  end;
+  for i := 0 to FGlobalProject.Files.Count - 1 do
+  begin
+    if FGlobalProject.Files[i] is TkpsProjectFile then
+      if not (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False) then Exit;   // I4687
+  end;
 end;
 
 function TfrmProject.ShouldHandleNavigation(URL: string): Boolean;
@@ -489,20 +510,7 @@ begin
   end
   else if Command = 'compileall' then   // I4686
   begin
-    ClearMessages;
-    for i := 0 to FGlobalProject.Files.Count - 1 do
-    begin
-      if (FGlobalProject.Files[i] is TkmnProjectFile) or
-        (FGlobalProject.Files[i] is TmodelTsProjectFile) then
-      begin
-        if not (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False) then Exit;   // I4687
-      end;
-    end;
-    for i := 0 to FGlobalProject.Files.Count - 1 do
-    begin
-      if FGlobalProject.Files[i] is TkpsProjectFile then
-        if not (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False) then Exit;   // I4687
-    end;
+    CompileAll;
   end
   else if Command = 'cleanall' then   // I4692
   begin

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -5,6 +5,7 @@
 * Feature: Add unsupported kmdecomp decompiler utility (#2419)
 * Feature: Show QRCode for web debugger URLs in Keyboard and Package editors (#2433)
 * Feature: Hotkeys defined in .kmn no longer need to be quoted (#2432)
+* Feature: F7 in Project window compiles the whole project (#2442)
 * Bug Fix: Keyboard ID was not clean by default with Import Windows Keyboard (#2431)
 
 ## 2019-11-18 12.0.55 stable


### PR DESCRIPTION
Fixes #192. This does not implement Ctrl+F7 but just F7 to compile the 'project'. I can see potential in the future to consolidate the 'compile' command into a single command rather than splitting between Model and Keyboard, and have the same shortcut. But I won't do that in this PR.