### PR TITLE
feat(windows): setup select tier from filename or parameter

### DIFF
--- a/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
@@ -117,6 +117,7 @@ type
     FIsNewerAvailable: Boolean;
     FTempPath: string;
     FShouldInstallKeyman: Boolean;
+    FTier: string;
     function GetBestMsi: TInstallInfoFileLocation;
     function GetPackageMetadata(const KmpFilename: string; p: TPackage): Boolean;
   public
@@ -124,7 +125,7 @@ type
     destructor Destroy; override;
     procedure LoadSetupInf(const SetupInfPath: string);
 
-    procedure LocatePackagesFromFilename(Filename: string);
+    procedure LocatePackagesAndTierFromFilename(Filename: string);
     procedure LocatePackagesFromParameter(const Param: string);
     procedure LocatePackagesInPath(const path: string);
 
@@ -151,6 +152,8 @@ type
     property TitleImageFilename: string read FTitleImageFilename;
     property StartDisabled: Boolean read FStartDisabled;
     property StartWithConfiguration: Boolean read FStartWithConfiguration;
+
+    property Tier: string read FTier write FTier;
 
     property ShouldInstallKeyman: Boolean read FShouldInstallKeyman write FShouldInstallKeyman;
   end;
@@ -181,6 +184,7 @@ begin
   FMsiLocations := TInstallInfoFileLocations.Create;
   FPackages := TInstallInfoPackages.Create;
   FStrings := TStringList.Create;
+  FTier := KeymanVersion.CKeymanVersionInfo.Tier;
   FShouldInstallKeyman := True;
 end;
 
@@ -328,26 +332,37 @@ begin
   end;
 end;
 
-procedure TInstallInfo.LocatePackagesFromFilename(Filename: string);
+procedure TInstallInfo.LocatePackagesAndTierFromFilename(Filename: string);
+const
+  SKeymanSetupPrefix = 'keyman-setup';
+  SKeymanSetup_Alpha = SKeymanSetupPrefix+'-'+TIER_ALPHA;
+  SKeymanSetup_Beta = SKeymanSetupPrefix+'-'+TIER_BETA;
+  SKeymanSetup_Stable = SKeymanSetupPrefix+'-'+TIER_STABLE;
 var
   n: Integer;
   res: TArray<string>;
-  id, FBCP47: string;
+  p, id, FBCP47: string;
   m: TMatch;
 begin
   // Get just the base filename
   Filename := ExtractFileName(ChangeFileExt(Filename, ''));
 
   // Strip " (1)" appended for multiple downloads of same file by most browsers
-  m := TRegEx.Match(Filename, '^(keyman-setup.+) \(\d+\)$');
+  m := TRegEx.Match(Filename, '^('+SKeymanSetupPrefix+'.+) \(\d+\)$');
   if m.Success then
     Filename := m.Groups[1].Value;
 
   // Look for our recognised pattern of keyman-setup.package_id.bcp47...
   res := TRegEx.Split(Filename, '\.');
-  if (Length(res) < 2) or (res[0].ToLower <> 'keyman-setup') then
-    // No packages embedded in filename
+  if (Length(res) < 1) or not res[0].ToLower.StartsWith(SKeymanSetupPrefix) then
+    // No packages embedded in filename, or not a recognised filename pattern
     Exit;
+
+  // Look for an embedded tier in the filename, if not set, use default
+  p := res[0].ToLower;
+  if p.Equals(SKeymanSetup_Stable) then FTier := TIER_STABLE
+  else if p.Equals(SKeymanSetup_Beta) then FTier := TIER_BETA
+  else if p.Equals(SKeymanSetup_Alpha) then FTier := TIER_ALPHA;
 
   n := 1;
   while n < Length(res) do

--- a/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
@@ -46,7 +46,7 @@ begin
   try
     http.Request.SetURL(MakeAPIURL(API_Path_UpdateCheck_Windows));
     http.Fields.Add('version', AnsiString(currentVersion));
-    http.Fields.Add('tier', AnsiString(KeymanVersion.CKeymanVersionInfo.Tier));
+    http.Fields.Add('tier', AnsiString(AInstallInfo.Tier));
     http.Fields.Add('update', '0'); // This is probably a fresh install of a package, not an update
     for pack in AInstallInfo.Packages do
       http.Fields.Add(AnsiString('package_'+pack.ID), AnsiString(pack.Locations.LatestVersion));

