### PR TITLE
feat(linux): Install keyboard on Gnome

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 120
+ignore =
+  E402,  # module level import not at top of file
+  W504,  # line break after binary operator

--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -6,15 +6,15 @@ import urllib.parse
 import webbrowser
 
 import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('WebKit2', '4.0')
+
 from gi.repository import Gtk, WebKit2
 from keyman_config.get_kmp import get_download_folder, download_kmp_file
 from keyman_config.install_window import InstallKmpWindow
 from keyman_config.accelerators import init_accel
 from keyman_config.get_info import GetInfo
 from keyman_config import __releaseversion__
-
-gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
 
 
 class DownloadKmpWindow(Gtk.Dialog):

--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+import logging
+import os
+from gi.repository import Gio
+
+from gi.overrides.GLib import Variant
+
+
+class GnomeKeyboardsUtil():
+    def __init__(self):
+        self.input_sources = Gio.Settings.new("org.gnome.desktop.input-sources")
+
+    def read_input_sources(self):
+        sourcesVal = self.input_sources.get_value("sources")
+        sources = self._convert_variant_to_array(sourcesVal)
+        return sources
+
+    def write_input_sources(self, sources):
+        sourcesVal = self._convert_array_to_variant(sources)
+        self.input_sources.set_value("sources", sourcesVal)
+
+    def _convert_variant_to_array(self, variant):
+        if variant is None:
+            return []
+
+        values = []
+        # a(ss)
+        nChildren = variant.n_children()
+        for i in range(nChildren):
+            # (ss)
+            val = variant.get_child_value(i)
+            typeVariant = val.get_child_value(0)
+            type = typeVariant.get_string()
+            idVariant = val.get_child_value(1)
+            id = idVariant.get_string()
+            values.append((type, id))
+        return values
+
+    def _convert_array_to_variant(self, array):
+        if len(array) == 0:
+            return None
+
+        children = []
+        for (type, id) in array:
+            typeVariant = Variant.new_string(type)
+            idVariant = Variant.new_string(id)
+            child = Variant.new_tuple(typeVariant, idVariant)
+            children.append(child)
+        return Variant.new_array(None, children)
+
+
+__is_gnome_shell = None
+
+
+def is_gnome_shell():
+    global __is_gnome_shell
+
+    if __is_gnome_shell is None:
+        code = os.system('pidof gnome-shell >/dev/null 2>&1')
+        __is_gnome_shell = (code == 0)
+    return __is_gnome_shell
+
+
+def _reset_gnome_shell():
+    # used in unit tests
+    global __is_gnome_shell
+
+    __is_gnome_shell = None
+
+
+def get_keyboard_id(keyboard, packageDir, ignore_language=False):
+    kmx_file = os.path.join(packageDir, keyboard['id'] + ".kmx")
+    if not ignore_language and "languages" in keyboard and len(keyboard["languages"]) > 0:
+        logging.debug(keyboard["languages"][0])
+        return "%s:%s" % (keyboard["languages"][0]['id'], kmx_file)
+    return kmx_file

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -4,9 +4,8 @@ import gi
 import logging
 import subprocess
 
-from gi.repository import IBus, Gio
-
 gi.require_version('IBus', '1.0')
+from gi.repository import IBus, Gio
 
 
 def get_ibus_bus():

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -4,11 +4,10 @@ import gi
 import logging
 import webbrowser
 
-from gi.repository import Gtk, WebKit2
-from keyman_config.accelerators import bind_accelerator, init_accel
-
 gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit2', '4.0')
+from gi.repository import Gtk, WebKit2
+from keyman_config.accelerators import bind_accelerator, init_accel
 
 # NOTE: WebKit2 is not able to load XHTML files nor files with an encoding other
 # than ASCII or UTF-8

