### PR TITLE
fix(developer): adds utility script to facilitate Developer-build Lerna compatibility

### DIFF
--- a/resources/package-utils.sh
+++ b/resources/package-utils.sh
@@ -2,16 +2,19 @@
 
 display_usage ( ) {
   echo ""
-  echo "package-utils.sh link-stash | link-unstash"
-  echo
+  echo "package-utils.sh accepts one of the following options:"
+  echo ""
   echo "  clean-external-deps  to erase the node_modules folder without erasing links."
-  echo "                       Internally uses both link-stash and link-unstash"
+  echo "                       Internally uses both link-stash and link-unstash."
   echo ""
   echo "  link-stash           to 'stash' the package's local links in a temporary"
   echo "                       directory."
   echo ""
   echo "  link-unstash         reverses 'link-stash', restoring the links to their"
   echo "                       original location and removing the temp directory."
+  echo ""
+  echo "  list-links           outputs the list of local dependencies used by the"
+  echo "                       current package.json."
   echo "" 
   exit 1
 }
@@ -21,7 +24,7 @@ PACKAGE_STASH='__node_modules'
 
 # Stores all @keymanapp package dependency/dev-dependency names to the 'packages' array.
 get_local_dependencies() {
-  localDeps=`cat package.json | jq -r '.dependencies, .devDependencies | to_entries | map(select(.key | match("@keymanapp/";"i"))) | map(.key) | .[]'`
+  localDeps=`cat package.json | jq -r ".dependencies, .devDependencies | to_entries | map(select(.key | match(\"@keymanapp/\";\"i\"))) | map(.key) | .[]"`
 
   # Sadly, we can't rely on the bash script `readlines` command - not all shells  (eg: macOS) support it!
   # This will have the same net effect.
@@ -62,6 +65,13 @@ if [ $# -eq 0 ]; then
   display_usage
 else
   case $1 in
+    list-links)
+      get_local_dependencies
+
+      for dep in "${packages[@]}"; do
+        echo "$dep"
+      done
+      ;;
     link-stash)
       QUIET=false
       stash_package_links

--- a/resources/package-utils.sh
+++ b/resources/package-utils.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+display_usage ( ) {
+  echo ""
+  echo "package-utils.sh link-stash | link-unstash"
+  echo
+  echo "  clean-external-deps  to erase the node_modules folder without erasing links."
+  echo "                       Internally uses both link-stash and link-unstash"
+  echo ""
+  echo "  link-stash           to 'stash' the package's local links in a temporary"
+  echo "                       directory."
+  echo ""
+  echo "  link-unstash         reverses 'link-stash', restoring the links to their"
+  echo "                       original location and removing the temp directory."
+  echo "" 
+  exit 1
+}
+
+PACKAGE_SOURCE='node_modules'
+PACKAGE_STASH='__node_modules'
+
+# Stores all @keymanapp package dependency/dev-dependency names to the 'packages' array.
+get_local_dependencies() {
+  localDeps=`cat package.json | jq -r '.dependencies, .devDependencies | to_entries | map(select(.key | match("@keymanapp/";"i"))) | map(.key) | .[]'`
+
+  # Sadly, we can't rely on the bash script `readlines` command - not all shells  (eg: macOS) support it!
+  # This will have the same net effect.
+  IFS=$'\n'
+  packages=(${localDeps}); # Convert the output $localDeps string into a script-friendly array.
+  unset IFS
+}
+
+stash_package_links() {
+  get_local_dependencies
+
+  mkdir -p "$PACKAGE_STASH/@keymanapp"
+  for dep in "${packages[@]}"; do
+    if [ "${QUIET:-false}" = false ]; then
+      echo "Stashing link-based dependency: $dep"
+    fi
+    mv "$PACKAGE_SOURCE/$dep" "$PACKAGE_STASH/@keymanapp"
+  done
+}
+
+unstash_package_links() {
+  get_local_dependencies
+
+  mkdir -p "$PACKAGE_SOURCE/@keymanapp"
+  for dep in "${packages[@]}"; do
+    if [ "${QUIET:-false}" = false ]; then
+      echo "Restoring link-based dependency: $dep"
+    fi
+    mv "$PACKAGE_STASH/$dep" "$PACKAGE_SOURCE/@keymanapp"
+  done
+
+  rm -r "$PACKAGE_STASH"
+}
+
+# Parse args
+# If no argument was provided, print help.
+if [ $# -eq 0 ]; then
+  display_usage
+else
+  case $1 in
+    link-stash)
+      QUIET=false
+      stash_package_links
+      ;;
+    link-unstash)
+      QUIET=false
+      unstash_package_links
+      ;;
+    clean-external-deps)
+      QUIET=true
+
+      stash_package_links
+      rm -rf node_modules
+      unstash_package_links
+      ;;
+    # Default case - display help
+    *)
+      display_usage
+      ;;
+  esac
+fi