--- a/windows/src/desktop/setup/SetupStrings.pas
+++ b/windows/src/desktop/setup/SetupStrings.pas
@@ -87,7 +87,9 @@ type
     { Download dialog }
 
     ssDownloadingTitle,
-    ssDownloadingText
+    ssDownloadingText,
+
+    ssOffline
   );
 
 const
@@ -157,7 +159,11 @@ const
   {ssOptionsDefaultLanguage}                  'Default language',
 
   {ssDownloadingTitle}                        'Downloading %0:s',    // %0:s: filename
-  {ssDownloadingText}                         'Downloading %0:s'     // %0:s: filename
+  {ssDownloadingText}                         'Downloading %0:s',    // %0:s: filename
+
+  {ssOffline}                                 'Keyman Setup could not connect to keyman.com to download additional resources.'#13#10#13#10+
+                                              'Please check that you are online, and give Keyman Setup permission to access the Internet in your firewall settings.'#13#10#13#10+
+                                              'Click Abort to exit Setup, Retry to try and download resources again, or Ignore to continue offline.'
 
 );
 

--- a/windows/src/desktop/setup/TntDialogHelp.pas
+++ b/windows/src/desktop/setup/TntDialogHelp.pas
@@ -91,13 +91,19 @@ begin
     IDCANCEL: Result := mrCancel;
     IDYES: Result := mrYes;
     IDNO: Result := mrNo;
+    IDABORT: Result := mrAbort;
+    IDIGNORE: Result := mrIgnore;
+    IDRETRY: Result := mrRetry;
     else Result := mrOk;
   end;
 end;
 
 procedure ShowMessageW(const Message: WideString);
 begin
-  Tnt_MessageBoxW(GetActiveWindow, PWideChar(Message), PChar(FInstallInfo.Text(ssMessageBoxTitle)), MB_OK);
+  if Assigned(FInstallInfo) then
+    Tnt_MessageBoxW(GetActiveWindow, PWideChar(Message), PChar(FInstallInfo.Text(ssMessageBoxTitle)), MB_OK)
+  else
+    Tnt_MessageBoxW(GetActiveWindow, PWideChar(Message), PChar('Setup'), MB_OK);
 end;
 
 end.

--- a/windows/src/desktop/setup/UfrmInstallOptions.pas
+++ b/windows/src/desktop/setup/UfrmInstallOptions.pas
@@ -102,6 +102,8 @@ uses
 { TfrmInstallOptions }
 
 procedure TfrmInstallOptions.FormCreate(Sender: TObject);
+var
+  FAllowOptions: Boolean;
 begin
   Caption := FInstallInfo.Text(ssOptionsTitle);
   chkStartWithWindows.Caption := FInstallInfo.Text(ssOptionsStartWithWindows);
@@ -116,6 +118,12 @@ begin
   lblDefaultKeymanSettings.Caption := FInstallInfo.Text(ssOptionsTitleDefaultKeymanSettings);
   lblSelectModulesToInstall.Caption := FInstallInfo.Text(ssOptionsTitleSelectModulesToInstall);
   lblAssociatedKeyboardLanguage.Caption := FInstallInfo.Text(ssOptionsTitleAssociatedKeyboardLanguage);
+
+  FAllowOptions := not FInstallInfo.IsInstalled and FInstallInfo.IsNewerAvailable;
+  lblDefaultKeymanSettings.Visible := FAllowOptions;
+  chkAutomaticallyReportUsage.Visible := FAllowOptions;
+  chkCheckForUpdates.Visible := FAllowOptions;
+  chkStartWithWindows.Visible := FAllowOptions;
 
   SetupDynamicOptions;
 end;
@@ -241,8 +249,8 @@ begin
       end
     else
       case FInstallInfo.BestMsi.LocationType of
-        iilLocal:  Text := FInstallInfo.Text(ssOptionsInstallKeyman, [FInstallInfo.BestMsi.Version]);
-        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadInstallKeyman, [FInstallInfo.BestMsi.Version, FormatFileSize(FInstallInfo.BestMsi.Size)]);
+        iilLocal:  Text := FInstallInfo.Text(ssOptionsUpgradeKeyman, [FInstallInfo.BestMsi.Version]);
+        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadUpgradeKeyman, [FInstallInfo.BestMsi.Version, FormatFileSize(FInstallInfo.BestMsi.Size)]);
       end;
   end
   else if FInstallInfo.IsInstalled then

--- a/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
+++ b/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
@@ -12,7 +12,7 @@ type
   TInstallInfoTest = class(TObject)
   public
     [Test]
