### PR TITLE
fix(android): Fix back button after System Keyboard dismissed

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -226,9 +226,12 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       switch (keyCode) {
         case KeyEvent.KEYCODE_BACK:
-          // Dismiss the keyboard
-          KMManager.hideSystemKeyboard();
-          return true;
+          // Dismiss the keyboard if currently shown
+          if (isInputViewShown()) {
+            KMManager.hideSystemKeyboard();
+            return true;
+          }
+          break;
       }
     }
 


### PR DESCRIPTION
Follow-on to #2950 (Use back button to minimize System Keyboard)

A user reported 
> When I tested it out, I found that hitting Back now hides the keyboard, but hitting Back again and multiple times does nothing, the UI that was up is not dismissed. It seems Keyman is still active somehow and capturing Back.
>
>I added the following check and am now able to hit Back to exit to previous UI (browser, Signal, etc)
```java
if (isInputViewShown()) {
  KMManager.hideSystemKeyboard();
  return true;
}
```

### User Testing
* Load Keyman
* From the "Get Started" screen, enable Keyman as a system keyboard
* Open a Chrome browser and browse to a few pages
* With Keyman selected as a system keyboard, start typing
* Hit the back button once (will dismiss the system keyboard)
* Hit the back button a few more times and verify the browser goes back with each press
