### PR TITLE
refactor(web/engine): reworks default output handling to return RuleBehaviors

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -309,7 +309,7 @@
       var kmw=window['keyman'];
       //window.console.log('executeHardwareKeystroke:('+code+', ' + shift + ', ' + lstates + ');');
       try {
-        if (!kmw['executeHardwareKeystroke'](code, shift, lstates)) {
+        if (kmw['executeHardwareKeystroke'](code, shift, lstates)) { // false if matched, true if not
           // KMW didn't process the key, so have the Android app dispatch the key with the original event modifiers
           window.jsInterface.dispatchKey(code, eventModifiers);
         }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -124,12 +124,10 @@ namespace com.keyman.osk {
 }
 
 namespace com.keyman.text {
-  let nativeForBaseKeys = DefaultOutput.forBaseKeys;
+  let nativeForBaseKeys = DefaultOutput.forBaseKeys; // a static method.
 
   // Overrides the 'native'-mode implementation with in-app friendly defaults prioritized over 'native' defaults.
-  DefaultOutput.forBaseKeys = function(this: Processor, Lkc: KeyEvent, keyShiftState: number): string {
-    let keyman = com.keyman.singleton;
-
+  DefaultOutput.forBaseKeys = function(Lkc: KeyEvent, keyShiftState: number): string {
     // Note:  this assumes Lelem is properly attached and has an element interface.
     // Currently true in the Android and iOS apps.
     let Codes = com.keyman.text.Codes;
@@ -147,7 +145,7 @@ namespace com.keyman.text {
     }
 
     // Use 'native'-mode defaults, determining the character from the OSK
-    return nativeForBaseKeys.call(this, Lkc, keyShiftState);
+    return nativeForBaseKeys(Lkc, keyShiftState); // is a static method, so no .call (which implies a need for `this`.)
   }
 }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -124,12 +124,10 @@ namespace com.keyman.osk {
 }
 
 namespace com.keyman.text {
-  let nativeForBaseKeys = DefaultOutput.forBaseKeys; // a static method.
+  let nativeForBaseKeys = DefaultOutput.forBaseKeys;
 
   // Overrides the 'native'-mode implementation with in-app friendly defaults prioritized over 'native' defaults.
   DefaultOutput.forBaseKeys = function(Lkc: KeyEvent, keyShiftState: number): string {
-    // Note:  this assumes Lelem is properly attached and has an element interface.
-    // Currently true in the Android and iOS apps.
     let Codes = com.keyman.text.Codes;
     let code = Lkc.Lcode;
 
@@ -145,7 +143,7 @@ namespace com.keyman.text {
     }
 
     // Use 'native'-mode defaults, determining the character from the OSK
-    return nativeForBaseKeys(Lkc, keyShiftState); // is a static method, so no .call (which implies a need for `this`.)
+    return nativeForBaseKeys(Lkc, keyShiftState);
   }
 }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -124,10 +124,10 @@ namespace com.keyman.osk {
 }
 
 namespace com.keyman.text {
-  let nativeDefaultKeyOutput = Processor.prototype.defaultKeyOutput;
+  let nativeForBaseKeys = DefaultOutput.forBaseKeys;
 
   // Overrides the 'native'-mode implementation with in-app friendly defaults prioritized over 'native' defaults.
-  Processor.prototype.defaultKeyOutput = function(this: Processor, Lkc: KeyEvent, keyShiftState: number, usingOSK: boolean): string {
+  DefaultOutput.forBaseKeys = function(this: Processor, Lkc: KeyEvent, keyShiftState: number): string {
     let keyman = com.keyman.singleton;
 
     // Note:  this assumes Lelem is properly attached and has an element interface.
@@ -137,16 +137,7 @@ namespace com.keyman.text {
 
     // Intentionally not assigning K_TAB or K_ENTER so KMW will pass them back
     // to the mobile apps to handle (insert characters or navigate forms).
-    if (code == Codes.keyCodes.K_SPACE) {
-      return ' ';
-    } else if (code == Codes.keyCodes.K_BKSP) {
-      if(!(Lkc.Ltarg instanceof Mock) ) {
-        keyman['interface'].defaultBackspace();
-        return '';
-      } else {
-        return '\b';
-      }
-    } else if (code == Codes.keyCodes.K_oE2) {
+    if (code == Codes.keyCodes.K_oE2) {
       // Using defaults of English US layout for the 102nd key
       if (Lkc.Lmodifiers == Codes.modifierCodes['SHIFT']) {
         return '|';
@@ -156,7 +147,7 @@ namespace com.keyman.text {
     }
 
     // Use 'native'-mode defaults, determining the character from the OSK
-    return nativeDefaultKeyOutput.call(this, Lkc, keyShiftState, usingOSK);
+    return nativeForBaseKeys.call(this, Lkc, keyShiftState);
   }
 }
 

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -23,6 +23,10 @@ namespace com.keyman.text {
       return code;
     }
 
+    /**
+     * Serves as a default keycode lookup table.  This may be referenced safely by mnemonic handling without fear of side-effects.
+     * Also used by Processor.defaultRuleOutput to generate output after filtering for special cases.
+     */
     public static forAny(Lkc: KeyEvent, shiftState: number) {
       var char = '';
 

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -4,6 +4,12 @@
 /// <reference path="keyEvent.ts" />
 
 namespace com.keyman.text {
+  export enum EmulationKeystrokes {
+    Space = ' ',
+    Enter = '\n',
+    Backspace = '\b'
+  }
+
   /**
    * Defines a collection of static library functions that define KeymanWeb's default (implied) keyboard rule behaviors.
    */
@@ -141,18 +147,21 @@ namespace com.keyman.text {
      * Codes matched here generally have default implementations when in a browser but require emulation
      * for 'synthetic' `OutputTarget`s like `Mock`s, which have no default text handling.
      */
-    public static forSpecialEmulation(Lkc: KeyEvent): string {
+    public static forSpecialEmulation(Lkc: KeyEvent): EmulationKeystrokes {
       let code = DefaultOutput.codeForEvent(Lkc);
 
       switch(code) {
         case Codes.keyCodes['K_BKSP']:
-          return '\b';
+          return EmulationKeystrokes.Backspace;
         case Codes.keyCodes['K_ENTER']:
-          return '\n'; 
+          return EmulationKeystrokes.Enter;
+        // (Probably) only here for legacy reasons; it's always been handled alongside the other two.
         case Codes.keyCodes['K_SPACE']:
-          return ' ';
+          return EmulationKeystrokes.Space;
         // case Codes.keyCodes['K_DEL']:
         //   return '\u007f'; // 127, ASCII / Unicode control code for DEL.
+        default:
+          return null;
       }
     }
 

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -42,16 +42,18 @@ namespace com.keyman.text {
       } else if(char = DefaultOutput.forBaseKeys(Lkc, shiftState)) {
         return char;
       } else {
-        // For headless and embeddded, we may well allow '\t'.  It's DOM mode that has other uses.
-        // Not originally defined for text output within defaultKeyOutput.
-        switch(code) {
-          case Codes.keyCodes['K_TAB']:
-          case Codes.keyCodes['K_TABBACK']:
-          case Codes.keyCodes['K_TABFWD']:
-            return '\t';
-          default:
-            return '';
-        }
+        // // For headless and embeddded, we may well allow '\t'.  It's DOM mode that has other uses.
+        // // Not originally defined for text output within defaultKeyOutput.
+        // // We can't enable it yet, as it'll cause hardware keystrokes in the DOM to output '\t' rather
+        // // than rely on the browser-default handling.
+        // switch(code) {
+        //   case Codes.keyCodes['K_TAB']:
+        //   case Codes.keyCodes['K_TABBACK']:
+        //   case Codes.keyCodes['K_TABFWD']:
+        //     return '\t';
+        //   default:
+        //     return '';
+        // }
       }
     }
 

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -25,7 +25,7 @@ namespace com.keyman.text {
 
     /**
      * Serves as a default keycode lookup table.  This may be referenced safely by mnemonic handling without fear of side-effects.
-     * Also used by Processor.defaultRuleOutput to generate output after filtering for special cases.
+     * Also used by Processor.defaultRuleBehavior to generate output after filtering for special cases.
      */
     public static forAny(Lkc: KeyEvent, shiftState: number) {
       var char = '';

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -12,15 +12,7 @@ namespace com.keyman.text {
     }
 
     static codeForEvent(Lkc: KeyEvent) {
-      let keyName = Lkc.kName;
-      let n = Lkc.Lcode;
-
-      var code = Codes.keyCodes[keyName];
-      if(!code) {
-        code = n;
-      }
-
-      return code;
+      return Codes.keyCodes[Lkc.kName] || Lkc.Lcode;;
     }
 
     /**
@@ -46,14 +38,14 @@ namespace com.keyman.text {
         // // Not originally defined for text output within defaultKeyOutput.
         // // We can't enable it yet, as it'll cause hardware keystrokes in the DOM to output '\t' rather
         // // than rely on the browser-default handling.
-        // switch(code) {
+        switch(code) {
         //   case Codes.keyCodes['K_TAB']:
         //   case Codes.keyCodes['K_TABBACK']:
         //   case Codes.keyCodes['K_TABFWD']:
         //     return '\t';
-        //   default:
-        //     return '';
-        // }
+          default:
+           return '';
+        }
       }
     }
 
@@ -71,7 +63,7 @@ namespace com.keyman.text {
     }
 
     /**
-     * forCommands - returns a boolean indicating if a non-text event should be triggered by the keystroke.
+     * isCommand - returns a boolean indicating if a non-text event should be triggered by the keystroke.
      */
     public static isCommand(Lkc: KeyEvent): boolean {
       let code = DefaultOutput.codeForEvent(Lkc);
@@ -91,16 +83,10 @@ namespace com.keyman.text {
      * It would then be assigned to this class via classic JS method extension practices as an 'override'
      * of `applyCommand`, reusing the base version of that name seen in this class, which is
      * designed for web-core.
-     */
-    /**
-     * This function is designed for future migration into a separate, explicitly-DOM-aware module.
-     * It would then be assigned to this class via classic JS method extension practices as an 'override'
-     * of `applyCommand`, reusing the base version of that name seen in this class, which is
-     * designed for web-core.
      * 
-     * for___Commands - returns boolean indicating if a non-text event should be triggered by the keystroke.
+     * apply___Command - used when a RuleBehavior represents a non-text "command" within the Engine.
      */
-    public static applyDOMCommand(Lkc: KeyEvent, keyShiftState: number) {
+    public static applyDOMCommand(Lkc: KeyEvent, keyShiftState: number): void {
       let code = DefaultOutput.codeForEvent(Lkc);
       let domManager = com.keyman.singleton.domManager;
 
@@ -117,7 +103,12 @@ namespace com.keyman.text {
       }
     }
 
-    public static applyCommand(Lkc: KeyEvent, keyShiftState: number) {
+    /**
+     * Used when a RuleBehavior represents a non-text "command" within the Engine.  This will generally 
+     * trigger events that require context reset - often by moving the caret or by moving what OutputTarget
+     * the caret is in.  However, we let those events perform the actual context reset.
+     */
+    public static applyCommand(Lkc: KeyEvent, keyShiftState: number): void {
       DefaultOutput.applyDOMCommand(Lkc, keyShiftState);
 
       // Notes for potential default-handling extensions:
@@ -147,7 +138,8 @@ namespace com.keyman.text {
     }
 
     /**
-     * Codes matched here may need special handling to apply to an OutputTarget, but still produce output.
+     * Codes matched here generally have default implementations when in a browser but require emulation
+     * for 'synthetic' `OutputTarget`s like `Mock`s, which have no default text handling.
      */
     public static forSpecialEmulation(Lkc: KeyEvent): string {
       let code = DefaultOutput.codeForEvent(Lkc);
@@ -214,6 +206,7 @@ namespace com.keyman.text {
     public static forBaseKeys(Lkc: KeyEvent, keyShiftState: number, ruleBehavior?: RuleBehavior) {
       let n = Lkc.Lcode;
       // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
+      // TODO:  Extend to allow AltGr as well - better mnemonic support.
       if(keyShiftState != 0 && keyShiftState != 1) {
         if(ruleBehavior) {
           ruleBehavior.warningLog = "KMW only defines default key output for the 'default' and 'shift' layers!";

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -11,68 +11,112 @@ namespace com.keyman.text {
     private constructor() {
     }
 
-    /**
-     * This function is designed for future migration into a separate, explicitly-DOM-aware module.
-     * It would then be assigned to this class via classic JS method extension practices as an 'override'
-     * of `applyCommand`, reusing the base version of that name seen in this class, which is
-     * designed for web-core.
-     */
-    public static applyDOMCommand(outputTarget: OutputTarget, code: number, keyShiftState: number) {
-      let quiet = outputTarget instanceof Mock;
-
-      let domManager = com.keyman.singleton.domManager;
-
-      switch(code) {
-        case Codes.keyCodes['K_TAB']:
-          if(!quiet) {
-            domManager.moveToNext(keyShiftState);
-          }
-          break;
-        case Codes.keyCodes['K_TABBACK']:
-          if(!quiet) {
-            domManager.moveToNext(true);
-          }
-          break;
-        case Codes.keyCodes['K_TABFWD']:
-          if(!quiet) {
-            domManager.moveToNext(false);
-          }
-          break;
-      }
-    }
-
-    public static applyCommand(Lkc: KeyEvent, keyShiftState: number) {
+    static codeForEvent(Lkc: KeyEvent) {
       let keyName = Lkc.kName;
       let n = Lkc.Lcode;
-      let outputTarget = Lkc.Ltarg;
-
-      let keyman = com.keyman.singleton;
-
-      let quiet = outputTarget instanceof Mock;
 
       var code = Codes.keyCodes[keyName];
       if(!code) {
         code = n;
       }
 
-      DefaultOutput.applyDOMCommand(outputTarget, code, keyShiftState);
+      return code;
+    }
+
+    public static forAny(Lkc: KeyEvent, shiftState: number) {
+      var char = '';
+
+      let code = DefaultOutput.codeForEvent(Lkc);
+
+      // A pretty simple table of lookups, corresponding VERY closely to the original defaultKeyOutput.
+      if(char = DefaultOutput.forSpecialEmulation(Lkc)) {
+        return char;
+      } else if(char = DefaultOutput.forNumpadKeys(Lkc)) {
+        return char;
+      } else if(char = DefaultOutput.forUnicodeKeynames(Lkc)) {
+        return char;
+      } else if(char = DefaultOutput.forBaseKeys(Lkc, shiftState)) {
+        return char;
+      } else {
+        // For headless and embeddded, we may well allow '\t'.  It's DOM mode that has other uses.
+        // Not originally defined for text output within defaultKeyOutput.
+        switch(code) {
+          case Codes.keyCodes['K_TAB']:
+          case Codes.keyCodes['K_TABBACK']:
+          case Codes.keyCodes['K_TABFWD']:
+            return '\t';
+          default:
+            return '';
+        }
+      }
+    }
+
+    public static isDOMCommand(Lkc: KeyEvent): boolean {
+      let code = DefaultOutput.codeForEvent(Lkc);
 
       switch(code) {
-        case Codes.keyCodes['K_BKSP']:  //Only desktop UI, not touch devices. TODO: add repeat while mouse down for desktop UI
-          if(quiet) {
-            // TODO:  Remove need for this clause via refactoring.  It's currently needed for predictive text Mocks.
-            return '\b'; // the escape sequence for backspace.
-          } else {
-            keyman.interface.defaultBackspace(outputTarget);
-          }
-          return '';
-        case Codes.keyCodes['K_ENTER']:
-          outputTarget.handleNewlineAtCaret();
+        case Codes.keyCodes['K_TAB']:
+        case Codes.keyCodes['K_TABBACK']:
+        case Codes.keyCodes['K_TABFWD']:
+          return true;
+        default:
+          return false;
+      }
+    }
 
-          return '\n';  // We still return this, as it ensures we generate a rule-match.
-        case Codes.keyCodes['K_SPACE']:
-          return ' ';
-        //
+    /**
+     * forCommands - returns a boolean indicating if a non-text event should be triggered by the keystroke.
+     */
+    public static isCommand(Lkc: KeyEvent): boolean {
+      let code = DefaultOutput.codeForEvent(Lkc);
+
+      switch(code) {
+        // Should we ever implement them:
+        // case Codes.keyCodes['K_LEFT']:  // would not output text, but would alter the caret's position in the context.
+        // case Codes.keyCodes['K_RIGHT']:
+        //   return true;
+        default:
+          return this.isDOMCommand(Lkc);
+      }
+    }
+
+    /**
+     * This function is designed for future migration into a separate, explicitly-DOM-aware module.
+     * It would then be assigned to this class via classic JS method extension practices as an 'override'
+     * of `applyCommand`, reusing the base version of that name seen in this class, which is
+     * designed for web-core.
+     */
+    /**
+     * This function is designed for future migration into a separate, explicitly-DOM-aware module.
+     * It would then be assigned to this class via classic JS method extension practices as an 'override'
+     * of `applyCommand`, reusing the base version of that name seen in this class, which is
+     * designed for web-core.
+     * 
+     * for___Commands - returns boolean indicating if a non-text event should be triggered by the keystroke.
+     */
+    public static applyDOMCommand(Lkc: KeyEvent, keyShiftState: number) {
+      let code = DefaultOutput.codeForEvent(Lkc);
+      let domManager = com.keyman.singleton.domManager;
+
+      switch(code) {
+        case Codes.keyCodes['K_TAB']:
+          domManager.moveToNext(keyShiftState);
+          break;
+        case Codes.keyCodes['K_TABBACK']:
+          domManager.moveToNext(true);
+          break;
+        case Codes.keyCodes['K_TABFWD']:
+          domManager.moveToNext(false);
+          break;
+      }
+    }
+
+    public static applyCommand(Lkc: KeyEvent, keyShiftState: number) {
+      DefaultOutput.applyDOMCommand(Lkc, keyShiftState);
+
+      // Notes for potential default-handling extensions:
+      // 
+      // switch(code) {
         // // Problem:  clusters, and doing them right.
         // // The commented-out code below should be a decent starting point, but clusters make it complex.
         // // Mostly based on pre-12.0 code, but the general idea should be relatively clear.
@@ -91,18 +135,26 @@ namespace com.keyman.text {
         //   if(code == VisualKeyboard.keyCodes['K_RIGHT']) {
         //     break;
         //   }
-        // // Should we include this?  It could be tricky to do correctly...
+      // }
+      //
+      // Note that these would be useful even outside of a DOM context.
+    }
+
+    /**
+     * Codes matched here may need special handling to apply to an OutputTarget, but still produce output.
+     */
+    public static forSpecialEmulation(Lkc: KeyEvent): string {
+      let code = DefaultOutput.codeForEvent(Lkc);
+
+      switch(code) {
+        case Codes.keyCodes['K_BKSP']:
+          return '\b';
+        case Codes.keyCodes['K_ENTER']:
+          return '\n'; 
+        case Codes.keyCodes['K_SPACE']:
+          return ' ';
         // case Codes.keyCodes['K_DEL']:
-        //   // Move caret right one unit, then backspace.
-        //   if(touchAlias) {
-        //     var caretPos = keymanweb.getTextCaret(Lelem);
-        //     keymanweb.setTextCaret(Lelem, caretPos + 1);
-        //     if(caretPos == keymanweb.getTextCaret(Lelem)) {
-        //       // Failed to move right - there's nothing to delete.
-        //       break;
-        //     }
-        //     kbdInterface.defaultBackspace();
-        //   }
+        //   return '\u007f'; // 127, ASCII / Unicode control code for DEL.
       }
     }
 
@@ -126,7 +178,7 @@ namespace com.keyman.text {
 
     // Test for fall back to U_xxxxxx key id
     // For this first test, we ignore the keyCode and use the keyName
-    public static forUnicodeKeynames(Lkc: KeyEvent) {
+    public static forUnicodeKeynames(Lkc: KeyEvent, ruleBehavior?: RuleBehavior) {
       let quiet = Lkc.Ltarg instanceof Mock;
       let keyName = Lkc.kName;
 
@@ -140,8 +192,8 @@ namespace com.keyman.text {
       if (((0x0 <= codePoint) && (codePoint <= 0x1F)) || ((0x80 <= codePoint) && (codePoint <= 0x9F))) {
         // Code points [U_0000 - U_001F] and [U_0080 - U_009F] refer to Unicode C0 and C1 control codes.
         // Check the codePoint number and do not allow output of these codes via U_xxxxxx shortcuts.
-        if(!quiet) {
-          console.log("Suppressing Unicode control code: U_00" + codePoint.toString(16));
+        if(ruleBehavior) {
+          ruleBehavior.errorLog = ("Suppressing Unicode control code: U_00" + codePoint.toString(16));
         }
         return '';
       } else {
@@ -153,12 +205,12 @@ namespace com.keyman.text {
 
     // Test for otherwise unimplemented keys on the the base default & shift layers.
     // Those keys must be blocked by keyboard rules if intentionally unimplemented; otherwise, this function will trigger.
-    public static forBaseKeys(Lkc: KeyEvent, keyShiftState: number) {
+    public static forBaseKeys(Lkc: KeyEvent, keyShiftState: number, ruleBehavior?: RuleBehavior) {
       let n = Lkc.Lcode;
       // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
       if(keyShiftState != 0 && keyShiftState != 1) {
-        if(!(Lkc.Ltarg instanceof Mock)) {
-          console.warn("KMW only defines default key output for the 'default' and 'shift' layers!");
+        if(ruleBehavior) {
+          ruleBehavior.warningLog = "KMW only defines default key output for the 'default' and 'shift' layers!";
         }
       }
 
@@ -174,8 +226,8 @@ namespace com.keyman.text {
             return Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
           }
         } catch (e) {
-          if(!(Lkc.Ltarg instanceof Mock)) {
-            console.error("Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default'));
+          if(ruleBehavior) {
+            ruleBehavior.errorLog = "Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default');
           }
         }
       }

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -180,6 +180,21 @@ namespace com.keyman.text {
      * A set of changed store values triggered by the matched keyboard rule.
      */
     setStore: {[id: number]: string} = {};
+
+    /**
+     * Denotes a non-output default behavior; this should be evaluated later, against the true keystroke.
+     */
+    triggersDefaultCommand?: boolean;
+
+    /**
+     * Denotes error log messages generated when attempting to generate this behavior.
+     */
+    errorLog?: string;
+
+    /**
+     * Denotes warning log messages generated when attempting to generate this behavior.
+     */
+    warningLog?: string;
   }
 
   export class KeyboardInterface {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -90,11 +90,17 @@ namespace com.keyman.text {
 
       if(!matched) {
         if(char = DefaultOutput.forAny(Lkc, keyShiftState)) {
-          if(char == '\b') { // physical keystrokes.
-            keyman.interface.defaultBackspace(outputTarget);
+          special = DefaultOutput.forSpecialEmulation(Lkc)
+          if(special == EmulationKeystrokes.Backspace) {
+            // A browser's default backspace may fail to delete both parts of an SMP character.
+            keyman.interface.defaultBackspace();
           } else {
-            keyman.interface.output(0, outputTarget, char);
+            // We only do the "for special emulation" cases under the condition above... aside from backspace
+            // Let the browser handle those.
+            return null;
           }
+
+          keyman.interface.output(0, outputTarget, char);
         } else {
           // No match, no default RuleBehavior.
           return null;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -88,7 +88,11 @@ namespace com.keyman.text {
 
       if(!matched) {
         if(char = DefaultOutput.forAny(Lkc, keyShiftState)) {
-          keyman.interface.output(0, outputTarget, char);
+          if(char == '\b') { // physical keystrokes.
+            keyman.interface.defaultBackspace(outputTarget);
+          } else {
+            keyman.interface.output(0, outputTarget, char);
+          }
         } else {
           // No match, no default RuleBehavior.
           return null;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -53,6 +53,7 @@ namespace com.keyman.text {
 
       let matched = false;
       var char = '';
+      var special: EmulationKeystrokes;
       if(usingOSK || outputTarget.isSynthetic) {
         matched = true;  // All the conditions below result in matches until the final else, which restores the expected default
                          // if no match occurs.
@@ -63,22 +64,23 @@ namespace com.keyman.text {
 
           // We'd rather let the browser handle these keys, but we're using emulated keystrokes, forcing KMW
           // to emulate default behavior here.
-        } else if(char = DefaultOutput.forSpecialEmulation(Lkc)) { 
-          switch(char) {
-            case '\b':
+        } else if(special = DefaultOutput.forSpecialEmulation(Lkc)) { 
+          switch(special) {
+            case EmulationKeystrokes.Backspace:
               keyman.interface.defaultBackspace(outputTarget);
               break;
-            case '\n':
+            case EmulationKeystrokes.Enter:
               outputTarget.handleNewlineAtCaret();
               break;
-            case ' ':
+            case EmulationKeystrokes.Space:
               keyman.interface.output(0, outputTarget, ' ');
               break;
             // case '\u007f': // K_DEL
               // // For (possible) future implementation.
               // // Would recommend (conceptually) equaling K_RIGHT + K_BKSP, the former of which would technically be a 'command'.
             default:
-              ruleBehavior.errorLog = "Unexpected 'special emulation' character (\\u" + char.kmwCharCodeAt(0).toString(16) + ") went unhandled!";
+              // In case we extend the allowed set, but forget to implement its handling case above.
+              ruleBehavior.errorLog = "Unexpected 'special emulation' character (\\u" + (special as String).kmwCharCodeAt(0).toString(16) + ") went unhandled!";
           } 
         } else {
           // Back to the standard default, pending normal matching.

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -30,6 +30,82 @@ namespace com.keyman.text {
     // Denotes whether or not KMW needs to 'swallow' the next keypress.
     swallowKeypress: boolean = false;
 
+    /**
+     * Get the default RuleBehavior for the specified key, looking up keycodes as necessary.
+     * Performs similar lookups to defaultKeyOutput; it's designed for application to OutputTargets
+     * and ALSO for matching against cases that don't produce typical text output.
+     *
+     * @param   {object}  Lkc  The pre-analyzed key event object
+     * @param   {number}  keyShiftState
+     * @param   {boolean} usingOSK
+     * @return  {string}
+     */
+    defaultRuleBehavior(Lkc: KeyEvent, keyShiftState: number, usingOSK: boolean): RuleBehavior {
+      let keyman = com.keyman.singleton;
+
+      let outputTarget = Lkc.Ltarg;
+      let preInput = Mock.from(outputTarget);
+      let ruleBehavior = new RuleBehavior();
+
+      // check if exact match to SHIFT's code.  Only the 'default' and 'shift' layers should have default key outputs.
+      if (keyShiftState == Codes.modifierCodes['SHIFT']) {
+        keyShiftState = 1; // It's used as an index in some called methods.
+      }
+
+      let matched = false;
+      var char = '';
+      if(usingOSK || outputTarget.isSynthetic) {
+        matched = true;  // All the conditions below result in matches until the final else, which restores the expected default
+                         // if no match occurs.
+
+        if(DefaultOutput.isCommand(Lkc)) {
+          // Note this in the rule behavior, return successfully.  We'll consider applying it later.
+          ruleBehavior.triggersDefaultCommand = true;
+
+          // We'd rather let the browser handle these keys, but we're using emulated keystrokes, forcing KMW
+          // to emulate default behavior here.
+        } else if(char = DefaultOutput.forSpecialEmulation(Lkc)) { 
+          switch(char) {
+            case '\b':
+              keyman.interface.defaultBackspace(outputTarget);
+              break;
+            case '\n':
+              outputTarget.handleNewlineAtCaret();
+              break;
+            case ' ':
+              keyman.interface.output(0, outputTarget, ' ');
+              break;
+            // case '\u007f': // K_DEL
+              // // For (possible) future implementation.
+              // // Would recommend (conceptually) equaling K_RIGHT + K_BKSP, the former of which would technically be a 'command'.
+            default:
+              ruleBehavior.errorLog = "Unexpected 'special emulation' character (\\u" + char.kmwCharCodeAt(0).toString(16) + ") went unhandled!";
+          } 
+        } else {
+          // Back to the standard default, pending normal matching.
+          matched = false;
+        }
+      }
+
+      if(!matched) {
+        if(char = DefaultOutput.forAny(Lkc, keyShiftState)) {
+          keyman.interface.output(0, outputTarget, char);
+        } else {
+          // No match, no default RuleBehavior.
+          return null;
+        }
+      }
+
+      // Shortcut things immediately if there were issues generating this rule behavior.
+      if(ruleBehavior.errorLog) {
+        return ruleBehavior;
+      }
+
+      let transcription = outputTarget.buildTranscriptionFrom(preInput, Lkc);
+      ruleBehavior.transcription = transcription;
+
+      return ruleBehavior;
+    }
 
     /**
      * Get the default key string. If keyName is U_xxxxxx, use that Unicode codepoint.
@@ -53,11 +129,7 @@ namespace com.keyman.text {
       // If this was triggered by the OSK -or- if it was triggered by a 'synthetic' OutputTarget (TouchAlias, Mock)
       // that lacks default key processing behavior.
       if(usingOSK || outputTarget.isSynthetic) {
-        let result = DefaultOutput.applyCommand(Lkc, keyShiftState);
-
-        if(result) {
-          return result;
-        }
+        DefaultOutput.applyCommand(Lkc, keyShiftState);
       } else if(Lkc.Lcode == 8) {
         keyman.interface.defaultBackspace();
         return '';
@@ -73,6 +145,8 @@ namespace com.keyman.text {
       } else if(code = DefaultOutput.forBaseKeys(Lkc, keyShiftState)) {
         return code;
       }
+
+      return '';
     }
 
     static getOutputTarget(Lelem?: HTMLElement): OutputTarget {
@@ -217,23 +291,12 @@ namespace com.keyman.text {
         // Handle unmapped keys, including special keys
         // The following is physical layout dependent, so should be avoided if possible.  All keys should be mapped.
         kbdInterface.activeTargetOutput = outputTarget;
-        let preInput = Mock.from(outputTarget);
 
-        var ch = this.defaultKeyOutput(keyEvent, keyEvent.Lmodifiers, fromOSK);
+        // Match against the 'default keyboard' - rules to mimic the default string output when typing in a browser.
+        // Many keyboards rely upon these 'implied rules'.
+        matchBehavior = this.defaultRuleBehavior(keyEvent, keyEvent.Lmodifiers, fromOSK);
+
         kbdInterface.activeTargetOutput = null;
-        if(ch) {
-          if(ch == '\b') { // Is only returned when disableDOM is true, which prevents automatic default backspace application.
-            // defaultKeyOutput can't always find the outputTarget if we're working with alternates!
-            kbdInterface.defaultBackspace(outputTarget);
-          } else if(ch != '\n') { // \n is handled automatically now.
-            kbdInterface.output(0, outputTarget, ch);
-          }
-          matchBehavior = new RuleBehavior();
-          matchBehavior.transcription = outputTarget.buildTranscriptionFrom(preInput, keyEvent);
-        } else if(keyEvent.Lcode == 8) { // Backspace
-          matchBehavior = new RuleBehavior();
-          matchBehavior.transcription = outputTarget.buildTranscriptionFrom(preInput, keyEvent);
-        }
       }
 
       return matchBehavior;
@@ -341,37 +404,43 @@ namespace com.keyman.text {
       if(ruleBehavior != null) {
         let alternates: Alternate[];
 
-        // Note - we don't yet do fat-fingering with longpress keys.
-        if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
-          let activeLayout = keyman['osk'].vkbd.layout as osk.ActiveLayout;
-          alternates = [];
-  
-          for(let pair of keyEvent.keyDistribution) {
-            let mock = Mock.from(preInputMock);
-            
-            let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
-            if(!altKey) {
-              console.warn("Potential fat-finger key could not be found in layer!");
-              continue;
-            }
+        // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
+        // Also, don't do fat-finger stuff if predictive text isn't enabled.
+        if(keyman.modelManager.enabled && !ruleBehavior.triggersDefaultCommand) {
+          // Note - we don't yet do fat-fingering with longpress keys.
+          if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
+            let activeLayout = keyman['osk'].vkbd.layout as osk.ActiveLayout;
+            alternates = [];
+    
+            for(let pair of keyEvent.keyDistribution) {
+              let mock = Mock.from(preInputMock);
+              
+              let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
+              if(!altKey) {
+                console.warn("Potential fat-finger key could not be found in layer!");
+                continue;
+              }
 
-            let altEvent = this._GetClickEventProperties(altKey, keyEvent.Ltarg.getElement());
-            altEvent.Ltarg = mock;
-            let alternateBehavior = this.processKeystroke(altEvent, mock, fromOSK);
-            if(alternateBehavior) {
-              // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
-              //       so a user should never have intended to type it.  Should probably renormalize 
-              //       the distribution afterward, though...
-              
-              let transform: Transform = alternateBehavior.transcription.transform;
-              
-              // Ensure that the alternate's token id matches that of the current keystroke, as we only
-              // record the matched rule's context (since they match)
-              transform.id = ruleBehavior.transcription.token;
-              alternates.push({sample: transform, 'p': pair.p});
+              let altEvent = this._GetClickEventProperties(altKey, keyEvent.Ltarg.getElement());
+              altEvent.Ltarg = mock;
+              let alternateBehavior = this.processKeystroke(altEvent, mock, fromOSK);
+              if(alternateBehavior) {
+                // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
+                //       so a user should never have intended to type it.  Should probably renormalize 
+                //       the distribution afterward, though...
+                
+                let transform: Transform = alternateBehavior.transcription.transform;
+                
+                // Ensure that the alternate's token id matches that of the current keystroke, as we only
+                // record the matched rule's context (since they match)
+                transform.id = ruleBehavior.transcription.token;
+                alternates.push({sample: transform, 'p': pair.p});
+              }
             }
           }
         }
+
+        // - start:  application of 'delayed' effects specified by RuleBehaviors -
 
         if(ruleBehavior.beep) {
           // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
@@ -396,6 +465,19 @@ namespace com.keyman.text {
           }
         }
 
+        if(ruleBehavior.triggersDefaultCommand) {
+          let keyEvent = ruleBehavior.transcription.keystroke;
+          DefaultOutput.applyCommand(keyEvent, keyEvent.Lmodifiers);
+        }
+
+        if(ruleBehavior.warningLog) {
+          console.warn(ruleBehavior.warningLog);
+        } else if(ruleBehavior.errorLog) {
+          console.error(ruleBehavior.errorLog);
+        }
+
+        // - end section
+
         // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
         //
         // TODO:  This check should be done IN a dom module, not here in web-core space.  This place is closer 
@@ -411,6 +493,7 @@ namespace com.keyman.text {
         
         // Notify the ModelManager of new input - it's predictive text time!
         ruleBehavior.transcription.alternates = alternates;
+        // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
         keyman.modelManager.predict(ruleBehavior.transcription);
 
         // KMEA and KMEI (embedded mode) use direct insertion of the character string


### PR DESCRIPTION
The second half of #2853.

Now it's time for the real default key output rework.  For a while now, KMW has been overloading `defaultKeyOutput` to do a lot of different things all in a single place:

- mnemonic key mapping
- character lookups (for base layouts, Unicode keys)
- browser behavior emulation (especially for the OSK)
- lookup error output (but only for actual user keystrokes, not predicted ones)

These changes look to untangle a lot of the mess that resulted from this.  For example, when doing mnemonic key mapping, we aren't looking to _apply_ a backspace - simply returning '\b' is far more accurate.

On `DefaultOutput`:
- The function `forAny` is extremely analogous to the old `defaultKeyOutput` - it's basically a plain character-lookup version devoid of special handling.  This is ideal for use in mnemonic scenarios and can easily be reused elsewhere.
- `isCommand` / `isDOMCommand` looks to detect cases where an actual keystroke may have intended side effects that typically don't modify text.  Since they have _other_ impacts, it's important to only execute these when actually intended.
- Toward that end, `applyCommand` / `applyDOMCommand` finalize command-type keystrokes when the corresponding `RuleBehavior` is finalized.
    - Seeing how that's grown, I think moving its section in `processKeyEvent` to a `RuleBehavior` class method - say, `finalize()` - is in order.

On `Processor.defaultRuleOutput`:
- This is the output-emulation version of the old `defaultKeyOutput`.  It heavily reuses `DefaultOutput.forAny` where possible, but first filters for special cases.
- This is designed to function as an 'implied default keyboard' version of `Processor.processKeystroke`, complete with matching return type and interpretation thereof.
    - This did require extending the `RuleBehavior` type a bit, though.
    - By placing console warning/error log messages on the `RuleBehavior`, we can automatically filter out unwanted messages from predictive-alternate generation... and it helps clean up logging that will interfere with headless.

---

There's a bit more cleanup here that can be done, but there are easily enough changes here already to merit a review.

TODOs (for the next PRs):
- Move `RuleBehavior` finalization to a class method.
    - It's currently a 35-ish line section in `Processor.processKeyEvent`.
    - I mean, I _could_ move it now, but it's easier to review as is for now.  Less moving parts at once = better, right?
- Eliminate the `shiftState` parameter on the `DefaultOutput` functions.
    - Analysis shows that we can _always_ get the right value from `Lkc.Lmodifiers`, leaving us with a much more consistent type signature across the set.

Notes for other future work:
- Unit tests against `DefaultOutput` and `defaultRuleBehavior` would be ideal, now that this set of PRs is starting to wrap up.
   - Fortunately, `defaultRuleBehavior` doesn't actually have to load a keyboard.  :)
   - Should probably also make some for `KeyboardInterface.processKeystroke`, to validate its new return values.
        - The two will have the same return type, so there should be some nice overlap here.

---

## User Testing

- [ ] Extra care must be taken for Android, since one of its special handling methods required some reworking.
    - See its extension of `DefaultOutput.forBaseKeys`.
    - [ ] I lack access to a 102-key keyboard to test the extension with, but have validated backspace.

There's also a minor "thrown-in fix" to prevent double-output from the ENTER key on Android from physical keystrokes - turns out that one's on `master`, possibly from an earlier refactor PR.  (See the fix(android) commit.)

Tested against the following scenarios in 'native' mode:
- `sil_euro_latin`:  The touch layout implements a _lot_ of its keys through default behaviors.
    - Almost all of the base layer rely on `forBaseKeys`.
    - Most of the popup keys rely on `forUnicodeKeynames`.
    - All cases for `forSpecialEmulation` also apply.
    - Predictive text (on the prediction-ui test page) still works nicely.
- On the standard 'unminified' test page, desktop form-factor:
    - The OSK's tab acts as expected.  (`isCommand`/`isDOMCommand`/`applyCommand`/`applyDOMCommand`)