### PR TITLE
fix(android/engine): Update deprecated call to switch system keyboard for Android P

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1268,11 +1268,14 @@ public final class KMManager {
   }
 
   public static void advanceToNextInputMode() {
-    InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
-
-    // TODO: this method is added in API level 16 and deprecated in API level 28
-    // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#switchToNextInputMethod(android.os.IBinder,%20boolean)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      if (IMService != null) {
+        IMService.switchToNextInputMethod(false);
+      }
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      // This method is added in API level 16 and deprecated in API level 28
+      // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#switchToNextInputMethod(android.os.IBinder,%20boolean)
+      InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
       imm.switchToNextInputMethod(getToken(), false);
     }
   }


### PR DESCRIPTION
Fixes #3328 

The Android call to switch system keyboards (while on the lock screen) has been deprecated in Android P to now use [InputMethodService.switchToNextInputMethod](https://developer.android.com/reference/android/inputmethodservice/InputMethodService#switchToNextInputMethod(boolean)) 

This PR updates the call in `advanceToNextInputMode()` accordingly.