### PR TITLE
fix(developer): crash in context help

### DIFF
--- a/windows/src/developer/TIKE/main/UfrmHelp.pas
+++ b/windows/src/developer/TIKE/main/UfrmHelp.pas
@@ -132,7 +132,7 @@ begin
           FormName := (FHelpControl as TTIKEForm).HelpTopic
         else if FHelpControl is TCustomForm then
           FormName := FHelpControl.ClassName
-        else
+        else if (FHelpControl <> nil) then
         begin
           o := FHelpControl.Owner;
           while ((o is TframeCEFHost) or not(o is TTIKEForm)) and (o <> nil) do


### PR DESCRIPTION
Fixes sillsdev/keyman-issues#6207.
Fixes sillsdev/keyman-issues#5801.
Fixes sillsdev/keyman-issues#5742.
Fixes sillsdev/keyman-issues#6186.
Fixes sillsdev/keyman-issues#6124.
Fixes sillsdev/keyman-issues#5647.
Fixes sillsdev/keyman-issues#5726.
Fixes sillsdev/keyman-issues#6149.
Fixes sillsdev/keyman-issues#6228.
Fixes sillsdev/keyman-issues#6001.
Fixes sillsdev/keyman-issues#6148.
Fixes sillsdev/keyman-issues#6159.
Fixes sillsdev/keyman-issues#6171.

This fixes a crash when context help is unable to determine the
current context.