### PR TITLE
refactor(web/engine): InputProcessor/KeyboardProcessor split

### DIFF
--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -68,7 +68,7 @@ namespace com.keyman.renderer {
 
         eleDescription.appendChild(document.createTextNode('Name: ' + kbd['Name']));
         eleDescription.appendChild(document.createElement('br'));
-        eleDescription.appendChild(document.createTextNode('Font:  ' + window['keyman'].textProcessor.activeKeyboard.legacyLayoutSpec.F));
+        eleDescription.appendChild(document.createTextNode('Font:  ' + window['keyman'].core.activeKeyboard._legacyLayoutSpec.F));
 
       } else {
         eleDescription.appendChild(document.createTextNode('Unable to load this keyboard!'));
@@ -110,7 +110,7 @@ namespace com.keyman.renderer {
         } else {
           // The desktop OSK will be overpopulated, with a number of blank layers to display in most cases.
           // We instead rely upon the KLS definition to ensure we keep the renders sparse.
-          layers = keyman.textProcessor.activeKeyboard.legacyLayoutSpec.KLS;
+          layers = keyman.core.activeKeyboard._legacyLayoutSpec.KLS;
         }
 
         let renderLayer = function(i: number) {
@@ -118,9 +118,9 @@ namespace com.keyman.renderer {
             // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
             if(keyman.osk.vkbd) {
               if(isMobile) {
-                keyman.textProcessor.layerId = layers[i].id;
+                keyman.core.keyboardProcessor.layerId = layers[i].id;
               } else {
-                keyman.textProcessor.layerId = Object.keys(layers)[i];
+                keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
               }
             } else {
               console.error("Error - keyman.osk.vkbd is undefined!");
@@ -187,7 +187,7 @@ namespace com.keyman.renderer {
     }
 
     setActiveDummy() {
-      com.keyman['DOMEventHandlers'].states.activeElement = BatchRenderer.dummy;
+      com.keyman['dom']['DOMEventHandlers'].states.activeElement = BatchRenderer.dummy;
     }
 
     run() {

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -241,7 +241,7 @@ namespace com.keyman.dom {
       this.keyman.uiManager.justActivated = false;
       
       var isActivating = this.keyman.uiManager.isActivating;
-      let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
+      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
       if(!isActivating && activeKeyboard) {
         activeKeyboard.notify(0, Utils.getOutputTarget(Ltarg as HTMLElement), 0);  // I2187
       }
@@ -284,7 +284,7 @@ namespace com.keyman.dom {
      *                      whenever a KMW-enabled page element loses control.
      */
     _BlurKeyboardSettings(PInternalName?: string, PLgCode?: string) {
-      var keyboardID = this.keyman.textProcessor.activeKeyboard ? this.keyman.textProcessor.activeKeyboard.id : '';
+      var keyboardID = this.keyman.core.activeKeyboard ? this.keyman.core.activeKeyboard.id : '';
       var langCode = this.keyman.keyboardManager.getActiveLanguage();
       
       if(PInternalName !== undefined && PLgCode !== undefined) {
@@ -347,7 +347,7 @@ namespace com.keyman.dom {
       }
       DOMEventHandlers.states._DisableInput = false; 
 
-      let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
+      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
       if(!uiManager.justActivated) {
         if(target && Utils.getOutputTarget(target)) {
           Utils.getOutputTarget(target).deadkeys().clear();
@@ -390,7 +390,7 @@ namespace com.keyman.dom {
      * not affected.
      */ 
     _KeyDown: (e: KeyboardEvent) => boolean = function(this: DOMEventHandlers, e: KeyboardEvent): boolean {
-      var activeKeyboard = this.keyman.textProcessor.activeKeyboard;
+      var activeKeyboard = this.keyman.core.activeKeyboard;
       var osk = this.keyman.osk;
       var util = this.keyman.util;
 
@@ -442,7 +442,7 @@ namespace com.keyman.dom {
      * Description Processes keypress event (does not pass data to keyboard)
      */       
     _KeyPress: (e: KeyboardEvent) => boolean = function(this: DOMEventHandlers, e: KeyboardEvent): boolean {
-      if(DOMEventHandlers.states._DisableInput || this.keyman.textProcessor.activeKeyboard == null) {
+      if(DOMEventHandlers.states._DisableInput || this.keyman.core.activeKeyboard == null) {
         return true;
       }
 

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -161,7 +161,7 @@ namespace com.keyman.dom {
      * Description  Reset/terminate beep or flash (not currently used: Aug 2011)
      */    
     beepReset(): void {
-      com.keyman.singleton.textProcessor.keyboardInterface.resetContextCache();
+      com.keyman.singleton.core.keyboardInterface.resetContextCache();
 
       var Lbo;
       this._BeepTimeout = 0;
@@ -784,7 +784,7 @@ namespace com.keyman.dom {
      * @param       {Object}      Ptarg      Target element
      */    
     _SetTargDir(Ptarg: HTMLElement) {
-      let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
+      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
       var elDir=(activeKeyboard && activeKeyboard.isRTL) ? 'rtl' : 'ltr';
 
       if(Ptarg) {
@@ -1484,9 +1484,9 @@ namespace com.keyman.dom {
       var device = util.device;
 
       // Set callbacks for proper feedback from web-core.
-      this.keyman.textProcessor.core.beepHandler = this.doBeep.bind(this);
-      this.keyman.textProcessor.core.warningLogger = console.warn.bind(console);
-      this.keyman.textProcessor.core.errorLogger = console.error.bind(console);
+      this.keyman.core.keyboardProcessor.beepHandler = this.doBeep.bind(this);
+      this.keyman.core.keyboardProcessor.warningLogger = console.warn.bind(console);
+      this.keyman.core.keyboardProcessor.errorLogger = console.error.bind(console);
 
       // Local function to convert relative to absolute URLs
       // with respect to the source path, server root and protocol 

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1484,9 +1484,9 @@ namespace com.keyman.dom {
       var device = util.device;
 
       // Set callbacks for proper feedback from web-core.
-      this.keyman.textProcessor.beepHandler = this.doBeep.bind(this);
-      this.keyman.textProcessor.warningLogger = console.warn.bind(console);
-      this.keyman.textProcessor.errorLogger = console.error.bind(console);
+      this.keyman.textProcessor.core.beepHandler = this.doBeep.bind(this);
+      this.keyman.textProcessor.core.warningLogger = console.warn.bind(console);
+      this.keyman.textProcessor.core.errorLogger = console.error.bind(console);
 
       // Local function to convert relative to absolute URLs
       // with respect to the source path, server root and protocol 

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -53,7 +53,7 @@ namespace com.keyman.dom {
       }
 
       // Stage 1 - track the true state of the keyboard's modifiers.
-      var prevModState = processor.modStateFlags, curModState = 0x0000;
+      var prevModState = processor.core.modStateFlags, curModState = 0x0000;
       var ctrlEvent = false, altEvent = false;
       
       let keyCodes = text.Codes.keyCodes;
@@ -116,8 +116,8 @@ namespace com.keyman.dom {
       curModState |= s.Lstates;
 
       // Stage 3 - Set our modifier state tracking variable and perform basic AltGr-related management.
-      s.LmodifierChange = processor.modStateFlags != curModState;
-      processor.modStateFlags = curModState;
+      s.LmodifierChange = processor.core.modStateFlags != curModState;
+      processor.core.modStateFlags = curModState;
 
       // For European keyboards, not all browsers properly send both key-up events for the AltGr combo.
       var altGrMask = modifierCodes['RALT'] | modifierCodes['LCTRL'];
@@ -153,7 +153,7 @@ namespace com.keyman.dom {
       if(activeKeyboard && activeKeyboard.isMnemonic) {
         // The following will never set a code corresponding to a modifier key, so it's fine to do this,
         // which may change the value of Lcode, here.
-        text.Processor.setMnemonicCode(s, e.getModifierState("Shift"), e.getModifierState("CapsLock"));
+        text.KeyboardProcessor.setMnemonicCode(s, e.getModifierState("Shift"), e.getModifierState("CapsLock"));
       }
 
       // The 0x6F used to be 0x60 - this adjustment now includes the chiral alt and ctrl modifiers in that check.
@@ -171,7 +171,7 @@ namespace com.keyman.dom {
         // Positional Layout
 
         /* 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard */
-        var Lbase = KeyMapping.languageMap[processor.baseLayout];
+        var Lbase = KeyMapping.languageMap[processor.core.baseLayout];
         if(Lbase && Lbase['k'+s.Lcode]) {
           s.Lcode=Lbase['k'+s.Lcode];
         }
@@ -254,7 +254,7 @@ namespace com.keyman.dom {
         return true;
       }
 
-      return processor.doModifierPress(Levent, false);
+      return processor.core.doModifierPress(Levent, false);
     }
 
     static keyPress(e: KeyboardEvent): boolean {

--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -1,4 +1,6 @@
 /// <reference path="defaultLayouts.ts" />
+/// <reference path="activeLayout.ts" />
+/// <reference path="../text/kbdInterface.ts" />
 
 namespace com.keyman.keyboards {
   /**

--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -289,7 +289,7 @@ namespace com.keyman.keyboards {
       // No pre-built layout available; time to start constructing it via defaults.
       // First, if we have non-default keys specified by the ['BK'] array, we've got
       // enough to work with to build a default layout.
-      let rawSpecifications: any = null;  // TODO:  better typing, same type as this.legacyLayoutSpec.
+      let rawSpecifications: any = null;  // TODO:  better typing, same type as this._legacyLayoutSpec.
       if(this._legacyLayoutSpec != null && this._legacyLayoutSpec['KLS']) { // KLS is only specified whenever there are non-default keys.
         rawSpecifications = this._legacyLayoutSpec;
       } else if(this._legacyLayoutSpec != null && this._legacyLayoutSpec['BK'] != null) {

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -110,8 +110,8 @@ namespace com.keyman.keyboards {
     }
 
     getActiveKeyboardName(): string {
-      let textProcessor = com.keyman.singleton.textProcessor;
-      return textProcessor.activeKeyboard ? textProcessor.activeKeyboard.id : '';
+      let core = com.keyman.singleton.core;
+      return core.activeKeyboard ? core.activeKeyboard.id : '';
     }
 
     getActiveLanguage(fullName?: boolean): string {
@@ -410,7 +410,7 @@ namespace com.keyman.keyboards {
       var util = keyman.util;
       var osk = keyman.osk;
 
-      let activeKeyboard = keyman.textProcessor.activeKeyboard;
+      let activeKeyboard = keyman.core.activeKeyboard;
 
       // Set default language code
       if(arguments.length < 2 || (!PLgCode)) {
@@ -464,7 +464,7 @@ namespace com.keyman.keyboards {
         }
       }
 
-      keyman.textProcessor.activeKeyboard = null;
+      keyman.core.activeKeyboard = null;
       this.activeStub = null;
 
       // Hide OSK and do not update keyboard list if using internal keyboard (desktops)
@@ -481,7 +481,7 @@ namespace com.keyman.keyboards {
       // Determine if the keyboard was previously loaded but is not active and use the prior load if so.
       for(Ln=0; Ln<this.keyboards.length; Ln++) { // I1511 - array prototype extended
         if(this.keyboards[Ln]['KI'] == PInternalName) {
-          keyman.textProcessor.activeKeyboard = new Keyboard(this.keyboards[Ln]);
+          keyman.core.activeKeyboard = new Keyboard(this.keyboards[Ln]);
           this.keymanweb.domManager._SetTargDir(this.keymanweb.domManager.getLastActiveElement());  // I2077 - LTR/RTL timing
         
           // and update the active stub
@@ -496,7 +496,7 @@ namespace com.keyman.keyboards {
         }
       }
 
-      if(keyman.textProcessor.activeKeyboard == null) {
+      if(keyman.core.activeKeyboard == null) {
         for(Ln=0; Ln<this.keyboardStubs.length; Ln++) { // I1511 - array prototype extended
           if((this.keyboardStubs[Ln]['KI'] == PInternalName) 
             && ((this.keyboardStubs[Ln]['KLC'] == PLgCode) || (PLgCode == '---'))) {
@@ -576,7 +576,7 @@ namespace com.keyman.keyboards {
         this.keymanweb.domManager._SetTargDir(this.keymanweb.domManager.getLastActiveElement());  // I2077 - LTR/RTL timing
       }
 
-      var Pk=keyman.textProcessor.activeKeyboard;  // I3319
+      var Pk=keyman.core.activeKeyboard;  // I3319
       if(Pk !== null)  // I3363 (Build 301)
         Pk = Pk.scriptObject;
         String.kmwEnableSupplementaryPlane(Pk && ((Pk['KS'] && (Pk['KS'] == 1)) || (Pk['KN'] == 'Hieroglyphic'))); // I3319
@@ -611,7 +611,7 @@ namespace com.keyman.keyboards {
       var kbdName = kbdStub['KN'];
 
       var manager = this;
-      let textProcessor = com.keyman.singleton.textProcessor;
+      let core = com.keyman.singleton.core;
 
       // Add a handler for cases where the new <script> block fails to load.
       Lscript.addEventListener('error', function() {
@@ -645,7 +645,7 @@ namespace com.keyman.keyboards {
           //Activate keyboard, if it's still the active stub.
           if(kbdStub == manager.activeStub) {
             manager.doBeforeKeyboardChange(kbd['KI'],kbdStub['KLC']);
-            textProcessor.activeKeyboard=new Keyboard(kbd);
+            core.activeKeyboard=new Keyboard(kbd);
 
             if(manager.keymanweb.domManager.getLastActiveElement() != null) { // TODO:  Resolve without need for the cast.
               manager.keymanweb.uiManager.justActivated = true; // TODO:  Resolve without need for the cast.
@@ -717,7 +717,7 @@ namespace com.keyman.keyboards {
      */    
     restoreCurrentKeyboard() {
       var stubs = this.keyboardStubs, i, n=stubs.length;
-      let textProcessor = com.keyman.singleton.textProcessor;
+      let core = com.keyman.singleton.core;
 
       // Do nothing if no stubs loaded
       if(stubs.length < 1) return;
@@ -739,7 +739,7 @@ namespace com.keyman.keyboards {
     
       // Sets the default stub (as specified with the `getSavedKeyboard` call) as active.
       // if((i < n) || (device.touchable && (this.activeKeyboard == null)))
-      if((i < n) || (textProcessor.activeKeyboard == null))
+      if((i < n) || (core.activeKeyboard == null))
       {
         this._SetActiveKeyboard(t[0],t[1],false);
         this.keymanweb.globalKeyboard = t[0];

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -125,7 +125,7 @@ if(!window['keyman']['initialized']) {
     function resetVKShift() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk.vkbd) {
-        keyman.textProcessor.core._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
+        keyman.core.keyboardProcessor._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
       }
     }
 

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -125,7 +125,7 @@ if(!window['keyman']['initialized']) {
     function resetVKShift() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk.vkbd) {
-        keyman.textProcessor._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
+        keyman.textProcessor.core._UpdateVKShift(null, 15, 0);  //this should be enabled !!!!! TODO
       }
     }
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -71,7 +71,7 @@ namespace com.keyman {
     domManager: dom.DOMManager;
     hotkeyManager: HotkeyManager;
     uiManager: UIManager;
-    textProcessor: text.InputProcessor;
+    core: text.InputProcessor;
     modelManager: text.prediction.ModelManager;
 
     touchAliasing: dom.DOMEventHandlers;
@@ -126,13 +126,13 @@ namespace com.keyman {
       }
       this._BrowserIsSafari = (navigator.userAgent.indexOf('AppleWebKit') >= 0);  // I732 END - Support for European underlying keyboards #1      
 
-      this.textProcessor = new text.InputProcessor({
+      this.core = new text.InputProcessor({
         baseLayout: baseLayout,
         variableStoreSerializer: new dom.VariableStoreCookieSerializer()
       });
 
       // Used by the embedded apps.
-      this['interface'] = this.textProcessor.keyboardInterface;
+      this['interface'] = this.core.keyboardInterface;
       
       this.modelManager = new text.prediction.ModelManager();
       this.osk = this['osk'] = new com.keyman.osk.OSKManager();
@@ -364,7 +364,7 @@ namespace com.keyman {
       if(k0) {
         kbd = new keyboards.Keyboard(k0);
       } else {
-        kbd = this.textProcessor.activeKeyboard;
+        kbd = this.core.activeKeyboard;
       }
 
       return kbd && kbd.isCJK;
@@ -382,7 +382,7 @@ namespace com.keyman {
       if(k0) {
         kbd = new keyboards.Keyboard(k0);
       } else {
-        kbd = this.textProcessor.activeKeyboard;
+        kbd = this.core.activeKeyboard;
       }
       return kbd.isChiral;
     }
@@ -464,7 +464,7 @@ namespace com.keyman {
       if(outputTarget) {
         outputTarget.resetContext();
       }
-      this.textProcessor.resetContext();
+      this.core.resetContext();
     };
 
     /**
@@ -473,7 +473,7 @@ namespace com.keyman {
      * Description  Set OSK to numeric layer if it exists
      */
     ['setNumericLayer']() {
-      this.textProcessor.core.setNumericLayer(this.util.device.coreSpec);
+      this.core.keyboardProcessor.setNumericLayer(this.util.device.coreSpec);
     };
 
     /**

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -7,7 +7,7 @@
 // Defines the web-page interface object.
 /// <reference path="singleton.ts" />
 // Defines the core text processor.
-/// <reference path="text/processor.ts" />
+/// <reference path="text/inputProcessor.ts" />
 // Extends KeyboardInterface with DOM-oriented offerings.
 /// <reference path="text/domKbdInterface.ts" />
 // Defines the web-page interface object.
@@ -71,7 +71,7 @@ namespace com.keyman {
     domManager: dom.DOMManager;
     hotkeyManager: HotkeyManager;
     uiManager: UIManager;
-    textProcessor: text.Processor;
+    textProcessor: text.InputProcessor;
     modelManager: text.prediction.ModelManager;
 
     touchAliasing: dom.DOMEventHandlers;
@@ -126,7 +126,7 @@ namespace com.keyman {
       }
       this._BrowserIsSafari = (navigator.userAgent.indexOf('AppleWebKit') >= 0);  // I732 END - Support for European underlying keyboards #1      
 
-      this.textProcessor = new text.Processor({
+      this.textProcessor = new text.InputProcessor({
         baseLayout: baseLayout,
         variableStoreSerializer: new dom.VariableStoreCookieSerializer()
       });
@@ -473,7 +473,7 @@ namespace com.keyman {
      * Description  Set OSK to numeric layer if it exists
      */
     ['setNumericLayer']() {
-      this.textProcessor.setNumericLayer(this.util.device.coreSpec);
+      this.textProcessor.core.setNumericLayer(this.util.device.coreSpec);
     };
 
     /**

--- a/web/source/kmwdebug.js
+++ b/web/source/kmwdebug.js
@@ -12,7 +12,7 @@ if(!window['keyman']['initialized']) {
 
   (function() 
   {
-    var keymanweb=window['keyman'],util=keymanweb['util'],kbdInterface=keymanweb.textProcessor.kbdInterface;
+    var keymanweb=window['keyman'],util=keymanweb['util'],kbdInterface=keymanweb.core.kbdInterface;
     
     keymanweb._LogDebug = true; //false; // typeof(debug) == 'undefined' ? true : debug;
     if(util.device.formFactor == 'phone')return; // I3363 (Build 301)

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -354,10 +354,10 @@ namespace com.keyman.text {
    *  @param  {string}  keyName   key identifier
    **/            
   keymanweb['executePopupKey'] = function(keyName: string) {
-      let processor = (<KeymanBase> keymanweb).textProcessor;
+      let core = (<KeymanBase> keymanweb).core;
 
       var origArg = keyName;
-      if(!keymanweb.textProcessor.activeKeyboard || !osk.vkbd) {
+      if(!keymanweb.core.activeKeyboard || !osk.vkbd) {
         return false;
       }
 
@@ -367,15 +367,15 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues      
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
       
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.core.layerId);
+      var t=keyName.split('-'),layer=(t.length>1?t[0]:core.keyboardProcessor.layerId);
       keyName=t[t.length-1];
       if(layer == 'undefined') {
-        layer=processor.core.layerId;
+        layer=core.keyboardProcessor.layerId;
       }
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.core.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=core.keyboardProcessor.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -427,20 +427,20 @@ namespace com.keyman.text {
       };
 
       // Process modifier key action
-      if(processor.core.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
+      if(core.keyboardProcessor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
         return true;      
       }
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
       // we can handle many other pre-processing steps the same way with this common method.
-      processor.core.setSyntheticEventDefaults(Lkc);
+      core.keyboardProcessor.setSyntheticEventDefaults(Lkc);
 
       //if(!Lkc.Lcode) return false;  // Value is now zero if not known (Build 347)
       //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014      
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          processor.core.selectLayer(Lkc);
+          core.keyboardProcessor.selectLayer(Lkc);
         }
         return false;
       }
@@ -470,7 +470,7 @@ namespace com.keyman.text {
    **/            
   keymanweb['executeHardwareKeystroke'] = function(code, shift, lstates = 0) {
     let keyman = com.keyman.singleton;
-    if(!keyman.textProcessor.activeKeyboard || code == 0) {
+    if(!keyman.core.activeKeyboard || code == 0) {
       return false;
     }
 
@@ -499,7 +499,7 @@ namespace com.keyman.text {
     try {
       // Now that we've manually constructed a proper keystroke-sourced KeyEvent, pass control
       // off to the processor for its actual execution.
-      return keyman.textProcessor.processKeyEvent(Lkc); // Lack of second argument -> `usingOSK == false`
+      return keyman.core.processKeyEvent(Lkc); // Lack of second argument -> `usingOSK == false`
     } catch (err) {
       console.error(err.message, err);
       return false;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -367,15 +367,15 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues      
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
       
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.layerId);
+      var t=keyName.split('-'),layer=(t.length>1?t[0]:processor.core.layerId);
       keyName=t[t.length-1];
       if(layer == 'undefined') {
-        layer=processor.layerId;
+        layer=processor.core.layerId;
       }
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=processor.core.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 
@@ -427,20 +427,20 @@ namespace com.keyman.text {
       };
 
       // Process modifier key action
-      if(processor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
+      if(processor.core.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
         return true;      
       }
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
       // we can handle many other pre-processing steps the same way with this common method.
-      processor.setSyntheticEventDefaults(Lkc);
+      processor.core.setSyntheticEventDefaults(Lkc);
 
       //if(!Lkc.Lcode) return false;  // Value is now zero if not known (Build 347)
       //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014      
       if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
-          processor.selectLayer(Lkc);
+          processor.core.selectLayer(Lkc);
         }
         return false;
       }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -324,7 +324,7 @@ namespace com.keyman.osk {
         suggestionText = '\xa0';  // default:  nbsp.
       } else {
         // Default the LTR ordering to match that of the active keyboard.
-        let activeKeyboard = keyman.textProcessor.activeKeyboard;
+        let activeKeyboard = keyman.core.activeKeyboard;
         let rtl = activeKeyboard && activeKeyboard.isRTL;
         let orderCode = rtl ? 0x202e /* RTL */ : 0x202d /* LTR */;
         suggestionText = String.fromCharCode(orderCode) + suggestion.displayAs;
@@ -373,7 +373,7 @@ namespace com.keyman.osk {
        * the elements are inserted for RTL.  This allows the banner to be RTL
        * for visuals/UI while still being internally LTR.
        */
-      let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
+      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
       let rtl = activeKeyboard && activeKeyboard.isRTL;
       for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
         let indexToInsert = rtl ? SuggestionBanner.SUGGESTION_LIMIT - i -1 : i;

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -146,7 +146,7 @@ namespace com.keyman.osk {
       let util = keymanweb.util;
       let device = util.device;
 
-      var activeKeyboard = keymanweb.textProcessor.activeKeyboard;
+      var activeKeyboard = keymanweb.core.activeKeyboard;
 
       // If _Load called before OSK is ready, must wait and call again
       if(this._Box == null) {
@@ -336,8 +336,8 @@ namespace com.keyman.osk {
       bar.className='kmw-title-bar';
       bar.onmousedown=this._VMoveMouseDown;
 
-      if(keymanweb.textProcessor.activeKeyboard) {
-        title=keymanweb.textProcessor.activeKeyboard.name;
+      if(keymanweb.core.activeKeyboard) {
+        title=keymanweb.core.activeKeyboard.name;
       }
       var Ltitle=util._CreateElement('span');
       Ltitle.className='kmw-title-bar-caption';
@@ -1231,7 +1231,7 @@ namespace com.keyman.osk {
       }
 
       // Never display the OSK for desktop browsers unless KMW element is focused, and a keyboard selected
-      if((!device.touchable) && (keymanweb.textProcessor.activeKeyboard == null || !this._Enabled)) {
+      if((!device.touchable) && (keymanweb.core.activeKeyboard == null || !this._Enabled)) {
         return;
       }
 

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -2,9 +2,9 @@ namespace com.keyman.osk {
   export class PreProcessor {
     static _GetClickEventProperties(e: keyboards.ActiveKey, Lelem: HTMLElement): text.KeyEvent {
       let keyman = com.keyman.singleton;
-      let processor = keyman.textProcessor;
+      let core = keyman.core;
 
-      var activeKeyboard = processor.activeKeyboard;
+      var activeKeyboard = core.activeKeyboard;
       let formFactor = keyman.util.device.formFactor;
 
       // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
@@ -14,7 +14,7 @@ namespace com.keyman.osk {
       // Start:  mirrors _GetKeyEventProperties
 
       // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-      var keyShiftState = processor.core.getModifierState(layer);
+      var keyShiftState = core.keyboardProcessor.getModifierState(layer);
 
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: text.KeyEvent = {
@@ -37,11 +37,11 @@ namespace com.keyman.osk {
         case 'K_CAPS':
         case 'K_NUMLOCK':
         case 'K_SCROLL':
-          processor.core.stateKeys[keyName] = ! processor.core.stateKeys[keyName];
+          core.keyboardProcessor.stateKeys[keyName] = ! core.keyboardProcessor.stateKeys[keyName];
       }
 
       // Performs common pre-analysis for both 'native' and 'embedded' OSK key & subkey input events.
-      processor.core.setSyntheticEventDefaults(Lkc);
+      core.keyboardProcessor.setSyntheticEventDefaults(Lkc);
 
       // End - mirrors _GetKeyEventProperties
 
@@ -51,7 +51,7 @@ namespace com.keyman.osk {
         if(Lkc.Lcode != text.Codes.keyCodes['K_SPACE']) { // exception required, March 2013
           // Jan 2019 - interesting that 'K_SPACE' also affects the caps-state check...
           Lkc.vkCode = Lkc.Lcode;
-          text.KeyboardProcessor.setMnemonicCode(Lkc, layer.indexOf('shift') != -1, processor.core.stateKeys['K_CAPS']);
+          text.KeyboardProcessor.setMnemonicCode(Lkc, layer.indexOf('shift') != -1, core.keyboardProcessor.stateKeys['K_CAPS']);
         }
       } else {
         Lkc.vkCode=Lkc.Lcode;
@@ -128,7 +128,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      let retVal = keyman.textProcessor.processKeyEvent(Lkc);
+      let retVal = keyman.core.processKeyEvent(Lkc);
 
       return retVal;
     }

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -14,7 +14,7 @@ namespace com.keyman.osk {
       // Start:  mirrors _GetKeyEventProperties
 
       // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-      var keyShiftState = processor.getModifierState(layer);
+      var keyShiftState = processor.core.getModifierState(layer);
 
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: text.KeyEvent = {
@@ -37,11 +37,11 @@ namespace com.keyman.osk {
         case 'K_CAPS':
         case 'K_NUMLOCK':
         case 'K_SCROLL':
-          processor.stateKeys[keyName] = ! processor.stateKeys[keyName];
+          processor.core.stateKeys[keyName] = ! processor.core.stateKeys[keyName];
       }
 
       // Performs common pre-analysis for both 'native' and 'embedded' OSK key & subkey input events.
-      processor.setSyntheticEventDefaults(Lkc);
+      processor.core.setSyntheticEventDefaults(Lkc);
 
       // End - mirrors _GetKeyEventProperties
 
@@ -51,7 +51,7 @@ namespace com.keyman.osk {
         if(Lkc.Lcode != text.Codes.keyCodes['K_SPACE']) { // exception required, March 2013
           // Jan 2019 - interesting that 'K_SPACE' also affects the caps-state check...
           Lkc.vkCode = Lkc.Lcode;
-          text.Processor.setMnemonicCode(Lkc, layer.indexOf('shift') != -1, processor.stateKeys['K_CAPS']);
+          text.KeyboardProcessor.setMnemonicCode(Lkc, layer.indexOf('shift') != -1, processor.core.stateKeys['K_CAPS']);
         }
       } else {
         Lkc.vkCode=Lkc.Lcode;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -211,7 +211,7 @@ namespace com.keyman.osk {
         ts.fontSize=spec['fontsize'];
       }
 
-      let activeKeyboard = com.keyman.singleton.textProcessor.activeKeyboard;
+      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
 
       // For some reason, fonts will sometimes 'bug out' for the embedded iOS page if we
       // instead assign fontFamily to the existing style 'ts'.  (Occurs in iOS 12.)
@@ -427,13 +427,13 @@ namespace com.keyman.osk {
 
     getId(osk: VisualKeyboard): string {
       let spec = this.spec;
-      let processor = com.keyman.singleton.textProcessor;
+      let core = com.keyman.singleton.core;
       // Create (temporarily) unique ID by prefixing 'popup-' to actual key ID
       if(typeof(this.layer) == 'string' && this.layer != '') {
         return 'popup-'+this.layer+'-'+spec['id'];
       } else {
         // We only create subkeys when they're needed - the currently-active layer should be fine.
-        return 'popup-' + processor.core.layerId + '-'+spec['id'];
+        return 'popup-' + core.keyboardProcessor.layerId + '-'+spec['id'];
       }
     }
 
@@ -605,7 +605,7 @@ namespace com.keyman.osk {
 
       let keyman = com.keyman.singleton;
       // Ensure the OSK's current layer is kept up to date.
-      keyman.textProcessor.core.layerStore.handler = this.layerChangeHandler;
+      keyman.core.keyboardProcessor.layerStore.handler = this.layerChangeHandler;
 
       let util = keyman.util;
       this.device = device = device || util.device;
@@ -1003,8 +1003,6 @@ namespace com.keyman.osk {
      *
      **/
     release: (e: TouchEvent) => void = function(this: VisualKeyboard, e: TouchEvent) {
-      let Processor = com.keyman.singleton.textProcessor;
-
       // Prevent incorrect multi-touch behaviour if native or device popup visible
       var sk = document.getElementById('kmw-popup-keys'), t = this.currentTarget;
 
@@ -1394,7 +1392,7 @@ namespace com.keyman.osk {
      */
     _UpdateVKShiftStyle(layerId?: string) {
       var i, n, layer=null, layerElement=null;
-      let Processor = com.keyman.singleton.textProcessor;
+      let core = com.keyman.singleton.core;
 
       if(layerId) {
         for(n=0; n<this.layers.length; n++) {
@@ -1421,7 +1419,7 @@ namespace com.keyman.osk {
           continue;
         }
 
-        keys[i]['sp'] = Processor.core.stateKeys[states[i]] ? keyboards.Layouts.buttonClasses['SHIFT-ON'] : keyboards.Layouts.buttonClasses['SHIFT'];
+        keys[i]['sp'] = core.keyboardProcessor.stateKeys[states[i]] ? keyboards.Layouts.buttonClasses['SHIFT-ON'] : keyboards.Layouts.buttonClasses['SHIFT'];
         let keyId = layerId+'-'+states[i]
         var btn = document.getElementById(keyId);
 
@@ -2056,7 +2054,7 @@ namespace com.keyman.osk {
       let keymanweb = com.keyman.singleton;
       let util = keymanweb.util;
 
-      var activeKeyboard = keymanweb.textProcessor.activeKeyboard;
+      var activeKeyboard = keymanweb.core.activeKeyboard;
       var activeStub: com.keyman.keyboards.KeyboardStub = keymanweb.keyboardManager.activeStub;
 
       // Do not do anything if a null stub
@@ -2160,7 +2158,7 @@ namespace com.keyman.osk {
      */
     static buildDocumentationKeyboard(PInternalName,Pstatic,argFormFactor,argLayerId): HTMLElement { // I777
       let keymanweb = com.keyman.singleton;
-      var PKbd=keymanweb.textProcessor.activeKeyboard,Ln,
+      var PKbd=keymanweb.core.activeKeyboard,Ln,
           formFactor=(typeof(argFormFactor) == 'undefined' ? 'desktop' : argFormFactor),
           layerId=(typeof(argLayerId) == 'undefined' ? 'default' : argLayerId),
           device = new Device();

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -433,7 +433,7 @@ namespace com.keyman.osk {
         return 'popup-'+this.layer+'-'+spec['id'];
       } else {
         // We only create subkeys when they're needed - the currently-active layer should be fine.
-        return 'popup-' + processor.layerId + '-'+spec['id'];
+        return 'popup-' + processor.core.layerId + '-'+spec['id'];
       }
     }
 
@@ -605,7 +605,7 @@ namespace com.keyman.osk {
 
       let keyman = com.keyman.singleton;
       // Ensure the OSK's current layer is kept up to date.
-      keyman.textProcessor.layerStore.handler = this.layerChangeHandler;
+      keyman.textProcessor.core.layerStore.handler = this.layerChangeHandler;
 
       let util = keyman.util;
       this.device = device = device || util.device;
@@ -1421,7 +1421,7 @@ namespace com.keyman.osk {
           continue;
         }
 
-        keys[i]['sp'] = Processor.stateKeys[states[i]] ? keyboards.Layouts.buttonClasses['SHIFT-ON'] : keyboards.Layouts.buttonClasses['SHIFT'];
+        keys[i]['sp'] = Processor.core.stateKeys[states[i]] ? keyboards.Layouts.buttonClasses['SHIFT-ON'] : keyboards.Layouts.buttonClasses['SHIFT'];
         let keyId = layerId+'-'+states[i]
         var btn = document.getElementById(keyId);
 

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -16,12 +16,12 @@ namespace com.keyman.text {
       this.kbdProcessor = new KeyboardProcessor(options);
     }
 
-    public get core(): KeyboardProcessor {
+    public get keyboardProcessor(): KeyboardProcessor {
       return this.kbdProcessor;
     }
 
     public get keyboardInterface(): text.KeyboardInterface {
-      return this.core.keyboardInterface;
+      return this.keyboardProcessor.keyboardInterface;
     }
 
     public get activeKeyboard(): keyboards.Keyboard {
@@ -57,14 +57,14 @@ namespace com.keyman.text {
       if((formFactor == FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
         // If it's a desktop OSK style and this triggers a layer change,
         // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
-        if(this.core.selectLayer(keyEvent)) {
+        if(this.keyboardProcessor.selectLayer(keyEvent)) {
           return true;
         }
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
       // of state management.
-      if(!fromOSK && this.core.doModifierPress(keyEvent, !fromOSK)) {
+      if(!fromOSK && this.keyboardProcessor.doModifierPress(keyEvent, !fromOSK)) {
         return true;
       }
 
@@ -86,11 +86,11 @@ namespace com.keyman.text {
       // // ...end I3363 (Build 301)
 
       let preInputMock = Mock.from(outputTarget);
-      let ruleBehavior = this.core.processKeystroke(keyEvent, outputTarget);
+      let ruleBehavior = this.keyboardProcessor.processKeystroke(keyEvent, outputTarget);
 
       // Swap layer as appropriate.
       if(keyEvent.kNextLayer) {
-        this.core.selectLayer(keyEvent);
+        this.keyboardProcessor.selectLayer(keyEvent);
       }
       
       // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
@@ -116,7 +116,7 @@ namespace com.keyman.text {
 
               let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, outputTarget.getElement());
               altEvent.Ltarg = mock;
-              let alternateBehavior = this.core.processKeystroke(altEvent, mock);
+              let alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
               if(alternateBehavior) {
                 // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
                 //       so a user should never have intended to type it.  Should probably renormalize 
@@ -135,7 +135,7 @@ namespace com.keyman.text {
 
         // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
         // by the actual keystroke occur.
-        ruleBehavior.finalize(this.core);
+        ruleBehavior.finalize(this.keyboardProcessor);
 
         // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
         //
@@ -183,7 +183,7 @@ namespace com.keyman.text {
 
     public resetContext() {
       let keyman = com.keyman.singleton;
-      this.core.resetContext();
+      this.keyboardProcessor.resetContext();
 
       if(keyman.modelManager) {
         keyman.modelManager.invalidateContext();

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -1,0 +1,193 @@
+/// <reference path="keyboardProcessor.ts" />
+
+namespace com.keyman.text {
+  export class InputProcessor {
+    public static readonly DEFAULT_OPTIONS: ProcessorInitOptions = {
+      baseLayout: 'us'
+    }
+
+    kbdProcessor: KeyboardProcessor;
+
+    constructor(options?: ProcessorInitOptions) {
+      if(!options) {
+        options = InputProcessor.DEFAULT_OPTIONS;
+      }
+
+      this.kbdProcessor = new KeyboardProcessor(options);
+    }
+
+    public get core(): KeyboardProcessor {
+      return this.kbdProcessor;
+    }
+
+    public get keyboardInterface(): text.KeyboardInterface {
+      return this.core.keyboardInterface;
+    }
+
+    public get activeKeyboard(): keyboards.Keyboard {
+      return this.keyboardInterface.activeKeyboard;
+    }
+
+    public set activeKeyboard(keyboard: keyboards.Keyboard) {
+      this.keyboardInterface.activeKeyboard = keyboard;
+
+      // All old deadkeys and keyboard-specific cache should immediately be invalidated
+      // on a keyboard change.
+      this.resetContext();
+    }
+
+        /**
+     * Simulate a keystroke according to the touched keyboard button element
+     *
+     * Handles default output and keyboard processing for both OSK and physical keystrokes.
+     * 
+     * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
+     */
+    processKeyEvent(keyEvent: KeyEvent): boolean {
+      let keyman = com.keyman.singleton;
+      let formFactor = keyEvent.device.formFactor;
+
+      // Determine the current target for text output and create a "mock" backup
+      // of its current, pre-input state.  Current, long-existing assumption - it's DOM-backed.
+      let outputTarget = keyEvent.Ltarg as dom.targets.OutputTarget;
+      let fromOSK = keyEvent.isSynthetic;
+
+      // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
+      // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
+      if((formFactor == FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
+        // If it's a desktop OSK style and this triggers a layer change,
+        // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
+        if(this.core.selectLayer(keyEvent)) {
+          return true;
+        }
+      }
+
+      // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
+      // of state management.
+      if(!fromOSK && this.core.doModifierPress(keyEvent, !fromOSK)) {
+        return true;
+      }
+
+      // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
+      // If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
+      // We check the first condition here, while the prediction UI handles the second through the try__() methods below.
+      if(keyman.modelManager.enabled) {
+        // The following code relies on JS's logical operator "short-circuit" properties to prevent unwanted triggering of the second condition.
+
+        // Can the suggestion UI revert a recent suggestion?  If so, do that and swallow the backspace.
+        if((keyEvent.kName == "K_BKSP" || keyEvent.Lcode == Codes.keyCodes["K_BKSP"]) && keyman.modelManager.tryRevertSuggestion()) {
+          return;
+          // Can the suggestion UI accept an existing suggestion?  If so, do that and swallow the space character.
+        } else if((keyEvent.kName == "K_SPACE" || keyEvent.Lcode == Codes.keyCodes["K_SPACE"]) && keyman.modelManager.tryAcceptSuggestion('space')) {
+          return;
+        }
+      }
+
+      // // ...end I3363 (Build 301)
+
+      let preInputMock = Mock.from(outputTarget);
+      let ruleBehavior = this.core.processKeystroke(keyEvent, outputTarget);
+
+      // Swap layer as appropriate.
+      if(keyEvent.kNextLayer) {
+        this.core.selectLayer(keyEvent);
+      }
+      
+      // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
+      if(ruleBehavior != null) {
+        let alternates: Alternate[];
+
+        // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
+        // Also, don't do fat-finger stuff if predictive text isn't enabled.
+        if(keyman.modelManager.enabled && !ruleBehavior.triggersDefaultCommand) {
+          // Note - we don't yet do fat-fingering with longpress keys.
+          if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
+            let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
+            alternates = [];
+    
+            for(let pair of keyEvent.keyDistribution) {
+              let mock = Mock.from(preInputMock);
+              
+              let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
+              if(!altKey) {
+                console.warn("Potential fat-finger key could not be found in layer!");
+                continue;
+              }
+
+              let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, outputTarget.getElement());
+              altEvent.Ltarg = mock;
+              let alternateBehavior = this.core.processKeystroke(altEvent, mock);
+              if(alternateBehavior) {
+                // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
+                //       so a user should never have intended to type it.  Should probably renormalize 
+                //       the distribution afterward, though...
+                
+                let transform: Transform = alternateBehavior.transcription.transform;
+                
+                // Ensure that the alternate's token id matches that of the current keystroke, as we only
+                // record the matched rule's context (since they match)
+                transform.id = ruleBehavior.transcription.token;
+                alternates.push({sample: transform, 'p': pair.p});
+              }
+            }
+          }
+        }
+
+        // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
+        // by the actual keystroke occur.
+        ruleBehavior.finalize(this.core);
+
+        // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
+        //
+        // TODO:  This check should be done IN a dom module, not here in web-core space.  This place is closer 
+        //        to that goal than it previously was, at least.
+        let ruleTransform = ruleBehavior.transcription.transform;
+        if(ruleTransform.insert != "" || ruleTransform.deleteLeft > 0 || ruleTransform.deleteRight > 0) {
+          if(outputTarget.getElement() == dom.DOMEventHandlers.states.activeElement) {
+            dom.DOMEventHandlers.states.changed = true;
+          }
+        }
+
+        // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
+        
+        // Notify the ModelManager of new input - it's predictive text time!
+        ruleBehavior.transcription.alternates = alternates;
+        // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
+        keyman.modelManager.predict(ruleBehavior.transcription);
+
+        // KMEA and KMEI (embedded mode) use direct insertion of the character string
+        if(keyman.isEmbedded) {
+          // A special embedded callback used to setup direct callbacks to app-native code.
+          keyman['oninserttext'](ruleTransform.deleteLeft, ruleTransform.insert, ruleTransform.deleteRight);
+          keyman.refreshElementContent(outputTarget.getElement());
+        }
+
+        // Text did not change (thus, no text "input") if we tabbed or merely moved the caret.
+        if(!ruleBehavior.triggersDefaultCommand) {
+          // For DOM-aware targets, this will trigger a DOM event page designers may listen for.
+          outputTarget.doInputEvent();
+        }
+      }
+
+      /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
+
+      // TODO:  rework the return value to be `ruleBehavior` instead.  Functions that call this one are
+      //        the ones that should worry about event handler returns, etc.  Not this one.
+      //
+      //        They should also be the ones to handle the TODOs seen earlier in this function -
+      //        once THOSE are properly relocated.  (They're too DOM-heavy to remain in web-core.)
+
+      // Only return true (for the eventual event handler's return value) if we didn't match a rule.
+      return ruleBehavior == null;
+    }
+
+    public resetContext() {
+      let keyman = com.keyman.singleton;
+      this.core.resetContext();
+
+      if(keyman.modelManager) {
+        keyman.modelManager.invalidateContext();
+      }
+    }
+  }
+}

--- a/web/source/text/kbdInterface.ts
+++ b/web/source/text/kbdInterface.ts
@@ -917,7 +917,7 @@ namespace com.keyman.text {
      * Description  Encapsulates calls to keyboard input processing.
      * @returns     {number}        0 if no match is made, otherwise 1.
      */
-    processKeystroke(outputTarget: OutputTarget, keystroke: KeyEvent/*|com.keyman.text.LegacyKeyEvent*/): RuleBehavior {
+    processKeystroke(outputTarget: OutputTarget, keystroke: KeyEvent): RuleBehavior {
       // Clear internal state tracking data from prior keystrokes.
       if(!outputTarget) {
         throw "No target specified for keyboard output!";

--- a/web/source/text/keyEvent.ts
+++ b/web/source/text/keyEvent.ts
@@ -1,4 +1,5 @@
 /// <reference path="engineDeviceSpec.ts" />
+/// <reference path="outputTarget.ts" />
 
 namespace com.keyman.text {
   // Represents a probability distribution over a keyboard's keys.

--- a/web/source/text/keyboardProcessor.ts
+++ b/web/source/text/keyboardProcessor.ts
@@ -27,7 +27,7 @@ namespace com.keyman.text {
     variableStoreSerializer?: VariableStoreSerializer;
   }
 
-  export class Processor {
+  export class KeyboardProcessor {
     public static readonly DEFAULT_OPTIONS: ProcessorInitOptions = {
       baseLayout: 'us'
     }
@@ -56,7 +56,7 @@ namespace com.keyman.text {
 
     constructor(options?: ProcessorInitOptions) {
       if(!options) {
-        options = Processor.DEFAULT_OPTIONS;
+        options = KeyboardProcessor.DEFAULT_OPTIONS;
       }
 
       this.baseLayout = options.baseLayout || 'us'; // default BaseLayout
@@ -248,151 +248,6 @@ namespace com.keyman.text {
       }
 
       return matchBehavior;
-    }
-
-    /**
-     * Simulate a keystroke according to the touched keyboard button element
-     *
-     * Handles default output and keyboard processing for both OSK and physical keystrokes.
-     * 
-     * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
-     */
-    processKeyEvent(keyEvent: KeyEvent): boolean {
-      let keyman = com.keyman.singleton;
-      let formFactor = keyEvent.device.formFactor;
-
-      // Determine the current target for text output and create a "mock" backup
-      // of its current, pre-input state.  Current, long-existing assumption - it's DOM-backed.
-      let outputTarget = keyEvent.Ltarg as dom.targets.OutputTarget;
-      let fromOSK = keyEvent.isSynthetic;
-
-      // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
-      // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
-      if((formFactor == FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
-        // If it's a desktop OSK style and this triggers a layer change,
-        // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
-        if(this.selectLayer(keyEvent)) {
-          return true;
-        }
-      }
-
-      // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.
-      if(!fromOSK && this.doModifierPress(keyEvent, !fromOSK)) {
-        return true;
-      }
-
-      // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
-      // If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
-      // We check the first condition here, while the prediction UI handles the second through the try__() methods below.
-      if(keyman.modelManager.enabled) {
-        // The following code relies on JS's logical operator "short-circuit" properties to prevent unwanted triggering of the second condition.
-
-        // Can the suggestion UI revert a recent suggestion?  If so, do that and swallow the backspace.
-        if((keyEvent.kName == "K_BKSP" || keyEvent.Lcode == Codes.keyCodes["K_BKSP"]) && keyman.modelManager.tryRevertSuggestion()) {
-          return;
-          // Can the suggestion UI accept an existing suggestion?  If so, do that and swallow the space character.
-        } else if((keyEvent.kName == "K_SPACE" || keyEvent.Lcode == Codes.keyCodes["K_SPACE"]) && keyman.modelManager.tryAcceptSuggestion('space')) {
-          return;
-        }
-      }
-
-      // // ...end I3363 (Build 301)
-
-      let preInputMock = Mock.from(outputTarget);
-      let ruleBehavior = this.processKeystroke(keyEvent, outputTarget);
-
-      // Swap layer as appropriate.
-      if(keyEvent.kNextLayer) {
-        this.selectLayer(keyEvent);
-      }
-      
-      // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
-      if(ruleBehavior != null) {
-        let alternates: Alternate[];
-
-        // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
-        // Also, don't do fat-finger stuff if predictive text isn't enabled.
-        if(keyman.modelManager.enabled && !ruleBehavior.triggersDefaultCommand) {
-          // Note - we don't yet do fat-fingering with longpress keys.
-          if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
-            let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
-            alternates = [];
-    
-            for(let pair of keyEvent.keyDistribution) {
-              let mock = Mock.from(preInputMock);
-              
-              let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
-              if(!altKey) {
-                console.warn("Potential fat-finger key could not be found in layer!");
-                continue;
-              }
-
-              let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, outputTarget.getElement());
-              altEvent.Ltarg = mock;
-              let alternateBehavior = this.processKeystroke(altEvent, mock);
-              if(alternateBehavior) {
-                // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,
-                //       so a user should never have intended to type it.  Should probably renormalize 
-                //       the distribution afterward, though...
-                
-                let transform: Transform = alternateBehavior.transcription.transform;
-                
-                // Ensure that the alternate's token id matches that of the current keystroke, as we only
-                // record the matched rule's context (since they match)
-                transform.id = ruleBehavior.transcription.token;
-                alternates.push({sample: transform, 'p': pair.p});
-              }
-            }
-          }
-        }
-
-        // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
-        // by the actual keystroke occur.
-        ruleBehavior.finalize(this);
-
-        // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
-        //
-        // TODO:  This check should be done IN a dom module, not here in web-core space.  This place is closer 
-        //        to that goal than it previously was, at least.
-        let ruleTransform = ruleBehavior.transcription.transform;
-        if(ruleTransform.insert != "" || ruleTransform.deleteLeft > 0 || ruleTransform.deleteRight > 0) {
-          if(outputTarget.getElement() == dom.DOMEventHandlers.states.activeElement) {
-            dom.DOMEventHandlers.states.changed = true;
-          }
-        }
-
-        // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
-        
-        // Notify the ModelManager of new input - it's predictive text time!
-        ruleBehavior.transcription.alternates = alternates;
-        // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
-        keyman.modelManager.predict(ruleBehavior.transcription);
-
-        // KMEA and KMEI (embedded mode) use direct insertion of the character string
-        if(keyman.isEmbedded) {
-          // A special embedded callback used to setup direct callbacks to app-native code.
-          keyman['oninserttext'](ruleTransform.deleteLeft, ruleTransform.insert, ruleTransform.deleteRight);
-          keyman.refreshElementContent(outputTarget.getElement());
-        }
-
-        // Text did not change (thus, no text "input") if we tabbed or merely moved the caret.
-        if(!ruleBehavior.triggersDefaultCommand) {
-          // For DOM-aware targets, this will trigger a DOM event page designers may listen for.
-          outputTarget.doInputEvent();
-        }
-      }
-
-      /* I732 END - 13/03/2007 MCD: End Positional Layout support in OSK */
-
-      // TODO:  rework the return value to be `ruleBehavior` instead.  Functions that call this one are
-      //        the ones that should worry about event handler returns, etc.  Not this one.
-      //
-      //        They should also be the ones to handle the TODOs seen earlier in this function -
-      //        once THOSE are properly relocated.  (They're too DOM-heavy to remain in web-core.)
-
-      // Only return true (for the eventual event handler's return value) if we didn't match a rule.
-      return ruleBehavior == null;
     }
 
     // FIXME:  makes some bad assumptions.
@@ -662,7 +517,6 @@ namespace com.keyman.text {
 
       // Change layer and refresh OSK
       this.updateLayer(keyEvent, nextLayer);
-      com.keyman.singleton.osk._Show();
 
       return true;
     }
@@ -808,15 +662,10 @@ namespace com.keyman.text {
     }
 
     resetContext() {
-      let keyman = com.keyman.singleton;
       this.layerId = 'default';
 
       this.keyboardInterface.resetContextCache();
       this._UpdateVKShift(null, 15, 0);
-      
-      if(keyman.modelManager) {
-        keyman.modelManager.invalidateContext();
-      }
     };
 
     setNumericLayer(device: EngineDeviceSpec) {

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -1,5 +1,5 @@
 // Defines the text processing KMW core.
-///<reference path="../processor.ts" />
+///<reference path="../keyboardProcessor.ts" />
 // Defines the LMLayer's outer shell
 ///<reference path="../../includes/lmlayer.ts" />
 // Defines the ModelManager and its related types.

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -38,7 +38,7 @@ namespace com.keyman.text {
      */
     warningLog?: string;
 
-    finalize(processor: Processor) {
+    finalize(processor: KeyboardProcessor) {
       let outputTarget = this.transcription.keystroke.Ltarg;
 
       if(processor.beepHandler && this.beep) {

--- a/web/testing/chirality/chirality.js
+++ b/web/testing/chirality/chirality.js
@@ -42,7 +42,7 @@ function Keyboard_chirality() {
   };
   this.g0 = function (t, e) {
     var k = KeymanWeb, r = 0, m = 0;
-    var Processor = keyman.textProcessor;
+    var core = keyman.core;
     var Constants = com.keyman.text.Codes;
     
     // Handwritten time!
@@ -54,7 +54,7 @@ function Keyboard_chirality() {
     for(var i = 0; i < layers.length; i++) {
       // Obtain the modifier code to match for the selected layer.
       // The following uses a non-public property potentially subject to change in the future.
-      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | Processor.getModifierState(layers[i]);
+      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | core.keyboardProcessor.getModifierState(layers[i]);
       var layer = layers[i];
       
       for(var key=0; key < kls[layer].length; key++) {

--- a/web/testing/regression-tests/src/test-runner.js
+++ b/web/testing/regression-tests/src/test-runner.js
@@ -122,7 +122,7 @@ var testRunner = {
       })
       .then(function() {
         console.log('Starting test for '+id);
-        keyman.textProcessor.keyboardInterface.registerStub({
+        keyman.core.keyboardInterface.registerStub({
           'KN': 'Stub',
           'KI': 'Keyboard_'+id,
           'KL': 'en',
@@ -272,7 +272,7 @@ var testRunner = {
     if(test !== undefined) {
       //console.log('Running test '+id+':'+index);
       try {
-        keyman.textProcessor.keyboardInterface.resetContext();
+        keyman.core.keyboardInterface.resetContext();
         receiver.value = test.context || '';
         // Keyman 12 now uses com.keyman.text.KeyEvent
         let e = com.keyman.KeyEvent ? new com.keyman.KeyEvent() : new com.keyman.text.KeyEvent();
@@ -285,7 +285,7 @@ var testRunner = {
         e.LisVirtualKey = true;
         e.vkCode = test.key;
         // Keyman 12 changes the processKeystroke interface
-        keyman.textProcessor.keyboardInterface.processKeystroke(keyman.util.physicalDevice, com.keyman.text ? com.keyman.dom.Utils.getOutputTarget(receiver) : receiver, e);
+        keyman.core.keyboardInterface.processKeystroke(keyman.util.physicalDevice, com.keyman.text ? com.keyman.dom.Utils.getOutputTarget(receiver) : receiver, e);
         this.keyboards[keyboardId].results[testId] = receiver.value;
       } catch(err) {
         console.warn(err.toString());

--- a/web/unit_tests/cases/engine.js
+++ b/web/unit_tests/cases/engine.js
@@ -26,7 +26,7 @@ function runEngineRuleSet(ruleSet, defaultNoun) {
       ruleSeq.simulateSequenceOn(inputElem);
 
       // Now for the real test!
-      var res = keyman.textProcessor.keyboardInterface.fullContextMatch(ruleDef.n, inputElem._kmwAttachment.interface, ruleDef.rule);
+      var res = keyman.core.keyboardInterface.fullContextMatch(ruleDef.n, inputElem._kmwAttachment.interface, ruleDef.rule);
 
       var msg = matchTest.msg;
       if(!msg) {
@@ -806,7 +806,7 @@ describe('Engine', function() {
         var s = STORES[i];
 
         String.kmwEnableSupplementaryPlane(s.smp);
-        var result = keyman.textProcessor.keyboardInterface._ExplodeStore(s.in);
+        var result = keyman.core.keyboardInterface._ExplodeStore(s.in);
         assert.sameOrderedMembers(result, s.out, "Failure exploding " + (s.smp ? "SMP" : "non-SMP") + " string value \"" + s.in + "\"");
       }
       String.kmwEnableSupplementaryPlane(false);
@@ -828,7 +828,7 @@ describe('Engine', function() {
         ruleSeq.simulateSequenceOn(inputElem);
 
         // Now for the real test!
-        var res = keyman.textProcessor.keyboardInterface._BuildExtendedContext(ruleDef.n, ruleDef.ln, inputElem._kmwAttachment.interface);
+        var res = keyman.core.keyboardInterface._BuildExtendedContext(ruleDef.n, ruleDef.ln, inputElem._kmwAttachment.interface);
 
         assert.sameOrderedMembers(res.valContext, ruleDef.contextCache);
 


### PR DESCRIPTION
Referring to our [Web-Core Refactor design doc](https://docs.google.com/document/d/1yXcxuVoXaT1nRFvGq9ws7U9GluZVI9t1VsGLEP0SbFE/edit?usp=sharing), it's almost time to complete "stage 1" for a headless web-core.

This PR splits the old `Processor` into two separate modules - `KeyboardProcessor`, which will be free of all references to predictive text, and `InputProcessor`, which will manage both `KeyboardProcessor` and predictive text operations as the outermost class for the eventual completed web-core (stage 2).  For now, `InputProcessor` still has DOM-references in need of fixing, while `KeyboardProcessor` is headless-ready outside of two small, final ties.

To follow the conventions we've set in our discussions, `InputProcessor` will be referred to as `keyman.core` - as it's the eventual outer class of web's "core", while the `KeyboardProcessor` will be referred to as `keyman.core.keyboardProcessor`.  There were numerous tweaks throughout the code base to get the references right.