### PR TITLE
[Linux] Cleanup to build 13.0 on upcoming 20.04 LTS (Focal Fossa)

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -15,7 +15,7 @@
 - It is helpful to be using the [packages.sil.org](http://packages.sil.org) repo
 
 - Install packages required for building and developing KMFL and Keyman for Linux
-`sudo apt install cdbs debhelper libx11-dev autotools-dev build-essential devtools dh-autoreconf flex bison libibus-1.0-dev python3-setuptools meson libjson-glib-dev libgtk-3-dev libxml2-utils help2man python3-lxml python3-magic python3-numpy python3-pil python3-pip python3-requests python3-requests-cache python3 python3-gi gir1.2-webkit-3.0 dconf-cli`
+`sudo apt install cdbs debhelper libx11-dev autotools-dev build-essential dh-autoreconf flex bison libibus-1.0-dev python3-setuptools meson libjson-glib-dev libgtk-3-dev libxml2-utils help2man python3-lxml python3-magic python3-numpy python3-pil python3-pip python3-requests python3-requests-cache python3 python3-gi dconf-cli`
 
 ### Compiling from Command Line
 

--- a/linux/history.md
+++ b/linux/history.md
@@ -2,6 +2,7 @@
 
 ## 13.0 alpha
 * Start version 13.0
+* Revert default tier to alpha (#2474)
 
 ## 2019-09-19 12.0.18 beta
 * Bug Fix:

--- a/linux/scripts/version.sh
+++ b/linux/scripts/version.sh
@@ -3,7 +3,7 @@
 version()
 {
     if [[ -z "${TIER}" ]]; then
-        tier="beta"
+        tier="alpha"
     else
         tier="${TIER}"
     fi


### PR DESCRIPTION
Address some of #2435

In README.md, clean up packages to install
* remove devtools (maybe later change to ubuntu-dev-tools?)
* remove gir1.2-webkit-3.0 (deprecated by gir1.2-webkit2-4.0 which is already installed)

Fix default tier so the correct version number is generated during build