### PR TITLE
feat(android): Implement menu to add language for installed keyboard pkg

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -226,6 +226,18 @@
       android:parentActivityName=".KeymanSettingsActivity"
       android:launchMode="singleTask"
       android:theme="@style/AppTheme.Base" />
+    <activity
+      android:name=".SelectPackageActivity"
+      android:label="@string/app_name"
+      android:parentActivityName=".KeymanSettingsInstallActivity"
+      android:launchMode="singleTask"
+      android:theme="@style/AppTheme.Base" />
+    <activity
+      android:name=".SelectLanguageActivity"
+      android:label="@string/app_name"
+      android:parentActivityName=".SelectPackageActivity"
+      android:launchMode="singleTask"
+      android:theme="@style/AppTheme.Base" />
 
     <provider
       android:name="androidx.core.content.FileProvider"

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsInstallActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsInstallActivity.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMPBrowserActivity;
+import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.MapCompat;
 
 public class KeymanSettingsInstallActivity extends AppCompatActivity {
@@ -107,6 +108,11 @@ public class KeymanSettingsInstallActivity extends AppCompatActivity {
         if (itemTitle.equals(getString(R.string.install_from_other_device))) {
           // Scan QR code not implemented yet
           return false;
+        } else if (itemTitle.equals(getString(R.string.add_language_to_installed_keyboard))) {
+          if (KeyboardController.getInstance().getInstalledPackagesList() == null) {
+            // Disable if no keyboard packages installed
+            return false;
+          }
         }
 
         return super.isEnabled(position);
@@ -150,7 +156,8 @@ public class KeymanSettingsInstallActivity extends AppCompatActivity {
 
         // Add language from keyboard package already installed
         } else if (itemTitle.equals(getString(R.string.add_language_to_installed_keyboard))) {
-          // TODO
+          Intent intent = new Intent(context, SelectPackageActivity.class);
+          context.startActivity(intent);
         }
       }
     });

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
@@ -63,9 +63,10 @@ public final class SelectLanguageActivity extends AppCompatActivity {
     final String packageID = keyboard.getPackageID();
     final String keyboardID = keyboard.getKeyboardID();
     final String keyboardName = keyboard.getKeyboardName();
-    String title = String.format(getString(R.string.title_select_language_for_package), keyboardName);
+    String title_install = String.format(getString(R.string.title_select_language_for_package), keyboardName);
+    String title_no_install = getString(R.string.all_languages_installed);
     final TextView textView = findViewById(R.id.bar_title);
-    textView.setText(title);
+    textView.setText(title_no_install);
     if (titleFont != null) {
       textView.setTypeface(titleFont, Typeface.BOLD);
     }
@@ -88,6 +89,9 @@ public final class SelectLanguageActivity extends AppCompatActivity {
           k.getPackageID(), k.getKeyboardID(), k.getLanguageID())) {
         icon = String.valueOf(R.drawable.ic_check);
         enable = "false";
+      } else {
+        // Update title
+        textView.setText(title_install);
       }
       hashMap.put(iconKey, icon);
       hashMap.put(isEnabledKey, enable);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmapro;
