### PR TITLE
chore(common): Cleanup unused folders and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,8 +256,5 @@ compile_flags.txt
 # Auto-generated resource script
 resources/environment.sh
 
-# Keyman translations from https://crowdin.com/project/keyman
-.crowdin-tmp/
-crowdin/
-
+# Copy of the master VERSION.md used for Linux packaging
 /common/core/desktop/VERSION.md

--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -31,7 +31,7 @@ To check your CLI setup,
 crowdin list project
 ```
 
-You should see the CLI fetching project info and generating a list of files associated with the project. If you get Java ConnectionExceptions, try connecting VPN.
+You should see the CLI fetching project info and generating a list of files associated with the project. 
 
 ## Downloading from Crowdin
 


### PR DESCRIPTION
Crowdin CLI doesn't extract into a temporary `.crowdin-tmp/` folder so that can be removed. (.crowdin-tmp was used in prior Bash scripts).

Also moved note about using a VPN to the wiki https://github.com/keymanapp/keyman/wiki/Crowdin-CLI