### PR TITLE
feat(common/lmlayer): allow for verbose word breaker specification

### DIFF
--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -109,7 +109,11 @@ function compileWordBreaker(spec: WordBreakerSpec): string {
   }
 }
 
-function normalizeWordBreakerSpec(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec): WordBreakerSpec {
+/**
+ * Given a word breaker specification in any of the messy ways,
+ * normalizes it to a common form that the compiler can deal with.
+ */
+function normalizeWordBreakerSpec(wordBreakerSpec: LexicalModelSource["wordBreaker"]): WordBreakerSpec {
   if (!wordBreakerSpec) {
     // Use the default word breaker when it's unspecified
     return { use: 'default' };

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -114,12 +114,10 @@ function compileWordBreaker(spec: WordBreakerSpec): string {
  * normalizes it to a common form that the compiler can deal with.
  */
 function normalizeWordBreakerSpec(wordBreakerSpec: LexicalModelSource["wordBreaker"]): WordBreakerSpec {
-  if (!wordBreakerSpec) {
+  if (wordBreakerSpec == undefined) {
     // Use the default word breaker when it's unspecified
     return { use: 'default' };
-  } else if (wordBreakerSpec === "default" || wordBreakerSpec === 'ascii') {
-    return { use: wordBreakerSpec };
-  } else if (typeof wordBreakerSpec === "function") {
+  } else if (isSimpleWordBreaker(wordBreakerSpec)) {
     // The word breaker was passed as a literal function; use its source code.
     return { use: wordBreakerSpec };
   } else if (wordBreakerSpec.use) {
@@ -129,3 +127,6 @@ function normalizeWordBreakerSpec(wordBreakerSpec: LexicalModelSource["wordBreak
   }
 }
 
+function isSimpleWordBreaker(spec: WordBreakerSpec | SimpleWordBreakerSpec): spec is SimpleWordBreakerSpec  {
+  return typeof spec === "function" || spec === "default" || spec === "ascii";
+}

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -97,17 +97,26 @@ export class ModelSourceError extends Error {
  * Returns a JavaScript expression (as a string) that can serve as a word
  * breaking function.
  */
-function compileWordBreaker(wordBreakerSpec: SimpleWordBreakerSpec) {
+function compileWordBreaker(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec) {
   // Use the default word breaker when it's unspecified
+  let spec_: WordBreakerSpec;
   if (!wordBreakerSpec) {
-    wordBreakerSpec = 'default';
+    spec_ = { use: 'default' };
+  } else if (wordBreakerSpec === "default" || wordBreakerSpec === 'ascii') {
+    spec_ = { use: wordBreakerSpec };
+  } else if (typeof wordBreakerSpec === "function") {
+    // The word breaker was passed as a literal function; use its source code.
+    spec_ = { use: wordBreakerSpec };
+  } else if (wordBreakerSpec.use) {
+    spec_ = wordBreakerSpec;
+  } else {
+    throw new Error(`Unknown word breaker: ${wordBreakerSpec}`)
   }
 
-  if (typeof wordBreakerSpec === "string") {
+  if (typeof spec_.use === "string") {
     // It must be a builtin word breaker, so just instantiate it.
     return `wordBreakers['${wordBreakerSpec}']`;
   } else {
-    // The word breaker was passed as a literal function; use its source code.
     return wordBreakerSpec.toString()
       // Note: the .toString() might just be the property name, but we want a
       // plain function:

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -55,7 +55,7 @@ export default class LexicalModelCompiler {
         }, {\n`;
 
 
-        let wordBreakerSourceCode = compileWordBreaker(modelSource.wordBreaker);
+        let wordBreakerSourceCode = compileWordBreaker(normalizeWordBreakerSpec(modelSource.wordBreaker));
         func += `  wordBreaker: ${wordBreakerSourceCode},\n`;
 
         func += `  searchTermToKey: ${searchTermToKey.toString()},\n`;
@@ -97,22 +97,21 @@ export class ModelSourceError extends Error {
  * Returns a JavaScript expression (as a string) that can serve as a word
  * breaking function.
  */
-function compileWordBreaker(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec) {
-  // Use the default word breaker when it's unspecified
-  let spec_ = normalizeWordBreakerSpec(wordBreakerSpec);
-
-  if (typeof spec_.use === "string") {
+function compileWordBreaker(spec: WordBreakerSpec): string {
+  if (typeof spec.use === "string") {
     // It must be a builtin word breaker, so just instantiate it.
-    return `wordBreakers['${wordBreakerSpec}']`;
+    return `wordBreakers['${spec.use}']`;
   } else {
-    return wordBreakerSpec.toString()
+    return spec.use.toString()
       // Note: the .toString() might just be the property name, but we want a
       // plain function:
       .replace(/^wordBreak(ing|er)\b/, 'function');
   }
 }
+
 function normalizeWordBreakerSpec(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec): WordBreakerSpec {
   if (!wordBreakerSpec) {
+    // Use the default word breaker when it's unspecified
     return { use: 'default' };
   } else if (wordBreakerSpec === "default" || wordBreakerSpec === 'ascii') {
     return { use: wordBreakerSpec };

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -54,7 +54,6 @@ export default class LexicalModelCompiler {
           createTrieDataStructure(filenames, searchTermToKey)
         }, {\n`;
 
-
         let wordBreakerSourceCode = compileWordBreaker(normalizeWordBreakerSpec(modelSource.wordBreaker));
         func += `  wordBreaker: ${wordBreakerSourceCode},\n`;
 
@@ -68,10 +67,6 @@ export default class LexicalModelCompiler {
       default:
         throw new ModelSourceError(`Unknown model format: ${modelSource.format}`);
     }
-
-    //
-    // TODO: Load custom wordbreak source files
-    //
 
     func += fileSuffix;
 

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -99,19 +99,7 @@ export class ModelSourceError extends Error {
  */
 function compileWordBreaker(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec) {
   // Use the default word breaker when it's unspecified
-  let spec_: WordBreakerSpec;
-  if (!wordBreakerSpec) {
-    spec_ = { use: 'default' };
-  } else if (wordBreakerSpec === "default" || wordBreakerSpec === 'ascii') {
-    spec_ = { use: wordBreakerSpec };
-  } else if (typeof wordBreakerSpec === "function") {
-    // The word breaker was passed as a literal function; use its source code.
-    spec_ = { use: wordBreakerSpec };
-  } else if (wordBreakerSpec.use) {
-    spec_ = wordBreakerSpec;
-  } else {
-    throw new Error(`Unknown word breaker: ${wordBreakerSpec}`)
-  }
+  let spec_ = normalizeWordBreakerSpec(wordBreakerSpec);
 
   if (typeof spec_.use === "string") {
     // It must be a builtin word breaker, so just instantiate it.
@@ -123,3 +111,18 @@ function compileWordBreaker(wordBreakerSpec: WordBreakerSpec | SimpleWordBreaker
       .replace(/^wordBreak(ing|er)\b/, 'function');
   }
 }
+function normalizeWordBreakerSpec(wordBreakerSpec: WordBreakerSpec | SimpleWordBreakerSpec): WordBreakerSpec {
+  if (!wordBreakerSpec) {
+    return { use: 'default' };
+  } else if (wordBreakerSpec === "default" || wordBreakerSpec === 'ascii') {
+    return { use: wordBreakerSpec };
+  } else if (typeof wordBreakerSpec === "function") {
+    // The word breaker was passed as a literal function; use its source code.
+    return { use: wordBreakerSpec };
+  } else if (wordBreakerSpec.use) {
+    return wordBreakerSpec;
+  } else {
+    throw new Error(`Unknown word breaker: ${wordBreakerSpec}`);
+  }
+}
+

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -97,7 +97,7 @@ export class ModelSourceError extends Error {
  * Returns a JavaScript expression (as a string) that can serve as a word
  * breaking function.
  */
-function compileWordBreaker(wordBreakerSpec: WordBreakerSpec) {
+function compileWordBreaker(wordBreakerSpec: SimpleWordBreakerSpec) {
   // Use the default word breaker when it's unspecified
   if (!wordBreakerSpec) {
     wordBreakerSpec = 'default';

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -9,7 +9,7 @@ interface LexicalModelDeclaration {
   //... metadata ...
 }
 
-type WordBreakerSpec = 'default' | 'ascii' | WordBreakingFunction;
+type SimpleWordBreakerSpec = 'default' | 'ascii' | WordBreakingFunction;
 
 interface LexicalModelSource extends LexicalModelDeclaration {
   readonly sources: Array<string>;
@@ -27,7 +27,7 @@ interface LexicalModelSource extends LexicalModelDeclaration {
    *  - word breaking function -- provide your own function that breaks words.
    *  - class-based word-breaker - may be supported in the future.
    */
-  readonly wordBreaker?: WordBreakerSpec;
+  readonly wordBreaker?: SimpleWordBreakerSpec;
 
   /**
    * How to simplify words, to convert them into simplifired search keys

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -10,7 +10,7 @@ interface LexicalModelDeclaration {
 }
 
 /**
- * Keyman 13.0+ word breaker specification:
+ * Keyman 14.0+ word breaker specification:
  *
  * Can support all old word breaking specification,
  * but can also be extended with options.

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -9,6 +9,16 @@ interface LexicalModelDeclaration {
   //... metadata ...
 }
 
+/**
+ * How to specify a word breaker.
+ */
+interface WordBreakerSpec {
+  readonly use: SimpleWordBreakerSpec;
+}
+
+/**
+ * Keyman 11.0 word breaker specification:
+ */
 type SimpleWordBreakerSpec = 'default' | 'ascii' | WordBreakingFunction;
 
 interface LexicalModelSource extends LexicalModelDeclaration {
@@ -27,7 +37,7 @@ interface LexicalModelSource extends LexicalModelDeclaration {
    *  - word breaking function -- provide your own function that breaks words.
    *  - class-based word-breaker - may be supported in the future.
    */
-  readonly wordBreaker?: SimpleWordBreakerSpec;
+  readonly wordBreaker?: WordBreakerSpec | SimpleWordBreakerSpec;
 
   /**
    * How to simplify words, to convert them into simplifired search keys

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -10,14 +10,17 @@ interface LexicalModelDeclaration {
 }
 
 /**
- * How to specify a word breaker.
+ * Keyman 13.0+ word breaker specification:
+ *
+ * Can support all old word breaking specification,
+ * but can also be extended with options.
  */
 interface WordBreakerSpec {
   readonly use: SimpleWordBreakerSpec;
 }
 
 /**
- * Keyman 11.0 word breaker specification:
+ * Keyman 11.0+ word breaker specification:
  */
 type SimpleWordBreakerSpec = 'default' | 'ascii' | WordBreakingFunction;
 

--- a/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
+++ b/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
@@ -1,7 +1,7 @@
 const source: LexicalModelSource = {
   format: 'trie-1.0',
   sources: ['wordlist.tsv'],
-  /* Keyman 13.0+ word breaker specification: */
+  /* Keyman 14.0+ word breaker specification: */
   wordBreaker: {
     use: 'default'
   }

--- a/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
+++ b/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
@@ -1,6 +1,7 @@
 const source: LexicalModelSource = {
   format: 'trie-1.0',
   sources: ['wordlist.tsv'],
+  /* Keyman 13.0+ word breaker specification: */
   wordBreaker: {
     use: 'default'
   }

--- a/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
+++ b/developer/js/tests/fixtures/example.qaa.wordbreaker/example.qaa.wordbreaker.model.ts
@@ -1,0 +1,8 @@
+const source: LexicalModelSource = {
+  format: 'trie-1.0',
+  sources: ['wordlist.tsv'],
+  wordBreaker: {
+    use: 'default'
+  }
+};
+export default source;

--- a/developer/js/tests/fixtures/example.qaa.wordbreaker/wordlist.tsv
+++ b/developer/js/tests/fixtures/example.qaa.wordbreaker/wordlist.tsv
@@ -1,0 +1,3 @@
+I
+like
+turtles

--- a/developer/js/tests/test-compile-model.ts
+++ b/developer/js/tests/test-compile-model.ts
@@ -10,6 +10,7 @@ describe('compileModel', function () {
     'example.qaa.sencoten',
     'example.qaa.trivial',
     'example.qaa.utf16le',
+    'example.qaa.wordbreaker'
   ];
 
   for (let modelID of MODELS) {
@@ -17,14 +18,14 @@ describe('compileModel', function () {
 
     it(`should compile ${modelID}`, function () {
       let code = compileModel(modelPath);
-      let r;
+      let r: unknown;
       assert.doesNotThrow(() => {
         r = compileModelSourceCode(code);
       });
       let compilation = r as CompilationResult;
 
-      assert.isFalse(compilation.hasSyntaxError);
-      assert.isNull(compilation.error);
+      assert.isFalse(compilation.hasSyntaxError, 'model code had syntax error');
+      assert.isNull(compilation.error, `compilation error: ${compilation.error}`);
       assert.equal(compilation.modelConstructorName, 'TrieModel');
     });
   }


### PR DESCRIPTION
This introduces an expanded way that the word breaker can be specified.

Whereas before, we'd have this:

```typescript
{
    wordBreaker: 'default'
}
```

Now we _may_ have this:

```typescript
{
    wordBreaker: {
        use: 'default',
    }
}
```

This makes it easier to add options to the word breaker specification (see #2753), as the options can be provided as additional properties to the `wordBreaker` object. e.g., in the future, we could have this:

```typescript
{
    wordBreaker: {
        use: 'default',
        joinWordsAt: ['-'],
    }
}
```

This change is backward-compatible. The old way of specifying word breakers still works.