### PR TITLE
refactor(web/engine): doInputEvent moved to OutputTarget

### DIFF
--- a/web/source/dom/contentEditable.ts
+++ b/web/source/dom/contentEditable.ts
@@ -261,5 +261,9 @@ namespace com.keyman.dom {
         range.insertNode(n);
       }
     }
+
+    doInputEvent() {
+      this.dispatchInputEventOn(this.root);
+    }
   }
 }

--- a/web/source/dom/designIFrame.ts
+++ b/web/source/dom/designIFrame.ts
@@ -329,5 +329,10 @@ namespace com.keyman.dom {
         }
       }
     }
+
+    doInputEvent() {
+      // Root = the iframe, the outermost component and the one we were originally told to attach to.
+      this.dispatchInputEventOn(this.root);
+    }
   }
 }

--- a/web/source/dom/input.ts
+++ b/web/source/dom/input.ts
@@ -162,5 +162,9 @@ namespace com.keyman.dom {
         }
       }
     }
+
+    doInputEvent() {
+      this.dispatchInputEventOn(this.root);
+    }
   }
 }

--- a/web/source/dom/textarea.ts
+++ b/web/source/dom/textarea.ts
@@ -153,5 +153,9 @@ namespace com.keyman.dom {
     handleNewlineAtCaret(): void {
       this.insertTextBeforeCaret('\n');
     }
+
+    doInputEvent() {
+      this.dispatchInputEventOn(this.root);
+    }
   }
 }

--- a/web/source/dom/touchAlias.ts
+++ b/web/source/dom/touchAlias.ts
@@ -80,5 +80,10 @@ namespace com.keyman.dom {
     protected setTextAfterCaret(s: string) {
       this.root.setText(this.getTextBeforeCaret() + s, this.getTextBeforeCaret()._kmwLength());
     }
+
+    doInputEvent() {
+      // Dispatch the event on the aliased element, not the TouchAliasElement itself.
+      this.dispatchInputEventOn(this.root.base);
+    }
   }
 }

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -1027,23 +1027,6 @@ namespace com.keyman.text {
       this.cachedContextEx.reset();
     }
 
-    doInputEvent(_target: HTMLElement|Document) {
-      var event: Event;
-      // TypeScript doesn't yet recognize InputEvent as a type!
-      if(typeof window['InputEvent'] == 'function') {
-        event = new window['InputEvent']('input', {"bubbles": true, "cancelable": false});
-      } // No else - there is no supported version in some browsers.
-
-      // Ensure that touch-aliased elements fire as if from the aliased element.
-      if(_target['base'] && _target['base']['kmw_ip']) {
-        _target = _target['base'];
-      }
-
-      if(_target && event) {
-        _target.dispatchEvent(event);
-      }
-    }
-
     defaultBackspace(outputTarget?: OutputTarget) {
       if(!outputTarget) {
         // Find the correct output target to manipulate.

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -284,7 +284,12 @@ namespace com.keyman.text {
      * @param elem 
      */
     protected dispatchInputEventOn(elem: HTMLElement) {
-      let event = new InputEvent('input', {"bubbles": true, "cancelable": false});
+      let event: InputEvent;
+
+      // `undefined` in Edge and IE.
+      if(InputEvent) {
+        event = new InputEvent('input', {"bubbles": true, "cancelable": false});
+      }
 
       if(elem && event) {
         elem.dispatchEvent(event);

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -273,6 +273,23 @@ namespace com.keyman.text {
     restoreProperties(){
       // Most element interfaces won't need anything here. 
     }
+
+    /**
+     * Generates a synthetic event on the underlying element, signalling that its value has changed.
+     */
+    abstract doInputEvent(): void;
+
+    /**
+     * A helper method for doInputEvent; creates a simple common event and default dispatching.
+     * @param elem 
+     */
+    protected dispatchInputEventOn(elem: HTMLElement) {
+      let event = new InputEvent('input', {"bubbles": true, "cancelable": false});
+
+      if(elem && event) {
+        elem.dispatchEvent(event);
+      }
+    }
   }
 
   // Due to some interesting requirements on compile ordering in TS,
@@ -363,6 +380,10 @@ namespace com.keyman.text {
 
     protected setTextAfterCaret(s: string): void {
       this.text = this.getTextBeforeCaret() + s;
+    }
+
+    doInputEvent() {
+      // Mock isn't backed by an element, so it won't have any event listeners.
     }
   }
 }

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -287,7 +287,7 @@ namespace com.keyman.text {
       let event: InputEvent;
 
       // `undefined` in Edge and IE.
-      if(InputEvent) {
+      if(window['InputEvent']) { // can't condition on the type directly; TS optimizes that out.
         event = new InputEvent('input', {"bubbles": true, "cancelable": false});
       }
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -463,10 +463,10 @@ namespace com.keyman.text {
           keyman['oninserttext'](ruleTransform.deleteLeft, ruleTransform.insert, ruleTransform.deleteRight);
         }
 
-        // Since this method now performs changes for 'default' keystrokes, synthetic 'change' event generation
-        // belongs here, rather than only in interface.processKeystroke() as in versions pre-12.
-        if(outputTarget.getElement()) {
-          keyman['interface'].doInputEvent(outputTarget.getElement());
+        // Text did not change (thus, no text "input") if we tabbed or merely moved the caret.
+        if(!ruleBehavior.triggersDefaultCommand) {
+          // For DOM-aware targets, this will trigger a DOM event page designers may listen for.
+          outputTarget.doInputEvent();
         }
 
         this.swallowKeypress = (e && keyEvent.Lcode != 8 ? keyEvent.Lcode != 0 : false);


### PR DESCRIPTION
Just removing yet another DOM dependency from `KeyboardInterface` in preparation for headless mode.

While I could move it earlier in the PR chain, there's a single (but desired) `if`-check dependent on work on the PR's current base.