### PR TITLE
chore(windows): improve build script tests

### DIFF
--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -153,7 +153,7 @@ PHPEXE=$(PHPDIR)\php.exe
 
 BRCC32=rc.exe
 
-HHC=\progra~1\htmlhe~1\hhc
+HHC="C:\Program Files (x86)\HTML Help Workshop\hhc.exe"
 NMAKE=nmake.exe
 CL=cl.exe
 MSBUILD=msbuild.exe
@@ -173,8 +173,9 @@ VCBUILD=error
 
 COPY=copy
 ISXBUILD=C:\PROGRA~1\INSTALLSHIELD\Express\System\IsExpCmdBld
-WZZIP="C:\program files\7-zip\7z.exe" a
-WZUNZIP="C:\program files\7-zip\7z.exe" e
+WZZIPPATH="C:\program files\7-zip\7z.exe"
+WZZIP=$(WZZIPPATH) a
+WZUNZIP=$(WZZIPPATH) e
 
 XSLTPROC=$(ROOT)\src\ext\libxslt\xsltproc.exe
 

--- a/windows/src/Makefile
+++ b/windows/src/Makefile
@@ -6,24 +6,24 @@
 
 default:
     @echo The following make targets are available:
-    @echo     build                 builds everything except help files (-DBUILDHELP to build help)
-    @echo     install               installs packages into Delphi IDE (run after a build)
-    @echo     clean                 removes all temp files
-    @echo     release               make a release
-    @echo     web-install           sends the documentation to the website
-    @echo     test-certificate      create a test certificate + CA (and install test CA)
-    @echo     signcode              sign the build artifacts
+    @echo .   build                 builds everything except help files (-DBUILDHELP to build help)
+    @echo .   install               installs packages into Delphi IDE (run after a build)
+    @echo .   clean                 removes all temp files
+    @echo .   release               make a release
+    @echo .   web-install           sends the documentation to the website
+    @echo .   test-certificate      create a test certificate + CA (and install test CA)
+    @echo .   signcode              sign the build artifacts
     @echo.
-    @echo     Build flags:
-    @echo           DEBUG           Include debug information
-    @echo           SC_TIMESTAMP    Don't timestamp certificates (for internal releases only, offline)
-    @echo           BUILDHELP       Build the helpfiles (implicit when 'make release')
-    @echo           LINT            Turns on $MESSAGE hints and warnings and all extra string warnings
-    @echo           QUIET           Ignore hints and warnings
-    @echo           RELEASE_OEM     Build executables for third party products in oem folder (e.g. FirstVoices)
+    @echo .   Build flags:
+    @echo .         DEBUG           Include debug information
+    @echo .         SC_TIMESTAMP    Don't timestamp certificates (for internal releases only, offline)
+    @echo .         BUILDHELP       Build the helpfiles (implicit when 'make release')
+    @echo .         LINT            Turns on $MESSAGE hints and warnings and all extra string warnings
+    @echo .         QUIET           Ignore hints and warnings
+    @echo .         RELEASE_OEM     Build executables for third party products in oem folder (e.g. FirstVoices)
     @echo.
-    @echo     To view help on the build process, in /src/inst, run:
-    @echo           make help
+    @echo .   To view help on the build process, in /src/inst, run:
+    @echo .         make help
     @echo.
 
 # ----------------------------------------------------------------------
@@ -95,7 +95,7 @@ unit-tests:
 # release
 # ----------------------------------------------------------------------
 
-release: clean-pathdefines test-release-cef-path test-releasebuildcheck test-uiaccess test-klog test-releaseexists test-cert clean
+release: clean-pathdefines test-release-cef-path test-releasebuildcheck test-uiaccess test-klog test-releaseexists test-cert test-hhc test-7zip test-wix clean
     cd $(ROOT)\src
     $(MAKE) global-versions
     $(MAKE) build-release-wrapper
@@ -120,6 +120,27 @@ test-release-cef-path:
 test-cert:
     copy $(SC_PFX_SHA1) $(ROOT)\src\pfx.tmp
     del $(ROOT)\src\pfx.tmp
+
+#
+# Test that hhc is installed
+#
+
+test-hhc:
+    if not exist $(HHC) exit 1
+
+#
+# Test that WiX is installed
+#
+
+test-wix:
+    if not exist $(WIXPATH)\candle.exe exit 1
+
+#
+# Test that 7-zip is installed
+#
+
+test-7zip:
+    if not exist $(WZZIPPATH) exit 1
 
 #
 # Test that klog is disabled

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -15,6 +15,7 @@
 10. In order to run Keyman Developer in the development build, you need to specify where the
    https://github.com/keymanapp/CEF4Delphi_binary repo is on your system, with the registry setting `HKCU\Software\Keyman\Debug`,
    `Debug_CEFPath`.
+11. npm must use cmd for its shell: `npm config delete script-shell` (we may change this in the future)
 
 ### Release build prerequisites
 


### PR DESCRIPTION
Make sure that our prerequisites are in place *before* starting a release build. Note: doesn't currently check that certificates are valid so that's a future test we could include.

One day it'd be nice to remove dependency on 7-zip: perhaps we won't need it once we have better crash reporting.

Note: Only setting this up as draft so it doesn't confuse during release phase. Will merge post release of 13.