### PR TITLE
fix(developer): upgrade removes preferences 🍒

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -130,13 +130,13 @@ type
 
     function GetProjectFile: TProjectFile; override;
 
+  public
     function CanChangeTab(FForward: Boolean): Boolean; override;
     procedure ChangeTab(FForward: Boolean); override;
 
     function CanChangeView(FView: TCodeDesignView): Boolean; override;
     procedure ChangeView(FView: TCodeDesignView); override;
 
-  public
     procedure FindError(const Filename: string; s: string; line: Integer); override;   // I4081
     procedure NotifyStartedWebDebug;
   end;

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,12 @@
 # Keyman Developer Version History
 
+## 2020-02-18 13.0.76 beta
+* Bug Fix(Install): Upgrading would lose user settings (resolves after 2 upgrades) (#2668)
+
+## 2020-02-17 13.0.75 beta
+* Bug Fix(IDE): In some situations, the context help window could cause Developer to crash (#2661)
+* Bug Fix(IDE): Attempting to import a blank OSK into the Touch Layout Editor would eventually crash (#2663)
+
 ## 2020-02-13 13.0.73 beta
 * Bug Fix(IDE/Model Editor): Would never be set into modified state for changes exclusively in a wordlist. (#2634)
 * Bug Fix(IDE/Model Editor): Add context help (#2634)

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -173,7 +173,7 @@
       <Component>
         <File Name="kmdecomp.md" KeyPath="yes" Source="..\..\developer\kmdecomp\kmdecomp.md" />
       </Component>
-      
+
       <Component>
         <File Name="kmcomp.exe" KeyPath="yes" />
       </Component>
@@ -273,7 +273,7 @@
     <ComponentGroup Id="AppData">
       <Component Id="AppDataRemovals" Guid="{780C99E9-E97E-4EB0-BBF5-D4591EEABA7C}" Directory="App_KeymanDev_Databases">
         <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer" Name="root path" Type="string" Value="[INSTALLDIR]" />
-        <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\Keyman\Keyman Developer" />
+        <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="no" Root="HKCU" Key="Software\Keyman\Keyman Developer" />
         <RemoveFolder Id="AD_Uninstall" On="uninstall" Directory="App_KeymanRoot" />
         <RemoveFolder Id="AD_KeymanDev_Uninstall" On="uninstall" Directory="App_KeymanDev" />
         <RemoveFolder Id="AD_KeymanDev_Databases_Uninstall" On="uninstall" Directory="App_KeymanDev_Databases" />


### PR DESCRIPTION
The uninstall is supposed to remove HKCU settings for developer. However a
side-effect is that an upgrade (which msi treats as uninstall/ install
internally) also removes HKCU settings. This is sad and it is probably
better overall to leave a dangling HKCU key after uninstall.

Fixes #2667.

Cherry-pick of #2668