### PR TITLE
fix(ios): keyboard stability

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -530,7 +530,8 @@ extension KeymanWebViewController: KeymanWebDelegate {
     
     let shouldReloadKeyboard = Manager.shared.shouldReloadKeyboard
     var newKb = Defaults.keyboard
-    if Manager.shared.currentKeyboardID == nil && !shouldReloadKeyboard {
+
+    if !shouldReloadKeyboard { // otherwise, we automatically reload anyway.
       let userData = Manager.shared.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
       if let id = userData.currentKeyboardID {
         if let kb = Storage.active.userDefaults.userKeyboard(withFullID: id) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -560,7 +560,6 @@ extension KeymanWebViewController: KeymanWebDelegate {
 
     NotificationCenter.default.post(name: Notifications.keyboardLoaded, object: self, value: newKb!)
     if shouldReloadKeyboard {
-      log.debug("IVC: Setting timer to reload keyboard.")
       NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.resetKeyboard), object: nil)
       perform(#selector(self.resetKeyboard), with: nil, afterDelay: 0.25)
       Manager.shared.shouldReloadKeyboard = false

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -529,19 +529,26 @@ extension KeymanWebViewController: KeymanWebDelegate {
     setDeviceType(UIDevice.current.userInterfaceIdiom)
     
     let shouldReloadKeyboard = Manager.shared.shouldReloadKeyboard
-    var newKb = Defaults.keyboard
+    var newKb = Manager.shared.currentKeyboard
 
     if !shouldReloadKeyboard { // otherwise, we automatically reload anyway.
       let userData = Manager.shared.isSystemKeyboard ? UserDefaults.standard : Storage.active.userDefaults
-      if let id = userData.currentKeyboardID {
-        if let kb = Storage.active.userDefaults.userKeyboard(withFullID: id) {
-          newKb = kb
+      if newKb == nil {
+        if let id = userData.currentKeyboardID {
+          if let kb = Storage.active.userDefaults.userKeyboard(withFullID: id) {
+            newKb = kb
+          }
+        } else if let userKbs = Storage.active.userDefaults.userKeyboards, !userKbs.isEmpty {
+          newKb = userKbs[0]
         }
-      } else if let userKbs = Storage.active.userDefaults.userKeyboards, !userKbs.isEmpty {
-        newKb = userKbs[0]
       }
       log.info("Setting initial keyboard.")
-      _ = Manager.shared.setKeyboard(newKb)
+      _ = Manager.shared.setKeyboard(newKb!)
+    }
+
+    // in case `shouldReloadKeyboard == true`.  Is set otherwise above.
+    if(newKb == nil) {
+      newKb = Defaults.keyboard
     }
 
     updateShowBannerSetting()
@@ -551,8 +558,9 @@ extension KeymanWebViewController: KeymanWebDelegate {
     
     fixLayout()
 
-    NotificationCenter.default.post(name: Notifications.keyboardLoaded, object: self, value: newKb)
+    NotificationCenter.default.post(name: Notifications.keyboardLoaded, object: self, value: newKb!)
     if shouldReloadKeyboard {
+      log.debug("IVC: Setting timer to reload keyboard.")
       NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.resetKeyboard), object: nil)
       perform(#selector(self.resetKeyboard), with: nil, afterDelay: 0.25)
       Manager.shared.shouldReloadKeyboard = false

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -274,7 +274,12 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
   ///
   /// - Throws: error if the keyboard was unchanged
   public func setKeyboard(_ kb: InstallableKeyboard) -> Bool {
-    if kb.fullID == currentKeyboardID {
+    // KeymanWebViewController relies upon this method to activate the keyboard after a page reload,
+    // and as a system keyboard, the controller is rebuilt each time the keyboard is loaded.
+    //
+    // We MUST NOT shortcut this method as a result; doing so may (rarely) result in the infamous
+    // blank keyboard bug!
+    if kb.fullID == currentKeyboardID && !self.isSystemKeyboard {
       log.info("Keyboard unchanged: \(kb.fullID)")
       return false
      // throw KeyboardError.unchanged

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-01-29 13.0.61 beta
+* Bug fix: System keyboard would sometimes appear blank (#2545)
+
 ## 2020-01-28 13.0.60 beta
 * Feature: Adds file browsing for installable KMPs and makes KMPs for resources installed this way available to the Files app (#2457, #2489, #2510)
 * Feature: Adds support for iOS 13.0's dark mode feature (#2277, #2312, #2468, #2521)


### PR DESCRIPTION
May fix #2259; at a minimum, strongly mitigates it.

Long story short, turns out the bug was double-layered.

**Layer 1**:  assuming that only two states may exist within `KeymanWebViewController.keyboardLoaded()`. 
- First load of the keyboard:
  - `Manager.shared.currentKeyboardID = nil` - it hasn't yet been set.
  - `shouldReloadKeyboard == false` - why reload when you haven't reloaded once?
- Subsequent loads of the keyboard
  - `Manager.shared.currentKeyboardID` has been set (a default was previously chosen, if naught else)
  - `shouldReloadKeyboard == true` - this WebView has already loaded once, but to be safe, it's best if we reset everything to regain a blank slate.

Somehow (I've yet to pin down _exactly_ how, but it's likely due to erraticness with the `viewWillDisappear` lifecycle event), it turns out that a _**third**_ state is possible in system-keyboard mode:
  - `Manager.shared.currentKeyboardID` has already been set
    - This can occur if the keyboard was previously loaded once, hidden, and then reloaded - iOS likes to "reuse" a single process for our app extension when possible, only exiting after a few minutes of inactivity.
  - `shouldReloadKeyboard == false`.  (The part affected by `viewWillDisappear()`.)

The `KeymanWebViewController` changes are designed to properly handle this mysterious third state.

When the keyboard went unset as a result of this third state, this led to the blank keyboard bug.

**Layer 2**: Even with the issue above fixed, the (KMW-side) keyboard was often not being set on system-keyboard load.  (In particular, for _re_-loads of the iOS-side keyboard.)

iOS builds a new instance of the keyboard each time it is redisplayed.  As a result, we must set the keyboard anew for each instance - but the in-app-centered logic seen in `Manager` blocked "reassignments", preventing the keyboard from being reset to the same keyboard as prior instances.   Recognizing how the lifecycle of keyboard app extensions work, it's best (for now) to simply prevent `setKeyboard` from filtering out "duplicate" set requests for a keyboard when in system-keyboard mode, since the "duplicate" may well target a different (iOS-side) keyboard instance.

-----

As far as I can tell, this _should_ be enough to resolve the bug... but given its nature, it's quite hard to guarantee that there's not an extra, mysterious third layer somewhere in the code for a smaller set of edge cases.  Getting even this much to a moderate level of reproducibility was tricky as it was.

- [x] TODO:  history.md