### PR TITLE
chore(ios): replace distribution certificate

### DIFF
--- a/ios/exportAppStore.plist
+++ b/ios/exportAppStore.plist
@@ -7,9 +7,9 @@
     <key>teamID</key>
     <string>3YE4W86L3G</string>
     <key>signingCertificate</key>
-    <string>B5388B19BC7040BB9CCBFBA1ED7B685D5733CF7C</string>
+    <string>75E268DBF9EA1618EBC047C82F279E9D027A132F</string>
     <key>installerSigningCertificate</key>
-    <string>B5388B19BC7040BB9CCBFBA1ED7B685D5733CF7C</string>
+    <string>75E268DBF9EA1618EBC047C82F279E9D027A132F</string>
     <key>provisioningProfiles</key>
     <dict>
         <key>Tavultesoft.Keyman</key>


### PR DESCRIPTION
With a new build agent, we have a new distribution certificate for iOS. Given the thumbprint is stored as a parameter, we need to update it.

For the future, we could consider making this an environment variable and putting it into the TC
configuration.