### PR TITLE
fix(web): Hotfixes recent break for text prediction

### DIFF
--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -33,16 +33,16 @@ namespace com.keyman.text.prediction {
 
     constructor(mock: Mock, config: Configuration) {
       this.left = mock.getTextBeforeCaret();
-      this.startOfBuffer = this.left._kmwLength() > config.leftContextCodeUnits;
+      this.startOfBuffer = this.left._kmwLength() > config.leftContextCodePoints;
       if(!this.startOfBuffer) {
         // Our custom substring version will return the last n characters if param #1 is given -n.
-        this.left = this.left._kmwSubstr(-config.leftContextCodeUnits);
+        this.left = this.left._kmwSubstr(-config.leftContextCodePoints);
       }
 
       this.right = mock.getTextAfterCaret();
-      this.endOfBuffer = this.right._kmwLength() > config.rightContextCodeUnits;
+      this.endOfBuffer = this.right._kmwLength() > config.leftContextCodePoints;
       if(!this.endOfBuffer) {
-        this.right = this.right._kmwSubstr(0, config.rightContextCodeUnits);
+        this.right = this.right._kmwSubstr(0, config.leftContextCodePoints);
       }
     }
   }


### PR DESCRIPTION
Fixes #2516.

Turns out I forgot to change a few references when working on #2477, which broke text prediction in the alpha.  Simple enough to fix, though it's a shame that slipped through.