### PR TITLE
refactor(web/engine): Processor now manages current layer; OSK listens via callback

### DIFF
--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -118,9 +118,9 @@ namespace com.keyman.renderer {
             // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
             if(keyman.osk.vkbd) {
               if(isMobile) {
-                keyman.osk.vkbd.layerId = layers[i].id;
+                keyman.textProcessor.layerId = layers[i].id;
               } else {
-                keyman.osk.vkbd.layerId = Object.keys(layers)[i];
+                keyman.textProcessor.layerId = Object.keys(layers)[i];
               }
             } else {
               console.error("Error - keyman.osk.vkbd is undefined!");

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -469,7 +469,7 @@ namespace com.keyman {
      * Description  Set OSK to numeric layer if it exists
      */
     ['setNumericLayer']() {
-      this.textProcessor.setNumericLayer();
+      this.textProcessor.setNumericLayer(this.util.device.coreSpec);
     };
 
     /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -367,10 +367,11 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues      
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
       
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:osk.vkbd.layerId);
+      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.layerId);
       keyName=t[t.length-1];
-      if(layer == 'undefined') layer=osk.vkbd.layerId;
-      
+      if(layer == 'undefined') {
+        layer=processor.layerId;
+      }
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -913,7 +913,7 @@ namespace com.keyman.osk {
 
       let touchKbdPos = this.getTouchCoordinatesOnKeyboard(touch);
       let layerGroup = this.kbdDiv.firstChild as HTMLDivElement;  // Always has proper dimensions, unlike kbdDiv itself.
-      return this.layout.layer[this.layerIndex].getTouchProbabilities(touchKbdPos, layerGroup.offsetWidth / layerGroup.offsetHeight);
+      return this.layout.getLayer(this.layerId).getTouchProbabilities(touchKbdPos, layerGroup.offsetWidth / layerGroup.offsetHeight);
     }
 
     /**

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -848,14 +848,10 @@ namespace com.keyman.text {
      * @return      {boolean}                 True if the test succeeds 
      */       
     ifStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
-      let keyman = com.keyman.singleton;
-
       var result=true;
-      if(systemId == KeyboardInterface.TSS_LAYER) {
-        // How would this be handled in an eventual headless mode?
-        result = (keyman.osk.vkbd.layerId === strValue);
-      } else if(systemId == KeyboardInterface.TSS_PLATFORM) {
-        result = this.systemStores[KeyboardInterface.TSS_PLATFORM].matches(strValue);
+      let store = this.systemStores[systemId];
+      if(store) {
+        result = store.matches(strValue);
       }
       return result; //Moved from previous line, now supports layer selection, Build 350 
     }

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -178,7 +178,7 @@ namespace com.keyman.text {
     static readonly TSS_LAYER:    number = 33;
     static readonly TSS_PLATFORM: number = 31;
 
-    platformSystemStore = new PlatformSystemStore(this);
+    systemStores: {[storeID: number]: SystemStore};
 
     _AnyIndices:  number[] = [];    // AnyIndex - array of any/index match indices
 
@@ -187,6 +187,10 @@ namespace com.keyman.text {
     activeDevice: EngineDeviceSpec;
 
     constructor() {
+      this.systemStores = {};
+      
+      this.systemStores[KeyboardInterface.TSS_PLATFORM] = new PlatformSystemStore(this);
+      this.systemStores[KeyboardInterface.TSS_LAYER] = new MutableSystemStore(KeyboardInterface.TSS_LAYER, 'default');
     }
 
     /**
@@ -851,7 +855,7 @@ namespace com.keyman.text {
         // How would this be handled in an eventual headless mode?
         result = (keyman.osk.vkbd.layerId === strValue);
       } else if(systemId == KeyboardInterface.TSS_PLATFORM) {
-        result = this.platformSystemStore.matches(strValue);
+        result = this.systemStores[KeyboardInterface.TSS_PLATFORM].matches(strValue);
       }
       return result; //Moved from previous line, now supports layer selection, Build 350 
     }

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -323,7 +323,7 @@ namespace com.keyman.text {
         if(keyman.modelManager.enabled && !ruleBehavior.triggersDefaultCommand) {
           // Note - we don't yet do fat-fingering with longpress keys.
           if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
-            let activeLayout = keyman['osk'].vkbd.layout as keyboards.ActiveLayout;
+            let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
             alternates = [];
     
             for(let pair of keyEvent.keyDistribution) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -77,6 +77,19 @@ namespace com.keyman.text {
       this.keyboardInterface.activeKeyboard = keyboard;
     }
 
+    get layerStore(): MutableSystemStore {
+      return this.keyboardInterface.systemStores[KeyboardInterface.TSS_LAYER] as MutableSystemStore;
+    }
+
+    public get layerId(): string {
+      return this.layerStore.value;
+    }
+
+    // Note:  will trigger an 'event' callback designed to notify the OSK of layer changes.
+    public set layerId(value: string) {
+      this.layerStore.set(value);
+    }
+
     /**
      * Get the default RuleBehavior for the specified key, attempting to mimic standard browser defaults 
      * where and when appropriate.
@@ -524,7 +537,6 @@ namespace com.keyman.text {
      */
     _UpdateVKShift(e: KeyEvent, v: number, d: boolean|number): boolean {
       var keyShiftState=0, lockStates=0, i;
-      let keyman = com.keyman.singleton;
 
       var lockNames  = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'];
       var lockKeys   = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'];
@@ -568,16 +580,7 @@ namespace com.keyman.text {
         }
       }
 
-      // Find and display the selected OSK layer
-      if(keyman['osk'].vkbd) {
-        keyman['osk'].vkbd.showLayer(this.getLayerId(keyShiftState));
-      }
-
-      // osk._UpdateVKShiftStyle will be called automatically upon the next _Show.
-      if(keyman.osk._Visible) {
-        keyman.osk._Show();
-      }
-
+      this.layerId = this.getLayerId(keyShiftState);
       return true;
     }
 
@@ -678,14 +681,7 @@ namespace com.keyman.text {
      * @param       {string}      id      layer id (e.g. ctrlshift)
      */
     updateLayer(keyEvent: KeyEvent, id: string) {
-      let keyman = com.keyman.singleton;
-      let vkbd = keyman['osk'].vkbd;
-
-      if(!vkbd) {
-        return;
-      }
-
-      let activeLayer = vkbd.layerId;
+      let activeLayer = this.layerId;
       var s = activeLayer;
 
       // Do not change layer unless needed (27/08/2015)
@@ -773,11 +769,11 @@ namespace com.keyman.text {
         s = id;
       }
 
-      // Actually set the new layer id.
-      if(vkbd) {
-        if(!vkbd.showLayer(s)) {
-          vkbd.showLayer('default');
-        }
+      let layout = this.activeKeyboard.layout(keyEvent.device.formFactor);
+      if(layout.getLayer(s)) {
+        this.layerId = s;
+      } else {
+        this.layerId = 'default';
       }
     }
 
@@ -820,9 +816,7 @@ namespace com.keyman.text {
 
     resetContext() {
       let keyman = com.keyman.singleton;
-      if(!keyman.isHeadless && keyman.osk.vkbd) {
-        keyman.osk.vkbd.layerId = 'default';
-      }
+      this.layerId = 'default';
 
       this.keyboardInterface.resetContextCache();
       this.resetVKShift();
@@ -830,23 +824,12 @@ namespace com.keyman.text {
       if(keyman.modelManager) {
         keyman.modelManager.invalidateContext();
       }
-
-      if(!keyman.isHeadless) {
-        keyman.osk._Show();
-      }
     };
 
-    setNumericLayer() {
-      let keyman = com.keyman.singleton;
-      var i;
-      if(!keyman.isHeadless) {
-        let osk = keyman.osk.vkbd;
-        for(i=0; i<osk.layers.length; i++) {
-          if (osk.layers[i].id == 'numeric') {
-            osk.layerId = 'numeric';
-            keyman.osk._Show();
-          }
-        }
+    setNumericLayer(device: EngineDeviceSpec) {
+      let layout = this.activeKeyboard.layout(device.formFactor);
+      if(layout.getLayer('numeric')) {
+        this.layerId = 'numeric';
       }
     };
 

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -34,6 +34,8 @@ namespace com.keyman.text {
     warningLog?: string;
 
     finalize() {
+      // TODO:  Rework logging and references to be fully headless-compatible.  
+      //        We'll probably need warning/error callbacks on Processor to facilitate that.
       let keyman = com.keyman.singleton;
       let outputTarget = this.transcription.keystroke.Ltarg;
 
@@ -44,24 +46,19 @@ namespace com.keyman.text {
       }
 
       for(let storeID in this.setStore) {
-        // TODO:  Must be relocated further 'out' to complete the full, planned web-core refactor.
-        //        `Processor` shouldn't be directly setting anything on the OSK when the refactor is complete.
-        //
-        //        There's also the issue of Stores in general, which rely on cookies...
-        //        Gotta handle variable stores as well, which we currently do nothing for!
-        
-        // How would this be handled in an eventual headless mode?
-        switch(Number.parseInt(storeID)) { // Because the number was converted into a String for 'dictionary' use.
-          case KeyboardInterface.TSS_LAYER:
-            keyman.textProcessor.layerId = this.setStore[storeID];
-            break;
-          case KeyboardInterface.TSS_PLATFORM:
+        let sysStore = keyman.textProcessor.keyboardInterface.systemStores[storeID];
+        if(sysStore) {
+          try {
+            sysStore.set(this.setStore[storeID]);
+          } catch (error) {
             console.error("Rule attempted to perform illegal operation - 'platform' may not be changed.");
-            break;
-          default:
-            console.warn("Unknown store affected by keyboard rule: " + storeID);
+          }
+        } else {
+          console.warn("Unknown store affected by keyboard rule: " + storeID);
         }
       }
+
+      // TODO: Gotta handle variable store save commands, which currently rely on cookies.
 
       if(this.triggersDefaultCommand) {
         let keyEvent = this.transcription.keystroke;

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -53,7 +53,7 @@ namespace com.keyman.text {
         // How would this be handled in an eventual headless mode?
         switch(Number.parseInt(storeID)) { // Because the number was converted into a String for 'dictionary' use.
           case KeyboardInterface.TSS_LAYER:
-            keyman.osk.vkbd.showLayer(this.setStore[storeID]); //Build 350, osk reference now OK, so should work
+            keyman.textProcessor.layerId = this.setStore[storeID];
             break;
           case KeyboardInterface.TSS_PLATFORM:
             console.error("Rule attempted to perform illegal operation - 'platform' may not be changed.");

--- a/web/source/text/systemStores.ts
+++ b/web/source/text/systemStores.ts
@@ -19,6 +19,42 @@ namespace com.keyman.text {
   }
 
   /**
+   * A handler designed to receive feedback whenever a system store's value is changed.
+   * @param source    The system store being mutated, before the value change occurs.
+   * @param newValue  The new value being set
+   * @returns         `false` / `undefined` to allow the change, `true` to block the change.
+   */
+  export type SystemStoreChangedHandler = (source: MutableSystemStore, newValue: string) => boolean;
+
+  export class MutableSystemStore extends SystemStore {
+    private _value: string;
+    handler?: SystemStoreChangedHandler = null;
+
+    constructor(id: number, defaultValue: string) {
+      super(id);
+      this._value = defaultValue;
+    }
+
+    get value() {
+      return this._value;
+    }
+
+    matches(value: string) {
+      return this._value == value;
+    }
+
+    set(value: string) {
+      if(this.handler) {
+        if(this.handler(this, value)) {
+          return;
+        }
+      }
+
+      this._value = value;
+    }
+  }
+
+  /**
    * Handles checks against the current platform.
    */
   export class PlatformSystemStore extends SystemStore {

--- a/web/source/text/systemStores.ts
+++ b/web/source/text/systemStores.ts
@@ -24,11 +24,11 @@ namespace com.keyman.text {
    * @param newValue  The new value being set
    * @returns         `false` / `undefined` to allow the change, `true` to block the change.
    */
-  export type SystemStoreChangedHandler = (source: MutableSystemStore, newValue: string) => boolean;
+  export type SystemStoreMutationHandler = (source: MutableSystemStore, newValue: string) => boolean;
 
   export class MutableSystemStore extends SystemStore {
     private _value: string;
-    handler?: SystemStoreChangedHandler = null;
+    handler?: SystemStoreMutationHandler = null;
 
     constructor(id: number, defaultValue: string) {
       super(id);


### PR DESCRIPTION
Picking up where #2919 left off, this is part 2 of 2 for the layer management rework.

This PR now formalizes layer as a web-core accessible system store, with the OSK listening for changes rather than being the layer manager.  This change turned out to be... remarkably more direct than I feared it would be, which was a very pleasant surprise.

I've tested against the following scenarios:
- The desktop OSK properly changes layers to match the currently-held modifier keys (tested with `khmer_angkor`, though any keyboard should suffice)
- Touch tests:
    - `sil_cameroon_qwerty` - has a _lot_ of layers, next layer behaviors, and keys with custom layer properties that don't match the layer they're on.
    - `nrc_crk_cans` - has a lot of next-layer stuff going on to compose vowels, uses `KSETS` (`saveStore`)