### PR TITLE
feat(common): auto-update for package versioning

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -100,6 +100,18 @@ if [ "$action" == "commit" ]; then
   git tag -a "release-$VERSION_WITH_TAG" -m "Keyman release $VERSION_WITH_TAG"
   git checkout -b "$branch"
   git add VERSION.md HISTORY.md
+
+  # Also updates package versions, committing those changes
+  # Uses the 'version' run script defined in the base package.json.
+  npm run version -- "$NEWVERSION"
+
+  # Version info will be updated in lerna.json and all the lerna-managed package.json files.
+  git add lerna.json
+  # Iterates through all lerna-managed packages in serial mode (--concurrency 1),
+  # git-adding only the updated package.json and package-lock.json files.
+  npm run lerna -- exec --concurrency 1 -- git add package.json package-lock.json
+
+  # Now that all version-related changes are ready and git-added, it's time to commit.
   git commit -m "$message"
   git push --tags origin "$branch"
   hub pull-request -f --no-edit -b $base -l auto


### PR DESCRIPTION
Time for a little "`lerna`-fu", as it were.

This PR leverages the [versioning `npm` script](https://github.com/keymanapp/keyman/pull/2997#discussion_r415486289) defined in #2997 (implemented [here](https://github.com/keymanapp/keyman/blob/bd0de177e859df3c84347360bdb29317690ca7c6/package.json#L10)) to auto-update of all our lerna-managed package.json versioning.

It seemed wiser to simply incorporate it as part of the increment-version shell script, rather than try to force it into the TS-based script that manages the other components.