### PR TITLE
refactor(ios/engine): reworks resource updates to use package-version query results

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -858,11 +858,13 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
                                                         completionBlock: completionBlock)
   }
 
+  @available(*, deprecated, message: "") // TODO:  Write method on KeymanPackage for this.
   public func stateForKeyboard(withID keyboardID: String) -> KeyboardState {
     return ResourceDownloadManager.shared.stateForKeyboard(withID: keyboardID)
   }
 
   // Technically new, but it does closely parallel an old API point.
+  @available(*, deprecated, message: "") // TODO:  Write method on KeymanPackage for this.
   public func stateForLexicalModel(withID modelID: String) -> KeyboardState {
     return ResourceDownloadManager.shared.stateForLexicalModel(withID: modelID)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/FullKeyboardID.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A complete identifier for an `InstallableKeyboard`. Keyboards must have unique `FullKeyboardID`s.
-public struct FullKeyboardID: Codable, LanguageResourceFullID, Equatable {
+public struct FullKeyboardID: Codable, LanguageResourceFullID, Hashable {
   public typealias Resource = InstallableKeyboard
   
   public var keyboardID: String

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/FullLexicalModelID.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/FullLexicalModelID.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A complete identifier for an `InstallableLexicalModel`. LexicalModels must have unique `FullLexicalModelID`s.
-public struct FullLexicalModelID: Codable, LanguageResourceFullID, Equatable {
+public struct FullLexicalModelID: Codable, LanguageResourceFullID, Hashable {
   public typealias Resource = InstallableLexicalModel
   
   public var lexicalModelID: String

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -39,13 +39,21 @@ extension AnyLanguageResourceFullID where Self: Equatable {
   }
 }
 
+extension AnyLanguageResourceFullID where Self: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.id)
+    hasher.combine(self.languageID)
+    hasher.combine(self.type)
+  }
+}
+
 extension AnyLanguageResourceFullID {
   var description: String {
     return "{\(type): {id = \(id), languageID=\(languageID)}}"
   }
 }
 
-public protocol LanguageResourceFullID: AnyLanguageResourceFullID {
+public protocol LanguageResourceFullID: AnyLanguageResourceFullID, Hashable {
   associatedtype Resource: LanguageResource where Resource.FullID == Self
 }
 
@@ -79,7 +87,7 @@ extension AnyLanguageResource {
 // Necessary due to Swift details 'documented' at
 // https://stackoverflow.com/questions/42561685/why-cant-a-get-only-property-requirement-in-a-protocol-be-satisfied-by-a-proper
 public protocol LanguageResource: AnyLanguageResource {
-  associatedtype FullID: LanguageResourceFullID where FullID: Equatable, FullID.Resource == Self
+  associatedtype FullID: LanguageResourceFullID where FullID.Resource == Self
   associatedtype Package: KeymanPackage
   var typedFullID: FullID { get }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
@@ -152,8 +152,8 @@ extension Queries {
       self.cachedResults = [.keyboard: [:], .lexicalModel: [:]]
     }
 
-    static func cachedResult<FullID: AnyLanguageResourceFullID>(for fullID: FullID) -> ResultEntry? {
-      return cachedResults[fullID.type]![fullID.id]
+    static func cachedResult(for packageKey: KeymanPackage.Key) -> ResultEntry? {
+      return cachedResults[packageKey.type]![packageKey.id]
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -399,35 +399,6 @@ public class ResourceDownloadManager {
     }
   }
 
-  /**
-   * Runs the package-version query against all installed resources to determine if any updates are available.
-   */
-  public func fetchAvailableUpdates(completionBlock: (([KeymanPackage.Key]?, Error?) -> Void)? = nil) {
-    let userDefaults = Storage.active.userDefaults
-    let keyboardPackages = userDefaults.userKeyboards?.map { $0.packageKey }
-    let lexicalModelPackages = userDefaults.userLexicalModels?.map { $0.packageKey }
-
-    let packageKeys = (keyboardPackages ?? []) + (lexicalModelPackages ?? [])
-
-    Queries.PackageVersion.fetch(for: packageKeys) { results, error in
-      guard error == nil else {
-        completionBlock?(nil, error)
-        return
-      }
-
-      // If no completionBlock was specified, the caller simply wanted a prefetch.
-      // Any further processing we might try to do would go to waste, so stop here.
-      guard let completionBlock = completionBlock else {
-        return
-      }
-
-      // Check for updates among the returned versions IF a completion block is specified.
-      // This facilitates a more proactive update notification.
-
-      // TODO:  flesh out!
-    }
-  }
-
   public func getAvailableUpdates() -> [AnyLanguageResource]? {
     // Relies upon KMManager's preload; this was the case before the rework.
     if Manager.shared.apiKeyboardRepository.languages == nil && Manager.shared.apiLexicalModelRepository.languages == nil {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -210,9 +210,8 @@ public class ResourceDownloadManager {
       return .needsDownload
     }
 
-    // TODO:  convert to use of package-version API.
     // Check version
-    if let repositoryVersionString = Manager.shared.apiKeyboardRepository.keyboards?[keyboardID]?.version {
+    if let repositoryVersionString = Queries.PackageVersion.cachedResult(for: fullKeyboardID)?.version {
       let downloadedVersion = Version(userKeyboard.version) ?? Version.fallback
       let repositoryVersion = Version(repositoryVersionString) ?? Version.fallback
       if downloadedVersion < repositoryVersion {
@@ -333,9 +332,8 @@ public class ResourceDownloadManager {
       return .needsDownload
     }
 
-    // TODO:  Convert to use of package-version API.
     // Check version
-    if let repositoryVersionString = Manager.shared.apiLexicalModelRepository.lexicalModels?[lexicalModelID]?.version {
+    if let repositoryVersionString = Queries.PackageVersion.cachedResult(for: fullLexicalModelID)?.version {
       let downloadedVersion = Version(userLexicalModel.version) ?? Version.fallback
       let repositoryVersion = Version(repositoryVersionString) ?? Version.fallback
       if downloadedVersion < repositoryVersion {

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -18,6 +18,7 @@ class QueryPackageVersionTests: XCTestCase {
 
   override func tearDownWithError() throws {
     let queueWasCleared = mockedURLSession!.queueIsEmpty
+    Queries.PackageVersion.cachedResults = [:]
     mockedURLSession = nil
 
     if !queueWasCleared {
@@ -101,6 +102,46 @@ class QueryPackageVersionTests: XCTestCase {
           }
         }
       }
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 5)
+  }
+
+  /**
+   * Tests the caching behavior of fetch calls..
+   */
+  func testFetchCaching() throws {
+    let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Queries.package_version_case_1, error: nil)
+    mockedURLSession?.queueMockResult(.data(mockedResult))
+
+    let badKbdFullID = FullKeyboardID(keyboardID: "foo", languageID: "en")
+    let badLexFullID = FullLexicalModelID(lexicalModelID: "bar", languageID: "km")
+    let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
+                   TestUtils.Keyboards.sil_euro_latin.fullID,
+                   badKbdFullID,
+                   TestUtils.LexicalModels.mtnt.fullID,
+                   badLexFullID]
+
+    let expectation = XCTestExpectation(description: "Query complete and results analyzed")
+
+    Queries.PackageVersion.fetch(for: fullIDs, withSession: mockedURLSession!) { results, error in
+      if let _ = error {
+        XCTFail(String(describing: error))
+        expectation.fulfill()
+        return
+      }
+      XCTAssertNotNil(results)
+
+      // Check to see that the results were appropriately cached.
+      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.Keyboards.khmer_angkor.fullID])
+      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.Keyboards.sil_euro_latin.fullID])
+      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.LexicalModels.mtnt.fullID])
+
+      // Error results are not cached.
+      XCTAssertNil(Queries.PackageVersion.cachedResults[badKbdFullID])
+      XCTAssertNil(Queries.PackageVersion.cachedResults[badLexFullID])
+
       expectation.fulfill()
     }
 

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -117,15 +117,15 @@ class QueryPackageVersionTests: XCTestCase {
 
     let badKbdFullID = FullKeyboardID(keyboardID: "foo", languageID: "en")
     let badLexFullID = FullLexicalModelID(lexicalModelID: "bar", languageID: "km")
-    let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
-                   TestUtils.Keyboards.sil_euro_latin.fullID,
-                   badKbdFullID,
-                   TestUtils.LexicalModels.mtnt.fullID,
-                   badLexFullID]
+    let packageKeys = [TestUtils.Keyboards.khmer_angkor.fullID,
+                       TestUtils.Keyboards.sil_euro_latin.fullID,
+                       badKbdFullID,
+                       TestUtils.LexicalModels.mtnt.fullID,
+                       badLexFullID].map { packageKey(for: $0) }
 
     let expectation = XCTestExpectation(description: "Query complete and results analyzed")
 
-    Queries.PackageVersion.fetch(for: fullIDs, withSession: mockedURLSession!) { results, error in
+    Queries.PackageVersion.fetch(for: packageKeys, withSession: mockedURLSession!) { results, error in
       if let _ = error {
         XCTFail(String(describing: error))
         expectation.fulfill()
@@ -134,13 +134,13 @@ class QueryPackageVersionTests: XCTestCase {
       XCTAssertNotNil(results)
 
       // Check to see that the results were appropriately cached.
-      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.Keyboards.khmer_angkor.fullID))
-      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.Keyboards.sil_euro_latin.fullID))
-      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.LexicalModels.mtnt.fullID))
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: self.packageKey(for: TestUtils.Keyboards.khmer_angkor.fullID)))
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: self.packageKey(for: TestUtils.Keyboards.sil_euro_latin.fullID)))
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: self.packageKey(for: TestUtils.LexicalModels.mtnt.fullID)))
 
       // Error results are not cached.
