### PR TITLE
refactor(web/engine): variable store storage abstraction

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -10,6 +10,8 @@
 /// <reference path="touchAliasElement.ts" />
 // Defines per-element-type OutputTarget element wrapping.
 /// <reference path="targets/wrapElement.ts" />
+// Defines cookie-based variable store serialization
+/// <reference path="variableStoreCookieSerializer.ts" />
 
 namespace com.keyman.dom {
   // Utility object used to handle beep (keyboard error response) operations.

--- a/web/source/dom/variableStoreCookieSerializer.ts
+++ b/web/source/dom/variableStoreCookieSerializer.ts
@@ -1,0 +1,24 @@
+namespace com.keyman.dom {
+  export class VariableStoreCookieSerializer implements text.VariableStoreSerializer {
+    loadStore(kbdName: string, storeName: string): text.VariableStore {
+      var cName='KeymanWeb_'+kbdName+'_Option_'+storeName;
+      let map = com.keyman.singleton.util.loadCookie(cName) as text.VariableStore;
+
+      if(typeof map[storeName] != 'undefined') {
+        // Since it was stored in a cookie.
+        map[storeName] = decodeURIComponent(map[storeName]);
+      }
+
+      return map || {};
+    }
+    
+    saveStore(kbdName: string, storeName: string, storeMap: text.VariableStore) {
+      // The cookie entry includes the store name...
+      var cName='KeymanWeb_'+kbdName+'_Option_'+storeName;
+      storeMap[storeName] = encodeURIComponent(storeMap[storeName]);
+
+      // And the lookup under that entry looks for the value under the store name, again.
+      com.keyman.singleton.util.saveCookie(cName, storeMap);
+    }
+  }
+}

--- a/web/source/dom/variableStoreCookieSerializer.ts
+++ b/web/source/dom/variableStoreCookieSerializer.ts
@@ -1,7 +1,7 @@
 namespace com.keyman.dom {
   export class VariableStoreCookieSerializer implements text.VariableStoreSerializer {
-    loadStore(kbdName: string, storeName: string): text.VariableStore {
-      var cName='KeymanWeb_'+kbdName+'_Option_'+storeName;
+    loadStore(keyboardID: string, storeName: string): text.VariableStore {
+      var cName='KeymanWeb_'+keyboardID+'_Option_'+storeName;
       let map = com.keyman.singleton.util.loadCookie(cName) as text.VariableStore;
 
       if(typeof map[storeName] != 'undefined') {
@@ -12,9 +12,9 @@ namespace com.keyman.dom {
       return map || {};
     }
     
-    saveStore(kbdName: string, storeName: string, storeMap: text.VariableStore) {
+    saveStore(keyboardID: string, storeName: string, storeMap: text.VariableStore) {
       // The cookie entry includes the store name...
-      var cName='KeymanWeb_'+kbdName+'_Option_'+storeName;
+      var cName='KeymanWeb_'+keyboardID+'_Option_'+storeName;
       storeMap[storeName] = encodeURIComponent(storeMap[storeName]);
 
       // And the lookup under that entry looks for the value under the store name, again.

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -126,7 +126,11 @@ namespace com.keyman {
       }
       this._BrowserIsSafari = (navigator.userAgent.indexOf('AppleWebKit') >= 0);  // I732 END - Support for European underlying keyboards #1      
 
-      this.textProcessor = new text.Processor(baseLayout);
+      this.textProcessor = new text.Processor({
+        baseLayout: baseLayout,
+        variableStoreSerializer: new dom.VariableStoreCookieSerializer()
+      });
+
       // Used by the embedded apps.
       this['interface'] = this.textProcessor.keyboardInterface;
       

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -926,7 +926,15 @@ namespace com.keyman.text {
       // And the lookup under that entry looks for the value under the store name, again.
       let valueObj: VariableStore = {};
       valueObj[storeName] = optValue;
-      this.ruleBehavior.saveStore[storeName] = valueObj;
+
+      // Null-check in case of invocation during unit-test
+      if(this.ruleBehavior) {
+        this.ruleBehavior.saveStore[storeName] = valueObj;
+      } else {
+        // We're in a unit-test environment, directly invoking this method from outside of a keyboard.
+        // In this case, we should immediately commit the change.
+        this.variableStoreSerializer.saveStore(this.activeKeyboard.id, storeName, this.saveStore[storeName]);
+      }
       return true;
     }
 

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -897,9 +897,12 @@ namespace com.keyman.text {
      */    
     loadStore(kbdName: string, storeName:string, dfltValue:string): string {
       this.resetContextCache();
-      let cValue = this.variableStoreSerializer.loadStore(kbdName, storeName);
-
-      return cValue[storeName] || dfltValue;
+      if(this.variableStoreSerializer) {
+        let cValue = this.variableStoreSerializer.loadStore(kbdName, storeName);
+        return cValue[storeName] || dfltValue;
+      } else {
+        return dfltValue;
+      }
     }
 
     /**

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -923,7 +923,7 @@ namespace com.keyman.text {
       // And the lookup under that entry looks for the value under the store name, again.
       let valueObj: VariableStore = {};
       valueObj[storeName] = optValue;
-      this.variableStoreSerializer.saveStore(kbd.id, storeName, valueObj);
+      this.ruleBehavior.saveStore[storeName] = valueObj;
       return true;
     }
 

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -933,7 +933,7 @@ namespace com.keyman.text {
       } else {
         // We're in a unit-test environment, directly invoking this method from outside of a keyboard.
         // In this case, we should immediately commit the change.
-        this.variableStoreSerializer.saveStore(this.activeKeyboard.id, storeName, this.saveStore[storeName]);
+        this.variableStoreSerializer.saveStore(this.activeKeyboard.id, storeName, valueObj);
       }
       return true;
     }

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -31,6 +31,8 @@ namespace com.keyman.text {
 
   type KeyboardStore = PlainKeyboardStore | ComplexKeyboardStore;
 
+  export type VariableStore = {[name: string]: string};
+
   type RuleChar = string;
 
   class RuleDeadkey {
@@ -186,11 +188,15 @@ namespace com.keyman.text {
     activeKeyboard: any;
     activeDevice: EngineDeviceSpec;
 
-    constructor() {
+    variableStoreSerializer?: VariableStoreSerializer;
+
+    constructor(variableStoreSerializer: VariableStoreSerializer = null) {
       this.systemStores = {};
       
       this.systemStores[KeyboardInterface.TSS_PLATFORM] = new PlatformSystemStore(this);
       this.systemStores[KeyboardInterface.TSS_LAYER] = new MutableSystemStore(KeyboardInterface.TSS_LAYER, 'default');
+
+      this.variableStoreSerializer = variableStoreSerializer;
     }
 
     /**
@@ -890,15 +896,10 @@ namespace com.keyman.text {
      * to initialize a store value on the keyboard's script object.
      */    
     loadStore(kbdName: string, storeName:string, dfltValue:string): string {
-      let keyman = com.keyman.singleton;
       this.resetContextCache();
-      var cName='KeymanWeb_'+kbdName+'_Option_'+storeName;
-      var cValue=keyman.util.loadCookie(cName);
-      if(typeof cValue[storeName] != 'undefined') {
-        return decodeURIComponent(cValue[storeName]);
-      } else {
-        return dfltValue;
-      }
+      let cValue = this.variableStoreSerializer.loadStore(kbdName, storeName);
+
+      return cValue[storeName] || dfltValue;
     }
 
     /**
@@ -913,21 +914,16 @@ namespace com.keyman.text {
      * value across sessions, providing a custom user default for later uses of the keyboard.
      */    
     saveStore(storeName:string, optValue:string): boolean {
-      let keyman = com.keyman.singleton;
       this.resetContextCache();
       var kbd=this.activeKeyboard;
       if(!kbd || typeof kbd.id == 'undefined' || kbd.id == '') {
         return false;
       }
-      
-      // The cookie entry includes the store name...
-      var cName='KeymanWeb_'+kbd.id+'_Option_'+storeName;
-      var cValue=encodeURIComponent(optValue);
 
       // And the lookup under that entry looks for the value under the store name, again.
-      let valueObj = {};
-      valueObj[storeName] = cValue;
-      keyman.util.saveCookie(cName, valueObj);
+      let valueObj: VariableStore = {};
+      valueObj[storeName] = optValue;
+      this.variableStoreSerializer.saveStore(kbd.id, storeName, valueObj);
       return true;
     }
 

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -18,8 +18,8 @@ namespace com.keyman.text {
   export type LogMessageHandler = (str: string) => void;
 
   export interface VariableStoreSerializer {
-    loadStore(kbdName: string, storeName: string): VariableStore;
-    saveStore(kbdName: string, storeName: string, storeMap: VariableStore);
+    loadStore(keyboardID: string, storeName: string): VariableStore;
+    saveStore(keyboardID: string, storeName: string, storeMap: VariableStore);
   }
 
   export interface ProcessorInitOptions {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -17,14 +17,20 @@ namespace com.keyman.text {
   export type BeepHandler = (outputTarget: OutputTarget) => void;
   export type LogMessageHandler = (str: string) => void;
 
-  export class LegacyKeyEvent {
-    Ltarg: HTMLElement;
-    Lcode: number;
-    Lmodifiers: number;
-    LisVirtualKey: number;
+  export interface VariableStoreSerializer {
+    loadStore(kbdName: string, storeName: string): VariableStore;
+    saveStore(kbdName: string, storeName: string, storeMap: VariableStore);
+  }
+
+  export interface ProcessorInitOptions {
+    baseLayout?: string;
+    variableStoreSerializer?: VariableStoreSerializer;
   }
 
   export class Processor {
+    public static readonly DEFAULT_OPTIONS: ProcessorInitOptions = {
+      baseLayout: 'us'
+    }
 
     // Tracks the simulated value for supported state keys, allowing the OSK to mirror a physical keyboard for them.
     // Using the exact keyCode name from the Codes definitions will allow for certain optimizations elsewhere in the code.
@@ -49,9 +55,13 @@ namespace com.keyman.text {
     warningLogger?: LogMessageHandler;
     errorLogger?: LogMessageHandler;
 
-    constructor(baseLayout?: string) {
-      this.baseLayout = baseLayout || 'us'; // default BaseLayout
-      this.keyboardInterface = new KeyboardInterface();
+    constructor(options?: ProcessorInitOptions) {
+      if(!options) {
+        options = Processor.DEFAULT_OPTIONS;
+      }
+
+      this.baseLayout = options.baseLayout || 'us'; // default BaseLayout
+      this.keyboardInterface = new KeyboardInterface(options.variableStoreSerializer);
       this.installInterface();
     }
 

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -60,8 +60,10 @@ namespace com.keyman.text {
         }
       }
 
-      for(let storeID in this.saveStore) {
-        processor.keyboardInterface.variableStoreSerializer.saveStore(processor.activeKeyboard.id, storeID, this.saveStore[storeID]);
+      if(processor.keyboardInterface.variableStoreSerializer) {
+        for(let storeID in this.saveStore) {
+          processor.keyboardInterface.variableStoreSerializer.saveStore(processor.activeKeyboard.id, storeID, this.saveStore[storeID]);
+        }
       }
 
       if(this.triggersDefaultCommand) {

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -19,6 +19,11 @@ namespace com.keyman.text {
     setStore: {[id: number]: string} = {};
 
     /**
+     * A set of variable stores with save requests triggered by the matched keyboard rule
+     */
+    saveStore: {[name: string]: VariableStore} = {};
+
+    /**
      * Denotes a non-output default behavior; this should be evaluated later, against the true keystroke.
      */
     triggersDefaultCommand?: boolean;
@@ -55,7 +60,9 @@ namespace com.keyman.text {
         }
       }
 
-      // TODO: Gotta handle variable store save commands, which currently rely on cookies.
+      for(let storeID in this.saveStore) {
+        processor.keyboardInterface.variableStoreSerializer.saveStore(processor.activeKeyboard.id, storeID, this.saveStore[storeID]);
+      }
 
       if(this.triggersDefaultCommand) {
         let keyEvent = this.transcription.keystroke;


### PR DESCRIPTION
This PR simply abstracts the currently-existing variable store load/save model.  While the objects involved aren't necessarily the most efficient, they are accurate to how KMW has operated thus far and are compatible with saved values in older cookies.  We'll worry about a headless implementation of the abstraction after we finally turn web-core headless and are ready to unit-test this functionality in that environment.

This also brought to light the need for a proper "options" object for `Processor` initialization.