### PR TITLE
feat(ios/engine): package-version query implementation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		C0D3F3601F9F3AD80055C7CF /* InstallableKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F35F1F9F3AD80055C7CF /* InstallableKeyboard.swift */; };
 		C0E30C8C1FC40D0400C80416 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E30C8B1FC40D0400C80416 /* Storage.swift */; };
 		C0EF3E7B1F95B65300CE9BD4 /* KeymanWebDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */; };
+		CE02EE0C24A5863100D58F92 /* Queries.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE02EE0B24A5863100D58F92 /* Queries.bundle */; };
+		CE02EE0E24A5869500D58F92 /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02EE0D24A5869500D58F92 /* Queries.swift */; };
+		CE02EE1024A5892200D58F92 /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02EE0F24A5892200D58F92 /* URLSessionDataTaskMock.swift */; };
 		CE07E3D2247E3FB100DFA9D2 /* HTTPDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE07E3D1247E3FB100DFA9D2 /* HTTPDownloaderTests.swift */; };
 		CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE07E3D5247E41DB00DFA9D2 /* URLSessionMock.swift */; };
 		CE07E3D8247E43CB00DFA9D2 /* URLSessionDownloadTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE07E3D7247E43CB00DFA9D2 /* URLSessionDownloadTaskMock.swift */; };
@@ -438,6 +441,9 @@
 		C0ED71B21F6BB0B1002A2FD6 /* HTTPDownloadRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPDownloadRequest.swift; sourceTree = "<group>"; };
 		C0ED71B41F6BBFAF002A2FD6 /* HTTPDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPDownloader.swift; sourceTree = "<group>"; };
 		C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanWebDelegate.swift; sourceTree = "<group>"; };
+		CE02EE0B24A5863100D58F92 /* Queries.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Queries.bundle; sourceTree = "<group>"; };
+		CE02EE0D24A5869500D58F92 /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
+		CE02EE0F24A5892200D58F92 /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		CE07E3D1247E3FB100DFA9D2 /* HTTPDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDownloaderTests.swift; sourceTree = "<group>"; };
 		CE07E3D5247E41DB00DFA9D2 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
 		CE07E3D7247E43CB00DFA9D2 /* URLSessionDownloadTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDownloadTaskMock.swift; sourceTree = "<group>"; };
@@ -824,6 +830,7 @@
 			isa = PBXGroup;
 			children = (
 				CE07E3D5247E41DB00DFA9D2 /* URLSessionMock.swift */,
+				CE02EE0F24A5892200D58F92 /* URLSessionDataTaskMock.swift */,
 				CE07E3D7247E43CB00DFA9D2 /* URLSessionDownloadTaskMock.swift */,
 				CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */,
 			);
@@ -842,6 +849,7 @@
 		CE37C38923FCC9AF007031C6 /* resources */ = {
 			isa = PBXGroup;
 			children = (
+				CE02EE0B24A5863100D58F92 /* Queries.bundle */,
 				CEA6BA9C249872E7002D44CE /* Simple 13.0 Migration.bundle */,
 				CE8B5BB12491DA530075CCB0 /* 13.0 Cloud to Package Migration.bundle */,
 				CE973D822484A5DB00F66045 /* PackageJSON.bundle */,
@@ -920,6 +928,7 @@
 				CE9CD88223FCC4E3002BF2F8 /* UserDefaults.swift */,
 				CE973D802484A56500F66045 /* PackageJSON.swift */,
 				CE37C38C23FCD41E007031C6 /* Keyboards.swift */,
+				CE02EE0D24A5869500D58F92 /* Queries.swift */,
 				CE37C39023FCD617007031C6 /* LexicalModels.swift */,
 				CE9B440B23FE49F000499CAB /* Migrations.swift */,
 			);
@@ -1280,6 +1289,7 @@
 				CE9B440F23FE4E7500499CAB /* 12.0 Ad-hoc Migration.bundle in Resources */,
 				CE8B5BB22491DA540075CCB0 /* 13.0 Cloud to Package Migration.bundle in Resources */,
 				9A0FCA0922D7C58B00D33F86 /* Keyman.bundle in Resources */,
+				CE02EE0C24A5863100D58F92 /* Queries.bundle in Resources */,
 				CEA6BA9D249872E8002D44CE /* Simple 13.0 Migration.bundle in Resources */,
 				CEF888D323FE6ADF00667693 /* Simple 10.0 Migration.bundle in Resources */,
 				CE37C38F23FCD52F007031C6 /* Lexical Models.bundle in Resources */,
@@ -1422,7 +1432,9 @@
 				CE37C38D23FCD41E007031C6 /* Keyboards.swift in Sources */,
 				CE9CD88323FCC4E3002BF2F8 /* UserDefaults.swift in Sources */,
 				CE8B0BBD248734240045EB2E /* KeymanPackageTests.swift in Sources */,
+				CE02EE0E24A5869500D58F92 /* Queries.swift in Sources */,
 				CE973D852484A71700F66045 /* KMPJSONTests.swift in Sources */,
+				CE02EE1024A5892200D58F92 /* URLSessionDataTaskMock.swift in Sources */,
 				CE89642524A46D0000D5EB8E /* QueryPackageVersionTests.swift in Sources */,
 				CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */,
 				CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -179,6 +179,9 @@
 		CE867FEF2485E97A00B2EAED /* KMPMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE867FEE2485E97A00B2EAED /* KMPMetadata.swift */; };
 		CE867FF12485EE1500B2EAED /* KMPInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE867FF02485EE1500B2EAED /* KMPInfo.swift */; };
 		CE88042F247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */; };
