### PR TITLE
refactor(ios/engine): Centralized package download utility function

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		CE867FEF2485E97A00B2EAED /* KMPMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE867FEE2485E97A00B2EAED /* KMPMetadata.swift */; };
 		CE867FF12485EE1500B2EAED /* KMPInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE867FF02485EE1500B2EAED /* KMPInfo.swift */; };
 		CE88042F247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */; };
+		CE88143A24A9B7F4002809C3 /* ResourceDownloadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE88143924A9B7F4002809C3 /* ResourceDownloadQueueTests.swift */; };
 		CE89641F24A4686000D5EB8E /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89641E24A4686000D5EB8E /* Queries.swift */; };
 		CE89642124A468B200D5EB8E /* Queries+PackageVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */; };
 		CE89642524A46D0000D5EB8E /* QueryPackageVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */; };
@@ -473,6 +474,7 @@
 		CE867FEE2485E97A00B2EAED /* KMPMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPMetadata.swift; sourceTree = "<group>"; };
 		CE867FF02485EE1500B2EAED /* KMPInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMPInfo.swift; sourceTree = "<group>"; };
 		CE88042E247F4B97009BCA1A /* ExpectationDownloaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectationDownloaderDelegate.swift; sourceTree = "<group>"; };
+		CE88143924A9B7F4002809C3 /* ResourceDownloadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadQueueTests.swift; sourceTree = "<group>"; };
 		CE89641E24A4686000D5EB8E /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
 		CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queries+PackageVersion.swift"; sourceTree = "<group>"; };
 		CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPackageVersionTests.swift; sourceTree = "<group>"; };
@@ -737,6 +739,7 @@
 				CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */,
 				CE973D842484A71700F66045 /* KMPJSONTests.swift */,
 				CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */,
+				CE88143924A9B7F4002809C3 /* ResourceDownloadQueueTests.swift */,
 			);
 			path = KeymanEngineTests;
 			sourceTree = "<group>";
@@ -1442,6 +1445,7 @@
 				CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */,
 				CE9CD88023FCC1CA002BF2F8 /* TestUtils.swift in Sources */,
 				CE973D812484A56500F66045 /* PackageJSON.swift in Sources */,
+				CE88143A24A9B7F4002809C3 /* ResourceDownloadQueueTests.swift in Sources */,
 				CE8EDEB123F53D1A009E1FF6 /* FileManagementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		CEA6BA9D249872E8002D44CE /* Simple 13.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEA6BA9C249872E7002D44CE /* Simple 13.0 Migration.bundle */; };
 		CEC0C66C2410AC9A003E1BCD /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC0C66B2410AC9A003E1BCD /* Sentry.framework */; };
 		CEC0C6772410E049003E1BCD /* SentryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC0C6762410E049003E1BCD /* SentryManager.swift */; };
+		CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */; };
 		CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */; };
 		CEF888D223FE6ADF00667693 /* No-defaults 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */; };
 		CEF888D323FE6ADF00667693 /* Simple 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */; };
@@ -499,6 +500,7 @@
 		CEC0C6762410E049003E1BCD /* SentryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryManager.swift; sourceTree = "<group>"; };
 		CECB38931F2199BC0098882F /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reachability.h; path = KeymanEngine/lib/Reachability/Reachability.h; sourceTree = SOURCE_ROOT; };
 		CECB38941F2199BC0098882F /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Reachability.m; path = KeymanEngine/lib/Reachability/Reachability.m; sourceTree = SOURCE_ROOT; };
+		CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManagerTests.swift; sourceTree = "<group>"; };
 		CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "No-defaults 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "Simple 10.0 Migration.bundle"; sourceTree = "<group>"; };
@@ -739,6 +741,7 @@
 				CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */,
 				CE973D842484A71700F66045 /* KMPJSONTests.swift */,
 				CE89642424A46D0000D5EB8E /* QueryPackageVersionTests.swift */,
+				CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */,
 				CE88143924A9B7F4002809C3 /* ResourceDownloadQueueTests.swift */,
 			);
 			path = KeymanEngineTests;
@@ -1443,6 +1446,7 @@
 				CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */,
 				CE8EDEB323F53F96009E1FF6 /* VersionTests.swift in Sources */,
 				CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */,
