### PR TITLE
refactor(ios/engine): Resource-download installation closures

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -164,8 +164,12 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
   }
 
   func downloadHandler(_ keyboardIndex: Int) {
-    ResourceDownloadManager.shared.downloadKeyboard(withID: language.keyboards![keyboardIndex].id,
-                                      languageID: language.id, isUpdate: isUpdate)
+    let fullID = FullKeyboardID(keyboardID: language.keyboards![keyboardIndex].id, languageID: language.id)
+    let installClosure = ResourceDownloadManager.shared.standardKeyboardInstallCompletionBlock(forFullID: fullID, withModel: true)
+    ResourceDownloadManager.shared.downloadKeyboard(withID: fullID.keyboardID,
+                                                    languageID: fullID.languageID,
+                                                    isUpdate: isUpdate,
+                                                    completionBlock: installClosure)
   }
   
   func showActivityView() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -235,8 +235,9 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     
   func downloadHandler(_ keyboardIndex: Int) {
     let language = languages[selectedSection]
-    let keyboard = language.keyboards![keyboardIndex]
-    ResourceDownloadManager.shared.downloadKeyboard(withID: keyboard.id, languageID: language.id, isUpdate: isUpdate)
+    let fullID = FullKeyboardID(keyboardID: language.keyboards![keyboardIndex].id, languageID: language.id)
+    let installClosure = ResourceDownloadManager.shared.standardKeyboardInstallCompletionBlock(forFullID: fullID, withModel: true)
+    ResourceDownloadManager.shared.downloadKeyboard(withID: fullID.keyboardID, languageID: fullID.languageID, isUpdate: isUpdate, completionBlock: installClosure)
   }
 
   private func keyboardDownloadStarted() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -193,13 +193,6 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
       navigationItem.rightBarButtonItem?.isEnabled = true
     }
     
-    // Add lexicalModel.
-    for lexicalModel in lexicalModels {
-      if lexicalModel.languageID == language?.id {
-        switchLexicalModel(lexicalModel)
-      }
-    }
-    
     navigationController?.popToRootViewController(animated: true)
   }
   
@@ -315,7 +308,9 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
         DispatchQueue.main.async {
           let button: UIButton? = (self.navigationController?.toolbar?.viewWithTag(toolbarButtonTag) as? UIButton)
           button?.isEnabled = false
-          let vc = LanguageLMDetailViewController(language: self.language)
+          let vc = LanguageLMDetailViewController(language: self.language, onSuccess: { lm in
+            self.switchLexicalModel(lm)
+          })
           vc.lexicalModels = lexicalModels!
           self.navigationController?.pushViewController(vc, animated: true)
         }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -838,18 +838,24 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
    */
 
   public func downloadKeyboard(withID: String, languageID: String, isUpdate: Bool, fetchRepositoryIfNeeded: Bool = true) {
+    let kbdFullID = FullKeyboardID(keyboardID: withID, languageID: languageID)
+    let completionBlock = ResourceDownloadManager.shared.standardKeyboardInstallCompletionBlock(forFullID: kbdFullID, withModel: true)
     ResourceDownloadManager.shared.downloadKeyboard(withID: withID,
                                                     languageID: languageID,
                                                     isUpdate: isUpdate,
-                                                    fetchRepositoryIfNeeded: fetchRepositoryIfNeeded)
+                                                    fetchRepositoryIfNeeded: fetchRepositoryIfNeeded,
+                                                    completionBlock: completionBlock)
   }
 
   // A new API, but it so closely parallels downloadKeyboard that we should add a 'helper' handler here.
   public func downloadLexicalModel(withID: String, languageID: String, isUpdate: Bool, fetchRepositoryIfNeeded: Bool = true) {
+    let lmFullID = FullLexicalModelID(lexicalModelID: withID, languageID: languageID)
+    let completionBlock = ResourceDownloadManager.shared.standardLexicalModelInstallCompletionBlock(forFullID: lmFullID)
     ResourceDownloadManager.shared.downloadLexicalModel(withID: withID,
                                                         languageID: languageID,
                                                         isUpdate: isUpdate,
-                                                        fetchRepositoryIfNeeded: fetchRepositoryIfNeeded)
+                                                        fetchRepositoryIfNeeded: fetchRepositoryIfNeeded,
+                                                        completionBlock: completionBlock)
   }
 
   public func stateForKeyboard(withID keyboardID: String) -> KeyboardState {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -312,30 +312,16 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     log.info("keyboardDownloadCompleted: InstalledLanguagesViewController")
     Manager.shared.shouldReloadKeyboard = true
     
-    // Update keyboard version
-    for keyboard in keyboards {
-      Manager.shared.updateUserKeyboards(with: keyboard)
-    }
-    
     if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
       toolbar.displayStatus("Keyboard successfully downloaded!", withIndicator: false, duration: 3.0)
     }
     restoreNavigation()
-    
-    // Add keyboard.
-    for keyboard in keyboards {
-      _ = Manager.shared.setKeyboard(keyboard)
-    }
     
     navigationController?.popToRootViewController(animated: true)
   }
   
   private func lexicalModelDownloadCompleted(_ lexicalModels: [InstallableLexicalModel]) {
     log.info("lexicalModelDownloadCompleted: InstalledLanguagesViewController")
-    // Add models.
-    for lexicalModel in lexicalModels {
-      _ = Manager.shared.registerLexicalModel(lexicalModel)
-    }
     
     if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
       toolbar.displayStatus("Dictionary successfully downloaded!", withIndicator: false, duration: 3.0)


### PR DESCRIPTION
This extracts the data-management aspects of resource installation from the various KeymanEngine views and defines it in the same class as the actual installation methods.  I've set things up with a few functions that configure installation closures that may be set to run when downloads complete.  This helps to ensure installation consistency regardless of origin in the view hierarchy while also allowing further configurability / customization as needed.

This doesn't add unit tests for all the recent downloader-refactoring work; the plan is to address that once KeymanEngine is downloading keyboard KMPs.  At that point, `ResourceDownloadQueue` will be far more stable.  While it's already more test-friendly than before, use of keyboard KMPs will improve things on that level as well.