### PR TITLE
fix(ios): initial-install check within Migrations

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
@@ -116,6 +116,11 @@ public enum Migrations {
 
     // Detect possible version matches.
     let userResources = Storage.active.userDefaults.userResources ?? []
+
+    // If there are no pre-existing resources and we need to detect a version, this is a fresh install.
+    if userResources.count == 0 {
+      return [Version.freshInstall]
+    }
     let possibleMatches: [Version] = resourceHistory.compactMap { set in
       if set.version < Version("12.0")! {
         // Are all of the version's default resources present?
@@ -183,7 +188,7 @@ public enum Migrations {
       }
     }
 
-    if lastVersion != nil {
+    if lastVersion != nil && lastVersion != Version.freshInstall {
       // Time to deinstall the old version's resources.
       // First, find the most recent version with a listed history.
       let possibleHistories: [VersionResourceSet] = resourceHistory.compactMap { set in

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
@@ -14,6 +14,7 @@ public struct Version: Comparable {
   public static let current = Version("13.0.65")!
 
   // The Engine first started tracking the 'last loaded version' in 12.0.
+  public static let freshInstall = Version("0.0")!
   public static let firstTracked = Version("12.0")!
 
   // The Keyman App's file browser was first added in 13.0 alpha;


### PR DESCRIPTION
Fixes an issue introduced by #2578 - the app would not automatically install the default lexical model for English.

Turns out I made an invalid assumption; `Migration.updateResources` was not able to handle initial installations because it didn't realize there was no prior installation.  The keyboard was being installed due to our failsafe "if no keyboards, reinstall EuroLatin" check later in the code.

By adding a check for this condition, signaling it with a simple `Version.freshInstall` sentinel, that control path can now properly "upgrade"/"migrate" from a nil install, handling both initial installs and migration for prior app/engine versions.