### PR TITLE
fix(web): fixes internal reference for validation tool

### DIFF
--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -106,7 +106,7 @@ namespace com.keyman.renderer {
         // Uses 'private' APIs that may be subject to change in the future.  Keep it updated!
         var layers;
         if(isMobile) {
-          layers = keyman.osk.layers;
+          layers = keyman.osk.vkbd.layers;
         } else {
           // The desktop OSK will be overpopulated, with a number of blank layers to display in most cases.
           // We instead rely upon the KLS definition to ensure we keep the renders sparse.
@@ -132,7 +132,7 @@ namespace com.keyman.renderer {
             renderer.render(box, isMobile).then(function(imgEle: HTMLImageElement) {
               let eleLayer = document.createElement('div');
               let eleLayerId = document.createElement('p');
-              eleLayerId.textContent = 'Layer ID:  ' + (isMobile ? keyman.osk.layers[i].id : Object.keys(layers)[i]);
+              eleLayerId.textContent = 'Layer ID:  ' + (isMobile ? layers[i].id : Object.keys(layers)[i]);
 
               eleLayer.appendChild(eleLayerId);
               eleLayer.appendChild(imgEle);
@@ -145,7 +145,7 @@ namespace com.keyman.renderer {
         };
 
         // The resulting Promise will only call it's `.then()` once all of this keyboard's renders have been completed.
-        return renderer.arrayPromiseIteration(renderLayer, isMobile ? keyman.osk.layers.length : Object.keys(layers).length);
+        return renderer.arrayPromiseIteration(renderLayer, isMobile ? layers.length : Object.keys(layers).length);
       }).catch(function() {
         console.log("Failed to load the \"" + kbd['InternalName'] + "\" keyboard for rendering!");
         divSummary.appendChild(renderer.createKeyboardHeader(kbd, false));

--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -116,10 +116,14 @@ namespace com.keyman.renderer {
         let renderLayer = function(i: number) {
           return new Promise(function(resolve) {
             // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
-            if(isMobile) {
-              keyman.osk.layerId = layers[i].id;
+            if(keyman.osk.vkbd) {
+              if(isMobile) {
+                keyman.osk.vkbd.layerId = layers[i].id;
+              } else {
+                keyman.osk.vkbd.layerId = Object.keys(layers)[i];
+              }
             } else {
-              keyman.osk.layerId = Object.keys(layers)[i];
+              console.error("Error - keyman.osk.vkbd is undefined!");
             }
             // Make sure the active element's still set!
             renderer.setActiveDummy();


### PR DESCRIPTION
So, in v12 we split the OSK into two pieces - the `OSKManager` and the `VisualKeyboard`.  The bulk renderer never quite got the memo, as a critical (internal) reference for bulk rendering was moved from `keyman.osk` to `keyman.osk.vkbd` as a result - the part responsible for changing layers.