### PR TITLE
fix(developer): distributed model complier no longer relies on npm link

### DIFF
--- a/developer/js/package-lock.json
+++ b/developer/js/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@keymanapp/lexical-model-types": {
+      "version": "13.0.107",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-types/-/lexical-model-types-13.0.107.tgz",
+      "integrity": "sha512-9C2F8gKcC5bWR1sHnXAkBu/npaJ8TUBIQ0VqD5pHApOmhDQ2AJTRiLqTrw2yWdnXEitUIPeBLKbuUAide7Ifbw=="
+    },
     "@types/chai": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",

--- a/developer/js/package.json
+++ b/developer/js/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "test": "mocha",
-    "install": "npm link @keymanapp/lexical-model-types",
+    "prepare": "npm link @keymanapp/lexical-model-types",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -38,6 +38,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "@keymanapp/lexical-model-types": "^13.0.107",
     "commander": "^3.0.0",
     "typescript": "^3.2.4",
     "xml2js": "^0.4.19"

--- a/windows/src/developer/history.md
+++ b/windows/src/developer/history.md
@@ -1,5 +1,9 @@
 # Keyman Developer Version History
 
+## 2020-07-15 13.0.110 stable
+* Bug fix(Compiler): Lexical model compiler no longer attempts to form npm link when the package is installed (#3352)
+* Bug fix(Compiler): Lexical model compiler merges wordlist entries for duplicate words during compilation (#3351) 
+
 ## 2020-06-03 13.0.109 stable
 * Bug Fix(Keyboard Editor): Touch Layout Compiler fixes invalidly formatted strings during compile (#3204)
 


### PR DESCRIPTION
So, the current issue we're dealing with in [keymanapp/lexical-models](https://github.com/keymanapp/lexical-models) is actually due to the lexical model compiler's package.json.  In particular, its `install` script, which sees use for both local _and_ remote (distributed) `npm install` commands.

By converting the `install` to a `prepare` script, local development use of `npm install` will now go fetch the latest version of the dependency... but then immediately run the `prepare` script afterward, establishing an `npm link` for development use.

`prepare` will not affect the distributed package, and so this will drop the current `npm link` nonsense when CI compiles models for distribution from [keymanapp/lexical-models](https://github.com/keymanapp/lexical-models).

As current 14.0 development instead uses a `lerna`-based strategy to prevent this, no equivalent set of changes is needed against `master`.