### PR TITLE
fix(android): Resize PackageActivity title text

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
@@ -7,7 +7,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="label_width">200dp</dimen>
-    <dimen name="titlebar_label_textsize">6sp</dimen>
+    <dimen name="titlebar_label_textsize">4sp</dimen>
     <dimen name="package_label_width">250dp</dimen>
     <dimen name="keyman_bar_height">8dp</dimen>
     <dimen name="checkbox_margin">8dp</dimen>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -32,8 +32,8 @@ public class KMPBrowserActivity extends AppCompatActivity {
   private WebView webView;
   private static final String KMP_PRODUCTION_HOST = "https://keyman.com";
   private static final String KMP_STAGING_HOST = "https://staging-keyman-com.azurewebsites.net";
-  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards?q=%sembed=android&version=%s";
-  private static final String KMP_LANGUAGE_FORMATSTR = "l:id:%s&";
+  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards%s?embed=android&version=%s";
+  private static final String KMP_LANGUAGE_FORMATSTR = "/languages/%s";
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -32,8 +32,8 @@ public class KMPBrowserActivity extends AppCompatActivity {
   private WebView webView;
   private static final String KMP_PRODUCTION_HOST = "https://keyman.com";
   private static final String KMP_STAGING_HOST = "https://staging-keyman-com.azurewebsites.net";
-  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards%s?embed=android&version=%s";
-  private static final String KMP_LANGUAGE_FORMATSTR = "/languages/%s";
+  private static final String KMP_SEARCH_URL_FORMATSTR = "%s/keyboards?q=%sembed=android&version=%s";
+  private static final String KMP_LANGUAGE_FORMATSTR = "l:id:%s&";
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
 


### PR DESCRIPTION
[description edited per review comments]
~This small PR adjusts the language query (if given) to specify BCP 47 match.~

Also makes the PackgeActivity title font size smaller so the string "Install Keyboard Package version X.Y.Z" fits