### PR TITLE
refactor(web/engine): extended abstraction with OutputTarget

### DIFF
--- a/web/source/dom/contentEditable.ts
+++ b/web/source/dom/contentEditable.ts
@@ -218,6 +218,20 @@ namespace com.keyman.dom {
       Lsel.collapseToEnd();
     }
 
+    handleNewlineAtCaret(): void {
+      // TODO:  Implement.
+      //
+      // As it turns out, we never had an implementation for handling newline inputs from the OSK for this element type.
+      // At least this way, it's more explicit.
+      //
+      // Note:  consult "// Create a new text node - empty control" case in insertTextBeforeCaret - 
+      // this helps to handle the browser-default implementation of newline handling.  In particular,
+      // entry of the first character after a newline.
+      //
+      // If raw newlines are entered into the HTML, but as with usual HTML, they're interpreted as excess whitespace and
+      // have no effect.  We need to add DOM elements for a functional newline.
+    }
+
     protected setTextAfterCaret(s: string) {
       if(!this.hasSelection()) {
         return;

--- a/web/source/dom/contentEditable.ts
+++ b/web/source/dom/contentEditable.ts
@@ -31,6 +31,10 @@ namespace com.keyman.dom {
       }
     }
 
+    get isSynthetic(): boolean {
+      return false;
+    }
+
     getElement(): HTMLElement {
       return this.root;
     }

--- a/web/source/dom/designIFrame.ts
+++ b/web/source/dom/designIFrame.ts
@@ -49,6 +49,10 @@ namespace com.keyman.dom {
       }
     }
 
+    get isSynthetic(): boolean {
+      return false;
+    }
+
     getElement(): HTMLIFrameElement {
       return this.root;
     }

--- a/web/source/dom/designIFrame.ts
+++ b/web/source/dom/designIFrame.ts
@@ -224,6 +224,20 @@ namespace com.keyman.dom {
       Lsel.collapseToEnd();
     }
 
+    handleNewlineAtCaret(): void {
+      // TODO:  Implement.
+      //
+      // As it turns out, we never had an implementation for handling newline inputs from the OSK for this element type.
+      // At least this way, it's more explicit.
+      //
+      // Note:  consult "// Create a new text node - empty control" case in insertTextBeforeCaret - 
+      // this helps to handle the browser-default implementation of newline handling.  In particular,
+      // entry of the first character after a newline.
+      //
+      // If raw newlines are entered into the HTML, but as with usual HTML, they're interpreted as excess whitespace and
+      // have no effect.  We need to add DOM elements for a functional newline.
+    }
+
     protected setTextAfterCaret(s: string) {
       if(!this.hasSelection()) {
         return;

--- a/web/source/dom/input.ts
+++ b/web/source/dom/input.ts
@@ -29,6 +29,10 @@ namespace com.keyman.dom {
       this._cachedSelectionStart = -1;
     }
 
+    get isSynthetic(): boolean {
+      return false;
+    }
+
     getElement(): HTMLInputElement {
       return this.root;
     }

--- a/web/source/dom/input.ts
+++ b/web/source/dom/input.ts
@@ -142,5 +142,19 @@ namespace com.keyman.dom {
       this.root.value = front + s + back;
       this.setCaret(caret + s._kmwLength());
     }
+
+    handleNewlineAtCaret(): void {
+      Input.newlineHandler(this.root);
+    }
+
+    static newlineHandler(inputEle: HTMLInputElement) {
+      // Can't occur for Mocks - just Input and TouchAlias types.
+      if (inputEle && (inputEle.type == 'search' || inputEle.type == 'submit')) {
+        inputEle.disabled=false;
+        inputEle.form.submit();
+      } else {
+        com.keyman.singleton.domManager.moveToNext(false);
+      }
+    }
   }
 }

--- a/web/source/dom/input.ts
+++ b/web/source/dom/input.ts
@@ -153,7 +153,13 @@ namespace com.keyman.dom {
         inputEle.disabled=false;
         inputEle.form.submit();
       } else {
-        com.keyman.singleton.domManager.moveToNext(false);
+        // Allows compiling this separately from the main body of KMW.
+        // TODO:  rework class to accept a class-static 'callback' from the DOM module that this can call.
+        //        Would eliminate the need for this 'static' reference. 
+        //        Only strongly matters once we better modularize KMW, with web-dom vs web-dom-targets vs web-core, etc.
+        if(com.keyman["singleton"]) {
+          com.keyman["singleton"].domManager.moveToNext(false);
+        }
       }
     }
   }

--- a/web/source/dom/textarea.ts
+++ b/web/source/dom/textarea.ts
@@ -36,6 +36,10 @@ namespace com.keyman.dom {
       this._cachedSelectionStart = -1;
     }
 
