### PR TITLE
fix(linux): Fix 'About' keyboard when missing copyright

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,9 @@
 # Keyman for Linux Version History
 
+## 2020-02-05 13.0.25 beta
+* Bug Fix:
+  * Fix "About" keyboard when missing copyright info (#2583)
+
 ## 2020-02-04 13.0.23 beta
 * Remove cosmic and disco releases. Add eoan (#2574)
 

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -122,16 +122,17 @@ class KeyboardDetailsView(Gtk.Window):
             label.set_selectable(True)
             grid.attach_next_to(label, lbl_pkg_auth, Gtk.PositionType.RIGHT, 1, 1)
 
-        lbl_pkg_cpy = Gtk.Label()
-        lbl_pkg_cpy.set_text("Package copyright:   ")
-        lbl_pkg_cpy.set_halign(Gtk.Align.END)
-        grid.attach_next_to(lbl_pkg_cpy, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
-        prevlabel = lbl_pkg_cpy
-        label = Gtk.Label()
-        label.set_text(info['copyright']['description'])
-        label.set_halign(Gtk.Align.START)
-        label.set_selectable(True)
-        grid.attach_next_to(label, lbl_pkg_cpy, Gtk.PositionType.RIGHT, 1, 1)
+        if "copyright" in info:
+            lbl_pkg_cpy = Gtk.Label()
+            lbl_pkg_cpy.set_text("Package copyright:   ")
+            lbl_pkg_cpy.set_halign(Gtk.Align.END)
+            grid.attach_next_to(lbl_pkg_cpy, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
+            prevlabel = lbl_pkg_cpy
+            label = Gtk.Label()
+            label.set_text(info['copyright']['description'])
+            label.set_halign(Gtk.Align.START)
+            label.set_selectable(True)
+            grid.attach_next_to(label, lbl_pkg_cpy, Gtk.PositionType.RIGHT, 1, 1)
 
         # Padding and full width horizontal divider
         lbl_pad = Gtk.Label()


### PR DESCRIPTION
Found during investigation of #2575 after installing the attached Malayalam keyboard package.

### Keyman Config
"About" keyboard fails to show when package copyright information is missing.
This PR adds a check for the copyright info (normally displayed below "Package version")

![about missing copyright](https://user-images.githubusercontent.com/7358010/73725436-f2408000-475f-11ea-8931-4534f6c086c7.png)
