### PR TITLE
fix(linux): Use __release_version__ for downloadkeyboard window

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -15,7 +15,7 @@
 - It is helpful to be using the [packages.sil.org](http://packages.sil.org) repo
 
 - Install packages required for building and developing KMFL and Keyman for Linux
-`sudo apt install cdbs debhelper libx11-dev autotools-dev build-essential dh-autoreconf flex bison libibus-1.0-dev python3-setuptools meson libjson-glib-dev libgtk-3-dev libxml2-utils help2man python3-lxml python3-magic python3-numpy python3-pil python3-pip python3-qrcode python3-requests python3-requests-cache python3 python3-gi dconf-cli`
+`sudo apt install cdbs debhelper libx11-dev autotools-dev build-essential dh-autoreconf flex bison libibus-1.0-dev python3-setuptools meson libjson-glib-dev libgtk-3-dev libxml2-utils help2man python3-lxml python3-magic python3-numpy python3-pil python3-pip python3-qrcode python3-requests python3-requests-cache python3 python3-gi dconf-cli dconf-editor`
 
 ### Compiling from Command Line
 
@@ -103,7 +103,7 @@ Run `ibus restart` after installing any of them
 
 #### Activating a Keyman keyboard
 
-##### GNOME3 (bionic default)
+##### GNOME3 (focal and bionic default)
 
  * Click the connection/sound/shutdown section in the top right. Then the tools icon for Settings.
 

--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -1,2 +1,3 @@
 from .version import __version__
 from .version import __majorversion__
+from .version import __releaseversion__

--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -15,7 +15,7 @@ from keyman_config.get_kmp import get_download_folder, download_kmp_file
 from keyman_config.install_window import InstallKmpWindow
 from keyman_config.accelerators import bind_accelerator, init_accel
 from keyman_config.get_info import GetInfo
-from keyman_config import __majorversion__
+from keyman_config import __releaseversion__
 
 class DownloadKmpWindow(Gtk.Window):
 
@@ -31,7 +31,7 @@ class DownloadKmpWindow(Gtk.Window):
         s = Gtk.ScrolledWindow()
         webview = WebKit2.WebView()
         webview.connect("decide-policy", self.keyman_policy)
-        webview.load_uri("https://keyman.com/go/linux/"+__majorversion__+"/download-keyboards")
+        webview.load_uri("https://keyman.com/go/linux/"+__releaseversion__+"/download-keyboards")
         s.add(webview)
         vbox.pack_start(s, True, True, 0)
 

--- a/linux/keyman-config/keyman_config/version.py.in
+++ b/linux/keyman-config/keyman_config/version.py.in
@@ -6,3 +6,4 @@
 # 3) we can import it into your module module
 __version__ = "_VERSION_"
 __majorversion__ = "_MAJORVERSION_"
+__releaseversion__ = "_RELEASEVERSION_"

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -61,7 +61,7 @@ for proj in ${extra_projects}; do
         cd keyman-config
         make clean
         cd keyman_config
-        sed -e "s/_VERSION_/${newvers}/g" -e "s/_MAJORVERSION_/${VERSION_MAJOR}/g" version.py.in > version.py
+        sed -e "s/_VERSION_/${newvers}/g" -e "s/_MAJORVERSION_/${VERSION_MAJOR}/g" -e "s/_RELEASEVERSION_/${VERSION_RELEASE}/g" version.py.in > version.py
     fi
     cd $BASEDIR
 done


### PR DESCRIPTION
In 13.0, the VERSION.md file contained 13.0 and so that was used for downloadkeyboards.

As of 14.0, `resources/build/build-utils.sh` define the build variables:

```
#   VERSION:          Full current build version, e.g. "14.0.1"
#   VERSION_WIN:      Full current build version for Windows, e.g. "14.0.1.0"
#   VERSION_RELEASE:  Current release version, e.g. "14.0"
#   VERSION_MAJOR:    Major version, e.g. "14"
#   VERSION_MINOR:    Minor version, e.g. "0"
#   VERSION_PATCH:    Patch version, e.g. "1"
```

The go/linux links need an #.# version (e.g. 14.0 instead of 14) so this PR changes from __majorversion__ to __releaseversion__.

Also updated the linux README.md for minor edits