### PR TITLE
fix(common): RTL model specification

### DIFF
--- a/common/lexical-model-types/index.d.ts
+++ b/common/lexical-model-types/index.d.ts
@@ -361,4 +361,11 @@ interface LexicalModelPunctuation {
    * Default: ` `
    */
   readonly insertAfterWord: string;
+
+  /**
+   * Whether or not the model's language is typically displayed in RTL form.
+   * 
+   * Default: false (or undefined)
+   */
+  readonly isRTL?: boolean;
 }

--- a/common/predictive-text/docs/worker-communication-protocol.md
+++ b/common/predictive-text/docs/worker-communication-protocol.md
@@ -139,7 +139,7 @@ After this, it is safe to assume the `config` was performed successfully and is 
 The LMLayer needs to know the platform's abilities and restrictions (capabilities).
 
 ```typescript
-interface LoadMessage {
+interface ConfigMessage {
   message: 'load';
 
   /**

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -130,7 +130,15 @@ class ModelCompositor {
     // Add the surrounding quotes to the "keep" option's display string:
     if (keepOption) {
       let { open, close } = punctuation.quotesForKeepSuggestion;
-      keepOption.displayAs = open + keepOption.displayAs + close;
+      
+      // Should we also ensure that we're using the default quote marks first?
+      // Or is it reasonable to say that the "left" mark is always the one
+      // called "open"?
+      if(!punctuation.isRTL) {
+        keepOption.displayAs = open + keepOption.displayAs + close;
+      } else {
+        keepOption.displayAs = close + keepOption.displayAs + open;
+      }
     }
 
     // Now that we've calculated a unique set of probability masses, time to make them into a proper
@@ -176,8 +184,11 @@ class ModelCompositor {
       quotesForKeepSuggestion = defaults.quotesForKeepSuggestion;
     }
 
+    let isRTL = specifiedPunctuation.isRTL;
+    // Default:  false / undefined, so no need to directly specify it.
+
     return {
-      insertAfterWord, quotesForKeepSuggestion
+      insertAfterWord, quotesForKeepSuggestion, isRTL
     }
   }
 }

--- a/web/history.md
+++ b/web/history.md
@@ -1,6 +1,9 @@
 # KeymanWeb Version History
 
-## 2020-01-28 13.0.32 beta
+## 2020-01-30 13.0.32 beta
+* Bug fix: Predictive-text tweaks for RTL language lexical models (#2553, #2554)
+
+## 2020-01-28 13.0.31 beta
 * Start version 13.0
 * Feature: iOS dark mode support (#2468, #2484)
 * Bug fix: Scroll characters into view on Chrome when editing (#2514)


### PR DESCRIPTION
Fixes #2522.

This allows for the model's LTR/RTL preference to be specified for use in generating suggestion text.  As noted with upcoming specifications:

> so bcc-Arab uses
>
>     <delimiters>
>     <quotationStart>«</quotationStart>
>     <quotationEnd>»</quotationEnd>
>
> from http://ldml.api.sil.org/bcc-Arab

Note that following that spec, `quotationStart` should be inserted **_after_** `quotationEnd` for RTL languages.  This happens to work nicely with our punctuation defaults; when using the standard English opening & closing quotes, the "open" quote would need to go last for RTL language use.

I did debate for a while whether or not `isRTL` should be specified outside of the `LexicalModelPunctuation` object or not; here's why I eventually went with the version seen here.

index.d.ts of `lexical-model-types`, L74+, as part of the definition for `LexicalModel`:

      /**
       * Punctuation and presentational settings that the underlying lexical model
       * expects to be applied at higher levels. e.g., the ModelCompositor.
       * 
       * @see LexicalModelPunctuation
       */
      readonly punctuation?: LexicalModelPunctuation;

RTL is definitely a "presentational setting" and is used directly as part of the logic to apply certain punctuation marks, so I decided to put it here.  It's easy enough to move if needed, though, so feel free to suggest it be done the other way.

### Resulting screenshot:

![Screen Shot 2020-01-30 at 2 34 00 PM](https://user-images.githubusercontent.com/25213402/73429206-a8295a00-436d-11ea-9456-41612d26ea5a.png)

### Known issues:

First, this fix may need Keyman Developer support in order to properly handle (and preferably, auto-populate) the new `isRTL` flag as part of a model's parameter set.

Secondly, if a user swaps back and forth between keyboards frequently, malformed suggestions may appear if the most recent context is for a different language:

![Screen Shot 2020-01-30 at 12 40 32 PM](https://user-images.githubusercontent.com/25213402/73429258-cb540980-436d-11ea-90d7-23df82c539ae.png)

As we expect most usage to stick on the same keyboard for long stretches during predictive text use, we feel this to be an acceptable trade-off for now.

### Unit Testing

For testing purposes, I've provided an [Edited Balochi dictionary KMP](https://jahorton.github.io/sil.bcc-arab.upp_ptwl1.model.kmp) via my github.io page.  The only distinction compared to the version currently in keymanapp/lexical-models is that it sets the `isRTL` property appropriately within the `options` parameter.  (I have not edited its punctuation mark spec to match the notes above.)