### PR TITLE
fix(common, linux): Misc keyboard processor fixes for Xenial

### DIFF
--- a/common/engine/keyboardprocessor/src/utfcodec.hpp
+++ b/common/engine/keyboardprocessor/src/utfcodec.hpp
@@ -19,7 +19,14 @@
 
 typedef uint32_t  uchar_t;
 
+/* Intentional fallthrough */
+#if defined(__clang__)
 #define fallthrough [[clang::fallthrough]]
+#elif defined(__GNUC__) && __GNUC___ >=  7
+#define fallthrough [[gnu::fallthrough]]
+#else
+#define fallthrough ((void)0)
+#endif
 
 template <int N>
 struct _utf_codec

--- a/common/engine/keyboardprocessor/src/utfcodec.hpp
+++ b/common/engine/keyboardprocessor/src/utfcodec.hpp
@@ -22,7 +22,7 @@ typedef uint32_t  uchar_t;
 /* Intentional fallthrough */
 #if defined(__clang__)
 #define fallthrough [[clang::fallthrough]]
-#elif defined(__GNUC__) && __GNUC___ >=  7
+#elif defined(__GNUC__) && __GNUC__ >=  7
 #define fallthrough [[gnu::fallthrough]]
 #else
 #define fallthrough ((void)0)

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,13 @@
 # Keyman for Linux Version History
 
+# 2020-02-17 13.0.29 beta
+* Bug Fix: 
+  * Fix keyboard processor compilation for Xenial (#2648)
+ 
+# 2020-02-11 13.0.28.beta
+* Bug Fix:
+  * Incorporate packaging fixes from 14.0 development (#2624)
+
 ## 2020-02-10 13.0.27 beta
 * Bug Fix:
   * Fix setting context when >= 64 characters (common #2607)

--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -3,9 +3,9 @@ Section: utils
 Priority: optional
 Maintainer: Daniel Glassey <wdg@debian.org>
 Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, pkg-config,
- libkmnkbp-dev (>=0.0.0~), libibus-1.0-dev (>= 1.2), libjson-glib-dev (>= 1.4.0),
- libgtk-3-dev
-Standards-Version: 3.9.8
+ libkmnkbp-dev (>=0.0.0~), libibus-1.0-dev (>= 1.2), libjson-glib-dev (>= 1.4.0) <!pkg.keyman-config.xenial>,
+ libjson-glib-dev (1.1.2) <pkg.keyman-config.xenial>, libgtk-3-dev
+Standards-Version: 4.5.0
 Homepage: http://www.keyman.com
 
 Package: ibus-keyman

--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -4,6 +4,7 @@ default: clean version man
 	python3 setup.py build
 
 install: # run as sudo
+	pip3 install qrcode
 	python3 setup.py install
 	# install icons
 	mkdir -p /usr/local/share/keyman/icons
@@ -26,7 +27,6 @@ uninstall: clean # run as sudo
 	rm -f /usr/local/bin/km-package-install
 	rm -f /usr/local/bin/km-package-list-installed
 	rm -f /usr/local/bin/km-package-uninstall
-	rm -f /usr/local/bin/qr
 
 clean:
 	-rm -rf dist make_deb build keyman_config/version.py *.egg-info __pycache__

--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -2,8 +2,9 @@ Source: keyman-config
 Maintainer: Daniel Glassey <wdg@debian.org>
 Section: python
 Priority: optional
-Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), bash-completion,
- python3-magic, python3-qrcode
+Build-Depends: dh-python, python3-setuptools, python3-all, python3-pip, debhelper (>= 9), bash-completion,
+ python3-magic, python3-qrcode <!pkg.keyman-config.xenial>,
+ python-qrcode <pkg.keyman-config.xenial>
 Standards-Version: 4.5.0
 Homepage: http://www.keyman.com/
 

--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -3,8 +3,7 @@ Maintainer: Daniel Glassey <wdg@debian.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9), bash-completion,
- python3-magic, python3-qrcode <!pkg.keyman-config.xenial>,
- python-qrcode <pkg.keyman-config.xenial>
+ python3-magic, python3-qrcode
 Standards-Version: 4.5.0
 Homepage: http://www.keyman.com/
 


### PR DESCRIPTION
Fixes #2645 and addresses some of #1648 

* Define `fallthrough` macro appropriate for the gcc version on a particular LTS
* Use a lower version of `libjson-glib-dev` for Xenial (the version it comes with)

With this PR, keyboard processor builds cleanly on Xenial. But I still have integration issues with ibus (Keyman keyboards can install, but ibus doesn't see them)