### PR TITLE
feat(android/oem): Add nrc.str.sencoten model and update SystemKeyboard from KMAPro

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -91,11 +91,11 @@ fi
 
 
 # Download default keyboard and dictionary
-if [ $DO_KEYBOARDS_DOWNLOAD = true ]; then
+if [ "$DO_KEYBOARDS_DOWNLOAD" = true ]; then
   downloadKeyboardPackage "$KEYBOARD_PACKAGE_ID" "$KEYBOARDS_TARGET"
 fi
 
-if [ $DO_MODELS_DOWNLOAD = true ]; then
+if [ "$DO_MODELS_DOWNLOAD" = true ]; then
   downloadModelPackage "$MODEL_PACKAGE_ID" "$MODELS_TARGET"
 fi
 

--- a/oem/firstvoices/android/.gitignore
+++ b/oem/firstvoices/android/.gitignore
@@ -22,6 +22,7 @@
 app/src/main/assets/packages
 app/src/main/assets/keyboards.csv
 app/src/main/assets/fv_all.kmp
+app/src/main/assets/nrc.str.sencoten.model.kmp
 
 # Legacy Eclipse IDE files
 .classpath

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 import android.util.Log;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.packages.PackageProcessor;
+import com.tavultesoft.kmea.util.FileUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -37,7 +39,16 @@ final class FVShared {
 
     private static final String FVKeyboardHelpLink = "http://help.keyman.com/keyboard/";
 
-    private static final String FVDefault_PackageID = "fv_all";
+    public static final String FVDefault_PackageID = "fv_all";
+
+    // Default Dictionary Info
+    public static final String FVDefault_DictionaryPackageID = "nrc.str.sencoten";
+    public static final String FVDefault_DictionaryModelID = "nrc.str.sencoten";
+    public static final String FVDefault_DictionaryModelName = "SENĆOŦEN (Saanich Dialect) Lexical Model";
+    public static final String FVDefault_DictionaryLanguageID = "str-latn";
+    public static final String FVDefault_DictionaryLanguageName = "SENĆOŦEN";
+    public static final String FVDefault_DictionaryVersion = "1.0.5";
+    public static final String FVDefault_DictionaryKMP = FVDefault_DictionaryPackageID + FileUtils.MODELPACKAGE;
 
     /// Describes a keyboard used in FirstVoices Keyboards
     static class FVKeyboard {
@@ -234,25 +245,21 @@ final class FVShared {
                 KMManager.removeKeyboard(context, i);
         }
 
+        File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
+        PackageProcessor kmpProcessor =  new PackageProcessor(resourceRoot);
+
         // Recreate active keyboards list
         for(FVRegion region : regionList) {
             for(FVKeyboard keyboard : region.keyboards) {
                 if(loadedKeyboards.contains(keyboard.id)) {
-                    // Load the .keyboard_info file and find its first language code
-                    Keyboard kbInfo = new Keyboard(
-                      FVDefault_PackageID, //TODO: we want to share keyboard build scripts between ios and android; can we do this?
+                    // Parse kmp.json for the keyboard info
+                    Keyboard kbd = kmpProcessor.getKeyboard(
+                      FVDefault_PackageID,
                       keyboard.id,
-                      keyboard.name,
-                      "en", //TODO: use language code from kmp.json
-                      keyboard.name,
-                      "1.0", //TODO: use keyboard version from kmp.json
-                      String.format("%s%s", FVKeyboardHelpLink, keyboard.id),
-                      "", // kmp link
-                      false,
-                      "NotoSansCanadianAboriginal.ttf",
-                      "NotoSansCanadianAboriginal.ttf");
-
-                    KMManager.addKeyboard(context, kbInfo);
+                      null); // get first associated language ID
+                    if (kbd != null) {
+                      KMManager.addKeyboard(context, kbd);
+                    }
                 }
             }
         }
@@ -264,15 +271,8 @@ final class FVShared {
                     KMManager.setKeyboard(context, 0);
             }
             else {
-                // Add a default keyboard in if none are available
-                HashMap<String, String> kbInfo = new HashMap<>();
-                kbInfo.put(KMManager.KMKey_PackageID, KMManager.KMDefault_PackageID);
-                kbInfo.put(KMManager.KMKey_KeyboardID, KMManager.KMDefault_KeyboardID);
-                kbInfo.put(KMManager.KMKey_LanguageID, KMManager.KMDefault_LanguageID);
-                kbInfo.put(KMManager.KMKey_KeyboardName, KMManager.KMDefault_KeyboardName);
-                kbInfo.put(KMManager.KMKey_LanguageName, KMManager.KMDefault_LanguageName);
-                //kbInfo.put(KMManager.KMKey_KeyboardVersion, KMManager.getLatestKeyboardFileVersion(context, KMManager.KMDefault_KeyboardID));
-                kbInfo.put(KMManager.KMKey_Font, KMManager.KMDefault_KeyboardFont);
+                // Add a default keyboard if none are available
+                Keyboard kbInfo = KMManager.getDefaultKeyboard(context);
                 KMManager.addKeyboard(context, kbInfo);
             }
         }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -47,7 +47,6 @@ final class FVShared {
     public static final String FVDefault_DictionaryModelName = "SENĆOŦEN (Saanich Dialect) Lexical Model";
     public static final String FVDefault_DictionaryLanguageID = "str-latn";
     public static final String FVDefault_DictionaryLanguageName = "SENĆOŦEN";
-    public static final String FVDefault_DictionaryVersion = "1.0.5";
     public static final String FVDefault_DictionaryKMP = FVDefault_DictionaryPackageID + FileUtils.MODELPACKAGE;
 
     /// Describes a keyboard used in FirstVoices Keyboards
@@ -245,7 +244,7 @@ final class FVShared {
                 KMManager.removeKeyboard(context, i);
         }
 
-        File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
+        File resourceRoot =  new File(getResourceRoot());
         PackageProcessor kmpProcessor =  new PackageProcessor(resourceRoot);
 
         // Recreate active keyboards list
@@ -258,6 +257,7 @@ final class FVShared {
                       keyboard.id,
                       null); // get first associated language ID
                     if (kbd != null) {
+                      // TODO: Override fonts to NotoSansCanadianAboriginal.ttf
                       KMManager.addKeyboard(context, kbd);
                     }
                 }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -18,9 +18,10 @@ import io.sentry.core.Sentry;
 import com.tavultesoft.kmea.*;
 import com.tavultesoft.kmea.data.Keyboard;
 
-public class MainActivity extends AppCompatActivity {
-    public static final String FVDefault_PackageID = "fv_all";
+import java.util.ArrayList;
+import java.util.HashMap;
 
+public class MainActivity extends AppCompatActivity {
     @SuppressWarnings("SetJavascriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,10 +53,10 @@ public class MainActivity extends AppCompatActivity {
          * as a system keyboard.
         */
         String version = KMManager.getLatestKeyboardFileVersion(
-            context, FVDefault_PackageID, KMManager.KMDefault_KeyboardID);
+            context, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID);
         KMManager.setDefaultKeyboard(
             new Keyboard(
-                FVDefault_PackageID,
+                FVShared.FVDefault_PackageID,
                 KMManager.KMDefault_KeyboardID,
                 KMManager.KMDefault_KeyboardName,
                 KMManager.KMDefault_LanguageID,
@@ -67,6 +68,19 @@ public class MainActivity extends AppCompatActivity {
                 KMManager.KMDefault_KeyboardFont,
                 KMManager.KMDefault_KeyboardFont)
         );
+
+        ArrayList<HashMap<String, String>> modelsList = KMManager.getLexicalModelsList(context);
+        if (modelsList == null || modelsList.size() == 0) {
+          // Add default dictionaries
+          HashMap<String, String> lexicalModelInfo = new HashMap<String, String>();
+          lexicalModelInfo.put(KMManager.KMKey_PackageID, FVShared.FVDefault_DictionaryPackageID);
+          lexicalModelInfo.put(KMManager.KMKey_LanguageID, FVShared.FVDefault_DictionaryLanguageID);
+          lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, FVShared.FVDefault_DictionaryModelID);
+          lexicalModelInfo.put(KMManager.KMKey_LexicalModelName, FVShared.FVDefault_DictionaryModelName);
+          lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, FVShared.FVDefault_DictionaryVersion);
+          KMManager.addLexicalModel(context, lexicalModelInfo);
+          KMManager.registerAssociatedLexicalModel(FVShared.FVDefault_DictionaryLanguageID);
+        }
 
       final String htmlPath = "file:///android_asset/setup/main.html";
         WebView webView = findViewById(R.id.webView);

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -71,13 +71,16 @@ public class MainActivity extends AppCompatActivity {
 
         ArrayList<HashMap<String, String>> modelsList = KMManager.getLexicalModelsList(context);
         if (modelsList == null || modelsList.size() == 0) {
+          String lexicalModelVersion = KMManager.getLexicalModelPackageVersion(
+            context, FVShared.FVDefault_DictionaryPackageID);
+
           // Add default dictionaries
           HashMap<String, String> lexicalModelInfo = new HashMap<String, String>();
           lexicalModelInfo.put(KMManager.KMKey_PackageID, FVShared.FVDefault_DictionaryPackageID);
           lexicalModelInfo.put(KMManager.KMKey_LanguageID, FVShared.FVDefault_DictionaryLanguageID);
           lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, FVShared.FVDefault_DictionaryModelID);
           lexicalModelInfo.put(KMManager.KMKey_LexicalModelName, FVShared.FVDefault_DictionaryModelName);
-          lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, FVShared.FVDefault_DictionaryVersion);
+          lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, lexicalModelVersion);
           KMManager.addLexicalModel(context, lexicalModelInfo);
           KMManager.registerAssociatedLexicalModel(FVShared.FVDefault_DictionaryLanguageID);
         }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.Typeface;
 import android.inputmethodservice.InputMethodService;
