### PR TITLE
refactor(web): headless device representation

### DIFF
--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -161,6 +161,12 @@ namespace com.keyman.dom {
       var LisVirtualKeyCode = (typeof e.charCode != 'undefined' && e.charCode != null  &&  (e.charCode == 0 || (s.Lmodifiers & 0x6F) != 0));
       s.LisVirtualKey = LisVirtualKeyCode || e.type != 'keypress';
 
+      // Physically-typed keys require use of a 'desktop' form factor and thus are based on a virtual "physical" Device.
+      s.device = keyman.util.physicalDevice.headlessSpec;
+
+      // This is based on a KeyboardEvent, so it's not considered 'synthetic' within web-core.
+      s.isSynthetic = false;
+
       // Other minor physical-keyboard adjustments
       if(activeKeyboard && !activeKeyboard.isMnemonic) {
         // Positional Layout
@@ -181,7 +187,9 @@ namespace com.keyman.dom {
             LisVirtualKey: false,
             vkCode: s.Lcode, // Helps to merge OSK and physical keystroke control paths.
             Lstates: s.Lstates,
-            kName: ''
+            kName: '',
+            device: keyman.util.physicalDevice.headlessSpec,
+            isSynthetic: false
           };
         }
       }
@@ -262,7 +270,17 @@ namespace com.keyman.dom {
       /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
       
       // Only reached if it's a mnemonic keyboard.
-      if(processor.swallowKeypress || processor.keyboardInterface.processKeystroke(keyman.util.physicalDevice, Levent.Ltarg, Levent)) {
+      
+      // This pathway won't have .processKeyEvent's FF keycode check, so we must do it here on
+      // .processKeystroke's behalf.
+      if(!keyman.isEmbedded && keyman.util.device.browser == 'firefox') {
+        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
+        // FireFox, Mozilla Suite
+        if(KeyMapping.browserMap.FF['k'+Levent.Lcode]) {
+          Levent.Lcode=KeyMapping.browserMap.FF['k'+Levent.Lcode];
+        }
+      }
+      if(processor.swallowKeypress || processor.keyboardInterface.processKeystroke(Levent.Ltarg, Levent)) {
         processor.swallowKeypress = false;
         if(e && e.preventDefault) {
           e.preventDefault();

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -162,7 +162,7 @@ namespace com.keyman.dom {
       s.LisVirtualKey = LisVirtualKeyCode || e.type != 'keypress';
 
       // Physically-typed keys require use of a 'desktop' form factor and thus are based on a virtual "physical" Device.
-      s.device = keyman.util.physicalDevice.headlessSpec;
+      s.device = keyman.util.physicalDevice.coreSpec;
 
       // This is based on a KeyboardEvent, so it's not considered 'synthetic' within web-core.
       s.isSynthetic = false;
@@ -188,7 +188,7 @@ namespace com.keyman.dom {
             vkCode: s.Lcode, // Helps to merge OSK and physical keystroke control paths.
             Lstates: s.Lstates,
             kName: '',
-            device: keyman.util.physicalDevice.headlessSpec,
+            device: keyman.util.physicalDevice.coreSpec,
             isSynthetic: false
           };
         }

--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -158,10 +158,10 @@ namespace com.keyman.keyboards {
       return this.cacheTag.stores;
     }
 
-    usesDesktopLayoutOnDevice(device: Device) {
+    usesDesktopLayoutOnDevice(device: text.EngineDeviceSpec) {
       if(this.scriptObject['KVKL']) {
         // A custom mobile layout is defined... but are we using it?
-        return device.formFactor == 'desktop';
+        return device.formFactor == text.FormFactor.Desktop;
       } else {
         return true;
       }

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -1,6 +1,7 @@
 // Includes version-related functionality
 ///<reference path="utils/version.ts"/>
 ///<reference path="utils/styleConstants.ts" />
+///<reference path="text/engineDeviceSpec.ts" />
 
 // The Device object definition -------------------------------------------------
 
@@ -248,6 +249,10 @@ namespace com.keyman {
       }
 
       return this._styles;
+    }
+
+    public get headlessSpec(): text.EngineDeviceSpec {
+      return new text.EngineDeviceSpec(this.browser, this.formFactor, this.OS, this.touchable);
     }
   }
 }

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -251,6 +251,9 @@ namespace com.keyman {
       return this._styles;
     }
 
+    /**
+     * Returns a slimmer, web-core compatible version of this object.
+     */
     public get coreSpec(): text.EngineDeviceSpec {
       return new text.EngineDeviceSpec(this.browser, this.formFactor, this.OS, this.touchable);
     }

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -251,7 +251,7 @@ namespace com.keyman {
       return this._styles;
     }
 
-    public get headlessSpec(): text.EngineDeviceSpec {
+    public get coreSpec(): text.EngineDeviceSpec {
       return new text.EngineDeviceSpec(this.browser, this.formFactor, this.OS, this.touchable);
     }
   }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -408,11 +408,6 @@ namespace com.keyman.text {
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");
       }
-      
-      // Process modifier key action
-      if(processor.selectLayer(keyName)) {
-        return true;      
-      }
 
       let Codes = com.keyman.text.Codes;
       
@@ -430,6 +425,11 @@ namespace com.keyman.text {
         device: keymanweb.util.device.coreSpec
       };
 
+      // Process modifier key action
+      if(processor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
+        return true;      
+      }
+
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
       // we can handle many other pre-processing steps the same way with this common method.
       processor.setSyntheticEventDefaults(Lkc);
@@ -439,7 +439,7 @@ namespace com.keyman.text {
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          processor.selectLayer(keyName, nextLayer);
+          processor.selectLayer(Lkc);
         }
         return false;
       }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -480,7 +480,7 @@ namespace com.keyman.text {
       Lstates: lstates,
       LisVirtualKey: true,
       kName: '',
-      device: keyman.util.physicalDevice.headlessSpec, // As we're executing a hardware keystroke.
+      device: keyman.util.physicalDevice.coreSpec, // As we're executing a hardware keystroke.
       isSynthetic: false
     }; 
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -374,7 +374,7 @@ namespace com.keyman.text {
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),Lkc,keyShiftState=processor.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -417,14 +417,17 @@ namespace com.keyman.text {
       let Codes = com.keyman.text.Codes;
       
       // Check the virtual key 
-      Lkc = {
+      let Lkc: com.keyman.text.KeyEvent = {
         Ltarg: com.keyman.text.Processor.getOutputTarget(Lelem),
         Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],
         LisVirtualKey: true,
         kName: keyName,
-        kNextLayer: nextLayer
+        kNextLayer: nextLayer,
+        vkCode: null, // was originally undefined
+        isSynthetic: true,
+        device: keymanweb.util.device.coreSpec
       };
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -479,7 +479,9 @@ namespace com.keyman.text {
       Lcode: code,
       Lstates: lstates,
       LisVirtualKey: true,
-      kName: ''
+      kName: '',
+      device: keyman.util.physicalDevice.headlessSpec, // As we're executing a hardware keystroke.
+      isSynthetic: false
     }; 
 
     try {

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -27,7 +27,9 @@ namespace com.keyman.osk {
         kName: keyName,
         kLayer: layer,
         kbdLayer: e.displayLayer,
-        kNextLayer: e.nextlayer
+        kNextLayer: e.nextlayer,
+        device: keyman.util.device.headlessSpec,  // The OSK's events always use the 'true' device.
+        isSynthetic: true
       };
 
       // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -28,7 +28,7 @@ namespace com.keyman.osk {
         kLayer: layer,
         kbdLayer: e.displayLayer,
         kNextLayer: e.nextlayer,
-        device: keyman.util.device.headlessSpec,  // The OSK's events always use the 'true' device.
+        device: keyman.util.device.coreSpec,  // The OSK's events always use the 'true' device.
         isSynthetic: true
       };
 

--- a/web/source/text/engineDeviceSpec.ts
+++ b/web/source/text/engineDeviceSpec.ts
@@ -25,8 +25,9 @@ namespace com.keyman.text {
   }
 
   /**
-   * This class provides an abstract version of com.keyman.Device that is headless-friendly, 
-   * containing only the information needed by web-core for text processing use.
+   * This class provides an abstract version of com.keyman.Device that is core-friendly, 
+   * containing only the information needed by web-core for text processing use, devoid
+   * of any direct references to the DOM.
    */
   export class EngineDeviceSpec {
     readonly browser: Browser;

--- a/web/source/text/engineDeviceSpec.ts
+++ b/web/source/text/engineDeviceSpec.ts
@@ -10,11 +10,11 @@ namespace com.keyman.text {
   }
 
   export enum OperatingSystem {
-    Windows = 'Windows',
-    macOS = 'MacOSX',
-    Linux = 'Linux',
-    Android = 'Android',
-    iOS = 'iOS',
+    Windows = 'windows',
+    macOS = 'macosx',
+    Linux = 'linux',
+    Android = 'android',
+    iOS = 'ios',
     Other = 'other'
   }
 

--- a/web/source/text/engineDeviceSpec.ts
+++ b/web/source/text/engineDeviceSpec.ts
@@ -43,7 +43,7 @@ namespace com.keyman.text {
         case Browser.Native:
         case Browser.Opera:
         case Browser.Safari:
-          this.browser = browser as Browser;
+          this.browser = browser.toLowerCase() as Browser;
           break;
         default:
           this.browser = Browser.Other;
@@ -53,10 +53,10 @@ namespace com.keyman.text {
         case FormFactor.Desktop:
         case FormFactor.Phone:
         case FormFactor.Tablet:
-          this.formFactor = formFactor as FormFactor;
+          this.formFactor = formFactor.toLowerCase() as FormFactor;
           break;
         default:
-          throw ("Invalid form factor specified for device!");
+          throw ("Invalid form factor specified for device: " + formFactor);
       }
 
       switch(OS.toLowerCase()) {
@@ -65,7 +65,7 @@ namespace com.keyman.text {
         case OperatingSystem.Linux.toLowerCase():
         case OperatingSystem.Android.toLowerCase():
         case OperatingSystem.iOS.toLowerCase():
-          this.OS = OS as OperatingSystem;
+          this.OS = OS.toLowerCase() as OperatingSystem;
           break;
         default:
           this.OS = OperatingSystem.Other;

--- a/web/source/text/engineDeviceSpec.ts
+++ b/web/source/text/engineDeviceSpec.ts
@@ -36,7 +36,7 @@ namespace com.keyman.text {
     readonly touchable: boolean;
 
     constructor(browser: string, formFactor: string, OS: string, touchable: boolean) {
-      switch(browser as Browser) {
+      switch(browser.toLowerCase() as Browser) {
         case Browser.Chrome:
         case Browser.Edge:
         case Browser.Firefox:
@@ -49,7 +49,7 @@ namespace com.keyman.text {
           this.browser = Browser.Other;
       }
 
-      switch(formFactor.toLowerCase()) {
+      switch(formFactor.toLowerCase() as FormFactor) {
         case FormFactor.Desktop:
         case FormFactor.Phone:
         case FormFactor.Tablet:
@@ -59,7 +59,7 @@ namespace com.keyman.text {
           throw ("Invalid form factor specified for device: " + formFactor);
       }
 
-      switch(OS.toLowerCase()) {
+      switch(OS.toLowerCase() as OperatingSystem) {
         case OperatingSystem.Windows.toLowerCase():
         case OperatingSystem.macOS.toLowerCase():
         case OperatingSystem.Linux.toLowerCase():

--- a/web/source/text/engineDeviceSpec.ts
+++ b/web/source/text/engineDeviceSpec.ts
@@ -1,0 +1,76 @@
+namespace com.keyman.text {
+  export enum Browser {
+    Chrome = 'chrome',
+    Edge = 'edge',
+    Firefox = 'firefox',
+    Native = 'native', // Used by embedded mode
+    Opera = 'opera',
+    Safari = 'safari',
+    Other = 'other'
+  }
+
+  export enum OperatingSystem {
+    Windows = 'Windows',
+    macOS = 'MacOSX',
+    Linux = 'Linux',
+    Android = 'Android',
+    iOS = 'iOS',
+    Other = 'other'
+  }
+
+  export enum FormFactor {
+    Desktop = 'desktop',
+    Phone = 'phone',
+    Tablet = 'tablet'
+  }
+
+  /**
+   * This class provides an abstract version of com.keyman.Device that is headless-friendly, 
+   * containing only the information needed by web-core for text processing use.
+   */
+  export class EngineDeviceSpec {
+    readonly browser: Browser;
+    readonly formFactor: FormFactor;
+    readonly OS: OperatingSystem;
+    readonly touchable: boolean;
+
+    constructor(browser: string, formFactor: string, OS: string, touchable: boolean) {
+      switch(browser as Browser) {
+        case Browser.Chrome:
+        case Browser.Edge:
+        case Browser.Firefox:
+        case Browser.Native:
+        case Browser.Opera:
+        case Browser.Safari:
+          this.browser = browser as Browser;
+          break;
+        default:
+          this.browser = Browser.Other;
+      }
+
+      switch(formFactor.toLowerCase()) {
+        case FormFactor.Desktop:
+        case FormFactor.Phone:
+        case FormFactor.Tablet:
+          this.formFactor = formFactor as FormFactor;
+          break;
+        default:
+          throw ("Invalid form factor specified for device!");
+      }
+
+      switch(OS.toLowerCase()) {
+        case OperatingSystem.Windows.toLowerCase():
+        case OperatingSystem.macOS.toLowerCase():
+        case OperatingSystem.Linux.toLowerCase():
+        case OperatingSystem.Android.toLowerCase():
+        case OperatingSystem.iOS.toLowerCase():
+          this.OS = OS as OperatingSystem;
+          break;
+        default:
+          this.OS = OperatingSystem.Other;
+      }
+      
+      this.touchable = touchable;
+    }
+  }
+}

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -865,7 +865,7 @@ namespace com.keyman.text {
             case 'android':
             case 'ios':
             case 'linux':
-              if(this.activeDevice.OS.toLowerCase() != constraint) {
+              if(this.activeDevice.OS != constraint) {
                 result=false;
               }
               break;

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -179,7 +179,7 @@ namespace com.keyman.text {
 
     // Must be accessible to some of the keyboard API methods.
     activeKeyboard: any;
-    activeDevice: com.keyman.Device;
+    activeDevice: EngineDeviceSpec;
 
     constructor() {
     }
@@ -873,13 +873,13 @@ namespace com.keyman.text {
             case 'tablet':
             case 'phone':
             case 'desktop':
-              if(keyman.util.device.formFactor != constraint) {
+              if(this.activeDevice.formFactor != constraint) {
                 result=false;
               }
               break;
 
             case 'web':
-              if(keyman.util.device.browser == 'native') {
+              if(this.activeDevice.browser == 'native') {
                 result=false; // web matches anything other than 'native'
               }
               break;
@@ -892,7 +892,7 @@ namespace com.keyman.text {
             case 'safari':
             case 'edge':
             case 'opera':
-              if(keyman.util.device.browser != constraint) {
+              if(this.activeDevice.browser != constraint) {
                 result=false;
               }
               break;
@@ -998,13 +998,12 @@ namespace com.keyman.text {
     /**
      * Function     processKeystroke
      * Scope        Private
-     * @param       {Object}        device      The device object properties to be utilized for this keystroke.
      * @param       {Object}        element     The page element receiving input
      * @param       {Object}        keystroke   The input keystroke (with its properties) to be mapped by the keyboard.
      * Description  Encapsulates calls to keyboard input processing.
      * @returns     {number}        0 if no match is made, otherwise 1.
      */
-    processKeystroke(device: Device, outputTarget: OutputTarget, keystroke: KeyEvent/*|com.keyman.text.LegacyKeyEvent*/): RuleBehavior {
+    processKeystroke(outputTarget: OutputTarget, keystroke: KeyEvent/*|com.keyman.text.LegacyKeyEvent*/): RuleBehavior {
       // Clear internal state tracking data from prior keystrokes.
       if(!outputTarget) {
         throw "No target specified for keyboard output!";
@@ -1025,7 +1024,7 @@ namespace com.keyman.text {
 
       // Ensure the settings are in place so that KIFS/ifState activates and deactivates
       // the appropriate rule(s) for the modeled device.
-      this.activeDevice = device;
+      this.activeDevice = keystroke.device;
 
       // Calls the start-group of the active keyboard.
       this.activeTargetOutput = outputTarget;

--- a/web/source/text/keyEvent.ts
+++ b/web/source/text/keyEvent.ts
@@ -1,3 +1,5 @@
+/// <reference path="engineDeviceSpec.ts" />
+
 namespace com.keyman.text {
   // Represents a probability distribution over a keyboard's keys.
   // Defined here to avoid compilation issues.
@@ -19,9 +21,20 @@ namespace com.keyman.text {
     kLayer?: string;   // The key's layer property
     kbdLayer?: string; // The virtual keyboard's active layer
     kNextLayer?: string;
+    
     // Holds relevant event properties leading to construction of this KeyEvent.
-    source?: KeyEvent|MouseEvent|Touch;
+    source?: any; // Technically, KeyEvent|MouseEvent|Touch - but those are DOM types that must be kept out of headless mode.
     // Holds a generated fat-finger distribution (when appropriate)
     keyDistribution?: KeyDistribution;
+    
+    /**
+     * The device model for web-core to follow when processing the keystroke.
+     */
+    device: EngineDeviceSpec;
+
+    /**
+     * `true` if this event was produced by sources other than a DOM-based KeyboardEvent.
+     */
+    isSynthetic: boolean = true;
   };
 }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -284,7 +284,7 @@ namespace com.keyman.text {
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
-      if((formFactor == 'desktop' || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
+      if((formFactor == FormFactor.Desktop || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
         // If it's a desktop OSK style and this triggers a layer change,
         // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
         if(this.selectLayer(keyEvent.kName, keyEvent.kNextLayer)) {
@@ -299,7 +299,7 @@ namespace com.keyman.text {
       }
 
       // TODO: This keymapping should be relocated outside of this method.
-      if(!keyman.isEmbedded && !fromOSK && keyEvent.device.browser == 'firefox') {
+      if(!keyman.isEmbedded && !fromOSK && keyEvent.device.browser == Browser.Firefox) {
         // I1466 - Convert the - keycode on mnemonic as well as positional layouts
         // FireFox, Mozilla Suite
         if(KeyMapping.browserMap.FF['k'+keyEvent.Lcode]) {
@@ -747,14 +747,14 @@ namespace com.keyman.text {
       var s = activeLayer;
 
       // Do not change layer unless needed (27/08/2015)
-      if(id == activeLayer && keyman.util.device.formFactor != 'desktop') {
+      if(id == activeLayer && keyman.util.device.formFactor != FormFactor.Desktop) {
         return false;
       }
 
       var idx=id;
       var i;
 
-      if(keyman.util.device.formFactor == 'desktop') {
+      if(keyman.util.device.formFactor == FormFactor.Desktop) {
         // Need to test if target layer is a standard layer (based on the plain 'default')
         var replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -254,7 +254,7 @@ namespace com.keyman.text {
      */
     processKeyEvent(keyEvent: KeyEvent, e?: osk.KeyElement | boolean): boolean {
       let keyman = com.keyman.singleton;
-      let formFactor = keyman.util.device.formFactor;
+      let formFactor = keyEvent.device.formFactor;
 
       // Determine the current target for text output and create a "mock" backup
       // of its current, pre-input state.
@@ -284,7 +284,7 @@ namespace com.keyman.text {
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
-      if((formFactor == 'desktop' || this.activeKeyboard.usesDesktopLayoutOnDevice(keyman.util.device)) && fromOSK) {
+      if((formFactor == 'desktop' || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
         // If it's a desktop OSK style and this triggers a layer change,
         // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
         if(this.selectLayer(keyEvent.kName, keyEvent.kNextLayer)) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -10,7 +10,7 @@
 /// <reference path="../keyboards/keyboard.ts" />
 // Defines built-in keymapping.
 /// <reference path="keyMapping.ts" />
-// Defines a headless-compatible 'Device' analogue for use in keyEvent processing
+// Defines a core-compatible 'Device' analogue for use in keyEvent processing
 /// <reference path="engineDeviceSpec.ts" />
 
 namespace com.keyman.text {


### PR DESCRIPTION
And now for some actual changes.  Keystroke processing is partly reliant on device awareness, especially since we have the `ifStore` rule component that tests against various device properties.  So, we need a headless-friendly version that can exist within web-core that is separate from the current `com.keyman.Device` class.  (That class includes lots of detection methods that are DOM-reliant.)

The particularly icky stuff is yet to come, though.