### PR TITLE
fix(developer): touch layout editor character map integration

### DIFF
--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -686,7 +686,7 @@ end;
 
 procedure TframeTouchLayoutBuilder.SetupCharMapDrop;
 begin
-  GetCharMapDropTool.Handle(cef.cefwp, cmimDefault, CharMapDragOver, CharMapDragDrop);
+  GetCharMapDropTool.Handle(cef, cmimDefault, CharMapDragOver, CharMapDragDrop);
 end;
 
 end.

--- a/windows/src/engine/keyman/touchkeyboard/Keyman.System.FrameworkInputPane.pas
+++ b/windows/src/engine/keyman/touchkeyboard/Keyman.System.FrameworkInputPane.pas
@@ -63,6 +63,7 @@ type
 implementation
 
 uses
+  System.Types,
   Winapi.ActiveX,
   Keyman.System.DebugLogClient;
 


### PR DESCRIPTION
Fixes #2577.

The touch layout editor was not accepting characters inserted from character map by double-clicking or using the menu, only by drag+drop.