+
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Typeface;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.SimpleAdapter;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.KMPBrowserActivity;
+import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
+import com.tavultesoft.kmea.data.CloudRepository;
+import com.tavultesoft.kmea.data.Dataset;
+import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.data.KeyboardController;
+import com.tavultesoft.kmea.data.adapters.AdapterFilter;
+import com.tavultesoft.kmea.data.adapters.NestedAdapter;
+import com.tavultesoft.kmea.logic.ResourcesUpdateTool;
+import com.tavultesoft.kmea.packages.PackageProcessor;
+import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.MapCompat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Keyman Settings --> KeymanInstallActivity --> SelectPackageActivity --> SelectLanguageActivity
+ * Displays a list of available languages for the user to add for a given installed packageID/keyboardID.
+ */
+public final class SelectLanguageActivity extends AppCompatActivity {
+  private static final String TAG = "SelectLanguageActivity";
+  private static ArrayList<HashMap<String, String>> list = null;
+  private static KMListAdapter listAdapter = null;
+  private static Typeface titleFont = null;
+  private static final String titleKey = "title";
+  private static final String subtitleKey = "subtitle";
+  private static final String iconKey = "icon";
+  private static Context context;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    context = this;
+
+    setContentView(R.layout.activity_list_layout);
+    final Toolbar toolbar = findViewById(R.id.list_toolbar);
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setDisplayShowHomeEnabled(true);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+    final ListView listView = findViewById(R.id.listView);
+    listView.setFastScrollEnabled(true);
+
+    final Keyboard keyboard = (Keyboard)getIntent().getSerializableExtra("keyboard");
+    final String packageID = keyboard.getPackageID();
+    final String keyboardID = keyboard.getKeyboardID();
+    final String keyboardName = keyboard.getKeyboardName();
+    String title = String.format(getString(R.string.title_select_language_for_package), keyboardName);
+    final TextView textView = findViewById(R.id.bar_title);
+    textView.setText(title);
+    if (titleFont != null) {
+      textView.setTypeface(titleFont, Typeface.BOLD);
+    }
+
+    // Get the list of available languages from kmp.json
+    File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
+    PackageProcessor kmpProcessor =  new PackageProcessor(resourceRoot);
+    List<Keyboard> availableKeyboardsList = kmpProcessor.getLanguageList(packageID, keyboardID);
+
+    list = new ArrayList<HashMap<String, String>>();
+    for (Keyboard k : availableKeyboardsList) {
+      final String noIcon = "0";
+      HashMap<String, String> hashMap = new HashMap<>();
+      hashMap.put(titleKey, k.getLanguageName());
+      hashMap.put(subtitleKey, k.getLanguageID());
+      String icon = String.valueOf(R.drawable.ic_arrow_forward);
+      hashMap.put(iconKey, icon);
+      list.add(hashMap);
+    }
+
+    String[] from = new String[]{titleKey, subtitleKey, iconKey};
+    int[] to = new int[]{com.tavultesoft.kmea.R.id.text1, com.tavultesoft.kmea.R.id.text2, com.tavultesoft.kmea.R.id.image1};
+
+    ListAdapter adapter = new SimpleAdapter(context, list, com.tavultesoft.kmea.R.layout.list_row_layout2, from, to) {
+    };
+    listView.setAdapter(adapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        HashMap<String, String> hashMap = (HashMap<String, String>) parent.getItemAtPosition(position);
+        Keyboard k = availableKeyboardsList.get(position);
+        KMManager.addKeyboard(context, k);
+        Toast.makeText(context, "Keyboard added", Toast.LENGTH_LONG).show();
+        finish();
+      }
+    });
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    super.onBackPressed();
+    return true;
+  }
+}

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
@@ -4,54 +4,29 @@
 
 package com.tavultesoft.kmapro;
 
-import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.Typeface;
-import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.AdapterView;
-import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.KMPBrowserActivity;
-import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
-import com.tavultesoft.kmea.data.CloudRepository;
-import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
-import com.tavultesoft.kmea.data.KeyboardController;
-import com.tavultesoft.kmea.data.adapters.AdapterFilter;
-import com.tavultesoft.kmea.data.adapters.NestedAdapter;
-import com.tavultesoft.kmea.logic.ResourcesUpdateTool;
 import com.tavultesoft.kmea.packages.PackageProcessor;
