### PR TITLE
Fix the region subtag description of TW.

### DIFF
--- a/resources/standards-data/language-subtag-registry/language-subtag-registry
+++ b/resources/standards-data/language-subtag-registry/language-subtag-registry
@@ -46017,7 +46017,7 @@ Added: 2005-10-16
 %%
 Type: region
 Subtag: TW
-Description: Taiwan, Province of China
+Description: Taiwan
 Added: 2005-10-16
 %%
 Type: region


### PR DESCRIPTION
According to US GOV document here, Taiwan is the proper name.

> Applicants with Taiwan passports may indicate Taiwan as country of nationality on their Form N-400 (Taiwan passports show “Republic of China”). Such applicants’ Certificates of Naturalization are issued showing Taiwan as country of former nationality. USCIS does not issue certificates showing “Taiwan, PRC,” “Taiwan, China,” “Taiwan, Republic of China,” or “Taiwan, ROC.” People’s Republic of China (PRC) is the country name used for applicants with PRC passports.

https://www.uscis.gov/policy-manual/volume-12-part-k-chapter-3#footnote-3
