### PR TITLE
refactor(web/engine): Preps keyboard layouts definitions for web-core

### DIFF
--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -136,9 +136,8 @@ namespace com.keyman.dom {
       if(activeKeyboard && activeKeyboard.isChiral) {
         s.Lmodifiers = curModState & modifierBitmasks.CHIRAL;
 
-        // Note for future - embedding a kill switch here or in keymanweb.osk.emulatesAltGr would facilitate disabling
-        // AltGr / Right-alt simulation.
-        if(keyboards.Layouts.emulatesAltGr() && (s.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM']) {
+        // Note for future - embedding a kill switch here would facilitate disabling AltGr / Right-alt simulation.
+        if(activeKeyboard.emulatesAltGr && (s.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM']) {
           s.Lmodifiers ^= modifierBitmasks['ALT_GR_SIM'];
           s.Lmodifiers |= modifierCodes['RALT'];
         }

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -138,7 +138,7 @@ namespace com.keyman.dom {
 
         // Note for future - embedding a kill switch here or in keymanweb.osk.emulatesAltGr would facilitate disabling
         // AltGr / Right-alt simulation.
-        if(osk.Layouts.emulatesAltGr() && (s.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM']) {
+        if(keyboards.Layouts.emulatesAltGr() && (s.Lmodifiers & modifierBitmasks['ALT_GR_SIM']) == modifierBitmasks['ALT_GR_SIM']) {
           s.Lmodifiers ^= modifierBitmasks['ALT_GR_SIM'];
           s.Lmodifiers |= modifierCodes['RALT'];
         }

--- a/web/source/keyboards/activeLayout.ts
+++ b/web/source/keyboards/activeLayout.ts
@@ -1,4 +1,4 @@
-namespace com.keyman.osk {
+namespace com.keyman.keyboards {
   type KeyDistribution = text.KeyDistribution;
 
 

--- a/web/source/keyboards/defaultLayouts.ts
+++ b/web/source/keyboards/defaultLayouts.ts
@@ -112,8 +112,8 @@ namespace com.keyman.keyboards {
     * @return  {Object}
     */
     static buildDefaultLayout(PVK, kbdDevVersion: utils.Version, kbdBitmask: number, formFactor: string): LayoutFormFactor {
-      let keyman = com.keyman.singleton;
-      let util = keyman.util;
+      // TODO:  Only here because of util.deepCopy.  Start a web-core utils so that it's accessible in headless.
+      let util = com.keyman.singleton.util;
 
       // Build a layout using the default for the device
       var layoutType=formFactor;
@@ -203,7 +203,13 @@ namespace com.keyman.keyboards {
 
             // Create a new subkey for the specified layer so that it will be accessible via OSK.
             var specialChar = Layouts.modifierSpecials[layerID]; 
-            shiftKey['sk'].push(new osk.OSKKeySpec("K_" + specialChar, specialChar, null, "1", layerID));
+            let subkey: LayoutKey = {
+              id: "K_" + specialChar,
+              text: specialChar,
+              sp: "1",
+              nextlayer: layerID
+            }
+            shiftKey['sk'].push(subkey);
           }
         } else {
           // Seriously, this should never happen.  It's here for the debugging log only.

--- a/web/source/keyboards/defaultLayouts.ts
+++ b/web/source/keyboards/defaultLayouts.ts
@@ -5,7 +5,7 @@
 
 ///<reference path="../utils/version.ts"/>
 
-namespace com.keyman.osk {
+namespace com.keyman.keyboards {
   let Codes = com.keyman.text.Codes;
 
   export type KLS = {[layerName: string]: string[]};
@@ -203,7 +203,7 @@ namespace com.keyman.osk {
 
             // Create a new subkey for the specified layer so that it will be accessible via OSK.
             var specialChar = Layouts.modifierSpecials[layerID]; 
-            shiftKey['sk'].push(new OSKKeySpec("K_" + specialChar, specialChar, null, "1", layerID));
+            shiftKey['sk'].push(new osk.OSKKeySpec("K_" + specialChar, specialChar, null, "1", layerID));
           }
         } else {
           // Seriously, this should never happen.  It's here for the debugging log only.

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -2,7 +2,7 @@
 // Includes KMW string extension declarations.
 /// <reference path="../text/kmwstring.ts" /> 
 // Includes the default layout specification.
-/// <reference path="defaultLayouts.ts" /> 
+/// <reference path="../keyboards/defaultLayouts.ts" /> 
 // Includes the touch-mode language picker UI.
 /// <reference path="languageMenu.ts" />
 // Includes the banner
@@ -268,7 +268,7 @@ namespace com.keyman.osk {
         if(Lviskbd != null || Lhelp == '' || device.touchable) { // I3363 (Build 301)
           // TODO: May want to define a default BK array here as well
           if(Lviskbd == null) {
-            Lviskbd={'F':'Tahoma', 'BK': Layouts.dfltText}; //DDOSK
+            Lviskbd={'F':'Tahoma', 'BK': keyboards.Layouts.dfltText}; //DDOSK
           }
 
           this._GenerateVisualKeyboard(Lviskbd, Lhelp, layout, activeKeyboard.modifierBitmask);

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -1,6 +1,6 @@
 namespace com.keyman.osk {
   export class PreProcessor {
-    static _GetClickEventProperties(e: osk.ActiveKey, Lelem: HTMLElement): text.KeyEvent {
+    static _GetClickEventProperties(e: keyboards.ActiveKey, Lelem: HTMLElement): text.KeyEvent {
       let keyman = com.keyman.singleton;
       let processor = keyman.textProcessor;
 
@@ -93,7 +93,7 @@ namespace com.keyman.osk {
         // Deleting matched deadkeys here seems to correct some of the issues.   (JD 6/6/14)
         outputTarget.deadkeys().deleteMatched();      // Delete any matched deadkeys before continuing
   
-        let Lkc = PreProcessor._GetClickEventProperties(e['key'].spec as osk.ActiveKey, Lelem);
+        let Lkc = PreProcessor._GetClickEventProperties(e['key'].spec as keyboards.ActiveKey, Lelem);
         if(keyman.modelManager.enabled) {
           Lkc.source = touch;
           Lkc.keyDistribution = keyDistribution;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -626,7 +626,7 @@ namespace com.keyman.osk {
         } else {
           kbdDevVersion = new utils.Version(keyman['version']);
         }
-        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, device.formFactor);
+        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, device.formFactor, activeKeyboard);
       }
 
       // Create the collection of HTML elements from the device-dependent layout object
@@ -2224,7 +2224,7 @@ namespace com.keyman.osk {
       // Else get a default layout for the device for this keyboard
       if(layout == null && PVK != null) {
         let kbdDevVersion = PKbd.compilerVersion;
-        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, PKbd.modifierBitmask, formFactor);
+        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, PKbd.modifierBitmask, formFactor, PKbd);
       }
 
       // Cannot create an OSK if no layout defined, just return empty DIV

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1,4 +1,4 @@
-/// <reference path="activeLayout.ts" />
+/// <reference path="../keyboards/activeLayout.ts" />
 /// <reference path="../utils/version.ts" />
 /// <reference path="preProcessor.ts" />
 
@@ -46,10 +46,10 @@ namespace com.keyman.osk {
   //#endregion
 
   //#region OSK key objects and construction
-  export class OSKKeySpec implements LayoutKey {
+  export class OSKKeySpec implements keyboards.LayoutKey {
     id: string;
     text?: string;
-    sp?: number | ButtonClass;
+    sp?: number | keyboards.ButtonClass;
     width: string;
     layer?: string; // The key will derive its base modifiers from this property - may not equal the layer on which it is displayed.
     nextlayer?: string;
@@ -58,7 +58,7 @@ namespace com.keyman.osk {
     padpc?: number; // Added during OSK construction.
     sk?: OSKKeySpec[];
 
-    constructor(id: string, text?: string, width?: string, sp?: number | ButtonClass, nextlayer?: string, pad?: string) {
+    constructor(id: string, text?: string, width?: string, sp?: number | keyboards.ButtonClass, nextlayer?: string, pad?: string) {
       this.id = id;
       this.text = text;
       this.width = width ? width : "50";
@@ -329,7 +329,7 @@ namespace com.keyman.osk {
       btn.appendChild(skIcon);
     }
 
-    construct(osk: VisualKeyboard, layout: LayoutFormFactor, rowStyle: CSSStyleDeclaration, totalPercent: number): {element: HTMLDivElement, percent: number} {
+    construct(osk: VisualKeyboard, layout: keyboards.LayoutFormFactor, rowStyle: CSSStyleDeclaration, totalPercent: number): {element: HTMLDivElement, percent: number} {
       let util = com.keyman.singleton.util;
       let spec = this.spec;
       let isDesktop = this.formFactor == "desktop"
@@ -526,8 +526,8 @@ namespace com.keyman.osk {
      * so that its geometry may be updated on rotations and keyboard resize events, as
      * said geometry needs to be accurate for fat-finger probability calculations.
      */
-    layout: ActiveLayout;
-    layers: LayoutLayer[];
+    layout: keyboards.ActiveLayout;
+    layers: keyboards.LayoutLayer[];
     layerId: string = "default";
     layerIndex: number;
 
@@ -593,7 +593,7 @@ namespace com.keyman.osk {
      * @param       {Number}      kbdBitmask  Keyboard modifier bitmask
      * Description  Generates the base visual keyboard element, prepping for attachment to KMW
      */
-    constructor(PVK, Lhelp, layout0: LayoutFormFactor, kbdBitmask: number, device?: Device, isStatic?: boolean) {
+    constructor(PVK, Lhelp, layout0: keyboards.LayoutFormFactor, kbdBitmask: number, device?: Device, isStatic?: boolean) {
       // Add handler stubs if not otherwise defined.  (We can no longer in-line default-define with the declaration.)
       this.highlightSubKeys = this.highlightSubKeys || function(k,x,y) {};
       this.drawPreview = this.drawPreview || function(c,w,h,e) {};
@@ -626,11 +626,11 @@ namespace com.keyman.osk {
         } else {
           kbdDevVersion = new utils.Version(keyman['version']);
         }
-        layout=Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, device.formFactor);
+        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, kbdBitmask, device.formFactor);
       }
 
       // Create the collection of HTML elements from the device-dependent layout object
-      this.layout = ActiveLayout.polyfill(layout, device.formFactor);
+      this.layout = keyboards.ActiveLayout.polyfill(layout, device.formFactor);
       this.layers=layout['layer'];
 
       // Override font if specified by keyboard
@@ -673,7 +673,8 @@ namespace com.keyman.osk {
      * @return    {Object}    An object that contains default key properties
      */
     getDefaultKeyObject(): OSKKeySpec {
-      return new OSKKeySpec(undefined, '', ActiveKey.DEFAULT_KEY.width, ActiveKey.DEFAULT_KEY.sp as ButtonClass, null, ActiveKey.DEFAULT_KEY.pad);
+      return new OSKKeySpec(undefined, '', keyboards.ActiveKey.DEFAULT_KEY.width, keyboards.ActiveKey.DEFAULT_KEY.sp as keyboards.ButtonClass,
+          null, keyboards.ActiveKey.DEFAULT_KEY.pad);
     };
 
     /**
@@ -683,7 +684,7 @@ namespace com.keyman.osk {
      * @param       {string}              formFactor  layout form factor
      * @return      {Object}                          fully formatted OSK object
      */
-    deviceDependentLayout(layout: LayoutFormFactor, formFactor: string): HTMLDivElement {
+    deviceDependentLayout(layout: keyboards.LayoutFormFactor, formFactor: string): HTMLDivElement {
       let util = com.keyman.singleton.util;
       let oskManager = com.keyman.singleton.osk;
       let rowsPercent = 100;
@@ -720,9 +721,9 @@ namespace com.keyman.osk {
 
       // Create a separate OSK div for each OSK layer, only one of which will ever be visible
       var n: number, i: number, j: number;
-      var layers: LayoutLayer[], gDiv: HTMLDivElement;
+      var layers: keyboards.LayoutLayer[], gDiv: HTMLDivElement;
       var rowHeight: number, rDiv: HTMLDivElement;
-      var keys: LayoutKey[], key: LayoutKey, rs: CSSStyleDeclaration, gs: CSSStyleDeclaration;
+      var keys: keyboards.LayoutKey[], key: keyboards.LayoutKey, rs: CSSStyleDeclaration, gs: CSSStyleDeclaration;
 
       layers=layout['layer'];
 
@@ -777,7 +778,7 @@ namespace com.keyman.osk {
       }
 
       for(n=0; n<layers.length; n++) {
-        let layer=layers[n] as ActiveLayer;
+        let layer=layers[n] as keyboards.ActiveLayer;
         gDiv=util._CreateElement('div'), gs=gDiv.style;
         gDiv.className='kmw-key-layer';
 
@@ -826,14 +827,14 @@ namespace com.keyman.osk {
             keys[j]['padpc']=padPercent;
 
             // Recompute center's x-coord with exact, in-browser values.
-            (<ActiveKey> keys[j]).proportionalX = (totalPercent + padPercent + (keyPercent/2))/objectWidth;
-            (<ActiveKey> keys[j]).proportionalWidth = keyPercent / objectWidth;
+            (<keyboards.ActiveKey> keys[j]).proportionalX = (totalPercent + padPercent + (keyPercent/2))/objectWidth;
+            (<keyboards.ActiveKey> keys[j]).proportionalWidth = keyPercent / objectWidth;
 
             totalPercent += padPercent+keyPercent;
           }
 
           // Allow for right OSK margin (15 layout units)
-          let rightMargin = ActiveKey.DEFAULT_RIGHT_MARGIN*objectWidth/layer.totalWidth;
+          let rightMargin = keyboards.ActiveKey.DEFAULT_RIGHT_MARGIN*objectWidth/layer.totalWidth;
           totalPercent += rightMargin;
 
           // If a single key, and padding is negative, add padding to right align the key
@@ -844,8 +845,8 @@ namespace com.keyman.osk {
             keys[0]['padpc']=(objectWidth-totalPercent);
 
             // Recompute center's x-coord with exact, in-browser values.
-            (<ActiveKey> keys[0]).proportionalX = (totalPercent - rightMargin - keyPercent/2)/objectWidth;
-            (<ActiveKey> keys[0]).proportionalWidth = keyPercent / objectWidth;
+            (<keyboards.ActiveKey> keys[0]).proportionalX = (totalPercent - rightMargin - keyPercent/2)/objectWidth;
+            (<keyboards.ActiveKey> keys[0]).proportionalWidth = keyPercent / objectWidth;
           } else if(keys.length > 0) {
             j=keys.length-1;
             padPercent = keys[j]['padpc'] * objectWidth;
@@ -854,8 +855,8 @@ namespace com.keyman.osk {
             keys[j]['widthpc']= keyPercent = (objectWidth-totalPercent);
 
             // Recompute center's x-coord with exact, in-browser values.
-            (<ActiveKey> keys[j]).proportionalX = (objectWidth - rightMargin - keyPercent/2)/objectWidth;
-            (<ActiveKey> keys[j]).proportionalWidth = keyPercent / objectWidth;
+            (<keyboards.ActiveKey> keys[j]).proportionalX = (objectWidth - rightMargin - keyPercent/2)/objectWidth;
+            (<keyboards.ActiveKey> keys[j]).proportionalWidth = keyPercent / objectWidth;
           }
 
           //Create the key square (an outer DIV) for each key element with padding, and an inner DIV for the button (btn)
@@ -1410,7 +1411,7 @@ namespace com.keyman.osk {
           continue;
         }
 
-        keys[i]['sp'] = Processor.stateKeys[states[i]] ? Layouts.buttonClasses['SHIFT-ON'] : Layouts.buttonClasses['SHIFT'];
+        keys[i]['sp'] = Processor.stateKeys[states[i]] ? keyboards.Layouts.buttonClasses['SHIFT-ON'] : keyboards.Layouts.buttonClasses['SHIFT'];
         let keyId = layerId+'-'+states[i]
         var btn = document.getElementById(keyId);
 
@@ -2223,7 +2224,7 @@ namespace com.keyman.osk {
       // Else get a default layout for the device for this keyboard
       if(layout == null && PVK != null) {
         let kbdDevVersion = PKbd.compilerVersion;
-        layout=Layouts.buildDefaultLayout(PVK, kbdDevVersion, PKbd.modifierBitmask, formFactor);
+        layout=keyboards.Layouts.buildDefaultLayout(PVK, kbdDevVersion, PKbd.modifierBitmask, formFactor);
       }
 
       // Cannot create an OSK if no layout defined, just return empty DIV

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -202,7 +202,7 @@ namespace com.keyman.text {
       }
 
       // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
-      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && osk.Layouts.emulatesAltGr()) {
+      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && keyboards.Layouts.emulatesAltGr()) {
         Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
         Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
       }
@@ -310,7 +310,7 @@ namespace com.keyman.text {
         if(keyman.modelManager.enabled && !ruleBehavior.triggersDefaultCommand) {
           // Note - we don't yet do fat-fingering with longpress keys.
           if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
-            let activeLayout = keyman['osk'].vkbd.layout as osk.ActiveLayout;
+            let activeLayout = keyman['osk'].vkbd.layout as keyboards.ActiveLayout;
             alternates = [];
     
             for(let pair of keyEvent.keyDistribution) {
@@ -539,7 +539,7 @@ namespace com.keyman.text {
         lockStates = e.Lstates;
 
         // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
-        if(this.activeKeyboard.isChiral && osk.Layouts.emulatesAltGr() && 
+        if(this.activeKeyboard.isChiral && keyboards.Layouts.emulatesAltGr() && 
             (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
           keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
           keyShiftState &= ~Codes.modifierCodes['RALT'];
@@ -582,7 +582,7 @@ namespace com.keyman.text {
     }
 
     getLayerId(modifier: number): string {
-      return osk.Layouts.getLayerId(modifier);
+      return keyboards.Layouts.getLayerId(modifier);
     }
 
     /**

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -202,7 +202,7 @@ namespace com.keyman.text {
       }
 
       // Handles modifier states when the OSK is emulating rightalt through the leftctrl-leftalt layer.
-      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && keyboards.Layouts.emulatesAltGr()) {
+      if((Lkc.Lmodifiers & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM'] && this.activeKeyboard.emulatesAltGr) {
         Lkc.Lmodifiers &= ~Codes.modifierBitmasks['ALT_GR_SIM'];
         Lkc.Lmodifiers |= Codes.modifierCodes['RALT'];
       }
@@ -539,7 +539,7 @@ namespace com.keyman.text {
         lockStates = e.Lstates;
 
         // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
-        if(this.activeKeyboard.isChiral && keyboards.Layouts.emulatesAltGr() && 
+        if(this.activeKeyboard.isChiral && (this.activeKeyboard.emulatesAltGr) && 
             (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
           keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
           keyShiftState &= ~Codes.modifierCodes['RALT'];


### PR DESCRIPTION
Also places `emulatesAltGr` as property of the `Keyboard` wrapper object.

As things already were, the `ActiveLayout` and `DefaultLayouts` classes are practically headless-ready; just a bit more tweaking will be needed.

Next goal:  have the `Keyboard` wrapper handle default layout construction as needed; it'll help with `OSK`/`VisualKeyboard` cleanup and guarantee that the abstracted layout is available for web-core use and testing.