### PR TITLE
fix(web): fixes positioning of native-mode language menu

### DIFF
--- a/web/history.md
+++ b/web/history.md
@@ -1,6 +1,6 @@
 # KeymanWeb Version History
 
-## 2020-02-13
+## 2020-02-13 13.0.38 beta
 * Bug fix: language menu not positioned correctly for touch-based devices (#2642)
 
 ## 2020-02-03 13.0.33 beta

--- a/web/history.md
+++ b/web/history.md
@@ -1,5 +1,8 @@
 # KeymanWeb Version History
 
+## 2020-02-13
+* Bug fix: language menu not positioned correctly for touch-based devices (#2642)
+
 ## 2020-02-03 13.0.33 beta
 * Bug fix: BKSP not working corrrectly with design-mode iframes (#2561)
 

--- a/web/source/dom/touchAliasElement.ts
+++ b/web/source/dom/touchAliasElement.ts
@@ -601,7 +601,9 @@ namespace com.keyman.dom {
 
       if(window['keyman']) {
         var osk = window['keyman'].osk;
-        oskHeight = osk._Box.offsetHeight;
+        if(osk && osk._Box) {
+          oskHeight = osk._Box.offsetHeight;
+        }
       }
 
       // Get the absolute position of the caret

--- a/web/source/osk/languageMenu.ts
+++ b/web/source/osk/languageMenu.ts
@@ -234,9 +234,8 @@ namespace com.keyman.osk {
       }
       s.height=menuHeight+'px';
 
-      // Position menu at bottom of screen, but referred to top (works for both iOS and Firefox)
-      s.top=(dom.Utils.getAbsoluteY(osk._Box)+osk._Box.offsetHeight-menuHeight+window.pageYOffset-6)+'px';
-      s.bottom='auto';
+      // Position menu at bottom of screen using the same positioning model as the OSK.
+      s.bottom='0px';
 
       // Explicitly set the scroller and index heights to the container height
       mx.style.height=m2.style.height=s.height;

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -345,7 +345,7 @@ div.android #keytip {background-color:#f00;}
 .kmw-osk-none:before{content:'Installing keyboard...';}
       
 /* OSK language menu styles */
-#kmw-language-menu{position:absolute;left:0;width:232px;max-width:232px;z-index:10004;background-color:rgba(128,128,128,1);
+#kmw-language-menu{position:fixed;left:0;width:232px;max-width:232px;z-index:10004;background-color:rgba(128,128,128,1);
         border:3px solid #888;padding:0;border-radius:4px;-webkit-border-radius:4px;
         box-shadow:3px 3px 2px #ccc;-webkit-box-shadow:3px 3px 2px #ccc; 
         overflow:hidden;


### PR DESCRIPTION
I'm honestly surprised this hadn't been reported as an issue yet.

While testing something else, I noticed some very odd behavior with the touch-OSK's display of the native-mode language menu:.  The following images are from use of the testing/attachment-api testing page (in Chrome emulation, with 5 'input' elements labeled with text from 'a' through 'e'.):

Position where I clicked on the Globe key:

<img width="289" alt="Screen Shot 2020-02-12 at 11 01 17 AM" src="https://user-images.githubusercontent.com/25213402/74303680-49140e00-4d8d-11ea-9dce-05f5850d8786.png">

Position where the language menu actually appeared:

<img width="288" alt="Screen Shot 2020-02-12 at 11 01 42 AM" src="https://user-images.githubusercontent.com/25213402/74303723-677a0980-4d8d-11ea-8b02-c312700b184e.png">

In short, for long web pages, the language menu wouldn't properly align with the OSK's position.  Also, as may be noticed, the language menu was at an 'absolute' position on the page and would not scroll with the page.

---

Rather than do anything terribly complicated, this PR sets the language menu to use a similar positioning strategy to that of the OSK - `position: fixed; bottom: 0`.  With these changes in place, the language menu scrolls easily with the OSK and is always correctly positioned, at least in my tests.

I also threw in an extra fix for an error I noted on the "input recorder" test-resource page with touch elements; I was using that page when I first discovered the language-menu error.  (It's a naturally-long web page, thus would also suffer from the error.)