### PR TITLE
fix(android): Add wrapper for logging errors & exceptions

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/BookmarksActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/BookmarksActivity.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -38,8 +37,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 
-public class BookmarksActivity extends AppCompatActivity {
+import com.tavultesoft.kmea.util.KMLog;
 
+public class BookmarksActivity extends AppCompatActivity {
+  private static final String TAG = "BookmarksActivity";
   private static ListView listView;
   private static ArrayList<HashMap<String, String>> list = null;
   private static String bookmarksFilename = "bookmarks.dat";
@@ -186,7 +187,7 @@ public class BookmarksActivity extends AppCompatActivity {
         list = (ArrayList<HashMap<String, String>>) inputStream.readObject();
         inputStream.close();
       } catch (Exception e) {
-        Log.e("KMAPro", "Failed to read bookmarks list: " + e.getMessage());
+        KMLog.LogException(TAG, "Failed to read bookmarks list: ", e);
         list = null;
       }
     } else {
@@ -206,7 +207,7 @@ public class BookmarksActivity extends AppCompatActivity {
       outputStream.close();
       result = true;
     } catch (Exception e) {
-      Log.e("KMAPro", "Failed to save bookmarks list: " + e.getMessage());
+      KMLog.LogException(TAG, "Failed to save bookmarks list: ", e);
       result = false;
     }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -6,6 +6,7 @@ package com.tavultesoft.kmapro;
 
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.FormFactor;
+import com.tavultesoft.kmea.util.KMLog;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -24,7 +25,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 
 public class InfoActivity extends AppCompatActivity {
-
+  private final static String TAG = "InfoActivity";
   private WebView webView;
   private final String kmHelpBaseUrl = "https://help.keyman.com/products/android";
   private String kmUrl = "";
@@ -61,6 +62,8 @@ public class InfoActivity extends AppCompatActivity {
       pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
       versionStr = pInfo.versionName;
     } catch (NameNotFoundException e) {
+      KMLog.LogException(TAG, "", e);
+
       // Fallback to a "current" version. This does not need to be maintained
       versionStr = "12.0.0.0";
     }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -30,6 +30,7 @@ import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
+import com.tavultesoft.kmea.util.KMLog;
 
 import android.Manifest;
 import android.app.ProgressDialog;
@@ -251,6 +252,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         Intent getUserdataIntent = new Intent("keyman.ACTION_GET_USERDATA");
         startActivityForResult(getUserdataIntent, 0);
       } catch (Exception e) {
+        KMLog.LogException(TAG, "", e);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean(MainActivity.didCheckUserDataKey, true);
         editor.commit();
@@ -301,8 +303,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
             inputStream.close();
           }
         } catch (Exception e) {
+          KMLog.LogException(TAG, "", e);
           didFail = true;
-          Log.e(TAG, e.getMessage());
         }
       }
 
@@ -365,11 +367,13 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
             data = Uri.parse(builder.build().toString());
             downloadKMP(scheme);
           } else {
-            Log.e(TAG, "Unrecognized scheme: " + scheme);
+            String msg = "Unrecognized scheme: " + scheme;
+            KMLog.LogError(TAG, msg);
           }
           break;
         default :
-          Log.e(TAG, "Unrecognized scheme: " + scheme);
+          String msg = "Unrecognized scheme: " + scheme;
+          KMLog.LogError(TAG, msg);
       }
     }
     intent.setData(null);
@@ -632,6 +636,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
             startService(downloadIntent);
           } catch (Exception e) {
+            KMLog.LogException(TAG, "", e);
             if (progressDialog != null && progressDialog.isShowing()) {
               progressDialog.dismiss();
             }
@@ -646,6 +651,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       }
     } catch (UnsupportedOperationException e) {
       String message = "Download failed. Invalid URL.";
+      KMLog.LogException(TAG,  message, e);
       Toast.makeText(getApplicationContext(), message,
         Toast.LENGTH_SHORT).show();
     }
@@ -956,8 +962,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     } catch (Exception e) {
       String message = "Access denied to " + filename +
         ".\nCheck Android Settings --> Apps --> Keyman to grant storage permissions";
+      KMLog.LogException(TAG, "Unable to copy " + filename + " to app cache ", e);
       Toast.makeText(context, message, Toast.LENGTH_LONG).show();
-      Log.e(TAG, "Unable to copy " + filename + " to app cache");
       return;
     }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -28,6 +28,7 @@ import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONObject;
 
@@ -38,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PackageActivity extends AppCompatActivity {
-
+  private final static String TAG = "PackageActivity";
   private Toolbar toolbar;
   private WebView webView;
   private AlertDialog alertDialog;
@@ -78,6 +79,7 @@ public class PackageActivity extends AppCompatActivity {
       tempPackagePath = kmpProcessor.unzipKMP(kmpFile);
 
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       showErrorToast(context, getString(R.string.failed_to_extract));
       return;
     }
@@ -236,7 +238,7 @@ public class PackageActivity extends AppCompatActivity {
         FileUtils.deleteDirectory(tempPackagePath);
       }
     } catch (Exception e) {
-      Log.e("PackageActivity", "cleanup() failed with error " + e);
+      KMLog.LogException(TAG, "cleanup() failed with error ", e);
     } finally {
       finish();
     }
@@ -367,7 +369,7 @@ public class PackageActivity extends AppCompatActivity {
         }
       }
     } catch (Exception e) {
-      Log.e("PackageActivity", "Error " + e);
+      KMLog.LogException(TAG, "", e);
       showErrorDialog(context, pkgId, getString(R.string.no_targets_to_install));
     }
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SplashScreenActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SplashScreenActivity.java
@@ -8,9 +8,12 @@ import android.app.Activity;
 import android.content.Intent;
 import android.widget.TextView;
 
