### PR TITLE
fix(ios): Engine demo fix

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -1134,7 +1134,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "#if which swiftlint >/dev/null; then\n#    swiftlint --config ../../.swiftlint.yml\n#else\n#    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n#fi\n";
 		};
 		C0A5FF391F6684DE00BE740C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1147,7 +1147,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "#if which swiftlint >/dev/null; then\n#    swiftlint --config ../../.swiftlint.yml\n#else\n#    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n#fi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		CE808A4D236697D500713E6B /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0FC9FC22D66D9E00D33F86 /* Reachability.framework */; };
 		CE808A4F236697D800713E6B /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1687ACCC1FD8DE5300926D69 /* XCGLogger.framework */; };
 		CE808A532366980A00713E6B /* Zip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 165C8B8B1FD8220600D4A78D /* Zip.framework */; };
+		CE976D4F23FA380700FFDF3A /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0FC9FC22D66D9E00D33F86 /* Reachability.framework */; };
+		CE976D5023FA380700FFDF3A /* Reachability.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0FC9FC22D66D9E00D33F86 /* Reachability.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -304,6 +306,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				C059FCB81FD924DC00BD1A64 /* Zip.framework in Embed Frameworks */,
+				CE976D5023FA380700FFDF3A /* Reachability.framework in Embed Frameworks */,
 				C07705DE1FD8ED9E00D2F3C7 /* ObjcExceptionBridging.framework in Embed Frameworks */,
 				C06D375E1F82089200F61AE0 /* KeymanEngine.framework in Embed Frameworks */,
 				CE2B1E4A21B60FB1007D092E /* DeviceKit.framework in Embed Frameworks */,
@@ -481,6 +484,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C06D37571F82060900F61AE0 /* KeymanEngine.framework in Frameworks */,
+				CE976D4F23FA380700FFDF3A /* Reachability.framework in Frameworks */,
 				C07705DD1FD8ED9E00D2F3C7 /* ObjcExceptionBridging.framework in Frameworks */,
 				C07705DF1FD8ED9E00D2F3C7 /* XCGLogger.framework in Frameworks */,
 				CE2B1E4821B60E8A007D092E /* DeviceKit.framework in Frameworks */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
@@ -115,30 +115,4 @@ extension Colors {
       }
     }
   }
-
-  public static var helpBubbleGradient1: UIColor {
-    get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient1")!
-      } else {
-        return UIColor(red: 253.0 / 255.0,
-                       green: 244.0 / 255.0,
-                       blue: 196.0 / 255.0,
-                       alpha: 1.0)
-      }
-    }
-  }
-
-  public static var helpBubbleGradient2: UIColor {
-    get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient2")!
-      } else {
-        return UIColor(red: 233.0 / 255.0,
-                       green: 224.0 / 255.0,
-                       blue: 176.0 / 255.0,
-                       alpha: 1.0)
-      }
-    }
-  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
@@ -105,4 +105,30 @@ public class Colors {
       }
     }
   }
+
+  public static var helpBubbleGradient1: UIColor {
+    get {
+      if #available(iOSApplicationExtension 11.0, *) {
+        return UIColor(named: "HelpBubbleGradient1", in: engineBundle, compatibleWith: nil)!
+      } else {
+        return UIColor(red: 253.0 / 255.0,
+                       green: 244.0 / 255.0,
+                       blue: 196.0 / 255.0,
+                       alpha: 1.0)
+      }
+    }
+  }
+
+  public static var helpBubbleGradient2: UIColor {
+    get {
+      if #available(iOSApplicationExtension 11.0, *) {
+        return UIColor(named: "HelpBubbleGradient2", in: engineBundle, compatibleWith: nil)!
+      } else {
+        return UIColor(red: 233.0 / 255.0,
+                       green: 224.0 / 255.0,
+                       blue: 176.0 / 255.0,
+                       alpha: 1.0)
+      }
+    }
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/HelpBubbleGradient1.colorset/Contents.json
+++ b/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/HelpBubbleGradient1.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "253",
+          "red" : "0.992",
           "alpha" : "1.000",
-          "blue" : "196",
-          "green" : "244"
+          "blue" : "0.769",
+          "green" : "0.957"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "126",
+          "red" : "0.494",
           "alpha" : "1.000",
-          "blue" : "98",
-          "green" : "122"
+          "blue" : "0.384",
+          "green" : "0.478"
         }
       }
     }

--- a/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/HelpBubbleGradient2.colorset/Contents.json
+++ b/ios/engine/KMEI/KeymanEngine/Keyboard Colors.xcassets/HelpBubbleGradient2.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "233",
+          "red" : "0.914",
           "alpha" : "1.000",
-          "blue" : "176",
-          "green" : "224"
+          "blue" : "0.690",
+          "green" : "0.878"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "106",
+          "red" : "0.416",
           "alpha" : "1.000",
-          "blue" : "78",
-          "green" : "102"
+          "blue" : "0.306",
+          "green" : "0.400"
         }
       }
     }

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,5 +1,8 @@
 # Keyman for iPhone and iPad Version History
 
+## 2020-02-19 13.0.72 beta
+* Fixes issue with KeymanEngine demo app and missing color definition in KeymanEngine library (#2662)
+
 ## 2020-02-14 13.0.70 beta
 * Change: restyles suggestion banner to more closely match the iOS system default (#2629)
 


### PR DESCRIPTION
While working on #2649, I stumbled upon the solution to get the old KeymanEngineDemo target compiling properly; as it turns out, a similar project as a "test container" for file-oriented user tests seems ideal.  Getting the 'original' demo project up and running should help with developing a more focused "test container".

While it's not perfect, these changes are sufficient to get the demo up and running, at least at a basic level.

![Screen Shot 2020-02-17 at 11 01 39 AM](https://user-images.githubusercontent.com/25213402/74625363-9c67d100-517e-11ea-85fc-9b2406baa705.png)

On the iPhone SE, things look proper; the layout issues are likely related (at least in part) to either the notch or the larger resolution of the iPhone X.

Changelist:

- Turns out the source of the compile errors?  Use of `swiftlint` on KeymanEngine code.
  - We'll probably want a pass at KeymanEngine code formatting separately in the future, but for now this can wait.
- The `Reachability` framework wasn't included, causing an instant crash upon launch
- The color definitions needed a bit more tweaking in their organization; the incorrect location caused a crash upon opening the keyboard.