### PR TITLE
fix(mac): invalid build script params removed

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -443,7 +443,7 @@ elif $PREPRELEASE ; then
     eval "./build.sh"
     popd
 
-    eval "$KM4MIM_BASE_PATH/make-km-dmg.sh" -version $KM_VERSION $QUIET_FLAG
+    eval "$KM4MIM_BASE_PATH/make-km-dmg.sh" $QUIET_FLAG
     if [ $? == 0 ]; then
         displayInfo "Creating disk image succeeded!" ""
     else


### PR DESCRIPTION
I accidentally pulled old parameters into mac/build.sh for the
make-km-dmg.sh script when merging from beta. The script no longer
requires `-version`. This fixes that.