### PR TITLE
fix(android/app) Download associated dictionary when installing cloud keyboard package

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -29,9 +29,7 @@ import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.LexicalModel;
-import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
-import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
 import com.tavultesoft.kmea.util.KMLog;
 
@@ -39,8 +37,6 @@ import android.Manifest;
 import android.app.ProgressDialog;
 import android.content.ComponentName;
 import android.content.pm.PackageManager;
-import android.content.res.AssetManager;
-import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
 import android.net.Uri.Builder;
@@ -76,7 +72,6 @@ import android.os.ResultReceiver;
 import android.provider.OpenableColumns;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.FileProvider;
 import androidx.appcompat.widget.PopupMenu;
 
 import android.text.Html;
@@ -97,8 +92,6 @@ import android.widget.Toast;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.core.Sentry;
 
-import static com.tavultesoft.kmea.KMKeyboardDownloaderActivity.kKeymanApiModelURL;
-
 public class MainActivity extends AppCompatActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener,
     ActivityCompat.OnRequestPermissionsResultCallback {
   public static Context context;
@@ -115,8 +108,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   private int textSize = minTextSize;
   private static final String defaultKeyboardInstalled = "DefaultKeyboardInstalled";
   private static final String defaultDictionaryInstalled = "DefaultDictionaryInstalled";
-  private static final String defaultKeyboardPath = "sil_euro_latin.kmp";
-  private static final String defaultDictionaryPath = "nrc.en.mtnt.model.kmp";
   private static final String userTextKey = "UserText";
   private static final String userTextSizeKey = "UserTextSize";
   protected static final String didCheckUserDataKey = "DidCheckUserData";
@@ -158,7 +149,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           packageIntent.putExtras(bundle);
           startActivity(packageIntent);
 
-          // Determine if associated lexical model should be downloaded
+          // Determine if associated lexical model for languageID should be downloaded
           if (FileUtils.hasKeymanPackageExtension(kmpFilename) && !FileUtils.hasLexicalModelPackageExtension(kmpFilename)
               && (languageID != null) && !languageID.isEmpty()) {
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -306,7 +306,7 @@ public final class KeyboardPickerActivity extends AppCompatActivity {
 
     if (keyboardInfo != null) {
       String languageID = keyboardInfo.getLanguageID();
-      if (!CloudRepository.shared.hasAssociatedLexicalModel(context, languageID)) {
+      if (CloudRepository.shared.getAssociatedLexicalModel(context, languageID) == null) {
         // Only invalidate the lexical cache if there's no associated lexical model
         CloudRepository.shared.invalidateLexicalModelCache(context);
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -127,21 +127,21 @@ public class CloudRepository {
 
   /**
    * Search the available lexical models list and see there's an associated model for a
-   * given language ID. Available models are from the cloud catalog and locally installed models
+   * given language ID. Available models are from the cloud catalog and locally installed models.
    * @param context Context
    * @param languageID String of the language ID to search
-   * @return boolean true if an associated lexical model exists
+   * @return LexicalModel of an associated lexical model. Null if no match found
    */
-  public boolean hasAssociatedLexicalModel(@NonNull Context context, String languageID) {
+  public LexicalModel getAssociatedLexicalModel(@NonNull Context context, String languageID) {
     if (memCachedDataset != null) {
       for (int i=0; i < memCachedDataset.lexicalModels.getCount(); i++) {
         LexicalModel lm = memCachedDataset.lexicalModels.getItem(i);
         if (BCP47.languageEquals(lm.getLanguageID(), languageID)) {
-          return true;
+          return lm;
         }
       }
     }
-    return false;
+    return null;
   }
 
   // Should be called whenever a new language code starts being managed in order to help signal


### PR DESCRIPTION
When installing cloud keyboard packages that have a specified language ID, this PR fixes the feature to download the associated dictionary package.

Some things to note about the current staging keyboard search:
* Keyboard searches won't specify language ID unless it's a language query (`q:l:id:...`)
* Search results currently use `tag=` for language ID, but eventually production will use `bcp47=`.
* Language searches involving script (e.g. `glk-arab`) currently return a tag `glk`. If the associated dictionary package (`sil.glk-arab.ptwl1`) doesn't include that tag (it only lists `glk-arab`), the dictionary package won't get installed.

### User Testing
@MakaraSok 
1. Load the test build
2. Install fv_sencoten from the cloud
    * From "Settings" --> "Install Keyboard or Dictionary" --> "Install from keyman.com"
    * In the search bar, do a language search for SENĆOŦEN by typing `l:id:str`
    Note, make sure the system keyboard doesn't change your query with autocorrection (Gboard would replace `id` with `I'd`)
![Screenshot_1593741487](https://user-images.githubusercontent.com/7358010/86424645-4babdb80-bd0d-11ea-9c90-ce399d571024.png)
    * Install fv_sencoten keyboard package
3. Keyman will find the associated `nrc.str.sencoten` dictionary package and install it in the background (this may take some time depending on network traffic)
- [ ] Verify Keyman installs SENĆOŦEN keyboard and dictionary packages (keyboard displays **Straits Salish (Latin)**

