### PR TITLE
change(developer): packs ModelCompiler via npm pack, 7-zip

### DIFF
--- a/developer/js/.npmignore
+++ b/developer/js/.npmignore
@@ -2,5 +2,4 @@
 build.sh
 source/*
 tests/*
-*.js.map
 tsconfig.json

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -102,7 +102,10 @@ heat-model-compiler:
 
     # Creates the directory referenced by $(KEYMAN_WIX_TEMP_MODELCOMPILER).
     move package ModelCompiler
-    del kmlmc.*
+
+    # Cleans up the npm pack artifacts, which are no longer needed.
+    del kmlmc.tgz
+    del kmlmc.tar
 
     # Step 2 - the model compiler has one in-repo dependency that will also need to be packed.
     # Managing other in-repo dependencies will be simpler; they install into ModelCompiler's
@@ -119,6 +122,9 @@ heat-model-compiler:
     copy $(KEYMAN_MODELCOMPILER_ROOT)\package-lock.json $(KEYMAN_WIX_TEMP_MODELCOMPILER)
     npm install kmtypes.tgz --production --no-optional
     npm install --production --no-optional
+
+    # Clean up the npm pack artifacts for the dependencies.
+    del kmtypes.tgz
 
     # We don't need the unit tests
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\tests

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -12,6 +12,7 @@ TIER=alpha
 
 # We use different directories so that heat generates
 # different identifiers for the various folders
+KEYMAN_WIX_TEMP_BASE=$(TEMP)\keyman_wix_build
 KEYMAN_WIX_TEMP_XML=$(TEMP)\keyman_wix_build\xml
 KEYMAN_WIX_TEMP_CEF=$(TEMP)\keyman_wix_build\cef
 KEYMAN_WIX_TEMP_TEMPLATES=$(TEMP)\keyman_wix_build\templates
@@ -76,30 +77,49 @@ heat-model-compiler:
 !else
     start /wait .\build.sh -version "$VERSION" -tier "$(TIER)"
 !endif
-    # While we could use npm-bundle or similar, this gives us more control on the set of
-    # files we want to distribute with the Keyman Developer installer. For users on other
-    # operating systems, node.js is a dependency and the compiler can be installed with
+    # We use `npm pack` to extract only the aspects of the model-compiler actually needed for distribution.
+    # While we could use npm-bundle or similar, that adds extra, unwanted cruft; our approach gives us more
+    # control of the set of files distributed with the Keyman Developer installer.
+    #
+    # For users on other operating systems, node.js is a dependency and the compiler can be installed with
     # `npm install @keymanapp/lexical-model-compiler`.
 
     # We copy the files to a temp folder in order to exclude thumbs.db, .vs, etc from harvesting
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)
-    mkdir $(KEYMAN_WIX_TEMP_MODELCOMPILER)
-    xcopy $(KEYMAN_MODELCOMPILER_ROOT)\* $(KEYMAN_WIX_TEMP_MODELCOMPILER)\ /s
 
-    # Remove files we don't want to harvest; build a product node_modules folder
+    # Step 1 - npm-pack the model compiler package, then unpack it in our bundling directory.
+    # This automatically strips the package to its barebones.
+    npm pack
+    ren keymanapp-lexical-model-compiler*.tgz kmlmc.tgz
+    move kmlmc.tgz $(KEYMAN_WIX_TEMP_BASE)
+
+    # We extract the npm-packed version of the model compiler in order to reproduce our needed bundle.
+    cd $(KEYMAN_WIX_TEMP_BASE)
+
+    # Requires use of 7-zip, which we're already depending on elsewhere in the build process.
+    $(WZZIPPATH) x kmlmc.tgz
+    $(WZZIPPATH) x kmlmc.tar
+
+    # Creates the directory referenced by $(KEYMAN_WIX_TEMP_MODELCOMPILER).
+    move package ModelCompiler
+    del kmlmc.*
+
+    # Step 2 - the model compiler has one in-repo dependency that will also need to be packed.
+    # Managing other in-repo dependencies will be simpler; they install into ModelCompiler's
+    # extracted bundle.
+    cd $(KEYMAN_MODELCOMPILER_ROOT)\node_modules\@keymanapp\models-types
+    npm pack
+    ren keymanapp-models-types*.tgz kmtypes.tgz
+    move kmtypes.tgz $(KEYMAN_WIX_TEMP_MODELCOMPILER)
+
+    # Step 3 - install just the bare essentials by using our packed local dependency, followed by
+    # all external production dependencies.
     cd $(KEYMAN_WIX_TEMP_MODELCOMPILER)
-    -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\node_modules
-    npm install --production
+    npm install kmtypes.tgz
+    npm install --production --no-optional
 
-    # We don't need source for the compiler or the unit tests
-    -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\source
+    # We don't need the unit tests
     -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\tests
-
-    # We don't need another binary copy of node
-    -rmdir /s/q $(KEYMAN_WIX_TEMP_MODELCOMPILER)\node_modules\node
-
-    # We don't need the build script
-    -del $(KEYMAN_WIX_TEMP_MODELCOMPILER)\build.sh
 
     # Build the .wxs file
     cd $(ROOT)\src\developer\inst

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -115,7 +115,9 @@ heat-model-compiler:
     # Step 3 - install just the bare essentials by using our packed local dependency, followed by
     # all external production dependencies.
     cd $(KEYMAN_WIX_TEMP_MODELCOMPILER)
-    npm install kmtypes.tgz
+    # package-lock.json wasn't bundled; this is needed to keep dependency versions consistent.
+    copy $(KEYMAN_MODELCOMPILER_ROOT)\package-lock.json $(KEYMAN_WIX_TEMP_MODELCOMPILER)
+    npm install kmtypes.tgz --production --no-optional
     npm install --production --no-optional
 
     # We don't need the unit tests


### PR DESCRIPTION
Replaces #3119 as a patch to #3071.  Turns out that approach had a number of continuing issues, not the least of which would be major complications with our newfound use of npm `prepare` scripts breaking during the `--production` bootstrap.

Instead, a paradigm shift is in order - why aren't we relying on existing `npm` functionality to package the model compiler?  In particular:  `npm pack`, which basically does `npm publish`, but just to a local file - which is thus precompiled and stripped down to the bare essentials.

Obviously, that's a bit too far, and then there's the fact that we _would_ run into problems installing the unpublished local copy of `@keymanapp/models-types`... if it weren't for the fact that we can `npm install` the packed tarball, which then overrides remote lookups come the `--production` install.

The resulting bundle is even sparser than the original!  We can probably eliminate the kmtypes.tgz as well; I just left it in place since it's that package instance's local source for `@keymanapp/models-types` and it's just a small, compressed file.

## User Testing
@MakaraSok 

1.  Go to the passed build test and install Keyman Developer from the build artifact.
2.  Use it to compile a lexical model project.

My results:

![model-compile-success](https://user-images.githubusercontent.com/25213402/82859794-ddbc0980-9f41-11ea-8dac-7e0b053392f8.png)