### PR TITLE
fix(developer): insert from charmap into touch editor

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -763,6 +763,9 @@ end;
 
 procedure TfrmKeymanWizard.FocusTabTouchLayout;   // I3885
 begin
+  if pagesTouchLayout.ActivePage = pageTouchLayoutDesign
+    then DoFocus(frameTouchLayout)
+    else DoFocus(frameTouchLayoutSource);
 end;
 
 {-----------------------------------------------------------------------------}
@@ -3172,7 +3175,9 @@ begin
   begin
     frameTouchLayoutSource.EditorText := frameTouchLayout.SaveToString;
     DoFocus(frameTouchLayoutSource);
-  end;
+  end
+  else
+    DoFocus(frameTouchLayout);
   FLoading := False;
 end;
 

--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -115,6 +115,7 @@ type
 
   public
     { Public declarations }
+    procedure SetFocus; override;
     procedure SetupCharMapDrop;
     function Load(const AFilename: string; ALoadFromTemplate, ALoadFromString: Boolean): Boolean;
     procedure Save(const AFilename: string);
@@ -606,6 +607,11 @@ end;
 procedure TframeTouchLayoutBuilder.SelectAll;
 begin
   cef.cef.SelectAll;
+end;
+
+procedure TframeTouchLayoutBuilder.SetFocus;
+begin
+  cef.SetFocus;
 end;
 
 procedure TframeTouchLayoutBuilder.SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);   // I4057

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -2,6 +2,7 @@
 
 ## 2020-02-24 13.0.101 stable
 * Bug Fix(Keyboard Editor): Touch Layout Editor could crash switching templates (#2721)
+* Bug Fix(Keyboard Editor): Touch Layout Editor would not always accept character map insertions (#2736)
 
 ## 2020-02-19 13.0.100 stable
 * Chore: Keyman Developer 13.0.100 release


### PR DESCRIPTION
Double-click to insert a character from char map into the touch layout
editor would not work reliably after focus changes.

Fixes #2702.