+import com.tavultesoft.kmea.util.KMLog;
+
 import java.util.Calendar;
 
 public class SplashScreenActivity extends Activity {
+  private final static String TAG = "Splash";
 
   // For now, disable this Activity so app is not delayed showing version/copyright text
   private static int SPLASH_TIME_OUT = 0; // msec
@@ -27,6 +30,7 @@ public class SplashScreenActivity extends Activity {
       pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
       ver = String.format("%s: %s", version.getText(), pInfo.versionName);
     } catch (PackageManager.NameNotFoundException e) {
+      KMLog.LogException(TAG, "", e);
       // Could not get version number
     }
     // TODO: Add version and copyright info when Android supports TextViews in the splash screen

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -43,6 +43,8 @@ import android.webkit.WebViewClient;
 import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.tavultesoft.kmea.util.KMLog;
+
 public class WebBrowserActivity extends AppCompatActivity {
   private static final String TAG = "WebBrowserActivity";
   private WebView webView;
@@ -321,6 +323,8 @@ public class WebBrowserActivity extends AppCompatActivity {
           try {
             new URL(urlStr);
           } catch (MalformedURLException e) {
+            KMLog.LogException(TAG, "", e);
+
             if (Patterns.WEB_URL.matcher(String.format("%s%s", "http://", urlStr)).matches()) {
               urlStr = String.format("%s%s", "http://", urlStr);
             } else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/JSONParser.java
@@ -22,8 +22,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.tavultesoft.kmea.util.Connection;
-
-import android.util.Log;
+import com.tavultesoft.kmea.util.KMLog;
 
 public final class JSONParser {
   private final String TAG = "JSONParser";
@@ -49,23 +48,23 @@ public final class JSONParser {
         obj = (T) new JSONArray(jsonStr);
       }
     } catch (UnsupportedEncodingException e) {
-      Log.e(logTag, (e.getMessage() == null) ? "UnsupportedEncodingException" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     } catch (InterruptedIOException e) {
       // Disregard from cancelling action
-      Log.e(logTag, (e.getMessage() == null) ? "InterruptedIOException" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
     } catch (IOException e) {
-      Log.e(logTag, (e.getMessage() == null) ? "IOException" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     } catch (JSONException e) {
-      Log.e(logTag, (e.getMessage() == null) ? "JSONException" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     } catch (Exception e) {
-      Log.e(logTag, (e.getMessage() == null) ? "Exception" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     }
@@ -90,7 +89,7 @@ public final class JSONParser {
       jsonObj = getJSONObjectFromReader(reader, type);
     } catch (FileNotFoundException e) {
       String errorString = (e.getMessage() == null) ? "FileNotFoundException" : e.getMessage();
-      Log.e(TAG, "JSONObjectFromFile error " + errorString);
+      KMLog.LogException(TAG, "JSONObjectFromFile error ", e);
       jsonObj = null;
       System.err.println(e);
     } finally {
@@ -98,7 +97,7 @@ public final class JSONParser {
         try {
           reader.close();
         } catch (IOException e) {
-          Log.e(TAG, "getJSONObjectFromFile error: " + e);
+          KMLog.LogException(TAG, "getJSONObjectFromFile error: ", e);
           // Ignore.
         }
       }
@@ -145,11 +144,11 @@ public final class JSONParser {
         obj = (T) getJSONObjectFromReader(reader, type);
       }
     } catch (UnsupportedEncodingException e) {
-      Log.e(logTag, (e.getMessage() == null) ? "UnsupportedEncodingException" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     } catch (Exception e) {
-      Log.e(logTag, (e.getMessage() == null) ? "Exception" : e.getMessage());
+      KMLog.LogException(logTag, "", e);
       obj = null;
       System.err.println(e);
     } finally {
@@ -159,6 +158,7 @@ public final class JSONParser {
         try {
           reader.close();
         } catch (IOException e) {
+          KMLog.LogException(logTag, "", e);
           // Ignore.
         }
       }
@@ -179,6 +179,7 @@ public final class JSONParser {
     try {
       return getJSONObjectFromString(java.net.URLDecoder.decode(str, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
+      KMLog.LogException(TAG, "", e);
       return null;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -19,6 +19,7 @@ import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -57,6 +58,7 @@ import io.sentry.core.Sentry;
 import io.sentry.core.SentryLevel;
 
 final class KMKeyboard extends WebView {
+  private static final String TAG = "KMKeyboard";
   private final Context context;
   private KeyboardType keyboardType = KeyboardType.KEYBOARD_TYPE_UNDEFINED;
   private String packageID;
@@ -135,10 +137,10 @@ final class KMKeyboard extends WebView {
 
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {
+        String msg = String.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());
         if (KMManager.isDebugMode()) {
-          Log.d("KMEA", "Keyman JS Log: Line " + cm.lineNumber() + ", " + cm.sourceId() + ":" + cm.message());
           if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
-            Log.e("KMEA", "Keyman JS Log: ERROR");
+            Log.d(TAG, msg);
           }
         }
 
@@ -329,6 +331,7 @@ final class KMKeyboard extends WebView {
       if (subKeysWindow != null && subKeysWindow.isShowing())
         subKeysWindow.dismiss();
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
     }
   }
 
@@ -338,6 +341,7 @@ final class KMKeyboard extends WebView {
         suggestionMenuWindow.dismiss();
       }
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
     }
   }
 
@@ -670,6 +674,9 @@ final class KMKeyboard extends WebView {
    */
   private String getFontFilename(String jsonString) {
     String font = "";
+    if (jsonString == null || jsonString.isEmpty()) {
+      return font;
+    }
     try {
       JSONObject fontObj = new JSONObject(jsonString);
       JSONArray sourceArray = fontObj.optJSONArray(KMManager.KMKey_FontSource);
@@ -692,6 +699,7 @@ final class KMKeyboard extends WebView {
         }
       }
     } catch (JSONException e) {
+      KMLog.LogException(TAG, "", e);
       font = "";
     }
 
@@ -1053,6 +1061,7 @@ final class KMKeyboard extends WebView {
         }
       }
     } catch (JSONException e) {
+      KMLog.LogException(TAG, "", e);
       return "''";
     }
 
@@ -1157,6 +1166,7 @@ final class KMKeyboard extends WebView {
           if (keyPreviewWindow != null && keyPreviewWindow.isShowing())
             keyPreviewWindow.dismiss();
         } catch (Exception e) {
+          KMLog.LogException(TAG, "", e);
         }
       }
     }, delay);
@@ -1269,6 +1279,7 @@ final class KMKeyboard extends WebView {
         return false;
       }
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return true;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -71,6 +71,7 @@ import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.CharSequenceUtil;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.MapCompat;
 
 import org.json.JSONArray;
@@ -293,7 +294,8 @@ public final class KMManager {
     } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       initSystemKeyboard(appContext);
     } else {
-      Log.e(TAG, "Cannot initialize: Invalid keyboard type");
+      String msg = "Cannot initialize: Invalid keyboard type";
+      KMLog.LogError(TAG, msg);
     }
 
     JSONUtils.initialize(new File(getPackagesDir()));
@@ -571,7 +573,7 @@ public final class KMManager {
         }
       }
     } catch (Exception e) {
-      Log.e(TAG, "Failed to copy assets. Error: " + e);
+      KMLog.LogException(TAG, "Failed to copy assets. Error: ", e);
     }
   }
 
@@ -603,7 +605,7 @@ public final class KMManager {
         result = 0;
       }
     } catch (Exception e) {
-      Log.e(TAG, "Failed to copy asset. Error: " + e);
+      KMLog.LogException(TAG, "Failed to copy asset. Error: ", e);
       result = -1;
     }
     return result;
@@ -711,7 +713,7 @@ public final class KMManager {
       }
 
     } catch (IOException e) {
-      Log.e(TAG, "Failed to migrate assets. Error: " + e);
+      KMLog.LogException(TAG, "Failed to migrate assets. Error: ", e);
     }
   }
 
@@ -752,7 +754,7 @@ public final class KMManager {
         }
       }
     } catch (Exception e) {
-      Log.e(TAG, "Failed to create Typeface: " + fontFilename);
+      KMLog.LogException(TAG, "Failed to create Typeface: " + fontFilename, e);
     }
     return font;
   }
