### PR TITLE
change(common/lmlayer): improvements to default searchTermToKey

### DIFF
--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -392,7 +392,7 @@ namespace Trie {
  * and removing common diacritical marks.
  *
  * This is a very speculative implementation, that might work with
- * your language. We don't guarentee that this will be perfect for your
+ * your language. We don't guarantee that this will be perfect for your
  * language, but it's a start.
  *
  * This uses String.prototype.normalize() to convert normalize into NFKD.

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -387,27 +387,29 @@ namespace Trie {
 
 /**
  * Converts wordforms into an indexable form. It does this by
- * normalizing the letter case of Latin characters and removing
- * common diacritical marks.
+ * normalizing the letter case of characters INDIVIDUALLY (to disregard
+ * context-sensitive case transformations), normalizing to NFKD form,
+ * and removing common diacritical marks.
  *
- * This is a very naïve implementation, that I only think will work on
- * some languages that use the Latin script. As of 2020-04-08, only
- * 4 out of 11 (36%) of published language models use the Latin script,
- * so this might not actually be a great default.
+ * This is a very speculative implementation, that might work with
+ * your language. We don't guarentee that this will be perfect for your
+ * language, but it's a start.
  *
- * This uses String.prototype.normalize() to convert normalize into NFD.
- * NFD is an easy way to separate a Latin character from its diacritics;
- * Even then, some Latin-based orthographies use code points that,
- * under NFD normalization, do NOT decompose into an ASCII letter and a
- * combining diacritical mark (e.g., SENĆOŦEN).
+ * This uses String.prototype.normalize() to convert normalize into NFKD.
+ * NFKD neutralizes some funky distinctions, e.g., ꬲ, ｅ, e should all be the
+ * same character; plus, it's an easy way to separate a Latin character from
+ * its diacritics; Even then, orthographies regularly use code points
+ * that, under NFKD normalization, do NOT decompose appropriately for your 
+ * language (e.g., SENĆOŦEN, Plains Cree in syllabics).
  *
- * Use this only in early iterations of the model. For a production lexical
- * model, you SHOULD write/generate your own key function, tailored to your
- * language.
+ * Use this in early iterations of the model. For a production lexical model,
+ * you will probably write/generate your own key function, tailored to your
+ * language. There is a chance the default will work properly out of the box.
  */
 export function defaultSearchTermToKey(wordform: string): string {
-  return wordform
-    .toLowerCase()
+  return Array.from(wordform)
+    .map(c => c.toLowerCase())
+    .join('')
     .normalize('NFKD')
     // Remove all combining diacritics (if input is in NFD)
     // common to Latin-orthographies.

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -411,9 +411,8 @@ export function defaultSearchTermToKey(wordform: string): string {
     .map(c => c.toLowerCase())
     .join('')
     .normalize('NFKD')
-    // Remove all combining diacritics (if input is in NFD)
-    // common to Latin-orthographies.
-    .replace(/[\u0300-\u036f]/g, '');
+    // Remove any combining diacritics (if input is in NFKD)
+    .replace(/[\u0300-\u036F]/g, '');
 }
 
 

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -408,7 +408,7 @@ namespace Trie {
 export function defaultSearchTermToKey(wordform: string): string {
   return wordform
     .toLowerCase()
-    .normalize('NFD')
+    .normalize('NFKD')
     // Remove all combining diacritics (if input is in NFD)
     // common to Latin-orthographies.
     .replace(/[\u0300-\u036f]/g, '');

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -24,9 +24,25 @@ describe('The default searchTermToKey() function', function () {
     ['ΣΚΥΛΟΣ', 'σκυλος'],
 
     // full-width romaji is compatibility-canonical with ASCII characters:
-    ['ａｅｓｔｈｅｔｉｃ', 'aesthetic']
+    ['ａｅｓｔｈｅｔｉｃ', 'aesthetic'],
 
-    // TODO: test angstrom, greek semicolon, and other dumb stuff
+    // U+212B ANGSTROM SIGN (Å)
+    // U+00C5 LATIN CAPITAL LETTER A WITH RING ABOVE (Å)
+    // and should both normalize to 'a'
+    ['\u212B', 'a'],
+    ['\u00C5', 'a'],
+
+    // We should not fall for U+037E GREEK QUESTION MARK's trolling:
+    ['\u037e', ';'],
+
+    // Test presentational forms of Arabic:
+    // U+FE8D ARABIC LETTER ALEF ISOLATED FORM -> U+0627 ARABIC LETTER ALEF
+    // U+FEDF ARABIC LETTER LAM INITIAL FORM -> U+0644 ARABIC LETTER LAM
+    // U+FED8 ARABIC LETTER QAF MEDIAL FORM -> U+0642 ARABIC LETTER QAF
+    // U+FEEC ARABIC LETTER HEH MEDIAL FORM -> U+0647 ARABIC LETTER HEH
+    // U+FEEE ARABIC LETTER WAW FINAL FORM -> U+0648 ARABIC LETTER WAW
+    // U+FE93 ARABIC LETTER TEH MARBUTA ISOLATED FORM -> U+0629 ARABIC LETTER TEH MARBUTA
+    ['\uFE8D\uFEDF\uFED8\uFEEC\uFEEE\uFE93', '\u0627\u0644\u0642\u0647\u0648\u0629']
   ];
 
   for (let [input, expected] of testCases) {

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -42,7 +42,11 @@ describe('The default searchTermToKey() function', function () {
     // U+FEEC ARABIC LETTER HEH MEDIAL FORM -> U+0647 ARABIC LETTER HEH
     // U+FEEE ARABIC LETTER WAW FINAL FORM -> U+0648 ARABIC LETTER WAW
     // U+FE93 ARABIC LETTER TEH MARBUTA ISOLATED FORM -> U+0629 ARABIC LETTER TEH MARBUTA
-    ['\uFE8D\uFEDF\uFED8\uFEEC\uFEEE\uFE93', '\u0627\u0644\u0642\u0647\u0648\u0629']
+    ['\uFE8D\uFEDF\uFED8\uFEEC\uFEEE\uFE93', '\u0627\u0644\u0642\u0647\u0648\u0629'],
+
+    // Combine both NFKD **AND** knocking off diacritics:
+    // U+01C4 Ǆ -> U+0044 U+005A DZ
+    ['\u01C4', 'dz'],
   ];
 
   for (let [input, expected] of testCases) {

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -5,21 +5,28 @@ import { defaultSearchTermToKey } from '../dist/lexical-model-compiler/build-tri
 
 
 describe('The default searchTermToKey() function', function () {
-  it('should lowercase and THEN normalize', function() {
+  const testCases: [string, string][] = [
     // "İstanbul" has a U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE.
     // This should be lowercased.
-    assert.equal(defaultSearchTermToKey('İstanbul'), 'istanbul');
+    ['İstanbul', 'istanbul'],
+
     // The DEFAULT function is NOT responsible for understanding the Turkish
     // case regarding the lowercasing of:
     // 'I' U+0048 LATIN CAPITAL LETTER I to 'ı' U+0131 LATIN SMALL LETTER DOTLESS I
     // For Turkic languages, the recommendation is to make a
     // custom searchTermToKey function:
-    assert.equal(defaultSearchTermToKey('DİYARBAKIR'), 'diyarbakir');
+    ['DİYARBAKIR', 'diyarbakir'],
 
     // "skýlos" is Greek for dog 🇬🇷🐶
     // starts with an 's' and ends with an 's'
     // which are DIFFERENT CHARACTERS in lowercased Greek!
-    assert.equal(defaultSearchTermToKey('σκύλος'), 'σκυλος');
-    assert.equal(defaultSearchTermToKey('ΣΚΥΛΟΣ'), 'σκυλος');
-  });
+    ['σκύλος', 'σκυλος'],
+    ['ΣΚΥΛΟΣ', 'σκυλος'],
+  ];
+
+  for (let [input, expected] of testCases) {
+    it(`should normalize '${input}' to '${expected}'`, function() {
+      assert.equal(defaultSearchTermToKey(input), expected);
+    });
+  }
 });

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -45,8 +45,8 @@ describe('The default searchTermToKey() function', function () {
     ['\uFE8D\uFEDF\uFED8\uFEEC\uFEEE\uFE93', '\u0627\u0644\u0642\u0647\u0648\u0629'],
 
     // Combine both NFKD **AND** knocking off diacritics:
-    // U+01C4 Ǆ -> U+0044 U+005A DZ
-    ['\u01C4', 'dz'],
+    // U+01C4 LATIN CAPITAL LETTER DZ WITH CARON (Ǆ) -> <U+0064, U+007A> (dz)
+    ['Ǆ', 'dz'],
   ];
 
   for (let [input, expected] of testCases) {

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -22,6 +22,11 @@ describe('The default searchTermToKey() function', function () {
     // which are DIFFERENT CHARACTERS in lowercased Greek!
     ['σκύλος', 'σκυλος'],
     ['ΣΚΥΛΟΣ', 'σκυλος'],
+
+    // full-width romaji is compatibility-canonical with ASCII characters:
+    ['ａｅｓｔｈｅｔｉｃ', 'aesthetic']
+
+    // TODO: test angstrom, greek semicolon, and other dumb stuff
   ];
 
   for (let [input, expected] of testCases) {

--- a/developer/js/tests/test-default-search-term-to-key.ts
+++ b/developer/js/tests/test-default-search-term-to-key.ts
@@ -21,7 +21,7 @@ describe('The default searchTermToKey() function', function () {
     // starts with an 's' and ends with an 's'
     // which are DIFFERENT CHARACTERS in lowercased Greek!
     ['σκύλος', 'σκυλος'],
-    ['ΣΚΥΛΟΣ', 'σκυλος'],
+    ['ΣΚΥΛΟΣ', 'σκυλοσ'],
 
     // full-width romaji is compatibility-canonical with ASCII characters:
     ['ａｅｓｔｈｅｔｉｃ', 'aesthetic'],


### PR DESCRIPTION
Following from the discussion in #2971, I've changed the default `searchTermToKey` in two ways:

 * lowercases input one code point at a time, to eliminate context-sensitive lowercasing (e.g., `ΣΚΥΛΟΣ` to `σκυλος`)
 * normalizes to NKFD to neutralize confusing compatibility forms of characters (e.g., Arabic presentational forms, alternate Latin letter forms)

**Question**: Should NFKD normalization happen after or before lowercasing forms individually? Are there any edge cases you can think of that I should test?