### PR TITLE
refactor(developer/compilers): reading from a wordlist

### DIFF
--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -44,8 +44,7 @@ export function createTrieDataStructure(filenames: string[], searchTermToKey?: (
  * @param filename filename of the word list
  */
 export function parseWordListFromFilename(wordlist: WordList, filename: string): void {
-  let contents = readFileSync(filename, detectEncoding(filename));
-  parseWordList(wordlist, contents);
+  parseWordList(wordlist, new WordListFromFilename(filename));
 }
 
 /**
@@ -128,6 +127,24 @@ class WordListFromMemory implements WordListSource {
 
   *lines(): Generator<[number, string]> {
     let lines = this._contents.split(NEWLINE_SEPARATOR);
+    let i = 1;
+    for (let line of lines) {
+      yield [i, line];
+      i++;
+    }
+  }
+}
+
+class WordListFromFilename {
+  readonly name: string;
+  constructor(filename: string) {
+    this.name = filename;
+  }
+
+  *lines(): Generator<[number, string]> {
+    let contents = readFileSync(this.name, detectEncoding(this.name));
+    let lines = contents.split(NEWLINE_SEPARATOR);
+
     let i = 1;
     for (let line of lines) {
       yield [i, line];

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -44,7 +44,30 @@ export function createTrieDataStructure(filenames: string[], searchTermToKey?: (
  * @param filename filename of the word list
  */
 export function parseWordListFromFilename(wordlist: WordList, filename: string): void {
-  parseWordList(wordlist, new WordListFromFilename(filename));
+  _parseWordList(wordlist, new WordListFromFilename(filename));
+}
+
+/**
+ * Parses a word list from a string. The string should have multiple lines
+ * with LF or CRLF line terminators.
+ *
+ * @param wordlist word list to merge entries into (may have existing entries)
+ * @param filename filename of the word list
+ */
+export function parseWordListFromContents(wordlist: WordList, contents: string): void {
+  _parseWordList(wordlist, new WordListFromMemory(contents));
+}
+
+/**
+ * @deprecated
+ * Please use parseWordListFromFilename or parseWordListFromContents instead.
+ */
+export function parseWordList(wordlist: WordList, contents: string | WordListSource): void {
+  let source = typeof contents == "string"
+    ? new WordListFromMemory(contents)
+    : contents;
+
+  _parseWordList(wordlist, source);
 }
 
 /**
@@ -71,13 +94,9 @@ export function parseWordListFromFilename(wordlist: WordList, filename: string):
  *
  * @param wordlist word list to merge entries into (may have existing entries)
  * @param contents contents of the file to import
- *
  */
-export function parseWordList(wordlist: WordList, contents: string | WordListSource): void {
+function _parseWordList(wordlist: WordList, source:  WordListSource): void {
   const TAB = "\t";
-  let source = typeof contents == "string"
-    ? new WordListFromMemory(contents)
-    : contents;
 
   // @ts-ignore: unused
   for (let [lineno, line] of source.lines()) {

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -59,18 +59,6 @@ export function parseWordListFromContents(wordlist: WordList, contents: string):
 }
 
 /**
- * @deprecated
- * Please use parseWordListFromFilename or parseWordListFromContents instead.
- */
-export function parseWordList(wordlist: WordList, contents: string | WordListSource): void {
-  let source = typeof contents == "string"
-    ? new WordListFromMemory(contents)
-    : contents;
-
-  _parseWordList(wordlist, source);
-}
-
-/**
  * Reads a tab-separated values file into a word list. This function converts all
  * entries into NFC and merges duplicate entries across wordlists. Duplication is
  * on the basis of character-for-character equality after normalisation to NFC.

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -132,7 +132,7 @@ class WordListFromMemory implements WordListSource {
     this._contents = contents;
   }
 
-  *lines(): Generator<[number, string]> {
+  *lines() {
     yield *enumerateLines(this._contents.split(NEWLINE_SEPARATOR));
   }
 }
@@ -143,7 +143,7 @@ class WordListFromFilename {
     this.name = filename;
   }
 
-  *lines(): Generator<[number, string]> {
+  *lines() {
     let contents = readFileSync(this.name, detectEncoding(this.name));
     yield *enumerateLines(contents.split(NEWLINE_SEPARATOR));
   }
@@ -152,7 +152,7 @@ class WordListFromFilename {
 /**
  * Yields pairs of [lineno, line], given an Array of lines.
  */
-function* enumerateLines(lines: string[]): Generator<[number, string]> {
+function* enumerateLines(lines: string[]): Generator<LineNoAndText> {
     let i = 1;
     for (let line of lines) {
       yield [i, line];

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -74,9 +74,11 @@ export function parseWordListFromFilename(wordlist: WordList, filename: string):
  * @param contents contents of the file to import
  *
  */
-export function parseWordList(wordlist: WordList, contents: string): void {
+export function parseWordList(wordlist: WordList, contents: string | WordListSource): void {
   const TAB = "\t";
-  let source = new WordListFromMemory(contents);
+  let source = typeof contents == "string"
+    ? new WordListFromMemory(contents)
+    : contents;
 
   // @ts-ignore: unused
   for (let [lineno, line] of source.lines()) {

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -133,12 +133,7 @@ class WordListFromMemory implements WordListSource {
   }
 
   *lines(): Generator<[number, string]> {
-    let lines = this._contents.split(NEWLINE_SEPARATOR);
-    let i = 1;
-    for (let line of lines) {
-      yield [i, line];
-      i++;
-    }
+    yield *enumerateLines(this._contents.split(NEWLINE_SEPARATOR));
   }
 }
 
@@ -150,14 +145,19 @@ class WordListFromFilename {
 
   *lines(): Generator<[number, string]> {
     let contents = readFileSync(this.name, detectEncoding(this.name));
-    let lines = contents.split(NEWLINE_SEPARATOR);
+    yield *enumerateLines(contents.split(NEWLINE_SEPARATOR));
+  }
+}
 
+/**
+ * Yields pairs of [lineno, line], given an Array of lines.
+ */
+function* enumerateLines(lines: string[]): Generator<[number, string]> {
     let i = 1;
     for (let line of lines) {
       yield [i, line];
       i++;
     }
-  }
 }
 
 namespace Trie {

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -1,4 +1,4 @@
-import {parseWordList, parseWordListFromFilename, WordList} from '../dist/lexical-model-compiler/build-trie';
+import {parseWordListFromContents, parseWordListFromFilename, WordList} from '../dist/lexical-model-compiler/build-trie';
 import {assert} from 'chai';
 import 'mocha';
 import { makePathToFixture } from './helpers';
@@ -17,7 +17,7 @@ const SENCOTEN_WORDLIST = {
   'I': 1884
 };
 
-describe('parseWordList', function () {
+describe('parsing a word list', function () {
   it('should remove the UTF-8 byte order mark from files', function () {
     let word = 'hello';
     let count = 1;
@@ -26,10 +26,10 @@ describe('parseWordList', function () {
 
     let file = `# this is a comment\n${word}\t${count}`;
     let withoutBOM: WordList = {};
-    parseWordList(withoutBOM, file);
+    parseWordListFromContents(withoutBOM, file);
     assert.deepEqual(withoutBOM, expected, "expected regular file to parse properly");
     let withBOM: WordList = {};
-    parseWordList(withBOM, `${BOM}${file}`)
+    parseWordListFromContents(withBOM, `${BOM}${file}`)
     assert.deepEqual(withBOM, expected, "expected BOM to be ignored");
   });
 
@@ -80,7 +80,7 @@ describe('parseWordList', function () {
       file += `${words[i]}\t${i+1}\n`;
     }
     let repeatedWords: WordList = {};
-    parseWordList(repeatedWords, file);
+    parseWordListFromContents(repeatedWords, file);
 
     assert.deepEqual(repeatedWords, expected);
   });


### PR DESCRIPTION
To produce better error/warning messages, we want the word list parser to know which line of which file it's on. Hence, I refactored the parser to take a `WordListSource` which can either be from memory or from a file name. The parser itself can then consult the `WordListSource` about which file it's working on, and what line number it's processing. Our tests use files in memory, which is supported too but with the filename `<memory>`.