### PR TITLE
fix(developer): insert from charmap into touch editor 🍒

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -764,6 +764,9 @@ end;
 
 procedure TfrmKeymanWizard.FocusTabTouchLayout;   // I3885
 begin
+  if pagesTouchLayout.ActivePage = pageTouchLayoutDesign
+    then DoFocus(frameTouchLayout)
+    else DoFocus(frameTouchLayoutSource);
 end;
 
 {-----------------------------------------------------------------------------}
@@ -3185,7 +3188,9 @@ begin
   begin
     frameTouchLayoutSource.EditorText := frameTouchLayout.SaveToString;
     DoFocus(frameTouchLayoutSource);
-  end;
+  end
+  else
+    DoFocus(frameTouchLayout);
   FLoading := False;
 end;
 

--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -115,6 +115,7 @@ type
 
   public
     { Public declarations }
+    procedure SetFocus; override;
     procedure SetupCharMapDrop;
     function Load(const AFilename: string; ALoadFromTemplate, ALoadFromString: Boolean): Boolean;
     procedure Save(const AFilename: string);
@@ -606,6 +607,11 @@ end;
 procedure TframeTouchLayoutBuilder.SelectAll;
 begin
   cef.cef.SelectAll;
+end;
+
+procedure TframeTouchLayoutBuilder.SetFocus;
+begin
+  cef.SetFocus;
 end;
 
 procedure TframeTouchLayoutBuilder.SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);   // I4057


### PR DESCRIPTION
Double-click to insert a character from char map into the touch layout
editor would not work reliably after focus changes.

Fixes #2702.

🍒 of #2736.