### PR TITLE
feat(developer): Default project path

### DIFF
--- a/windows/src/developer/TIKE/dialogs/UfrmNew.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNew.pas
@@ -90,7 +90,7 @@ uses
   Keyman.Developer.System.Project.ProjectFile,
   Keyman.System.KeyboardUtils,
   Keyman.System.LexicalModelUtils,
-  shlobj,
+  KeymanDeveloperOptions,
   utilsystem;
 
 {$R *.DFM}
@@ -218,7 +218,7 @@ var
 begin
   inherited;
   if FGlobalProject.Untitled
-    then FRootPath := GetFolderPath(CSIDL_PERSONAL)
+    then FRootPath := FKeymanDeveloperOptions.DefaultProjectPath
     else FRootPath := ExtractFilePath(FGlobalProject.FileName);
 
   lvItems.Selected := lvItems.Items[0];

--- a/windows/src/developer/TIKE/dialogs/UfrmNewFileDetails.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmNewFileDetails.pas
@@ -66,11 +66,8 @@ type
 implementation
 
 uses
-  ShlObj,
-
-  Keyman.Developer.System.HelpTopics,
-
-  utilsystem;
+  KeymanDeveloperOptions,
+  Keyman.Developer.System.HelpTopics;
 
 {$R *.DFM}
 
@@ -109,7 +106,7 @@ end;
 procedure TfrmNewFileDetails.SetBaseFileName(Value: string);
 begin
   if ExtractFilePath(Value) = ''   // I4798
-    then editFilePath.Text := ExcludeTrailingPathDelimiter(GetFolderPath(CSIDL_PERSONAL))   // I4798
+    then editFilePath.Text := ExcludeTrailingPathDelimiter(FKeymanDeveloperOptions.DefaultProjectPath)   // I4798
     else editFilePath.Text := ExtractFileDir(Value);   // I4798
   editFileName.Text := '';   // I4798
 end;

--- a/windows/src/developer/TIKE/dialogs/UfrmOptions.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmOptions.dfm
@@ -442,7 +442,7 @@ inherited frmOptions: TfrmOptions
     Top = 403
   end
   object dlgBrowseDefaultProjectPath: TBrowse4Folder
-    InitialDir = 'C:\Users\mcdurdin\Desktop\'
+    InitialDir = ''
     Root = Desktop
     Title = 'Browse for Default Project Folder'
     Left = 176

--- a/windows/src/developer/TIKE/dialogs/UfrmOptions.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmOptions.dfm
@@ -30,7 +30,7 @@ inherited frmOptions: TfrmOptions
       ExplicitHeight = 0
       object cmdProxySettings: TButton
         Left = 8
-        Top = 160
+        Top = 209
         Width = 125
         Height = 25
         Caption = '&Proxy Settings...'
@@ -40,29 +40,29 @@ inherited frmOptions: TfrmOptions
       object gbExternalEditor: TGroupBox
         Left = 8
         Top = 71
-        Width = 237
+        Width = 401
         Height = 45
         Caption = '&External Editor Path'
         TabOrder = 1
         object editExternalEditorPath: TEdit
           Left = 8
           Top = 16
-          Width = 141
+          Width = 311
           Height = 21
           TabOrder = 0
         end
         object cmdBrowseExternalEditor: TButton
-          Left = 156
+          Left = 325
           Top = 16
-          Width = 73
+          Width = 69
           Height = 21
           Caption = '&Browse...'
           TabOrder = 1
         end
       end
       object cmdSMTPSettings: TButton
-        Left = 139
-        Top = 160
+        Left = 8
+        Top = 240
         Width = 125
         Height = 25
         Caption = 'S&MTP Settings...'
@@ -79,7 +79,7 @@ inherited frmOptions: TfrmOptions
       end
       object cmdResetToolWindows: TButton
         Left = 8
-        Top = 129
+        Top = 178
         Width = 125
         Height = 25
         Caption = '&Reset tool windows'
@@ -93,6 +93,30 @@ inherited frmOptions: TfrmOptions
         Height = 17
         Caption = '&Allow multiple instances of Keyman Developer'
         TabOrder = 5
+      end
+      object gbDefaultProjectPath: TGroupBox
+        Left = 8
+        Top = 122
+        Width = 401
+        Height = 45
+        Caption = '&Default Project Folder'
+        TabOrder = 6
+        object editDefaultProjectPath: TEdit
+          Left = 8
+          Top = 16
+          Width = 311
+          Height = 21
+          TabOrder = 0
+        end
+        object cmdBrowseDefaultProjectPath: TButton
+          Left = 325
+          Top = 16
+          Width = 69
+          Height = 21
+          Caption = '&Browse...'
+          TabOrder = 1
+          OnClick = cmdBrowseDefaultProjectPathClick
+        end
       end
     end
     object tabEditor: TTabSheet
@@ -416,5 +440,12 @@ inherited frmOptions: TfrmOptions
     Title = 'Browse for Editor Theme'
     Left = 212
     Top = 403
+  end
+  object dlgBrowseDefaultProjectPath: TBrowse4Folder
+    InitialDir = 'C:\Users\mcdurdin\Desktop\'
+    Root = Desktop
+    Title = 'Browse for Default Project Folder'
+    Left = 176
+    Top = 400
   end
 end

--- a/windows/src/developer/TIKE/main/KeymanDeveloperOptions.pas
+++ b/windows/src/developer/TIKE/main/KeymanDeveloperOptions.pas
@@ -58,6 +58,7 @@ type
     FDisplayTheme: string;
     FEditorTheme: string;
     FFix183_LadderLength: Integer;
+    FDefaultProjectPath: string;
     procedure CloseRegistry;
     procedure OpenRegistry;
     function regReadString(const nm, def: string): string;
