### PR TITLE
fix(common/resources): web-environment package-lock.json

### DIFF
--- a/resources/web-environment/package-lock.json
+++ b/resources/web-environment/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@keymanapp/web-environment",
+  "version": "14.0.95",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Adds a simple package-lock.json for the new `@keymanapp/web-resources` packages so that our lerna-based version updates don't fall over.  

(Refer to #3171, which fixed a similar situation in the recent past.)