+import android.text.InputType;
 import android.util.Log;
 import android.view.Display;
 import android.view.KeyEvent;
@@ -27,6 +28,7 @@ import io.sentry.core.Sentry;
 public class SystemKeyboard extends InputMethodService implements KeyboardEventHandler.OnKeyboardEventListener {
 
     private View inputView = null;
+    private static ExtractedText exText = null;
     private KMHardwareKeyboardInterpreter interpreter = null;
 
     private static final String TAG = "SystemKeyboard";
@@ -106,6 +108,23 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
         attribute.imeOptions |= EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_FULLSCREEN;
         super.onStartInput(attribute, restarting);
         KMManager.onStartInput(attribute, restarting);
+        KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+
+        // Select numeric layer if applicable
+        int inputType = attribute.inputType;
+        if (((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_NUMBER) ||
+                ((inputType & InputType.TYPE_MASK_CLASS) == InputType.TYPE_CLASS_PHONE)) {
+            KMManager.setNumericLayer(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+        }
+
+        // Temporarily disable predictions if entering a hidden password field
+        KMManager.setMayPredictOverride(inputType);
+        if (KMManager.getMayPredictOverride()) {
+            KMManager.setBannerOptions(false);
+        } else {
+            final boolean mayPredict = true;
+            KMManager.setBannerOptions(mayPredict);
+        }
 
         // User switched to a new input field so we should extract the text from input field
         // and pass it to Keyman Engine together with selection range
@@ -113,10 +132,13 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
         if (ic != null) {
             ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
             if (icText != null) {
-                KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
+                boolean didUpdateText = KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
                 int selStart = icText.startOffset + icText.selectionStart;
                 int selEnd = icText.startOffset + icText.selectionEnd;
-                KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM, selStart, selEnd);
+                boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM, selStart, selEnd);
+                if (!didUpdateText || !didUpdateSelection) {
+                    exText = icText;
+                }
             }
         }
 
@@ -157,8 +179,9 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
         if (inputView != null)
             inputViewHeight = inputView.getHeight();
 
+        int bannerHeight = KMManager.getBannerHeight(this);
         int kbHeight = KMManager.getKeyboardHeight(this);
-        outInsets.contentTopInsets = inputViewHeight - kbHeight;
+        outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
         outInsets.touchableInsets = Insets.TOUCHABLE_INSETS_REGION;
         outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);
     }
