### PR TITLE
feat(android): Propagate languageID when downloading kmp

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -136,10 +136,12 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           break;
         case FileUtils.DOWNLOAD_SUCCESS :
           String downloadedFilename = resultData.getString("filename");
+          String languageID = resultData.getString("language");
           String kmpFilename = resultData.getString("destination") + File.separator + downloadedFilename;
 
           Bundle bundle = new Bundle();
           bundle.putString("kmpFile", kmpFilename);
+          bundle.putString("language", languageID);
           Intent packageIntent = new Intent(getApplicationContext(), PackageActivity.class);
           packageIntent.putExtras(bundle);
           startActivity(packageIntent);
@@ -548,52 +550,67 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
    */
   private void downloadKMP() {
     Intent downloadIntent;
-    String url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
-    if (url == null) {
-      url = data.toString();
-    }
-    if (url != null) {
-      // URL contains KMP to download in background.
-      boolean isCustom = FileUtils.isCustomKeyboard(url);
-
-      String filename = data.getQueryParameter("filename");
-      if (filename == null) {
-        int index = url.lastIndexOf("/") + 1;
-        if (index >= 0 && index <= url.length()) {
-          filename = url.substring(index);
-        }
+    try {
+      String url = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_URL);
+      if (url == null) {
+        url = data.toString();
       }
+      if (url != null) {
+        // URL contains KMP to download in background.
+        boolean isCustom = FileUtils.isCustomKeyboard(url);
 
-      // Only handle ad-hoc kmp packages or from keyman.com
-      if (FileUtils.hasKeymanPackageExtension(url) || data.getScheme().toLowerCase().equals("keyman")) {
-        try {
-          // Download the KMP to app cache
-          downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
-          downloadIntent.putExtra("url", url);
-          downloadIntent.putExtra("filename", filename);
-          downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
-          downloadIntent.putExtra("receiver", resultReceiver);
-
-          progressDialog = new ProgressDialog(MainActivity.this);
-          String ellipsisStr = "\u2026";
-          progressDialog.setMessage(String.format("%s\n%s%s",
-            getString(R.string.downloading_keyboard_package), filename, ellipsisStr));
-          progressDialog.setCancelable(false);
-          progressDialog.show();
-
-          startService(downloadIntent);
-        } catch (Exception e) {
-          if (progressDialog != null && progressDialog.isShowing()) {
-            progressDialog.dismiss();
+        String filename = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_Filename);
+        if (filename == null) {
+          int index = url.lastIndexOf("/") + 1;
+          if (index >= 0 && index <= url.length()) {
+            filename = url.substring(index);
           }
-          progressDialog = null;
-          return;//break;
         }
-      } else {
-        String message = "Download failed. Not a .kmp keyboard package.";
-        Toast.makeText(getApplicationContext(), message,
-          Toast.LENGTH_SHORT).show();
+
+        String languageID = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_Language);
+        String languageStr = (languageID != null) ? String.format("&language=%s", languageID) : "";
+        url = String.format("%s%s", url, languageStr);
+
+        String platform = data.getQueryParameter("platform");
+        String platformStr = (platform != null) ? String.format("&platform=%s", platform) : "";
+        url = String.format("%s%s", url, platformStr);
+
+        // Only handle ad-hoc kmp packages or from keyman.com
+        if (FileUtils.hasKeymanPackageExtension(url) || data.getScheme().toLowerCase().equals("keyman")) {
+          try {
+            // Download the KMP to app cache
+            downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
+            downloadIntent.putExtra("url", url);
+            downloadIntent.putExtra("filename", filename);
+            downloadIntent.putExtra("language", languageID);
+            downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
+            downloadIntent.putExtra("receiver", resultReceiver);
+
+            progressDialog = new ProgressDialog(MainActivity.this);
+            String ellipsisStr = "\u2026";
+            progressDialog.setMessage(String.format("%s\n%s%s",
+              getString(R.string.downloading_keyboard_package), filename, ellipsisStr));
+            progressDialog.setCancelable(false);
+            progressDialog.show();
+
+            startService(downloadIntent);
+          } catch (Exception e) {
+            if (progressDialog != null && progressDialog.isShowing()) {
+              progressDialog.dismiss();
+            }
+            progressDialog = null;
+            return;//break;
+          }
+        } else {
+          String message = "Download failed. Not a .kmp keyboard package.";
+          Toast.makeText(getApplicationContext(), message,
+            Toast.LENGTH_SHORT).show();
+        }
       }
+    } catch (UnsupportedOperationException e) {
+      String message = "Download failed. Invalid URL.";
+      Toast.makeText(getApplicationContext(), message,
+        Toast.LENGTH_SHORT).show();
     }
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -567,6 +567,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           }
         }
 
+        // Append to "url" as needed to satisfy the keyboard download endpoint
+        // Usage: download.php?id=<keyboard_id>&platform=[&mode=<bundle|standalone>][&cid=xxxx]
         String languageID = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_Language);
         String languageStr = (languageID != null) ? String.format("&language=%s", languageID) : "";
         url = String.format("%s%s", url, languageStr);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -53,12 +53,14 @@ public class PackageActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_package_installer);
     boolean silentInstall = false;
