### PR TITLE
fix(web): fixes design mode and content editable issues

### DIFF
--- a/web/source/dom/contentEditable.ts
+++ b/web/source/dom/contentEditable.ts
@@ -198,6 +198,7 @@ namespace com.keyman.dom {
         range.setStart(start.node, start.offset);
         range.collapse(true);
         range.insertNode(n);
+        finalCaret.setStart(n, s.length);
       }
 
       finalCaret.collapse(true);

--- a/web/source/dom/designIFrame.ts
+++ b/web/source/dom/designIFrame.ts
@@ -204,6 +204,7 @@ namespace com.keyman.dom {
         range.setStart(start.node, start.offset);
         range.collapse(true);
         range.insertNode(n);
+        finalCaret.setStart(n, s.length);
       }
 
       finalCaret.collapse(true);

--- a/web/source/dom/utils.ts
+++ b/web/source/dom/utils.ts
@@ -78,7 +78,7 @@ namespace com.keyman.dom {
         var Ldoc=Lobj.ownerDocument;   // I2404 - Support for IFRAMEs
 
         if(Ldoc && Ldoc.defaultView && Ldoc.defaultView.frameElement) {
-          return Lcurtop + Utils.getAbsoluteY(<HTMLElement>Ldoc.defaultView.frameElement) - Ldoc.documentElement.scrollTop;
+          return Lcurtop + Utils.getAbsoluteY(<HTMLElement>Ldoc.defaultView.frameElement);
         }
       }
       return Lcurtop;

