### PR TITLE
[Web] Fix K_TAB from external keyboard

### DIFF
--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,7 @@
 ## 2020-01-31 13.0.6051 beta
 * Bug fix:
   * Fix cancelling dictionary update notifications (#2547)
+  * Fix external keyboard key "tab" (updated Keyman Web Engine #2546)
 
 ## 2020-01-28 13.0.6050 beta
 * New Features:

--- a/web/history.md
+++ b/web/history.md
@@ -1,6 +1,9 @@
 # KeymanWeb Version History
 
-## 2020-01-28 13.0.32 beta
+## 2020-01-31 13.0.32 beta
+* Bug fix: Fixed external keyboard key "tab" for embedded devices (#2546)
+
+## 2020-01-28 13.0.31 beta
 * Start version 13.0
 * Feature: iOS dark mode support (#2468, #2484)
 * Bug fix: Scroll characters into view on Chrome when editing (#2514)

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -135,11 +135,9 @@ namespace com.keyman.text {
     let Codes = com.keyman.text.Codes;
     let code = Lkc.Lcode;
 
-    // Intentionally not assigning K_ENTER so KMW will pass them back
-    // to the mobile apps to handle (insert characters).
-    if (code == Codes.keyCodes.K_TAB) {
-      return '\t';
-    } else if (code == Codes.keyCodes.K_SPACE) {
+    // Intentionally not assigning K_TAB or K_ENTER so KMW will pass them back
+    // to the mobile apps to handle (insert characters or navigate forms).
+    if (code == Codes.keyCodes.K_SPACE) {
       return ' ';
     } else if (code == Codes.keyCodes.K_BKSP) {
       if(!disableDOM) {

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -135,9 +135,11 @@ namespace com.keyman.text {
     let Codes = com.keyman.text.Codes;
     let code = Lkc.Lcode;
 
-    // Intentionally not assigning K_TAB or K_ENTER so KMW will pass them back
-    // to the mobile apps to handle (insert characters or navigate forms).
-    if (code == Codes.keyCodes.K_SPACE) {
+    // Intentionally not assigning K_ENTER so KMW will pass them back
+    // to the mobile apps to handle (insert characters).
+    if (code == Codes.keyCodes.K_TAB) {
+      return '\t';
+    } else if (code == Codes.keyCodes.K_SPACE) {
       return ' ';
     } else if (code == Codes.keyCodes.K_BKSP) {
       if(!disableDOM) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -77,10 +77,6 @@ namespace com.keyman.text {
             }
             return '';
           case Codes.keyCodes['K_TAB']:
-            if(keyman.isEmbedded) {
-              // In embedded mode, let the device handle the tab character
-              return '\t';
-            }
             if(!disableDOM) {
               domManager.moveToNext(keyShiftState);
             }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -519,6 +519,12 @@ namespace com.keyman.text {
         keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
       }
 
+      // Special case for embedded to pass K_TAB back to device to process
+      if(keyman.isEmbedded && (keyEvent.Lcode == Codes.keyCodes["K_TAB"] ||
+          keyEvent.Lcode == Codes.keyCodes["K_TABBACK"] || keyEvent.Lcode == Codes.keyCodes["K_TABFWD"])) {
+        return false;
+      }
+
       return !LeventMatched;
     }
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -77,6 +77,9 @@ namespace com.keyman.text {
             }
             return '';
           case Codes.keyCodes['K_TAB']:
+            if(keyman.isEmbedded) {
+              return '\t';
+            }
             if(!disableDOM) {
               domManager.moveToNext(keyShiftState);
             }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -78,6 +78,7 @@ namespace com.keyman.text {
             return '';
           case Codes.keyCodes['K_TAB']:
             if(keyman.isEmbedded) {
+              // In embedded mode, let the device handle the tab character
               return '\t';
             }
             if(!disableDOM) {


### PR DESCRIPTION
Fixes #2540

This fixes KMW for embedded devices to not process `K_TAB` so the device will handle it.

### User Testing
Hardware needed: Android device, external keyboard (either via Bluetooth or USB). This won't work in Android Studio emulator

* Rebuild and load the Keyman app
* Set Keyman as the system keyboard

### Verify Tab navigates
* Open an Android app like Chrome or Google Keep
* Using the external keyboard, type in a text field and verify they appear
* Hit the "Tab" key
* Verify the app navigates to another field
* Hit Shift+Tab
* Verify the app navigates to a previous field

Note: if Google Chrome goes to a page like https://downloads.keyman.com/android/beta
Tabbing will highlight different release folders

I haven't seen an app that will insert `\t` when tab is hit yet...
