### PR TITLE
modify(android): Add methods to go between LanguageResource and JSON

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -206,11 +206,14 @@ public final class KMManager {
   public static final String KMDefault_KeyboardName = "EuroLatin (SIL) Keyboard";
   public static final String KMDefault_LanguageName = "English";
   public static final String KMDefault_KeyboardFont = "DejaVuSans.ttf";
+  public static final String KMDefault_KeyboardVersion = "1.8.1";
+  public static final String KMDefault_KeyboardKMP = KMDefault_PackageID + FileUtils.KEYMANPACKAGE;
 
   // Default Dictionary Info
   public static final String KMDefault_DictionaryPackageID = "nrc.en.mtnt";
   public static final String KMDefault_DictionaryModelID = "nrc.en.mtnt";
   public static final String KMDefault_DictionaryModelName = "English dictionary (MTNT)";
+  public static final String KMDefault_DictionaryVersion = "0.1.4";
   public static final String KMDefault_DictionaryKMP = KMDefault_DictionaryPackageID + FileUtils.MODELPACKAGE;
 
   // Keyman files

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -93,7 +93,7 @@ public class CloudDataJsonUtil {
       int modelsLength = models.length();
       for (int i = 0; i < modelsLength; i++) {
         JSONObject modelJSON = models.getJSONObject(i);
-        modelList.add(new LexicalModel(modelJSON));
+        modelList.add(new LexicalModel(modelJSON, true));
       }
     } catch (JSONException | NullPointerException e) {
       Log.e(TAG, "JSONParse Error: " + e);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -21,6 +21,38 @@ public class Keyboard extends LanguageResource implements Serializable {
   private String font;
   private String oskFont;
 
+  // JSON keys
+  public static String KB_NEW_KEYBOARD_KEY = "isNewKeyboard";
+  public static String KB_FONT_KEY = "font";
+  public static String KB_OSK_FONT_KEY = "oskFont";
+
+  /**
+   * Constructor using JSON Objects from installed keyboards list
+   * @param installedObj
+   */
+  public Keyboard(JSONObject installedObj) {
+    try {
+      this.packageID = installedObj.getString(LanguageResource.LR_PACKAGE_ID_KEY);
+      this.resourceID = installedObj.getString(LanguageResource.LR_RESOURCE_ID_KEY);
+      this.resourceName = installedObj.getString(LanguageResource.LR_RESOURCE_NAME_KEY);
+      this.languageID = installedObj.getString(LanguageResource.LR_LANGUAGE_ID_KEY);
+      this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
+      this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
+      this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
+
+      this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
+      this.font = installedObj.getString(KB_FONT_KEY);
+      this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
+    } catch (JSONException e) {
+      Log.e(TAG, "JSON exception: " + e);
+    }
+  }
+
+  /**
+   * Constructor usong JSON Objects from keyboard cloud catalog
+   * @param languageJSON
+   * @param keyboardJSON
+   */
   public Keyboard(JSONObject languageJSON, JSONObject keyboardJSON) {
     try {
       this.packageID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
@@ -101,4 +133,30 @@ public class Keyboard extends LanguageResource implements Serializable {
     return false;
   }
 
+  public JSONObject toJSON() {
+    JSONObject o = super.toJSON();
+    if (o != null) {
+      try {
+        o.put(KB_NEW_KEYBOARD_KEY, this.isNewKeyboard);
+        o.put(KB_FONT_KEY, this.font);
+        o.put(KB_OSK_FONT_KEY, this.oskFont);
+      } catch (JSONException e) {
+        Log.e(TAG, "toJSON exception: " + e);
+      }
+    }
+    return o;
+  }
+
+  // Default sil_euro_latin keyboard
+  public static final Keyboard DEFAULT_KEYBOARD = new Keyboard(
+    KMManager.KMDefault_PackageID,
+    KMManager.KMDefault_KeyboardID,
+    KMManager.KMDefault_KeyboardName,
+    KMManager.KMDefault_LanguageID,
+    KMManager.KMDefault_LanguageName,
+    KMManager.KMDefault_KeyboardVersion,
+    null, // will use help.keyman.com link because context required to determine local welcome.htm path
+    false,
+    KMManager.KMDefault_KeyboardFont,
+    KMManager.KMDefault_KeyboardFont);
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
@@ -31,21 +34,8 @@ public class Keyboard extends LanguageResource implements Serializable {
    * @param installedObj
    */
   public Keyboard(JSONObject installedObj) {
-    try {
-      this.packageID = installedObj.getString(LanguageResource.LR_PACKAGE_ID_KEY);
-      this.resourceID = installedObj.getString(LanguageResource.LR_RESOURCE_ID_KEY);
-      this.resourceName = installedObj.getString(LanguageResource.LR_RESOURCE_NAME_KEY);
-      this.languageID = installedObj.getString(LanguageResource.LR_LANGUAGE_ID_KEY);
-      this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
-      this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
-      this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
-
-      this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
-      this.font = installedObj.getString(KB_FONT_KEY);
-      this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
-    } catch (JSONException e) {
-      Log.e(TAG, "JSON exception: " + e);
-    }
+    super(installedObj);
+    this.fromJSON(installedObj);
   }
 
   /**
@@ -54,6 +44,7 @@ public class Keyboard extends LanguageResource implements Serializable {
    * @param keyboardJSON
    */
   public Keyboard(JSONObject languageJSON, JSONObject keyboardJSON) {
+    super(languageJSON, keyboardJSON);
     try {
       this.packageID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
 
@@ -81,16 +72,12 @@ public class Keyboard extends LanguageResource implements Serializable {
     }
   }
 
-  public Keyboard(String packageID, String keyboardID, String keyboardName, String languageID, String languageName,
-                  String version, String helpLink,
+  public Keyboard(String packageID, String keyboardID, String keyboardName,
+                  String languageID, String languageName, String version,
+                  String helpLink,
                   boolean isNewKeyboard, String font, String oskFont) {
+    super(packageID, keyboardID, keyboardName, languageID, languageName, version);
 
-    this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
-    this.resourceID = keyboardID;
-    this.resourceName = keyboardName;
-    this.languageID = languageID.toLowerCase();
-    this.languageName = languageName;
-    this.version = (version != null) ? version : "1.0";
     this.helpLink = (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
       String.format(HELP_URL_FORMATSTR, this.resourceID, this.version);
 
@@ -131,6 +118,17 @@ public class Keyboard extends LanguageResource implements Serializable {
     }
 
     return false;
+  }
+
+  protected void fromJSON(JSONObject installedObj) {
+    super.fromJSON(installedObj);
+    try {
+      this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
+      this.font = installedObj.getString(KB_FONT_KEY);
+      this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
+    } catch (JSONException e) {
+      Log.e(TAG, "fromJSON exception: " + e);
+    }
   }
 
   public JSONObject toJSON() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -25,26 +25,24 @@ public class Keyboard extends LanguageResource implements Serializable {
   private String oskFont;
 
   // JSON keys
-  public static String KB_NEW_KEYBOARD_KEY = "isNewKeyboard";
-  public static String KB_FONT_KEY = "font";
-  public static String KB_OSK_FONT_KEY = "oskFont";
+  private static String KB_NEW_KEYBOARD_KEY = "isNewKeyboard";
+  private static String KB_FONT_KEY = "font";
+  private static String KB_OSK_FONT_KEY = "oskFont";
 
   /**
    * Constructor using JSON Objects from installed keyboards list
    * @param installedObj
    */
   public Keyboard(JSONObject installedObj) {
-    super(installedObj);
     this.fromJSON(installedObj);
   }
 
   /**
-   * Constructor usong JSON Objects from keyboard cloud catalog
+   * Constructor using JSON Objects from keyboard cloud catalog
    * @param languageJSON
    * @param keyboardJSON
    */
   public Keyboard(JSONObject languageJSON, JSONObject keyboardJSON) {
-    super(languageJSON, keyboardJSON);
     try {
       this.packageID = keyboardJSON.optString(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
 
@@ -76,10 +74,9 @@ public class Keyboard extends LanguageResource implements Serializable {
                   String languageID, String languageName, String version,
                   String helpLink,
                   boolean isNewKeyboard, String font, String oskFont) {
-    super(packageID, keyboardID, keyboardName, languageID, languageName, version);
-
-    this.helpLink = (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
-      String.format(HELP_URL_FORMATSTR, this.resourceID, this.version);
+    super(packageID, keyboardID, keyboardName, languageID, languageName, version,
+      (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
+        String.format(HELP_URL_FORMATSTR, keyboardID, version));
 
     this.isNewKeyboard = isNewKeyboard;
     this.font = (font != null) ? font : "";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -1,7 +1,12 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
 import android.util.Log;
+
+import com.tavultesoft.kmea.KMManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -58,6 +63,57 @@ public abstract class LanguageResource implements Serializable {
   }
 
   public abstract Bundle buildDownloadBundle();
+
+  /**
+   * Constructor using JSON Objects from installed language resource list
+   * @param installedObj
+   */
+  public LanguageResource(JSONObject installedObj) {
+    this.fromJSON(installedObj);
+  }
+
+  public LanguageResource(JSONObject languageJSON, JSONObject keyboardJSON) {
+    // Noop - needed for Keyboard()
+  }
+
+  public LanguageResource(JSONObject lexicalModelJSON, boolean fromCloud) {
+    // Noop - needed for LexicalModel()
+  }
+
+  /**
+   * Constructor using properties
+   * For now, helpLink not included because it's only used by Keyboard
+   * @param packageID
+   * @param resourceID
+   * @param resourceName
+   * @param languageID
+   * @param languageName
+   * @param version
+   */
+  public LanguageResource(String packageID, String resourceID, String resourceName,
+                          String languageID, String languageName, String version) {
+    this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
+    this.resourceID = resourceID;
+    this.resourceName = resourceName;
+    this.languageID = languageID.toLowerCase();
+    // If language name not provided, fallback to re-use language ID
+    this.languageName = (languageName != null && !languageName.isEmpty()) ? languageName : this.languageID;
+    this.version = (version != null) ? version : "1.0";
+  }
+
+  protected void fromJSON(JSONObject installedObj) {
+    try {
+      this.packageID = installedObj.getString(LanguageResource.LR_PACKAGE_ID_KEY);
+      this.resourceID = installedObj.getString(LanguageResource.LR_RESOURCE_ID_KEY);
+      this.resourceName = installedObj.getString(LanguageResource.LR_RESOURCE_NAME_KEY);
+      this.languageID = installedObj.getString(LanguageResource.LR_LANGUAGE_ID_KEY);
+      this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
+      this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
+      this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
+    } catch (JSONException e) {
+      Log.e(TAG, "fromJSON() exception: " + e);
+    }
+  }
 
   public JSONObject toJSON() {
     JSONObject o = new JSONObject();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -69,14 +69,6 @@ public abstract class LanguageResource implements Serializable {
   }
 
   /**
-   * Constructor using JSON Objects from installed language resource list
-   * @param installedObj
-   */
-  public LanguageResource(JSONObject installedObj) {
-    this.fromJSON(installedObj);
-  }
-
-  /**
    * Constructor using properties
    * @param packageID
    * @param resourceID

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -3,6 +3,9 @@ package com.tavultesoft.kmea.data;
 import android.os.Bundle;
 import android.util.Log;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.Serializable;
 
 public abstract class LanguageResource implements Serializable {
@@ -13,6 +16,17 @@ public abstract class LanguageResource implements Serializable {
   protected String languageName;
   protected String version;
   protected String helpLink;
+
+  // JSON keys
+  public static String LR_PACKAGE_ID_KEY = "packageID";
+  public static String LR_RESOURCE_ID_KEY = "resourceID";
+  public static String LR_RESOURCE_NAME_KEY = "resourceName";
+  public static String LR_LANGUAGE_ID_KEY = "languageID";
+  public static String LR_LANGUAGE_NAME_KEY = "languageName";
+  public static String LR_VERSION_KEY = "version";
+  public static String LR_HELP_LINK_KEY = "helpLink";
+
+  private static final String TAG = "LanguageResource";
 
   public String getResourceID() { return resourceID; }
 
@@ -45,5 +59,20 @@ public abstract class LanguageResource implements Serializable {
 
   public abstract Bundle buildDownloadBundle();
 
-  //public abstract boolean equals();
+  public JSONObject toJSON() {
+    JSONObject o = new JSONObject();
+    try {
+      o.put(LR_PACKAGE_ID_KEY, this.packageID);
+      o.put(LR_RESOURCE_ID_KEY, this.resourceID);
+      o.put(LR_RESOURCE_NAME_KEY, this.resourceName);
+      o.put(LR_LANGUAGE_ID_KEY, this.languageID);
+      o.put(LR_LANGUAGE_NAME_KEY, this.languageName);
+      o.put(LR_VERSION_KEY, this.version);
+      o.put(LR_HELP_LINK_KEY, this.helpLink);
+    } catch (JSONException e) {
+      Log.e(TAG, "toJSON() exception: " + e);
+    }
+
+    return o;
+  }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -23,13 +23,13 @@ public abstract class LanguageResource implements Serializable {
   protected String helpLink;
 
   // JSON keys
-  public static String LR_PACKAGE_ID_KEY = "packageID";
-  public static String LR_RESOURCE_ID_KEY = "resourceID";
-  public static String LR_RESOURCE_NAME_KEY = "resourceName";
-  public static String LR_LANGUAGE_ID_KEY = "languageID";
-  public static String LR_LANGUAGE_NAME_KEY = "languageName";
-  public static String LR_VERSION_KEY = "version";
-  public static String LR_HELP_LINK_KEY = "helpLink";
+  private static String LR_PACKAGE_ID_KEY = "packageID";
+  private static String LR_RESOURCE_ID_KEY = "resourceID";
+  private static String LR_RESOURCE_NAME_KEY = "resourceName";
+  private static String LR_LANGUAGE_ID_KEY = "languageID";
+  private static String LR_LANGUAGE_NAME_KEY = "languageName";
+  private static String LR_VERSION_KEY = "version";
+  private static String LR_HELP_LINK_KEY = "helpLink";
 
   private static final String TAG = "LanguageResource";
 
@@ -64,6 +64,10 @@ public abstract class LanguageResource implements Serializable {
 
   public abstract Bundle buildDownloadBundle();
 
+  public LanguageResource() {
+    // Noop
+  }
+
   /**
    * Constructor using JSON Objects from installed language resource list
    * @param installedObj
@@ -72,26 +76,19 @@ public abstract class LanguageResource implements Serializable {
     this.fromJSON(installedObj);
   }
 
-  public LanguageResource(JSONObject languageJSON, JSONObject keyboardJSON) {
-    // Noop - needed for Keyboard()
-  }
-
-  public LanguageResource(JSONObject lexicalModelJSON, boolean fromCloud) {
-    // Noop - needed for LexicalModel()
-  }
-
   /**
    * Constructor using properties
-   * For now, helpLink not included because it's only used by Keyboard
    * @param packageID
    * @param resourceID
    * @param resourceName
    * @param languageID
    * @param languageName
    * @param version
+   * @param helpLink
    */
   public LanguageResource(String packageID, String resourceID, String resourceName,
-                          String languageID, String languageName, String version) {
+                          String languageID, String languageName, String version,
+                          String helpLink) {
     this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
     this.resourceID = resourceID;
     this.resourceName = resourceName;
@@ -99,6 +96,7 @@ public abstract class LanguageResource implements Serializable {
     // If language name not provided, fallback to re-use language ID
     this.languageName = (languageName != null && !languageName.isEmpty()) ? languageName : this.languageID;
     this.version = (version != null) ? version : "1.0";
+    this.helpLink = helpLink;
   }
 
   protected void fromJSON(JSONObject installedObj) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -19,7 +19,35 @@ public class LexicalModel extends LanguageResource implements Serializable {
   // Only used to build download bundle from cloud
   private String modelURL;
 
-  public LexicalModel(JSONObject lexicalModelJSON) {
+  // JSON key
+  public static String LM_MODEL_URL_KEY = "modelURL";
+
+  /**
+   * Constructor using JSON Object from installed lexical models list
+   * @param installedObj
+   */
+  public LexicalModel(JSONObject installedObj) {
+    try {
+      this.packageID = installedObj.getString(LanguageResource.LR_PACKAGE_ID_KEY);
+      this.resourceID = installedObj.getString(LanguageResource.LR_RESOURCE_ID_KEY);
+      this.resourceName = installedObj.getString(LanguageResource.LR_RESOURCE_NAME_KEY);
+      this.languageID = installedObj.getString(LanguageResource.LR_LANGUAGE_ID_KEY);
+      this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
+      this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
+      this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
+
+      this.modelURL = installedObj.getString(LM_MODEL_URL_KEY);
+    } catch (JSONException e) {
+      Log.e(TAG, "JSON exception: " + e);
+    }
+  }
+
+  /**
+   * Constructor using JSON Object from lexical model cloud catalog
+   * @param lexicalModelJSON
+   * @param fromCloud boolean - only really used to make a unique prototype
+   */
+  public LexicalModel(JSONObject lexicalModelJSON, boolean fromCloud) {
     try {
       this.modelURL = lexicalModelJSON.optString("packageFilename", "");
 
@@ -115,4 +143,27 @@ public class LexicalModel extends LanguageResource implements Serializable {
     return false;
   }
 
+  public JSONObject toJSON() {
+    JSONObject o = super.toJSON();
+    if (o != null) {
+      try {
+        o.put(LM_MODEL_URL_KEY, this.modelURL);
+      } catch (JSONException e) {
+        Log.e(TAG, "toJSON exception: " + e);
+      }
+    }
+
+    return o;
+  }
+
+  // default nrc.en.mtnt English dictionary
+  public static final LexicalModel DEFAULT_LEXICAL_MODEL = new LexicalModel(
+    KMManager.KMDefault_DictionaryPackageID,
+    KMManager.KMDefault_DictionaryModelID,
+    KMManager.KMDefault_DictionaryModelName,
+    KMManager.KMDefault_LanguageID,
+    KMManager.KMDefault_LanguageName,
+    KMManager.KMDefault_DictionaryVersion,
+    "",
+    "");
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -23,14 +23,13 @@ public class LexicalModel extends LanguageResource implements Serializable {
   private String modelURL;
 
   // JSON key
-  public static String LM_MODEL_URL_KEY = "modelURL";
+  private static String LM_MODEL_URL_KEY = "modelURL";
 
   /**
    * Constructor using JSON Object from installed lexical models list
    * @param installedObj
    */
   public LexicalModel(JSONObject installedObj) {
-    super(installedObj);
     this.fromJSON(installedObj);
   }
 
@@ -40,7 +39,6 @@ public class LexicalModel extends LanguageResource implements Serializable {
    * @param fromCloud boolean - only really used to make a unique prototype
    */
   public LexicalModel(JSONObject lexicalModelJSON, boolean fromCloud) {
-    super(lexicalModelJSON, fromCloud);
     try {
       this.modelURL = lexicalModelJSON.optString("packageFilename", "");
 
@@ -87,9 +85,10 @@ public class LexicalModel extends LanguageResource implements Serializable {
                       String languageID, String languageName,  String version,
                       String helpLink,
                       String modelURL) {
-    super(packageID, lexicalModelID, lexicalModelName, languageID, languageName, version);
+    // TODO: handle help links
+    super(packageID, lexicalModelID, lexicalModelName, languageID, languageName,
+        version, "");
 
-    this.helpLink = ""; // TODO: Handle help links
     this.modelURL = modelURL;
   }
 
@@ -131,6 +130,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
   }
 
   protected void fromJSON(JSONObject installedObj) {
+    super.fromJSON(installedObj);
     try {
       this.modelURL = installedObj.getString(LM_MODEL_URL_KEY);
     } catch (JSONException e) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
@@ -27,19 +30,8 @@ public class LexicalModel extends LanguageResource implements Serializable {
    * @param installedObj
    */
   public LexicalModel(JSONObject installedObj) {
-    try {
-      this.packageID = installedObj.getString(LanguageResource.LR_PACKAGE_ID_KEY);
-      this.resourceID = installedObj.getString(LanguageResource.LR_RESOURCE_ID_KEY);
-      this.resourceName = installedObj.getString(LanguageResource.LR_RESOURCE_NAME_KEY);
-      this.languageID = installedObj.getString(LanguageResource.LR_LANGUAGE_ID_KEY);
-      this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
-      this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
-      this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
-
-      this.modelURL = installedObj.getString(LM_MODEL_URL_KEY);
-    } catch (JSONException e) {
-      Log.e(TAG, "JSON exception: " + e);
-    }
+    super(installedObj);
+    this.fromJSON(installedObj);
   }
 
   /**
@@ -48,6 +40,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
    * @param fromCloud boolean - only really used to make a unique prototype
    */
   public LexicalModel(JSONObject lexicalModelJSON, boolean fromCloud) {
+    super(lexicalModelJSON, fromCloud);
     try {
       this.modelURL = lexicalModelJSON.optString("packageFilename", "");
 
@@ -90,18 +83,12 @@ public class LexicalModel extends LanguageResource implements Serializable {
     }
   }
 
-  public LexicalModel(String packageID, String lexicalModelID, String lexicalModelName, String languageID, String languageName,
-                      String version, String helpLink,
+  public LexicalModel(String packageID, String lexicalModelID, String lexicalModelName,
+                      String languageID, String languageName,  String version,
+                      String helpLink,
                       String modelURL) {
+    super(packageID, lexicalModelID, lexicalModelName, languageID, languageName, version);
 
-    this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
-    this.resourceID = lexicalModelID;
-    this.resourceName = lexicalModelName;
-    this.languageID = languageID.toLowerCase();
-    // If language name not provided, fallback to re-use language ID
-    this.languageName = (languageName != null && !languageName.isEmpty()) ? languageName : this.languageID;
-
-    this.version = (version != null) ? version : "1.0";
     this.helpLink = ""; // TODO: Handle help links
     this.modelURL = modelURL;
   }
@@ -143,13 +130,21 @@ public class LexicalModel extends LanguageResource implements Serializable {
     return false;
   }
 
+  protected void fromJSON(JSONObject installedObj) {
+    try {
+      this.modelURL = installedObj.getString(LM_MODEL_URL_KEY);
+    } catch (JSONException e) {
+      Log.e(TAG, "fromJSON() exception: " + e);
+    }
+  }
+
   public JSONObject toJSON() {
     JSONObject o = super.toJSON();
     if (o != null) {
       try {
         o.put(LM_MODEL_URL_KEY, this.modelURL);
       } catch (JSONException e) {
-        Log.e(TAG, "toJSON exception: " + e);
+        Log.e(TAG, "toJSON() exception: " + e);
       }
     }
 


### PR DESCRIPTION
This PR is laying some groundwork towards migrating the installed keyboards list and installed lexical models list from HashMaps to JSONArray

There's also some static utility constants for default LexicalModel and default Keyboard.
They will be for the use-cases where the current dictionary/keyboard needs to revert to the default ones.