### PR TITLE
fix(linux): Always restart IBus when installing keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -189,9 +189,7 @@ def install_kmp_user(inputfile, online=False):
         os.makedirs(packageDir)
 
     extract_kmp(inputfile, packageDir)
-    if not is_gnome_shell():
-        # restart IBus so it knows about the keyboards being installed
-        restart_ibus()
+    restart_ibus()
 
     info, system, options, keyboards, files = get_metadata(packageDir)
 


### PR DESCRIPTION
We have to restart IBus even when installing keyboards in Gnome.
Otherwise the new keyboards won't show up in the list of input
sources.

This fixes #3283.