@@ -93,6 +94,7 @@ type
     property AllowMultipleInstances: Boolean read FAllowMultipleInstances write FAllowMultipleInstances;
 
     property OpenKeyboardFilesInSourceView: Boolean read FOpenKeyboardFilesInSourceView write FOpenKeyboardFilesInSourceView;   // I4751
+    property DefaultProjectPath: string read FDefaultProjectPath write FDefaultProjectPath;
 
     property DisplayTheme: string read FDisplayTheme write FDisplayTheme;   // I4796
 
@@ -117,9 +119,14 @@ const
     (Name: 'hc-black'; Desc: 'High Constrast (hc-black)')
   );
 
+const
+  CDefaultProjectPath = 'Keyman Developer\Projects\';
+
 implementation
 
 uses
+  Winapi.ShlObj,
+  utilsystem,
   OnlineConstants,
   GetOSVersion;
 
@@ -195,6 +202,8 @@ begin
     FTestEmailAddresses := regReadString(SRegValue_IDEOptTestEmailAddresses, '');   // I4506
 
     FFix183_LadderLength := regReadInt(SRegValue_IDEOpt_WebLadderLength, CRegValue_IDEOpt_WebLadderLength_Default);
+
+    FDefaultProjectPath := IncludeTrailingPathDelimiter(regReadString(SRegValue_IDEOpt_DefaultProjectPath, GetFolderPath(CSIDL_PERSONAL) + CDefaultProjectPath));
   finally
     CloseRegistry;
   end;
@@ -231,6 +240,8 @@ begin
     regWriteString(SRegValue_IDEOptTestEmailAddresses,          FTestEmailAddresses);   // I4506
 
     regWriteInt(SRegValue_IDEOpt_WebLadderLength, FFix183_LadderLength);
+
+    regWriteString(SRegValue_IDEOpt_DefaultProjectPath, FDefaultProjectPath);
   finally
     CloseRegistry;
   end;

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -416,6 +416,7 @@ implementation
 uses
   System.Math,
   Winapi.WinInet,
+  Winapi.ShlObj,
   Winapi.Urlmon,
   Winapi.UxTheme,
   System.Win.ComObj,
@@ -478,6 +479,13 @@ var
   FActiveProject: string;
 begin
   inherited;
+
+  if not ForceDirectories(FKeymanDeveloperOptions.DefaultProjectPath) then
+  begin
+    // Fall back to Documents folder if we cannot create the default project path
+    // Documents folder should always exist
+    FKeymanDeveloperOptions.DefaultProjectPath := GetFolderPath(CSIDL_PERSONAL);
+  end;
 
   FFirstShow := True;
 

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
@@ -117,14 +117,12 @@ function ShowNewModelProjectParameters(Owner: TComponent): Boolean;
 implementation
 
 uses
-  Winapi.ShlObj,
-
   Keyman.System.LanguageCodeUtils,
   Keyman.System.LexicalModelUtils,
   BCP47Tag,
   utilstr,
-  utilsystem,
   dmActionsMain,
+  KeymanDeveloperOptions,
   Keyman.Developer.System.HelpTopics,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.Project.ProjectFile,
@@ -179,7 +177,7 @@ end;
 procedure TfrmNewModelProjectParameters.FormCreate(Sender: TObject);
 begin
   inherited;
-  editPath.Text := GetFolderPath(CSIDL_PERSONAL);
+  editPath.Text := FKeymanDeveloperOptions.DefaultProjectPath;
 
   pack := TKPSFile.Create;
   pack.LexicalModels.Add(TPackageLexicalModel.Create(pack));

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -105,13 +105,11 @@ function ShowNewProjectParameters(Owner: TComponent): Boolean;
 implementation
 
 uses
-  Winapi.ShlObj,
-
   Keyman.System.LanguageCodeUtils,
   BCP47Tag,
   utilstr,
-  utilsystem,
   dmActionsMain,
+  KeymanDeveloperOptions,
   Keyman.Developer.System.HelpTopics,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.Project.ProjectFile,
@@ -178,7 +176,7 @@ var
   i: TKeymanTarget;
 begin
   inherited;
-  editPath.Text := GetFolderPath(CSIDL_PERSONAL);
+  editPath.Text := FKeymanDeveloperOptions.DefaultProjectPath;
 
   pack := TKPSFile.Create;
   pack.Keyboards.Add(TPackageKeyboard.Create(pack));

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -6,6 +6,7 @@
 * Feature: Show QRCode for web debugger URLs in Keyboard and Package editors (#2433)
 * Feature: Hotkeys defined in .kmn no longer need to be quoted (#2432)
 * Feature: F7 in Project window compiles the whole project (#2442)
+* Feature: Default Project Path is now Documents\Keyman Developer\Projects (#2449)
 * Bug Fix: Keyboard ID was not clean by default with Import Windows Keyboard (#2431)
 * Bug Fix: Zero-length store names are no longer permitted (#2443)
 * Change: Rename UI references of 'TIKE' to 'Keyman Developer' (#2439)

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -396,6 +396,8 @@ const
   SRegValue_IDEOpt_WebLadderLength = 'web ladder length';                           // CU
   CRegValue_IDEOpt_WebLadderLength_Default = 100;
 
+  SRegValue_IDEOpt_DefaultProjectPath = 'default project path';
+
   { SRegKey_KCT values }
 
 //  SRegValue_KCTTemplatePath = 'template path';                                      // LM


### PR DESCRIPTION
Fixes #1689. Sets the default project path to 'Documents\Keyman Developer\Projects' so that Keyman Developer files don't clutter user's Documents folder. Can be changed in Options dialog.