### PR TITLE
fix(web): Initialization option - device detection preference

### DIFF
--- a/web/source/dom/touchAliasElement.ts
+++ b/web/source/dom/touchAliasElement.ts
@@ -60,12 +60,19 @@ namespace com.keyman.dom {
 
     __resizeHandler: () => void;
 
+    // Used for unit-tests when detached from KeymanEngine.
     private static device: Device;
 
     private static getDevice(): Device {
       if(!TouchAliasData.device) {
-        let device = new com.keyman.Device();
-        device.detect();
+        var device: com.keyman.Device;
+
+        if(com.keyman['singleton']) {
+          device = com.keyman['singleton']['util']['device'];
+        } else {
+          device = new com.keyman.Device();
+          device.detect();
+        }
 
         TouchAliasData.device = device;
       }

--- a/web/source/dom/utils.ts
+++ b/web/source/dom/utils.ts
@@ -145,7 +145,8 @@ namespace com.keyman.dom {
       // only executes when com.keyman.DOMEventHandlers is defined.
       //
       // We also bypass this whenever operating in the embedded format.
-      if(com && com.keyman && com.keyman['DOMEventHandlers'] && !com.keyman.singleton.isEmbedded) {
+      let keymanCoreLoaded = com.keyman['DOMEventHandlers'] && com.keyman['singleton'];
+      if(com && com.keyman && keymanCoreLoaded && !com.keyman['singleton'].isEmbedded) {
         let DOMEventHandlers = com.keyman['DOMEventHandlers'];
 
         let selectionStart = element.selectionStart;

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -105,8 +105,6 @@ if(!window['keyman']['initialized']) {
      */
     keymanweb.debugElement=null;
     var dbg=keymanweb.debug;
-        
-    keymanweb.delayedInit();
 
     // I732 START - Support for European underlying keyboards #1
     if(typeof(window['KeymanWeb_BaseLayout']) !== 'undefined') 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -87,7 +87,8 @@ namespace com.keyman {
       'keyboards':'',
       'fonts':'',
       'attachType':'',
-      'ui':null
+      'ui':null,
+      'deviceDetection': 'default'
     };
 
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -140,11 +140,6 @@ namespace com.keyman {
       this['loaded'] = true;
     }
 
-    delayedInit() {
-      // Track the selected Event-handling object.
-      this.touchAliasing = this.util.device.touchable ? this.domManager.touchHandlers : this.domManager.nonTouchHandlers;
-    }
-
     /**
      * Triggers a KeymanWeb engine shutdown to facilitate a full system reset.
      * This function is designed for use with KMW unit-testing, which reloads KMW

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -204,12 +204,14 @@ namespace com.keyman {
           if(this.formFactor != 'desktop') {
             this.formFactor = 'desktop';
           }
+          this.touchable = false;
           break;
         case 'touchOnly':
           if(this.formFactor == 'desktop') {
             // Desktops have high resolution, which better matches tablets.
             this.formFactor = 'tablet';
           }
+          this.touchable = true;
           break;
         default:
           break;

--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -1375,7 +1375,6 @@ namespace com.keyman {
       var p, dTrailer, ds;
       var osk = this.keyman.osk;
       var util = this.keyman.util;
-      var device = util.device;
 
       // Local function to convert relative to absolute URLs
       // with respect to the source path, server root and protocol 
@@ -1456,6 +1455,8 @@ namespace com.keyman {
       }
 
       var domManager = this;
+      // Could not be initialized at top.
+      let device = util.device;
 
       // Do not initialize until the document has been fully loaded
       if(document.readyState !== 'complete')

--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -1436,10 +1436,10 @@ namespace com.keyman {
         opt['attachType'] = 'auto';
       }
 
-      // Set default device options
-      keyman.setDefaultDeviceOptions(opt);
-
       keyman.util.initDevices(opt['deviceDetection'] as DeviceDetectOption);
+
+      // Set default device options (must come after they are initialized)
+      keyman.setDefaultDeviceOptions(opt);
 
       // Requires Device initialization; establishes appropriate device-specific handler objects.
       this.nonTouchHandlers = new DOMEventHandlers(keyman);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -162,13 +162,13 @@ namespace com.keyman.text {
 
 (function() {
   // Declare KeymanWeb and related objects
-  var keymanweb=window['keyman'], osk: com.keyman.osk.OSKManager = keymanweb['osk'],util=keymanweb['util'],device=util.device;
+  var keymanweb=window['keyman'], osk: com.keyman.osk.OSKManager = keymanweb['osk'],util=keymanweb['util'];
   var dom = com.keyman.dom;
-  var Layouts = com.keyman.osk.Layouts;
-  var kbdInterface=keymanweb['interface'];
 
   // Allow definition of application name
   keymanweb.options['app']='';
+  // Embedded mode should exclusively use touch form-factors.
+  keymanweb.options['deviceDetection'] = 'touchOnly';
   
   // Flag to control refreshing of a keyboard that is already loaded
   keymanweb.mustReloadKeyboard = true;
@@ -181,6 +181,7 @@ namespace com.keyman.text {
   // Set default device options
   keymanweb.setDefaultDeviceOptions = function(opt) {
     opt['attachType'] = 'manual';
+    let device = (keymanweb as KeymanBase).util.device;
     device.app=opt['app'];
     device.touchable=true; 
     device.formFactor='phone'; 

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -435,7 +435,7 @@ if(!window['keyman']['initialized']) {
   /*****************************************/
   (function() {
     // Declare KeymanWeb object
-    var keymanweb=window['keyman'],osk=keymanweb['osk'],util=keymanweb['util'],device=util.device;
+    var keymanweb=window['keyman'],osk=keymanweb['osk'],util=keymanweb['util'];
     var dbg=keymanweb.debug;
     var dom = com.keyman.dom;
 
@@ -448,7 +448,7 @@ if(!window['keyman']['initialized']) {
      */
     keymanweb.setDefaultDeviceOptions=function(opt) {
       // Element attachment type
-      if(opt['attachType'] == '') opt['attachType'] = (device.touchable ? 'manual' : 'auto');
+      if(opt['attachType'] == '') opt['attachType'] = (keymanweb.util.device.touchable ? 'manual' : 'auto');
     }
 
   /**
@@ -513,7 +513,7 @@ if(!window['keyman']['initialized']) {
      * 
      **/
     keymanweb.alignInputs = function(eleList: HTMLElement[]) {
-      if(device.touchable) {
+      if(keymanweb.util.device.touchable) {
         var domManager = keymanweb.domManager;
         var processList: HTMLElement[] = [];
 
@@ -556,7 +556,7 @@ if(!window['keyman']['initialized']) {
      **/
     keymanweb.hideInputs = function() {
       var domManager = keymanweb.domManager;
-      if(device.touchable) {
+      if(keymanweb.util.device.touchable) {
         for(var i=0; i<domManager.inputList.length; i++) {
           domManager.inputList[i].style.visibility='hidden';
           domManager.inputList[i].base.style.visibility='visible';
@@ -571,7 +571,7 @@ if(!window['keyman']['initialized']) {
      * @return  {boolean}
      **/          
     keymanweb.isPositionSynthesized = function() {
-      return device.touchable;
+      return keymanweb.util.device.touchable;
     }
 
     /**

--- a/web/source/kmwuibutton.ts
+++ b/web/source/kmwuibutton.ts
@@ -28,9 +28,6 @@ if(!window['keyman']['ui']['name']) {
     var keymanweb=window['keyman'],osk=keymanweb['osk'],
       util=keymanweb['util'],dbg=keymanweb['debug'];
     
-    // Disable UI for touch devices
-    if(util['isTouchDevice']()) throw '';
-    
     // User interface global and variables      
     keymanweb['ui'] = {};
     var ui=keymanweb['ui'];
@@ -278,7 +275,9 @@ if(!window['keyman']['ui']['name']) {
         window.setTimeout(ui.Initialize,250); return;
       }
       
-      if(ui.init || util['isTouchDevice']()) return; 
+      if(ui.init || util['isTouchDevice']()) {
+        return;
+      }
       
       ui.init = true;
           

--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -31,9 +31,6 @@ if(!window['keyman']['ui']['name']) {
     var util=keymanweb['util'];
     var osk=keymanweb['osk'];
     var dbg=keymanweb['debug'];
-
-    // Disable UI for touch devices
-    if(util['isTouchDevice']()) throw '';
     
     // User interface global and local variables
     keymanweb['ui'] = {};
@@ -79,7 +76,9 @@ if(!window['keyman']['ui']['name']) {
         window.setTimeout(ui.Initialize,50); return;
       }
       
-      if(ui.initialized || util['isTouchDevice']()) return;
+      if(ui.initialized || util['isTouchDevice']()) {
+        return;
+      }
           
       var imgPath=util['getOption']('resources')+"ui/float/";
       

--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -126,7 +126,7 @@ if(!window['keyman']['ui']['name']) {
 
       // Check required interface alignment and default keyboard
       var opt=util['getOption']('ui'),dfltKeyboard='English';
-      if(typeof(opt) == 'object')
+      if(opt && typeof(opt) == 'object')
       {
         if(typeof(opt['position']) == 'string' && opt['position'] == 'right') 
           ui.floatRight = true;
@@ -483,7 +483,7 @@ if(!window['keyman']['ui']['name']) {
     keymanweb['addEventListener']('controlfocused',
       function(params)
       {
-        if(params['activeControl'] == null || params['activeControl']['LEnabled'])
+        if(params['activeControl'] != null)
         {
           /*if(keymanweb._IsIEEditableIframe(Ltarg))
             Ltarg = Ltarg.ownerDocument.parentWindow.frameElement;

--- a/web/source/kmwuitoggle.ts
+++ b/web/source/kmwuitoggle.ts
@@ -29,9 +29,6 @@ if(!window['keyman']['ui']['name']) {
     // Declare KeymanWeb, OnScreen Keyboard and Util objects
     var keymanweb=window['keyman'],osk=keymanweb['osk'],util=keymanweb['util'];
     var dbg=keymanweb['debug'];
-    
-    // Disable UI for touch devices
-    if(util['isTouchDevice']()) throw '';
 
     // Initialize user interface common variables       
     var ui:any=keymanweb['ui'] = {
@@ -394,6 +391,11 @@ if(!window['keyman']['ui']['name']) {
     { 
       //Never initialize before KMW!
       if(!keymanweb['initialized'] || util['isTouchDevice']()) return;
+
+      // Disable UI for touch devices
+      if(util['isTouchDevice']()) {
+        return;
+      }
         
       if(!ui.initialized)  // I2403 - Allow toggle design to be loaded twice
       {
@@ -583,6 +585,9 @@ if(!window['keyman']['ui']['name']) {
     ui.updateMenu = function(kbdName,lgCode)
     {        
       var i,_k=document.getElementById('KMWSel_$');
+      if(!ui.initialized) {
+        return;
+      }
 
       for(i=0; i<ui.keyboards.length; i++)
       { 

--- a/web/source/kmwuitoggle.ts
+++ b/web/source/kmwuitoggle.ts
@@ -460,7 +460,7 @@ if(!window['keyman']['ui']['name']) {
      **/   
     ui.updateKeyboardList=function()
     {                 
-      if(!(keymanweb['initialized'] || ui.initialized)) return; //TODO: may want to restart the timer??
+      if(!(keymanweb['initialized'] && ui.initialized)) return; //TODO: may want to restart the timer??
                       
       ui.updateList = false;
 

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -26,9 +26,6 @@ if(!window['keyman']['ui']['name']) {
 
     // Declare KeymanWeb, OnScreen keyboard and Util objects
     var keymanweb=window['keyman'],osk=keymanweb['osk'],util=keymanweb['util'],dbg=keymanweb['debug'];
-
-    // Disable UI for touch devices
-    if(util['isTouchDevice']()) throw '';
     
     // User interface local variables
     keymanweb['ui'] = {
@@ -122,6 +119,10 @@ if(!window['keyman']['ui']['name']) {
     ui['initialize'] = ui.initToolbarUI = function()
     {
       if(!keymanweb['initialized'] || ui.init) return;
+
+      if(util['isTouchDevice']()) {
+        return;
+      }
     
       // Find the controller DIV, insert at top of body if undefined
       var e = document.getElementById('KeymanWebControl');    
@@ -142,8 +143,6 @@ if(!window['keyman']['ui']['name']) {
       e.style.visibility='hidden'; e.style.maxHeight='35px';
 
       ui.init = true;
-      
-      if(util['isTouchDevice']()) return;
 
       util['linkStyleSheet'](util['getOption']('resources')+'ui/toolbar/kmwuitoolbar.css');
         

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -48,8 +48,6 @@ namespace com.keyman {
     private keyman: KeymanBase; // Closure doesn't like relying on the global object from within a class def.
 
     constructor(keyman: any) {
-      this.initDevices();
-
       this.keyman = keyman;
     }
 
@@ -63,9 +61,9 @@ namespace com.keyman {
       }
     }
 
-    initDevices(): void {
-      this.device = new Device();
-      this.physicalDevice = new Device();
+    public initDevices(option?: DeviceDetectOption): void {
+      this.device = new Device(option);
+      this.physicalDevice = new Device(option);
       this.activeDevice = this.device;
 
       // Initialize the true device values.

--- a/web/testing/unminified.html
+++ b/web/testing/unminified.html
@@ -38,7 +38,8 @@
     <script>
       var kmw=window.keyman;
       kmw.init({
-		attachType:'auto'
+    attachType:'auto',
+    //deviceDetection: 'touchOnly'
         });
     </script> 
     


### PR DESCRIPTION
Fixes #2271.

This adds an initialization option allowing page designers to specify whether or not KeymanWeb should perform device aliasing (or dealiasing) for use with its device-based settings.

Note that this has an interesting ramification: for the option to be set as part of KeymanWeb's initialization process, we have to delay the device-detection logic.  This has a few effects across various parts of the code, but actually results in a net positive, providing a bit of TLC/cleanup for KMW's setup logic.  (This also affected the desktop UI modules, which also received a bit of touch-up accordingly.)

I've yet to fully test what happens when `desktopOnly` is used on a mobile device or `touchOnly` is used on a desktop device.  I've identified an initial issue with each situation, as shown below.
- 'touchOnly' on macOS Safari desktop fails to display the keyboard currently because it requires a **touch** event to display - standard focus events won't cut it.
- 'desktopOnly' on an iPhone SE shows the desktop OSK, but it shows up small and is difficult (at best) to resize.

Note that these issues are only the initial barrier for each control path; the possibilities that these combinations represent may complicate keyboard rules that depend on form-factor and platform combinations, and it'd probably be best to add a bit more aliasing logic (at a minimum) before publishing the commit.

It may be better to just support `default` and `naive` for now, rather than try to fully answer these questions this close to beta.