### PR TITLE
fix(ci): don't include build-utils.sh

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -25,8 +25,11 @@ fi
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
 
+KEYMAN_ROOT=$(dirname $(dirname $(dirname "$THIS_SCRIPT")))
+readonly KEYMAN_ROOT
+
 # THIS DOESN'T WORK FOR 13.0 BETA
-# but we don't need it...
+# but we don't need it
 # . "$(dirname "$THIS_SCRIPT")/build-utils.sh"
 
 ## END STANDARD BUILD SCRIPT INCLUDE

--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -24,7 +24,11 @@ fi
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
-. "$(dirname "$THIS_SCRIPT")/build-utils.sh"
+
+# THIS DOESN'T WORK FOR 13.0 BETA
+# but we don't need it...
+# . "$(dirname "$THIS_SCRIPT")/build-utils.sh"
+
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$(dirname "$THIS_SCRIPT")/trigger-definitions.sh"


### PR DESCRIPTION
It depends on 14.0 alpha version infrastructure; we shouldn't need it for triggering the test builds for beta.