### PR TITLE
fix(linux): Fix CI dist path to common/core/desktop

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -76,10 +76,10 @@ for proj in ${extra_projects}; do
         cp dist/*.tar.gz ../dist
     fi
     if [ "${proj}" == "keyboardprocessor" ]; then
-        cd ../common/engine
-        vers=`grep -Po "version: '(.*)'" keyboardprocessor/meson.build|grep -Po "\d+(.\d+)*"`
+        cd ../common/core
+        vers=`grep -Po "version: '(.*)'" desktop/meson.build|grep -Po "\d+(.\d+)*"`
         kbpvers="keyman-keyboardprocessor-$vers"
-        cp -a keyboardprocessor $kbpvers
+        cp -a desktop $kbpvers
         tar cvzf $kbpvers.tar.gz --exclude=debian --exclude=build --exclude=.gitignore $kbpvers
         rm -rf $kbpvers
         cp $kbpvers.tar.gz ../../linux/dist


### PR DESCRIPTION
Follow-on to #2735

The dist.sh script also needs to be updated to fix path from common/engine/keyboardprocessor/
to common/core/desktop/