### PR TITLE
refactor(web/engine): lm-layer enablement state management rework

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -6,6 +6,8 @@
 /// <reference path="domEventHandlers.ts" />
 // References DOM-specific output handling.
 /// <reference path="domDefaultOutput.ts" />
+// References other DOM-specific web-core overrides.
+/// <reference path="domOverrides.ts" />
 // Includes KMW string extension declarations.
 /// <reference path="../text/kmwstring.ts" />
 // Defines the touch-alias element structure used for mobile devices.

--- a/web/source/dom/domOverrides.ts
+++ b/web/source/dom/domOverrides.ts
@@ -1,0 +1,15 @@
+namespace com.keyman.dom {
+  text.prediction.LanguageProcessor.prototype.canEnable = function(): boolean {
+    let keyman = com.keyman.singleton;
+
+    if(keyman.util.getIEVersion() == 10) {
+      console.warn("KeymanWeb cannot properly initialize its WebWorker in this version of IE.");
+      return false;
+    } else if(keyman.util.getIEVersion() < 10) {
+      console.warn("WebWorkers are not supported in this version of IE.");
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -75,7 +75,7 @@ namespace com.keyman.osk {
 
       // Register a listener for model change events so that we can hot-swap the banner as needed.
       let keyman = com.keyman.singleton;
-      keyman.modelManager['addEventListener']('modelchange', this.selectBanner.bind(this));
+      keyman.modelManager['addEventListener']('statechange', this.selectBanner.bind(this));
     }
 
     /**
@@ -204,11 +204,11 @@ namespace com.keyman.osk {
     }
 
     /**
-     * Handles `ModelManager`'s `'modelchange'` events, 
+     * Handles `LanguageProcessor`'s `'statechange'` events, 
      * allowing logic to automatically hot-swap `Banner`s as needed.
      * @param state 
      */
-    private selectBanner(state?: text.prediction.ModelChangeEnum) {
+    private selectBanner(state?: text.prediction.StateChangeEnum) {
       let keyman = com.keyman.singleton;
 
       // Only display a SuggestionBanner when LanguageProcessor states it is active.s

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -211,11 +211,8 @@ namespace com.keyman.osk {
     private selectBanner(state?: text.prediction.ModelChangeEnum) {
       let keyman = com.keyman.singleton;
 
-      // Only display a SuggestionBanner when the current 
-      // language has an active predictive model.
-      // ModelManager will never have an active model 
-      // when predictions are disabled.
-      if(keyman.core.activeModel) {
+      // Only display a SuggestionBanner when LanguageProcessor states it is active.s
+      if(keyman.core.languageProcessor.isActive) {
         this.setBanner('suggestion');
       } else if(this.alwaysShow) {
         this.setBanner('image');

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -49,7 +49,7 @@ namespace com.keyman.osk {
         outputTarget.deadkeys().deleteMatched();      // Delete any matched deadkeys before continuing
   
         let Lkc = PreProcessor._GetClickEventProperties(e['key'].spec as keyboards.ActiveKey, Lelem);
-        if(keyman.core.languageProcessor.enabled) {
+        if(keyman.core.languageProcessor.isActive) {
           Lkc.source = touch;
           Lkc.keyDistribution = keyDistribution;
         }

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -82,7 +82,7 @@ namespace com.keyman.text {
       // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.
       // If a suggestion was just accepted AND backspace is pressed, revert the change and do not process the backspace.
       // We check the first condition here, while the prediction UI handles the second through the try__() methods below.
-      if(this.languageProcessor.enabled) {
+      if(this.languageProcessor.isActive) {
         // The following code relies on JS's logical operator "short-circuit" properties to prevent unwanted triggering of the second condition.
 
         // Can the suggestion UI revert a recent suggestion?  If so, do that and swallow the backspace.
@@ -110,7 +110,7 @@ namespace com.keyman.text {
 
         // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
         // Also, don't do fat-finger stuff if predictive text isn't enabled.
-        if(this.languageProcessor.enabled && !ruleBehavior.triggersDefaultCommand) {
+        if(this.languageProcessor.isActive && !ruleBehavior.triggersDefaultCommand) {
           // Note - we don't yet do fat-fingering with longpress keys.
           if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
             let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);

--- a/web/source/text/prediction/languageProcessor.ts
+++ b/web/source/text/prediction/languageProcessor.ts
@@ -69,11 +69,19 @@ namespace com.keyman.text.prediction {
     }
 
     public wordbreak(target: OutputTarget): Promise<string> {
+      if(!this.enabled) {
+        return null;
+      }
+
       let context = new TranscriptionContext(Mock.from(target), this.configuration);
       return this.lmEngine.wordbreak(context);
     }
 
     public predict(transcription?: Transcription) {
+      if(!this.enabled) {
+        return;
+      }
+
       let keyman = com.keyman.singleton;
 
       // If there's no active model, there can be no predictions.
@@ -153,17 +161,8 @@ namespace com.keyman.text.prediction {
       return this.activeModel && this._mayPredict;
     }
 
-    private canEnable(): boolean {
-      let keyman = com.keyman.singleton;
-
-      if(keyman.util.getIEVersion() == 10) {
-        console.warn("KeymanWeb cannot properly initialize its WebWorker in this version of IE.");
-        return false;
-      } else if(keyman.util.getIEVersion() < 10) {
-        console.warn("WebWorkers are not supported in this version of IE.");
-        return false;
-      }
-
+    public canEnable(): boolean {
+      // Is overridden for dom-aware KMW in case of old IE versions.
       return true;
     }
 

--- a/web/source/text/prediction/languageProcessor.ts
+++ b/web/source/text/prediction/languageProcessor.ts
@@ -1,4 +1,27 @@
 namespace com.keyman.text.prediction {
+  /**
+   * Corresponds to the 'suggestionsready' LanguageProcessor event.
+   */
+  export type ReadySuggestionsHandler = (prediction: ReadySuggestions) => boolean;
+
+  export type StateChangeEnum = 'active'|'inactive';
+  /**
+   * Corresponds to the 'statechange' LanguageProcessor event.
+   */
+  export type StateChangeHandler = (state: StateChangeEnum) => boolean;
+
+  /**
+   * Covers both 'tryaccept' and 'tryrevert' events.
+   */
+  export type TryUIHandler = (source: string) => boolean;
+
+  export type InvalidateSourceEnum = 'new'|'context';
+
+  /**
+   * Corresponds to the 'invalidatesuggestions' LanguageProcessor event.
+   */
+  export type InvalidateSuggestionsHandler = (source: InvalidateSourceEnum) => boolean;
+
   export class LanguageProcessor {
     private lmEngine: LMLayer;
     private currentModel?: ModelSpec;
@@ -38,7 +61,7 @@ namespace com.keyman.text.prediction {
       delete this.configuration;
 
       let keyman = com.keyman.singleton;
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'unloaded');
+      keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', 'inactive');
     }
 
     loadModel(model: ModelSpec): Promise<void> {
@@ -56,7 +79,7 @@ namespace com.keyman.text.prediction {
 
         try {
           let keyman = com.keyman.singleton;
-          keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', 'loaded');
+          keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', 'active');
         } catch (err) {
           // Does this provide enough logging information?
           console.error("Could not load model '" + model.id + "': " + (err as Error).message);
@@ -193,10 +216,9 @@ namespace com.keyman.text.prediction {
       let oldVal = this._mayPredict;
       this._mayPredict = flag;
 
-      // 'modelchange' always did signify more of a 'is active' flag.
       if(oldVal != flag) {
         let keyman = com.keyman.singleton;
-        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'modelchange', flag ? 'loaded' : 'unloaded');
+        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', flag ? 'active' : 'inactive');
       }
     }
 

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -47,12 +47,8 @@ namespace com.keyman.text.prediction {
     }
   }
 
-  export type InvalidateSourceEnum = 'new'|'context';
-
-  /**
-   * Corresponds to the 'invalidatesuggestions' ModelManager event.
-   */
-  export type InvalidateSuggestionsHandler = (source: InvalidateSourceEnum) => boolean;
+  type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "statechange" | "tryaccept" | "tryrevert";
+  type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | StateChangeHandler | TryUIHandler;
 
   export class ReadySuggestions {
     suggestions: Suggestion[];
@@ -63,25 +59,6 @@ namespace com.keyman.text.prediction {
       this.transcriptionID = id;
     }
   }
-
-  /**
-   * Corresponds to the 'suggestionsready' ModelManager event.
-   */
-  export type ReadySuggestionsHandler = (prediction: ReadySuggestions) => boolean;
-
-  export type ModelChangeEnum = 'loaded'|'unloaded';
-  /**
-   * Corresponds to the 'modelchange' ModelManager event.
-   */
-  export type ModelChangeHandler = (state: ModelChangeEnum) => boolean;
-
-  /**
-   * Covers both 'tryaccept' and 'tryrevert' events.
-   */
-  export type TryUIHandler = (source: string) => boolean;
-
-  type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "modelchange" | "tryaccept" | "tryrevert";
-  type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | ModelChangeHandler | TryUIHandler;
 
   export class ModelManager {
     // Tracks registered models by ID.


### PR DESCRIPTION
Based on #2974.

The old enablement model presents a few issues for going headless; changing `mayPredict` from `false` to `true` required access to the central `com.keyman.singleton` object.  Allowing a model to be loaded while `mayPredict` is false is more-headless friendly - models can be set from outside the `LanguageProcessor` even while prediction is off and will no longer need to be dynamically loaded on state change.

To allow this without breaking things, we simply prevent interactions (`predict`, `wordbreak`) from proceeding while `mayPredict` is false (and thus, `isActive` is false).  Accordingly, the `'modelchange'` event has been retooled into a `'statechange'` event that has the same actual meaning within KMW as `'modelchange'` always had; it just realigns the semantics to better reflect the altered design.