### PR TITLE
fix(common/models/types): fixes models-types build script, sets std header

### DIFF
--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -6,8 +6,13 @@
 # Exit on command failure and when using unset variables:
 set -eu
 
-# Include some helper functions from resources
-. ../../resources/shellHelperFunctions.sh
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 EX_USAGE=64
 
 


### PR DESCRIPTION
Build script was missing a minor but important tweak after the `models-types` rename & relocation - a simple `../`.

But, while we're here... standard `build.sh` header time.

Fixes the following error for Web's `master` build configuration:

```
[01:13:41]
Step 4/4: Publish Lexical Model Types NPM modules (Command Line) (4s)
[01:13:41]
Starting: C:\BuildAgent\temp\agentTmp\custom_script1069343044492610800.cmd
[01:13:41]
in directory: C:\BuildAgent\work\281d1bc6d3c88cfd\keyman\common\models\types
[01:13:42]
build.sh: line 10: ../../resources/shellHelperFunctions.sh: No such file or directory
[01:13:43]
build.sh: line 10: ../../resources/shellHelperFunctions.sh: No such file or directory
[01:13:44]
build.sh: line 10: ../../resources/shellHelperFunctions.sh: No such file or directory
[01:13:44]
Process exited with code 1
[01:13:46]
Process exited with code 1 (Step: Publish Lexical Model Types NPM modules (Command Line))
[01:13:45]
Step Publish Lexical Model Types NPM modules (Command Line) failed
```

We went from `common/lexical-model-types` to `common/models/types`, one subdirectory deeper.