### PR TITLE
refactor(web/engine): predictive data routing, LanguageProcessor as EventEmitter

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -666,15 +666,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
-    "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "extend": {
       "version": "3.0.2",
@@ -941,6 +935,14 @@
         "eventemitter3": "^3.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        }
       }
     },
     "https-proxy-agent": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -671,6 +671,11 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
+    "events": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@types/node": "^11.9.4",
     "es6-shim": "^0.35.5",
-    "events": "^3.1.0",
+    "eventemitter3": "^4.0.0",
     "ts-node": "^8.0.2"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@types/node": "^11.9.4",
     "es6-shim": "^0.35.5",
+    "events": "^3.1.0",
     "ts-node": "^8.0.2"
   }
 }

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -224,7 +224,7 @@ namespace com.keyman.dom {
         return true;
       }
 
-      var LeventMatched = !core.processKeyEvent(Levent);
+      var LeventMatched = (core.processKeyEvent(Levent) != null);
 
       if(LeventMatched) {
         if(e  &&  e.preventDefault) {

--- a/web/source/includes/blank-module.ts
+++ b/web/source/includes/blank-module.ts
@@ -1,2 +1,0 @@
-//@ts-ignore
-window['module'] = {}; // Needed for some node-oriented modules to load properly.

--- a/web/source/includes/blank-module.ts
+++ b/web/source/includes/blank-module.ts
@@ -1,0 +1,2 @@
+//@ts-ignore
+window['module'] = {}; // Needed for some node-oriented modules to load properly.

--- a/web/source/includes/events.ts
+++ b/web/source/includes/events.ts
@@ -1,12 +1,20 @@
-///<reference path="blank-module.ts" />
 // Implements Node's EventEmitter class and related module components in a near
 // browser-compatible way.  (Just requires a blank 'module' object on the window.)
-///<reference path="../../node_modules/events/events.js" />
+///<reference path="../../node_modules/eventemitter3/index.js" />
 
 // Unfortunately, I can't get it to recognize type information properly
 // because we can't use require statements.  So, a small-scale manual definition.
 declare class EventEmitter {
-  on(eventName: string, func: (...args: any[]) => boolean);
+  /** Add a listener for a given event */
+  on(event: string, func: (...args: any[]) => boolean, context?: any);
+  /** Add a one-time listener for a given event */
+  once(event: string, func: (...args: any[]) => boolean, context?: any);
+  removeListener(event: string, func: (...args: any[]) => boolean, context?: any, once?: boolean);
 
+  // Defines their alternately-themed aliases.
+  addListener: typeof EventEmitter.prototype.on;
+  off: typeof EventEmitter.prototype.removeListener;
+
+  // Defines the actual event-raising function.
   emit(eventName: string, ...args: any[]);
 }  

--- a/web/source/includes/events.ts
+++ b/web/source/includes/events.ts
@@ -1,0 +1,4 @@
+///<reference path="blank-module.ts" />
+// Implements Node's EventEmitter class and related module components in a near
+// browser-compatible way.  (Just requires a blank 'module' object on the window.)
+///<reference path="../../node_modules/events/events.js" />

--- a/web/source/includes/events.ts
+++ b/web/source/includes/events.ts
@@ -3,5 +3,10 @@
 // browser-compatible way.  (Just requires a blank 'module' object on the window.)
 ///<reference path="../../node_modules/events/events.js" />
 
-declare class EventEmitter {}  // Unfortunately, I can't get it to recognize type information properly
-                               // because we can't use require statements.
+// Unfortunately, I can't get it to recognize type information properly
+// because we can't use require statements.  So, a small-scale manual definition.
+declare class EventEmitter {
+  on(eventName: string, func: (...args: any[]) => boolean);
+
+  emit(eventName: string, ...args: any[]);
+}  

--- a/web/source/includes/events.ts
+++ b/web/source/includes/events.ts
@@ -2,3 +2,6 @@
 // Implements Node's EventEmitter class and related module components in a near
 // browser-compatible way.  (Just requires a blank 'module' object on the window.)
 ///<reference path="../../node_modules/events/events.js" />
+
+declare class EventEmitter {}  // Unfortunately, I can't get it to recognize type information properly
+                               // because we can't use require statements.

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -499,7 +499,7 @@ namespace com.keyman.text {
     try {
       // Now that we've manually constructed a proper keystroke-sourced KeyEvent, pass control
       // off to the processor for its actual execution.
-      return keyman.core.processKeyEvent(Lkc); // Lack of second argument -> `usingOSK == false`
+      return keyman.core.processKeyEvent(Lkc) != null;
     } catch (err) {
       console.error(err.message, err);
       return false;

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -423,10 +423,10 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
       let manager = this.manager;
 
-      keyman.core.languageProcessor.on('invalidatesuggestions', manager.invalidateSuggestions);
-      keyman.core.languageProcessor.on('suggestionsready', manager.updateSuggestions);
-      keyman.core.languageProcessor.on('tryaccept', manager.tryAccept);
-      keyman.core.languageProcessor.on('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.addListener('invalidatesuggestions', manager.invalidateSuggestions);
+      keyman.core.languageProcessor.addListener('suggestionsready', manager.updateSuggestions);
+      keyman.core.languageProcessor.addListener('tryaccept', manager.tryAccept);
+      keyman.core.languageProcessor.addListener('tryrevert', manager.tryRevert);
 
       // Trigger a null-based initial prediction to kick things off.
       keyman.core.languageProcessor.predict();
@@ -436,10 +436,10 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
       let manager = this.manager;
 
-      keyman.core.languageProcessor.on('invalidatesuggestions', manager.invalidateSuggestions);
-      keyman.core.languageProcessor.on('suggestionsready', manager.updateSuggestions);
-      keyman.core.languageProcessor.on('tryaccept', manager.tryAccept);
-      keyman.core.languageProcessor.on('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.removeListener('invalidatesuggestions', manager.invalidateSuggestions);
+      keyman.core.languageProcessor.removeListener('suggestionsready', manager.updateSuggestions);
+      keyman.core.languageProcessor.removeListener('tryaccept', manager.tryAccept);
+      keyman.core.languageProcessor.removeListener('tryrevert', manager.tryRevert);
     }
 
     rotateSuggestions() {

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -423,10 +423,10 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
       let manager = this.manager;
 
-      keyman.modelManager['addEventListener']('invalidatesuggestions', manager.invalidateSuggestions);
-      keyman.modelManager['addEventListener']('suggestionsready', manager.updateSuggestions);
-      keyman.modelManager['addEventListener']('tryaccept', manager.tryAccept);
-      keyman.modelManager['addEventListener']('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.on('invalidatesuggestions', manager.invalidateSuggestions);
+      keyman.core.languageProcessor.on('suggestionsready', manager.updateSuggestions);
+      keyman.core.languageProcessor.on('tryaccept', manager.tryAccept);
+      keyman.core.languageProcessor.on('tryrevert', manager.tryRevert);
 
       // Trigger a null-based initial prediction to kick things off.
       keyman.core.languageProcessor.predict();
@@ -436,10 +436,10 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
       let manager = this.manager;
 
-      keyman.modelManager['removeEventListener']('invalidatesuggestions', manager.invalidateSuggestions);
-      keyman.modelManager['removeEventListener']('suggestionsready', manager.updateSuggestions);
-      keyman.modelManager['removeEventListener']('tryaccept', manager.tryAccept);
-      keyman.modelManager['removeEventListener']('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.on('invalidatesuggestions', manager.invalidateSuggestions);
+      keyman.core.languageProcessor.on('suggestionsready', manager.updateSuggestions);
+      keyman.core.languageProcessor.on('tryaccept', manager.tryAccept);
+      keyman.core.languageProcessor.on('tryrevert', manager.tryRevert);
     }
 
     rotateSuggestions() {

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -75,7 +75,7 @@ namespace com.keyman.osk {
 
       // Register a listener for model change events so that we can hot-swap the banner as needed.
       let keyman = com.keyman.singleton;
-      keyman.modelManager['addEventListener']('statechange', this.selectBanner.bind(this));
+      keyman.core.languageProcessor.on('statechange', this.selectBanner.bind(this));
     }
 
     /**

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -83,7 +83,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      let retVal = keyman.core.processKeyEvent(Lkc);
+      let retVal = (keyman.core.processKeyEvent(Lkc) != null);
 
       return retVal;
     }

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -54,7 +54,7 @@ namespace com.keyman.text {
      * 
      * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
      */
-    processKeyEvent(keyEvent: KeyEvent): boolean {
+    processKeyEvent(keyEvent: KeyEvent) {
       let keyman = com.keyman.singleton;
       let formFactor = keyEvent.device.formFactor;
 
@@ -163,7 +163,7 @@ namespace com.keyman.text {
         // Notify the ModelManager of new input - it's predictive text time!
         ruleBehavior.transcription.alternates = alternates;
         // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
-        this.languageProcessor.predict(ruleBehavior.transcription);
+        ruleBehavior.predictionPromise = this.languageProcessor.predict(ruleBehavior.transcription);
 
         // KMEA and KMEI (embedded mode) use direct insertion of the character string
         if(keyman.isEmbedded) {
@@ -188,7 +188,7 @@ namespace com.keyman.text {
       //        once THOSE are properly relocated.  (They're too DOM-heavy to remain in web-core.)
 
       // Only return true (for the eventual event handler's return value) if we didn't match a rule.
-      return ruleBehavior == null;
+      return ruleBehavior;
     }
 
     public resetContext() {

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -1,3 +1,5 @@
+// Defines a 'polyfill' of sorts for NPM's events module
+/// <reference path="../includes/events.ts" />
 /// <reference path="keyboardProcessor.ts" />
 /// <reference path="prediction/languageProcessor.ts" />
 

--- a/web/source/text/prediction/languageProcessor.ts
+++ b/web/source/text/prediction/languageProcessor.ts
@@ -22,7 +22,7 @@ namespace com.keyman.text.prediction {
    */
   export type InvalidateSuggestionsHandler = (source: InvalidateSourceEnum) => boolean;
 
-  export class LanguageProcessor {
+  export class LanguageProcessor extends EventEmitter {
     private lmEngine: LMLayer;
     private currentModel?: ModelSpec;
     private configuration?: Configuration;
@@ -60,8 +60,7 @@ namespace com.keyman.text.prediction {
       delete this.currentModel;
       delete this.configuration;
 
-      let keyman = com.keyman.singleton;
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', 'inactive');
+      this.emit('statechange', 'inactive');
     }
 
     loadModel(model: ModelSpec): Promise<void> {
@@ -70,16 +69,15 @@ namespace com.keyman.text.prediction {
       }
 
       let file = model.path;
-      let mm = this;
+      let lp = this;
 
       // We should wait until the model is successfully loaded before setting our state values.
       return this.lmEngine.loadModel(file).then(function(config: Configuration) { 
-        mm.currentModel = model;
-        mm.configuration = config;
+        lp.currentModel = model;
+        lp.configuration = config;
 
         try {
-          let keyman = com.keyman.singleton;
-          keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', 'active');
+          lp.emit('statechange', 'active');
         } catch (err) {
           // Does this provide enough logging information?
           console.error("Could not load model '" + model.id + "': " + (err as Error).message);
@@ -88,10 +86,8 @@ namespace com.keyman.text.prediction {
     }
 
     public invalidateContext() {
-      let keyman = com.keyman.singleton;
-
       // Signal to any predictive text UI that the context has changed, invalidating recent predictions.
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'context');
+      this.emit('invalidatesuggestions', 'context');
 
       // If there's no active model, there can be no predictions.
       // We'll also be missing important data needed to even properly REQUEST the predictions.
@@ -116,8 +112,6 @@ namespace com.keyman.text.prediction {
         return null;
       }
 
-      let keyman = com.keyman.singleton;
-
       // If there's no active model, there can be no predictions.
       // We'll also be missing important data needed to even properly REQUEST the predictions.
       if(!this.currentModel || !this.configuration) {
@@ -126,7 +120,7 @@ namespace com.keyman.text.prediction {
             
       // We've already invalidated any suggestions resulting from any previously-existing Promise -
       // may as well officially invalidate them via event.
-      keyman.util.callEvent(ModelManager.EVENT_PREFIX + "invalidatesuggestions", 'new');
+      this.emit("invalidatesuggestions", 'new');
 
       return this.predict_internal(transcription);
     }
@@ -137,8 +131,6 @@ namespace com.keyman.text.prediction {
      * @param transcription The triggering transcription (if it exists)
      */
     private predict_internal(transcription?: Transcription): Promise<Suggestion[]> {
-      let keyman = com.keyman.singleton;
-
       if(!transcription) {
         let t = dom.Utils.getOutputTarget();
         if(t) {
@@ -154,12 +146,12 @@ namespace com.keyman.text.prediction {
       let transform = transcription.transform;
       var promise = this.currentPromise = this.lmEngine.predict(transcription.alternates || transcription.transform, context);
 
-      let mm = this;
+      let lp = this;
       return promise.then(function(suggestions: Suggestion[]) {
-        if(promise == mm.currentPromise) {
+        if(promise == lp.currentPromise) {
           let result = new ReadySuggestions(suggestions, transform.id);
-          keyman.util.callEvent(ModelManager.EVENT_PREFIX + "suggestionsready", result);
-          mm.currentPromise = null;
+          lp.emit("suggestionsready", result);
+          lp.currentPromise = null;
         }
 
         return suggestions;
@@ -219,8 +211,7 @@ namespace com.keyman.text.prediction {
       this._mayPredict = flag;
 
       if(oldVal != flag) {
-        let keyman = com.keyman.singleton;
-        keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'statechange', flag ? 'active' : 'inactive');
+        this.emit('statechange', flag ? 'active' : 'inactive');
       }
     }
 
@@ -233,17 +224,13 @@ namespace com.keyman.text.prediction {
     }
 
     public tryAcceptSuggestion(source: string): boolean {
-      let keyman = com.keyman.singleton;
-      
       // Handlers of this event should return 'false' when the 'try' is successful.
-      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryaccept', source);
+      return !this.emit('tryaccept', source);
     }
 
     public tryRevertSuggestion(): boolean {
-      let keyman = com.keyman.singleton;
-      
       // Handlers of this event should return 'false' when the 'try' is successful.
-      return !keyman.util.callEvent(ModelManager.EVENT_PREFIX + 'tryrevert', null);
+      return !this.emit('tryrevert', null);
     }
   }
 }

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -153,31 +153,5 @@ namespace com.keyman.text.prediction {
     isRegistered(model: ModelSpec): boolean {
       return !! this.registeredModels[model.id];
     }
-
-    /**
-     * Function     addEventListener
-     * Scope        Public
-     * @param       {string}            event     event to handle
-     * @param       {function(Event)}   func      event handler function
-     * @return      {boolean}                     value returned by util.addEventListener
-     * Description  Wrapper function to add and identify handlers for ModelManager events
-     */       
-    ['addEventListener'](event: SupportedEventNames, func: SupportedEventHandler): boolean {
-      let keyman = com.keyman.singleton;
-      return keyman.util.addEventListener(ModelManager.EVENT_PREFIX + event, func);
-    }
-
-    /**
-     * Function     removeEventListener
-     * Scope        Public
-     * @param       {string}            event     event to handle
-     * @param       {function(Event)}   func      event handler function
-     * @return      {boolean}                     value returned by util.addEventListener
-     * Description  Wrapper function to remove previously-added handlers for ModelManager events
-     */       
-    ['removeEventListener'](event: SupportedEventNames, func: SupportedEventHandler): boolean {
-      let keyman = com.keyman.singleton;
-      return keyman.util.removeEventListener(ModelManager.EVENT_PREFIX + event, func);
-    }
   }
 }

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -66,8 +66,6 @@ namespace com.keyman.text.prediction {
 
     // Allows for easy model lookup by language code; useful when switching keyboards.
     languageModelMap: {[language:string]: ModelSpec} = {};
-
-    static EVENT_PREFIX: string = "kmw.mm.";
     
     init() {
       let keyman = com.keyman.singleton;

--- a/web/source/text/ruleBehavior.ts
+++ b/web/source/text/ruleBehavior.ts
@@ -38,6 +38,11 @@ namespace com.keyman.text {
      */
     warningLog?: string;
 
+    /**
+     * If predictive text is active, contains a Promise returning predictive Suggestions.
+     */
+    predictionPromise?: Promise<Suggestion[]>;
+
     finalize(processor: KeyboardProcessor) {
       let outputTarget = this.transcription.keystroke.Ltarg;
 


### PR DESCRIPTION
WIth this in place, we're getting close to taking `InputProcessor` headless, though there are a few odds and ends yet to tie up.

The trickiest remaining part - making `lm-layer` headless-ready, as it currently depends on the `Worker` type and paradigm.