### PR TITLE
fix(developer): crash when switching layout templates

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1328,7 +1328,7 @@ $(function () {
 
     $('.skcontrol.wedge-horz,.skcontrol.wedge-vert,div#btnDelSubKey,input#inpSubKeyCap').css('display', '');
     builder.selectedKey().removeClass('selected');
-    if (key) {
+    if (key && $(key).length) {
       $(key).addClass('selected');
       $('.kcontrol.wedge-horz,.kcontrol.wedge-vert,div#btnDelKey,input#inpKeyCap').css('display', 'block');
       var rowOffset = $(key).parent().offset();


### PR DESCRIPTION
Keyman Developer could crash if a specific sequence was invoked
importing a keyboard into a touch layout and then changing the
template. Fixes #2712.

Same as #2721, for master.