### PR TITLE
refactor(ios/engine): Language resource + keying polymorphism

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -134,12 +134,12 @@ public extension UserDefaults {
     }
   }
 
-  var userResources: [LanguageResource]? {
+  var userResources: [AnyLanguageResource]? {
     get {
       let keyboards = userKeyboards ?? []
       let lexicalModels = userLexicalModels ?? []
       
-      let resources: [LanguageResource] = keyboards + lexicalModels
+      let resources: [AnyLanguageResource] = keyboards + lexicalModels
       if resources.count == 0 {
         return nil
       } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class KeyboardKeymanPackage : KeymanPackage {
+public class KeyboardKeymanPackage : TypedKeymanPackage<InstallableKeyboard> {
   internal var keyboards: [KMPKeyboard]!
 
   override init(metadata: KMPMetadata, folder: URL) {
@@ -24,6 +24,8 @@ public class KeyboardKeymanPackage : KeymanPackage {
         }
       }
     }
+
+    self.setInstallableResourceSets(for: keyboards)
   }
   
   public override func defaultInfoHtml() -> String {
@@ -34,7 +36,7 @@ public class KeyboardKeymanPackage : KeymanPackage {
     return str
   }
 
-  override var resources: [KMPResource] {
+  override var resources: [AnyKMPResource] {
     return keyboards
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -52,7 +52,7 @@ public class KeymanPackage {
     return metadata.version
   }
 
-  var resources: [KMPResource] {
+  var resources: [AnyKMPResource] {
     fatalError("abstract base method went uninplemented by derived class")
   }
 
@@ -64,10 +64,8 @@ public class KeymanPackage {
    * with 1 entry:  an array with three InstallableLexicalModel entries, one for each supported language of the model, identical
    * aside from language-specific metadata.
    */
-  public var installableResourceSets: [[LanguageResource]] {
-    return resources.map { resource in
-      return resource.installableResources
-    }
+  public var installableResourceSets: [[AnyLanguageResource]] {
+    fatalError("abstract base method went unimplemented by derived class")
   }
   
   static public func parse(_ folder: URL) -> KeymanPackage? {
@@ -117,5 +115,22 @@ public class KeymanPackage {
                           complete()
                         }
                       })
+  }
+}
+
+public class TypedKeymanPackage<TypedLanguageResource: LanguageResource>: KeymanPackage {
+  public private(set) var installables: [[TypedLanguageResource]] = []
+
+  internal func setInstallableResourceSets<Resource: KMPResource>(for kmpResources: [Resource]) where Resource.LanguageResourceType == TypedLanguageResource {
+    self.installables = kmpResources.map { resource in
+      return resource.typedInstallableResources
+    } as [[TypedLanguageResource]]
+  }
+
+  // Cannot directly override base class's installableResourceSets with more specific type,
+  // despite covariance.  So, we have to provide two separate properties.  Joy.
+  // See https://forums.swift.org/t/confusing-limitations-on-covariant-overriding/16252
+  public override var installableResourceSets: [[AnyLanguageResource]] {
+    return installables
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/ResourceInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/ResourceInfoViewController.swift
@@ -24,7 +24,7 @@ class ResourceInfoViewController: UIViewController, UIAlertViewDelegate, UITable
 
   private var infoArray = [[String: String]]()
 
-  let resource: LanguageResource
+  let resource: AnyLanguageResource
 
   @IBOutlet weak var scrollView: UIScrollView!
   @IBOutlet weak var contentView: UIView!
@@ -35,7 +35,7 @@ class ResourceInfoViewController: UIViewController, UIAlertViewDelegate, UITable
   @IBOutlet weak var tableHeightConstraint: NSLayoutConstraint!
   @IBOutlet weak var labelHeightConstraint: NSLayoutConstraint!
 
-  init(for resource: LanguageResource) {
+  init(for resource: AnyLanguageResource) {
     self.resource = resource
 
     super.init(nibName: "ResourceInfoView", bundle: Bundle.init(for: ResourceInfoViewController.self))

--- a/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class LexicalModelKeymanPackage : KeymanPackage {
+public class LexicalModelKeymanPackage : TypedKeymanPackage<InstallableLexicalModel> {
   internal var models : [KMPLexicalModel]!
 
   override init(metadata: KMPMetadata, folder: URL) {
@@ -26,6 +26,8 @@ public class LexicalModelKeymanPackage : KeymanPackage {
         }
       }
     }
+
+    self.setInstallableResourceSets(for: models)
   }
 
   public override func defaultInfoHtml() -> String {
@@ -37,7 +39,7 @@ public class LexicalModelKeymanPackage : KeymanPackage {
     return str
   }
 
-  override var resources: [KMPResource] {
+  override var resources: [AnyKMPResource] {
     return models
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -617,8 +617,8 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       throw KMPError.wrongPackageType
     }
 
-    for r in kmp.resources {
-      let installableFiles: [(LanguageResource, [(String, URL)])] = r.installableResources.map { resource in
+    for r in kmp.resources as! [KMPKeyboard] {
+      let installableFiles: [(InstallableKeyboard, [(String, URL)])] = r.typedInstallableResources.map { resource in
         // (source file, destination file)
         var set: [(String, URL)] = [(resource.sourceFilename, Storage.active.resourceURL(for: resource)!)]
         let installableFonts: [(String, URL)] = resource.fonts.map { font in
@@ -668,7 +668,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
         // Only one keyboard is installed by default from a KMP.
         // Also, only the first language-pairing it contains
         if !haveInstalledOne {
-          Manager.shared.addKeyboard(resource as! InstallableKeyboard)
+          Manager.shared.addKeyboard(resource)
           haveInstalledOne = true
         }
       }
@@ -681,8 +681,8 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       throw KMPError.wrongPackageType
     }
 
-    for r in kmp.resources {
-      let installableFiles: [(LanguageResource, [(String, URL)])] = r.installableResources.map { resource in
+    for r in kmp.resources as! [KMPLexicalModel] {
+      let installableFiles: [(InstallableLexicalModel, [(String, URL)])] = r.installableResources.map { resource in
         // (source file, destination file)
         let set: [(String, URL)] = [(resource.sourceFilename, Storage.active.resourceURL(for: resource)!)]
         // no fonts for lexical models
@@ -722,7 +722,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
 
         // All pairings are installed for lexical models.
         // Also, all models within the KMP
-        Manager.addLexicalModel(resource as! InstallableLexicalModel)
+        Manager.addLexicalModel(resource)
       }
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
@@ -16,10 +16,10 @@ private enum MigrationLevel {
 
 struct VersionResourceSet {
   var version: Version
-  var resources: [LanguageResource]
+  var resources: [AnyLanguageResource]
   // but how to handle deprecation?
 
-  init(version: Version, resources: [LanguageResource]) {
+  init(version: Version, resources: [AnyLanguageResource]) {
     self.version = version
     self.resources = resources
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
@@ -9,9 +9,17 @@
 import Foundation
 
 /// A complete identifier for an `InstallableKeyboard`. Keyboards must have unique `FullKeyboardID`s.
-public struct FullKeyboardID: Codable {
+public struct FullKeyboardID: Codable, LanguageResourceFullID {
   public var keyboardID: String
   public var languageID: String
+
+  public var id: String {
+    return keyboardID
+  }
+
+  public var type: LanguageResourceType {
+    return .keyboard
+  }
 }
 
 // MARK: - Equatable

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/FullLexicalModelID.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/FullLexicalModelID.swift
@@ -9,9 +9,17 @@
 import Foundation
 
 /// A complete identifier for an `InstallableLexicalModel`. LexicalModels must have unique `FullLexicalModelID`s.
-public struct FullLexicalModelID: Codable {
+public struct FullLexicalModelID: Codable, LanguageResourceFullID {
   public var lexicalModelID: String
   public var languageID: String
+
+  public var id: String {
+    return lexicalModelID
+  }
+
+  public var type: LanguageResourceType {
+    return .lexicalModel
+  }
 }
 
 // MARK: - Equatable

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// Mainly differs from the API `Keyboard` by having an associated language.
 public struct InstallableKeyboard: Codable, LanguageResource {
+  public typealias FullID = FullKeyboardID
+  
   // Details what properties are coded and decoded re: serialization.
   enum CodingKeys: String, CodingKey {
     case id
@@ -51,8 +53,13 @@ public struct InstallableKeyboard: Codable, LanguageResource {
     return lgCode.lowercased()
   }
 
-  public var fullID: FullKeyboardID {
+  // Weird scheme due to https://stackoverflow.com/a/58774558.
+  public var typedFullID: FullKeyboardID {
     return FullKeyboardID(keyboardID: id, languageID: languageID)
+  }
+
+  public var fullID: FullKeyboardID {
+    return typedFullID
   }
 
   public init(id: String,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableLexicalModel.swift
@@ -39,9 +39,14 @@ public struct InstallableLexicalModel: Codable, LanguageResource {
       return nil
     }
   }
-  
-  public var fullID: FullLexicalModelID {
+
+  // Weird scheme due to https://stackoverflow.com/a/58774558
+  public var typedFullID: FullLexicalModelID {
     return FullLexicalModelID(lexicalModelID: id, languageID: languageID)
+  }
+
+  public var fullID: FullLexicalModelID {
+    return typedFullID
   }
   
   public init(id: String,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -12,9 +12,20 @@ public enum LanguageResourceType {
   case keyboard, lexicalModel
 }
 
-public protocol LanguageResource {
+public protocol LanguageResourceFullID {
   var id: String { get }
   var languageID: String { get }
+  var type: LanguageResourceType { get }
+}
+
+// Alas, 'associatedtype' stuff isn't exactly generic, and it's impossible to wildcard.
+// So, this supports Swift's "type erasure" pattern, acting as a "wildcarded"
+// LanguageResource that doesn't care about the specific associatedtype(s) that
+// specific LanguageResources use.
+public protocol AnyLanguageResource {
+  var id: String { get }
+  var languageID: String { get }
+  var fullID: LanguageResourceFullID { get }
   var version: String { get }
 
   // Used for generating QR codes.
@@ -23,4 +34,19 @@ public protocol LanguageResource {
   // Used during resource installation
   var fonts: [Font] { get }
   var sourceFilename: String { get }
+}
+
+// Necessary due to Swift details 'documented' at
+// https://stackoverflow.com/questions/42561685/why-cant-a-get-only-property-requirement-in-a-protocol-be-satisfied-by-a-proper
+public protocol LanguageResource: AnyLanguageResource {
+  associatedtype FullID: LanguageResourceFullID
+  var typedFullID: FullID { get }
+}
+
+extension LanguageResource {
+  // Thanks to https://stackoverflow.com/a/58774558 (on same thread mentioned above)
+  // for this approach.
+  public var fullID: LanguageResourceFullID {
+    return typedFullID
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
@@ -20,11 +20,11 @@ public struct LexicalModelDownloadFailedNotification {
   public let lmOrLanguageID: String
   public let error: Error
 }
-public typealias BatchUpdateStartedNotification = [LanguageResource]
+public typealias BatchUpdateStartedNotification = [AnyLanguageResource]
 
 public struct BatchUpdateCompletedNotification {
-  public let successes: [[LanguageResource]]
-  public let failures: [[LanguageResource]]
+  public let successes: [[AnyLanguageResource]]
+  public let failures: [[AnyLanguageResource]]
   public let errors: [Error]
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -365,7 +365,7 @@ public class ResourceDownloadManager {
     }
   }
   
-  public func getAvailableUpdates() -> [LanguageResource]? {
+  public func getAvailableUpdates() -> [AnyLanguageResource]? {
     // Relies upon KMManager's preload; this was the case before the rework.
     if Manager.shared.apiKeyboardRepository.languages == nil && Manager.shared.apiLexicalModelRepository.languages == nil {
       return nil
@@ -373,7 +373,7 @@ public class ResourceDownloadManager {
 
     isDidUpdateCheck = true
     
-    var updatables: [LanguageResource] = []
+    var updatables: [AnyLanguageResource] = []
 
     // Gets the list of current, local keyboards in need of an update.
     // Version matches the current version, not the updated version.
@@ -391,7 +391,7 @@ public class ResourceDownloadManager {
     }
   }
   
-  public func performUpdates(forResources resources: [LanguageResource]) {
+  public func performUpdates(forResources resources: [AnyLanguageResource]) {
     // The plan is to create new notifications to handle batch updates here, rather than
     // require a UI to manage the update queue.
     var batches: [DownloadBatch] = []

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -10,7 +10,7 @@ import Foundation
 import Reachability
 
 protocol DownloadNode {
-  var resources: [LanguageResource]? { get }
+  var resources: [AnyLanguageResource]? { get }
 }
 
 class DownloadTask: DownloadNode {
@@ -19,10 +19,10 @@ class DownloadTask: DownloadNode {
   }
   
   public final var type: Resource
-  public final var resources: [LanguageResource]?
+  public final var resources: [AnyLanguageResource]?
   public final var request: HTTPDownloadRequest
   
-  public init(do request: HTTPDownloadRequest, for resources: [LanguageResource]?, type: DownloadTask.Resource) {
+  public init(do request: HTTPDownloadRequest, for resources: [AnyLanguageResource]?, type: DownloadTask.Resource) {
     self.request = request
     self.type = type
     self.resources = resources
@@ -80,9 +80,9 @@ class DownloadBatch: DownloadNode {
     self.errors = Array(repeating: nil, count: tasks.count)
   }
   
-  public var resources: [LanguageResource]? {
+  public var resources: [AnyLanguageResource]? {
     get {
-      var resArray: [LanguageResource] = []
+      var resArray: [AnyLanguageResource] = []
       
       tasks.forEach{ task in
         resArray.append(contentsOf: task.resources ?? [])
@@ -376,8 +376,8 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
   }
   
   public func updateBatchFinished(_ batch: DownloadBatch) {
-    var successes: [[LanguageResource]] = []
-    var failures: [[LanguageResource]] = []
+    var successes: [[AnyLanguageResource]] = []
+    var failures: [[AnyLanguageResource]] = []
     var errors: [Error] = []
     
     // Remember, since this is for .composite batches, batch.tasks is of type [DownloadBatch].

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -374,7 +374,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     self.present(alertController, animated: true, completion: nil)
   }
   
-  private func batchUpdateStarted(_: [LanguageResource]) {
+  private func batchUpdateStarted(_: [AnyLanguageResource]) {
     log.info("batchUpdateStarted: InstalledLanguagesViewController")
     view.isUserInteractionEnabled = false
     navigationItem.setHidesBackButton(true, animated: true)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Storage.swift
@@ -93,7 +93,7 @@ class Storage {
     return lexicalModelDir.appendingPathComponent(lexicalModelID)
   }
 
-  func resourceDir(for resource: LanguageResource) -> URL? {
+  func resourceDir(for resource: AnyLanguageResource) -> URL? {
     if let keyboard = resource as? InstallableKeyboard {
       return keyboardDir(forID: keyboard.id)
     } else if let lexicalModel = resource as? InstallableLexicalModel {
@@ -112,7 +112,7 @@ class Storage {
   }
 
   // Facilitates abstractions based on the LanguageResource protocol.
-  func resourceURL(for resource: LanguageResource) -> URL? {
+  func resourceURL(for resource: AnyLanguageResource) -> URL? {
     if let keyboard = resource as? InstallableKeyboard {
       return keyboardURL(for: keyboard)
     } else if let lexicalModel = resource as? InstallableLexicalModel {
@@ -153,7 +153,7 @@ class Storage {
     return keyboardDir(forID: keyboardID).appendingPathComponent(filename)
   }
 
-  func fontURL(forResource resource: LanguageResource, filename: String) -> URL? {
+  func fontURL(forResource resource: AnyLanguageResource, filename: String) -> URL? {
     if let keyboard = resource as? InstallableKeyboard {
       return fontURL(forKeyboardID: keyboard.id, filename: filename)
     } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
@@ -60,7 +60,15 @@ class KMPKeyboard: Codable, KMPResource {
     return installableKeyboards
   }
 
-  public var installableResources: [LanguageResource] {
+  // Needed to properly support AnyKMPResource.installableResources
+  // because of weird, weird Swift rules.
+  public var typedInstallableResources: [InstallableKeyboard] {
+    return installableKeyboards
+  }
+
+  // Provides our class's method of the same signature, but with
+  // the local type signature we know is available.
+  public var installableResources: [InstallableKeyboard] {
     return installableKeyboards
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPLexicalModel.swift
@@ -57,7 +57,15 @@ class KMPLexicalModel: Codable, KMPResource {
     return installableLexicalModels
   }
 
-  public var installableResources: [LanguageResource] {
+  // Needed to properly support AnyKMPResource.installableResources
+  // because of weird, weird Swift rules.
+  public var typedInstallableResources: [InstallableLexicalModel] {
+    return installableLexicalModels
+  }
+
+  // Provides our class's method of the same signature, but with
+  // the local type signature we know is available.
+  public var installableResources: [InstallableLexicalModel] {
     return installableLexicalModels
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPResource.swift
@@ -8,9 +8,20 @@
 
 import Foundation
 
-protocol KMPResource {
+protocol AnyKMPResource {
   // Returns the represented resource's ID.
   var id: String { get }
 
-  var installableResources: [LanguageResource] { get }
+  var installableResources: [AnyLanguageResource] { get }
+}
+
+protocol KMPResource: AnyKMPResource {
+  associatedtype LanguageResourceType: LanguageResource
+  var typedInstallableResources: [LanguageResourceType] { get }
+}
+
+extension KMPResource {
+  var installableResources: [AnyLanguageResource] {
+    return typedInstallableResources
+  }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Migrations.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Migrations.swift
@@ -65,10 +65,10 @@ extension TestUtils {
       }
     }
 
-    static func getVersionHistory(for version: Version) -> [LanguageResource] {
+    static func getVersionHistory(for version: Version) -> [AnyLanguageResource] {
       let resourceHistory = KeymanEngine.Migrations.resourceHistory
 
-      let match: [[LanguageResource]] = resourceHistory.compactMap() { entry in
+      let match: [[AnyLanguageResource]] = resourceHistory.compactMap() { entry in
         if entry.version == version {
           return entry.resources
         } else {


### PR DESCRIPTION
Swift generics are... really weird and cumbersome.  Especially once `protocol`s get involved.

Most of the changes contained in this PR are to approximate Java-style generic polymorphism regarding language resources and how we key them.  Alas, Swift lacks the ability to "wildcard" its generics, so "type erasure" is necessary - note the `Any*` classes.

Some "fun" Swift reading along those lines:  https://medium.com/@bobgodwinx/swift-associated-type-design-patterns-6c56c5b0a73a
- I followed the "Shadow Type Erasure" strategy where possible.

All of this is to allow a few things:
- `KeymanKeyboardPackage.installables` is of type `[[InstallableKeyboards]]` - something reasonably clear (though I could improve its docs) and exposable as an API on packages.
    - Likewise, `KeymanLexicalModelPackage` is of type `[[InstallableLexicalModels]]`.
    - The base, type-erased `KeymanPackage` exports `installableResourceSets: [[LanguageResource]]`.  
        - It was impossible to fully do "shadow type erasure" here so that the same name was used for all cases.
    - One of my big goals - the `KMPMetadata` classes will _not_ be exposed as API - they'll be internal-only.
- `FullKeyboardID` and `FullLexicalModelID` are now related via `Protocol` while maintaining their original type signatures and accessibility.
    - As a result, `fullID` is now exposed as a property on `AnyLanguageResource` (and its implementing classes).
    - Existing uses of `InstallableKeyboard` and `InstallableLexicalModel` are practically unaffected despite the shifts in its type hierarchy.
    - Great pains were taken to avoid breaking anything with the changes involved.

This allows us to easily get the unique keying information for any installed resources so that we can use it to find "matches" within a KMP as part of the cloud -> KMP migration process.

-----

Other notes:
- This is designed to further enhance #3207 along the lines of our recent offline discussions - that bit about using the "unique keying information" will now be far more possible.
    - In fact, this started off on that branch until I realized how complex things were becoming and that a separate, focused review would be far better.
- Noting the comment on #3212 [here](https://github.com/keymanapp/keyman/pull/3212#discussion_r437146769), this same pattern provides a more "Swift-like" solution to that problem; we'll be able to constrain the `init` method such that nothing unexpected can be passed in.