### PR TITLE
fix(web): fixes embedded kbd initialization

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -118,7 +118,7 @@
 
     function setKeymanLanguage(keyboardName, internalName, languageName, langId, kbdFile, font, oskFont, package) {
       var kmw=window['keyman'];
-      var kbdInterface=kmw['interface'];
+      var kbdInterface=window['KeymanWeb'];
 
       // Defaults for missing arguments
       switch (arguments.length) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -118,7 +118,7 @@
 
     function setKeymanLanguage(keyboardName, internalName, languageName, langId, kbdFile, font, oskFont, package) {
       var kmw=window['keyman'];
-      var kbdInterface=window['KeymanWeb'];
+      var kbdInterface=window.KeymanWeb;
 
       // Defaults for missing arguments
       switch (arguments.length) {

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -114,7 +114,7 @@
             function setKeymanLanguage(stub) {
                 var kmw = window.keyman;
 
-                kmw.interface.registerStub(stub);
+                KeymanWeb.registerStub(stub);
                 kmw.setActiveKeyboard(stub.KI, stub.KLC);
                 kmw.osk.show(true);
             }


### PR DESCRIPTION
Looks like I missed one detail on #2863 - the Android and iOS apps have been looking at  `keyman.interface` when setting the keyboard.  Merging that broke them, though it's at least a simple fix.  The `KeymanWeb` global doesn't seem to be going away any time soon.

Fixes KEYMAN-ANDROID-H.