+		CE89641F24A4686000D5EB8E /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89641E24A4686000D5EB8E /* Queries.swift */; };
+		CE89642124A468B200D5EB8E /* Queries+PackageVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */; };
+		CE89642524A46D0000D5EB8E /* QueryPackageVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */; };
 		CE8B0BBD248734240045EB2E /* KeymanPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8B0BBC248734240045EB2E /* KeymanPackageTests.swift */; };
 		CE8B0BBF248764ED0045EB2E /* KMPResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8B0BBE248764ED0045EB2E /* KMPResource.swift */; };
 		CE8B5BB22491DA540075CCB0 /* 13.0 Cloud to Package Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE8B5BB12491DA530075CCB0 /* 13.0 Cloud to Package Migration.bundle */; };
@@ -464,6 +467,9 @@
 		CE867FEE2485E97A00B2EAED /* KMPMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPMetadata.swift; sourceTree = "<group>"; };
 		CE867FF02485EE1500B2EAED /* KMPInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPInfo.swift; sourceTree = "<group>"; };
 		CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectationDownloaderDelegate.swift; sourceTree = "<group>"; };
+		CE89641E24A4686000D5EB8E /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
+		CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queries+PackageVersion.swift"; sourceTree = "<group>"; };
+		CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPackageVersionTests.swift; sourceTree = "<group>"; };
 		CE8B0BBC248734240045EB2E /* KeymanPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanPackageTests.swift; sourceTree = "<group>"; };
 		CE8B0BBE248764ED0045EB2E /* KMPResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPResource.swift; sourceTree = "<group>"; };
 		CE8B5BB12491DA530075CCB0 /* 13.0 Cloud to Package Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "13.0 Cloud to Package Migration.bundle"; sourceTree = "<group>"; };
@@ -724,6 +730,7 @@
 				CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */,
 				CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */,
 				CE973D842484A71700F66045 /* KMPJSONTests.swift */,
+				CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */,
 			);
 			path = KeymanEngineTests;
 			sourceTree = "<group>";
@@ -885,6 +892,15 @@
 			path = kmp.json;
 			sourceTree = "<group>";
 		};
