### PR TITLE
modify(android): Update minimum SDK to 21

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         applicationId "com.tavultesoft.kmapro"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         //println "===DUMPING PROPERTIES==="

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample1"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.kmsample2"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         // VERSION_CODE and VERSION_NAME from version.gradle

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "com.firstvoices.keyboards"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
 
         String env_services_json_file = System.getenv('oem_firstvoices_services_json_file')


### PR DESCRIPTION
Fixes #2989

This updates the minimum supported Android SDK to 21 (Lollipop). This applies to KMEA, KMAPro, Sample Apps, KeyboardHarness, and FV Android app.

Tests/keyCode doesn't use KMEA so no change there.