### PR TITLE
fix(android): Fix globe button crash on 3rd party apps

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1269,6 +1269,7 @@ public final class KMManager {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       Intent i = new Intent(context, KeyboardPickerActivity.class);
       i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+      i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       i.putExtra(KMKey_DisplayKeyboardSwitcher, false);
       context.startActivity(i);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {


### PR DESCRIPTION
Fixes #2786 as reported by user

I verified globe button still works as before for the apps:
Keyman - both in-app and system keyboard
KMSample1 - in-app