### PR TITLE
feat(common): add release finalization for Sentry

### DIFF
--- a/resources/build/sentry-control.sh
+++ b/resources/build/sentry-control.sh
@@ -26,13 +26,16 @@ function isSentryCliAvailable() {
 function makeSentryRelease() {
   if isSentryConfigured; then
     if isSentryCliAvailable; then
+      # This version tag matches the repository version tag release-x.y.z
       local SENTRY_RELEASE_VERSION="release-$VERSION_WITH_TAG"
       echo "Making a Sentry release for tag $SENTRY_RELEASE_VERSION"
       sentry-cli releases new -p keyman-android -p keyman-developer -p keyman-ios -p keyman-linux -p keyman-mac -p keyman-web -p keyman-windows $SENTRY_RELEASE_VERSION
-      # Testing: sentry-cli releases new -p keyman-windows $SENTRY_RELEASE_VERSION
 
       echo "Setting commits for release tag $SENTRY_RELEASE_VERSION"
       sentry-cli releases set-commits --auto $SENTRY_RELEASE_VERSION
+
+      echo "Finalizing release tag $SENTRY_RELEASE_VERSION"
+      sentry-cli releases finalize "$SENTRY_RELEASE_VERSION"
     fi
   fi
 }


### PR DESCRIPTION
It's not 100% clear to me what the purpose of splitting 'new' and 'final' versions of releases is in [Sentry](https://docs.sentry.io/cli/releases/#finalizing-releases). But here it is.