### PR TITLE
[Linux] Fix tier used in debian watch files

### DIFF
--- a/common/engine/keyboardprocessor/debian/watch
+++ b/common/engine/keyboardprocessor/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/keyman-keyboardprocessor-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/keyman-keyboardprocessor-(.+)\.tar\.gz debian uupdate

--- a/common/engine/keyboardprocessor/debian/watch
+++ b/common/engine/keyboardprocessor/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/keyman-keyboardprocessor-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/keyman-keyboardprocessor-(.+)\.tar\.gz debian uupdate

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,13 @@
 # Keyman for Linux Version History
 
+## 2020-02-17 13.0.29 beta
+* Bug Fix:
+  * Fix how tier is determined for debian watch files (#2664)
+
+## 2020-02-11 13.0.28 beta
+* Bug Fix:
+  * Incorporate packaging fixes from 14.0 development (#2624)
+
 ## 2020-02-10 13.0.27 beta
 * Bug Fix:
   * Fix setting context when >= 64 characters (common #2607)

--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Daniel Glassey <wdg@debian.org>
 Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, pkg-config,
  libkmnkbp-dev (>=0.0.0~), libibus-1.0-dev (>= 1.2), libjson-glib-dev (>= 1.4.0) <!pkg.keyman-config.xenial>,
- libjson-glib-dev (1.1.2) <pkg.keyman-config.xenial>, libgtk-3-dev
+ libjson-glib-dev (= 1.1.2) <pkg.keyman-config.xenial>, libgtk-3-dev
 Standards-Version: 4.5.0
 Homepage: http://www.keyman.com
 

--- a/linux/ibus-keyman/debian/watch
+++ b/linux/ibus-keyman/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-keyman/debian/watch
+++ b/linux/ibus-keyman/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-kmfl/debian/watch
+++ b/linux/ibus-kmfl/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-kmfl/debian/watch
+++ b/linux/ibus-kmfl/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/keyman-config/debian/watch
+++ b/linux/keyman-config/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate

--- a/linux/keyman-config/debian/watch
+++ b/linux/keyman-config/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate

--- a/linux/kmflcomp/debian/watch
+++ b/linux/kmflcomp/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate

--- a/linux/kmflcomp/debian/watch
+++ b/linux/kmflcomp/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate

--- a/linux/libkmfl/debian/watch
+++ b/linux/libkmfl/debian/watch
@@ -1,2 +1,3 @@
 version=4
-https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/libkmfl/debian/watch
+++ b/linux/libkmfl/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://downloads.keyman.com/linux/(?:beta|stable)/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate
+https://downloads.keyman.com/linux/(?:$tier)/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -77,6 +77,10 @@ for proj in ${projects}; do
     else
         tarname="${proj}"
     fi
+
+    # Update tier in Debian watch file
+    sed 's/$tier/${tier}/g' debian/watch
+
     version=`uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -`
     dirversion=`uscan --report --dehs|xmllint --xpath "//dehs/upstream-url/text()" - | cut -d/ -f6`
     echo "${proj} version is ${version}"


### PR DESCRIPTION
Fixes #2552 

The current debian/watch files won't work for `stable` tier because the regex `(beta|stable)` matches the existing beta versions first.

Also, to support upcoming 14.0, the tier will be set by a `TIER.md` file.

This PR updates launchpad.sh so that:
1. tier is determined by `TIER.md` file or environment var $TIER. Fail if not set
2. Use `sed` to update debian/watch files with the specified `${tier}`. This will overwrite the tier from a previous run.