### PR TITLE
chore(common/lmlayer): do not run tests in IE11 in Windows

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -87,12 +87,6 @@ module.exports = function(config) {
       browser: 'chrome',
       browser_version: '70.0'
     },
-    bs_ie_win: {
-      os: 'Windows',
-      os_version: '10',
-      browser: 'ie',
-      browser_version: '11.0'
-    },
     // On recent versions of Edge, launcher fails to start and/or stop Edge successfully
     //bs_edge_win: {
     //  os: 'Windows',

--- a/common/predictive-text/unit_tests/in_browser/browser-test.sh
+++ b/common/predictive-text/unit_tests/in_browser/browser-test.sh
@@ -32,7 +32,7 @@ get_browser_set_for_OS ( ) {
     if [ $os_id = "mac" ]; then
         BROWSERS="--browsers Firefox,Chrome,Safari"
     elif [ $os_id = "win" ]; then
-        BROWSERS="--browsers Chrome,IE"
+        BROWSERS="--browsers Chrome"
     else
         BROWSERS="--browsers Firefox,Chrome"
     fi


### PR DESCRIPTION
The LMLayer was still testing under IE11. I apparently didn't get the memo that we dropped for support for IE11, and I can't seem to find the documentation supporting this. In fact, I've found this documentation:

https://help.keyman.com/troubleshooting/browsers

> KeymanWeb is designed to be fully compatible with the following browsers:
>  Internet Explorer 6, 7, 8
>  Firefox 2, 3, 3.5
>  Safari 4
>  Chrome 2

That documentation is so out-of-date, it's probably best to just delete it!

Anyway, this gets rid of the IE11 config. I may add testing in Edge in a separate PR.