### PR TITLE
feat(android): Migrate installed keyboards list to keyboards_list.json

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -63,6 +63,7 @@ import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
 import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.data.Dataset;
+import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.logic.ResourcesUpdateTool;
 import com.tavultesoft.kmea.packages.JSONUtils;
 import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
@@ -223,6 +224,10 @@ public final class KMManager {
   protected static final String KMFilename_KmwCss = "kmwosk.css";
   protected static final String KMFilename_Osk_Ttf_Font = "keymanweb-osk.ttf";
   protected static final String KMFilename_Osk_Woff_Font = "keymanweb-osk.woff";
+
+  public static final String KMFilename_InstalledLexicalModelsList = "lexical_models_list.json";
+
+  // Deprecated by KMFilename_Installed_KeyboardsList and KMFilename_InstalledLexicalModelsList above
   public static final String KMFilename_KeyboardsList = "keyboards_list.dat";
   public static final String KMFilename_LexicalModelsList = "lexical_models_list.dat";
 
@@ -289,6 +294,8 @@ public final class KMManager {
     }
 
     JSONUtils.initialize(new File(getPackagesDir()));
+
+    KeyboardController.getInstance().initialize(appContext);
 
     CloudDownloadMgr.getInstance().initialize(appContext);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -225,7 +225,7 @@ public final class KMManager {
   protected static final String KMFilename_Osk_Ttf_Font = "keymanweb-osk.ttf";
   protected static final String KMFilename_Osk_Woff_Font = "keymanweb-osk.woff";
 
-  public static final String KMFilename_InstalledLexicalModelsList = "lexical_models_list.json";
+  public static final String KMFilename_Installed_LexicalModelsList = "lexical_models_list.json";
 
   // Deprecated by KMFilename_Installed_KeyboardsList and KMFilename_InstalledLexicalModelsList above
   public static final String KMFilename_KeyboardsList = "keyboards_list.dat";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -25,37 +25,27 @@ import java.util.HashMap;
 import java.util.List;
 
 public class KeyboardController {
-  public static final String TAG = "InstalledKBList";
+  public static final String TAG = "KeyboardController";
   public static final String KMFilename_Installed_KeyboardsList = "keyboards_list.json";
 
   private static KeyboardController instance;
 
   /**
-   * @return get or create shared instance.
+   * @return get or create shared singleton instance.
    */
   public static KeyboardController getInstance() {
     if (instance == null) {
-      createInstance();
+      instance = new KeyboardController();
     }
     return instance;
-  }
-
-  /**
-   * create singleton instance.
-   */
-  private synchronized static void createInstance()
-  {
-    if (instance != null) {
-      return;
-    }
-    instance = new KeyboardController();
   }
 
   private boolean isInitialized = false;
   private List<Keyboard> list;
 
-  public synchronized  void initialize(Context context) {
+  public synchronized void initialize(Context context) {
     if (isInitialized) {
+      Log.w(TAG, "initialize called multiple times");
       return;
     }
 
@@ -124,6 +114,8 @@ public class KeyboardController {
       if (!keyboards_json.exists()) {
         save(context);
       }
+
+      // TODO when feature stabilized: Delete legacy keyboards_list.dat (KMManager.KMFilename_KeyboardsList)
     }
     isInitialized = true;
   }
@@ -134,7 +126,8 @@ public class KeyboardController {
    */
   public List<Keyboard> get() {
     if (!isInitialized) {
-      return null; // Log error?
+      Log.e(TAG, "get while KeyboardController() not initialized");
+      return null;
     }
     return list;
   }
@@ -145,7 +138,11 @@ public class KeyboardController {
    * @return Keyboard
    */
   public Keyboard getKeyboardInfo(int index) {
-    if (!isInitialized || (index < 0)) {
+    if (!isInitialized) {
+      Log.e(TAG, "getKeyboardInfo while KeyboardController() not initialized");
+      return null;
+    } else if (index < 0) {
+      Log.e(TAG, "getKeyboardInfo with invalid index: " + index);
       return null;
     }
 
@@ -154,6 +151,7 @@ public class KeyboardController {
       return k;
     }
 
+    Log.e(TAG, "getKeyboardInfo failed with index " + index);
     return null;
   }
 
@@ -164,6 +162,7 @@ public class KeyboardController {
    */
   public void add(Keyboard newKeyboard) {
     if (!isInitialized || list == null) {
+      Log.e(TAG, "add while KeyboardController() not initialized");
       return;
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmea.data;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.tavultesoft.kmea.JSONParser;
+import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.KeyboardPickerActivity;
+import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.MapCompat;
+import com.tavultesoft.kmea.KMManager;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class KeyboardController {
+  public static final String TAG = "InstalledKBList";
+  public static final String KMFilename_Installed_KeyboardsList = "keyboards_list.json";
+
+  private static KeyboardController instance;
+
+  /**
+   * @return get or create shared instance.
+   */
+  public static KeyboardController getInstance() {
+    if (instance == null) {
+      createInstance();
+    }
+    return instance;
+  }
+
+  /**
+   * create singleton instance.
+   */
+  private synchronized static void createInstance()
+  {
+    if (instance != null) {
+      return;
+    }
+    instance = new KeyboardController();
+  }
+
+  private boolean isInitialized = false;
+  private List<Keyboard> list;
+
+  public synchronized  void initialize(Context context) {
+    if (isInitialized) {
+      return;
+    }
+
+    File keyboards_dat = new File(context.getDir("userdata", Context.MODE_PRIVATE),
+      KMManager.KMFilename_KeyboardsList);
+    File keyboards_json = new File(context.getDir("userdata", Context.MODE_PRIVATE),
+      KMFilename_Installed_KeyboardsList);
+    if (list == null) {
+      list = new ArrayList<Keyboard>();
+      if (keyboards_dat.exists() && !keyboards_json.exists()) {
+        try {
+          // Migrate installed_keyboards.dat to installed_keyboards.json
+          ObjectInputStream inputStream = new ObjectInputStream(new FileInputStream(keyboards_dat));
+          ArrayList<HashMap<String, String>> dat_list = (ArrayList<HashMap<String, String>>) inputStream.readObject();
+          inputStream.close();
+
+          for(HashMap<String, String> kbdMap : dat_list) {
+            boolean isNewKeyboard = kbdMap.containsKey(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD) &&
+              kbdMap.get(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD).equals(KeyboardPickerActivity.KMKEY_INTERNAL_NEW_KEYBOARD);
+
+            Keyboard k = new Keyboard(
+              kbdMap.get(KMManager.KMKey_PackageID),
+              kbdMap.get(KMManager.KMKey_KeyboardID),
+              kbdMap.get(KMManager.KMKey_KeyboardName),
+              kbdMap.get(KMManager.KMKey_LanguageID),
+              kbdMap.get(KMManager.KMKey_LanguageName),
+              MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
+              MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, ""),
+              isNewKeyboard,
+              MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
+              MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null)
+            );
+            list.add(k);
+          }
+
+        } catch (Exception e) {
+          Log.e(TAG, "Exception migrating installed_keyboards.dat");
+          list.add(Keyboard.DEFAULT_KEYBOARD);
+        }
+      } else if (keyboards_json.exists()) {
+        try {
+          // Get installed keyboards from installed_keyboards.json
+          JSONParser jsonParser = new JSONParser();
+          JSONArray json_list = jsonParser.getJSONObjectFromFile(keyboards_json, JSONArray.class);
+          if (json_list != null) {
+            // Can't foreach JSONArray
+            for (int i=0; i<json_list.length(); i++) {
+              JSONObject o = json_list.getJSONObject(i);
+              if (o != null) {
+                Keyboard k = new Keyboard(o);
+                list.add(k);
+              }
+            }
+          }
+        } catch (Exception e) {
+          Log.e(TAG, "Exception reading installed_keyboards.json");
+          list.add(Keyboard.DEFAULT_KEYBOARD);
+        }
+      } else {
+        // No installed keyboards lists so assume default
+        // TODO: What about 3rd-party apps w/o sil_euro_latin?
+        list.add(Keyboard.DEFAULT_KEYBOARD);
+      }
+
+      // We'd prefer not to overwrite a file if it exists
+      if (!keyboards_json.exists()) {
+        save(context);
+      }
+    }
+    isInitialized = true;
+  }
+
+  /**
+   * Return the installed keyboards list
+   * @return
+   */
+  public List<Keyboard> get() {
+    if (!isInitialized) {
+      return null; // Log error?
+    }
+    return list;
+  }
+
+  /**
+   * Return the keyboard info at index
+   * @param index - int
+   * @return Keyboard
+   */
+  public Keyboard getKeyboardInfo(int index) {
+    if (!isInitialized || (index < 0)) {
+      return null;
+    }
+
+    if (list != null && index < list.size()) {
+      Keyboard k = list.get(index);
+      return k;
+    }
+
+    return null;
+  }
+
+  /**
+   * Add a new keyboard to the keyboard list. If the keyboard already exists, the keyboard
+   * information is updated
+   * @param newKeyboard
+   */
+  public void add(Keyboard newKeyboard) {
+    if (!isInitialized || list == null) {
+      return;
+    }
+
+    for (int i=0; i<list.size(); i++) {
+      // Update existing keyboard entry
+      if (newKeyboard.equals(list.get(i))) {
+        Log.d(TAG, "Updating keyboard with newKeyboard");
+        list.set(i, newKeyboard);
+        return;
+      }
+    }
+
+    // Add new keyboard
+    list.add(newKeyboard);
+  }
+
+
+  /**
+   * Convert the installed keyboard list to JSONArray and write to file
+   * @param context
+   */
+  public void save(Context context) {
+    JSONArray arr = new JSONArray();
+    for (Keyboard k : list) {
+      JSONObject o = k.toJSON();
+      arr.put(o);
+    }
+    FileUtils.saveList(context, KMFilename_Installed_KeyboardsList, arr);
+  }
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -62,6 +62,10 @@ public abstract class LanguageResource implements Serializable {
     return id.hashCode() * lgCode.hashCode();
   }
 
+  public String getKey() {
+    return String.format("%s_%s", languageID, resourceID);
+  }
+
   public abstract Bundle buildDownloadBundle();
 
   public LanguageResource() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -6,13 +6,18 @@ import android.util.Log;
 
 import com.tavultesoft.kmea.KMManager;
 
+import org.json.JSONArray;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,6 +28,7 @@ import java.util.regex.Pattern;
   * This might be usable once we can upgrade to Android Oreo
  */
 public final class FileUtils {
+  public static final String TAG = "FileUtils";
 
   public static final int DOWNLOAD_ERROR = -1;
   public static final int DOWNLOAD_SUCCESS = 1;
@@ -213,6 +219,23 @@ public final class FileUtils {
     }
   }
 
+  public static boolean saveList(Context context, String listName, JSONArray arr) {
+    boolean result;
+    final int INDENT = 2; // 2 spaces indent
+    try {
+      File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), listName);
+      OutputStreamWriter outputStream = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
+      outputStream.write(arr.toString(INDENT));
+      outputStream.flush();
+      outputStream.close();
+      result = true;
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to save " + listName + ". Error: " + e);
+      result = false;
+    }
+
+    return result;
+  }
   /**
    * Utility to parse a URL and extract the filename
    * @param urlStr String


### PR DESCRIPTION
Follow-on to #3079 

This adds a controller to start managing the installed keyboards list.  The intention in a future PR is to replace the processing of [KeyboardPickerActivity.keyboardslist](https://github.com/keymanapp/keyman/blob/master/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java#L57) with KeyboardController methods.

The installed keyboards list is also migrated to `keyboards_list.json`. (Easier to maintain than keyboards_list.dat)

