### PR TITLE
fix(web): fixes build number reference of API call

### DIFF
--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1212,7 +1212,7 @@ namespace com.keyman {
         Lscript = this.keymanweb.util._CreateElement('script');
       
       URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
-        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+this.keymanweb['build'];
+        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version'];
 
       var kbdManager = this;
       

--- a/web/source/kmwkeyboards.ts
+++ b/web/source/kmwkeyboards.ts
@@ -1212,7 +1212,7 @@ namespace com.keyman {
         Lscript = this.keymanweb.util._CreateElement('script');
       
       URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
-        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+KeymanBase['__BUILD__'];
+        +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version']+'.'+this.keymanweb['build'];
 
       var kbdManager = this;
       


### PR DESCRIPTION
A 🍒-pick of #2796.  Fixes #2785 on stable-13.0.

Proof the cause is the same for 13.0:

<img width="1723" alt="Screen Shot 2020-03-09 at 9 59 17 PM" src="https://user-images.githubusercontent.com/25213402/76227062-4b18a200-6251-11ea-9a4d-c2a364542c1b.png">

Use of `keyman.build` (over the old `com.keyman.__BUILD__`, which is now `undefined`) was supposed to be 14.0+, but it apparently slipped into 13.0 somehow.