### PR TITLE
fix(linux): Fix packaging of keyman-config on Xenial

### DIFF
--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -3,8 +3,9 @@ Maintainer: Daniel Glassey <wdg@debian.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), bash-completion,
- python3-magic, python3-qrcode | python-qrcode
-Standards-Version: 3.9.7
+ python3-magic, python3-qrcode <!pkg.keyman-config.xenial>,
+ python-qrcode <pkg.keyman-config.xenial>
+Standards-Version: 4.5.0
 Homepage: http://www.keyman.com/
 
 Package: python3-keyman-config


### PR DESCRIPTION
Xenial doesn't provide python3-qrcode, and specifying the
alternative package in the control file doesn't work because the
build always uses the first specified alternative. This change
makes use of build profiles ([1]) to select the correct package.

[1] https://wiki.debian.org/BuildProfileSpec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2609)
<!-- Reviewable:end -->