--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -534,7 +534,7 @@ namespace com.keyman {
             if(util.device.browser == 'firefox') {
               util.attachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
               util.attachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-            } else { // Chrome
+            } else { // Chrome, Safari
               util.attachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
               util.attachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
             }
@@ -573,9 +573,10 @@ namespace com.keyman {
           if(Lelem.designMode.toLowerCase() == 'on') {
             // Mozilla      // I2404 - Attach to  IFRAMEs child objects, only editable IFRAMEs here
             if(util.device.browser == 'firefox') {
+              // Firefox won't handle these events on Lelem.body - only directly on Lelem (the doc) instead.
               util.detachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
               util.detachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-            } else { // Chrome
+            } else { // Chrome, Safari
               util.detachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
               util.detachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
             }

--- a/web/source/kmwdom.ts
+++ b/web/source/kmwdom.ts
@@ -531,18 +531,23 @@ namespace com.keyman {
         if(Lelem) {
           if(Lelem.designMode.toLowerCase() == 'on') {
             // I2404 - Attach to IFRAMEs child objects, only editable IFRAMEs here
-            util.attachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-            util.attachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-            util.attachDOMEvent(Lelem,'keydown', this.getHandlers(Pelem)._KeyDown);
-            util.attachDOMEvent(Lelem,'keypress', this.getHandlers(Pelem)._KeyPress);
-            util.attachDOMEvent(Lelem,'keyup', this.getHandlers(Pelem)._KeyUp);
+            if(util.device.browser == 'firefox') {
+              util.attachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
+              util.attachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
+            } else { // Chrome
+              util.attachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
+              util.attachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
+            }
+            util.attachDOMEvent(Lelem.body,'keydown', this.getHandlers(Pelem)._KeyDown);
+            util.attachDOMEvent(Lelem.body,'keypress', this.getHandlers(Pelem)._KeyPress);
+            util.attachDOMEvent(Lelem.body,'keyup', this.getHandlers(Pelem)._KeyUp);
 
             // Set up a reference alias; the internal document will need the same attachment info!
             this.setupElementAttachment(Pelem);
             Lelem.body._kmwAttachment = Pelem._kmwAttachment;
           } else {
             // Lelem is the IFrame's internal document; set 'er up!
-            this._SetupDocument(Lelem);	   // I2404 - Manage IE events in IFRAMEs
+            this._SetupDocument(Lelem.body);	   // I2404 - Manage IE events in IFRAMEs
           }
         }
       }
@@ -567,17 +572,22 @@ namespace com.keyman {
         if(Lelem) {
           if(Lelem.designMode.toLowerCase() == 'on') {
             // Mozilla      // I2404 - Attach to  IFRAMEs child objects, only editable IFRAMEs here
-            util.detachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-            util.detachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-            util.detachDOMEvent(Lelem,'keydown', this.getHandlers(Pelem)._KeyDown);
-            util.detachDOMEvent(Lelem,'keypress', this.getHandlers(Pelem)._KeyPress);
-            util.detachDOMEvent(Lelem,'keyup', this.getHandlers(Pelem)._KeyUp);
+            if(util.device.browser == 'firefox') {
+              util.detachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
+              util.detachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
+            } else { // Chrome
+              util.detachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
+              util.detachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
+            }
+            util.detachDOMEvent(Lelem.body,'keydown', this.getHandlers(Pelem)._KeyDown);
+            util.detachDOMEvent(Lelem.body,'keypress', this.getHandlers(Pelem)._KeyPress);
+            util.detachDOMEvent(Lelem.body,'keyup', this.getHandlers(Pelem)._KeyUp);
 
             // Remove the reference to our prior attachment data!
             Lelem.body._kmwAttachment = null;
           } else {
             // Lelem is the IFrame's internal document; set 'er up!
-            this._ClearDocument(Lelem);	   // I2404 - Manage IE events in IFRAMEs
+            this._ClearDocument(Lelem.body);	   // I2404 - Manage IE events in IFRAMEs
           }
         }
       }
@@ -594,10 +604,10 @@ namespace com.keyman {
      * @return      {Array<Element>}        A list of potentially-editable controls.  Further filtering [as with isKMWInput() and
      *                                      isKMWDisabled()] is required.
      */
-    _GetDocumentEditables(Pelem: HTMLElement|Document): (HTMLElement|Document)[] {
+    _GetDocumentEditables(Pelem: HTMLElement): (HTMLElement)[] {
       var util = this.keyman.util;
 
-      var possibleInputs: (HTMLElement|Document)[] = [];
+      var possibleInputs: (HTMLElement)[] = [];
 
       // Document.ownerDocument === null, so we better check that it's not null before proceeding.
       if(Pelem.ownerDocument && Pelem instanceof Pelem.ownerDocument.defaultView.HTMLElement) {
@@ -645,7 +655,7 @@ namespace com.keyman {
      * @param       {Element}     Pelem - the root element of a document, including IFrame documents.
      * Description  Used to automatically attach KMW to editable controls, regardless of control path.
      */
-    _SetupDocument(Pelem: HTMLElement|Document) { // I1961
+    _SetupDocument(Pelem: HTMLElement) { // I1961
       var possibleInputs = this._GetDocumentEditables(Pelem);
 
       for(var Li = 0; Li < possibleInputs.length; Li++) {
@@ -663,7 +673,7 @@ namespace com.keyman {
      * Description  Used to automatically detach KMW from editable controls, regardless of control path.
      *              Mostly used to clear out all controls of a detached IFrame.
      */
-    _ClearDocument(Pelem: HTMLElement|Document) { // I1961
+    _ClearDocument(Pelem: HTMLElement) { // I1961
       var possibleInputs = this._GetDocumentEditables(Pelem);
 
       for(var Li = 0; Li < possibleInputs.length; Li++) {

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -79,6 +79,10 @@ namespace com.keyman {
       if (Ltarg == null) {
         return true;
       }
+
+      if(Ltarg['body']) {
+        Ltarg = Ltarg['body']; // Occurs in Firefox for design-mode iframes.
+      }
     
       // Prevent any action if a protected input field
       if(device.touchable && (Ltarg.className == null || Ltarg.className.indexOf('keymanweb-input') < 0)) {
@@ -92,6 +96,8 @@ namespace com.keyman {
         if(!(et == 'text' || et == 'search')) {
           return true;
         }
+      } else if(Ltarg.ownerDocument && Ltarg.ownerDocument.designMode == 'on') {
+        // continue; don't block this one!
       } else if((device.touchable || !Ltarg.isContentEditable) 
           && !(Ltarg.ownerDocument && Ltarg instanceof Ltarg.ownerDocument.defaultView.HTMLTextAreaElement)) {
         return true;
@@ -190,6 +196,10 @@ namespace com.keyman {
         return true;
       }
 
+      if(Ltarg['body']) {
+        Ltarg = Ltarg['body']; // Occurs in Firefox for design-mode iframes.
+      }
+
       if(DOMEventHandlers.states._IgnoreBlurFocus) {
         // Prevent triggering other blur-handling events (as possible)
         e.cancelBubble = true;
@@ -209,6 +219,7 @@ namespace com.keyman {
         Ltarg = Ltarg.parentNode as HTMLElement;
       }
 
+      // TODO:  Needs tidy-up.
       if(Ltarg.ownerDocument) {
         if(Ltarg instanceof Ltarg.ownerDocument.defaultView.HTMLIFrameElement) {
           Ltarg=Ltarg.contentWindow.document;

--- a/web/source/kmwuitoggle.ts
+++ b/web/source/kmwuitoggle.ts
@@ -84,10 +84,11 @@ if(!window['keyman']['ui']['name']) {
     
       p = util['getAbsolute'](someElement); x = p['x']; y=p['y'];
 
-      if(someElement.defaultView && someElement.defaultView.frameElement)
+      var ownerDoc = someElement.ownerDocument;
+      if(ownerDoc.designMode == 'on' && ownerDoc.defaultView && ownerDoc.defaultView.frameElement)
       { 
-        w = someElement.defaultView.frameElement.clientWidth;
-        h = someElement.defaultView.frameElement.clientHeight;
+        w = ownerDoc.defaultView.frameElement.clientWidth;
+        h = ownerDoc.defaultView.frameElement.clientHeight;
       }
       else
       {

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -1331,6 +1331,13 @@ namespace com.keyman.osk {
             Ls.top=this.y+'px';
           } else {
             var el=keymanweb.domManager.getActiveElement();
+
+            // Special case - design mode iframes.  Don't use the active element (inside the design-mode doc);
+            // use its containing iframe from the doc itself.
+            let ownerDoc = el.ownerDocument;
+            if(ownerDoc.designMode == 'on' && ownerDoc.defaultView && ownerDoc.defaultView.frameElement) { 
+              el = ownerDoc.defaultView.frameElement as HTMLElement;
+            }
             if(this.dfltX) {
               Ls.left=this.dfltX;
             } else if(typeof el != 'undefined' && el != null) {


### PR DESCRIPTION
For a little while now, design-mode iframes have been a bit... broken - they've never displayed the OSK or the Float/Toggle UI modules when active.  Before fixing #539, it's best to get these working again so that they aren't _further_ broken by anything uncaught during that upcoming rework.

As it turns out, there was _also_ a break whenever the ENTER key was pressed within either a content-editable or a design-mode iframe - this one a regression from 11.0 to 12.0, when the `OutputTarget`s were introduced.  Turns out that issue was embarrassingly simple to resolve, at least.  (See the single line added to the respective wrapper classes... which took over an hour or two of debugging to realize.  Yay, end-of-day debugging.)

So, after all that, a snippet from the Attachment API testing page:

<img width="527" alt="Screen Shot 2020-03-17 at 8 49 02 AM" src="https://user-images.githubusercontent.com/25213402/76814019-38dbcc80-682c-11ea-9f68-3eec3fc81a23.png">

This does include a bit of `|Document` cleanup for some parameter typing - those comprise a small, small start toward #539 that (more importantly) helps to clarify the solutions to the issues this PR addresses.