### PR TITLE
fix(common/core): buffer overrun in context api

### DIFF
--- a/common/engine/keyboardprocessor/src/km_kbp_context_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_context_api.cpp
@@ -242,7 +242,7 @@ json & operator << (json & j, km::kbp::context const & ctxt) {
 
 json & operator << (json & j, km_kbp_context_item const & i)
 {
-  utf8::codeunit_t cps[4] = {0,};
+  utf8::codeunit_t cps[7] = {0,};
   int8_t l = 4;
 
   switch (i.type)

--- a/common/engine/keyboardprocessor/src/km_kbp_context_api.cpp
+++ b/common/engine/keyboardprocessor/src/km_kbp_context_api.cpp
@@ -242,7 +242,7 @@ json & operator << (json & j, km::kbp::context const & ctxt) {
 
 json & operator << (json & j, km_kbp_context_item const & i)
 {
-  utf8::codeunit_t cps[7] = {0,};
+  utf8::codeunit_t cps[7] = {0,}; // 6 bytes for maximal UTF-8 char (e.g. U+10FFFF) + nul terminator
   int8_t l = 4;
 
   switch (i.type)


### PR DESCRIPTION
A static buffer for UTF-8 encoded characters used in debugging and test logs did not provide enough space for SMP characters (require 6 bytes rather than 4). This was used only for test cases and not in production code -- outputting JSON text. Also requires nul terminator.

This should fix the failing keyboardprocessor test builds on Windows and macOS.