### PR TITLE
modify(android): Refactor Keyboard class to not use Map

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
@@ -122,28 +122,10 @@ final class KMKeyboardPickerAdapter extends NestedAdapter<Keyboard, Dataset.Keyb
 
   @Override
   public void onClick(View v) {
-    @SuppressWarnings("unchecked")
     Keyboard kbInfo = (Keyboard) v.getTag();
     Intent i = new Intent(this.getContext(), KeyboardInfoActivity.class);
     i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-    String packageID = kbInfo.getPackage();
-    String keyboardID = kbInfo.getResourceId();
-    if (packageID == null || packageID.isEmpty()) {
-      packageID = KMManager.KMDefault_UndefinedPackageID;
-    }
-    i.putExtra(KMManager.KMKey_PackageID, packageID);
-    i.putExtra(KMManager.KMKey_KeyboardID, keyboardID);
-    i.putExtra(KMManager.KMKey_LanguageID, kbInfo.getLanguageCode());
-    i.putExtra(KMManager.KMKey_KeyboardName, kbInfo.getResourceName());
-    String keyboardVersion = KMManager.getLatestKeyboardFileVersion(this.getContext(), packageID, keyboardID);
-    i.putExtra(KMManager.KMKey_KeyboardVersion, keyboardVersion);
-    i.putExtra(KMManager.KMKey_CustomKeyboard, kbInfo.isCustomKeyboard());
-    String helpLink = kbInfo.getCustomHelpLink();
-    if (FileUtils.isWelcomeFile(helpLink)) {
-      i.putExtra(KMManager.KMKey_CustomHelpLink, helpLink);
-    } else {
-      i.putExtra(KMManager.KMKey_HelpLink, helpLink);
-    }
+    i.putExtra(KMManager.KMKey_Keyboard, kbInfo);
     KeyboardInfoActivity.titleFont = listFont;
     this.getContext().startActivity(i);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -158,6 +158,7 @@ public final class KMManager {
   public static final String KMKey_KeyboardCount = "kbCount";
   public static final String KMKey_HelpLink = "helpLink";
   public static final String KMKey_Icon = "icon";
+  public static final String KMKey_Keyboard = "keyboard";
   public static final String KMKey_KeyboardID = "kbId";
   public static final String KMKey_KeyboardName = "kbName";
   public static final String KMKey_KeyboardVersion = "version";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -28,7 +28,9 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.util.FileProviderUtils;
+import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.HelpFile;
 import com.tavultesoft.kmea.util.MapCompat;
 import com.tavultesoft.kmea.util.QRCodeUtil;
@@ -59,12 +61,11 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
     getSupportActionBar().setDisplayShowTitleEnabled(false);
 
     listView = (ListView) findViewById(R.id.listView);
-
-    final String packageID = getIntent().getStringExtra(KMManager.KMKey_PackageID);
-    final String kbID = getIntent().getStringExtra(KMManager.KMKey_KeyboardID);
-    String kbName = getIntent().getStringExtra(KMManager.KMKey_KeyboardName);
-    final String kbVersion = getIntent().getStringExtra(KMManager.KMKey_KeyboardVersion);
-    final boolean isCustomKeyboard = getIntent().getBooleanExtra(KMManager.KMKey_CustomKeyboard, false);
+    final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
+    final String packageID = kbd.getPackage();
+    final String kbID = kbd.getResourceId();
+    final String kbName = kbd.getResourceName();
+    final String kbVersion = kbd.getVersion();
 
     final TextView textView = (TextView) findViewById(R.id.bar_title);
     textView.setText(kbName);
@@ -82,8 +83,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
 
     // Display keyboard help link
     hashMap = new HashMap<String, String>();
-    final String helpUrlStr = getIntent().getStringExtra(KMManager.KMKey_HelpLink);
-    final String customHelpLink = getIntent().getStringExtra(KMManager.KMKey_CustomHelpLink);
+    final String customHelpLink = kbd.getCustomHelpLink();
     // Check if app declared FileProvider
     String icon = String.valueOf(R.drawable.ic_arrow_forward);
     // Don't show help link arrow if File Provider unavailable, or custom help doesn't exist
@@ -123,7 +123,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         if (position == 1) {
-          if (customHelpLink != null) {
+          if (FileUtils.isWelcomeFile(customHelpLink)) {
             // Display local welcome.htm help file, including associated assets
             Intent i = HelpFile.toActionView(context, customHelpLink, packageID);
 
@@ -132,7 +132,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
             }
           } else {
             Intent i = new Intent(Intent.ACTION_VIEW);
-            i.setData(Uri.parse(helpUrlStr));
+            i.setData(Uri.parse(customHelpLink));
             startActivity(i);
           }
         }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -146,7 +146,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_BASE, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -62,7 +62,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
 
     listView = (ListView) findViewById(R.id.listView);
     final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
-    final String packageID = kbd.getPackage();
+    final String packageID = kbd.getPackageID();
     final String kbID = kbd.getResourceId();
     final String kbName = kbd.getResourceName();
     final String kbVersion = kbd.getVersion();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -578,14 +578,32 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
       return storageDataset;
     }
 
-    List<? extends Map<String, String>> kbdMapList = getKeyboardsList(context);
+    List<HashMap<String, String>> kbdMapList = getKeyboardsList(context);
     if (kbdMapList == null) {
       kbdMapList = new ArrayList<>(0);
     }
     List<Keyboard> kbdsList = new ArrayList<>(kbdMapList.size());
 
-    for(Map<String, String> map: kbdMapList) {
-      kbdsList.add(new Keyboard(map));
+    for(HashMap<String, String> kbdMap: kbdMapList) {
+      boolean isCustom = kbdMap.containsKey(KMManager.KMKey_CustomKeyboard) &&
+        kbdMap.get(KMManager.KMKey_CustomKeyboard).equals("Y");
+      boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
+        kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
+
+      Keyboard k = new Keyboard(
+        kbdMap.get(KMManager.KMKey_PackageID),
+        kbdMap.get(KMManager.KMKey_KeyboardID),
+        kbdMap.get(KMManager.KMKey_KeyboardName),
+        kbdMap.get(KMManager.KMKey_LanguageID),
+        kbdMap.get(KMManager.KMKey_LanguageName),
+        isCustom,
+        isNewKeyboard,
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, "")
+      );
+      kbdsList.add(k);
     }
 
     List<? extends Map<String, String>> lexMapList = getLexicalModelsList(context);
@@ -612,10 +630,28 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     storage.keyboards.setNotifyOnChange(false);
     storage.keyboards.clear();
 
-    List<? extends Map<String, String>> mapList = getKeyboardsList(context);
+    List<HashMap<String, String>> mapList = getKeyboardsList(context);
     List<Keyboard> kbdList = new ArrayList<>(mapList.size());
-    for(Map<String, String> map: mapList) {
-      kbdList.add(new Keyboard(map));
+    for(HashMap<String, String> kbdMap: mapList) {
+      boolean isCustom = kbdMap.containsKey(KMManager.KMKey_CustomKeyboard) &&
+        kbdMap.get(KMManager.KMKey_CustomKeyboard).equals("Y");
+      boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
+        kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
+
+      Keyboard k = new Keyboard(
+        kbdMap.get(KMManager.KMKey_PackageID),
+        kbdMap.get(KMManager.KMKey_KeyboardID),
+        kbdMap.get(KMManager.KMKey_KeyboardName),
+        kbdMap.get(KMManager.KMKey_LanguageID),
+        kbdMap.get(KMManager.KMKey_LanguageName),
+        isCustom,
+        isNewKeyboard,
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, "")
+      );
+      kbdList.add(k);
     }
     storage.keyboards.addAll(kbdList);
     storage.keyboards.notifyDataSetChanged();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -69,8 +69,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     final ListView listView = findViewById(R.id.listView);
 
     final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
-    final String packageID = kbd.getPackage();
-    final String languageID = kbd.getLanguageCode();
+    final String packageID = kbd.getPackageID();
+    final String languageID = kbd.getLanguageID();
     final String languageName = kbd.getLanguageName();
     final String kbID = kbd.getResourceId();
     final String kbName = kbd.getResourceName();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -68,25 +68,18 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
     final ListView listView = findViewById(R.id.listView);
 
-    final String packageID = getIntent().getStringExtra(KMManager.KMKey_PackageID);
-    final String languageID = getIntent().getStringExtra(KMManager.KMKey_LanguageID);
-    final String languageName = getIntent().getStringExtra(KMManager.KMKey_LanguageName);
-    final String kbID = getIntent().getStringExtra(KMManager.KMKey_KeyboardID);
-    final String kbName = getIntent().getStringExtra(KMManager.KMKey_KeyboardName);
-    final String kbVersion = getIntent().getStringExtra(KMManager.KMKey_KeyboardVersion);
+    final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
+    final String packageID = kbd.getPackage();
+    final String languageID = kbd.getLanguageCode();
+    final String languageName = kbd.getLanguageName();
+    final String kbID = kbd.getResourceId();
+    final String kbName = kbd.getResourceName();
+    final String kbVersion = kbd.getVersion();
     String latestKbdCloudVersion = kbVersion;
 
     // Determine if keyboard update is available from the cloud
     Dataset dataset = CloudRepository.shared.fetchDataset(this);
-    HashMap<String, String> kbInfo = new HashMap<>();
-    kbInfo.put(KMManager.KMKey_PackageID, packageID);
-    kbInfo.put(KMManager.KMKey_LanguageID, languageID);
-    kbInfo.put(KMManager.KMKey_LanguageName, languageName);
-    kbInfo.put(KMManager.KMKey_KeyboardID, kbID);
-    kbInfo.put(KMManager.KMKey_KeyboardName, kbName);
-
-    Keyboard kbdQuery = new Keyboard(kbInfo);
-    final Keyboard latestKbd = dataset.keyboards.findMatch(kbdQuery);
+    final Keyboard latestKbd = dataset.keyboards.findMatch(kbd);
     if (latestKbd != null) {
       latestKbdCloudVersion = latestKbd.getVersion();
     }
@@ -113,8 +106,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
     // Display keyboard help link
     hashMap = new HashMap<>();
-    final String helpUrlStr = getIntent().getStringExtra(KMManager.KMKey_HelpLink);
-    final String customHelpLink = getIntent().getStringExtra(KMManager.KMKey_CustomHelpLink);
+    final String customHelpLink = kbd.getCustomHelpLink();
     // Check if app declared FileProvider
     icon = String.valueOf(R.drawable.ic_arrow_forward);
     // Don't show help link arrow if File Provider unavailable, or custom help doesn't exist
@@ -174,7 +166,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
         // "Help" link clicked
         } else if (itemTitle.equals(getString(R.string.help_link))) {
-          if (customHelpLink != null) {
+          if (FileUtils.isWelcomeFile(customHelpLink)) {
             // Display local welcome.htm help file, including associated assets
             Intent i = HelpFile.toActionView(context, customHelpLink, packageID);
 
@@ -183,7 +175,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
             }
           } else {
             Intent i = new Intent(Intent.ACTION_VIEW);
-            i.setData(Uri.parse(helpUrlStr));
+            i.setData(Uri.parse(customHelpLink));
             startActivity(i);
           }
 
@@ -206,7 +198,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_BASE, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -30,7 +30,7 @@ import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.adapters.NestedAdapter;
-import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.util.FileUtils;
 
 import java.util.HashMap;
 
@@ -206,31 +206,10 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         listView.setItemChecked(position, true);
         listView.setSelection(position);
-        Keyboard kbd = ((FilteredKeyboardsAdapter) listView.getAdapter()).getItem(position);
-        HashMap<String, String> kbInfo = new HashMap<>(kbd.map);
-        String packageID = kbInfo.get(KMManager.KMKey_PackageID);
-        String keyboardID = kbInfo.get(KMManager.KMKey_KeyboardID);
-        if (packageID == null || packageID.isEmpty()) {
-          packageID = KMManager.KMDefault_UndefinedPackageID;
-        }
+        Keyboard kbdInfo = ((FilteredKeyboardsAdapter) listView.getAdapter()).getItem(position);
         Intent intent = new Intent(context, KeyboardSettingsActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-        intent.putExtra(KMManager.KMKey_PackageID, packageID);
-        intent.putExtra(KMManager.KMKey_KeyboardID, keyboardID);
-        intent.putExtra(KMManager.KMKey_LanguageID, kbInfo.get(KMManager.KMKey_LanguageID));
-        intent.putExtra(KMManager.KMKey_LanguageName, kbInfo.get(KMManager.KMKey_LanguageName));
-        intent.putExtra(KMManager.KMKey_KeyboardName, kbInfo.get(KMManager.KMKey_KeyboardName));
-        String keyboardVersion = KMManager.getLatestKeyboardFileVersion(context, packageID, keyboardID);
-        intent.putExtra(KMManager.KMKey_KeyboardVersion, keyboardVersion);
-        boolean isCustom = MapCompat.getOrDefault(kbInfo, KMManager.KMKey_CustomKeyboard, "N").equals("Y") ? true : false;
-        intent.putExtra(KMManager.KMKey_CustomKeyboard, isCustom);
-        String customHelpLink = kbInfo.get(KMManager.KMKey_CustomHelpLink);
-        if (customHelpLink != null) {
-          intent.putExtra(KMManager.KMKey_CustomHelpLink, customHelpLink);
-        } else {
-          intent.putExtra(KMManager.KMKey_HelpLink,
-            String.format("https://help.keyman.com/keyboard/%s/%s/", keyboardID, keyboardVersion));
-        }
+        intent.putExtra(KMManager.KMKey_Keyboard, kbdInfo);
         startActivity(intent);
       }
     });
