### PR TITLE
chore(ci): trigger builds after version increment

### DIFF
--- a/resources/build/trigger-builds.sh
+++ b/resources/build/trigger-builds.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# Tell TeamCity to trigger new builds
+#
+
+function triggerBuilds() {
+  local base=`git branch --show-current`
+  if [[ $base == master ]]; then
+    local TEAMCITY_BUILDTYPES=( KeymanAndroid_Build Keyman_iOS_Master KeymanLinux_Master KeymanMac_Master Keyman_Build Keymanweb_Build )
+    local TEAMCITY_VCS_ID=HttpsGithubComKeymanappKeyman
+  elif [[ $base == beta ]]; then
+    local TEAMCITY_BUILDTYPES=( KeymanAndroid_Beta Keyman_iOS_Beta KeymanLinux_Beta KeymanMac_Beta KeymanDesktop_Beta Keymanweb_Beta )
+    local TEAMCITY_VCS_ID=Keyman_KeymanappKeymanBeta
+  else
+    exit 1
+  fi
+
+  for TEAMCITY_BUILDTYPE in "${TEAMCITY_BUILDTYPES[@]}"; do
+    triggerBuild $TEAMCITY_BUILDTYPE $TEAMCITY_VCS_ID
+  done
+}
+
+function triggerBuild() {
+  local TEAMCITY_BUILDTYPE="$1"
+  local TEAMCITY_VCS_ID="$2"
+
+# 2caf29b27b3b364433c9298ec4d032fd178a210e
+  local GIT_OID=`git rev-parse HEAD`
+  local TEAMCITY_SERVER=https://build.palaso.org
+
+  curl -s --header "Authorization: Bearer $TEAMCITY_TOKEN" \
+    -X POST \
+    -H "Content-Type: application/xml" \
+    -H "Accept: application/json" \
+    -H "Origin: $TEAMCITY_SERVER" \
+    $TEAMCITY_SERVER/app/rest/buildQueue \
+    -d "<build><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID,buildType:(id:$TEAMCITY_BUILDTYPE)'/></lastChanges></build>"
+}

--- a/resources/build/trigger-builds.sh
+++ b/resources/build/trigger-builds.sh
@@ -25,7 +25,6 @@ function triggerBuild() {
   local TEAMCITY_BUILDTYPE="$1"
   local TEAMCITY_VCS_ID="$2"
 
-# 2caf29b27b3b364433c9298ec4d032fd178a210e
   local GIT_OID=`git rev-parse HEAD`
   local TEAMCITY_SERVER=https://build.palaso.org
 


### PR DESCRIPTION
After a version is incremented, we trigger builds for all the platforms based on the *last* commit before the version change.

This ensures that history and version numbers are valid and complete before we start the build. In the future, we could import the version history into the documentation or archive for the projects.