-      XCTAssertNil(Queries.PackageVersion.cachedResult(for: badKbdFullID))
-      XCTAssertNil(Queries.PackageVersion.cachedResult(for: badLexFullID))
+      XCTAssertNil(Queries.PackageVersion.cachedResult(for: self.packageKey(for: badKbdFullID)))
+      XCTAssertNil(Queries.PackageVersion.cachedResult(for: self.packageKey(for: badLexFullID)))
 
       expectation.fulfill()
     }

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -18,7 +18,7 @@ class QueryPackageVersionTests: XCTestCase {
 
   override func tearDownWithError() throws {
     let queueWasCleared = mockedURLSession!.queueIsEmpty
-    Queries.PackageVersion.cachedResults = [:]
+    Queries.PackageVersion.resetCache()
     mockedURLSession = nil
 
     if !queueWasCleared {
@@ -134,13 +134,13 @@ class QueryPackageVersionTests: XCTestCase {
       XCTAssertNotNil(results)
 
       // Check to see that the results were appropriately cached.
-      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.Keyboards.khmer_angkor.fullID])
-      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.Keyboards.sil_euro_latin.fullID])
-      XCTAssertNotNil(Queries.PackageVersion.cachedResults[TestUtils.LexicalModels.mtnt.fullID])
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.Keyboards.khmer_angkor.fullID))
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.Keyboards.sil_euro_latin.fullID))
+      XCTAssertNotNil(Queries.PackageVersion.cachedResult(for: TestUtils.LexicalModels.mtnt.fullID))
 
       // Error results are not cached.
