### PR TITLE
fix(developer): upgrade removes preferences

### DIFF
--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -173,7 +173,7 @@
       <Component>
         <File Name="kmdecomp.md" KeyPath="yes" Source="..\..\developer\kmdecomp\kmdecomp.md" />
       </Component>
-      
+
       <Component>
         <File Name="kmcomp.exe" KeyPath="yes" />
       </Component>
@@ -273,7 +273,7 @@
     <ComponentGroup Id="AppData">
       <Component Id="AppDataRemovals" Guid="{780C99E9-E97E-4EB0-BBF5-D4591EEABA7C}" Directory="App_KeymanDev_Databases">
         <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer" Name="root path" Type="string" Value="[INSTALLDIR]" />
-        <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer" />
+        <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no" Root="HKCU" Key="Software\Keyman\Keyman Developer" />
         <RemoveFolder Id="AD_Uninstall" On="uninstall" Directory="App_KeymanRoot" />
         <RemoveFolder Id="AD_KeymanDev_Uninstall" On="uninstall" Directory="App_KeymanDev" />
         <RemoveFolder Id="AD_KeymanDev_Databases_Uninstall" On="uninstall" Directory="App_KeymanDev_Databases" />


### PR DESCRIPTION
The uninstall is supposed to remove HKCU settings for developer. However
a side-effect is that an upgrade (which msi treats as uninstall/
install internally) also removes HKCU settings. This is sad and it is
probably better overall to leave a dangling HKCU key after uninstall.

Fixes #2667.