### PR TITLE
fix(ios): try embed of sentry again for fv

### DIFF
--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -2,3 +2,4 @@ github "marmelroy/Zip"
 github "DaveWoodCom/XCGLogger" ~> 6.1.0
 github "dennisweissmann/DeviceKit" ~> 1.11
 github "ashleymills/Reachability.swift"
+github "getsentry/sentry-cocoa" ~> 4.4.3

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "DaveWoodCom/XCGLogger" "6.1.0"
-github "ashleymills/Reachability.swift" "v4.3.1"
+github "ashleymills/Reachability.swift" "v5.0.0"
 github "dennisweissmann/DeviceKit" "1.13.0"
+github "getsentry/sentry-cocoa" "4.5.0"
 github "marmelroy/Zip" "1.1.0"

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		37150F74231637EA00C73C6A /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37150F6F231637EA00C73C6A /* Reachability.framework */; };
 		37150F75231637EA00C73C6A /* Zip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37150F70231637EA00C73C6A /* Zip.framework */; };
 		37150F76231637EA00C73C6A /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37150F71231637EA00C73C6A /* XCGLogger.framework */; };
-		37B1C772245CD88B00A95075 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37B1C771245CD88B00A95075 /* Sentry.framework */; };
+		372A4B9D245E904A001C1F80 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 372A4B9C245E904A001C1F80 /* Sentry.framework */; };
 		37C183B922932AD2009F9EFD /* FVKeyboardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C183B822932AD2009F9EFD /* FVKeyboardList.swift */; };
 		37C183BD2293321C009F9EFD /* Instructions in Resources */ = {isa = PBXBuildFile; fileRef = 37C183BC2293321C009F9EFD /* Instructions */; };
 		37EA1F1F228A1823003E710C /* KeymanEngine.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 37EA1F1D228A1809003E710C /* KeymanEngine.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -81,6 +81,7 @@
 		37150F6F231637EA00C73C6A /* Reachability.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Reachability.framework; path = Carthage/Build/iOS/Reachability.framework; sourceTree = "<group>"; };
 		37150F70231637EA00C73C6A /* Zip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Zip.framework; path = Carthage/Build/iOS/Zip.framework; sourceTree = "<group>"; };
 		37150F71231637EA00C73C6A /* XCGLogger.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCGLogger.framework; path = Carthage/Build/iOS/XCGLogger.framework; sourceTree = "<group>"; };
+		372A4B9C245E904A001C1F80 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = Carthage/Build/iOS/Sentry.framework; sourceTree = "<group>"; };
 		37B1C771245CD88B00A95075 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = ../../../ios/Carthage/Build/iOS/Sentry.framework; sourceTree = "<group>"; };
 		37C183B822932AD2009F9EFD /* FVKeyboardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FVKeyboardList.swift; sourceTree = "<group>"; };
 		37C183BC2293321C009F9EFD /* Instructions */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Instructions; path = FirstVoices/Instructions; sourceTree = "<group>"; };
@@ -127,8 +128,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37B1C772245CD88B00A95075 /* Sentry.framework in Frameworks */,
 				37150F72231637EA00C73C6A /* DeviceKit.framework in Frameworks */,
+				372A4B9D245E904A001C1F80 /* Sentry.framework in Frameworks */,
 				37150F73231637EA00C73C6A /* ObjcExceptionBridging.framework in Frameworks */,
 				37150F74231637EA00C73C6A /* Reachability.framework in Frameworks */,
 				37150F75231637EA00C73C6A /* Zip.framework in Frameworks */,
@@ -251,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				37B1C771245CD88B00A95075 /* Sentry.framework */,
+				372A4B9C245E904A001C1F80 /* Sentry.framework */,
 				37150F6D231637E900C73C6A /* DeviceKit.framework */,
 				37150F6E231637EA00C73C6A /* ObjcExceptionBridging.framework */,
 				37150F6F231637EA00C73C6A /* Reachability.framework */,


### PR DESCRIPTION
FV keyboards still crashing with missing Sentry framework. This appears to match the ios Keyman build so not sure exactly why this is happening. Trying an alternative.