### PR TITLE
feat(android): Add additional info on installed keyboards exceptions

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -60,7 +60,7 @@ public class KeyboardController {
       list = new ArrayList<Keyboard>();
       if (keyboards_dat.exists() && !keyboards_json.exists()) {
         try {
-          // Migrate installed_keyboards.dat to installed_keyboards.json
+          // Migrate installed_keyboards.dat to keyboards_list.json
           ObjectInputStream inputStream = new ObjectInputStream(new FileInputStream(keyboards_dat));
           ArrayList<HashMap<String, String>> dat_list = (ArrayList<HashMap<String, String>>) inputStream.readObject();
           inputStream.close();
@@ -72,7 +72,7 @@ public class KeyboardController {
       } else if (keyboards_json.exists()) {
         JSONArray json_list = null;
         try {
-          // Get installed keyboards from installed_keyboards.json
+          // Get installed keyboards from keyboards_list.json
           JSONParser jsonParser = new JSONParser();
           json_list = jsonParser.getJSONObjectFromFile(keyboards_json, JSONArray.class);
           if (json_list != null) {
@@ -85,10 +85,11 @@ public class KeyboardController {
               }
             }
           } else {
-            KMLog.LogError(TAG, "installed_keyboards.json is null");
+            KMLog.LogError(TAG, KMFilename_Installed_KeyboardsList + " is null");
           }
         } catch (Exception e) {
-          KMLog.LogJSONException(TAG, "Exception reading installed_keyboards.json", json_list, e);
+          KMLog.LogExceptionWithData(TAG, "Exception reading " + KMFilename_Installed_KeyboardsList,
+            KMFilename_Installed_KeyboardsList, json_list, e);
           list.add(Keyboard.getDefaultKeyboard(context));
         }
       } else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -70,10 +70,11 @@ public class KeyboardController {
           list.add(Keyboard.getDefaultKeyboard(context));
         }
       } else if (keyboards_json.exists()) {
+        JSONArray json_list = null;
         try {
           // Get installed keyboards from installed_keyboards.json
           JSONParser jsonParser = new JSONParser();
-          JSONArray json_list = jsonParser.getJSONObjectFromFile(keyboards_json, JSONArray.class);
+          json_list = jsonParser.getJSONObjectFromFile(keyboards_json, JSONArray.class);
           if (json_list != null) {
             // Can't foreach JSONArray
             for (int i=0; i<json_list.length(); i++) {
@@ -83,9 +84,11 @@ public class KeyboardController {
                 list.add(k);
               }
             }
+          } else {
+            KMLog.LogError(TAG, "installed_keyboards.json is null");
           }
         } catch (Exception e) {
-          KMLog.LogException(TAG, "Exception reading installed_keyboards.json", e);
+          KMLog.LogJSONException(TAG, "Exception reading installed_keyboards.json", json_list, e);
           list.add(Keyboard.getDefaultKeyboard(context));
         }
       } else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -11,6 +11,7 @@ import io.sentry.core.SentryLevel;
 import org.json.JSONArray;
 
 public final class KMLog {
+  private static final String TAG = "KMLog";
 
   /**
    * Utility to log error and send to Sentry
@@ -49,24 +50,24 @@ public final class KMLog {
   }
 
   /**
-   * Utility to include JSONArray in the log exception sent to Sentry
+   * Utility to print an Object in the log exception sent to Sentry
    * @param tag String of the caller
    * @param msg String of the exception message
-   * @param array JSONArray of the installed keyboards_list.json file
+   * @param objName String of the object name
+   * @param obj Object which will be formatted as a string
    * @param e Throwable exception
    */
-  public static void LogJSONException(String tag, String msg, JSONArray array, Throwable e) {
-    if (array != null && Sentry.isEnabled()) {
-      String formattedList = null;
+  public static void LogExceptionWithData(String tag, String msg,
+                                          String objName, Object obj, Throwable e) {
+    if (obj != null && Sentry.isEnabled()) {
+      String objStr = null;
       try {
-        // Try to pretty-print the installed keyboards list
-        final int indentSpaces = 2;
-        formattedList = array.toString(indentSpaces);
-        Sentry.setExtra("keyboards_list.json", formattedList);
+        objStr = obj.toString();
+        Sentry.setExtra(objName, objStr);
       } catch (Exception innerE) {
-        // Throwaway the formatting exception and just report the original one
-        Sentry.setExtra("keyboards_list.json", array.toString());
+        LogException(TAG, "Sentry.setExtra failed for " + objName, innerE);
       }
+      // Report the original exception
       LogException(tag, msg, e);
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -8,8 +8,6 @@ import android.util.Log;
 import io.sentry.core.Sentry;
 import io.sentry.core.SentryLevel;
 
-import org.json.JSONArray;
-
 public final class KMLog {
   private static final String TAG = "KMLog";
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import io.sentry.core.Sentry;
 import io.sentry.core.SentryLevel;
 
+import org.json.JSONArray;
+
 public final class KMLog {
 
   /**
@@ -43,6 +45,29 @@ public final class KMLog {
         Sentry.addBreadcrumb(msg);
       }
       Sentry.captureException(e);
+    }
+  }
+
+  /**
+   * Utility to include JSONArray in the log exception sent to Sentry
+   * @param tag String of the caller
+   * @param msg String of the exception message
+   * @param array JSONArray of the installed keyboards_list.json file
+   * @param e Throwable exception
+   */
+  public static void LogJSONException(String tag, String msg, JSONArray array, Throwable e) {
+    if (array != null && Sentry.isEnabled()) {
+      String formattedList = null;
+      try {
+        // Try to pretty-print the installed keyboards list
+        final int indentSpaces = 2;
+        formattedList = array.toString(indentSpaces);
+        Sentry.setExtra("keyboards_list.json", formattedList);
+      } catch (Exception innerE) {
+        // Throwaway the formatting exception and just report the original one
+        Sentry.setExtra("keyboards_list.json", array.toString());
+      }
+      LogException(tag, msg, e);
     }
   }
 }


### PR DESCRIPTION
Fixes #3311 
This PR creates a utility `LogJSONException()` which provides additional logging to Sentry if there's issues reading the installed keyboards list.

Now we'll get reports if the installed keyboard list is null.
If the file has content but fails to parse, we'll get the contents of `installed_keyboards.json` written to Sentry.