### PR TITLE
fix(android): Cherrypick #2711 to fix null kbdMapList

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -577,6 +577,9 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     }
 
     List<? extends Map<String, String>> kbdMapList = getKeyboardsList(context);
+    if (kbdMapList == null) {
+      kbdMapList = new ArrayList<>(0);
+    }
     List<Keyboard> kbdsList = new ArrayList<>(kbdMapList.size());
 
     for(Map<String, String> map: kbdMapList) {

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,12 @@
 # Keyman for Android Version History
 
+## 2020-02-25 13.0.6201 stable
+* Bug fix:
+  * Fix crash involving empty keyboard list (#2723)
+
+## 2020-02-19 13.0.6200 stable
+* Release 13.0
+
 ## 2020-02-14 13.0.6059 beta
 * Bug fix:
   * Re-initialize CloudDownloadManager when downloading resources after Keyman app is closed (#2635)

--- a/android/history.md
+++ b/android/history.md
@@ -3,6 +3,7 @@
 ## 2020-02-25 13.0.6201 stable
 * Bug fix:
   * Fix crash involving empty keyboard list (#2723)
+  * Sanitize app version for api query (#2724)
 
 ## 2020-02-19 13.0.6200 stable
 * Release 13.0


### PR DESCRIPTION
For stable-13.0, initialize null `kbdMapList`. This follows the pattern of lexMapList.