### PR TITLE
fix(android) Fix crash on kbdMapList

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -577,6 +577,10 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     }
 
     List<? extends Map<String, String>> kbdMapList = getKeyboardsList(context);
+    if (kbdMapList == null) {
+      Log.d(TAG, "kbdMapList == null");
+      kbdMapList = new ArrayList<>(0);
+    }
     List<Keyboard> kbdsList = new ArrayList<>(kbdMapList.size());
 
     for(Map<String, String> map: kbdMapList) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -578,7 +578,6 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
 
     List<? extends Map<String, String>> kbdMapList = getKeyboardsList(context);
     if (kbdMapList == null) {
-      Log.d(TAG, "kbdMapList == null");
       kbdMapList = new ArrayList<>(0);
     }
     List<Keyboard> kbdsList = new ArrayList<>(kbdMapList.size());


### PR DESCRIPTION
Fixes #2711 and the corresponding [crash](https://fabric.io/keymanproduction/android/apps/com.firstvoices.keyboards/issues/2f6322b926b19e5cf28f3b85c9c0a844) for the FirstVoices app.

This PR adds a null check on the `kbdMapList` and initializes accordingly.
It follows the pattern of `lexMapList` a few lines later (l. 590)
