### PR TITLE
fix(linux) Remove cosmic and disco releases

### DIFF
--- a/linux/.pbuilderrc
+++ b/linux/.pbuilderrc
@@ -14,7 +14,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("disco", "cosmic" "bionic" "xenial" "trusty")
+UBUNTU_SUITES=("disco" "bionic" "xenial" "trusty")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="deb.debian.org"

--- a/linux/.pbuilderrc
+++ b/linux/.pbuilderrc
@@ -14,7 +14,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("bionic" "xenial" "trusty")
+UBUNTU_SUITES=("eoan" "bionic" "xenial" "trusty")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="deb.debian.org"

--- a/linux/.pbuilderrc
+++ b/linux/.pbuilderrc
@@ -14,7 +14,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("disco" "bionic" "xenial" "trusty")
+UBUNTU_SUITES=("bionic" "xenial" "trusty")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="deb.debian.org"

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,8 @@
 # Keyman for Linux Version History
 
+## 2020-02-04 13.0.23 beta
+* Remove cosmic and disco releases. Add eoan (#2574)
+
 ## 2020-01-28 13.0.21 beta
 * Revert default tier to alpha (#2474)
 * Add QR Codes to share keyboards (#2486)

--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='bionic xenial'
+distributions='eoan bionic xenial'
 
 dpkgcheck=`dpkg-query -l cowbuilder`
 if [ $? != 0 ]; then

--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='disco bionic xenial'
+distributions='bionic xenial'
 
 dpkgcheck=`dpkg-query -l cowbuilder`
 if [ $? != 0 ]; then

--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='disco cosmic bionic xenial'
+distributions='disco bionic xenial'
 
 dpkgcheck=`dpkg-query -l cowbuilder`
 if [ $? != 0 ]; then

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -50,7 +50,7 @@ fi
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="xenial bionic cosmic disco"
+    distributions="xenial bionic disco"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -50,7 +50,7 @@ fi
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="xenial bionic disco"
+    distributions="xenial bionic"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -50,7 +50,7 @@ fi
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="xenial bionic"
+    distributions="xenial bionic eoan"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then


### PR DESCRIPTION
Since cosmic and disco Ubuntu releases are EOL, launchpad is rejecting package updates for those releases. This PR removes them from CI.