### PR TITLE
iOS: Refactors KMP installation's connection to app UI

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -57,28 +57,7 @@ public class PackageInstallViewController: UIViewController {
 
   @objc func installBtnHandler() {
     dismiss(animated: true, completion: {
-      let package = self.package
-      do {
-        // Time to pass the package off to the final installers - the parse__KMP methods.
-        // ... they should probably be moved to ResourceFileManager eventually.
-        if package.isKeyboard() {
-          try Manager.shared.parseKbdKMP(package.sourceFolder)
-        } else {
-          try Manager.parseLMKMP(package.sourceFolder)
-        }
-        self.completionHandler(nil)
-      } catch {
-        log.error(error as! KMPError)
-        self.completionHandler(error)
-      }
-
-      //this can fail gracefully and not show errors to users
-      do {
-        try FileManager.default.removeItem(at: package.sourceFolder)
-      } catch {
-        log.error("unable to delete temp files: \(error)")
-        self.completionHandler(error)
-      }
+      ResourceFileManager.shared.finalizePackageInstall(self.package, completionHandler: self.completionHandler)
     })
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -92,26 +92,27 @@ public class ResourceFileManager {
   /**
    * A  utility version of `prepareKMPInstall` that displays default UI alerts if errors occur when preparing a KMP for installation.
    */
-  @available(iOSApplicationExtension, unavailable)
   public func prepareKMPInstall(from url: URL, alertHost: UIViewController, completionHandler: @escaping (KeymanPackage) -> Void) {
     self.prepareKMPInstall(from: url, completionHandler: { package, error in
       if error != nil {
-        self.showKMPError(KMPError.copyFiles)
+        let alert = self.buildKMPError(KMPError.copyFiles)
+        alertHost.present(alert, animated: true, completion: nil)
       } else {
         completionHandler(package!)
       }
     })
   }
 
-  @available(iOSApplicationExtension, unavailable)
-  public func promptAdHocInstall(_ kmp: KeymanPackage, in rootVC: UIViewController) {
-    let vc = PackageInstallViewController(for: kmp, completionHandler: { error in
+  public func promptPackageInstall(of package: KeymanPackage, in rootVC: UIViewController) {
+    let vc = PackageInstallViewController(for: package, completionHandler: { error in
       if let err = error {
         if let kmpError = err as? KMPError {
-          self.showKMPError(kmpError)
+          let alert = self.buildKMPError(kmpError)
+          rootVC.present(alert, animated: true, completion: nil)
         }
       } else {
-        self.showSimpleAlert(title: "Success", message: "Installed successfully.")
+        let alert = self.buildSimpleAlert(title: "Success", message: "Installed successfully.")
+        rootVC.present(alert, animated: true, completion: nil)
       }
     })
 
@@ -119,20 +120,19 @@ public class ResourceFileManager {
     rootVC.present(nvc, animated: true, completion: nil)
   }
 
-  @available(iOSApplicationExtension, unavailable)
-  public func showKMPError(_ error: KMPError) {
-    showSimpleAlert(title: "Error", message: error.rawValue)
+  public func buildKMPError(_ error: KMPError) -> UIAlertController {
+    return buildSimpleAlert(title: "Error", message: error.rawValue)
   }
 
-  @available(iOSApplicationExtension, unavailable)
-  public func showSimpleAlert(title: String, message: String) {
+  public func buildSimpleAlert(title: String, message: String) -> UIAlertController {
     let alertController = UIAlertController(title: title, message: message,
                                             preferredStyle: UIAlertController.Style.alert)
     alertController.addAction(UIAlertAction(title: "OK",
                                             style: UIAlertAction.Style.default,
                                             handler: nil))
 
-    UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: true, completion: nil)
+    //UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: true, completion: nil)
+    return alertController
   }
 
   /**

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -56,47 +56,55 @@ public class ResourceFileManager {
 
   /**
    * Use this function to "install" external KMP files to within the Keyman app's alloted iOS file management domain.
-   * Note that we don't request permissions to support opening/modifying files "in place," so we need to copy .kmps
-   * before unzipping them.
-   *
-   * This implementation does not change how files are managed by the app; only where the file management code
-   * is located.
+   * Note that we don't request permissions to support opening/modifying files "in place," so  .kmps should already be
+   * located in app-space (by use of `importFile`)  before unzipping them.
    */
-  @available(iOSApplicationExtension, unavailable)
-  public func installFile(_ url: URL) {
-      // Once selected, start the standard install process.
-      log.info("Installing KMP from \(url)")
+  public func prepareKMPInstall(from url: URL, completionHandler: @escaping (KeymanPackage?, Error?) -> Void) {
+    // Once selected, start the standard install process.
+    log.info("Installing KMP from \(url)")
 
-      // Step 1: Copy it to a temporary location, making it a .zip in the process
-      var destinationUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-      destinationUrl.appendPathComponent("\(url.lastPathComponent).zip")
+    // Step 1: Copy it to a temporary location, making it a .zip in the process
+    let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    var archiveUrl = cacheDirectory
+    archiveUrl.appendPathComponent("\(url.lastPathComponent).zip")
 
-      do {
-        try copyWithOverwrite(from: url, to: destinationUrl)
-        installAdhocKeyboard(url: destinationUrl)
-      } catch {
-        showKMPError(KMPError.copyFiles)
-        log.error(error)
+    do {
+      try copyWithOverwrite(from: url, to: archiveUrl)
+    } catch {
+      log.error(error)
+      completionHandler(nil, KMPError.copyFiles)
+      return
+    }
+
+    var extractionFolder = cacheDirectory
+    extractionFolder.appendPathComponent("temp/\(archiveUrl.lastPathComponent)")
+
+    KeymanPackage.extract(fileUrl: archiveUrl, destination: extractionFolder, complete: { kmp in
+      if let kmp = kmp {
+        completionHandler(kmp, nil)
+      } else {
+        log.error(KMPError.invalidPackage)
+        completionHandler(nil, KMPError.invalidPackage)
       }
+    })
   }
 
+  /**
+   * A  utility version of `prepareKMPInstall` that displays default UI alerts if errors occur when preparing a KMP for installation.
+   */
   @available(iOSApplicationExtension, unavailable)
-  private func installAdhocKeyboard(url: URL) {
-    let documentsDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-    var destination = documentsDirectory
-    destination.appendPathComponent("temp/\(url.lastPathComponent)")
-
-    KeymanPackage.extract(fileUrl: url, destination: destination, complete: { kmp in
-      if let kmp = kmp {
-        self.promptAdHocInstall(kmp)
+  public func prepareKMPInstall(from url: URL, alertHost: UIViewController, completionHandler: @escaping (KeymanPackage) -> Void) {
+    self.prepareKMPInstall(from: url, completionHandler: { package, error in
+      if error != nil {
+        self.showKMPError(KMPError.copyFiles)
       } else {
-        self.showKMPError(KMPError.invalidPackage)
+        completionHandler(package!)
       }
     })
   }
 
   @available(iOSApplicationExtension, unavailable)
-  private func promptAdHocInstall(_ kmp: KeymanPackage) {
+  public func promptAdHocInstall(_ kmp: KeymanPackage, in rootVC: UIViewController) {
     let vc = PackageInstallViewController(for: kmp, completionHandler: { error in
       if let err = error {
         if let kmpError = err as? KMPError {
@@ -108,7 +116,7 @@ public class ResourceFileManager {
     })
 
     let nvc = UINavigationController.init(rootViewController: vc)
-    UIApplication.shared.keyWindow?.rootViewController?.present(nvc, animated: true, completion: nil)
+    rootVC.present(nvc, animated: true, completion: nil)
   }
 
   @available(iOSApplicationExtension, unavailable)
@@ -125,5 +133,32 @@ public class ResourceFileManager {
                                             handler: nil))
 
     UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: true, completion: nil)
+  }
+
+  /**
+   * Performs the actual installation of a package's resources once confirmation has been received from the user.
+   */
+  public func finalizePackageInstall(_ package: KeymanPackage, completionHandler: (Error?) -> Void) {
+    do {
+      // Time to pass the package off to the final installers - the parse__KMP methods.
+      // TODO: (14.0+) These functions should probably be refactored to within this class eventually.
+      if package.isKeyboard() {
+        try Manager.shared.parseKbdKMP(package.sourceFolder)
+      } else {
+        try Manager.parseLMKMP(package.sourceFolder)
+      }
+      completionHandler(nil)
+    } catch {
+      log.error(error as! KMPError)
+      completionHandler(error)
+    }
+
+    //this can fail gracefully and not show errors to users
+    do {
+      try FileManager.default.removeItem(at: package.sourceFolder)
+    } catch {
+      log.error("unable to delete temp files: \(error)")
+      completionHandler(error)
+    }
   }
 }

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -25,11 +25,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // We really should validate that it is a .kmp first... but the app doesn't yet
     // process URL links, so it's fine for now.  (Will change with QR code stuff.)
 
-    guard let destinationUrl = ResourceFileManager.shared.importFile(url) else {
+    let rfm = ResourceFileManager.shared
+    guard let destinationUrl = rfm.importFile(url) else {
       return false
     }
 
-    ResourceFileManager.shared.installFile(destinationUrl)
+    if let vc = window?.rootViewController {
+      rfm.prepareKMPInstall(from: destinationUrl,
+                            alertHost: vc,
+                            completionHandler: { package in
+                              rfm.promptAdHocInstall(package, in: vc)
+                            })
+    } else {
+      log.error("Cannot find app's root UIViewController")
+    }
+
     return true
   }
 

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -34,7 +34,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       rfm.prepareKMPInstall(from: destinationUrl,
                             alertHost: vc,
                             completionHandler: { package in
-                              rfm.promptAdHocInstall(package, in: vc)
+                              // We choose to prompt the user for comfirmation, rather
+                              // than automatically installing the package.
+                              rfm.promptPackageInstall(of: package, in: vc)
                             })
     } else {
       log.error("Cannot find app's root UIViewController")

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -476,7 +476,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if launchUrl != nil {
       perform(#selector(self.dismissActivityIndicator), with: nil, afterDelay: 1.0)
       let error = notification.error
-      ResourceFileManager.shared.showSimpleAlert(title: "Keyboard Download Error", message: error.localizedDescription)
+      let alert = ResourceFileManager.shared.buildSimpleAlert(title: "Keyboard Download Error",
+                                                              message: error.localizedDescription)
+      self.present(alert, animated: true, completion: nil)
       launchUrl = nil
     }
   }
@@ -825,8 +827,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     if let urlString = params["url"] {
       // Download and set custom keyboard
       guard let url = URL(string: urlString) else {
-        ResourceFileManager.shared.showSimpleAlert(title: "Custom Keyboard",
+        let alert = ResourceFileManager.shared.buildSimpleAlert(title: "Custom Keyboard",
                                     message: "The keyboard could not be installed: Invalid Url")
+        self.present(alert, animated: true, completion: nil)
         launchUrl = nil
         return
       }


### PR DESCRIPTION
As noted in "Yet to do" on #2460, the current state of KMP installation on iOS generates alerts tied to a specific `UIViewController` (the main, bottom-level one) in the app.  Since this will be a problem once we integrate file browsing into the app... and since keeping functionality tightly tied to UI code is a bad practice, this PR factorizes those two aspects.

Note that the functions now maintain a split between UI management and the various aspects of KMP installation.  The new breakdown:

- `prepareKMPInstall` takes in a KMP file and decompresses it to facilitate installation.
  - Its "completion handler" will receive the corresponding `KeymanPackage` object if successful, indicating that the KMP's contents are not corrupted.
  - It comes in two flavors:
    - The first one does all the file management and heavy lifting, passing errors and successes to external functions.
    - The second one is a helper version that provides default UI alerts, provided a base `UIViewController` to host it.
    - This allows us to customize or rework either aspect more easily in the future.
- `finalizePackageInstall` directly finalizes installation.
  - It's currently called by the package install prompt, but now can be called (if desired) without prompting first.  (Basically, these changes give us that option.)
  - Consider this the "first flavor" of `prepareKMPInstall` - it does all the heavy lifting and contains none of the UI.
- `promptPackageInstall` was always UI oriented, so it's been retooled to require a `rootVC` parameter so that it can display well at different points in the app.
  - It serves as a "default" prompting UI, much like the second flavor of `prepareKMPInstall`.
- The old `show` alert/error functions have been retooled into `build` functions that simply return the UIAlertController rather than immediately presenting it.
  - This allows them to be displayed from any `UIViewController` in the app, not just the base one.

Note that this PR serves as a base for #2457.