+				CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */,
 				CE9CD88023FCC1CA002BF2F8 /* TestUtils.swift in Sources */,
 				CE973D812484A56500F66045 /* PackageJSON.swift in Sources */,
 				CE88143A24A9B7F4002809C3 /* ResourceDownloadQueueTests.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/HTTPDownloader.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol HTTPDownloadDelegate: class {
   func downloadRequestStarted(_ request: HTTPDownloadRequest)
   func downloadRequestFinished(_ request: HTTPDownloadRequest)
-  func downloadRequestFailed(_ request: HTTPDownloadRequest)
+  func downloadRequestFailed(_ request: HTTPDownloadRequest, with: Error?)
   func downloadQueueFinished(_ queue: HTTPDownloader)
   func downloadQueueCancelled(_ queue: HTTPDownloader)
 }
@@ -79,7 +79,16 @@ class HTTPDownloader: NSObject {
       //
       // Force the callback onto the main thread.
       DispatchQueue.main.async {
-        self.handler?.downloadRequestFailed(currentRequest)
+        self.handler?.downloadRequestFailed(currentRequest, with: nil)
+        self.runRequest()
+      }
+      return
+    }
+
+    guard error == nil else {
+      // The download process itself encountered an error.
+      DispatchQueue.main.async {
+        self.handler?.downloadRequestFailed(currentRequest, with: error)
         self.runRequest()
       }
       return
@@ -119,7 +128,7 @@ class HTTPDownloader: NSObject {
 
     guard let data = data else {
       DispatchQueue.main.async {
-        self.handler?.downloadRequestFailed(currentRequest)
+        self.handler?.downloadRequestFailed(currentRequest, with: nil)
         self.runRequest()
       }
       return

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -201,6 +201,21 @@ public class TypedKeymanPackage<TypedLanguageResource: LanguageResource>: Keyman
     } as [[TypedLanguageResource]]
   }
 
+  internal static func baseFilename(for fullID: TypedLanguageResource.FullID) -> String {
+    var ext: String
+
+    switch(TypedLanguageResource.self) {
+      case is InstallableKeyboard.Type:
+        ext = "kmp"
+      case is InstallableLexicalModel.Type:
+        ext = "model.kmp"
+      default:
+        fatalError("Unsupported language resource type")
+    }
+
+    return "\(fullID.id).\(ext)"
+  }
+
   // Cannot directly override base class's installableResourceSets with more specific type,
   // despite covariance.  So, we have to provide two separate properties.  Joy.
   // See https://forums.swift.org/t/confusing-limitations-on-covariant-overriding/16252

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -14,7 +14,8 @@ import Foundation
 // This will be the public face of resource download management in KMEI, while the other half is private and
 // only accessible within the library.
 public class ResourceDownloadManager {
-  private var downloader: ResourceDownloadQueue
+  // internal b/c testing access.
+  internal var downloader: ResourceDownloadQueue
   private var isDidUpdateCheck = false
 
   public typealias CompletionHandler<Resource: LanguageResource> = (Resource.Package?, Error?) -> Void where Resource.Package: TypedKeymanPackage<Resource>

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -426,7 +426,14 @@ public class ResourceDownloadManager {
   }
 
   /**
-   * A nice, centralized function designed to cleanly handle package-oriented downloads once the package's URL is known.
+   * Downloads a package for the specified `LanguageResourceFullID` (`FullKeyboardID` / `FullLexicalModelID`)
+   * and parses it automatically, given a pre-known URL.  The fully parsed package (`KeyboardKeymanPackage` /
+   * `LexicalModelKeymanPackage`) or `Error` that results is available upon completion.
+   *
+   * Actual installation of the resource is left to calling code; consider use of `ResourceFileManager`'s `install` methods
+   * with the returned package.
+   *
+   * `withNotifications` specifies whether or not any of KeymanEngine's `NotificationCenter` notifications should be generated.
    */
   public func downloadPackage<FullID: LanguageResourceFullID>(forFullID fullID: FullID,
                                                               from url: URL,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -85,7 +85,7 @@ class DownloadTask<FullID: LanguageResourceFullID>: AnyDownloadTask {
     self.finalFile = destURL
     self.request = request
 
-    self.downloadFinalizationBlock = DownloadTask.resourceDownloadFinalizationClosure(tempURL: url, finalURL: destURL)
+    self.downloadFinalizationBlock = DownloadTask.resourceDownloadFinalizationClosure(tempURL: tempURL, finalURL: destURL)
   }
 
 
@@ -183,22 +183,29 @@ class DownloadBatch<FullID: LanguageResourceFullID>: AnyDownloadBatch where Full
   }
 
   public func completeWithCancellation() {
-    completionBlock?(nil, nil)
+    let complete = completionBlock
+    completionBlock = nil
+    complete?(nil, nil)
   }
 
   public func completeWithError(error: Error) {
-    completionBlock?(nil, error)
+    let complete = completionBlock
+    completionBlock = nil
+    complete?(nil, error)
   }
 
   public func completeWithPackage(fromKMP file: URL) {
+    let complete = completionBlock
+    completionBlock = nil
+
     do {
       if let package = try ResourceFileManager.shared.prepareKMPInstall(from: file) as? FullID.Resource.Package {
-        completionBlock?(package, nil)
+        complete?(package, nil)
       } else {
-        completionBlock?(nil, KMPError.invalidPackage)
+        complete?(nil, KMPError.invalidPackage)
       }
     } catch {
-      completionBlock?(nil, error)
+      complete?(nil, error)
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -126,13 +126,13 @@ class DownloadBatch<FullID: LanguageResourceFullID>: AnyDownloadBatch where Full
 
     self.startBlock = startBlock
 
-    self.completionBlock = resourceDownloadFinalizeClosure(tempURL: tempArtifact, finalURL: finalFile, closure: completionBlock)
+    self.completionBlock = DownloadBatch.resourceDownloadFinalizeClosure(tempURL: tempArtifact, finalURL: finalFile, closure: completionBlock)
   }
 
   /**
    * Supports downloading to a 'temp' file that is renamed once the download completes.
    */
-  internal func resourceDownloadFinalizeClosure(tempURL: URL,
+  internal static func resourceDownloadFinalizeClosure(tempURL: URL,
                                                 finalURL: URL,
                                                 closure: CompletionHandler<FullID.Resource>?)
                                                  -> CompletionHandler<FullID.Resource> {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -540,20 +540,22 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
       }
     }
   }