-import com.tavultesoft.kmea.util.KMLog;
-import com.tavultesoft.kmea.util.MapCompat;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Keyman Settings --> KeymanInstallActivity --> SelectPackageActivity --> SelectLanguageActivity
@@ -60,7 +35,6 @@ import java.util.Map;
 public final class SelectLanguageActivity extends AppCompatActivity {
   private static final String TAG = "SelectLanguageActivity";
   private static ArrayList<HashMap<String, String>> list = null;
-  private static KMListAdapter listAdapter = null;
   private static Typeface titleFont = null;
   private static final String titleKey = "title";
   private static final String subtitleKey = "subtitle";

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
@@ -16,16 +16,12 @@ import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.KMPBrowserActivity;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.KMLog;
-import com.tavultesoft.kmea.util.MapCompat;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2020 SIL International. All rights reserved.
+ */
+
+package com.tavultesoft.kmapro;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Typeface;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.SimpleAdapter;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.KMPBrowserActivity;
+import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.data.KeyboardController;
+import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.MapCompat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Keyman Settings --> KeymanInstallActivity --> SelectPackageActivity
+ * Displays a list of installed package ID / keyboard IDs so the user can select a language from the kmp.json
+ */
+public final class SelectPackageActivity extends AppCompatActivity {
+  private static final String TAG = "SelectPackageActivity";
+  private static ArrayList<HashMap<String, String>> list = null;
+  private static Typeface titleFont = null;
+  private static final String titleKey = "title";
+  private static final String subtitleKey = "subtitle";
+  private static final String iconKey = "icon";
+  private static Context context;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    context = this;
+
+    setContentView(R.layout.activity_list_layout);
+    final Toolbar toolbar = findViewById(R.id.list_toolbar);
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setDisplayShowHomeEnabled(true);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+    final ListView listView = findViewById(R.id.listView);
+    listView.setFastScrollEnabled(true);
+
+    Bundle bundle = getIntent().getExtras();
+
+    final TextView textView = findViewById(R.id.bar_title);
+    textView.setText(getString(R.string.title_select_keyboard_package_list));
+    if (titleFont != null) {
+      textView.setTypeface(titleFont, Typeface.BOLD);
+    }
+
+    List<Keyboard> packagesList = KeyboardController.getInstance().getInstalledPackagesList();
+    if (packagesList == null) {
+      // Should never actually happen
+      KMLog.LogError(TAG, "Installed keyboard package list is empty");
+      finish();
+    }
+
+    list = new ArrayList<HashMap<String, String>>();
+    for (Keyboard k : packagesList) {
+      String keyboardName = k.getKeyboardName();
+      String pkgID = k.getPackageID();
+      final String noIcon = "0";
+      HashMap<String, String> hashMap = new HashMap<>();
+      hashMap.put(titleKey, keyboardName);
+      hashMap.put(subtitleKey, pkgID);
+      String icon = String.valueOf(R.drawable.ic_arrow_forward);
+      hashMap.put(iconKey, icon);
+      list.add(hashMap);
+    }
+
+    String[] from = new String[]{titleKey, subtitleKey, iconKey};
+    int[] to = new int[]{com.tavultesoft.kmea.R.id.text1, com.tavultesoft.kmea.R.id.text2, com.tavultesoft.kmea.R.id.image1};
+
+    ListAdapter adapter = new SimpleAdapter(context, list, com.tavultesoft.kmea.R.layout.list_row_layout2, from, to) {
+    };
+    listView.setAdapter(adapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        HashMap<String, String> hashMap = (HashMap<String, String>) parent.getItemAtPosition(position);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable("keyboard", packagesList.get(position));
+        Intent intent = new Intent(context, SelectLanguageActivity.class);
+        intent.putExtras(bundle);
+        context.startActivity(intent);
+      }
+    });
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    super.onBackPressed();
+    return true;
+  }
+}

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
   <string name="title_select_keyboard_package_list">Select Keyboard Package</string>
   <string name="title_select_language_for_package">Select language for %1$s</string>
   <string name="added_language_to_keyboard">Added language %1$s to %2$s</string>
+  <string name="all_languages_installed">All languages already installed</string>
 
   <!-- Web Browser strings -->
   <string name="hint_text">Search or type URL</string>

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -58,9 +58,10 @@
   <string name="add_language_to_installed_keyboard">Add language to installed keyboard</string>
   <string name="add_language_subtext">(from keyboard package)</string>
 
-  <!-- Package List menu strings -->
+  <!-- Select Package and Select Language menu strings -->
   <string name="title_select_keyboard_package_list">Select Keyboard Package</string>
-  <string name="title_select_language_for_package">Select language for %1$s\</string>
+  <string name="title_select_language_for_package">Select language for %1$s</string>
+  <string name="added_language_to_keyboard">Added language %1$s to %2$s</string>
 
   <!-- Web Browser strings -->
   <string name="hint_text">Search or type URL</string>

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -58,6 +58,10 @@
   <string name="add_language_to_installed_keyboard">Add language to installed keyboard</string>
   <string name="add_language_subtext">(from keyboard package)</string>
 
