### PR TITLE
Fix/android/package updates

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -1074,6 +1074,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         hashMap.get(KMManager.KMKey_LanguageName),
         hashMap.get(KMManager.KMKey_Version),
         hashMap.get(KMManager.KMKey_HelpLink),
+        "", // kmp link
         true,
         hashMap.get(KMManager.KMKey_Font),
         hashMap.get(KMManager.KMKey_OskFont));

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -1074,16 +1074,14 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         hashMap.get(KMManager.KMKey_LanguageName),
         hashMap.get(KMManager.KMKey_Version),
         hashMap.get(KMManager.KMKey_HelpLink),
-        "", // kmp link
+        hashMap.get(KMManager.KMKey_KMPLink),
         true,
         hashMap.get(KMManager.KMKey_Font),
         hashMap.get(KMManager.KMKey_OskFont));
 
       if (i == 0) {
         if (KMManager.addKeyboard(this, keyboardInfo)) {
-          //KMManager.setKeyboard(keyboardInfo);
-          KMManager.setKeyboard(keyboardInfo.getPackageID(), keyboardInfo.getKeyboardID(), keyboardInfo.getLanguageID());
-          KMManager.getKeyboardState(this, keyboardInfo.getPackageID(), keyboardInfo.getKeyboardID(), keyboardInfo.getLanguageID()); // For testing: do not commit
+          KMManager.setKeyboard(keyboardInfo);
         }
       } else {
         KMManager.addKeyboard(this, keyboardInfo);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -1080,7 +1080,9 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
       if (i == 0) {
         if (KMManager.addKeyboard(this, keyboardInfo)) {
-          KMManager.setKeyboard(keyboardInfo);
+          //KMManager.setKeyboard(keyboardInfo);
+          KMManager.setKeyboard(keyboardInfo.getPackageID(), keyboardInfo.getKeyboardID(), keyboardInfo.getLanguageID());
+          KMManager.getKeyboardState(this, keyboardInfo.getPackageID(), keyboardInfo.getKeyboardID(), keyboardInfo.getLanguageID()); // For testing: do not commit
         }
       } else {
         KMManager.addKeyboard(this, keyboardInfo);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardDownloaderActivity.java
@@ -37,6 +37,7 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
   public static final String ARG_MODEL_NAME = "KMKeyboardActivity.modelName";
   public static final String ARG_MODEL_URL = "KMKeyboardActivity.modelURL";
   public static final String ARG_CUSTOM_HELP_LINK = "KMKeyboardActivity.customHelpLink";
+  public static final String ARG_KMP_LINK = "KMKeyboardActivity.kmpLink";
 
   public static final String kKeymanApiBaseURL = "https://api.keyman.com/package-version?platform=android";
   //public static final String kKeymanApiBaseURL = "https://api.keyman.com/cloud/4.0/languages";
@@ -99,11 +100,12 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
     if (downloadOnlyLexicalModel) {
       modelID = bundle.getString(ARG_MODEL_ID);
       modelName = bundle.getString(ARG_MODEL_NAME);
-      url = bundle.getString(ARG_MODEL_URL);
+      url = bundle.getString(ARG_MODEL_URL); // sort this out
     } else {
 
       kbID = bundle.getString(ARG_KB_ID);
       kbName = bundle.getString(ARG_KB_NAME);
+      url = bundle.getString(ARG_KMP_LINK);
     }
 
     // Download keyboard from cloud server
@@ -124,6 +126,13 @@ public class KMKeyboardDownloaderActivity extends AppCompatActivity {
     }
 
     dialog.show(getFragmentManager(), "dialog");
+  }
+
+  private ArrayList<CloudApiTypes.CloudApiParam> prepareCloudApiParamsForKeyboardPackageDownload() {
+    ArrayList<CloudApiTypes.CloudApiParam> _params = new ArrayList<>();
+    _params.add(new CloudApiTypes.CloudApiParam(
+      CloudApiTypes.ApiTarget.KeyboardPackage, url));
+    return _params;
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -71,6 +71,7 @@ import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.CharSequenceUtil;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.MapCompat;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -180,6 +181,7 @@ public final class KMManager {
   public static final String KMKey_CustomModel = "CustomModel";
 
   public static final String KMKey_CustomHelpLink = "CustomHelpLink";
+  public static final String KMKey_KMPLink = "kmp";
   public static final String KMKey_UserKeyboardIndex = "UserKeyboardIndex";
   public static final String KMKey_DisplayKeyboardSwitcher = "DisplayKeyboardSwitcher";
   public static final String KMKey_LexicalModel = "lm";
@@ -920,12 +922,13 @@ public final class KMManager {
     String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
     String version = keyboardInfo.get(KMManager.KMKey_KeyboardVersion);
     String helpLink = keyboardInfo.get(KMManager.KMKey_CustomHelpLink);
+    String kmpLink = MapCompat.getOrDefault(keyboardInfo, KMManager.KMKey_KMPLink, "");
     String font = keyboardInfo.get(KMManager.KMKey_Font);
     String oskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
     boolean isNewKeyboard = true;
 
     Keyboard k = new Keyboard(packageID, keyboardID, keyboardName,
-          languageID, languageName, version, helpLink,
+          languageID, languageName, version, helpLink, kmpLink,
       isNewKeyboard, font, oskFont);
     return addKeyboard(context, k);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1128,8 +1128,7 @@ public final class KMManager {
         kbVersion = kbInfo.getVersion();
         if (kbVersion != null) {
           // See if update is available
-          String kmp = kbInfo.getKMP();
-          if (kmp != null && !kmp.isEmpty()) {
+          if (kbInfo.hasUpdateAvailable()) {
             kbState = KeyboardState.KEYBOARD_STATE_NEEDS_UPDATE;
           } else {
             kbState = KeyboardState.KEYBOARD_STATE_UP_TO_DATE;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1127,10 +1127,9 @@ public final class KMManager {
       if (kbInfo != null) {
         kbVersion = kbInfo.getVersion();
         if (kbVersion != null) {
-          // Compare with the cloud package to see if update is available
-          String latestCloudPackageVersion = getLatestKeyboardFileVersion(context, packageID, keyboardID); // fix this
-
-          if (FileUtils.compareVersions(latestCloudPackageVersion, kbVersion) == FileUtils.VERSION_GREATER) {
+          // See if update is available
+          String kmp = kbInfo.getKMP();
+          if (kmp != null && !kmp.isEmpty()) {
             kbState = KeyboardState.KEYBOARD_STATE_NEEDS_UPDATE;
           } else {
             kbState = KeyboardState.KEYBOARD_STATE_UP_TO_DATE;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -500,9 +500,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         lmMap.get(KMManager.KMKey_LanguageName),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
-        "",
-        "" // TODO: add model URL
-      );
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_KMPLink, ""));
       lexList.add(m);
     }
 
@@ -541,9 +539,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         lmMap.get(KMManager.KMKey_LanguageName),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
-        "", // latest kmp link
-        ""  // model URL
-      );
+        MapCompat.getOrDefault(lmMap, KMManager.KMKey_KMPLink, ""));
       lexList.add(m);
     }
     storage.lexicalModels.addAll(lexList);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -500,6 +500,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         lmMap.get(KMManager.KMKey_LanguageName),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
+        "",
         "" // TODO: add model URL
       );
       lexList.add(m);
@@ -540,7 +541,8 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         lmMap.get(KMManager.KMKey_LanguageName),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_LexicalModelVersion, "1.0"),
         MapCompat.getOrDefault(lmMap, KMManager.KMKey_CustomHelpLink, ""),
-        "" // model URL
+        "", // latest kmp link
+        ""  // model URL
       );
       lexList.add(m);
     }
@@ -639,6 +641,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
       keyboardInfo.get(KMManager.KMKey_LanguageName),
       keyboardInfo.get(KMManager.KMKey_KeyboardVersion),
       keyboardInfo.get(KMManager.KMKey_HelpLink),
+      keyboardInfo.get(KMManager.KMKey_KMPLink),
       isNewKeyboard,
       keyboardInfo.get(KMManager.KMKey_Font),
       keyboardInfo.get(KMManager.KMKey_OskFont));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import android.app.DialogFragment;
+import android.app.DownloadManager;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -32,6 +33,10 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.cloud.CloudApiTypes;
+import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
+import com.tavultesoft.kmea.cloud.impl.CloudKeyboardPackageDownloadCallback;
+import com.tavultesoft.kmea.cloud.impl.CloudLexicalPackageDownloadCallback;
 import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
@@ -161,6 +166,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
           Intent i = new Intent(getApplicationContext(), KMKeyboardDownloaderActivity.class);
           i.putExtras(args);
           startActivity(i);
+          finish();
 
         // "Help" link clicked
         } else if (itemTitle.equals(getString(R.string.help_link))) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -85,9 +85,6 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     final String kbName = kbd.getKeyboardName();
     final String kbVersion = kbd.getVersion();
 
