### PR TITLE
fix(developer/compiler): compiler sometimes merges touch platform support wrongly in .keyboard_info

### DIFF
--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -118,6 +118,7 @@ uses
   BCP47Tag,
   JsonUtil,
   Keyman.System.KeyboardInfoFile,
+  Keyman.System.KeyboardUtils,
   Keyman.System.LanguageCodeUtils,
   utilfiletypes,
   VersionInfo;
@@ -925,6 +926,17 @@ var
     end;
   end;
 
+  function packageContainsKeyboardJs(const id: string): Boolean;
+  var
+    kf: TKeyboardInfoMap;
+  begin
+    for kf in FPackageJSFileInfos do
+      if SameText(TKeyboardUtils.KeyboardFileNameToID(kf.Filename), id) then
+        Exit(True);
+
+    Result := False;
+  end;
+
 begin
   try
     // Validate pre-existing platformSupport
@@ -978,8 +990,11 @@ begin
       AddNewPair('windows', 'full');
       AddNewPair('macos', 'full');
       AddNewPair('linux', 'full');
-      AddNewPair('android', 'full');
-      AddNewPair('ios', 'full');
+      if packageContainsKeyboardJs(TKeyboardUtils.KeyboardFileNameToId(keyboardFile.Filename)) then
+      begin
+        AddNewPair('android', 'full');
+        AddNewPair('ios', 'full');
+      end;
     end
     else
     begin
@@ -1006,20 +1021,23 @@ begin
         if target = ktLinux then
           AddNewPair('linux', 'full');
 
-        // FPackageKMXFileInfos can contain target information for web/mobile targets.
-        // This is a current limitation of FPackageJSFileInfos if there's no kmx files
-        if (target = ktMobile) then
+        if packageContainsKeyboardJs(TKeyboardUtils.KeyboardFileNameToId(keyboardFile.Filename)) then
         begin
-          AddNewPair('android', 'full');
-          AddNewPair('ios', 'full');
-        end;
-        if (target = ktIphone) or (target = ktIpad) then
-        begin
-          AddNewPair('ios', 'full');
-        end;
-        if (target = ktAndroidphone) or (target = ktAndroidtablet) then
-        begin
-          AddNewPair('android', 'full');
+          // FPackageKMXFileInfos can contain target information for web/mobile targets.
+          // This is a current limitation of FPackageJSFileInfos if there's no kmx files
+          if (target = ktMobile) then
+          begin
+            AddNewPair('android', 'full');
+            AddNewPair('ios', 'full');
+          end;
+          if (target = ktIphone) or (target = ktIpad) then
+          begin
+            AddNewPair('ios', 'full');
+          end;
+          if (target = ktAndroidphone) or (target = ktAndroidtablet) then
+          begin
+            AddNewPair('android', 'full');
+          end;
         end;
       end;
     end;

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 2020-02-11 13.0.66 beta
+* Bug Fix(Compiler): Merge of .keyboard_info files would not always get platform support correct (#2621)
+
 ## 2020-01-28 13.0.65 beta
 * Feature(Compiler): Hotkeys defined in .kmn no longer need to be quoted (#2432)
 * Feature(IDE): Enhanced Lexical Model Editor (#2396)


### PR DESCRIPTION
Fixes #2498.

The .keyboard_info merge was incorrectly assuming the presence of a .js in the .kmp file if the source .kmn file asserted support for touch platforms, when testing the .kmx files. Now, platform support for Android and iOS will only be added if the package actually includes the .js file that makes that possible.