### PR TITLE
fix(ios): Fixes embedded subkey layer-shifting

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -460,9 +460,7 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      let retVal = processor.processKeyEvent(Lkc, true);
-
-      return retVal;
+      return processor.processKeyEvent(Lkc, true);
   };
 
   /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -409,6 +409,7 @@ namespace com.keyman.text {
           // It should be within the popupBaseKey's subkey list.
           for(let subKey of baseKey.sk) {
             if(subKey.id == keyName) {
+              // ... to consider:  why are we not just taking the keyspec wholesale right here?
               nextLayer = subKey.nextlayer;
               found = true;
               break;
@@ -437,7 +438,8 @@ namespace com.keyman.text {
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],
         LisVirtualKey: true,
-        kName: keyName
+        kName: keyName,
+        kNextLayer: nextLayer
       };
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
@@ -458,7 +460,9 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      return processor.processKeyEvent(Lkc, true);
+      let retVal = processor.processKeyEvent(Lkc, true);
+
+      return retVal;
   };
 
   /**

--- a/web/source/osk/defaultLayouts.ts
+++ b/web/source/osk/defaultLayouts.ts
@@ -208,7 +208,7 @@ namespace com.keyman.osk {
             }
 
             // Create a new subkey for the specified layer so that it will be accessible via OSK.
-            var specialChar = Layouts.modifierSpecials[layerID];
+            var specialChar = Layouts.modifierSpecials[layerID]; 
             shiftKey['sk'].push(new OSKKeySpec("K_" + specialChar, specialChar, null, "1", layerID));
           }
         } else {


### PR DESCRIPTION
Note:  this may also affect (and fix!) the same issue for Android, if it exists there.  Given what was needed... I expect it to have been a problem on Android, too.

Fixes an issue noted [here](https://github.com/keymanapp/keyman/issues/2530#issuecomment-577954518):
> Testing the French: French keyboard - the Alt-Ctrl layer does not activate when selected.

Turns out that the `nextLayer` property for subkeys was never being mapped onto the `KeyEvent` generated for embedded popup key processing... _probably_ a significant oversight.

----

There are a few other idiosyncracies I noted in the function and in how the base & subkey themselves were managed... these aspects are probably in need of some TLC for a future version.
- The key's id isn't set correctly (defaultLayouts.ts, line 212) - left unfixed because that doesn't actually fix anything on its own.
- The `selectLayer` function doesn't process key names for layers with combined modifiers (which is why the previous detail wouldn't result in a fix).