### PR TITLE
fix(android): Removes Closure's auto-polyfills, adds test case bypass

### DIFF
--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -13,7 +13,8 @@ display_usage ( ) {
     echo "  -no-kmw-build           Don't build KMW. Just copy existing artifacts"
     echo "  -no-kmw                 Don't build KMW. Don't copy artifacts"
     echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"
-    echo "  -no-test                Don't run the unit-test suite."
+    echo "  -no-test                Don't run the unit-test suite.  Use for development builds"
+    echo "                          to facilitate manual debugging and testing"
     exit 1
 }
 
@@ -83,6 +84,7 @@ done
 echo
 echo "DO_BUILD: $DO_BUILD"
 echo "DO_COPY: $DO_COPY"
+echo "DO_TEST: $DO_TEST"
 echo "NO_DAEMON: $NO_DAEMON"
 echo "DEBUG_BUILD: $DEBUG_BUILD"
 echo "EMBED_BUILD: $EMBED_BUILD"

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -67,8 +67,8 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -debug)
             DEBUG_BUILD=true
-            #EMBED_BUILD=-debug_embedded
-            #KMW_PATH=unminified
+            EMBED_BUILD=-debug_embedded
+            KMW_PATH=unminified
             ;;
         -h|-?)
             display_usage

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -83,7 +83,8 @@ minifier="$CLOSURECOMPILERPATH/compiler.jar"
 # `jsDocMissingType` prevents errors on type documentation Closure thinks is missing.  TypeScript may not
 # have the same requirements, and we trust TypeScript over Closure.
 minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode"
-minifycmd="$JAVA -jar $minifier --compilation_level WHITESPACE_ONLY $minifier_warnings --generate_exports"
+minifier_lang_specs="--language_in ECMASCRIPT5 --language_out ECMASCRIPT5"
+minifycmd="$JAVA -jar $minifier --compilation_level WHITESPACE_ONLY $minifier_warnings --generate_exports $minifier_lang_specs"
 
 if ! [ -f $minifier ];
 then

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -83,6 +83,12 @@ minifier="$CLOSURECOMPILERPATH/compiler.jar"
 # `jsDocMissingType` prevents errors on type documentation Closure thinks is missing.  TypeScript may not
 # have the same requirements, and we trust TypeScript over Closure.
 minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode"
+
+# We use these to prevent Closure from auto-inserting its own polyfills.  Turns out, they can break in the 
+# WebView used by Android API 19, which our app still supports.
+#
+# Also, we currently apply all needed polyfills either manually or during TS compilation; we don't need the extra,
+# excess code.
 minifier_lang_specs="--language_in ECMASCRIPT5 --language_out ECMASCRIPT5"
 minifycmd="$JAVA -jar $minifier --compilation_level WHITESPACE_ONLY $minifier_warnings --generate_exports $minifier_lang_specs"
 


### PR DESCRIPTION
Fixes #2323.

So, it turns out that the final issue for #2323 was being caused by the Closure minifier, which tries to be helpful by adding polyfills for us.  Just... that actually broke things on API 19, which apparently is too old for one of its polyfills.

This also adds a simple "build without testing" option to Android's build.sh, allowing for easier compilation of the entire app whenever unit tests fail.  Sometimes this is useful for narrowing things down with live testing.

Note that this issue originally wasn't caught because it doesn't show up with the `debug_embedded` flag for KMW, which itself is set by using the `-debug` flag when compiling the Android app.  Testing locally may require the state seen in commit https://github.com/keymanapp/keyman/commit/4600e2a4069b7db6dce6f8d1f51514b245a7b652, where the responsible lines have been commented out.