### PR TITLE
[iOS] Keyboard download error notifications

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		CE7A26D823CEEC640005955C /* Colors+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7A26D723CEEC630005955C /* Colors+Extension.swift */; };
 		CE7A26D923CEEC640005955C /* Colors+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7A26D723CEEC630005955C /* Colors+Extension.swift */; };
 		CE7A26DB23CEEF640005955C /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7A26DA23CEEF640005955C /* Colors.swift */; };
+		CE7ADD6623DE89FC00BC9A00 /* Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7ADD6523DE89FC00BC9A00 /* Alerts.swift */; };
 		CE808A48236697BE00713E6B /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2B1E4521B60E7C007D092E /* DeviceKit.framework */; };
 		CE808A4B236697D400713E6B /* ObjcExceptionBridging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1687ACCD1FD8DE5300926D69 /* ObjcExceptionBridging.framework */; };
 		CE808A4D236697D500713E6B /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0FC9FC22D66D9E00D33F86 /* Reachability.framework */; };
@@ -429,6 +430,7 @@
 		CE7A26D023CEE5790005955C /* Keyboard Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Keyboard Colors.xcassets"; sourceTree = "<group>"; };
 		CE7A26D723CEEC630005955C /* Colors+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colors+Extension.swift"; sourceTree = "<group>"; };
 		CE7A26DA23CEEF640005955C /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		CE7ADD6523DE89FC00BC9A00 /* Alerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alerts.swift; sourceTree = "<group>"; };
 		CECB38931F2199BC0098882F /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reachability.h; path = KeymanEngine/lib/Reachability/Reachability.h; sourceTree = SOURCE_ROOT; };
 		CECB38941F2199BC0098882F /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Reachability.m; path = KeymanEngine/lib/Reachability/Reachability.m; sourceTree = SOURCE_ROOT; };
 		F243887E14BBD43000A3E055 /* KeymanEngineDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeymanEngineDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -879,6 +881,7 @@
 				C05B14321FD914870082A316 /* Log.swift */,
 				C08E698C1FDA392D0026056B /* Migrations.swift */,
 				CE79B24823C711FF007E72AE /* KeyboardScaleMap.swift */,
+				CE7ADD6523DE89FC00BC9A00 /* Alerts.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1284,6 +1287,7 @@
 				C06D37421F81F5C400F61AE0 /* KeyboardPickerButton.swift in Sources */,
 				165EB3A12098993900040A69 /* KeyboardError.swift in Sources */,
 				C05F432D1FBD5A4C0058CBD4 /* KeyboardAPICall.swift in Sources */,
