### PR TITLE
fix(android/engine): Use available models for ModelPickerActivity()

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -304,9 +304,11 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
     List<Keyboard> keyboardsList = KeyboardController.getInstance().get();
 
     if (keyboardInfo != null) {
-      // TODO:  Possible optimization - do we have anything with this language code already?
-      //        Only invalidate the lexical cache if not.
-      CloudRepository.shared.invalidateLexicalModelCache(context);
+      String languageID = keyboardInfo.getLanguageID();
+      if (!CloudRepository.shared.hasAssociatedLexicalModel(context, languageID)) {
+        // Only invalidate the lexical cache if there's no associated lexical model
+        CloudRepository.shared.invalidateLexicalModelCache(context);
+      }
 
       keyboardInfo.setNewKeyboard(true);
       KeyboardController.getInstance().add(keyboardInfo);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -85,14 +85,14 @@ public final class ModelPickerActivity extends AppCompatActivity {
       repo = CloudRepository.shared.fetchDataset(context);
 
       // Initialize the dataset of installed lexical models
-      listView.setAdapter(new FilteredLexicalModelAdapter(context, KeyboardPickerActivity.getInstalledDataset(context), languageID));
+      //listView.setAdapter(new FilteredLexicalModelAdapter(context, KeyboardPickerActivity.getInstalledDataset(context), languageID));
+      listView.setAdapter(new FilteredLexicalModelAdapter(context, repo, languageID));
       listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
         @Override
         public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
           int selectedIndex = position;
           LexicalModel model = ((FilteredLexicalModelAdapter) listView.getAdapter()).getItem(position);
-          //Map<String, String> modelInfo = model.map;
           String packageID = model.getPackageID();
           String languageID = model.getLanguageID();
           String modelID = model.getLexicalModelID();
@@ -103,7 +103,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
           // File check to see if lexical model already exists locally
           File modelCheck = new File(KMManager.getLexicalModelsDir() + packageID + File.separator + modelID + ".model.js");
 
-          String modelKey = String.format("%s_%s_%s", packageID, languageID, modelID);
+          String modelKey = model.getKey();
           boolean modelInstalled = KeyboardPickerActivity.containsLexicalModel(context, modelKey);
           boolean immediateRegister = false;
           HashMap<String, String> preInstalledModelMap = KMManager.getAssociatedLexicalModel(languageID);
@@ -250,21 +250,17 @@ public final class ModelPickerActivity extends AppCompatActivity {
       }
 
       // Needed for the check below.
-      String packageID = model.getPackageID();
-      String languageID = model.getLanguageID();
-      String modelID = model.getLexicalModelID();
-      String modelKey = String.format("%s_%s_%s", packageID, languageID, modelID);
+      String modelKey = model.getKey();
 
       // TODO:  Refactor this check - we should instead test against the installed models listing
       //        once it has its own backing Dataset instance.
       // Is this an installed model or not?
 
+      holder.imgDetails.setImageResource(R.drawable.ic_arrow_forward);
       if (KeyboardPickerActivity.containsLexicalModel(context, modelKey)) {
         holder.imgInstalled.setImageResource(R.drawable.ic_check);
-        holder.imgDetails.setImageResource(R.drawable.ic_arrow_forward);
       } else {
         holder.imgInstalled.setImageResource(0);
-        holder.imgDetails.setImageResource(0);
       }
 
       holder.text.setText(model.getLexicalModelName());

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -84,8 +84,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
       didExecuteParser = true;
       repo = CloudRepository.shared.fetchDataset(context);
 
-      // Initialize the dataset of installed lexical models
-      //listView.setAdapter(new FilteredLexicalModelAdapter(context, KeyboardPickerActivity.getInstalledDataset(context), languageID));
+      // Initialize the dataset of available lexical models (installed and from the cloud catalog)
       listView.setAdapter(new FilteredLexicalModelAdapter(context, repo, languageID));
       listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
@@ -100,26 +99,18 @@ public final class ModelPickerActivity extends AppCompatActivity {
           String langName = model.getLanguageName();
           String version = model.getVersion();
 
-          // File check to see if lexical model already exists locally
-          File modelCheck = new File(KMManager.getLexicalModelsDir() + packageID + File.separator + modelID + ".model.js");
+          boolean immediateRegister = false;
 
+          // File check to see if lexical model file already exists locally (may not be currently installed)
+          File modelCheck = new File(KMManager.getLexicalModelsDir() + packageID + File.separator + modelID + ".model.js");
           String modelKey = model.getKey();
           boolean modelInstalled = KeyboardPickerActivity.containsLexicalModel(context, modelKey);
-          boolean immediateRegister = false;
-          HashMap<String, String> preInstalledModelMap = KMManager.getAssociatedLexicalModel(languageID);
-
           if (modelInstalled) {
             // Show Model Info
             listView.setItemChecked(position, true);
             listView.setSelection(position);
 
             // Start intent for selected Predictive Text Model screen
-            /*
-            if (!languageID.equalsIgnoreCase(modelInfo.get(KMManager.KMKey_LanguageID))) {
-              Log.d(TAG, "Language ID " + languageID + " doesn't match model language ID: " +
-                  modelInfo.get(KMManager.KMKey_LanguageID));
-            }
-             */
             Intent i = new Intent(context, ModelInfoActivity.class);
             i.putExtra(KMManager.KMKey_LexicalModel, model);
             startActivityForResult(i, 1);
@@ -155,6 +146,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
           if(!modelInstalled) {
             // While awkward, we must obtain the preInstalledModelMap before any installations occur.
             // We don't want to remove the model we just installed, after all!
+            HashMap<String, String> preInstalledModelMap = KMManager.getAssociatedLexicalModel(languageID);
             if(preInstalledModelMap != null) {
               // This might be unncessary
               LexicalModel preInstalled = new LexicalModel(

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -104,7 +104,13 @@ public class CloudDataJsonUtil {
     return keyboardsList;
   }
 
-  public static List<LexicalModel> processLexicalModelJSON(JSONArray models) {
+  /**
+   * Parse a JSONArray of models to create a list of LexicalModel
+   * @param models
+   * @param fromKMP - boolean. If true, only  the first language in an array is processed
+   * @return List of LexicalModel
+   */
+  public static List<LexicalModel> processLexicalModelJSON(JSONArray models, boolean fromKMP) {
     List<LexicalModel> modelList = new ArrayList<>(models.length());
 
     try {
@@ -112,7 +118,7 @@ public class CloudDataJsonUtil {
       int modelsLength = models.length();
       for (int i = 0; i < modelsLength; i++) {
         JSONObject modelJSON = models.getJSONObject(i);
-        modelList.add(new LexicalModel(modelJSON, true));
+        modelList.addAll(LexicalModel.LexicalModelList(modelJSON, fromKMP));
       }
     } catch (JSONException | NullPointerException e) {
       Log.e(TAG, "JSONParse Error: " + e);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -146,7 +146,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       return;
     }
 
-    List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON);
+    List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON, false);
 
     Dataset installedData = KeyboardPickerActivity.getInstalledDataset(context);
     final List<Bundle> updateBundles = new ArrayList<>();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -146,7 +146,8 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       return;
     }
 
-    List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON, false);
+    boolean fromKMP = false;
+    List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON, fromKMP);
 
     Dataset installedData = KeyboardPickerActivity.getInstalledDataset(context);
     final List<Bundle> updateBundles = new ArrayList<>();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -146,7 +146,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
       return;
     }
 
-    boolean fromKMP = false;
+    final boolean fromKMP = false;
     List<LexicalModel> lexicalModelsArrayList = CloudDataJsonUtil.processLexicalModelJSON(jsonTuple.lexicalModelJSON, fromKMP);
 
     Dataset installedData = KeyboardPickerActivity.getInstalledDataset(context);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -272,6 +272,7 @@ public class CloudRepository {
     // Consolidate kmp.json info from packages/
     JSONObject kmpLanguagesArray = wrapKmpKeyboardJSON(JSONUtils.getLanguages());
     JSONArray kmpLexicalModelsArray = JSONUtils.getLexicalModels();
+    boolean fromKMP = true;
 
     try {
       if (kmpLanguagesArray.getJSONObject(KMKeyboardDownloaderActivity.KMKey_Languages).
@@ -279,7 +280,7 @@ public class CloudRepository {
         memCachedDataset.keyboards.addAll(CloudDataJsonUtil.processKeyboardJSON(kmpLanguagesArray, true));
       }
       if (kmpLexicalModelsArray.length() > 0) {
-        memCachedDataset.lexicalModels.addAll(CloudDataJsonUtil.processLexicalModelJSON(kmpLexicalModelsArray, true));
+        memCachedDataset.lexicalModels.addAll(CloudDataJsonUtil.processLexicalModelJSON(kmpLexicalModelsArray, fromKMP));
       }
     } catch (Exception e) {
       Log.e(TAG, "preCacheDataSet error " + e);
@@ -310,7 +311,7 @@ public class CloudRepository {
     }
 
     // Reuse any valid parts of the cache.
-    if (!cacheValid) {
+    if (cacheValid) {
       CloudCatalogDownloadReturns jsonData = new CloudCatalogDownloadReturns(kbdData, lexData, pkgData);
 
       // Call the processor method directly with the cached API data.

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -162,7 +162,7 @@ public class CloudRepository {
       CloudApiTypes.ApiTarget.PackageVersion, queryURL).setType(CloudApiTypes.JSONType.Object);
   }
 
-  private CloudApiTypes.CloudApiParam prepareLexicalModellUpdateQuery(Context aContext)
+  private CloudApiTypes.CloudApiParam prepareLexicalModelUpdateQuery(Context aContext)
   {
     // This allows us to directly get the full lexical model catalog.
     // TODO:  Remove and replace with commented-out code below once the proper multi-language
@@ -265,7 +265,7 @@ public class CloudRepository {
         memCachedDataset.keyboards.addAll(CloudDataJsonUtil.processKeyboardJSON(kmpLanguagesArray, true));
       }
       if (kmpLexicalModelsArray.length() > 0) {
-        memCachedDataset.lexicalModels.addAll(CloudDataJsonUtil.processLexicalModelJSON(kmpLexicalModelsArray));
+        memCachedDataset.lexicalModels.addAll(CloudDataJsonUtil.processLexicalModelJSON(kmpLexicalModelsArray, true));
       }
     } catch (Exception e) {
       Log.e(TAG, "preCacheDataSet error " + e);
@@ -296,7 +296,7 @@ public class CloudRepository {
     }
 
     // Reuse any valid parts of the cache.
-    if (cacheValid) {
+    if (!cacheValid) {
       CloudCatalogDownloadReturns jsonData = new CloudCatalogDownloadReturns(kbdData, lexData, pkgData);
 
       // Call the processor method directly with the cached API data.
@@ -354,7 +354,7 @@ public class CloudRepository {
     List<CloudApiTypes.CloudApiParam> cloudQueries = new ArrayList<>(2);
 
     if (!cacheValid) {
-      cloudQueries.add(prepareLexicalModellUpdateQuery(context));
+      cloudQueries.add(prepareLexicalModelUpdateQuery(context));
       cloudQueries.add(prepareResourcesUpdateQuerty(context));
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -124,9 +124,14 @@ public class CloudRepository {
     }
   }
 
+  /**
+   * Search the available lexical models list and see there's an associated model for a
+   * given language ID. Available models are from the cloud catalog and locally installed models
+   * @param context Context
+   * @param languageID String of the language ID to search
+   * @return boolean true if an associated lexical model exists
+   */
   public boolean hasAssociatedLexicalModel(@NonNull Context context, String languageID) {
-    boolean status = false;
-
     if (memCachedDataset != null) {
       for (int i=0; i < memCachedDataset.lexicalModels.getCount(); i++) {
         LexicalModel lm = memCachedDataset.lexicalModels.getItem(i);
@@ -135,7 +140,7 @@ public class CloudRepository {
         }
       }
     }
-    return status;
+    return false;
   }
 
   // Should be called whenever a new language code starts being managed in order to help signal
@@ -272,7 +277,7 @@ public class CloudRepository {
     // Consolidate kmp.json info from packages/
     JSONObject kmpLanguagesArray = wrapKmpKeyboardJSON(JSONUtils.getLanguages());
     JSONArray kmpLexicalModelsArray = JSONUtils.getLexicalModels();
-    boolean fromKMP = true;
+    final boolean fromKMP = true;
 
     try {
       if (kmpLanguagesArray.getJSONObject(KMKeyboardDownloaderActivity.KMKey_Languages).

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -124,6 +124,20 @@ public class CloudRepository {
     }
   }
 
+  public boolean hasAssociatedLexicalModel(@NonNull Context context, String languageID) {
+    boolean status = false;
+
+    if (memCachedDataset != null) {
+      for (int i=0; i < memCachedDataset.lexicalModels.getCount(); i++) {
+        LexicalModel lm = memCachedDataset.lexicalModels.getItem(i);
+        if (lm.getLanguageID().equalsIgnoreCase(languageID)) {
+          return true;
+        }
+      }
+    }
+    return status;
+  }
+
   // Should be called whenever a new language code starts being managed in order to help signal
   // retrieval of the language code's lexical models.
   public void invalidateLexicalModelCache(@NonNull Context context) {

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtilTest.java
@@ -47,7 +47,7 @@ public class CloudDataJsonUtilTest {
     // Test processLexicalModelJSON()
     JSONParser parser = new JSONParser();
     JSONArray cloud = parser.getJSONObjectFromFile(new File(TEST_RESOURCE_ROOT, "sencoten.json"), JSONArray.class);
-      List<LexicalModel> results = CloudDataJsonUtil.processLexicalModelJSON(cloud);
+      List<LexicalModel> results = CloudDataJsonUtil.processLexicalModelJSON(cloud, true);
 
     LexicalModel lmInfo = results.get(0);
     Assert.assertEquals("str-latn", lmInfo.getLanguageID());


### PR DESCRIPTION
This is a pre-req in #2708 before lexical-model package updates can be retrieved  from api.keyman.com

Currently, `ModelPickerActivity()` is only displaying **installed** models.
Since there's a TODO to download associated lexical model after downloading a cloud keyboard package, only the default nrc.en.mtnt model is ever getting installed.

This PR updates `ModelPickerActivity()` so it displays **available** models (sourced from the lexical model cloud catalog and lexical model packages that exist on the filesystem). The lexical model package on the filesystem could be previously installed, since uninstalled.  

This way, the user can choose the language, browse the associated models, and click on them to install the lexical model package.

### User Testing
From a clean install of Keyman
1. From the "Settings" menu, install "fv_sencoten" keyboard
2. From the "Settings" menu, go to "Salish Straits (Latin)" --> Dictionaries. (There may be a processing lag due to some TODO optimization on generating the Dataset)
3. Verify SENĆOŦEN dictionary is not installed (lack of checkmark on the left)
4. Click on the dictionary and download
5. Exit the screen
6. From the "Settings" menu, go to "Salish Straits (Latin)" --> Dictionaries
7. Verify SENĆOŦEN dictionary is:
    a. Installed (checkmark on the left)
    b. Clicking on the model brings up the model info page

![Screenshot_1590893858](https://user-images.githubusercontent.com/7358010/83343489-3b2ace80-a325-11ea-936d-acb5b28d9591.png)
Screenshot showing dictionary installed
