### PR TITLE
refactor(web/engine): web-core build prep

### DIFF
--- a/web/source/build-web-core.sh
+++ b/web/source/build-web-core.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+# 
+# Compile KeymanWeb's 'keyboard-processor' module, one of the components of Web's 'core' module.
+#
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# This script runs from its own folder
+cd "$(dirname "$THIS_SCRIPT")"
+
+# Generates a linkable TS file; defined in resources/build-utils.sh.
+exportEnvironmentDefinitionTS
+
+# Compile web's `keyboard-processor` module.
+npm run tsc -- -p source/web-core.tsconfig.json

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -335,6 +335,7 @@ namespace com.keyman.dom {
      *                      should be terminated immediately after the call.
      */
     _CommonFocusHelper(target: HTMLElement): boolean {
+      let keyman = com.keyman.singleton;
       var uiManager = this.keyman.uiManager;
       //TODO: the logic of the following line doesn't look right!!  Both variables are true, but that doesn't make sense!
       //_Debug(keymanweb._IsIEEditableIframe(Ltarg,1) + '...' +keymanweb._IsMozillaEditableIframe(Ltarg,1));
@@ -347,7 +348,7 @@ namespace com.keyman.dom {
       }
       DOMEventHandlers.states._DisableInput = false; 
 
-      let activeKeyboard = com.keyman.singleton.core.activeKeyboard;
+      let activeKeyboard = keyman.core.activeKeyboard;
       if(!uiManager.justActivated) {
         if(target && Utils.getOutputTarget(target)) {
           Utils.getOutputTarget(target).deadkeys().clear();
@@ -364,6 +365,10 @@ namespace com.keyman.dom {
       uiManager.justActivated = false;
 
       DOMEventHandlers.states._SelectionControl = target;
+
+      if(keyman.core.languageProcessor.isActive) {
+        keyman.core.languageProcessor.predictFromTarget(Utils.getOutputTarget(target));
+      }
       return false;
     }
 

--- a/web/source/dom/domOverrides.ts
+++ b/web/source/dom/domOverrides.ts
@@ -12,4 +12,30 @@ namespace com.keyman.dom {
 
     return true;
   }
+
+  let headlessRuleBehaviorFinalize = text.RuleBehavior.prototype.finalize;
+  text.RuleBehavior.prototype.finalize = function(this: text.RuleBehavior, processor: text.KeyboardProcessor) {
+    let outputTarget = this.transcription.keystroke.Ltarg;
+
+    // Execute the standard baseline stuff first.
+    headlessRuleBehaviorFinalize.call(this, processor);
+
+    // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
+    let ruleTransform = this.transcription.transform;
+    if(ruleTransform.insert != "" || ruleTransform.deleteLeft > 0 || ruleTransform.deleteRight > 0) {
+      if(outputTarget instanceof targets.OutputTarget && outputTarget.getElement() == dom.DOMEventHandlers.states.activeElement) {
+        dom.DOMEventHandlers.states.changed = true;
+      }
+    }
+
+    let keyman = com.keyman.singleton;
+    // KMEA and KMEI (embedded mode) use direct insertion of the character string
+    if(keyman.isEmbedded) {
+      // A special embedded callback used to setup direct callbacks to app-native code.
+      keyman['oninserttext'](ruleTransform.deleteLeft, ruleTransform.insert, ruleTransform.deleteRight);
+      if(outputTarget instanceof targets.OutputTarget) {
+        keyman.refreshElementContent(outputTarget.getElement());
+      }
+    }
+  }
 }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -429,7 +429,7 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.on('tryrevert', manager.tryRevert);
 
       // Trigger a null-based initial prediction to kick things off.
-      keyman.core.languageProcessor.predict();
+      keyman.core.languageProcessor.predictFromTarget(dom.Utils.getOutputTarget());
     }
 
     deactivate() {
@@ -607,7 +607,7 @@ namespace com.keyman.osk {
       // Request a 'new' prediction based on current context with a nil Transform.
       let keyman = com.keyman.singleton;
       this.swallowPrediction = true;
-      keyman.core.languageProcessor.predict();
+      keyman.core.languageProcessor.predictFromTarget(dom.Utils.getOutputTarget());
     }
 
     private showRevert() {

--- a/web/source/text/inputProcessor.ts
+++ b/web/source/text/inputProcessor.ts
@@ -1,5 +1,7 @@
 // Defines a 'polyfill' of sorts for NPM's events module
 /// <reference path="../includes/events.ts" />
+/// <reference path="../includes/lmlayer.ts" />
+/// <reference path="../includes/lmMsgs.d.ts" />
 /// <reference path="keyboardProcessor.ts" />
 /// <reference path="prediction/languageProcessor.ts" />
 

--- a/web/source/text/prediction/modelManager.ts
+++ b/web/source/text/prediction/modelManager.ts
@@ -6,60 +6,6 @@
 ///<reference path="../../keyboards/kmwkeyboards.ts" />
 
 namespace com.keyman.text.prediction {
-  export interface ModelSpec {
-    /**
-     * The model's unique identifier.
-     */
-    id: string;
-
-    /**
-     * The list of supported BCP-47 language codes.  Only one language should be supported,
-     * although multiple variants based on region code (at min) may be specified.
-     */
-    languages: string[];
-
-    /**
-     * The path/URL to the file that defines the model.
-     */
-    path: string;
-  }
-
-  export class TranscriptionContext implements Context {
-    left: string;
-    right?: string;
-
-    startOfBuffer: boolean;
-    endOfBuffer: boolean;
-
-    constructor(mock: Mock, config: Configuration) {
-      this.left = mock.getTextBeforeCaret();
-      this.startOfBuffer = this.left._kmwLength() > config.leftContextCodePoints;
-      if(!this.startOfBuffer) {
-        // Our custom substring version will return the last n characters if param #1 is given -n.
-        this.left = this.left._kmwSubstr(-config.leftContextCodePoints);
-      }
-
-      this.right = mock.getTextAfterCaret();
-      this.endOfBuffer = this.right._kmwLength() > config.leftContextCodePoints;
-      if(!this.endOfBuffer) {
-        this.right = this.right._kmwSubstr(0, config.leftContextCodePoints);
-      }
-    }
-  }
-
-  type SupportedEventNames = "suggestionsready" | "invalidatesuggestions" | "statechange" | "tryaccept" | "tryrevert";
-  type SupportedEventHandler = InvalidateSuggestionsHandler | ReadySuggestionsHandler | StateChangeHandler | TryUIHandler;
-
-  export class ReadySuggestions {
-    suggestions: Suggestion[];
-    transcriptionID: number;
-
-    constructor(suggestions: Suggestion[], id: number) {
-      this.suggestions = suggestions;
-      this.transcriptionID = id;
-    }
-  }
-
   export class ModelManager {
     // Tracks registered models by ID.
     private registeredModels: {[id: string]: ModelSpec} = {};

--- a/web/source/web-core.tsconfig.json
+++ b/web/source/web-core.tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+	"allowJs": true,
+	"module": "none",
+	"outDir": "../intermediate/",
+	"inlineSources": true,
+  "sourceMap": true,
+  "sourceRoot": "/keyman/",
+  "target": "es5",
+  "types": ["node"],
+  "lib": ["es6"],
+  "outFile": "../intermediate/web-core/index.js"
+  },
+  "files": [
+		"text/inputProcessor.ts"
+  ]
+}


### PR DESCRIPTION
After these changes, the only needed changes remaining are those that will allow the lm-layer to be used headlessly.  (These have their own, separate PR chain - #2986, #2987, and #2988.)  The current lm-layer design requires DOM access for WebWorkers, after all.

The exact compilation errors:
```
jahorton@Joshuas-MacBook-Pro source % ./build-web-core.sh

> keyman@11.0.0 tsc /Users/jahorton/keymanapp/keyman/web
> tsc "-p" "source/web-core.tsconfig.json"

../common/predictive-text/index.ts:51:22 - error TS2304: Cannot find name 'Worker'.

51     private _worker: Worker;
                        ~~~~~~

../common/predictive-text/index.ts:65:54 - error TS2304: Cannot find name 'Worker'.

65     constructor(capabilities: Capabilities, worker?: Worker) {
                                                        ~~~~~~

../common/predictive-text/index.ts:67:36 - error TS2552: Cannot find name 'Worker'. Did you mean 'worker'?

67       this._worker = worker || new Worker(LMLayer.asBlobURI(LMLayerWorkerCode));
                                      ~~~~~~

  ../common/predictive-text/index.ts:65:45
    65     constructor(capabilities: Capabilities, worker?: Worker) {
                                                   ~~~~~~~~~~~~~~~
    'worker' is declared here.

../common/predictive-text/index.ts:144:30 - error TS2304: Cannot find name 'MessageEvent'.

144     private onMessage(event: MessageEvent): void {
                                 ~~~~~~~~~~~~

../common/predictive-text/index.ts:202:22 - error TS2552: Cannot find name 'Blob'. Did you mean 'blob'?

202       let blob = new Blob([code], { type: 'text/javascript' });
                         ~~~~

  ../common/predictive-text/index.ts:202:11
    202       let blob = new Blob([code], { type: 'text/javascript' });
                  ~~~~
    'blob' is declared here.

../common/predictive-text/index.ts:203:14 - error TS2304: Cannot find name 'URL'.

203       return URL.createObjectURL(blob);
```

Note that no build errors arise from code within the `keyman/web` section of the repo; fixing those was the focus of this PR.