### PR TITLE
change(android): Update app dependencies

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -117,7 +117,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api(name: 'keyman-engine', ext: 'aar')
     implementation "com.google.firebase:firebase-analytics:17.2.1"

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -66,7 +66,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'commons-io:commons-io:2.6'
 

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api(name: 'keyman-engine', ext: 'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api (name:'keyman-engine', ext:'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api (name:'keyman-engine', ext:'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -19,7 +19,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'androidx.test:core:1.1.0'

--- a/android/history.md
+++ b/android/history.md
@@ -1,8 +1,13 @@
 # Keyman for Android Version History
 
-## 2020-02-12 13.0.6056 beta
+## 2020-02-12 13.0.6057 beta
 * Change:
   * Update in-app help for 13.0 (#2641)
+  * Update oem dependency to `androidx.appcompat:appcompat:1.2.0-alpha02` to
+    fix WebView crash on Android 5.0 devices (#2640)
+
+## 2020-02-11 13.0.6056 beta
+* No change to Keyman for Android (updated Keyman Web Engine, #2623)
 
 ## 2020-02-10 13.0.6055 beta
 * Change:

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,10 @@
 # Keyman for Android Version History
 
+## 2020-02-13 13.0.6058 beta
+* Change:
+  * Update rest of Android apps' dependency to `androidx.appcompat:appcompat:1.2.0-alpha02` to
+    fix WebView crash on Android 5.0 devices (#2644)
+
 ## 2020-02-12 13.0.6057 beta
 * Change:
   * Update in-app help for 13.0 (#2641)


### PR DESCRIPTION
#2640 fixed the FirstVoices OEM app from crashing on Android 5.0 devices.

This applies the same fix (updating to `androidx.appcompat:appcompat:1.2.0-alpha02`) for all the other Android apps.

* Also fix up history.md entries

### Testing Configuration
Android Studio emulator for Pixel 2 XL API 21 (no Play Store)