### PR TITLE
fix(android): Clarify label that shows "Get Started" on startup

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -70,6 +70,7 @@ public class GetStartedActivity extends AppCompatActivity {
     });
 
     final TextView getStartedText = findViewById(R.id.getStartedText);
+    getStartedText.setText(String.format(getString(R.string.show_get_started), getString(R.string.get_started)));
     getStartedText.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -73,7 +73,8 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
 
     SwitchPreference getStartedPreference = new SwitchPreference(context);
     getStartedPreference.setKey(GetStartedActivity.showGetStartedKey);
-    getStartedPreference.setTitle(getString(R.string.show_get_started));
+    getStartedPreference.setTitle(String.format(getString(R.string.show_get_started), getString(R.string.get_started)));
+
     getStartedPreference.setDefaultValue(true);
 
     // Blocks the default checkmark interaction; we want to control the checkmark's state separately

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
   <string name="enable_system_keyboard">Enable Keyman as system-wide keyboard</string>
   <string name="set_keyman_as_default">Set Keyman as default keyboard</string>
   <string name="more_info" comment="Open the help page">More info</string>
-  <string name="show_get_started">Show this menu on startup</string>
+  <string name="show_get_started">Show \"%1$s\" on startup</string>
 
 
   <!-- Keyman Settings menu strings -->


### PR DESCRIPTION
PR #2751 cleaned up UI strings, changing the label from `Show "Get Started" on startup` to `Show this menu on startup`. This change was fine for the "Get Started" menu, but the label is confusing when reused on the Keyman Settings menu.

This PR reverts the label (while formatting the string to include the localized string for "Get Started".

stable-13.0 didn't have the cleaned up strings, so this doesn't need to be cherry-picked

### Screenshots of fixed labels
![get started](https://user-images.githubusercontent.com/7358010/80169480-bfe04980-860f-11ea-927d-4dd753c3e98e.png)

![settings](https://user-images.githubusercontent.com/7358010/80169482-c2db3a00-860f-11ea-844c-8c778831e080.png)

