### PR TITLE
refactor(web/engine): proper split-off of DOM-reliant code

### DIFF
--- a/web/source/dom/domDefaultOutput.ts
+++ b/web/source/dom/domDefaultOutput.ts
@@ -1,0 +1,39 @@
+namespace com.keyman.text {
+  let coreIsCommand = DefaultOutput.isCommand;
+  let coreApplyCommand = DefaultOutput.applyCommand;
+
+  DefaultOutput.isCommand = function(Lkc: KeyEvent): boolean {
+    let code = DefaultOutput.codeForEvent(Lkc);
+
+    switch(code) {
+      case Codes.keyCodes['K_TAB']:
+      case Codes.keyCodes['K_TABBACK']:
+      case Codes.keyCodes['K_TABFWD']:
+        return true;
+      default:
+        return coreIsCommand(Lkc);
+    }
+  }
+
+  /**
+   * applyCommand - used when a RuleBehavior represents a non-text "command" within the Engine.
+   */
+  DefaultOutput.applyCommand = function(Lkc: KeyEvent): void {
+    let code = DefaultOutput.codeForEvent(Lkc);
+    let domManager = com.keyman.singleton.domManager;
+
+    switch(code) {
+      case Codes.keyCodes['K_TAB']:
+        domManager.moveToNext((Lkc.Lmodifiers & text.Codes.modifierCodes['SHIFT']) != 0);
+        break;
+      case Codes.keyCodes['K_TABBACK']:
+        domManager.moveToNext(true);
+        break;
+      case Codes.keyCodes['K_TABFWD']:
+        domManager.moveToNext(false);
+        break;
+    }
+
+    coreApplyCommand(Lkc);
+  }
+}