@@ -784,7 +786,7 @@ public final class KMManager {
       modelObj.put("path", path);
       modelObj.put("CustomHelpLink", lexicalModelInfo.get(KMKey_CustomHelpLink));
     } catch (JSONException e) {
-      Log.e(TAG, "Invalid lexical model to register");
+      KMLog.LogException(TAG, "Invalid lexical model to register", e);
       return false;
     }
 
@@ -1083,7 +1085,8 @@ public final class KMManager {
       return SystemKeyboard;
     } else {
       // What should we do if KeyboardType.KEYBOARD_TYPE_UNDEFINED?
-      Log.e("KMManager", "Invalid keyboard");
+      String msg = "Keyboard type undefined";
+      KMLog.LogError(TAG, msg);
       return null;
     }
   }
@@ -1205,6 +1208,7 @@ public final class KMManager {
 
         return PackageProcessor.getKeyboardVersion(kmpObject, keyboardID);
       } catch (Exception e) {
+        KMLog.LogException(TAG, "", e);
         return null;
       }
     }
@@ -1231,6 +1235,7 @@ public final class KMManager {
 
       return LexicalModelPackageProcessor.getPackageVersion(kmpObject);
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return null;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
+import com.tavultesoft.kmea.util.KMLog;
 
 import android.view.ContextThemeWrapper;
 import androidx.appcompat.app.AppCompatActivity;
@@ -16,7 +17,6 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,6 +29,7 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
 public final class KMTextView extends AppCompatEditText {
+  private static final String TAG = "KMTextView";
   private Context context;
   protected KMHardwareKeyboardInterpreter hardwareKeyboardInterpreter;
 
@@ -198,7 +199,7 @@ public final class KMTextView extends AppCompatEditText {
       dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyEventCode));
       dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyEventCode));
     } catch (Exception e) {
-      Log.e("KMEA Error:", e.toString());
+      KMLog.LogException(TAG, "", e);
     } finally {
       _blockEventProcessing = false;
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -20,6 +20,7 @@ import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.data.LexicalModel;
+import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.MapCompat;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -252,7 +253,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
       outputStream.close();
       result = true;
     } catch (Exception e) {
-      Log.e(TAG, "Failed to save " + listName + ". Error: " + e);
+      KMLog.LogException(TAG, "Failed to save " + listName + ". Error: ", e);
       result = false;
     }
 
@@ -312,7 +313,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
       KeyboardController.getInstance().add(keyboardInfo);
       result = KeyboardController.getInstance().save(context);
       if (!result) {
-        Log.e(TAG, "addKeyboard failed to save");
+        KMLog.LogError(TAG, "addKeyboard failed to save");
       }
     }
     notifyKeyboardsUpdate(context);
@@ -471,7 +472,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
         list = (ArrayList<HashMap<String, String>>) inputStream.readObject();
         inputStream.close();
       } catch (Exception e) {
-        Log.e(TAG, "Failed to read " + filename + ". Error: " + e);
+        KMLog.LogException(TAG, "Failed to read " + filename + ". Error: ", e);
         list = null;
       }
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -31,6 +30,7 @@ import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.adapters.NestedAdapter;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import java.util.HashMap;
 