-  
-  func downloadRequestFailed(_ request: HTTPDownloadRequest) {
-    // We should never be in a state to return 'Unknown error", but better safe than sorry.
-    downloadRequestFailed(request, with: request.error ?? NSError(domain: "Keyman", code: 0,
-                          userInfo: [NSLocalizedDescriptionKey: "Unknown error"]))
-  }
 
-  func downloadRequestFailed(_ request: HTTPDownloadRequest, with error: Error) {
+  func downloadRequestFailed(_ request: HTTPDownloadRequest, with error: Error?) {
     currentFrame.batch?.errors[currentFrame.index] = error
     let task = request.userInfo[Key.downloadTask] as! AnyDownloadTask
     let batch = request.userInfo[Key.downloadBatch] as! AnyDownloadBatch
 
+    var err: Error
+    if let error = error {
+      err = error
+    } else {
+      err = NSError(domain: "Keyman", code: 0,
+                          userInfo: [NSLocalizedDescriptionKey: "Unknown error"])
+    }
+
     try? task.downloadFinalizationBlock?(false)
-    batch.completeWithError(error: error)
+    batch.completeWithError(error: err)
     downloader!.cancelAllOperations()
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -43,6 +43,20 @@ public class ResourceFileManager {
     }
   }
 
+  internal func packageDownloadTempPath<FullID: LanguageResourceFullID>(forID fullID: FullID) -> URL {
+    let documentDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let tempFilename = TypedKeymanPackage<FullID.Resource>.baseFilename(for: fullID)
+    let url = documentDir.appendingPathComponent("\(tempFilename).partial") // marks it as a download in progress
+    return url
+  }
+
+  internal func cachedPackagePath<FullID: LanguageResourceFullID>(forID fullID: FullID) -> URL {
+    let documentDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    let filename = TypedKeymanPackage<FullID.Resource>.baseFilename(for: fullID)
+    let url = documentDir.appendingPathComponent(filename)
+    return url
+  }
+
   /**
    * Apple doesn't provide a method that performs copy-and-overwrite functionality.  This function fills in that gap.
    */

--- a/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
@@ -51,7 +51,7 @@ class HTTPDownloaderTests: XCTestCase {
 
   func testSingleRequestFailure() throws {
     // A twist on the previous version - the 'download' fails.
-    let mockedResult = TestUtils.Downloading.MockResult(location: nil, error: NSError(domain: "KeymanTests", code: 1, userInfo: nil))
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: NSError(domain: "KeymanTests", code: 1, userInfo: nil))
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
     let testDelegate = TestUtils.Downloading.ExpectationDownloaderDelegate()

--- a/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/HTTPDownloaderTests.swift
@@ -51,7 +51,7 @@ class HTTPDownloaderTests: XCTestCase {
 
   func testSingleRequestFailure() throws {
     // A twist on the previous version - the 'download' fails.
-    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: NSError(domain: "KeymanTests", code: 1, userInfo: nil))
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: TestUtils.mockedError)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
     let testDelegate = TestUtils.Downloading.ExpectationDownloaderDelegate()
@@ -115,6 +115,7 @@ class HTTPDownloaderTests: XCTestCase {
     testDelegate.expectAbsence(method: .RequestStarted, request: request2)
     testDelegate.expectAbsence(method: .RequestFinished, request: request2)
     testDelegate.expect(method: .QueueCancelled, queue: downloader!)
+    testDelegate.expectAbsence(method: .QueueFinished, queue: downloader!)
 
     // Placed here for chronological ordering.  We expect the request to finish because of
     // our mocking structure, but want to delay its completion long enough for the

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -32,6 +32,30 @@ class ResourceDownloadManagerTests: XCTestCase {
     }
   }
 
+  func testDownloadPackageForKeyboard() throws {
+    let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
+    let mtnt_id = TestUtils.Keyboards.khmer_angkor.fullID
+
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
+    mockedURLSession?.queueMockResult(.download(mockedResult))
+
+    downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
+
+      // TODO:  Add assertion:  file exists in the documents directory, where we expect it
+      XCTAssertNil(error)
+      XCTAssertNotNil(package)
+
+      // TODO:  Add assertions: it really is the khmer_angkor keyboard package.
+
+      expectation.fulfill()
+    }
+
+    let downloadQueue = downloadManager!.downloader
+    downloadQueue.step()
+
+    wait(for: [expectation], timeout: 5)
+  }
+
   func testDownloadPackageForLexicalModel() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
     let mtnt_id = TestUtils.LexicalModels.mtnt.fullID

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -41,11 +41,21 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
-      // TODO:  Add assertion:  file exists in the documents directory, where we expect it
+      // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
+      let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+      let cachedDocumentsKMP = documentsDir.appendingPathComponent(
+        TypedKeymanPackage<InstallableKeyboard>.baseFilename(for: TestUtils.Keyboards.khmer_angkor.fullID))
+
+      XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
+
       XCTAssertNil(error)
       XCTAssertNotNil(package)
 
-      // TODO:  Add assertions: it really is the khmer_angkor keyboard package.
+      // Basic verification that it really is the khmer_angkor keyboard package.
+      if let package = package {
+        XCTAssertEqual(package.id, TestUtils.Keyboards.khmer_angkor.id)
+        XCTAssertNotNil(package.findResource(withID: TestUtils.Keyboards.khmer_angkor.fullID))
+      }
 
       expectation.fulfill()
     }
