### PR TITLE
fix(common): Update configure-repo.sh to ln commit-msg-defs

### DIFF
--- a/configure-repo.sh
+++ b/configure-repo.sh
@@ -26,6 +26,9 @@ case $1 in
     else
       ln -sf "$PWD/resources/git-hooks/commit-msg" "$PWD/.git/hooks/commit-msg"
       ln -sf "$PWD/resources/git-hooks/prepare-commit-msg" "$PWD/.git/hooks/prepare-commit-msg"
+
+      # For Linux
+      ln -sf "$PWD/resources/git-hooks/commit-msg-defs" "$PWD/.git/hooks/commit-msg-defs"
     fi
     ;;
   *)


### PR DESCRIPTION
On Linux, the `configure-repo.sh` script to setup the repo for Conventional Commits isn't linking `commit-msg-defs`.

This prevented commits from being added.

Not an issue on Windows or macOS