### PR TITLE
feat(android): Additional Sentry integration

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <!--    how to enable Sentry's debug mode-->
     <meta-data
       android:name="io.sentry.debug" android:value="true" />
+    <!-- Disable monitoring "Application Not Responding" (ANR).  Too many reports at the default 4000 ms -->
+    <meta-data
+      android:name="io.sentry.anr.enable" android:value="false" />
 
     <service
       android:name="com.keyman.android.SystemKeyboard"

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -480,9 +480,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       case R.id.action_settings:
         showSettings();
         return true;
-      case R.id.action_crash:
-        showCrash();
-        return true;
       case R.id.action_update_keyboards:
         KMManager.getUpdateTool().executeOpenUpdates();
         return true;
@@ -917,11 +914,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   private void showSettings() {
     Intent settingsIntent = new Intent(this, KeymanSettingsActivity.class);
     startActivity(settingsIntent);
-  }
-
-  // Temporary menu item to intentionally generate crashes for Sentry
-  private void showCrash() {
-    throw new NullPointerException("MainActivity throwing null");
   }
 
   public static Drawable getActionBarDrawable(Context context) {

--- a/android/KMAPro/kMAPro/src/main/res/menu/overflow_menu.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu/overflow_menu.xml
@@ -34,13 +34,6 @@
         app:showAsAction="never"
         android:icon="@drawable/ic_settings" />
 
-      <!-- temp item to generate intentional crashes for Sentry -->
-      <item
-        android:id="@+id/action_crash"
-        android:title="Crash"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_action_close" />
-
       <item
         android:id="@+id/action_update_keyboards"
         android:title="@string/action_install_updates"

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -634,10 +634,6 @@ final class KMKeyboard extends WebView {
   }
 
   private void sendKMWError(int lineNumber, String sourceId, String message) {
-    if (this.packageID == null || this.keyboardID == null || this.keyboardName == null || this.keyboardVersion == null) {
-      return;
-    }
-
     if (Sentry.isEnabled()) {
       Breadcrumb breadcrumb = new Breadcrumb();
       breadcrumb.setMessage("KMKeyboard.sendKMWError");
@@ -656,11 +652,19 @@ final class KMKeyboard extends WebView {
       } else {
         breadcrumb.setData("keyboardType", "UNDEFINED");
       }
-      breadcrumb.setData("packageID", this.packageID);
-      breadcrumb.setData("keyboardID", this.keyboardID);
-      breadcrumb.setData("keyboardName", this.keyboardName);
-      breadcrumb.setData("keyboardVersion", this.keyboardVersion);
 
+      if (this.packageID != null) {
+        breadcrumb.setData("packageID", this.packageID);
+      }
+      if (this.keyboardID != null) {
+        breadcrumb.setData("keyboardID", this.keyboardID);
+      }
+      if (this.keyboardName != null) {
+        breadcrumb.setData("keyboardName", this.keyboardName);
+      }
+      if (this.keyboardVersion != null) {
+        breadcrumb.setData("keyboardVersion", this.keyboardVersion);
+      }
       Sentry.addBreadcrumb(breadcrumb);
       Sentry.captureMessage("sendKMWError", SentryLevel.ERROR);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -634,6 +634,10 @@ final class KMKeyboard extends WebView {
   }
 
   private void sendKMWError(int lineNumber, String sourceId, String message) {
+    if (this.packageID == null || this.keyboardID == null || this.keyboardName == null || this.keyboardVersion == null) {
+      return;
+    }
+
     if (Sentry.isEnabled()) {
       Breadcrumb breadcrumb = new Breadcrumb();
       breadcrumb.setMessage("KMKeyboard.sendKMWError");


### PR DESCRIPTION
Revert intentional crash from #2778

Now that the call stack in Sentry is tested on Release build
http://sentry.keyman.com/organizations/keyman/issues/61/?project=7

* The temporary menu to generate the intentional crash can be removed.

Additional updates
* Disable monitoring Application Not Responding (ANR)
* Add NPE checks before sending KMW error to Sentry.

(Addresses https://sentry.keyman.com/organizations/keyman/issues/58)

Fixes KEYMAN-ANDROID-K.