@@ -65,11 +75,21 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
 
-      // TODO:  Add assertion:  file exists in the documents directory, where we expect it
+      // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
+      let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+      let cachedDocumentsKMP = documentsDir.appendingPathComponent(
+        TypedKeymanPackage<InstallableLexicalModel>.baseFilename(for: TestUtils.LexicalModels.mtnt.fullID))
+
+      XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
+
       XCTAssertNil(error)
       XCTAssertNotNil(package)
 
-      // TODO:  Add assertions: it really is the MTNT lexical model package.
+      // Basic verification that it really is the khmer_angkor keyboard package.
+      if let package = package {
+        XCTAssertEqual(package.id, TestUtils.LexicalModels.mtnt.id)
+        XCTAssertNotNil(package.findResource(withID: TestUtils.LexicalModels.mtnt.fullID))
+      }
 
       expectation.fulfill()
     }

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -41,10 +41,12 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
-      // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-      let cachedDocumentsKMP = documentsDir.appendingPathComponent(
-        TypedKeymanPackage<InstallableKeyboard>.baseFilename(for: TestUtils.Keyboards.khmer_angkor.fullID))
+
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
+      
+      // Assertions:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
 
       XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
 
@@ -75,10 +77,11 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
 
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.LexicalModels.mtnt.fullID)
+      XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
+
       // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-      let cachedDocumentsKMP = documentsDir.appendingPathComponent(
-        TypedKeymanPackage<InstallableLexicalModel>.baseFilename(for: TestUtils.LexicalModels.mtnt.fullID))
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.LexicalModels.mtnt.fullID)
 
       XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
 
@@ -109,10 +112,11 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
+
       // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-      let cachedDocumentsKMP = documentsDir.appendingPathComponent(