--- a/web/source/dom/domDefaultOutput.ts
+++ b/web/source/dom/domDefaultOutput.ts
@@ -1,4 +1,10 @@
-namespace com.keyman.text {
+namespace com.keyman.dom {
+  // Basically, these are shorthand imports, only viewable within this file.
+  let DefaultOutput = text.DefaultOutput;
+  let Codes = text.Codes;
+  type KeyEvent = text.KeyEvent;
+
+  // Now for some classic JS method "extension".
   let coreIsCommand = DefaultOutput.isCommand;
   let coreApplyCommand = DefaultOutput.applyCommand;
 

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -461,7 +461,7 @@ namespace com.keyman.dom {
       if(Levent == null || !osk.ready) {
         return true;
       }
-      var inputEle = Levent.Ltarg.getElement();
+      var inputEle = (Levent.Ltarg as targets.OutputTarget).getElement();
 
       // Since this part concerns DOM element + browser interaction management, we preprocess it for
       // browser form commands before passing control to the Processor module.

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -4,6 +4,8 @@
 /// <reference path="../kmwbase.ts" />
 // References DOM event handling interfaces and classes.
 /// <reference path="domEventHandlers.ts" />
+// References DOM-specific output handling.
+/// <reference path="domDefaultOutput.ts" />
 // Includes KMW string extension declarations.
 /// <reference path="../text/kmwstring.ts" />
 // Defines the touch-alias element structure used for mobile devices.

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -112,11 +112,15 @@ namespace com.keyman.dom {
      * @param       {Object}      Pelem     element to flash
      * Description  Flash body as substitute for audible beep; notify embedded device to vibrate
      */    
-    doBeep(outputTarget: text.OutputTarget) {
+    doBeep(outputTarget: targets.OutputTarget) {
       // Handles embedded-mode beeps.
       let keyman = com.keyman.singleton;
       if ('beepKeyboard' in keyman) {
         keyman['beepKeyboard']();
+        return;
+      }
+
+      if(!(outputTarget instanceof targets.OutputTarget)) {
         return;
       }
 

--- a/web/source/dom/targets/contentEditable.ts
+++ b/web/source/dom/targets/contentEditable.ts
@@ -19,7 +19,7 @@ namespace com.keyman.dom.targets {
     }
   }
 
-  export class ContentEditable extends text.OutputTarget {
+  export class ContentEditable extends OutputTarget {
     root: HTMLElement;
 
     constructor(ele: HTMLElement) {

--- a/web/source/dom/targets/designIFrame.ts
+++ b/web/source/dom/targets/designIFrame.ts
@@ -30,7 +30,7 @@ namespace com.keyman.dom.targets {
     }
   }
 
-  export class DesignIFrame extends text.OutputTarget {
+  export class DesignIFrame extends OutputTarget {
     root: HTMLIFrameElement;
     doc: Document;
     docRoot: HTMLElement;

--- a/web/source/dom/targets/input.ts
+++ b/web/source/dom/targets/input.ts
@@ -1,8 +1,6 @@
-/// <reference path="../../text/outputTarget.ts" />
-
 namespace com.keyman.dom.targets {
 
-  export class Input extends text.OutputTarget {
+  export class Input extends OutputTarget {
     root: HTMLInputElement;
 
     /**

--- a/web/source/dom/targets/outputTarget.ts
+++ b/web/source/dom/targets/outputTarget.ts
@@ -1,0 +1,25 @@
+namespace com.keyman.dom.targets {
+  export abstract class OutputTarget extends text.OutputTarget {
+    /**
+     * Returns the underlying element / document modeled by the wrapper.
+     */
+    abstract getElement(): HTMLElement;
+
+    /**
+     * A helper method for doInputEvent; creates a simple common event and default dispatching.
+     * @param elem 
+     */
+    protected dispatchInputEventOn(elem: HTMLElement) {
+      let event: InputEvent;
+
+      // `undefined` in Edge and IE.
+      if(window['InputEvent']) { // can't condition on the type directly; TS optimizes that out.
+        event = new InputEvent('input', {"bubbles": true, "cancelable": false});
+      }
+
+      if(elem && event) {
+        elem.dispatchEvent(event);
+      }
+    }
+  }
+}

--- a/web/source/dom/targets/textarea.ts
+++ b/web/source/dom/targets/textarea.ts
@@ -1,5 +1,5 @@
 namespace com.keyman.dom.targets {
-  export class TextArea extends text.OutputTarget {
+  export class TextArea extends OutputTarget {
     root: HTMLTextAreaElement;
 
     /**

--- a/web/source/dom/targets/touchAlias.ts
+++ b/web/source/dom/targets/touchAlias.ts
@@ -4,7 +4,7 @@
 /// <reference path="../../text/outputTarget.ts" />
 
 namespace com.keyman.dom.targets {
-  export class TouchAlias extends text.OutputTarget {
+  export class TouchAlias extends OutputTarget {
     root: TouchAliasElement;
 
     constructor(e: TouchAliasElement) {

--- a/web/source/dom/targets/wrapElement.ts
+++ b/web/source/dom/targets/wrapElement.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../text/outputTarget.ts" />
+/// <reference path="outputTarget.ts" />
 // Defines a basic HTMLInputElement wrapper.
 ///<reference path="input.ts" />
 // Defines a basic HTMLTextAreaElement wrapper.
@@ -11,7 +11,7 @@
 ///<reference path="touchAlias.ts" />
 
 namespace com.keyman.dom.targets {
-  export function wrapElement(e: HTMLElement): text.OutputTarget {
+  export function wrapElement(e: HTMLElement): OutputTarget {
     // Complex type scoping is implemented here so that kmwutils.ts is not a dependency for test compilations.
 
     if(Utils.instanceof(e, "HTMLInputElement")) {

--- a/web/source/keyboards/defaultLayouts.ts
+++ b/web/source/keyboards/defaultLayouts.ts
@@ -4,6 +4,7 @@
 ***/
 
 ///<reference path="../utils/version.ts"/>
+///<reference path="../utils/deepCopy.ts"/>
 
 namespace com.keyman.keyboards {
   let Codes = com.keyman.text.Codes;
@@ -115,9 +116,6 @@ namespace com.keyman.keyboards {
     * @return  {Object}
     */
     static buildDefaultLayout(PVK, keyboard: Keyboard, formFactor: string): LayoutFormFactor {
-      // TODO:  Only here because of util.deepCopy.  Start a web-core utils so that it's accessible in headless.
-      let util = com.keyman.singleton.util;
-
       // Build a layout using the default for the device
       var layoutType=formFactor;
 
@@ -138,7 +136,7 @@ namespace com.keyman.keyboards {
       }
 
       // Clone the default layout object for this device
-      var layout: LayoutFormFactor = util.deepCopy(Layouts.dfltLayout[layoutType]);
+      var layout: LayoutFormFactor = utils.deepCopy(Layouts.dfltLayout[layoutType]);
 
       var n,layers=layout['layer'], keyLabels: KLS=PVK['KLS'], key102=PVK['K102'];
       var i, j, k, m, row, rows: LayoutRow[], key: LayoutKey, keys: LayoutKey[];
@@ -235,7 +233,7 @@ namespace com.keyman.keyboards {
       for(n=0; n<idList.length; n++) {
         // Populate non-default (shifted) keygroups
         if(n > 0) {
-          layers[n]=util.deepCopy(layers[0]);
+          layers[n]=utils.deepCopy(layers[0]);
         }
         layers[n]['id']=idList[n];
         layers[n]['nextlayer']=idList[n]; // This would only be different for a dynamic keyboard

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -367,15 +367,15 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues      
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
       
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.layerId);
+      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.core.layerId);
       keyName=t[t.length-1];
       if(layer == 'undefined') {
-        layer=processor.layerId;
+        layer=processor.core.layerId;
       }
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.core.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -427,20 +427,20 @@ namespace com.keyman.text {
       };
 
       // Process modifier key action
-      if(processor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
+      if(processor.core.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
         return true;      
       }
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
       // we can handle many other pre-processing steps the same way with this common method.
-      processor.setSyntheticEventDefaults(Lkc);
+      processor.core.setSyntheticEventDefaults(Lkc);
 
       //if(!Lkc.Lcode) return false;  // Value is now zero if not known (Build 347)
       //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014      
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          processor.selectLayer(Lkc);
+          processor.core.selectLayer(Lkc);
         }
         return false;
       }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -367,15 +367,15 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues      
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
       
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.core.layerId);
+      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.layerId);
       keyName=t[t.length-1];
       if(layer == 'undefined') {
-        layer=processor.core.layerId;
+        layer=processor.layerId;
       }
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.core.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -427,20 +427,20 @@ namespace com.keyman.text {
       };
 
       // Process modifier key action
-      if(processor.core.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
+      if(processor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
         return true;      
       }
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
       // we can handle many other pre-processing steps the same way with this common method.
-      processor.core.setSyntheticEventDefaults(Lkc);
+      processor.setSyntheticEventDefaults(Lkc);
 
       //if(!Lkc.Lcode) return false;  // Value is now zero if not known (Build 347)
       //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014      
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          processor.core.selectLayer(Lkc);
+          processor.selectLayer(Lkc);
         }
         return false;
       }

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -4,6 +4,8 @@
 /// <reference path="kmwdevice.ts" />
 // Includes the DOM utils, since our UI modules need access to certain methods here.
 /// <reference path="dom/utils.ts" />
+// Include other important utils
+/// <reference path="utils/deepCopy.ts" />
 
 namespace com.keyman {
   class DOMEventTracking {
@@ -909,30 +911,6 @@ namespace com.keyman {
       }
 
       return ''+item;
-    }
-
-    /**
-     * Function     deepCopy
-     * Scope        Private
-     * @param       {Object}      p           object to copy
-     * @param       {Array=}      c0          array member being copied
-     * @return      {Object}                  clone ('deep copy') of object
-     * Description  Makes an actual copy (not a reference) of an object, copying simple members,
-     *              arrays and member objects but not functions, so use with care!
-     */
-    deepCopy<T>(p:T, c0?): T {
-      var c = c0 || {};
-      for (var i in p) {
-        if(typeof p[i] === 'object') {
-          c[i] = (p[i].constructor === Array ) ? [] : {};
-          this.deepCopy(p[i],c[i]);
-        }
-        else {
-          c[i] = p[i];
-        }
-      }
-
-      return c;
     }
 
     /**

--- a/web/source/text/defaultOutput.ts
+++ b/web/source/text/defaultOutput.ts
@@ -54,19 +54,6 @@ namespace com.keyman.text {
       }
     }
 
-    public static isDOMCommand(Lkc: KeyEvent): boolean {
-      let code = DefaultOutput.codeForEvent(Lkc);
-
-      switch(code) {
-        case Codes.keyCodes['K_TAB']:
-        case Codes.keyCodes['K_TABBACK']:
-        case Codes.keyCodes['K_TABFWD']:
-          return true;
-        default:
-          return false;
-      }
-    }
-
     /**
      * isCommand - returns a boolean indicating if a non-text event should be triggered by the keystroke.
      */
@@ -79,32 +66,7 @@ namespace com.keyman.text {
         // case Codes.keyCodes['K_RIGHT']:
         //   return true;
         default:
-          return this.isDOMCommand(Lkc);
-      }
-    }
-
-    /**
-     * This function is designed for future migration into a separate, explicitly-DOM-aware module.
-     * It would then be assigned to this class via classic JS method extension practices as an 'override'
-     * of `applyCommand`, reusing the base version of that name seen in this class, which is
-     * designed for web-core.
-     * 
-     * apply___Command - used when a RuleBehavior represents a non-text "command" within the Engine.
-     */
-    public static applyDOMCommand(Lkc: KeyEvent): void {
-      let code = DefaultOutput.codeForEvent(Lkc);
-      let domManager = com.keyman.singleton.domManager;
-
-      switch(code) {
-        case Codes.keyCodes['K_TAB']:
-          domManager.moveToNext((Lkc.Lmodifiers & Codes.modifierCodes['SHIFT']) != 0);
-          break;
-        case Codes.keyCodes['K_TABBACK']:
-          domManager.moveToNext(true);
-          break;
-        case Codes.keyCodes['K_TABFWD']:
-          domManager.moveToNext(false);
-          break;
+          return false;
       }
     }
 
@@ -112,10 +74,10 @@ namespace com.keyman.text {
      * Used when a RuleBehavior represents a non-text "command" within the Engine.  This will generally 
      * trigger events that require context reset - often by moving the caret or by moving what OutputTarget
      * the caret is in.  However, we let those events perform the actual context reset.
+     * 
+     * Note:  is extended by DOM-aware KeymanWeb code.
      */
     public static applyCommand(Lkc: KeyEvent): void {
-      DefaultOutput.applyDOMCommand(Lkc);
-
       // Notes for potential default-handling extensions:
       // 
       // switch(code) {

--- a/web/source/text/outputTarget.ts
+++ b/web/source/text/outputTarget.ts
@@ -196,11 +196,6 @@ namespace com.keyman.text {
     protected abstract setTextAfterCaret(s: string): void;
 
     /**
-     * Returns the underlying element / document modeled by the wrapper.
-     */
-    abstract getElement(): HTMLElement;
-
-    /**
      * Clears any selected text within the wrapper's element(s).
      * Silently does nothing if no such text exists.
      */
@@ -282,23 +277,6 @@ namespace com.keyman.text {
      * Generates a synthetic event on the underlying element, signalling that its value has changed.
      */
     abstract doInputEvent(): void;
-
-    /**
-     * A helper method for doInputEvent; creates a simple common event and default dispatching.
-     * @param elem 
-     */
-    protected dispatchInputEventOn(elem: HTMLElement) {
-      let event: InputEvent;
-
-      // `undefined` in Edge and IE.
-      if(window['InputEvent']) { // can't condition on the type directly; TS optimizes that out.
-        event = new InputEvent('input', {"bubbles": true, "cancelable": false});
-      }
-
-      if(elem && event) {
-        elem.dispatchEvent(event);
-      }
-    }
   }
 
   // Due to some interesting requirements on compile ordering in TS,
@@ -327,10 +305,6 @@ namespace com.keyman.text {
       clone.setDeadkeys(outputTarget.deadkeys());
 
       return clone;
-    }
-
-    getElement(): HTMLElement {
-      return null;
     }
     
     clearSelection(): void {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -165,7 +165,7 @@ namespace com.keyman.text {
             // We only do the "for special emulation" cases under the condition above... aside from backspace
             // Let the browser handle those.
             return null;
-          } else if(char != '') {
+          } else {
             this.keyboardInterface.output(0, outputTarget, char);
           }
         } else {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -262,8 +262,8 @@ namespace com.keyman.text {
       let formFactor = keyEvent.device.formFactor;
 
       // Determine the current target for text output and create a "mock" backup
-      // of its current, pre-input state.
-      let outputTarget = keyEvent.Ltarg;
+      // of its current, pre-input state.  Current, long-existing assumption - it's DOM-backed.
+      let outputTarget = keyEvent.Ltarg as dom.targets.OutputTarget;
       let fromOSK = keyEvent.isSynthetic;
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
@@ -328,7 +328,7 @@ namespace com.keyman.text {
                 continue;
               }
 
-              let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, keyEvent.Ltarg.getElement());
+              let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, outputTarget.getElement());
               altEvent.Ltarg = mock;
               let alternateBehavior = this.processKeystroke(altEvent, mock);
               if(alternateBehavior) {

--- a/web/source/text/processor.ts
+++ b/web/source/text/processor.ts
@@ -161,11 +161,11 @@ namespace com.keyman.text {
           if(special == EmulationKeystrokes.Backspace) {
             // A browser's default backspace may fail to delete both parts of an SMP character.
             this.keyboardInterface.defaultBackspace(Lkc.Ltarg);
-          } else if(special) {
+          } else if(special || DefaultOutput.isCommand(Lkc)) { // Filters out 'commands' like TAB.
             // We only do the "for special emulation" cases under the condition above... aside from backspace
             // Let the browser handle those.
             return null;
-          } else {
+          } else if(char != '') {
             this.keyboardInterface.output(0, outputTarget, char);
           }
         } else {

--- a/web/source/utils/deepCopy.ts
+++ b/web/source/utils/deepCopy.ts
@@ -1,0 +1,25 @@
+namespace com.keyman.utils {
+  /**
+   * Function     deepCopy
+   * Scope        Private
+   * @param       {Object}      p           object to copy
+   * @param       {Array=}      c0          array member being copied
+   * @return      {Object}                  clone ('deep copy') of object
+   * Description  Makes an actual copy (not a reference) of an object, copying simple members,
+   *              arrays and member objects but not functions, so use with care!
+   */
+  export function deepCopy<T>(p:T, c0?): T {
+    var c = c0 || {};
+    for (var i in p) {
+      if(typeof p[i] === 'object') {
+        c[i] = (p[i].constructor === Array ) ? [] : {};
+        deepCopy(p[i],c[i]);
+      }
+      else {
+        c[i] = p[i];
+      }
+    }
+
+    return c;
+  }
+}


### PR DESCRIPTION
Referring to our [Web-Core Refactor design doc](https://docs.google.com/document/d/1yXcxuVoXaT1nRFvGq9ws7U9GluZVI9t1VsGLEP0SbFE/edit?usp=sharing), it's almost time to complete "stage 1" for a headless web-core.  To facilitate the actual split, this PR splits a few classes into headless vs DOM-aware variants.

It's largely just moving code around and tying up the loose ends that process causes.