### PR TITLE
fix(oem): Update version of androidx.appcompat

### DIFF
--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -111,10 +111,11 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation "com.google.firebase:firebase-core:17.2.1"
+    implementation "com.google.firebase:firebase-analytics:17.2.1"
+    implementation "com.google.firebase:firebase-messaging:20.0.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
     implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
         transitive = true


### PR DESCRIPTION
On older Android 5.0 (API 21) devices without Play Store, androidx.appcompat:1.1.0 is causing the FirstVoices app to crash inflating WebView.

* Per SO suggestion, update androidx.appcompat to version `1.2.0-alpha02`

While updating build.gradle
* Also split `firebase-core` dependency to `firebase-analytics` and `firebase-messaging` (mirrors kMAPro)