### PR TITLE
fix(ios): Fixes default model (MTNT) installation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -189,7 +189,8 @@ extension Storage {
 
     // Perform an auto-install of the lexical model's KMP if not already installed.
     let lexicalModelURLasZIP = Storage.active.lexicalModelPackageURL(forID: Defaults.lexicalModel.id,
-                                                                     version: Defaults.lexicalModel.version)
+                                                                     version: Defaults.lexicalModel.version,
+                                                                    asZip: true)
     let lexicalModelURL = Storage.active.lexicalModelPackageURL(forID: Defaults.lexicalModel.id,
                                                                 version: Defaults.lexicalModel.version,
                                                                 asZip: false)


### PR DESCRIPTION
Addresses one issue noted here:  https://github.com/keymanapp/keyman/issues/2530#issuecomment-577954518.  This allows MTNT to be properly default-installed again, even if the constant reinstallation still needs addressing (see #2512).

This one small tidbit was missed after the other code changes to the KMP installation rework; `asZip`'s default value was inverted in [#2489](https://github.com/keymanapp/keyman/pull/2489/files#diff-bfe1674a30111bbeb987ff86394c1519R125).