### PR TITLE
fix(windows): some sentry symbolication was not working

### DIFF
--- a/windows/src/developer/TIKE/main/KeymanDeveloperUtils.pas
+++ b/windows/src/developer/TIKE/main/KeymanDeveloperUtils.pas
@@ -48,12 +48,14 @@ interface
 
 uses
   System.UITypes,
-  Windows,
-  Messages,
-  ComObj,
-  Graphics,
+  System.Win.ComObj,
+  Vcl.Graphics,
+  Winapi.Messages,
+  Winapi.Windows,
+
   KeymanPaths,
   keymanapi_TLB,
+  Sentry.Client,
   UserMessages;
 
 const
@@ -83,6 +85,8 @@ procedure RemoveOldestTikeTestFonts(FMaxLessOne: Boolean);
 function GetCurrentDateTime: string;
 function GetKMShellPath(var ps: string): Boolean;   // I3655
 function WaitForElevatedConfiguration(WindowHandle: THandle; const Parameters: WideString; FWait: Boolean): Cardinal;   // I3655
+
+procedure TestSentry;
 
 var
   kmcom: IKeyman = nil;
@@ -662,6 +666,11 @@ begin
   end
   else
     ShowMessage(SysErrorMessage(GetLastError));
+end;
+
+procedure TestSentry;
+begin
+  raise ESentryTest.Create('Just testing Sentry integration');
 end;
 
 end.

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -444,6 +444,7 @@ uses
   RedistFiles,
   ErrorControlledRegistry,
   RegistryKeys,
+  Sentry.Client,
   TikeUnicodeData,
   UfrmCharacterMapDock,
   UfrmMessages,
@@ -1413,11 +1414,8 @@ begin
 end;
 
 procedure TfrmKeymanDeveloper.crash1Click(Sender: TObject);
-var
-  p: PChar;
 begin
-  p := nil;
-  p^ := #0;
+  raise ESentryTest.Create('Just testing Sentry');
 end;
 
 procedure TfrmKeymanDeveloper.SetActiveChild(const Value: TfrmTikeChild);

--- a/windows/src/ext/sentry/Sentry.Client.pas
+++ b/windows/src/ext/sentry/Sentry.Client.pas
@@ -67,6 +67,11 @@ type
 
   TSentryClientClass = class of TSentryClient;
 
+  // When testing Sentry integration, ESentryTest is an appropriate exception to
+  // raise.
+  ESentryTest = class(Exception)
+  end;
+
 procedure SentryHandleException(E: Exception; AExceptAddr: Pointer = nil);
 
 implementation

--- a/windows/src/ext/tds2dbg/tds2dbg.sln
+++ b/windows/src/ext/tds2dbg/tds2dbg.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1000
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tds2dbg", "tds2dbg.vcxproj", "{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Debug|x64.ActiveCfg = Debug|x64
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Debug|x64.Build.0 = Debug|x64
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Debug|x86.ActiveCfg = Debug|Win32
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Debug|x86.Build.0 = Debug|Win32
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Release|x64.ActiveCfg = Release|x64
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Release|x64.Build.0 = Release|x64
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Release|x86.ActiveCfg = Release|Win32
+		{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {50FB6E2C-4FEF-4828-A315-1017276BF47A}
+	EndGlobalSection
+EndGlobal

--- a/windows/src/ext/tds2dbg/tds2dbg.vcxproj
+++ b/windows/src/ext/tds2dbg/tds2dbg.vcxproj
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{40BFECE3-7FC0-4649-A3DC-E017FF84C75B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="fileutils.cpp" />
+    <ClCompile Include="log.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="tds2dbg.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="fileutils.h" />
+    <ClInclude Include="log.h" />
+    <ClInclude Include="tds2dbg.h" />
+    <ClInclude Include="tdscvstructs.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="tds2dbg.bin" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/windows/src/ext/tds2dbg/tds2dbg.vcxproj.filters
+++ b/windows/src/ext/tds2dbg/tds2dbg.vcxproj.filters
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="fileutils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="log.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tds2dbg.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="fileutils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="tds2dbg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="tdscvstructs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="tds2dbg.bin">
+      <Filter>Resource Files</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -115,7 +115,7 @@ begin
     then o.DSN := SENTRY_DSN_DESKTOP
     else o.DSN := SENTRY_DSN_DEVELOPER;
 
-  {$MESSAGE HINT 'Support proxies'}
+  // Note: system proxy is used automatically if no proxy is defined
 
   o.Release := 'release-'+CKeymanVersionInfo.VersionWithTag;
 


### PR DESCRIPTION
Two issues:
* There was a bug in the map file line number mapping where length of the last line in a function was too long
* Functions without line information were ignored by Sentry so adding a synthetic line entry for those functions (library functions primarily)

Two tweaks:
* Added a Visual Studio project file for the existing tds2dbg code (which was previously built with Borland C++? many years ago) while looking at alternative mapping solutions and decided to keep it.
* Instead of an access violation for crash tests, now uses a specific `ESentryTest` exception which is better for filtering.