### PR TITLE
chore: Allow to override hook defs

### DIFF
--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -15,7 +15,11 @@
 # Get the directory where this script lives, i.e. resources/git-hooks
 HOOK_DIRECTORY="$(dirname "$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")")"
 
-. $HOOK_DIRECTORY/commit-msg-defs
+if [ -f $(dirname "${BASH_SOURCE[0]}")/commit-msg-defs ]; then
+  . $(dirname "${BASH_SOURCE[0]}")/commit-msg-defs
+else
+  . $HOOK_DIRECTORY/commit-msg-defs
+fi
 
 #
 # Define terminal colours.


### PR DESCRIPTION
This change allows a different project to override the definitions
by providing a local `commit-msg-defs` file while still sharing the
`commit-msg` hook. Other projects might have a different set of
scopes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/keyman/3112)
<!-- Reviewable:end -->
