### PR TITLE
fix(android): Use tier to determine keyboard search host

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -114,6 +114,12 @@ public final class KMManager {
     TABLET;
   }
 
+  public enum Tier {
+    ALPHA,
+    BETA,
+    STABLE
+  }
+
   private static InputMethodService IMService;
   private static boolean debugMode = false;
   private static boolean shouldAllowSetKeyboard = true;
@@ -256,8 +262,37 @@ public final class KMManager {
     return getResourceRoot() + KMDefault_UndefinedPackageID + File.separator;
   }
 
+  public static FormFactor getFormFactor() {
+    String device_type = appContext.getResources().getString(R.string.device_type);
+
+    return device_type.equals("AndroidMobile") ? FormFactor.PHONE : FormFactor.TABLET;
+  }
+
   /**
-   * Extract app version #.#.# from VERSION_NAME
+   * Extract KMEA tier from versionName. Uses parameter so we can unit test.
+   * @param versionName String - If not provided, determine tier from
+   *                    com.tavultesoft.kmea.BuildConfig.VERSION_NAME
+   * @return Tier (ALPHA, BETA, STABLE)
+   */
+  public static Tier getTier(String versionName) {
+    if (versionName == null || versionName.isEmpty()) {
+      versionName = com.tavultesoft.kmea.BuildConfig.VERSION_NAME;
+    }
+    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)-(alpha|beta|stable)-.*");
+    Matcher matcher = pattern.matcher(versionName);
+    if (matcher.matches() && matcher.groupCount() >= 2) {
+      switch (matcher.group(2)) {
+        case "alpha": return Tier.ALPHA;
+        case "beta": return Tier.BETA;
+        default:
+          return Tier.STABLE;
+      }
+    }
+    return Tier.STABLE;
+  }
+
+  /**
+   * Extract KMEA version #.#.# from VERSION_NAME
    * @return String
    */
   public static String getVersion() {
@@ -1600,12 +1635,6 @@ public final class KMManager {
     }
 
     return result;
-  }
-
-  public static FormFactor getFormFactor() {
-    String device_type = appContext.getResources().getString(R.string.device_type);
-
-    return device_type.equals("AndroidMobile") ? FormFactor.PHONE : FormFactor.TABLET;
   }
 
   public static boolean isHelpBubbleEnabled() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -32,7 +32,7 @@ public class KMPBrowserActivity extends AppCompatActivity {
   private WebView webView;
   private static final String KMP_PRODUCTION_HOST = "https://keyman.com";
   private static final String KMP_STAGING_HOST = "https://staging-keyman-com.azurewebsites.net";
-  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards%s?embed=linux&version=%s"; // TODO: Update to Android
+  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards%s?embed=android&version=%s";
   private static final String KMP_LANGUAGE_FORMATSTR = "/languages/%s";
   private boolean isLoading = false;
   private boolean didFinishLoading = false;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -24,11 +24,15 @@ import android.webkit.WebViewClient;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.KMManager.Tier;
 
 public class KMPBrowserActivity extends AppCompatActivity {
   private static final String TAG = "KMPBrowserActivity";
   private WebView webView;
-  private static final String KMP_SEARCH_URL_FORMATSTR = "https://keyman.com/keyboards%s?embed=linux&version=%s"; // TODO: Update to Android
+  private static final String KMP_PRODUCTION_HOST = "https://keyman.com";
+  private static final String KMP_STAGING_HOST = "https://staging-keyman-com.azurewebsites.net";
+  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards%s?embed=linux&version=%s"; // TODO: Update to Android
   private static final String KMP_LANGUAGE_FORMATSTR = "/languages/%s";
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
@@ -99,11 +103,14 @@ public class KMPBrowserActivity extends AppCompatActivity {
       }
     });
 
+    // Tier determines the keyboard search host
+    String host = (KMManager.getTier(BuildConfig.VERSION_NAME) == Tier.STABLE) ?
+      KMP_PRODUCTION_HOST : KMP_STAGING_HOST;
     // If language ID is provided, include it in the keyboard search
     String languageID = getIntent().getStringExtra("languageCode");
     String languageStr = (languageID != null) ? String.format(KMP_LANGUAGE_FORMATSTR, languageID) : "";
     String appVersion = KMManager.getVersion();
-    String kmpSearchUrl = String.format(KMP_SEARCH_URL_FORMATSTR, languageStr, appVersion);
+    String kmpSearchUrl = String.format(KMP_SEARCH_URL_FORMATSTR, host, languageStr, appVersion);
     webView.loadUrl(kmpSearchUrl);
   }
 

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/KMManagerTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/KMManagerTest.java
@@ -44,6 +44,29 @@ public class KMManagerTest {
     }
   }
 
+  @Test
+  public void test_getTier() {
+    String versionName = "14.0.248-alpha-local";
+    KMManager.Tier tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.ALPHA, tier);
+
+    versionName = "14.0.248-beta-local";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.BETA, tier);
+
+    versionName = "14.0.248-stable-local";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.STABLE, tier);
+
+    // If versionName is null or blank, tier based on com.tavultesoft.kmea.BuildConfig.VERSION_NAME
+    // But we can't test for it.
+
+    // If regex fails, tier is stable
+    versionName = "14.0.248";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.STABLE, tier);
+  }
+
   /*
   * This test is manually run to edit/regenerate the old keyboards list
   */


### PR DESCRIPTION
For pre-release builds (`alpha` and `beta` tier), use the keyboard search from the staging site
https://staging-keyman-com.azurewebsites.net/keyboards