### PR TITLE
refactor(ios/engine): Resource download cleanup and mocking prep

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -21,8 +21,8 @@ public class ResourceDownloadManager {
   
   public static let shared = ResourceDownloadManager()
   
-  private init() {
-    downloader = ResourceDownloadQueue()
+  internal init(session: URLSession = URLSession.shared) {
+    downloader = ResourceDownloadQueue(session: session)
   }
   
   // MARK: - Common functionality
@@ -378,6 +378,8 @@ public class ResourceDownloadManager {
                                  fromPath: URL.init(string: filename)!,
                                  completionBlock: completionBlock)
   }
+
+
   
   /// - Returns: The current state for a lexical model
   //TODO: rename KeyboardState to ResourceState? so it can be used with both keybaoards and lexical models without confusion

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -194,7 +194,7 @@ public class ResourceDownloadManager {
   public func stateForKeyboard(withID keyboardID: String) -> KeyboardState {
     // For this call, we don't actually need the language ID to be correct.
     let fullKeyboardID = FullKeyboardID(keyboardID: keyboardID, languageID: "")
-    if downloader.containsResourceInQueue(matchingID: fullKeyboardID) {
+    if downloader.containsResourceInQueue(matchingID: fullKeyboardID, requireLanguageMatch: false) {
       return .downloading
     }
 
@@ -399,7 +399,7 @@ public class ResourceDownloadManager {
   public func stateForLexicalModel(withID lexicalModelID: String) -> KeyboardState {
     // For this call, we don't actually need the language ID to be correct.
     let fullLexicalModelID = FullLexicalModelID(lexicalModelID: lexicalModelID, languageID: "")
-    if downloader.containsResourceInQueue(matchingID: fullLexicalModelID) {
+    if downloader.containsResourceInQueue(matchingID: fullLexicalModelID, requireLanguageMatch: false) {
       return .downloading
     }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -362,11 +362,17 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     }
   }
 
-  func containsResourceInQueue(matchingID: AnyLanguageResourceFullID) -> Bool {
+  func containsResourceInQueue(matchingID: AnyLanguageResourceFullID, requireLanguageMatch: Bool = true) -> Bool {
     return queueRoot.nodes.contains { node in
       node.resources.contains { resource in
-        // We don't actually care about the language ID when downloading - just the resource's ID and type.
-        return resource.fullID.type == matchingID.type && resource.fullID.id == matchingID.id
+        // We don't actually care about the language ID when dowßΩnloading - just the resource's ID and type.
+        let result = resource.fullID.type == matchingID.type && resource.fullID.id == matchingID.id
+
+        if requireLanguageMatch {
+          return result && resource.fullID.languageID == matchingID.languageID
+        } else {
+          return result
+        }
       }
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -362,37 +362,13 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     }
   }
 
-  // TODO: Needs validation.
-  func keyboardIdForCurrentRequest() -> String? {
-    if let currentRequest = currentRequest {
-      let tmpStr = currentRequest.url.lastPathComponent
-      if tmpStr.hasJavaScriptExtension {
-        return String(tmpStr.dropLast(3))
+  func containsResourceInQueue(matchingID: AnyLanguageResourceFullID) -> Bool {
+    return queueRoot.nodes.contains { node in
+      node.resources.contains { resource in
+        // We don't actually care about the language ID when downloading - just the resource's ID and type.
+        return resource.fullID.type == matchingID.type && resource.fullID.id == matchingID.id
       }
-    } else {
-      // TODO:  search the queue instead.
-//      let kbInfo = downloader!.userInfo[Key.keyboardInfo]
-//      if let keyboards = kbInfo as? [InstallableKeyboard], let keyboard = keyboards.first {
-//        return keyboard.id
-//      }
     }
-    return nil
-  }
-  
-  func lexicalModelIdForCurrentRequest() -> String? {
-    if let currentRequest = currentRequest {
-      let tmpStr = currentRequest.url.lastPathComponent
-      if tmpStr.hasJavaScriptExtension {
-        return String(tmpStr.dropLast(3))
-      }
-    } else {
-      // TODO: search the queue instead.
-//      let kbInfo = downloader!.userInfo[Key.lexicalModelInfo]
-//      if let lexicalModels = kbInfo as? [InstallableLexicalModel], let lexicalModel = lexicalModels.first {
-//        return lexicalModel.id
-//      }
-    }
-    return nil
   }
 
   // MARK - notification methods


### PR DESCRIPTION
After some of the recent download-rework PRs, a small bit of extra work allows us to remove some now-dead code.

This also contains traces of setup code for mocked downloads for unit tests, although none are added at this time.