### PR TITLE
fix(ios): Proper handling for xcassets colors in sys kbd

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
@@ -115,4 +115,30 @@ extension Colors {
       }
     }
   }
+
+  public static var helpBubbleGradient1: UIColor {
+    get {
+      if #available(iOSApplicationExtension 11.0, *) {
+        return UIColor(named: "HelpBubbleGradient1")!
+      } else {
+        return UIColor(red: 253.0 / 255.0,
+                       green: 244.0 / 255.0,
+                       blue: 196.0 / 255.0,
+                       alpha: 1.0)
+      }
+    }
+  }
+
+  public static var helpBubbleGradient2: UIColor {
+    get {
+      if #available(iOSApplicationExtension 11.0, *) {
+        return UIColor(named: "HelpBubbleGradient2")!
+      } else {
+        return UIColor(red: 233.0 / 255.0,
+                       green: 224.0 / 255.0,
+                       blue: 176.0 / 255.0,
+                       alpha: 1.0)
+      }
+    }
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
@@ -83,32 +83,6 @@ public class Colors {
     }
   }
 
-  public static var helpBubbleGradient1: UIColor {
-    get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient1")!
-      } else {
-        return UIColor(red: 253.0 / 255.0,
-                       green: 244.0 / 255.0,
-                       blue: 196.0 / 255.0,
-                       alpha: 1.0)
-      }
-    }
-  }
-
-  public static var helpBubbleGradient2: UIColor {
-    get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient2")!
-      } else {
-        return UIColor(red: 233.0 / 255.0,
-                       green: 224.0 / 255.0,
-                       blue: 176.0 / 255.0,
-                       alpha: 1.0)
-      }
-    }
-  }
-
   public static var keyboardBackground: UIColor {
     get {
       if #available(iOSApplicationExtension 11.0, *) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
@@ -58,21 +58,22 @@ public class Colors {
 
   public static var popupKeyHighlighted: UIColor {
     get {
-//      if #available(iOSApplicationExtension 11.0, *) {
-//        return UIColor(named: "SelectionPrimary")!
-//      } else {
+      if #available(iOSApplicationExtension 11.0, *) {
+        return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
+      } else {
         return UIColor(red: 136.0 / 255.0,
                        green: 136.0 / 255.0,
                        blue: 1.0,
                        alpha: 1.0)
-//      }
+      }
     }
   }
 
+  // I'm not 100% on the distinction, but this should be fine for now.
   public static var popupKeyTint: UIColor {
     get {
       if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "SelectionPrimary")!
+        return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
       } else {
         return UIColor(red: 181.0 / 255.0,
                        green: 181.0 / 255.0,

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
@@ -252,7 +252,7 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
 
     let cell = UITableViewCell(style: .default, reuseIdentifier: cellIdentifier)
     let selectionColor = UIView()
-    selectionColor.backgroundColor = Colors.selectionSecondary
+    selectionColor.backgroundColor = Colors.popupKeyTint
     cell.selectedBackgroundView = selectionColor
     return cell
   }

--- a/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/SelectedKey.colorset/Contents.json
+++ b/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/SelectedKey.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "204",
+          "alpha" : "1.000",
+          "blue" : "34",
+          "green" : "136"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "102",
+          "alpha" : "1.000",
+          "blue" : "17",
+          "green" : "68"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #2519.

As it turns out, the system keyboard can't access color definitions managed solely by the main app's bundle.  (The keyboard was crashing from unexpected `nil` values that resulted; they were referenced for popup key/menu formatting.)  We could simply include those as part of the SWKeyboard target, but it's more important that they be accessible from KeymanEngine instead, since they'll be needed by anyone who wishes to link with KMEI.

Retrieving resources from `Bundle`s is easy when everything's in the top-level one (for the app), but it's a bit trickier when you need an embedded framework's `Bundle` instead.