### PR TITLE
fix(web): patches Float and Toggle UI issues

### DIFF
--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -127,7 +127,7 @@ if(!window['keyman']['ui']['name']) {
 
       // Check required interface alignment and default keyboard
       var opt=util['getOption']('ui'),dfltKeyboard='English';
-      if(typeof(opt) == 'object')
+      if(opt && typeof(opt) == 'object')
       {
         if(typeof(opt['position']) == 'string' && opt['position'] == 'right') 
           ui.floatRight = true;
@@ -484,7 +484,7 @@ if(!window['keyman']['ui']['name']) {
     keymanweb['addEventListener']('controlfocused',
       function(params)
       {
-        if(params['activeControl'] == null || params['activeControl']['LEnabled'])
+        if(params['activeControl'] == null || params['activeControl']['_kmwAttachment'])
         {
           /*if(keymanweb._IsIEEditableIframe(Ltarg))
             Ltarg = Ltarg.ownerDocument.parentWindow.frameElement;

--- a/web/source/kmwuitoggle.ts
+++ b/web/source/kmwuitoggle.ts
@@ -596,6 +596,11 @@ if(!window['keyman']['ui']['name']) {
         _k.className='selected'; ui.selectedMenuItem=_k;
       }
 
+      // Occurs for desktop form-factors when no keyboard (aka the sys default) is active.
+      if(!ui.oskButton) {
+        return;
+      }
+
       // Hide the OSK button for CJK keyboards (or non-mapped)
       if(lgCode=='cmn' || lgCode=='jpn' || lgCode=='kor')
       {


### PR DESCRIPTION
Fixes #2595.

While I was at it, I also checked the other UI styles and noticed that Float seemed to be broken.  A small bit of investigation later, and it turned out that the `'LEnabled'` check was the only reference to the property; it was changed in KeymanWeb itself a while back by some of the refactoring.  Conditioning on the referenced element being 'attached' seems a natural fix and gets the Float UI working properly, too.