+    String languageID = null;
 
     final Context context = this;
     Bundle bundle = getIntent().getExtras();
     if (bundle != null) {
       kmpFile = new File(bundle.getString("kmpFile"));
       silentInstall = bundle.getBoolean("silentInstall", false);
+      languageID = bundle.getString("language", null);
     }
 
     File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
@@ -88,7 +90,7 @@ public class PackageActivity extends AppCompatActivity {
 
     // Silent installation (skip displaying welcome.htm and user confirmation)
     if (silentInstall) {
-      installPackage(context, pkgTarget, pkgId,true);
+      installPackage(context, pkgTarget, pkgId, languageID, true);
       return;
     }
 
@@ -166,7 +168,7 @@ public class PackageActivity extends AppCompatActivity {
     if (files.length > 0 && files[0].exists() && files[0].length() > 0) {
       webView.loadUrl("file:///" + files[0].getAbsolutePath());
     } else {
-      // No welcome.htm so display minimal package information
+      // No readme.htm so display minimal package information
       String targetString = "";
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
         targetString = pkgName != null && pkgName.toLowerCase().endsWith("keyboard")
@@ -181,16 +183,17 @@ public class PackageActivity extends AppCompatActivity {
       webView.loadData(htmlString, "text/html; charset=utf-8", "UTF-8");
     }
 
-    initializeButtons(context, pkgId, pkgTarget);
+    initializeButtons(context, pkgId, languageID, pkgTarget);
   }
 
   /**
    * Initialize buttons of package installer.
    * @param context the context
    * @param pkgId the keyman package id
+   * @param languageID the optional language id
    * @param pkgTarget  String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
    */
-  private void initializeButtons(final Context context, final String pkgId, final String pkgTarget) {
+  private void initializeButtons(final Context context, final String pkgId, final String languageID, final String pkgTarget) {
     final Button installButton = (Button) findViewById(R.id.installButton);
     final Button cancelButton = (Button) findViewById(R.id.cancelButton);
     final Button finishButton = (Button) findViewById(R.id.finishButton);
@@ -198,7 +201,9 @@ public class PackageActivity extends AppCompatActivity {
     installButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        installPackage(context, pkgTarget, pkgId,false);
+
+
+        installPackage(context, pkgTarget, pkgId, languageID, false);
       }
     });
 
@@ -310,13 +315,19 @@ public class PackageActivity extends AppCompatActivity {
    * @param context Context   The activity context
    * @param pkgTarget String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
    * @param pkgId String      The Keyman package ID
+   * @param languageID String The optional language ID
+   * @param anSilentInstall boolean If true, don't display readme.htm/welcome.htm content during installation
    */
-  private void installPackage(Context context, String pkgTarget, String pkgId, boolean anSilentInstall) {
+  private void installPackage(Context context, String pkgTarget, String pkgId, String languageID, boolean anSilentInstall) {
     try {
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
         // processKMP will remove currently installed package and install
+
+        //Dataset kmpDataset = new Dataset(context);
+        //kmpDataset.keyboards.addAll(kbdsList);
+
         List<Map<String, String>> installedPackageKeyboards =
-          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY);
+          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, languageID);
         // Do the notifications!
         boolean success = installedPackageKeyboards.size() != 0;
         boolean _cleanup = true;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
@@ -17,6 +17,7 @@ public class DownloadIntentService extends IntentService {
     String url = intent.getStringExtra("url");
     String filename = intent.getStringExtra("filename");
     String destination = intent.getStringExtra("destination");
+    String languageID = intent.getStringExtra("language");
     final ResultReceiver receiver = intent.getParcelableExtra("receiver");
     Bundle bundle = new Bundle();
 
@@ -25,7 +26,10 @@ public class DownloadIntentService extends IntentService {
       if (result == FileUtils.DOWNLOAD_SUCCESS) {
         bundle.putString("destination", destination);
         bundle.putString("filename", filename);
+        bundle.putString("language", languageID);
         receiver.send(FileUtils.DOWNLOAD_SUCCESS, bundle);
+      } else {
+        receiver.send(FileUtils.DOWNLOAD_ERROR, bundle);
       }
     } catch (Exception e) {
       receiver.send(FileUtils.DOWNLOAD_ERROR, Bundle.EMPTY);


### PR DESCRIPTION
This updates how the Keyman app handles URLs for downloading kmp files (in preparation for keyboard picker revamp).

If the URL contains "language" or "platform", those values are propagated for when the kmp gets downloaded.  The "languageID" is then used during kmp installation.

Also fixed a few things with URL handling:
* Catch UnsupportedOperationException if the original URL has invalid query parameters
* Handle DownloadIntentService fails

### User Testing:
Load the Keyman app.
Open a Chrome browser and go to the link:
```
keyman://?filename=sil_cameroon_qwerty.kmp&url=https://keyman.com/keyboard/download?id=sil_cameroon_qwerty&language=bbj-Latn&platform=android
```

The KMP should install and use the specified `bbj-Latn` language (Ghomálá').
Normally, sil_cameroon_qwerty defaults to `aal` (Afade).