### PR TITLE
feat(windows): etl2log support tool

### DIFF
--- a/windows/src/support/Makefile
+++ b/windows/src/support/Makefile
@@ -2,7 +2,7 @@
 # Support Makefile
 #
 
-TARGETS=oskbulkrenderer
+TARGETS=oskbulkrenderer etl2log
 CLEANS=clean-support
 
 !include ..\Header.mak
@@ -11,6 +11,10 @@ CLEANS=clean-support
 
 oskbulkrenderer:
     cd $(ROOT)\src\support\oskbulkrenderer
+    $(MAKE) $(TARGET)
+
+etl2log:
+    cd $(ROOT)\src\support\etl2log
     $(MAKE) $(TARGET)
 
 # ----------------------------------------------------------------------

--- a/windows/src/support/etl2log/Makefile
+++ b/windows/src/support/etl2log/Makefile
@@ -1,0 +1,21 @@
+#
+# etl2log Makefile
+#
+
+!include ..\..\Defines.mak
+
+build: version.res dirs
+    $(MSBUILD) etl2log.vcxproj $(MSBUILD_BUILD)
+    $(COPY) $(MSBUILD_TARGET)\etl2log.exe $(PROGRAM)\support
+    $(COPY) $(MSBUILD_TARGET)\etl2log.pdb $(DEBUGPATH)\support
+
+clean: def-clean
+    $(MSBUILD) etl2log.vcxproj $(MSBUILD_CLEAN)
+
+signcode:
+    $(SIGNCODE) /d "Keyman Engine Tools" $(PROGRAM)\support\etl2log.exe
+
+backup:
+    $(WZZIP) $(BUILD)\support\etl2log.zip  $(BACKUPDEFAULTS) etl2log.exe
+
+!include ..\..\Target.mak

--- a/windows/src/support/etl2log/etl2log.cpp
+++ b/windows/src/support/etl2log/etl2log.cpp
@@ -1,0 +1,27 @@
+// etl2log.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include "stdafx.h"
+#include <iostream>
+
+BOOL Convert(PTSTR szPath, PTSTR szOutputFile);
+
+int wmain(int argc, wchar_t **argv) {
+  if (argc < 3) {
+    std::cout << "Usage: etl2log infile.etl outfile.log\n";
+    return 2;
+  }
+
+  return Convert(argv[1], argv[2]) ? 0 : 1;
+}
+
+// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
+// Debug program: F5 or Debug > Start Debugging menu
+
+// Tips for Getting Started: 
+//   1. Use the Solution Explorer window to add/manage files
+//   2. Use the Team Explorer window to connect to source control
+//   3. Use the Output window to see build output and other messages
+//   4. Use the Error List window to view errors
+//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
+//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file

--- a/windows/src/support/etl2log/etl2log.sln
+++ b/windows/src/support/etl2log/etl2log.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1000
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "etl2log", "etl2log.vcxproj", "{8754791A-42D7-4E93-84F1-97DEF9D644EB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Debug|x64.ActiveCfg = Debug|x64
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Debug|x64.Build.0 = Debug|x64
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Debug|x86.ActiveCfg = Debug|Win32
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Debug|x86.Build.0 = Debug|Win32
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Release|x64.ActiveCfg = Release|x64
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Release|x64.Build.0 = Release|x64
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Release|x86.ActiveCfg = Release|Win32
+		{8754791A-42D7-4E93-84F1-97DEF9D644EB}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {237ADAF6-56FC-4915-B29F-F4767EBBA15C}
+	EndGlobalSection
+EndGlobal

--- a/windows/src/support/etl2log/etl2log.vcxproj
+++ b/windows/src/support/etl2log/etl2log.vcxproj
@@ -165,6 +165,9 @@
     <ClInclude Include="logging.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="version.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/windows/src/support/etl2log/etl2log.vcxproj
