### PR TITLE
refactor(ios/engine):  download queue & download state detection cleanup

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -200,6 +200,19 @@ public class KeymanPackage {
     }
   }
 
+  internal static func baseFilename(for key: KeymanPackage.Key) -> String {
+    var ext: String
+
+    switch(key.type) {
+      case .keyboard:
+        ext = "kmp"
+      case .lexicalModel:
+        ext = "model.kmp"
+    }
+
+    return "\(key.id).\(ext)"
+  }
+
   public var key: Key {
     return Key(for: self)
   }
@@ -431,21 +444,6 @@ public class TypedKeymanPackage<TypedLanguageResource: LanguageResource>: Keyman
     self.installables = kmpResources.map { resource in
       return resource.typedInstallableResources as! [TypedLanguageResource]
     } as [[TypedLanguageResource]]
-  }
-
-  internal static func baseFilename(for fullID: TypedLanguageResource.FullID) -> String {
-    var ext: String
-
-    switch(TypedLanguageResource.self) {
-      case is InstallableKeyboard.Type:
-        ext = "kmp"
-      case is InstallableLexicalModel.Type:
-        ext = "model.kmp"
-      default:
-        fatalError("Unsupported language resource type")
-    }
-
-    return "\(fullID.id).\(ext)"
   }
 
   // Cannot directly override base class's installableResourceSets with more specific type,

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageLMDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageLMDetailViewController.swift
@@ -151,7 +151,7 @@ class LanguageLMDetailViewController: UITableViewController, UIAlertViewDelegate
       }
     }
 
-    ResourceDownloadManager.shared.downloadPackage(forFullID: lmFullID, from: package.1, withNotifications: true, completionBlock: completionClosure)
+    ResourceDownloadManager.shared.downloadPackage(forFullID: lmFullID, withKey: package.0.packageKey, from: package.1, withNotifications: true, completionBlock: completionClosure)
   }
   
   private func lexicalModelDownloadStarted() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -58,16 +58,16 @@ public class ResourceFileManager {
     return KeymanPackage.parse(Storage.active.packageDir(forKey: key))
   }
 
