### PR TITLE
fix(ios): Responsive predictive toggles

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -302,11 +302,11 @@ extension KeymanWebViewController {
       // Pass these off to KMW!
       // We do these first so that they're automatically set for the to-be-registered model in advance.
       webView!.evaluateJavaScript("enableSuggestions(\(stubString), \(predict), \(correct))")
+      self.activeModel = predict
     } else {  // We're registering a model in the background - don't change settings.
       webView!.evaluateJavaScript("keyman.registerModel(\(stubString));", completionHandler: nil)
     }
 
-    self.activeModel = true
     setBannerHeight(to: Int(InputViewController.topBarHeight))
   }
   

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -101,6 +101,11 @@ class LanguageSettingsViewController: UITableViewController {
         // re-register the model - that'll enact the settings.
         _ = Manager.shared.registerLexicalModel(lm)
       }
+      // Based on how Manager chooses the model in setKeyboard.
+    } else if let lm = userDefaults.userLexicalModels?.first(where: { $0.languageID == self.language.id }) {
+      if Manager.shared.currentKeyboardID?.languageID == self.language.id {
+        _ = Manager.shared.registerLexicalModel(lm)
+      }
     }
   }
   
@@ -113,6 +118,11 @@ class LanguageSettingsViewController: UITableViewController {
     if let lm = Manager.shared.preferredLexicalModel(userDefaults, forLanguage: self.language.id) {
       if Manager.shared.currentKeyboardID?.languageID == self.language.id {
         // re-register the model - that'll enact the settings.
+        _ = Manager.shared.registerLexicalModel(lm)
+      }
+      // Based on how Manager chooses the model in setKeyboard.
+    } else if let lm = userDefaults.userLexicalModels?.first(where: { $0.languageID == self.language.id }) {
+      if Manager.shared.currentKeyboardID?.languageID == self.language.id {
         _ = Manager.shared.registerLexicalModel(lm)
       }
     }


### PR DESCRIPTION
Fixes #2673.

Turns out that there's a property (`preferredLexicalModel`) that was never getting properly set, which meant that the "update" code for settings changes was never triggering.  I've added secondary handlers to match what already existed within `Manager.setKeyboard()` that perform the same default, allowing the settings to properly trigger now.

Also, `self.activeModel`  was being used as part of the condition for adding the additional height needed for a banner.  This was always being added, even if predictions were deactivated - this field is now set to `false` so that this specific case does not occur, as deactivated predictions means a deactivated model.