-      XCTAssertNil(Queries.PackageVersion.cachedResults[badKbdFullID])
-      XCTAssertNil(Queries.PackageVersion.cachedResults[badLexFullID])
+      XCTAssertNil(Queries.PackageVersion.cachedResult(for: badKbdFullID))
+      XCTAssertNil(Queries.PackageVersion.cachedResult(for: badLexFullID))
 
       expectation.fulfill()
     }

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -206,7 +206,7 @@ class ResourceDownloadManagerTests: XCTestCase {
     let versionQuery = XCTestExpectation()
 
     // Now to do a package-version check.
-    Queries.PackageVersion.fetch(for: [khmer_angkor_id], withSession: downloadManager!.session) { _, _ in
+    Queries.PackageVersion.fetch(for: [KeymanPackage.Key(id: khmer_angkor_id.id, type: .keyboard)], withSession: downloadManager!.session) { _, _ in
       XCTAssertEqual(self.downloadManager!.stateForKeyboard(withID: khmer_angkor_id.id), .needsUpdate)
       versionQuery.fulfill()
     }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Queries.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Queries.swift
@@ -16,6 +16,8 @@ extension TestUtils {
 
     static let package_version_case_mtnt = query_bundle.url(forResource: "package-version-case-mtnt", withExtension: "json")!
 
+    static let package_version_km_updated = query_bundle.url(forResource: "package-version-km-updated", withExtension: "json")!
+
     static let model_case_en = query_bundle.url(forResource: "model-case-en", withExtension: "json")!
   }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/resources/Queries.bundle/package-version-km-updated.json
+++ b/ios/engine/KMEI/KeymanEngineTests/resources/Queries.bundle/package-version-km-updated.json
@@ -1,0 +1,8 @@
+{
+    "keyboards": {
+        "khmer_angkor": {
+            "version": "1.1.0",
+            "kmp": "https://downloads.keyman.com/keyboards/khmer_angkor/1.0.6/khmer_angkor.kmp"
+        }
+    }
+}


### PR DESCRIPTION
The next step for iOS - fully shifting keyboard & model updates to use the results of the new-ish package-version query.

This is still very much incomplete / in "draft mode" at this time.