### PR TITLE
fix(developer/compilers): normalise touch layout on compile

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -1704,11 +1704,9 @@ begin
         end;
       end;
 
-      if not FDebug then   // I4139
-      begin
-        // This strips out formatting for a big saving in file size
-        sLayoutFile := Save(False);
-      end;
+      // If not debugging, then this strips out formatting for a big saving in file size
+      // This also normalises any values such as Pad or Width which should be strings
+      sLayoutFile := Write(FDebug);
     finally
       Free;
     end;


### PR DESCRIPTION
Works around #119 on the compiler side. This normalises the touch layout file in the compile phase, fixing integers which should be strings, etc. This means that we no longer need to correct the issue in the Engine; a rebuild of affected keyboards is sufficient (although of course we'll need a version bump in order for them to be distributed.

Given this is an isolated fix, I think I will cherry-pick this to 13.0, after testing to make sure that the result doesn't break existing keyboards -- it is low risk though!