### PR TITLE
feat(common/lmlayer): create join word breaker decorator

### DIFF
--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -1,0 +1,11 @@
+var assert = require('chai').assert;
+
+var defaultWordBreaker = require('../../build/intermediate').wordBreakers['default'];
+var joinWordBreaker = require('../../build/intermediate').wordBreakers['--join-word'];
+
+describe('The join word breaker decorator', function () {
+  it('should decorate an existing word breaker', function () {
+    let breakWords = joinWordBreaker(defaultWordBreaker);
+    assert.isFunction(breakWords);
+  });
+});

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -13,6 +13,18 @@ describe('The join word breaker decorator', function () {
     /* input,      joiners,  default breaks,        breaks with joins */
     // Original test case from https://github.com/keymanapp/keyman/issues/2753
     ['khui-chhùi', ['-'],   ["khui", "-", "chhùi"], ["khui-chhùi"]], 
+
+    // Plains Cree SRO: 
+    ['ê-kotiskâwêyâhk', ['-'], ['ê', '-', 'kotiskâwêyâhk'], ['ê-kotiskâwêyâhk']],
+
+    // Edge cases:
+
+    // Joiner alone:
+    ['-', ['-'], ['-'], ['-']],
+    // Joiner at the end: 
+    ['ni-', ['-'], ['ni', '-'], ['ni-']],
+    // Joiner at the end: 
+    ['-ân', ['-'], ['-', 'ân'], ['-ân']],
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -33,6 +33,9 @@ describe('The join word breaker decorator', function () {
       ["-", "yâhk", "ê", "-", "nitawi", "-", "kotiskâwêyâhk", "ni", "-"],
       ["-yâhk", "ê-nitawi-kotiskâwêyâhk", "ni-"]
     ],
+
+    // Do not perform any joins:
+    ["hello world", "-", ["hello", "world"], ["hello", "world"]],
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -8,4 +8,22 @@ describe('The join word breaker decorator', function () {
     let breakWords = decorateWithJoin(defaultWordBreaker, ['-']);
     assert.isFunction(breakWords);
   });
+
+  it('should join spans at the given delimiter', function () {
+    let phrase = 'khui-chhùi';
+    let breakWords = decorateWithJoin(defaultWordBreaker, ['-']);
+
+    let undecoratedResult = defaultWordBreaker(phrase).map(onlyText);
+    let actualResult = breakWords(phrase).map(onlyText);
+    assert.deepEqual(undecoratedResult, ["khui", "-", "chhùi"]);
+    assert.deepEqual(actualResult, ["khui-chhùi"]);
+  });
+
+  /**
+   * Get just the text from a span.
+   * @param {Span} span 
+   */
+  function onlyText(span) {
+    return span.text;
+  }
 });

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -1,11 +1,11 @@
 var assert = require('chai').assert;
 
 var defaultWordBreaker = require('../../build/intermediate').wordBreakers['default'];
-var joinWordBreaker = require('../../build/intermediate').wordBreakers['--join-word'];
+var decorateWithJoin = require('../../build/intermediate').wordBreakers['join_'];
 
 describe('The join word breaker decorator', function () {
   it('should decorate an existing word breaker', function () {
-    let breakWords = joinWordBreaker(defaultWordBreaker);
+    let breakWords = decorateWithJoin(defaultWordBreaker, ['-']);
     assert.isFunction(breakWords);
   });
 });

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -9,15 +9,21 @@ describe('The join word breaker decorator', function () {
     assert.isFunction(breakWords);
   });
 
-  it('should join spans at the given delimiter', function () {
-    let phrase = 'khui-chhùi';
-    let breakWords = decorateWithJoin(defaultWordBreaker, ['-']);
+  const TEST_CASES = [
+    /* input,      joiners,  default breaks,        breaks with joins */
+    // Original test case from https://github.com/keymanapp/keyman/issues/2753
+    ['khui-chhùi', ['-'],   ["khui", "-", "chhùi"], ["khui-chhùi"]], 
+  ]
 
-    let undecoratedResult = defaultWordBreaker(phrase).map(onlyText);
-    let actualResult = breakWords(phrase).map(onlyText);
-    assert.deepEqual(undecoratedResult, ["khui", "-", "chhùi"]);
-    assert.deepEqual(actualResult, ["khui-chhùi"]);
-  });
+  for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {
+    it(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
+      let breakWords = decorateWithJoin(defaultWordBreaker, joiners);
+      let unjoinedResult = defaultWordBreaker(phrase).map(onlyText);
+      let actualResult = breakWords(phrase).map(onlyText);
+      assert.deepEqual(unjoinedResult, unjoined);
+      assert.deepEqual(actualResult, expected);
+    });
+  }
 
   /**
    * Get just the text from a span.

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -51,11 +51,19 @@ describe('The join word breaker decorator', function () {
       ["@"],
       ["nobody", "@", "@", "example.com"],
       ["nobody@@example.com"]
-    ]
+    ],
+
+    // it should NOT join non-contiguous spans:
+    [
+      "this- is -bad",
+      ["-"],
+      ["this", "-", "is", "-", "bad"],
+      ["this-", "is", "-bad"]
+    ],
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {
-    it(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
+    it.only(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
       let breakWords = decorateWithJoin(defaultWordBreaker, joiners);
       let unjoinedResult = defaultWordBreaker(phrase).map(onlyText);
       assert.deepEqual(unjoinedResult, unjoined);

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -36,6 +36,22 @@ describe('The join word breaker decorator', function () {
 
     // Do not perform any joins:
     ["hello world", "-", ["hello", "world"], ["hello", "world"]],
+
+    // Joining using multiple joiners
+    [
+      "Email: no-body@example.com",
+      ["@", "-"],
+      ["Email", ":", "no", "-", "body", "@", "example.com"],
+      ["Email", ":", "no-body@example.com"]
+    ],
+    
+    // Joining with two or more joiners in a row 
+    [
+      "nobody@@example.com",
+      ["@"],
+      ["nobody", "@", "@", "example.com"],
+      ["nobody@@example.com"]
+    ]
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -63,7 +63,7 @@ describe('The join word breaker decorator', function () {
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {
-    it.only(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
+    it(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
       let breakWords = decorateWithJoin(defaultWordBreaker, joiners);
       let unjoinedResult = defaultWordBreaker(phrase).map(onlyText);
       assert.deepEqual(unjoinedResult, unjoined);

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -25,14 +25,22 @@ describe('The join word breaker decorator', function () {
     ['ni-', ['-'], ['ni', '-'], ['ni-']],
     // Joiner at the end: 
     ['-ân', ['-'], ['-', 'ân'], ['-ân']],
+
+    // This was my guiding test case:
+    [
+      "-yâhk ê-nitawi-kotiskâwêyâhk ni-",
+      ["-"],
+      ["-", "yâhk", "ê", "-", "nitawi", "-", "kotiskâwêyâhk", "ni", "-"],
+      ["-yâhk", "ê-nitawi-kotiskâwêyâhk", "ni-"]
+    ],
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {
     it(`should break «${[phrase]}» as [${expected.join(' ;; ')}]`, function () {
       let breakWords = decorateWithJoin(defaultWordBreaker, joiners);
       let unjoinedResult = defaultWordBreaker(phrase).map(onlyText);
-      let actualResult = breakWords(phrase).map(onlyText);
       assert.deepEqual(unjoinedResult, unjoined);
+      let actualResult = breakWords(phrase).map(onlyText);
       assert.deepEqual(actualResult, expected);
     });
   }

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -63,10 +63,19 @@ describe('The join word breaker decorator', function () {
 
     // different but adjacent joiners
     [
-      "kawé:-conjugator",
+      "I made the kawé:-conjugator.",
       ["-", ":"],
-      ["kawé", ":", "-", "conjugator"],
-      ["kawé:-conjugator"],
+      ["I", "made", "the", "kawé", ":", "-", "conjugator", "."],
+      ["I", "made", "the", "kawé:-conjugator", "."]
+    ],
+
+    // 3+ joiners in a row
+    [
+      // NB: – is U+2001 EN DASH
+      "This language is nut–=💠¤~ty!",
+      ["~", "–", "¤", "=", "💠"],
+      ["This", "language", "is", "nut", "–", "=", "💠", "¤", "~", "ty", "!"],
+      ["This", "language", "is", "nut–=💠¤~ty", "!"],
     ],
   ]
 

--- a/common/predictive-text/unit_tests/headless/join-word-breaker.js
+++ b/common/predictive-text/unit_tests/headless/join-word-breaker.js
@@ -60,6 +60,14 @@ describe('The join word breaker decorator', function () {
       ["this", "-", "is", "-", "bad"],
       ["this-", "is", "-bad"]
     ],
+
+    // different but adjacent joiners
+    [
+      "kawé:-conjugator",
+      ["-", ":"],
+      ["kawé", ":", "-", "conjugator"],
+      ["kawé:-conjugator"],
+    ],
   ]
 
   for (let [phrase, joiners, unjoined, expected] of TEST_CASES) {

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -13,24 +13,9 @@ namespace wordBreakers {
 
     return function (input: string): Span[] {
       let originalResults = breaker(input);
-
-      // Stores ranges of indices of spans that should be concatenated.
       let joinRanges = createJoinRanges(originalResults);
-      let contiguousRanges = fillInGapsInRanges(joinRanges, originalResults);
-
-      return contiguousRanges.map(range => {
-        if (range.length === 1) {
-          return originalResults[range[0]]
-        } else {
-          let spansToJoin = range.map(i => originalResults[i]);
-          let currentSpan = spansToJoin.shift();
-          while (spansToJoin.length > 0) {
-            let nextSpan = spansToJoin.shift();
-            currentSpan = concatenateSpans(currentSpan, nextSpan)
-          }
-          return currentSpan;
-        }
-      });
+      let contiguousRanges = fillInGapsInRanges(joinRanges, originalResults.length);
+      return concatenateSpansFromRanges(contiguousRanges, originalResults);
     }
 
     /**
@@ -92,8 +77,28 @@ namespace wordBreakers {
             contiguousRanges.push([index]);
           }
         }
-      });
+      }
       return contiguousRanges;
+    }
+
+    /**
+     * Given an array of ranges of indices, and the corresponding spans,
+     * concatenates spans according to the ranges of indices.
+     */
+    function concatenateSpansFromRanges(ranges: number[][], originalSpans: Span[]): Span[] {
+      return ranges.map(range => {
+        if (range.length === 1) {
+          return originalSpans[range[0]];
+        } else {
+          let spansToJoin = range.map(i => originalSpans[i]);
+          let currentSpan = spansToJoin.shift();
+          while (spansToJoin.length > 0) {
+            let nextSpan = spansToJoin.shift();
+            currentSpan = concatenateSpans(currentSpan, nextSpan);
+          }
+          return currentSpan;
+        }
+      });
     }
 
     function concatenateSpans(former: Span, latter: Span) {

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -37,9 +37,21 @@ namespace wordBreakers {
 
       // Figure out where there are spans to join.
       results.forEach((span, index) => {
-        if (includes(delimiters, span.text)) {
-          messyJoinRanges.push([index - 1, index, index + 1]);
+        if (!includes(delimiters, span.text)) {
+          return;
         }
+
+        let window = [];
+        if (results[index - 1] && results[index - 1].end === results[index].start) {
+          window.push(index - 1);
+        }
+        window.push(index);
+
+        if (results[index + 1] && results[index].end === results[index + 1].start) {
+          window.push(index + 1);
+        }
+
+        messyJoinRanges.push(window);
       });
 
       // Some indices pushed above are out of range.

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -16,32 +16,32 @@ namespace wordBreakers {
 
       // Stores indices of spans that should be concatenated.
       // Contiguous indices in will be joined.
-      let joinRanges: number[][] = [];
+      let messyJoinRanges: number[][] = [];
 
       // Figure out where there are spans to join.
       originalResults.forEach((span, index) => {
         if (includes(delimiters, span.text)) {
-          joinRanges.push([index - 1, index, index + 1]);
+          messyJoinRanges.push([index - 1, index, index + 1]);
         }
       });
 
       // Clean up any invalid indices pushed above.
-      if (joinRanges.length > 0) {
-        if (joinRanges[0][0] < 0) {
-          joinRanges[0].shift();
+      if (messyJoinRanges.length > 0) {
+        if (messyJoinRanges[0][0] < 0) {
+          messyJoinRanges[0].shift();
         }
-        if (lastFrom(lastFrom(joinRanges)) >= originalResults.length) {
-          lastFrom(joinRanges).pop();
+        if (lastFrom(lastFrom(messyJoinRanges)) >= originalResults.length) {
+          lastFrom(messyJoinRanges).pop();
         }
       }
 
       // Join together ranges.
       let lastRange: number[] | undefined;
-      let betterRanges: number[][] = []
-      for (let range of joinRanges) {
+      let joinRanges: number[][] = []
+      for (let range of messyJoinRanges) {
         if (lastRange == undefined) {
           lastRange = range;
-          betterRanges.push(range);
+          joinRanges.push(range);
           continue;
         }
 
@@ -54,12 +54,12 @@ namespace wordBreakers {
           }
         } else {
           lastRange = range;
-          betterRanges.push(range);
+          joinRanges.push(range);
         }
       }
       
       // TODO: place empty ranges in between.
-      let contiguousRanges: number[][] = betterRanges.concat();
+      let contiguousRanges: number[][] = joinRanges.concat();
 
       return contiguousRanges.map(range => {
         if (range.length === 1) {

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -122,6 +122,7 @@ namespace wordBreakers {
     function mergeOverlappingRanges(messyRanges: number[][]): number[][] {
       let lastRange: number[] | undefined;
       let ranges: number[][] = [];
+
       for (let range of messyRanges) {
         if (lastRange == undefined) {
           lastRange = range;
@@ -130,9 +131,14 @@ namespace wordBreakers {
         }
 
         let last = lastFrom(lastRange);
-        if (last === range[0]) {
-          // exclude the first element:
-          range.shift();
+        if (last >= range[0]) {
+          // Remove the overlapping elements:
+          while (range.length > 0 && last >= range[0]) {
+            range.shift();
+            last = lastFrom(lastRange);
+          }
+
+          // Extend the last range with what remains.
           for (let v of range) {
             lastRange.push(v);
           }

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -41,17 +41,21 @@ namespace wordBreakers {
           return;
         }
 
-        let previous: Span | undefined = results[index - 1];
-        let next: Span | undefined = results[index + 1];
+        // the span at this index SHOULD be joined with its neighbors
+        // let's create a window of 1–3 contiguous indices that
+        // should be joined:
+        let window = [];
         let current: Span | undefined = results[index];
 
-        let window = [];
+        let previous: Span | undefined = results[index - 1];
         if (previous && spansAreBackToBack(previous, current)) {
           window.push(index - 1);
         }
 
+        // The window ALWAYS contains the joiner.
         window.push(index);
 
+        let next: Span | undefined = results[index + 1];
         if (next && spansAreBackToBack(current, next)) {
           window.push(index + 1);
         }

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -54,19 +54,6 @@ namespace wordBreakers {
         messyJoinRanges.push(window);
       });
 
-      // Some indices pushed above are out of range.
-      // Get rid of them!
-      if (messyJoinRanges.length > 0) {
-        // We may have added -1
-        if (messyJoinRanges[0][0] < 0) {
-          messyJoinRanges[0].shift();
-        }
-        // We may have added 1 past the array's valid indices
-        if (lastFrom(lastFrom(messyJoinRanges)) >= results.length) {
-          lastFrom(messyJoinRanges).pop();
-        }
-      }
-
       // Merge overlapping regions:
       return mergeOverlappingRanges(messyJoinRanges);
     }

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -15,8 +15,7 @@ namespace wordBreakers {
       let originalResults = breaker(input);
 
       // Stores ranges of indices of spans that should be concatenated.
-      let messyJoinRanges: number[][] = createMessyJoinRanges(originalResults);
-      let joinRanges = mergeOverlappingRanges(messyJoinRanges);
+      let joinRanges = createJoinRanges(originalResults);
 
       let contiguousRanges: number[][] = [];
       let insideRange = false;
@@ -54,9 +53,19 @@ namespace wordBreakers {
 
     /**
      * Returns ranges of indices of results that should be merged.
-     * Note! These WILL be overlapping! 
+     * 
+     * e.g., if joining on "-":
+     * 
+     *  ["-", "yâhk", "ê", "-", "nitawi", "-", "kotiskâwêyâhk", "ni", "-"]
+     *    0     1      2    3    4         5    6                7     8[:-]
+     * 
+     * will return:
+     * 
+     *  [[0, 1], [2, 3, 4, 5, 6], [7, 8]]
+     * 
+     * Those indices correspond to spans that should be joined.
      */
-    function createMessyJoinRanges(results: Span[]): number[][] {
+    function createJoinRanges(results: Span[]): number[][] {
       let messyJoinRanges: number[][] = [];
 
       // Figure out where there are spans to join.
@@ -77,7 +86,8 @@ namespace wordBreakers {
         }
       }
 
-      return messyJoinRanges;
+      // Merge overlapping regions:
+      return mergeOverlappingRanges(messyJoinRanges);
     }
 
     function concatenateSpans(former: Span, latter: Span) {

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -1,7 +1,79 @@
 namespace wordBreakers {
+  /**
+   * Returns a word breaker that joins spans of an existing word breaker.
+   * Spans are joined if they are connected by a delimiter.
+   *
+   * @param breaker The word breaker whose results will be decorated.
+   * @param joiners What delimiters should be used to join spans.
+   */
   export function join_(breaker: WordBreakingFunction, joiners: string[]): WordBreakingFunction {
-    return function (s: string): Span[] {
-      return [];
+    // Make a copy so that if the original array is accidentally mutated, it
+    // won't affect the joiner.
+    const delimiters = joiners.concat();
+
+    return function (input: string): Span[] {
+      let joinCandidate: Span | undefined;
+      let shouldJoinNext = false;
+
+      let originalResults = breaker(input);
+      let results: Span[] = [];
+
+      for (let span of originalResults) {
+        // We should join these spans!
+        if (shouldJoinNext) {
+          joinCandidate = {
+            start: joinCandidate.start,
+            end: span.end,
+            length: joinCandidate.length + span.length,
+            text: joinCandidate.text + span.text
+          }
+          shouldJoinNext = false;
+          continue;
+        }
+
+        // No join candidate? Now it is!
+        if (!joinCandidate) {
+          joinCandidate = span;
+          shouldJoinNext = false;
+          continue;
+        }
+
+        // Should we bother joining these spans?
+        if (!includes(delimiters, span.text)) {
+          // We can't join them
+          results.push(joinCandidate);
+          joinCandidate = span;
+          shouldJoinNext = false;
+          continue;
+        }
+
+        // LET'S JOIN THE TWO SPANS!
+        joinCandidate = {
+          start: joinCandidate.start,
+          end: span.end,
+          length: joinCandidate.length + span.length,
+          text: joinCandidate.text + span.text
+        };
+        shouldJoinNext = true;
+      }
+
+      // Add the leftover span.
+      if (joinCandidate) {
+        results.push(joinCandidate);
+      }
+
+      return results;
+    }
+
+    /**
+     * When Array.prototype.include() doesn't exist:
+     */
+    function includes<T>(haystack: T[], needle: T) {
+      for (let item of haystack) {
+        if (item === needle)
+          return true;
+      }
+      return false;
     }
   }
 }

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -42,7 +42,7 @@ namespace wordBreakers {
         }
       });
 
-      // Some indices push above are out of range.
+      // Some indices pushed above are out of range.
       // Get rid of them!
       if (messyJoinRanges.length > 0) {
         if (messyJoinRanges[0][0] < 0) {
@@ -57,18 +57,22 @@ namespace wordBreakers {
       return mergeOverlappingRanges(messyJoinRanges);
     }
 
-    function fillInGapsInRanges<T>(joinRanges: number[][], originalResults: T[]) {
+    /**
+     * Given an array of ranges of indices that may have "gaps",
+     * e.g., not covering all indices less than {limit},
+     * fills in those gaps with "singleton" ranges.
+     */
+    function fillInGapsInRanges(joinRanges: number[][], limit: number) {
       let contiguousRanges: number[][] = [];
       let insideRange = false;
       let currentJoin = joinRanges.shift();
-      originalResults.forEach((_, index) => {
+      for (let index = 0; index < limit; index++) {
         if (insideRange) {
           if (index === lastFrom(currentJoin)) {
             insideRange = false;
             currentJoin = joinRanges.shift();
           }
-        }
-        else {
+        } else {
           if (currentJoin && index === currentJoin[0]) {
             insideRange = true;
             contiguousRanges.push(currentJoin);

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -12,10 +12,10 @@ namespace wordBreakers {
     const delimiters = joiners.concat();
 
     return function (input: string): Span[] {
-      let originalResults = breaker(input);
-      let joinRanges = createJoinRanges(originalResults);
-      let contiguousRanges = fillInGapsInRanges(joinRanges, originalResults.length);
-      return concatenateSpansFromRanges(contiguousRanges, originalResults);
+      let originalSpans = breaker(input);
+      let joinRanges = createJoinRanges(originalSpans);
+      let contiguousRanges = fillInGapsInRanges(joinRanges, originalSpans.length);
+      return concatenateSpansFromRanges(contiguousRanges, originalSpans);
     }
 
     /**

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -20,12 +20,7 @@ namespace wordBreakers {
 
       for (let current of originalResults) {
         if (shouldJoinNextSpan) {
-          previous = {
-            start: previous.start,
-            end: current.end,
-            length: previous.length + current.length,
-            text: previous.text + current.text
-          }
+          previous = concatenateSpans(previous, current);
           shouldJoinNextSpan = false;
           continue;
         }
@@ -46,13 +41,9 @@ namespace wordBreakers {
           continue;
         }
 
-        // LET'S JOIN THE TWO SPANS!
-        previous = {
-          start: previous.start,
-          end: current.end,
-          length: previous.length + current.length,
-          text: previous.text + current.text
-        };
+        // The delimiter indicates we should join this,
+        // the previous span, and the next span!
+        previous = concatenateSpans(previous, current);
         shouldJoinNextSpan = true;
       }
 
@@ -62,6 +53,15 @@ namespace wordBreakers {
       }
 
       return results;
+    }
+
+    function concatenateSpans(former: Span, latter: Span) {
+      return {
+        start: former.start,
+        end: latter.end,
+        length: former.length + latter.length,
+        text: former.text + latter.text
+      };
     }
 
     /**

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -16,25 +16,7 @@ namespace wordBreakers {
 
       // Stores ranges of indices of spans that should be concatenated.
       let joinRanges = createJoinRanges(originalResults);
-
-      let contiguousRanges: number[][] = [];
-      let insideRange = false;
-      let currentJoin = joinRanges.shift();
-      originalResults.forEach((_, index) => {
-        if (insideRange) {
-          if (index === lastFrom(currentJoin)) {
-            insideRange = false;
-            currentJoin = joinRanges.shift();
-          }
-        } else {
-          if (currentJoin && index === currentJoin[0]) {
-            insideRange = true;
-            contiguousRanges.push(currentJoin);
-          } else {
-            contiguousRanges.push([index]);
-          }
-        }
-      })
+      let contiguousRanges = fillInGapsInRanges(joinRanges, originalResults);
 
       return contiguousRanges.map(range => {
         if (range.length === 1) {
@@ -88,6 +70,30 @@ namespace wordBreakers {
 
       // Merge overlapping regions:
       return mergeOverlappingRanges(messyJoinRanges);
+    }
+
+    function fillInGapsInRanges<T>(joinRanges: number[][], originalResults: T[]) {
+      let contiguousRanges: number[][] = [];
+      let insideRange = false;
+      let currentJoin = joinRanges.shift();
+      originalResults.forEach((_, index) => {
+        if (insideRange) {
+          if (index === lastFrom(currentJoin)) {
+            insideRange = false;
+            currentJoin = joinRanges.shift();
+          }
+        }
+        else {
+          if (currentJoin && index === currentJoin[0]) {
+            insideRange = true;
+            contiguousRanges.push(currentJoin);
+          }
+          else {
+            contiguousRanges.push([index]);
+          }
+        }
+      });
+      return contiguousRanges;
     }
 
     function concatenateSpans(former: Span, latter: Span) {

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -56,6 +56,10 @@ namespace wordBreakers {
     }
 
     function concatenateSpans(former: Span, latter: Span) {
+      if (latter.start !== former.end) {
+        throw new Error(`Cannot concatenate non-contiguous spans: ${former}/${latter}`);
+      }
+
       return {
         start: former.start,
         end: latter.end,

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -12,54 +12,53 @@ namespace wordBreakers {
     const delimiters = joiners.concat();
 
     return function (input: string): Span[] {
-      let joinCandidate: Span | undefined;
-      let shouldJoinNext = false;
+      let previous: Span | undefined;
+      let shouldJoinNextSpan = false;
 
       let originalResults = breaker(input);
       let results: Span[] = [];
 
-      for (let span of originalResults) {
-        // We should join these spans!
-        if (shouldJoinNext) {
-          joinCandidate = {
-            start: joinCandidate.start,
-            end: span.end,
-            length: joinCandidate.length + span.length,
-            text: joinCandidate.text + span.text
+      for (let current of originalResults) {
+        if (shouldJoinNextSpan) {
+          previous = {
+            start: previous.start,
+            end: current.end,
+            length: previous.length + current.length,
+            text: previous.text + current.text
           }
-          shouldJoinNext = false;
+          shouldJoinNextSpan = false;
           continue;
         }
 
         // No join candidate? Now it is!
-        if (!joinCandidate) {
-          joinCandidate = span;
-          shouldJoinNext = false;
+        if (!previous) {
+          previous = current;
+          shouldJoinNextSpan = false;
           continue;
         }
 
         // Should we bother joining these spans?
-        if (!includes(delimiters, span.text)) {
+        if (!includes(delimiters, current.text)) {
           // We can't join them
-          results.push(joinCandidate);
-          joinCandidate = span;
-          shouldJoinNext = false;
+          results.push(previous);
+          previous = current;
+          shouldJoinNextSpan = false;
           continue;
         }
 
         // LET'S JOIN THE TWO SPANS!
-        joinCandidate = {
-          start: joinCandidate.start,
-          end: span.end,
-          length: joinCandidate.length + span.length,
-          text: joinCandidate.text + span.text
+        previous = {
+          start: previous.start,
+          end: current.end,
+          length: previous.length + current.length,
+          text: previous.text + current.text
         };
-        shouldJoinNext = true;
+        shouldJoinNextSpan = true;
       }
 
       // Add the leftover span.
-      if (joinCandidate) {
-        results.push(joinCandidate);
+      if (previous) {
+        results.push(previous);
       }
 
       return results;

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -46,12 +46,13 @@ namespace wordBreakers {
         let current: Span | undefined = results[index];
 
         let window = [];
-        if (previous && previous.end === current.start) {
+        if (previous && spansAreBackToBack(previous, current)) {
           window.push(index - 1);
         }
+
         window.push(index);
 
-        if (next && current.end === next.start) {
+        if (next && spansAreBackToBack(current, next)) {
           window.push(index + 1);
         }
 
@@ -90,6 +91,14 @@ namespace wordBreakers {
         }
       }
       return contiguousRanges;
+    }
+
+    /**
+     * Returns true when the spans are contiguous.
+     * Order matters when calling this function!
+     */
+    function spansAreBackToBack(former: Span, latter: Span): boolean {
+      return former.end === latter.start;
     }
 
     /**

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -41,13 +41,17 @@ namespace wordBreakers {
           return;
         }
 
+        let previous: Span | undefined = results[index - 1];
+        let next: Span | undefined = results[index + 1];
+        let current: Span | undefined = results[index];
+
         let window = [];
-        if (results[index - 1] && results[index - 1].end === results[index].start) {
+        if (previous && previous.end === current.start) {
           window.push(index - 1);
         }
         window.push(index);
 
-        if (results[index + 1] && results[index].end === results[index + 1].start) {
+        if (next && current.end === next.start) {
           window.push(index + 1);
         }
 

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -58,8 +58,24 @@ namespace wordBreakers {
         }
       }
       
-      // TODO: place empty ranges in between.
-      let contiguousRanges: number[][] = joinRanges.concat();
+      let contiguousRanges: number[][] = [];
+      let insideRange = false;
+      let currentJoin = joinRanges.shift();
+      originalResults.forEach((_, index) => {
+        if (insideRange) {
+          if (index === lastFrom(currentJoin)) {
+            insideRange = false;
+            currentJoin = joinRanges.shift();
+          }
+        } else {
+          if (currentJoin && index === currentJoin[0]) {
+            insideRange = true;
+            contiguousRanges.push(currentJoin);
+          } else {
+            contiguousRanges.push([index]);
+          }
+        }
+      })
 
       return contiguousRanges.map(range => {
         if (range.length === 1) {
@@ -100,7 +116,10 @@ namespace wordBreakers {
       return false;
     }
 
-    function lastFrom<T>(array: T[]): T {
+    /**
+     * Get the last element from the array.
+     */
+    function lastFrom<T>(array: T[]): T | undefined {
       return array[array.length - 1];
     }
   }

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -1,0 +1,7 @@
+namespace wordBreakers {
+  export function join_(breaker: WordBreakingFunction, joiners: string[]): WordBreakingFunction {
+    return function (s: string): Span[] {
+      return [];
+    }
+  }
+}

--- a/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
+++ b/common/predictive-text/worker/word_breaking/join-word-breaker-decorator.ts
@@ -35,29 +35,8 @@ namespace wordBreakers {
         }
       }
 
-      // Join together ranges.
-      let lastRange: number[] | undefined;
-      let joinRanges: number[][] = []
-      for (let range of messyJoinRanges) {
-        if (lastRange == undefined) {
-          lastRange = range;
-          joinRanges.push(range);
-          continue;
-        }
+      let joinRanges = mergeOverlappingRanges(messyJoinRanges);
 
-        let last = lastFrom(lastRange);
-        if (last === range[0]) {
-          // exclude the first element:
-          range.shift();
-          for (let v of range) {
-            lastRange.push(v);
-          }
-        } else {
-          lastRange = range;
-          joinRanges.push(range);
-        }
-      }
-      
       let contiguousRanges: number[][] = [];
       let insideRange = false;
       let currentJoin = joinRanges.shift();
@@ -103,6 +82,40 @@ namespace wordBreakers {
         length: former.length + latter.length,
         text: former.text + latter.text
       };
+    }
+
+    /**
+     * Given ranges like this that may overlap:
+     * 
+     *  [[1, 2, 3], [3, 4, 5], [6, 7, 8]]
+     * 
+     * Returns this:
+     * 
+     *  [[1, 2, 3, 4, 5], [6, 7, 8]]
+     */
+    function mergeOverlappingRanges(messyRanges: number[][]): number[][] {
+      let lastRange: number[] | undefined;
+      let ranges: number[][] = [];
+      for (let range of messyRanges) {
+        if (lastRange == undefined) {
+          lastRange = range;
+          ranges.push(range);
+          continue;
+        }
+
+        let last = lastFrom(lastRange);
+        if (last === range[0]) {
+          // exclude the first element:
+          range.shift();
+          for (let v of range) {
+            lastRange.push(v);
+          }
+        } else {
+          lastRange = range;
+          ranges.push(range);
+        }
+      }
+      return ranges;
     }
 
     /**


### PR DESCRIPTION
Laying down some work for #2753. This adds a new word breaker _decorator_. The word breaker decorator takes an existing word breaker, and outputs an enhanced word breaker. The enhanced word breaker joins spans that were a broken a little _too_ much by the given word breaker.

For example:

```javascript
defaultWordBreaker("khui-chhùi").map(s=>s.text) === ["khui", "-", "chhùi"];
```

But with the joiner:

```javascript
let improvedWordBreaker = decorateWithJoin(defaultWordBreaker, ['-']);
improvedWordBreaker("khui-chhùi").map(s=>s.text) === ["khui-chhùi"];
```

Importantly, `decorateWithJoin(existingWordBreaker, ...)` returns another word breaker!

This means that features like joining at hyphens can be implemented _without modifying existing word breaker code_. By using this decorator, all existing word breakers get new functionality for free!