@@ -166,6 +189,8 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
     @Override
     public void onKeyboardLoaded(KeyboardType keyboardType) {
         // Handle Keyman keyboard loaded event here if needed
+        if (exText != null)
+            exText = null;
     }
 
     @Override

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -24,7 +24,7 @@ display_usage ( ) {
   echo "  -no-update              Don't copy or build the Keyman Engine library in (assumes already present)"
   echo "  -lib-build              Force rebuild of the Keyman Engine library"
   echo "  -no-lib-build           Only rebuild the Keyman Engine library if it doesn't exist in /android"
-  echo "  -download-keyboards     Download keyboards from downloads.keyman.com"
+  echo "  -download-resources     Download fv_all.kmp and nrc.str.sencoten.model.kmp from downloads.keyman.com"
   echo ""
   exit 1
 }
@@ -33,22 +33,26 @@ export TARGET=FirstVoices
 KEYBOARD_PACKAGE_ID="fv_all"
 KEYBOARDS_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/${KEYBOARD_PACKAGE_ID}.kmp"
 KEYBOARDS_CSV_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/keyboards.csv"
+MODEL_PACKAGE_ID="nrc.str.sencoten"
+MODELS_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/${MODEL_PACKAGE_ID}.model.kmp"
 
 # This build script assumes that the https://github.com/keymanapp/keyboards repo is in
 # the same parent folder as this repo, with the default name 'keyboards'
 