-        TypedKeymanPackage<InstallableKeyboard>.baseFilename(for: TestUtils.Keyboards.khmer_angkor.fullID))
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
 
       // On download failure, we shouldn't be producing a file here.
       XCTAssertFalse(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -1,0 +1,58 @@
+//
+//  ResourceDownloadManagement.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 6/29/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import XCTest
+@testable import KeymanEngine
+
+class ResourceDownloadManagerTests: XCTestCase {
+  var mockedURLSession: TestUtils.Downloading.URLSessionMock?
+  var downloadManager: ResourceDownloadManager?
+
+  override func setUp() {
+    mockedURLSession = TestUtils.Downloading.URLSessionMock()
+    downloadManager = ResourceDownloadManager(session: mockedURLSession!, autoExecute: false)
+  }
+
+  override func tearDownWithError() throws {
+    // Resets resource directories for a clean slate.
+    TestUtils.standardTearDown()
+
+    let queueWasCleared = mockedURLSession!.queueIsEmpty
+    mockedURLSession = nil
+
+    if !queueWasCleared {
+      throw NSError(domain: "Keyman",
+                    code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "A test did not fully utilize its queued mock results!"])
+    }
+  }
+
+  func testDownloadPackageForLexicalModel() throws {
+    let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
+    let mtnt_id = TestUtils.LexicalModels.mtnt.fullID
+
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.LexicalModels.mtntKMP, error: nil)
+    mockedURLSession?.queueMockResult(.download(mockedResult))
+
+    downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
+
+      // TODO:  Add assertion:  file exists in the documents directory, where we expect it
+      XCTAssertNil(error)
+      XCTAssertNotNil(package)
+
+      // TODO:  Add assertions: it really is the MTNT lexical model package.
+
+      expectation.fulfill()
+    }
+
+    let downloadQueue = downloadManager!.downloader
+    downloadQueue.step()
+
+    wait(for: [expectation], timeout: 5)
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
@@ -1,0 +1,113 @@
+//
+//  ResourceDownloadQueueTests.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 6/29/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import XCTest
+@testable import KeymanEngine
+
+class ResourceDownloadQueueTests: XCTestCase {
+  override func tearDown() {
+    // Resets resource directories for a clean slate.
+    TestUtils.standardTearDown()
+  }
+
+  func testResourceDownloadFinalizeClosureNoOverwrite() throws {
+    let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
+
+    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
+      XCTAssertNotNil(package)
+      XCTAssertNil(error)
+    }
+
+    // May need a stand-in empty package for the first parameter in the future.
+    let khmer_angkor_metadata = KMPMetadata(from: TestUtils.Keyboards.khmer_angkor)
+    // Creates a placeholder package, rather than extracting a real one for use as a placeholder.
+    let dummyPackage = KeyboardKeymanPackage(metadata: khmer_angkor_metadata, folder: TestUtils.keyboardsBundle.bundleURL)
+    closure(dummyPackage, nil)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
+  }
+
+  func testResourceDownloadFinalizeClosureWithOverwrite() throws {
+    let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: destFileURL)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
+
+    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
+      XCTAssertNotNil(package)
+      XCTAssertNil(error)
+    }
+
+    // May need a stand-in empty package for the first parameter in the future.
+    let khmer_angkor_metadata = KMPMetadata(from: TestUtils.Keyboards.khmer_angkor)
+    // Creates a placeholder package, rather than extracting a real one for use as a placeholder.
+    let dummyPackage = KeyboardKeymanPackage(metadata: khmer_angkor_metadata, folder: TestUtils.keyboardsBundle.bundleURL)
+    closure(dummyPackage, nil)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
+  }
+
+  func testResourceDownloadFinalizeClosureWithError() throws {
+    let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
+
+    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
+      XCTAssertNil(package)
+      XCTAssertNotNil(error)
+    }
+
+    // Error chosen as a stand-in / dummy value.
+    closure(nil, ResourceDownloadQueue.QueueState.busy.error)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
+  }
+
+  func testResourceDownloadFinalizeClosurePreexistingWithError() throws {
+    let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
+    try FileManager.default.copyItem(at: khmer_angkor_src_url, to: destFileURL)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
+
+    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
+      XCTAssertNil(package)
+      XCTAssertNotNil(error)
+    }
+
+    // Error chosen as a stand-in / dummy value.
+    closure(nil, ResourceDownloadQueue.QueueState.busy.error)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
+  }
+}

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
@@ -25,16 +25,8 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
-      XCTAssertNotNil(package)
-      XCTAssertNil(error)
-    }
-
-    // May need a stand-in empty package for the first parameter in the future.
-    let khmer_angkor_metadata = KMPMetadata(from: TestUtils.Keyboards.khmer_angkor)
-    // Creates a placeholder package, rather than extracting a real one for use as a placeholder.
-    let dummyPackage = KeyboardKeymanPackage(metadata: khmer_angkor_metadata, folder: TestUtils.keyboardsBundle.bundleURL)
-    closure(dummyPackage, nil)
+    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
+    try? closure(true)
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
@@ -51,16 +43,10 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
-      XCTAssertNotNil(package)
-      XCTAssertNil(error)
-    }
+    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
     // May need a stand-in empty package for the first parameter in the future.
