### PR TITLE
chore(common/lmlayer): change author from personal to work affiliation

### DIFF
--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"
   },
-  "author": "Eddie Antonio Santos <easantos@ualberta.ca> (http://eddieantonio.ca/)",
+  "author": "Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/keymanapp/keyman/issues"


### PR DESCRIPTION
I just noticed this mistake! My affiliation in the package is incorrect; it should be my NRC affiliation, and not my personal one.