### PR TITLE
fix(ios/engine): version equality

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
@@ -124,7 +124,25 @@ public class Version: NSObject, Comparable {
    * (For example, 12.3.45 beta is considered equal to 12.3.45 stable.)
    */
   public static func ==(lhs: Version, rhs: Version) -> Bool {
-    return lhs.components == rhs.components
+    var left = lhs.components
+    while(left.last == 0 && left.count > 0) {
+      left.removeLast()
+    }
+
+    var right = rhs.components
+    while(right.last == 0 && right.count > 0) {
+      right.removeLast()
+    }
+
+    return left.elementsEqual(right)
+  }
+
+  public override func isEqual(_ object: Any?) -> Bool {
+    if let object = object as? Version {
+      return self == object
+    } else {
+      return false
+    }
   }
 
   // For nice logging output & debugger visibility.

--- a/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
@@ -84,6 +84,11 @@ class VersionTests: XCTestCase {
 
     // Tests in "optional" mode.  Was trickier than it would appear!
     XCTAssertEqual(Version("12.0"), Version("12.0"))
+
+    // Some tests against major-version zero to ensure the edge case is covered.
+    XCTAssertEqual(Version("0"), Version("0"))
+    XCTAssertEqual(Version("0"), Version("0.0"))
+    XCTAssertNotEqual(Version("0"), Version("0.0.1"))
   }
 
   func testValidCurrentEngineVersion() {

--- a/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
@@ -63,6 +63,29 @@ class VersionTests: XCTestCase {
     XCTAssertTrue(complex.majorMinor == Version("11.0")!, "Did not properly trim off excess version components")
   }
 
+  func testEquals() {
+    let simple = Version("12.0")!
+    let other = Version("12.0")!
+
+    XCTAssertTrue(simple == other)
+
+    let longer = Version("12.0.0.0")!
+
+    XCTAssertTrue(simple == longer)
+
+    let unequal_1 = Version("12.0.0.1")!
+
+    XCTAssertFalse(simple == unequal_1)
+    XCTAssertFalse(longer == unequal_1)
+
+    let diffMajor = Version("13.0")!
+
+    XCTAssertFalse(simple == diffMajor)
+
+    // Tests in "optional" mode.  Was trickier than it would appear!
+    XCTAssertEqual(Version("12.0"), Version("12.0"))
+  }
+
   func testValidCurrentEngineVersion() {
     let version = Version.current
 


### PR DESCRIPTION
Turns out custom use of `==` in Swift is a little trickier to get right than was first thought.  It appears that the complexity arises because `Version` is a `class`, and thus `isEqual` also needs to be defined in order for things to work correctly for optionals.  `struct`s do not have to override this method, as they aren't derived from `NSObject`, unlike `class`es.