### PR TITLE
fix(android): Change KeyboardHarness/build.sh to not rebuild KMEA

### DIFF
--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -172,6 +172,6 @@ echo "Copying Keyman Engine for Android to KMAPro, Sample apps, and Tests"
 mv $KMA_ROOT/KMEA/app/build/outputs/aar/$ARTIFACT $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample1/app/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample2/app/libs/keyman-engine.aar
-cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Tests/keyman-engine.aar
+cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Tests/KeyboardHarness/app/libs/keyman-engine.aar
 
 cd ..\

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -18,13 +18,6 @@ echo Build KeyboardHarness test app
 #
 SHLVL=0
 
-echo Build KMEA first
-cd ../../KMEA
-./build.sh
-cd ../Tests/KeyboardHarness
-cp ../keyman-engine.aar app/libs/
-
-
 NO_DAEMON=false
 ONLY_DEBUG=false
 

--- a/android/Tests/KeyboardHarness/readme.md
+++ b/android/Tests/KeyboardHarness/readme.md
@@ -10,6 +10,19 @@ and consists of these engineering keyboards:
 * web/testing/chirality/chirality.js
 * web/testing/platform/platformtest.js
 
+### Compiling From Command Line
+1. Launch a command prompt to the `android/` folder
+2. Compile KMEA. This will build and copy `keyman-engine.aar` to the Samples and Test projects
+    ```
+    cd KMEA
+    ./build.sh
+    ```
+3. Compile KeyboardHarness
+    ```
+    cd ../Tests/KeyboardHarness
+    ./build.sh
+    ```
+
 ## Version History ##
 
 ## 2017-09-26 1.0


### PR DESCRIPTION
On CI, the `android/` folder was getting locked because KeyboardHarness/build.sh would rebuild KMEA without passing `-no-daemon`.

This PR updates KeyboardHarness/build.sh to follow KMAPro and Sample apps build.sh scripts and not build KMEA.

KMEA/build.sh also updated to directly copy the artifact to the KeyboardHarness project