### PR TITLE
fix(developer): char map drop into text editor 🍒

### DIFF
--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -85,6 +85,7 @@ type
       eventFlags: Cardinal; out Result: Boolean);
     procedure cefPreKeySyncEvent(Sender: TObject; e: TCEFHostKeyEventData; out isShortcut, Handled: Boolean);
     procedure cefKeyEvent(Sender: TObject; e: TCEFHostKeyEventData; wasShortcut, wasHandled: Boolean);
+    procedure cefLoadEnd(Sender: TObject);
 
     procedure WMUser_TextEditor_Command(var Message: TMessage); message WM_USER_TextEditor_Command;
     procedure WMUser_SyntaxColourChange(var Message: TMessage); message WM_USER_SYNTAXCOLOURCHANGE;
@@ -95,7 +96,6 @@ type
     procedure ExecuteLineCommand(ALine: Integer; const command: string);
     procedure UpdateToken(command: string);
     procedure SetCursorPosition(AColumn, ARow: Integer);
-    procedure cefLoadEnd(Sender: TObject);
     procedure DoBreakpointClicked(const line: string);
     procedure UpdateEditorFonts;
     procedure CharMapDragDrop(Sender, Source: TObject; X, Y: Integer);
@@ -325,12 +325,13 @@ end;
 
 procedure TframeTextEditor.SetupCharMapDrop;
 begin
-  GetCharMapDropTool.Handle(cef.cefwp, cmimDefault, CharMapDragOver, CharMapDragDrop);
+  GetCharMapDropTool.Handle(cef, cmimDefault, CharMapDragOver, CharMapDragDrop);
 end;
 
 procedure TframeTextEditor.cefLoadEnd(Sender: TObject);
 begin
   FHasBeenLoaded := True;
+  SetupCharMapDrop;
 end;
 
 type

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -3,6 +3,9 @@
 ## 13.0 alpha
 * Start version 13.0
 
+## 2020-01-20 12.0.66 stable
+* Bug Fix: Character Map was not reliably dropping into Text Editor (#2504)
+
 ## 2020-01-20 12.0.65 stable
 * Bug Fix: Lexical model compiler fails to compile packages that don't contain email address (#2496)
 


### PR DESCRIPTION
Cherry-pick of #2503.

With changes to the text editor relating to focus,
double-clicking and drag-dropping from character
map no longer worked reliably. This patch resolves
this problem.

Fixes #2466.