### PR TITLE
change(web/utils): add and distribute type declaration

### DIFF
--- a/common/core/web/utils/package.json
+++ b/common/core/web/utils/package.json
@@ -2,7 +2,8 @@
   "name": "@keymanapp/web-utils",
   "version": "14.0.78",
   "description": "Common utility functions used throughout other Keyman packages",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types:": "./dist/index.d.ts",
   "scripts": {
     "tsc": "tsc"
   },

--- a/common/core/web/utils/package.json
+++ b/common/core/web/utils/package.json
@@ -5,6 +5,8 @@
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",
   "scripts": {
+    "build": "tsc -p ./src/tsconfig.json",
+    "prepare": "npm run build",
     "tsc": "tsc"
   },
   "repository": {

--- a/common/core/web/utils/src/tsconfig.json
+++ b/common/core/web/utils/src/tsconfig.json
@@ -1,16 +1,16 @@
 {
   "compilerOptions": {
-	"allowJs": true,
-	"module": "none",
-	"outDir": "../dist/",
-	"inlineSources": true,
-  "sourceMap": true,
-  "target": "es5",
-  "types": ["node"],
-  "lib": ["es6"],
-  "outFile": "../dist/index.js"
+    "allowJs": true,
+    "module": "none",
+    "outDir": "../dist/",
+    "inlineSources": true,
+    "sourceMap": true,
+    "target": "es5",
+    "types": ["node"],
+    "lib": ["es6"],
+    "outFile": "../dist/index.js"
   },
   "files": [
-		"index.ts"
+    "index.ts"
   ]
 }

--- a/common/core/web/utils/src/tsconfig.json
+++ b/common/core/web/utils/src/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/",
     "inlineSources": true,
     "sourceMap": true,
-	"declaration": true,
+    "declaration": true,
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],

--- a/common/core/web/utils/src/tsconfig.json
+++ b/common/core/web/utils/src/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "../dist/",
     "inlineSources": true,
     "sourceMap": true,
+	"declaration": true,
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],


### PR DESCRIPTION
It would be useful if the `index.d.ts` was usable in other packages. This PR:

 1. builds an `index.d.ts`
 2. lists it in the `package.json` as the types of this package
 3. runs the build automatically _before_ the package is "published"; in this case, during a `lerna bootstrap`. This makes the `index.d.ts` available to all internal packages that depend on this one.

Note: merging this would help out #3128 a lot ^.^