### PR TITLE
refactor(ios/engine): package download notifications

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageDetailViewController.swift
@@ -70,11 +70,11 @@ class LanguageDetailViewController: UITableViewController, UIAlertViewDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
     keyboardDownloadStartedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.keyboardDownloadStarted,
+      forName: Notifications.packageDownloadStarted,
       observer: self,
       function: LanguageDetailViewController.keyboardDownloadStarted)
     keyboardDownloadFailedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.keyboardDownloadFailed,
+      forName: Notifications.packageDownloadFailed,
       observer: self,
       function: LanguageDetailViewController.keyboardDownloadFailed)
     log.info("viewDidLoad: LanguageDetailViewController (registered for keyboardDownloadStarted)")

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageLMDetailViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageLMDetailViewController.swift
@@ -46,11 +46,11 @@ class LanguageLMDetailViewController: UITableViewController, UIAlertViewDelegate
   override func viewDidLoad() {
     super.viewDidLoad()
     lexicalModelDownloadStartedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.lexicalModelDownloadStarted,
+      forName: Notifications.packageDownloadStarted,
       observer: self,
       function: LanguageLMDetailViewController.lexicalModelDownloadStarted)
     lexicalModelDownloadFailedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.lexicalModelDownloadFailed,
+      forName: Notifications.packageDownloadFailed,
       observer: self,
       function: LanguageLMDetailViewController.lexicalModelDownloadFailed)
     log.info("viewDidLoad: LanguageLMDetailViewController (registered for lexicalModelDownloadStarted)")
@@ -143,7 +143,7 @@ class LanguageLMDetailViewController: UITableViewController, UIAlertViewDelegate
   func downloadHandler(_ lexicalModelIndex: Int) {
     let package = packages[lexicalModelIndex]
     let lmFullID = package.0.fullID
-    let completionClosure: ResourceDownloadManager.CompletionHandler<InstallableLexicalModel> = { package, error in
+    let completionClosure: ResourceDownloadManager.CompletionHandler<LexicalModelKeymanPackage> = { package, error in
       ResourceDownloadManager.shared.standardLexicalModelInstallCompletionBlock(forFullID: lmFullID)(package, error)
 
       if let lm = package?.findResource(withID: lmFullID) {
@@ -151,7 +151,7 @@ class LanguageLMDetailViewController: UITableViewController, UIAlertViewDelegate
       }
     }
 
-    ResourceDownloadManager.shared.downloadPackage(forFullID: lmFullID, withKey: package.0.packageKey, from: package.1, withNotifications: true, completionBlock: completionClosure)
+    ResourceDownloadManager.shared.downloadPackage(withKey: package.0.packageKey, from: package.1, withNotifications: true, completionBlock: completionClosure)
   }
   
   private func lexicalModelDownloadStarted() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LanguageViewController.swift
@@ -65,11 +65,11 @@ class LanguageViewController: UITableViewController, UIAlertViewDelegate {
     title = "Add New Keyboard"
     selectedSection = NSNotFound
     keyboardDownloadStartedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.keyboardDownloadStarted,
+      forName: Notifications.packageDownloadStarted,
       observer: self,
       function: LanguageViewController.keyboardDownloadStarted)
     keyboardDownloadFailedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.keyboardDownloadFailed,
+      forName: Notifications.packageDownloadFailed,
       observer: self,
       function: LanguageViewController.keyboardDownloadFailed)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelPickerViewController.swift
@@ -44,15 +44,15 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     navigationController?.toolbar?.barTintColor = Colors.statusToolbar
     
     lexicalModelDownloadStartedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.lexicalModelDownloadStarted,
+      forName: Notifications.packageDownloadStarted,
       observer: self,
       function: LexicalModelPickerViewController.lexicalModelDownloadStarted)
     lexicalModelDownloadCompletedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.lexicalModelDownloadCompleted,
+      forName: Notifications.packageDownloadCompleted,
       observer: self,
       function: LexicalModelPickerViewController.lexicalModelDownloadCompleted)
     lexicalModelDownloadFailedObserver = NotificationCenter.default.addObserver(
-      forName: Notifications.lexicalModelDownloadFailed,
+      forName: Notifications.packageDownloadFailed,
       observer: self,
       function: LexicalModelPickerViewController.lexicalModelDownloadFailed)
     
