### PR TITLE
fix(android): Fix min SDK version for Sample and Test apps

### DIFF
--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle


### PR DESCRIPTION
As part of supporting RTL layouts in #2816,  the KMEA `minSdkVersion` API version upgraded from 16 to 19.
This PR updates the Sample apps and Tests/KeyboardHarness to also use API version 19.

Test/keycode does not use KMEA so it doesn't need to update atm.