### PR TITLE
fix(android): Add check for WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.VIBRATE" />
 
   <application

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -159,6 +159,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
     SentryAndroid.init(context);
 
+    checkStoragePermission(null);
     resultReceiver = new DownloadResultReceiver(new Handler());
 
     if (BuildConfig.DEBUG) {
@@ -812,7 +813,9 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (requestCode == PERMISSION_REQUEST_STORAGE) {
       // Request for storage permission
-      if (grantResults.length == 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      if (grantResults.length ==2 &&
+          grantResults[0] == PackageManager.PERMISSION_GRANTED &&
+          grantResults[1] == PackageManager.PERMISSION_GRANTED) {
         // Permission has been granted. Resume task needing this permission
         useLocalKMP(context, data);
       } else {
@@ -827,8 +830,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   private void checkStoragePermission(Uri data) {
     // Check if the Storage permission has been granted
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) ==
-        PackageManager.PERMISSION_GRANTED) {
+      if ((checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) &&
+          (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)) {
         useLocalKMP(context, data);
       } else {
         // Permission is missing and must be requested
@@ -841,27 +844,36 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   }
 
   /**
-   * Requests the {@link android.Manifest.permission#READ_EXTERNAL_STORAGE} permission
+   * Requests the {@link android.Manifest.permission#READ_EXTERNAL_STORAGE} and
+   *              {@link android.Manifest.permission#WRITE_EXTERNAL_STORAGE} permissions
    */
   private void requestStoragePermission() {
-    if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-        Manifest.permission.READ_EXTERNAL_STORAGE)) {
+    if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+        ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       // Provide additional rationale to the user if the permission was not granted
-      String message = "To install keyboard package, allow Keyman permission to read storage.";
+      String message = "To install keyboard packages, allow Keyman permission to read/write storage.";
       Toast.makeText(getApplicationContext(), message ,
         Toast.LENGTH_LONG).show();
-      ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+      ActivityCompat.requestPermissions(this,
+        new String[]{
+          Manifest.permission.READ_EXTERNAL_STORAGE,
+          Manifest.permission.WRITE_EXTERNAL_STORAGE},
         PERMISSION_REQUEST_STORAGE);
     } else {
       // Request the permission. The result will be received in onRequestPermissionResult().
-      ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+      ActivityCompat.requestPermissions(this,
+        new String[]{
+          Manifest.permission.READ_EXTERNAL_STORAGE,
+          Manifest.permission.WRITE_EXTERNAL_STORAGE},
         PERMISSION_REQUEST_STORAGE);
     }
   }
 
   // TODO: Move this to KMEA during Keyman 13.0 refactoring
   public static void useLocalKMP(Context context, Uri data) {
-    useLocalKMP(context, data, false);
+    if (data != null) {
+      useLocalKMP(context, data, false);
+    }
   }
 
   public static void useLocalKMP(Context context, Uri data, boolean silentInstall) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDownloadMgr.java
@@ -239,6 +239,9 @@ public class CloudDownloadMgr{
   private CloudApiTypes.SingleCloudDownload createRequest(Context aContext, int aNo, CloudApiTypes.CloudApiParam aParam)
   {
 
+    // From DownloadManager documentation:
+    // https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationUri(android.net.Uri)
+    // Must be a file to a path on external storage, and the calling app must have the WRITE_EXTERNAL_STORAGE permission
     File _file=new File(aContext.getExternalFilesDir(null),"download_"+System.currentTimeMillis()+"_"+aNo);
        /*
        Create a DownloadManager.Request with all the information necessary to start the download


### PR DESCRIPTION
Fixes #2710

The DownloadManager used to get cloud updates can only save to external storage. On some Android devices, this requires the `WRITE_EXTERNAL_STORAGE` permission.