### PR TITLE
fix(ios): Now (eventually) uses sys pref for kbd clicks

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -21,7 +21,7 @@ public enum MenuBehaviour {
   case showNever
 }
 
-private class CustomInputView: UIInputView {
+private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
   var setFrame: CGRect = CGRect.zero
   var keymanWeb: KeymanWebViewController!
 
@@ -38,6 +38,13 @@ private class CustomInputView: UIInputView {
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+  }
+
+  public var enableInputClicksWhenVisible: Bool {
+    get {
+      // Implemented as noted by https://developer.apple.com/documentation/uikit/uidevice/1620050-playinputclick.
+      return true
+    }
   }
 
   override var intrinsicContentSize: CGSize {
@@ -308,7 +315,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     }
 
     if isInputClickSoundEnabled {
-      DispatchQueue.global(qos: .default).async { AudioServicesPlaySystemSound(0x450) }
+      UIDevice.current.playInputClick()
 
       // Disable input click sound for 0.1 second to ensure it plays for single key stroke.
       isInputClickSoundEnabled = false

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-01-30 13.0.62 beta
+* Bug fix: System keyboard now respects "Sounds > Keyboard Clicks" setting (#2550)
+
 ## 2020-01-29 13.0.61 beta
 * Bug fix: System keyboard would sometimes appear blank (#2545)
 


### PR DESCRIPTION
Fixes #2549.

It turns out that our iOS app has indeed been ignoring the "Keyboard Clicks" system setting that iOS provides.  Fortunately, there's a way to utilize this:  https://developer.apple.com/documentation/uikit/uidevice/1620050-playinputclick

That stated, there's an unfortunate part.  iOS feels that apps and app extensions should only ever need to poll this setting when they first load.  If the user backs out and changes the "Clicks" setting, neither will update until the process is terminated and restarted... despite the fact that iOS's default keyboard will _instantly_ update.  (Thanks, Apple.)

I've done some web searching to find ways to _force_ an update to the setting check, but the only lead I found [only worked back in 2010](https://stackoverflow.com/a/6236350), so... yeah.  I'd be happy if someone could find a more up-to-date way to force an update.  That said, this _is_ an edge case that practically resolves itself when a user stops using the device for more than 5 minutes or so, so this fix is probably fine enough as it is.