### PR TITLE
fix(web): fixes build number reference of API call

### DIFF
--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1212,7 +1212,7 @@ namespace com.keyman {
         Lscript = this.keymanweb.util._CreateElement('script');
       
       URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
-        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+this.keymanweb['build'];
+        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version'];
 
       var kbdManager = this;
       

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1212,7 +1212,7 @@ namespace com.keyman {
         Lscript = this.keymanweb.util._CreateElement('script');
       
       URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
-        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+KeymanBase['__BUILD__'];
+        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+this.keymanweb['build'];
 
       var kbdManager = this;
       


### PR DESCRIPTION
Fixes #2785.

I'd actually noticed this behavior recently on the KMW local testing pages, but just hadn't gotten around to making an issue for it in the midst of everything else last week.  It turns out that a change intended only for 14.0 got backported to 13.0 - how the old `_BUILD_` property is now relocated to `keyman.build` so that it can be set by environment.inc.ts.

The resulting issue is best highlighted by the two following API calls, both requesting `sil_euro_latin@no` - a Norwegian-tagged request for use of the SIL EuroLatin keyboard:
- (Current) https://api.keyman.com/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=14.0.undefined&keyboardid=sil_euro_latin@no&timerid=7
- (Fixed) https://api.keyman.com/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=14.0.18&keyboardid=sil_euro_latin@no&timerid=7

There's something about the API query that breaks when _both_ the keyboard ID _and_ the language ID are specified for a single keyboard whenever the build-number component is `undefined`.  Unfortunately, this is _**exactly**_ the use case that the KMW Bookmarklet uses.