### PR TITLE
Feature: Android - Handle keyman:// protocol to download kmp keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -162,6 +162,17 @@
           android:pathPattern=".*\\.kmp"
           android:scheme="https" />
       </intent-filter>
+
+      <intent-filter>
+        <!-- deep linking to keyman.com/keyboards -->
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+          android:scheme="keyman" />
+      </intent-filter>
     </activity>
     <activity
       android:name=".InfoActivity"

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -552,7 +552,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     }
     if (url != null) {
       // URL contains KMP to download in background.
-      boolean isCustom = KMKeyboardDownloaderActivity.isCustom(url);
+      boolean isCustom = FileUtils.isCustomKeyboard(url);
 
       String filename = data.getQueryParameter("filename");
       if (filename == null) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -295,14 +295,13 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       switch (data.getScheme().toLowerCase()) {
         // Android DownloadManager
         case "content":
-          checkStoragePermission(data);
-          break;
         // Chrome downloads and Filebrowsers
         case "file":
           checkStoragePermission(data);
           break;
         case "http" :
         case "https" :
+        case "keyman" :
           Intent downloadIntent;
           String url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
           if (url == null) {
@@ -312,18 +311,21 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
             // URL contains KMP to download in background.
             boolean isCustom = KMKeyboardDownloaderActivity.isCustom(url);
 
-            int index = url.lastIndexOf("/") + 1;
-            String filename = "unknown:";
-            if (index >= 0 && index <= url.length()) {
-              filename = url.substring(index);
+            String filename = data.getQueryParameter("filename");
+            if (filename == null) {
+              int index = url.lastIndexOf("/") + 1;
+              if (index >= 0 && index <= url.length()) {
+                filename = url.substring(index);
+              }
             }
 
-            // Only handle ad-hoc kmp packages
-            if (FileUtils.hasKeymanPackageExtension(url)) {
+            // Only handle ad-hoc kmp packages or from keyman.com
+            if (FileUtils.hasKeymanPackageExtension(url) || data.getScheme().toLowerCase().equals("keyman")) {
               try {
                 // Download the KMP to app cache
                 downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
                 downloadIntent.putExtra("url", url);
+                downloadIntent.putExtra("filename", filename);
                 downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
                 downloadIntent.putExtra("receiver", resultReceiver);
 
@@ -349,6 +351,15 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
             }
           }
           break;
+          /*
+        case "keyman":
+          url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
+          if (url != null) {
+            Uri uri = Uri.parse(url);
+            checkStoragePermission(uri);
+          }
+          break;
+          */
         default :
           Log.e(TAG, "Unrecognized protocol " + data.getScheme());
       }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 SIL International. All rights reserved.
+ * Copyright (C) 2018-2020 SIL International. All rights reserved.
  */
 
 package com.tavultesoft.kmapro;
@@ -25,7 +25,6 @@ import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KMTextView;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
-import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
@@ -293,63 +292,18 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     if (data != null) {
 
       switch (data.getScheme().toLowerCase()) {
-        // Android DownloadManager
+        // content:// Android DownloadManager
+        // file:// Chrome downloads and Filebrowsers
         case "content":
-        // Chrome downloads and Filebrowsers
         case "file":
           checkStoragePermission(data);
           break;
         case "http" :
         case "https" :
+          downloadKMP();
+          break;
         case "keyman" :
-          Intent downloadIntent;
-          String url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
-          if (url == null) {
-            url = data.toString();
-          }
-          if (url != null) {
-            // URL contains KMP to download in background.
-            boolean isCustom = KMKeyboardDownloaderActivity.isCustom(url);
-
-            String filename = data.getQueryParameter("filename");
-            if (filename == null) {
-              int index = url.lastIndexOf("/") + 1;
-              if (index >= 0 && index <= url.length()) {
-                filename = url.substring(index);
-              }
-            }
-
-            // Only handle ad-hoc kmp packages or from keyman.com
-            if (FileUtils.hasKeymanPackageExtension(url) || data.getScheme().toLowerCase().equals("keyman")) {
-              try {
-                // Download the KMP to app cache
-                downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
-                downloadIntent.putExtra("url", url);
-                downloadIntent.putExtra("filename", filename);
-                downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
-                downloadIntent.putExtra("receiver", resultReceiver);
-
-                progressDialog = new ProgressDialog(MainActivity.this);
-                String ellipsisStr = "\u2026";
-                progressDialog.setMessage(String.format("%s\n%s%s",
-                  getString(R.string.downloading_keyboard_package), filename, ellipsisStr));
-                progressDialog.setCancelable(false);
-                progressDialog.show();
-
-                startService(downloadIntent);
-              } catch (Exception e) {
-                if (progressDialog != null && progressDialog.isShowing()) {
-                  progressDialog.dismiss();
-                }
-                progressDialog = null;
-                break;
-              }
-            } else {
-              String message = "Download failed. Not a .kmp keyboard package.";
-              Toast.makeText(getApplicationContext(), message,
-                Toast.LENGTH_SHORT).show();
-            }
-          }
+          downloadKMP();
           break;
         default :
           Log.e(TAG, "Unrecognized protocol " + data.getScheme());
@@ -583,6 +537,61 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       SharedPreferences.Editor editor = prefs.edit();
       editor.putBoolean(defaultDictionaryInstalled, true);
       editor.commit();
+    }
+  }
+
+  /**
+   * Parse the URI data to determine the URL for the .kmp keyboard package.
+   *
+   */
+  private void downloadKMP() {
+    Intent downloadIntent;
+    String url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
+    if (url == null) {
+      url = data.toString();
+    }
+    if (url != null) {
+      // URL contains KMP to download in background.
+      boolean isCustom = KMKeyboardDownloaderActivity.isCustom(url);
+
+      String filename = data.getQueryParameter("filename");
+      if (filename == null) {
+        int index = url.lastIndexOf("/") + 1;
+        if (index >= 0 && index <= url.length()) {
+          filename = url.substring(index);
+        }
+      }
+
+      // Only handle ad-hoc kmp packages or from keyman.com
+      if (FileUtils.hasKeymanPackageExtension(url) || data.getScheme().toLowerCase().equals("keyman")) {
+        try {
+          // Download the KMP to app cache
+          downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
+          downloadIntent.putExtra("url", url);
+          downloadIntent.putExtra("filename", filename);
+          downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
+          downloadIntent.putExtra("receiver", resultReceiver);
+
+          progressDialog = new ProgressDialog(MainActivity.this);
+          String ellipsisStr = "\u2026";
+          progressDialog.setMessage(String.format("%s\n%s%s",
+            getString(R.string.downloading_keyboard_package), filename, ellipsisStr));
+          progressDialog.setCancelable(false);
+          progressDialog.show();
+
+          startService(downloadIntent);
+        } catch (Exception e) {
+          if (progressDialog != null && progressDialog.isShowing()) {
+            progressDialog.dismiss();
+          }
+          progressDialog = null;
+          return;//break;
+        }
+      } else {
+        String message = "Download failed. Not a .kmp keyboard package.";
+        Toast.makeText(getApplicationContext(), message,
+          Toast.LENGTH_SHORT).show();
+      }
     }
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -351,15 +351,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
             }
           }
           break;
-          /*
-        case "keyman":
-          url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
-          if (url != null) {
-            Uri uri = Uri.parse(url);
-            checkStoragePermission(uri);
-          }
-          break;
-          */
         default :
           Log.e(TAG, "Unrecognized protocol " + data.getScheme());
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -286,7 +286,8 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
 
   public static boolean isCustom(String u) {
     boolean ret = false;
-    if (u != null && !u.contains(kKeymanBaseURL)) {
+    if (u != null && !u.contains(KMKeyboardDownloaderActivity.kKeymanApiBaseURL) &&
+        !u.contains(KMKeyboardDownloaderActivity.kKeymanApiRemoteURL) && !u.contains(kKeymanBaseURL)) {
       ret = true;
     }
     return ret;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -41,6 +41,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   public static final String ARG_URL = "KMKeyboardActivity.url";
   public static final String ARG_FILENAME = "KMKeyboardActivity.filename";
 
+  public static final String kKeymanBaseURL = "https://keyman.com";
   public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
   public static final String kKeymanApiModelURL = "https://api.keyman.com/model";
   public static final String kKeymanApiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url=";
@@ -285,8 +286,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
 
   public static boolean isCustom(String u) {
     boolean ret = false;
-    if (u != null && !u.contains(KMKeyboardDownloaderActivity.kKeymanApiBaseURL) &&
-      !u.contains(KMKeyboardDownloaderActivity.kKeymanApiRemoteURL)) {
+    if (u != null && !u.contains(kKeymanBaseURL)) {
       ret = true;
     }
     return ret;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -41,10 +41,8 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   public static final String ARG_URL = "KMKeyboardActivity.url";
   public static final String ARG_FILENAME = "KMKeyboardActivity.filename";
 
-  public static final String kKeymanBaseURL = "https://keyman.com";
   public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
   public static final String kKeymanApiModelURL = "https://api.keyman.com/model";
-  public static final String kKeymanApiRemoteURL = "https://r.keymanweb.com/api/2.0/remote?url=";
 
   private static final String TAG = "KMKbdDownloaderActivity"; // TAG needs to be less than 28 chars
 
@@ -282,18 +280,6 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
 
     ((AppCompatActivity) context).finish();
   }
-
-
-  public static boolean isCustom(String u) {
-    boolean ret = false;
-    if (u != null && !u.contains(KMKeyboardDownloaderActivity.kKeymanApiBaseURL) &&
-        !u.contains(KMKeyboardDownloaderActivity.kKeymanApiRemoteURL) && !u.contains(kKeymanBaseURL)) {
-      ret = true;
-    }
-    return ret;
-  }
-
-
 
   public static void addKeyboardDownloadEventListener(KeyboardEventHandler.OnKeyboardDownloadEventListener listener) {
     if (kbDownloadEventListeners == null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
@@ -15,8 +15,8 @@ public class DownloadIntentService extends IntentService {
   @Override
   protected void onHandleIntent(Intent intent) {
     String url = intent.getStringExtra("url");
+    String filename = intent.getStringExtra("filename");
     String destination = intent.getStringExtra("destination");
-    String filename = FileUtils.getFilename(url);
     final ResultReceiver receiver = intent.getParcelableExtra("receiver");
     Bundle bundle = new Bundle();
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -13,6 +13,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
   * Limitations:
@@ -225,6 +227,24 @@ public final class FileUtils {
         filename = urlStr.substring(urlStr.lastIndexOf('/') + 1);
     }
     return filename;
+  }
+
+  /**
+   * Utility to parse a URL and determine if it's a custom keyboard
+   * @param u String of the URL
+   * @return boolean false if URL matches [*.]keyman.com/
+   */
+  public static boolean isCustomKeyboard(String u) {
+    boolean ret = true;
+    if (u == null) {
+      return ret;
+    }
+    Pattern pattern = Pattern.compile("^http(s)?://(.+\\.)?keyman.com/.*");
+    Matcher matcher = pattern.matcher(u);
+    if (matcher.matches()) {
+      ret = false;
+    }
+    return ret;
   }
 
   /**

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -32,6 +32,28 @@ public class FileUtilsTest {
   }
 
   @Test
+  public void test_isCustomKeyboard() {
+    // True because URL is null or empty (doesn't match *.keyman.com)
+    Assert.assertTrue(FileUtils.isCustomKeyboard(null));
+    Assert.assertTrue(FileUtils.isCustomKeyboard(""));
+
+    Assert.assertFalse(FileUtils.isCustomKeyboard("http://keyman.com/"));
+    Assert.assertFalse(FileUtils.isCustomKeyboard("https://keyman.com/"));
+    Assert.assertFalse(FileUtils.isCustomKeyboard("http://api.keyman.com/"));
+    Assert.assertFalse(FileUtils.isCustomKeyboard("https://api.keyman.com/"));
+    Assert.assertFalse(FileUtils.isCustomKeyboard("https://keyman.com/keyboard/khmer_angkor"));
+
+    // True because trailing slash is missing
+    Assert.assertTrue(FileUtils.isCustomKeyboard("http://keyman.com"));
+    Assert.assertTrue(FileUtils.isCustomKeyboard("https://keyman.com"));
+    Assert.assertTrue(FileUtils.isCustomKeyboard("http://api.keyman.com"));
+    Assert.assertTrue(FileUtils.isCustomKeyboard("https://api.keyman.com"));
+
+    // "custom" site
+    Assert.assertTrue(FileUtils.isCustomKeyboard("https://amerikeyman.com/"));
+  }
+
+  @Test
   public void test_compareVersions() {
     Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions(null, "1.0"));
     Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("" , "1.0"));


### PR DESCRIPTION
Addresses deep linking for #2708 
Handle `keyman://` protocol for downloading .kmp packages

Verified with the test link
`keyman://?filename=khmer_angkor.kmp&url=https%3A%2F%2Fkeyman.com%2Fkeyboard%2Fdownload%3Fid%3Dkhmer_angkor%26platform%3Dandroid`

TODO for a future PR - download in the background
