### PR TITLE
fix(ios): Icon image change on light/dark mode transition

### DIFF
--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -345,6 +345,17 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     return UIBarButtonItem(customView: containerView)
   }
 
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard let previousTraitCollection = previousTraitCollection else {return}
+    if #available(iOS 13.0, *) {
+      if previousTraitCollection.hasDifferentColorAppearance(comparedTo: traitCollection) {
+          // do things
+          log.info("Transition needed!")
+      }
+    }
+  }
+
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -319,26 +319,22 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
                                   imageScale scaleF: CGFloat,
                                   action selector: Selector,
                                   orientation: UIInterfaceOrientation) -> UIBarButtonItem {
-    let icon = image.resize(to: CGSize(width: image.size.width * scaleF, height: image.size.height * scaleF))
-        .withRenderingMode(.alwaysOriginal)
-    let iconHighlighted = imageHighlighted.resize(to:
-        CGSize(width: imageHighlighted.size.width * scaleF, height: imageHighlighted.size.height * scaleF))
-        .withRenderingMode(.alwaysOriginal)
+    let size = CGSize(width: image.size.width * scaleF, height: image.size.height * scaleF)
 
     let vAdjPort: CGFloat = UIScreen.main.scale == 2.0 ? -3.6 : -2.6
     let vAdjLscpe: CGFloat = -1.6
 
     let vAdj = orientation.isPortrait ? vAdjPort : vAdjLscpe
     let navBarHeight = self.navBarHeight()
-    let y = (navBarHeight - icon.size.height) / 2.0 + vAdj
+    let y = (navBarHeight - size.height) / 2.0 + vAdj
 
     let customButton = UIButton(type: .custom)
-    customButton.setImage(icon, for: .normal)
-    customButton.setImage(iconHighlighted, for: .highlighted)
-    customButton.frame = CGRect(x: 0.0, y: y, width: icon.size.width, height: icon.size.height)
+    customButton.setImage(image, for: .normal)
+    customButton.setImage(imageHighlighted, for: .highlighted)
+    customButton.frame = CGRect(x: 0.0, y: y, width: size.width, height: size.height)
     customButton.addTarget(self, action: selector, for: .touchUpInside)
 
-    let containerView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: icon.size.width, height: navBarHeight))
+    let containerView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: size.width, height: navBarHeight))
     containerView.backgroundColor = UIColor.clear
     containerView.addSubview(customButton)
 


### PR DESCRIPTION
Addresses part of #2491.

By having the `customButton` perform image scaling instead of prescaling the image, iOS will automatically transition the icon images for our nav-bar buttons.

This PR does _not_ fix the lack of a "dark mode image banner" - that is addressed instead by #2594.