### PR TITLE
fix(web): default BKSP output targeting

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 2020-02-03 13.0.33 beta
+* Bug fix: BKSP not working corrrectly with design-mode iframes (#2561)
+
 ## 2020-01-30 13.0.32 beta
 * Bug fix: Predictive-text tweaks for RTL language lexical models (#2553, #2554)
 * Bug fix: Fixed external keyboard key "tab" for embedded devices (#2546)

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -73,7 +73,13 @@ namespace com.keyman.text {
             if(disableDOM) {
               return '\b'; // the escape sequence for backspace.
             } else {
-              keyman.interface.defaultBackspace();
+              // If we have an available target (via Lkc/Lelem), use that instead of 
+              // forcing defaultBackspace to search for it.
+              var target: OutputTarget;
+              if(Lelem && Lelem._kmwAttachment) {
+                target = Lelem._kmwAttachment.interface;
+              }
+              keyman.interface.defaultBackspace(target);
             }
             return '';
           case Codes.keyCodes['K_TAB']:


### PR DESCRIPTION
Fixes the Windows-OS issue noted here:  https://github.com/keymanapp/keyman/issues/2528#issuecomment-578565837

> Attempting to use BKSP within a design-mode <iframe> seems to redirect backspaces to the most recent alternative input and focuses that one instead. Other keystrokes are fine; just BKSP.
>
>    - If the design-mode <iframe> had been the previous input (due to focus loss + regain), it'll accept them then
>    - Content-editables do not share this issue.
>    - Happens in all browsers on Windows; does not happen on macOS.

While I didn't fully investigate why this only broke on Windows, it turns out there was a glaring inefficiency in the code that, when fixed, resolved the issue anyway - the `defaultKeyOutput` method actually _does_ have access to the current `OutputTarget`, so we should just provide that to `defaultBackspace` rather than forcing it to re-find it.

----

In case it does matter in the future, a few notes toward the Windows breakage:

The triggering symptom (of whatever the root bug is) is that when `getOutputTarget` is called by `defaultBackspace`, there _isn't_ an `activeTargetOutput` set.  This is enough to force a backup to be used - `.getLastActiveElement`'s `OutputTarget` - hence why the prior element was receiving BKSP commands.