--- a/resources/package-utils.sh
+++ b/resources/package-utils.sh
@@ -34,7 +34,7 @@ get_local_dependencies() {
 
   # Sadly, we can't rely on the bash script `readlines` command - not all shells  (eg: macOS) support it!
   # This will have the same net effect.
-  IFS=$'\n'
+  IFS=$'\r\n'
   packages=(${localDeps}); # Convert the output $localDeps string into a script-friendly array.
   unset IFS
 }

--- a/resources/package-utils.sh
+++ b/resources/package-utils.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+## END STANDARD BUILD SCRIPT INCLUDE
+. "$(dirname "$THIS_SCRIPT")/build/jq.inc.sh"
+
 display_usage ( ) {
   echo ""
   echo "package-utils.sh accepts one of the following options:"
@@ -24,7 +30,7 @@ PACKAGE_STASH='__node_modules'
 
 # Stores all @keymanapp package dependency/dev-dependency names to the 'packages' array.
 get_local_dependencies() {
-  localDeps=`cat package.json | jq -r ".dependencies, .devDependencies | to_entries | map(select(.key | match(\"@keymanapp/\";\"i\"))) | map(.key) | .[]"`
+  localDeps=`cat package.json | $JQ -r ".dependencies, .devDependencies | to_entries | map(select(.key | match(\"@keymanapp/\";\"i\"))) | map(.key) | .[]"`
 
   # Sadly, we can't rely on the bash script `readlines` command - not all shells  (eg: macOS) support it!
   # This will have the same net effect.

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -88,7 +88,14 @@ heat-model-compiler:
 
     # Remove files we don't want to harvest; build a product node_modules folder
     cd $(KEYMAN_WIX_TEMP_MODELCOMPILER)
-    -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\node_modules
+
+    # Clear out the node_modules folder while keeping any pre-established npm links.
+!ifdef GIT_BASH_FOR_KEYMAN
+    $(GIT_BASH_FOR_KEYMAN) $(KEYMAN_ROOT)\resources\package-utils.sh clean-external-deps
+!else
+    start /wait $(KEYMAN_ROOT)\resources\package-utils.sh clean-external-deps
+!endif
+
     npm install --production
 
     # We don't need source for the compiler or the unit tests


### PR DESCRIPTION
**NOTE:** This is intended as a patch-PR for an issue noted in #3071.  Feel free to automatically approve + merge it at any point if the patch seems acceptable.

Now that we're transitioning toward use of `lerna` for NPM dependency installs, our build scripts no longer manually create npm links.  This affects the build script for Developer, `npm install` would attempt to install now-listed dependencies that aren't actually npm published and/or are not yet published (eg: test builds).

Since `npm install` ignores any packages that would install over `npm link` sites, simply preserving the `npm` links across a `node_modules` folder wipe keeps the Developer script happy.  It just takes a bit of work to actually auto-detect and preserve them.