### PR TITLE
modify(android/engine): Clean up naming for formatting QR code URL

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -146,7 +146,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format(QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -199,7 +199,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format(QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
@@ -11,7 +11,7 @@ import net.glxn.qrgen.android.QRCode;
 public final class QRCodeUtil {
   public static final int DEFAULT_HEIGHT = 800;
   public static final int DEFAULT_WIDTH = 800;
-  public static final String QR_BASE = "https://keyman.com/go/keyboard/%s/share";
+  public static final String QR_CODE_URL_FORMATSTR = "https://keyman.com/go/keyboard/%s/share";
 
   /**
    * Generate QR Code as a Bitmap


### PR DESCRIPTION
For `master`, this is a trivial rename from `QR_BASE`  to `QR_CODE_URL_FORMATSTR` to convey it's a format string.

The intent for this PR is to later cherry-pick to `stable-13.0` to fix the shared QR Code.