### PR TITLE
feat: prepare-commit-msg hook for autogenerated conventional commit messages

### DIFF
--- a/configure-repo.sh
+++ b/configure-repo.sh
@@ -22,8 +22,10 @@ case $1 in
       # https://stackoverflow.com/a/39160850/1836776
       WinPWD=$(cmd //C cd)
       cmd //C "mklink $WinPWD\\.git\\hooks\\commit-msg $WinPWD\\resources\\git-hooks\\commit-msg"
+      cmd //C "mklink $WinPWD\\.git\\hooks\\prepare-commit-msg $WinPWD\\resources\\git-hooks\\prepare-commit-msg"
     else
       ln -sf "$PWD/resources/git-hooks/commit-msg" "$PWD/.git/hooks/commit-msg"
+      ln -sf "$PWD/resources/git-hooks/prepare-commit-msg" "$PWD/.git/hooks/prepare-commit-msg"
     fi
     ;;
   *)

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -12,24 +12,16 @@
 # Reference: https://github.com/keymanapp/keyman/wiki/Pull-Request-and-Commit-workflow-notes
 #
 
-#
-# Configurable options for types, scopes and message length.
-#
+# Step 1 - resolve the source directory of the hook, ALSO resolving any symlinks.
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$DIR/$SCRIPT_SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+HOOK_DIRECTORY="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
 
-types=(fix feat chore change docs style refactor test auto)
-scopes=( \
-  android android/app android/browser android/engine android/oem \
-  ci \
-  common common/core common/lmlayer \
-  developer developer/compiler developer/ide developer/tools \
-  ios ios/app ios/browser ios/engine ios/oem \
-  linux linux/config linux/engine linux/ibus linux/oem \
-  mac mac/config mac/engine mac/oem \
-  web web/engine web/oem web/ui \
-  windows windows/config windows/engine windows/oem \
-)
-min_length=4
-max_length=128
+. $HOOK_DIRECTORY/commit-msg-defs
 
 #
 # Define terminal colours.

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -13,6 +13,7 @@
 #
 
 # Step 1 - resolve the source directory of the hook, ALSO resolving any symlinks.
+# From https://stackoverflow.com/a/246128.
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -16,10 +16,20 @@
 # Configurable options for types, scopes and message length.
 #
 
-types=(fix feat chore change docs style refactor test)
-scopes=(android ci common developer ios linux mac web windows)
+types=(fix feat chore change docs style refactor test auto)
+scopes=( \
+  android android/engine android/browser android/app \
+  ci \
+  common common/core \
+  developer developer/compiler developer/ide developer/tools \
+  ios ios/engine ios/browser ios/app \
+  linux linux/ibus linux/engine linux/config \
+  mac mac/engine mac/config \
+  web web/engine web/lmlayer web/ui \
+  windows windows/engine windows/config \
+)
 min_length=4
-max_length=72
+max_length=128
 
 #
 # Define terminal colours.