@@ -118,7 +118,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     Bundle bundle = getIntent().getExtras();
     if (bundle == null) {
       // Should never actually happen.
-      Log.e(TAG, "Language data not specified for LanguageSettingsActivity!");
+      KMLog.LogError(TAG, "Language data not specified for LanguageSettingsActivity!");
       finish();
 
       if(KMManager.isDebugMode()) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -3,7 +3,6 @@ package com.tavultesoft.kmea.cloud;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.tavultesoft.kmea.JSONParser;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -14,6 +13,7 @@ import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -97,7 +97,7 @@ public class CloudDataJsonUtil {
         }
       }
     } catch (JSONException | NullPointerException e) {
-      Log.e(TAG, "JSONParse Error: " + e);
+      KMLog.LogException(TAG, "JSONParse Error: ", e);
       return new ArrayList<Keyboard>();  // Is this ideal?
     }
 
@@ -115,7 +115,7 @@ public class CloudDataJsonUtil {
         modelList.add(new LexicalModel(modelJSON, true));
       }
     } catch (JSONException | NullPointerException e) {
-      Log.e(TAG, "JSONParse Error: " + e);
+      KMLog.LogException(TAG, "JSONParse Error: ", e);
       return new ArrayList<LexicalModel>();  // Is this ideal?
     }
 
@@ -162,7 +162,7 @@ public class CloudDataJsonUtil {
           }
         }
       } catch (JSONException | NullPointerException e) {
-        Log.e(TAG, "processPackageUpdateJSON Error process keyboards: " + e);
+        KMLog.LogException(TAG, "processPackageUpdateJSON Error process keyboards: ", e);
       }
     }
 
@@ -178,7 +178,7 @@ public class CloudDataJsonUtil {
         JSONArray modelPackages = pkgData.getJSONArray(CDKey_Models);
         // TODO: continue to process this (similar to processKeyboardPackageUpdateJSON) for lexical model updates
       } catch (JSONException | NullPointerException e) {
-        Log.e(TAG, "processPackageUpdateJSON Error processing models: " + e);
+        KMLog.LogException(TAG, "processPackageUpdateJSON Error processing models: ", e);
       }
     }
   }
@@ -193,7 +193,7 @@ public class CloudDataJsonUtil {
         objInput.close();
       }
     } catch (Exception e) {
-      Log.e(TAG, "getCachedJSONArray failed to read from cache file. Error: " + e);
+      KMLog.LogException(TAG, "getCachedJSONArray failed to read from cache file. Error: ", e);
       lmData = null;
     }
 
@@ -215,7 +215,7 @@ public class CloudDataJsonUtil {
         objInput.close();
       }
     } catch (Exception e) {
-      Log.e(TAG, "getCachedJSONObject failed to read from cache file. Error: " + e);
+      KMLog.LogException(TAG, "getCachedJSONObject failed to read from cache file. Error: ", e);
       kbData = null;
     }
 
@@ -236,7 +236,7 @@ public class CloudDataJsonUtil {
       objOutput.writeObject(json.toString());
       objOutput.close();
     } catch (Exception e) {
-      Log.e(TAG, "Failed to save to cache file. Error: " + e);
+      KMLog.LogException(TAG, "Failed to save to cache file. Error: ", e);
     }
   }
 
@@ -276,7 +276,7 @@ public class CloudDataJsonUtil {
             dataObject = jsonParser.getJSONObjectFromFile(aDownload.getDestinationFile(),JSONObject.class);
           }
         } catch (Exception e) {
-          Log.d(TAG, e.getMessage(),e);
+          KMLog.LogException(TAG, "", e);
         } finally {
           aDownload.getDestinationFile().delete();
         }
@@ -324,7 +324,7 @@ public class CloudDataJsonUtil {
         }
       }
     } catch (JSONException e) {
-      Log.e(TAG, "findTTF exception" + e);
+      KMLog.LogException(TAG, "findTTF exception", e);
     }
   }
 
@@ -339,7 +339,7 @@ public class CloudDataJsonUtil {
       }
       return false;
     } catch (JSONException e) {
-      Log.e(TAG, "hasTTFFont exception" + e);
+      KMLog.LogException(TAG, "hasTTFFont exception", e);
       return false;
     }
   }
@@ -379,6 +379,7 @@ public class CloudDataJsonUtil {
             urls.add(baseUri + fontFilename);
           }
         } catch (JSONException e) {
+          KMLog.LogException(TAG, "", e);
           return null;
         }
       }
@@ -393,6 +394,7 @@ public class CloudDataJsonUtil {
           urls.add(baseUri + fontFilename);
         }
       } catch (JSONException e) {
+        KMLog.LogException(TAG, "", e);
         return null;
       }
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDownloadMgr.java
@@ -8,6 +8,8 @@ import android.content.IntentFilter;
 import android.net.Uri;
 import android.util.Log;
 
+import com.tavultesoft.kmea.util.KMLog;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +62,7 @@ public class CloudDownloadMgr{
       aContext.registerReceiver(completeListener, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
     } catch (IllegalStateException e) {
       String message = "initialize error: ";
-      Log.e(TAG, message + e);
+      KMLog.LogException(TAG, message, e);
     }
     isInitialized = true;
   }
@@ -77,7 +79,7 @@ public class CloudDownloadMgr{
       aContext.unregisterReceiver(completeListener);
     } catch (IllegalStateException e) {
       String message = "shutdown error: ";
-      Log.e(TAG, message + e);
+      KMLog.LogException(TAG, message, e);
     }
     isInitialized = false;
   }
@@ -138,7 +140,7 @@ public class CloudDownloadMgr{
 
       CloudApiTypes.CloudDownloadSet _parentSet = getDownloadSetForInternalDownloadId(anInternalDownloadId);
       if(_parentSet==null) {
-        Log.e(TAG, "Download with ID " + anInternalDownloadId + " is not available");
+        KMLog.LogError(TAG, "Download with ID " + anInternalDownloadId + " is not available");
         return;
       }
       _parentSet.setDone(anInternalDownloadId);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardDataDownloadCallback.java
@@ -10,6 +10,7 @@ import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.cloud.CloudApiTypes;
 import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import java.io.File;
 import java.io.IOException;
@@ -83,9 +84,8 @@ public class CloudKeyboardDataDownloadCallback implements ICloudDownloadCallback
             FileUtils.copy(_d.getDestinationFile(), _data_file);
 
         }
