### PR TITLE
fix(ios): fixes lerna concurrency workaround and missing func reference

### DIFF
--- a/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
+++ b/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
@@ -144,7 +144,6 @@ class MainViewController: UIViewController, UIAlertViewDelegate, TextViewDelegat
     // Button - download custom keyboard
     let downloadButton = UIButton(type: .roundedRect)
     downloadButton.setTitle("Download custom keyboard", for: .normal)
-    downloadButton.addTarget(self, action: #selector(self.downloadButtonTapped), for: .touchUpInside)
     downloadButton.sizeToFit()
     downloadButton.center = CGPoint(x: contentWidth / 2.0, y: dismissButton.frame.maxY + 30.0)
     downloadButton.frame = downloadButton.frame.integral
@@ -212,10 +211,6 @@ class MainViewController: UIViewController, UIAlertViewDelegate, TextViewDelegat
                       self.view.frame = newFrame
       }, completion: nil)
     }
-  }
-
-  @objc func downloadButtonTapped(_ sender: UIButton) {
-    downloadCustomKeyboard()
   }
 
   // MARK: - Responding to Keyman notifications

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -308,7 +308,9 @@ verify_npm_setup () {
     # https://github.com/lerna/lerna/issues/789 - there seems to sometimes be a concurrency issue when
     # bootstrapping on macOS.
     if [ ${os_id} == 'mac' ]; then
-      npm run bootstrap -- --concurrency=1
+      # --concurrency=1 is a modification on the lerna command, not for forwarding through the bootstrap command.
+      # It's a bit tricky.
+      npm run lerna -- bootstrap --concurrency=1 -- --no-optional
     else
       npm run bootstrap
     fi


### PR DESCRIPTION
So, turns out a late tweak on #3071 wasn't implemented quite right, according to our most recent iOS Master build:

```
[01:33:25]
> root@ bootstrap /Users/mcdurdin/buildAgent/work/99b311828f4ee7c/keyman
[01:33:25]
> lerna bootstrap -- --no-optional "--concurrency=1"
[01:33:25]
[01:33:26]
lerna notice cli v3.21.0
[01:33:26]
lerna info ci enabled
[01:33:26]
lerna info Bootstrapping 12 packages
[01:33:26]
lerna info Installing external dependencies
[01:33:26]
lerna info hoist Pruning hoisted dependencies
[01:33:26]
lerna info hoist Finished pruning hoisted dependencies
[01:33:26]
lerna info hoist Finished bootstrapping root
[01:33:29]
lerna ERR! npm install --global-style --no-save --no-optional --concurrency=1 exited 254 in '@keymanapp/input-processor'
[01:33:29]
lerna ERR! npm install --global-style --no-save --no-optional --concurrency=1 stderr:
```

The way I'd passed in the `--concurrency` parameter was misplaced, causing it to be ignored by `lerna` and forwarded to `npm`.  This is fixed with a small tweak.

----

Past that, in #3186 [when removing `downloadCustomKeyboard`](https://github.com/keymanapp/keyman/pull/3186/files#diff-6ae429a133ef0b83c08a4149a6e0ad18) I managed to miss a reference... that somehow didn't cause a build error at the time?  But it's causing them now locally.  As best as I can tell, the affected call isn't actually accessible anywhere within the app, so simply removing the action should be fine.