### PR TITLE
change(web): starts StyleConstants object for centralized style defs

### DIFF
--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -1,5 +1,6 @@
 // Includes version-related functionality
 ///<reference path="utils/version.ts"/>
+///<reference path="utils/styleConstants.ts" />
 
 // The Device object definition -------------------------------------------------
 
@@ -13,6 +14,10 @@ namespace com.keyman {
     version: string;
     orientation: string|number;
     browser: string;
+    colorScheme: 'light' | 'dark';
+
+    private detected: boolean = false;
+    private _styles: utils.StyleConstants;
 
     // Generates a default Device value.
     constructor() {
@@ -178,6 +183,9 @@ namespace com.keyman {
           }
         }
       }
+
+      this.colorScheme = this.prefersDarkMode() ? 'dark' : 'light';
+      this.detected = true;
     }
 
     static _GetIEVersion() {
@@ -218,6 +226,28 @@ namespace com.keyman {
       }
     
       return 999;
+    }
+
+    /**
+     * Checks is a user's browser is in dark mode, if the feature is supported.  Returns false otherwise.
+     * 
+     * Thanks to https://stackoverflow.com/a/57795518 for this code.
+     */
+    private prefersDarkMode(): boolean {
+      // Ensure the detector exists (otherwise, returns false)
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
+    public get styles(): utils.StyleConstants {
+      if(!this._styles) {
+        if(!this.detected) {
+          this.detect();
+        }
+        
+        this._styles = new utils.StyleConstants(this);
+      }
+
+      return this._styles;
     }
   }
 }

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -233,14 +233,9 @@ namespace com.keyman.osk {
     // Define appearance of preview (cannot be done directly in CSS)
     if(device.OS == 'Android') {
       var wx=(w1+w2)/2; 
-      w1 = w2 = wx;    
-      ctx.fillStyle = '#999';
-    } else {
-      // #0f1319 is the current dark-mode background color set in kmwosk.css.
-      // There might be a way to automatically retrieve it, but that'll take a
-      // bit of research to find.
-      ctx.fillStyle = util.prefersDarkMode() ? '#0f1319' : '#ffffff';
-    }  
+      w1 = w2 = wx;
+    }
+    ctx.fillStyle = device.styles.popupCanvasBackgroundColor;
     ctx.lineWidth = 1;
     ctx.strokeStyle = '#cccccc';
 

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -1211,16 +1211,6 @@ namespace com.keyman {
 
       return this.checkFont(fd);
     }
-
-    /**
-     * Checks is a user's browser is in dark mode, if the feature is supported.  Returns false otherwise.
-     * 
-     * Thanks to https://stackoverflow.com/a/57795518 for this code.
-     */
-    prefersDarkMode(): boolean {
-      // Ensure the detector exists (otherwise, returns false)
-      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
   }
 }
 

--- a/web/source/utils/styleConstants.ts
+++ b/web/source/utils/styleConstants.ts
@@ -1,0 +1,24 @@
+// Includes Device definitions, which may play a role in constant logic.
+///<reference path="../kmwdevice.ts" />
+
+/*
+ * This file is intended for CSS-styling constants that see use with the OSK.
+ */
+
+namespace com.keyman.utils {
+  /**
+   * Defines device-level constants used for CSS styling.
+   */
+  export class StyleConstants {
+    constructor(device: Device) {
+      // popupCanvasBackgroundColor
+      if(device.OS == 'Android') {
+        this.popupCanvasBackgroundColor = '#999';
+      } else {
+        this.popupCanvasBackgroundColor = device.colorScheme == 'dark' ? '#0f1319' : '#ffffff';
+      }  
+    }
+
+    public readonly popupCanvasBackgroundColor: string;
+  }
+}


### PR DESCRIPTION
As noted by @mcdurdin in https://github.com/keymanapp/keyman/pull/2468#discussion_r364990442,

> I think it would be good to be factoring these types of constants out of the code here and either to the top of the file or into a separate file. I don't have a huge problem with the disconnect between this and the CSS; it's not ideal, of course, but the work to unify this is significant and not really worthwhile.

In further discussion, we decided to merely start an object for this - we can always add to it in the future as future tasks permit.