### PR TITLE
feat(android): Add utility to check BCP47 equivalence

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -69,6 +69,7 @@ import com.tavultesoft.kmea.logic.ResourcesUpdateTool;
 import com.tavultesoft.kmea.packages.JSONUtils;
 import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.CharSequenceUtil;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
@@ -879,7 +880,7 @@ public final class KMManager {
       int length = lexicalModelsList.size();
       for (int i = 0; i < length; i++) {
         HashMap<String, String> lmInfo = lexicalModelsList.get(i);
-        if (langId.equalsIgnoreCase(lmInfo.get(KMManager.KMKey_LanguageID))) {
+        if (BCP47.languageEquals(langId, lmInfo.get(KMManager.KMKey_LanguageID))) {
           return lmInfo;
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -4,7 +4,6 @@ package com.tavultesoft.kmea;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -23,6 +22,7 @@ import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.data.adapters.NestedAdapter;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.MapCompat;
 
 import java.io.File;
@@ -168,7 +168,7 @@ public final class ModelPickerActivity extends AppCompatActivity {
             // Register associated lexical model if it matches the active keyboard's language code;
             // it's safe since we're on the same thread.  Needs to be called AFTER deinstalling the old one.
             String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-            if(kbdLgCode.equals(languageID)) {
+            if(BCP47.languageEquals(kbdLgCode, languageID)) {
               KMManager.registerAssociatedLexicalModel(languageID);
             }
           }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -17,6 +17,7 @@ import com.tavultesoft.kmea.cloud.impl.CloudCatalogDownloadReturns;
 import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
 import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.packages.JSONUtils;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.KMLog;
 
 import org.json.JSONArray;
@@ -135,7 +136,7 @@ public class CloudRepository {
     if (memCachedDataset != null) {
       for (int i=0; i < memCachedDataset.lexicalModels.getCount(); i++) {
         LexicalModel lm = memCachedDataset.lexicalModels.getItem(i);
-        if (lm.getLanguageID().equalsIgnoreCase(languageID)) {
+        if (BCP47.languageEquals(lm.getLanguageID(), languageID)) {
           return true;
         }
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
 
@@ -111,7 +112,7 @@ public class Keyboard extends LanguageResource implements Serializable {
 
   public boolean equals(Object obj) {
     if(obj instanceof Keyboard) {
-      boolean lgCodeMatch = ((Keyboard) obj).getLanguageID().equals(this.getLanguageID());
+      boolean lgCodeMatch = BCP47.languageEquals(((Keyboard) obj).getLanguageID(), this.getLanguageID());
       boolean idMatch = ((Keyboard) obj).getKeyboardID().equals(this.getKeyboardID());
 
       return lgCodeMatch && idMatch;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
 
@@ -129,7 +130,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
 
   public boolean equals(Object obj) {
     if(obj instanceof LexicalModel) {
-      boolean lgCodeMatch = ((LexicalModel) obj).getLanguageID().equals(this.getLanguageID());
+      boolean lgCodeMatch = BCP47.languageEquals(((LexicalModel) obj).getLanguageID(), this.getLanguageID());
       boolean idMatch = ((LexicalModel) obj).getLexicalModelID().equals(this.getLexicalModelID());
 
       return lgCodeMatch && idMatch;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/BCP47.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/BCP47.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmea.util;
+
+public final class BCP47 {
+  /**
+   * Utility to compare two language ID strings
+   * @param id1 Language ID 1
+   * @param id2 Language ID 2
+   * @return true if the two strings are case-insensitive equal
+   */
+  public static boolean languageEquals(String id1, String id2) {
+    if (id1 == null || id2 == null) {
+      return false;
+    }
+
+    return id1.equalsIgnoreCase(id2);
+  }
+}

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/BCP47Test.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/BCP47Test.java
@@ -1,0 +1,30 @@
+package com.tavultesoft.kmea.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import com.tavultesoft.kmea.util.BCP47;
+
+@RunWith(RobolectricTestRunner.class)
+public class BCP47Test {
+
+  private final String LANGUAGE_ID_1 = "str-latn";
+  private final String LANGUAGE_ID_2 = "str-Latn";
+  private final String LANGUAGE_ID_3 = "str";
+
+  @Test
+  public void test_languageEquals() {
+    // Test null language ID
+    Assert.assertFalse(BCP47.languageEquals(null, LANGUAGE_ID_2));
+    Assert.assertFalse(BCP47.languageEquals(LANGUAGE_ID_1, null));
+    Assert.assertFalse(BCP47.languageEquals(null, null));
+
+    Assert.assertFalse(BCP47.languageEquals(LANGUAGE_ID_1, LANGUAGE_ID_3));
+    Assert.assertFalse(BCP47.languageEquals(LANGUAGE_ID_2, LANGUAGE_ID_3));
+
+    Assert.assertTrue(BCP47.languageEquals(LANGUAGE_ID_1, LANGUAGE_ID_1));
+    Assert.assertTrue(BCP47.languageEquals(LANGUAGE_ID_1, LANGUAGE_ID_2));
+  }
+}


### PR DESCRIPTION
Fixes #2972
Add a BCP47 utility to check if two language IDs are equivalent.

For now, this simple utility only handles language IDs, and not intended to parse BCP 47 subtags.