@@ -80,7 +90,7 @@ function build_regex() {
   remessage=".{$min_length,$max_length}[^.]"
   refixes="(\. Fixes #[[:digit:]]+)?"
 
-  regexp="^${retypes}${rescope}: ${remessage}${refixes}\s*$"
+  regexp="^${retypes}${rescope}: ${remessage}${refixes}[[:space:]]*$"
 }
 
 # Print out a standard error message which explains

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -18,15 +18,15 @@
 
 types=(fix feat chore change docs style refactor test auto)
 scopes=( \
-  android android/engine android/browser android/app \
+  android android/app android/browser android/engine android/oem \
   ci \
-  common common/core \
+  common common/core common/lmlayer \
   developer developer/compiler developer/ide developer/tools \
-  ios ios/engine ios/browser ios/app \
-  linux linux/ibus linux/engine linux/config \
-  mac mac/engine mac/config \
-  web web/engine web/lmlayer web/ui \
-  windows windows/engine windows/config \
+  ios ios/app ios/browser ios/engine ios/oem \
+  linux linux/config linux/engine linux/ibus linux/oem \
+  mac mac/config mac/engine mac/oem \
+  web web/engine web/oem web/ui \
+  windows windows/config windows/engine windows/oem \
 )
 min_length=4
 max_length=128

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -51,6 +51,15 @@ if (git remote -v | grep -E "origin|upstream" | grep -Eq "keyboards|lexical-mode
   exit 0
 fi
 
+# If this script is called by another hook, it may insert a -q parameter to silence the help text.
+QUIET=0
+case $1 in
+  -q|--quiet)
+    shift   # Remove the parameter, making it equivalent to a standard git-hook call.
+    QUIET=1
+    ;;
+esac
+
 # build the regex pattern based on the config file
 function build_regex() {
   retypes=
@@ -97,6 +106,8 @@ build_regex
 
 if [[ ! $msg =~ $regexp ]]; then
   # commit message is invalid according to config - block commit
-  print_error
+  if [ $QUIET -eq 0 ]; then
+    print_error
+  fi
   exit 1
 fi

--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -78,7 +78,7 @@ function build_regex() {
   rescope="(\((${rescope%?})\))?"
 
   remessage=".{$min_length,$max_length}[^.]"
-  refixes="( \. Fixes #\d+)?"
+  refixes="(\. Fixes #[[:digit:]]+)?"
 
   regexp="^${retypes}${rescope}: ${remessage}${refixes}\s*$"
 }

--- a/resources/git-hooks/commit-msg-defs
+++ b/resources/git-hooks/commit-msg-defs
@@ -1,0 +1,18 @@
+#
+# Configurable options for types, scopes and message length.
+#
+
+types=(fix feat chore change docs style refactor test auto)
+scopes=( \
+  android android/app android/browser android/engine android/oem \
+  ci \
+  common common/core common/lmlayer \
+  developer developer/compiler developer/ide developer/tools \
+  ios ios/app ios/browser ios/engine ios/oem \
+  linux linux/config linux/engine linux/ibus linux/oem \
+  mac mac/config mac/engine mac/oem \
+  web web/engine web/oem web/ui \
+  windows windows/config windows/engine windows/oem \
+)
+min_length=4
+max_length=128

--- a/resources/git-hooks/commit-msg-defs
+++ b/resources/git-hooks/commit-msg-defs
@@ -1,4 +1,4 @@
-#
+#!/bin/bash
 # Configurable options for types, scopes and message length.
 #
 

--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -4,10 +4,11 @@
 # This prepare-commit-msg hook prepares commit messages to ensure 
 # that they meet our conventional commit standard.
 #
+# Whenever `git` detects an incoming commit, it will trigger this hook.  If the message does not
+# our conventional commit format, it will set it to the following format.  (commit and merge only)
 #
-#   "type: message"
 #   "type(scope): message"
-#   Optionally, append ". Fixes #1234"
+#   If an issue number is detected at the front of the message and it is not a merge, also adds "___. Fixes #1234"
 #
 # Reference: https://github.com/keymanapp/keyman/wiki/Pull-Request-and-Commit-workflow-notes
 #
@@ -52,7 +53,6 @@ function prepend_scope() {
   # Step 1:  if the branch follows our preferred branch conventions, we can use that!
   branch=$(git rev-parse --abbrev-ref HEAD)
   build_regex
-  echo "branch: $branch"
 
   # Perform the actual regex check.
   if [[ $branch =~ $regexp ]]; then
@@ -73,13 +73,17 @@ function prepend_scope() {
     if [ -n "${ISSUE// }" ]; then # Refer to https://unix.stackexchange.com/a/146945 for explanation.
       # This technically does pass the conventional commits test - it doesn't -ensure- that the
       # "Fixes #____" section doesn't count toward the core message.
-      postfix="___. Fixes #$ISSUE"
+      postfix="\n"
+      postfix="${postfix}# Keyman Conventional Commit suggestions:\n"
+      postfix="${postfix}# - Consider appending the text \". Fixes #$ISSUE\" to your commit message."
     else
       postfix=""
     fi
-    prefix="$TYPE($SCOPE): $postfix"
+    prefix="$TYPE($SCOPE): "
     
-    echo -e "$prefix$(cat $COMMIT_MSG_FILE)" > $COMMIT_MSG_FILE
+    # Reuse any existing message text, wrapping it in our conventional commit formatting before
+    # presenting it to the user for any final edits.
+    echo -e "$prefix$(cat $COMMIT_MSG_FILE)$postfix" > $COMMIT_MSG_FILE
   fi
 
   # If it doesn't follow our branch-name format, we can't provide any help.

--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -16,14 +16,20 @@
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3
-HOOK_DIRECTORY=`git rev-parse --git-dir`/hooks
+
+# Step 1 - resolve the source directory of the hook, ALSO resolving any symlinks.
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$DIR/$SCRIPT_SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+HOOK_DIRECTORY="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+. $HOOK_DIRECTORY/commit-msg-defs
 
 # build the regex pattern based on the config file
 function build_regex() {
-  # Definitions from commit-msg.
-  types=(fix feat chore change docs style refactor test)
-  scopes=(android ci common developer ios linux mac web windows)
-
   retypes=
   for type in "${types[@]}"
   do

--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -18,6 +18,7 @@ COMMIT_SOURCE=$2
 SHA1=$3
 
 # Step 1 - resolve the source directory of the hook, ALSO resolving any symlinks.
+# From https://stackoverflow.com/a/246128.
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" >/dev/null 2>&1 && pwd )"
@@ -69,10 +70,13 @@ function prepend_scope() {
     ISSUE=${BASH_REMATCH[5]}
     NAME=${BASH_REMATCH[6]}
 
+    EXTRA_WHITESPACE="\n"
+
     # For known merge commits, consider the merge operation to be a 'chore'.
     if [ "${COMMIT_SOURCE}" = "merge" ]; then
       TYPE="chore"
       ISSUE= # Invalidates adding the 'postfix' for these commit types.
+      EXTRA_WHITESPACE=
     fi
 
     # Now that we have the components finalized, we can proceed.
@@ -85,7 +89,7 @@ function prepend_scope() {
     else
       postfix=""
     fi
-    prefix="$TYPE($SCOPE): "
+    prefix="$TYPE($SCOPE): $EXTRA_WHITESPACE"
     
     # Reuse any existing message text, wrapping it in our conventional commit formatting before
     # presenting it to the user for any final edits.

--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# This prepare-commit-msg hook prepares commit messages to ensure 
+# that they meet our conventional commit standard.
+#
+#
+#   "type: message"
+#   "type(scope): message"
+#   Optionally, append ". Fixes #1234"
+#
+# Reference: https://github.com/keymanapp/keyman/wiki/Pull-Request-and-Commit-workflow-notes
+#
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+HOOK_DIRECTORY=`git rev-parse --git-dir`/hooks
+
+#
+# Configurable options for types, scopes and message length.
+#
+
+# Definitions from commit-msg; we should match the format.
+#
+# types=(fix feat chore change docs style refactor test)
+# scopes=(android ci common developer ios linux mac web windows)
+# min_length=4
+# max_length=72
+
+# Step 1 - is the prepared message already in our conventional commits format?
+$HOOK_DIRECTORY/commit-msg -q $COMMIT_MSG_FILE
+isConventional=$? # Grabs the exit code. 
+
+echo "pre-commit hook says hi"
+
+if [ $isConventional -eq 0 ]; then
+  # If so, great!  Don't do a thing!
+  exit 0
+fi

--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -17,24 +17,105 @@ COMMIT_SOURCE=$2
 SHA1=$3
 HOOK_DIRECTORY=`git rev-parse --git-dir`/hooks
 
+# build the regex pattern based on the config file
+function build_regex() {
+  # Definitions from commit-msg.
+  types=(fix feat chore change docs style refactor test)
+  scopes=(android ci common developer ios linux mac web windows)
+
+  retypes=
+  for type in "${types[@]}"
+  do
+    retypes="${retypes}$type|"
+  done
+  retypes="(${retypes%?})"
+
+  rescope=
+  for scope in "${scopes[@]}"
+  do
+    rescope="${rescope}$scope|"
+  done
+  # %? removes last |
+  rescope="(${rescope%?})?"
+
+  recherry="(cherry-pick\/)?"
+
+  # Optionally captures an issue number at the front of the branch's name.
+  rebranchname="(([[:digit:]]+)\-)?(.+)"
+
+  regexp="^${retypes}\/${rescope}\/?${recherry}${rebranchname}\s*$"
+}
+
+function prepend_scope() {
+  # COMMIT_MSG_FILE and $COMMIT_SOURCE are already available.
+
+  # Step 1:  if the branch follows our preferred branch conventions, we can use that!
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  build_regex
+  echo "branch: $branch"
+
+  # Perform the actual regex check.
+  if [[ $branch =~ $regexp ]]; then
+    TYPE=${BASH_REMATCH[1]}
+    SCOPE=${BASH_REMATCH[2]}
+    # 3 - cherry-pick (if it exists)
+    # 4 - just ISSUE, but with an appended '-'.  Ashame BASH doesn't support non-capture groups.
+    ISSUE=${BASH_REMATCH[5]}
+    NAME=${BASH_REMATCH[6]}
+
+    # For known merge commits, consider the merge operation to be a 'chore'.
+    if [ "${COMMIT_SOURCE}" = "merge" ]; then
+      TYPE="chore"
+      ISSUE= # Invalidates adding the 'postfix' for these commit types.
+    fi
+
+    # Now that we have the components finalized, we can proceed.
+    if [ -n "${ISSUE// }" ]; then # Refer to https://unix.stackexchange.com/a/146945 for explanation.
+      # This technically does pass the conventional commits test - it doesn't -ensure- that the
+      # "Fixes #____" section doesn't count toward the core message.
+      postfix="___. Fixes #$ISSUE"
+    else
+      postfix=""
+    fi
+    prefix="$TYPE($SCOPE): $postfix"
+    
+    echo -e "$prefix$(cat $COMMIT_MSG_FILE)" > $COMMIT_MSG_FILE
+  fi
+
+  # If it doesn't follow our branch-name format, we can't provide any help.
+}
+
 #
 # Configurable options for types, scopes and message length.
 #
-
-# Definitions from commit-msg; we should match the format.
-#
-# types=(fix feat chore change docs style refactor test)
-# scopes=(android ci common developer ios linux mac web windows)
-# min_length=4
-# max_length=72
 
 # Step 1 - is the prepared message already in our conventional commits format?
 $HOOK_DIRECTORY/commit-msg -q $COMMIT_MSG_FILE
 isConventional=$? # Grabs the exit code. 
 
-echo "pre-commit hook says hi"
-
 if [ $isConventional -eq 0 ]; then
   # If so, great!  Don't do a thing!
   exit 0
 fi
+
+# Debugging aides
+#echo "COMMIT_MSG_FILE=$COMMIT_MSG_FILE"
+#echo "COMMIT_SOURCE=$COMMIT_SOURCE"
+
+# The default message is NOT in conventional format.  Time to help out with that.
+case $COMMIT_SOURCE in
+  squash)
+    # We don't help with squashes - this tends to combine two separate messages,
+    # and that can be messy.
+    exit 0
+    ;;
+  merge|commit|'') # '' = plain `git commit`
+    # We can help here!
+    prepend_scope
+    ;;
+  *)
+    # Default handler - we don't handle these types yet.  Might be worth considering.
+    # Known possibilities:  message (-m), template (-t)
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
Having gotten more than a bit annoyed at how the default merge commit messages are blocked by the current conventional commit-hook checks, I decided to invest a bit of effort to develop a `prepare-commit-msg` hook for use within the Keyman repo.

Refer to https://git-scm.com/docs/githooks for documentation if desired, and compare against [git's official example](https://github.com/git/git/blob/master/templates/hooks--prepare-commit-msg.sample).

**Rule 1** - if it's already in our [Conventional Commits format](https://github.com/keymanapp/keyman/wiki/Pull-Request-and-Commit-workflow-notes), don't touch it.

If the message _isn't already in the right format_, then for certain event types this hook will then alter the suggested message before presenting it to the user for editing.  To do so, it relies upon following our conventions for branch naming, as seen in the same document linked above.

For now, this is tested to work well against the following event cases:
- `git commit`
    - With no issue number in the conventional branch format:
![Screen Shot 2020-02-04 at 12 54 32 PM](https://user-images.githubusercontent.com/25213402/73718308-b224d180-474e-11ea-9742-665b0808d549.png)

    - With an issue number in the conventional branch format:
![Screen Shot 2020-02-04 at 12 53 02 PM](https://user-images.githubusercontent.com/25213402/73718267-9ae5e400-474e-11ea-9b98-d73a8252c573.png)

      As you can see, we can append extra instructions/documentation here if we want!

- `git merge`
    - Regardless of a detected issue number:
![Screen Shot 2020-02-04 at 12 56 20 PM](https://user-images.githubusercontent.com/25213402/73718272-9d483e00-474e-11ea-94c4-3f718f4d98de.png)
       Yes, that says `chore` - since merging branches typically qualifies as such.  It's branch upkeep, rather than actual coding work.

These are the new auto-generated commit messages for these events when this hook is in place.

Note that the following commit types have explicit bypasses for now:

- During a `git rebase`: `squash`
    - Way too complex to attempt an automatic message-merge.
- `git commit -m`
    - The message is already provided; the user knows what they're doing.
- `git commit -t`
    - Not that we use them, but apparently commit templates are a thing.

If the hook's script doesn't have a case to handle certain commits (or has an explicit bypass), it will simply allow the originally-generated message to pass through unaltered.  (Basically, it doesn't touch what it knows it can't handle.)

### Using this hook
To activate this hook within your local development repo, simply follow [these instructions](https://github.com/keymanapp/keyman/wiki/How-to-setup-conventional-commits-git-commit-msg-hook).  The setup script has been modified to include the new hook.