### PR TITLE
fix(developer/compilers): merge duplicate words during compile

### DIFF
--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -19,30 +19,32 @@ export function createTrieDataStructure(filenames: string[], searchTermToKey?: (
     throw new TypeError("searchTermToKey must be explicitly specified")
   }
   // Make one big word list out of all of the filenames provided.
-  let wordlist = filenames
-    .map(parseWordListFromFilename)
-    .reduce((bigWordlist, current) => bigWordlist.concat(current), []);
+  let wordlist: WordList = [];
+  filenames.forEach(filename => parseWordListFromFilename(wordlist, filename));
+
   let trie = Trie.buildTrie(wordlist, searchTermToKey as Trie.SearchTermToKey);
   return JSON.stringify(trie);
 }
 
 /**
  * Parses a word list from its filename.
- * 
+ *
  * The word list may be encoded in:
- * 
+ *
  *  - UTF-8, with or without BOM [exported by most software]
  *  - UTF-16, little endian, with BOM [exported by Microsoft Excel]
- * 
+ *
  * @param filename filename of the word list
  */
-export function parseWordListFromFilename(filename: string): WordList {
+export function parseWordListFromFilename(wordlist: WordList, filename: string): void {
   let contents = readFileSync(filename, detectEncoding(filename));
-  return parseWordList(contents);
+  parseWordList(wordlist, contents);
 }
 
 /**
- * Reads a tab-separated values file into a word list.
+ * Reads a tab-separated values file into a word list. This function converts all
+ * entries into NFC and merges duplicate entries across wordlists. Duplication is
+ * on the basis of character-for-character equality after normalisation.
  *
  * Format specification:
  *
@@ -61,19 +63,18 @@ export function parseWordListFromFilename(filename: string): WordList {
  *    times this entry has appeared in the corpus. Blank means 'indeterminate'.
  *  - column 3 (optional): comment: an informative comment, ignored by the tool.
  */
-export function parseWordList(contents: string): WordList {
+export function parseWordList(wordlist: WordList, contents: string): void {
   // Supports LF or CRLF line terminators.
   const NEWLINE_SEPARATOR = /\u000d?\u000a/;
   const TAB = "\t";
   // TODO: format validation.
   let lines = contents.split(NEWLINE_SEPARATOR);
 
-  let result: WordList = [];
   for (let line of lines) {
     // Remove the byte-order mark (BOM) from the beginning of the string.
     // Because `contents` can be the concatenation of several files, we have to remove
     // the BOM from every possible start of file -- i.e., beginning of every line.
-    line = line.replace(/^\uFEFF/, '');
+    line = line.replace(/^\uFEFF/, '').trim();
 
     if (line.startsWith('#') || line === "") {
       continue; // skip comments and empty lines
@@ -83,7 +84,7 @@ export function parseWordList(contents: string): WordList {
     let [wordform, countText] = line.split(TAB);
 
     // Clean the word form.
-    // TODO: what happens if we get duplicate forms?
+    // TODO: #2880 -- warn if we have multiple normalisation forms in the same file
     wordform = wordform.normalize('NFC').trim();
     countText = (countText || '').trim();
     let count = parseInt(countText, 10);
@@ -94,9 +95,19 @@ export function parseWordList(contents: string): WordList {
       // Treat it like a hapax legonmenom -- it exist, but only once.
       count = 1;
     }
-    result.push([wordform, count]);
+
+    // TODO: this merge is very naive. We should consider whether the merge
+    // needs to be a little more aggressive. This may also be slow for large
+    // wordlists; probably O(n log n). We could improve this with a hash table
+    // if it becomes a performance problem.
+    const item = wordlist.find(value => value[0] === wordform);
+    if(item) {
+      item[1] += count;
+    }
+    else {
+      wordlist.push([wordform, count]);
+    }
   }
-  return result;
 }
 
 namespace Trie {
@@ -399,7 +410,7 @@ namespace Trie {
  * NFKD neutralizes some funky distinctions, e.g., ꬲ, ｅ, e should all be the
  * same character; plus, it's an easy way to separate a Latin character from
  * its diacritics; Even then, orthographies regularly use code points
- * that, under NFKD normalization, do NOT decompose appropriately for your 
+ * that, under NFKD normalization, do NOT decompose appropriately for your
  * language (e.g., SENĆOŦEN, Plains Cree in syllabics).
  *
  * Use this in early iterations of the model. For a production lexical model,
@@ -418,17 +429,17 @@ export function defaultSearchTermToKey(wordform: string): string {
 
 /**
  * Detects the encoding of a text file.
- * 
+ *
  * Supported encodings are:
- * 
+ *
  *  - UTF-8, with or without BOM
  *  - UTF-16, little endian, with BOM
- * 
+ *
  * UTF-16 in big endian is explicitly NOT supported! The reason is two-fold:
  * 1) Node does not support it without resorting to an external library (or
  * swapping every byte in the file!); and 2) I'm not sure anything actually
  * outputs in this format anyway!
- * 
+ *
  * @param filename filename of the file to detect encoding
  */
 function detectEncoding(filename: string): 'utf8' | 'utf16le' {

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
  * A word list is an array of pairs: the concrete word form itself, followed by
  * a non-negative count.
  */
-type WordList = [string, number][];
+export type WordList = [string, number][];
 
 /**
  * Returns a data structure that can be loaded by the TrieModel.

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -27,13 +27,14 @@ export function createTrieDataStructure(filenames: string[], searchTermToKey?: (
 }
 
 /**
- * Parses a word list from its filename.
+ * Parses a word list from a file, merging duplicate entries.
  *
  * The word list may be encoded in:
  *
  *  - UTF-8, with or without BOM [exported by most software]
  *  - UTF-16, little endian, with BOM [exported by Microsoft Excel]
  *
+ * @param wordlist word list to merge entries into (may have existing entries)
  * @param filename filename of the word list
  */
 export function parseWordListFromFilename(wordlist: WordList, filename: string): void {
@@ -44,7 +45,7 @@ export function parseWordListFromFilename(wordlist: WordList, filename: string):
 /**
  * Reads a tab-separated values file into a word list. This function converts all
  * entries into NFC and merges duplicate entries across wordlists. Duplication is
- * on the basis of character-for-character equality after normalisation.
+ * on the basis of character-for-character equality after normalisation to NFC.
  *
  * Format specification:
  *
@@ -62,6 +63,10 @@ export function parseWordListFromFilename(wordlist: WordList, filename: string):
  *  - column 2 (optional): the count: a non-negative integer specifying how many
  *    times this entry has appeared in the corpus. Blank means 'indeterminate'.
  *  - column 3 (optional): comment: an informative comment, ignored by the tool.
+ *
+ * @param wordlist word list to merge entries into (may have existing entries)
+ * @param contents contents of the file to import
+ *
  */
 export function parseWordList(wordlist: WordList, contents: string): void {
   // Supports LF or CRLF line terminators.


### PR DESCRIPTION
This reworks the file loading strategy for wordlists to merge duplicate terms found in wordlists during the load, and sum their weights. This also helps to resolve situations where there are words with different normalization forms in the wordlist. See #2880 for more on this (this PR mitigates but doesn't completely solve the issue as reported).

This was reported initially on the Community Forum at https://community.software.sil.org/t/lexical-models-how-to-influence-predictive-text-behaviour/3597/5.

While the pattern I have used is naive (in terms of its duplicate detection strategy) and not the most performant (in terms of its search), it is also probably the simplest change I could come up with.

I have updated test cases accordingly.

(On performance: the wordlist would probably be quite a bit faster to build as a hash table but I don't know if it would help us for converting it into a trie; I haven't checked that.)