### PR TITLE
feat(common): Use Crowdin CLI (v3) for handling l10n files

### DIFF
--- a/android/crowdin.yml
+++ b/android/crowdin.yml
@@ -24,10 +24,18 @@ files:
   - source: /KMEA/app/src/main/res/values/strings.xml
     dest: /android/KMEA/app/src/main/res/values/strings.xml
     translation: /KMEA/app/src/main/res/values-%android_code%/%original_file_name%
+    languages_mapping:
+      # Prevent invalid region pap-rPAP
+      android_code:
+        pap: pap
 
   - source: /KMAPro/kMAPro/src/main/res/values/strings.xml
     dest: /android/KMAPro/kMAPro/src/main/res/values/strings.xml
     translation: /KMAPro/kMAPro/src/main/res/values-%android_code%/%original_file_name%
+    languages_mapping:
+      # Prevent invalid region pap-rPAP
+      android_code:
+        pap: pap
 
   # crowdin parameters descriptions:
 

--- a/android/crowdin.yml
+++ b/android/crowdin.yml
@@ -1,0 +1,147 @@
+#
+# Your Crowdin credentials
+#
+project_id_env: "CROWDIN_PROJECT_ID"
+api_token_env: "CROWDIN_PERSONAL_TOKEN"
+base_path: . # local base path
+base_url: https://api.crowdin.com
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+preserve_hierarchy: true
+
+#
+# Files configuration
+#
+files:
+  # source: local path of file that gets uploaded to crowdin
+  # dest: crowdin path in https://crowdin.com/project/keyman
+  # translation: local path where downloaded translations from crowdin go
+
+  # Android files
+  - source: /KMEA/app/src/main/res/values/strings.xml
+    dest: /android/KMEA/app/src/main/res/values/strings.xml
+    translation: /KMEA/app/src/main/res/values-%android_code%/%original_file_name%
+
+  - source: /KMAPro/kMAPro/src/main/res/values/strings.xml
+    dest: /android/KMAPro/kMAPro/src/main/res/values/strings.xml
+    translation: /KMAPro/kMAPro/src/main/res/values-%android_code%/%original_file_name%
+
+  # crowdin parameters descriptions:
+
+  #
+  # Source files filter
+  # e.g. "/resources/en/*.json"
+  #
+ 
+  #
+  # Where translations will be placed
+  # e.g. "/resources/%two_letters_code%/%original_file_name%"
+  #
+  #"translation" : "",
+
+  #
+  # Files or directories for ignore
+  # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
+  #
+  #"ignore" : [],
+
+  #
+  # The dest allows you to specify a file name in Crowdin
+  # e.g. "/messages.json"
+  #
+  #"dest" : "",
+
+  #
+  # File type
+  # e.g. "json"
+  #
+  #"type" : "",
+
+  #
+  # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
+  # e.g. "update_as_unapproved" or "update_without_changes"
+  #
+  #"update_option" : "",
+
+  #
+  # Start block (for XML only)
+  #
+
+  #
+  # Defines whether to translate tags attributes.
+  # e.g. 0 or 1  (Default is 1)
+  #
+  # "translate_attributes" : 1,
+
+  #
+  # Defines whether to translate texts placed inside the tags.
+  # e.g. 0 or 1 (Default is 1)
+  #
+  # "translate_content" : 1,
+
+  #
+  # This is an array of strings, where each item is the XPaths to DOM element that should be imported
+  # e.g. ["/content/text", "/content/text[@value]"]
+  #
+  # "translatable_elements" : [],
+
+  #
+  # Defines whether to split long texts into smaller text segments
+  # e.g. 0 or 1 (Default is 1)
+  #
+  # "content_segmentation" : 1,
+
+  #
+  # End block (for XML only)
+  #
+
+  #
+  # Start .properties block
+  #
+
+  #
+  # Defines whether single quote should be escaped by another single quote or backslash in exported translations
+  # e.g. 0 or 1 or 2 or 3 (Default is 3)
+  # 0 - do not escape single quote;
+  # 1 - escape single quote by another single quote;
+  # 2 - escape single quote by backslash;
+  # 3 - escape single quote by another single quote only in strings containing variables ( {0} ).
+  #
+  # "escape_quotes" : 3,
+
+  #
+  # Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.
+  # e.g. 0 or 1 (Default is 0)
+  # 0 - do not escape special characters
+  # 1 - escape special characters by a backslash
+  #
+  # "escape_special_characters": 0
+  #
+
+  #
+  # End .properties block
+  #
+
+  #
+  # Often software projects have custom names for the directories where translations are placed. crowdin-cli allows you to map your own languages to be understandable by Crowdin.
+  #
+  #"languages_mapping" : {
+  #  "two_letters_code" : {
+  #    "crowdin_language_code" : "local_name"
+  #   }
+  #},
+
+  #
+  # Does the first line contain header?
+  # e.g. true or false
+  #
+  #"first_line_contains_header" : true,
+
+  #
+  # for spreadsheets
+  # e.g. "identifier,source_phrase,context,uk,ru,fr"
+  #
+  # "scheme" : "",