-  internal func packageDownloadTempPath<FullID: LanguageResourceFullID>(forID fullID: FullID) -> URL {
+  internal func packageDownloadTempPath(forKey key: KeymanPackage.Key) -> URL {
     let documentDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-    let tempFilename = TypedKeymanPackage<FullID.Resource>.baseFilename(for: fullID)
+    let tempFilename = KeymanPackage.baseFilename(for: key)
     let url = documentDir.appendingPathComponent("\(tempFilename).partial") // marks it as a download in progress
     return url
   }
 
-  internal func cachedPackagePath<FullID: LanguageResourceFullID>(forID fullID: FullID) -> URL {
+  internal func cachedPackagePath(forKey key: KeymanPackage.Key) -> URL {
     let documentDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-    let filename = TypedKeymanPackage<FullID.Resource>.baseFilename(for: fullID)
+    let filename = KeymanPackage.baseFilename(for: key)
     let url = documentDir.appendingPathComponent(filename)
     return url
   }

--- a/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
@@ -322,7 +322,7 @@ class KeymanPackageTests: XCTestCase {
     XCTAssertEqual(package.versionState, .needsUpdate)
   }
 
-    func testInstallState() throws {
+  func testInstallState() throws {
     // Step 1:  Install khmer_angkor.  Fixture:  version 1.0.6.
     guard let installPackage = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.khmerAngkorKMP) as? KeyboardKeymanPackage else {
       XCTFail("Could not load keyboard KMP for test")

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -35,18 +35,19 @@ class ResourceDownloadManagerTests: XCTestCase {
   func testDownloadPackageForKeyboard() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
     let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
+    let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
+    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
 
-      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
       
       // Assertions:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forKey: packageKey)
 
       XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
 
@@ -71,17 +72,18 @@ class ResourceDownloadManagerTests: XCTestCase {
   func testDownloadPackageForLexicalModel() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
     let mtnt_id = TestUtils.LexicalModels.mtnt.fullID
+    let packageKey = TestUtils.LexicalModels.mtnt.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.LexicalModels.mtntKMP, error: nil)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: mtnt_id, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
+    downloadManager?.downloadPackage(forFullID: mtnt_id, withKey: packageKey, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
 
-      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.LexicalModels.mtnt.fullID)
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
 
       // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.LexicalModels.mtnt.fullID)
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forKey: packageKey)
 
       XCTAssertTrue(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
 
@@ -106,17 +108,18 @@ class ResourceDownloadManagerTests: XCTestCase {
   func testDownloadPackageFailure() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete, though with an error.")
     let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
+    let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: TestUtils.mockedError)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
+    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
-      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
 
       // Assertion:  a copy of the KMP file exists in the documents directory, facilitating user sharing.
-      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+      let cachedDocumentsKMP = ResourceFileManager.shared.cachedPackagePath(forKey: packageKey)
 
       // On download failure, we shouldn't be producing a file here.
       XCTAssertFalse(FileManager.default.fileExists(atPath: cachedDocumentsKMP.path))
@@ -198,6 +201,7 @@ class ResourceDownloadManagerTests: XCTestCase {
   func testStateForKeyboard() {
     let baseInstallation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
     let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
+    let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
     mockedURLSession?.queueMockResult(.download(mockedResult))
@@ -205,8 +209,9 @@ class ResourceDownloadManagerTests: XCTestCase {
     XCTAssertEqual(downloadManager!.stateForKeyboard(withID: khmer_angkor_id.id), .needsDownload)
 
     downloadManager!.downloadPackage(forFullID: khmer_angkor_id,
-                                                   from: TestUtils.Keyboards.khmerAngkorKMP,
-                                                   withNotifications: false) { package, error in
+                                     withKey: packageKey,
+                                     from: TestUtils.Keyboards.khmerAngkorKMP,
+                                     withNotifications: false) { package, error in
       if let _ = error {
         XCTFail()
         baseInstallation.fulfill()

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadQueueTests.swift
@@ -17,15 +17,17 @@ class ResourceDownloadQueueTests: XCTestCase {
 
   func testResourceDownloadFinalizeClosureNoOverwrite() throws {
     let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
-    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
-    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let key = TestUtils.Keyboards.khmer_angkor.packageKey
+
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forKey: key)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forKey: key)
 
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
 
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
+    let closure = DownloadTask.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
     try? closure(true)
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: tempFileURL.path))
@@ -34,8 +36,10 @@ class ResourceDownloadQueueTests: XCTestCase {
 
   func testResourceDownloadFinalizeClosureWithOverwrite() throws {
     let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
-    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
-    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let key = TestUtils.Keyboards.khmer_angkor.packageKey
+
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forKey: key)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forKey: key)
 
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: destFileURL)
@@ -43,7 +47,7 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
+    let closure = DownloadTask.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
     // May need a stand-in empty package for the first parameter in the future.
     try? closure(true)
@@ -54,15 +58,17 @@ class ResourceDownloadQueueTests: XCTestCase {
 
   func testResourceDownloadFinalizeClosureWithError() throws {
     let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
-    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
-    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let key = TestUtils.Keyboards.khmer_angkor.packageKey
+
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forKey: key)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forKey: key)
 
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
 
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertFalse(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
+    let closure = DownloadTask.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
     // Error occurred; abort.
     try? closure(false)
@@ -73,8 +79,10 @@ class ResourceDownloadQueueTests: XCTestCase {
 
   func testResourceDownloadFinalizeClosurePreexistingWithError() throws {
     let khmer_angkor_src_url = TestUtils.Keyboards.khmerAngkorKMP
-    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
-    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forID: TestUtils.Keyboards.khmer_angkor.fullID)
+    let key = TestUtils.Keyboards.khmer_angkor.packageKey
+
+    let tempFileURL = ResourceFileManager.shared.packageDownloadTempPath(forKey: key)
+    let destFileURL = ResourceFileManager.shared.cachedPackagePath(forKey: key)
 
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: tempFileURL)
     try FileManager.default.copyItem(at: khmer_angkor_src_url, to: destFileURL)
@@ -82,7 +90,7 @@ class ResourceDownloadQueueTests: XCTestCase {
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempFileURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: destFileURL.path))
 
-    let closure = DownloadTask<FullKeyboardID>.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
+    let closure = DownloadTask.resourceDownloadFinalizationClosure(tempURL: tempFileURL, finalURL: destFileURL)
 
     // Error occurred, abort.
     try? closure(false)


### PR DESCRIPTION
Removes some of the old JS-download-specific code and simplifies related parts of the codebase.  A fair number of the changes are also preparation for proper implementation of resource updates, now that both keyboards and lexical models are installed from KMPs.

Keyboard updates are still broken at this point, but this paves the way to resolve that within my planned followup-PR.