### PR TITLE
fix(linux): Use language from search when installing keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -68,9 +68,14 @@ def _reset_gnome_shell():
     __is_gnome_shell = None
 
 
-def get_ibus_keyboard_id(keyboard, packageDir, ignore_language=False):
+def get_ibus_keyboard_id(keyboard, packageDir, language=None, ignore_language=False):
     kmx_file = os.path.join(packageDir, keyboard['id'] + ".kmx")
-    if not ignore_language and "languages" in keyboard and len(keyboard["languages"]) > 0:
+    if ignore_language:
+        return kmx_file
+    if language is not None:
+        logging.debug(language)
+        return "%s:%s" % (language, kmx_file)
+    if "languages" in keyboard and len(keyboard["languages"]) > 0:
         logging.debug(keyboard["languages"][0])
         return "%s:%s" % (keyboard["languages"][0]['id'], kmx_file)
     return kmx_file

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -85,7 +85,7 @@ def extract_package_id(inputfile):
     return packageID.lower()
 
 
-def install_kmp_shared(inputfile, online=False):
+def install_kmp_shared(inputfile, online=False, language=None):
     """
     Install a kmp file to /usr/local/share/keyman
 
@@ -168,10 +168,7 @@ def install_kmp_shared(inputfile, online=False):
                         fpath = os.path.join(packageDir, kb['id'] + '.kmx')
                 extractico(fpath)
 
-        for kb in keyboards:
-            # install all kmx for first lang not just packageID
-            kmx_file = os.path.join(packageDir, kb['id'] + ".kmx")
-            install_to_ibus(lang, kmx_file)
+        install_keyboards_to_ibus(keyboards, packageDir, language)
     else:
         logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
         logging.info("Contents of %s:", inputfile)
@@ -182,7 +179,7 @@ def install_kmp_shared(inputfile, online=False):
         raise InstallError(InstallStatus.Abort, message)
 
 
-def install_kmp_user(inputfile, online=False):
+def install_kmp_user(inputfile, online=False, language=None):
     packageID = extract_package_id(inputfile)
     packageDir = user_keyboard_dir(packageID)
     if not os.path.isdir(packageDir):
@@ -238,7 +235,7 @@ def install_kmp_user(inputfile, online=False):
                         fpath = os.path.join(packageDir, kb['id'] + '.kmx')
                 extractico(fpath)
 
-        install_keyboards(keyboards, packageDir)
+        install_keyboards(keyboards, packageDir, language)
     else:
         logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
         logging.info("Contents of %s:", inputfile)
@@ -249,19 +246,19 @@ def install_kmp_user(inputfile, online=False):
         raise InstallError(InstallStatus.Abort, message)
 
 
-def install_keyboards(keyboards, packageDir):
+def install_keyboards(keyboards, packageDir, language=None):
     if is_gnome_shell():
-        install_keyboards_to_gnome(keyboards, packageDir)
+        install_keyboards_to_gnome(keyboards, packageDir, language)
     else:
-        install_keyboards_to_ibus(keyboards, packageDir)
+        install_keyboards_to_ibus(keyboards, packageDir, language)
 
 
-def install_keyboards_to_ibus(keyboards, packageDir):
+def install_keyboards_to_ibus(keyboards, packageDir, language=None):
     bus = get_ibus_bus()
     if bus:
         # install all kmx for first lang not just packageID
         for kb in keyboards:
-            ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir)
+            ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
             install_to_ibus(bus, ibus_keyboard_id)
         restart_ibus(bus)
         bus.destroy()
@@ -269,19 +266,19 @@ def install_keyboards_to_ibus(keyboards, packageDir):
         logging.debug("could not install keyboards to IBus")
 
 
-def install_keyboards_to_gnome(keyboards, packageDir):
+def install_keyboards_to_gnome(keyboards, packageDir, language=None):
     gnomeKeyboardsUtil = GnomeKeyboardsUtil()
     sources = gnomeKeyboardsUtil.read_input_sources()
 
     # install all kmx for first lang not just packageID
     for kb in keyboards:
-        ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir)
+        ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
         sources.append(('ibus', ibus_keyboard_id))
 
     gnomeKeyboardsUtil.write_input_sources(sources)
 
 
-def install_kmp(inputfile, online=False, sharedarea=False):
+def install_kmp(inputfile, online=False, sharedarea=False, language=None):
     """
     Install a kmp file
 
