### PR TITLE
refactor(web): cleanup for Processor.processKeyEvent

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -23,6 +23,7 @@ namespace com.keyman.dom {
     focusTimer: number;
 
     changed: boolean;         // Tracks if the element has been edited since gaining focus.
+    swallowKeypress: boolean; // Notes if a keypress should be swallowed; used when handing mnemonics.
 
     /* ----------------------- Static event-related methods ------------------------ */
 

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -193,6 +193,15 @@ namespace com.keyman.dom {
           };
         }
       }
+
+      // Check for any browser-based keymapping before returning the object.
+      if(!keyman.isEmbedded && s.device.browser == text.Browser.Firefox) {
+        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
+        // FireFox, Mozilla Suite
+        if(KeyMapping.browserMap.FF['k'+s.Lcode]) {
+          s.Lcode = KeyMapping.browserMap.FF['k'+s.Lcode];
+        }
+      }
       
       return s;
     }
@@ -270,16 +279,6 @@ namespace com.keyman.dom {
       /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
       
       // Only reached if it's a mnemonic keyboard.
-      
-      // This pathway won't have .processKeyEvent's FF keycode check, so we must do it here on
-      // .processKeystroke's behalf.
-      if(!keyman.isEmbedded && keyman.util.device.browser == 'firefox') {
-        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
-        // FireFox, Mozilla Suite
-        if(KeyMapping.browserMap.FF['k'+Levent.Lcode]) {
-          Levent.Lcode=KeyMapping.browserMap.FF['k'+Levent.Lcode];
-        }
-      }
       if(processor.swallowKeypress || processor.keyboardInterface.processKeystroke(Levent.Ltarg, Levent)) {
         processor.swallowKeypress = false;
         if(e && e.preventDefault) {

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -217,7 +217,7 @@ namespace com.keyman.dom {
      */ 
     static keyDown(e: KeyboardEvent): boolean {
       let processor = com.keyman.singleton.textProcessor;
-      processor.swallowKeypress = false;
+      DOMEventHandlers.states.swallowKeypress = false;
 
       // Get event properties  
       var Levent = this._GetKeyEventProperties(e, true);
@@ -233,12 +233,12 @@ namespace com.keyman.dom {
           e.stopPropagation();
         }
 
-        processor.swallowKeypress = (Levent.Lcode != 8 ? Levent.Lcode != 0 : false);
+        DOMEventHandlers.states.swallowKeypress = (Levent.Lcode != 8 ? Levent.Lcode != 0 : false);
         if(Levent.Lcode == 8) {
-          processor.swallowKeypress = false;
+          DOMEventHandlers.states.swallowKeypress = false;
         }
       } else {
-        processor.swallowKeypress = false;
+        DOMEventHandlers.states.swallowKeypress = false;
       }
 
       return !LeventMatched;
@@ -270,7 +270,7 @@ namespace com.keyman.dom {
 
       /* I732 START - 13/03/2007 MCD: Swedish: Start positional keyboard layout code: prevent keystroke */
       if(!processor.activeKeyboard.isMnemonic) {
-        if(!processor.swallowKeypress) {
+        if(!DOMEventHandlers.states.swallowKeypress) {
           return true;
         }
         if(Levent.Lcode < 0x20 || ((<any>keyman)._BrowserIsSafari  &&  (Levent.Lcode > 0xF700  &&  Levent.Lcode < 0xF900))) {
@@ -286,8 +286,8 @@ namespace com.keyman.dom {
       /* I732 END - 13/03/2007 MCD: Swedish: End positional keyboard layout code */
       
       // Only reached if it's a mnemonic keyboard.
-      if(processor.swallowKeypress || processor.keyboardInterface.processKeystroke(Levent.Ltarg, Levent)) {
-        processor.swallowKeypress = false;
+      if(DOMEventHandlers.states.swallowKeypress || processor.keyboardInterface.processKeystroke(Levent.Ltarg, Levent)) {
+        DOMEventHandlers.states.swallowKeypress = false;
         if(e && e.preventDefault) {
           e.preventDefault();
           e.stopPropagation();
@@ -295,7 +295,7 @@ namespace com.keyman.dom {
         return false;
       }
 
-      processor.swallowKeypress = false;
+      DOMEventHandlers.states.swallowKeypress = false;
       return true;
     }
   }

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -232,6 +232,13 @@ namespace com.keyman.dom {
           e.preventDefault();
           e.stopPropagation();
         }
+
+        processor.swallowKeypress = (Levent.Lcode != 8 ? Levent.Lcode != 0 : false);
+        if(Levent.Lcode == 8) {
+          processor.swallowKeypress = false;
+        }
+      } else {
+        processor.swallowKeypress = false;
       }
 
       return !LeventMatched;

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -233,7 +233,8 @@ namespace com.keyman.dom {
           e.stopPropagation();
         }
 
-        DOMEventHandlers.states.swallowKeypress = (Levent.Lcode != 8 ? Levent.Lcode != 0 : false);
+        DOMEventHandlers.states.swallowKeypress = !!Levent.Lcode;
+        // Don't swallow backspaces on keypresses; this allows physical BKSP presses to repeat.
         if(Levent.Lcode == 8) {
           DOMEventHandlers.states.swallowKeypress = false;
         }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -448,7 +448,15 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      return com.keyman.osk.PreProcessor.processClick(Lkc, null);
+      let retVal = com.keyman.osk.PreProcessor.processClick(Lkc, null);
+
+      // Special case for embedded to pass K_TAB back to device to process
+      if(Lkc.Lcode == Codes.keyCodes["K_TAB"] || Lkc.Lcode == Codes.keyCodes["K_TABBACK"] 
+          || Lkc.Lcode == Codes.keyCodes["K_TABFWD"]) {
+        return false;
+      }
+
+      return retVal;
   };
 
   /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -448,7 +448,7 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      return processor.processKeyEvent(Lkc, true);
+      return com.keyman.osk.PreProcessor.processClick(Lkc, null);
   };
 
   /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -448,7 +448,7 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      let retVal = com.keyman.osk.PreProcessor.processClick(Lkc, null);
+      let retVal = com.keyman.osk.PreProcessor.handleClick(Lkc, null);
 
       // Special case for embedded to pass K_TAB back to device to process
       if(Lkc.Lcode == Codes.keyCodes["K_TAB"] || Lkc.Lcode == Codes.keyCodes["K_TABBACK"] 

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -116,9 +116,10 @@ namespace com.keyman.osk {
       }
     }
 
-    // Created during refactoring for web-core.  Mostly serves to hold DOM-dependent
-    // code that affects both 'native' and 'embedded' mode OSK use after the KeyEvent
-    // object has been properly instantiated.
+    // Serves to hold DOM-dependent code that affects both 'native' and 'embedded' mode OSK use 
+    // after the KeyEvent object has been properly instantiated.  This should help catch any 
+    // mutual last-minute DOM-side interactions before passing control to the processor... such as
+    // the UI-control command keys as seen below.
     static handleClick(Lkc: text.KeyEvent, e: KeyElement) {
       let keyman = com.keyman.singleton;
         // Exclude menu and OSK hide keys from normal click processing

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -106,7 +106,7 @@ namespace com.keyman.osk {
           com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
         }
 
-        let retVal = PreProcessor.processClick(Lkc, e);
+        let retVal = PreProcessor.handleClick(Lkc, e);
 
         // Now that processing is done, we can do a bit of post-processing, too.
         keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
@@ -119,7 +119,7 @@ namespace com.keyman.osk {
     // Created during refactoring for web-core.  Mostly serves to hold DOM-dependent
     // code that affects both 'native' and 'embedded' mode OSK use after the KeyEvent
     // object has been properly instantiated.
-    static processClick(Lkc: text.KeyEvent, e: KeyElement) {
+    static handleClick(Lkc: text.KeyEvent, e: KeyElement) {
       let keyman = com.keyman.singleton;
         // Exclude menu and OSK hide keys from normal click processing
       if(Lkc.kName == 'K_LOPT' || Lkc.kName == 'K_ROPT') {

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -98,6 +98,14 @@ namespace com.keyman.osk {
           Lkc.source = touch;
           Lkc.keyDistribution = keyDistribution;
         }
+
+        if(!keyman.isEmbedded) {
+          keyman.uiManager.setActivatingUI(true);
+          com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 100;
+          keyman.domManager.focusLastActiveElement();
+          com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
+        }
+
         return keyman.textProcessor.processKeyEvent(Lkc, e);
       } else {
         return true;

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -127,7 +127,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      let retVal = keyman.textProcessor.processKeyEvent(Lkc, e);
+      let retVal = keyman.textProcessor.processKeyEvent(Lkc);
 
       return retVal;
     }

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -106,7 +106,11 @@ namespace com.keyman.osk {
           com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
         }
 
-        return PreProcessor.processClick(Lkc, e);
+        let retVal = PreProcessor.processClick(Lkc, e);
+
+        // Now that processing is done, we can do a bit of post-processing, too.
+        keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
+        return retVal;
       } else {
         return true;
       }

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -106,10 +106,26 @@ namespace com.keyman.osk {
           com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
         }
 
-        return keyman.textProcessor.processKeyEvent(Lkc, e);
+        return PreProcessor.processClick(Lkc, e);
       } else {
         return true;
       }
+    }
+
+    // Created during refactoring for web-core.  Mostly serves to hold DOM-dependent
+    // code that affects both 'native' and 'embedded' mode OSK use after the KeyEvent
+    // object has been properly instantiated.
+    static processClick(Lkc: text.KeyEvent, e: KeyElement) {
+      let keyman = com.keyman.singleton;
+        // Exclude menu and OSK hide keys from normal click processing
+      if(Lkc.kName == 'K_LOPT' || Lkc.kName == 'K_ROPT') {
+        keyman['osk'].vkbd.optionKey(e, Lkc.kName, true);
+        return true;
+      }
+
+      let retVal = keyman.textProcessor.processKeyEvent(Lkc, e);
+
+      return retVal;
     }
   }
 }

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -212,6 +212,7 @@ namespace com.keyman.text {
       let outputTarget: OutputTarget = this.activeTargetOutput ? this.activeTargetOutput : text.Processor.getOutputTarget();
 
       if(outputTarget != null) {
+        // Required for the `sil_euro_latin` keyboard's desktop OSK/table to function properly.
         if(!keyman.isHeadless) {
           keyman.uiManager.setActivatingUI(true);
           dom.DOMEventHandlers.states._IgnoreNextSelChange = 100;

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -252,7 +252,7 @@ namespace com.keyman.text {
      * 
      * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
      */
-    processKeyEvent(keyEvent: KeyEvent, e?: osk.KeyElement | boolean): boolean {
+    processKeyEvent(keyEvent: KeyEvent): boolean {
       let keyman = com.keyman.singleton;
       let formFactor = keyEvent.device.formFactor;
 
@@ -260,11 +260,6 @@ namespace com.keyman.text {
       // of its current, pre-input state.
       let outputTarget = keyEvent.Ltarg;
       let fromOSK = keyEvent.isSynthetic;
-
-      // Enables embedded-path OSK sourcing detection.
-      if(typeof e == 'boolean') {
-        e = null as osk.KeyElement; // Cast is necessary for TS type-checking later in the method.
-      }
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -298,18 +298,6 @@ namespace com.keyman.text {
         return true;
       }
 
-      // TODO: This keymapping should be relocated outside of this method.
-      if(!keyman.isEmbedded && !fromOSK && keyEvent.device.browser == Browser.Firefox) {
-        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
-        // FireFox, Mozilla Suite
-        if(KeyMapping.browserMap.FF['k'+keyEvent.Lcode]) {
-          keyEvent.Lcode = KeyMapping.browserMap.FF['k'+keyEvent.Lcode];
-        }
-      } //else 
-      //{
-      // Safari, IE, Opera?
-      //}
-
       // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
       // If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
       // We check the first condition here, while the prediction UI handles the second through the try__() methods below.

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -35,8 +35,6 @@ namespace com.keyman.text {
     // in keyboard state not otherwise captured by the hosting page in the browser.
     // Needed for AltGr simulation.
     modStateFlags: number = 0;
-    // Denotes whether or not KMW needs to 'swallow' the next keypress.
-    swallowKeypress: boolean = false;
 
     keyboardInterface: KeyboardInterface;
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -313,16 +313,9 @@ namespace com.keyman.text {
         }
       }
 
-      if(fromOSK && !keyman.isEmbedded) {
-        keyman.uiManager.setActivatingUI(true);
-        com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 100;
-        keyman.domManager.focusLastActiveElement();
-        com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
-      }
       // // ...end I3363 (Build 301)
 
       let preInputMock = Mock.from(outputTarget);
-
       let ruleBehavior = this.processKeystroke(keyEvent, outputTarget);
 
       // Swap layer as appropriate.

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -269,19 +269,6 @@ namespace com.keyman.text {
 
       this.swallowKeypress = false;
 
-      if(fromOSK && !keyman.isEmbedded) {
-        keyman.domManager.initActiveElement(keyEvent.Ltarg.getElement());
-
-        // Turn off key highlighting (or preview)
-        keyman['osk'].vkbd.highlightKey(e,false);
-      }
-
-      // Exclude menu and OSK hide keys from normal click processing
-      if(keyEvent.kName == 'K_LOPT' || keyEvent.kName == 'K_ROPT') {
-        keyman['osk'].vkbd.optionKey(e, keyEvent.kName, true);
-        return true;
-      }
-
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
       if((formFactor == FormFactor.Desktop || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -266,8 +266,6 @@ namespace com.keyman.text {
         e = null as osk.KeyElement; // Cast is necessary for TS type-checking later in the method.
       }
 
-      this.swallowKeypress = false;
-
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
       if((formFactor == FormFactor.Desktop || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
@@ -383,14 +381,6 @@ namespace com.keyman.text {
           // For DOM-aware targets, this will trigger a DOM event page designers may listen for.
           outputTarget.doInputEvent();
         }
-
-        this.swallowKeypress = (e && keyEvent.Lcode != 8 ? keyEvent.Lcode != 0 : false);
-        if(keyEvent.Lcode == 8) {
-          this.swallowKeypress = false;
-        }
-        return false;
-      } else {
-        this.swallowKeypress = false;
       }
 
       /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -259,7 +259,6 @@ namespace com.keyman.text {
       // Determine the current target for text output and create a "mock" backup
       // of its current, pre-input state.
       let outputTarget = keyEvent.Ltarg;
-
       let fromOSK = keyEvent.isSynthetic;
 
       // Enables embedded-path OSK sourcing detection.
@@ -395,16 +394,6 @@ namespace com.keyman.text {
       }
 
       /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
-      
-      if(fromOSK && !keyman.isEmbedded) {
-        keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
-      }
-
-      // Special case for embedded to pass K_TAB back to device to process
-      if(keyman.isEmbedded && (keyEvent.Lcode == Codes.keyCodes["K_TAB"] ||
-          keyEvent.Lcode == Codes.keyCodes["K_TABBACK"] || keyEvent.Lcode == Codes.keyCodes["K_TABFWD"])) {
-        return false;
-      }
 
       // TODO:  rework the return value to be `ruleBehavior` instead.  Functions that call this one are
       //        the ones that should worry about event handler returns, etc.  Not this one.


### PR DESCRIPTION
This PR aims to relocate most of the condition-specific code out of the `Processor`.

A significant amount of code was embedded-OSK specific, some not-embedded-only specific, and some was hardware-specific.

The most tricky aspects to follow will likely be the `swallowKeypress` changes.  I ended up comparing against KMW 10.0, in which this was only set for hardware keystrokes toward support for mnemonics.

Mnemonics... have long been significantly broken in KMW (it's been termed low-priority); we'll look for a more comprehensive mnemonic review and fix at a later point.  The amount of work needed in KMW's current state to completely validate such keyboards would delay web-core work far too much.

----

I aimed to keep commits small and focused, in case that might help with the review process.  There are a few pieces moving about in this PR, after all; generally, each commit targets a single one of those "moving" pieces at a time.