### PR TITLE
fix(common/core/web): fixes transcription buffer cap

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -92,7 +92,7 @@ namespace com.keyman.text.prediction {
     private _mayPredict: boolean = true;
     private _mayCorrect: boolean = true;
 
-    private static readonly TRANSCRIPTION_BUFFER: 10;
+    private static readonly TRANSCRIPTION_BUFFER: 10 = 10;
 
     public init(supportsRightDeletions: boolean = false) {
       // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer


### PR DESCRIPTION
An important thing to remember with TS type definitions:  `var a: 10` means that the variable's type is constrained to only allow initialization with `10`.  It does _**not**_, however, actually initialize it.

This bug was found while investigating https://community.software.sil.org/t/the-more-i-type-the-slower-the-prediction-speed/3552.  In KMW's currently-published versions, including stable-13.0, the buffer is currently broken due to the defined constant's lack of actual initialization:

![unbuffered transcriptions](https://user-images.githubusercontent.com/25213402/86097631-25a0f400-badf-11ea-8d5e-18ea6c630411.png)

This basically serves as a memory leak, as old transcriptions are kept around in memory.  In reference to the linked posting, two pages' worth of text should be into the thousands of entries.  Considering that transcriptions are _also_ buffered with their corresponding fat-finger alternate distributions, the memory growth can start to add up significantly over time.

This small change quickly hard-caps the array's size to 10, as originally intended.