### PR TITLE
fix(ios/engine): migration of preload-sourced resources

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
@@ -698,4 +698,10 @@ public enum Migrations {
 
     return matched + mappedResources
   }
+
+  internal static func resourceHasPackageMetadata<Resource: LanguageResource>(_ resource: Resource) -> Bool {
+    var resourceDir = Storage.active.resourceDir(for: resource)!
+    resourceDir.appendPathComponent("kmp.json")
+    return FileManager.default.fileExists(atPath: resourceDir.path)
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -217,6 +217,12 @@ public class ResourceFileManager {
     }
   }
 
+  /**
+   * Searches the specified package for a language resource with the indicated resource-language-code "full ID" key,
+   * importing the package's files and installing the indicated resource-language pairing upon success.
+   *
+   * The`resourcesWithIDs:` variant is better optimized for installing multiple resources from the same package.
+   */
   public func install<ResourceType: LanguageResource,
                       PackageType: TypedKeymanPackage<ResourceType>> (
                         resourceWithID fullID: ResourceType.FullID,
@@ -225,6 +231,10 @@ public class ResourceFileManager {
     try install(resourcesWithIDs: [fullID], from: package)
   }
 
+  /**
+   * Searches the specified package for language resources with the indicated resource-language-code "full ID" keys
+   * importing the package's files and installing the indicated resource-language pairings upon success.
+   */
   public func install<Resource: LanguageResource,
                       Package: TypedKeymanPackage<Resource>> (
                         resourcesWithIDs fullIDs: [Resource.FullID], from package: Package) throws {


### PR DESCRIPTION
While this doesn't fully fix up the FV app for 14.0, this should provide a decent stopgap for any 3rd party libraries that have been relying on use of the now-deprecated `preloadFiles` command to add resources.

As `preloadFiles` only, well, _preloads_ the files, we need to wait for the matching `addKeyboard`/`addLexicalModel` call in order to obtain the `LanguageResource` key necessary for migration.

-----

In regard to the FV app, this will take effect on the next in-app keyboard selection.  However, the FV app itself does not bother with migrating resources (direct use of `Migrations`) in any fashion, so it won't automatically generate kmp.json files for all available keyboards - not even if installed from an earlier version.

Of course, for a _proper_ FV app, we should be installing the resources from a .kmp instead - but that'll be a later PR.  This one is more concerned with legacy API maintenance, though use of the FV app provided a good testing ground for it.