### PR TITLE
change(common/lmlayer): Build product enhancement

### DIFF
--- a/common/predictive-text/worker/tsconfig.json
+++ b/common/predictive-text/worker/tsconfig.json
@@ -4,8 +4,8 @@
     "declaration": true,
     "module": "none",
     "outFile": "../build/intermediate/index.js",
+    "inlineSourceMap": true,
     "inlineSources": true,
-    "sourceMap": true,
     "lib": ["webworker", "es6"],
     "target": "es5"
   }


### PR DESCRIPTION
The lm-layer worker's sourcemapping was never quite working right; turns out all that we needed was a simple tweak.

I had been looking to do one more change (to facilitate automatic .d.ts generation for all of the lm-layer), but that turned out to be way more tricky than I anticipated.  The force-push dropped that (incomplete) work.