### PR TITLE
fix(ios):  Fixes margins on keyboard in iOS 9/10

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -74,9 +74,11 @@ private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
     let innerView = keymanWeb.view!
 
     var guide: UILayoutGuide
+    var conditionalGuide: Bool = false
 
     if #available(iOSApplicationExtension 11.0, *) {
       guide = self.safeAreaLayoutGuide
+      conditionalGuide = true
     } else {
       guide = self.layoutMarginsGuide
     }
@@ -84,11 +86,21 @@ private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
     // Fallback on earlier versions
     innerView.topAnchor.constraint(equalTo:    guide.topAnchor).isActive = true
     innerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
-    innerView.leftAnchor.constraint(equalTo:   guide.leftAnchor).isActive = true
-    innerView.rightAnchor.constraint(equalTo:  guide.rightAnchor).isActive = true
+    if conditionalGuide {
+      innerView.leftAnchor.constraint(equalTo:   guide.leftAnchor).isActive = true
+      innerView.rightAnchor.constraint(equalTo:  guide.rightAnchor).isActive = true
+    } else {
+      innerView.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
+      innerView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
+    }
 
     // Allow these to be broken if/as necessary to resolve layout issues.
-    let kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: guide.widthAnchor)
+    var kbdWidthConstraint: NSLayoutConstraint
+    if conditionalGuide {
+      kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: guide.widthAnchor)
+    } else {
+      kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: self.widthAnchor)
+    }
     kbdWidthConstraint.priority = .defaultHigh
     kbdWidthConstraint.isActive = true
 

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-02-03 13.0.63 beta
+* Bug fix: Fixes keyboard widths/margins in iOS 9 and 10 (#2560)
+
 ## 2020-01-30 13.0.62 beta
 * Feature: Initial keyboard setup process simplified with direct Settings link [iOS 11.0+ only] (#2548)
 * Bug fix: System keyboard now respects "Sounds > Keyboard Clicks" setting (#2550)


### PR DESCRIPTION
Fixes another issue noted at https://github.com/keymanapp/keyman/issues/2530#issuecomment-577954518.

Before:

![Screen Shot 2020-01-31 at 2 38 46 PM](https://user-images.githubusercontent.com/25213402/73521081-af1c9f00-4437-11ea-84d9-f0ce5e384c72.png)

After:

![Screen Shot 2020-01-31 at 2 39 22 PM](https://user-images.githubusercontent.com/25213402/73521085-b2b02600-4437-11ea-8815-86a5aede8294.png)