### PR TITLE
chore: labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,85 @@
+#
+# This file adds labels based on the scopes in resources/scopes/scopes.json.
+# Currently it must be manually kept up to date. Not all labels are added, only
+# common ones. The others are commented out. There is still some variance between
+# folder names and labels; consider this documentation of that ;-)
+#
+
+andrdoid/: android/**
+android/app/: android/KMAPro/**
+#android/browser/:
+android/engine/: android/KMEA/**
+#android/resources/:
+android/samples/: android/Samples/**
+
+common/: common/**
+common/core/: common/core/**
+common/core/desktop/: common/core/desktop/**
+common/core/web/: common/core/web/**
+
+common/models/: common/models/**
+common/models/types/: common/models/types/**
+common/models/templates/: common/models/templates/**
+common/models/wordbreakers/: common/models/wordbreakers/**
+
+common/resources/: resources/**
+
+developer/:
+  - developer/**
+  - windows/src/developer/**
+
+developer/compilers/:
+  - windows/src/developer/kmcomp/**
+  - developer/js/**
+
+developer/ide/:
+  - windows/src/developer/TIKE/**
+
+# developer/resources/
+# developer/tools/
+
+ios/: ios/**
+ios/app/: ios/keyman/**
+# ios/browser/
+ios/engine/: ios/engine/**
+# ios/resources/
+ios/samples/: ios/samples/**
+
+linux/: linux/**
+linux/config/: linux/keyman-config/**
+linux/engine/:
+  - linux/ibus-keyman/**
+  - linux/ibus-kmfl/**
+  - linux/kmflcomp/**
+  - linux/libkmfl/**
+  - linux/scim_kmfl_imengine/**
+# linux/resources/
+# linux/samples/
+
+mac/: mac/**
+# mac/config/:
+mac/engine/: mac/**
+# mac/resources/
+# mac/samples/
+
+oem/: oem/**
+oem/fv/: oem/firstvoices/**
+oem/fv/android/: oem/firstvoices/android/**
+oem/fv/ios/: oem/firstvoices/ios/**
+oem/fv/windows/: oem/firstvoices/windows/**
+
+web/: web/**
+# web/bookmarklet/
+web/engine/: web/source/**
+# web/resources/
+web/ui/: web/source/kmwui*
+web/samples/: web/samples/**
+
+# Somewhat messy since we try and exclude Developer :)
+windows/:
+  - any: ['windows/**', '!windows/src/developer/**']
+
+windows/config/: windows/src/desktop/**
+windows/engine/: windows/src/engine/**
+# windows/resources/
+# windows/samples/

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@
 # folder names and labels; consider this documentation of that ;-)
 #
 
-andrdoid/: android/**
+android/: android/**
 android/app/: android/KMAPro/**
 #android/browser/:
 android/engine/: android/KMEA/**
@@ -77,7 +77,7 @@ web/samples/: web/samples/**
 
 # Somewhat messy since we try and exclude Developer :)
 windows/:
-  - any: ['windows/**', '!windows/src/developer/**']
+- any: ['windows/**', '!windows/src/developer/**']
 
 windows/config/: windows/src/desktop/**
 windows/engine/: windows/src/engine/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,9 @@ android/engine/: android/KMEA/**
 #android/resources/:
 android/samples/: android/Samples/**
 
-common/: common/**
+common/:
+  - common/**
+  - resources/**
 common/core/: common/core/**
 common/core/desktop/: common/core/desktop/**
 common/core/web/: common/core/web/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@4b52aec09ba832eb9aecccddbccce644ba9ba69d
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/resources/scopes/README.md
+++ b/resources/scopes/README.md
@@ -8,6 +8,7 @@ This folder contains definitions for valid scopes and commit types for Keyman.
 
 * A tree structured JSON object, with root node `"scopes"`.
 * Keys must have lower case alpha names; leaf nodes must always be `null`.
+* If you change scopes here, please update /.github/labeler.yml accordingly.
 
 ## commit-types.json
 


### PR DESCRIPTION
Using GitHub's labeler action to apply appropriate labels automatically based on paths. Fixes #3231.