### PR TITLE
fix(android): Fix how custom ad-hoc packages are treated

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -54,6 +54,7 @@ public class PackageActivity extends AppCompatActivity {
     setContentView(R.layout.activity_package_installer);
     boolean silentInstall = false;
     String languageID = null;
+    boolean isCustom = true;
 
     final Context context = this;
     Bundle bundle = getIntent().getExtras();
@@ -61,6 +62,7 @@ public class PackageActivity extends AppCompatActivity {
       kmpFile = new File(bundle.getString("kmpFile"));
       silentInstall = bundle.getBoolean("silentInstall", false);
       languageID = bundle.getString("language", null);
+      isCustom = bundle.getBoolean("custom", true);
     }
 
     File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
@@ -90,7 +92,7 @@ public class PackageActivity extends AppCompatActivity {
 
     // Silent installation (skip displaying welcome.htm and user confirmation)
     if (silentInstall) {
-      installPackage(context, pkgTarget, pkgId, languageID, true);
+      installPackage(context, pkgTarget, pkgId, languageID, isCustom, true);
       return;
     }
 
@@ -183,7 +185,7 @@ public class PackageActivity extends AppCompatActivity {
       webView.loadData(htmlString, "text/html; charset=utf-8", "UTF-8");
     }
 
-    initializeButtons(context, pkgId, languageID, pkgTarget);
+    initializeButtons(context, pkgId, languageID, isCustom, pkgTarget);
   }
 
   /**
@@ -191,9 +193,11 @@ public class PackageActivity extends AppCompatActivity {
    * @param context the context
    * @param pkgId the keyman package id
    * @param languageID the optional language id
+   * @param isCustom Boolean: true if custom ad-hoc package install
    * @param pkgTarget  String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
    */
-  private void initializeButtons(final Context context, final String pkgId, final String languageID, final String pkgTarget) {
+  private void initializeButtons(final Context context, final String pkgId, final String languageID,
+                                 final boolean isCustom, final String pkgTarget) {
     final Button installButton = (Button) findViewById(R.id.installButton);
     final Button cancelButton = (Button) findViewById(R.id.cancelButton);
     final Button finishButton = (Button) findViewById(R.id.finishButton);
@@ -203,7 +207,7 @@ public class PackageActivity extends AppCompatActivity {
       public void onClick(View v) {
 
 
-        installPackage(context, pkgTarget, pkgId, languageID, false);
+        installPackage(context, pkgTarget, pkgId, languageID, isCustom,false);
       }
     });
 
@@ -316,9 +320,11 @@ public class PackageActivity extends AppCompatActivity {
    * @param pkgTarget String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
    * @param pkgId String      The Keyman package ID
    * @param languageID String The optional language ID
+   * @param isCustom boolean  If true, the package is considered custom ad-hoc install
    * @param anSilentInstall boolean If true, don't display readme.htm/welcome.htm content during installation
    */
-  private void installPackage(Context context, String pkgTarget, String pkgId, String languageID, boolean anSilentInstall) {
+  private void installPackage(Context context, String pkgTarget, String pkgId, String languageID,
+                              boolean isCustom, boolean anSilentInstall) {
     try {
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
         // processKMP will remove currently installed package and install
@@ -327,7 +333,8 @@ public class PackageActivity extends AppCompatActivity {
         //kmpDataset.keyboards.addAll(kbdsList);
 
         List<Map<String, String>> installedPackageKeyboards =
-          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, languageID);
+          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY,
+            languageID, isCustom);
         // Do the notifications!
         boolean success = installedPackageKeyboards.size() != 0;
         boolean _cleanup = true;
@@ -347,7 +354,8 @@ public class PackageActivity extends AppCompatActivity {
         }
       } else if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
         List<Map<String, String>> installedLexicalModels =
-          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_LEXICAL_MODELS_KEY);
+          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_LEXICAL_MODELS_KEY,
+            languageID, isCustom);
         // Do the notifications
         boolean success = installedLexicalModels.size() != 0;
         boolean _cleanup = true;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -527,6 +527,8 @@ public final class KMManager {
       }
 
       // Copy and install all KMP files (Issue for FV app?)
+      // These are treated as non-custom
+      boolean isCustom = false;
       File resourceRoot = new File(getResourceRoot());
       PackageProcessor kmpProcessor = new PackageProcessor(resourceRoot);
       LexicalModelPackageProcessor lmkmpProcessor = new LexicalModelPackageProcessor(resourceRoot);
@@ -542,11 +544,11 @@ public final class KMManager {
           tempPackagePath = kmpProcessor.unzipKMP(kmpFile);
 
           if (FileUtils.hasLexicalModelPackageExtension(assetFile)) {
-            lmkmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_LEXICAL_MODELS_KEY);
+            lmkmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_LEXICAL_MODELS_KEY, isCustom);
           } else {
             // Not using the list of entries returned from processKMP()
             // because the main App will add the keyboard/lexical model info
-            kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY);
+            kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, isCustom);
           }
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -98,7 +98,10 @@ public final class ModelPickerActivity extends AppCompatActivity {
           String modelID = modelInfo.get(KMManager.KMKey_LexicalModelID);
           String modelName = modelInfo.get(KMManager.KMKey_LexicalModelName);
           String langName = modelInfo.get(KMManager.KMKey_LanguageName);
-
+          String customModel = "Y";
+          if (modelInfo.containsKey(KMManager.KMKey_CustomModel)) {
+            customModel = modelInfo.get(KMManager.KMKey_CustomModel);
+          }
           // File check to see if lexical model already exists locally
           File modelCheck = new File(KMManager.getLexicalModelsDir() + packageID + File.separator + modelID + ".model.js");
 
@@ -127,6 +130,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
             bundle.putString(KMManager.KMKey_LexicalModelVersion,
                 modelInfo.get(KMManager.KMKey_LexicalModelVersion));
             bundle.putString(KMManager.KMKey_CustomHelpLink, customHelpLink);
+            bundle.putString(KMManager.KMKey_CustomModel, customModel);
             Intent i = new Intent(context, ModelInfoActivity.class);
             i.putExtras(bundle);
             startActivityForResult(i, 1);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
@@ -65,7 +65,9 @@ public class CloudLexicalPackageDownloadCallback implements ICloudDownloadCallba
             String pkgTarget = kmpProcessor.getPackageTarget(kmpFile);
             if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
               File unzipPath = kmpProcessor.unzipKMP(kmpFile);
-              installedLexicalModels.addAll(kmpProcessor.processKMP(kmpFile, unzipPath, PackageProcessor.PP_LEXICAL_MODELS_KEY));
+              // All cloud lexical model packages are not custom
+              boolean isCustom = false;
+              installedLexicalModels.addAll(kmpProcessor.processKMP(kmpFile, unzipPath, PackageProcessor.PP_LEXICAL_MODELS_KEY, isCustom));
             }
           }
         }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -237,7 +237,9 @@ public class JSONUtils {
                 modelObj.put(KMManager.KMKey_Name, modelName);
                 modelObj.put("filename", modelFilename);
                 modelObj.put(KMManager.KMKey_LexicalModelVersion, packageVersion);
-                modelObj.put(KMManager.KMKey_CustomModel, "Y");
+
+                // KMManager.KMKey_CustomModel is inconclusive since we don't know where the kmp.json originated
+
                 if (containsHelp) {
                   File welcomeFile = new File(pkg, "welcome.htm");
                   modelObj.put(KMManager.KMKey_CustomHelpLink, welcomeFile.getPath());

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessor.java
@@ -58,8 +58,10 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
     return false;
   }
 
-  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion, String languageID) throws JSONException {
+  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion,
+                                            String languageID, boolean isCustom) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray("languages");
+    String isCustomStr = isCustom ? "Y" : "N";
 
     String modelId = jsonEntry.getString("id");
     if (lexicalModelExists(packageId, modelId)) {
@@ -74,6 +76,8 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
         models[i].put(KMManager.KMKey_LexicalModelVersion, packageVersion);
         models[i].put(KMManager.KMKey_LanguageID, languages.getJSONObject(i).getString("id").toLowerCase());
         models[i].put(KMManager.KMKey_LanguageName, languages.getJSONObject(i).getString("name"));
+
+        models[i].put(KMManager.KMKey_CustomModel, isCustomStr);
 
         if (welcomeExists(packageId)) {
           File kmpFile = new File(packageId + ".kmp");
@@ -96,13 +100,15 @@ public class LexicalModelPackageProcessor extends PackageProcessor {
    * @param path Filepath of a newly downloaded .kmp file.
    * @param tempPath Filepath of temporarily extracted .kmp file
    * @param key String of jsonArray to iterate through ("keyboards" or "lexicalModels")
+   * @param isCustom Boolean if ad-hoc custom install
    * @return A list of data maps of the newly installed and/or newly upgraded lexical models found in the package.
    * May be empty if the package file is actually an old version.
    * <br/><br/>
    * @throws IOException
    * @throws JSONException
    */
-  public List<Map<String, String>> processKMP(File path, File tempPath, String key) throws IOException, JSONException {
-    return super.processKMP(path, tempPath, key, null);
+  public List<Map<String, String>> processKMP(File path, File tempPath, String key,
+                                              boolean isCustom) throws IOException, JSONException {
+    return super.processKMP(path, tempPath, key, null, isCustom);
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -143,11 +143,14 @@ public class PackageProcessor {
    * @param packageVersion Package version (used for lexical model version)
    * @param languageID Preferred language ID to associate with the entry. If not found,
    *                   the first language in kmp.json is used.
+   * @param isCustom Boolean if package is custom ad-hoc install
    * @return A list of maps defining one keyboard-language pairing each.
    * @throws JSONException
    */
-  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion, String languageID) throws JSONException {
+  public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion,
+                                            String languageID, boolean isCustom) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray("languages");
+    String isCustomStr = isCustom ? "Y" : "N";
 
     String keyboardId = jsonEntry.getString("id");
     if (touchKeyboardExists(packageId, keyboardId)) {
@@ -174,8 +177,7 @@ public class PackageProcessor {
         keyboards[i].put(KMManager.KMKey_OskFont, jsonEntry.getString("oskFont"));
       }
 
-      // For now, all KMP distributed keyboards are custom
-      keyboards[i].put(KMManager.KMKey_CustomKeyboard, "Y");
+      keyboards[i].put(KMManager.KMKey_CustomKeyboard, isCustomStr);
       if (welcomeExists(packageId)) {
         File kmpFile = new File(packageId + ".kmp");
         File packageDir = constructPath(kmpFile, false);
@@ -414,6 +416,7 @@ public class PackageProcessor {
    * @param key String of jsonArray to iterate through ("keyboards" or "lexicalModels")
    * @param languageID String of the preferred language ID to associate with the entry. If languageID is null or
    *                   not found in kmp.json, then the first entry will be added.
+   * @param isCustom Boolean if custom ad-hoc install
    * @return A list of data maps of the newly installed and/or newly upgraded entries found in the package.
    * May be empty if the package file is actually an old version.
    * <br/><br/>
@@ -422,7 +425,8 @@ public class PackageProcessor {
    * @throws IOException
    * @throws JSONException
    */
-  public List<Map<String, String>> processKMP(File path, File tempPath, String key, String languageID) throws IOException, JSONException {
+  public List<Map<String, String>> processKMP(File path, File tempPath, String key,
+                                              String languageID, boolean isCustom) throws IOException, JSONException {
     // Block reserved namespaces, like /cloud/.
     // TODO:  Consider throwing an exception instead?
     ArrayList<Map<String, String>> specs = new ArrayList<>();
@@ -456,7 +460,8 @@ public class PackageProcessor {
       JSONArray entries = newInfoJSON.getJSONArray(key);
 
       for (int i = 0; i < entries.length(); i++) {
-        Map<String, String>[] maps = processEntry(entries.getJSONObject(i), packageId, packageVersion, languageID);
+        Map<String, String>[] maps = processEntry(entries.getJSONObject(i), packageId, packageVersion,
+          languageID, isCustom);
         if (maps != null) {
           specs.addAll(Arrays.asList(maps));
         }
@@ -467,7 +472,8 @@ public class PackageProcessor {
     return specs;
   }
 
-  public List<Map<String, String>> processKMP(File path, File tempPath, String key) throws IOException, JSONException {
-    return processKMP(path, tempPath, key, null);
+  public List<Map<String, String>> processKMP(File path, File tempPath, String key,
+                                              boolean isCustom) throws IOException, JSONException {
+    return processKMP(path, tempPath, key, null, isCustom);
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
@@ -27,6 +27,7 @@ public class DownloadIntentService extends IntentService {
         bundle.putString("destination", destination);
         bundle.putString("filename", filename);
         bundle.putString("language", languageID);
+        bundle.putString("url", url);
         receiver.send(FileUtils.DOWNLOAD_SUCCESS, bundle);
       } else {
         receiver.send(FileUtils.DOWNLOAD_ERROR, bundle);

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/LexicalModelPackageProcessorTest.java
@@ -65,7 +65,7 @@ public class LexicalModelPackageProcessorTest {
     Assert.assertNotNull(json);
     String pkgVersion = lmPP.getPackageVersion(json);
 
-    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom", pkgVersion, "en");
+    Map<String, String>[] models = lmPP.processEntry(json.getJSONArray("lexicalModels").getJSONObject(0), "example.en.custom", pkgVersion, "en", true);
 
     HashMap<String, String> en_custom = new HashMap<String, String>();
     en_custom.put(KMManager.KMKey_PackageID, "example.en.custom");
@@ -75,6 +75,7 @@ public class LexicalModelPackageProcessorTest {
     en_custom.put(KMManager.KMKey_LanguageID, "en");
     en_custom.put(KMManager.KMKey_LanguageName, "English");
     en_custom.put(KMManager.KMKey_CustomHelpLink, "");
+    en_custom.put(KMManager.KMKey_CustomModel, "Y");
 
     Assert.assertEquals(en_custom, models[0]);
 
@@ -88,7 +89,7 @@ public class LexicalModelPackageProcessorTest {
 
   @Test
   public void test_kmpProcessLexicalModel() throws Exception {
-    List<Map<String, String>> installedModels = lmPP.processKMP(TEST_EN_CUSTOM_MODEL_KMP_FILE, tempPkg, PackageProcessor.PP_LEXICAL_MODELS_KEY);
+    List<Map<String, String>> installedModels = lmPP.processKMP(TEST_EN_CUSTOM_MODEL_KMP_FILE, tempPkg, PackageProcessor.PP_LEXICAL_MODELS_KEY, false);
 
     Assert.assertEquals(TEST_EN_CUSTOM_MODEL_COUNT, installedModels.size());
   }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -134,7 +134,8 @@ public class PackageProcessorTest {
     String pkgVersion = PP.getPackageVersion(json);
 
     String languageID = null;
-    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
+    Map<String, String>[] keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0),
+      "gff_amh_7_test_json", pkgVersion, languageID, false);
 
     HashMap<String, String> amharic = new HashMap<String, String>();
     amharic.put(KMManager.KMKey_PackageID, "gff_amh_7_test_json");
@@ -143,7 +144,7 @@ public class PackageProcessorTest {
     amharic.put(KMManager.KMKey_LanguageID, "am");
     amharic.put(KMManager.KMKey_LanguageName, "Amharic");
     amharic.put(KMManager.KMKey_KeyboardVersion, "1.4");
-    amharic.put(KMManager.KMKey_CustomKeyboard, "Y");
+    amharic.put(KMManager.KMKey_CustomKeyboard, "N");
     amharic.put(KMManager.KMKey_CustomHelpLink, TEST_GFF_KMP_TARGET + File.separator + "welcome.htm");
 
     // If languageID doesn't match, verify only the first language is installed with the keyboard
@@ -151,14 +152,15 @@ public class PackageProcessorTest {
     Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
 
     languageID = "am";
-    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
+    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0),
+      "gff_amh_7_test_json", pkgVersion, languageID, false);
 
     // Verify "am" matched
     Assert.assertEquals(amharic, keyboards[0]);
     Assert.assertEquals(TEST_GFF_KBD_COUNT, keyboards.length);
 
     languageID = "GEZ";
-    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID);
+    keyboards = PP.processEntry(json.getJSONArray("keyboards").getJSONObject(0), "gff_amh_7_test_json", pkgVersion, languageID, true);
 
     HashMap<String, String> geez = new HashMap<String, String>();
     geez.put(KMManager.KMKey_PackageID, "gff_amh_7_test_json");
@@ -185,7 +187,7 @@ public class PackageProcessorTest {
 
   @Test
   public void test_installKMP() throws Exception {
-    List<Map<String, String>> installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY);
+    List<Map<String, String>> installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY, false);
 
     Assert.assertTrue(TEST_GFF_KMP_TARGET.exists());
     Assert.assertEquals(TEST_GFF_KBD_COUNT, installedKbds.size());
@@ -197,13 +199,13 @@ public class PackageProcessorTest {
     List<Map<String, String>> installedKbds;
     String version;
 
-    installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY);
+    installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY, false);
     version = PP.getPackageVersion(PP.loadPackageInfo(installedKMP));
     Assert.assertEquals(TEST_GFF_KBD_COUNT, installedKbds.size());
     Assert.assertEquals("1.4", version);
 
     extractAltTestPackage();
-    installedKbds = PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY);
+    installedKbds = PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY, false);
     version = PP_ALT.getPackageVersion(PP_ALT.loadPackageInfo(installedKMP));
     Assert.assertEquals(TEST_GFF_KBD_COUNT, installedKbds.size());
     Assert.assertEquals("1.5", version);
@@ -216,13 +218,13 @@ public class PackageProcessorTest {
     String version;
 
     extractAltTestPackage();
-    installedKbds = PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY);
+    installedKbds = PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY, false);
     version = PP_ALT.getPackageVersion(PP_ALT.loadPackageInfo(installedKMP));
     Assert.assertEquals(TEST_GFF_KBD_COUNT, installedKbds.size());
     Assert.assertEquals("1.5", version);
 
     extractBaseTestPackage();
-    installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY);
+    installedKbds = PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY, false);
     version = PP.getPackageVersion(PP.loadPackageInfo(installedKMP));
     Assert.assertEquals(TEST_GFF_KBD_COUNT, installedKbds.size());
     Assert.assertEquals("1.4", version);
@@ -271,14 +273,14 @@ public class PackageProcessorTest {
     Assert.assertFalse(PP.isSameVersion(TEST_GFF_KMP_FILE));
 
     extractAltTestPackage();
-    PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY);
+    PP_ALT.processKMP(TEST_GFF_KMP_FILE_ALT, tempPkgAlt, PackageProcessor.PP_KEYBOARDS_KEY, false);
 
     Assert.assertTrue(PP.isDowngrade(TEST_GFF_KMP_FILE));
     Assert.assertFalse(PP.isSameVersion(TEST_GFF_KMP_FILE));
 
     // Test 2 - when it's an equal version.
     extractBaseTestPackage();
-    PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY);
+    PP.processKMP(TEST_GFF_KMP_FILE, tempPkg, PackageProcessor.PP_KEYBOARDS_KEY, false);
     Assert.assertFalse(PP.isDowngrade(TEST_GFF_KMP_FILE));
     Assert.assertTrue(PP.isSameVersion(TEST_GFF_KMP_FILE));
 

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/view/FunctionalTestHelper.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/view/FunctionalTestHelper.java
@@ -66,7 +66,7 @@ class FunctionalTestHelper {
     PackageProcessor kmpProcessor =  new PackageProcessor(new File(KMManager.getResourceRoot()));
 
     File tempPackagePath = kmpProcessor.unzipKMP(aKPMFile);
-    List<Map<String, String>> installedKbds = kmpProcessor.processKMP(aKPMFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY);
+    List<Map<String, String>> installedKbds = kmpProcessor.processKMP(aKPMFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, true);
 
     Assert.assertEquals(installedKbds.size(),1);
 


### PR DESCRIPTION
The meaning of a "custom ad-hoc keyboard/lexical-model installation" has changed over the years.
Back in Keyman 10, cloud keyboards didn't use kmp's, and "custom" keyboards used ad-hoc kmp installations. Thus, there was a convention to treat all kmp installs as "custom".

Now in Keyman 14, cloud keyboards are also installed via kmp packages.

This PR updates the convention on what "custom" keyboard/lexical model means:
### Not Custom packages
* Default kmp's installed with the app (sil_euro_latin.kmp and nrc.en.mtnt.model.kmp that are in the app's assets/ folder)
* kmp's directly download from URL https://*.keyman.com

### Custom packages
* Local kmp installation (kmp previously downloaded to the Android device)
* All other kmp's from other sites.

There's some tentacles propagating the `isCustom` flag through the callstack:
MainActivity --> PackageActivity --> PackageProcessor / LexicalModelPackageProcessor