-        catch (IOException _e)
-        {
-          Log.e(TAG,_e.getLocalizedMessage(),_e);
+        catch (IOException e) {
+          KMLog.LogException(TAG, "", e);
         }
       }
       else

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardMetaDataDownloadCallback.java
@@ -2,7 +2,6 @@ package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -15,6 +14,7 @@ import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -174,7 +174,7 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
               _r.additionalDownloads= urls;
             }
           } catch (JSONException e) {
-            Log.e(TAG, "Error parsing lexical model from api.keyman.com. " + e);
+            KMLog.LogException(TAG, "Error parsing lexical model from api.keyman.com. ", e);
           }
         }
       }
@@ -277,9 +277,8 @@ public class CloudKeyboardMetaDataDownloadCallback implements ICloudDownloadCall
           _pkgID, _lang_id, _langName, _key_id, _kbName, _kbVersion, _font, _oskFont, _customHelpLink);
       theKbData.additionalDownloads = urls;
     }
-    catch(JSONException _e)
-    {
-      Log.e(TAG,_e.getLocalizedMessage(),_e);
+    catch(JSONException e) {
+      KMLog.LogException(TAG, "", e);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
@@ -1,7 +1,6 @@
 package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -12,6 +11,7 @@ import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
 import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONException;
 
@@ -73,9 +73,8 @@ public class CloudKeyboardPackageDownloadCallback implements ICloudDownloadCallb
             }
           }
         }
-        catch (IOException | JSONException _e)
-        {
-          Log.e(TAG,_e.getLocalizedMessage(),_e);
+        catch (IOException | JSONException e) {
+          KMLog.LogException(TAG, "", e);
         }
       }
       else

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
@@ -1,7 +1,6 @@
 package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -12,6 +11,7 @@ import com.tavultesoft.kmea.cloud.ICloudDownloadCallback;
 import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONException;
 
@@ -68,9 +68,8 @@ public class CloudLexicalPackageDownloadCallback implements ICloudDownloadCallba
             }
           }
         }
-        catch (IOException | JSONException _e)
-        {
-          Log.e(TAG,_e.getLocalizedMessage(),_e);
+        catch (IOException | JSONException e) {
+          KMLog.LogException(TAG, "", e);
         }
       }
       else

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -2,7 +2,6 @@ package com.tavultesoft.kmea.data;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -18,6 +17,7 @@ import com.tavultesoft.kmea.cloud.impl.CloudCatalogDownloadReturns;
 import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
 import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.packages.JSONUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -268,7 +268,7 @@ public class CloudRepository {
         memCachedDataset.lexicalModels.addAll(CloudDataJsonUtil.processLexicalModelJSON(kmpLexicalModelsArray));
       }
     } catch (Exception e) {
-      Log.e(TAG, "preCacheDataSet error " + e);
+      KMLog.LogException(TAG, "preCacheDataSet error ", e);
     }
     CloudCatalogDownloadCallback _download_callback = new CloudCatalogDownloadCallback(
       context, updateHandler, onSuccess, onFailure);
@@ -387,7 +387,7 @@ public class CloudRepository {
       JSONObject json = new JSONObject().put(KMKeyboardDownloaderActivity.KMKey_Languages, languagesArray);
       return new JSONObject().put(KMKeyboardDownloaderActivity.KMKey_Languages, json);
     } catch (JSONException e) {
-      Log.e(TAG, "Failed to properly handle KMP JSON.  Error: " + e);
+      KMLog.LogException(TAG, "Failed to properly handle KMP JSON.  Error: ", e);
       return null;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -4,12 +4,12 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
-import android.util.Log;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -66,7 +66,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.helpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink,
         String.format(HELP_URL_FORMATSTR, this.resourceID, this.version));
     } catch (JSONException e) {
-      Log.e(TAG, "Keyboard exception parsing JSON: " + e);
+      KMLog.LogException(TAG, "Keyboard exception parsing JSON: ", e);
     }
   }
 
@@ -127,7 +127,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
     } catch (JSONException e) {
-      Log.e(TAG, "fromJSON exception: " + e);
+      KMLog.LogException(TAG, "fromJSON exception: ", e);
     }
   }
 
