### PR TITLE
fix(android): Sanitize app version for api query

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -227,8 +227,10 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
     else
     {
       // Keyman cloud
+      // Sanitize appVersion to #.#.# to match the API spec
+      String appVersion = KMManager.getVersion();
       String _remoteUrl = String.format("%s/%s/%s?version=%s&device=%s&languageidtype=bcp47",
-        kKeymanApiBaseURL, langID, kbID, BuildConfig.VERSION_NAME, deviceType);
+        kKeymanApiBaseURL, langID, kbID, appVersion, deviceType);
       cloudQueries.add(
         new CloudApiTypes.CloudApiParam(
           CloudApiTypes.ApiTarget.Keyboard, _remoteUrl)

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import android.annotation.SuppressLint;
 import android.app.Dialog;
@@ -224,8 +226,20 @@ public final class KMManager {
     return getResourceRoot() + KMDefault_UndefinedPackageID + File.separator;
   }
 
+  /**
+   * Extract app version #.#.# from VERSION_NAME
+   * @return String
+   */
   public static String getVersion() {
-    return com.tavultesoft.kmea.BuildConfig.VERSION_NAME;
+    // Regex needs to match the entire string
+    String appVersion = com.tavultesoft.kmea.BuildConfig.VERSION_NAME;
+    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+).*");
+    Matcher matcher = pattern.matcher(appVersion);
+    if (matcher.matches() && matcher.groupCount() >= 1) {
+      appVersion = matcher.group(1);
+    }
+
+    return appVersion;
   }
 
   // Check if a keyboard namespace is reserved

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 public class CloudRepository {
   static public final CloudRepository shared = new CloudRepository();
@@ -130,13 +128,7 @@ public class CloudRepository {
 
     // Sanitize appVersion to #.#.# to match the API spec
     // Regex needs to match the entire string
-    String appVersion = BuildConfig.VERSION_NAME;
-    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+).*");
-    Matcher matcher = pattern.matcher(appVersion);
-    if (matcher.matches() && matcher.groupCount() >= 1) {
-      appVersion = matcher.group(1);
-    }
-
+    String appVersion = KMManager.getVersion();
     // Retrieves the cloud-based keyboard catalog in Android's preferred format.
     String keyboardURL = String.format("%s?version=%s&device=%s&languageidtype=bcp47",
       KMKeyboardDownloaderActivity.kKeymanApiBaseURL, appVersion, deviceType);


### PR DESCRIPTION
Cherrypick #2715 to stable-13.0

Regex to only use `#.#.#` for the app version.

history.md to be updated in #2723