### PR TITLE
fix(web): lerna dependencies broke master

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,7 @@
     "common/core/web/utils",
     "common/models/*",
     "common/predictive-text",
+    "common/lexical-model-types",
     "web"
   ],
   "version": "14.0.79"

--- a/web/package.json
+++ b/web/package.json
@@ -54,7 +54,7 @@
     "@keymanapp/input-processor": "^14.0.79",
     "@keymanapp/keyboard-processor": "^14.0.79",
     "@keymanapp/lexical-model-layer": "^14.0.79",
-    "@keymanapp/lexical-model-types": "^14.0.78",
+    "@keymanapp/models-types": "^14.0.78",
     "@keymanapp/recorder-core": "^14.0.79",
     "@keymanapp/web-utils": "^14.0.79",
     "@types/node": "^11.9.4",


### PR DESCRIPTION
We still need to reference common/lexical-model-types until there are no dependencies on it.

We can see the symptoms of the issue here in the nightly version increment: https://github.com/keymanapp/keyman/commit/43a82ba7e528179d914c241a9e3cf14f3ed30473#diff-a617739352ce5dc2cf29c8e1d39d2fafR33
