### PR TITLE
feat(linux): Add onboard as recommended package

### DIFF
--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -33,6 +33,7 @@ Package: keyman
 Section: utils
 Architecture: all
 Depends: ${misc:Depends}, python3-keyman-config
+Recommends: onboard
 Description: Type in your language with Keyman for Linux
  Keyman makes it possible for you to type in over 1,000 languages on Windows, macOS, Linux,
  iPhone, iPad, Android tablets and phones, and even instantly in your web browser. With the


### PR DESCRIPTION
This change adds `onboard` as a recommended package. This will
install it by default for most users, unless they told their
package manager not to automatically install recommended packages.

This implements part of #3223.