--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -1,12 +1,49 @@
 # Localization Maintenance
+Localization for Keyman is maintained at https://crowdin.com/project/keyman
+The Crowdin CLI (v3) tool is used to automate downloading and updating files 
+between Keyman and Crowdin. The configuration file for each platform is a YAML file named `crowdin.yml`.
 
-Localization for Keyman is handled at https://crowdin.com/project/keyman
+On Windows, use `crowdin.bat` instead of `crowdin` for all the syntax below.
 
-In order to incorporate those files into the Keyman platforms:
-1. Download the translations to `/.crowdin-tmp/Keyman.zip`
-2. From git bash, run `./parse-crowdin.sh` with the specified platforms
-Platform options: `-all`, `-android`, `-common`, `-developer`, `-ios`, `-linux`, `-mac`, `-web`, `-windows`
+## Setup
+Install the [Crowdin CLI (v3)](https://support.crowdin.com/cli-tool-v3/) for your OS. 
+Note, it has a prerequisite on Java 8.
 
-This will extract `/.crowdin-tmp/Keyman.zip` into `/crowdin/` and copy files to the respective platforms.
+### Environment Variables
+In Crowdin, create a [personal access token](https://crowdin.com/settings#api-key) 
+and set it as an environment variable `CROWDIN_PERSONAL_TOKEN`.
 
-TODO: Add parameter to select locales
+Also copy the [project id](https://crowdin.com/project/keyman/settings#api) 
+from API v2 and set it as an environment variable `CROWDIN_PROJECT_ID`.
+
+### Testing Crowdin CLI is Set Up Correctly 
+To check your CLI setup, 
+```
+crowdin list project
+```
+
+You should see the CLI fetching project info and generating a list of files associated with the project.
+
+## Downloading from Crowdin
+
+To download a platform's latest translations from Crowdin, open a command line at a platform's folder and run:
+```
+crowdin download
+```
+
+To download latest translations for the specific language:
+```
+crowdin download -l {language_code}
+```
+
+To display a list of latest translations from Crowdin:
+```
+crowdin download --dryrun
+```
+
+## Uploading to crowdin
+
+To upload source files to Crowdin:
+```
+crowdin upload sources
+```


### PR DESCRIPTION
This PR adds the [Crowdin CLI (v3)](https://support.crowdin.com/cli-tool-v3/#configuration) to automate downloading/uploading files between Keyman platforms and https://crowdin.com/project/keyman

We should be able to remove the previous scripting in `/resources/build/l10n`.

Setup notes are in resources/build/l10n/README.md

### User Testing
1. To upload Android strings
```
crowdin upload sources
```

2. To download Android strings (for Khmer)
```
crowdin download -l km
```

