### PR TITLE
refactor(ios/engine): ID-based download tracking, update notification rework

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -17,8 +17,22 @@ public protocol AnyLanguageResourceFullID {
   var id: String { get }
   var languageID: String { get }
   var type: LanguageResourceType { get }
+
+  func matches(_ other: AnyLanguageResourceFullID, requireLanguageMatch: Bool) -> Bool
 }
 
+extension AnyLanguageResourceFullID {
+  // For matching when we're not sure if the underlying types actually match.
+  public func matches(_ other: AnyLanguageResourceFullID, requireLanguageMatch: Bool = true) -> Bool {
+    if requireLanguageMatch {
+      return id == other.id && type == other.type && languageID == other.languageID
+    } else {
+      return id == other.id && type == other.type
+    }
+  }
+}
+
+// Equatable only really makes sense when the types are identical.
 extension AnyLanguageResourceFullID where Self: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     return lhs.id == rhs.id && lhs.languageID == rhs.languageID && lhs.type == rhs.type


### PR DESCRIPTION
While preparing to start downloading packages based solely on a resource's ID, I noticed a problem with the current download management within KeymanEngine - it still requires full resource metadata (because of cloud keyboard installs).  Fortunately, with a little work, that can be dropped with no downsides.
- If the user were to perform a keyboard search, that search would yield the package filename, possibly with the resource's id & preferred language code... but not the rest of `InstallableKeyboard`'s metadata.
- As a result, KeymanEngine will have less data from the search than it had with the old cloud-based installs.  This PR adjusts the downloading infrastructure accordingly.

The trickiest aspect of this was the requirement to rework update notifications at the same time; the existing behavior reports full metadata on what is and isn't updated, so the implementation had to be moved.  Moving them to a closure-based implementation is sufficient, as the closure can be granted access to the resources' metadata when built.  The queue then tracks the closure and calls it when complete.

For now, keyboard `DownloadTask`s must still track the full `InstallableKeyboard` due to how cloud installs work.  Once they're package-based, the `resources` field may be fully retired.