### PR TITLE
feat(android): Download cloud keyboards from https://keyman.com/keyboards

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -176,14 +176,17 @@
       </intent-filter>
 
       <intent-filter>
-        <!-- deep linking to keyman.com/keyboards -->
+        <!-- keyman:download deep linking to https://keyman.com/keyboards/ -->
         <action android:name="android.intent.action.VIEW" />
 
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
         <data
-          android:scheme="keyman" />
+          android:host="*"
+          android:scheme="keyman"
+          android:sspPrefix="download" />
+
       </intent-filter>
     </activity>
     <activity

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -32,6 +32,7 @@ import com.tavultesoft.kmea.util.DownloadIntentService;
 
 import android.Manifest;
 import android.app.ProgressDialog;
+import android.content.ComponentName;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
@@ -332,6 +333,13 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     KMKeyboardDownloaderActivity.addKeyboardDownloadEventListener(this);
     PackageActivity.addKeyboardDownloadEventListener(this);
 
+    // Get calling activity
+    ComponentName component = this.getCallingActivity();
+    String caller = null;
+    if (component != null) {
+      caller = component.getClassName();
+    }
+
     Intent intent = getIntent();
     data = intent.getData();
 
@@ -349,7 +357,11 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           downloadKMP(scheme);
           break;
         case "keyman" :
-          if (FileUtils.isKeymanLink(data.toString())) {
+          // Only accept download links from Keyman browser activities
+          if (FileUtils.isKeymanLink(data.toString()) && caller != null &&
+            (caller.equalsIgnoreCase("com.tavultesoft.kmea.KMPBrowserActivity") ||
+             caller.equalsIgnoreCase("com.tavultesoft.kmapro.WebBrowserActivity"))) {
+
             // Convert opaque URI to hierarchical URI so the query parameters can be parsed
             Builder builder = new Uri.Builder();
             builder.scheme("https")

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -17,6 +17,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
@@ -256,9 +257,16 @@ public class WebBrowserActivity extends AppCompatActivity {
 
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        if (!url.toLowerCase().equals("about:blank"))
-          view.loadUrl(url);
-
+        if (!url.toLowerCase().equals("about:blank")) {
+          if (url.startsWith("keyman:download")) {
+            Intent intent = new Intent(context, MainActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setData(Uri.parse(url));
+            startActivityForResult(intent, 1);
+          } else {
+            view.loadUrl(url);
+          }
+        }
         return true;
       }
 

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -13,6 +13,11 @@
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
         <activity
+            android:name=".KMPBrowserActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+            android:label="@string/app_name">
+        </activity>
+        <activity
             android:name="com.tavultesoft.kmea.KeyboardPickerActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -50,6 +50,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   public static final String KMKey_URL = "url";
   public static final String KMKey_Keyboard = "keyboard";
   public static final String KMKey_LanguageKeyboards = "keyboards";
+  public static final String KMKey_BCP47 = "bcp47";
   public static final String KMKey_Options = "options";
   public static final String KMKey_Language = "language";
   public static final String KMKey_Languages = "languages";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmea;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.PorterDuff.Mode;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageButton;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.tavultesoft.kmea.util.FileUtils;
+
+public class KMPBrowserActivity extends AppCompatActivity {
+  private static final String TAG = "KMPBrowserActivity";
+  private WebView webView;
+  private static final String KMP_SEARCH_URL_FORMATSTR = "https://keyman.com/keyboards%s?embed=linux&version=%s"; // TODO: Update to Android
+  private static final String KMP_LANGUAGE_FORMATSTR = "/languages/%s";
+  private boolean isLoading = false;
+  private boolean didFinishLoading = false;
+
+  @SuppressLint({"SetJavaScriptEnabled", "InflateParams"})
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    final Context context = this;
+
+    setContentView(R.layout.activity_kmp_browser);
+
+    webView = (WebView) findViewById(R.id.kmpBrowserWebView);
+    webView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
+    webView.getSettings().setJavaScriptEnabled(true);
+    webView.getSettings().setUseWideViewPort(true);
+    webView.getSettings().setLoadWithOverviewMode(true);
+    webView.getSettings().setBuiltInZoomControls(true);
+    webView.getSettings().setSupportZoom(true);
+    webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+
+    webView.setWebChromeClient(new WebChromeClient() {
+      public void onProgressChanged(WebView view, int progress) {
+      }
+    });
+    webView.setWebViewClient(new WebViewClient() {
+      @Override
+      public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+        didFinishLoading = true;
+        isLoading = false;
+      }
+
+      @Override
+      public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        String lowerURL = url.toLowerCase();
+        if (lowerURL.equals("about:blank")) {
+          return true; // never load a blank page, e.g. when the component initializes
+        }
+        if (FileUtils.isKeymanLink(lowerURL)) {
+          // KMAPro main activity will handle this intent
+          // Pass original url because path and query are case-sensitive
+          Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+          startActivityForResult(intent, 1);
+
+          // Finish activity
+          finish();
+        }
+        if (lowerURL.startsWith("keyman:")) {
+          // Warn for unsupported keyman schemes
+          Log.d(TAG, "Scheme for " + url + " not handled");
+          return true;
+        }
+
+        // Display URL
+        return false;
+      }
+
+      @Override
+      public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        isLoading = true;
+        didFinishLoading = false;
+      }
+
+      @Override
+      public void onPageFinished(WebView view, String url) {
+        didFinishLoading = true;
+        isLoading = false;
+      }
+    });
+
+    // If language ID is provided, include it in the keyboard search
+    String languageID = getIntent().getStringExtra("languageCode");
+    String languageStr = (languageID != null) ? String.format(KMP_LANGUAGE_FORMATSTR, languageID) : "";
+    String appVersion = KMManager.getVersion();
+    String kmpSearchUrl = String.format(KMP_SEARCH_URL_FORMATSTR, languageStr, appVersion);
+    webView.loadUrl(kmpSearchUrl);
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    if (webView != null) {
+      webView.reload();
+    }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    if (webView != null) {
+      if (resultCode == RESULT_OK && data != null) {
+        String url = data.getStringExtra("url");
+        if (url != null)
+          webView.loadUrl(url);
+      }
+    }
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+  }
+
+  @Override
+  public void onBackPressed() {
+    if (webView != null && webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      super.onBackPressed();
+      finish();
+    }
+  }
+
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -273,10 +273,12 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     return pos;
   }
 
