### PR TITLE
fix(linux): Update launchpad PPA by tier

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -3,7 +3,7 @@
 ## 2020-01-28 13.0.21 beta
 * Revert default tier to alpha (#2474)
 * Add QR Codes to share keyboards (#2486)
-* Work on Linux packaging (#2263, #2290, #2320, #2321, #2325, #2474, #2515)
+* Work on Linux packaging (#2263, #2290, #2320, #2321, #2325, #2474, #2515, #2551)
 
 ## 2019-09-19 12.0.18 beta
 * Bug Fix:

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -30,6 +30,11 @@ else
     tier="${TIER}"
 fi
 
+if [ "${tier}" == "stable" ]; then
+    ppa="ppa:keymanapp/keyman"
+else
+    ppa="ppa:keymanapp/keyman-daily"
+fi
 
 if [ ! `which xmllint` ]; then
     echo "you must install xmllint (libxml2-utils package) to use this script"
@@ -96,7 +101,7 @@ for proj in ${projects}; do
     done
     cd ..
     for dist in ${distributions}; do
-        dput ${SIM} ppa:keymanapp/keyman-daily ${proj}_${version}-${packageversion}~${dist}_source.changes
+        dput ${SIM} ${ppa} ${proj}_${version}-${packageversion}~${dist}_source.changes
     done
     cd ${BASEDIR}
 done


### PR DESCRIPTION
Update launchpad.sh so that `${tier}` corresponds to the ppa link:
`stable` --> ppa:keymanapp/keyman
others --> ppa:keymanapp/keyman-daily
