### PR TITLE
feat(android): Dismiss system keyboard on Back press

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -220,6 +220,15 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_DOWN) {
+      switch (keyCode) {
+        case KeyEvent.KEYCODE_BACK:
+          // Dismiss the keyboard
+          KMManager.hideSystemKeyboard();
+          return true;
+      }
+    }
+
     return interpreter.onKeyDown(keyCode, event);  // if false, will revert to default handling.
   }
 


### PR DESCRIPTION
Fixes #2950

Update system keyboard to hide the OSK when Back pressed.