@@ -139,7 +139,7 @@ public class Keyboard extends LanguageResource implements Serializable {
         o.put(KB_FONT_KEY, this.font);
         o.put(KB_OSK_FONT_KEY, this.oskFont);
       } catch (JSONException e) {
-        Log.e(TAG, "toJSON exception: " + e);
+        KMLog.LogException(TAG, "toJSON exception: ", e);
       }
     }
     return o;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -13,6 +13,7 @@ import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.MapCompat;
 import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -84,7 +85,7 @@ public class KeyboardController {
           }
 
         } catch (Exception e) {
-          Log.e(TAG, "Exception migrating installed_keyboards.dat");
+          KMLog.LogException(TAG, "Exception migrating installed_keyboards.dat", e);
           list.add(Keyboard.DEFAULT_KEYBOARD);
         }
       } else if (keyboards_json.exists()) {
@@ -103,7 +104,7 @@ public class KeyboardController {
             }
           }
         } catch (Exception e) {
-          Log.e(TAG, "Exception reading installed_keyboards.json");
+          KMLog.LogException(TAG, "Exception reading installed_keyboards.json", e);
           list.add(Keyboard.DEFAULT_KEYBOARD);
         }
       } else {
@@ -129,7 +130,7 @@ public class KeyboardController {
    */
   public List<Keyboard> get() {
     if (!isInitialized) {
-      Log.e(TAG, "get while KeyboardController() not initialized");
+      KMLog.LogError(TAG, "get while KeyboardController() not initialized");
       return null;
     }
     synchronized (list) {
@@ -144,10 +145,10 @@ public class KeyboardController {
    */
   public Keyboard getKeyboardInfo(int index) {
     if (!isInitialized) {
-      Log.e(TAG, "getKeyboardInfo while KeyboardController() not initialized");
+      KMLog.LogError(TAG, "getKeyboardInfo while KeyboardController() not initialized");
       return null;
     } else if (index < 0) {
-      Log.e(TAG, "getKeyboardInfo with invalid index: " + index);
+      KMLog.LogError(TAG, "getKeyboardInfo with invalid index: " + index);
       return null;
     }
 
@@ -158,7 +159,7 @@ public class KeyboardController {
       }
     }
 
-    Log.e(TAG, "getKeyboardInfo failed with index " + index);
+    KMLog.LogError(TAG, "getKeyboardInfo failed with index " + index);
     return null;
   }
 
@@ -171,7 +172,7 @@ public class KeyboardController {
   public int getKeyboardIndex(String key) {
     int index = INDEX_NOT_FOUND;
     if (!isInitialized || list == null) {
-      Log.e(TAG, "getIndexOfKey while KeyboardController() not initialized");
+      KMLog.LogError(TAG, "getIndexOfKey while KeyboardController() not initialized");
       return index;
     }
     if (key == null || key.isEmpty()) {
@@ -187,7 +188,7 @@ public class KeyboardController {
       }
     }
 
-    Log.e(TAG, "getKeyboardIndex failed for key " + key);
+    KMLog.LogError(TAG, "getKeyboardIndex failed for key " + key);
     return index;
   }
 
@@ -219,7 +220,7 @@ public class KeyboardController {
    */
   public void add(Keyboard newKeyboard) {
     if (!isInitialized || list == null) {
-      Log.e(TAG, "add while KeyboardController() not initialized");
+      KMLog.LogError(TAG, "add while KeyboardController() not initialized");
       return;
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -4,9 +4,9 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
-import android.util.Log;
 
 import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -70,7 +70,7 @@ public abstract class LanguageResource implements Serializable {
     String id = getResourceID();
     String lgCode = getLanguageID();
     if (id == null || lgCode == null) {
-      Log.e("LanguageResource", "Invalid hashCode");
+      KMLog.LogError("LanguageResource", "Invalid hashCode");
     }
     return id.hashCode() * lgCode.hashCode();
   }
@@ -125,7 +125,7 @@ public abstract class LanguageResource implements Serializable {
         this.kmp = "";
       }
     } catch (JSONException e) {
-      Log.e(TAG, "fromJSON() exception: " + e);
+      KMLog.LogException(TAG, "fromJSON() exception: ", e);
     }
   }
 
@@ -141,7 +141,7 @@ public abstract class LanguageResource implements Serializable {
       o.put(LR_HELP_LINK_KEY, this.helpLink);
       o.put(LR_KMP_KEY, this.kmp);
     } catch (JSONException e) {
-      Log.e(TAG, "toJSON() exception: " + e);
+      KMLog.LogException(TAG, "toJSON() exception: ", e);
     }
 
     return o;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -4,17 +4,19 @@
 package com.tavultesoft.kmea.data;
 
 import android.os.Bundle;
-import android.util.Log;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Serializable;
+
+import io.sentry.core.Sentry;
 
 public class LexicalModel extends LanguageResource implements Serializable {
   private static final String TAG = "lexicalModel";
@@ -45,7 +47,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
         this.packageID = filename.replace(FileUtils.MODELPACKAGE, "");
       } else {
         // Invalid Package ID
-        Log.e(TAG, "Invalid package ID");
+        KMLog.LogError(TAG, "Invalid package ID");
       }
 
       this.resourceID = lexicalModelJSON.getString(KMManager.KMKey_ID);
@@ -70,7 +72,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
 
       this.helpLink = ""; // TOODO: Handle help links
     } catch (JSONException e) {
-      Log.e(TAG, "Lexical model exception parsing JSON: " + e);
+      KMLog.LogException(TAG, "Lexical model exception parsing JSON: ", e);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -18,8 +18,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.sentry.core.Sentry;
-
 public class LexicalModel extends LanguageResource implements Serializable {
   private static final String TAG = "lexicalModel";
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/adapters/NestedAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/adapters/NestedAdapter.java
@@ -7,6 +7,8 @@ import android.widget.ArrayAdapter;
 
 import androidx.annotation.NonNull;
 
+import com.tavultesoft.kmea.util.KMLog;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -178,7 +180,7 @@ public class NestedAdapter<Element, A extends ArrayAdapter<Element> & ListBacked
     try {
       super.addAll(collection);
     } catch (UnsupportedOperationException e) {
-      Log.e(TAG, "_internalAddAll exception " + e);
+      KMLog.LogException(TAG, "_internalAddAll exception ", e);
     }
   }
 
@@ -186,7 +188,7 @@ public class NestedAdapter<Element, A extends ArrayAdapter<Element> & ListBacked
     try {
       super.clear();
     } catch (UnsupportedOperationException e) {
-      Log.e(TAG, "_internalClear exception " + e);
+      KMLog.LogException(TAG, "_internalClear exception ", e);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -12,7 +12,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
@@ -27,6 +26,7 @@ import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.data.CloudRepository;
+import com.tavultesoft.kmea.util.KMLog;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
 
 public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownloadEventListener, CloudRepository.UpdateHandler{
   private static final String TAG = "ResourceUpdateTool";
@@ -325,7 +324,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           }
         }
       } catch (JSONException e) {
-        Log.e(TAG, "JSON Exception parsing ignoreNotifications preference");
+        KMLog.LogException(TAG, "JSON Exception parsing ignoreNotifications preference", e);
       }
     }
 
@@ -366,7 +365,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       editor.putString(PREF_KEY_IGNORE_NOTIFICATIONS, ignoredNotificationsObj.toString());
       editor.commit();
     } catch (JSONException e) {
-      Log.e(TAG, "JSON Exception updating ignoreNotifications preference");
+      KMLog.LogException(TAG, "JSON Exception updating ignoreNotifications preference", e);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/JSONUtils.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.JSONParser;
+import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -112,7 +113,7 @@ public class JSONUtils {
               }
             }
           } catch (JSONException e) {
-            Log.e(TAG, "getLanguages() Error parsing " + file.getName());
+            KMLog.LogException(TAG, "getLanguages() Error parsing " + file.getName(), e);
           }
         }
       }
