### PR TITLE
fix(linux): Restart km-config after installing keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -256,7 +256,8 @@ class InstallKmpWindow(Gtk.Dialog):
 
     def run(self):
         if self.checkcontinue:
-            Gtk.Dialog.run(self)
+            return Gtk.Dialog.run(self)
+        return Gtk.ResponseType.CANCEL
 
     def doc_policy(self, web_view, decision, decision_type):
         logging.info("Checking policy")
@@ -284,9 +285,9 @@ class InstallKmpWindow(Gtk.Dialog):
             if os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.debug(uri_path)
-                w = WelcomeView(uri_path, self.kbname)
-                w.resize(800, 600)
-                w.show_all()
+                w = WelcomeView(self, uri_path, self.kbname)
+                w.run()
+                w.destroy()
             else:
                 dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.INFO,
                     Gtk.ButtonsType.OK, "Keyboard " + self.kbname + " installed")

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -24,21 +24,20 @@ from keyman_config.kmpmetadata import parsemetadata
 # there is data in kmp.inf/kmp.json
 # there is possibly data in kbid.json (downloaded from api)
 
-class KeyboardDetailsView(Gtk.Window):
+class KeyboardDetailsView(Gtk.Dialog):
     # TODO Display all the information that is available
     #    especially what is displayed for Keyman on Windows
     # TODO clean up file once have what we want
-    def __init__(self, kmp):
+    def __init__(self, parent, kmp):
         #kmp has name, version, packageID, area
         if "keyboard" in kmp["name"].lower():
             wintitle = kmp["name"]
         else:
             wintitle = kmp["name"] + " keyboard"
-        Gtk.Window.__init__(self, title=wintitle)
+        Gtk.Dialog.__init__(self, wintitle, parent)
         init_accel(self)
 
-        hbox_outer = Gtk.Box(spacing = 12)
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_border_width(6)
 
         packageDir = os.path.join(kmp['areapath'], kmp['packageID'])
         kmp_json = os.path.join(packageDir, "kmp.json")
@@ -289,10 +288,6 @@ class KeyboardDetailsView(Gtk.Window):
                         # label.set_halign(Gtk.Align.START)
                         # label.set_selectable(True)
                         # grid.attach_next_to(label, label9, Gtk.PositionType.RIGHT, 1, 1)
-        vbox.pack_start(box, True, True, 12)
-
-        hbox = Gtk.Box(spacing = 6)
-        vbox.pack_start(hbox, False, False, 12)
 
         # Add an entire row of padding
         lbl_pad = Gtk.Label()
@@ -329,17 +324,8 @@ class KeyboardDetailsView(Gtk.Window):
         grid.attach_next_to(lbl_share_kbd, image, Gtk.PositionType.BOTTOM, 2, 1)
         prevlabel = lbl_share_kbd
 
-        button = Gtk.Button.new_with_mnemonic("_Close")
-        button.set_tooltip_text("Close window")
-        button.connect("clicked", self.on_close_clicked)
+        self.add_button("_Close", Gtk.ResponseType.CLOSE)
 
-        hbox.pack_end(button, False, False, 0)
-        bind_accelerator(self.accelerators, button, '<Control>w')
-
-        hbox_outer.pack_start(vbox, True, True, 12)
-        self.add(hbox_outer)
-        self.resize(635, 270)
-
-    def on_close_clicked(self, button):
-        logging.debug("Closing keyboard details window")
-        self.close()
+        self.get_content_area().pack_start(box, True, True, 12)
+        self.resize(800, 450)
+        self.show_all()

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -299,9 +299,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             if welcome_file and os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.info("opening " + uri_path)
-                w = WelcomeView(uri_path, model[treeiter][3])
-                w.resize(800, 600)
-                w.show_all()
+                w = WelcomeView(self, uri_path, model[treeiter][3])
+                w.run()
+                w.destroy()
             else:
                 logging.info("welcome.htm not available")
 
@@ -346,9 +346,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             logging.info("Show keyboard details of " + model[treeiter][1])
             areapath = get_install_area_path(model[treeiter][4])
             kmp = { "name" : model[treeiter][1], "version" : model[treeiter][2], "packageID" : model[treeiter][3],  "areapath" : areapath}
-            w = KeyboardDetailsView(kmp)
-            w.resize(800, 450)
-            w.show_all()
+            w = KeyboardDetailsView(self, kmp)
+            w.run()
+            w.destroy()
 
 if __name__ == '__main__':
     w = ViewInstalledWindow()

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -3,6 +3,8 @@
 import logging
 import os.path
 import pathlib
+import subprocess
+import sys
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -47,6 +49,8 @@ class ViewInstalledWindowBase(Gtk.Window):
 
         if file != None:
             self.install_file(file)
+            subprocess.Popen(sys.argv)
+            self.close()
 
     def on_installfile_clicked(self, button):
         logging.debug("Install from file clicked")

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -16,26 +16,25 @@ from keyman_config.accelerators import bind_accelerator, init_accel
 # NOTE: WebKit2 is not able to load XHTML files nor files with an encoding other
 # than ASCII or UTF-8
 
-class WelcomeView(Gtk.Window):
+class WelcomeView(Gtk.Dialog):
 
-    def __init__(self, welcomeurl, keyboardname):
+    def __init__(self, parent, welcomeurl, keyboardname):
         self.accelerators = None
         kbtitle = keyboardname + " installed"
         self.welcomeurl = welcomeurl
-        Gtk.Window.__init__(self, title=kbtitle)
+        Gtk.Dialog.__init__(self, kbtitle, parent)
         init_accel(self)
-
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
 
         s = Gtk.ScrolledWindow()
         self.webview = WebKit2.WebView()
         self.webview.connect("decide-policy", self.doc_policy)
         self.webview.load_uri(welcomeurl)
         s.add(self.webview)
-        vbox.pack_start(s, True, True, 0)
+
+        self.get_content_area().pack_start(s, True, True, 0)
 
         hbox = Gtk.Box(spacing=12)
-        vbox.pack_start(hbox, False, False, 6)
+        self.get_content_area().pack_start(hbox, False, False, 6)
 
         button = Gtk.Button.new_with_mnemonic("Open in _Web browser")
         button.connect("clicked", self.on_openweb_clicked)
@@ -47,7 +46,8 @@ class WelcomeView(Gtk.Window):
         hbox.pack_end(button, False, False, 12)
         bind_accelerator(self.accelerators, button, '<Control>w')
 
-        self.add(vbox)
+        self.resize(800, 600)
+        self.show_all()
 
     def doc_policy(self, web_view, decision, decision_type):
         logging.info("Checking policy")
@@ -70,4 +70,5 @@ class WelcomeView(Gtk.Window):
 
     def on_ok_clicked(self, button):
         logging.info("Closing welcome window")
+        self.response(Gtk.ResponseType.OK)
         self.close()

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -13,6 +13,9 @@ from gi.repository import Gtk, WebKit2
 from keyman_config.check_mime_type import check_mime_type
 from keyman_config.accelerators import bind_accelerator, init_accel
 
+# NOTE: WebKit2 is not able to load XHTML files nor files with an encoding other
+# than ASCII or UTF-8
+
 class WelcomeView(Gtk.Window):
 
     def __init__(self, welcomeurl, keyboardname):


### PR DESCRIPTION
This fixes the problem where typing inside of `km-config` is not possible after installing a keyboard.
This fixes #2087.

This PR also adds a comment about the limitations of WebKit2. It also converts two additional windows to modal dialogs.