### PR TITLE
refactor(web/engine): renames DeviceSpec, moves to utils

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -66,7 +66,7 @@ namespace com.keyman.text {
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
       // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
-      if((formFactor == FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
+      if((formFactor == utils.FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
         // If it's a desktop OSK style and this triggers a layer change,
         // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
         if(this.keyboardProcessor.selectLayer(keyEvent)) {

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -107,7 +107,7 @@ namespace com.keyman.keyboards {
       this.baseKeyEvent = Lkc;
     }
 
-    constructKeyEvent(keyboardProcessor: text.KeyboardProcessor, target: text.OutputTarget, device: text.EngineDeviceSpec): text.KeyEvent {
+    constructKeyEvent(keyboardProcessor: text.KeyboardProcessor, target: text.OutputTarget, device: utils.DeviceSpec): text.KeyEvent {
       // Make a deep copy of our preconstructed key event, filling it out from there.
       let Lkc = utils.deepCopy(this.baseKeyEvent);
       Lkc.Ltarg = target;
@@ -466,7 +466,7 @@ namespace com.keyman.keyboards {
     keyLabels: boolean;
     isDefault?: boolean;
     keyboard: Keyboard;
-    formFactor: text.FormFactor;
+    formFactor: utils.FormFactor;
 
     /**
      * Facilitates mapping layer id strings to their specification objects.
@@ -486,7 +486,7 @@ namespace com.keyman.keyboards {
      * @param layout
      * @param formFactor
      */
-    static polyfill(layout: LayoutFormFactor, keyboard: Keyboard, formFactor: text.FormFactor): ActiveLayout {
+    static polyfill(layout: LayoutFormFactor, keyboard: Keyboard, formFactor: utils.FormFactor): ActiveLayout {
       if(layout == null) {
         throw new Error("Cannot build an ActiveLayout for a null specification.");
       }

--- a/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -251,10 +251,10 @@ namespace com.keyman.keyboards {
       return true;
     }
 
-    usesDesktopLayoutOnDevice(device: text.EngineDeviceSpec) {
+    usesDesktopLayoutOnDevice(device: utils.DeviceSpec) {
       if(this.scriptObject['KVKL']) {
         // A custom mobile layout is defined... but are we using it?
-        return device.formFactor == text.FormFactor.Desktop;
+        return device.formFactor == utils.FormFactor.Desktop;
       } else {
         return true;
       }
@@ -273,16 +273,16 @@ namespace com.keyman.keyboards {
       }
     }
 
-    private findOrConstructLayout(formFactor: text.FormFactor): LayoutFormFactor {
+    private findOrConstructLayout(formFactor: utils.FormFactor): LayoutFormFactor {
       if(this._layouts) {
         // Search for viable layouts.  `null` is allowed for desktop form factors when help text is available,
         // so we check explicitly against `undefined`.
         if(this._layouts[formFactor] !== undefined) {
           return this._layouts[formFactor];
-        } else if(formFactor == text.FormFactor.Phone && this._layouts[text.FormFactor.Tablet]) {
-          return this._layouts[text.FormFactor.Phone] = this._layouts[text.FormFactor.Tablet];
-        } else if(formFactor == text.FormFactor.Tablet && this._layouts[text.FormFactor.Phone]) {
-          return this._layouts[text.FormFactor.Tablet] = this._layouts[text.FormFactor.Phone];
+        } else if(formFactor == utils.FormFactor.Phone && this._layouts[utils.FormFactor.Tablet]) {
+          return this._layouts[utils.FormFactor.Phone] = this._layouts[utils.FormFactor.Tablet];
+        } else if(formFactor == utils.FormFactor.Tablet && this._layouts[utils.FormFactor.Phone]) {
+          return this._layouts[utils.FormFactor.Tablet] = this._layouts[utils.FormFactor.Phone];
         }
       }
 
@@ -304,7 +304,7 @@ namespace com.keyman.keyboards {
 
       // If we don't have key definitions to use for a layout but also lack help text or are a touch-based layout,
       // we make a default layout anyway.  We have to show display something usable.
-      if(!rawSpecifications && (this.helpText == '' || formFactor != text.FormFactor.Desktop)) {
+      if(!rawSpecifications && (this.helpText == '' || formFactor != utils.FormFactor.Desktop)) {
         rawSpecifications = {'F':'Tahoma', 'BK': Layouts.dfltText};
       }
 
@@ -333,7 +333,7 @@ namespace com.keyman.keyboards {
      * In such cases, please use either `helpText` or `insertHelpHTML` instead.
      * @param formFactor {string} The desired form factor for the layout.
      */
-    public layout(formFactor: text.FormFactor): ActiveLayout {
+    public layout(formFactor: utils.FormFactor): ActiveLayout {
       let rawLayout = this.findOrConstructLayout(formFactor);
 
       if(rawLayout) {
@@ -349,13 +349,13 @@ namespace com.keyman.keyboards {
       }
     }
 
-    public markLayoutCalibrated(formFactor: text.FormFactor) {
+    public markLayoutCalibrated(formFactor: utils.FormFactor) {
       if(this.layoutStates[formFactor] != LayoutState.NOT_LOADED) {
         this.layoutStates[formFactor] = LayoutState.CALIBRATED;
       }
     }
 
-    public getLayoutState(formFactor: text.FormFactor) {
+    public getLayoutState(formFactor: utils.FormFactor) {
       return this.layoutStates[formFactor];
     }
   }

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -185,7 +185,7 @@ namespace com.keyman.text {
 
     // Must be accessible to some of the keyboard API methods.
     activeKeyboard: keyboards.Keyboard;
-    activeDevice: EngineDeviceSpec;
+    activeDevice: utils.DeviceSpec;
 
     variableStoreSerializer?: VariableStoreSerializer;
 

--- a/common/core/web/keyboard-processor/src/text/keyEvent.ts
+++ b/common/core/web/keyboard-processor/src/text/keyEvent.ts
@@ -1,4 +1,3 @@
-/// <reference path="engineDeviceSpec.ts" />
 /// <reference path="outputTarget.ts" />
 
 namespace com.keyman.text {
@@ -31,7 +30,7 @@ namespace com.keyman.text {
     /**
      * The device model for web-core to follow when processing the keystroke.
      */
-    device: EngineDeviceSpec;
+    device: utils.DeviceSpec;
 
     /**
      * `true` if this event was produced by sources other than a DOM-based KeyboardEvent.

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -10,8 +10,6 @@
 /// <reference path="../keyboards/keyboard.ts" />
 // Defines built-in keymapping.
 /// <reference path="keyMapping.ts" />
-// Defines a core-compatible 'Device' analogue for use in keyEvent processing
-/// <reference path="engineDeviceSpec.ts" />
 
 // Also relies on @keymanapp/web-utils, which is included via tsconfig.json.
 
@@ -534,14 +532,14 @@ namespace com.keyman.text {
       var s = activeLayer;
 
       // Do not change layer unless needed (27/08/2015)
-      if(id == activeLayer && keyEvent.device.formFactor != FormFactor.Desktop) {
+      if(id == activeLayer && keyEvent.device.formFactor != utils.FormFactor.Desktop) {
         return false;
       }
 
       var idx=id;
       var i;
 
-      if(keyEvent.device.formFactor == FormFactor.Desktop) {
+      if(keyEvent.device.formFactor == utils.FormFactor.Desktop) {
         // Need to test if target layer is a standard layer (based on the plain 'default')
         var replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
 
@@ -670,7 +668,7 @@ namespace com.keyman.text {
       this._UpdateVKShift(null, 15, 0);
     };
 
-    setNumericLayer(device: EngineDeviceSpec) {
+    setNumericLayer(device: utils.DeviceSpec) {
       let layout = this.activeKeyboard.layout(device.formFactor);
       if(layout.getLayer('numeric')) {
         this.layerId = 'numeric';

--- a/common/core/web/keyboard-processor/src/text/systemStores.ts
+++ b/common/core/web/keyboard-processor/src/text/systemStores.ts
@@ -1,5 +1,3 @@
-/// <reference path="engineDeviceSpec.ts" />
-
 namespace com.keyman.text {
   /**
    * Defines common behaviors associated with system stores.

--- a/common/core/web/tools/recorder/src/index.ts
+++ b/common/core/web/tools/recorder/src/index.ts
@@ -1,4 +1,3 @@
-/// <reference path="../node_modules/@keymanapp/keyboard-processor/src/text/engineDeviceSpec.ts" />
 /// <reference path="../node_modules/@keymanapp/keyboard-processor/src/text/keyEvent.ts" />
 /// <reference path="proctor.ts" />
 
@@ -452,7 +451,7 @@ namespace KMWRecorder {
       }
     }
 
-    matchesClient(device: com.keyman.text.EngineDeviceSpec, usingOSK?: boolean) {
+    matchesClient(device: com.keyman.utils.DeviceSpec, usingOSK?: boolean) {
       // #1:  Platform check.
       if(usingOSK === true) {
         if(this.target != device.formFactor) {
@@ -521,7 +520,7 @@ namespace KMWRecorder {
     constraint: Constraint;
 
     addTest(seq: Sequence): void;
-    isValidForDevice(device: com.keyman.text.EngineDeviceSpec, usingOSK?: boolean): boolean;
+    isValidForDevice(device: com.keyman.utils.DeviceSpec, usingOSK?: boolean): boolean;
     test(proctor: Proctor): TestFailure[];
   }
 
@@ -553,7 +552,7 @@ namespace KMWRecorder {
     }
 
     // Used to determine if the current EventSpecTestSet is applicable to be run on a device.
-    isValidForDevice(device: com.keyman.text.EngineDeviceSpec, usingOSK?: boolean) {
+    isValidForDevice(device: com.keyman.utils.DeviceSpec, usingOSK?: boolean) {
       return this.constraint.matchesClient(device, usingOSK);
     }
 
@@ -603,7 +602,7 @@ namespace KMWRecorder {
     }
 
     // Used to determine if the current EventSpecTestSet is applicable to be run on a device.
-    isValidForDevice(device: com.keyman.text.EngineDeviceSpec, usingOSK?: boolean) {
+    isValidForDevice(device: com.keyman.utils.DeviceSpec, usingOSK?: boolean) {
       return this.constraint.matchesClient(device, usingOSK);
     }
 

--- a/common/core/web/tools/recorder/src/nodeProctor.ts
+++ b/common/core/web/tools/recorder/src/nodeProctor.ts
@@ -6,7 +6,7 @@ namespace KMWRecorder {
     private keyboard: com.keyman.keyboards.Keyboard;
     public __debug = false;
 
-    constructor(keyboard: com.keyman.keyboards.Keyboard, device: com.keyman.text.EngineDeviceSpec, assert: AssertCallback) {
+    constructor(keyboard: com.keyman.keyboards.Keyboard, device: com.keyman.utils.DeviceSpec, assert: AssertCallback) {
       super(device, assert);
 
       this.keyboard = keyboard;

--- a/common/core/web/tools/recorder/src/proctor.ts
+++ b/common/core/web/tools/recorder/src/proctor.ts
@@ -8,11 +8,11 @@ namespace KMWRecorder {
    * keyboard-processor and input-processor will use a Node-based version instead.
    */
   export abstract class Proctor {
-    device: com.keyman.text.EngineDeviceSpec;
+    device: com.keyman.utils.DeviceSpec;
 
     _assert: AssertCallback;
 
-    constructor(device: com.keyman.text.EngineDeviceSpec, assert: AssertCallback) {
+    constructor(device: com.keyman.utils.DeviceSpec, assert: AssertCallback) {
       this.device = device;
 
       this._assert = assert;

--- a/common/core/web/utils/src/deviceSpec.ts
+++ b/common/core/web/utils/src/deviceSpec.ts
@@ -1,4 +1,4 @@
-namespace com.keyman.text {
+namespace com.keyman.utils {
   export enum Browser {
     Chrome = 'chrome',
     Edge = 'edge',
@@ -29,7 +29,7 @@ namespace com.keyman.text {
    * containing only the information needed by web-core for text processing use, devoid
    * of any direct references to the DOM.
    */
-  export class EngineDeviceSpec {
+  export class DeviceSpec {
     readonly browser: Browser;
     readonly formFactor: FormFactor;
     readonly OS: OperatingSystem;

--- a/common/core/web/utils/src/index.ts
+++ b/common/core/web/utils/src/index.ts
@@ -3,3 +3,4 @@
 ///<reference path="globalObject.ts" />
 ///<reference path="version.ts" />
 ///<reference path="kmwstring.ts" />
+///<reference path="deviceSpec.ts" />

--- a/web/bulk_rendering/tsconfig.json
+++ b/web/bulk_rendering/tsconfig.json
@@ -9,7 +9,6 @@
 	},
   "files": [
 		"../node_modules/@keymanapp/web-utils/src/index.ts",
-		"../node_modules/@keymanapp/keyboard-processor/src/text/engineDeviceSpec.ts",
 		"../node_modules/@keymanapp/lexical-model-layer/message.d.ts",
 		"renderer_core.ts"
   ]

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -194,7 +194,7 @@ namespace com.keyman.dom {
       }
 
       // Check for any browser-based keymapping before returning the object.
-      if(!keyman.isEmbedded && s.device.browser == text.Browser.Firefox) {
+      if(!keyman.isEmbedded && s.device.browser == utils.Browser.Firefox) {
         // I1466 - Convert the - keycode on mnemonic as well as positional layouts
         // FireFox, Mozilla Suite
         if(KeyMapping.browserMap.FF['k'+s.Lcode]) {

--- a/web/source/kmwdevice.ts
+++ b/web/source/kmwdevice.ts
@@ -252,8 +252,8 @@ namespace com.keyman {
     /**
      * Returns a slimmer, web-core compatible version of this object.
      */
-    public get coreSpec(): text.EngineDeviceSpec {
-      return new text.EngineDeviceSpec(this.browser, this.formFactor, this.OS, this.touchable);
+    public get coreSpec(): utils.DeviceSpec {
+      return new utils.DeviceSpec(this.browser, this.formFactor, this.OS, this.touchable);
     }
   }
 }

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -226,7 +226,7 @@ namespace com.keyman.osk {
 
         // Generate a visual keyboard from the layout (or layout default)
         // Condition is false if no key definitions exist, formFactor == desktop, AND help text exists.  All three.
-        if(activeKeyboard && activeKeyboard.layout(device.formFactor as text.FormFactor)) {
+        if(activeKeyboard && activeKeyboard.layout(device.formFactor as utils.FormFactor)) {
           this._GenerateVisualKeyboard(activeKeyboard);
         } else if(!activeKeyboard) {
           this._GenerateVisualKeyboard(null);

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -597,7 +597,7 @@ namespace com.keyman.osk {
       var Lkbd=util._CreateElement('div');
       let layout: keyboards.ActiveLayout;
       if(keyboard) {
-        layout = this.layout = keyboard.layout(device.formFactor as text.FormFactor);
+        layout = this.layout = keyboard.layout(device.formFactor as utils.FormFactor);
       } else {
         // This COULD be called with no backing keyboard; KMW will try to force-show the OSK even without 
         // a backing keyboard on mobile, using the most generic default layout as the OSK's base.
@@ -605,7 +605,7 @@ namespace com.keyman.osk {
         // In KMW's current state, it'd take a major break, though - Processor always has an activeKeyboard,
         // even if it's "hollow".
         let rawLayout = keyboards.Layouts.buildDefaultLayout(null, null, device.formFactor);
-        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, null, device.formFactor as text.FormFactor);
+        layout = this.layout = keyboards.ActiveLayout.polyfill(rawLayout, null, device.formFactor as utils.FormFactor);
       }
       this.layers=layout['layer'];
 
@@ -619,7 +619,7 @@ namespace com.keyman.osk {
       // Set flag to add default (US English) key label if specified by keyboard
       layout.keyLabels = keyboard && keyboard.displaysUnderlyingKeys;
 
-      let divLayerContainer = this.deviceDependentLayout(keyboard, device.formFactor as text.FormFactor);
+      let divLayerContainer = this.deviceDependentLayout(keyboard, device.formFactor as utils.FormFactor);
 
       this.ddOSK = true;
 
@@ -656,7 +656,7 @@ namespace com.keyman.osk {
      * @param       {string}              formFactor  layout form factor
      * @return      {Object}                          fully formatted OSK object
      */
-    deviceDependentLayout(keyboard: keyboards.Keyboard, formFactor: text.FormFactor): HTMLDivElement {
+    deviceDependentLayout(keyboard: keyboards.Keyboard, formFactor: utils.FormFactor): HTMLDivElement {
       let layout = keyboard.layout(formFactor);
       let util = com.keyman.singleton.util;
       let oskManager = com.keyman.singleton.osk;

--- a/web/tools/recorder/browserProctor.ts
+++ b/web/tools/recorder/browserProctor.ts
@@ -30,7 +30,7 @@ namespace KMWRecorder {
     target: HTMLElement;
     usingOSK: boolean;
 
-    constructor(target: HTMLElement, device: com.keyman.text.EngineDeviceSpec, usingOSK: boolean, assert: AssertCallback) {
+    constructor(target: HTMLElement, device: com.keyman.utils.DeviceSpec, usingOSK: boolean, assert: AssertCallback) {
       super(device, assert);
 
       this.target = target;


### PR DESCRIPTION
As a followup to #3130, this PR renames `text.EngineDeviceSpec` to `utils.DeviceSpec`.  It's really more of a common utility type across the Web codebase than anything directly text-related.  As this type was only introduced during the Alpha, now's the time to perform little polishes like this before they become cemented.

It was also overly verbose; "EngineDeviceSpec" was simply the first decent name I could come up with during KMW's recent refactoring, as I was too worried at the time about confusing it with `com.keyman.Device`.  I feel that a simple `DeviceSpec` still accomplishes this while feeling cleaner, matching its use for `com.keyman.Device.coreSpec` - the property that returns the matching `DeviceSpec` for the detected device.