### PR TITLE
modify(android): Refactor LanguageResource() and remove "Custom" property

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -605,9 +605,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         url = data.toString();
       }
       if (url != null) {
-        // URL contains KMP to download in background.
-        boolean isCustom = FileUtils.isCustomKeyboard(url);
-
         String filename = data.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_Filename);
         if (filename == null) {
           FileUtils.getFilename(url);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
@@ -50,8 +50,6 @@ final class KMKeyboardPickerAdapter extends NestedAdapter<Keyboard, Dataset.Keyb
         List<Keyboard> kbdList = new ArrayList<>(kbdMapList.size());
 
         for(HashMap<String, String> kbdMap: kbdMapList) {
-          boolean isCustom = kbdMap.containsKey(KMManager.KMKey_CustomKeyboard) &&
-            kbdMap.get(KMManager.KMKey_CustomKeyboard).equals("Y");
           boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
             kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
 
@@ -61,12 +59,11 @@ final class KMKeyboardPickerAdapter extends NestedAdapter<Keyboard, Dataset.Keyb
             kbdMap.get(KMManager.KMKey_KeyboardName),
             kbdMap.get(KMManager.KMKey_LanguageID),
             kbdMap.get(KMManager.KMKey_LanguageName),
-            isCustom,
+            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, ""),
             isNewKeyboard,
             MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
-            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null),
-            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
-            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, "")
+            MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null)
           );
           kbdList.add(k);
         }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -174,6 +174,7 @@ public final class KMManager {
   public static final String KMKey_CustomHelpLink = "CustomHelpLink";
   public static final String KMKey_UserKeyboardIndex = "UserKeyboardIndex";
   public static final String KMKey_DisplayKeyboardSwitcher = "DisplayKeyboardSwitcher";
+  public static final String KMKey_LexicalModel = "lm";
   public static final String KMKey_LexicalModelID = "lmId";
   public static final String KMKey_LexicalModelName = "lmName";
   public static final String KMKey_LexicalModelVersion = "lmVersion";
@@ -743,14 +744,6 @@ public final class KMManager {
           shouldUpdateList = true;
         }
 
-        String isCustom = kbInfo.get(KMManager.KMKey_CustomKeyboard);
-        if (isCustom == null || isCustom.equals("U")) {
-          String kbKey = String.format("%s_%s", langID, kbID);
-          kbInfo.put(KMManager.KMKey_CustomKeyboard, isCustomKeyboard(context, kbKey));
-          kbList.set(i, kbInfo);
-          shouldUpdateList = true;
-        }
-
         if (kbID.equals(KMManager.KMDefault_KeyboardID) && langID.equals(KMManager.KMDefault_LanguageID)) {
           int defKbIndex = KMManager.getKeyboardIndex(context, KMManager.KMDefault_KeyboardID, KMManager.KMDefault_LanguageID);
           if (defKbIndex == 0 && i > 0)
@@ -784,21 +777,6 @@ public final class KMManager {
         }
       }
     }
