### PR TITLE
change(web): build.sh recompilation of LMLayer only performed when needed

### DIFF
--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -73,12 +73,6 @@ minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedL
 minifier_lang_specs="--language_in ECMASCRIPT5 --language_out ECMASCRIPT5"
 minifycmd="$JAVA -jar $minifier --compilation_level WHITESPACE_ONLY $minifier_warnings --generate_exports $minifier_lang_specs"
 
-if ! [ -f $minifier ];
-then
-    echo File $minifier does not exist:  have you set the environment variable \$CLOSURECOMPILERPATH?
-    exit 1
-fi
-
 readonly minifier
 readonly minifycmd
 
@@ -295,6 +289,13 @@ npm install --no-optional
 
 if [ $? -ne 0 ]; then
     fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+fi
+
+# NPM install is required for the file to be present.
+if ! [ -f $minifier ];
+then
+    echo File $minifier does not exist:  have you set the environment variable \$CLOSURECOMPILERPATH?
+    exit 1
 fi
 
 generate_environment_ts_file ( ) {

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -6,9 +6,10 @@
 display_usage ( ) {
     echo "build.sh [-ui | -test | -embed | -web | -debug_embedded] [-no_minify] [-clean]"
     echo
-    echo "  -ui               to compile desktop user interface modules to output folder"
+    echo "  -ui               to compile only desktop user interface modules"
     echo "  -test             to compile for testing without copying resources or" 
-    echo "                    updating the saved version number."
+    echo "                    updating the saved version number.  Assumes dependencies
+                              are unaltered."
     echo "  -embed            to compile only the KMEA/KMEI embedded engine."
     echo "  -web              to compile only the KeymanWeb engine."
     echo "  -debug_embedded   to compile a readable version of the embedded KMEA/KMEI code"
@@ -41,14 +42,6 @@ fail() {
 WEB_TARGET=( "keymanweb.js" )
 UI_TARGET=( "kmwuibutton.js" "kmwuifloat.js" "kmwuitoggle.js" "kmwuitoolbar.js" )
 EMBED_TARGET=( "keyman.js" )
-
-# Ensure the dependencies are downloaded.  --no-optional should help block fsevents warnings.
-echo "Node.js + dependencies check"
-npm install --no-optional
-
-if [ $? -ne 0 ]; then
-    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
-fi
 
 # Variables for the LMLayer
 PREDICTIVE_TEXT_SOURCE="../../common/predictive-text/unit_tests/in_browser/resources/models/simple-trie.js"
@@ -295,6 +288,14 @@ readonly BUILD_FULLWEB
 readonly BUILD_DEBUG_EMBED
 readonly BUILD_COREWEB
 readonly DO_MINIFY
+
+# Ensure the dependencies are downloaded.  --no-optional should help block fsevents warnings.
+echo "Node.js + dependencies check"
+npm install --no-optional
+
+if [ $? -ne 0 ]; then
+    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+fi
 
 generate_environment_ts_file ( ) {
     if [ -f $ENVIRONMENT_FILE ];


### PR DESCRIPTION
This simply fixes a couple of minor gripes that've been bugging me for a bit, along with one small logic error.

Small logic error:  proper error reporting if Node.js isn't installed.  Gotta read that error code in the right spot.

Minor gripe 1:  the `-test` and `-ui` compilation options really shouldn't force a rebuild of the lm-layer - these options exist for streamlined, rapid re-compilation for testing during development.  So, I tweaked the script a bit to allow skipping lm-layer compilation for these options.

Minor gripe 2:  it's rather bad form for `./build.sh -h` to trigger a `npm install` before it, you know, actually displays the help message.  (Also, it _**absolutely**_ shouldn't require compiling the lm-layer, which was the case before this PR!)

Since a `npm install` isn't logically required for displaying a simple help message, I simply relocated the `npm install` to after the `-h` flag check (which exits the script after outputting the message).  Since the lm-layer part is being moved for "gripe 1", this doesn't cause any breaks.