### PR TITLE
refactor(ios/engine): hashable package keys

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/LanguageResource.swift
@@ -58,6 +58,7 @@ public protocol AnyLanguageResource {
   var languageID: String { get }
   // Was not always tracked within KeymanEngine - is optional for legacy reasons.
   var packageID: String? { get }
+  var packageKey: KeymanPackage.Key { get }
   var fullID: AnyLanguageResourceFullID { get }
   var version: String { get }
 
@@ -67,6 +68,12 @@ public protocol AnyLanguageResource {
   // Used during resource installation
   var fonts: [Font] { get }
   var sourceFilename: String { get }
+}
+
+extension AnyLanguageResource {
+  public var packageKey: KeymanPackage.Key {
+    return KeymanPackage.Key(forResource: self)
+  }
 }
 
 // Necessary due to Swift details 'documented' at

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
@@ -76,12 +76,14 @@ extension Queries {
         }
       }
 
-      func entryFor<FullID: LanguageResourceFullID>(_ fullID: FullID) -> Entry {
+      func entryFor(_ key: KeymanPackage.Key) -> Entry {
         var result: ResultComponent?
-        if let fullID = fullID as? FullKeyboardID, let keyboards = self.keyboards {
-          result = keyboards[fullID.keyboardID]
-        } else if let fullID = fullID as? FullLexicalModelID, let models = self.models {
-          result = models[fullID.lexicalModelID]
+
+        switch(key.type) {
+          case .keyboard:
+            result = keyboards?[key.id]
+          case .lexicalModel:
+            result = models?[key.id]
         }
 
         if let entry = result as? ResultEntry {
@@ -94,22 +96,22 @@ extension Queries {
 
     private static let PACKAGE_VERSION_ENDPOINT = URLComponents(string: "https://api.keyman.com/package-version")!
 
-    public static func fetch(for fullIDs: [AnyLanguageResourceFullID],
+    public static func fetch(for packageKeys: [KeymanPackage.Key],
                              withSession session: URLSession = .shared,
                              fetchCompletion: @escaping JSONQueryCompletionBlock<Result>) {
       // Step 1:  build the query
       var urlComponents = PACKAGE_VERSION_ENDPOINT
 
-      let queryItems: [URLQueryItem] = fullIDs.map { fullID in
+      let queryItems: [URLQueryItem] = packageKeys.map { key in
         var resourceField: String
-        switch(fullID.type) {
+        switch(key.type) {
           case .keyboard:
             resourceField = "keyboard"
           case .lexicalModel:
             resourceField = "model"
         }
 
-        return URLQueryItem(name: resourceField, value: fullID.id)
+        return URLQueryItem(name: resourceField, value: key.id)
       }
 
       urlComponents.queryItems = queryItems + [URLQueryItem(name: "platform", value: "ios")]

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -274,7 +274,8 @@ public class ResourceDownloadManager {
     //        For consistency with keyboard download behavior, we use the PackageVersion query here.
 
     let lmFullID = FullLexicalModelID(lexicalModelID: lexicalModelID, languageID: languageID)
-    Queries.PackageVersion.fetch(for: [lmFullID], withSession: session) { result, error in
+    let packageKey = KeymanPackage.Key(id: lexicalModelID, type: .lexicalModel)
+    Queries.PackageVersion.fetch(for: [packageKey], withSession: session) { result, error in
       guard let result = result, error == nil else {
         log.info("Error occurred requesting location for \(lmFullID.description)")
         self.resourceDownloadFailed(forFullID: lmFullID, with: error ?? .noData)
@@ -282,8 +283,8 @@ public class ResourceDownloadManager {
         return
       }
 
-      guard case let .success(data) = result.entryFor(lmFullID) else {
-        if case let .failure(errorEntry) = result.entryFor(lmFullID) {
+      guard case let .success(data) = result.entryFor(packageKey) else {
+        if case let .failure(errorEntry) = result.entryFor(packageKey) {
           if let errorEntry = errorEntry {
             log.info("Query reported error: \(String(describing: errorEntry.error))")
           }

--- a/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/QueryPackageVersionTests.swift
@@ -27,6 +27,11 @@ class QueryPackageVersionTests: XCTestCase {
     }
   }
 
+  // Makes a few assumptions that don't belong in the actual framework.
+  func packageKey(for fullID: AnyLanguageResourceFullID) -> KeymanPackage.Key {
+    return KeymanPackage.Key(id: fullID.id, type: fullID.type)
+  }
+
   /**
    * A rigorous test of our package-version query code that runs against a fixture copied from an actual api.keyman.com query return (26 Jun 2020).
    */
@@ -36,15 +41,15 @@ class QueryPackageVersionTests: XCTestCase {
 
     let badKbdFullID = FullKeyboardID(keyboardID: "foo", languageID: "en")
     let badLexFullID = FullLexicalModelID(lexicalModelID: "bar", languageID: "km")
-    let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
-                   TestUtils.Keyboards.sil_euro_latin.fullID,
-                   badKbdFullID,
-                   TestUtils.LexicalModels.mtnt.fullID,
-                   badLexFullID]
+    let packageKeys = [TestUtils.Keyboards.khmer_angkor.fullID,
+                       TestUtils.Keyboards.sil_euro_latin.fullID,
+                       badKbdFullID,
+                       TestUtils.LexicalModels.mtnt.fullID,
+                       badLexFullID].map { packageKey(for: $0) }
 
     let expectation = XCTestExpectation(description: "Query complete and results analyzed")
 
-    Queries.PackageVersion.fetch(for: fullIDs, withSession: mockedURLSession!) { results, error in
+    Queries.PackageVersion.fetch(for: packageKeys, withSession: mockedURLSession!) { results, error in
       if let _ = error {
         XCTFail(String(describing: error))
         expectation.fulfill()
@@ -110,7 +115,7 @@ class QueryPackageVersionTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Query complete and results analyzed")
 
     // As it's a mocked fetch, it happens synchronously.
-    Queries.PackageVersion.fetch(for: [TestUtils.LexicalModels.mtnt.fullID], withSession: mockedURLSession!) { results, error in
+    Queries.PackageVersion.fetch(for: [packageKey(for: TestUtils.LexicalModels.mtnt.fullID)], withSession: mockedURLSession!) { results, error in
       if let _ = error {
         XCTFail(String(describing: error))
         expectation.fulfill()
@@ -135,15 +140,15 @@ class QueryPackageVersionTests: XCTestCase {
 
     let badKbdFullID = FullKeyboardID(keyboardID: "foo", languageID: "en")
     let badLexFullID = FullLexicalModelID(lexicalModelID: "bar", languageID: "km")
-    let fullIDs = [TestUtils.Keyboards.khmer_angkor.fullID,
-                   TestUtils.Keyboards.sil_euro_latin.fullID,
-                   badKbdFullID,
-                   TestUtils.LexicalModels.mtnt.fullID,
-                   badLexFullID]
+    let packageKeys = [TestUtils.Keyboards.khmer_angkor.fullID,
+                       TestUtils.Keyboards.sil_euro_latin.fullID,
+                       badKbdFullID,
+                       TestUtils.LexicalModels.mtnt.fullID,
+                       badLexFullID].map { packageKey(for: $0) }
 
     let expectation = XCTestExpectation(description: "Query complete and results analyzed")
 
-    Queries.PackageVersion.fetch(for: fullIDs, withSession: mockedURLSession!) { results, error in
+    Queries.PackageVersion.fetch(for: packageKeys, withSession: mockedURLSession!) { results, error in
       if let _ = error {
         XCTFail(String(describing: error))
         expectation.fulfill()
@@ -155,19 +160,19 @@ class QueryPackageVersionTests: XCTestCase {
         XCTAssertNotNil(results.keyboards)
         XCTAssertNotNil(results.models)
 
-        let khmer_angkor = results.entryFor(TestUtils.Keyboards.khmer_angkor.fullID)
+        let khmer_angkor = results.entryFor(self.packageKey(for: TestUtils.Keyboards.khmer_angkor.fullID))
         if case .failure(_) = khmer_angkor {
           XCTFail("API result object reported error for khmer_angkor, not a version entry")
         }
 
 
-        let foo = results.entryFor(badKbdFullID)
+        let foo = results.entryFor(self.packageKey(for: badKbdFullID))
         if case .success(_) = foo {
           XCTFail("API result object reported a version entry for foo, not an error")
         }
 
 
-        let foobar = results.entryFor(FullKeyboardID(keyboardID: "foobar", languageID: "en"))
+        let foobar = results.entryFor(KeymanPackage.Key(id: "foobar", type: .keyboard))
         if case .success(_) = foobar {
           XCTFail("Query should not have results data for unqueried resource")
         }


### PR DESCRIPTION
In #3327, use of `LanguageResourceFullID`s in the package-version query was starting to bother me, since those specify language IDs that aren't useful as part of package lookups.  These get in the way when trying to simply but uniquely identify packages in need of updating.

Enter `KeymanPackage.Key`, which is more explicit about being language-agnostic and is designed for use in keying "dictionary" (hash-map) structures.