### PR TITLE
chore: add Jetbrains IDE files to top level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,9 @@
 # VS Code
 .vscode
 
+# IDE files
+**/.idea/**/*.xml
+**/.idea/**/*.iml
 
 .DS_Store
 


### PR DESCRIPTION
This adds Jetbrains IDE files to the top-level .gitignore.
