### PR TITLE
fix(android): Back button to dismiss KMSample2 system keyboard

### DIFF
--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -184,6 +184,18 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_DOWN) {
+      switch (keyCode) {
+        case KeyEvent.KEYCODE_BACK:
+          // Dismiss the keyboard if currently shown
+          if (isInputViewShown()) {
+            KMManager.hideSystemKeyboard();
+            return true;
+          }
+          break;
+      }
+    }
+
     return interpreter.onKeyDown(keyCode, event);  // if false, will revert to default handling.
   }
 


### PR DESCRIPTION
Bring in the changes from #2950 and #3093 to KMSample2

This PR has the back button to dismiss the KMSample2 system keyboard