### PR TITLE
fix(ios): [cherry] popup keys over base keys no longer emit base char

### DIFF
--- a/ios/history.md
+++ b/ios/history.md
@@ -1,6 +1,9 @@
 
 # Keyman for iPhone and iPad Version History
 
+## 2020-03-24 13.0.106 stable
+* Fixes issue where base key could output at same time a popup key was selected (#2882)
+
 ## 2020-03-17 13.0.105 stable
 * Fixes issues with keyboard banner display (#2841)
 

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,7 +1,9 @@
 
 # Keyman for iPhone and iPad Version History
 
-## 2020-03-24 13.0.106 stable
+## 2020-04-15 13.0.106 stable
+* Adds workaround for iOS 13.4 bug that breaks longpresses (#2960, #2970)
+* Mitigates bug where in-app keyboard would reset inappropriately (#2952)
 * Fixes issue where base key could output at same time a popup key was selected (#2882)
 
 ## 2020-03-17 13.0.105 stable

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1000,7 +1000,7 @@ namespace com.keyman.osk {
       // Clear repeated backspace if active, preventing 'sticky' behavior.
       this.cancelDelete();
 
-      if((sk && sk.style.visibility == 'visible') || this.popupVisible) {
+      if((sk && sk.style.visibility == 'visible')) {
         // Ignore release if a multiple touch
         if(e.touches.length > 0) {
           return;
@@ -1013,6 +1013,15 @@ namespace com.keyman.osk {
           this.keyPending = null;
           this.touchPending = null;
         }
+      }
+
+      // Only set when embedded in our Android/iOS app.  Signals that the device is handling 
+      // subkeys, so we shouldn't allow output for the base key.
+      //
+      // Note that on iOS (at least), this.release() will trigger before kmwembedded.ts's
+      // executePopupKey() function.
+      if(this.popupVisible) {
+        return;
       }
 
       // Handle menu key release event


### PR DESCRIPTION
A :cherries:-pick of #2881.