### PR TITLE
fix(web): applies base key layer property to unassigned subkeys

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -314,6 +314,11 @@ namespace com.keyman.osk {
           var oldText=bsk[bsn]['text'];
           bsk[bsn]['text']=this.renameSpecialKey(oldText);
         }
+
+        // If a subkey doesn't have a defined layer property, copy it from the base key's layer by default.
+        if(!bsk[bsn].layer) {
+          bsk[bsn].layer = btn.key.layer
+        }
       }
 
       // If a subkey array is defined, add an icon


### PR DESCRIPTION
Fixes #2756.

For review, it may help to refer to VisualKeyboard.ts, line 74 or so.  `.layer` is the key's display layer, while `.spec.layer` refers to the modifier layer.  Tracking these properties gets a bit tricky.

### User Testing

@mcdurdin has data for a (private) keyboard affected by the bug this addresses; please ensure that it behaves as expected when on a build based off this branch.  (Note the "attached keyboard" detail in the original issue... which was not attached.)