### PR TITLE
fix(android/engine): Fix unbound variable in build script

### DIFF
--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -63,6 +63,7 @@ DO_BUILD=true
 DO_COPY=true
 DO_TEST=true
 NO_DAEMON=false
+DEBUG_BUILD=false
 EMBED_BUILD=-embed
 KMW_PATH=
 


### PR DESCRIPTION
#3300 tightened up the Android `build.sh` scripts.  But it caused release builds to fail because `DEBUG_BUILD` is an unbound variable.

This one-liner fixes the build.