-PARAM_DOWNLOAD_KEYBOARDS=
 PARAM_DEBUG=
 PARAM_NO_DAEMON=
 PARAM_NO_UPDATE=
 PARAM_LIB_BUILD=
 PARAM_NO_LIB_BUILD=
+DO_KEYBOARDS_DOWNLOAD=false
+DO_MODELS_DOWNLOAD=false
 
 while [[ $# -gt 0 ]] ; do
   key="$1"
   case $key in
-    -download-keyboards)
-      PARAM_DOWNLOAD_KEYBOARDS=-download-keyboards
+    -download-resources)
+      DO_KEYBOARDS_DOWNLOAD=true
+      DO_MODELS_DOWNLOAD=true
       ;;
     -h|-?)
       display_usage
@@ -72,10 +76,15 @@ while [[ $# -gt 0 ]] ; do
   shift
 done
 
-# Verify default keyboard package exists
+# Verify default keyboard and dictionary packages exists
 if [[ ! -f "$KEYBOARDS_TARGET" || ! -f "$KEYBOARDS_CSV_TARGET" ]]; then
   echo "$KEYBOARDS_TARGET and $KEYBOARDS_CSV_TARGET required. Will download the latest version"
-  PARAM_DOWNLOAD_KEYBOARDS=-download-keyboards
+  DO_KEYBOARDS_DOWNLOAD=true
+fi
+
+if [[ ! -f "$MODELS_TARGET" ]]; then
+  echo "$MODELS_TARGET doesn't exist. Will download the latest version"
+  DO_MODELS_DOWNLOAD=true
 fi
 
 if [ ! -z "$PARAM_LIB_BUILD" ] && [ ! -z "$PARAM_NO_LIB_BUILD" ]; then
@@ -83,11 +92,16 @@ if [ ! -z "$PARAM_LIB_BUILD" ] && [ ! -z "$PARAM_NO_LIB_BUILD" ]; then
   exit 1
 fi
 
-if [ "$PARAM_DOWNLOAD_KEYBOARDS" == "-download-keyboards" ]; then
+# Download default keyboard and dictionary packages
+if [ "$DO_KEYBOARDS_DOWNLOAD" = true ]; then
   echo "Copying keyboards.csv"
   cp "$KEYMAN_ROOT/oem/firstvoices/keyboards.csv" "$KEYBOARDS_CSV_TARGET"
 
   downloadKeyboardPackage "$KEYBOARD_PACKAGE_ID" "$KEYBOARDS_TARGET"
+fi
+
+if [ "$DO_MODELS_DOWNLOAD" = true ]; then
+  downloadModelPackage "$MODEL_PACKAGE_ID" "$MODELS_TARGET"
 fi
 
 # TODO: in the future build_common.sh should probably be shared with all oem products?


### PR DESCRIPTION
From discussion on [3322](https://github.com/keymanapp/keyman/pull/3322#pullrequestreview-445130562)
> We're going to need to add the nrc.str.sencoten model as well I think? That could go in a separate PR too.

This PR adds nrc.str.sencoten model to the FV Android app.

### SystemKeyboard changes
Since SystemKeyboard needs to adjust for banner height, I also incorporated other changes from KMAPro:
* Select numeric layer if applicable
* Disable predictions if entering a hidden password field

### FVShared changes
* FVShared updated to rebuild active keyboards list using info from kmp.json.

### MainActivity changes
* Add nrc.str.sencoten and register if no models exist

### Limitations
Previous versions of the FV app had assigned languageID "en" to all the keyboards. This PR does not handle any migrations to fix those language ID's.

nrc.str.sencoten model will only be available from clean installs...