### PR TITLE
refactor(web/engine): start of system store abstraction

### DIFF
--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -2,6 +2,9 @@
 /// <reference path="../kmwbase.ts" />
 /// <reference path="ruleBehavior.ts" />
 
+// Defines classes for handling system stores
+/// <reference path="systemStores.ts" />
+
 /***
    KeymanWeb 11.0
    Copyright 2019 SIL International
@@ -174,6 +177,8 @@ namespace com.keyman.text {
 
     static readonly TSS_LAYER:    number = 33;
     static readonly TSS_PLATFORM: number = 31;
+
+    platformSystemStore = new PlatformSystemStore(this);
 
     _AnyIndices:  number[] = [];    // AnyIndex - array of any/index match indices
 
@@ -846,63 +851,7 @@ namespace com.keyman.text {
         // How would this be handled in an eventual headless mode?
         result = (keyman.osk.vkbd.layerId === strValue);
       } else if(systemId == KeyboardInterface.TSS_PLATFORM) {
-        var i,constraint,constraints=strValue.split(' ');
-        for(i=0; i<constraints.length; i++) {
-          constraint=constraints[i].toLowerCase();
-          switch(constraint) {
-            case 'touch':
-            case 'hardware':
-              if(this.activeDevice.touchable != (constraint == 'touch')) {
-                result=false;
-              }
-              break;
-
-            case 'macos':
-            case 'mac':
-              constraint = 'macosx';
-              // fall through
-            case 'macosx':
-            case 'windows':
-            case 'android':
-            case 'ios':
-            case 'linux':
-              if(this.activeDevice.OS != constraint) {
-                result=false;
-              }
-              break;
-          
-            case 'tablet':
-            case 'phone':
-            case 'desktop':
-              if(this.activeDevice.formFactor != constraint) {
-                result=false;
-              }
-              break;
-
-            case 'web':
-              if(this.activeDevice.browser == 'native') {
-                result=false; // web matches anything other than 'native'
-              }
-              break;
-              
-            case 'native':
-              // This will return true for embedded KeymanWeb
-            case 'ie':
-            case 'chrome':
-            case 'firefox':
-            case 'safari':
-            case 'edge':
-            case 'opera':
-              if(this.activeDevice.browser != constraint) {
-                result=false;
-              }
-              break;
-              
-            default:
-              result=false;
-          }
-          
-        }
+        result = this.platformSystemStore.matches(strValue);
       }
       return result; //Moved from previous line, now supports layer selection, Build 350 
     }

--- a/web/source/text/systemStores.ts
+++ b/web/source/text/systemStores.ts
@@ -1,0 +1,97 @@
+/// <reference path="engineDeviceSpec.ts" />
+
+namespace com.keyman.text {
+  /**
+   * Defines common behaviors associated with system stores.
+   */
+  export abstract class SystemStore {
+    public readonly id: number;
+
+    constructor(id: number) {
+      this.id = id;
+    }
+
+    abstract matches(value: string): boolean;
+
+    set(value: string): void {
+      throw new Error("System store with ID " + this.id + " may not be directly set.");
+    }
+  }
+
+  /**
+   * Handles checks against the current platform.
+   */
+  export class PlatformSystemStore extends SystemStore {
+    private readonly kbdInterface: KeyboardInterface;
+
+    constructor(keyboardInterface: KeyboardInterface) {
+      super(KeyboardInterface.TSS_PLATFORM);
+
+      this.kbdInterface = keyboardInterface;
+    }
+
+    matches(value: string) {
+      var i,constraint,constraints=value.split(' ');
+      let device = this.kbdInterface.activeDevice;
+
+      for(i=0; i<constraints.length; i++) {
+        constraint=constraints[i].toLowerCase();
+        switch(constraint) {
+          case 'touch':
+          case 'hardware':
+            if(device.touchable != (constraint == 'touch')) {
+              return false;
+            }
+            break;
+
+          case 'macos':
+          case 'mac':
+            constraint = 'macosx';
+            // fall through
+          case 'macosx':
+          case 'windows':
+          case 'android':
+          case 'ios':
+          case 'linux':
+            if(device.OS != constraint) {
+              return false;
+            }
+            break;
+
+          case 'tablet':
+          case 'phone':
+          case 'desktop':
+            if(device.formFactor != constraint) {
+              return false;
+            }
+            break;
+
+          case 'web':
+            if(device.browser == 'native') {
+              return false; // web matches anything other than 'native'
+            }
+            break;
+            
+          case 'native':
+            // This will return true for embedded KeymanWeb
+          case 'ie':
+          case 'chrome':
+          case 'firefox':
+          case 'safari':
+          case 'edge':
+          case 'opera':
+            if(device.browser != constraint) {
+              return false;
+            }
+            break;
+            
+          default:
+            return false;
+        }
+      }
+
+      // Everything we checked against was valid and had matches - it's a match!
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
This is part 1 of 2 toward reworking how and where KMW manages the current OSK layer.

The new abstract `SystemStore` base class will also be used for managing the layer, but first I felt it best to convert over the _other_ existing system store, since its conversion is far more straightforward to verify.

Tested against the following keyboards:
- `khmer_angkor` (Has a form-factor dependent BKSP implementation)