### PR TITLE
fix(ios): Fixes lexical model url generation for updates

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -533,7 +533,7 @@ public class ResourceDownloadManager {
           }
         }
       } else if let lex = res as? InstallableLexicalModel {
-        if let filename = Manager.shared.apiLexicalModelRepository.lexicalModels?[lex.id]?.filename,
+        if let filename = Manager.shared.apiLexicalModelRepository.lexicalModels?[lex.id]?.packageFilename,
            let path = URL.init(string: filename) {
           if let batch = self.buildLexicalModelDownloadBatch(for: lex, withFilename: path, asActivity: .update) {
             batches.append(batch)

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,9 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-02-11 13.0.67 beta
+* Bug fix: fixed issue with sample apps and engine keyboard switcher (#2626)
+* Bug fix: fixed issue with dictionary updates (#2627)
+
 ## 2020-02-10 13.0.66 beta
 * Bug fix: Fixed migration of old resources to new app versions, updated default MTNT dictionary (#2512)
 * Bug fix: Fixed issues when iOS system transitions between light and dark modes (#2593, #2594)

--- a/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
+++ b/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
@@ -21,7 +21,8 @@ class KeyboardViewController: InputViewController {
     #endif
     Manager.applicationGroupIdentifier = "group.KM4I"
 
-    topBarImageSource = ImageBannerViewController(nibName: "ImageBanner", bundle: Bundle(for: KeyboardViewController.self))
+    let bundle = Bundle(for: KeyboardViewController.self)
+    topBarImageSource = ImageBannerViewController(nibName: "ImageBanner", bundle: bundle)
 
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }


### PR DESCRIPTION
Fixes #2597.

It usually helps for a file to actually be a .zip file when you try to decompress it.  Try as you might, it just doesn't work the same when you try to decompress a renamed .js file.

---

Also fixes a lint warning about line length by splitting the offending line into two.