-  }
-
-  private static String isCustomKeyboard(Context context, String keyboardKey) {
-    String isCustom = "U";
-    HashMap<String, HashMap<String, String>> keyboardsInfo = LanguageListUtil.getKeyboardsInfo(context);
-    if (keyboardsInfo != null) {
-      HashMap<String, String> kbInfo = keyboardsInfo.get(keyboardKey);
-      if (kbInfo != null) {
-        isCustom = "N";
-      } else {
-        isCustom = "Y";
-      }
-    }
-
-    return isCustom;
   }
 
   /**
@@ -1784,7 +1762,6 @@ public final class KMManager {
         double width = Float.parseFloat(urlCommand.getQueryParameter("w"));
         double height = Float.parseFloat(urlCommand.getQueryParameter("h"));
         String suggestionJSON = urlCommand.getQueryParameter("suggestion");
-        boolean isCustom = Boolean.parseBoolean(urlCommand.getQueryParameter("custom"));
 
         JSONParser parser = new JSONParser();
         JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
@@ -1796,7 +1773,7 @@ public final class KMManager {
         try {
           Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
           Log.v("KMEA", "Suggestion's banner coords: " + x + ", " + y + ", " + width + ", " + height);
-          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom); // likely outdated now that tags exist.
+          Log.v("KMEA", "Is a <keep> suggestion: "); // likely outdated now that tags exist.
         } catch (JSONException e) {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
@@ -2026,7 +2003,6 @@ public final class KMManager {
         double width = Float.parseFloat(urlCommand.getQueryParameter("w"));
         double height = Float.parseFloat(urlCommand.getQueryParameter("h"));
         String suggestionJSON = urlCommand.getQueryParameter("suggestion");
-        boolean isCustom = Boolean.parseBoolean(urlCommand.getQueryParameter("custom"));
 
         JSONParser parser = new JSONParser();
         JSONObject obj = parser.getJSONObjectFromURIString(suggestionJSON);
@@ -2038,7 +2014,7 @@ public final class KMManager {
         try {
           Log.v("KMEA", "Suggestion display: " + obj.getString("displayAs"));
           Log.v("KMEA", "Suggestion's banner coords: " + x + ", " + y + ", " + width + ", " + height);
-          Log.v("KMEA", "Is a <keep> suggestion: " + isCustom); // likely outdated now that tags exist.
+          Log.v("KMEA", "Is a <keep> suggestion: "); // likely outdated now that tags exist.
         } catch (JSONException e) {
           //e.printStackTrace();
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -63,8 +63,8 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
     listView = (ListView) findViewById(R.id.listView);
     final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
     final String packageID = kbd.getPackageID();
-    final String kbID = kbd.getResourceId();
-    final String kbName = kbd.getResourceName();
+    final String kbID = kbd.getKeyboardID();
+    final String kbName = kbd.getKeyboardName();
     final String kbVersion = kbd.getVersion();
 
     final TextView textView = (TextView) findViewById(R.id.bar_title);
@@ -83,7 +83,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
 
     // Display keyboard help link
     hashMap = new HashMap<String, String>();
-    final String customHelpLink = kbd.getCustomHelpLink();
+    final String customHelpLink = kbd.getHelpLink();
     // Check if app declared FileProvider
     String icon = String.valueOf(R.drawable.ic_arrow_forward);
     // Don't show help link arrow if File Provider unavailable, or custom help doesn't exist

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -585,8 +585,6 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     List<Keyboard> kbdsList = new ArrayList<>(kbdMapList.size());
 
     for(HashMap<String, String> kbdMap: kbdMapList) {
-      boolean isCustom = kbdMap.containsKey(KMManager.KMKey_CustomKeyboard) &&
-        kbdMap.get(KMManager.KMKey_CustomKeyboard).equals("Y");
       boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
         kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
 
@@ -596,24 +594,33 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         kbdMap.get(KMManager.KMKey_KeyboardName),
         kbdMap.get(KMManager.KMKey_LanguageID),
         kbdMap.get(KMManager.KMKey_LanguageName),
-        isCustom,
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, ""),
         isNewKeyboard,
         MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, "")
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null)
       );
       kbdsList.add(k);
     }
 
-    List<? extends Map<String, String>> lexMapList = getLexicalModelsList(context);
+    List<HashMap<String, String>> lexMapList = getLexicalModelsList(context);
     if(lexMapList == null) {
       lexMapList = new ArrayList<>(0);
     }
     List<LexicalModel> lexList = new ArrayList<>(lexMapList.size());
 
-    for(Map<String, String> map: lexMapList) {
-      lexList.add(new LexicalModel(map));
+    for(HashMap<String, String> lmMap: lexMapList) {
+      LexicalModel m = new LexicalModel(
+        lmMap.get(KMManager.KMKey_PackageID),
+        lmMap.get(KMManager.KMKey_LexicalModelID),
+        lmMap.get(KMManager.KMKey_LexicalModelName),
+        lmMap.get(KMManager.KMKey_LanguageID),
+        lmMap.get(KMManager.KMKey_LanguageName),
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
+        "" // TODO: add model URL
+      );
+      lexList.add(m);
     }
 
     storageDataset = new Dataset(context);
@@ -633,8 +640,6 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     List<HashMap<String, String>> mapList = getKeyboardsList(context);
     List<Keyboard> kbdList = new ArrayList<>(mapList.size());
     for(HashMap<String, String> kbdMap: mapList) {
-      boolean isCustom = kbdMap.containsKey(KMManager.KMKey_CustomKeyboard) &&
-        kbdMap.get(KMManager.KMKey_CustomKeyboard).equals("Y");
       boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
         kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
 
@@ -644,12 +649,11 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         kbdMap.get(KMManager.KMKey_KeyboardName),
         kbdMap.get(KMManager.KMKey_LanguageID),
         kbdMap.get(KMManager.KMKey_LanguageName),
-        isCustom,
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, ""),
         isNewKeyboard,
         MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
-        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, "")
+        MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null)
       );
       kbdList.add(k);
     }
@@ -662,13 +666,22 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     storage.lexicalModels.setNotifyOnChange(false);
     storage.lexicalModels.clear();
 
-    List<? extends Map<String, String>> mapList = getLexicalModelsList(context);
+    List<HashMap<String, String>> mapList = getLexicalModelsList(context);
     List<LexicalModel> lexList = new ArrayList<>(mapList.size());
-    for(Map<String, String> map: mapList) {
-      lexList.add(new LexicalModel(map));
+    for(HashMap<String, String> lmMap: mapList) {
+      LexicalModel m = new LexicalModel(
+        lmMap.get(KMManager.KMKey_PackageID),
+        lmMap.get(KMManager.KMKey_LexicalModelID),
+        lmMap.get(KMManager.KMKey_LexicalModelName),
+        lmMap.get(KMManager.KMKey_LanguageID),
+        lmMap.get(KMManager.KMKey_LanguageName),
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
+        "" // model URL
+      );
+      lexList.add(m);
     }
     storage.lexicalModels.addAll(lexList);
-
     storage.lexicalModels.notifyDataSetChanged();
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -68,12 +68,16 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
     final ListView listView = findViewById(R.id.listView);
 
-    final Keyboard kbd = (Keyboard)getIntent().getSerializableExtra(KMManager.KMKey_Keyboard);
+    Bundle bundle = getIntent().getExtras();
+    if (bundle == null) {
+      return;
+    }
+    final Keyboard kbd = (Keyboard)bundle.getSerializable(KMManager.KMKey_Keyboard);
     final String packageID = kbd.getPackageID();
     final String languageID = kbd.getLanguageID();
     final String languageName = kbd.getLanguageName();
-    final String kbID = kbd.getResourceId();
-    final String kbName = kbd.getResourceName();
+    final String kbID = kbd.getKeyboardID();
+    final String kbName = kbd.getKeyboardName();
     final String kbVersion = kbd.getVersion();
     String latestKbdCloudVersion = kbVersion;
 
@@ -106,7 +110,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
     // Display keyboard help link
     hashMap = new HashMap<>();
-    final String customHelpLink = kbd.getCustomHelpLink();
+    final String customHelpLink = kbd.getHelpLink();
     // Check if app declared FileProvider
     icon = String.valueOf(R.drawable.ic_arrow_forward);
     // Don't show help link arrow if File Provider unavailable, or custom help doesn't exist

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageListUtil.java
@@ -75,7 +75,6 @@ public final class LanguageListUtil {
           String kbName = "";
           String langName = language.getString(KMManager.KMKey_Name);
           String kbVersion = "1.0";
-          String isCustom = "N";
           String kbFont = "";
           JSONArray langKeyboards = language.getJSONArray(KMKeyboardDownloaderActivity.KMKey_LanguageKeyboards);
           JSONObject keyboard = null;
@@ -95,7 +94,6 @@ public final class LanguageListUtil {
             hashMap.put(KMManager.KMKey_KeyboardName, kbName);
             hashMap.put(KMManager.KMKey_LanguageName, langName);
             hashMap.put(KMManager.KMKey_KeyboardVersion, kbVersion);
-            hashMap.put(KMManager.KMKey_CustomKeyboard, isCustom);
             hashMap.put(KMManager.KMKey_Font, kbFont);
             keyboardsInfo.put(kbKey, hashMap);
 
@@ -117,7 +115,6 @@ public final class LanguageListUtil {
               hashMap.put(KMManager.KMKey_KeyboardName, kbName);
               hashMap.put(KMManager.KMKey_LanguageName, langName);
               hashMap.put(KMManager.KMKey_KeyboardVersion, kbVersion);
-              hashMap.put(KMManager.KMKey_CustomKeyboard, isCustom);
               hashMap.put(KMManager.KMKey_Font, kbFont);
               keyboardsInfo.put(kbKey, hashMap);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -209,7 +209,9 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
         Keyboard kbdInfo = ((FilteredKeyboardsAdapter) listView.getAdapter()).getItem(position);
         Intent intent = new Intent(context, KeyboardSettingsActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-        intent.putExtra(KMManager.KMKey_Keyboard, kbdInfo);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(KMManager.KMKey_Keyboard, kbdInfo);
+        intent.putExtras(bundle);
         startActivity(intent);
       }
     });

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
@@ -61,25 +61,19 @@ public final class ModelInfoActivity extends AppCompatActivity {
 
     final ListView listView = findViewById(R.id.listView);
 
-    final String packageID = getIntent().getStringExtra(KMManager.KMKey_PackageID);
-    final String languageID = getIntent().getStringExtra(KMManager.KMKey_LanguageID);
-    final String modelID = getIntent().getStringExtra(KMManager.KMKey_LexicalModelID);
-    final String modelName = getIntent().getStringExtra(KMManager.KMKey_LexicalModelName);
-    final String modelVersion = getIntent().getStringExtra(KMManager.KMKey_LexicalModelVersion);
+    final LexicalModel lm = (LexicalModel)getIntent().getSerializableExtra(KMManager.KMKey_LexicalModel);
+    final String packageID = lm.getPackageID();
+    final String languageID = lm.getLanguageID();
+    final String modelID = lm.getLexicalModelID();
+    final String modelName = lm.getLexicalModelName();
+    final String modelVersion = lm.getVersion();
     String latestModelCloudVersion = modelVersion;
 
     // Determine if model update is available from the cloud
     Dataset dataset = CloudRepository.shared.fetchDataset(this);
-    HashMap<String, String> modelInfo = new HashMap<>();
-    modelInfo.put(KMManager.KMKey_PackageID, packageID);
-    modelInfo.put(KMManager.KMKey_LanguageID, languageID);
-    modelInfo.put(KMManager.KMKey_LexicalModelID, modelID);
-    modelInfo.put(KMManager.KMKey_LexicalModelName, modelName);
-
-    LexicalModel modelQuery = new LexicalModel(modelInfo);
-    final LexicalModel latestModel = dataset.lexicalModels.findMatch(modelQuery);
-    if (latestModel != null) {
-      latestModelCloudVersion = latestModel.getVersion();
+    final LexicalModel latestLM = dataset.lexicalModels.findMatch(lm);
+    if (latestLM != null) {
+      latestModelCloudVersion = latestLM.getVersion();
     }
 
     final TextView textView = findViewById(R.id.bar_title);
@@ -102,7 +96,7 @@ public final class ModelInfoActivity extends AppCompatActivity {
 
     // Display model help link
     hashMap = new HashMap<>();
-    final String customHelpLink = getIntent().getStringExtra(KMManager.KMKey_CustomHelpLink);
+    final String customHelpLink = lm.getHelpLink();
     // Check if app declared FileProvider
     // Currently, model help only available if custom link exists
     icon = String.valueOf(R.drawable.ic_arrow_forward);
@@ -154,7 +148,7 @@ public final class ModelInfoActivity extends AppCompatActivity {
 
         // "Version" link clicked to download latest model version from cloud
         if (itemTitle.equals(getString(R.string.model_version))) {
-          Bundle args = latestModel.buildDownloadBundle();
+          Bundle args = latestLM.buildDownloadBundle();
           Intent i = new Intent(getApplicationContext(), KMKeyboardDownloaderActivity.class);
           i.putExtras(args);
           startActivity(i);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -36,7 +36,7 @@ public class CloudDataJsonUtil {
   }
 
   public static HashMap<String,String> createKeyboardInfoMap(String aPackageId,String aLanguageId, String aLanguageName, String aKeyboardId,
-                                                   String aKeyboardName, String aKeyboardVersion, String anIsCustomKeyboard,
+                                                   String aKeyboardName, String aKeyboardVersion,
                                                    String aFont, String aOskFont, String aCustomHelpLink)
   {
     HashMap<String, String> keyboardInfo = new HashMap<String, String>();
@@ -46,7 +46,6 @@ public class CloudDataJsonUtil {
     keyboardInfo.put(KMManager.KMKey_KeyboardName, aKeyboardName);
     keyboardInfo.put(KMManager.KMKey_LanguageName, aLanguageName);
     keyboardInfo.put(KMManager.KMKey_KeyboardVersion, aKeyboardVersion);
-    keyboardInfo.put(KMManager.KMKey_CustomKeyboard, anIsCustomKeyboard);
     keyboardInfo.put(KMManager.KMKey_Font, aFont);
     if (aOskFont != null) {
       keyboardInfo.put(KMManager.KMKey_OskFont, aOskFont);
@@ -80,7 +79,7 @@ public class CloudDataJsonUtil {
       }
     } catch (JSONException | NullPointerException e) {
       Log.e(TAG, "JSONParse Error: " + e);
-      return new ArrayList<>();  // Is this ideal?
+      return new ArrayList<Keyboard>();  // Is this ideal?
     }
 
     return keyboardsList;
@@ -93,59 +92,12 @@ public class CloudDataJsonUtil {
       // Parse each model JSON Object.
       int modelsLength = models.length();
       for (int i = 0; i < modelsLength; i++) {
-        JSONObject model = models.getJSONObject(i);
-        String packageID = "", modelURL = "";
-        if (model.has(KMManager.KMKey_PackageID)) {
-          packageID = model.getString(KMManager.KMKey_PackageID);
-        } else {
-          // Determine package ID from packageFilename
-          modelURL = model.optString("packageFilename", "");
-          packageID = FileUtils.getFilename(modelURL);
-          packageID = packageID.replace(FileUtils.MODELPACKAGE, "");
-        }
-
-        // api.keyman.com query returns an array of language IDs Strings while
-        // kmp.json "languages" is an array of JSONObject
-        String languageID = "", langName = "";
-        Object obj = model.getJSONArray("languages");
-        if (((JSONArray) obj).get(0) instanceof String) {
-          // language name not provided, so re-use language ID
-          languageID = model.getJSONArray("languages").getString(0);
-          langName = languageID;
-        } else if (((JSONArray) obj).get(0) instanceof JSONObject) {
-          JSONObject languageObj = model.getJSONArray("languages").getJSONObject(0);
-          languageID = languageObj.getString("id");
-          langName = languageObj.getString("name");
-        }
-
-        String modelID = model.getString(KMManager.KMKey_ID);
-        String modelName = model.getString(KMManager.KMKey_Name);
-
-        // Cloud data may not contain lexical model version, so fallback to (package) version
-        String version = model.optString(KMManager.KMKey_Version, "1.0");
-        String modelVersion = model.optString(KMManager.KMKey_LexicalModelVersion, version);
-
-        String isCustom = model.optString(KMManager.KMKey_CustomModel, "N");
-        
-        String icon = "0";
-
-        HashMap<String, String> hashMap = new HashMap<String, String>();
-        hashMap.put(KMManager.KMKey_PackageID, packageID);
-        hashMap.put(KMManager.KMKey_LanguageID, languageID.toLowerCase());
-        hashMap.put(KMManager.KMKey_LexicalModelID, modelID);
-        hashMap.put(KMManager.KMKey_LexicalModelName, modelName);
-        hashMap.put(KMManager.KMKey_LanguageName, langName);
-        hashMap.put(KMManager.KMKey_LexicalModelVersion, modelVersion);
-        hashMap.put(KMManager.KMKey_CustomModel, isCustom);
-        hashMap.put(KMManager.KMKey_LexicalModelPackageFilename, modelURL);
-        hashMap.put("isEnabled", "true");
-        hashMap.put(KMManager.KMKey_Icon, String.valueOf(R.drawable.ic_arrow_forward));
-
-        modelList.add(new LexicalModel(hashMap));
+        JSONObject modelJSON = models.getJSONObject(i);
+        modelList.add(new LexicalModel(modelJSON));
       }
     } catch (JSONException | NullPointerException e) {
       Log.e(TAG, "JSONParse Error: " + e);
-      return new ArrayList<>();  // Is this ideal?
+      return new ArrayList<LexicalModel>();  // Is this ideal?
     }
 
     return modelList;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
@@ -43,10 +43,6 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
   private static final String TAG = "CloudKeyboardMetaDldCb";
 
   /**
-   * Additional Cloud API parameter: Is custom keyboard.
-   */
-  public static final String PARAM_IS_CUSTOM = "is_custom";
-  /**
    * Additional Cloud API parameter: language id.
    */
   public static final String PARAM_LANG_ID = "lang_id";
