### PR TITLE
fix(developer): crash when switching layout templates 🍒

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1328,7 +1328,7 @@ $(function () {
 
     $('.skcontrol.wedge-horz,.skcontrol.wedge-vert,div#btnDelSubKey,input#inpSubKeyCap').css('display', '');
     builder.selectedKey().removeClass('selected');
-    if (key) {
+    if (key && $(key).length) {
       $(key).addClass('selected');
       $('.kcontrol.wedge-horz,.kcontrol.wedge-vert,div#btnDelKey,input#inpKeyCap').css('display', 'block');
       var rowOffset = $(key).parent().offset();

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,11 @@
 # Keyman Developer Version History
 
+## 2020-02-24 13.0.101 stable
+* Bug Fix(Keyboard Editor): Touch Layout Editor could crash switching templates (#2721)
+
+## 2020-02-19 13.0.100 stable
+* Chore: Keyman Developer 13.0.100 release
+
 ## 2020-02-18 13.0.76 beta
 * Bug Fix(Install): Upgrading would lose user settings (resolves after 2 upgrades) (#2668)
 


### PR DESCRIPTION
Keyman Developer could crash if a specific sequence was invoked importing a keyboard into a touch layout and then changing the template. Fixes #2712.