### PR TITLE
fix(web): dev_resource compile fix

### DIFF
--- a/web/source/dom/utils.ts
+++ b/web/source/dom/utils.ts
@@ -145,7 +145,7 @@ namespace com.keyman.dom {
       // only executes when com.keyman.DOMEventHandlers is defined.
       //
       // We also bypass this whenever operating in the embedded format.
-      if(com && com.keyman && com.keyman['DOMEventHandlers'] && !com.keyman.singleton.isEmbedded) {
+      if(com && com.keyman && com.keyman['DOMEventHandlers'] && !com.keyman['singleton']['isEmbedded']) {
         let DOMEventHandlers = com.keyman['DOMEventHandlers'];
 
         let selectionStart = element.selectionStart;


### PR DESCRIPTION
Fixes bug that shows up in `build_dev_resources.sh`:

    source/dom/utils.ts(148,77): error TS2339: Property 'singleton' does not exist on type 'typeof keyman'.

Since that build script ignores kmwbase.ts in order to keep the "dev resources" lightweight for simpler testing, `com.keyman.singleton` isn't defined in this pathway.  For now, `com.keyman.DOMEventHandlers` existing is sufficient to ensure that `com.keyman.singleton` exists as well... though that could be made a bit more explicit.