### PR TITLE
fix(common/lmlayer): use searchTermToKey() on input

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -67,11 +67,11 @@ describe('LMLayer using the trie model', function () {
         return lmLayer.predict(type('ï'), atEndOfBuffer('na'));
       }).then(function (rawSuggestions) {
         // Discard the keep suggestion
-        let suggestions = rawSuggestions.filter(s => s.tag != 'keep')
+        var suggestions = rawSuggestions.filter(s => s.tag != 'keep')
         assert.isAtLeast(suggestions.length, 1)
 
-        // We SHOULD get 'naïve' suggested, despite never typing a diaeresis.
-        let topSuggestion = suggestions[0];
+        // We SHOULD get 'naïve' suggested
+        var topSuggestion = suggestions[0];
         assert.equal(topSuggestion.displayAs, "naïve")
         assert.include(topSuggestion.transform.insert, "ïve")
       });

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -50,7 +50,7 @@ describe('LMLayer using the trie model', function () {
     // search key is 'naive' accordingly (default searchTermToKey transforms
     // to NFD and removes common diacritics).
     //
-    // The lookup should also do the same!
+    // The lookup should also do the same to the input!
     //
     // https://community.software.sil.org/t/search-term-to-key-in-lexical-model-not-working-both-ways-by-default/3133
     it('should use the default searchTermToKey()', function () {
@@ -62,8 +62,9 @@ describe('LMLayer using the trie model', function () {
       ).then(function (_actualConfiguration) {
         return Promise.resolve();
       }).then(function () {
-        // Pretend we are typing 'na|i'
-        return lmLayer.predict(type('i'), atEndOfBuffer('na'));
+        // Pretend we are typing 'na|ï'
+        // Notice that we are typing the diacritic!
+        return lmLayer.predict(type('ï'), atEndOfBuffer('na'));
       }).then(function (rawSuggestions) {
         // Discard the keep suggestion
         let suggestions = rawSuggestions.filter(s => s.tag != 'keep')

--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -67,7 +67,9 @@ describe('LMLayer using the trie model', function () {
         return lmLayer.predict(type('ï'), atEndOfBuffer('na'));
       }).then(function (rawSuggestions) {
         // Discard the keep suggestion
-        var suggestions = rawSuggestions.filter(s => s.tag != 'keep')
+        var suggestions = rawSuggestions.filter(function skimKeepSuggestions(s) {
+          return s.tag !== 'keep'
+        })
         assert.isAtLeast(suggestions.length, 1)
 
         // We SHOULD get 'naïve' suggested

--- a/common/predictive-text/unit_tests/in_browser/resources/models/naive-trie.js
+++ b/common/predictive-text/unit_tests/in_browser/resources/models/naive-trie.js
@@ -1,0 +1,5 @@
+(function() {
+'use strict';
+LMLayerWorker.loadModel(new models.TrieModel({"totalWeight":1,"root":{"type":"leaf","weight":1,"entries":[{"key":"naive","weight":1,"content":"naïve"}]}}, {
+}));
+})();

--- a/common/predictive-text/worker/models/trie-model.ts
+++ b/common/predictive-text/worker/models/trie-model.ts
@@ -429,7 +429,10 @@
    */
   function defaultWordform2Key(wordform: string): SearchKey {
     return wordform
-      .replace(/[\u0100-\u2200]/g, function (c) {
+      // remove all combining diacritics (if input is in NFD)
+      .replace(/[\u0300-\u036f]/g, '')
+      // remove all composed diacritics (if input is in NFC) LATIN-ONLY!
+      .replace(/[\u00C0-\u212A]/g, function (c) {
         if (c in PARTIAL_NFD_LOOKUP) {
           return PARTIAL_NFD_LOOKUP[c];
         }


### PR DESCRIPTION
Here's a regression test for https://community.software.sil.org/t/search-term-to-key-in-lexical-model-not-working-both-ways-by-default/3133.

However, I could not reproduce this error? I will ask the author of the issue for more details.

**EDIT**: I realize I misinterpreted the original poster's question. I'll be back!
**EDIT 2**: Issue reproduced! Now to fix it >.<
**EDIT 3**: My regex character range was incorrect 🤦‍♂️ Fixed!