### PR TITLE
fix(android): Back button to dismiss system keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -209,6 +209,18 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_DOWN) {
+      switch (keyCode) {
+        case KeyEvent.KEYCODE_BACK:
+          // Dismiss the keyboard if currently shown
+          if (isInputViewShown()) {
+            KMManager.hideSystemKeyboard();
+            return true;
+          }
+          break;
+      }
+    }
+
     return interpreter.onKeyDown(keyCode, event);  // if false, will revert to default handling.
   }
 

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -184,6 +184,18 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_DOWN) {
+      switch (keyCode) {
+        case KeyEvent.KEYCODE_BACK:
+          // Dismiss the keyboard if currently shown
+          if (isInputViewShown()) {
+            KMManager.hideSystemKeyboard();
+            return true;
+          }
+          break;
+      }
+    }
+
     return interpreter.onKeyDown(keyCode, event);  // if false, will revert to default handling.
   }
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android Version History
 
+## 2020-05-07 13.0.6210 stable
+* Bug fix:
+  * Back button dismisses system keyboard ()
+
 ## 2020-04-20 13.0.6209 stable
 * Bug fix:
   * Fix crash involving system keyboard update notifications (#3007)

--- a/android/history.md
+++ b/android/history.md
@@ -2,7 +2,7 @@
 
 ## 2020-05-07 13.0.6210 stable
 * Bug fix:
-  * Back button dismisses system keyboard ()
+  * Back button dismisses system keyboard (#3094)
 
 ## 2020-04-20 13.0.6209 stable
 * Bug fix:


### PR DESCRIPTION
Cherry-pick  #2950 and #3093 to stable-13.0

This allows the back button to dismiss the system keyboard if shown. Additional back-presses revert to default UI behavior.

As a throw-in, I made the same change to KMSample2

### User Testing
* Load Keyman
* From the "Get Started" screen, enable Keyman as a system keyboard
* Open a Chrome browser and browse to a few pages
* With Keyman selected as a system keyboard, start typing
* Hit the back button once (will dismiss the system keyboard)
* Hit the back button a few more times and verify the browser goes back with each press

