### PR TITLE
fix(android): Fix cancelling ConfirmDialogFragment

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -49,13 +49,14 @@ public class ConfirmDialogFragment extends DialogFragment {
   }
 
   public static ConfirmDialogFragment newInstanceForLexicalModel(DialogType dialogType, String title, String message,
-                                                             String aModelId,
+                                                             String aLangId, String aModelId,
                                                              ArrayList<CloudApiTypes.CloudApiParam> aQueries) {
     ConfirmDialogFragment frag = new ConfirmDialogFragment();
     Bundle args = new Bundle();
     args.putSerializable(ARG_DIALOG_TYPE, dialogType);
     args.putString(ARG_TITLE, title);
     args.putString(ARG_MESSAGE, message);
+    args.putString(ARG_LANG_ID_KEY, aLangId);
     args.putString(ARG_MODEL_ID_KEY, aModelId);
     args.putSerializable(ARG_DOWNLOAD_QUERIES_KEY,aQueries);
     frag.setArguments(args);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -144,7 +144,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
       title = String.format("%s: %s", langName, modelName);
       dialog = ConfirmDialogFragment.newInstanceForLexicalModel(
         DIALOG_TYPE_DOWNLOAD_MODEL, title, getString(R.string.confirm_download_model),
-        modelID,
+        langID, modelID,
         prepareCloudApiParamsForLexicalModelDownload());
     } else {
       dialog = ConfirmDialogFragment.newInstanceForKeyboard(

--- a/android/history.md
+++ b/android/history.md
@@ -1,6 +1,10 @@
 # Keyman for Android Version History
 
-## 2020-01-28 13.0.6051 beta
+## 2020-01-31 13.0.6051 beta
+* Bug fix:
+  * Fix cancelling dictionary update notifications (#2547)
+
+## 2020-01-28 13.0.6050 beta
 * New Features:
   * Adding a download manager to execute downloads in background and cleanup the existing implementation (#2247, #2275, #2308, #2365)
   * Show spinner (without blocking UI), if user wants to add a language/keyboard and catalog download is in progress (#2313)


### PR DESCRIPTION
When cancelling the Android system notifications about lexical model update being available, the notification would still remain in the notifications bar.

This PR passes the language ID to lexical model confirmation dialogs so it can be cancelled.
Keyboard update notifications already were receiving language ID.