### PR TITLE
fix(ios): Tracks 'isCustom' flag for adhoc resources

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -595,7 +595,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
   }
     
   // MARK: - Adhoc keyboards
-  public func parseKbdKMP(_ folder: URL) throws -> Void {
+  public func parseKbdKMP(_ folder: URL, isCustom: Bool) throws -> Void {
     do {
       var path = folder
       path.appendPathComponent("kmp.json")
@@ -640,7 +640,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
                   isRTL: isrtl,
                   font: displayFont,
                   oskFont: oskFont,
-                  isCustom: false))
+                  isCustom: isCustom))
               }
             }
             
@@ -696,7 +696,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
   }
     
   // MARK: - Adhoc lexical models
-  static public func parseLMKMP(_ folder: URL) throws -> Void {
+  static public func parseLMKMP(_ folder: URL, isCustom: Bool) throws -> Void {
     do {
       var path = folder
       path.appendPathComponent("kmp.json")
@@ -742,7 +742,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
                   languageID: languageId,
 //                  languageName: languageName,
                   version: version,
-                  isCustom: false))
+                  isCustom: isCustom))
               }
             }
             
@@ -1032,14 +1032,14 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     return ResourceDownloadManager.shared.stateForLexicalModel(withID: modelID)
   }
 
-  public func parseKMP(_ folder: URL, type: LanguageResourceType = .keyboard) throws -> Void {
+  public func parseKMP(_ folder: URL, type: LanguageResourceType = .keyboard, isCustom: Bool) throws -> Void {
     switch type {
       case .keyboard:
-        try! parseKbdKMP(folder)
+        try! parseKbdKMP(folder, isCustom: isCustom)
         break
       case .lexicalModel:
         // Yep.  Unlike the original, THIS one is static.
-        try! Manager.parseLMKMP(folder)
+        try! Manager.parseLMKMP(folder, isCustom: isCustom)
         break
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -15,10 +15,12 @@ public class PackageInstallViewController: UIViewController {
   let package: KeymanPackage
   var wkWebView: WKWebView?
   let completionHandler: CompletionHandler
+  let isCustom: Bool
 
-  public init(for package: KeymanPackage, completionHandler: @escaping CompletionHandler) {
+  public init(for package: KeymanPackage, isCustom: Bool, completionHandler: @escaping CompletionHandler) {
     self.package = package
     self.completionHandler = completionHandler
+    self.isCustom = isCustom
     super.init(nibName: nil, bundle: nil)
 
     _ = view
@@ -57,7 +59,7 @@ public class PackageInstallViewController: UIViewController {
 
   @objc func installBtnHandler() {
     dismiss(animated: true, completion: {
-      ResourceFileManager.shared.finalizePackageInstall(self.package, completionHandler: self.completionHandler)
+      ResourceFileManager.shared.finalizePackageInstall(self.package, isCustom: self.isCustom, completionHandler: self.completionHandler)
     })
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -535,7 +535,7 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     ResourceFileManager.shared.prepareKMPInstall(from: downloadedPackageFile, completionHandler: { kmp, error in
       if let kmp = kmp as! LexicalModelKeymanPackage? {
         do {
-          ResourceFileManager.shared.finalizePackageInstall(kmp, completionHandler: { error in
+          ResourceFileManager.shared.finalizePackageInstall(kmp, isCustom: false, completionHandler: { error in
               if error != nil {
                 log.error("Error installing the lexical model: \(String(describing: error))")
               } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -111,8 +111,9 @@ public class ResourceFileManager {
 
   public func promptPackageInstall(of package: KeymanPackage,
                                    in rootVC: UIViewController,
+                                   isCustom: Bool,
                                    successHandler: ((KeymanPackage) -> Void)? = nil) {
-    let vc = PackageInstallViewController(for: package, completionHandler: { error in
+    let vc = PackageInstallViewController(for: package, isCustom: isCustom, completionHandler: { error in
       if let err = error {
         if let kmpError = err as? KMPError {
           let alert = self.buildKMPError(kmpError)
@@ -150,14 +151,14 @@ public class ResourceFileManager {
   /**
    * Performs the actual installation of a package's resources once confirmation has been received from the user.
    */
-  public func finalizePackageInstall(_ package: KeymanPackage, completionHandler: (Error?) -> Void) {
+  public func finalizePackageInstall(_ package: KeymanPackage, isCustom: Bool, completionHandler: (Error?) -> Void) {
     do {
       // Time to pass the package off to the final installers - the parse__KMP methods.
       // TODO: (14.0+) These functions should probably be refactored to within this class eventually.
       if package.isKeyboard() {
-        try Manager.shared.parseKbdKMP(package.sourceFolder)
+        try Manager.shared.parseKbdKMP(package.sourceFolder, isCustom: isCustom)
       } else {
-        try Manager.parseLMKMP(package.sourceFolder)
+        try Manager.parseLMKMP(package.sourceFolder, isCustom: isCustom)
       }
       completionHandler(nil)
     } catch {

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             completionHandler: { package in
                               // We choose to prompt the user for comfirmation, rather
                               // than automatically installing the package.
-                              rfm.promptPackageInstall(of: package, in: vc)
+                              rfm.promptPackageInstall(of: package, in: vc, isCustom: true)
                             })
     } else {
       log.error("Cannot find app's root UIViewController")

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -68,7 +68,7 @@ class PackageBrowserViewController: UIDocumentBrowserViewController, UIDocumentB
                             completionHandler: { package in
                               // We choose to prompt the user for comfirmation, rather
                               // than automatically installing the package.
-                              rfm.promptPackageInstall(of: package, in: self, successHandler: { _ in
+                              rfm.promptPackageInstall(of: package, in: self, isCustom: true, successHandler: { _ in
                                 // Auto-dismiss the document browser upon successful KMP install.
                                 // It's likely quite rare that someone would want to install 2+ at once.
                                 self.navigationController?.popViewController(animated: true)


### PR DESCRIPTION
Fixes #2508.

As noted by the issue above, turns out I may have slightly broken part of the adhoc install process with the document browser work.  This corrects that bug.