### PR TITLE
 fix(linux): Disable buttons if no keyboard installed

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -37,6 +37,7 @@ class KeyboardDetailsView(Gtk.Window):
         Gtk.Window.__init__(self, title=wintitle)
         init_accel(self)
 
+        hbox_outer = Gtk.Box(spacing = 12)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
 
         packageDir = os.path.join(kmp['areapath'], kmp['packageID'])
@@ -288,10 +289,10 @@ class KeyboardDetailsView(Gtk.Window):
                         # label.set_halign(Gtk.Align.START)
                         # label.set_selectable(True)
                         # grid.attach_next_to(label, label9, Gtk.PositionType.RIGHT, 1, 1)
-        vbox.pack_start(box, True, True, 0)
+        vbox.pack_start(box, True, True, 12)
 
-        hbox = Gtk.Box(spacing=6)
-        vbox.pack_start(hbox, False, False, 0)
+        hbox = Gtk.Box(spacing = 6)
+        vbox.pack_start(hbox, False, False, 12)
 
         # Add an entire row of padding
         lbl_pad = Gtk.Label()
@@ -335,7 +336,8 @@ class KeyboardDetailsView(Gtk.Window):
         hbox.pack_end(button, False, False, 0)
         bind_accelerator(self.accelerators, button, '<Control>w')
 
-        self.add(vbox)
+        hbox_outer.pack_start(vbox, True, True, 12)
+        self.add(hbox_outer)
         self.resize(635, 270)
 
     def on_close_clicked(self, button):

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -126,16 +126,19 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         self.uninstall_button = Gtk.Button.new_with_mnemonic("_Uninstall")
         self.uninstall_button.set_tooltip_text("Uninstall keyboard package")
         self.uninstall_button.connect("clicked", self.on_uninstall_clicked)
+        self.uninstall_button.set_sensitive(False)
         bbox_top.add(self.uninstall_button)
 
         self.about_button = Gtk.Button.new_with_mnemonic("_About")
         self.about_button.set_tooltip_text("About keyboard package")
         self.about_button.connect("clicked", self.on_about_clicked)
+        self.about_button.set_sensitive(False)
         bbox_top.add(self.about_button)
 
         self.help_button = Gtk.Button.new_with_mnemonic("_Help")
         self.help_button.set_tooltip_text("Help for keyboard package")
         self.help_button.connect("clicked", self.on_help_clicked)
+        self.help_button.set_sensitive(False)
         bbox_top.add(self.help_button)
 
         self.options_button = Gtk.Button.new_with_mnemonic("_Options")
@@ -246,12 +249,13 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             self.about_button.set_tooltip_text("About keyboard package " + model[treeiter][1])
             self.options_button.set_tooltip_text("Settings for keyboard package " + model[treeiter][1])
             logging.debug("You selected %s version %s", model[treeiter][1], model[treeiter][2])
+            self.about_button.set_sensitive(True)
             if model[treeiter][4] == InstallArea.IA_USER:
                 logging.debug("Enabling uninstall button for %s in %s", model[treeiter][3], model[treeiter][4])
                 self.uninstall_button.set_sensitive(True)
             else:
                 self.uninstall_button.set_sensitive(False)
-                logging.debug("Disabling uninstall button for %s in %s  ", model[treeiter][3], model[treeiter][4])
+                logging.debug("Disabling uninstall button for %s in %s", model[treeiter][3], model[treeiter][4])
             # welcome file if it exists
             if model[treeiter][5]:
                 self.help_button.set_sensitive(True)
@@ -262,6 +266,15 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 self.options_button.set_sensitive(True)
             else:
                 self.options_button.set_sensitive(False)
+        else:
+            self.uninstall_button.set_tooltip_text("Uninstall keyboard package")
+            self.help_button.set_tooltip_text("Help for keyboard package")
+            self.about_button.set_tooltip_text("About keyboard package")
+            self.options_button.set_tooltip_text("Settings for keyboard package")
+            self.uninstall_button.set_sensitive(False)
+            self.about_button.set_sensitive(False)
+            self.help_button.set_sensitive(False)
+            self.options_button.set_sensitive(False)
 
     def on_help_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
@@ -270,7 +283,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             welcome_file = model[treeiter][5]
             if welcome_file and os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
-                logging.info("opening" + uri_path)
+                logging.info("opening " + uri_path)
                 w = WelcomeView(uri_path, model[treeiter][3])
                 w.resize(800, 600)
                 w.show_all()
@@ -284,7 +297,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
           options_file = model[treeiter][6]
           if options_file and os.path.isfile(options_file):
               uri_path = pathlib.Path(options_file).as_uri()
-              logging.info("opening" + uri_path)
+              logging.info("opening " + uri_path)
               # TODO: Determine keyboardID
               info = { "optionurl": uri_path, "packageID": model[treeiter][3], "keyboardID": model[treeiter][3] }
               w = OptionsView(info)


### PR DESCRIPTION
This change disables the uninstall, about, and help buttons in km-config if the list of installed keyboards is empty.

This fixes #3181.

This change also increases the padding on the inside of the About window so that there is more whitespace between the UI elements and the window border.

# Screenshots

## km-config

### km-config before

![Issue#3181_Before](https://user-images.githubusercontent.com/181336/83122557-21467d00-a0d4-11ea-8aa6-504f192fdeef.png)

### km-config with these changes

![Issue#3181_After](https://user-images.githubusercontent.com/181336/83159890-cf6b1a80-a106-11ea-8498-bd90aa754ae2.png)

## About dialog

### About dialog before

![About_Before](https://user-images.githubusercontent.com/181336/83159934-da25af80-a106-11ea-8387-3af1708bc569.png)

### About dialog with these changes

![About_after](https://user-images.githubusercontent.com/181336/83159950-e1e55400-a106-11ea-8849-a1195abccfb1.png)
