### PR TITLE
refactor(ios/engine): Download notifications via completion blocks

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -528,12 +528,7 @@ public class ResourceDownloadManager {
   internal func resourceUpdateCompletionClosure<Resource: LanguageResource>(for resources: [Resource], handler: CompletionHandler<Resource>?) -> CompletionHandler<Resource> {
     // Updates should not generate notifications per resource.
     return { package, error in
-      if let _ = package {
-        // successful download
-        // Problem:  this uses the lookup-version of the resources, which may not be perfect matches
-        // for what lies within the newly-downloaded package.
-        self.resourceDownloadCompleted(for: resources)
-      } // No special handling if errors exist.
+      // Do not send notifications for individual resource updates.
 
       handler?(package, error)
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -65,7 +65,12 @@ public class ResourceDownloadManager {
                                     completionBlock: CompletionHandler<InstallableKeyboard>? = nil) -> DownloadBatch<InstallableKeyboard>? {
     let startClosure = self.resourceDownloadStartClosure(for: keyboards)
     let completionClosure = self.resourceDownloadCompletionClosure(for: keyboards, handler: completionBlock)
-    if let dlBatch = buildKeyboardDownloadBatch(for: keyboards[0], withFilename: filename, asActivity: activity, withOptions: options, startBlock: startClosure, completionBlock: completionClosure) {
+    if let dlBatch = buildKeyboardDownloadBatch(for: keyboards[0],
+                                                withFilename: filename,
+                                                asActivity: activity,
+                                                withOptions: options,
+                                                startBlock: startClosure,
+                                                completionBlock: completionClosure) {
       let tasks = dlBatch.downloadTasks
       // We want to denote ALL language variants of a keyboard as part of the batch's metadata, even if we only download a single time.
       tasks.forEach { task in
@@ -73,11 +78,9 @@ public class ResourceDownloadManager {
       }
       
       // Perform common 'can download' check.  We need positive reachability and no prior download queue.
-      // The parameter facilitates error logging.
-      if !downloader.canExecute(.simpleBatch(dlBatch)) {
-        let error = NSError(domain: "Keyman", code: 0,
-                  userInfo: [NSLocalizedDescriptionKey: "Download queue is either busy or lacks internet connection"])
-        resourceDownloadFailed(for: keyboards, with: error)
+      let queueState = downloader.state
+      if queueState != .clear {
+        resourceDownloadFailed(for: keyboards, with: queueState.error!)
         return nil
       }
       
@@ -226,7 +229,11 @@ public class ResourceDownloadManager {
                                         completionBlock: CompletionHandler<InstallableLexicalModel>? = nil) -> DownloadBatch<InstallableLexicalModel>? {
     let startClosure = self.resourceDownloadStartClosure(for: lexicalModels)
     let completionClosure = self.resourceDownloadCompletionClosure(for: lexicalModels, handler: completionBlock)
-    if let dlBatch = buildLexicalModelDownloadBatch(for: lexicalModels[0], withFilename: path, asActivity: activity, startBlock: startClosure, completionBlock: completionClosure) {
+    if let dlBatch = buildLexicalModelDownloadBatch(for: lexicalModels[0],
+                                                    withFilename: path,
+                                                    asActivity: activity,
+                                                    startBlock: startClosure,
+                                                    completionBlock: completionClosure) {
       let tasks = dlBatch.downloadTasks
       // We want to denote ALL language variants of a keyboard as part of the batch's metadata, even if we only download a single time.
       tasks.forEach { task in
@@ -234,11 +241,9 @@ public class ResourceDownloadManager {
       }
       
       // Perform common 'can download' check.  We need positive reachability and no prior download queue.
-      // The parameter facilitates error logging.
-      if !downloader.canExecute(.simpleBatch(dlBatch)) {
-        let error = NSError(domain: "Keyman", code: 0,
-                          userInfo: [NSLocalizedDescriptionKey: "Download queue is either busy or lacks internet connection"])
-        resourceDownloadFailed(for: lexicalModels, with: error)
+      let queueState = downloader.state
+      if queueState != .clear {
+        resourceDownloadFailed(for: lexicalModels, with: queueState.error!)
         return nil
       }
       

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -115,14 +115,21 @@ public class ResourceDownloadManager {
       let fontTask = DownloadTask<InstallableKeyboard>(do: request, for: nil, type: nil)
       batchTasks.append(fontTask)
     }
-    
-    let batch = DownloadBatch(do: batchTasks, as: activity, ofType: .keyboard, completionBlock: completionBlock)
+
+    let startHandler = { self.defaultKeyboardStartBlock(for: keyboard) }
+    let batch = DownloadBatch(do: batchTasks, as: activity, ofType: .keyboard, startBlock: startHandler, completionBlock: completionBlock)
     batchTasks.forEach { task in
       task.request.userInfo[Key.downloadBatch] = batch
       task.request.userInfo[Key.downloadTask] = task
     }
     
     return batch
+  }
+
+  internal func defaultKeyboardStartBlock(for keyboard: InstallableKeyboard) {
+    NotificationCenter.default.post(name: Notifications.keyboardDownloadStarted,
+                                        object: self,
+                                        value: [keyboard])
   }
 
   /// Asynchronously fetches the .js file for the keyboard with given IDs.
@@ -257,14 +264,21 @@ public class ResourceDownloadManager {
 
     let lexicalModelTask = DownloadTask(do: request, for: [lexicalModel], type: .lexicalModel)
     let batchTasks: [DownloadTask<InstallableLexicalModel>] = [ lexicalModelTask ]
-    
-    let batch = DownloadBatch(do: batchTasks, as: activity, ofType: .lexicalModel, completionBlock: completionBlock)
+
+    let startHandler = { self.defaultLexicalModelStartBlock(for: lexicalModel) }
+    let batch = DownloadBatch(do: batchTasks, as: activity, ofType: .lexicalModel, startBlock: startHandler, completionBlock: completionBlock)
     batchTasks.forEach { task in
       task.request.userInfo[Key.downloadBatch] = batch
       task.request.userInfo[Key.downloadTask] = task
     }
     
     return batch
+  }
+
+  internal func defaultLexicalModelStartBlock(for lexicalModel: InstallableLexicalModel) {
+    NotificationCenter.default.post(name: Notifications.lexicalModelDownloadStarted,
+                                        object: self,
+                                        value: [lexicalModel])
   }
   
   // Can be called by the cloud keyboard downloader and utilized.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -17,7 +17,7 @@ public class ResourceDownloadManager {
   private var downloader: ResourceDownloadQueue
   private var isDidUpdateCheck = false
 
-  public typealias CompletionHandler<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>> = (Package?, Error?) -> Void
+  public typealias CompletionHandler<Resource: LanguageResource> = (Resource.Package?, Error?) -> Void
   
   public static let shared = ResourceDownloadManager()
   
@@ -62,7 +62,7 @@ public class ResourceDownloadManager {
                                     asActivity activity: DownloadActivityType,
                                     withFilename filename: String,
                                     withOptions options: Options,
-                                    completionBlock: CompletionHandler<InstallableKeyboard, KeyboardKeymanPackage>? = nil) -> DownloadBatch<InstallableKeyboard, KeyboardKeymanPackage>? {
+                                    completionBlock: CompletionHandler<InstallableKeyboard>? = nil) -> DownloadBatch<InstallableKeyboard>? {
 
     if let dlBatch = buildKeyboardDownloadBatch(for: keyboards[0], withFilename: filename, asActivity: activity, withOptions: options, completionBlock: completionBlock) {
       let tasks = dlBatch.downloadTasks
@@ -87,7 +87,7 @@ public class ResourceDownloadManager {
                                           withFilename filename: String,
                                           asActivity activity: DownloadActivityType,
                                           withOptions options: Options,
-                                          completionBlock: CompletionHandler<InstallableKeyboard, KeyboardKeymanPackage>? = nil) -> DownloadBatch<InstallableKeyboard, KeyboardKeymanPackage>? {
+                                          completionBlock: CompletionHandler<InstallableKeyboard>? = nil) -> DownloadBatch<InstallableKeyboard>? {
     let keyboardURL = options.keyboardBaseURL.appendingPathComponent(filename)
     let fontURLs = Array(Set(keyboardFontURLs(forFont: keyboard.font, options: options) +
                              keyboardFontURLs(forFont: keyboard.oskFont, options: options)))
@@ -134,7 +134,7 @@ public class ResourceDownloadManager {
                                languageID: String,
                                isUpdate: Bool,
                                fetchRepositoryIfNeeded: Bool = true,
-                               completionBlock: CompletionHandler<InstallableKeyboard, KeyboardKeymanPackage>? = nil) {
+                               completionBlock: CompletionHandler<InstallableKeyboard>? = nil) {
     guard let _ = Manager.shared.apiKeyboardRepository.keyboards,
       let options = Manager.shared.apiKeyboardRepository.options
     else {
@@ -217,7 +217,7 @@ public class ResourceDownloadManager {
   private func downloadLexicalModelCore(withMetadata lexicalModels: [InstallableLexicalModel],
                                         asActivity activity: DownloadActivityType,
                                         fromPath path: URL,
-                                        completionBlock: CompletionHandler<InstallableLexicalModel, LexicalModelKeymanPackage>? = nil) -> DownloadBatch<InstallableLexicalModel, LexicalModelKeymanPackage>? {
+                                        completionBlock: CompletionHandler<InstallableLexicalModel>? = nil) -> DownloadBatch<InstallableLexicalModel>? {
 
     if let dlBatch = buildLexicalModelDownloadBatch(for: lexicalModels[0], withFilename: path, asActivity: activity, completionBlock: completionBlock) {
       let tasks = dlBatch.downloadTasks
@@ -241,7 +241,7 @@ public class ResourceDownloadManager {
   private func buildLexicalModelDownloadBatch(for lexicalModel: InstallableLexicalModel,
                                               withFilename path: URL,
                                               asActivity activity: DownloadActivityType,
-                                              completionBlock: CompletionHandler<InstallableLexicalModel, LexicalModelKeymanPackage>? = nil) -> DownloadBatch<InstallableLexicalModel, LexicalModelKeymanPackage>? {
+                                              completionBlock: CompletionHandler<InstallableLexicalModel>? = nil) -> DownloadBatch<InstallableLexicalModel>? {
     do {
       try FileManager.default.createDirectory(at: Storage.active.resourceDir(for: lexicalModel)!,
                                               withIntermediateDirectories: true)
@@ -317,7 +317,7 @@ public class ResourceDownloadManager {
                                    languageID: String,
                                    isUpdate: Bool,
                                    fetchRepositoryIfNeeded: Bool = true,
-                                   completionBlock: CompletionHandler<InstallableLexicalModel, LexicalModelKeymanPackage>? = nil) {
+                                   completionBlock: CompletionHandler<InstallableLexicalModel>? = nil) {
     
     // TODO:  We should always force a refetch after new keyboards are installed so we can redo our language queries.
     //        That should probably be done on successful keyboard installs, not here, though.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -547,6 +547,7 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     // The extra check is there to filter out other potential request types in the future.
     let batch = request.userInfo[Key.downloadBatch] as! AnyDownloadBatch
 
+    // TODO:  remove the != .update check - that should be handled when startBlocks are assigned.
     if batch.activity != .update {
       batch.startBlock?()
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -100,6 +100,7 @@ class DownloadBatch<Resource: LanguageResource>: AnyDownloadBatch {
     self.downloadTasks = tasks
 
     self.errors = Array(repeating: nil, count: tasks.count)
+    self.startBlock = startBlock
     self.completionBlock = completionBlock
   }
 
@@ -546,19 +547,8 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     // The extra check is there to filter out other potential request types in the future.
     let batch = request.userInfo[Key.downloadBatch] as! AnyDownloadBatch
 
-    if request.tag == 0 && batch.activity != .update {
-      let task = request.userInfo[Key.downloadTask] as! AnyDownloadTask
-      if task.type == .keyboard {
-        let task = task as! DownloadTask<InstallableKeyboard>
-        NotificationCenter.default.post(name: Notifications.keyboardDownloadStarted,
-                                        object: self,
-                                        value: task.resources!)
-      } else if task.type == .lexicalModel {
-        let task = task as! DownloadTask<InstallableLexicalModel>
-        NotificationCenter.default.post(name: Notifications.lexicalModelDownloadStarted,
-                                        object: self,
-                                        value: task.resources!)
-      }
+    if batch.activity != .update {
+      batch.startBlock?()
     }
   }
 


### PR DESCRIPTION
This PR finally starts to implement completion-block callbacks for KeymanEngine's download requests.  At this stage of implementation, I've managed to refactor all of the download-related notifications (save for resource updates) out of `ResourceDownloadQueue` and have placed them in closures defined within `ResourceDownloadManager`.

The plan for the next PR is to move the actual downloaded-resource installation code into completion blocks, which will be defined where the original download requests are generated.  The completion blocks / closures are already receiving the downloaded `KeymanPackage`; they're just not being used yet, as getting the notification stuff right was already complex enough.