### PR TITLE
fix(common): drops version updates for deprecated common/lexical-model-types

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,6 @@
     "common/core/web/tools/recorder",
     "common/core/web/tools/sentry-manager",
     "common/core/web/utils",
-    "common/lexical-model-types",
     "common/predictive-text",
     "common/models/*",
     "web"


### PR DESCRIPTION
Fixes our failed build triggers from last night.

Turns out, `lerna version` isn't functioning properly for us when a package doesn't actually have a package-lock.json file.  That said... if we've marked a package as deprecated, should we actually be updating its version?

```
[01:00:59]
lerna info ci enabled
[01:00:59]
lerna info Executing command in 10 packages: "git add package.json package-lock.json"
[01:00:59]
warning: LF will be replaced by CRLF in common/core/web/tools/sentry-manager/package-lock.json.
[01:00:59]
The file will have its original line endings in your working directory
[01:00:59]
warning: LF will be replaced by CRLF in common/core/web/tools/sentry-manager/package.json.

...

[01:00:59]
warning: LF will be replaced by CRLF in common/models/types/package.json.
[01:00:59]
The file will have its original line endings in your working directory
[01:00:59]
fatal: pathspec 'package-lock.json' did not match any files
[01:00:59]
lerna ERR! git add package.json package-lock.json exited 128 in '@keymanapp/lexical-model-types'
[01:00:59]
lerna ERR! git add package.json package-lock.json exited 128 in '@keymanapp/lexical-model-types'
```

Note the **`fatal: pathspec 'package-lock.json' did not match any files`** line.