### PR TITLE
feat(linux): Make two windows modal dialogs

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -91,10 +91,10 @@ def change_to_keyboard(bus, keyboard_id):
     try:
         contextname = bus.current_input_context()
         ic = IBus.InputContext.get_input_context(contextname, bus.get_connection())
-        if bus_has_engine(bus, name) <= 0:
-            logging.warning("Could not find engine %s"%name)
+        if bus_has_engine(bus, keyboard_id) <= 0:
+            logging.warning("Could not find engine %s" % keyboard_id)
         else:
-            ic.set_engine(name)
+            ic.set_engine(keyboard_id)
     except Exception as e:
         logging.warning("Failed to change keyboard")
         logging.warning(e)

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -254,6 +254,10 @@ class InstallKmpWindow(Gtk.Dialog):
         self.resize(800, 450)
         self.show_all()
 
+    def run(self):
+        if self.checkcontinue:
+            Gtk.Dialog.run(self)
+
     def doc_policy(self, web_view, decision, decision_type):
         logging.info("Checking policy")
         logging.debug("received policy decision request of type: {0}".format(decision_type.value_name))

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -67,6 +67,12 @@ class ViewInstalledWindowBase(Gtk.Window):
         installDlg.run()
         installDlg.destroy()
 
+    def run(self):
+        self.resize(576, 324)
+        self.connect("destroy", Gtk.main_quit)
+        self.show_all()
+        Gtk.main()
+
 class ViewInstalledWindow(ViewInstalledWindowBase):
     def __init__(self):
         ViewInstalledWindowBase.__init__(self)

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -38,9 +38,15 @@ class ViewInstalledWindowBase(Gtk.Window):
 
     def on_download_clicked(self, button):
         logging.debug("Download clicked")
-        w = DownloadKmpWindow(self)
-        w.resize(800, 450)
-        w.show_all()
+        downloadDlg = DownloadKmpWindow(self)
+        response = downloadDlg.run()
+        file = None
+        if response == Gtk.ResponseType.OK:
+            file = downloadDlg.downloadfile
+        downloadDlg.destroy()
+
+        if file != None:
+            self.install_file(file)
 
     def on_installfile_clicked(self, button):
         logging.debug("Install from file clicked")
@@ -53,14 +59,13 @@ class ViewInstalledWindowBase(Gtk.Window):
         dlg.add_filter(filter_text)
         response = dlg.run()
         if response == Gtk.ResponseType.OK:
-            kmpfile = dlg.get_filename()
-            w = InstallKmpWindow(kmpfile, viewkmp=self)
-            w.resize(800, 450)
-            if w.checkcontinue:
-                w.show_all()
-            else:
-                w.destroy()
+            self.install_file(dlg.get_filename())
         dlg.destroy()
+
+    def install_file(self, kmpfile):
+        installDlg = InstallKmpWindow(kmpfile, viewkmp=self)
+        installDlg.run()
+        installDlg.destroy()
 
 class ViewInstalledWindow(ViewInstalledWindowBase):
     def __init__(self):

--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -29,13 +29,9 @@ if __name__ == '__main__':
         if os.path.isfile(args.install):
             from keyman_config.install_window import InstallKmpWindow
             w = InstallKmpWindow(args.install)
-            w.resize(800, 450)
-            w.connect("destroy", Gtk.main_quit)
             if w.checkcontinue:
-                w.show_all()
-                Gtk.main()
-            else:
-                w.destroy()
+                w.run()
+            w.destroy()
         else:
             logging.error("Can't find file " + args.install)
     else:

--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -29,15 +29,12 @@ if __name__ == '__main__':
         if os.path.isfile(args.install):
             from keyman_config.install_window import InstallKmpWindow
             w = InstallKmpWindow(args.install)
-            if w.checkcontinue:
-                w.run()
+            w.run()
             w.destroy()
         else:
             logging.error("Can't find file " + args.install)
     else:
         from keyman_config.view_installed import ViewInstalledWindow
         w = ViewInstalledWindow()
-        w.resize(576, 324)
-        w.connect("destroy", Gtk.main_quit)
-        w.show_all()
-        Gtk.main()
+        w.run()
+        w.destroy()


### PR DESCRIPTION
This change modifies DownloadKmpWindow and InstallKmpWindow so that
they are modal dialogs. This will cause them to show up in front of
the km-config window and will prevent accidentally open multiple
download windows.

This change also fixes an unused method in ibus_util that was using
a variable that got renamed previously.