### PR TITLE
fix(android/engine): Update deprecated call to switch system keyboard for Android P 🍒-pick of #3353

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1057,11 +1057,14 @@ public final class KMManager {
   }
 
   public static void advanceToNextInputMode() {
-    InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
-
-    // TODO: this method is added in API level 16 and deprecated in API level 28
-    // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#switchToNextInputMethod(android.os.IBinder,%20boolean)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      if (IMService != null) {
+        IMService.switchToNextInputMethod(false);
+      }
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      // This method is added in API level 16 and deprecated in API level 28
+      // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#switchToNextInputMethod(android.os.IBinder,%20boolean)
+      InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
       imm.switchToNextInputMethod(getToken(), false);
     }
   }

--- a/android/history.md
+++ b/android/history.md
@@ -2,7 +2,7 @@
 
 ## 2020-07-17 13.0.6216 stable
 * Bug fix:
-  * Update deprecated call to switch system keyboard for Android P (#3358)
+  * Make sure switch to system keyboard works on lock screen for Android P (#3358)
 
 ## 2020-07-16 13.0.6215 stable
 * Improve performance when typing long documents with predictive text (#3302)

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android Version History
 
+## 2020-07-17 13.0.6216 stable
+* Bug fix:
+  * Update deprecated call to switch system keyboard for Android P (#3358)
+
 ## 2020-07-16 13.0.6215 stable
 * Improve performance when typing long documents with predictive text (#3302)
 


### PR DESCRIPTION
Addresses #3328 for stable-13.0

The Android call to switch system keyboards (while on the lock screen) has been deprecated in Android P to now use [InputMethodService.switchToNextInputMethod](https://developer.android.com/reference/android/inputmethodservice/InputMethodService#switchToNextInputMethod(boolean))

This PR updates the call in advanceToNextInputMode() accordingly.