+    get isSynthetic(): boolean {
+      return false;
+    }
+
     getElement(): HTMLTextAreaElement {
       return this.root;
     }

--- a/web/source/dom/textarea.ts
+++ b/web/source/dom/textarea.ts
@@ -149,5 +149,9 @@ namespace com.keyman.dom {
       this.root.value = front + s + back;
       this.setCaret(caret + s._kmwLength());
     }
+
+    handleNewlineAtCaret(): void {
+      this.insertTextBeforeCaret('\n');
+    }
   }
 }

--- a/web/source/dom/touchAlias.ts
+++ b/web/source/dom/touchAlias.ts
@@ -63,6 +63,20 @@ namespace com.keyman.dom {
       this.root.setTextBeforeCaret(this.root.getTextBeforeCaret() + s);
     }
 
+    handleNewlineAtCaret(): void {
+      // Insert new line in text area fields
+      if(this.root.base.nodeName == 'TEXTAREA') {
+        // As the TouchAliasElement was implemented long before OutputTargets, it already has
+        // built-in newline handling.
+        this.insertTextBeforeCaret('\n');
+      } else if(dom.Utils.instanceof(this.root.base, "HTMLInputElement")) {
+        // HTMLInputElements do not permit newlines; they instead have DOM-specific behaviors.
+        Input.newlineHandler(this.root.base as HTMLInputElement);
+      } else {
+        console.warn("TouchAlias OutputTarget cannot output newlines for unexpected base element types!");
+      }
+    }
+
     protected setTextAfterCaret(s: string) {
       this.root.setText(this.getTextBeforeCaret() + s, this.getTextBeforeCaret()._kmwLength());
     }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -433,7 +433,7 @@ namespace com.keyman.text {
       
       // Check the virtual key 
       Lkc = {
-        Ltarg: Lelem,
+        Ltarg: com.keyman.text.Processor.getOutputTarget(Lelem),
         Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -127,7 +127,7 @@ namespace com.keyman.text {
   let nativeDefaultKeyOutput = Processor.prototype.defaultKeyOutput;
 
   // Overrides the 'native'-mode implementation with in-app friendly defaults prioritized over 'native' defaults.
-  Processor.prototype.defaultKeyOutput = function(this: Processor, Lkc: KeyEvent, keyShiftState: number, usingOSK: boolean, disableDOM: boolean): string {
+  Processor.prototype.defaultKeyOutput = function(this: Processor, Lkc: KeyEvent, keyShiftState: number, usingOSK: boolean): string {
     let keyman = com.keyman.singleton;
 
     // Note:  this assumes Lelem is properly attached and has an element interface.
@@ -140,7 +140,7 @@ namespace com.keyman.text {
     if (code == Codes.keyCodes.K_SPACE) {
       return ' ';
     } else if (code == Codes.keyCodes.K_BKSP) {
-      if(!disableDOM) {
+      if(!(Lkc.Ltarg instanceof Mock) ) {
         keyman['interface'].defaultBackspace();
         return '';
       } else {

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -59,6 +59,14 @@ namespace com.keyman.text {
       this._dks = new text.DeadkeyTracker();
     }
 
+    /**
+     * Signifies that this OutputTarget has no default key processing behaviors.  This should be false
+     * for OutputTargets backed by web elements like HTMLInputElement or HTMLTextAreaElement.
+     */
+    get isSynthetic(): boolean {
+      return true;
+    }
+
     deadkeys(): text.DeadkeyTracker {
       return this._dks;
     }

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -252,6 +252,13 @@ namespace com.keyman.text {
     abstract insertTextBeforeCaret(s: string): void;
 
     /**
+     * Allows element-specific handling for ENTER key inputs.  Conceptually, this should usually
+     * correspond to `insertTextBeforeCaret('\n'), but actual implementation will vary greatly among
+     * elements.
+     */
+    abstract handleNewlineAtCaret(): void;
+
+    /**
      * Saves element-specific state properties prone to mutation, enabling restoration after
      * text-output operations.
      */
@@ -348,6 +355,10 @@ namespace com.keyman.text {
     insertTextBeforeCaret(s: string): void {
       this.text = this.getTextBeforeCaret() + s + this.getTextAfterCaret();
       this.caretIndex += s.kmwLength();
+    }
+
+    handleNewlineAtCaret(): void {
+      this.insertTextBeforeCaret('\n');
     }
 
     protected setTextAfterCaret(s: string): void {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -64,8 +64,9 @@ namespace com.keyman.text {
         }
       }
 
-      // If this was triggered by the OSK -or- if it was triggered within a touch-aliased DIV element.
-      if(touchAlias || usingOSK) {
+      // If this was triggered by the OSK -or- if it was triggered by a 'synthetic' OutputTarget (TouchAlias, Mock)
+      // that lacks default key processing behavior.
+      if(usingOSK || outputTarget.isSynthetic) {
         var code = Codes.keyCodes[keyName];
         if(!code) {
           code = n;
@@ -164,12 +165,8 @@ namespace com.keyman.text {
         // Not strictly if `Lkc.vkCode` is properly maintained, but it's good to have an
         // extra safety; this would have blocked the backspace bug as well.
       } else if(Lkc.Lcode == 8) {
-        if(quiet) {
-          return '\b'; // the escape sequence for backspace.
-        } else {
-          keyman.interface.defaultBackspace();
-          return '';
-        }
+        keyman.interface.defaultBackspace();
+        return '';
       }
 
       // Translate numpad keystrokes into their non-numpad equivalents

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -95,7 +95,12 @@ namespace com.keyman.text {
             }
             break;
           case Codes.keyCodes['K_ENTER']:
+            // Ensure the newline is forwarded when in an embedded context!  It doesn't yet have its own specialized OutputTarget type.
+            if(keyman.isEmbedded && !quiet) { // Don't pass it along for Mocks, though.  They're (currently) only used in predictive text.
+              keyman['oninserttext'](0, '\n');
+            }
             outputTarget.handleNewlineAtCaret();
+
             return '\n';  // We still return this, as it ensures we generate a rule-match.
           case Codes.keyCodes['K_SPACE']:
             return ' ';

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -96,31 +96,7 @@ namespace com.keyman.text {
             }
             break;
           case Codes.keyCodes['K_ENTER']:
-            if(!Lelem) {
-              return '\n';
-            }
-            // Insert new line in text area fields
-            if(Lelem.nodeName == 'TEXTAREA' || (typeof Lelem.base != 'undefined' && Lelem.base.nodeName == 'TEXTAREA')) {
-              return '\n';
-            // Or move to next field from TEXT fields
-            } else if(usingOSK) {
-              var inputEle: HTMLInputElement;
-              if(keyman.isEmbedded) { // In embedded mode, the OutputTarget may not meet other conditions.
-                return '\n';
-              } else if(dom.Utils.instanceof(Lelem, "HTMLInputElement")) {
-                inputEle = <HTMLInputElement> Lelem;
-              } else if(typeof(Lelem.base) != 'undefined' && dom.Utils.instanceof(Lelem.base, "HTMLInputElement")) {
-                inputEle = <HTMLInputElement> Lelem.base;
-              }
-              
-              // Can't occur for Mocks - just Input and TouchAlias types.
-              if (inputEle && (inputEle.type == 'search' || inputEle.type == 'submit')) {
-                inputEle.disabled=false;
-                inputEle.form.submit();
-              } else {
-                domManager.moveToNext(false);
-              }
-            }
+            outputTarget.handleNewlineAtCaret();
             break;
           case Codes.keyCodes['K_SPACE']:
             return ' ';

--- a/web/testing/prediction-ui/index.html
+++ b/web/testing/prediction-ui/index.html
@@ -41,7 +41,7 @@
 		    attachType:'auto'
       }).then(function() {
         kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
-        kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic.js'});
+        kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)


### PR DESCRIPTION
Adds two new members to the `OutputTarget` abstraction type:

* `OutputTarget.isSynthetic` - notes whether or not an element has default keystroke processing, as provided by a browser.
    - `false` for most types, `true` for `TouchAlias` and `Mock`.
* `OutputTarget.handleNewlineAtCaret` - provides element-specific default handling for the ENTER key, allowing us to remove that code from `defaultKeyOutput`.
    - Note that two types (`DesignIFrame` and `ContentEditable`) explicitly lack actual handling.
    - There's no actual functionality change here - this is documenting problems that have already long existed within KeymanWeb.  I noted this detail during work on #2838.

With those changes in place, significant cleanup of `defaultKeyOutput` was then possible, which helped to remove most of its references to the DOM.  (Again, nearly all remaining references center on `keyman.domManager`.)

There's easily more that can be done here, but the upcoming changes are large enough that breaking the PR here would be wise.  I can't help but notice a couple of TODOs (one new, granted) in `defaultKeyOutput`'s body, and I think the time has come to address them.

### User Testing

* Tested with iOS Simulator, ensured predictive text, backspaces, longpresses, and newlines all function correctly.
  - `sil_euro_latin`
  - `khmer_angkor`
* Tested against all (supported) element types for proper backspace, newline execution.
  - Physically typed and via OSK interaction.