@@ -177,13 +177,13 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     return globalIndex
   }
   
-  private func lexicalModelDownloadStarted(_ lexicalModels: [InstallableLexicalModel]) {
+  private func lexicalModelDownloadStarted() {
     view.isUserInteractionEnabled = false
     navigationItem.leftBarButtonItem?.isEnabled = false
     navigationItem.rightBarButtonItem?.isEnabled = false
   }
   
-  private func lexicalModelDownloadCompleted(_ lexicalModels: [InstallableLexicalModel]) {
+  private func lexicalModelDownloadCompleted() {
     log.info("lexicalModelDownloadCompleted LexicalModelPicker")
     
     // Actually used now.
@@ -196,7 +196,7 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
     navigationController?.popToRootViewController(animated: true)
   }
   
-  private func lexicalModelDownloadFailed(_ notification: LexicalModelDownloadFailedNotification) {
+  private func lexicalModelDownloadFailed(_ notification: PackageDownloadFailedNotification) {
     view.isUserInteractionEnabled = true
     navigationItem.leftBarButtonItem?.isEnabled = true
     if let item = navigationItem.rightBarButtonItem {
@@ -296,7 +296,7 @@ class LexicalModelPickerViewController: UITableViewController, UIAlertViewDelega
       if let error = error {
         log.info("Failed to fetch lexical model list for "+self.language.id+". error: "+error.localizedDescription)
         DispatchQueue.main.async {
-          self.lexicalModelDownloadFailed(LexicalModelDownloadFailedNotification(lmOrLanguageID: self.language.id, error: error))
+          self.lexicalModelDownloadFailed(PackageDownloadFailedNotification(packageKey: nil, error: error))
         }
         return
       }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Notification/Notifications.swift
@@ -8,18 +8,33 @@
 
 import Foundation
 
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadStartedNotification` instead.")
 public typealias KeyboardDownloadStartedNotification = [InstallableKeyboard]
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadCompletedNotification` instead.")
 public typealias KeyboardDownloadCompletedNotification = [InstallableKeyboard]
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadFailedNotification` instead.")
 public struct KeyboardDownloadFailedNotification {
   public let keyboards: [InstallableKeyboard]
   public let error: Error
 }
+
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadStartedNotification` instead.")
 public typealias LexicalModelDownloadStartedNotification = [InstallableLexicalModel]
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadCompletedNotification` instead.")
 public typealias LexicalModelDownloadCompletedNotification = [InstallableLexicalModel]
+@available(*, deprecated, message: "Download notifications are now package-based.  Use `PackageDownloadFailedNotification` instead.")
 public struct LexicalModelDownloadFailedNotification {
   public let lmOrLanguageID: String
   public let error: Error
 }
+
+public typealias PackageDownloadStartedNotification = KeymanPackage.Key
+public typealias PackageDownloadCompletedNotification = KeymanPackage
+public struct PackageDownloadFailedNotification {
+  public let packageKey: KeymanPackage.Key?
+  public let error: Error
+}
+
 public typealias BatchUpdateStartedNotification = [AnyLanguageResource]
 
 public struct BatchUpdateCompletedNotification {
@@ -41,10 +56,17 @@ public typealias LexicalModelRemovedNotification = InstallableLexicalModel
 public typealias LexicalModelPickerDismissedNotification = Void
 
 public struct Notifications {
+  public static let packageDownloadStarted = NotificationName<PackageDownloadStartedNotification>("KeymanPackageDownloadStarted")
+  public static let packageDownloadCompleted = NotificationName<PackageDownloadCompletedNotification>("KeymanPackageDownloadCompleted")
+  public static let packageDownloadFailed = NotificationName<PackageDownloadFailedNotification>("KeymanPackageDownloadFailed")
+
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadStarted` instead.", renamed: "packageDownloadStarted")
   public static let keyboardDownloadStarted =
     NotificationName<KeyboardDownloadStartedNotification>("KeymanKeyboardDownloadStarted")
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadCompleted` instead.", renamed: "packageDownloadCompleted")
   public static let keyboardDownloadCompleted =
     NotificationName<KeyboardDownloadCompletedNotification>("KeymanKeyboardDownloadCompleted")
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadFailed` instead.", renamed: "packageDownloadFailed")
   public static let keyboardDownloadFailed =
     NotificationName<KeyboardDownloadFailedNotification>("KeymanKeyboardDownloadFailed")
 
@@ -58,10 +80,13 @@ public struct Notifications {
   public static let keyboardPickerDismissed =
     NotificationName<KeyboardPickerDismissedNotification>("KeymanKeyboardPickerDismissed")
 
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadStarted` instead.", renamed: "packageDownloadStarted")
   public static let lexicalModelDownloadStarted =
     NotificationName<LexicalModelDownloadStartedNotification>("KeymanLexicalModelDownloadStarted")
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadCompleted` instead.", renamed: "packageDownloadCompleted")
   public static let lexicalModelDownloadCompleted =
     NotificationName<LexicalModelDownloadCompletedNotification>("KeymanLexicalModelDownloadCompleted")
+  @available(swift, deprecated: 0.1, obsoleted: 0.1, message: "Download notifications are now package-based.  Use `packageDownloadFailed` instead.", renamed: "packageDownloadFailed")
   public static let lexicalModelDownloadFailed =
     NotificationName<LexicalModelDownloadFailedNotification>("KeymanLexicalModelDownloadFailed")
     

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -123,17 +123,17 @@ protocol AnyDownloadBatch {
 /**
  * Represents one overall resource-related command for requests against the Keyman Cloud API.
  */
-class DownloadBatch<FullID: LanguageResourceFullID>: AnyDownloadBatch where FullID.Resource.Package: TypedKeymanPackage<FullID.Resource> {
+class DownloadBatch<Package: KeymanPackage>: AnyDownloadBatch {
   typealias CompletionHandler = ResourceDownloadManager.CompletionHandler
 
   public final var downloadTasks: [DownloadTask]
   var errors: [Error?] // Only used by the ResourceDownloadQueue.
   public final var startBlock: (() -> Void)? = nil
-  public final var completionBlock: CompletionHandler<FullID.Resource>? = nil
+  public final var completionBlock: CompletionHandler<Package>? = nil
   
   public init?(do tasks: [DownloadTask],
                startBlock: (() -> Void)? = nil,
-               completionBlock: CompletionHandler<FullID.Resource>? = nil) {
+               completionBlock: CompletionHandler<Package>? = nil) {
     self.downloadTasks = tasks
 
     self.errors = Array(repeating: nil, count: tasks.count)
@@ -144,7 +144,7 @@ class DownloadBatch<FullID: LanguageResourceFullID>: AnyDownloadBatch where Full
   public init(forPackageWithKey packageKey: KeymanPackage.Key,
               from url: URL,
               startBlock: (() -> Void)?,
-              completionBlock: CompletionHandler<FullID.Resource>?) {
+              completionBlock: CompletionHandler<Package>?) {
     // If we can't build a proper DownloadTask, we can't build the batch.
     let tempArtifact = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
     let finalFile = ResourceFileManager.shared.cachedPackagePath(forKey: packageKey)
@@ -189,7 +189,7 @@ class DownloadBatch<FullID: LanguageResourceFullID>: AnyDownloadBatch where Full
     completionBlock = nil
 
     do {
-      if let package = try ResourceFileManager.shared.prepareKMPInstall(from: file) as? FullID.Resource.Package {
+      if let package = try ResourceFileManager.shared.prepareKMPInstall(from: file) as? Package {
         complete?(package, nil)
       } else {
         complete?(nil, KMPError.invalidPackage)

--- a/ios/engine/KMEI/KeymanEngineTests/FileManagementTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/FileManagementTests.swift
@@ -170,8 +170,7 @@ class FileManagementTests: XCTestCase {
     // State 2:  Download requested.
     //           Note - we don't need to actually run the queue.
     let downloadManager = ResourceDownloadManager(session: TestUtils.Downloading.URLSessionMock(), autoExecute: false)
-    downloadManager.downloadPackage(forFullID: TestUtils.Keyboards.khmer_angkor.fullID,
-                                    withKey: khmer_angkor_key,
+    downloadManager.downloadPackage(withKey: khmer_angkor_key,
                                     from: TestUtils.Keyboards.khmerAngkorKMP,
                                     completionBlock: { _, _ in })
 

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -34,14 +34,12 @@ class ResourceDownloadManagerTests: XCTestCase {
 
   func testDownloadPackageForKeyboard() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
-    let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
     let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
-
+    downloadManager?.downloadPackage(withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { (package: KeyboardKeymanPackage?, error: Error?) in
 
       let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
@@ -71,14 +69,12 @@ class ResourceDownloadManagerTests: XCTestCase {
 
   func testDownloadPackageForLexicalModel() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
-    let mtnt_id = TestUtils.LexicalModels.mtnt.fullID
     let packageKey = TestUtils.LexicalModels.mtnt.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.LexicalModels.mtntKMP, error: nil)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: mtnt_id, withKey: packageKey, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { package, error in
-
+    downloadManager?.downloadPackage(withKey: packageKey, from: TestUtils.LexicalModels.mtntKMP, withNotifications: false) { (package: LexicalModelKeymanPackage?, error: Error?) in
       let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
 
@@ -107,13 +103,12 @@ class ResourceDownloadManagerTests: XCTestCase {
 
   func testDownloadPackageFailure() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete, though with an error.")
-    let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
     let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
 
     let mockedResult = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: TestUtils.mockedError)
     mockedURLSession?.queueMockResult(.download(mockedResult))
 
-    downloadManager?.downloadPackage(forFullID: khmer_angkor_id, withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
+    downloadManager?.downloadPackage(withKey: packageKey, from: TestUtils.Keyboards.khmerAngkorKMP, withNotifications: false) { package, error in
 
       let tempDownloadKMP = ResourceFileManager.shared.packageDownloadTempPath(forKey: packageKey)
       XCTAssertFalse(FileManager.default.fileExists(atPath: tempDownloadKMP.path))
@@ -208,10 +203,9 @@ class ResourceDownloadManagerTests: XCTestCase {
 
     XCTAssertEqual(downloadManager!.stateForKeyboard(withID: khmer_angkor_id.id), .needsDownload)
 
-    downloadManager!.downloadPackage(forFullID: khmer_angkor_id,
-                                     withKey: packageKey,
+    downloadManager!.downloadPackage(withKey: packageKey,
                                      from: TestUtils.Keyboards.khmerAngkorKMP,
-                                     withNotifications: false) { package, error in
+                                     withNotifications: false) { (package: KeyboardKeymanPackage?, error) in
       if let _ = error {
         XCTFail()
         baseInstallation.fulfill()


### PR DESCRIPTION
_**Note**_:  This one's features a number of small-scale breaking changes, but at least they're on things that should be less utilized.  In particular, please note that the FV app still builds, despite there being absolutely zero changes to its code.

---

Try as I might, I couldn't find a way to continue forward with resource updates that didn't involve significantly reworking KeymanEngine's notification scheme.  That stated, the scheme did need a significant overhaul anyway - as of 14.0, it will only be downloading _packages_, and so those are what it should raise notifications about, rather than what those packages contain.

- `keyboardDownloadStarted`, `lexicalModelDownloadStarted` -> `packageDownloadStarted`
- `keyboardDownloadCompleted`, `lexicalModelDownloadCompleted` -> `packageDownloadCompleted`
- `keyboardDownloadFailed`, `lexicalModelDownloadFailed` -> `packageDownloadFailed`

All three of the new targets either directly receive or receive an object containing a `KeymanPackage.Key` that may be used to identify the source of the notification.  (It's `Hashable`, and thus is quite useful for package lookup operations.)  This may be `nil` in some edge-case uses of the `Failed` variant; some existing UI code used the older versions when no package for download could be identified, pre-emptively.  Also, the new `packageDownloadCompleted` will actually forward the full `KeymanPackage` instance, providing a more informative notification object than before.

Fortunately, the general usage pattern of the notification matches that of the original notifications, so conversion to the new signatures should be fairly straightforward; it's largely a shift in type signature.

-----

In the midst of all the type cleanup that was possible as a result, I also identified a few 'dead code' functions and removed them, giving rise to the PR's favorable addition/deletion ratio.