### PR TITLE
refactor(ios/engine): Abstraction of KMP installation methods

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		CE867FF12485EE1500B2EAED /* KMPInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE867FF02485EE1500B2EAED /* KMPInfo.swift */; };
 		CE88042F247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */; };
 		CE8B0BBD248734240045EB2E /* KeymanPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8B0BBC248734240045EB2E /* KeymanPackageTests.swift */; };
+		CE8B0BBF248764ED0045EB2E /* KMPResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8B0BBE248764ED0045EB2E /* KMPResource.swift */; };
 		CE8EDEB123F53D1A009E1FF6 /* FileManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A079DD1223194B100581263 /* FileManagementTests.swift */; };
 		CE8EDEB323F53F96009E1FF6 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8EDEB223F53F96009E1FF6 /* VersionTests.swift */; };
 		CE973D812484A56500F66045 /* PackageJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE973D802484A56500F66045 /* PackageJSON.swift */; };
@@ -462,6 +463,7 @@
 		CE867FF02485EE1500B2EAED /* KMPInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPInfo.swift; sourceTree = "<group>"; };
 		CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectationDownloaderDelegate.swift; sourceTree = "<group>"; };
 		CE8B0BBC248734240045EB2E /* KeymanPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanPackageTests.swift; sourceTree = "<group>"; };
+		CE8B0BBE248764ED0045EB2E /* KMPResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPResource.swift; sourceTree = "<group>"; };
 		CE8EDEB223F53F96009E1FF6 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		CE973D802484A56500F66045 /* PackageJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageJSON.swift; sourceTree = "<group>"; };
 		CE973D822484A5DB00F66045 /* PackageJSON.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = PackageJSON.bundle; sourceTree = "<group>"; };
@@ -871,6 +873,7 @@
 				CE973D882484DBA600F66045 /* KMPSystem.swift */,
 				CE973D8A2484DCA300F66045 /* KMPOptions.swift */,
 				CE973D8C2484DD1900F66045 /* KMPFile.swift */,
+				CE8B0BBE248764ED0045EB2E /* KMPResource.swift */,
 			);
 			path = kmp.json;
 			sourceTree = "<group>";
@@ -1429,6 +1432,7 @@
 				C06D37361F81F5C300F61AE0 /* KeyboardMenuView.swift in Sources */,
 				CE67D961228A6F190029F2B5 /* KeyboardCommandStructs.swift in Sources */,
 				9A4609972241B39B00B0BFD1 /* LexicalModelInfoViewController.swift in Sources */,
