### PR TITLE
[stable][linux]: Add gsettings schema to manifest

### DIFF
--- a/linux/history.md
+++ b/linux/history.md
@@ -1,6 +1,6 @@
 # Keyman for Linux Version History
 
-# 2020-02-20113.0.101 stable
+# 2020-02-20 13.0.101 stable
 * Bug Fix: Add Keyman gsettings schema to manifest (#2688)
 
 # 2020-02-19 13.0.100 stable

--- a/linux/history.md
+++ b/linux/history.md
@@ -1,5 +1,11 @@
 # Keyman for Linux Version History
 
+# 2020-02-20113.0.101 stable
+* Bug Fix: Add Keyman gsettings schema to manifest (#2688)
+
+# 2020-02-19 13.0.100 stable
+* 13.0 stable release
+
 # 2020-02-18 13.0.30 beta
 * Bug Fix:
   * Include Keyman gsettings schema for packaging (#2675)

--- a/linux/keyman-config/MANIFEST.in
+++ b/linux/keyman-config/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include keyman_config/icons *
 recursive-include icons *
 include README.md
+include com.keyman.gschema.xml
 include *.bash-completion


### PR DESCRIPTION
Attempts to address #2682.

Launchpad keyman-config build fails because `com.keyman.gschema.xml` isn't included in the manifest so it can't be copied into the destination.