@@ -193,15 +189,9 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
    */
   private void handleKeyboardMetaData(MetaDataResult theKbData)
   {
-    if (theKbData.params.getAdditionalProperty(PARAM_IS_CUSTOM,Boolean.class)) {
-      throw new IllegalStateException("Cannot download custom non-KMP keyboard");
-    }
-
     String _key_id = theKbData.params.getAdditionalProperty(PARAM_KB_ID,String.class);
     String _lang_id = theKbData.params.getAdditionalProperty(PARAM_LANG_ID,String.class);
 
-    String _kbIsCustom =
-      theKbData.params.getAdditionalProperty(PARAM_IS_CUSTOM,Boolean.class) ? "Y" : "N";
     JSONObject _kb_data = theKbData.returnjson.jsonObject;
 
     try {
@@ -277,7 +267,7 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
       theKbData.additionalDownloadid = CloudKeyboardDataDownloadCallback.createDownloadId(_key_id);
       theKbData.keyboardInfo = CloudDataJsonUtil
         .createKeyboardInfoMap(
-          _pkgID, _lang_id, _langName, _key_id, _kbName, _kbVersion, _kbIsCustom, _font, _oskFont, _customHelpLink);
+          _pkgID, _lang_id, _langName, _key_id, _kbName, _kbVersion, _font, _oskFont, _customHelpLink);
       theKbData.additionalDownloads = urls;
     }
     catch(JSONException _e)

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
@@ -112,7 +112,7 @@ public class Dataset extends ArrayAdapter<Dataset.LanguageDataset> implements Li
 
     public Type findMatch(Type target) {
       for(Type obj: data) {
-        if(obj.getResourceId().equals(target.getResourceId()) && obj.getLanguageID().equals(target.getLanguageID())) {
+        if (target.equals(obj)) {
           return obj;
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -1,21 +1,49 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
+import android.util.Log;
 
-public interface LanguageResource {
-  String getResourceId();
-  String getResourceName();
-  String getLanguageID();
+import java.io.Serializable;
+
+public abstract class LanguageResource implements Serializable {
+  protected String packageID;
+  protected String resourceID;
+  protected String resourceName;
+  protected String languageID;
+  protected String languageName;
+  protected String version;
+  protected String helpLink;
+
+  public String getResourceID() { return resourceID; }
+
+  public String getResourceName() { return resourceName; }
+
+  public String getLanguageID() { return languageID; }
 
   // Deprecated in Keyman 14.0 by getLanguageID();
-  String getLanguageCode();
-  String getLanguageName();
-  String getVersion();
-  String getPackageID();
+  public String getLanguageCode() { return languageID; }
+
+  public String getLanguageName() { return languageName; }
+
+  public String getVersion() { return version; }
+
+  public String getPackageID() { return packageID; }
 
   // Deprecated in Keyman 14.0 by getPackageID()
-  String getPackage();
-  String getCustomHelpLink();
+  public String getPackage() { return packageID; }
 
-  Bundle buildDownloadBundle();
+  public String getHelpLink() { return helpLink; }
+
+  public int hashCode() {
+    String id = getResourceID();
+    String lgCode = getLanguageID();
+    if (id == null || lgCode == null) {
+      Log.e("LanguageResource", "Invalid hashCode");
+    }
+    return id.hashCode() * lgCode.hashCode();
+  }
+
+  public abstract Bundle buildDownloadBundle();
+
+  //public abstract boolean equals();
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -1,97 +1,105 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.util.FileUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.Serializable;
-import java.util.Map;
 
-public class LexicalModel implements Serializable, LanguageResource {
-  public final Map<String, String> map;
+public class LexicalModel extends LanguageResource implements Serializable {
+  private static final String TAG = "lexicalModel";
 
-  /* TODO:  (v13 refactor)
-   * Drop the HashMap and instead directly represent the following as object properties:
-   *
-   *   hashMap.put(KMManager.KMKey_PackageID, packageID);
-   *   hashMap.put(KMManager.KMKey_LanguageID, languageID);
-   *   hashMap.put(KMManager.KMKey_LexicalModelID, modelID);
-   *   hashMap.put(KMManager.KMKey_LexicalModelName, modelName);
-   *   hashMap.put(KMManager.KMKey_LanguageName, langName);
-   *   hashMap.put(KMManager.KMKey_LexicalModelVersion, modelVersion);
-   *   hashMap.put(KMManager.KMKey_CustomModel, isCustom);
-   */
+  // Only used to build download bundle from cloud
+  private String modelURL;
 
-  public LexicalModel(Map<String, String> modelData) {
-    this.map = modelData;
-  }
+  public LexicalModel(JSONObject lexicalModelJSON) {
+    try {
+      this.modelURL = lexicalModelJSON.optString("packageFilename", "");
 
-  public String getResourceId() {
-    return this.map.get(KMManager.KMKey_LexicalModelID);
-  }
+      if (lexicalModelJSON.has(KMManager.KMKey_PackageID)) {
+        this.packageID = lexicalModelJSON.getString(KMManager.KMKey_PackageID);
+      } else if (this.modelURL != null && FileUtils.hasLexicalModelPackageExtension(this.modelURL)) {
+        // Extract package ID from packageFilename
+        String filename = FileUtils.getFilename(this.modelURL);
+        // Truncate .model.kmp file extension
+        this.packageID = filename.replace(FileUtils.MODELPACKAGE, "");
+      } else {
+        // Invalid Package ID
+        Log.e(TAG, "Invalid package ID");
+      }
 
-  public String getLanguageID() {
-    return this.map.get(KMManager.KMKey_LanguageID);
-  }
+      this.resourceID = lexicalModelJSON.getString(KMManager.KMKey_ID);
 
-  // Deprecate in Keyman 14.0 for getLanguageID()
-  @Override
-  public String getLanguageCode() {
-    return this.map.get(KMManager.KMKey_LanguageID);
-  }
+      this.resourceName = lexicalModelJSON.getString(KMManager.KMKey_Name);
 
-  public String getLanguageName() {
-    return this.map.get(KMManager.KMKey_LanguageName);
-  }
+      // language ID and language name from lexicalModelJSON
+      Object obj = lexicalModelJSON.getJSONArray("languages");
+      if (((JSONArray) obj).get(0) instanceof String) {
+        // language name not provided so re-use language ID
+        this.languageID = lexicalModelJSON.getJSONArray("languages").getString(0).toLowerCase();
+        this.languageName = languageID;
+      } else if (((JSONArray) obj).get(0) instanceof JSONObject) {
+        JSONObject languageObj = lexicalModelJSON.getJSONArray("languages").getJSONObject(0);
+        this.languageID = languageObj.getString(KMManager.KMKey_ID).toLowerCase();
+        this.languageName = languageObj.getString(KMManager.KMKey_Name);
+      }
 
-  public String getResourceName() {
-    return this.map.get(KMManager.KMKey_LexicalModelName);
-  }
+      // Cloud data may not contain lexical model version, so fallback to (package) version
+      String version = lexicalModelJSON.optString(KMManager.KMKey_Version, "1.0");
+      this.version = lexicalModelJSON.optString(KMManager.KMKey_LexicalModelVersion, version);
 
-  public String getVersion() {
-    return this.map.get(KMManager.KMKey_LexicalModelVersion);
-  }
-
-  public String getPackageID() { return this.map.get(KMManager.KMKey_PackageID); }
-
-  // Deprecate in Keyman 14.0 for getPackageID()
-  public String getPackage() {
-    return this.map.get(KMManager.KMKey_PackageID);
-  }
-
-  public String getCustomHelpLink() {
-    if (this.map.containsKey(KMManager.KMKey_CustomHelpLink)) {
-      return this.map.get(KMManager.KMKey_CustomHelpLink);
+      this.helpLink = ""; // TOODO: Handle help links
+      this.modelURL = modelURL;
+    } catch (JSONException e) {
+      Log.e(TAG, "Lexical model exception parsing JSON: " + e);
     }
-    return null;
   }
+
+  public LexicalModel(String packageID, String lexicalModelID, String lexicalModelName, String languageID, String languageName,
+                      String version, String helpLink,
+                      String modelURL) {
+
+    this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
+    this.resourceID = lexicalModelID;
+    this.resourceName = lexicalModelName;
+    this.languageID = languageID.toLowerCase();
+    // If language name not provided, fallback to re-use language ID
+    this.languageName = (languageName != null && !languageName.isEmpty()) ? languageName : this.languageID;
+
+    this.version = (version != null) ? version : "1.0";
+    this.helpLink = ""; // TODO: Handle help links
+    this.modelURL = modelURL;
+  }
+
+  public String getLexicalModelID() { return getResourceID(); }
+  public String getLexicalModelName() { return getResourceName(); }
 
   public Bundle buildDownloadBundle() {
     Bundle bundle = new Bundle();
 
     // Make sure we have an actual download URL.  If not, we can't build a proper download bundle -
     // the downloader conditions on this URL's existence in 12.0!
-    String modelURL = map.get(KMManager.KMKey_LexicalModelPackageFilename);
     if(modelURL == null) {
       return null;
     } else if (modelURL.equals("")) {
       return null;
     }
 
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, getPackageID());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_ID, getResourceId());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_ID, getLanguageCode());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_NAME, getResourceName());
-    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_NAME, getLanguageName());
-    bundle.putBoolean(KMKeyboardDownloaderActivity.ARG_IS_CUSTOM, false);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_PKG_ID, packageID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_ID, resourceID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_ID, languageID);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_NAME, resourceName);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_NAME, languageName);
     bundle.putString(KMKeyboardDownloaderActivity.ARG_MODEL_URL, modelURL);
 
-    String customHelpLink = map.get(KMManager.KMKey_CustomHelpLink);
-    if (customHelpLink != null) {
-      bundle.putString(KMKeyboardDownloaderActivity.ARG_CUSTOM_HELP_LINK, customHelpLink);
-    }
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_CUSTOM_HELP_LINK, helpLink);
 
     return bundle;
   }
@@ -99,7 +107,7 @@ public class LexicalModel implements Serializable, LanguageResource {
   public boolean equals(Object obj) {
     if(obj instanceof LexicalModel) {
       boolean lgCodeMatch = ((LexicalModel) obj).getLanguageID().equals(this.getLanguageID());
-      boolean idMatch = ((LexicalModel) obj).getResourceId().equals(this.getResourceId());
+      boolean idMatch = ((LexicalModel) obj).getLexicalModelID().equals(this.getLexicalModelID());
 
       return lgCodeMatch && idMatch;
     }
@@ -107,8 +115,4 @@ public class LexicalModel implements Serializable, LanguageResource {
     return false;
   }
 
-  @Override
-  public int hashCode() {
-    return getResourceId().hashCode() * getLanguageCode().hashCode();
-  }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -230,25 +230,6 @@ public final class FileUtils {
   }
 
   /**
-   * Utility to parse a URL and determine if it's a custom keyboard
-   * @param u String of the URL
-   * @return boolean false if URL matches [*.]keyman.com/
-   */
-  public static boolean isCustomKeyboard(String u) {
-    boolean ret = true;
-    if (u == null) {
-      return ret;
-    }
-    String lowerU = u.toLowerCase();
-    Pattern pattern = Pattern.compile("^http(s)?://(.+\\.)?keyman.com/.*");
-    Matcher matcher = pattern.matcher(lowerU);
-    if (matcher.matches()) {
-      ret = false;
-    }
-    return ret;
-  }
-
-  /**
    * Utility to parse a URL and determine if it's a valid keyman:<method>
    * Currently, only "keyman" scheme with "download" path and query is supported.
    * Legacy keyman:// protocol is deprecated and not supported.

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
@@ -41,7 +41,7 @@ public class CloudDataJsonUtilTest {
   public void shouldLowercaseLanguageID() {
     // Test createKeyboardInfoMap() used by processKeyboardJSON()
     HashMap<String, String> kbInfo = CloudDataJsonUtil.createKeyboardInfoMap(
-      pkgID, langID, langName, keyboardID, keyboardName, keyboardVersion, customKeyboard, aFont, oskFont, customHelpLink);
+      pkgID, langID, langName, keyboardID, keyboardName, keyboardVersion, aFont, oskFont, customHelpLink);
     Assert.assertEquals(langID.toLowerCase(), kbInfo.get(KMManager.KMKey_LanguageID));
 
     // Test processLexicalModelJSON()

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -32,28 +32,6 @@ public class FileUtilsTest {
   }
 
   @Test
-  public void test_isCustomKeyboard() {
-    // True because URL is null or empty (doesn't match *.keyman.com)
-    Assert.assertTrue(FileUtils.isCustomKeyboard(null));
-    Assert.assertTrue(FileUtils.isCustomKeyboard(""));
-
-    Assert.assertFalse(FileUtils.isCustomKeyboard("http://keyman.com/"));
-    Assert.assertFalse(FileUtils.isCustomKeyboard("https://keyman.com/"));
-    Assert.assertFalse(FileUtils.isCustomKeyboard("http://api.keyman.com/"));
-    Assert.assertFalse(FileUtils.isCustomKeyboard("https://api.keyman.com/"));
-    Assert.assertFalse(FileUtils.isCustomKeyboard("https://keyman.com/keyboard/khmer_angkor"));
-
-    // True because trailing slash is missing
-    Assert.assertTrue(FileUtils.isCustomKeyboard("http://keyman.com"));
-    Assert.assertTrue(FileUtils.isCustomKeyboard("https://keyman.com"));
-    Assert.assertTrue(FileUtils.isCustomKeyboard("http://api.keyman.com"));
-    Assert.assertTrue(FileUtils.isCustomKeyboard("https://api.keyman.com"));
-
-    // "custom" site
-    Assert.assertTrue(FileUtils.isCustomKeyboard("https://amerikeyman.com/"));
-  }
-
-  @Test
   public void test_isKeymanLink() {
     Assert.assertFalse(FileUtils.isKeymanLink(null));
     Assert.assertFalse(FileUtils.isKeymanLink(""));


### PR DESCRIPTION
This PR follows-on to #3020 in addressing more tech debt

## Remove tracking whether keyboard/lexical model is "custom"
The meaning of a "custom ad-hoc keyboard/lexical-model installation" has changed over the years.
Back in Keyman 10, cloud keyboards didn't use kmp's, and "custom" keyboards used ad-hoc kmp installations. Thus, there was a convention to treat all kmp installs as "custom".

Now in Keyman 14, cloud keyboards are also installed via kmp packages. So the properties  "custom" keyboard and "custom" lexical-model can be removed.

## Remove more HashMap usages by modifying LanguageResource() and refactoring LexicalModel
* Convert LanguageResource() base class from interface to abstract
  * This involves moving the order of some common parameters (version and help link)
* Add some helper functions in Keyboard

There's some temporary HashMaps that got added, but will be completely removed in a future PR when the installed dat files get migrated from HashMaps to JSON objects.