+				CE8B0BBF248764ED0045EB2E /* KMPResource.swift in Sources */,
 				9AD4F53C229F85AC007992D3 /* LanguageSettingsViewController.swift in Sources */,
 				CE7A26DB23CEEF640005955C /* Colors.swift in Sources */,
 				9A9CB08022416E5400231FB9 /* LexicalModelPickerViewController.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class KeyboardKeymanPackage : KeymanPackage {
-  public var keyboards: [KMPKeyboard]!
+  internal var keyboards: [KMPKeyboard]!
 
   override init(metadata: KMPMetadata, folder: URL) {
     super.init(metadata: metadata, folder: folder)
@@ -32,6 +32,10 @@ public class KeyboardKeymanPackage : KeymanPackage {
       str += keyboard.keyboardId + "<br/>"
     }
     return str
+  }
+
+  override var resources: [KMPResource] {
+    return keyboards
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -55,6 +55,20 @@ public class KeymanPackage {
   var resources: [KMPResource] {
     fatalError("abstract base method went uninplemented by derived class")
   }
+
+  /**
+   * Returns an array of arrays corresponding to the available permutations of resource + language for each resource
+   * specified by the package.
+   *
+   * Example:  nrc.en.mtnt supports three languages.  A package containing only said lexical model would return an array
+   * with 1 entry:  an array with three InstallableLexicalModel entries, one for each supported language of the model, identical
+   * aside from language-specific metadata.
+   */
+  public var installableResourceSets: [[LanguageResource]] {
+    return resources.map { resource in
+      return resource.installableResources
+    }
+  }
   
   static public func parse(_ folder: URL) -> KeymanPackage? {
     do {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -20,7 +20,7 @@ public enum KMPError : String, Error {
 public class KeymanPackage {
   static private let kmpFile = "kmp.json"
   public let sourceFolder: URL
-  public let metadata: KMPMetadata
+  internal let metadata: KMPMetadata
 
   init(metadata: KMPMetadata, folder: URL) {
     sourceFolder = folder
@@ -50,6 +50,10 @@ public class KeymanPackage {
 
   public var version: String? {
     return metadata.version
+  }
+
+  var resources: [KMPResource] {
+    fatalError("abstract base method went uninplemented by derived class")
   }
   
   static public func parse(_ folder: URL) -> KeymanPackage? {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class LexicalModelKeymanPackage : KeymanPackage {
-  public var models : [KMPLexicalModel]!
+  internal var models : [KMPLexicalModel]!
 
   override init(metadata: KMPMetadata, folder: URL) {
     super.init(metadata: metadata, folder: folder)
@@ -35,6 +35,10 @@ public class LexicalModelKeymanPackage : KeymanPackage {
       str += model.lexicalModelId + "<br/>"
     }
     return str
+  }
+
+  override var resources: [KMPResource] {
+    return models
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -618,14 +618,6 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     }
 
     for r in kmp.resources {
-      do {
-        try FileManager.default.createDirectory(at: Storage.active.resourceDir(for: r)!,
-                                                withIntermediateDirectories: true)
-      } catch {
-        log.error("Could not create dir for download: \(error)")
-        throw KMPError.fileSystem
-      }
-
       let installableFiles: [(LanguageResource, [(String, URL)])] = r.installableResources.map { resource in
         // (source file, destination file)
         var set: [(String, URL)] = [(resource.sourceFilename, Storage.active.resourceURL(for: resource)!)]
@@ -633,7 +625,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
           // KMPs only list a single font file for each entry whenever one is included.
           // A pre-existing assumption.
           let fontFile = font.source[0]
-          return (fontFile, Storage.active.fontURL(forResource: r, filename: fontFile)!)
+          return (fontFile, Storage.active.fontURL(forResource: resource, filename: fontFile)!)
         }
 
         set.append(contentsOf: installableFonts)
@@ -646,6 +638,15 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       for set in installableFiles {
         let resource = set.0
         let files = set.1
+
+        do {
+          try FileManager.default.createDirectory(at: Storage.active.resourceDir(for: resource)!,
+                                                  withIntermediateDirectories: true)
+        } catch {
+          log.error("Could not create dir for download: \(error)")
+          throw KMPError.fileSystem
+        }
+
         do {
           for item in files {
             var filePath = folder
@@ -681,14 +682,6 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     }
 
     for r in kmp.resources {
-      do {
-        try FileManager.default.createDirectory(at: Storage.active.resourceDir(for: r)!,
-                                                withIntermediateDirectories: true)
-      } catch {
-        log.error("Could not create dir for download: \(error)")
-        throw KMPError.fileSystem
-      }
-
       let installableFiles: [(LanguageResource, [(String, URL)])] = r.installableResources.map { resource in
         // (source file, destination file)
         let set: [(String, URL)] = [(resource.sourceFilename, Storage.active.resourceURL(for: resource)!)]
@@ -699,8 +692,17 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       }
 
       for set in installableFiles {
-        let lexicalModel = set.0
+        let resource = set.0
         let files = set.1
+
+        do {
+          try FileManager.default.createDirectory(at: Storage.active.resourceDir(for: resource)!,
+                                                  withIntermediateDirectories: true)
+        } catch {
+          log.error("Could not create dir for download: \(error)")
+          throw KMPError.fileSystem
+        }
+
         do {
           for item in files {
             var filePath = folder
@@ -720,7 +722,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
 
         // All pairings are installed for lexical models.
         // Also, all models within the KMP
-        Manager.addLexicalModel(lexicalModel as! InstallableLexicalModel)
+        Manager.addLexicalModel(resource as! InstallableLexicalModel)
       }
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -632,12 +632,12 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       for keyboard in installableKeyboards {
         let storedPath = Storage.active.resourceURL(for: keyboard)!
 
-        var installableFiles: [[Any]] = [[keyboard.sourceFilename, storedPath]]
-        let installableFonts: [[Any]] = keyboard.fonts.map { font in
+        var installableFiles: [(String, URL)] = [(keyboard.sourceFilename, storedPath)]
+        let installableFonts: [(String, URL)] = keyboard.fonts.map { font in
           // KMPs only list a single font file for each entry whenever one is included.
           // A pre-existing assumption.
           let fontFile = font.source[0]
-          return [fontFile, Storage.active.fontURL(forResource: k, filename: fontFile)!]
+          return (fontFile, Storage.active.fontURL(forResource: k, filename: fontFile)!)
         }
 
         installableFiles.append(contentsOf: installableFonts)
@@ -645,15 +645,14 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
         do {
           for item in installableFiles {
             var filePath = folder
-            filePath.appendPathComponent(item[0] as! String)
+            filePath.appendPathComponent(item.0)
 
             // TODO:  The rest of this block may be replaced with ResourceFileManager.copyWithOverwrite
             //        once this method is fully abstracted and its core is placed within said class.
-            if(FileManager.default.fileExists(atPath: (item[1] as! URL).path)) {
-              try FileManager.default.removeItem(at: item[1] as! URL)
+            if(FileManager.default.fileExists(atPath: (item.1).path)) {
+              try FileManager.default.removeItem(at: item.1)
             }
-            try FileManager.default.copyItem(at: filePath,
-                                             to: item[1] as! URL)
+            try FileManager.default.copyItem(at: filePath, to: item.1)
 
           }
         } catch {
@@ -688,19 +687,18 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       for lexicalModel in installableLexicalModels {
         let storedPath = Storage.active.resourceURL(for: lexicalModel)!
 
-        let installableFiles: [[Any]] = [[lexicalModel.sourceFilename, storedPath]]
+        let installableFiles: [(String, URL)] = [(lexicalModel.sourceFilename, storedPath)]
         do {
           for item in installableFiles {
             var filePath = folder
-            filePath.appendPathComponent(item[0] as! String)
+            filePath.appendPathComponent(item.0)
 
             // TODO:  The rest of this block may be replaced with ResourceFileManager.copyWithOverwrite
             //        once this method is fully abstracted and its core is placed within said class.
-            if(FileManager.default.fileExists(atPath: (item[1] as! URL).path)) {
-              try FileManager.default.removeItem(at: item[1] as! URL)
+            if(FileManager.default.fileExists(atPath: (item.1).path)) {
+              try FileManager.default.removeItem(at: item.1)
             }
-            try FileManager.default.copyItem(at: filePath,
-                                             to: item[1] as! URL)
+            try FileManager.default.copyItem(at: filePath, to: item.1)
           }
         } catch {
           log.error("Error saving the lexical model download: \(error)")

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -86,4 +86,22 @@ public struct InstallableKeyboard: Codable, LanguageResource {
     self.oskFont = keyboard.oskFont
     self.isCustom = isCustom
   }
+
+  public var fonts: [Font] {
+    var fonts: [Font] = []
+
+    if let displayFont = self.font {
+      fonts.append(displayFont)
+    }
+
+    if let oskFont = self.oskFont {
+      fonts.append(oskFont)
+    }
+
+    return fonts
+  }
+
+  public var sourceFilename: String {
+    return "\(id).js"
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
@@ -63,5 +63,14 @@ public struct InstallableLexicalModel: Codable, LanguageResource {
     self.version = lexicalModel.version ?? InstallableConstants.defaultVersion
     self.isCustom = isCustom
   }
+
+  // Lexical models don't bundle fonts.  At least, not yet?
+  public var fonts: [Font] {
+    return []
+  }
+
+  public var sourceFilename: String {
+    return "\(id).model.js"
+  }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -19,4 +19,8 @@ public protocol LanguageResource {
 
   // Used for generating QR codes.
   var sharableURL: String? { get }
+
+  // Used during resource installation
+  var fonts: [Font] { get }
+  var sourceFilename: String { get }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -93,10 +93,10 @@ class Storage {
     return lexicalModelDir.appendingPathComponent(lexicalModelID)
   }
 
-  func resourceDir(for resource: KMPResource) -> URL? {
-    if let keyboard = resource as? KMPKeyboard {
+  func resourceDir(for resource: LanguageResource) -> URL? {
+    if let keyboard = resource as? InstallableKeyboard {
       return keyboardDir(forID: keyboard.id)
-    } else if let lexicalModel = resource as? KMPLexicalModel {
+    } else if let lexicalModel = resource as? InstallableLexicalModel {
       return lexicalModelDir(forID: lexicalModel.id)
     } else {
       return nil
@@ -153,8 +153,8 @@ class Storage {
     return keyboardDir(forID: keyboardID).appendingPathComponent(filename)
   }
 
-  func fontURL(forResource resource: KMPResource, filename: String) -> URL? {
-    if let keyboard = resource as? KMPKeyboard {
+  func fontURL(forResource resource: LanguageResource, filename: String) -> URL? {
+    if let keyboard = resource as? InstallableKeyboard {
       return fontURL(forKeyboardID: keyboard.id, filename: filename)
     } else {
       // Lexical models do not yet support fonts.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -92,6 +92,16 @@ class Storage {
   func lexicalModelDir(forID lexicalModelID: String) -> URL {
     return lexicalModelDir.appendingPathComponent(lexicalModelID)
   }
+
+  func resourceDir(for resource: KMPResource) -> URL? {
+    if let keyboard = resource as? KMPKeyboard {
+      return keyboardDir(forID: keyboard.id)
+    } else if let lexicalModel = resource as? KMPLexicalModel {
+      return lexicalModelDir(forID: lexicalModel.id)
+    } else {
+      return nil
+    }
+  }
   
   func keyboardURL(for keyboard: InstallableKeyboard) -> URL {
     return keyboardURL(forID: keyboard.id, version: keyboard.version)
@@ -99,6 +109,17 @@ class Storage {
   
   func lexicalModelURL(for lexicalModel: InstallableLexicalModel) -> URL {
     return lexicalModelURL(forID: lexicalModel.id, version: lexicalModel.version)
+  }
+
+  // Facilitates abstractions based on the LanguageResource protocol.
+  func resourceURL(for resource: LanguageResource) -> URL? {
+    if let keyboard = resource as? InstallableKeyboard {
+      return keyboardURL(for: keyboard)
+    } else if let lexicalModel = resource as? InstallableLexicalModel {
+      return lexicalModelURL(for: lexicalModel)
+    } else {
+      return nil
+    }
   }
   
   func lexicalModelPackageURL(for lexicalModel: InstallableLexicalModel) -> URL {
@@ -130,6 +151,15 @@ class Storage {
 
   func fontURL(forKeyboardID keyboardID: String, filename: String) -> URL {
     return keyboardDir(forID: keyboardID).appendingPathComponent(filename)
+  }
+
+  func fontURL(forResource resource: KMPResource, filename: String) -> URL? {
+    if let keyboard = resource as? KMPKeyboard {
+      return fontURL(forKeyboardID: keyboard.id, filename: filename)
+    } else {
+      // Lexical models do not yet support fonts.
+      return nil
+    }
   }
 
   var keyboardDirs: [URL]? {

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPFile.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPFile.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct KMPFile: Codable {
+struct KMPFile: Codable {
   var name: String
   var description: String
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class KMPKeyboard: Codable, KMPResource {
+class KMPKeyboard: Codable, KMPResource {
   public var name: String
   public var keyboardId: String
   public var version: String
@@ -41,7 +41,7 @@ public class KMPKeyboard: Codable, KMPResource {
     languages = try values.decode([KMPLanguage].self, forKey: .languages)
   }
 
-  public var installableKeyboards: [InstallableKeyboard] {
+  internal var installableKeyboards: [InstallableKeyboard] {
     var installableKeyboards : [InstallableKeyboard] = []
 
     for language in self.languages {
@@ -57,6 +57,10 @@ public class KMPKeyboard: Codable, KMPResource {
       installableKeyboards.append( keyboard )
     }
 
+    return installableKeyboards
+  }
+
+  public var installableResources: [LanguageResource] {
     return installableKeyboards
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class KMPKeyboard: Codable {
+public class KMPKeyboard: Codable, KMPResource {
   public var name: String
   public var keyboardId: String
   public var version: String
@@ -79,5 +79,9 @@ public class KMPKeyboard: Codable {
     // Any file-based checks will be performed by the object's owner,
     // which knows the containing package's root folder.
     return installableKeyboards.count > 0 && self.languages.count > 0
+  }
+
+  public var id: String {
+    return keyboardId
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLanguage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLanguage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct KMPLanguage: Codable {
+struct KMPLanguage: Codable {
   public var name: String
   public var languageId: String
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class KMPLexicalModel: Codable {
+public class KMPLexicalModel: Codable, KMPResource {
   public var name: String
   public var lexicalModelId: String
   public var version: String?
@@ -63,6 +63,10 @@ public class KMPLexicalModel: Codable {
     // which knows the containing package's root folder.
     return installableLexicalModels.count > 0
       && self.languages.count > 0
+  }
+
+  public var id: String {
+    return lexicalModelId
   }
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class KMPLexicalModel: Codable, KMPResource {
+class KMPLexicalModel: Codable, KMPResource {
   public var name: String
   public var lexicalModelId: String
   public var version: String?
@@ -42,7 +42,7 @@ public class KMPLexicalModel: Codable, KMPResource {
     self.version = self.version ?? version
   }
 
-  public var installableLexicalModels: [InstallableLexicalModel] {
+  internal var installableLexicalModels: [InstallableLexicalModel] {
     var installableLexicalModels : [InstallableLexicalModel] = []
 
     for language in self.languages {
@@ -54,6 +54,10 @@ public class KMPLexicalModel: Codable, KMPResource {
       installableLexicalModels.append( model )
     }
 
+    return installableLexicalModels
+  }
+
+  public var installableResources: [LanguageResource] {
     return installableLexicalModels
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPMetadata.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPMetadata.swift
@@ -16,7 +16,7 @@ import Foundation
  *
  * Documentation link: https://help.keyman.com/developer/current-version/reference/file-types/metadata
  */
-public class KMPMetadata: Codable {
+class KMPMetadata: Codable {
   var system: KMPSystem
   var options: KMPOptions
   var info: KMPInfo?

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPOptions.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPOptions.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct KMPOptions: Codable {
+struct KMPOptions: Codable {
   public var readmeFile: String?
   public var graphicFile: String?
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
@@ -11,4 +11,6 @@ import Foundation
 protocol KMPResource {
   // Returns the represented resource's ID.
   var id: String { get }
+
+  var installableResources: [LanguageResource] { get }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
@@ -1,0 +1,14 @@
+//
+//  KMPResource.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 6/3/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+protocol KMPResource {
+  // Returns the represented resource's ID.
+  var id: String { get }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPSystem.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPSystem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct KMPSystem: Codable {
+struct KMPSystem: Codable {
   public var keymanDeveloperVersion: String?
   public var fileVersion: String
 }

--- a/ios/engine/KMEI/KeymanEngineTests/FileManagementTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/FileManagementTests.swift
@@ -39,6 +39,9 @@ class FileManagementTests: XCTestCase {
 
         XCTAssertEqual(keyboards.count, 1, "Unexpected number of keyboards were installed")
         XCTAssertEqual(keyboards[0].id, "khmer_angkor", "Installed keyboard ID mismatch")
+
+        let fontURL = Storage.active.fontURL(forKeyboardID: "khmer_angkor", filename: "Mondulkiri-R.ttf")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fontURL.path))
       }
     }
   }


### PR DESCRIPTION
Continues on from the work in #3205.

I figured I'd put this up for review before I modify the core aspects (`parseKbdKMP`, `parseLMKMP`) even further beyond recognition than I already have.

The goal here:  as seen after a bit of abstraction work, `parseKbdKMP` and `parseLMKMP` are nigh-identical in what they do, with just one point of distinct logic separating them.  I've preserved all the logic exactly, with one exception:
- `FileManager.default.createDirectory` may be called multiple times for the same directory.  Fortunately, our call is idempotent, so it still yields the same result.

The next step is to merge the two implementations into a single method, maintaining the original functions as helpers for legacy purposes.  This will then pave the way toward selective resource installing.  See notes below.