### PR TITLE
feat(android): Specify optional language ID for installing kmp

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
@@ -58,7 +58,7 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
     return false;
   }
 
-  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion) throws JSONException {
+  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion, String languageID) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray("languages");
 
     String modelId = jsonEntry.getString("id");
@@ -103,6 +103,6 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
    * @throws JSONException
    */
   public List<Map<String, String>> processKMP(File path, File tempPath, String key) throws IOException, JSONException {
-    return super.processKMP(path, tempPath, key);
+    return super.processKMP(path, tempPath, key, null);
   }
 }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
@@ -65,7 +65,7 @@ public class LexicalModelPackageProcessorTest {
     Assert.assertNotNull(json);
     String pkgVersion = lmPP.getPackageVersion(json);
 
-    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom", pkgVersion);
+    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom", pkgVersion, "en");
 
     HashMap<String, String> en_custom = new HashMap<String, String>();
     en_custom.put(KMManager.KMKey_PackageID, "example.en.custom");

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -133,9 +133,8 @@ public class PackageProcessorTest {
     Assert.assertNotNull(json);
     String pkgVersion = PP.getPackageVersion(json);
 
-    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion);
-    // Only the first language is installed with the keyboard
-    Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
+    String languageID = null;
+    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
 
     HashMap<String, String> amharic = new HashMap<String, String>();
     amharic.put(KMManager.KMKey_PackageID, "gff_amh_7_test_json");
@@ -147,7 +146,33 @@ public class PackageProcessorTest {
     amharic.put(KMManager.KMKey_CustomKeyboard, "Y");
     amharic.put(KMManager.KMKey_CustomHelpLink, TEST_GFF_KMP_TARGET + File.separator + "welcome.htm");
 
+    // If languageID doesn't match, verify only the first language is installed with the keyboard
     Assert.assertEquals(amharic, keyboards[0]);
+    Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
+
+    languageID = "am";
+    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
+
+    // Verify "am" matched
+    Assert.assertEquals(amharic, keyboards[0]);
+    Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
+
+    languageID = "gez";
+    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
+
+    HashMap<String, String> geez = new HashMap<String, String>();
+    geez.put(KMManager.KMKey_PackageID, "gff_amh_7_test_json");
+    geez.put(KMManager.KMKey_KeyboardName, "Amharic");
+    geez.put(KMManager.KMKey_KeyboardID, "gff_amh_7");
+    geez.put(KMManager.KMKey_LanguageID, "gez");
+    geez.put(KMManager.KMKey_LanguageName, "Ge'ez");
+    geez.put(KMManager.KMKey_KeyboardVersion, "1.4");
+    geez.put(KMManager.KMKey_CustomKeyboard, "Y");
+    geez.put(KMManager.KMKey_CustomHelpLink, TEST_GFF_KMP_TARGET + File.separator + "welcome.htm");
+
+    // Verify "gez" matched
+    Assert.assertEquals(geez, keyboards[0]);
+    Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
   }
 
   @Test


### PR DESCRIPTION
Currently when installing a keyboard package where the keyboard is associated with several languages, only the first listed language gets associated with the keyboard.

In a future sprint where cloud keyboards install kmp files, we will need a way to specify a language ID that the user searched for.

This PR makes the language ID optional, so it it doesn't match in kmp.json, the first listed language gets used.

Note: the language ID parameter is passed but unused in `LexicalModelPackageProcessor` because all the model/language combinations are returned.