### PR TITLE
fix(ci): Fix increment-version.sh script

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -19,6 +19,7 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 . "$(dirname "$THIS_SCRIPT")/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "$(dirname "$THIS_SCRIPT")/trigger-definitions.config"
 . "$(dirname "$THIS_SCRIPT")/trigger-builds.sh"
 
 gitbranch=`git branch --show-current`
@@ -121,9 +122,9 @@ if [ "$action" == "commit" ]; then
   fi
 
   #
-  # After this script finishes in CI, we will be pushing the new history to 
+  # After this script finishes in CI, we will be pushing the new history to
   # downloads.keyman.com, so we need to finish with the branch here that has the
-  # latest history in it. We don't need to cleanup the branch because the CI will 
+  # latest history in it. We don't need to cleanup the branch because the CI will
   # do that for us.
   #
 


### PR DESCRIPTION
`trigger-builds.sh` now makes use of the definitions in `trigger-definitions.config`. Therefore we need to make those definitions available.

This change should fix the failure in https://build.palaso.org/viewLog.html?buildId=184503&buildTypeId=Keyman_TriggerReleaseBuildsMaster&tab=buildLog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2714)
<!-- Reviewable:end -->
