### PR TITLE
refactor(web/engine): reworks use of embedded's keyman['oninserttext']

### DIFF
--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -832,11 +832,6 @@ namespace com.keyman.text {
     output(dn: number, outputTarget: OutputTarget, s:string): void {
       this.resetContextCache();
       let keyman = com.keyman.singleton;
-      
-      // KeymanTouch for Android uses direct insertion of the character string
-      if('oninserttext' in keyman && !(outputTarget instanceof Mock)) {
-        keyman['oninserttext'](dn,s);
-      }
 
       outputTarget.saveProperties();
       outputTarget.clearSelection();
@@ -1041,9 +1036,6 @@ namespace com.keyman.text {
       }
 
       this.output(1, outputTarget, "");
-      if(outputTarget.getElement()) {
-        this.doInputEvent(outputTarget.getElement());
-      }
     }
 
     /**


### PR DESCRIPTION
While very small in terms of lines changed, this little number is important enough to merit its own specialized PR.  This one method - `keyman['oninserttext']` - is the lynchpin that connects embedded KMW's output to app-native code.

As originally implemented, this function was generally called once per output statement of a KMW keyboard's rule.  This may mean multiple calls:

Keyman rule (approximate):
```
'a' any(my_store) 'p' + K_1 > context(1) index(s2, 2) 'e'
```

Compiled output rule:
```
KeymanWeb.KO(2, 'p', t);
KeymanWeb.KIO(0, this.s2, 1, t);
KeymanWeb.KO(0, 'e', t);
```

As `KIO` calls `KO`, each of these would trigger separate calls.  That, and we had to explicitly block these calls when the outputTarget (`t`) was of `Mock` type.

Now, instead we simply accumulate all the effects of the keyboard rule _first_, generating no extra output events.  Once all processing is complete, we then send out the accumulated changes in a single batch at the same location we finalize the generated `RuleBehavior`.

## Benefits:
- Reduces amount of crosstalk between JS and app-native code (through their WebViews)
    - Each keystroke will only ever generate a single `keyman['oninserttext']` call now.

---

- All non-text-processing state changes and related events are now generated based on the final `RuleBehavior`, which automatically filters out any side effects from processing `Alternate`s on `Mock` elements.  (Thus, a continuation of the ideas from #2830.)

---

- This pattern will allow us to generate `RuleBehavior`s based on the after-effects of `defaultKeyOutput` calls in a very similar manner to `processKeystroke`.
    - This is the subject of the next (upcoming) PR in line; it'll actually produce `RuleBehavior`s.
    - This can allow us to detect if we have a 'rule match' against the default set of rules, even when there is no _direct_ output.
        - Like with some of the DOM interactions and the current return value checks.
        - This will allow dropping the current (and awkward) `'\n'` and `'\b'` return value checking conditions seen in `processKeystroke`; the returned `RuleBehavior` will suffice instead.

---

- As it turns out, `keyman['oninserttext']`'s parameter list (a pre-10.0 part of the apps' designs) already corresponds perfectly to the members of `Transform`.
    - It's a perfect match, and we've already been using it since 12.0 for predictive suggestion application within banner.ts.

## User Testing

Tested in-app with Keyman for iOS; predictions, backspace, standard typing, and newlines all work as intended.
- `sil_euro_latin`
- `khmer_angkor` - reorder rules confirmed to still work