### PR TITLE
fix(web): fixes activeElement typing

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -269,7 +269,7 @@ namespace com.keyman.dom {
      * @return      {boolean}      
      * Description  Execute external (UI) code needed on blur
      */       
-    doControlBlurred(_target: HTMLElement|Document, _event: Event, _isActivating: boolean|number): boolean {
+    doControlBlurred(_target: HTMLElement, _event: Event, _isActivating: boolean|number): boolean {
       var p={};
       p['target']=_target;
       p['event']=_event;
@@ -416,7 +416,7 @@ namespace com.keyman.dom {
       return PreProcessor.keyDown(e);
     }.bind(this);
 
-    doChangeEvent(_target: HTMLElement|Document) {
+    doChangeEvent(_target: HTMLElement) {
       if(DOMEventHandlers.states.changed) {
         var event: Event;
         if(typeof Event == 'function') {

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -16,8 +16,8 @@ namespace com.keyman.dom {
     _Selection = null;
     _SelectionControl: any = null;   // Type behavior is as with activeElement and the like.
     
-    activeElement: any;       // TODO:  Add type and fix resulting bugs!
-    lastActiveElement: any;   // TODO:  Add type and fix resulting bugs!
+    activeElement: HTMLElement;
+    lastActiveElement: HTMLElement;
 
     focusing: boolean;
     focusTimer: number;
@@ -192,7 +192,7 @@ namespace com.keyman.dom {
      * Respond to KMW losing focus on event
      */    
     _ControlBlur: (e: FocusEvent) => boolean = function(this: DOMEventHandlers, e: FocusEvent): boolean {
-      var Ltarg: HTMLElement | Document;  
+      var Ltarg: HTMLElement;  
 
       e = this.keyman._GetEventObject<FocusEvent>(e);   // I2404 - Manage IE events in IFRAMEs
       Ltarg = this.keyman.util.eventTarget(e) as HTMLElement;
@@ -223,10 +223,9 @@ namespace com.keyman.dom {
         Ltarg = Ltarg.parentNode as HTMLElement;
       }
 
-      // TODO:  Needs tidy-up.
       if(Ltarg.ownerDocument) {
         if(Ltarg instanceof Ltarg.ownerDocument.defaultView.HTMLIFrameElement) {
-          Ltarg=Ltarg.contentWindow.document;
+          Ltarg=Ltarg.contentWindow.frameElement as HTMLElement;
         }
       }
       
@@ -244,7 +243,7 @@ namespace com.keyman.dom {
       var isActivating = this.keyman.uiManager.isActivating;
       let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
       if(!isActivating && activeKeyboard) {
-        activeKeyboard.notify(0, text.Processor.getOutputTarget(Ltarg as HTMLElement), 0);  // I2187
+        activeKeyboard.notify(0, text.Processor.getOutputTarget(Ltarg), 0);  // I2187
       }
 
       //e = this.keyman._GetEventObject<FocusEvent>(e);   // I2404 - Manage IE events in IFRAMEs  //TODO: is this really needed again????
@@ -690,9 +689,9 @@ namespace com.keyman.dom {
     /**
      * Close OSK and remove simulated caret on losing focus
      */          
-    cancelInput(): void { 
-      if(DOMEventHandlers.states.activeElement && DOMEventHandlers.states.activeElement.hideCaret) {
-        DOMEventHandlers.states.activeElement.hideCaret();
+    cancelInput(): void {
+      if(DOMEventHandlers.states.activeElement && Utils.instanceof(DOMEventHandlers.states.activeElement, "TouchAliasElement")) {
+        (DOMEventHandlers.states.activeElement as TouchAliasElement).hideCaret();
       }
       DOMEventHandlers.states.activeElement=null; 
       this.keyman.osk.hideNow();

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1247,8 +1247,8 @@ namespace com.keyman.dom {
      *  @param  {boolean=}      setFocus  optionally set focus  (KMEW-123) 
      **/
     setActiveElement(e: string|HTMLElement, setFocus?: boolean) {
-      if(typeof(e) == "string") { // Can't instanceof string, and String is a different type.
-        e=document.getElementById(e);
+      if(typeof e == "string") { // Can't instanceof string, and String is a different type.
+        e = document.getElementById(e);
       }
 
       if(this.keyman.isEmbedded) {
@@ -1264,7 +1264,7 @@ namespace com.keyman.dom {
 
       // As this is an API function, someone may pass in the base of a touch element.
       // We need to respond appropriately.
-      e = e['kmw_ip'] ? e['kmw_ip'] : e;
+      e = (e['kmw_ip'] ? e['kmw_ip'] : e) as HTMLElement;
 
       // If we're changing controls, don't forget to properly manage the keyboard settings!
       // It's only an issue on 'native' (non-embedded) code paths.

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -210,12 +210,12 @@ namespace com.keyman {
       if (!e) {
         e = window.event as E;
         if(!e) {
-          var elem: HTMLElement|Document = this.domManager.getLastActiveElement();
+          var elem: HTMLElement = this.domManager.getLastActiveElement();
           if(elem) {
-            elem = elem.ownerDocument;
+            let doc = elem.ownerDocument;
             var win: Window;
-            if(elem) {
-              win = elem.defaultView;
+            if(doc) {
+              win = doc.defaultView;
             }
             if(!win) {
               return null;


### PR DESCRIPTION
Fixes #539.

#2838 resolved a lot of the ongoing type confusion for managing the active element within the DOM part of KMW.  After a little more work, we can finally eliminate the `HTMLElement|Document` dual-typed parameters, making things a bit cleaner overall.