### PR TITLE
[WIP] feat(linux): Add ability to configure keyboard options

### DIFF
--- a/linux/.editorconfig
+++ b/linux/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.py]
+trim_trailing_whitespace = true
+intent_stype = space
+intent_size = 4
+

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -397,9 +397,9 @@ ibus_keyman_engine_constructor (GType                   type,
             keyboard_opts[3].key = cp;
             cp = g_utf8_to_utf16 (option_tokens[1], -1, NULL, NULL, NULL);
             keyboard_opts[3].value = cp;
-            //g_strfreev(option_tokens);
+            g_strfreev(option_tokens);
         }
-        //g_free(options);
+        g_free(options);
     }
 
     // keyboard_opts[4] already initialised to {0, 0, 0}

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2009-2018 SIL International
+ * Copyright (C) 2009-2020 SIL International
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -385,43 +385,21 @@ ibus_keyman_engine_constructor (GType                   type,
     // TODO: Will need to handle multiple options. For now, keyboards are only 
     // setting one option.
     g_message("Loading options for kb_name: %s", keyman->kb_name);
-
-    /*
-    keyboard_opts[3].scope = KM_KBP_OPT_KEYBOARD;
-    //cp = g_utf8_to_utf16(option_tokens[0], -1, NULL, NULL, NULL);
-    cp = g_utf8_to_utf16("option_key", -1, NULL, NULL, NULL);
-    keyboard_opts[3].key = cp;
-    //cp = g_utf8_to_utf16 (option_tokens[1], -1, NULL, NULL, NULL);
-    cp = g_utf8_to_utf16("jianpu", -1, NULL, NULL, NULL);
-    keyboard_opts[3].value = cp;
-    */
-
     gchar **options = ibus_keyman_engine_keyboard_options(keyman->kb_name, keyman->kb_name);
     if (options != NULL) 
     {
-        
-        keyboard_opts[3].scope = KM_KBP_OPT_KEYBOARD;
-        cp = g_utf8_to_utf16("option_key", -1, NULL, NULL, NULL);
-        keyboard_opts[3].key = cp;
-        cp = g_utf8_to_utf16("jianpu", -1, NULL, NULL, NULL);
-        keyboard_opts[3].value = cp;
-        
-        /*
         gchar **option_tokens = g_strsplit(options[0], "=", 2);
         if (option_tokens != NULL)
         {
-            //g_message("option %s=%s", option_tokens[0], option_tokens[1]);
+            g_message("option %s=%s", option_tokens[0], option_tokens[1]);
             keyboard_opts[3].scope = KM_KBP_OPT_KEYBOARD;
-            //cp = g_utf8_to_utf16(option_tokens[0], -1, NULL, NULL, NULL);
-            cp = g_utf8_to_utf16("option_key", -1, NULL, NULL, NULL);
+            cp = g_utf8_to_utf16(option_tokens[0], -1, NULL, NULL, NULL);
             keyboard_opts[3].key = cp;
-            //cp = g_utf8_to_utf16 (option_tokens[1], -1, NULL, NULL, NULL);
-            cp = g_utf8_to_utf16("jianpu", -1, NULL, NULL, NULL);
+            cp = g_utf8_to_utf16 (option_tokens[1], -1, NULL, NULL, NULL);
             keyboard_opts[3].value = cp;
             //g_strfreev(option_tokens);
         }
         //g_free(options);
-        */
     }
 
     // keyboard_opts[4] already initialised to {0, 0, 0}
@@ -1034,8 +1012,7 @@ ibus_keyman_engine_keyboard_options(gchar *package_id,
                                     gchar *keyboard_id)
 {
     g_message("ibus_keyman_engine_keyboard_options");
-    //GSettings *settings = g_settings_new(KEYMAN_DCONF_NAME);
-    gchar *path = g_strdup_printf("%s%s/%s/options/", KEYMAN_DCONF_PATH, package_id, keyboard_id);
+    gchar *path = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_PATH, package_id, keyboard_id);
     GSettings *child_settings = g_settings_new_with_path(KEYMAN_CHILD_DCONF_NAME, path);
     gchar **options = NULL;
     if (child_settings != NULL)
@@ -1049,44 +1026,3 @@ ibus_keyman_engine_keyboard_options(gchar *package_id,
     return options;
 }
 
-static void
-ibus_keyman_engine_update_keyboard_options(IBusEngine *engine, gchar **options)
-{
-    IBusKeymanEngine *keyman = (IBusKeymanEngine *) engine;
-
-    if (options == NULL)
-    {
-        return;
-    }
-
-    // TODO: Handle more than 1 set of options
-    km_kbp_option_item *keyboard_opts = g_new0(km_kbp_option_item, 2);
-
-    gchar **option_tokens = g_strsplit(options[0], "=", 2);
-    km_kbp_cp *cp;
-    if (option_tokens != NULL) {
-        g_message("option %s=%s", option_tokens[0], option_tokens[1]);     
-        keyboard_opts[0].scope = KM_KBP_OPT_KEYBOARD;
-        cp = g_utf8_to_utf16(option_tokens[0], -1, NULL, NULL, NULL);
-        keyboard_opts[0].key = cp;
-        cp = g_utf8_to_utf16 (option_tokens[1], -1, NULL, NULL, NULL);
-        keyboard_opts[0].value = cp;
-
-        // keyboard_opts[1] already initialised to {0, 0, 0}
-
-        km_kbp_status event_status = km_kbp_state_options_update(keyman->state,
-            keyboard_opts);
-
-        if (event_status != KM_KBP_STATUS_OK)
-        {
-            g_warning("problem updating km_kbp_state_options_update");
-        }
-        for (int i =0; i < 1; i++) {
-            g_free((km_kbp_cp *)keyboard_opts[i].key);
-            g_free((km_kbp_cp *)keyboard_opts[i].value);
-        }
-    }
-
-    g_strfreev(option_tokens);
-    g_free(keyboard_opts);
-}

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -123,10 +123,6 @@ static gchar**  ibus_keyman_engine_keyboard_options
                                             (gchar *package_id,
                                              gchar *keyboard_id);
 
-static void ibus_keyman_engine_update_keyboard_options
-                                            (IBusEngine *engine,
-                                             gchar **options);
-
 static IBusEngineClass *parent_class = NULL;
 
 GType

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -813,6 +813,19 @@ ibus_keyman_engine_process_key_event (IBusEngine     *engine,
                 break;
             case KM_KBP_IT_PERSIST_OPT:
                 g_message("PERSIST_OPT action %d/%d", i+1, (int)num_action_items);
+                // Save keyboard option
+                if (action_items[i].option != NULL)
+                {
+                    // Allocate for 1 option plus 1 pad struct of 0's
+                    km_kbp_option_item *keyboard_opts = g_new0(km_kbp_option_item, 2);
+                    memmove(&(keyboard_opts[0]), action_items[i].option, sizeof(km_kbp_option_item));
+                    event_status = km_kbp_state_options_update(keyman->state, keyboard_opts);
+                    if (event_status != KM_KBP_STATUS_OK)
+                    {
+                        g_warning("problem saving option for km_kbp_keyboard");
+                    }
+                    g_free(keyboard_opts);
+                }
                 break;
             case KM_KBP_IT_EMIT_KEYSTROKE:
                 if (keyman->char_buffer != NULL)

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -338,7 +338,7 @@ ibus_keyman_engine_constructor (GType                   type,
     int num_options = g_queue_get_length(queue_options);
 
     // Allocate enough options for: 3 environments plus num_options plus 1 pad struct of 0's
-    km_kbp_option_item *keyboard_opts = g_new0(km_kbp_option_item, 3 + num_options + 1);
+    km_kbp_option_item *keyboard_opts = g_new0(km_kbp_option_item, KEYMAN_ENVIRONMENT_OPTIONS + num_options + 1);
 
     keyboard_opts[0].scope = KM_KBP_OPT_ENVIRONMENT;
     km_kbp_cp *cp = g_utf8_to_utf16 ("platform", -1, NULL, NULL, NULL);
@@ -385,10 +385,9 @@ ibus_keyman_engine_constructor (GType                   type,
     keyboard_opts[2].value = cp;
 
     // If queue_options contains keyboard options, pop them into keyboard_opts[3] onward
-    int index = 3;
     for(int i=0; i<num_options; i++)
     {
-        memmove(&(keyboard_opts[index+i]), g_queue_pop_head(queue_options), sizeof(km_kbp_option_item));
+        memmove(&(keyboard_opts[KEYMAN_ENVIRONMENT_OPTIONS+i]), g_queue_pop_head(queue_options), sizeof(km_kbp_option_item));
     }
 
     // keyboard_opts[tail] already initialised to {0, 0, 0}
@@ -408,7 +407,7 @@ ibus_keyman_engine_constructor (GType                   type,
     {
         g_warning("problem creating km_kbp_state");
     }
-    for (int i =0; i < 3 + num_options + 1; i++) {
+    for (int i=0; i < KEYMAN_ENVIRONMENT_OPTIONS + num_options + 1; i++) {
         g_free((km_kbp_cp *)keyboard_opts[i].key);
         g_free((km_kbp_cp *)keyboard_opts[i].value);
     }
@@ -1022,7 +1021,7 @@ ibus_keyman_engine_keyboard_options(gchar *package_id,
         while (options[index] != NULL)
         {
             gchar **option_tokens = g_strsplit(options[index], "=", 2);
-            if (*option_tokens != NULL && option_tokens[0] != NULL && option_tokens[1] != NULL)
+            if (option_tokens != NULL && option_tokens[0] != NULL && option_tokens[1] != NULL)
             {
                 g_message("Keyboard Option [%d], %s=%s", index, option_tokens[0], option_tokens[1]);
                 km_kbp_option_item *opt = g_new0(km_kbp_option_item, 1);

--- a/linux/ibus-keyman/src/engine.h
+++ b/linux/ibus-keyman/src/engine.h
@@ -31,6 +31,10 @@
 #define KEYMAN_DCONF_PATH "/desktop/ibus/keyman/options/"
 #define KEYMAN_DCONF_OPTIONS_KEY "options"
 
+// Number of default Keyboard processor environment options for: "platform", "baseLayout", and "baseLayoutAlt"
+#define KEYMAN_ENVIRONMENT_OPTIONS 3
+
+#define
 #define IBUS_TYPE_KEYMAN_ENGINE	\
 	(ibus_keyman_engine_get_type ())
 

--- a/linux/ibus-keyman/src/engine.h
+++ b/linux/ibus-keyman/src/engine.h
@@ -34,7 +34,6 @@
 // Number of default Keyboard processor environment options for: "platform", "baseLayout", and "baseLayoutAlt"
 #define KEYMAN_ENVIRONMENT_OPTIONS 3
 
-#define
 #define IBUS_TYPE_KEYMAN_ENGINE	\
 	(ibus_keyman_engine_get_type ())
 

--- a/linux/ibus-keyman/src/engine.h
+++ b/linux/ibus-keyman/src/engine.h
@@ -26,6 +26,11 @@
 
 #include <ibus.h>
 
+#define KEYMAN_DCONF_NAME "com.keyman.options"
+#define KEYMAN_CHILD_DCONF_NAME "com.keyman.options.child"
+#define KEYMAN_DCONF_PATH "/desktop/ibus/keyman/options/"
+#define KEYMAN_DCONF_OPTIONS_KEY "options"
+
 #define IBUS_TYPE_KEYMAN_ENGINE	\
 	(ibus_keyman_engine_get_type ())
 

--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -16,7 +16,7 @@ install-temp:
 	mkdir -p /tmp/kmfl/`python3 -c 'import sys;import os;pythonver="python%d.%d" % (sys.version_info[0], sys.version_info[1]);sitedir = os.path.join("lib", pythonver, "site-packages");print(sitedir)'`
 	PYTHONUSERBASE=/tmp/kmfl python3 setup.py install --user
 
-uninstall: # run as sudo
+uninstall: clean # run as sudo
 	rm -rf /usr/local/share/keyman/icons
 	rm -f /usr/local/share/man/man1/km-*.1
 	pip3 uninstall keyman_config

--- a/linux/keyman-config/README.md
+++ b/linux/keyman-config/README.md
@@ -10,8 +10,15 @@ python3-requests-cache python3 python3-gi gir1.2-webkit-3.0 dconf-cli python3-se
 
 You will also need kmflcomp either from a package or built and installed locally.
 
-run the script `./createkeymandirs.sh` to create the directories for these programs to
+Run the script `./createkeymandirs.sh` to create the directories for these programs to
 install the packages to
+
+Also copy and compile the GSettings schema
+```bash
+cd keyman_config
+sudo cp com.keyman.gschema.xml /usr/share/glib-2.0/schemas
+sudo glib-compile-schemas /usr/share/glib-2.0/schemas
+```
 
 ### Installing manually from the repo
 
@@ -32,6 +39,7 @@ This displays a configuration panel that shows the currently installed Keyman ke
 * `Uninstall` - uninstall selected keyboard
 * `About` - show information about selected keyboard
 * `Help` - display help documentation about selected keyboard
+* `Options` - display options.htm form for setting keyboard options
 -----------------------------------
 
 * `Refresh` - useful if you install or uninstall on the commandline while running km-config.
@@ -43,12 +51,9 @@ This displays a configuration panel that shows the currently installed Keyman ke
 
 This uses the keyman.com website to install kmps.
 
-The website doesn't know about linux yet (until after 10.0 release) so
-pretending to be a mac for now.
-
-Search for a language or keyboard in the search box
-Select a keyboard from the list
-In 'Downloads for your device' there will be a 'Install keyboard' button for the keyboard for macOS
+Search for a language or keyboard in the search box.
+Select a keyboard from the list.
+In 'Downloads for your device' there will be an 'Install keyboard' button for the keyboard for Linux.
 Click it to download the keyboard and bring up the `InstallKmpWindow` for more details and to confirm installing.
 
 Secondary-click gives you a menu including 'Back' to go back a page.

--- a/linux/keyman-config/com.keyman.gschema.xml
+++ b/linux/keyman-config/com.keyman.gschema.xml
@@ -1,0 +1,15 @@
+<schemalist>
+  <schema id="com.keyman.options" path="/desktop/ibus/keyman/options/">
+
+    <child name="keyboard-options" schema="com.keyman.options.child"/>
+
+  </schema>
+
+  <schema id="com.keyman.options.child">
+    <key name="options" type="as">
+      <default>[]</default>
+      <summary>keyboard options.htm settings</summary>
+      <description>List of strings</description>
+    </key>
+  </schema>
+</schemalist>

--- a/linux/keyman-config/keyman_config/dconf_util.py
+++ b/linux/keyman-config/keyman_config/dconf_util.py
@@ -22,37 +22,51 @@ def get_child_schema(info):
 def get_option(info):
     """
     Get the Keyman keyboard options from DConf
+    Convert from list of comma-separated strings into dictionary
 
     Args:
         info: dictionary
-            packageID (str): package ID
-            keyboardID (str): keyboard ID
+            packageID (str): Package ID
+            keyboardID(str): Keyboard ID
 
     Returns:
-        keyboard options (list)
+        result (dictionary): Keyboard options
     """
+    result = {}
     if "packageID" in info and "keyboardID" in info:
         child_schema = get_child_schema(info)
-        result = child_schema.get_strv("options")
-        return result
+        list_options = child_schema.get_strv("options")
+        result = dict(option.split("=") for option in list_options)
+    return result
 
 
-def set_option(info):
+def set_option(info, options):
     """
-    Store the Keyman keyboard option in DConf
+    Store the Keyman keyboard options in DConf as a list of strings
 
     Args:
         info: dictionary
             packageID (str): package ID
             keyboardID (str): keyboard ID
-            list (str): list of keyboard options
+        options: dictionary
+            key and values to store
     """
-    if "packageID" in info and "keyboardID" in info and "list" in info:
+    if "packageID" in info and "keyboardID" in info and options:
+        # Convert dictionary of options into a list of comma-separated option strings
+        list_options = []
+        for key, value in options.items():
+            list_options.append(key+"="+value)
+
         child_schema = get_child_schema(info)
-        child_schema.set_strv("options", info["list"])
+        child_schema.set_strv("options", list_options)
 
 
 if __name__ == '__main__':
-    info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music", "list": ['option_key=jianpu', 'option_three=two'] }
-    set_option(info)
-    result = get_option(info)
+    info = {"packageID": "invalid", "keyboardID": "invalid"}
+    options = get_option(info)
+
+    info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
+    options = get_option(info)
+
+    options["set_nfc"] = "1"
+    set_option(info, options)

--- a/linux/keyman-config/keyman_config/dconf_util.py
+++ b/linux/keyman-config/keyman_config/dconf_util.py
@@ -64,6 +64,7 @@ def set_option(info, options):
 if __name__ == '__main__':
     info = {"packageID": "invalid", "keyboardID": "invalid"}
     options = get_option(info)
+    assert(options == {})
 
     info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
     options = get_option(info)

--- a/linux/keyman-config/keyman_config/dconf_util.py
+++ b/linux/keyman-config/keyman_config/dconf_util.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+import logging
+from gi.repository import Gio, Gtk
+
+# DConf path destkop/ibus/keyman/options
+DCONF_BASE = "com.keyman.options"
+
+# Utilities to get and set Keyman options in DConf:
+# /desktop/ibus/keyman/options/packageID/keyboardID/options
+
+
+def get_child_schema(info):
+    settings = Gio.Settings.new(DCONF_BASE)
+    path = settings.get_property('path')
+    if not path.endswith('/'):
+        path += '/'
+    path += info['packageID'] + '/' + info['keyboardID'] + '/'
+    return Gio.Settings(DCONF_BASE + '.child', path)
+
+
+def get_option(info):
+    """
+    Get the Keyman keyboard options from DConf
+
+    Args:
+        info: dictionary
+            packageID (str): package ID
+            keyboardID (str): keyboard ID
+
+    Returns:
+        keyboard options (list)
+    """
+    if "packageID" in info and "keyboardID" in info:
+        child_schema = get_child_schema(info)
+        result = child_schema.get_strv("options")
+        return result
+
+
+def set_option(info):
+    """
+    Store the Keyman keyboard option in DConf
+
+    Args:
+        info: dictionary
+            packageID (str): package ID
+            keyboardID (str): keyboard ID
+            list (str): list of keyboard options
+    """
+    if "packageID" in info and "keyboardID" in info and "list" in info:
+        child_schema = get_child_schema(info)
+        child_schema.set_strv("options", info["list"])
+
+
+if __name__ == '__main__':
+    info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music", "list": ['option_key=jianpu', 'option_three=two'] }
+    set_option(info)
+    result = get_option(info)

--- a/linux/keyman-config/keyman_config/options.py
+++ b/linux/keyman-config/keyman_config/options.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+
+import ast
+import gi
+import logging
+import webbrowser
+import urllib.parse
+gi.require_version('Gtk', '3.0')
+gi.require_version('WebKit2', '4.0')
+from gi.repository import Gtk, WebKit2
+from keyman_config.accelerators import bind_accelerator, init_accel
+from keyman_config.dconf_util import get_option, set_option
+
+class OptionsView(Gtk.Window):
+
+    def __init__(self, info):
+        self.accelerators = None
+        self.optionurl = info["optionurl"]
+        self.packageID = info["packageID"]
+        self.keyboardID = info["keyboardID"]
+        kbtitle = self.packageID + " Settings"
+        Gtk.Window.__init__(self, title=kbtitle)
+        init_accel(self)
+
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+
+        # Keyman Desktop gets current option settings from the registry.
+        # Similarly, we'll read Keyman options from dconf and update optionurl
+        info = {"packageID": self.packageID, "keyboardID": self.keyboardID}
+        array_option = get_option(info)
+        params = ""
+        if array_option:
+            # Convert options from dconf into form parameters to pass to options.htm
+            for index, param in enumerate(array_option):
+                if index == 0:
+                    params = "?"
+                else:
+                    params += "&"
+                params += param
+
+        s = Gtk.ScrolledWindow()
+        self.webview = WebKit2.WebView()
+        self.webview.connect("decide-policy", self.doc_policy)
+        self.webview.load_uri(self.optionurl + params)
+        s.add(self.webview)
+        vbox.pack_start(s, True, True, 0)
+
+        hbox = Gtk.Box(spacing=12)
+        vbox.pack_start(hbox, False, False, 6)
+
+        self.add(vbox)
+
+    def doc_policy(self, web_view, decision, decision_type):
+        logging.info("Checking policy")
+        logging.debug("received policy decision request of type: {0}".format(decision_type.value_name))
+        if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION or \
+                decision_type == WebKit2.PolicyDecisionType.NEW_WINDOW_ACTION:
+            nav_action = decision.get_navigation_action()
+            request = nav_action.get_request()
+            uri = request.get_uri()
+            logging.debug("nav request is for uri %s", uri)
+            parsed = urllib.parse.urlparse(uri)
+            if parsed.scheme == "keyman":
+                logging.debug("using keyman scheme")
+                if parsed.path == "cancel":
+                    pass
+                elif parsed.path == "ok":
+                    logging.debug("submit options form")
+                    # Parse the response for the option_key value
+                    if parsed.query:
+                        array_option = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+                        list_option = []
+                        for index, tuple_option in enumerate(array_option):
+                            list_option.append(tuple_option[0] + "=" + tuple_option[1])
+                        self.process_option(list_option)
+
+                self.close()
+                return True
+
+            if not "options.htm" in uri:
+                logging.debug("opening uri %s in webbrowser")
+                webbrowser.open(uri)
+                decision.ignore()
+                return True
+        return False
+
+    def process_option(self, list_option):
+        #print(self.packageID + " list_option " + str(list_option))
+
+        # Write the Keyman option to dconf
+        info = { "packageID": self.packageID, "keyboardID": self.keyboardID, "list": list_option }
+        set_option(info)
+

--- a/linux/keyman-config/keyman_config/options.py
+++ b/linux/keyman-config/keyman_config/options.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qsl, urlencode
 from keyman_config.accelerators import bind_accelerator, init_accel
 from keyman_config.dconf_util import get_option, set_option
 
+
 class OptionsView(Gtk.Window):
 
     def __init__(self, info):
@@ -83,4 +84,3 @@ class OptionsView(Gtk.Window):
         # Write the Keyman options to DConf
         info = { "packageID": self.packageID, "keyboardID": self.keyboardID}
         set_option(info, self.options)
-

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -9,8 +9,9 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
 from gi.repository import Gtk, Gdk, GdkPixbuf, GObject
 
-from keyman_config.list_installed_kmp import get_installed_kmp, InstallArea
+from keyman_config.list_installed_kmp import get_install_area_path, get_installed_kmp, InstallArea
 from keyman_config.welcome import WelcomeView
+from keyman_config.options import OptionsView
 from keyman_config.keyboard_details import KeyboardDetailsView
 from keyman_config.downloadkeyboard import DownloadKmpWindow
 from keyman_config.install_window import InstallKmpWindow, find_keyman_image
@@ -68,7 +69,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 # window is split left/right hbox
 # right is ButtonBox
 #     possibly 2 ButtonBox in a vbox
-#         top one with _Remove, _About, ?_Welcome? or ?Read_Me?
+#         top one with _Remove, _About, ?_Welcome? or ?Read_Me?, _Options
 #         bottom one with _Download, _Install, Re_fresh, _Close
 # left is GtkTreeView - does it need to be inside anything else apart from the hbox?
 #     with liststore which defines columns
@@ -91,7 +92,8 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             str,    # version
             str,    # packageID
             int,    # enum InstallArea (KmpArea is GObject version)
-            str)    # path to welcome file if it exists or None
+            str,    # path to welcome file if it exists or None
+            str)    # path to options file if it exists or None
 
         # add installed keyboards to the the store e.g.
         # treeiter = store.append([GdkPixbuf.Pixbuf.new_from_file_at_size("/usr/local/share/keyman/libtralo/libtralo.ico.png", 16, 16), \
@@ -136,6 +138,12 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         self.help_button.connect("clicked", self.on_help_clicked)
         bbox_top.add(self.help_button)
 
+        self.options_button = Gtk.Button.new_with_mnemonic("_Options")
+        self.options_button.set_tooltip_text("Settings for keyboard")
+        self.options_button.connect("clicked", self.on_options_clicked)
+        self.options_button.set_sensitive(False)
+        bbox_top.add(self.options_button)
+
         vbox.pack_start(bbox_top, False, False, 12)
 
 
@@ -176,16 +184,19 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
             if install_area == InstallArea.IA_USER:
                 welcome_file = os.path.join(user_keyboard_dir(kmpdata['packageID']), "welcome.htm")
+                options_file = os.path.join(user_keyboard_dir(kmpdata['packageID']), "options.htm")
                 icofile = os.path.join(user_keyboard_dir(kmpdata['packageID']), kmpdata['packageID'] + bmppng)
                 if not os.path.isfile(icofile):
                     icofile = os.path.join(user_keyboard_dir(kmpdata['packageID']), kmpdata['keyboardID'] + bmppng)
             elif install_area == InstallArea.IA_SHARED:
                 welcome_file = os.path.join("/usr/local/share/keyman", kmpdata['packageID'], "welcome.htm")
+                options_file = os.path.join("/usr/local/share/keyman", kmpdata['packageID'], "options.htm")
                 icofile = os.path.join("/usr/local/share/keyman", kmpdata['packageID'], kmpdata['packageID'] + bmppng)
                 if not os.path.isfile(icofile):
                     icofile = os.path.join("/usr/local/share/keyman", kmpdata['packageID'], kmpdata['keyboardID'] + bmppng)
             else:
                 welcome_file = os.path.join("/usr/share/keyman", kmpdata['packageID'], "welcome.htm")
+                options_file = os.path.join("/usr/share/keyman", kmpdata['packageID'], "options.htm")
                 icofile = os.path.join("/usr/share/keyman", kmpdata['packageID'], kmpdata['packageID'] + bmppng)
                 if not os.path.isfile(icofile):
                     icofile = os.path.join("/usr/share/keyman", kmpdata['packageID'], kmpdata['keyboardID'] + bmppng)
@@ -194,13 +205,15 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
             if not os.path.isfile(welcome_file):
                 welcome_file = None
-
+            if not os.path.isfile(options_file):
+                options_file = None
             treeiter = store.append([GdkPixbuf.Pixbuf.new_from_file_at_size(icofile, 16, 16), \
                 kmpdata['name'], \
                 kmpdata['version'], \
                 kmpdata['packageID'], \
                 install_area, \
-                welcome_file])
+                welcome_file, \
+                options_file])
 
     def refresh_installed_kmp(self):
         logging.debug("Refreshing listview")
@@ -225,13 +238,13 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 self.incomplete_kmp.append(kmpdata)
         self.addlistitems(os_kmp, self.store, InstallArea.IA_OS)
 
-
     def on_tree_selection_changed(self, selection):
         model, treeiter = selection.get_selected()
         if treeiter is not None:
             self.uninstall_button.set_tooltip_text("Uninstall keyboard package " + model[treeiter][1])
             self.help_button.set_tooltip_text("Help for keyboard package " + model[treeiter][1])
             self.about_button.set_tooltip_text("About keyboard package " + model[treeiter][1])
+            self.options_button.set_tooltip_text("Settings for keyboard package " + model[treeiter][1])
             logging.debug("You selected %s version %s", model[treeiter][1], model[treeiter][2])
             if model[treeiter][4] == InstallArea.IA_USER:
                 logging.debug("Enabling uninstall button for %s in %s", model[treeiter][3], model[treeiter][4])
@@ -239,10 +252,16 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             else:
                 self.uninstall_button.set_sensitive(False)
                 logging.debug("Disabling uninstall button for %s in %s  ", model[treeiter][3], model[treeiter][4])
+            # welcome file if it exists
             if model[treeiter][5]:
                 self.help_button.set_sensitive(True)
             else:
                 self.help_button.set_sensitive(False)
+            # options file if it exists
+            if model[treeiter][6]:
+                self.options_button.set_sensitive(True)
+            else:
+                self.options_button.set_sensitive(False)
 
     def on_help_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
@@ -257,6 +276,22 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 w.show_all()
             else:
                 logging.info("welcome.htm not available")
+
+    def on_options_clicked(self, button):
+      model, treeiter = self.tree.get_selection().get_selected()
+      if treeiter is not None:
+          logging.info("Open options.htm for %s if available", model[treeiter][1])
+          options_file = model[treeiter][6]
+          if options_file and os.path.isfile(options_file):
+              uri_path = pathlib.Path(options_file).as_uri()
+              logging.info("opening" + uri_path)
+              # TODO: Determine keyboardID
+              info = { "optionurl": uri_path, "packageID": model[treeiter][3], "keyboardID": model[treeiter][3] }
+              w = OptionsView(info)
+              w.resize(800, 600)
+              w.show_all()
+          else:
+              logging.info("options.htm not available")
 
     def on_uninstall_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
@@ -281,12 +316,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None:
             logging.info("Show keyboard details of " + model[treeiter][1])
-            if model[treeiter][4] == InstallArea.IA_USER:
-                areapath = user_keyman_dir()
-            elif model[treeiter][4] == InstallArea.IA_SHARED:
-                areapath = "/usr/local/share/keyman"
-            else:
-                areapath = "/usr/share/keyman"
+            areapath = get_install_area_path(model[treeiter][4])
             kmp = { "name" : model[treeiter][1], "version" : model[treeiter][2], "packageID" : model[treeiter][3],  "areapath" : areapath}
             w = KeyboardDetailsView(kmp)
             w.resize(800, 450)

--- a/linux/scripts/install.sh
+++ b/linux/scripts/install.sh
@@ -78,6 +78,9 @@ if [[ "${SUDOINSTALL}" == "yes" ]]; then
 		echo "keyman-config must be built before it is installed. Run 'make configure' if needed then 'make'"
 		exit 1
 	fi
+	echo "doing sudo glib-compile-schemas for keyman-config"
+	cp com.keyman.gschema.xml /usr/share/glib-2.0/schemas/
+	glib-compile-schemas /usr/share/glib-2.0/schemas/
 	echo "doing sudo install of keyman-config"
 	make install
 elif [[ "${SUDOINSTALL}" == "uninstall" ]]; then


### PR DESCRIPTION
Originally started to address #1790

Some keyboards (e.g sil_ipa or sil_cipher_music) include an `options.htm` file to adjust keyboard settings. On Keyman Desktop, this gets stored in the registry and Keyman Desktop applies the setting when the keyboard is selected.

This PR modifies Keyman for Linux with the following :

### keyman-config
Add an "Options" button that is enabled if the keyboard includes an `options.htm` file. The list of options are then stored in DConf in the path `/desktop/ibus/keyman/options/packageID/keyboardID/options.` as a string such as
```
['option_key=jianpu','another_key=two']
```


![keyman config options](https://user-images.githubusercontent.com/7358010/72680111-bca56100-3ae8-11ea-9885-36dd7007f872.png)

### ibus-keyman
When initializing a keyboard, also read the "options" key in Dconf. If the key-value pair exists, pass it to the keyboard processor.

### Limitations
These TODO's can be deferred for a future release:
- [ ] Currently, Keyman Config displays keyboard packages in the list. So the "Options" button is limited to where package ID = keyboard ID
- [x] Multiple options could be defined in `options.htm`. For now, only the first one gets processed in ibus-keyman
- [ ] For now, the user needs to toggle keyboards for the options to take effect. ibus-keyman would need to be updated to watch for updates in DConf and apply the options to keyboardprocessor.

----

### User Testing
1. Check out repo (assuming steps for dev environment in README.md are already done)
2. In the `/linux` folder
  * `make reconf`
  * `make fullbuild`
  * `sudo make install`
3. Launch km-config (in `/usr/local/bin`) and download and install keyboards (follow steps from the [guide](https://help.keyman.com/products/linux/12.0/guide/installing-keyboard)
  * Pick 1 keyboard that doesn't have `options.htm` (like khmer_angkor)
  * Pick 1 keyboard that does have `options.htm` (like sil_ipa or sil_cipher_music)
4. For the keyboard without `options.htm`, verify keyboard functions fine
5. For the keyboard with options.htm (sil_cipher_music), verify Indoensian cipher (default option)
  * Enable "Indonesian (Cipher Music (SIL)) keyboard
  * Type `q` which is rendered `ꞌ`.
  * Type `=` two times to get `̿`  
6. From Keyman Config, select sil_cipher_music and click "Options" and set "Chinese cipher"
  * Toggle to another keyboard "English" and toggle back to "Indonesian (Cipher Music (SIL)).
  * Type `q` which is rendered `ꞌ`.  
  * Type `=` two times to get `̳`

# SIL Cipher Music keyboard options
![sil_cipher_music options](https://user-images.githubusercontent.com/7358010/72681181-99cc7a00-3af3-11ea-87fc-652ab07fe6f5.png)

# SIL IPA keyboard options
![sil_ipa options](https://user-images.githubusercontent.com/7358010/72681188-a6e96900-3af3-11ea-9600-a2e3e32ed698.png)
