### PR TITLE
fix(android): Fix exception in ResourcesUpdateTool

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -431,6 +431,7 @@ public final class KMManager {
     if (SystemKeyboard != null) {
       SystemKeyboard.onDestroy();
     }
+    updateTool.destroyNotificationChannel(appContext);
     CloudDownloadMgr.getInstance().shutdown(appContext);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -49,7 +49,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * Force resource update.
    * Only for testing, should be false for merging
    */
-  public static final boolean FORCE_RESOURCE_UPDATE = true;
+  public static final boolean FORCE_RESOURCE_UPDATE = false;
 
   /**
    * Send update notifications.

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -49,7 +49,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * Force resource update.
    * Only for testing, should be false for merging
    */
-  public static final boolean FORCE_RESOURCE_UPDATE = false;
+  public static final boolean FORCE_RESOURCE_UPDATE = true;
 
   /**
    * Send update notifications.
@@ -150,6 +150,13 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       // or other notification behaviors after this
       NotificationManager notificationManager = aContext.getSystemService(NotificationManager.class);
       notificationManager.createNotificationChannel(channel);
+    }
+  }
+
+  public static void destroyNotificationChannel(Context aContext) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && aContext != null) {
+      NotificationManager notificationManager = (NotificationManager) aContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.deleteNotificationChannel(ResourcesUpdateTool.class.getName());
     }
   }
 
@@ -330,6 +337,9 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * @param id : keyboard or lexical model ID to ignore for MONTHS_TO_IGNORE_NOTIFICATION months
    */
   private void setPrefKeyIgnoreNotifications(String id) {
+    if (currentContext == null) {
+      return;
+    }
     SharedPreferences prefs = currentContext.getSharedPreferences(
       currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();


### PR DESCRIPTION
Fixes #2743 and crashlytic issue
https://console.firebase.google.com/u/1/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/5abd6c9831c913e93eb75d28da472079

which affected many users.

The primary fix was checking the context isn't null.

While updating ResourcesUpdateTool(), also added a cleanup method to clear the notification bar when exiting Keyman.