+  <!-- Package List menu strings -->
+  <string name="title_select_keyboard_package_list">Select Keyboard Package</string>
+  <string name="title_select_language_for_package">Select language for %1$s\</string>
+
   <!-- Web Browser strings -->
   <string name="hint_text">Search or type URL</string>
   <string name="title_bookmarks">Bookmarks</string>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -123,6 +123,37 @@ public class KeyboardController {
   }
 
   /**
+   * Returns the list of installed keyboards with unique packageID/keyboardID
+   */
+  public List<Keyboard> getInstalledPackagesList() {
+    if (!isInitialized) {
+      KMLog.LogError(TAG, "getInstalledPackagesList while KeyboardController() not initialized");
+      return null;
+    }
+    synchronized (list) {
+      List<Keyboard> packagesList = new ArrayList<Keyboard>();
+      // Iterate through the installed keyboards list to find unique packageID/keyboardID
+      for (int i=0; i<list.size(); i++) {
+        Keyboard k = list.get(i);
+        String pkgID = k.getPackageID();
+        String keyboardID = k.getKeyboardID();
+        // Ignore "cloud" keyboards"
+        if (pkgID.equals(KMManager.KMDefault_UndefinedPackageID)) {
+          continue;
+        }
+
+        // If we search getKeyboardIndex with blank languageID, it will give us the first
+        // unique pkgID/keyboardID keyboard in the list
+        int firstMatchingIndex = getKeyboardIndex(pkgID, keyboardID, "");
+        if (firstMatchingIndex != KeyboardController.INDEX_NOT_FOUND && (firstMatchingIndex == i)) {
+          packagesList.add(k);
+        }
+      }
+      return packagesList;
+    }
+  }
+
+  /**
    * Return the keyboard info at index
    * @param index - int
    * @return Keyboard
@@ -175,20 +206,6 @@ public class KeyboardController {
     Log.w(TAG, "getKeyboardIndex failed for key " + key);
     return index;
   }
-
-  /**
-   * Given a languageID and keyboardID, return the index of the matching keyboard.
-   * If no match, returns INDEX_NOT_FOUND
-   * @param languageID - String of the language ID
-   * @param keyboardID - String of the keyboard ID
-   * @return int - Index of the matching keyboard
-   */
-  /*
-  public int getKeyboardIndex(String languageID, String keyboardID) {
-    String key = String.format("%s_%s", languageID, keyboardID);
-    return getKeyboardIndex(key);
-  }
- */
 
   /**
    * Given a packageID, keyboardID, and languageID, return the index of the matching keyboard.


### PR DESCRIPTION
Follow-on to #3245 
This PR implements the menu to **"Add language to installed keyboard"**

When the user selects this menu, they're given a list of installed package ID / keyboard ID pairing.  When selecting a keyboard, they are then given a list of associated languages (from kmp.json). 
* Languages that aren't installed have an arrow and can be clicked to install
* Installed languages have a check and are disabled.
* If the entire language list is installed, the title reflects that.

------------------------------

## Screenshots

#### Install menu
![Screenshot_1592297482](https://user-images.githubusercontent.com/7358010/85035469-6b8bbd00-b1ad-11ea-9469-b3f2bdc0be0e.png)


#### Select Keyboard menu
Each entry is an installed keyboard name and package ID
![Screenshot_1592477693](https://user-images.githubusercontent.com/7358010/85035526-7c3c3300-b1ad-11ea-9d14-895c0ef8565c.png)


#### Select Language menu
(updated with installed languages being disabled)
![Screenshot_1592545503](https://user-images.githubusercontent.com/7358010/85103072-2eb4da00-b230-11ea-839d-d8c60552f7bc.png)

Different title if all languages installed
![Screenshot_1592547598](https://user-images.githubusercontent.com/7358010/85103089-370d1500-b230-11ea-9a66-43f21367f562.png)

(original screenshot showed list of uninstalled languages)
![Screenshot_1592491139](https://user-images.githubusercontent.com/7358010/85035608-9413b700-b1ad-11ea-8a9a-2957265bc39d.png)



## User Testing 
@MakaraSok 
1. Load the PR test build
2. From the "Settings" menu, install some keyboard packages that have long language lists (e.g.  sil_cameroon_qwerty)
    a. Settings --> Install Keyboard or Dictionary --> Install from keyman.com --> ....
3. From the "Settings" menu, install a keyboard package that contains multiple  keyboards (e.g. galaxie_greek_hebrew_mnemonic)
4. Click the globe button to open the keyboard picker and observe the installed languages and keyboards
5. From the "Settings" menu, add another language for an installed keyboard package
    a. Settings --> Install Keyboard or Dictionary --> Add language to installed keyboard -->
    b. Verify the "Select keyboard package" menu contains the keyboards you've installed
    c. Click on a keyboard to bring up the "Select a language" menu"
6. From the "Select a language" menu
    a. Observe installed languages are grayed out, disabled, and have a checkmark
    b. Observe languages not installed are enabled and have a right (forward) arrow
    c.  If all the languages are installed, observe the menu is disabled, and the title says "All languages already installed"
    d. For an uninstalled language, click on the language   
- [x] Verify the new language and keyboard are installed and available in the keyboard picker
