### PR TITLE
feat(common): Support git worktree when configuring local hooks

### DIFF
--- a/configure-repo.sh
+++ b/configure-repo.sh
@@ -6,7 +6,6 @@
 # Run this script once to configure your system to work with our Git workflow.
 #
 
-ROOT=$(git rev-parse --show-toplevel)
 if [[ -n "$WINDIR" ]]; then
   # https://stackoverflow.com/a/39160850/1836776
   SCRIPT_DIR=$(cmd //C cd)
@@ -32,8 +31,9 @@ case $1 in
       cmd //C "mklink $WinPWD\\.git\\hooks\\commit-msg $WinPWD\\resources\\git-hooks\\commit-msg"
       cmd //C "mklink $WinPWD\\.git\\hooks\\prepare-commit-msg $WinPWD\\resources\\git-hooks\\prepare-commit-msg"
     else
-      ln -sf "$SCRIPT_DIR/resources/git-hooks/commit-msg" "$ROOT/.git/hooks/commit-msg"
-      ln -sf "$SCRIPT_DIR/resources/git-hooks/prepare-commit-msg" "$ROOT/.git/hooks/prepare-commit-msg"
+      HOOKSDIR=$(git rev-parse --git-path hooks)
+      ln -sf "$SCRIPT_DIR/resources/git-hooks/commit-msg" "$HOOKSDIR/commit-msg"
+      ln -sf "$SCRIPT_DIR/resources/git-hooks/prepare-commit-msg" "$HOOKSDIR/prepare-commit-msg"
     fi
     ;;
   *)


### PR DESCRIPTION
When using worktrees in git the hooks directory is under the main
worktree directory. `$ROOT/.git` might be a text file instead of a
folder. `git rev-parse` will return the correct location in all
cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/2722)
<!-- Reviewable:end -->
