### PR TITLE
fix(ios/oem): Fixes FV app's system keyboard

### DIFF
--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,5 +1,5 @@
 github "marmelroy/Zip"
 github "DaveWoodCom/XCGLogger" ~> 6.1.0
-github "dennisweissmann/DeviceKit" ~> 1.11
+github "dennisweissmann/DeviceKit" ~> 2.3
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 4.4.3

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "DaveWoodCom/XCGLogger" "6.1.0"
 github "ashleymills/Reachability.swift" "v5.0.0"
-github "dennisweissmann/DeviceKit" "1.13.0"
+github "dennisweissmann/DeviceKit" "2.3.0"
 github "getsentry/sentry-cocoa" "4.5.0"
-github "marmelroy/Zip" "1.1.0"
+github "marmelroy/Zip" "2.0.0"

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -662,7 +662,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -678,10 +678,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices_Keyboards";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -692,7 +692,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -707,9 +707,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices_Keyboards";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -718,7 +718,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SWKeyboard/SWKeyboard.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -736,11 +736,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards.swkeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards SWKeyboard Development";
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices_Keyboards_SWKeyboard";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -749,7 +749,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SWKeyboard/SWKeyboard.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -766,10 +766,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards.swkeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards SWKeyboard Development";
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices_Keyboards_SWKeyboard";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		98C9A8F01BFBF6C1009E9A4F /* banner-Portrait@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 98C9A8E51BFBF6C1009E9A4F /* banner-Portrait@2x~ipad.png */; };
 		98C9A8F11BFBF6C1009E9A4F /* banner-Portrait@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 98C9A8E61BFBF6C1009E9A4F /* banner-Portrait@3x.png */; };
 		98C9A8F21BFBF6C1009E9A4F /* banner-Portrait~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 98C9A8E71BFBF6C1009E9A4F /* banner-Portrait~ipad.png */; };
+		CECB62572463E9FA006E47B5 /* DeviceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37150F6D231637E900C73C6A /* DeviceKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -148,6 +149,7 @@
 				37EA1F20228A183E003E710C /* KeymanEngine.framework in Frameworks */,
 				3729344024613C9900C5428C /* ObjcExceptionBridging.framework in Frameworks */,
 				3729344124613CA700C5428C /* XCGLogger.framework in Frameworks */,
+				CECB62572463E9FA006E47B5 /* DeviceKit.framework in Frameworks */,
 				3729344224613CB600C5428C /* Sentry.framework in Frameworks */,
 				3729344324613CC200C5428C /* Zip.framework in Frameworks */,
 			);
@@ -660,7 +662,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -676,10 +678,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = FirstVoices_Keyboards;
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -690,7 +692,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -705,9 +707,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = FirstVoices_Keyboards;
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -716,7 +718,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SWKeyboard/SWKeyboard.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -734,11 +736,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards.swkeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = FirstVoices_Keyboards_SWKeyboard;
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards SWKeyboard Development";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -747,7 +749,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SWKeyboard/SWKeyboard.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -764,10 +766,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.firstvoices.keyboards.swkeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = FirstVoices_Keyboards_SWKeyboard;
+				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards SWKeyboard Development";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/oem/firstvoices/ios/FirstVoices/FVKeyboardList.swift
+++ b/oem/firstvoices/ios/FirstVoices/FVKeyboardList.swift
@@ -229,7 +229,7 @@ class FVRegionStorage {
 
           let keyboard: InstallableKeyboard = InstallableKeyboard.init(id: kb.id,
                                                                        name: kb.name,
-                                                                       languageID: keyboardInfo.languages.keys[keyboardInfo.languages.startIndex],
+                                                                       languageID: keyboardInfo.languages[keyboardInfo.languages.startIndex],
                                                                        languageName: kb.name,
                                                                        version: keyboardInfo.version,
                                                                        isRTL: false,

--- a/oem/firstvoices/ios/FirstVoices/KeyboardInfo.swift
+++ b/oem/firstvoices/ios/FirstVoices/KeyboardInfo.swift
@@ -17,17 +17,12 @@ import Foundation
 // display and install the keyboard into Keyman Engine. Most of the data
 // in the files is ignored.
 //
-struct KeyboardInfoLanguage: Decodable {
-  let displayName: String
-  let languageName: String
-  let scriptName: String
-}
 
 struct KeyboardInfo: Decodable {
   let id: String
   let version: String
   let name: String
-  let languages: [String:KeyboardInfoLanguage]
+  let languages: [String]
 }
 
 class KeyboardInfoParser {

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -109,7 +109,16 @@ done
 # Build Keyman Engine
 #
 
-KEYMAN_ENGINE_FRAMEWORK_SRC="$KMEI_BUILD_DIR/build/Build/Products/$CONFIG-iphoneos/KeymanEngine.framework"
+if [ $CONFIG = "Debug" ]; then
+    # When doing a debug run, we'd like to be able to run the result in the Simulator.
+    # 'universal' can be run both on real devices and in the simulator.
+    PLATFORM_TARGET="universal"
+else
+    # Actual release builds can't have Simulator-targeted content; Apple will block the submission.
+    PLATFORM_TARGET="iphoneos"
+fi
+
+KEYMAN_ENGINE_FRAMEWORK_SRC="$KMEI_BUILD_DIR/build/Build/Products/$CONFIG-$PLATFORM_TARGET/KeymanEngine.framework"
 KEYMAN_ENGINE_FRAMEWORK_DST=./
 
 if [ $DO_UPDATE = true ]; then


### PR DESCRIPTION
A few changes were needed to get the FV app up and running again.

For one, #3040 didn't provide the app with the same keyboard metadata as before, so I've tweaked the typings to match the new format.

Outside of that, there was just a bit of project linkage to the dependencies that had to be resolved.

I also threw in a bit of work on `build_common.sh` that will facilitate running the app in the Simulator for `-debug` builds.  There was also some local certificate manipulation, but I'd rather not include that, as it might break our CI builds.

----

One issue still remains:

![Screen Shot 2020-05-07 at 4 00 47 PM](https://user-images.githubusercontent.com/25213402/81364325-9810db80-910f-11ea-97ec-4e9b25d2d915.png)

The red bar expected for the FV banner is missing due to CSS misalignments within KMW.

![banner-Landscape-568h@2x](https://user-images.githubusercontent.com/25213402/81364607-3f8e0e00-9110-11ea-8690-6c583b736acf.png)

Adjusting the `top: 6px` entry (for the KMW-based banner) to something more like `3px` for this particular case fixes it, but that affects predictive banners and is also an issue (though less notably) within the standard Keyman app... so... separate issue.