### PR TITLE
fix(linux): Fix how keyboardprocessor version is set in dist.sh

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -77,7 +77,7 @@ for proj in ${extra_projects}; do
     fi
     if [ "${proj}" == "keyboardprocessor" ]; then
         cd ../common/core
-        vers=`grep -Po "version: '(.*)'" desktop/meson.build|grep -Po "\d+(.\d+)*"`
+        vers=`cat ../../VERSION.md`
         kbpvers="keyman-keyboardprocessor-$vers"
         cp -a desktop $kbpvers
         tar cvzf $kbpvers.tar.gz --exclude=debian --exclude=build --exclude=.gitignore $kbpvers


### PR DESCRIPTION
Follow on to #2735 and #2795 

The project.version in meson.build is no longer replaced to `#.#.#` in the file, which caused dist.sh to fail on CI test builds.

This PR has vers use the same VERSION.md file as all the other platforms. 

