### PR TITLE
fix(lmlayer): Trie model SMP compatibility

### DIFF
--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -118,6 +118,7 @@ wrap-worker-code ( ) {
   # This one's straight from MDN - I didn't find any NPM ones that don't
   # use the node `require` statement.
   cat "polyfills/array.from.js"
+
   echo ""
 
   cat "${js}"

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -30,6 +30,7 @@
  */
 
 /// <reference path="../message.d.ts" />
+/// <reference path="../../../web/source/text/kmwstring.ts" />
 /// <reference path="models/dummy-model.ts" />
 /// <reference path="word_breaking/ascii-word-breaker.ts" />
 /// <reference path="./model-compositor.ts" />

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -113,7 +113,7 @@
       let newContext = models.applyTransform(transform, context);
 
       // Computes the different in word length after applying the transform above.
-      let leftDelOffset = transform.deleteLeft - transform.insert.length;
+      let leftDelOffset = transform.deleteLeft - transform.insert.kmwLength();
 
       // All text to the left of the cursor INCLUDING anything that has
       // just been typed.
@@ -127,7 +127,7 @@
           // Delete whatever the prefix that the user wrote.
           // Note: a separate capitalization/orthography engine can take this
           // result and transform it as needed.
-          deleteLeft: leftDelOffset + prefix.length,
+          deleteLeft: leftDelOffset + prefix.kmwLength(),
         },
         displayAs: text,
         p: p


### PR DESCRIPTION
Fixes #2469.

I'm not entirely comfortable with direct-linking KMW's `kmwstring.ts` file directly like this, especially with how we've moved away from that pattern toward `npm link` dependencies instead... but it's admittedly simpler to do and helped make this quick proof-of-concept for a finalized fix possible.

So, a lingering question:  Would it be worth the time to make our SMP-handling library compatible with `npm link` instead of using the TS `<reference path='...'/>` used here?