### PR TITLE
feat(ios): cleans up old file location on install success

### DIFF
--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -36,7 +36,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             completionHandler: { package in
                               // We choose to prompt the user for comfirmation, rather
                               // than automatically installing the package.
-                              rfm.promptPackageInstall(of: package, in: vc, isCustom: true)
+                              rfm.promptPackageInstall(of: package, in: vc, isCustom: true, successHandler: { _ in
+                                do {
+                                  // Since we've successfully installed the resource, delete the original file.
+                                  // The 'imported' file will continue to exist.
+                                  if url != destinationUrl {
+                                    try FileManager.default.removeItem(at: url)
+                                  }
+                                } catch {
+                                  log.error(error)
+                                }
+                              })
                             })
     } else {
       log.error("Cannot find app's root UIViewController")

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -69,6 +69,15 @@ class PackageBrowserViewController: UIDocumentBrowserViewController, UIDocumentB
                               // We choose to prompt the user for comfirmation, rather
                               // than automatically installing the package.
                               rfm.promptPackageInstall(of: package, in: self, isCustom: true, successHandler: { _ in
+                                do {
+                                  // Since we've successfully installed the resource, delete the original file.
+                                  // The 'imported' file will continue to exist.
+                                  if url != destinationUrl {
+                                    try FileManager.default.removeItem(at: url)
+                                  }
+                                } catch {
+                                  log.error(error)
+                                }
                                 // Auto-dismiss the document browser upon successful KMP install.
                                 // It's likely quite rare that someone would want to install 2+ at once.
                                 self.navigationController?.popViewController(animated: true)


### PR DESCRIPTION
As the app currently stands, successful installation of a language resource from a KMP file results in a duplicate file being stored in Keyman's documents folder.  However, we currently do nothing with the original file, sometimes causing the "Recents" tab seen below to show both copies of the file.  (That state is not seen here, though.)

![Screen Shot 2020-02-14 at 1 57 00 PM](https://user-images.githubusercontent.com/25213402/74508557-e445e880-4f31-11ea-91b7-176ea034cb93.png)

Rather than leave the original copy in the downloads folder, _on successful installation_ we could instead simply delete the original file, indicating that it has been fully "imported" and installed.  Since it's an exposed file in the iOS file system, Keyman does, in fact, have access to delete that file.

This PR's changes do exactly that - so if the user backs out or installation is not successful, the original file will not be deleted.  (This allows the user to retry/restart installation without having to find the duplicate's location.)

Note that this does not establish read-only permission on the "imported" file - thus allowing the user to curate which files Keyman keeps around if desired.