### PR TITLE
fix(ios/engine): engine tier enum, proper detection

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -217,7 +217,6 @@
 		CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */; };
 		CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */; };
 		CEE0321124C56735005BFC73 /* Packages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321024C56735005BFC73 /* Packages.swift */; };
-		CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */; };
 		CEF888D223FE6ADF00667693 /* No-defaults 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */; };
 		CEF888D323FE6ADF00667693 /* Simple 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */; };
 		CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */; };
@@ -517,7 +516,6 @@
 		CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManagerTests.swift; sourceTree = "<group>"; };
 		CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		CEE0321024C56735005BFC73 /* Packages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Packages.swift; sourceTree = "<group>"; };
-		CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queries+Hosts.swift"; sourceTree = "<group>"; };
 		CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "No-defaults 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "Simple 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScaleTests.swift; sourceTree = "<group>"; };
@@ -929,7 +927,6 @@
 			isa = PBXGroup;
 			children = (
 				CE89641E24A4686000D5EB8E /* Queries.swift */,
-				CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */,
 				CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */,
 				CE5C8BE224B5B3BA00FAFB7F /* Queries+LexicalModel.swift */,
 			);
@@ -1548,7 +1545,6 @@
 				C082CE151F90AFD400860F02 /* Collection+SafeAccess.swift in Sources */,
 				C06D37441F81F5C400F61AE0 /* KeyboardNameTableViewCell.swift in Sources */,
 				9A3B14D2229370B20052A11F /* InstalledLanguagesViewController.swift in Sources */,
-				CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */,
 				C07A9D8A1FD1762700828ADD /* KeyboardRepository.swift in Sources */,
 				C08E69911FDA6F6F0026056B /* FullKeyboardID.swift in Sources */,
 				9A9CB0822241704800231FB9 /* APILexicalModelRepository.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */; };
 		CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */; };
 		CEE0321124C56735005BFC73 /* Packages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321024C56735005BFC73 /* Packages.swift */; };
+		CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */; };
 		CEF888D223FE6ADF00667693 /* No-defaults 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */; };
 		CEF888D323FE6ADF00667693 /* Simple 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */; };
 		CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */; };
@@ -516,6 +517,7 @@
 		CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManagerTests.swift; sourceTree = "<group>"; };
 		CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		CEE0321024C56735005BFC73 /* Packages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Packages.swift; sourceTree = "<group>"; };
+		CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queries+Hosts.swift"; sourceTree = "<group>"; };
 		CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "No-defaults 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "Simple 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScaleTests.swift; sourceTree = "<group>"; };
@@ -927,6 +929,7 @@
 			isa = PBXGroup;
 			children = (
 				CE89641E24A4686000D5EB8E /* Queries.swift */,
+				CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */,
 				CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */,
 				CE5C8BE224B5B3BA00FAFB7F /* Queries+LexicalModel.swift */,
 			);
@@ -1414,7 +1417,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n. \"$KEYMAN_ROOT/resources/build/xcode-utils.sh\"\n\nphaseSetBundleVersions\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n. \"$KEYMAN_ROOT/resources/build/xcode-utils.sh\"\n\nphaseSetBundleVersions true\n";
 			showEnvVarsInLog = 0;
 		};
 		CEC0C66F2410B005003E1BCD /* ShellScript */ = {
@@ -1545,6 +1548,7 @@
 				C082CE151F90AFD400860F02 /* Collection+SafeAccess.swift in Sources */,
 				C06D37441F81F5C400F61AE0 /* KeyboardNameTableViewCell.swift in Sources */,
 				9A3B14D2229370B20052A11F /* InstalledLanguagesViewController.swift in Sources */,
+				CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */,
 				C07A9D8A1FD1762700828ADD /* KeyboardRepository.swift in Sources */,
 				C08E69911FDA6F6F0026056B /* FullKeyboardID.swift in Sources */,
 				9A9CB0822241704800231FB9 /* APILexicalModelRepository.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/Version.swift
@@ -10,6 +10,12 @@ import Foundation
 
 /// Dotted-decimal version.
 public class Version: NSObject, Comparable {
+  public enum Tier: String {
+    case alpha
+    case beta
+    case stable
+  }
+
   public static let fallback = Version("1.0")!
   public static let latestFeature = packageBasedFileReorg
 
@@ -40,7 +46,7 @@ public class Version: NSObject, Comparable {
   private let components: [Int]
   public let plainString: String
   public let fullString: String
-  public let tier: String?
+  public let tier: Tier?
 
   public init?(_ string: String) {
     let tagComponents = string.components(separatedBy: "-")
@@ -59,11 +65,11 @@ public class Version: NSObject, Comparable {
     if tagComponents.count > 1 {
       switch tagComponents[1] {
         case "alpha":
-          fallthrough
+          tier = .alpha
         case "beta":
-          fallthrough
+          tier = .beta
         case "stable":
-          tier = tagComponents[1]
+          tier = .stable
         default:
           tier = nil
       }
@@ -75,7 +81,7 @@ public class Version: NSObject, Comparable {
     self.components = components
   }
 
-  public init?(_ components: [Int], tier: String? = nil) {
+  public init?(_ components: [Int], tier: Tier? = nil) {
     if components.count == 0 {
       return nil
     }

--- a/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/VersionTests.swift
@@ -28,7 +28,7 @@ class VersionTests: XCTestCase {
 
     XCTAssertNotNil(tagged, "Could not construct Verison instance from a text-tagged version string")
     XCTAssertTrue(tagged! == Version("14.0.18")!, "Did not produce expected version from text-tagged version string")
-    XCTAssertEqual(tagged!.tier, "alpha", "Did not properly store a tagged version's tier information")
+    XCTAssertEqual(tagged!.tier, .alpha, "Did not properly store a tagged version's tier information")
   }
 
   func testVersionComparison() {


### PR DESCRIPTION
A small tweak along with a small bug fix to prep for tier-based server selection.

While the main app ("Keyman") was properly getting its tier information set, `KeymanEngine` was not.  The project-file tweak fixes that.