### PR TITLE
feat(android): Add system globe action to show system keyboards

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -103,6 +103,7 @@ public final class KMManager {
     GLOBE_KEY_ACTION_SHOW_MENU,
     GLOBE_KEY_ACTION_SWITCH_TO_NEXT_KEYBOARD,         // Switch to next Keyman keyboard
     GLOBE_KEY_ACTION_ADVANCE_TO_NEXT_SYSTEM_KEYBOARD, // Advance to next system keyboard
+    GLOBE_KEY_ACTION_SHOW_SYSTEM_KEYBOARDS,
     GLOBE_KEY_ACTION_DO_NOTHING,
   }
 
@@ -1512,7 +1513,8 @@ public final class KMManager {
   }
 
   public static void setGlobeKeyAction(KeyboardType kbType, GlobeKeyAction action) {
-    if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+    if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP &&
+        action != GlobeKeyAction.GLOBE_KEY_ACTION_ADVANCE_TO_NEXT_SYSTEM_KEYBOARD) {
       inappKbGlobeKeyAction = action;
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       sysKbGlobeKeyAction = action;
@@ -1849,6 +1851,10 @@ public final class KMManager {
                 break;
               case GLOBE_KEY_ACTION_ADVANCE_TO_NEXT_SYSTEM_KEYBOARD:
                 advanceToNextInputMode();
+                break;
+              case GLOBE_KEY_ACTION_SHOW_SYSTEM_KEYBOARDS:
+                InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.showInputMethodPicker();
                 break;
               default:
                 // Do nothing


### PR DESCRIPTION
Fixes #3102

This adds a user-requested system globe action `GLOBE_KEY_ACTION_SHOW_SYSTEM_KEYBOARDS` that brings up the Android input method picker.

This action can only be set for `KEYBOARD_TYPE_SYSTEM`. 

Tested by modifying SystemKeyboard.onCreate() to
```java
    KMManager.setGlobeKeyAction(KeyboardType.KEYBOARD_TYPE_SYSTEM,
        KMManager.GlobeKeyAction.GLOBE_KEY_ACTION_SHOW_SYSTEM_KEYBOARDS);
```

(not included on this PR).

A screenshot of hitting the system globe button

![Screenshot_1591066121](https://user-images.githubusercontent.com/7358010/83474817-1cf4d800-a4b7-11ea-92d2-8c0109af8139.png)

I've added this to the 14.0 migration wiki, and documented the help.keyman.com change below