### PR TITLE
fix(common): adds package-lock.json for gosh package

### DIFF
--- a/resources/gosh/package-lock.json
+++ b/resources/gosh/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keymanapp/resources-gosh",
+  "version": "14.0.81",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
When the package rework for our "Good Ol' Shell" (`gosh`) was put in place, no `package-lock.json` was checked in.  While it may not have seemed necessary due to its lack of dependencies, `lerna` expects it to exist when doing versioning updates.

From last night's [build release trigger script](https://build.palaso.org/viewLog.html?buildId=207276&buildTypeId=Keyman_TriggerReleaseBuildsMaster&tab=buildLog):
```
[01:00:48] - @keymanapp/resources-gosh: 14.0.81 => 14.0.82 (private)
...
[01:00:49]> lerna "exec" "--concurrency" "1" "--" "git" "add" "package.json" "package-lock.json"
...
[01:00:50]
fatal: pathspec 'package-lock.json' did not match any files
[01:00:50]
lerna ERR! git add package.json package-lock.json exited 128 in '@keymanapp/resources-gosh'
```

Since it was unable to `git commit` the updated version properly, the build trigger failed.