### PR TITLE
fix(android): Revert KMManager.onDestroy

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -405,11 +405,9 @@ public final class KMManager {
   public static void onDestroy() {
     if (InAppKeyboard != null) {
       InAppKeyboard.onDestroy();
-      InAppKeyboard = null;
     }
     if (SystemKeyboard != null) {
       SystemKeyboard.onDestroy();
-      SystemKeyboard = null;
     }
     CloudDownloadMgr.getInstance().shutdown(appContext);
   }


### PR DESCRIPTION
Fixes #2539

During #2326, `KMManager.onDestroy()` was updated to set `InAppKeyboard` and `SystemKeyboard` to null. While good in practice, this created  an issue when closing Keyman as a System Keyboard. Lingering Javascript calls in the WebView would crash with the null keyboards.

This reverts `onDestroy()` to how it has been since before 2.8 stable

### Testing
- [ ] Start Keyman app
- [ ] With Keyman as System Keyboard, verify the following:
  * Rotate between profile and landscape orientation and verify Keyman doesn't crash
  * Use the globe button to bring up keyboard picker
  * Click "Close Keyman" to switch to next system keyboard and verify Keyman doesn't crash
  * Bring up Keyman app and verify Keyboard doesn't crash
