### PR TITLE
fix(android): Update min SDK versions for sample apps

### DIFF
--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample1"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample2"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle


### PR DESCRIPTION
These KMSample (bolded) files didn't get attached to #2860

> This PR updates the **Sample apps** and Tests/KeyboardHarness to also use API version 19.