### PR TITLE
refactor(web/engine): precomputation for OSK key events, headless production thereof

### DIFF
--- a/web/source/keyboards/activeLayout.ts
+++ b/web/source/keyboards/activeLayout.ts
@@ -53,7 +53,7 @@ namespace com.keyman.keyboards {
       aKey.constructBaseKeyEvent(layout, displayLayer);
     }
 
-    constructBaseKeyEvent(layout: ActiveLayout, displayLayer: string) {
+    private constructBaseKeyEvent(layout: ActiveLayout, displayLayer: string) {
       // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
       // Note - virtual keys should be treated case-insensitive, so we force uppercasing here.
       let layer = this.layer || displayLayer || '';
@@ -62,7 +62,7 @@ namespace com.keyman.keyboards {
       // Start:  mirrors _GetKeyEventProperties
 
       // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-      let keyShiftState = text.KeyboardProcessor.getModifierState(layer); // TODO:  should be a static method, so 'core' could be dropped.
+      let keyShiftState = text.KeyboardProcessor.getModifierState(layer);
 
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: text.KeyEvent = {

--- a/web/source/keyboards/activeLayout.ts
+++ b/web/source/keyboards/activeLayout.ts
@@ -97,9 +97,9 @@ namespace com.keyman.keyboards {
 
         // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
         if(!keyboard.definesPositionalOrMnemonic) {
-          // Not the best pattern, but currently safe - we don't look up any properties of either
-          // argument in this use case, and the object's scope is extremely limited.
-          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(this.constructKeyEvent(null, null));
+          // Not the best pattern, but currently safe - we don't look up any properties of any of the
+          // arguments in this use case, and the object's scope is extremely limited.
+          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(this.constructKeyEvent(null, null, null));
           Lkc.LisVirtualKey=false;
         }
       }
@@ -107,22 +107,21 @@ namespace com.keyman.keyboards {
       this.baseKeyEvent = Lkc;
     }
 
-    constructKeyEvent(target: text.OutputTarget, device: text.EngineDeviceSpec): text.KeyEvent {
-      let keyman = com.keyman.singleton;
-      let core = keyman.core;
-
+    constructKeyEvent(keyboardProcessor: text.KeyboardProcessor, target: text.OutputTarget, device: text.EngineDeviceSpec): text.KeyEvent {
       // Make a deep copy of our preconstructed key event, filling it out from there.
       let Lkc = utils.deepCopy(this.baseKeyEvent);
       Lkc.Ltarg = target;
       Lkc.device = device;
 
       if(this.isMnemonic) {
-        text.KeyboardProcessor.setMnemonicCode(Lkc, this.layer.indexOf('shift') != -1, core.keyboardProcessor.stateKeys['K_CAPS']);
+        text.KeyboardProcessor.setMnemonicCode(Lkc, this.layer.indexOf('shift') != -1, keyboardProcessor ? keyboardProcessor.stateKeys['K_CAPS'] : false);
       }
 
       // Performs common pre-analysis for both 'native' and 'embedded' OSK key & subkey input events.
       // This part depends on the keyboard processor's active state.
-      core.keyboardProcessor.setSyntheticEventDefaults(Lkc);
+      if(keyboardProcessor) {
+        keyboardProcessor.setSyntheticEventDefaults(Lkc);
+      }
 
       return Lkc;
     }

--- a/web/source/keyboards/activeLayout.ts
+++ b/web/source/keyboards/activeLayout.ts
@@ -40,33 +40,42 @@ namespace com.keyman.keyboards {
         }
       }
 
+      // Ensure subkeys are also properly extended.
+      if(key.sk) {
+        for(let subkey of key.sk) {
+          ActiveKey.polyfill(subkey, layout, displayLayer);
+        }
+      }
+
       let aKey = key as ActiveKey;
       aKey.displayLayer = displayLayer;
       aKey.layer = aKey.layer || displayLayer;
 
-      aKey.Lcode = text.Codes.keyCodes[key.id.toUpperCase()];
+      if(key.id) {
+        aKey.Lcode = text.Codes.keyCodes[key.id.toUpperCase()];
 
-      if(layout.keyboard) {
-        let keyboard = layout.keyboard;
+        if(layout.keyboard) {
+          let keyboard = layout.keyboard;
 
-        // Include *limited* support for mnemonic keyboards (Sept 2012)
-        // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
-        if(keyboard.isMnemonic && !(layout.isDefault && layout.formFactor != 'desktop')) {
-          if(aKey.Lcode != text.Codes.keyCodes['K_SPACE']) { // exception required, March 2013
-            // Jan 2019 - interesting that 'K_SPACE' also affects the caps-state check...
-            aKey.vkCode = aKey.Lcode;
-            aKey.isMnemonic = true;
+          // Include *limited* support for mnemonic keyboards (Sept 2012)
+          // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
+          if(keyboard.isMnemonic && !(layout.isDefault && layout.formFactor != 'desktop')) {
+            if(aKey.Lcode != text.Codes.keyCodes['K_SPACE']) { // exception required, March 2013
+              // Jan 2019 - interesting that 'K_SPACE' also affects the caps-state check...
+              aKey.vkCode = aKey.Lcode;
+              aKey.isMnemonic = true;
+            }
+          } else {
+            aKey.vkCode=aKey.Lcode;
           }
-        } else {
-          aKey.vkCode=aKey.Lcode;
-        }
 
-        // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
-        if(!keyboard.definesPositionalOrMnemonic) {
-          // Not the best pattern, but currently safe - we don't look up any properties of either
-          // argument in this use case, and the object's scope is extremely limited.
-          aKey.Lcode = KeyMapping._USKeyCodeToCharCode(aKey.constructKeyEvent(null, null));
-          aKey.isVirtualKey=false;
+          // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
+          if(!keyboard.definesPositionalOrMnemonic) {
+            // Not the best pattern, but currently safe - we don't look up any properties of either
+            // argument in this use case, and the object's scope is extremely limited.
+            aKey.Lcode = KeyMapping._USKeyCodeToCharCode(aKey.constructKeyEvent(null, null));
+            aKey.isVirtualKey=false;
+          }
         }
       }
     }

--- a/web/source/keyboards/keyboard.ts
+++ b/web/source/keyboards/keyboard.ts
@@ -339,7 +339,7 @@ namespace com.keyman.keyboards {
       if(rawLayout) {
         // Prevents accidentally reprocessing layouts; it's a simple enough check.
         if(this.layoutStates[formFactor] == LayoutState.NOT_LOADED) {
-          rawLayout = ActiveLayout.polyfill(rawLayout, formFactor);
+          rawLayout = ActiveLayout.polyfill(rawLayout, this, formFactor);
           this.layoutStates[formFactor] = LayoutState.POLYFILLED;
         }
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -375,7 +375,7 @@ namespace com.keyman.text {
       
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=core.keyboardProcessor.getModifierState(layer);
+      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=com.keyman.text.KeyboardProcessor.getModifierState(layer);
       
       keymanweb.domManager.initActiveElement(Lelem);
 

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -4,38 +4,20 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
       let core = keyman.core;
 
-      var activeKeyboard = core.activeKeyboard;
-      let formFactor = keyman.util.device.formFactor;
-
-      // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
-      // Note - virtual keys should be treated case-insensitive, so we force uppercasing here.
-      var layer = e.layer || e.displayLayer || '';
-
       // Start:  mirrors _GetKeyEventProperties
 
       // First check the virtual key, and process shift, control, alt or function keys
       let Lkc = e.constructKeyEvent(dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
 
+      // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
+      switch(Lkc.kName) {
+        case 'K_CAPS':
+        case 'K_NUMLOCK':
+        case 'K_SCROLL':
+          core.keyboardProcessor.stateKeys[Lkc.kName] = ! core.keyboardProcessor.stateKeys[Lkc.kName];
+      }
+
       // End - mirrors _GetKeyEventProperties
-
-      // Include *limited* support for mnemonic keyboards (Sept 2012)
-      // If a touch layout has been defined for a mnemonic keyout, do not perform mnemonic mapping for rules on touch devices.
-      if(activeKeyboard && activeKeyboard.isMnemonic && !(activeKeyboard.layout(formFactor as text.FormFactor).isDefault && formFactor != 'desktop')) {
-        if(Lkc.Lcode != text.Codes.keyCodes['K_SPACE']) { // exception required, March 2013
-          // Jan 2019 - interesting that 'K_SPACE' also affects the caps-state check...
-          Lkc.vkCode = Lkc.Lcode;
-          text.KeyboardProcessor.setMnemonicCode(Lkc, layer.indexOf('shift') != -1, core.keyboardProcessor.stateKeys['K_CAPS']);
-        }
-      } else {
-        Lkc.vkCode=Lkc.Lcode;
-      }
-
-      // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
-      if(!activeKeyboard.definesPositionalOrMnemonic) {
-        Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(Lkc);
-        Lkc.LisVirtualKey=false;
-      }
-
       return Lkc;
     }
 

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -7,7 +7,7 @@ namespace com.keyman.osk {
       // Start:  mirrors _GetKeyEventProperties
 
       // First check the virtual key, and process shift, control, alt or function keys
-      let Lkc = e.constructKeyEvent(dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
+      let Lkc = e.constructKeyEvent(core.keyboardProcessor, dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
 
       // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
       switch(Lkc.kName) {

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -9,39 +9,12 @@ namespace com.keyman.osk {
 
       // Get key name and keyboard shift state (needed only for default layouts and physical keyboard handling)
       // Note - virtual keys should be treated case-insensitive, so we force uppercasing here.
-      var layer = e.layer || e.displayLayer || '', keyName=e.id.toUpperCase();
+      var layer = e.layer || e.displayLayer || '';
 
       // Start:  mirrors _GetKeyEventProperties
 
-      // Override key shift state if specified for key in layout (corrected for popup keys KMEW-93)
-      var keyShiftState = core.keyboardProcessor.getModifierState(layer);
-
       // First check the virtual key, and process shift, control, alt or function keys
-      var Lkc: text.KeyEvent = {
-        Ltarg: dom.Utils.getOutputTarget(Lelem),
-        Lmodifiers: keyShiftState,
-        Lstates: 0,
-        Lcode: text.Codes.keyCodes[keyName],
-        LisVirtualKey: true,
-        vkCode: 0,
-        kName: keyName,
-        kLayer: layer,
-        kbdLayer: e.displayLayer,
-        kNextLayer: e.nextlayer,
-        device: keyman.util.device.coreSpec,  // The OSK's events always use the 'true' device.
-        isSynthetic: true
-      };
-
-      // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
-      switch(keyName) {
-        case 'K_CAPS':
-        case 'K_NUMLOCK':
-        case 'K_SCROLL':
-          core.keyboardProcessor.stateKeys[keyName] = ! core.keyboardProcessor.stateKeys[keyName];
-      }
-
-      // Performs common pre-analysis for both 'native' and 'embedded' OSK key & subkey input events.
-      core.keyboardProcessor.setSyntheticEventDefaults(Lkc);
+      let Lkc = e.constructKeyEvent(dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
 
       // End - mirrors _GetKeyEventProperties
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -625,7 +625,7 @@ namespace com.keyman.osk {
         // In KMW's current state, it'd take a major break, though - Processor always has an activeKeyboard,
         // even if it's "hollow".
         let rawLayout = keyboards.Layouts.buildDefaultLayout(null, null, device.formFactor);
-        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, device.formFactor);
+        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, keyboard, device.formFactor);
       }
       this.layers=layout['layer'];
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -625,7 +625,7 @@ namespace com.keyman.osk {
         // In KMW's current state, it'd take a major break, though - Processor always has an activeKeyboard,
         // even if it's "hollow".
         let rawLayout = keyboards.Layouts.buildDefaultLayout(null, null, device.formFactor);
-        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, keyboard, device.formFactor);
+        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, null, device.formFactor as text.FormFactor);
       }
       this.layers=layout['layer'];
 

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -114,8 +114,7 @@ namespace com.keyman.text {
                 continue;
               }
 
-              let altEvent = osk.PreProcessor._GetClickEventProperties(altKey, outputTarget.getElement());
-              altEvent.Ltarg = mock;
+              let altEvent = altKey.constructKeyEvent(this.keyboardProcessor, mock, keyEvent.device);
               let alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
               if(alternateBehavior) {
                 // TODO: if alternateBehavior.beep == true, set 'p' to 0.  It's a disallowed key sequence,

--- a/web/source/text/keyboardProcessor.ts
+++ b/web/source/text/keyboardProcessor.ts
@@ -303,7 +303,7 @@ namespace com.keyman.text {
      * @param       {string}      layerId       layer id (e.g. ctrlshift)
      * @return      {number}                    modifier key state (desktop keyboards)
      */
-    static getModifierState(layerId: string): number { // TODO:  make static.
+    static getModifierState(layerId: string): number {
       var modifier=0;
       if(layerId.indexOf('shift') >= 0) {
         modifier |= Codes.modifierCodes['SHIFT'];

--- a/web/source/text/keyboardProcessor.ts
+++ b/web/source/text/keyboardProcessor.ts
@@ -303,7 +303,7 @@ namespace com.keyman.text {
      * @param       {string}      layerId       layer id (e.g. ctrlshift)
      * @return      {number}                    modifier key state (desktop keyboards)
      */
-    getModifierState(layerId: string): number {
+    getModifierState(layerId: string): number { // TODO:  make static.
       var modifier=0;
       if(layerId.indexOf('shift') >= 0) {
         modifier |= Codes.modifierCodes['SHIFT'];

--- a/web/source/text/keyboardProcessor.ts
+++ b/web/source/text/keyboardProcessor.ts
@@ -303,7 +303,7 @@ namespace com.keyman.text {
      * @param       {string}      layerId       layer id (e.g. ctrlshift)
      * @return      {number}                    modifier key state (desktop keyboards)
      */
-    getModifierState(layerId: string): number { // TODO:  make static.
+    static getModifierState(layerId: string): number { // TODO:  make static.
       var modifier=0;
       if(layerId.indexOf('shift') >= 0) {
         modifier |= Codes.modifierCodes['SHIFT'];
@@ -563,7 +563,7 @@ namespace com.keyman.text {
         // if(idx == '') with accompanying if-else structural shift would be a far better test here.
         else {
           // Save our current modifier state.
-          var modifier=this.getModifierState(s);
+          var modifier=KeyboardProcessor.getModifierState(s);
 
           // Strip down to the base modifiable layer.
           for(i=0; i < replacements.length; i++) {

--- a/web/source/utils/deepCopy.ts
+++ b/web/source/utils/deepCopy.ts
@@ -11,7 +11,7 @@ namespace com.keyman.utils {
   export function deepCopy<T>(p:T, c0?): T {
     var c = c0 || {};
     for (var i in p) {
-      if(typeof p[i] === 'object') {
+      if(typeof p[i] === 'object' && p[i] != null) {
         c[i] = (p[i].constructor === Array ) ? [] : {};
         deepCopy(p[i],c[i]);
       }

--- a/web/testing/chirality/chirality.js
+++ b/web/testing/chirality/chirality.js
@@ -54,7 +54,7 @@ function Keyboard_chirality() {
     for(var i = 0; i < layers.length; i++) {
       // Obtain the modifier code to match for the selected layer.
       // The following uses a non-public property potentially subject to change in the future.
-      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | core.keyboardProcessor.getModifierState(layers[i]);
+      var modCode = Constants.modifierCodes['VIRTUAL_KEY'] | com.keyman.text.KeyboardProcessor.getModifierState(layers[i]);
       var layer = layers[i];
       
       for(var key=0; key < kls[layer].length; key++) {


### PR DESCRIPTION
To be able to do predictive text headlessly, we need to be able to generate events for untyped keys so that their results can be analyzed for potential corrections.  This previously relied on code with ties to the main, DOM-aware `com.keyman.singleton` object.

After this, there are still a few small ties that must yet be resolved:
- `InputProcessor` should own the `modelManager`.
- There's a critical `keyman.isEmbedded` check in `processKeyEvent` that needs to be properly resolved.