### PR TITLE
refactor(web/engine): KeyEvent object now refers to outputTarget over element

### DIFF
--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -72,7 +72,7 @@ minifier="$CLOSURECOMPILERPATH/compiler.jar"
 #
 # `jsDocMissingType` prevents errors on type documentation Closure thinks is missing.  TypeScript may not
 # have the same requirements, and we trust TypeScript over Closure.
-minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode"
+minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode --jscomp_off=missingRequire --jscomp_off=strictMissingRequire"
 
 # We use these to prevent Closure from auto-inserting its own polyfills.  Turns out, they can break in the 
 # WebView used by Android API 19, which our app still supports.

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -444,23 +444,23 @@ namespace com.keyman {
       if(Levent == null || !osk.ready) {
         return true;
       }
+      var inputEle = Levent.Ltarg.getElement();
 
       // Since this part concerns DOM element + browser interaction management, we preprocess it for
       // browser form commands before passing control to the Processor module.
       if(Levent.Lcode == 13) {
         var ignore = false;
-        if(Levent.Ltarg instanceof Levent.Ltarg.ownerDocument.defaultView.HTMLTextAreaElement) {
+        if(Levent.Ltarg instanceof inputEle.ownerDocument.defaultView.HTMLTextAreaElement) {
           ignore = true;
         }
       
-        if(Levent.Ltarg.base && Levent.Ltarg.base instanceof Levent.Ltarg.base.ownerDocument.defaultView.HTMLTextAreaElement) {
+        if(inputEle.base && inputEle.base instanceof inputEle.base.ownerDocument.defaultView.HTMLTextAreaElement) {
           ignore = true;
         }
 
         if(!ignore) {
           // For input fields, move to next input element
-          if(Levent.Ltarg instanceof Levent.Ltarg.ownerDocument.defaultView.HTMLInputElement) {
-            var inputEle = Levent.Ltarg;
+          if(inputEle instanceof inputEle.ownerDocument.defaultView.HTMLInputElement) {
             if(inputEle.type == 'search' || inputEle.type == 'submit') {
               inputEle.form.submit();
             } else {

--- a/web/source/kmwdomevents.ts
+++ b/web/source/kmwdomevents.ts
@@ -228,7 +228,7 @@ namespace com.keyman {
       
       var isActivating = this.keyman.uiManager.isActivating;
       if(!isActivating) {
-        this.keyman['interface'].notifyKeyboard(0, Ltarg, 0);  // I2187
+        this.keyman['interface'].notifyKeyboard(0, text.Processor.getOutputTarget(Ltarg as HTMLElement), 0);  // I2187
       }
 
       //e = this.keyman._GetEventObject<FocusEvent>(e);   // I2404 - Manage IE events in IFRAMEs  //TODO: is this really needed again????
@@ -336,7 +336,7 @@ namespace com.keyman {
         if(target && text.Processor.getOutputTarget(target)) {
           text.Processor.getOutputTarget(target).deadkeys().clear();
         }
-        this.keyman['interface'].notifyKeyboard(0, target, 1);  // I2187
+        this.keyman['interface'].notifyKeyboard(0, text.Processor.getOutputTarget(target), 1);  // I2187
       }
     
       if(!uiManager.justActivated && DOMEventHandlers.states._SelectionControl != target) {

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -488,7 +488,7 @@ namespace com.keyman.text {
 
     // Check the virtual key 
     var Lkc: com.keyman.text.KeyEvent = {
-      Ltarg: keyman.domManager.getActiveElement(),
+      Ltarg: com.keyman.text.Processor.getOutputTarget(keyman.domManager.getActiveElement()),
       Lmodifiers: shift,
       vkCode: code,
       Lcode: code,

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -218,20 +218,13 @@ namespace com.keyman.text {
      * @param       {number}    _PData        1 or 0    
      * Description  Notifies keyboard of keystroke or other event
      */    
-    notifyKeyboard(_PCommand: number, _PTarget: OutputTarget|HTMLElement|Document, _PData: number) { // I2187
+    notifyKeyboard(_PCommand: number, _PTarget: OutputTarget, _PData: number) { // I2187
       let keyman = com.keyman.singleton;
       var activeKeyboard = keyman.keyboardManager.activeKeyboard;
 
-      var target: OutputTarget;
-      if(_PTarget instanceof text.OutputTarget) {
-        target = _PTarget;
-      } else {
-        target = text.Processor.getOutputTarget(_PTarget as HTMLElement);
-      }
-
       // Good example use case - the Japanese CJK-picker keyboard
       if(activeKeyboard != null && typeof(activeKeyboard['KNS']) == 'function') {
-        activeKeyboard['KNS'](_PCommand, target, _PData);
+        activeKeyboard['KNS'](_PCommand, _PTarget, _PData);
       }
     }
       

--- a/web/source/text/keyEvent.ts
+++ b/web/source/text/keyEvent.ts
@@ -8,7 +8,7 @@ namespace com.keyman.text {
    * having to actually load the entirety of KMW.
    */
   export class KeyEvent {
-    Ltarg: HTMLElement;
+    Ltarg: OutputTarget;
     Lcode: number;
     Lstates: number;
     LmodifierChange?: boolean;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -440,7 +440,7 @@ namespace com.keyman.text {
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
       // of state management.
-      if(!fromOSK && this.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      if(!fromOSK && this.doModifierPress(keyEvent, !fromOSK)) {
         return true;
       }
 
@@ -1035,8 +1035,9 @@ namespace com.keyman.text {
 
     // Returns true if the key event is a modifier press, allowing keyPress to return selectively
     // in those cases.
-    private doModifierPress(Levent: KeyEvent, outputTarget: OutputTarget, isKeyDown: boolean): boolean {
+    private doModifierPress(Levent: KeyEvent, isKeyDown: boolean): boolean {
       let keyman = com.keyman.singleton;
+      let outputTarget = Levent.Ltarg;
 
       switch(Levent.Lcode) {
         case 8: 
@@ -1280,7 +1281,7 @@ namespace com.keyman.text {
         return true;
       }
 
-      return this.doModifierPress(Levent, Levent.Ltarg, false);
+      return this.doModifierPress(Levent, false);
     }
 
     keyPress(e: KeyboardEvent): boolean {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -43,7 +43,8 @@ namespace com.keyman.text {
 
       let keyName = Lkc.kName;
       let n = Lkc.Lcode;
-      let Lelem = Lkc.Ltarg;
+      let outputTarget = Lkc.Ltarg;
+      let Lelem = outputTarget.getElement();
 
       let keyman = com.keyman.singleton;
       let domManager = keyman.domManager;
@@ -264,7 +265,7 @@ namespace com.keyman.text {
 
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: KeyEvent = {
-        Ltarg: Lelem,
+        Ltarg: Processor.getOutputTarget(Lelem),
         Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],
@@ -404,7 +405,7 @@ namespace com.keyman.text {
 
       // Determine the current target for text output and create a "mock" backup
       // of its current, pre-input state.
-      let outputTarget = Processor.getOutputTarget(keyEvent.Ltarg);
+      let outputTarget = keyEvent.Ltarg;
 
       let fromOSK = !!e; // If specified, it's from the OSK.
 
@@ -419,7 +420,7 @@ namespace com.keyman.text {
       this.swallowKeypress = false;
 
       if(fromOSK && !keyman.isEmbedded) {
-        keyman.domManager.initActiveElement(keyEvent.Ltarg);
+        keyman.domManager.initActiveElement(keyEvent.Ltarg.getElement());
 
         // Turn off key highlighting (or preview)
         keyman['osk'].vkbd.highlightKey(e,false);
@@ -508,7 +509,7 @@ namespace com.keyman.text {
               continue;
             }
 
-            let altEvent = this._GetClickEventProperties(altKey, keyEvent.Ltarg);
+            let altEvent = this._GetClickEventProperties(altKey, keyEvent.Ltarg.getElement());
             let alternateBehavior = this.processKeystroke(altEvent, mock, fromOSK, true);
             if(alternateBehavior) {
               // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
@@ -1091,12 +1092,13 @@ namespace com.keyman.text {
         return null; // I2457 - Facebook meta-event generation mess -- two events generated for a keydown in Facebook contentEditable divs
       }    
 
-      s.Ltarg = keyman.util.eventTarget(e) as HTMLElement;
-      if (s.Ltarg == null) {
+      let target = keyman.util.eventTarget(e) as HTMLElement;
+      if (target == null) {
         return null;
-      } else if (s.Ltarg.nodeType == 3) {// defeat Safari bug
-        s.Ltarg = s.Ltarg.parentNode as HTMLElement;
+      } else if (target.nodeType == 3) {// defeat Safari bug
+        target = target.parentNode as HTMLElement;
       }
+      s.Ltarg = Processor.getOutputTarget(target);
 
       s.Lcode = this._GetEventKeyCode(e);
       if (s.Lcode == null) {
@@ -1282,9 +1284,7 @@ namespace com.keyman.text {
         return true;
       }
 
-      let outputTarget = Processor.getOutputTarget(Levent.Ltarg)
-
-      return this.doModifierPress(Levent, outputTarget, false);
+      return this.doModifierPress(Levent, Levent.Ltarg, false);
     }
 
     keyPress(e: KeyboardEvent): boolean {
@@ -1313,10 +1313,10 @@ namespace com.keyman.text {
         return false;
       }
       /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
-      let outputTarget = Processor.getOutputTarget(Levent.Ltarg);
+      let outputTarget = Levent.Ltarg;
       
       // Only reached if it's a mnemonic keyboard.
-      if(this.swallowKeypress || keyman['interface'].processKeystroke(keyman.util.physicalDevice, outputTarget, Levent)) {
+      if(this.swallowKeypress || keyman['interface'].processKeystroke(keyman.util.physicalDevice, Levent.Ltarg, Levent)) {
         this.swallowKeypress = false;
         if(e && e.preventDefault) {
           e.preventDefault();

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -78,13 +78,7 @@ namespace com.keyman.text {
             if(disableDOM) {
               return '\b'; // the escape sequence for backspace.
             } else {
-              // If we have an available target (via Lkc/Lelem), use that instead of 
-              // forcing defaultBackspace to search for it.
-              var target: OutputTarget;
-              if(Lelem && Lelem._kmwAttachment) {
-                target = Lelem._kmwAttachment.interface;
-              }
-              keyman.interface.defaultBackspace(target);
+              keyman.interface.defaultBackspace(outputTarget);
             }
             return '';
           case Codes.keyCodes['K_TAB']:
@@ -373,6 +367,8 @@ namespace com.keyman.text {
         kbdInterface.activeTargetOutput = outputTarget;
         let preInput = Mock.from(outputTarget);
 
+        // TODO:  That third parameter should be `fromOSK`, not always `true`.  Changing this breaks Mocks a bit, though,
+        //        and will likely have interactions with the '\b' check below.
         var ch = this.defaultKeyOutput(keyEvent, keyEvent.Lmodifiers, true, disableDOM);
         kbdInterface.activeTargetOutput = null;
         if(ch) {


### PR DESCRIPTION
Based on #2830.  While the changes likely aren't directly dependent, I'd like to avoid... uh, `git branch` hell as the refactoring work proceeds.  It's already looking a bit nasty in the near future regarding #2838, which has code that will need to be considered for the next stage of work.

------

If we're going to have a headless web-core, we have to remove the HTMLElement reference from `KeyEvent.Ltarg`.  Fortunately, we can easily replace that with the `OutputTarget` of the original reference.

### User Testing

* Important keyboards for testing:
    - `sil_euro_latin`:  Desktop mode still provides its custom OSK, which still functions correctly
    - `japanese`, `chinese`:  Both still display their pickers and are still fully functional.
* Predictive text (on testing/prediction-ui) is still properly functional.

These keyboards were concerning because they interact with KeymanWeb in "unusual" ways compared to other keyboards - all three have custom UI and specialized, handwritten code that is thus at risk of breaking when we change the API that keyboards refer to.  Fortunately, they seem to have been written well enough (i.e, use `KeyboardInterface.output`) for any important element interactions to automatically work with these changes.