-    let khmer_angkor_metadata = KMPMetadata(from: TestUtils.Keyboards.khmer_angkor)
-    // Creates a placeholder package, rather than extracting a real one for use as a placeholder.
-    let dummyPackage = KeyboardKeymanPackage(metadata: khmer_angkor_metadata, folder: TestUtils.keyboardsBundle.bundleURL)
-    closure(dummyPackage, nil)
+    try? closure(true)
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
@@ -76,13 +62,10 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
-      XCTAssertNil(package)
-      XCTAssertNotNil(error)
-    }
+    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
-    // Error chosen as a stand-in / dummy value.
-    closure(nil, ResourceDownloadQueue.QueueState.busy.error)
+    // Error occurred; abort.
+    try? closure(false)
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
@@ -99,13 +82,10 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadBatch<FullKeyboardID>.resourceDownloadFinalizeClosure(tempURL: tempFileURL, finalURL: destFileURL) { package, error in
-      XCTAssertNil(package)
-      XCTAssertNotNil(error)
-    }
+    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
-    // Error chosen as a stand-in / dummy value.
-    closure(nil, ResourceDownloadQueue.QueueState.busy.error)
+    // Error occurred, abort.
+    try? closure(false)
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/ExpectationDownloaderDelegate.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/ExpectationDownloaderDelegate.swift
@@ -87,7 +87,7 @@ extension TestUtils.Downloading {
       doExpectationMatch(method: .RequestFinished, request: request)
     }
 
-    func downloadRequestFailed(_ request: HTTPDownloadRequest) {
+    func downloadRequestFailed(_ request: HTTPDownloadRequest, with error: Error?) {
       doExpectationMatch(method: .RequestFailed, request: request)
     }
 

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDownloadTaskMock.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDownloadTaskMock.swift
@@ -14,9 +14,15 @@ extension TestUtils.Downloading {
    */
   class URLSessionDownloadTaskMock: URLSessionDownloadTask {
     private let closure: () -> Void
+    private let _response: URLResponse?
 
-    init(closure: @escaping () -> Void) {
+    init(response: URLResponse? = nil, closure: @escaping () -> Void) {
       self.closure = closure
+      self._response = response
+    }
+
+    public override var response: URLResponse? {
+      return _response
     }
 
     /*

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/TestUtils.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/TestUtils.swift
@@ -30,6 +30,8 @@ enum TestUtils {
   static let keyboardsBundle = findSubBundle(forResource: "Keyboards", ofType: "bundle")
   static let lexicalModelsBundle = findSubBundle(forResource: "Lexical Models", ofType: "bundle")
 
+  static let mockedError = NSError(domain: "KeymanTests", code: 1, userInfo: nil)
+
   static func clearDirectory(at url: URL) {
     do {
       // We'll run into problems if we delete the cache directory.  Instead, we delete all the items within it.


### PR DESCRIPTION
This PR is centered around the new function `downloadPackage(forFullID:from:)`, which is designed to facilitate download of any supported package type from a known URL.  (The URL should be sourced separately, which is where query code comes in.)  The method supports both keyboard and lexical model downloads, the former of which took a little work.  This also adds a "temporary" download naming scheme, only overwriting existing files when a download is confirmed to be successful.

All packages downloaded by this method will have a copy stored within the app's Documents directory, allowing users to share KMP files directly with others or to install other resources (language pairings) from them at a later time via the "Install From File" option.

When writing user tests, it became apparent that there were a few bugs in how errors were being handled, both by `ResourceDownloadQueue` and `HTTPDownloader`.  Since this was discovered entirely due to interactions with new unit tests / unit testing features, fixes for said issues got lumped into this PR.  (It's rather hard to split off, as the circumstances for detecting it near-require the level of integration used by the tests for the new method.)