### PR TITLE
fix(android/engine): Fix generation of QR code

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -146,7 +146,7 @@ public final class KeyboardInfoActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardSettingsActivity.java
@@ -205,7 +205,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format("%s%s", QRCodeUtil.QR_BASE, kbID);
+      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
@@ -11,7 +11,7 @@ import net.glxn.qrgen.android.QRCode;
 public final class QRCodeUtil {
   public static final int DEFAULT_HEIGHT = 800;
   public static final int DEFAULT_WIDTH = 800;
-  public static final String QR_BASE = "https://keyman.com/go/keyboard/%s/share";
+  public static final String QR_CODE_URL_FORMATSTR = "https://keyman.com/go/keyboard/%s/share";
 
   /**
    * Generate QR Code as a Bitmap

--- a/android/history.md
+++ b/android/history.md
@@ -1,6 +1,10 @@
 # Keyman for Android Version History
 
-## 2020-05-26 13.0.6213 stable
+## 2020-05-29 13.0.6214 stable
+* Bug fix:
+  * Fix format string of QR code for sharing keyboards (#3188)
+
+## 2020-05-27 13.0.6213 stable
 * Changes:
   * Add Tamil lexical model to KMSample2 (#3165)
 


### PR DESCRIPTION
Cherry-pick of #3187 to stable-13.0

This fixes the format string for generating the QR code link to share keyboards.

Screenshot with the fix

![Screenshot_1590741522](https://user-images.githubusercontent.com/7358010/83239878-c50e5680-a1c2-11ea-9146-1d3b3d76a9fe.png)

link goes to https://keyman.com/go/keyboard/khmer_angkor/share
