### PR TITLE
fix(android): Fix crash with null Keyboard Picker

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardPickerAdapter.java
@@ -47,10 +47,26 @@ final class KMKeyboardPickerAdapter extends NestedAdapter<Keyboard, Dataset.Keyb
         List<HashMap<String, String>> kbdMapList = KeyboardPickerActivity.getKeyboardsList(context);
         List<Keyboard> kbdList = new ArrayList<>(kbdMapList.size());
 
-        for(HashMap<String, String> kbdMap: kbdMapList) {
+        int kbdListSize = (kbdMapList != null) ? kbdMapList.size() : 1;
+        List<Keyboard> kbdList = new ArrayList<>(kbdListSize);
+
+        if (kbdMapList != null) {
+          for (HashMap<String, String> kbdMap : kbdMapList) {
+            kbdList.add(new Keyboard(kbdMap));
+          }
+        } else {
+          // Couldn't access keyboard list so just return default keyboard
+          HashMap<String, String> kbdMap = new HashMap<String, String>();
+          kbdMap.put(KMManager.KMKey_PackageID, KMManager.KMDefault_UndefinedPackageID);
+          kbdMap.put(KMManager.KMKey_KeyboardID, KMManager.KMDefault_KeyboardID);
+          kbdMap.put(KMManager.KMKey_LanguageID, KMManager.KMDefault_LanguageID);
+          kbdMap.put(KMManager.KMKey_KeyboardName, KMManager.KMDefault_KeyboardName);
+          kbdMap.put(KMManager.KMKey_LanguageName, KMManager.KMDefault_LanguageName);
+          kbdMap.put(KMManager.KMKey_KeyboardVersion, KMManager.getLatestKeyboardFileVersion(
+            context, KMManager.KMDefault_UndefinedPackageID, KMManager.KMDefault_KeyboardID));
+          kbdMap.put(KMManager.KMKey_Font, KMManager.KMDefault_KeyboardFont);
           kbdList.add(new Keyboard(kbdMap));
         }
-
         return kbdList;
       }
     }, null);


### PR DESCRIPTION
This PR fixes a keyboard picker crash reported in [Firebase](https://console.firebase.google.com/u/0/project/kmapro-ee779/crashlytics/app/android:com.tavultesoft.kmapro/issues/d31259b8bdc56459c2a9115e32d048f1)

In the event of exceptions getting the keyboard list from `keyboards_list.dat`, this ensures the Keyboard Picker can at least display the default sil_euro_latin keyboard.

The corresponding code in `master` branch  has been refactored to not use `kbdMapList`, so no need to 🍒 pick.