-    // Determine if keyboard update is available from the cloud
-    final String kmp = kbd.getKMP();
-
     final TextView textView = findViewById(R.id.bar_title);
     textView.setText(kbName);
     if (titleFont != null)
@@ -100,8 +97,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     HashMap<String, String> hashMap = new HashMap<>();
     hashMap.put(titleKey, getString(R.string.keyboard_version));
     hashMap.put(subtitleKey, kbVersion);
-    // Display notification to download update if there's a link to an updated kmp
-    if (kmp != null && !kmp.isEmpty()) {
+    // Display notification to download update if available
+    if (kbd.hasUpdateAvailable()) {
       hashMap.put(subtitleKey, context.getString(R.string.update_available, kbVersion));
       icon = String.valueOf(R.drawable.ic_cloud_download);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -79,14 +79,9 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     final String kbID = kbd.getKeyboardID();
     final String kbName = kbd.getKeyboardName();
     final String kbVersion = kbd.getVersion();
-    String latestKbdCloudVersion = kbVersion;
 
     // Determine if keyboard update is available from the cloud
-    Dataset dataset = CloudRepository.shared.fetchDataset(this);
-    final Keyboard latestKbd = dataset.keyboards.findMatch(kbd);
-    if (latestKbd != null) {
-      latestKbdCloudVersion = latestKbd.getVersion();
-    }
+    final String kmp = kbd.getKMP();
 
     final TextView textView = findViewById(R.id.bar_title);
     textView.setText(kbName);
@@ -100,8 +95,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     HashMap<String, String> hashMap = new HashMap<>();
     hashMap.put(titleKey, getString(R.string.keyboard_version));
     hashMap.put(subtitleKey, kbVersion);
-    // Display notification to download update if latestKbdCloudVersion > kbVersion (installed)
-    if (FileUtils.compareVersions(latestKbdCloudVersion, kbVersion) == FileUtils.VERSION_GREATER) {
+    // Display notification to download update if there's a link to an updated kmp
+    if (kmp != null && !kmp.isEmpty()) {
       hashMap.put(subtitleKey, context.getString(R.string.update_available, kbVersion));
       icon = String.valueOf(R.drawable.ic_cloud_download);
     }
@@ -162,7 +157,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
 
         // "Version" link clicked to download latest keyboard version from cloud
         if (itemTitle.equals(getString(R.string.keyboard_version))) {
-          Bundle args = latestKbd.buildDownloadBundle();
+          Bundle args = kbd.buildDownloadBundle();
           Intent i = new Intent(getApplicationContext(), KMKeyboardDownloaderActivity.class);
           i.putExtras(args);
           startActivity(i);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -165,6 +165,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
                 preInstalledModelMap.get(KMManager.KMKey_LanguageName),
                 preInstalledModelMap.get(KMManager.KMKey_LexicalModelVersion),
                 preInstalledModelMap.get(KMManager.KMKey_HelpLink),
+                preInstalledModelMap.get(KMManager.KMKey_KMPLink),
                 "" // String modelURL
                 );
               String itemKey = String.format("%s_%s_%s",

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -165,11 +165,8 @@ public final class ModelPickerActivity extends AppCompatActivity {
                 preInstalledModelMap.get(KMManager.KMKey_LanguageName),
                 preInstalledModelMap.get(KMManager.KMKey_LexicalModelVersion),
                 preInstalledModelMap.get(KMManager.KMKey_HelpLink),
-                preInstalledModelMap.get(KMManager.KMKey_KMPLink),
-                "" // String modelURL
-                );
-              String itemKey = String.format("%s_%s_%s",
-                  preInstalled.getPackageID(), preInstalled.getLanguageCode(), preInstalled.getResourceID());
+                MapCompat.getOrDefault(preInstalledModelMap, KMManager.KMKey_KMPLink, ""));
+              String itemKey = preInstalled.getKey();
               int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(context, itemKey);
               KeyboardPickerActivity.deleteLexicalModel(context, modelIndex, true);
             }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
@@ -62,6 +62,10 @@ public class CloudApiTypes {
      *  automatic lexical model download during keyboard download
      */
     LexicalModelPackage,
+    /**
+     * Package version download: download package version information for keyboards and lexical models
+     */
+    PackageVersion
   }
 
   public enum JSONType {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
@@ -45,6 +45,11 @@ public class CloudApiTypes {
      */
     LexicalModels,
     /**
+     * Catalog download: available keyboard and lexical model packages and the most current version.
+     * Used to determine if keyboard/lexical model updates are available
+     */
+    PackageVersion,
+    /**
      * Keyboard download: keyboard meta data for the selected keyboard.
      */
     Keyboard,
@@ -57,7 +62,8 @@ public class CloudApiTypes {
      */
     KeyboardData,
     /**
-     * Keyboard package download:
+     * Keyboard package download: download keyboard package
+     * Used for single keyboard download
      */
     KeyboardPackage,
     /**
@@ -65,11 +71,7 @@ public class CloudApiTypes {
      *  Used for single lexical model download and
      *  automatic lexical model download during keyboard download
      */
-    LexicalModelPackage,
-    /**
-     * Package version download: download package version information for keyboards and lexical models
-     */
-    PackageVersion
+    LexicalModelPackage
   }
 
   public enum JSONType {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
@@ -57,6 +57,10 @@ public class CloudApiTypes {
      */
     KeyboardData,
     /**
+     * Keyboard package download:
+     */
+    KeyboardPackage,
+    /**
      *  Lexical download: download lexical model package
      *  Used for single lexical model download and
      *  automatic lexical model download during keyboard download

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -147,9 +147,9 @@ public class CloudDataJsonUtil {
               String version = kbd.getVersion();
               if (keyboardID.equalsIgnoreCase(kbd.getKeyboardID()) &&
                   (FileUtils.compareVersions(cloudVersion, version) == FileUtils.VERSION_GREATER) &&
-                  (!kbd.getKMP().equalsIgnoreCase(cloudKMP))) {
+                  (!kbd.getUpdateKMP().equalsIgnoreCase(cloudKMP))) {
                 // Update keyboard with the latest KMP link
-                kbd.setKMP(cloudKMP);
+                kbd.setUpdateKMP(cloudKMP);
                 KeyboardController.getInstance().add(kbd);
 
                 // Update bundle list

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -101,11 +101,11 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
   void saveDataToCache(CloudCatalogDownloadReturns jsonTuple)
   {
     // First things first - we've successfully downloaded from the Cloud.  Cache that stuff!
-    if (jsonTuple.keyboardJSON != null) {
-      CloudDataJsonUtil.saveJSONObjectToCache(CloudDataJsonUtil.getKeyboardCacheFile(context), jsonTuple.keyboardJSON);
-    }
     if (jsonTuple.lexicalModelJSON != null) {
       CloudDataJsonUtil.saveJSONArrayToCache(CloudDataJsonUtil.getLexicalModelCacheFile(context), jsonTuple.lexicalModelJSON);
+    }
+    if (jsonTuple.packagesJSON != null) {
+      FileUtils.saveList(CloudDataJsonUtil.getResourcesCacheFile(context), jsonTuple.packagesJSON);
     }
   }
 
@@ -134,6 +134,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
   {
     jsonTuple.keyboardJSON = ensureInit(aContext,aDataSet,jsonTuple.keyboardJSON);
     jsonTuple.lexicalModelJSON = ensureInit(aContext,aDataSet, jsonTuple.lexicalModelJSON);
+    jsonTuple.packagesJSON = ensureInit(aContext, aDataSet, jsonTuple.packagesJSON);
   }
 
   public void processCloudReturns(Dataset aDataSet, CloudCatalogDownloadReturns jsonTuple, boolean executeCallbacks) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -146,7 +146,6 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       return;
     }
 
-    //List<Keyboard> keyboardsArrayList = CloudDataJsonUtil.processKeyboardJSON(jsonTuple.keyboardJSON, false);
     List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON);
 
     Dataset installedData = KeyboardPickerActivity.getInstalledDataset(context);
@@ -155,50 +154,12 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
     // We're about to do a big batch of edits.
     aDataSet.setNotifyOnChange(false);
 
-    /*
-    // Filter out any duplicates from KMP keyboards, properly merging the lists.
-    for (int i = 0; i < keyboardsArrayList.size(); i++) {
-      Keyboard keyboard = keyboardsArrayList.get(i);
-
-      // Check for duplicates / possible updates.
-      Keyboard match = aDataSet.keyboards.findMatch(keyboard);
-
-      if (match != null) {
-        if (compareVersions(keyboard, match) == FileUtils.VERSION_GREATER) {
-          aDataSet.keyboards.remove(match);
-        } else {
-          keyboardsArrayList.remove(keyboard);
-          i--; // Decrement our index to reflect the removal.
-        }
-      } // else no match == no special handling.
-    }
-
-*/
-
     // The actual update check
     CloudDataJsonUtil.processKeyboardPackageUpdateJSON(context, jsonTuple.packagesJSON, updateBundles);
 
-    // Add cloud-returned keyboard info to the CloudRepository's KeyboardsAdapter.
-    //aDataSet.keyboards.addAll(keyboardsArrayList);
+    // Only add installed kmp keyboards
     aDataSet.keyboards.clear();
     aDataSet.keyboards.addAll(KeyboardController.getInstance().get());
-
-
-    /*
-    // The actual update check.
-    for (int i = 0; i < installedData.keyboards.getCount(); i++) {
-      Keyboard keyboard = installedData.keyboards.getItem(i);
-
-      // Check for duplicates / possible updates.
-      Keyboard match = aDataSet.keyboards.findMatch(keyboard);
-
-      if (match != null) {
-        Bundle bundle = updateCheck(match, keyboard);
-        if (bundle != null) {
-          updateBundles.add(bundle);
-        }
-      } // else no match == no special handling.
-    }
 
     // Filter out any duplicates from already-installed models, properly merging the lists.
     for (int i = 0; i < lexicalModelsArrayList.size(); i++) {
@@ -216,7 +177,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
         }
       } // else no match == no special handling.
     }
-*/
+
     // Add the cloud-returned lexical model info to the CloudRepository's lexical models adapter.
     aDataSet.lexicalModels.addAll(lexicalModelsArrayList);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -13,6 +13,7 @@ import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
 import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.data.LanguageResource;
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.util.FileUtils;
@@ -145,7 +146,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       return;
     }
 
-    List<Keyboard> keyboardsArrayList = CloudDataJsonUtil.processKeyboardJSON(jsonTuple.keyboardJSON, false);
+    //List<Keyboard> keyboardsArrayList = CloudDataJsonUtil.processKeyboardJSON(jsonTuple.keyboardJSON, false);
     List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON);
 
     Dataset installedData = KeyboardPickerActivity.getInstalledDataset(context);
@@ -154,6 +155,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
     // We're about to do a big batch of edits.
     aDataSet.setNotifyOnChange(false);
 
+    /*
     // Filter out any duplicates from KMP keyboards, properly merging the lists.
     for (int i = 0; i < keyboardsArrayList.size(); i++) {
       Keyboard keyboard = keyboardsArrayList.get(i);
@@ -171,9 +173,18 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       } // else no match == no special handling.
     }
 
-    // Add cloud-returned keyboard info to the CloudRepository's KeyboardsAdapter.
-    aDataSet.keyboards.addAll(keyboardsArrayList);
+*/
 
+    // The actual update check
+    CloudDataJsonUtil.processKeyboardPackageUpdateJSON(context, jsonTuple.packagesJSON, updateBundles);
+
+    // Add cloud-returned keyboard info to the CloudRepository's KeyboardsAdapter.
+    //aDataSet.keyboards.addAll(keyboardsArrayList);
+    aDataSet.keyboards.clear();
+    aDataSet.keyboards.addAll(KeyboardController.getInstance().get());
+
+
+    /*
     // The actual update check.
     for (int i = 0; i < installedData.keyboards.getCount(); i++) {
       Keyboard keyboard = installedData.keyboards.getItem(i);
@@ -205,7 +216,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
         }
       } // else no match == no special handling.
     }
-
+*/
     // Add the cloud-returned lexical model info to the CloudRepository's lexical models adapter.
     aDataSet.lexicalModels.addAll(lexicalModelsArrayList);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadReturns.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadReturns.java
@@ -11,13 +11,15 @@ import java.util.List;
  * Result type for catalogue download.
  */
 public class CloudCatalogDownloadReturns {
-  public JSONObject keyboardJSON;
+  public JSONObject keyboardJSON; // TODO: remove
   public JSONArray lexicalModelJSON;
+  public JSONObject packagesJSON;
 
   // Used by the CloudCatalogDownloadTask, as it fits well with doInBackground's param structure.
   public CloudCatalogDownloadReturns(List<CloudApiTypes.CloudApiReturns> returns) {
     JSONObject kbd = null;
     JSONArray lex = null;
+    JSONObject pkg = null;
 
     //TODO: Seems to be wrong because only the last result for each type will be processed
     for(CloudApiTypes.CloudApiReturns ret: returns) {
@@ -27,23 +29,30 @@ public class CloudCatalogDownloadReturns {
           break;
         case LexicalModels:
           lex = ret.jsonArray;
+          break;
+        case PackageVersion:
+          pkg = ret.jsonObject;
+          break;
       }
     }
 
     // Errors are thrown if we try to do this assignment within the loop.
     this.keyboardJSON = kbd;
     this.lexicalModelJSON = lex;
+    this.packagesJSON = pkg;
   }
 
-  public CloudCatalogDownloadReturns(JSONObject keyboardJSON, JSONArray lexicalModelJSON) {
+  public CloudCatalogDownloadReturns(JSONObject keyboardJSON, JSONArray lexicalModelJSON, JSONObject packagesJSON) {
     this.keyboardJSON = keyboardJSON;
     this.lexicalModelJSON = lexicalModelJSON;
+    this.packagesJSON = packagesJSON;
   }
 
   public boolean isEmpty() {
     boolean emptyKbd = keyboardJSON == null || keyboardJSON.length() == 0;
     boolean emptyLex = lexicalModelJSON == null || lexicalModelJSON.length() == 0;
+    boolean emptyPkg = packagesJSON == null || packagesJSON.length() == 0;
 
-    return emptyKbd && emptyLex;
+    return emptyKbd && emptyLex && emptyPkg;
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardDownloadReturns.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardDownloadReturns.java
@@ -8,14 +8,14 @@ import java.util.Map;
  */
 public class CloudKeyboardDownloadReturns {
   public final Integer kbdResult;
-  public final List<Map<String, String>> installedLexicalModels;
+  public final List<Map<String, String>> installedResource;
 
   public CloudKeyboardDownloadReturns(Integer i) {
     this(i, null);
   }
 
-  public CloudKeyboardDownloadReturns(Integer i, List<Map<String, String>> installedLexicalModels) {
+  public CloudKeyboardDownloadReturns(Integer i, List<Map<String, String>> installedResource) {
     this.kbdResult = i;
-    this.installedLexicalModels = installedLexicalModels;
+    this.installedResource = installedResource;
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
@@ -1,6 +1,7 @@
 package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -180,7 +181,8 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
         JSONObject pkgData = _r.returnjson.jsonObject;
 
         if (pkgData != null) {
-          CloudDataJsonUtil.processKeyboardPackageUpdateJSON(aContext, pkgData);
+          List<Bundle> updateBundles = new ArrayList<>();
+          CloudDataJsonUtil.processKeyboardPackageUpdateJSON(aContext, pkgData, updateBundles);
           CloudDataJsonUtil.processLexicalModelPackageUpdateJSON(aContext, pkgData);
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
@@ -12,6 +12,7 @@ import com.tavultesoft.kmea.cloud.CloudApiTypes;
 import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
 import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
+import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.FileUtils;
 
 import org.json.JSONArray;
@@ -91,7 +92,7 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
       return;
     }
 
-    processCloudResults(aCloudResult);
+    processCloudResults(aContext, aCloudResult);
 
     startDownloads(aContext, aCloudResult);
   }
@@ -150,23 +151,18 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
    * process the meta data result and prepare the additional downloads.
    * @param aMetaDataResult the meta data results
    */
-  private void processCloudResults(List<MetaDataResult> aMetaDataResult) {
-    for(MetaDataResult _r:aMetaDataResult)
-    {
-      if(_r.returnjson.target== CloudApiTypes.ApiTarget.Keyboard)
-      {
+  private void processCloudResults(Context aContext, List<MetaDataResult> aMetaDataResult) {
+    for(MetaDataResult _r:aMetaDataResult) {
+      if (_r.returnjson.target== CloudApiTypes.ApiTarget.Keyboard) {
         handleKeyboardMetaData(_r);
       }
-      if(_r.returnjson.target== CloudApiTypes.ApiTarget.KeyboardLexicalModels)
-      {
+      if(_r.returnjson.target== CloudApiTypes.ApiTarget.KeyboardLexicalModels) {
         JSONArray lmData = _r.returnjson.jsonArray;
         if (lmData != null && lmData.length() > 0) {
-          try
-          {
+          try {
             JSONObject modelInfo = lmData.getJSONObject(0);
 
-            if (modelInfo.has("packageFilename") && modelInfo.has("id"))
-            {
+            if (modelInfo.has("packageFilename") && modelInfo.has("id")) {
               String _modelID = modelInfo.getString("id");
               ArrayList<CloudApiTypes.CloudApiParam> urls = new ArrayList<>();
               urls.add(new CloudApiTypes.CloudApiParam(
@@ -178,6 +174,14 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
           } catch (JSONException e) {
             Log.e(TAG, "Error parsing lexical model from api.keyman.com. " + e);
           }
+        }
+      }
+      if (_r.returnjson.target == CloudApiTypes.ApiTarget.PackageVersion) {
+        JSONObject pkgData = _r.returnjson.jsonObject;
+
+        if (pkgData != null) {
+          CloudDataJsonUtil.processKeyboardPackageUpdateJSON(aContext, pkgData);
+          CloudDataJsonUtil.processLexicalModelPackageUpdateJSON(aContext, pkgData);
         }
       }
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
@@ -150,12 +150,13 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
 
   /**
    * process the meta data result and prepare the additional downloads.
+   * @param aContext the context
    * @param aMetaDataResult the meta data results
    */
   private void processCloudResults(Context aContext, List<MetaDataResult> aMetaDataResult) {
     for(MetaDataResult _r:aMetaDataResult) {
       if (_r.returnjson.target== CloudApiTypes.ApiTarget.Keyboard) {
-        handleKeyboardMetaData(_r);
+        //handleKeyboardMetaData(_r);
       }
       if(_r.returnjson.target== CloudApiTypes.ApiTarget.KeyboardLexicalModels) {
         JSONArray lmData = _r.returnjson.jsonArray;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -76,7 +76,8 @@ public class Keyboard extends LanguageResource implements Serializable {
                   boolean isNewKeyboard, String font, String oskFont) {
     super(packageID, keyboardID, keyboardName, languageID, languageName, version,
       (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
-        String.format(HELP_URL_FORMATSTR, keyboardID, version), kmp);
+        String.format(HELP_URL_FORMATSTR, keyboardID, version),
+      kmp);
 
     this.isNewKeyboard = isNewKeyboard;
     this.font = (font != null) ? font : "";
@@ -103,6 +104,7 @@ public class Keyboard extends LanguageResource implements Serializable {
     bundle.putString(KMKeyboardDownloaderActivity.ARG_LANG_NAME, languageName);
 
     bundle.putString(KMKeyboardDownloaderActivity.ARG_CUSTOM_HELP_LINK, helpLink);
+    bundle.putString(KMKeyboardDownloaderActivity.ARG_KMP_LINK, kmp);
 
     return bundle;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -72,11 +72,11 @@ public class Keyboard extends LanguageResource implements Serializable {
 
   public Keyboard(String packageID, String keyboardID, String keyboardName,
                   String languageID, String languageName, String version,
-                  String helpLink,
+                  String helpLink, String kmp,
                   boolean isNewKeyboard, String font, String oskFont) {
     super(packageID, keyboardID, keyboardName, languageID, languageName, version,
       (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
-        String.format(HELP_URL_FORMATSTR, keyboardID, version));
+        String.format(HELP_URL_FORMATSTR, keyboardID, version), kmp);
 
     this.isNewKeyboard = isNewKeyboard;
     this.font = (font != null) ? font : "";
@@ -151,7 +151,8 @@ public class Keyboard extends LanguageResource implements Serializable {
     KMManager.KMDefault_LanguageID,
     KMManager.KMDefault_LanguageName,
     KMManager.KMDefault_KeyboardVersion,
-    null, // will use help.keyman.com link because context required to determine local welcome.htm path
+    null, // will use help.keyman.com link because context required to determine local welcome.htm path,
+    "",
     false,
     KMManager.KMDefault_KeyboardFont,
     KMManager.KMDefault_KeyboardFont);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class KeyboardController {
   public static final String TAG = "KeyboardController";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -75,6 +75,7 @@ public class KeyboardController {
               kbdMap.get(KMManager.KMKey_LanguageName),
               MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Version, "1.0"),
               MapCompat.getOrDefault(kbdMap, KMManager.KMKey_CustomHelpLink, ""),
+              MapCompat.getOrDefault(kbdMap, KMManager.KMKey_KMPLink, ""),
               isNewKeyboard,
               MapCompat.getOrDefault(kbdMap, KMManager.KMKey_Font, null),
               MapCompat.getOrDefault(kbdMap, KMManager.KMKey_OskFont, null)
@@ -275,7 +276,8 @@ public class KeyboardController {
       return result;
     }
 
-    result = FileUtils.saveList(context, KMFilename_Installed_KeyboardsList, arr);
+    result = FileUtils.saveList(new File(context.getDir("userdata", Context.MODE_PRIVATE),
+      KMFilename_Installed_KeyboardsList), arr);
     return result;
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -23,7 +23,6 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class KeyboardController {
   public static final String TAG = "KeyboardController";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -21,7 +21,7 @@ public abstract class LanguageResource implements Serializable {
   protected String languageName;
   protected String version;
   protected String helpLink;
-  protected String kmp; // link to latest kmp from the cloud
+  protected String kmp; // link to latest kmp from the cloud vs what is currently installed
 
   // JSON keys
   private static String LR_PACKAGE_ID_KEY = "packageID";
@@ -55,8 +55,16 @@ public abstract class LanguageResource implements Serializable {
 
   public String getHelpLink() { return helpLink; }
 
-  public String getKMP() { return kmp; }
-  public void setKMP(String kmp) { this.kmp = kmp; }
+  public String getUpdateKMP() { return kmp; }
+  public void setUpdateKMP(String kmp) { this.kmp = kmp; }
+
+  /**
+   * Helper method if the language resource has an updated kmp package available to download from the cloud
+   * @return boolean true if an updated kmp package is available
+   */
+  public boolean hasUpdateAvailable() {
+    return (kmp != null && !kmp.isEmpty());
+  }
 
   public int hashCode() {
     String id = getResourceID();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -21,6 +21,7 @@ public abstract class LanguageResource implements Serializable {
   protected String languageName;
   protected String version;
   protected String helpLink;
+  protected String kmp; // link to latest kmp from the cloud
 
   // JSON keys
   private static String LR_PACKAGE_ID_KEY = "packageID";
@@ -30,6 +31,7 @@ public abstract class LanguageResource implements Serializable {
   private static String LR_LANGUAGE_NAME_KEY = "languageName";
   private static String LR_VERSION_KEY = "version";
   private static String LR_HELP_LINK_KEY = "helpLink";
+  private static String LR_KMP_KEY = "kmp";
 
   private static final String TAG = "LanguageResource";
 
@@ -52,6 +54,9 @@ public abstract class LanguageResource implements Serializable {
   public String getPackage() { return packageID; }
 
   public String getHelpLink() { return helpLink; }
+
+  public String getKMP() { return kmp; }
+  public void setKMP(String kmp) { this.kmp = kmp; }
 
   public int hashCode() {
     String id = getResourceID();
@@ -81,10 +86,11 @@ public abstract class LanguageResource implements Serializable {
    * @param languageName
    * @param version
    * @param helpLink
+   * @param kmp
    */
   public LanguageResource(String packageID, String resourceID, String resourceName,
                           String languageID, String languageName, String version,
-                          String helpLink) {
+                          String helpLink, String kmp) {
     this.packageID = (packageID != null) ? packageID : KMManager.KMDefault_UndefinedPackageID;
     this.resourceID = resourceID;
     this.resourceName = resourceName;
@@ -93,6 +99,7 @@ public abstract class LanguageResource implements Serializable {
     this.languageName = (languageName != null && !languageName.isEmpty()) ? languageName : this.languageID;
     this.version = version;
     this.helpLink = helpLink;
+    this.kmp = kmp;
   }
 
   protected void fromJSON(JSONObject installedObj) {
@@ -104,6 +111,11 @@ public abstract class LanguageResource implements Serializable {
       this.languageName = installedObj.getString(LanguageResource.LR_LANGUAGE_NAME_KEY);
       this.version = installedObj.getString(LanguageResource.LR_VERSION_KEY);
       this.helpLink = installedObj.getString(LanguageResource.LR_HELP_LINK_KEY);
+      if (installedObj.has(LanguageResource.LR_KMP_KEY)) {
+        this.kmp = installedObj.getString(LanguageResource.LR_KMP_KEY);
+      } else {
+        this.kmp = "";
+      }
     } catch (JSONException e) {
       Log.e(TAG, "fromJSON() exception: " + e);
     }
@@ -119,6 +131,7 @@ public abstract class LanguageResource implements Serializable {
       o.put(LR_LANGUAGE_NAME_KEY, this.languageName);
       o.put(LR_VERSION_KEY, this.version);
       o.put(LR_HELP_LINK_KEY, this.helpLink);
+      o.put(LR_KMP_KEY, this.kmp);
     } catch (JSONException e) {
       Log.e(TAG, "toJSON() exception: " + e);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -19,7 +19,9 @@ import java.io.Serializable;
 public class LexicalModel extends LanguageResource implements Serializable {
   private static final String TAG = "lexicalModel";
 
-  // Only used to build download bundle from cloud
+  // Only used to build download bundle from cloud.
+  // This is for the initial download of the lexical model.
+  // "kmp" is used for downloading newer versions of the lexical model package.
   private String modelURL;
 
   // JSON key
@@ -83,11 +85,11 @@ public class LexicalModel extends LanguageResource implements Serializable {
 
   public LexicalModel(String packageID, String lexicalModelID, String lexicalModelName,
                       String languageID, String languageName,  String version,
-                      String helpLink,
+                      String helpLink, String kmp,
                       String modelURL) {
     // TODO: handle help links
     super(packageID, lexicalModelID, lexicalModelName, languageID, languageName,
-        version, "");
+        version, "", kmp);
 
     this.modelURL = modelURL;
   }
@@ -159,6 +161,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
     KMManager.KMDefault_LanguageID,
     KMManager.KMDefault_LanguageName,
     KMManager.KMDefault_DictionaryVersion,
+    "",
     "",
     "");
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -49,7 +49,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * Force resource update.
    * Only for testing, should be false for merging
    */
-  public static final boolean FORCE_RESOURCE_UPDATE = true;
+  public static final boolean FORCE_RESOURCE_UPDATE = false;
 
   /**
    * Send update notifications.
@@ -276,9 +276,9 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
   private void addOpenUpdate(Bundle theResourceBundle) {
 
     String langid = theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_LANG_ID);
-    boolean downloadOnlyLexicalModel = theResourceBundle.containsKey(KMKeyboardDownloaderActivity.ARG_MODEL_URL) &&
-      theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_URL) != null &&
-      !theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_URL).isEmpty();
+    boolean downloadOnlyLexicalModel = theResourceBundle.containsKey(KMKeyboardDownloaderActivity.ARG_MODEL_ID) &&
+      theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_ID) != null &&
+      !theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_ID).isEmpty();
 
     if (downloadOnlyLexicalModel) {
       String modelid = theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_ID);
@@ -379,9 +379,9 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
     String langid = theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_LANG_ID);
     String langName = theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_LANG_NAME);
-    boolean downloadOnlyLexicalModel = theResourceBundle.containsKey(KMKeyboardDownloaderActivity.ARG_MODEL_URL) &&
-      theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_URL) != null &&
-      !theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_URL).isEmpty();
+    boolean downloadOnlyLexicalModel = theResourceBundle.containsKey(KMKeyboardDownloaderActivity.ARG_MODEL_ID) &&
+      theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_ID) != null &&
+      !theResourceBundle.getString(KMKeyboardDownloaderActivity.ARG_MODEL_ID).isEmpty();
 
     int  notification_id = this.notificationid.incrementAndGet();
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -49,7 +49,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
    * Force resource update.
    * Only for testing, should be false for merging
    */
-  public static final boolean FORCE_RESOURCE_UPDATE = false;
+  public static final boolean FORCE_RESOURCE_UPDATE = true;
 
   /**
    * Send update notifications.

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.tavultesoft.kmea.KMManager;
 
+import org.json.JSONObject;
 import org.json.JSONArray;
 
 import java.io.BufferedInputStream;
@@ -219,23 +220,36 @@ public final class FileUtils {
     }
   }
 
-  public static boolean saveList(Context context, String listName, JSONArray arr) {
-    boolean result;
+  /**
+   * Write arr Object to filepath
+   * @param File path to filename to write
+   * @param obj JSONObject or JSONArray to save
+   * @return boolean if the save was successfull
+   */
+  public static boolean saveList(File filepath, Object obj) {
+    boolean result = false;
     final int INDENT = 2; // 2 spaces indent
     try {
-      File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), listName);
-      OutputStreamWriter outputStream = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
-      outputStream.write(arr.toString(INDENT));
+      OutputStreamWriter outputStream = new OutputStreamWriter(new FileOutputStream(filepath), StandardCharsets.UTF_8);
+      if (obj instanceof JSONObject) {
+        outputStream.write(((JSONObject)obj).toString(INDENT));
+        result = true;
+      } else if (obj instanceof JSONArray) {
+        outputStream.write(((JSONArray) obj).toString(INDENT));
+        result = true;
+      } else {
+        Log.e(TAG, "saveList failed. arr not JSONObject or JSONArray");
+      }
       outputStream.flush();
       outputStream.close();
-      result = true;
     } catch (Exception e) {
-      Log.e(TAG, "Failed to save " + listName + ". Error: " + e);
+      Log.e(TAG, "saveList failed to save " + filepath.getName() + ". Error: " + e);
       result = false;
     }
 
     return result;
   }
+
   /**
    * Utility to parse a URL and extract the filename
    * @param urlStr String

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -221,10 +221,10 @@ public final class FileUtils {
   }
 
   /**
-   * Write arr Object to filepath
+   * Write obj Object to filepath
    * @param File path to filename to write
    * @param obj JSONObject or JSONArray to save
-   * @return boolean if the save was successfull
+   * @return boolean if the save was successful
    */
   public static boolean saveList(File filepath, Object obj) {
     boolean result = false;

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -247,6 +247,7 @@ final class FVShared {
                       keyboard.name,
                       "1.0", //TODO: use keyboard version from kmp.json
                       String.format("%s%s", FVKeyboardHelpLink, keyboard.id),
+                      "", // kmp link
                       false,
                       "NotoSansCanadianAboriginal.ttf",
                       "NotoSansCanadianAboriginal.ttf");


### PR DESCRIPTION
This handles the keyboard update portion of #2708

Previously, the content of the keyboard cloud catalog was used for:
1. A Dataset merged list of keyboards (from the cloud catalog) and keyboards from installed packages would be generated. This would populate the super-long scroll list in previous keyboard pickers.
2. Determining when keyboard updates were available.
    * The JSON response of an api.keyman.com query determined the keyboard files to download (individual JS/font files, not a keyboard package).

For 14.0, the keyboard cloud catalog is no longer used. So updating a keyboard now involves downloading the latest keyboard package.

### LanguageResource changes: ###
* Add a "kmp" property. This is a link to the latest kmp and now gets populated by the callback to https://api.keyman.com/package-version/. This field gets blanked when the update is installed.
* Remove LexicalModel() "modelURL" property (using "kmp" instead)

### Other changes ###
* Dataset only gets keyboard list from installed packages
* cache the results of the https://api.keyman.com/package-version query to `jsonResourcesCache.json`.
* Update KMKeyboardDownloadActivity to download a keyboard package

TODO for other PRs
* Re-integrate installing lexical models (previously when downloading a cloud keyboard, a corresponding lexical model package would get added to the download queue).
* Finish integrating lexical model updates
* Cleanup remnants of keyboard cloud catalog  in the code
