### PR TITLE
fix(common/lmlayer): fixes word lookup from Tries for SMP script-based languages

### DIFF
--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -291,10 +291,14 @@
    * @param index The index in the prefix. Initially 0.
    */
   function findPrefix(node: Node, key: SearchKey, index: number = 0): Node | null {
-    if (node.type === 'leaf' || index === key.kmwLength()) {
+    // An important note - the Trie itself is built on a per-JS-character basis,
+    // not on a UTF-8 character-code basis.
+    if (node.type === 'leaf' || index === key.length) {
       return node;
     }
 
+    // So, for SMP models, we need to match each char of the supplementary pair
+    // in sequence.  Each has its own node in the Trie.
     let char = key[index];
     if (node.children[char]) {
       return findPrefix(node.children[char], key, index + 1);


### PR DESCRIPTION
This fixes a community-reported bug when for Trie-based lexical models for SMP-based languages.  The reported issue:  a character had to be typed twice for its suggestions to appear.  (Privacy has been requested for the original bug-reproducing resources, hence nothing being explicitly provided here.) 

As it turns out, the reason is that the second entry was necessary to traverse nodes to match the first actual character; we're currently building our Tries for SMP languages on a per-UCS-2 character basis, meaning that each UTF-8 SMP character has two nodes - one for each UCS-2 codepoint comprising it.  The first character was only ever "completed" once a second character (_any_ second character) was typed.

So, while our wordbreaking and transforms need to be SMP-aware, internally the Trie is not.  Recognizing this fixes the reported issue.