### PR TITLE
cherrypick(android) - Fix ResourcesUpdateTool crash

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -423,6 +423,7 @@ public final class KMManager {
     if (SystemKeyboard != null) {
       SystemKeyboard.onDestroy();
     }
+    updateTool.destroyNotificationChannel(appContext);
     CloudDownloadMgr.getInstance().shutdown(appContext);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -153,6 +153,13 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
     }
   }
 
+  public static void destroyNotificationChannel(Context aContext) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && aContext != null) {
+      NotificationManager notificationManager = (NotificationManager) aContext.getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.deleteNotificationChannel(ResourcesUpdateTool.class.getName());
+    }
+  }
+
   public void onUpdateDetection(final List<Bundle> updatableResources) {
     failedUpdateCount = 0;
 
@@ -330,6 +337,9 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * @param id : keyboard or lexical model ID to ignore for MONTHS_TO_IGNORE_NOTIFICATION months
    */
   private void setPrefKeyIgnoreNotifications(String id) {
+    if (currentContext == null) {
+      return;
+    }
     SharedPreferences prefs = currentContext.getSharedPreferences(
       currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,12 @@
 # Keyman for Android Version History
 
+## 2020-04-20 13.0.6209 stable
+* Bug fix:
+  * Fix crash involving system keyboard update notifications (#3007)
+
+## 2020-04-15 13.0.6208 stable
+* no change to Keyman for Android (updated Keyman Web Engine #2957)
+
 ## 2020-04-01 13.0.6207 stable
 * Bug fix:
   * Fix crash involving globe button with 3rd party apps (#2932)


### PR DESCRIPTION
Cherrypick #2933 to  stable-13.0

This fixes crashlytic [issue](https://console.firebase.google.com/u/1/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/5abd6c9831c913e93eb75d28da472079) by checking for valid context before setting a preference.