### PR TITLE
fix(developer/ide): model debugger mime type mismatch

### DIFF
--- a/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Base.pas
+++ b/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Base.pas
@@ -58,7 +58,11 @@ begin
     Exit;
   end;
 
-  AResponseInfo.ContentType :=  AResponseInfo.HTTPServer.MIMETable.GetFileMIMEType(AFileName);
+  if AResponseInfo.ContentType = '' then
+  begin
+    AResponseInfo.HTTPServer.MIMETable.LoadTypesFromOS := False;
+    AResponseInfo.ContentType := AResponseInfo.HTTPServer.MIMETable.GetFileMIMEType(AFileName);
+  end;
   AResponseInfo.CharSet := 'UTF-8';
   AResponseInfo.ContentLength := FileSizeByName(AFileName);
 //AResponseInfo.LastModified := GetFileDate(doc);

--- a/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Debugger.pas
+++ b/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Debugger.pas
@@ -652,6 +652,7 @@ begin
       Delete(doc, 1, 6);
 
       // Models always expire immediately
+      AResponseInfo.ContentType := 'application/javascript';
       AResponseInfo.Expires := EncodeDate(1990, 1, 1);   // I4037
       AResponseInfo.CacheControl := 'no-cache, no-store';   // I4037
       AResponseInfo.LastModified := Now;   // I4037
@@ -686,7 +687,11 @@ begin
 
     // Serve the file
 
-    AResponseInfo.ContentType :=  AResponseInfo.HTTPServer.MIMETable.GetFileMIMEType(doc);
+    if AResponseInfo.ContentType = '' then
+    begin
+      AResponseInfo.HTTPServer.MIMETable.LoadTypesFromOS := False;
+      AResponseInfo.ContentType :=  AResponseInfo.HTTPServer.MIMETable.GetFileMIMEType(doc);
+    end;
     AResponseInfo.CharSet := 'UTF-8';
     AResponseInfo.ContentLength := FileSizeByName(doc);
   //AResponseInfo.LastModified := GetFileDate(doc);

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,8 @@
 # Keyman Developer Version History
 
+## 2020-02-12 13.0.72 beta
+* Bug Fix(IDE/Debugger): MIME type mismatch on some systems could cause web test to fail (#2633)
+
 ## 2020-02-11 13.0.66 beta
 * Bug Fix(Compiler): Merge of .keyboard_info files would not always get platform support correct (#2621)
 * Bug Fix(Compiler): Missing keyboard file led to misleading error in package compiler (#2620)


### PR DESCRIPTION
Fixes #2630.

The MIME type for .js was being read from the registry, which on some systems has been corrupted to text/plain, which causes Chrome to abort loading the script. The fix is to avoid loading the system registered MIME types, which we don't need anyway, because all the MIME types we are using are in the default hard-coded list.