--- a/linux/keyman-config/tests/test_gnome_keyboards_util.py
+++ b/linux/keyman-config/tests/test_gnome_keyboards_util.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+import unittest
+from unittest.mock import patch
+
+from keyman_config.gnome_keyboards_util import GnomeKeyboardsUtil
+from keyman_config.gnome_keyboards_util import is_gnome_shell, _reset_gnome_shell
+
+
+class GnomeKeyboardsUtilTests(unittest.TestCase):
+    def setUp(self):
+        _reset_gnome_shell()
+        patcher = patch('keyman_config.ibus_util.Gio.Settings.new')
+        self.MockSettingsClass = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_ConvertArrayToVariantToArray_Empty(self):
+        # Setup
+        children = []
+        sut = GnomeKeyboardsUtil()
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_OneElement(self):
+        # Setup
+        children = [('t1', 'id1')]
+        sut = GnomeKeyboardsUtil()
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_MultipleElements(self):
+        # Setup
+        children = [('t1', 'id1'), ('t2', 'id2')]
+        sut = GnomeKeyboardsUtil()
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    @patch.object(GnomeKeyboardsUtil, '_convert_variant_to_array')
+    def test_ReadInputSources(self, convertVariantToArrayMethod):
+        # Setup
+        keyboards = [('xkb', 'en')]
+        mock_settingsInstance = self.MockSettingsClass.return_value
+        mock_settingsInstance.get_value.return_value = keyboards
+        convertVariantToArrayMethod.side_effect = lambda value: value
+        sut = GnomeKeyboardsUtil()
+        # Execute
+        result = sut.read_input_sources()
+        # Verify
+        self.assertEqual(result, keyboards)
+
+    @patch.object(GnomeKeyboardsUtil, '_convert_array_to_variant')
+    def test_WriteInputSources(self, convertArrayToVariantMethod):
+        # Setup
+        convertArrayToVariantMethod.side_effect = lambda value: value
+        sut = GnomeKeyboardsUtil()
+        keyboards = [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+        # Execute
+        sut.write_input_sources(keyboards)
+        # Verify
+        self.MockSettingsClass.return_value.set_value.assert_called_once_with(
+            "sources", keyboards)
+
+    @patch('keyman_config.install_kmp.os.system')
+    def test_IsGnomeShell_RunningGnomeShell(self, mockSystem):
+        # Setup
+        mockSystem.return_value = 0
+        # Execute/Verify
+        self.assertEqual(is_gnome_shell(), True)
+
+    @patch('keyman_config.install_kmp.os.system')
+    def test_IsGnomeShell_NotRunningGnomeShell(self, mockSystem):
+        # Setup
+        mockSystem.return_value = 1
+        # Execute/Verify
+        self.assertEqual(is_gnome_shell(), False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/linux/keyman-config/tests/test_ibus_util.py
+++ b/linux/keyman-config/tests/test_ibus_util.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 import unittest
-from unittest.mock import create_autospec, patch
+from unittest.mock import patch
 
-from keyman_config.ibus_util import get_ibus_bus, install_to_ibus, uninstall_from_ibus, IBus, Gio
+from keyman_config.ibus_util import get_ibus_bus, install_to_ibus, uninstall_from_ibus
+
 
 @patch('keyman_config.ibus_util.IBus.Bus')
 class IbusUtilTests(unittest.TestCase):
@@ -41,7 +42,7 @@ class IbusUtilTests(unittest.TestCase):
     def test_installToIbus_AlreadyInstalled(self, MockSettingsClass, MockIbusBusClass):
         # Setup
         mock_settingsInstance = MockSettingsClass.return_value
-        mock_settingsInstance.get_strv.return_value = [ 'k1', 'k2', 'k3' ]
+        mock_settingsInstance.get_strv.return_value = ['k1', 'k2', 'k3']
         mock_ibusBusInstance = MockIbusBusClass.return_value
         # Execute
         install_to_ibus(mock_ibusBusInstance, 'k3')
@@ -92,6 +93,7 @@ class IbusUtilTests(unittest.TestCase):
             "preload-engines", ['k1', 'k2', 'k3'])
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+import unittest
+from unittest.mock import patch
+
+from keyman_config.uninstall_kmp import uninstall_keyboards_from_gnome
+
+
+class UninstallKmpTests(unittest.TestCase):
+
+    def setUp(self):
+        patcher = patch('keyman_config.uninstall_kmp.GnomeKeyboardsUtil')
+        self.mockGnomeKeyboardsUtilClass = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_UninstallKeyboardsFromGnome_RemoveOneKeyboardFromEmpty(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = []
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([])
+
+    def test_UninstallKeyboardsFromGnome_RemoveNonExistingKeyboard(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('ibus', 'fooDir/foo2.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([
+            ('ibus', 'fooDir/foo2.kmx')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveOneKeyboard(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveMultipleKeyboards(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveAllKeyboards(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([])
+
+    def test_UninstallKeyboardsFromGnome_RemoveKeyboard_SingleLanguage(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveKeyboard_MultipleLanguages(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome(
+            [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveKeyboard_OneNotMatchingLanguage(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome(
+            [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])
+
+    def test_UninstallKeyboardsFromGnome_RemoveKeyboard_RemovesAllMatching(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
+            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx'), ('ibus', 'fr:fooDir/foo1.kmx')]
+        # Execute
+        uninstall_keyboards_from_gnome(
+            [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en')])


### PR DESCRIPTION
This change adds the keyboard to the Gnome input sources after
installing the .kmx file, and removes it on uninstall.

This implements #2728.