### PR TITLE
fix(ios/engine): Fixes context bug for certain keyboard rules after newlines

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -306,6 +306,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     }
 
     // What the actual heck, Apple.  Apparently, in system-keyboard mode, this is also self-triggered if we erase back to a newline.
+    // Refer to https://github.com/keymanapp/keyman/pull/2770 for context.
     if self.swallowBackspaceTextChange && Manager.shared.isSystemKeyboard && textDocumentProxy.documentContextBeforeInput == "\n" {
       self.swallowBackspaceTextChange = false
       return
@@ -358,7 +359,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
           textDocumentProxy.insertText(String(oldContext[lowerIndex..<upperIndex]))
         }
       }
-      
+
+      // Refer to `func textDidChange()` and https://github.com/keymanapp/keyman/pull/2770 for context.
       if textDocumentProxy.documentContextBeforeInput == nil ||
          (textDocumentProxy.documentContextBeforeInput == "\n" && Manager.shared.isSystemKeyboard) {
         if(self.swallowBackspaceTextChange) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -304,6 +304,12 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       self.swallowBackspaceTextChange = false
       return
     }
+
+    // What the actual heck, Apple.  Apparently, in system-keyboard mode, this is also self-triggered if we erase back to a newline.
+    if self.swallowBackspaceTextChange && Manager.shared.isSystemKeyboard && textDocumentProxy.documentContextBeforeInput == "\n" {
+      self.swallowBackspaceTextChange = false
+      return
+    }
     
     let contextBeforeInput = textDocumentProxy.documentContextBeforeInput ?? ""
     let contextAfterInput = textDocumentProxy.documentContextAfterInput ?? ""
@@ -353,7 +359,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
         }
       }
       
-      if textDocumentProxy.documentContextBeforeInput == nil {
+      if textDocumentProxy.documentContextBeforeInput == nil ||
+         (textDocumentProxy.documentContextBeforeInput == "\n" && Manager.shared.isSystemKeyboard) {
         if(self.swallowBackspaceTextChange) {
           // A single keyboard processing command should never trigger two of these in a row;
           // only one output function will perform deletions.


### PR DESCRIPTION
🍒-picked at #2776.

Turns out that #1756 was actually slightly incomplete in one aspect.

Apple has some really, uh, "interesting" behavior for its IME text context objects.  What was happening:

1. A user types a block of text
2. They then hit ENTER for a newline
3. Type a small bit of extra text that matches a keyboard rule prefix
4. Type the key that triggers the keyboard rule, deleting context up to the point of the newline as _part_ of the rule.

At this stage, Apple triggers a `textDidChange` event, saying "oh, your only context _is_ that newline"... _after_ the keyboard rules have been triggered and suggestions generated.  Not catching this detail causes a state where any suggestions accepted are then applied as if there were no context, creating masses of duplicated text.

So, we now know that `textDidChange` can be triggered at unwanted times when:
- all text has been erased (null prefix)
- (new) all text after a newline has been erased (so, uh, "newline prefix")

These scenarios never affect in-app keystrokes because the app has direct access to the current context, allowing it to bypass the IME abstraction.

Fortunately, as noted by [this review comment](https://github.com/keymanapp/keyman/pull/1756#pullrequestreview-237026764) on #1764,
> Targeted, documented fix, that will be easy to tweak if the situation ever changes.

And indeed it was; the trick was realizing that this was a new scenario that caused the same conditions.