### PR TITLE
fix(ios): fixes Carthage framework copy for Sentry

### DIFF
--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -131,9 +131,9 @@
 		C0FF769B1F5D368C00BD23C3 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF769A1F5D368C00BD23C3 /* KeyboardViewController.swift */; };
 		C0FF769E1F5D4ECB00BD23C3 /* ActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF769D1F5D4ECB00BD23C3 /* ActivityItemProvider.swift */; };
 		CE002CB52408B4A5002026CE /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE002CB42408B4A5002026CE /* Sentry.framework */; };
-		CE002CB62408B4A5002026CE /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE002CB42408B4A5002026CE /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE1F5ECE23331DA400141F3E /* OfflineHelp.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE1F5ECD23331DA400141F3E /* OfflineHelp.bundle */; };
 		CE2B1E4C21B6112B007D092E /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE2B1E4B21B6112B007D092E /* DeviceKit.framework */; };
+		CE4E73D024170C9A00EBD1A5 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE002CB42408B4A5002026CE /* Sentry.framework */; };
 		CE6138011FB99538009D0EF2 /* KeymanEngine.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE6137FF1FB99538009D0EF2 /* KeymanEngine.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE6138021FB999C8009D0EF2 /* KeymanEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6138031FB999C8009D0EF2 /* KeymanEngine.framework */; };
 		CE76FF8023EBB5CB005648A8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98C893F119F0811A000B9AC8 /* Images.xcassets */; };
@@ -177,7 +177,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				CE6138011FB99538009D0EF2 /* KeymanEngine.framework in Embed Frameworks */,
-				CE002CB62408B4A5002026CE /* Sentry.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -347,6 +346,7 @@
 				CE6138021FB999C8009D0EF2 /* KeymanEngine.framework in Frameworks */,
 				C059FCB91FD925AF00BD1A64 /* ObjcExceptionBridging.framework in Frameworks */,
 				C059FCBA1FD925AF00BD1A64 /* XCGLogger.framework in Frameworks */,
+				CE4E73D024170C9A00EBD1A5 /* Sentry.framework in Frameworks */,
 				C059FCBB1FD925AF00BD1A64 /* Zip.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -932,6 +932,7 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/XCGLogger.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/DeviceKit.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Reachability.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Sentry.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Looks like I didn't quite get the framework copying part of the build right when adding Sentry to the iOS app:

```
[01:57:07]
[Step 3/3] ERROR [2020-03-10 05:57:57.57]: [Transporter Error Output]: ERROR ITMS-90087: "Unsupported Architectures. The executable for Keyman.app/Frameworks/Sentry.framework contains unsupported architectures '[x86_64, i386]'."
[01:57:07]
[Step 3/3] 
[01:57:07]
[Step 3/3] ERROR [2020-03-10 05:57:57.57]: [Transporter Error Output]: ERROR ITMS-90209: "Invalid Segment Alignment. The app binary at 'Keyman.app/Frameworks/Sentry.framework/Sentry' does not have proper segment alignment. Try rebuilding the app with the latest Xcode version."
[01:57:07]
[Step 3/3] 
[01:57:07]
[Step 3/3] ERROR [2020-03-10 05:57:57.57]: [Transporter Error Output]: ERROR ITMS-90125: "The binary is invalid. The encryption info in the LC_ENCRYPTION_INFO load command is either missing or invalid, or the binary is already encrypted. This binary does not seem to have been built with Apple's linker."
```

I've now double-checked all those settings and tweaked them to better match those of our other existing dependencies; this should fix the iOS build.  (Wish they could more easily tell us this on a standard Xcode build before trying to upload...)