### PR TITLE
fix(ios): download fv keyboards

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -7,7 +7,8 @@
 * Carthage (`brew install carthage`)
 * [Node.js](https://nodejs.org/) 8.9+ (for building KeymanWeb)
 * Coreutils (`brew install coreutils`)
-* sentry-cli (`brew install getsentry/tools/sentry-cli) to utilize Sentry-based error reporting
+* sentry-cli (`brew install getsentry/tools/sentry-cli`) to utilize Sentry-based error reporting
+* jq (`brew install jq`)
 
 ## Keyman App
 
@@ -61,7 +62,7 @@ To build in Xcode,
 The framework will be built to **engine/KMEI/build/(Debug|Release)-universal/KeymanEngine.framework**.
 
 If it doesn't build, and you have upgraded from Xcode 10.0 (or earlier) to 10.1 (or later), it may not
-build due to "Could not find any available simulators for iOS" error from Carthage, probably while 
+build due to "Could not find any available simulators for iOS" error from Carthage, probably while
 building DeviceKit. Xcode 10.1 changed the output format which confuses Carthage. Upgrade Carthage:
 ```
 brew upgrade carthage

--- a/oem/firstvoices/ios/build.sh
+++ b/oem/firstvoices/ios/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 # TODO: support passing -copy-keyboards, -debug, -clean etc in to build_keyboards
-./build_keyboards.sh
+./build_keyboards.sh -download-keyboards
 
 TARGET=FirstVoices
 # TODO: in the future build_common.sh should probably be shared with all oem products?

--- a/oem/firstvoices/ios/build_keyboards.sh
+++ b/oem/firstvoices/ios/build_keyboards.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Build the keyboards referred to in ../keyboards.csv and copy them + metadata 
+# Build the keyboards referred to in ../keyboards.csv and copy them + metadata
 # to the FirstVoices/Keyboards folder
 
 # keyboards.csv has columns Shortname,ID,Name,Region,OldVersion
@@ -13,11 +13,18 @@ set -u
 # set -x: Debugging use, print each statement
 # set -x
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+# . "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$(dirname "$THIS_SCRIPT")/../../../resources/build/jq.inc.sh"
+
 # This build script assumes that the https://github.com/keymanapp/keyboards repo is in
 # the same parent folder as this repo, with the default name 'keyboards'
-KEYBOARDS_ROOT=../../../../keyboards
+KEYBOARDS_ROOT=$(dirname "$THIS_SCRIPT")/../../../../keyboards
 TARGET=FirstVoices/Keyboards
-
 
 
 function die {
@@ -127,7 +134,7 @@ if [ $DO_DOWNLOAD = true ]; then
     while IFS=, read -r shortname id name region old_keyboard; do
       echo "Downloading $id ($name)"
       # Get latest version
-      URL_DOWNLOAD_FILE=`curl -s "$URL_API_VERSION/$id" | jq -r .js`
+      URL_DOWNLOAD_FILE=`curl -s "$URL_API_VERSION/$id" | "$JQ" -r .js`
       curl -s "$URL_DOWNLOAD_FILE" > "$SCRIPT_ROOT/$TARGET/files/$id.js"
       curl -s "${URL_DOWNLOAD_FILE%.*}.keyboard_info" > "$SCRIPT_ROOT/$TARGET/files/$id.keyboard_info"
     done

--- a/oem/firstvoices/ios/build_keyboards.sh
+++ b/oem/firstvoices/ios/build_keyboards.sh
@@ -26,9 +26,10 @@ function die {
 }
 
 function display_usage {
-  echo "Usage: build_keyboards.sh [-copy-keyboards] [-clean-keyboards] [-debug] [-h|-?]"
+  echo "Usage: build_keyboards.sh [-download-keyboards] [-copy-keyboards] [-clean-keyboards] [-debug] [-h|-?]"
   echo "Builds all keyboards used by the app and copies them into the"
   echo "target path."
+  echo "  -download-keyboards: Download keyboards from downloads.keyman.com"
   echo "  -copy-keyboards: Only copy the keyboards; don't rebuild them"
   echo "  -clean-keyboards: Clean the keyboards from this repo"
   echo "  -debug: Build debug versions of the keyboards"
@@ -38,10 +39,16 @@ function display_usage {
 DO_CLEAN=true
 DO_COPY=true
 DO_BUILD=true
+DO_DOWNLOAD=false
 
 while [[ $# -gt 0 ]] ; do
   key="$1"
   case $key in
+    -download-keyboards)
+      DO_DOWNLOAD=true
+      DO_COPY=false
+      DO_BUILD=false
+      ;;
     -copy-keyboards)
       DO_BUILD=false
       ;;
@@ -101,4 +108,28 @@ if [ $DO_BUILD = true ] || [ $DO_COPY = true ]; then
   } < "$SCRIPT_ROOT/../keyboards.csv"
 
   popd
+fi
+
+if [ $DO_DOWNLOAD = true ]; then
+  echo "Downloading keyboards from downloads.keyman.com"
+
+  cp ../keyboards.csv "$TARGET/keyboards.csv"
+
+  SCRIPT_ROOT=`pwd`
+  URL_DOWNLOAD=https://downloads.keyman.com
+  URL_API_VERSION=${URL_DOWNLOAD}/api/keyboard/
+
+  {
+    # Skip header line
+    read
+
+    # Read CSV and build each referenced keyboard
+    while IFS=, read -r shortname id name region old_keyboard; do
+      echo "Downloading $id ($name)"
+      # Get latest version
+      URL_DOWNLOAD_FILE=`curl -s "$URL_API_VERSION/$id" | jq -r .js`
+      curl -s "$URL_DOWNLOAD_FILE" > "$SCRIPT_ROOT/$TARGET/files/$id.js"
+      curl -s "${URL_DOWNLOAD_FILE%.*}.keyboard_info" > "$SCRIPT_ROOT/$TARGET/files/$id.keyboard_info"
+    done
+  } < "$SCRIPT_ROOT/../keyboards.csv"
 fi

--- a/resources/build/jq.inc.sh
+++ b/resources/build/jq.inc.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Setup JQ environment variable according to the user's system
+#
+# Windows: /resources/build/jq-win64.exe
+# Linux/macOS: jq
+#
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+# . "$(dirname "$THIS_SCRIPT")/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+case "${OSTYPE}" in
+  "cygwin")
+    JQ=$(dirname "$THIS_SCRIPT")/jq-win64.exe
+    ;;
+  "msys")
+    JQ=$(dirname "$THIS_SCRIPT")/jq-win64.exe
+    ;;
+  *)
+    JQ=jq
+    ;;
+esac
+
+readonly JQ

--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -34,6 +34,7 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 . "$(dirname "$THIS_SCRIPT")/trigger-definitions.config"
 . "$(dirname "$THIS_SCRIPT")/trigger-builds.sh"
+. "$(dirname "$THIS_SCRIPT")/jq.inc.sh"
 
 #
 # Iterate through the platforms 'array' passed in and
@@ -81,10 +82,6 @@ fi
 # different pull requests; and there is no way to know which base is
 # targeted by the PR other than to ask GitHub, anyway.)
 #
-
-# For now, this script runs only on Windows agents. In the future we
-# may need to make this a little more platform-agnostic
-JQ="$(dirname "$THIS_SCRIPT")/jq-win64.exe"
 
 echo ". Get information about pull request #$PRNUM from GitHub"
 prinfo=`curl -s -H "User-Agent: @keymanapp" https://api.github.com/repos/keymanapp/keyman/pulls/$PRNUM`


### PR DESCRIPTION
Instead of building and copying from keyboards repo, just
download the final fv keyboards from download server. This
avoids a bunch of dependencies on macOS build agents.

Later, we'll do the same for Android. This will also need to
be reviewed when we move from embedding .js to embedding .kmp
later in phase 10 (14.0 alpha).