### PR TITLE
refactor(ios/engine): more dead code removal

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -277,12 +277,6 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     }
   }
   
-  func downloadHandler(_ keyboardIndex: Int) {
-    let language = languages[selectedSection]
-    let keyboard = language.keyboards![keyboardIndex]
-    ResourceDownloadManager.shared.downloadKeyboard(withID: keyboard.id, languageID: language.id, isUpdate: false)
-  }
-  
   private func restoreNavigation() {
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -760,35 +760,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     }
   }
 
-  private func performAction(from url: URL) {
-    guard let query = url.query else {
-      return
-    }
-
-    if url.lastPathComponent != "open" {
-      return
-    }
-
-    let params = self.params(of: query)
-    if let kbID = params["keyboard"], let langID = params["language"] {
-      // Query should include keyboard and language IDs to set the keyboard (first download if not available)
-      guard let keyboard = Manager.shared.apiKeyboardRepository.installableKeyboard(withID: kbID,
-                                                                                    languageID: langID) else {
-        return
-      }
-
-      if ResourceDownloadManager.shared.stateForKeyboard(withID: kbID) == .needsDownload {
-        keyboardToDownload = keyboard
-        confirmInstall(withTitle: "\(keyboard.languageName): \(keyboard.name)",
-          message: "Would you like to install this keyboard?",
-          installButtonHandler: proceedWithKeyboardDownload)
-      } else {
-        Manager.shared.addKeyboard(keyboard)
-        _ = Manager.shared.setKeyboard(keyboard)
-      }
-    }
-  }
-
   private func profileName(withFullID fullID: FullKeyboardID) -> String? {
     guard let keyboard = AppDelegate.activeUserDefaults().userKeyboard(withFullID: fullID),
           let font = keyboard.font else {

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -830,14 +830,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     self.present(alertController, animated: true, completion: nil)
   }
 
-  private func proceedWithKeyboardDownload(withAction action: UIAlertAction) {
-    if let keyboard = keyboardToDownload {
-      ResourceDownloadManager.shared.downloadKeyboard(withID: keyboard.id,
-                                                      languageID: keyboard.languageID,
-                                                      isUpdate: false)
-    }
-  }
-
   private func handleUserDecisionAboutInstallingProfile(withAction action: UIAlertAction) {
     if let profileName = profileName {
       checkedProfiles.append(profileName)


### PR DESCRIPTION
As it turns out, #3261 removed the last reference to `MainViewController.performAction(from:)`.  Since its use was dependent on `launchURL` being non-`nil`, it also hasn't seen use since 11.0.

I didn't chase down a version for the other removed block, but there were no references to it, either - parallel versions exist in the subviews that do the actual installation prompts.