@@ -355,7 +334,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-      com.tavultesoft.kmea.data.Keyboard kbd = this.getItem(position);
+      Keyboard kbd = this.getItem(position);
       ViewHolder holder;
 
       // If we're being told to reuse an existing view, do that.  It's automatic optimization.
@@ -369,7 +348,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
         holder = (ViewHolder) convertView.getTag();
       }
 
-      holder.text.setText(kbd.map.get(KMManager.KMKey_KeyboardName));
+      holder.text.setText(kbd.getResourceName());
       holder.img.setImageResource(R.drawable.ic_arrow_forward);
 
       return convertView;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -64,38 +64,18 @@ public class CloudDataJsonUtil {
       return keyboardsList;
     }
 
-    String isCustom = fromKMP ? "Y" : "N";
-
     try {
       // Thank you, Cloud API format.
       JSONArray languages = query.getJSONObject(KMKeyboardDownloaderActivity.KMKey_Languages).getJSONArray(KMKeyboardDownloaderActivity.KMKey_Languages);
       for (int i = 0; i < languages.length(); i++) {
-        JSONObject language = languages.getJSONObject(i);
+        JSONObject languageJSON = languages.getJSONObject(i);
+        JSONArray langKeyboards = languageJSON.getJSONArray(KMKeyboardDownloaderActivity.KMKey_LanguageKeyboards);
 
-        String langID = language.getString(KMManager.KMKey_ID);
-        String langName = language.getString(KMManager.KMKey_Name);
-
-        JSONArray langKeyboards = language.getJSONArray(KMKeyboardDownloaderActivity.KMKey_LanguageKeyboards);
-
+        // Can't foreach a JSONArray
         int kbLength = langKeyboards.length();
         for (int j = 0; j < kbLength; j++) {
           JSONObject keyboardJSON = langKeyboards.getJSONObject(j);
-          String pkgID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
-          String kbID = keyboardJSON.getString(KMManager.KMKey_ID);
-          String kbName = keyboardJSON.getString(KMManager.KMKey_Name);
-          String kbVersion = keyboardJSON.optString(KMManager.KMKey_KeyboardVersion, "1.0");
-          String kbFont = keyboardJSON.optString(KMManager.KMKey_Font, "");
-          String customHelpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink, null);
-
-          //String kbKey = String.format("%s_%s", langID, kbID);
-          HashMap<String, String> hashMap = createKeyboardInfoMap(pkgID,langID,langName,kbID,kbName,kbVersion,isCustom,kbFont,null, customHelpLink);
-
-
-//          if (keyboardModifiedDates.get(kbID) == null) {
-//            keyboardModifiedDates.put(kbID, keyboardJSON.getString(KMManager.KMKey_KeyboardModified));
-//          }
-
-          keyboardsList.add(new Keyboard(hashMap));
+          keyboardsList.add(new Keyboard(languageJSON, keyboardJSON));
         }
       }
     } catch (JSONException | NullPointerException e) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