@@ -291,6 +288,6 @@ def install_kmp(inputfile, online=False, sharedarea=False):
         sharedarea(bool, default=False): whether install kmp to shared area or user directory
     """
     if sharedarea:
-        install_kmp_shared(inputfile, online)
+        install_kmp_shared(inputfile, online, language)
     else:
-        install_kmp_user(inputfile, online)
+        install_kmp_user(inputfile, online, language)

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -37,12 +37,13 @@ def find_keyman_image(image_file):
 
 class InstallKmpWindow(Gtk.Dialog):
 
-    def __init__(self, kmpfile, online=False, viewkmp=None):
+    def __init__(self, kmpfile, online=False, viewkmp=None, language=None):
         logging.debug("InstallKmpWindow: kmpfile: %s", kmpfile)
         self.kmpfile = kmpfile
         self.online = online
         self.viewwindow = viewkmp
         self.accelerators = None
+        self.language = language
         keyboardid = os.path.basename(os.path.splitext(kmpfile)[0])
         installed_kmp_ver = get_kmp_version(keyboardid)
         if installed_kmp_ver:
@@ -284,7 +285,7 @@ class InstallKmpWindow(Gtk.Dialog):
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
         try:
-            install_kmp(self.kmpfile, self.online)
+            install_kmp(self.kmpfile, self.online, language=self.language)
             if self.viewwindow:
                 self.viewwindow.refresh_installed_kmp()
             keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -88,7 +88,7 @@ def uninstall_keyboards_from_gnome(keyboards, packageDir):
             sources.remove(tuple)
 
         toRemove = []
-        match_id = ":%s" % get_ibus_keyboard_id(kb, packageDir, True)
+        match_id = ":%s" % get_ibus_keyboard_id(kb, packageDir, ignore_language=True)
         for (type, id) in sources:
             if type == 'ibus' and id.endswith(match_id):
                 toRemove.append((type, id))

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -49,8 +49,9 @@ class ViewInstalledWindowBase(Gtk.Window):
             return
 
         file = downloadDlg.downloadfile
+        language = downloadDlg.language
         downloadDlg.destroy()
-        self.restart(self.install_file(file))
+        self.restart(self.install_file(file, language))
 
     def on_installfile_clicked(self, button):
         logging.debug("Install from file clicked")
@@ -71,8 +72,8 @@ class ViewInstalledWindowBase(Gtk.Window):
         dlg.destroy()
         self.restart(self.install_file(file))
 
-    def install_file(self, kmpfile):
-        installDlg = InstallKmpWindow(kmpfile, viewkmp=self)
+    def install_file(self, kmpfile, language=None):
+        installDlg = InstallKmpWindow(kmpfile, viewkmp=self, language=language)
         result = installDlg.run()
         installDlg.destroy()
         return result

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -76,6 +76,32 @@ class InstallKmpTests(unittest.TestCase):
         self.mockRestartIbus.assert_called_once()
         bus.destroy.assert_called_once()
 
+    def test_InstallKeyboardsToIbus_SingleKbMultipleLanguages_GivenLanguage(self):
+        # Setup
+        bus = self.mockGetIbusBus.return_value
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        install_keyboards_to_ibus(keyboards, 'fooDir', 'fr')
+        # Verify
+        self.mockInstallToIbus.assert_called_once()
+        self.mockInstallToIbus.assert_called_with(ANY, 'fr:fooDir/foo1.kmx')
+        # self.mockInstallToIbus.assert_not_called_with(ANY, 'en:fooDir/foo1.kmx')
+        self.mockRestartIbus.assert_called_once()
+        bus.destroy.assert_called_once()
+
+    def test_InstallKeyboardsToIbus_SingleKbMultipleLanguages_OtherLanguage(self):
+        # Setup
+        bus = self.mockGetIbusBus.return_value
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        install_keyboards_to_ibus(keyboards, 'fooDir', 'de')
+        # Verify
+        self.mockInstallToIbus.assert_called_once()
+        self.mockInstallToIbus.assert_called_with(ANY, 'de:fooDir/foo1.kmx')
+        # self.mockInstallToIbus.assert_not_called_with(ANY, 'en:fooDir/foo1.kmx')
+        self.mockRestartIbus.assert_called_once()
+        bus.destroy.assert_called_once()
+
     def test_InstallKeyboardsToGnome_SingleKbNoLanguages(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
@@ -122,6 +148,30 @@ class InstallKmpTests(unittest.TestCase):
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')])
+        self.mockRestartIbus.assert_not_called()
+
+    def test_InstallKeyboardsToGnome_SingleKbMultipleLanguages_GivenLanguage(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        install_keyboards_to_gnome(keyboards, 'fooDir', 'fr')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')])
+        self.mockRestartIbus.assert_not_called()
+
+    def test_InstallKeyboardsToGnome_SingleKbMultipleLanguages_OtherLanguage(self):
+        # Setup
+        mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
+        mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        install_keyboards_to_gnome(keyboards, 'fooDir', 'de')
+        # Verify
+        mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
+            [('xkb', 'en'), ('ibus', 'de:fooDir/foo1.kmx')])
         self.mockRestartIbus.assert_not_called()
 
 


### PR DESCRIPTION
When installing a keyboard install it under the language the user searched for (if any). This change depends on an API change (cf #1456).

This fixes #3282.