### PR TITLE
fix(ios/engine): fixes keyboard swapping

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -122,16 +122,7 @@
 
                 KeymanWeb.registerStub(stub);
 
-                var kbdID;
-                /* TODO:  Once 14.0 file reorganization/migration is completed,
-                 *        remove if-check and assume stub.KP exists.
-                 */
-                if(stub.KP) {
-                  kbdID = stub.KP + "::" + stub.KI;
-                } else {
-                  kbdID = stub.KI;
-                }
-                kmw.setActiveKeyboard(kbdID, stub.KLC);
+                kmw.setActiveKeyboard(stub.KI, stub.KLC);
                 kmw.osk.show(true);
             }
             


### PR DESCRIPTION
Looks like I got a bit over-eager with some of the package adjustments on iOS. I failed to realize that `keyman.registerStub` would mutate the stub's ID when packages are specified, which caused the package-id to be re-prepended before the `setKeyboard` call.  This went live with the package-based rework in 14.0.95, so it's not been in the wild for long.

Basically, I ended up with `khmer_angkor::khmer_angkor::Keyboard_khmer_angkor` because I re-prefixed the ID with the code being removed, which didn't match the internal single-prefixed version.  

Short version:  Bug = accidental `<package-id::package-id::keyboard-id>` did not match `<package-id::keyboard-id>`.