@@ -112,7 +112,7 @@ public class Dataset extends ArrayAdapter<Dataset.LanguageDataset> implements Li
 
     public Type findMatch(Type target) {
       for(Type obj: data) {
-        if(obj.getResourceId().equals(target.getResourceId()) && obj.getLanguageCode().equals(target.getLanguageCode())) {
+        if(obj.getResourceId().equals(target.getResourceId()) && obj.getLanguageID().equals(target.getLanguageID())) {
           return obj;
         }
       }
@@ -309,7 +309,7 @@ public class Dataset extends ArrayAdapter<Dataset.LanguageDataset> implements Li
   }
 
   protected void handleLanguageItemRemoval(LanguageResource coded) {
-    String lgCode = coded.getLanguageCode();
+    String lgCode = coded.getLanguageID();
     LanguageDataset lgData = languageMetadata.get(lgCode);
 
     if(lgData.keyboards.size() == 0 && lgData.lexicalModels.size() == 0) {
@@ -320,11 +320,11 @@ public class Dataset extends ArrayAdapter<Dataset.LanguageDataset> implements Li
   }
 
   protected LanguageDataset getMetadataFor(LanguageResource coded) {
-    final String lgCode = coded.getLanguageCode();
+    final String lgCode = coded.getLanguageID();
     LanguageDataset data = Dataset.this.languageMetadata.get(lgCode);
 
     if(data == null) {
-      data = new LanguageDataset(coded.getLanguageName(), coded.getLanguageCode());
+      data = new LanguageDataset(coded.getLanguageName(), coded.getLanguageID());
       Dataset.this.languageMetadata.put(lgCode, data);
       Dataset.this.add(data);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -1,90 +1,119 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
-import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.util.FileUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.Serializable;
 import java.util.Map;
 
 public class Keyboard implements Serializable, LanguageResource {
-  public final Map<String, String> map;
+  private static final String TAG = "Keyboard";
+  private static final String HELP_URL_FORMATSTR = "https://help.keyman.com/keyboard/%s/%s";
 
-  /* TODO:  (v13 refactor)
-   * Drop the HashMap and instead directly represent the following as object properties:
-   *
-   *  String kbId = kbInfo.get(KMManager.KMKey_KeyboardID);
-   *  String langId = kbInfo.get(KMManager.KMKey_LanguageID);
-   *  String kbName = kbInfo.get(KMManager.KMKey_KeyboardName);
-   *  String langName = kbInfo.get(KMManager.KMKey_LanguageName);
-   *  String kFont = kbInfo.get(KMManager.KMKey_Font);
-   *  String kOskFont = kbInfo.get(KMManager.KMKey_OskFont);
-   */
+  private String packageID;
+  private String keyboardID;
+  private String keyboardName;
+  private String languageID;
+  private String languageName;
+  private boolean isCustomKeyboard;
+  private boolean isNewKeyboard;
+  private String font;
+  private String oskFont;
+  private String helpLink;
+  private String version;
 
-  public Keyboard(Map<String, String> kbdData) {
-    this.map = kbdData;
+  public Keyboard(JSONObject languageJSON, JSONObject keyboardJSON) {
+    try {
+      this.packageID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
+
+      this.keyboardID = keyboardJSON.getString(KMManager.KMKey_ID);
+
+      this.keyboardName = keyboardJSON.getString(KMManager.KMKey_Name);
+
+      // language ID and language name from languageJSON
+      this.languageID = languageJSON.getString(KMManager.KMKey_ID).toLowerCase();
+      this.languageName = languageJSON.getString(KMManager.KMKey_Name);
+
+      this.isCustomKeyboard = keyboardJSON.has(KMManager.KMKey_CustomKeyboard) &&
+        keyboardJSON.get(KMManager.KMKey_CustomKeyboard).equals("Y");
+
+      this.isNewKeyboard = keyboardJSON.has(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
+        keyboardJSON.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
+
+      this.font = keyboardJSON.optString(KMManager.KMKey_Font, "");
+
+      this.oskFont = keyboardJSON.optString(KMManager.KMKey_OskFont, "");
+
+      this.version = keyboardJSON.optString(KMManager.KMKey_KeyboardVersion, "1.0");
+
+      this.helpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink,
+        String.format(HELP_URL_FORMATSTR, this.keyboardID, this.version));
+    } catch (JSONException e) {
+      Log.e(TAG, "Keyboard exception parsing JSON: " + e);
+    }
   }
 
+  public Keyboard(String packageID, String keyboardID, String keyboardName, String languageID, String languageName,
+                  boolean isCustomKeyboard, boolean isNewKeyboard,
+                  String font, String oskFont, String version, String helpLink) {
 
-
-  public boolean isNewKeyboard() {
-    return map.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD)!=null;
+    this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
+    this.keyboardID = keyboardID;
+    this.keyboardName = keyboardName;
+    this.languageID = languageID.toLowerCase();
+    this.languageName = languageName;
+    this.isCustomKeyboard = isCustomKeyboard;
+    this.isNewKeyboard = isNewKeyboard;
+    this.font = (font != null) ? font : "";
+    this.oskFont = (oskFont != null) ? oskFont : "";
+    this.version = (version != null) ? version : "1.0";
+    this.helpLink = (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
+      String.format(HELP_URL_FORMATSTR, this.keyboardID, this.version);
   }
 
-  public String getResourceId() {
-    return this.map.get(KMManager.KMKey_KeyboardID);
-  }
+  public boolean isCustomKeyboard() { return isCustomKeyboard; }
+
+  public boolean isNewKeyboard() { return isNewKeyboard; }
+
+  public String getResourceId() { return keyboardID; }
+
+  public String getFont() { return font; }
+
+  public String getOSKFont() { return oskFont; }
 
   @Override
-  public String getLanguageCode() {
-    return this.map.get(KMManager.KMKey_LanguageID);
-  }
+  public String getLanguageCode() { return languageID; }
 
-  public String getLanguageName() {
-    return this.map.get(KMManager.KMKey_LanguageName);
-  }
+  public String getLanguageName() { return languageName; }
 
-  public String getResourceName() {
-    return this.map.get(KMManager.KMKey_KeyboardName);
-  }
+  public String getResourceName() { return keyboardName; }
 
-  public String getCustomHelpLink() {
-    if (this.map.containsKey(KMManager.KMKey_CustomHelpLink)) {
-      return this.map.get(KMManager.KMKey_CustomHelpLink);
-    }
-    return null;
-  }
+  public String getCustomHelpLink() { return helpLink; }
 
-  public String getVersion() {
-    return this.map.get(KMManager.KMKey_KeyboardVersion);
-  }
+  public String getVersion() { return version; }
 
-  public String getPackage() {
-    return this.map.get(KMManager.KMKey_PackageID);
-  }
+  public String getPackage() { return packageID; }
 
   public Bundle buildDownloadBundle() {
     Bundle bundle = new Bundle();
 
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, getPackage());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_KB_ID, getResourceId());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_ID, getLanguageCode());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_KB_NAME, getResourceName());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_NAME, getLanguageName());
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, packageID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_KB_ID, keyboardID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_ID, languageID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_KB_NAME, keyboardName);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_NAME, languageName);
 
-    String isCustom = map.get(KMManager.KMKey_CustomKeyboard);
-    if(isCustom == null) {
-      isCustom = "N";
-    }
-    bundle.putBoolean(KMKeyboardDownloaderActivity.ARG_IS_CUSTOM, isCustom.equals("Y"));
+    bundle.putBoolean(KMKeyboardDownloaderActivity.ARG_IS_CUSTOM, isCustomKeyboard);
 
-    String customHelpLink = map.get(KMManager.KMKey_CustomHelpLink);
-    if (customHelpLink != null) {
-      bundle.putString(KMKeyboardDownloaderActivity.ARG_CUSTOM_HELP_LINK, getCustomHelpLink());
-    }
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_CUSTOM_HELP_LINK, helpLink);
 
     return bundle;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -89,6 +89,9 @@ public class Keyboard implements Serializable, LanguageResource {
 
   public String getOSKFont() { return oskFont; }
 
+  public String getLanguageID() { return languageID; }
+
+  // Deprecated in Keyman 14.0 for getLanguageID()
   @Override
   public String getLanguageCode() { return languageID; }
 
@@ -100,6 +103,10 @@ public class Keyboard implements Serializable, LanguageResource {
 
   public String getVersion() { return version; }
 
+  public String getPackageID() { return packageID; }
+
+  // Deprecated in Keyman 14.0 for getPackageID()
+  @Override
   public String getPackage() { return packageID; }
 
   public Bundle buildDownloadBundle() {
@@ -120,7 +127,7 @@ public class Keyboard implements Serializable, LanguageResource {
 
   public boolean equals(Object obj) {
     if(obj instanceof Keyboard) {
-      boolean lgCodeMatch = ((Keyboard) obj).getLanguageCode().equals(this.getLanguageCode());
+      boolean lgCodeMatch = ((Keyboard) obj).getLanguageID().equals(this.getLanguageID());
       boolean idMatch = ((Keyboard) obj).getResourceId().equals(this.getResourceId());
 
       return lgCodeMatch && idMatch;
@@ -132,7 +139,7 @@ public class Keyboard implements Serializable, LanguageResource {
   @Override
   public int hashCode() {
     String id = getResourceId();
-    String lgCode = getLanguageCode();
+    String lgCode = getLanguageID();
     return id.hashCode() * lgCode.hashCode();
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -5,9 +5,15 @@ import android.os.Bundle;
 public interface LanguageResource {
   String getResourceId();
   String getResourceName();
+  String getLanguageID();
+
+  // Deprecated in Keyman 14.0 by getLanguageID();
   String getLanguageCode();
   String getLanguageName();
   String getVersion();
+  String getPackageID();
+
+  // Deprecated in Keyman 14.0 by getPackageID()
   String getPackage();
   String getCustomHelpLink();
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -32,6 +32,11 @@ public class LexicalModel implements Serializable, LanguageResource {
     return this.map.get(KMManager.KMKey_LexicalModelID);
   }
 
+  public String getLanguageID() {
+    return this.map.get(KMManager.KMKey_LanguageID);
+  }
+
+  // Deprecate in Keyman 14.0 for getLanguageID()
   @Override
   public String getLanguageCode() {
     return this.map.get(KMManager.KMKey_LanguageID);
@@ -49,6 +54,9 @@ public class LexicalModel implements Serializable, LanguageResource {
     return this.map.get(KMManager.KMKey_LexicalModelVersion);
   }
 
+  public String getPackageID() { return this.map.get(KMManager.KMKey_PackageID); }
+
+  // Deprecate in Keyman 14.0 for getPackageID()
   public String getPackage() {
     return this.map.get(KMManager.KMKey_PackageID);
   }
@@ -72,7 +80,7 @@ public class LexicalModel implements Serializable, LanguageResource {
       return null;
     }
 
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, getPackage());
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, getPackageID());
     bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_ID, getResourceId());
     bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_ID, getLanguageCode());
     bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_NAME, getResourceName());
@@ -90,7 +98,7 @@ public class LexicalModel implements Serializable, LanguageResource {
 
   public boolean equals(Object obj) {
     if(obj instanceof LexicalModel) {
-      boolean lgCodeMatch = ((LexicalModel) obj).getLanguageCode().equals(this.getLanguageCode());
+      boolean lgCodeMatch = ((LexicalModel) obj).getLanguageID().equals(this.getLanguageID());
       boolean idMatch = ((LexicalModel) obj).getResourceId().equals(this.getResourceId());
 
       return lgCodeMatch && idMatch;

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
@@ -50,7 +50,7 @@ public class CloudDataJsonUtilTest {
       List<LexicalModel> results = CloudDataJsonUtil.processLexicalModelJSON(cloud);
 
     LexicalModel lmInfo = results.get(0);
-    Assert.assertEquals("str-latn", lmInfo.getLanguageCode());
+    Assert.assertEquals("str-latn", lmInfo.getLanguageID());
   }
 
 }


### PR DESCRIPTION
This PR refactors `com.tavultesoft.kmea.data.Keyboard` to not use Map.
Instead, the class can be instantiated via JSON Objects or passed properties.

There's still many areas to refactor HashMap out. Some TODOs for future PRs are:
* com.tavultesoft.kmea.data.LexicalModel (sibling class to Keyboard)
* installed keyboard lists and installed lexical models lists - these are currently saved as `ArrayList<HashMap<string, string>>` to the filesystem. Maybe we should migrate them to `ArrayList<Keyboard>` and save to new files?