+		CE89641B24A4665700D5EB8E /* Queries */ = {
+			isa = PBXGroup;
+			children = (
+				CE89641E24A4686000D5EB8E /* Queries.swift */,
+				CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */,
+			);
+			path = Queries;
+			sourceTree = "<group>";
+		};
 		CE973D7F2484A07300F66045 /* KMP Packaging */ = {
 			isa = PBXGroup;
 			children = (
@@ -1008,6 +1024,7 @@
 				C0452BA91F9F1CAF0064431A /* Model */,
 				C024C9921FA6EB340060583B /* Notification */,
 				C07A9D881FD1760800828ADD /* KeyboardRepository */,
+				CE89641B24A4665700D5EB8E /* Queries */,
 				9A60763E22892495003BCFBA /* Settings */,
 				CE25CCBB1F1DA72A005AA2BC /* HTTPRequest */,
 				987F00041AB8FCB700998116 /* KeyboardMenuView */,
@@ -1406,6 +1423,7 @@
 				CE9CD88323FCC4E3002BF2F8 /* UserDefaults.swift in Sources */,
 				CE8B0BBD248734240045EB2E /* KeymanPackageTests.swift in Sources */,
 				CE973D852484A71700F66045 /* KMPJSONTests.swift in Sources */,
+				CE89642524A46D0000D5EB8E /* QueryPackageVersionTests.swift in Sources */,
 				CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */,
 				CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */,
 				CE8EDEB323F53F96009E1FF6 /* VersionTests.swift in Sources */,
@@ -1452,6 +1470,7 @@
 				C0B901AA1FA1AFC200764EB8 /* UserDefaults+Types.swift in Sources */,
 				CE1F67A32304EB3800FF6972 /* ResourceDownloadManager.swift in Sources */,
 				9A079E372238680700581263 /* KMPLexicalModel.swift in Sources */,
+				CE89641F24A4686000D5EB8E /* Queries.swift in Sources */,
 				9A3E832522EAC14A00D22D2A /* KeyboardSwitcherViewController.swift in Sources */,
 				C0324B911F8763E100AF3785 /* TextViewDelegateProxy.swift in Sources */,
 				C0B09EAE1FCFD10F002F39AF /* FontManager.swift in Sources */,
@@ -1495,6 +1514,7 @@
 				CE22DFBA230B94DB00A4551C /* ResourceDownloadQueue.swift in Sources */,
 				CE973D872484BBC200F66045 /* KMPLanguage.swift in Sources */,
 				9A9CB084224170F700231FB9 /* LexicalModelRepository.swift in Sources */,
+				CE89642124A468B200D5EB8E /* Queries+PackageVersion.swift in Sources */,
 				C06D37461F81F5C400F61AE0 /* PopoverView.swift in Sources */,
 				9A4609992242047400B0BFD1 /* LexicalModelAPICall.swift in Sources */,
 				C007C4651F9F52D8006461B9 /* LanguagesAPICall.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
@@ -1,0 +1,98 @@
+//
+//  Queries+PackageVersion.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 6/25/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+extension Queries {
+  class PackageVersion {
+    class ResultComponent {}
+
+    class ResultEntry: ResultComponent, Decodable {
+      let version: String
+      let packageURL: String
+
+      enum CodingKeys: String, CodingKey {
+        case version
+        case packageURL = "kmp"
+      }
+    }
+
+    class ResultError: ResultComponent, Decodable {
+      let error: String
+
+      enum CodingKeys: String, CodingKey {
+        case error
+      }
+    }
+
+    struct Result: Decodable {
+      let keyboards: [String : ResultComponent]?
+      let models: [String : ResultComponent]?
+
+      enum CodingKeys: String, CodingKey {
+        case keyboards
+        case models
+      }
+
+      init(from decoder: Decoder) throws {
+        let rootValues = try decoder.container(keyedBy: CodingKeys.self)
+
+        func dictionaryReducer(container: KeyedDecodingContainer<Queries.IDCodingKey>, category: String) -> ([String: ResultComponent], Queries.IDCodingKey) throws -> [String: ResultComponent] {
+          return { (dict, id) -> [String: ResultComponent] in
+            var dict = dict
+            if let entry = try? container.decode(ResultEntry.self, forKey: id) {
+              dict[id.stringValue] = entry
+            } else if let error = try? container.decode(ResultError.self, forKey: id) {
+              dict[id.stringValue] = error
+            } else {
+              throw NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "Unexpected value contained during \(category) decoding, id \(id.stringValue)"])
+            }
+            return dict
+          }
+        }
+
+        let keyboardValueSet = try rootValues.nestedContainer(keyedBy: IDCodingKey.self, forKey: .keyboards)
+        keyboards = try keyboardValueSet.allKeys.reduce([String: ResultComponent](), dictionaryReducer(container: keyboardValueSet, category: "keyboard"))
+
+        let modelValueSet = try rootValues.nestedContainer(keyedBy: IDCodingKey.self, forKey: .models)
+        models = try modelValueSet.allKeys.reduce([String: ResultComponent](), dictionaryReducer(container: modelValueSet, category: "lexical model"))
+      }
+    }
+
+    private static let PACKAGE_VERSION_ENDPOINT = URLComponents(string: "https://api.keyman.com/package-version")!
+
+    public static func fetch(for fullIDs: [AnyLanguageResourceFullID],
+                             withSession session: URLSession = .shared,
+                             fetchCompletion: @escaping JSONQueryCompletionBlock<Result>) {
+      // Step 1:  build the query
+      var urlComponents = PACKAGE_VERSION_ENDPOINT
+
+      let queryItems: [URLQueryItem] = fullIDs.map { fullID in
+        var resourceField: String
+        switch(fullID.type) {
+          case .keyboard:
+            resourceField = "keyboard"
+          case .lexicalModel:
+            resourceField = "model"
+        }
+
+        return URLQueryItem(name: resourceField, value: fullID.id)
+      }
+
+      urlComponents.queryItems = queryItems + [URLQueryItem(name: "platform", value: "ios")]
+      log.info("Querying package versions through API endpoint: \(urlComponents.url!)")
+
+      // Step 2:  configure the completion closure.
+      let completionClosure = Queries.jsonDataTaskCompletionAdapter(resultType: Result.self, completionBlock: fetchCompletion)
+
+      // Step 3:  run the actual query, letting the prepared completion closure take care of the rest.
+      let task = session.dataTask(with: urlComponents.url!, completionHandler: completionClosure)
+      task.resume()
+    }
+  }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries.swift
@@ -1,0 +1,81 @@
+//
+//  Queries.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 6/25/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+// The core `Queries` definition provides common utility methods, handlers, etc across our API queries.
+class Queries {
+  public enum FetchError: Error {
+    case networkError(Error)
+    case noData
+    case parsingError(Error)
+
+    var localizedDescription: String {
+      switch self {
+        case .noData:
+          return "no data returned"
+        case .networkError(let baseError):
+          return "network error occurred - \(String(describing: baseError))"
+        case .parsingError(let baseError):
+          return "failure occurred when parsing results - \(String(describing: baseError))"
+      }
+    }
+  }
+
+  public struct IDCodingKey: CodingKey {
+    /* Required by CodingKey, though we don't particularly need these */
+    public var intValue: Int?
+
+    public init?(intValue: Int) {
+      self.init(stringValue: "\(intValue)")
+      self.intValue = intValue
+    }
+    /* End section */
+
+    var stringValue: String
+
+    init?(stringValue: String) {
+      self.stringValue = stringValue
+    }
+  }
+
+  typealias JSONQueryCompletionBlock<T: Decodable> = (_: T?, _: Queries.FetchError?) -> Void
+  typealias DataTaskCompletionBlock = (_: Data?, _: URLResponse?, _: Error?) -> Void
+
+  /**
+   * Returns a closure that wraps closures expecting a decodable type,
+   * performing standard error checking and decoding the query's results
+   * on behalf of the wrapped closure.
+   *
+   * Returns either the decoded result when successful or the error that
+   * occurred when attempting to run the query.
+   */
+  internal static func jsonDataTaskCompletionAdapter<T: Decodable>(resultType: T.Type, completionBlock: @escaping JSONQueryCompletionBlock<T>) -> DataTaskCompletionBlock {
+    return { data, response, baseError in
+      guard baseError == nil else {
+        DispatchQueue.main.async { completionBlock(nil, .networkError(baseError!)) }
+        return
+      }
+
+      guard let data = data else {
+        DispatchQueue.main.async { completionBlock(nil, .noData) }
+        return
+      }
+
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .secondsSince1970
+
+      do {
+        let result = try decoder.decode(resultType, from: data)
+        DispatchQueue.main.async { completionBlock(result, nil) }
+      } catch {
+        DispatchQueue.main.async { completionBlock(nil, .parsingError(error)) }
+      }
+    }
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
@@ -32,8 +32,8 @@ class HTTPDownloaderTests: XCTestCase {
 
   func testSingleRequestSuccess() throws {
     // Simple, easy case:  our local testing copy of the Khmer Angkor KMP file.
-    let mockedResult = TestUtils.Downloading.DownloadMockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
-    mockedURLSession?.queueMockResult(mockedResult)
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
+    mockedURLSession?.queueMockResult(.download(mockedResult))
 
     let testDelegate = TestUtils.Downloading.ExpectationDownloaderDelegate()
     downloader!.handler = testDelegate
@@ -51,8 +51,8 @@ class HTTPDownloaderTests: XCTestCase {
 
   func testSingleRequestFailure() throws {
     // A twist on the previous version - the 'download' fails.
-    let mockedResult = TestUtils.Downloading.DownloadMockResult(location: nil, error: NSError(domain: "KeymanTests", code: 1, userInfo: nil))
-    mockedURLSession?.queueMockResult(mockedResult)
+    let mockedResult = TestUtils.Downloading.MockResult(location: nil, error: NSError(domain: "KeymanTests", code: 1, userInfo: nil))
+    mockedURLSession?.queueMockResult(.download(mockedResult))
 
     let testDelegate = TestUtils.Downloading.ExpectationDownloaderDelegate()
     downloader!.handler = testDelegate
@@ -69,12 +69,12 @@ class HTTPDownloaderTests: XCTestCase {
   }
 
   func testSequentialRequests() {
-    let mockedResult1 = TestUtils.Downloading.DownloadMockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
-    mockedURLSession?.queueMockResult(mockedResult1)
+    let mockedResult1 = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
+    mockedURLSession?.queueMockResult(.download(mockedResult1))
 
-    let mockedResult2 = TestUtils.Downloading.DownloadMockResult(location:
+    let mockedResult2 = TestUtils.Downloading.MockResult(location:
         TestUtils.LexicalModels.mtntKMP, error: nil)
-    mockedURLSession?.queueMockResult(mockedResult2)
+    mockedURLSession?.queueMockResult(.download(mockedResult2))
 
     let testDelegate = TestUtils.Downloading.ExpectationDownloaderDelegate()
     downloader!.handler = testDelegate
@@ -98,8 +98,8 @@ class HTTPDownloaderTests: XCTestCase {
   }
 
   func testRequestCancellation() {
-    let mockedResult1 = TestUtils.Downloading.DownloadMockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
-    mockedURLSession?.queueMockResult(mockedResult1)
+    let mockedResult1 = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
+    mockedURLSession?.queueMockResult(.download(mockedResult1))
 
     // No second mocked result - its call should be cancelled.
 

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -10,17 +10,44 @@ import XCTest
 @testable import KeymanEngine
 
 class QueryPackageVersionTests: XCTestCase {
-  let PACKAGE_HOST_DOMAIN = "https://downloads.keyman.com/"
+  var mockedURLSession: TestUtils.Downloading.URLSessionMock?
+
+  override func setUp() {
+    mockedURLSession = TestUtils.Downloading.URLSessionMock()
+  }
+
+  override func tearDownWithError() throws {
+    let queueWasCleared = mockedURLSession!.queueIsEmpty
+    mockedURLSession = nil
+
+    if !queueWasCleared {
+      throw NSError(domain: "Keyman",
+                    code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "A test did not fully utilize its queued mock results!"])
+    }
+  }
+
   /**
-   * A rigorous test of our package-version query code that runs against the actual, live api.keyman.com endpoint.
+   * A rigorous test of our package-version query code that runs against a fixture copied from an actual api.keyman.com query return (26 Jun 2020).
    */
-  func testFetch() throws {
+  func testMockedFetchParse() throws {
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Queries.package_version_case_1, error: nil)
+    mockedURLSession?.queueMockResult(.data(mockedResult))
+
+    let badKbdFullID = FullKeyboardID(keyboardID: "foo", languageID: "en")
+    let badLexFullID = FullLexicalModelID(lexicalModelID: "bar", languageID: "km")
     let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
                    TestUtils.Keyboards.sil_euro_latin.fullID,
-                   TestUtils.LexicalModels.mtnt.fullID]
-    let expectation = XCTestExpectation(description: "Package-version query results received")
-    Queries.PackageVersion.fetch(for: fullIDs) { results, error in
-      XCTAssertNil(error)
+                   badKbdFullID,
+                   TestUtils.LexicalModels.mtnt.fullID,
+                   badLexFullID]
+
+    // As it's a mocked fetch, it happens synchronously.
+    Queries.PackageVersion.fetch(for: fullIDs, withSession: mockedURLSession!) { results, error in
+      if let _ = error {
+        XCTFail(String(describing: error))
+        return
+      }
       XCTAssertNotNil(results)
 
       if let results = results {
@@ -28,47 +55,45 @@ class QueryPackageVersionTests: XCTestCase {
         XCTAssertNotNil(results.models)
 
         if let keyboardVersions = results.keyboards, let modelVersions = results.models {
-          XCTAssertEqual(keyboardVersions.count, 2)
-          XCTAssertEqual(modelVersions.count, 1)
-
-          keyboardVersions.forEach { entry in
-            if let error = entry.value as? Queries.PackageVersion.ResultError {
-              XCTFail(String(describing: error))
-            }
-          }
+          XCTAssertEqual(keyboardVersions.count, 3)
+          XCTAssertEqual(modelVersions.count, 2)
 
           if let khmer_angkor = keyboardVersions["khmer_angkor"] as? Queries.PackageVersion.ResultEntry {
             XCTAssertGreaterThanOrEqual(Version(khmer_angkor.version)!,
                                         Version(TestUtils.Keyboards.khmer_angkor.version)!)
-            XCTAssertTrue(khmer_angkor.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
+            // Ensures that we are properly decoding the fixture's string entry for this property.
             XCTAssertTrue(khmer_angkor.packageURL.hasSuffix("khmer_angkor.kmp"))
+          } else {
+            XCTFail()
           }
 
           if let sil_euro_latin = keyboardVersions["sil_euro_latin"] as? Queries.PackageVersion.ResultEntry {
             XCTAssertGreaterThanOrEqual(Version(sil_euro_latin.version)!,
                                         Version(TestUtils.Keyboards.sil_euro_latin.version)!)
-            XCTAssertTrue(sil_euro_latin.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
             XCTAssertTrue(sil_euro_latin.packageURL.hasSuffix("sil_euro_latin.kmp"))
+          } else {
+            XCTFail()
           }
 
-          modelVersions.forEach { entry in
-            if let error = entry.value as? Queries.PackageVersion.ResultError {
-              XCTFail(String(describing: error))
-            }
+          if let foo = keyboardVersions["foo"] as? Queries.PackageVersion.ResultError {
+            XCTAssertEqual(foo.error, "not found")
+          } else {
+            XCTFail()
           }
 
-          if let nrc_en_mtnt = keyboardVersions["nrc_en_mtnt"] as? Queries.PackageVersion.ResultEntry {
+          if let nrc_en_mtnt = modelVersions["nrc.en.mtnt"] as? Queries.PackageVersion.ResultEntry {
             XCTAssertGreaterThanOrEqual(Version(nrc_en_mtnt.version)!,
                                         Version(TestUtils.LexicalModels.mtnt.version)!)
-            XCTAssertTrue(nrc_en_mtnt.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
             XCTAssertTrue(nrc_en_mtnt.packageURL.hasSuffix("nrc.en.mtnt.model.kmp"))
+          } else {
+            XCTFail()
+          }
+
+          if let bar = modelVersions["bar"] as? Queries.PackageVersion.ResultError {
+            XCTAssertEqual(bar.error, "not found")
           }
         }
       }
-
-      expectation.fulfill()
     }
-
-    wait(for: [expectation], timeout: 5)
   }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -1,0 +1,74 @@
+//
+//  QueryPackageVersionTests.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 6/25/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import XCTest
+@testable import KeymanEngine
+
+class QueryPackageVersionTests: XCTestCase {
+  let PACKAGE_HOST_DOMAIN = "https://downloads.keyman.com/"
+  /**
+   * A rigorous test of our package-version query code that runs against the actual, live api.keyman.com endpoint.
+   */
+  func testFetch() throws {
+    let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
+                   TestUtils.Keyboards.sil_euro_latin.fullID,
+                   TestUtils.LexicalModels.mtnt.fullID]
+    let expectation = XCTestExpectation(description: "Package-version query results received")
+    Queries.PackageVersion.fetch(for: fullIDs) { results, error in
+      XCTAssertNil(error)
+      XCTAssertNotNil(results)
+
+      if let results = results {
+        XCTAssertNotNil(results.keyboards)
+        XCTAssertNotNil(results.models)
+
+        if let keyboardVersions = results.keyboards, let modelVersions = results.models {
+          XCTAssertEqual(keyboardVersions.count, 2)
+          XCTAssertEqual(modelVersions.count, 1)
+
+          keyboardVersions.forEach { entry in
+            if let error = entry.value as? Queries.PackageVersion.ResultError {
+              XCTFail(String(describing: error))
+            }
+          }
+
+          if let khmer_angkor = keyboardVersions["khmer_angkor"] as? Queries.PackageVersion.ResultEntry {
+            XCTAssertGreaterThanOrEqual(Version(khmer_angkor.version)!,
+                                        Version(TestUtils.Keyboards.khmer_angkor.version)!)
+            XCTAssertTrue(khmer_angkor.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
+            XCTAssertTrue(khmer_angkor.packageURL.hasSuffix("khmer_angkor.kmp"))
+          }
+
+          if let sil_euro_latin = keyboardVersions["sil_euro_latin"] as? Queries.PackageVersion.ResultEntry {
+            XCTAssertGreaterThanOrEqual(Version(sil_euro_latin.version)!,
+                                        Version(TestUtils.Keyboards.sil_euro_latin.version)!)
+            XCTAssertTrue(sil_euro_latin.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
+            XCTAssertTrue(sil_euro_latin.packageURL.hasSuffix("sil_euro_latin.kmp"))
+          }
+
+          modelVersions.forEach { entry in
+            if let error = entry.value as? Queries.PackageVersion.ResultError {
+              XCTFail(String(describing: error))
+            }
+          }
+
+          if let nrc_en_mtnt = keyboardVersions["nrc_en_mtnt"] as? Queries.PackageVersion.ResultEntry {
+            XCTAssertGreaterThanOrEqual(Version(nrc_en_mtnt.version)!,
+                                        Version(TestUtils.LexicalModels.mtnt.version)!)
+            XCTAssertTrue(nrc_en_mtnt.packageURL.hasPrefix(self.PACKAGE_HOST_DOMAIN))
+            XCTAssertTrue(nrc_en_mtnt.packageURL.hasSuffix("nrc.en.mtnt.model.kmp"))
+          }
+        }
+      }
+
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 5)
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDataTaskMock.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDataTaskMock.swift
@@ -1,0 +1,30 @@
+//
+//  URLSessionDataTaskMock.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 6/26/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+extension TestUtils.Downloading {
+  /**
+   * Many thanks to https://www.swiftbysundell.com/articles/mocking-in-swift/ for the approach used here.
+   */
+  class URLSessionDataTaskMock: URLSessionDataTask {
+    private let closure: () -> Void
+
+    init(closure: @escaping () -> Void) {
+      self.closure = closure
+    }
+
+    /*
+     * For mocked DownloadTasks, just use the precomputed completion closure
+     * provided to the constructor.
+     */
+    override func resume() {
+      closure()
+    }
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Queries.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Queries.swift
@@ -1,0 +1,17 @@
+//
+//  Queries.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 6/26/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+extension TestUtils {
+  enum Queries {
+    static let query_bundle = TestUtils.findSubBundle(forResource: "Queries", ofType: ".bundle")
+
+    static let package_version_case_1 = query_bundle.url(forResource: "package-version-case-1", withExtension: "json")!
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/resources/Queries.bundle/package-version-case-1.json
+++ b/ios/engine/KMEI/KeymanEngineTests/resources/Queries.bundle/package-version-case-1.json
@@ -1,0 +1,24 @@
+{
+    "keyboards": {
+        "khmer_angkor": {
+            "version": "1.0.6",
+            "kmp": "https://downloads.keyman.com/keyboards/khmer_angkor/1.0.6/khmer_angkor.kmp"
+        },
+        "sil_euro_latin": {
+            "version": "1.9.1",
+            "kmp": "https://downloads.keyman.com/keyboards/sil_euro_latin/1.9.1/sil_euro_latin.kmp"
+        },
+        "foo": {
+            "error": "not found"
+        }
+    },
+    "models": {
+        "nrc.en.mtnt": {
+            "version": "0.1.4",
+            "kmp": "https://downloads.keyman.com/models/nrc.en.mtnt/0.1.4/nrc.en.mtnt.model.kmp"
+        },
+        "bar": {
+            "error": "not found"
+        }
+    }
+}


### PR DESCRIPTION
While currently not connected to anything within KeymanEngine, this PR adds support for use of our [package-version API](https://help.keyman.com/developer/cloud/package-version/1.0/) endpoint.  A unit test proving the code works has been included.

The likely best path forward for downloading KMPs for keyboards instead of JS will involve use of this endpoint.  It'll be useful long term for resource updates but also in the short-term for finding keyboard KMPs.