### PR TITLE
fix(ios): fixes build warning on Error coersion, fixes logged error for intermediate embedded state

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -327,7 +327,7 @@ public class ResourceDownloadManager {
     //get list of lexical models for this languageID  /?q=bcp47:en
     func listCompletionHandler(lexicalModels: [LexicalModel]?, error: Error?) -> Void {
       if let error = error {
-        log.info("Failed to fetch lexical model list for "+languageID+". error: "+(error as! String))
+        log.info("Failed to fetch lexical model list for "+languageID+". error: "+error.localizedDescription)
         downloader.downloadFailed(forLanguageID: languageID, error: error)
       } else if nil == lexicalModels {
         //TODO: put up an alert instead

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -657,6 +657,11 @@ namespace com.keyman.osk {
      * @return      {Object}                          fully formatted OSK object
      */
     deviceDependentLayout(keyboard: keyboards.Keyboard, formFactor: utils.FormFactor): HTMLDivElement {
+      if(!keyboard) {
+        // May occasionally be null in embedded contexts; have seen this when iOS engine sets
+        // keyboard height during change of keyboards.
+        keyboard = new keyboards.Keyboard(null);
+      }
       let layout = keyboard.layout(formFactor);
       let util = com.keyman.singleton.util;
       let oskManager = com.keyman.singleton.osk;


### PR DESCRIPTION
Fixes #3035.

Also fixes an error discovered while investigating #3038.  I couldn't reproduce the original issue, but did find an error that sometimes occurred in an intermediate state during keyboard swaps.  Adding a `null` check was simple enough to remedy that.