### PR TITLE
feat(ios):  Deeplink into Keyman settings for system keyboard setup

### DIFF
--- a/ios/history.md
+++ b/ios/history.md
@@ -1,9 +1,7 @@
 # Keyman for iPhone and iPad Version History
 
-## 2020-01-30 13.0.63 beta
-* Feature: Initial keyboard setup process simplified with direct Settings link [iOS 11.0+ only] (#2548)
-
 ## 2020-01-30 13.0.62 beta
+* Feature: Initial keyboard setup process simplified with direct Settings link [iOS 11.0+ only] (#2548)
 * Bug fix: System keyboard now respects "Sounds > Keyboard Clicks" setting (#2550)
 
 ## 2020-01-29 13.0.61 beta

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-01-30 13.0.63 beta
+* Feature: Initial keyboard setup process simplified with direct Settings link [iOS 11.0+ only] (#2548)
+
 ## 2020-01-30 13.0.62 beta
 * Bug fix: System keyboard now respects "Sounds > Keyboard Clicks" setting (#2550)
 

--- a/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
@@ -114,7 +114,13 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       }
     case 1:
       cell.textLabel?.text = "Set up Keyman as system-wide keyboard"
-      cell.detailTextLabel?.text = ""
+      if #available(iOS 11.0, *) {
+        // We can expedite this via near-direct settings link.
+        // So, let's add the one extra needed detail to our detail text.
+        cell.detailTextLabel?.text = "Keyboards > Enable \"Keyman\""
+      } else {
+        cell.detailTextLabel?.text = ""
+      }
       if !AppDelegate.isKeymanEnabledSystemWide() {
         cell.accessoryType = .none
       } else {
@@ -145,9 +151,17 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       mainViewController.dismissGetStartedView(nil)
       mainViewController.showInstalledLanguages()
     case 1:
+      if #available(iOS 11.0, *),  // if "Keyboards" is an option in our app's settings menu
+         let appSettings = URL(string: UIApplication.openSettingsURLString) {
+        UIApplication.shared.openURL(appSettings)
+      } else {
+        let setUpVC = SetUpViewController()
+        mainViewController.present(setUpVC, animated: true, completion: nil)
+      }
+
+      // While it'd be nice to keep it in view, it seems to be automatically dismissed.
+      // This at least helps keep the app's state properly managed.
       mainViewController.dismissGetStartedView(nil)
-      let setUpVC = SetUpViewController()
-      mainViewController.present(setUpVC, animated: true, completion: nil)
     case 2:
       mainViewController.dismissGetStartedView(nil)
       mainViewController.infoButtonClick(nil)


### PR DESCRIPTION
While investigating a different issue, we recently came across https://developer.apple.com/documentation/uikit/uiapplication/1623042-opensettingsurlstring.  A bit of investigation later, and it turns out that as of iOS 11, it's possible to set Keyman as system keyboard _through_ the Keyman settings submenu - making this a much simpler way to enable the system keyboard for compatible devices.

On older devices, though...

![Screen Shot 2020-01-30 at 9 44 39 AM](https://user-images.githubusercontent.com/25213402/73415685-29202b80-4345-11ea-8de5-4f1a9b1f9681.png)

So, as a result, we maintain the status quo for 10.0 and before:

![Screen Shot 2020-01-30 at 9 35 13 AM](https://user-images.githubusercontent.com/25213402/73415700-350bed80-4345-11ea-93b2-dcf665615ff0.png)

![Screen Shot 2020-01-30 at 9 35 18 AM](https://user-images.githubusercontent.com/25213402/73415710-39380b00-4345-11ea-9522-bb9be9d08893.png)

But for 11.0+, we can get fancy:

![Screen Shot 2020-01-30 at 9 36 56 AM](https://user-images.githubusercontent.com/25213402/73415715-405f1900-4345-11ea-8bc2-c17e5742fc48.png)

![Screen Shot 2020-01-30 at 9 37 04 AM](https://user-images.githubusercontent.com/25213402/73415716-42c17300-4345-11ea-8800-a4a534148b19.png)

(Please ignore the version string - this was generated outside of our CI pipeline that manages the actual alpha/beta/release versions.)

![Screen Shot 2020-01-30 at 9 37 10 AM](https://user-images.githubusercontent.com/25213402/73415719-45bc6380-4345-11ea-88f5-0240330fe639.png)

While yes, this doesn't suggest that users "Allow Full Access", it doesn't appear to be needed on iOS (11.0+, at least) anyway - our App Groups usage here seems to provide all that's needed, as the system keyboard updates appropriately without it enabled.

------

Of course, if we want to be a little more explicit, we can always do something like seen here: https://www.natashatherobot.com/ios-taking-the-user-to-settings/  

I feel like that's adding an unnecessary extra 'click' though, and it's considerable extra work to add and design such a screen.