### PR TITLE
refactor(web/engine): moves new RuleBehavior type & behaviors to own file

### DIFF
--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -1,5 +1,6 @@
 /// <reference path="deadkeys.ts" />
 /// <reference path="../kmwbase.ts" />
+/// <reference path="ruleBehavior.ts" />
 
 /***
    KeymanWeb 11.0
@@ -161,41 +162,6 @@ namespace com.keyman.text {
   };
 
   //#endregion
-
-  /**
-   * Represents the commands and state changes that result from a matched keyboard rule.
-   */
-  export class RuleBehavior {
-    /**
-     * The before-and-after Transform from matching a keyboard rule.
-     */
-    transcription: Transcription;
-
-    /**
-     * Indicates whether or not a BEEP command was issued by the matched keyboard rule.
-     */
-    beep?: boolean;
-
-    /**
-     * A set of changed store values triggered by the matched keyboard rule.
-     */
-    setStore: {[id: number]: string} = {};
-
-    /**
-     * Denotes a non-output default behavior; this should be evaluated later, against the true keystroke.
-     */
-    triggersDefaultCommand?: boolean;
-
-    /**
-     * Denotes error log messages generated when attempting to generate this behavior.
-     */
-    errorLog?: string;
-
-    /**
-     * Denotes warning log messages generated when attempting to generate this behavior.
-     */
-    warningLog?: string;
-  }
 
   export class KeyboardInterface {
     cachedContext: CachedContext = new CachedContext();

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -2,6 +2,8 @@
 /// <reference path="codes.ts" />
 // Defines our generalized "KeyEvent" class.
 /// <reference path="keyEvent.ts" />
+// Defines the RuleBehavior keyboard-processing return object.
+/// <reference path="ruleBehavior.ts" />
 // Defines default key handling behaviors.
 /// <reference path="defaultOutput.ts" />
 
@@ -395,43 +397,9 @@ namespace com.keyman.text {
           }
         }
 
-        // - start:  application of 'delayed' effects specified by RuleBehaviors -
-
-        if(ruleBehavior.beep) {
-          // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
-          //        We're still referencing the DOM, even if only the manager object.  (It's an improvement, at least.)
-          keyman.domManager.doBeep(outputTarget);
-        }
-
-        for(let storeID in ruleBehavior.setStore) {
-          // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
-          //        `Processor` shouldn't be directly setting anything on the OSK when the refactor is complete.
-          
-          // How would this be handled in an eventual headless mode?
-          switch(Number.parseInt(storeID)) { // Because the number was converted into a String for 'dictionary' use.
-            case KeyboardInterface.TSS_LAYER:
-              keyman.osk.vkbd.showLayer(ruleBehavior.setStore[storeID]); //Build 350, osk reference now OK, so should work
-              break;
-            case KeyboardInterface.TSS_PLATFORM:
-              console.error("Rule attempted to perform illegal operation - 'platform' may not be changed.");
-              break;
-            default:
-              console.warn("Unknown store affected by keyboard rule: " + storeID);
-          }
-        }
-
-        if(ruleBehavior.triggersDefaultCommand) {
-          let keyEvent = ruleBehavior.transcription.keystroke;
-          DefaultOutput.applyCommand(keyEvent);
-        }
-
-        if(ruleBehavior.warningLog) {
-          console.warn(ruleBehavior.warningLog);
-        } else if(ruleBehavior.errorLog) {
-          console.error(ruleBehavior.errorLog);
-        }
-
-        // - end section
+        // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
+        // by the actual keystroke occur.
+        ruleBehavior.finalize();
 
         // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
         //

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -1,0 +1,79 @@
+namespace com.keyman.text {
+  /**
+   * Represents the commands and state changes that result from a matched keyboard rule.
+   */
+  export class RuleBehavior {
+    /**
+     * The before-and-after Transform from matching a keyboard rule.
+     */
+    transcription: Transcription;
+
+    /**
+     * Indicates whether or not a BEEP command was issued by the matched keyboard rule.
+     */
+    beep?: boolean;
+
+    /**
+     * A set of changed store values triggered by the matched keyboard rule.
+     */
+    setStore: {[id: number]: string} = {};
+
+    /**
+     * Denotes a non-output default behavior; this should be evaluated later, against the true keystroke.
+     */
+    triggersDefaultCommand?: boolean;
+
+    /**
+     * Denotes error log messages generated when attempting to generate this behavior.
+     */
+    errorLog?: string;
+
+    /**
+     * Denotes warning log messages generated when attempting to generate this behavior.
+     */
+    warningLog?: string;
+
+    finalize() {
+      let keyman = com.keyman.singleton;
+      let outputTarget = this.transcription.keystroke.Ltarg;
+
+      if(this.beep) {
+        // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
+        //        We're still referencing the DOM, even if only the manager object.  (It's an improvement, at least.)
+        keyman.domManager.doBeep(outputTarget);
+      }
+
+      for(let storeID in this.setStore) {
+        // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
+        //        `Processor` shouldn't be directly setting anything on the OSK when the refactor is complete.
+        //
+        //        There's also the issue of Stores in general, which rely on cookies...
+        //        Gotta handle variable stores as well, which we currently do nothing for!
+        
+        // How would this be handled in an eventual headless mode?
+        switch(Number.parseInt(storeID)) { // Because the number was converted into a String for 'dictionary' use.
+          case KeyboardInterface.TSS_LAYER:
+            keyman.osk.vkbd.showLayer(this.setStore[storeID]); //Build 350, osk reference now OK, so should work
+            break;
+          case KeyboardInterface.TSS_PLATFORM:
+            console.error("Rule attempted to perform illegal operation - 'platform' may not be changed.");
+            break;
+          default:
+            console.warn("Unknown store affected by keyboard rule: " + storeID);
+        }
+      }
+
+      if(this.triggersDefaultCommand) {
+        let keyEvent = this.transcription.keystroke;
+        DefaultOutput.applyCommand(keyEvent);
+      }
+
+      // Safe both in browser and Node contexts.
+      if(this.warningLog) {
+        console.warn(this.warningLog);
+      } else if(this.errorLog) {
+        console.error(this.errorLog);
+      }
+    }
+  }
+}


### PR DESCRIPTION
A pretty simple code relocation PR.  Now that `RuleBehavior` is used in multiple files, it's probably best to give it its own *.ts.