+  // Previously, keyboard from package = custom keyboard
+  // Now, keyboard from package has a package ID != "cloud"
   protected static boolean hasKeyboardFromPackage() {
     for(HashMap<String, String> kbInfo: keyboardsList) {
-      String customKeyboard = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_CustomKeyboard, "N");
-      if (customKeyboard.equalsIgnoreCase("Y")) {
+      String pkgID = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
+      if (!pkgID.equalsIgnoreCase(KMManager.KMDefault_UndefinedPackageID)) {
         return true;
       }
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -238,13 +238,18 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     addButton = (ImageButton) findViewById(R.id.add_button);
     addButton.setOnClickListener(new View.OnClickListener() {
       public void onClick(View v) {
-        // Check that available keyboard information can be obtained via:
-        // 1. connection to cloud catalog
-        // 2. cached file
-        // 3. local kmp.json files in packages/
-        if (KMManager.hasConnection(context) || CloudRepository.shared.hasCache(context) ||
-          KeyboardPickerActivity.hasKeyboardFromPackage()){
-          // Rework to use languuage-specific (KeyboardList) picker!
+        // Check scenarios to add available keyboards:
+        if (KMManager.hasConnection(context)){
+          // Scenario 1: Connection to keyman.com catalog
+          // Pass the BCP47 language code to the KMPBrowserActivity
+          Intent i = new Intent(context, KMPBrowserActivity.class);
+          i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+          i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+          i.putExtra("languageCode", lgCode);
+          i.putExtra("languageName", lgName);
+          context.startActivity(i);
+        } else if (KeyboardPickerActivity.hasKeyboardFromPackage()) {
+          // Scenario 2: Local kmp.json files in packages/
           Intent i = new Intent(context, KeyboardListActivity.class);
           i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
           i.putExtra("languageCode", lgCode);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguagesSettingsActivity.java
@@ -109,12 +109,15 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
     addButton = (ImageButton) findViewById(R.id.add_button);
     addButton.setOnClickListener(new View.OnClickListener() {
       public void onClick(View v) {
-        // Check that available keyboard information can be obtained via:
-        // 1. connection to cloud catalog
-        // 2. cached file
-        // 3. local kmp.json files in packages/
-        if (KMManager.hasConnection(context) || CloudDataJsonUtil.getKeyboardCacheFile(context).exists() ||
-          KeyboardPickerActivity.hasKeyboardFromPackage()){
+        // Check scenarios to add available keyboards:
+        if (KMManager.hasConnection(context)) {
+          // Scenario 1: Connection to keyman.com catalog
+          Intent i = new Intent(context, KMPBrowserActivity.class);
+          i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+          i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+          context.startActivity(i);
+        } else if (KeyboardPickerActivity.hasKeyboardFromPackage()) {
+          // Scenario 2: Local kmp.json files in packages/
           dismissOnSelect = false;
           Intent i = new Intent(context, LanguageListActivity.class);
           i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -139,7 +139,7 @@ public class JSONUtils {
     try {
       for (int i=0; i < a.length(); i++) {
         JSONObject o = a.getJSONObject(i);
-        if (o.getString("id").equals(id)) {
+        if (o.getString("id").toLowerCase().equals(id.toLowerCase())) {
           return i;
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -239,10 +239,43 @@ public final class FileUtils {
     if (u == null) {
       return ret;
     }
+    String lowerU = u.toLowerCase();
     Pattern pattern = Pattern.compile("^http(s)?://(.+\\.)?keyman.com/.*");
-    Matcher matcher = pattern.matcher(u);
+    Matcher matcher = pattern.matcher(lowerU);
     if (matcher.matches()) {
       ret = false;
+    }
+    return ret;
+  }
+
+  /**
+   * Utility to parse a URL and determine if it's a valid keyman:<method>
+   * Currently, only "keyman" scheme with "download" path and query is supported.
+   * Legacy keyman:// protocol is deprecated and not supported.
+   * @param u String of the URL
+   * @return boolean true if URL is a supported Keyman link
+   */
+  public static boolean isKeymanLink(String u) {
+    boolean ret = false;
+    if (u == null) {
+      return ret;
+    }
+    String lowerU = u.toLowerCase();
+    Pattern pattern = Pattern.compile("^keyman:(\\w+)\\?(.+)");
+    Matcher matcher = pattern.matcher(lowerU);
+    // Check URL starts with "keyman"
+    if (matcher.matches() && (matcher.group(1) != null)) {
+      // For now, only handle "download"
+      switch (matcher.group(1).toLowerCase()) {
+        case "download":
+          if (matcher.group(2) != null) {
+            // Contains query
+            ret = true;
+          }
+          break;
+        default:
+          ret = false;
+      }
     }
     return ret;
   }

--- a/android/KMEA/app/src/main/res/layout/activity_kmp_browser.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_kmp_browser.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".KMPBrowserActivity"
+    android:orientation="vertical">
+
+  <WebView
+    android:id="@+id/kmpBrowserWebView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+
+</RelativeLayout>

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/JSONUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/JSONUtilsTest.java
@@ -69,6 +69,7 @@ public class JSONUtilsTest {
 
       // Verify first and last language for sil_cameroon_qwerty
       Assert.assertEquals(0, JSONUtils.findID(languagesArray, "aal-Latn"));
+      Assert.assertEquals(0, JSONUtils.findID(languagesArray, "aal-latn"));
       Assert.assertEquals(EXPECTED_NUM_LANGUAGES-1, JSONUtils.findID(languagesArray, "zuy-Latn"));
 
     } catch (JSONException e) {

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -157,7 +157,7 @@ public class PackageProcessorTest {
     Assert.assertEquals(amharic, keyboards[0]);
     Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
 
-    languageID = "gez";
+    languageID = "GEZ";
     keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
 
     HashMap<String, String> geez = new HashMap<String, String>();

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -54,6 +54,31 @@ public class FileUtilsTest {
   }
 
   @Test
+  public void test_isKeymanLink() {
+    Assert.assertFalse(FileUtils.isKeymanLink(null));
+    Assert.assertFalse(FileUtils.isKeymanLink(""));
+
+    // Valid Keyman links
+    Assert.assertTrue(FileUtils.isKeymanLink("keyman:download?keyboard"));
+    Assert.assertTrue(FileUtils.isKeymanLink("Keyman:Download?keyboard"));
+
+    // keyman:// invalid
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman://keyboard"));
+    Assert.assertFalse(FileUtils.isKeymanLink("Keyman://keyboard"));
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman:download//keyboard"));
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman://download/keyboard"));
+
+    // link missing query
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman:download?"));
+
+    // Other methods not supported
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman:method//keyboard"));
+    Assert.assertFalse(FileUtils.isKeymanLink("keyman:method?keyboard"));
+
+    Assert.assertFalse(FileUtils.isKeymanLink("example:keyman?"));
+  }
+
+  @Test
   public void test_compareVersions() {
     Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions(null, "1.0"));
     Assert.assertEquals(FileUtils.VERSION_INVALID, FileUtils.compareVersions("" , "1.0"));


### PR DESCRIPTION
Follow-on to #2944 and addresses most of #2708

For adding keyboards, this PR replaces the language/keyboard search
**From:** language picker (scrolling through the super long list)
**To:** Embedded webView to https://keyman.com/keyboards where the searchbox to find a keyboard.

Instead of using the legacy `keyman://` protocol for downloading cloud keyboards, we will use a deep link along the lines of
```
keyman:download?filename=sil_cameroon_qwerty.kmp&url=https%3A%2F%2Fkeyman.com%2Fkeyboard%2Fdownload%3Fid%3Dsil_cameroon_qwerty%26bcp47%3Dbbj-Latn%26platform%3Dandroid
```

The link is based on an embedded windows search
https://keyman.com/keyboards/blackfoot_syllabics_u?embed=windows&version=10.0.0.0

This PR also updates the intent handling to associate the opaque URI `keyman:download`.
The filename and url are then parsed so PackageActivity can handle accordingly.

Only the Keyman browsers will trigger the `keyman:download` links.

Finally, when a keyboard package is installed, a cloud query for an associated lexical model package is added to download and install that lexical model package.

- [ ] TODO: Update keyman.com/keyboard download links to include default languageID/BCP47. 

Dev note:
Because of how the url gets parsed now, we don't need to append "language" or "parameter" as before.