### PR TITLE
feat(common/lmlayer): compile joinWordsAt property

### DIFF
--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -93,11 +93,19 @@ export class ModelSourceError extends Error {
  * breaking function.
  */
 function compileWordBreaker(spec: WordBreakerSpec): string {
-  if (typeof spec.use === "string") {
+  return compileInnerWordBreaker(spec.use);
+}
+
+/**
+ * Compiles the base word breaker, that may be decorated later.
+ */
+function compileInnerWordBreaker(spec: SimpleWordBreakerSpec): string {
+  if (typeof spec === "string") {
     // It must be a builtin word breaker, so just instantiate it.
-    return `wordBreakers['${spec.use}']`;
+    return `wordBreakers['${spec}']`;
   } else {
-    return spec.use.toString()
+    // It must be a function:
+    return spec.toString()
       // Note: the .toString() might just be the property name, but we want a
       // plain function:
       .replace(/^wordBreak(ing|er)\b/, 'function');

--- a/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -93,11 +93,19 @@ export class ModelSourceError extends Error {
  * breaking function.
  */
 function compileWordBreaker(spec: WordBreakerSpec): string {
-  return compileInnerWordBreaker(spec.use);
+  let baseWordBreakerCode = compileInnerWordBreaker(spec.use);
+
+  if (spec.joinWordsAt == undefined) {
+    // No need to decorate; return it as-is
+    return baseWordBreakerCode;
+  }
+  // Let's decorate it with the join word breaker!
+  return `wordBreakers.join_(${baseWordBreakerCode},${JSON.stringify(spec.joinWordsAt)})`;
 }
 
 /**
  * Compiles the base word breaker, that may be decorated later.
+ * Returns the source code of a JavaScript expression.
  */
 function compileInnerWordBreaker(spec: SimpleWordBreakerSpec): string {
   if (typeof spec === "string") {

--- a/developer/js/source/lexical-model-compiler/lexical-model.ts
+++ b/developer/js/source/lexical-model-compiler/lexical-model.ts
@@ -17,6 +17,13 @@ interface LexicalModelDeclaration {
  */
 interface WordBreakerSpec {
   readonly use: SimpleWordBreakerSpec;
+  /**
+   * If present, joins words that were split by the word breaker
+   * together at the given strings. e.g.,
+   *
+   *    joinWordsAt: ['-'] // to keep hyphenated items together
+   */
+  readonly joinWordsAt?: string[];
 }
 
 /**

--- a/developer/js/tests/fixtures/example.qaa.joinwordbreaker/example.qaa.joinwordbreaker.model.ts
+++ b/developer/js/tests/fixtures/example.qaa.joinwordbreaker/example.qaa.joinwordbreaker.model.ts
@@ -1,0 +1,10 @@
+const source: LexicalModelSource = {
+  format: 'trie-1.0',
+  sources: ['wordlist.tsv'],
+  /* Keyman 14.0+ word breaker specification: */
+  wordBreaker: {
+    use: 'default',
+    joinWordsAt: [':', '-', '·']
+  }
+};
+export default source;

--- a/developer/js/tests/fixtures/example.qaa.joinwordbreaker/wordlist.tsv
+++ b/developer/js/tests/fixtures/example.qaa.joinwordbreaker/wordlist.tsv
@@ -1,0 +1,3 @@
+Kanien'kehá:ka	1000
+amiskwaciy-wâskahikan	100
+cel·la	10

--- a/developer/js/tests/test-compile-model.ts
+++ b/developer/js/tests/test-compile-model.ts
@@ -10,7 +10,8 @@ describe('compileModel', function () {
     'example.qaa.sencoten',
     'example.qaa.trivial',
     'example.qaa.utf16le',
-    'example.qaa.wordbreaker'
+    'example.qaa.wordbreaker',
+    'example.qaa.joinwordbreaker'
   ];
 
   for (let modelID of MODELS) {


### PR DESCRIPTION
This completes support for the `join` word breaker decorator.

Now you can specify a model like this:

```typescript
const source: LexicalModelSource = {
  format: 'trie-1.0',
  sources: ['wordlist.tsv'],
  wordBreaker: {
    use: 'default',
    /* 👇👀 */
    joinWordsAt: [':', '-', '·']
  }
};
export default source;
```

And words like _Kanien'kehá:ka_, _amiskwaciy-wâskahikan_, and _cel·la_ will no longer be split in the middle! 🙌

---


This will compile to the following model code:

```javascript
(function() {
'use strict';
LMLayerWorker.loadModel(new models.TrieModel({"totalWeight":1110,"root":{"type":"internal","weight":1000,"values":["k","a","c"],"children":{"k":{"type":"leaf","weight":1000,"entries":[{"key":"kanien'keha:ka","weight":1000,"content":"Kanien'kehá:ka"}]},"a":{"type":"leaf","weight":100,"entries":[{"key":"amiskwaciy-waskahikan","weight":100,"content":"amiskwaciy-wâskahikan"}]},"c":{"type":"leaf","weight":10,"entries":[{"key":"cel·la","weight":10,"content":"cel·la"}]}}}}, {
  wordBreaker: wordBreakers.join_(wordBreakers['default'],[":","-","·"]),
  searchTermToKey: function defaultSearchTermToKey(wordform) {
    return wordform
        .toLowerCase()
        .normalize('NFD')
        // Remove all combining diacritics (if input is in NFD)
        // common to Latin-orthographies.
        .replace(/[\u0300-\u036f]/g, '');
},
}));
})();
```

Requires #3021 to be merged.