### PR TITLE
fix(web): Web CI target reversion

### DIFF
--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -122,16 +122,10 @@ module.exports = function(config) {
   /*
    * Final selection of the sets to be used for BrowserStack testing.
    */
-  // var FINAL_LAUNCHER_DEFS = mergeLaunchers( CURRENT_ANDROID_LAUNCHERS,
-  //                                           CURRENT_IOS_LAUNCHERS,
-  //                                           CURRENT_WIN_LAUNCHERS,
-  //                                           CURRENT_MAC_LAUNCHERS);
-
-  var FINAL_LAUNCHER_DEFS = mergeLaunchers(
-    {
-      bs_edge_win: CURRENT_WIN_LAUNCHERS.bs_edge_win
-    }
-  );
+  var FINAL_LAUNCHER_DEFS = mergeLaunchers( CURRENT_ANDROID_LAUNCHERS,
+                                            CURRENT_IOS_LAUNCHERS,
+                                            CURRENT_WIN_LAUNCHERS,
+                                            CURRENT_MAC_LAUNCHERS);
 
   var FINAL_BROWSER_LIST = toBrowserList(FINAL_LAUNCHER_DEFS);
 


### PR DESCRIPTION
Someone (me) might have accidentally forgot to re-enable the other browser targets for testing after debugging issues with Edge...