### PR TITLE
fix(mac): altool second call report ci errors

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -405,7 +405,11 @@ if $PREPRELEASE || $NOTARIZE; then
       # We'll sleep 30 seconds before checking status, to give the altool server time to process the archive
       echo "Waiting 30 seconds for status"
       sleep 30
-      xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || fail "altool failed"
+      xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || (
+        ALTOOL_CODE=$?
+        cat "$ALTOOL_LOG_PATH"
+        fail "altool failed with code $ALTOOL_CODE"
+      )
       ALTOOL_STATUS=$(/usr/libexec/PlistBuddy -c "Print notarization-info:Status" "$ALTOOL_LOG_PATH")
       if [ "$ALTOOL_STATUS" == "success" ]; then
         ALTOOL_FINISHED=1


### PR DESCRIPTION
Follow-up on #3264 because I missed the second call to altool in the script.