@@ -143,7 +144,7 @@ public class JSONUtils {
         }
       }
     } catch (JSONException e) {
-      Log.e(TAG, "find ID() error: " + e);
+      KMLog.LogException(TAG, "find ID() error: ", e);
     }
     return ret;
   }
@@ -166,7 +167,7 @@ public class JSONUtils {
         }
       }
     } catch (JSONException e) {
-      Log.e(TAG, "findHelp() error: " + e);
+      KMLog.LogException(TAG, "findHelp() error: ", e);
     }
     return false;
   }
@@ -191,7 +192,7 @@ public class JSONUtils {
       options.put("fontBaseUri", "https://s.keyman.com/font/deploy/");
       options.put("keyboardVersion", "current");
     } catch (JSONException e) {
-      Log.e(TAG, "defaultOptions() error: " + e);
+      KMLog.LogException(TAG, "defaultOptions() error: ", e);
     }
     return options;
   }
@@ -273,7 +274,7 @@ public class JSONUtils {
               }
             }
           } catch (JSONException e) {
-            Log.e(TAG, "getLexicalModels() Error parsing " + file.getName());
+            KMLog.LogException(TAG, "getLexicalModels() Error parsing " + file.getName(), e);
           }
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -1,11 +1,11 @@
 package com.tavultesoft.kmea.packages;
 
 import androidx.annotation.NonNull;
-import android.util.Log;
 
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.JSONParser;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.ZipUtils;
 
 import java.io.File;
@@ -128,7 +128,7 @@ public class PackageProcessor {
       JSONParser parser = new JSONParser();
       return parser.getJSONObjectFromFile(infoFile);
     } else {
-      Log.e(TAG, "kmp.json does not exist");
+      KMLog.LogError(TAG, "kmp.json does not exist");
       return null;
     }
   }
@@ -211,6 +211,7 @@ public class PackageProcessor {
     try {
       return json.getJSONObject("info").getJSONObject("name").getString("description");
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return "";
     }
   }
@@ -225,6 +226,7 @@ public class PackageProcessor {
     try {
       return json.getJSONObject("info").getJSONObject("version").getString("description");
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return PP_DEFAULT_VERSION;
     }
   }
@@ -245,6 +247,7 @@ public class PackageProcessor {
         return PP_TARGET_INVALID;
       }
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return PP_TARGET_INVALID;
     }
   }
@@ -262,6 +265,7 @@ public class PackageProcessor {
       FileUtils.deleteDirectory(tempPath);
       return target;
     } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
       return PP_TARGET_INVALID;
     }
   }
@@ -460,7 +464,7 @@ public class PackageProcessor {
         }
       }
     }  else {
-      Log.e(TAG, path.getName() + " must contain \"" + key + "\"");
+      KMLog.LogError(TAG, path.getName() + " must contain \"" + key + "\"");
     }
     return specs;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/CharSequenceUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/CharSequenceUtil.java
@@ -1,7 +1,5 @@
 package com.tavultesoft.kmea.util;
 
-import android.util.Log;
-
 import java.lang.CharSequence;
 
 public final class CharSequenceUtil {
@@ -31,7 +29,7 @@ public final class CharSequenceUtil {
       } while ((lastIndex - counter >= 0) && (counter < dn) && (numPairs < dn));
       return numPairs;
     } catch (Exception e) {
-      Log.e(TAG, "Error in countSurrogatePairs: " + e);
+      KMLog.LogException(TAG, "Error in countSurrogatePairs: ", e);
       return numPairs;
     }
   }
@@ -60,7 +58,7 @@ public final class CharSequenceUtil {
       }
       return charsToRestore;
     } catch (Exception e) {
-      Log.e(TAG, "Error in restoreChars: " + e);
+      KMLog.LogException(TAG, "Error in restoreChars: ", e);
       return charsToRestore;
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
@@ -1,7 +1,5 @@
 package com.tavultesoft.kmea.util;
 
-import android.util.Log;
-
 import java.io.InputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/Connection.java
@@ -8,6 +8,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 public final class Connection {
+  private static final String TAG = "Connection";
   private static final int MAX_REDIRECTS = 5;
   private static final int TIMEOUT = 20 * 1000; // seconds
 
@@ -30,7 +31,7 @@ public final class Connection {
         return urlConnection.getInputStream();
       }
     } catch (IOException e) {
-      Log.e("Connection", "getInputStream failed: " + e);
+      KMLog.LogException(TAG, "getInputStream failed: ", e);
     }
     return urlConnection.getErrorStream();
   };
@@ -101,7 +102,7 @@ public final class Connection {
         }
       }
     } catch (Exception e) {
-      Log.e("Connection", "Initialization failed:" + e);
+      KMLog.LogException(TAG, "Initialization failed:", e);
     }
 
     return ret;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
