### PR TITLE
chore(common/resources): add `common/models` to build trigger definitions

### DIFF
--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -7,7 +7,7 @@ available_platforms=(android ios linux mac web windows)
 
 # the base folder for each pattern does not need to be included, nor oem folders
 # e.g. android='common/models|common/predictive-text'
-# will expand into android='^(android|(oem/[^/]+/android)|common/predictive-text|common/lexical-model-types)'
+# will expand into android='^(android|(oem/[^/]+/android)|common/models|common/predictive-text)'
 
 watch_android='web|common/models|common/predictive-text|common/lexical-model-types'
 watch_ios='web|common/models|common/predictive-text|common/lexical-model-types'

--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -6,14 +6,14 @@
 available_platforms=(android ios linux mac web windows)
 
 # the base folder for each pattern does not need to be included, nor oem folders
-# e.g. android='common/predictive-text|common/lexical-model-types'
+# e.g. android='common/models|common/predictive-text'
 # will expand into android='^(android|(oem/[^/]+/android)|common/predictive-text|common/lexical-model-types)'
 
-watch_android='web|common/predictive-text|common/lexical-model-types'
-watch_ios='web|common/predictive-text|common/lexical-model-types'
+watch_android='web|common/models|common/predictive-text|common/lexical-model-types'
+watch_ios='web|common/models|common/predictive-text|common/lexical-model-types'
 watch_linux='common/engine'
 watch_mac='common/engine'
-watch_web='common/predictive-text|common/lexical-model-types'
+watch_web='common/models|common/predictive-text|common/lexical-model-types'
 
 # Windows currently builds Developer and Desktop, so we need everything from common,developer,web
 watch_windows='common|developer|web'


### PR DESCRIPTION
**NOTE**: I have NO IDEA what I'm doing!!!!

When I was `git grep`'ing yesterday for `lexical-model-types`, I noticed this file. I assume this + `run-required-test-builds.sh` figures out when to run tests on TeamCity. So I updated the paths to include the new directory for all of the models stuff, namely, `common/models`. Feel free to reject or modify this PR as required!