### PR TITLE
refactor(web/engine): initial ModelManager split

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -322,7 +322,7 @@ namespace com.keyman.dom {
 
        // Now that we've fully entered the new context, invalidate the context so we can generate initial predictions from it.
       if(this.keyman.modelManager) {
-        this.keyman.modelManager.invalidateContext();
+        this.keyman.core.languageProcessor.invalidateContext();
       }
     }
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -170,7 +170,7 @@ namespace com.keyman {
       this.osk.shutdown();
       this.util.shutdown();
       this.keyboardManager.shutdown();
-      this.modelManager.shutdown();
+      this.core.languageProcessor.shutdown();
 
       if(this.ui && this.ui.shutdown) {
         this.ui.shutdown();
@@ -670,5 +670,8 @@ if(!window['keyman'] || !window['keyman']['loaded']) {
      * As this is the base object, not creating it prevents a KMW system reset.
      */
     window['keyman'] = com.keyman['singleton'] = com.keyman.singleton = new KeymanBase();
+
+    // TODO:  Eliminate the need for this.  Will require more refactoring & redesign to drop.
+    window['keyman'].core.languageProcessor.init();
   })();
 }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -257,7 +257,7 @@ namespace com.keyman.osk {
       }
       
       // Find the state of the context at the time the prediction-triggering keystroke was applied.
