### PR TITLE
fix(ios): iOS 13.4 subkey menu workaround

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -449,9 +449,12 @@ extension KeymanWebViewController: WKScriptMessageHandler {
 
       self.touchHoldBegan()
     } else if fragment.hasPrefix("#menuKeyDown-") {
+      perform(#selector(self.menuKeyHeld), with: self, afterDelay: 0.5)
       menuKeyDown(self)
       delegate?.menuKeyDown(self)
     } else if fragment.hasPrefix("#menuKeyUp-") {
+      // Blocks summoning the globe-key menu for quick taps.  (Hence the 0.5 delay.)
+      NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.menuKeyHeld), object: self)
       menuKeyUp(self)
       delegate?.menuKeyUp(self)
     } else if fragment.hasPrefix("#hideKeyboard-") {
@@ -832,6 +835,10 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
     hold.delegate = self
     subKeysView!.addGestureRecognizer(hold)
     setPopupVisible(true)
+  }
+
+  @objc func menuKeyHeld(_ keymanWeb: KeymanWebViewController) {
+    self.delegate?.menuKeyHeld(self)
   }
 
   @objc func subKeyButtonClick(_ sender: UIButton) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -127,10 +127,10 @@ class KeymanWebViewController: UIViewController {
     view = webView
 
     // Set UILongPressGestureRecognizer to show sub keys
-    let hold = UILongPressGestureRecognizer(target: self, action: #selector(self.holdAction))
-    hold.minimumPressDuration = 0.5
-    hold.delegate = self
-    view.addGestureRecognizer(hold)
+//    let hold = UILongPressGestureRecognizer(target: self, action: #selector(self.holdAction))
+//    hold.minimumPressDuration = 0.5
+//    hold.delegate = self
+//    view.addGestureRecognizer(hold)
 
     NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow),
                                            name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -446,6 +446,8 @@ extension KeymanWebViewController: WKScriptMessageHandler {
                             subkeyIDs: subkeyIDs,
                             subkeyTexts: subkeyTexts,
                             useSpecialFont: useSpecialFont)
+
+      self.touchHoldBegan()
     } else if fragment.hasPrefix("#menuKeyDown-") {
       menuKeyDown(self)
       delegate?.menuKeyDown(self)
@@ -672,6 +674,40 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
     return true
   }
 
+  // An adaptation of holdAction, just for direct taps.
+  @objc func tapAction(_ sender: UITapGestureRecognizer) {
+    switch sender.state {
+    case .ended:
+      // Touch Ended
+      guard let subKeysView = subKeysView else {
+        return
+      }
+
+      let touchPoint = sender.location(in: subKeysView.containerView)
+      var buttonClicked = false
+      for button in subKeys {
+        if button.frame.contains(touchPoint) {
+          button.isEnabled = true
+          button.isHighlighted = true
+          button.backgroundColor = subKeyColorHighlighted
+          button.sendActions(for: .touchUpInside)
+
+          buttonClicked = true
+        } else {
+          button.isHighlighted = false
+          button.isEnabled = false
+          button.backgroundColor = subKeyColor
+        }
+      }
+
+      if !buttonClicked {
+        clearSubKeyArrays()
+      }
+    default:
+      return
+    }
+  }
+
   @objc func holdAction(_ sender: UILongPressGestureRecognizer) {
     switch sender.state {
     case .ended:
@@ -695,16 +731,17 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
         clearSubKeyArrays()
       }
     case .began:
-      // Touch & Hold Began
-      let touchPoint = sender.location(in: sender.view)
-      // Check if touch was for language menu button
-      languageMenuPosition { keyFrame in
-        if keyFrame.contains(touchPoint) {
-          self.delegate?.menuKeyHeld(self)
-          return
-        }
-        self.touchHoldBegan()
-      }
+//      // Touch & Hold Began
+//      let touchPoint = sender.location(in: sender.view)
+//      // Check if touch was for language menu button
+//      languageMenuPosition { keyFrame in
+//        if keyFrame.contains(touchPoint) {
+//          self.delegate?.menuKeyHeld(self)
+//          return
+//        }
+//        self.touchHoldBegan()
+//      }
+      return
     default:
       // Hold & Move
       guard let subKeysView = subKeysView else {
@@ -786,6 +823,14 @@ extension KeymanWebViewController: UIGestureRecognizerDelegate {
     dismissKeyPreview()
     subKeysView = SubKeysView(keyFrame: subKeyAnchor, subKeys: subKeys)
     view.addSubview(subKeysView!)
+
+    let tap = UITapGestureRecognizer(target: self, action: #selector(self.tapAction))
+    subKeysView!.addGestureRecognizer(tap)
+
+    let hold = UILongPressGestureRecognizer(target: self, action: #selector(self.holdAction))
+    hold.minimumPressDuration = 0.01
+    hold.delegate = self
+    subKeysView!.addGestureRecognizer(hold)
     setPopupVisible(true)
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SubKeysView.swift
@@ -123,7 +123,7 @@ class SubKeysView: UIView {
     super.init(frame: CGRect(x: viewPosX, y: viewPosY, width: viewWidth, height: viewHeight))
 
     super.backgroundColor = UIColor.clear
-    isUserInteractionEnabled = false
+    //isUserInteractionEnabled = false
 
     addSubview(containerView)
     let fontSize = buttonHeight * (UIDevice.current.userInterfaceIdiom == .pad ? 0.4 : 0.5)


### PR DESCRIPTION
A temporary workaround for #2716.

Unfortunately, Apple broke something in iOS 13.4 that we've been heavily relying upon for longpresses on the keyboard.  Longpresses that start within a `WKWebView` can now be blocked by JS events, which completely broke all subkey menus.

This PR will adapt Keyman for iOS to rely on Web-side longpress detection instead.  Unfortunately, web-side longpresses can't exactly control Swift-side UI, but we _can_ at least trigger display of the subkey menus.

With this workaround in place, once the subkey menu displays, the user **must** start a second touch within that menu in order to select whatever key/option they desire.  We simply can't tie the menu-generating longpress to the Swift UI, unfortunately.  So, it won't be as smooth as before, but at least it'll _work_ on iOS 13.4, which is (hopefully) an acceptable tradeoff.  We'll want a more robust solution in the long-term, but far more work than this will be required to make that happen.

Currently addressed:
- [x] Popup keys now usable
- [x] Globe-based keyboard menu now usable