### PR TITLE
fix(oem): Disable monitoring of ANR for oem Android app

### DIFF
--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,10 @@
             android:name="io.sentry.dsn" android:value="https://a00ed3e10a2045acb3d93416be90d89a@sentry.keyman.com/7"/>
         <!--    how to enable Sentry's debug mode -->
         <meta-data
-           android:name="io.sentry.debug" android:value="true" />
+            android:name="io.sentry.debug" android:value="true" />
+        <!-- Disable monitoring "Application Not Responding" (ANR).  Too many reports at the default 4000 ms -->
+        <meta-data
+            android:name="io.sentry.anr.enable" android:value="false" />
 
         <service
             android:name="com.firstvoices.keyboards.SystemKeyboard"


### PR DESCRIPTION
This PR disables the OEM FirstVoices Android app from monitoring "Application Not Responding"
1. Matches KMAPro
2. The startup issue is tracked as #2811