+++ b/windows/src/support/etl2log/etl2log.vcxproj
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{8754791A-42D7-4E93-84F1-97DEF9D644EB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>etl2log</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="etl2log.cpp" />
+    <ClCompile Include="load.cpp" />
+    <ClCompile Include="logging.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="logging.h" />
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows/src/support/etl2log/etl2log.vcxproj.filters
+++ b/windows/src/support/etl2log/etl2log.vcxproj.filters
@@ -36,4 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="version.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/windows/src/support/etl2log/etl2log.vcxproj.filters
+++ b/windows/src/support/etl2log/etl2log.vcxproj.filters
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="etl2log.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="load.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="logging.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="logging.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/windows/src/support/etl2log/load.cpp
+++ b/windows/src/support/etl2log/load.cpp
@@ -1,0 +1,329 @@
+
+#include "stdafx.h"
+#include <stdio.h>
+#include <initguid.h>
+
+#define SESSION_NAME  TEXT("Keyman-Debug-ETWProvider")
+
+// {DA621615-E08B-4283-918E-D2502D3757AE}
+DEFINE_GUID(
+  g_Provider,
+  0xDA621615, 0xE08B, 0x4283, 0x91, 0x8E, 0xD2, 0x50, 0x2D, 0x37, 0x57, 0xAE);
+
+void WINAPI EventRecordCallback(PEVENT_RECORD event);
+BOOL InsertRecord(LONGLONG event_id, LONGLONG timestamp, ULONG pid, ULONG tid,
+  PEVENT_RECORD event, PTRACE_EVENT_INFO info);
+
+TRACEHANDLE hTrace = INVALID_PROCESSTRACE_HANDLE;
+LONGLONG recordNum = 0;
+FILE *fp = NULL;
+PTRACE_EVENT_INFO pInfo = NULL;
+DWORD pInfoBufferSize = 0;
+
+BOOL LoadTrace(PTSTR szPath) {
+  EVENT_TRACE_LOGFILE trace = { 0 };
+  TCHAR session[] = SESSION_NAME;
+
+  if (szPath != NULL) {
+    trace.LogFileName = szPath;
+    trace.ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD;
+  }
+  else {
+    trace.LoggerName = session;
+    trace.ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_REAL_TIME;
+  }
+
+  trace.EventRecordCallback = EventRecordCallback;
+
+  hTrace = OpenTrace(&trace);
+  if (hTrace == INVALID_PROCESSTRACE_HANDLE) {
+    DoLogError(L"OpenTrace failed with error %d", GetLastError());
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+BOOL CreateLogFile(PTSTR szOutputFile) {
+  _wfopen_s(&fp, szOutputFile, L"w");
+
+  fwprintf(fp,
+    L"Index\t"
+    L"Timestamp\t"
+    L"Platform\t"
+    L"Process\t"
+    L"PID\t"
+    L"TID\t"
+    L"ModifierState\t"
+    L"ModifierState\t"
+    L"ActualModifierState\t"
+    L"ActualModifierState\t"
+    L"TickCount\t"
+    L"FocusHWND\t"
+    L"ActiveHKL\t"
+    L"SourceFile\t"
+    L"SourceLine\t"
+    L"Message\n");
+
+  return TRUE;
+}
+
+BOOL Convert(PTSTR szPath, PTSTR szOutputFile) {
+  DWORD status;
+  int repeat = 0;
+  if (!LoadTrace(szPath)) return FALSE;
+  if (!CreateLogFile(szOutputFile)) return FALSE;
+
+  DoLogInfo(L"Starting to process trace from %s into %s", szPath, szOutputFile);
+  do {
+    status = ProcessTrace(&hTrace, 1, NULL, NULL);
+    if (status != ERROR_SUCCESS) {
+      DoLogError(L"ProcessTrace is not ready (received error %d). Waiting 0.1 seconds", status);
+      Sleep(100);
+      if (++repeat > 20) break;
+    }
+  } while (status != ERROR_SUCCESS);
+
+  CloseTrace(hTrace);
+
+  fclose(fp);
+
+  return TRUE;
+}
+
+void WINAPI EventRecordCallback(PEVENT_RECORD event) {
+  if (!IsEqualGUID(event->EventHeader.ProviderId, g_Provider)) {
+    return;
+  }
+
+  if (++recordNum % 10000 == 0) {
+    // This stops our buffers growing too large, and in theory
+    // in the future allows us to watch the trace in "real time"
+    DoLogInfo(L"... %lld records", recordNum);
+  }
+
+  DWORD status = TdhGetEventInformation(event, 0, NULL, pInfo, &pInfoBufferSize);
+  if (status == ERROR_INSUFFICIENT_BUFFER) {
+    if (pInfo) free(pInfo);
+    pInfo = (TRACE_EVENT_INFO *)malloc(pInfoBufferSize);
+    status = TdhGetEventInformation(event, 0, NULL, pInfo, &pInfoBufferSize);
+  }
+
+  if (status != ERROR_SUCCESS) {
+    DoLogError(L"Failed to get event information with error %d", status);
+    return;
+  }
+
+  //if (pInfo->TaskNameOffset == 0) {
+  //  DoLogError(L"Event has no task name");
+//    return;
+//  }
+
+  // TODO: this is calling out for refactoring ... ...
+  //PWSTR pTask = (PWSTR)((PBYTE)(pInfo)+pInfo->TaskNameOffset);
+  //if (wcscmp(pTask, L"Message") == 0) {
+
+    /*
+      < data name = "Platform" inType = "win:UInt32" map = "Platform" / >
+    <data name = "Process" inType = "win:UnicodeString" / >
+    <data name = "PID" inType = "win:UInt32" / >
+    <data name = "TID" inType = "win:UInt32" / >
+    <data name = "ModifierState" inType = "win:UInt32" map = "ModifierState" / >
+    <data name = "ActualModifierState" inType = "win:UInt32" map = "ModifierState" / >
+    <data name = "TickCount" inType = "win:UInt32" / >
+    <data name = "FocusHWND" inType = "win:UInt32" / >
+    <data name = "ActiveHKL" inType = "win:UInt32" / >
+    <data name = "SourceFile" inType = "win:UnicodeString" / >
+    <data name = "SourceLine" inType = "win:UInt32" / >
+    <data name = "Message" inType = "win:UnicodeString" / >
+
+
+*/
+
+
+    if (!InsertRecord(recordNum,
+        event->EventHeader.TimeStamp.QuadPart,
+        event->EventHeader.ProcessId,
+        event->EventHeader.ThreadId,
+        event,
+        pInfo)) {
+      DoLogError(L"Failed to insert Event record for Message");
+      return;
+    }
+  //}
+  //else {
+  //  DoLogError(L"Received an event with an unexpected name '%s'", pTask);
+  //  return;
+  //}
+}
+
+
+PBYTE propertyBuf = NULL;
+ULONG currentPropertyBufSize = 0, propertyBufSize = 0;
+
+BOOL GetEventProperties(PEVENT_RECORD event, PTRACE_EVENT_INFO info, int propertyIndex, PWSTR &propertyName) {
+  propertyName = (PWCHAR)((PBYTE)(pInfo)+pInfo->EventPropertyInfoArray[propertyIndex].NameOffset);
+  PROPERTY_DATA_DESCRIPTOR pdd = { 0 };
+  pdd.ArrayIndex = ULONG_MAX;
+  pdd.PropertyName = (ULONGLONG)(propertyName);
+
+  ULONG sz;
+  DWORD status = TdhGetPropertySize(event, 0, NULL, 1, &pdd, &sz);
+  if (status != ERROR_SUCCESS) {
+    DoLogError(L"Failed to get property size with error %d", status);
+    return FALSE;
+  }
+
+  if (sz == 0) {
+    return TRUE;
+  }
+  else {
+
+    if (sz + 2 > propertyBufSize) {
+      if (propertyBuf) delete propertyBuf;
+      propertyBufSize = sz + 2; // add trailing WCHAR nul
+      propertyBuf = new BYTE[propertyBufSize];
+    }
+    status = TdhGetProperty(event, 0, NULL, 1, &pdd, propertyBufSize, propertyBuf);
+    // Always nul terminate (even if not a string!)
+    propertyBuf[sz] = 0;
+    propertyBuf[sz + 1] = 0;
+    if (status != ERROR_SUCCESS) {
+      DoLogError(L"Failed to get property with error %d", status);
+      return FALSE;
+    }
+    return TRUE;
+  }
+}
+
+void PrintPlatform(int platform) {
+  switch (platform) {
+  case 1: fwprintf(fp, L"\tx86"); break;
+  case 2: fwprintf(fp, L"\tx64"); break;
+  default: fwprintf(fp, L"\t%d", platform); break;
+  }
+}
+
+#define LCTRLFLAG		0x0001		// Left Control flag
+#define RCTRLFLAG		0x0002		// Right Control flag
+#define LALTFLAG		0x0004		// Left Alt flag
+#define RALTFLAG		0x0008		// Right Alt flag
+#define K_SHIFTFLAG		0x0010		// Either shift flag
+#define K_CTRLFLAG		0x0020		// Either ctrl flag
+#define K_ALTFLAG		0x0040		// Either alt flag
+#define CAPITALFLAG		0x0100		// Caps lock on
+#define NOTCAPITALFLAG	0x0200		// Caps lock NOT on
+#define NUMLOCKFLAG		0x0400		// Num lock on
+#define NOTNUMLOCKFLAG	0x0800		// Num lock NOT on
+#define SCROLLFLAG		0x1000		// Scroll lock on
+#define NOTSCROLLFLAG	0x2000		// Scroll lock NOT on
+#define ISVIRTUALKEY	0x4000		// It is a Virtual Key Sequence
+#define VIRTUALCHARKEY	0x8000		// Keyman 6.0: Virtual Key Cap Sequence NOT YET
+
+void PrintModifierState(int state) {
+  fwprintf(fp, L"\t%x\t", state);
+  if (state == 0) {
+    fwprintf(fp, L"-");
+    return;
+  }
+
+  if (state & LCTRLFLAG) fwprintf(fp, L"LCTRL ");
+  if (state & RCTRLFLAG) fwprintf(fp, L"RCTRL ");
+  if (state & LALTFLAG) fwprintf(fp, L"LALT ");
+  if (state & RALTFLAG) fwprintf(fp, L"RALT ");
+  if (state & K_SHIFTFLAG) fwprintf(fp, L"SHIFT ");
+  if (state & K_CTRLFLAG) fwprintf(fp, L"CTRL ");
+  if (state & K_ALTFLAG) fwprintf(fp, L"ALT ");
+  if (state & CAPITALFLAG) fwprintf(fp, L"CAPS ");
+  if (state & NOTCAPITALFLAG) fwprintf(fp, L"NCAPS ");
+  if (state & NUMLOCKFLAG) fwprintf(fp, L"NUM ");
+  if (state & NOTNUMLOCKFLAG) fwprintf(fp, L"NNUM ");
+  if (state & SCROLLFLAG) fwprintf(fp, L"SCROLL ");
+  if (state & NOTSCROLLFLAG) fwprintf(fp, L"NSCROLL ");
+}
+
+void PrintHWND(HWND hwnd) {
+  fwprintf(fp, L"\t%x", (int) hwnd);
+}
+
+void PrintHKL(HKL hkl) {
+  fwprintf(fp, L"\t%08.8x", (int) hkl);
+}
+
+void PrintDefault(PWSTR propertyName, int type) {
+  switch (type) {
+  case TDH_INTYPE_UNICODESTRING:
+    fwprintf(fp, L"\t%s", (PWCHAR)propertyBuf);
+    break;
+  case TDH_INTYPE_ANSISTRING:
+    fwprintf(fp, L"\t%hs", (PCHAR)propertyBuf);
+    break;
+  case TDH_INTYPE_INT16:
+  case TDH_INTYPE_UINT16:
+    fwprintf(fp, L"\t%d", *(short *)propertyBuf);
+    break;
+  case TDH_INTYPE_INT32:
+  case TDH_INTYPE_UINT32:
+    fwprintf(fp, L"\t%d", *(int *)propertyBuf);
+    break;
+  case TDH_INTYPE_INT64:
+  case TDH_INTYPE_UINT64:
+    fwprintf(fp, L"\t%lld", *(LONGLONG *)propertyBuf);
+    break;
+  case TDH_INTYPE_BINARY:
+    // TODO?
+    break;
+  default:
+    DoLogError(L"Table has a property %s with unexpected type %d", propertyName, type);
+    //return FALSE;
+  }
+}
+
+BOOL InsertRecord(LONGLONG event_id, LONGLONG timestamp, ULONG pid, ULONG tid,
+  PEVENT_RECORD event, PTRACE_EVENT_INFO info) {
+
+  fwprintf(fp,
+    L"%lld\t"
+    L"%lld",
+    event_id,
+    timestamp);
+
+  for (ULONG i = 0, col = 0; i < pInfo->TopLevelPropertyCount; i++) {
+    PWSTR propertyName;
+    if (!GetEventProperties(event, info, i, propertyName)) return FALSE;
+
+    PWCHAR pdot = wcsstr(propertyName, L".Length");
+    if (pdot) {
+      // We assume this is a property for the length of the next field
+      // We'll use the field but we won't be inserting into the database
+      currentPropertyBufSize = *(int *)propertyBuf;
+      continue;
+    }
+
+    // Special case column formatting
+    switch (col) {
+    case 0: PrintPlatform(*(int *)propertyBuf); break;
+    case 4: PrintModifierState(*(int *)propertyBuf); break; // ModifierState
+    case 5: PrintModifierState(*(int *)propertyBuf); break; // ActualModifierState
+    case 7: PrintHWND(*(HWND *)propertyBuf); break; // FocusHWND
+    case 8: PrintHKL(*(HKL *)propertyBuf); break; // ActiveHKL
+    case 1: // process
+    case 2: // PID
+    case 3: // TID
+    case 6: // TickCount
+    case 9: // SourceFile
+    case 10: // SourceLine
+    case 11: // Message
+    default:
+      PrintDefault(propertyName, pInfo->EventPropertyInfoArray[i].nonStructType.InType);
+      break;
+    }
+
+
+    col++;
+  }
+
+  fwprintf(fp, L"\n");
+  return TRUE;
+}
+

--- a/windows/src/support/etl2log/logging.cpp
+++ b/windows/src/support/etl2log/logging.cpp
@@ -1,0 +1,53 @@
+
+#include "stdafx.h"
+#include <stdio.h>
+
+void DoLog(int level, const char *file, int line, const wchar_t *message, ...)
+{
+  wchar_t fmtbuf[256], outbuf[300];
+
+  if (level < 0 || level > 2) level = 0;
+  const wchar_t *state[] = { L"Info", L"Warning", L"Error" };
+
+  va_list vars;
+  va_start(vars, message);
+  _vsnwprintf_s(fmtbuf, _countof(fmtbuf), _TRUNCATE, message, vars);  // I2248   // I3547
+  fmtbuf[255] = 0;
+
+  wsprintfW(outbuf, L"[MMLog%s(%S:%d)] %s\n", state[level], file, line, fmtbuf);
+
+  if (LogToDebugConsole()) {
+    OutputDebugString(outbuf);
+  }
+
+#ifndef _USRDLL
+  outbuf[wcslen(outbuf) - 1] = 0; // remove final \n
+  _putws(outbuf);
+#endif
+}
+
+inline BOOL LogToDebugConsole() {
+  //#ifdef _DEBUG
+  return TRUE;
+  //#else
+    return FALSE;
+  //#endif
+}
+
+BOOL DoVerboseLogging() {
+  // 
+  return TRUE;
+}
+
+constexpr char hexmap[] = {
+  '0', '1', '2', '3', '4', '5', '6', '7',
+  '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' // lowercase because Delphi's System.Classes.HexToBin requires it
+};
+
+void hexStr2(PBYTE data, int len, wchar_t *out) {
+  for (int i = 0; i < len; ++i) {
+    out[2 * i] = hexmap[(data[i] & 0xF0) >> 4];
+    out[2 * i + 1] = hexmap[data[i] & 0x0F];
+  }
+  out[2 * len] = 0;
+}

--- a/windows/src/support/etl2log/logging.h
+++ b/windows/src/support/etl2log/logging.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#define __FILENAME__ (strrchr("\\" __FILE__, '\\') + 1)
+
+#define DoLogError(message,...)   DoLog(2, __FILENAME__, __LINE__, (message), __VA_ARGS__)
+#define DoLogWarning(message,...) if(DoVerboseLogging()) DoLog(1, __FILENAME__, __LINE__, (message), __VA_ARGS__)
+#define DoLogInfo(message,...)    if(DoVerboseLogging()) DoLog(0, __FILENAME__, __LINE__, (message), __VA_ARGS__)
+#define DoShowInfo(message,...)   DoLog(0, __FILENAME__, __LINE__, (message), __VA_ARGS__)
+
+void DoLog(int level, const char *file, int line, const wchar_t *message, ...);
+BOOL DoVerboseLogging();
+inline BOOL LogToDebugConsole();
+void hexStr2(PBYTE data, int len, wchar_t *out);

--- a/windows/src/support/etl2log/stdafx.cpp
+++ b/windows/src/support/etl2log/stdafx.cpp
@@ -1,0 +1,2 @@
+
+#include "stdafx.h"

--- a/windows/src/support/etl2log/stdafx.h
+++ b/windows/src/support/etl2log/stdafx.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <Windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <tdh.h>
+#include "logging.h"

--- a/windows/src/support/etl2log/version.in
+++ b/windows/src/support/etl2log/version.in
@@ -1,0 +1,30 @@
+1 VERSIONINFO
+  FILEVERSION		$VERSIONNUM
+  PRODUCTVERSION	$VERSIONNUM
+  FILEFLAGSMASK		0x3fL
+  FILEFLAGS		0x0L
+  FILEOS		0x4L
+  FILETYPE		0x2L
+  FILESUBTYPE		0x0L
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "0C0904E4"
+      BEGIN
+        VALUE "CompanyName", "SIL International\0"
+        VALUE "FileDescription", "Keyman etl to log converter\0"
+        VALUE "FileVersion", "$VERSION\0"
+        VALUE "InternalName", "KEYMAN32\0"
+        VALUE "LegalCopyright", "� SIL International\0"
+        VALUE "LegalTrademarks", "\0"
+        VALUE "OriginalFilename", "ETL2LOG.EXE\0"
+        VALUE "ProductName", "Keyman Engine\0"
+        VALUE "ProductVersion", "$VERSION\0"
+        VALUE "Comments", "\0"
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0xc09, 1252
+    END
+  END


### PR DESCRIPTION
Converts .etl logs from Keyman debug log into .log files for simpler analysis. These log files are generated when Keyman is running with Debugging on, into %localappdata%\Keyman\Diag.

The generated files are in UTF16 TSV which is easily loaded into Excel.

While the .etl files can also be loaded with Perfmon and other Event Tracing for Windows tools, they are typically cumbersome to configure and use.