### PR TITLE
fix(ios): Adhoc resource overwrite/file-replacement

### DIFF
--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -26,11 +26,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var destinationUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     destinationUrl.appendPathComponent("\(url.lastPathComponent).zip")
     do {
-      try FileManager.default.copyItem(at: url, to: destinationUrl)
+      let fileManager = FileManager.default
+
+      // For now, we'll always allow overwriting.
+      if fileManager.fileExists(atPath: destinationUrl.path) {
+        try fileManager.removeItem(at: destinationUrl)
+      }
+
+      // Throws an error if the destination file already exists, and there's no
+      // built-in override parameter.  Hence, the previous if-block.
+      try fileManager.copyItem(at: url, to: destinationUrl)
       installAdhocKeyboard(url: destinationUrl)
       return true
     } catch {
       showKMPError(KMPError.copyFiles)
+      log.error(error)
       return false
     }
   }


### PR DESCRIPTION
Fixes #2455.

All in all, a pretty simple fix once you realize what was going on.  Though... why doesn't Apple provide a parameter `permitOverride` or something like that?  Oh well.

Will need a 🍒-pick.

### User Testing

Easy test:

1. Go to https://keyman.com/keyboards/khmer_angkor (or similar page for any .kmp language resource, really)
2. Download the file in Safari.
3. From downloads, install into Keyman.  Follow through to complete installation.
4. Return to Safari, and repeat step 3.  (Installation should proceed without error, as if identical to step 3.)

When not fixed (so... current `master` branch), step 4 will fail - an error will be thrown on the attempt to open it in Keyman, as documented within #2455.

Note that steps 1 and 2 can be replaced with anything that loads the file onto iOS in an accessible manner.  If you can access a .kmp within iOS Files, that will suffice as a replacement.