+				CE7ADD6623DE89FC00BC9A00 /* Alerts.swift in Sources */,
 				CE754A0423D162E90030CB79 /* ResourceInfoViewController.swift in Sources */,
 				C055E6EB1F99ED090035C2DD /* RegisteredFont.swift in Sources */,
 				1645D5972036C9F80076C51B /* KMPKeyboard.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
@@ -1,0 +1,46 @@
+//
+//  Alerts.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 1/27/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Reachability
+
+open class Alerts {
+  public typealias AcceptanceHandler = ((UIAlertAction)) -> Void
+
+  public static func showErrorAlert(in vc: UIViewController, title: String, msg: String, handler: @escaping AcceptanceHandler) {
+    let alertController = UIAlertController(title: title,
+                                            message: msg,
+                                            preferredStyle: UIAlertController.Style.alert)
+    alertController.addAction(UIAlertAction(title: "OK",
+                                            style: UIAlertAction.Style.default,
+                                            handler: handler))
+
+    vc.present(alertController, animated: true, completion: nil)
+  }
+
+  public static func showConnectionErrorAlert(in vc: UIViewController, handler: @escaping AcceptanceHandler) {
+    showErrorAlert(in: vc, title: "Connection Error", msg: "Could not reach Keyman server.  Please try again later.", handler: handler)
+  }
+
+  public static func showDownloadErrorAlert(in vc: UIViewController, handler: @escaping AcceptanceHandler) {
+    let networkReachable = Reachability(hostname: "www.keyman.com")
+    if networkReachable?.connection == Reachability.Connection.none {
+      showConnectionErrorAlert(in: vc, handler: handler)
+    } else {
+      // Show a different alert!
+      showErrorAlert(in: vc, title: "Download error", msg: "Error occurred during download or installation.", handler: handler)
+    }
+  }
+
+  public static func popToNevigationRootHandler(for vc: UIViewController) -> AcceptanceHandler {
+    return { alertAction in
+      vc.navigationController?.popToRootViewController(animated: true)
+    }
+  }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
@@ -38,7 +38,7 @@ open class Alerts {
     }
   }
 
-  public static func popToNevigationRootHandler(for vc: UIViewController) -> AcceptanceHandler {
+  public static func popToNavigationRootHandler(for vc: UIViewController) -> AcceptanceHandler {
     return { alertAction in
       vc.navigationController?.popToRootViewController(animated: true)
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Reachability
 
 private let toolbarButtonTag = 100
 private let toolbarLabelTag = 101
@@ -190,17 +191,32 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
     activityView?.removeFromSuperview()
     view.isUserInteractionEnabled = true
   }
-  
-  private func showConnectionErrorAlert() {
+
+  // This really should be refactored to a common method.
+  private func showErrorAlert(title: String, msg: String) {
     dismissActivityView()
-    let alertController = UIAlertController(title: "Connection Error",
-                                            message: "Could not reach Keyman server. Please try again later.",
+    let alertController = UIAlertController(title: title,
+                                            message: msg,
                                             preferredStyle: UIAlertController.Style.alert)
     alertController.addAction(UIAlertAction(title: "OK",
                                             style: UIAlertAction.Style.default,
                                             handler: errorAcknowledgmentHandler))
-    
+
     self.present(alertController, animated: true, completion: nil)
+  }
+
+  private func showConnectionErrorAlert() {
+    showErrorAlert(title: "Connection Error", msg: "Could not reach Keyman server.  Please try again later.")
+  }
+
+  private func showDownloadErrorAlert() {
+    let networkReachable = Reachability(hostname: "www.keyman.com")
+    if networkReachable?.connection == Reachability.Connection.none {
+      showConnectionErrorAlert()
+    } else {
+      // Show a different alert!
+      showErrorAlert(title: "Download error", msg: "Error occurred during download or installation.")
+    }
   }
   
   func errorAcknowledgmentHandler(withAction action: UIAlertAction) {
@@ -215,6 +231,7 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
 
   private func keyboardDownloadFailed() {
     log.info("keyboardDownloadFailed: LanguageDetailViewController")
+    showDownloadErrorAlert()
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -192,35 +192,12 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
     view.isUserInteractionEnabled = true
   }
 
-  // This really should be refactored to a common method.
-  private func showErrorAlert(title: String, msg: String) {
-    dismissActivityView()
-    let alertController = UIAlertController(title: title,
-                                            message: msg,
-                                            preferredStyle: UIAlertController.Style.alert)
-    alertController.addAction(UIAlertAction(title: "OK",
-                                            style: UIAlertAction.Style.default,
-                                            handler: errorAcknowledgmentHandler))
-
-    self.present(alertController, animated: true, completion: nil)
-  }
-
   private func showConnectionErrorAlert() {
-    showErrorAlert(title: "Connection Error", msg: "Could not reach Keyman server.  Please try again later.")
+    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 
   private func showDownloadErrorAlert() {
-    let networkReachable = Reachability(hostname: "www.keyman.com")
-    if networkReachable?.connection == Reachability.Connection.none {
-      showConnectionErrorAlert()
-    } else {
-      // Show a different alert!
-      showErrorAlert(title: "Download error", msg: "Error occurred during download or installation.")
-    }
-  }
-  
-  func errorAcknowledgmentHandler(withAction action: UIAlertAction) {
-    navigationController?.popToRootViewController(animated: true)
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 
   private func keyboardDownloadStarted() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -192,7 +192,7 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func showConnectionErrorAlert() {
-    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNavigationRootHandler(for: self))
   }
 
   private func keyboardDownloadStarted() {
@@ -203,7 +203,7 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
 
   private func keyboardDownloadFailed() {
     log.info("keyboardDownloadFailed: LanguageDetailViewController")
-    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNavigationRootHandler(for: self))
 
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import Reachability
 
 private let toolbarButtonTag = 100
 private let toolbarLabelTag = 101
@@ -196,10 +195,6 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
     Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 
-  private func showDownloadErrorAlert() {
-    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
-  }
-
   private func keyboardDownloadStarted() {
     log.info("keyboardDownloadStarted: LanguageDetailViewController")
     view.isUserInteractionEnabled = false
@@ -208,7 +203,8 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
 
   private func keyboardDownloadFailed() {
     log.info("keyboardDownloadFailed: LanguageDetailViewController")
-    showDownloadErrorAlert()
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -233,10 +233,6 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     langDetailView.title = title
     navigationController?.pushViewController(langDetailView, animated: true)
   }
-
-  func errorAcknowledgmentHandler(withAction action: UIAlertAction) {
-    navigationController?.popToRootViewController(animated: true)
-  }
     
   func downloadHandler(_ keyboardIndex: Int) {
     let language = languages[selectedSection]
@@ -309,31 +305,12 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     return userKeyboards["\(languageID)_\(keyboardID)"] != nil
   }
 
-  // This really should be refactored to a common method.
-  private func showErrorAlert(title: String, msg: String) {
-    dismissActivityView()
-    let alertController = UIAlertController(title: title,
-                                            message: msg,
-                                            preferredStyle: UIAlertController.Style.alert)
-    alertController.addAction(UIAlertAction(title: "OK",
-                                            style: UIAlertAction.Style.default,
-                                            handler: errorAcknowledgmentHandler))
-    
-    self.present(alertController, animated: true, completion: nil)
-  }
-
   private func showConnectionErrorAlert() {
-    showErrorAlert(title: "Connection Error", msg: "Could not reach Keyman server.  Please try again later.")
+    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 
   private func showDownloadErrorAlert() {
-    let networkReachable = Reachability(hostname: "www.keyman.com")
-    if networkReachable?.connection == Reachability.Connection.none {
-      showConnectionErrorAlert()
-    } else {
-      // Show a different alert!
-      showErrorAlert(title: "Download error", msg: "Error occurred during download or installation.")
-    }
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -7,7 +7,6 @@
 //
 import QuartzCore
 import UIKit
-import Reachability
 
 private let activityViewTag = -2
 private let toolbarButtonTag = 100
@@ -246,7 +245,8 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func keyboardDownloadFailed() {
-    showDownloadErrorAlert()
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
   }
@@ -307,10 +307,6 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
 
   private func showConnectionErrorAlert() {
     Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
-  }
-
-  private func showDownloadErrorAlert() {
-    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -245,7 +245,7 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func keyboardDownloadFailed() {
-    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+    Alerts.showDownloadErrorAlert(in: self, handler: Alerts.popToNavigationRootHandler(for: self))
 
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
@@ -306,7 +306,7 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func showConnectionErrorAlert() {
-    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNevigationRootHandler(for: self))
+    Alerts.showConnectionErrorAlert(in: self, handler: Alerts.popToNavigationRootHandler(for: self))
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -7,6 +7,7 @@
 //
 import QuartzCore
 import UIKit
+import Reachability
 
 private let activityViewTag = -2
 private let toolbarButtonTag = 100
@@ -249,6 +250,7 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   private func keyboardDownloadFailed() {
+    showDownloadErrorAlert()
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
   }
@@ -307,16 +309,31 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     return userKeyboards["\(languageID)_\(keyboardID)"] != nil
   }
 
-  private func showConnectionErrorAlert() {
+  // This really should be refactored to a common method.
+  private func showErrorAlert(title: String, msg: String) {
     dismissActivityView()
-    let alertController = UIAlertController(title: "Connection Error",
-                                            message: "Could not reach Keyman server. Please try again later.",
+    let alertController = UIAlertController(title: title,
+                                            message: msg,
                                             preferredStyle: UIAlertController.Style.alert)
     alertController.addAction(UIAlertAction(title: "OK",
                                             style: UIAlertAction.Style.default,
                                             handler: errorAcknowledgmentHandler))
     
     self.present(alertController, animated: true, completion: nil)
+  }
+
+  private func showConnectionErrorAlert() {
+    showErrorAlert(title: "Connection Error", msg: "Could not reach Keyman server.  Please try again later.")
+  }
+
+  private func showDownloadErrorAlert() {
+    let networkReachable = Reachability(hostname: "www.keyman.com")
+    if networkReachable?.connection == Reachability.Connection.none {
+      showConnectionErrorAlert()
+    } else {
+      // Show a different alert!
+      showErrorAlert(title: "Download error", msg: "Error occurred during download or installation.")
+    }
   }
 }
 


### PR DESCRIPTION
Addresses part of the notes on #2530:

> After the app successfully loads the keyboard catalog, disable internet connectivity and then attempt to download a keyboard.
>    - This may either crash the app or fail silently.

I only ever saw the crash once during pre-beta testing, so that may have been an instability of sorts from branch hopping.  That said, the "fail silently" part definitely needs to be addressed, which is the aim of this PR.

... and, true to form, I made a small separate module to avoid code duplication for the two error cases that needed addressing.  The functions there should also be useful for lexical model downloads, but for now, "If it ain't broke, don't fix it."