### PR TITLE
fix(ios): fixes scale-selection logic 🍒

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardScaleMap.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardScaleMap.swift
@@ -206,7 +206,7 @@ class KeyboardScaleMap {
       return searchSet[0] // in case no matches can be found (like the screenSize == CGRect.zero case) - use smallest
     } else {
       // Use the largest potential device, which is the last one returned from the mapping (b/c we presorted the base array)
-      return searchSet.last!
+      return potentialMatches.last!
     }
   }
 


### PR DESCRIPTION
Cherrypick of #2695's bugfix.

The omitted changes from that PR were all in support of unit-testing.  As unit-testing won't be merged into the stable-13.0 branch, those may be safely left out.

This can technically be delayed until Apple releases a new device, but it's simple and safe enough to "throw in" whenever we have a more substantial iOS bug fix to release for Stable.