### PR TITLE
fix(common): parameter order incorrect in git diff

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -100,7 +100,7 @@ git fetch origin > /dev/null
 #
 
 echo ". Get list of changed files in the pull request"
-prfiles=`git diff "origin/$prbase"..."origin/$prhead" --name-only || ( if [ $? == 128 ]; then echo abort; else exit $?; fi )`
+prfiles=`git diff --name-only "origin/$prbase"..."origin/$prhead" || ( if [ $? == 128 ]; then echo abort; else exit $?; fi )`
 if [ "$prfiles" == "abort" ]; then
   # Don't trigger any builds, exit with success
   echo "Remote branch origin/$prhead has gone away; probably an automatic pull request. Skipping build."


### PR DESCRIPTION
This caused the build triggers to fail in some circumstances, for example see log at 
https://build.palaso.org/viewLog.html?buildId=188008&buildTypeId=Keyman_Test&tab=buildLog&_focus=113#_state=99

```
[12:56:36][Step 2/2]  * [new tag]             windows-release-stable-13.0.102.0 -> windows-release-stable-13.0.102.0
[12:56:36][Step 2/2] . Get list of changed files in the pull request
[12:56:36][Step 2/2] fatal: option '--name-only' must come before non-option arguments
```