-      let original = keyman.modelManager.getPredictionState(this._suggestion.transformId);
+      let original = keyman.core.languageProcessor.getPredictionState(this._suggestion.transformId);
       if(!original) {
         console.warn("Could not apply the Suggestion!");
         return [null, null];
@@ -280,7 +280,7 @@ namespace com.keyman.osk {
         // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
         // values as needed for use with their IME interfaces.
         let transform = final.buildTransformFrom(target);
-        let wordbreakPromise = keyman.modelManager.wordbreak(target); // Also build the display string for the reversion.
+        let wordbreakPromise = keyman.core.languageProcessor.wordbreak(target); // Also build the display string for the reversion.
         target.apply(transform);
 
         // Signal the necessary text changes to the embedding app, if it exists.
@@ -429,7 +429,7 @@ namespace com.keyman.osk {
       keyman.modelManager['addEventListener']('tryrevert', manager.tryRevert);
 
       // Trigger a null-based initial prediction to kick things off.
-      keyman.modelManager.predict();
+      keyman.core.languageProcessor.predict();
     }
 
     deactivate() {
@@ -607,7 +607,7 @@ namespace com.keyman.osk {
       // Request a 'new' prediction based on current context with a nil Transform.
       let keyman = com.keyman.singleton;
       this.swallowPrediction = true;
-      keyman.modelManager.predict();
+      keyman.core.languageProcessor.predict();
     }
 
     private showRevert() {

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -143,10 +143,10 @@ namespace com.keyman.osk {
             this.alwaysShow = optionSpec[key];
             break;
           case 'mayPredict':
-            keyman.modelManager.mayPredict = optionSpec[key]
+            keyman.core.languageProcessor.mayPredict = optionSpec[key]
             break;
           case 'mayCorrect':
-            keyman.modelManager.mayCorrect = optionSpec[key];
+            keyman.core.languageProcessor.mayCorrect = optionSpec[key];
             break;
           case 'imagePath':
             // Determines the image file to use for ImageBanners.
@@ -215,7 +215,7 @@ namespace com.keyman.osk {
       // language has an active predictive model.
       // ModelManager will never have an active model 
       // when predictions are disabled.
-      if(keyman.modelManager.activeModel) {
+      if(keyman.core.activeModel) {
         this.setBanner('suggestion');
       } else if(this.alwaysShow) {
         this.setBanner('image');

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -49,7 +49,7 @@ namespace com.keyman.osk {
         outputTarget.deadkeys().deleteMatched();      // Delete any matched deadkeys before continuing
   
         let Lkc = PreProcessor._GetClickEventProperties(e['key'].spec as keyboards.ActiveKey, Lelem);
-        if(keyman.modelManager.enabled) {
+        if(keyman.core.languageProcessor.enabled) {
           Lkc.source = touch;
           Lkc.keyDistribution = keyDistribution;
         }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -907,7 +907,7 @@ namespace com.keyman.osk {
 
     getTouchProbabilities(touch: Touch): text.KeyDistribution {
       let keyman = com.keyman.singleton;
-      if(!keyman.modelManager.mayCorrect) {
+      if(!keyman.core.languageProcessor.mayCorrect) {
         return null;
       }
 

--- a/web/source/text/prediction/languageProcessor.ts
+++ b/web/source/text/prediction/languageProcessor.ts
@@ -1,0 +1,209 @@
+namespace com.keyman.text.prediction {
+  export class LanguageProcessor {
+    private lmEngine: LMLayer;
+    private currentModel?: ModelSpec;
+    private configuration?: Configuration;
+    private currentPromise?: Promise<Suggestion[]>;
+
+    private recentTranscriptions: Transcription[] = [];
+
+    private _mayPredict: boolean = true;
+    private _mayCorrect: boolean = true;
+
+    private static readonly TRANSCRIPTION_BUFFER: 10;
+
+    public init(supportsRightDeletions: boolean = false) {
+      // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer
+      // model may expect.
+      let capabilities: Capabilities = {
+        maxLeftContextCodePoints: 64,
+        // Since the apps don't yet support right-deletions.
+        maxRightContextCodePoints: supportsRightDeletions ? 0 : 64
+      }
+
+      if(!this.canEnable()) {
+        return;
+      }
+
+      this.lmEngine = new LMLayer(capabilities);
+    }
+
+    public get activeModel(): ModelSpec {
+      return this.currentModel;
+    }
+
+    public unloadModel() {
+      this.lmEngine.unloadModel();
+      delete this.currentModel;
+      delete this.configuration;
+    }
+
+    loadModel(model: ModelSpec): Promise<void> {
+      if(!model) {
+        throw new Error("Null reference not allowed.");
+      }
+
+      let file = model.path;
+      let mm = this;
+
+      // We should wait until the model is successfully loaded before setting our state values.
+      return this.lmEngine.loadModel(file).then(function(config: Configuration) { 
+        mm.currentModel = model;
+        mm.configuration = config;
+      });
+    }
+
+    public invalidateContext() {
+      let keyman = com.keyman.singleton;
+
+      // Signal to any predictive text UI that the context has changed, invalidating recent predictions.
+      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'context');
+
+      // If there's no active model, there can be no predictions.
+      // We'll also be missing important data needed to even properly REQUEST the predictions.
+      if(!this.currentModel || !this.configuration) {
+        return;
+      }
+      
+      this.predict_internal();
+    }
+
+    public wordbreak(target: OutputTarget): Promise<string> {
+      let context = new TranscriptionContext(Mock.from(target), this.configuration);
+      return this.lmEngine.wordbreak(context);
+    }
+
+    public predict(transcription?: Transcription) {
+      let keyman = com.keyman.singleton;
+
+      // If there's no active model, there can be no predictions.
+      // We'll also be missing important data needed to even properly REQUEST the predictions.
+      if(!this.currentModel || !this.configuration) {
+        return;
+      }
+            
+      // We've already invalidated any suggestions resulting from any previously-existing Promise -
+      // may as well officially invalidate them via event.
+      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'new');
+
+      this.predict_internal(transcription);
+    }
+
+    /**
+     * Called internally to do actual predictions after any relevant "invalidatesuggestions" events
+     * have been raised.
+     * @param transcription The triggering transcription (if it exists)
+     */
+    private predict_internal(transcription?: Transcription) {
+      let keyman = com.keyman.singleton;
+
+      if(!transcription) {
+        let t = dom.Utils.getOutputTarget();
+        if(t) {
+          transcription = t.buildTranscriptionFrom(t, null);
+        } else {
+          return;
+        }
+      }
+
+      let context = new TranscriptionContext(transcription.preInput, this.configuration);
+      this.recordTranscription(transcription);
+
+      let transform = transcription.transform;
+      var promise = this.currentPromise = this.lmEngine.predict(transcription.alternates || transcription.transform, context);
+
+      let mm = this;
+      promise.then(function(suggestions: Suggestion[]) {
+        if(promise == mm.currentPromise) {
+          let result = new ReadySuggestions(suggestions, transform.id);
+          keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", result);
+          mm.currentPromise = null;
+        }
+      })
+    }
+
+    private recordTranscription(transcription: Transcription) {
+      this.recentTranscriptions.push(transcription);
+
+      if(this.recentTranscriptions.length > LanguageProcessor.TRANSCRIPTION_BUFFER) {
+        this.recentTranscriptions.splice(0, 1);
+      }
+    }
+
+    /**
+     * Retrieves the context and output state of KMW immediately before the prediction with 
+     * token `id` was generated.  Must correspond to a 'recent' one, as only so many are stored
+     * in `ModelManager`'s history buffer.
+     * @param id A unique identifier corresponding to a recent `Transcription`.
+     * @returns The matching `Transcription`, or `null` none is found.
+     */
+    public getPredictionState(id: number): Transcription {
+      let match = this.recentTranscriptions.filter(function(t: Transcription) {
+        return t.token == id;
+      })
+
+      return match.length == 0 ? null : match[0];
+    }
+
+    public shutdown() {
+      this.lmEngine.shutdown();
+    }
+
+    public get enabled(): boolean {
+      return this.activeModel && this._mayPredict;
+    }
+
+    private canEnable(): boolean {
+      let keyman = com.keyman.singleton;
+
+      if(keyman.util.getIEVersion() == 10) {
+        console.warn("KeymanWeb cannot properly initialize its WebWorker in this version of IE.");
+        return false;
+      } else if(keyman.util.getIEVersion() < 10) {
+        console.warn("WebWorkers are not supported in this version of IE.");
+        return false;
+      }
+
+      return true;
+    }
+
+    public get mayPredict() {
+      return this._mayPredict;
+    }
+
+    public set mayPredict(flag: boolean) {
+      let enabled = this.enabled;
+
+      if(!this.canEnable()) {
+        return;
+      }
+
+      this._mayPredict = flag;
+      if(enabled != this.enabled || flag) {
+        com.keyman.singleton.modelManager.doEnable(flag);
+      }
+    }
+
+    public get mayCorrect() {
+      return this._mayCorrect;
+    }
+
+    public set mayCorrect(flag: boolean) {
+      this._mayCorrect = flag;
+    }
+
+    public tryAcceptSuggestion(source: string): boolean {
+      let keyman = com.keyman.singleton;
+      
+      // Handlers of this event should return 'false' when the 'try' is successful.
+      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', source);
+    }
+
+    public tryRevertSuggestion(): boolean {
+      let keyman = com.keyman.singleton;
+      
+      // Handlers of this event should return 'false' when the 'try' is successful.
+      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryrevert', null);
+    }
+  }
+}

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -24,7 +24,7 @@ namespace com.keyman.text.prediction {
     path: string;
   }
 
-  class TranscriptionContext implements Context {
+  export class TranscriptionContext implements Context {
     left: string;
     right?: string;
 
@@ -84,75 +84,26 @@ namespace com.keyman.text.prediction {
   type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | ModelChangeHandler | TryUIHandler;
 
   export class ModelManager {
-    private lmEngine: LMLayer;
-    private currentModel?: ModelSpec;
-    private configuration?: Configuration;
-    private currentPromise?: Promise<Suggestion[]>;
-
-    private recentTranscriptions: Transcription[] = [];
-
-    private _mayPredict: boolean = true;
-    private _mayCorrect: boolean = true;
-
     // Tracks registered models by ID.
     private registeredModels: {[id: string]: ModelSpec} = {};
 
     // Allows for easy model lookup by language code; useful when switching keyboards.
-    private languageModelMap: {[language:string]: ModelSpec} = {};
+    languageModelMap: {[language:string]: ModelSpec} = {};
 
-    private static EVENT_PREFIX: string = "kmw.mm.";
-    private static readonly TRANSCRIPTION_BUFFER: 10;
-
+    static EVENT_PREFIX: string = "kmw.mm.";
+    
     init() {
       let keyman = com.keyman.singleton;
-      // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer
-      // model may expect.
-      let capabilities: Capabilities = {
-        maxLeftContextCodePoints: 64,
-        // Since the apps don't yet support right-deletions.
-        maxRightContextCodePoints: keyman.isEmbedded ? 0 : 64
-      }
-
-      if(!this.canEnable()) {
-        return;
-      }
-
-      this.lmEngine = new LMLayer(capabilities);
       
       // Registers this module for keyboard (language) and model change events.
       keyman['addEventListener']('keyboardchange', this.onKeyboardChange.bind(this));
     }
 
-    public get activeModel(): ModelSpec {
-      return this.currentModel;
-    }
-
-    public unloadModel() {
-      this.lmEngine.unloadModel();
-      delete this.currentModel;
-      delete this.configuration;
-    }
-
-    private loadModel(model: ModelSpec): Promise<void> {
-      if(!model) {
-        throw new Error("Null reference not allowed.");
-      }
-
-      let file = model.path;
-      let mm = this;
-
-      // We should wait until the model is successfully loaded before setting our state values.
-      return this.lmEngine.loadModel(file).then(function(config: Configuration) { 
-        mm.currentModel = model;
-        mm.configuration = config;
-      });
-    }
-
     onKeyboardChange(kbdInfo?: keyboards.KeyboardChangeData | string) {
       let keyman = com.keyman.singleton;
-      let mm: ModelManager = this;
+      let core = keyman.core;
 
-      if(!this.mayPredict) {
+      if(!core.languageProcessor.mayPredict) {
         return Promise.resolve();
       }
 
@@ -168,14 +119,14 @@ namespace com.keyman.text.prediction {
       let model = this.languageModelMap[lgCode];
       var loadPromise: Promise<void>;
 
-      if(this.currentModel !== model) {
-        if(this.currentModel) {
-          this.unloadModel();
+      if(core.activeModel !== model) {
+        if(core.activeModel) {
+          core.languageProcessor.unloadModel();
           keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
         }
 
         if(model) {
-          loadPromise = this.loadModel(model);
+          loadPromise = core.languageProcessor.loadModel(model);
         }
 
         // If we're loading a model, we need to defer until its completion before we report a change of state.
@@ -185,10 +136,10 @@ namespace com.keyman.text.prediction {
             // Because this is executed from a Promise, it's possible to have a race condition
             // where the 'loaded' event triggers after an 'unloaded' event meant to disable the model.
             // (Especially in the embedded apps.)  This will catch these cases.
-            if(mm.mayPredict) {
+            if(core.languageProcessor.mayPredict) {
               keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'loaded');
             } else {
-              mm.unloadModel();
+              core.languageProcessor.unloadModel();
             }
           }).catch(function(failReason: any) {
             // Does this provide enough logging information?
@@ -220,6 +171,7 @@ namespace com.keyman.text.prediction {
 
     deregister(modelId: string): void {
       let keyman = com.keyman.singleton;
+      let core = keyman.core;
       let model: ModelSpec;
 
       // Remove the model from the id-lookup associative array.
@@ -231,8 +183,8 @@ namespace com.keyman.text.prediction {
       }
 
       // Is it the active model?
-      if(this.currentModel && this.currentModel.id == modelId) {
-        this.unloadModel();
+      if(core.activeModel && core.activeModel.id == modelId) {
+        core.languageProcessor.unloadModel();
         keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
       }
 
@@ -247,6 +199,25 @@ namespace com.keyman.text.prediction {
 
     isRegistered(model: ModelSpec): boolean {
       return !! this.registeredModels[model.id];
+    }
+
+    doEnable(flag: boolean) {
+      let keyman = com.keyman.singleton;
+
+      if(flag) {
+        let lgCode = keyman.keyboardManager.getActiveLanguage();
+        if(keyman.modelManager.languageModelMap[lgCode]) {
+          // Just reuse the existing model-change trigger code.
+          keyman.modelManager.onKeyboardChange(lgCode);
+        }
+      } else {
+        if(keyman.core.activeModel) { // We only need to unload a model when one is actually loaded.
+          keyman.core.languageProcessor.unloadModel();
+        }
+
+        // Ensure that the banner is unloaded.
+        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
+      }
     }
 
     /**
@@ -273,180 +244,6 @@ namespace com.keyman.text.prediction {
     ['removeEventListener'](event: SupportedEventNames, func: SupportedEventHandler): boolean {
       let keyman = com.keyman.singleton;
       return keyman.util.removeEventListener(ModelManager.EVENT_PREFIX + event, func);
-    }
-
-    public invalidateContext() {
-      let keyman = com.keyman.singleton;
-
-      // Signal to any predictive text UI that the context has changed, invalidating recent predictions.
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'context');
-
-      // If there's no active model, there can be no predictions.
-      // We'll also be missing important data needed to even properly REQUEST the predictions.
-      if(!this.currentModel || !this.configuration) {
-        return;
-      }
-      
-      this.predict_internal();
-    }
-
-    public wordbreak(target: OutputTarget): Promise<string> {
-      let keyman = com.keyman.singleton;
-
-      let context = new TranscriptionContext(Mock.from(target), this.configuration);
-      return this.lmEngine.wordbreak(context);
-    }
-
-    public predict(transcription?: Transcription) {
-      let keyman = com.keyman.singleton;
-
-      // If there's no active model, there can be no predictions.
-      // We'll also be missing important data needed to even properly REQUEST the predictions.
-      if(!this.currentModel || !this.configuration) {
-        return;
-      }
-            
-      // We've already invalidated any suggestions resulting from any previously-existing Promise -
-      // may as well officially invalidate them via event.
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'new');
-
-      this.predict_internal(transcription);
-    }
-
-    /**
-     * Called internally to do actual predictions after any relevant "invalidatesuggestions" events
-     * have been raised.
-     * @param transcription The triggering transcription (if it exists)
-     */
-    private predict_internal(transcription?: Transcription) {
-      let keyman = com.keyman.singleton;
-
-      if(!transcription) {
-        let t = dom.Utils.getOutputTarget();
-        if(t) {
-          transcription = t.buildTranscriptionFrom(t, null);
-        } else {
-          return;
-        }
-      }
-
-      let context = new TranscriptionContext(transcription.preInput, this.configuration);
-      this.recordTranscription(transcription);
-
-      let transform = transcription.transform;
-      var promise = this.currentPromise = this.lmEngine.predict(transcription.alternates || transcription.transform, context);
-
-      let mm = this;
-      promise.then(function(suggestions: Suggestion[]) {
-        if(promise == mm.currentPromise) {
-          let result = new ReadySuggestions(suggestions, transform.id);
-          keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", result);
-          mm.currentPromise = null;
-        }
-      })
-    }
-
-    private recordTranscription(transcription: Transcription) {
-      this.recentTranscriptions.push(transcription);
-
-      if(this.recentTranscriptions.length > ModelManager.TRANSCRIPTION_BUFFER) {
-        this.recentTranscriptions.splice(0, 1);
-      }
-    }
-
-    /**
-     * Retrieves the context and output state of KMW immediately before the prediction with 
-     * token `id` was generated.  Must correspond to a 'recent' one, as only so many are stored
-     * in `ModelManager`'s history buffer.
-     * @param id A unique identifier corresponding to a recent `Transcription`.
-     * @returns The matching `Transcription`, or `null` none is found.
-     */
-    public getPredictionState(id: number): Transcription {
-      let match = this.recentTranscriptions.filter(function(t: Transcription) {
-        return t.token == id;
-      })
-
-      return match.length == 0 ? null : match[0];
-    }
-
-    public shutdown() {
-      this.lmEngine.shutdown();
-    }
-
-    public get enabled(): boolean {
-      return this.activeModel && this._mayPredict;
-    }
-
-    private canEnable(): boolean {
-      let keyman = com.keyman.singleton;
-
-      if(keyman.util.getIEVersion() == 10) {
-        console.warn("KeymanWeb cannot properly initialize its WebWorker in this version of IE.");
-        return false;
-      } else if(keyman.util.getIEVersion() < 10) {
-        console.warn("WebWorkers are not supported in this version of IE.");
-        return false;
-      }
-
-      return true;
-    }
-
-    private doEnable(flag: boolean) {
-      let keyman = com.keyman.singleton;
-
-      if(flag) {
-        let lgCode = keyman.keyboardManager.getActiveLanguage();
-        if(this.languageModelMap[lgCode]) {
-          // Just reuse the existing model-change trigger code.
-          this.onKeyboardChange(lgCode);
-        }
-      } else {
-        if(this.activeModel) { // We only need to unload a model when one is actually loaded.
-          this.unloadModel();
-        }
-
-        // Ensure that the banner is unloaded.
-        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
-      }
-    }
-
-    public get mayPredict() {
-      return this._mayPredict;
-    }
-
-    public set mayPredict(flag: boolean) {
-      let enabled = this.enabled;
-
-      if(!this.canEnable()) {
-        return;
-      }
-
-      this._mayPredict = flag;
-      if(enabled != this.enabled || flag) {
-        this.doEnable(flag);
-      }
-    }
-
-    public get mayCorrect() {
-      return this._mayCorrect;
-    }
-
-    public set mayCorrect(flag: boolean) {
-      this._mayCorrect = flag;
-    }
-
-    public tryAcceptSuggestion(source: string): boolean {
-      let keyman = com.keyman.singleton;
-      
-      // Handlers of this event should return 'false' when the 'try' is successful.
-      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', source);
-    }
-
-    public tryRevertSuggestion(): boolean {
-      let keyman = com.keyman.singleton;
-      
-      // Handlers of this event should return 'false' when the 'try' is successful.
-      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryrevert', null);
     }
   }
 }


### PR DESCRIPTION
Based on #2969, this PR starts formally splitting off `LanguageProcessor` functionality from `ModelManager` functionality, as noted by the [Web-Core Refactor design doc](https://docs.google.com/document/d/1yXcxuVoXaT1nRFvGq9ws7U9GluZVI9t1VsGLEP0SbFE/edit#).  `ModelManager` will remain in DOM-aware KMW, while `LanguageProcessor` will become a web-core component, and thus headless.

Since there's a lot of code to be moved and loose ends to keep tied before continuing, this one's pretty much just code relocation.