### PR TITLE
feat(android): Add QR Codes on Keyboard Info pages

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -20,5 +20,6 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -127,6 +127,13 @@ dependencies {
         transitive = true
     }
     implementation 'androidx.preference:preference:1.1.0'
+
+    // Add dependency for generating QR Codes
+    // (Even though it's embedded in KMEA, because we're manually copying keyman-engine.aar,
+    // we "lose" it in the dependency management)
+    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+        transitive = true
+    }
 }
 
 /*def void dumpProperties(it){

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -82,6 +82,11 @@ dependencies {
         transitive = true
     }
 
+    // Generate QR Codes
+    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+        transitive = true
+    }
+
     // Assign the annotation processor for tests.
     testAnnotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -12,14 +12,18 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.core.content.FileProvider;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.AdapterView;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
@@ -29,10 +33,12 @@ import android.widget.Toast;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.util.QRCodeUtil;
 
 // Public access is necessary to avoid IllegalAccessException
 public final class KeyboardInfoActivity extends AppCompatActivity {
 
+  private static final String TAG = "KeyboardInfoActivity";
   private static Toolbar toolbar = null;
   private static ListView listView = null;
   private static ArrayList<HashMap<String, String>> infoList = null;
@@ -150,6 +156,23 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
         }
       }
     });
+
+    // If QRGen library included, also display QR code for sharing keyboard
+    if (QRCodeUtil.exists(context)) {
+      String url = String.format("%s%s%s", QRCodeUtil.QR_BASE, kbID, "/share");
+
+      // Shorten listView so the QR code will show
+      ViewGroup.LayoutParams lp = listView.getLayoutParams();
+      lp.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+      listView.setLayoutParams(lp);
+
+      LinearLayout qrLayout = findViewById(R.id.qrLayout);
+      qrLayout.setVisibility(View.VISIBLE);
+
+      Bitmap myBitmap = QRCodeUtil.toBitmap(url);
+      ImageView imageView = (ImageView) findViewById(R.id.qrCode);
+      imageView.setImageBitmap(myBitmap);
+    }
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -158,8 +158,8 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
     });
 
     // If QRGen library included, also display QR code for sharing keyboard
-    if (QRCodeUtil.exists(context)) {
-      String url = String.format("%s%s%s", QRCodeUtil.QR_BASE, kbID, "/share");
+    if (QRCodeUtil.libraryExists(context)) {
+      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
 
       // Shorten listView so the QR code will show
       ViewGroup.LayoutParams lp = listView.getLayoutParams();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -13,14 +13,18 @@ import androidx.appcompat.widget.Toolbar;
 import android.app.DialogFragment;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.core.content.FileProvider;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.AdapterView;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
@@ -30,6 +34,7 @@ import android.widget.Toast;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.util.QRCodeUtil;
 
 import static com.tavultesoft.kmea.ConfirmDialogFragment.DialogType.DIALOG_TYPE_DELETE_KEYBOARD;
 
@@ -173,6 +178,23 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
         }
       }
     });
+
+    // If QRGen library included, also display QR code for sharing keyboard
+    if (QRCodeUtil.exists(context)) {
+      String url = String.format("%s%s%s", QRCodeUtil.QR_BASE, kbID, "/share");
+
+      // Shorten listView so the QR code will show
+      ViewGroup.LayoutParams lp = listView.getLayoutParams();
+      lp.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+      listView.setLayoutParams(lp);
+
+      LinearLayout qrLayout = findViewById(R.id.qrLayout);
+      qrLayout.setVisibility(View.VISIBLE);
+
+      Bitmap myBitmap = QRCodeUtil.toBitmap(url);
+      ImageView imageView = (ImageView) findViewById(R.id.qrCode);
+      imageView.setImageBitmap(myBitmap);
+    }
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -180,8 +180,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     });
 
     // If QRGen library included, also display QR code for sharing keyboard
-    if (QRCodeUtil.exists(context)) {
-      String url = String.format("%s%s%s", QRCodeUtil.QR_BASE, kbID, "/share");
+    if (QRCodeUtil.libraryExists(context)) {
+      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
 
       // Shorten listView so the QR code will show
       ViewGroup.LayoutParams lp = listView.getLayoutParams();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
@@ -1,0 +1,35 @@
+package com.tavultesoft.kmea.util;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import net.glxn.qrgen.android.QRCode;
+
+/**
+ * Utility to generate QR Code from a URL string
+ */
+public final class QRCodeUtil {
+  public static final int DEFAULT_HEIGHT = 800;
+  public static final int DEFAULT_WIDTH = 800;
+  public static final String QR_BASE = "https://keyman.com/go/keyboard/";
+
+  /**
+   * Generate QR Code as a Bitmap
+   * @param url String
+   * @return Bitmap of the QR Code
+   */
+  public static Bitmap toBitmap(String url) {
+    Bitmap result = QRCode.from(url).withSize(DEFAULT_WIDTH, DEFAULT_HEIGHT).bitmap();
+    return result;
+  }
+
+  public static boolean exists(Context context) {
+    boolean result = false;
+    try {
+      Class.forName("net.glxn.qrgen.android.QRCode");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
@@ -11,7 +11,7 @@ import net.glxn.qrgen.android.QRCode;
 public final class QRCodeUtil {
   public static final int DEFAULT_HEIGHT = 800;
   public static final int DEFAULT_WIDTH = 800;
-  public static final String QR_BASE = "https://keyman.com/go/keyboard/";
+  public static final String QR_BASE = "https://keyman.com/go/keyboard/%s/share";
 
   /**
    * Generate QR Code as a Bitmap
@@ -23,7 +23,7 @@ public final class QRCodeUtil {
     return result;
   }
 
-  public static boolean exists(Context context) {
+  public static boolean libraryExists(Context context) {
     boolean result = false;
     try {
       Class.forName("net.glxn.qrgen.android.QRCode");

--- a/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
@@ -10,4 +10,5 @@
 
     <include layout="@layout/list_layout" />
 
+    <include layout="@layout/qr_layout" />
 </LinearLayout>

--- a/android/KMEA/app/src/main/res/layout/qr_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/qr_layout.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/qrLayout"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:visibility="invisible">
+
+  <View style="@style/Divider.horizontal" />
+
+  <ImageView
+    android:id="@+id/qrCode"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/qr_height"
+    android:layout_gravity="center"
+    android:contentDescription="@string/image_button"/>
+
+  <TextView
+    android:id="@+id/qrDescription"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/keyboard_qr_code"
+    android:textSize="16sp"
+    android:textStyle="bold"
+    android:layout_marginTop="15dp"
+    android:layout_marginBottom="15dp"
+    android:layout_gravity="center"
+    />
+
+</LinearLayout>

--- a/android/KMEA/app/src/main/res/values/dimens.xml
+++ b/android/KMEA/app/src/main/res/values/dimens.xml
@@ -17,4 +17,5 @@
     <dimen name="close_button_margin">12dp</dimen>
     <dimen name="fab_margin">10dp</dimen>
     <dimen name="fab_padding">70dp</dimen>
+    <dimen name="qr_height">250dp</dimen>
 </resources>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="help_link" translatable="false">Help link</string>
     <string name="uninstall_keyboard" translatable="false">Uninstall keyboard</string>
     <string name="keyboard_picker_new_keyboard_prefix" translatable="false">[new]</string>
+    <string name="keyboard_qr_code" translatable="false">Scan this code to load this\nkeyboard on another device</string>
 
     <!-- Model Updates -->
     <string name="getting_model_catalog" translatable="false">Getting dictionary catalog.\nThis may take a while&#8230;</string>

--- a/android/KMEA/app/src/main/res/values/styles.xml
+++ b/android/KMEA/app/src/main/res/values/styles.xml
@@ -23,6 +23,15 @@
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
+    <style name="Divider">
+        <item name="android:background">@android:color/holo_red_dark</item>
+    </style>
+
+    <style name="Divider.horizontal" parent="Divider">
+      <item name="android:layout_width">match_parent</item>
+      <item name="android:layout_height">1dp</item>
+    </style>
+
     <style name="PopupAnim">
         <item name="android:windowEnterAnimation">@anim/fade_in</item>
         <item name="android:windowExitAnimation">@anim/fade_out</item>

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -14,5 +14,6 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }

--- a/android/README.md
+++ b/android/README.md
@@ -162,13 +162,20 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.google.firebase:firebase-core:15.0.2'
-    implementation 'com.google.firebase:firebase-crash:15.0.2'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
+    implementation 'androidx.appcompat:appcompat:1.1.1'
+    implementation 'com.google.android.material:material:1.0.0'
+    api (name:'keyman-engine', ext:'aar')
+    implementation "com.google.firebase:firebase-analytics:17.2.1"
+    implementation "com.google.firebase:firebase-messaging:20.0.1"
+    implementation "com.google.firebase:firebase-crash:16.2.1"
+    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
         transitive = true
     }
-    api (name:'keyman-engine', ext:'aar')
+
+    // Include this if you want to have QR Codes displayed on Keyboard Info
+    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+        transitive = true
+    }
 }
 
 ````

--- a/android/history.md
+++ b/android/history.md
@@ -10,6 +10,7 @@
   * Show available keyboard updates as android system notifications (#2335)
   * Add update indicator icon to inform user about updates and install updates in keyman app (#2335)
   * Add preference so update notifications can be ignored 3 months (#2412)
+  * Add QR Codes to Keyboard Info pages so users can share keyboard downloads (#2458)
 * Changes:
   * Update target Android SDK version to 29 (#2279)
   * Add simple UI tests for keyboard picker and keyboard info screens (#2326)


### PR DESCRIPTION
Addresses Android for #1535

Add QR Codes which link to the keyman.com keyboard page. These are displayed on Keyboard Info and Keyboard Settings Activity. I've also verified the QR codes generate fine on Android API 19.

### Screenshot to sil_eurolatin
![qr sil_eurolatin](https://user-images.githubusercontent.com/7358010/70980634-327f6c80-20e6-11ea-8976-f98f8be8e4ba.png)

If the main app doesn't include the QRGen libraries, the QR Code isn't generated/displayed.

### Screenshot of app without QRGen library
![no qr sil_eurolatin](https://user-images.githubusercontent.com/7358010/70980644-357a5d00-20e6-11ea-91ac-e5411406d242.png)



* Also update the list of dependencies in README.md
