### PR TITLE
fix(web/engine): default layout fix for chiral keyboards

### DIFF
--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -288,7 +288,9 @@ namespace com.keyman.keyboards {
       // First, if we have non-default keys specified by the ['BK'] array, we've got
       // enough to work with to build a default layout.
       let rawSpecifications: any = null;  // TODO:  better typing, same type as this.legacyLayoutSpec.
-      if(this._legacyLayoutSpec != null && this._legacyLayoutSpec['BK'] != null) {
+      if(this._legacyLayoutSpec['KLS']) { // KLS is only specified whenever there are non-default keys.
+        rawSpecifications = this._legacyLayoutSpec;
+      } else if(this._legacyLayoutSpec != null && this._legacyLayoutSpec['BK'] != null) {
         var keyCaps=this._legacyLayoutSpec['BK'];
         for(var i=0; i<keyCaps.length; i++) {
           if(keyCaps[i].length > 0) {


### PR DESCRIPTION
When doing the layout refactor, I forgot to check against chirality-enabled keyboards.  Due to their structure, they may not necessarily have a ['BK'] entry; we should first check for a ['KLS'] entry, which all chirality-enabled keyboards will have.