-    procedure TestLocatePackagesFromFilename;
+    procedure TestLocatePackagesAndTierFromFilename;
 
     [Test]
     procedure TestLocatePackagesFromParameter;
@@ -21,18 +21,56 @@ type
 implementation
 
 uses
+  KeymanVersion,
   Keyman.Setup.System.InstallInfo;
 
 { TInstallInfoTest }
 
-procedure TInstallInfoTest.TestLocatePackagesFromFilename;
+procedure TInstallInfoTest.TestLocatePackagesAndTierFromFilename;
 var
   ii: TInstallInfo;
 begin
   ii := TInstallInfo.Create('');
   try
     // It should match a standard pattern
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer_angkor.km.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer_angkor.km.exe');
+    Assert.AreEqual(CKeymanVersionInfo.Tier, ii.Tier);
+    Assert.AreEqual(1, ii.Packages.Count);
+    Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
+    Assert.AreEqual('km', ii.Packages[0].BCP47);
+  finally
+    ii.Free;
+  end;
+
+  ii := TInstallInfo.Create('');
+  try
+    // It should match a standard pattern with a tier
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup-alpha.khmer_angkor.km.exe');
+    Assert.AreEqual(TIER_ALPHA, ii.Tier);
+    Assert.AreEqual(1, ii.Packages.Count);
+    Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
+    Assert.AreEqual('km', ii.Packages[0].BCP47);
+  finally
+    ii.Free;
+  end;
+
+  ii := TInstallInfo.Create('');
+  try
+    // It should match a standard pattern with a tier
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup-beta.khmer_angkor.km.exe');
+    Assert.AreEqual(TIER_BETA, ii.Tier);
+    Assert.AreEqual(1, ii.Packages.Count);
+    Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
+    Assert.AreEqual('km', ii.Packages[0].BCP47);
+  finally
+    ii.Free;
+  end;
+
+  ii := TInstallInfo.Create('');
+  try
+    // It should match a standard pattern with a tier
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup-stable.khmer_angkor.km.exe');
+    Assert.AreEqual(TIER_STABLE, ii.Tier);
     Assert.AreEqual(1, ii.Packages.Count);
     Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
     Assert.AreEqual('km', ii.Packages[0].BCP47);
@@ -43,7 +81,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should match a standard pattern
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer_angkor.km.sil_euro_latin.fr.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer_angkor.km.sil_euro_latin.fr.exe');
     Assert.AreEqual(2, ii.Packages.Count);
     Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
     Assert.AreEqual('km', ii.Packages[0].BCP47);
@@ -56,7 +94,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should strip off " (1)" suffixes when these are added by web browser
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer_angkor.km (1).exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer_angkor.km (1).exe');
     Assert.AreEqual(1, ii.Packages.Count);
     Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
     Assert.AreEqual('km', ii.Packages[0].BCP47);
@@ -67,7 +105,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should give an empty BCP 47 tag if one is not provided
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer_angkor.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer_angkor.exe');
     Assert.AreEqual(1, ii.Packages.Count);
     Assert.AreEqual('khmer_angkor', ii.Packages[0].ID);
     Assert.IsEmpty(ii.Packages[0].BCP47);
@@ -78,7 +116,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should only match on keyman-setup
-    ii.LocatePackagesFromFilename('c:\foo\setup.khmer_angkor.km.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\setup.khmer_angkor.km.exe');
     Assert.AreEqual(0, ii.Packages.Count, 'setup.khmer_angkor.km.exe');
   finally
     ii.Free;
@@ -87,7 +125,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should match packages with less common characters in filename
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer angkor.km.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer angkor.km.exe');
     Assert.AreEqual(1, ii.Packages.Count);
     Assert.AreEqual('khmer angkor', ii.Packages[0].ID);
     Assert.AreEqual('km', ii.Packages[0].BCP47);
@@ -98,7 +136,7 @@ begin
   ii := TInstallInfo.Create('');
   try
     // It should match packages with less common characters in filename
-    ii.LocatePackagesFromFilename('c:\foo\keyman-setup.khmer-angkor.km.exe');
+    ii.LocatePackagesAndTierFromFilename('c:\foo\keyman-setup.khmer-angkor.km.exe');
     Assert.AreEqual(1, ii.Packages.Count);
     Assert.AreEqual('khmer-angkor', ii.Packages[0].ID);
     Assert.AreEqual('km', ii.Packages[0].BCP47);


### PR DESCRIPTION
If no tier is specified, it uses the tier from the executable version.