### PR TITLE
fix(windows): replaces empty eventid with underscore when autoreport errors off

### DIFF
--- a/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -37,6 +37,7 @@ uses
   System.Classes,
   System.Generics.Collections,
   System.JSON,
+  System.StrUtils,
   System.SysUtils,
   System.Win.Registry,
 {$IF NOT DEFINED(CONSOLE)}
@@ -124,7 +125,7 @@ begin
 
 
       CommandLine := Format('-c "%s" "%s" "%s" "%s" "%s" "%s"', [
-        EventID,
+        IfThen(EventID = '', '_', EventID),
         ApplicationTitle,
         AppID,
         ProjectName,


### PR DESCRIPTION
Fixes #2911. This adds a default parameter so the error reporting dialog can show details of the
report. It does not address manual report sending.