### PR TITLE
fix(windows): temporary stop of sentry

### DIFF
--- a/windows/src/developer/TIKE/main/KeymanDeveloperOptions.pas
+++ b/windows/src/developer/TIKE/main/KeymanDeveloperOptions.pas
@@ -222,7 +222,7 @@ begin
     FDefaultProjectPath := IncludeTrailingPathDelimiter(regReadString(SRegValue_IDEOpt_DefaultProjectPath, GetFolderPath(CSIDL_PERSONAL) + CDefaultProjectPath));
 
     // for consistency with Keyman.System.KeymanSentryClient, we need to use
-    // reg.ReadInteger, as regReadInt, which in the dim dark past started
+    // reg.ReadInteger, as regReadInt in the dim dark past started
     // to read integers as a REG_SZ type and that's far too messy to change now.
     FReportErrors := not reg.ValueExists(SRegValue_AutomaticallyReportErrors) or
       (reg.ReadInteger(SRegValue_AutomaticallyReportErrors) <> 0);

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -482,7 +482,7 @@ var
 begin
   inherited;
 
-  TKeymanSentryClient.Client.MessageEvent(SENTRY_LEVEL_INFO, TKeymanSentryClient.LOGGER_DEVELOPER_IDE, 'Started Keyman Developer');
+  //KEYMAN-SENTRY:UNDO: TKeymanSentryClient.Client.MessageEvent(SENTRY_LEVEL_INFO, TKeymanSentryClient.LOGGER_DEVELOPER_IDE, 'Started Keyman Developer');
 
   if not ForceDirectories(FKeymanDeveloperOptions.DefaultProjectPath) then
   begin

--- a/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
+++ b/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
@@ -50,8 +50,6 @@ uses
   Winapi.ShlObj,
   Winapi.Windows,
 
-  Sentry.Client,
-
   KeymanPaths,
   KeymanVersion,
 //  RedistFiles,

--- a/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -289,7 +289,7 @@ end;
 
 class procedure TKeymanSentryClient.Start(SentryClientClass: TSentryClientClass; AProject: TKeymanSentryClientProject; AFlags: TKeymanSentryClientFlags);
 begin
-  TKeymanSentryClient.Create(SentryClientClass, AProject, AFlags);
+  //KEYMAN-SENTRY:UNDO: TKeymanSentryClient.Create(SentryClientClass, AProject, AFlags);
 end;
 
 class procedure TKeymanSentryClient.Stop;

--- a/windows/src/global/vc/keymansentry.cpp
+++ b/windows/src/global/vc/keymansentry.cpp
@@ -49,6 +49,7 @@ int keyman_sentry_init(bool is_keyman_developer) {
 
   return sentry_init(options);
 #else
+  UNREFERENCED_PARAMETER(is_keyman_developer);
   return 0;
 #endif
 }
@@ -136,6 +137,9 @@ void keyman_sentry_report_exception(DWORD ExceptionCode, PVOID ExceptionAddress)
 
     perror(message);
   }
+#else
+  UNREFERENCED_PARAMETER(ExceptionCode);
+  UNREFERENCED_PARAMETER(ExceptionAddress);
 #endif
 }
 
@@ -163,6 +167,11 @@ void keyman_sentry_report_message(keyman_sentry_level_t level, const char *logge
 
     sentry_capture_event(event);
   }
+#else
+  UNREFERENCED_PARAMETER(level);
+  UNREFERENCED_PARAMETER(logger);
+  UNREFERENCED_PARAMETER(message);
+  UNREFERENCED_PARAMETER(includeStack);
 #endif
 }
 

--- a/windows/src/global/vc/keymansentry.cpp
+++ b/windows/src/global/vc/keymansentry.cpp
@@ -11,6 +11,7 @@
 bool g_report_exceptions, g_report_messages;
 
 int keyman_sentry_init(bool is_keyman_developer) {
+#if 0
   sentry_options_t *options = sentry_options_new();
   const char *key;
 
@@ -26,7 +27,7 @@ int keyman_sentry_init(bool is_keyman_developer) {
   if (RegOpenKeyExA(HKEY_CURRENT_USER, key, 0, KEY_READ, &hkey) == ERROR_SUCCESS) {
     DWORD dwType, dwValue, dwValueSize = 4;
 
-    g_report_exceptions = 
+    g_report_exceptions =
       RegQueryValueExA(hkey, REGSZ_AutomaticallyReportErrors, NULL, &dwType, (LPBYTE)&dwValue, &dwValueSize) != ERROR_SUCCESS || dwType != REG_DWORD || dwValue != 0;
 
     dwValueSize = 4;
@@ -47,10 +48,15 @@ int keyman_sentry_init(bool is_keyman_developer) {
   //sentry_options_set_debug(options, 1);
 
   return sentry_init(options);
+#else
+  return 0;
+#endif
 }
 
 void keyman_sentry_shutdown() {
+#if 0
   sentry_shutdown();
+#endif
 }
 
 //
@@ -97,6 +103,7 @@ sentry_value_t CaptureStackTrace(PVOID TopAddr, DWORD FramesToSkip) {
 }
 
 void keyman_sentry_report_exception(DWORD ExceptionCode, PVOID ExceptionAddress) {
+#if 0
   sentry_value_t event;
   const int FRAMES_TO_SKIP = 0;
 
@@ -129,9 +136,11 @@ void keyman_sentry_report_exception(DWORD ExceptionCode, PVOID ExceptionAddress)
 
     perror(message);
   }
+#endif
 }
 
 void keyman_sentry_report_message(keyman_sentry_level_t level, const char *logger, const char *message, bool includeStack) {
+#if 0
   const int FRAMES_TO_SKIP = 0;
 
   if ((g_report_exceptions && (level == SENTRY_LEVEL_ERROR || level == SENTRY_LEVEL_DEBUG)) || g_report_messages) {
@@ -154,6 +163,7 @@ void keyman_sentry_report_message(keyman_sentry_level_t level, const char *logge
 
     sentry_capture_event(event);
   }
+#endif
 }
 
 /* Wrappers for main, wmain */
@@ -167,7 +177,9 @@ LONG WINAPI FilterExceptions(_In_ struct _EXCEPTION_POINTERS *ExceptionInfo) {
 }
 
 void keyman_sentry_setexceptionfilter() {
+#if 0
   LastFilter = SetUnhandledExceptionFilter(FilterExceptions);
+#endif
 }
 
 int keyman_sentry_main(bool is_keyman_developer, int argc, char *argv[], int (*run)(int, char**)) {


### PR DESCRIPTION
This relates to the nasty issue in Sentry
https://github.com/getsentry/sentry-native/issues/220

Temporarily disables all sentry integration (although libraries are still loaded).