### PR TITLE
refactor(web/engine): relocates keyboard tag code, adds typing

### DIFF
--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -1,5 +1,16 @@
 namespace com.keyman.keyboards {
   /**
+   * Stores preprocessed properties of a keyboard for quick retrieval later.
+   */
+  class CacheTag {
+    stores: {[storeName: string]: text.ComplexKeyboardStore};
+
+    constructor() {
+      this.stores = {};
+    }
+  }
+
+  /**
    * Acts as a wrapper class for Keyman keyboards compiled to JS, providing type information
    * and keyboard-centered functionality in an object-oriented way without modifying the 
    * wrapped keyboard itself.
@@ -132,6 +143,21 @@ namespace com.keyman.keyboards {
       }
     }
 
+    private get cacheTag(): CacheTag {
+      let tag = this.scriptObject['_kmw'];
+
+      if(!tag) {
+        tag = new CacheTag();
+        this.scriptObject['_kmw'] = tag;
+      }
+
+      return tag; 
+    }
+
+    get explodedStores(): {[storeName: string]: text.ComplexKeyboardStore} {
+      return this.cacheTag.stores;
+    }
+
     usesDesktopLayoutOnDevice(device: Device) {
       if(this.scriptObject['KVKL']) {
         // A custom mobile layout is defined... but are we using it?
@@ -153,8 +179,5 @@ namespace com.keyman.keyboards {
         this.scriptObject['KNS'](_PCommand, _PTarget, _PData);
       }
     }
-
-    // TODO:  Provide public property-retrieving methods on this class, rather than as part of
-    //        the KeyboardManager object.
   }
 }

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -114,11 +114,6 @@ namespace com.keyman.keyboards {
       return textProcessor.activeKeyboard ? textProcessor.activeKeyboard.id : '';
     }
 
-    getActiveKeyboardTag(): KeyboardTag {
-      let textProcessor = com.keyman.singleton.textProcessor;
-      return textProcessor.activeKeyboard ? textProcessor.activeKeyboard.scriptObject['_kmw'] : null;
-    }
-
     getActiveLanguage(fullName?: boolean): string {
       if(this.activeStub == null) {
         return '';

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -626,12 +626,11 @@ namespace com.keyman.text {
 
     _ExplodeStore(store: KeyboardStore): ComplexKeyboardStore {
       if(typeof(store) == 'string') {
-        let keyman = com.keyman.singleton;
-        var kbdTag = keyman.keyboardManager.getActiveKeyboardTag();
+        let cachedStores = this.activeKeyboard.explodedStores;
 
         // Is the result cached?
-        if(kbdTag.stores[store]) {
-          return kbdTag.stores[store];
+        if(cachedStores[store]) {
+          return cachedStores[store];
         }
 
         // Nope, so let's build its cache.
@@ -641,7 +640,7 @@ namespace com.keyman.text {
         }
 
         // Cache the result for later!
-        kbdTag.stores[store] = result;
+        cachedStores[store] = result;
         return result;
       } else {
         return store;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -71,6 +71,10 @@ namespace com.keyman.text {
       // All old deadkeys and keyboard-specific cache should immediately be invalidated
       // on a keyboard change.
       this.keyboardInterface.resetContext();
+
+      // Ensure that the setting propagates immediately to the keyboard interface object.
+      // Matters for some unit tests.
+      this.keyboardInterface.activeKeyboard = keyboard;
     }
 
     /**


### PR DESCRIPTION
This PR is focused on refactoring references to the existing keyboard 'tag' object.  At present, it's only used to cache previously post-processed keyboard properties - "exploded" stores.

Tested with `khmer_angkor`, which has extensive use of stores with its reorder rules; everything checks out, and the cached stores are used properly after these changes are in place.