### PR TITLE
fix(developer/ide): double click to change layer update combo

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1000,7 +1000,8 @@ $(function () {
   }
 
   this.selectLayer = function (val) {
-    builder.lastLayerIndex = val || $('#selLayer').val();
+    if(val) $('#selLayer').val(val);
+    builder.lastLayerIndex = $('#selLayer').val();
     builder.prepareLayer();
     builder.selectKey($('#kbd > div.row > div.key')[0]);
   }


### PR DESCRIPTION
Fixes #2658. Double-clicking on a layer change key will now update the combo box at the top of the editor appropriately.