### PR TITLE
fix(ios): Resource update issues

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
@@ -33,15 +33,6 @@ URLSessionDataDelegate {
     downloadSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
   }
 
-  /**
-   * Used to facilitate unit-testing with mocked URL sessions.
-   */
-  internal init(_ handler: HTTPDownloadDelegate?, _ session: URLSession) {
-    super.init()
-    self.handler = handler
-    downloadSession = session
-  }
-
   func addRequest(_ request: HTTPDownloadRequest) {
     queue.append(request)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
@@ -33,6 +33,15 @@ URLSessionDataDelegate {
     downloadSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
   }
 
+  /**
+   * Used to facilitate unit-testing with mocked URL sessions.
+   */
+  internal init(_ handler: HTTPDownloadDelegate?, _ session: URLSession) {
+    super.init()
+    self.handler = handler
+    downloadSession = session
+  }
+
   func addRequest(_ request: HTTPDownloadRequest) {
     queue.append(request)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/KMPKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/KMPKeyboard.swift
@@ -51,14 +51,16 @@ public class KMPKeyboard
       && FileManager.default.fileExists(atPath: kmp.sourceFolder.appendingPathComponent("\(keyboardId!).js").path)
   }
   
-  public func parse(json: [String:AnyObject]) {
+  public func parse(json: [String:AnyObject], version: String) {
     if let name = json["name"] as? String {
       self.name = name
     }
     if let keyboardId = json["id"] as? String {
       self.keyboardId = keyboardId
     }
-    if let version = json["version"] as? String {
+    if let _version = json["version"] as? String {
+      self.version = _version
+    } else {
       self.version = version
     }
     

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/KMPLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/KMPLexicalModel.swift
@@ -32,14 +32,16 @@ public class KMPLexicalModel
       && FileManager.default.fileExists(atPath: kmp.sourceFolder.appendingPathComponent("\(lexicalModelId!).model.js").path)
   }
   
-  public func parse(json: [String:AnyObject]) {
+  public func parse(json: [String:AnyObject], version: String) {
     if let name = json["name"] as? String {
       self.name = name
     }
     if let lexicalModelId = json["id"] as? String {
       self.lexicalModelId = lexicalModelId
     }
-    if let version = json["version"] as? String {
+    if let _version = json["version"] as? String {
+      self.version = _version
+    } else {
       self.version = version
     }
     

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/KeyboardKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/KeyboardKeymanPackage.swift
@@ -12,13 +12,13 @@ public class KeyboardKeymanPackage : KeymanPackage
 {
   private var keyboards: [KMPKeyboard]!
   
-  public override func parse(json: [String:AnyObject]) {
+  public override func parse(json: [String:AnyObject], version: String) {
     self.keyboards = []
     
     if let packagedKeyboards = json["keyboards"] as? [[String:AnyObject]] {
       for keyboardJson in packagedKeyboards {
         let keyboard = KMPKeyboard.init(kmp: self)
-        keyboard.parse(json: keyboardJson)
+        keyboard.parse(json: keyboardJson, version: version)
         
         if(keyboard.isValid) {
           keyboards.append(keyboard)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/KeymanPackage.swift
@@ -30,7 +30,7 @@ public class KeymanPackage
   }
 
   // to be overridden by subclasses
-  public func parse(json: [String:AnyObject]) {
+  public func parse(json: [String:AnyObject], version: String) {
     return
   }
   
@@ -59,6 +59,15 @@ public class KeymanPackage
         let data = try Data(contentsOf: path, options: .mappedIfSafe)
         let jsonResult = try JSONSerialization.jsonObject(with: data, options: .mutableLeaves)
         if let jsonResult = jsonResult as? [String:AnyObject] {
+          // The 'version' info has moved, and is no longer available in the original
+          // location for lexical models.  Still present for keyboards, though!
+          var version: String = ""
+          if let info = jsonResult["info"] as? [String:AnyObject] {
+            if let versionBlock = info["version"] as? [String:AnyObject] {
+              version = versionBlock["description"] as? String ?? ""
+            }
+          }
+
           if let _ = jsonResult["keyboards"] as? [[String:AnyObject]] {
             if let _ = jsonResult["lexicalModels"] as? [[String:AnyObject]] {
                 //TODO: rrb show error to user, for now, just log
@@ -66,12 +75,12 @@ public class KeymanPackage
               return nil
             }
             let kmp = KeyboardKeymanPackage.init(folder: folder)
-            kmp.parse(json: jsonResult)
+            kmp.parse(json: jsonResult, version: version)
             return kmp
           }
           else if let _ = jsonResult["lexicalModels"] as? [[String:AnyObject]] {
             let kmm = LexicalModelKeymanPackage.init(folder: folder)
-            kmm.parse(json: jsonResult)
+            kmm.parse(json: jsonResult, version: version)
             return kmm
           }
         }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LexicalModelKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LexicalModelKeymanPackage.swift
@@ -22,13 +22,13 @@ public class LexicalModelKeymanPackage : KeymanPackage {
   
   // may be called parse()
   // returns a dictionary mapping language ID to lexical model ID
-  public override func parse(json: [String:AnyObject]) {
+  override public func parse(json: [String:AnyObject], version: String) {
     self.models = []
     
     if let packagedModels = json["lexicalModels"] as? [[String:AnyObject]] {
       for modelJson in packagedModels {
         let model = KMPLexicalModel.init(kmp: self)
-        model.parse(json: modelJson)
+        model.parse(json: modelJson, version: version)
         
         if(model.isValid) {
           models.append(model)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -416,6 +416,12 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
 
           if(!isUpdate) {
             downloadSucceeded(forKeyboards: keyboards)
+          } else {
+            // Since we don't generate the notification as above, we need to manually update
+            // the keyboards' metadata.
+            keyboards.forEach { keyboard in
+              Manager.shared.addKeyboard(keyboard)
+            }
           }
 
           let userDefaults = Storage.active.userDefaults
@@ -427,6 +433,10 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
         if let lm = installLexicalModelPackage(downloadedPackageFile: URL(fileURLWithPath: task.request.destinationFile!)) {
           if !isUpdate {
             downloadSucceeded(forLexicalModel: lm)
+          } else {
+            // Since we don't generate the notification as above, we need to manually update
+            // the lexical model's metadata.
+            Manager.shared.updateUserLexicalModels(with: lm)
           }
         } else if !isUpdate {
           let installError = NSError(domain: "Keyman", code: 0,


### PR DESCRIPTION
Turns out, iOS update + KMP parsing code was in need of a little TLC.

- Lexical models' versions were not found in the most up-to-date KMPs, as it's only specified at the top level now ("info" > "description"), and not on the model itself as before
- Version metadata wasn't being updated, so even after successful updates, the app still thought updates were needed
- There was a major CTRL-C/CTRL-V bug in one of the lexical model control paths that went unchecked until now