### PR TITLE
refactor(ios/engine): Notification rework prep, simplification

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -196,7 +196,6 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     // Add lexicalModel.
     for lexicalModel in lexicalModels {
       if lexicalModel.languageID == language?.id {
-        ResourceFileManager.shared.addResource(lexicalModel)
         switchLexicalModel(lexicalModel)
       }
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -420,14 +420,12 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
           //        Serves as a bridge until we're downloading actual .kmps for keyboards.
           let wrappedKeyboards = Migrations.migrateToKMPFormat(keyboards)
 
+          wrappedKeyboards.forEach { keyboard in
+            ResourceFileManager.shared.addResource(keyboard)
+          }
+
           if(!isUpdate) {
             downloadSucceeded(forKeyboards: wrappedKeyboards)
-          } else {
-            // Since we don't generate the notification as above, we need to manually update
-            // the keyboards' metadata.
-            wrappedKeyboards.forEach { keyboard in
-              ResourceFileManager.shared.addResource(keyboard)
-            }
           }
 
           let userDefaults = Storage.active.userDefaults

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -330,7 +330,6 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     
     // Add keyboard.
     for keyboard in keyboards {
-      ResourceFileManager.shared.addResource(keyboard)
       _ = Manager.shared.setKeyboard(keyboard)
     }
     
@@ -341,7 +340,6 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     log.info("lexicalModelDownloadCompleted: InstalledLanguagesViewController")
     // Add models.
     for lexicalModel in lexicalModels {
-      ResourceFileManager.shared.addResource(lexicalModel)
       _ = Manager.shared.registerLexicalModel(lexicalModel)
     }
     

--- a/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
+++ b/ios/engine/KMEI/KeymanEngineDemo/MainViewController.swift
@@ -223,7 +223,6 @@ class MainViewController: UIViewController, UIAlertViewDelegate, TextViewDelegat
     //   - for a list of all events, see KMManager.h
 
     for keyboard in keyboards {
-      Manager.shared.addKeyboard(keyboard)
       Manager.shared.setKeyboard(keyboard)
     }
     perform(#selector(self.dismissActivityIndicator), with: nil, afterDelay: 1.0)

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -53,7 +53,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   private var portRightMargin: CGFloat = 0.0
   private var lscpeLeftMargin: CGFloat = 0.0
   private var lscpeRightMargin: CGFloat = 0.0
-  private var didDownload = false
   private var didKeyboardLoad = false
 
   private var keyboardLoadedObserver: NotificationObserver?
@@ -61,8 +60,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   private var languagesDownloadFailedObserver: NotificationObserver?
   private var keyboardPickerDismissedObserver: NotificationObserver?
   private var keyboardChangedObserver: NotificationObserver?
-  private var keyboardDownloadStartedObserver: NotificationObserver?
-  private var keyboardDownloadCompletedObserver: NotificationObserver?
   private var keyboardRemovedObserver: NotificationObserver?
 
   var appDelegate: AppDelegate! {
@@ -103,10 +100,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       forName: Notifications.keyboardPickerDismissed,
       observer: self,
       function: MainViewController.keyboardPickerDismissed)
-    keyboardDownloadCompletedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.keyboardDownloadCompleted,
-      observer: self,
-      function: MainViewController.keyboardDownloadCompleted)
     keyboardRemovedObserver = NotificationCenter.default.addObserver(
       forName: Notifications.keyboardRemoved,
       observer: self,
@@ -423,17 +416,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   }
 
   private func keyboardChanged(_ kb: InstallableKeyboard) {
-    var listCheck: Bool = true
-    if didDownload {
-      listCheck = false
-      didDownload = false
-    }
-
-    checkProfile(forFullID: kb.fullID, doListCheck: listCheck)
-  }
-
-  private func keyboardDownloadCompleted(_ keyboards: [InstallableKeyboard]) {
-    didDownload = true
+    checkProfile(forFullID: kb.fullID, doListCheck: true)
   }
 
   private func keyboardPickerDismissed() {

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -467,7 +467,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     perform(#selector(self.dismissActivityIndicator), with: nil, afterDelay: 1.0)
 
     for keyboard in keyboards {
-      Manager.shared.addKeyboard(keyboard)
       _ = Manager.shared.setKeyboard(keyboard)
     }
 


### PR DESCRIPTION
This PR serves two purposes:
- Resources will no longer be installed through a `Notifications` callback.
    - Some related code may still require them, such as automatically setting newly installed keyboards as active.
- Removes a lot of old, unreferenced `Notifications`-related code from the codebase.
    - The biggest trigger:  `private var launchURL` hasn't seen use since 10.0 and was always `nil`.
        - Its last known non-`nil` use may be seen [here](https://github.com/keymanapp/keyman/blob/stable-10.0/ios/keyman/Keyman/Keyman/MainViewController.swift#L486).
        - Noting its method's comment, we actually _did_ remove said method in 11.0.