### PR TITLE
fix(windows): sentry cef shutdown interactions

### DIFF
--- a/windows/src/engine/Makefile
+++ b/windows/src/engine/Makefile
@@ -20,6 +20,18 @@ kmcomapi:
     cd $(ROOT)\src\engine\kmcomapi
     $(MAKE) $(TARGET)
 
+keyman32-build:
+    cd $(ROOT)\src\engine\keyman32
+    $(MAKE) build
+
+keyman32-signcode:
+    cd $(ROOT)\src\engine\keyman32
+    $(MAKE) signcode
+
+keyman32-install:
+    cd $(ROOT)\src\engine\keyman32
+    $(MAKE) install
+
 keyman32:
     cd $(ROOT)\src\engine\keyman32
     $(MAKE) $(TARGET)
@@ -39,6 +51,18 @@ keymanx64:
 keyman64:
     cd $(ROOT)\src\engine\keyman64
     $(MAKE) $(TARGET)
+
+keyman64-build:
+    cd $(ROOT)\src\engine\keyman64
+    $(MAKE) build
+
+keyman64-signcode:
+    cd $(ROOT)\src\engine\keyman64
+    $(MAKE) signcode
+
+keyman64-install:
+    cd $(ROOT)\src\engine\keyman64
+    $(MAKE) install
 
 mcompile:
     cd $(ROOT)\src\engine\mcompile

--- a/windows/src/engine/keyman/Makefile
+++ b/windows/src/engine/keyman/Makefile
@@ -39,7 +39,6 @@ debug-manifest:
 
 install:
     $(COPY) $(PROGRAM)\engine\keyman.exe "$(INSTALLPATH_KEYMANENGINE)"
-    $(COPY) keyman.rsm "$(INSTALLPATH_KEYMANENGINE)"
 
 test-uiaccess:
     grep -c "uiAccess=\"true\"" manifest.in

--- a/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
+++ b/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
@@ -53,12 +53,8 @@ uses
   Winapi.Tlhelp32,
   Winapi.Windows,
 
-  Sentry.Client,
-
-  Keyman.System.KeymanSentryClient,
   KeymanPaths,
   KeymanVersion,
-//  RedistFiles,
   RegistryKeys,
   VersionInfo,
   uCEFConstants,
@@ -67,7 +63,6 @@ uses
   uCEFMiscFunctions,
   uCEFProcessMessage,
   uCEFTypes;
-//  UTikeDebugMode;
 
 procedure GlobalCEFApp_ProcessMessageReceived(const browser       : ICefBrowser;
                                                     sourceProcess : TCefProcessId;

--- a/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
+++ b/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
@@ -154,6 +154,20 @@ begin
   Result := GlobalCEFApp.StartSubProcess;
 end;
 
+/// Start a watchdog thread to terminate process when parent does
+///
+/// Description: This should be run only in the context of the child process.
+/// It will normally only happen in an abnormal termination of the parent
+/// process (because otherwise the main thread of the child process receives an
+/// orderly request to shut down, and does so), but in the situation where the
+/// parent process disappears without making that request, this lets the child
+/// process do the work.
+///
+/// This is probably a gap in Chromium Embedded Framework but AFAICT it has not
+/// been resolved and this was the suggested fix, e.g. at
+/// https://magpcss.org/ceforum/viewtopic.php?p=37820&sid=11f6fcabc4089e41283bd5b9ec17267e#p37820
+/// which I have taken and cleaned up because it seemed appropriate.
+///
 procedure TCEFManager.LaunchWatchdog;
 
   function GetParentProcess: THandle;


### PR DESCRIPTION
When Sentry is trying to shutdown an app which has CEF windows active, the main process can hang waiting for the CEF renderer etc processes to shutdown. Instead, we now rely on the child (CEF renderer etc) processes to shutdown when their parent process aborts, with a watchdog thread, and  then abandon everything in the parent process with ExitProcess. This is more reliable, especially with nastier crashes like memory corruption or stack corruption.