### PR TITLE
fix(oem): Back button to dismiss FV Android system keyboard

### DIFF
--- a/oem/firstvoices/android/.gitignore
+++ b/oem/firstvoices/android/.gitignore
@@ -21,6 +21,7 @@
 # Files generated as part of the build
 app/src/main/assets/packages
 app/src/main/assets/keyboards.csv
+app/src/main/assets/fv_all.kmp
 
 # Legacy Eclipse IDE files
 .classpath

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -185,6 +185,18 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            switch (keyCode) {
+              case KeyEvent.KEYCODE_BACK:
+                // Dismiss the keyboard if currently shown
+                if (isInputViewShown()) {
+                  KMManager.hideSystemKeyboard();
+                  return true;
+                }
+                break;
+            }
+        }
+
         return interpreter.onKeyDown(keyCode, event);  // if false, will revert to default handling.
     }
 


### PR DESCRIPTION
Bring in the changes from #2950 and #3093 to the FV Android app