@@ -6,7 +6,7 @@ import android.os.Bundle;
 import android.os.ResultReceiver;
 
 public class DownloadIntentService extends IntentService {
-
+  private static final String TAG = "DownloadIntentSvc";
 
   public DownloadIntentService() {
     super(DownloadIntentService.class.getName());
@@ -33,6 +33,7 @@ public class DownloadIntentService extends IntentService {
       }
     } catch (Exception e) {
       receiver.send(FileUtils.DOWNLOAD_ERROR, Bundle.EMPTY);
+      KMLog.LogException(TAG, "", e);
     }
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -2,7 +2,6 @@ package com.tavultesoft.kmea.util;
 
 import android.content.Context;
 import android.os.Build;
-import android.util.Log;
 
 import com.tavultesoft.kmea.KMManager;
 
@@ -116,8 +115,8 @@ public final class FileUtils {
         ret = DOWNLOAD_SUCCESS;
       }
     } catch (Exception e) {
+      KMLog.LogException(TAG, "Download failed! Error: ", e);
       ret = -1;
-      Log.e("FileUtils", "Download failed! Error: " + e);
     } finally {
       if (ret > 0) {
         if (tmpFile.exists() && tmpFile.length() > 0) {
@@ -137,7 +136,7 @@ public final class FileUtils {
         if (tmpFile != null && tmpFile.exists()) {
           tmpFile.delete();
         }
-        Log.e("FileUtils", "Could not download filename " + filename);
+        KMLog.LogError(TAG, "Could not download filename " + filename);
       }
 
       Connection.disconnect();
@@ -238,12 +237,12 @@ public final class FileUtils {
         outputStream.write(((JSONArray) obj).toString(INDENT));
         result = true;
       } else {
-        Log.e(TAG, "saveList failed. arr not JSONObject or JSONArray");
+        KMLog.LogError(TAG, "saveList failed. arr not JSONObject or JSONArray");
       }
       outputStream.flush();
       outputStream.close();
     } catch (Exception e) {
-      Log.e(TAG, "saveList failed to save " + filepath.getName() + ". Error: " + e);
+      KMLog.LogException(TAG, "saveList failed to save " + filepath.getName() + ". Error: ", e);
       result = false;
     }
 
@@ -432,7 +431,7 @@ public final class FileUtils {
       int i = Integer.parseInt(s);
       retVal = new Integer(i);
     } catch (Exception e) {
-      Log.e("FileUtils", "parseInteger Error: " + e);
+      KMLog.LogException(TAG, "parseInteger Error: ", e);
       retVal = null;
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
@@ -5,7 +5,6 @@ import android.content.ClipDescription;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.core.content.FileProvider;
@@ -16,7 +15,6 @@ import com.tavultesoft.kmea.util.FileUtils;
 
 import java.io.File;
 import java.io.FileFilter;
-
 
 public final class HelpFile {
   private static final String TAG = "HelpFile";
@@ -78,7 +76,7 @@ public final class HelpFile {
       } catch (NullPointerException e) {
         String message = "FileProvider undefined in app to load" + customHelp.toString();
         Toast.makeText(context, message, Toast.LENGTH_LONG).show();
-        Log.e(TAG, message);
+        KMLog.LogException(TAG, message, e);
       }
     } else {
       i.setData(Uri.parse(helpFile));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmea.util;
+
+import android.util.Log;
+import io.sentry.core.Sentry;
+import io.sentry.core.SentryLevel;
+
+public final class KMLog {
+
+  /**
+   * Utility to log error and send to Sentry
+   * @param tag String of the caller
+   * @param msg String of the error message
+   */
+  public static void LogError(String tag, String msg) {
+    if (msg != null && !msg.isEmpty()) {
+      Log.e(tag, msg);
+
+      if (Sentry.isEnabled()) {
+        Sentry.captureMessage(msg, SentryLevel.ERROR);
+      }
+    }
+  }
+
+  /**
+   * Utility to log exceptions and send to Sentry
+   * @param tag String of the caller
+   * @param msg String of the exception message
+   * @param e Throwable exception
+   */
+  public static void LogException(String tag, String msg, Throwable e) {
+    if (msg != null && !msg.isEmpty()) {
+      Log.e(tag, msg + e);
+    } else if (e != null) {
+      Log.e(tag, e.getMessage(), e);
+    }
+
+    if (Sentry.isEnabled()) {
+      Sentry.captureException(e);
+    }
+  }
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -33,12 +33,15 @@ public final class KMLog {
    */
   public static void LogException(String tag, String msg, Throwable e) {
     if (msg != null && !msg.isEmpty()) {
-      Log.e(tag, msg + e);
+      Log.e(tag, msg + "\n" + e);
     } else if (e != null) {
       Log.e(tag, e.getMessage(), e);
     }
 
     if (Sentry.isEnabled()) {
+      if (msg != null && !msg.isEmpty()) {
+        Sentry.addBreadcrumb(msg);
+      }
       Sentry.captureException(e);
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/QRCodeUtil.java
@@ -29,6 +29,7 @@ public final class QRCodeUtil {
       Class.forName("net.glxn.qrgen.android.QRCode");
       return true;
     } catch (ClassNotFoundException e) {
+      // Intentionally not sending to Sentry because 3rd party apps may not include this library
       return false;
     }
   }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -26,7 +26,7 @@ public class FileUtilsTest {
     Assert.assertEquals(4, logs.size());
 
     Assert.assertEquals("Connection", logs.get(2).tag);
-    Assert.assertEquals("Initialization failed:java.net.MalformedURLException: no protocol: invalidURL", logs.get(2).msg);
+    Assert.assertEquals("Initialization failed:\njava.net.MalformedURLException: no protocol: invalidURL", logs.get(2).msg);
 
     Assert.assertEquals("FileUtils", logs.get(3).tag);
     Assert.assertEquals("Could not download filename ", logs.get(3).msg);


### PR DESCRIPTION
Fixes #3111
This PR adds a wrapper `KMLog()` so `Log.e()` events also get sent to Sentry