### PR TITLE
chore(windows): kmdecomp winsdk version to 8.1

### DIFF
--- a/windows/src/developer/kmdecomp/kmdecomp.vcxproj
+++ b/windows/src/developer/kmdecomp/kmdecomp.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{963D608A-6689-469C-AE42-F56696DD42CC}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
kmdecomp had the wrong Windows SDK dependency (note: this issue goes away with VS2019 but breaks build for VS2017 unless the specified SDK is present). We currently depend on 8.1 for all other Windows apps.