### PR TITLE
refactor(ios/engine): Centralized Keyman domain definitions

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -217,7 +217,7 @@
 		CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */; };
 		CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */; };
 		CEE0321124C56735005BFC73 /* Packages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321024C56735005BFC73 /* Packages.swift */; };
-		CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */; };
+		CEE0321324C58C90005BFC73 /* KeymanHosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE0321224C58C90005BFC73 /* KeymanHosts.swift */; };
 		CEF888D223FE6ADF00667693 /* No-defaults 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */; };
 		CEF888D323FE6ADF00667693 /* Simple 10.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */; };
 		CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */; };
@@ -517,7 +517,7 @@
 		CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceDownloadManagerTests.swift; sourceTree = "<group>"; };
 		CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		CEE0321024C56735005BFC73 /* Packages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Packages.swift; sourceTree = "<group>"; };
-		CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queries+Hosts.swift"; sourceTree = "<group>"; };
+		CEE0321224C58C90005BFC73 /* KeymanHosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanHosts.swift; sourceTree = "<group>"; };
 		CEF888D023FE6ADE00667693 /* No-defaults 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "No-defaults 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D123FE6ADF00667693 /* Simple 10.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "Simple 10.0 Migration.bundle"; sourceTree = "<group>"; };
 		CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScaleTests.swift; sourceTree = "<group>"; };
@@ -929,7 +929,6 @@
 			isa = PBXGroup;
 			children = (
 				CE89641E24A4686000D5EB8E /* Queries.swift */,
-				CEE0321224C58C90005BFC73 /* Queries+Hosts.swift */,
 				CE89642024A468B200D5EB8E /* Queries+PackageVersion.swift */,
 				CE5C8BE224B5B3BA00FAFB7F /* Queries+LexicalModel.swift */,
 			);
@@ -1081,6 +1080,7 @@
 				CE7A26D723CEEC630005955C /* Colors+Extension.swift */,
 				CE7A26DA23CEEF640005955C /* Colors.swift */,
 				C0B09EAD1FCFD10F002F39AF /* FontManager.swift */,
+				CEE0321224C58C90005BFC73 /* KeymanHosts.swift */,
 				C0EF3E7A1F95B65300CE9BD4 /* KeymanWebDelegate.swift */,
 				C05B14321FD914870082A316 /* Log.swift */,
 				C08E698C1FDA392D0026056B /* Migrations.swift */,
@@ -1548,7 +1548,7 @@
 				C082CE151F90AFD400860F02 /* Collection+SafeAccess.swift in Sources */,
 				C06D37441F81F5C400F61AE0 /* KeyboardNameTableViewCell.swift in Sources */,
 				9A3B14D2229370B20052A11F /* InstalledLanguagesViewController.swift in Sources */,
-				CEE0321324C58C90005BFC73 /* Queries+Hosts.swift in Sources */,
+				CEE0321324C58C90005BFC73 /* KeymanHosts.swift in Sources */,
 				C07A9D8A1FD1762700828ADD /* KeyboardRepository.swift in Sources */,
 				C08E69911FDA6F6F0026056B /* FullKeyboardID.swift in Sources */,
 				9A9CB0822241704800231FB9 /* APILexicalModelRepository.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		CEA9670B24BEC8030035AACF /* EngineStateBundler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9670A24BEC8030035AACF /* EngineStateBundler.swift */; };
 		CEA9670D24BEEFF80035AACF /* khmer_angkor update-base.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CEA9670C24BEEFF80035AACF /* khmer_angkor update-base.bundle */; };
 		CEA9670F24BEF05A0035AACF /* Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9670E24BEF05A0035AACF /* Updates.swift */; };
+		CEB8276724C6811800F3D39C /* KeymanHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB8276624C6811800F3D39C /* KeymanHostTests.swift */; };
 		CEC0C66C2410AC9A003E1BCD /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC0C66B2410AC9A003E1BCD /* Sentry.framework */; };
 		CEC0C6772410E049003E1BCD /* SentryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC0C6762410E049003E1BCD /* SentryManager.swift */; };
 		CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED8B63124A9C2400054E300 /* ResourceDownloadManagerTests.swift */; };
@@ -510,6 +511,7 @@
 		CEA9670A24BEC8030035AACF /* EngineStateBundler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineStateBundler.swift; sourceTree = "<group>"; };
 		CEA9670C24BEEFF80035AACF /* khmer_angkor update-base.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "khmer_angkor update-base.bundle"; sourceTree = "<group>"; };
 		CEA9670E24BEF05A0035AACF /* Updates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updates.swift; sourceTree = "<group>"; };
+		CEB8276624C6811800F3D39C /* KeymanHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeymanHostTests.swift; sourceTree = "<group>"; };
 		CEC0C66B2410AC9A003E1BCD /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = ../../Carthage/Build/iOS/Sentry.framework; sourceTree = "<group>"; };
 		CEC0C6762410E049003E1BCD /* SentryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryManager.swift; sourceTree = "<group>"; };
 		CECB38931F2199BC0098882F /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reachability.h; path = KeymanEngine/lib/Reachability/Reachability.h; sourceTree = SOURCE_ROOT; };
@@ -752,6 +754,7 @@
 				CE07E3D1247E3FB100DFA9D2 /* HTTPDownloaderTests.swift */,
 				9A079DD3223194B100581263 /* Info.plist */,
 				CE8EDEB223F53F96009E1FF6 /* VersionTests.swift */,
+				CEB8276624C6811800F3D39C /* KeymanHostTests.swift */,
 				CE4459CD23FBBA8D003151FD /* AppDelegate.swift */,
 				CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */,
 				CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */,
@@ -1475,6 +1478,7 @@
 				CEA9670924BEC4030035AACF /* ResourceUpdateTests.swift in Sources */,
 				CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */,
 				CE8EDEB323F53F96009E1FF6 /* VersionTests.swift in Sources */,
+				CEB8276724C6811800F3D39C /* KeymanHostTests.swift in Sources */,
 				CEDFEF8F23FE43B700BECF39 /* MigrationTests.swift in Sources */,
 				CED8B63224A9C2400054E300 /* ResourceDownloadManagerTests.swift in Sources */,
 				CE9CD88023FCC1CA002BF2F8 /* TestUtils.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Alerts.swift
@@ -31,7 +31,7 @@ open class Alerts {
   public static func showDownloadErrorAlert(in vc: UIViewController, handler: @escaping AcceptanceHandler) {
     var networkReachable: Reachability?
     do {
-      try networkReachable = Reachability(hostname: "keyman.com")
+      try networkReachable = Reachability(hostname: KeymanHosts.KEYMAN_COM.host!)
     } catch {
       log.debug("reachability could not start")
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APIKeyboardRepository.swift
@@ -17,7 +17,7 @@ public enum APIKeyboardFetchError: Error {
 }
 
 public class APIKeyboardRepository: KeyboardRepository {
-  private let languagesAPIURL = URLComponents(string: "https://api.keyman.com/cloud/4.0/languages")!
+  private let languagesAPIURL = URLComponents(string: "\(KeymanHosts.API_KEYMAN_COM)/cloud/4.0/languages")!
 
   public weak var delegate: KeyboardRepositoryDelegate?
   public private(set) var languages: [String: Language]?

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APILexicalModelRepository.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardRepository/APILexicalModelRepository.swift
@@ -17,7 +17,7 @@ public enum APILexicalModelFetchError: Error {
 
 @available(*, deprecated)
 public class APILexicalModelRepository: LexicalModelRepository {
-  private let modelsAPIURL = URLComponents(string: "https://api.keyman.com/model")!
+  private let modelsAPIURL = URLComponents(string: "\(KeymanHosts.API_KEYMAN_COM)/model")!
   
   public weak var delegate: LexicalModelRepositoryDelegate?
   public private(set) var languages: [String: Language]?

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
@@ -7,9 +7,73 @@
 
 import Foundation
 
+/**
+ * Defines constant-like definitions for Keyman's websites dependent upon the compile-time version
+ * of the KeymanEngine framework.
+ *
+ * Note that as a result, 'alpha', 'beta', and 'stable' versions of KeymanEngine may point to different
+ * sites.
+ */
+public enum KeymanHosts {
+  /**
+   * Used to enable '.local' variants of the endpoints for use in local development testing.
+   */
+  internal static let useLocal = false
 
-enum KeymanHosts {
-  static var API_KEYMAN_COM: URL {
-    return URL.init(string: "https://api.keyman.com")!
+  // This should never be used outside of the corresponding `static var`...
+  // save for use in automated testing.
+  internal static func getApiSiteURL(forTier: Version.Tier, useLocal: Bool) -> URL {
+    if useLocal {
+      return URL.init(string: "http://api.keyman.com.local")!
+    } else {
+      // TODO:  Once the staging-site changes are in place,
+      //        add switch-case here to select appropriate URL.
+      return URL.init(string: "https://api.keyman.com")!
+    }
+  }
+
+  /**
+   * Used for package-version and model queries.
+   */
+  public static var API_KEYMAN_COM: URL {
+    return getApiSiteURL(forTier: Version.currentTagged.tier ?? .stable, useLocal: useLocal)
+  }
+
+  // This should never be used outside of the corresponding `static var`...
+  // save for use in automated testing.
+  internal static func getHelpSiteURL(forTier: Version.Tier, useLocal: Bool) -> URL {
+    if useLocal {
+      return URL.init(string: "http://help.keyman.com.local")!
+    } else {
+      // TODO:  Once the staging-site changes are in place,
+      //        add switch-case here to select appropriate URL.
+      return URL.init(string: "https://help.keyman.com")!
+    }
+  }
+
+  /**
+   * Used for online help.
+   */
+  public static var HELP_KEYMAN_COM: URL {
+    return getHelpSiteURL(forTier: Version.currentTagged.tier ?? .stable, useLocal: useLocal)
+  }
+
+  // This should never be used outside of the corresponding `static var`...
+  // save for use in automated testing.
+  internal static func getMainSiteURL(forTier: Version.Tier, useLocal: Bool) -> URL {
+    if useLocal {
+      return URL.init(string: "http://keyman.com.local")!
+    } else {
+      // TODO:  Once the staging-site changes are in place,
+      //        add switch-case here to select appropriate URL.
+      return URL.init(string: "https://keyman.com")!
+    }
+  }
+
+  /**
+   * Used for keyboard searches and resource sharing links.
+   */
+  public static var KEYMAN_COM: URL {
+    return getMainSiteURL(forTier: Version.currentTagged.tier ?? .stable, useLocal: useLocal)
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
@@ -1,0 +1,15 @@
+//
+//  KeymanHosts.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 7/20/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+
+import Foundation
+
+
+enum KeymanHosts {
+  static var API_KEYMAN_COM: URL {
+    return URL.init(string: "https://api.keyman.com")!
+  }
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/LexicalModelInfoViewController.swift
@@ -69,7 +69,7 @@ class LexicalModelInfoViewController: UITableViewController, UIAlertViewDelegate
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     if !isCustomLexicalModel {
       if indexPath.row == 1 {
-        let url = URL(string: "http://help.keyman.com/lexicalModel/\(lexicalModelID)/\(lexicalModelVersion)/")!
+        let url = URL(string: "\(KeymanHosts.HELP_KEYMAN_COM)/lexicalModel/\(lexicalModelID)/\(lexicalModelVersion)/")!
         if let openURL = Manager.shared.openURL {
           _ = openURL(url)
         } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/ResourceInfoViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/ResourceInfoViewController.swift
@@ -129,7 +129,7 @@ class ResourceInfoViewController: UIViewController, UIAlertViewDelegate, UITable
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     if !isCustomKeyboard {
       if indexPath.row == 1 {
-        let url = URL(string: "http://help.keyman.com/keyboard/\(resource.id)/\(resource.version)/")!
+        let url = URL(string: "\(KeymanHosts.HELP_KEYMAN_COM)/keyboard/\(resource.id)/\(resource.version)/")!
         if let openURL = Manager.shared.openURL {
           _ = openURL(url)
         } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -36,9 +36,6 @@ public enum VibrationSupport {
 // Strings
 private let keyboardChangeHelpText = "Tap here to change keyboard"
 
-// URLs - used for reachability test
-private let keymanHostName = "api.keyman.com"
-
 public class Manager: NSObject, UIGestureRecognizerDelegate {
   /// Application group identifier for shared container. Set this before accessing the shared manager.
   public static var applicationGroupIdentifier: String?
@@ -208,7 +205,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     updateUserKeyboards(with: Defaults.keyboard)
 
     do {
-      try reachability = Reachability(hostname: keymanHostName)
+      try reachability = Reachability(hostname: KeymanHosts.API_KEYMAN_COM.host!)
     } catch {
       log.error("Could not start Reachability object: \(error)")
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -39,7 +39,7 @@ public struct InstallableKeyboard: Codable, KMPInitializableLanguageResource {
   public var oskFont: Font?
   public var isCustom: Bool
 
-  public static let sharingLink = "https://keyman.com/go/keyboard/%@/share"
+  public static let sharingLink = "\(KeymanHosts.KEYMAN_COM)/go/keyboard/%@/share"
 
   public var sharableURL: String? {
     get {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+LexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+LexicalModel.swift
@@ -42,7 +42,7 @@ extension Queries {
       }
     }
 
-    private static let MODEL_ENDPOINT = URLComponents(string: "https://api.keyman.com/model")!
+    private static let MODEL_ENDPOINT = URLComponents(string: "\(KeymanHosts.API_KEYMAN_COM)/model")!
 
     public static func fetch(forLanguageCode bcp47: String,
                              fetchCompletion: @escaping JSONQueryCompletionBlock<[Result]>) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+PackageVersion.swift
@@ -94,7 +94,7 @@ extension Queries {
       }
     }
 
-    private static let PACKAGE_VERSION_ENDPOINT = URLComponents(string: "https://api.keyman.com/package-version")!
+    private static let PACKAGE_VERSION_ENDPOINT = URLComponents(string: "\(KeymanHosts.API_KEYMAN_COM)/package-version")!
 
     public static func fetch(for packageKeys: [KeymanPackage.Key],
                              withSession session: URLSession = .shared,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -256,7 +256,6 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
   
   private var downloader: HTTPDownloader?
   private var reachability: Reachability?
-  private let keymanHostName = "api.keyman.com"
 
   private let session: URLSession
 
@@ -269,7 +268,7 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
 
   internal init(session: URLSession, autoExecute: Bool) {
     do {
-      try reachability = Reachability(hostname: keymanHostName)
+      try reachability = Reachability(hostname: KeymanHosts.API_KEYMAN_COM.host!)
     } catch {
       log.error("Could not start Reachability object: \(error)")
     }

--- a/ios/engine/KMEI/KeymanEngineTests/KMPJSONTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KMPJSONTests.swift
@@ -238,7 +238,7 @@ class KMPJSONTests: XCTestCase {
     let coder = JSONEncoder()
     let codedJSON = try coder.encode(constructedMetadata_khmer_angkor)
 
-    let schemaURL = URL(string: "https://api.keyman.com/schemas/package.json")!
+    let schemaURL = URL(string: "\(KeymanHosts.API_KEYMAN_COM)/schemas/package.json")!
     let schemaData = try Data(contentsOf: schemaURL)
 
     // - arguments ready, time to build the POST-based request

--- a/ios/engine/KMEI/KeymanEngineTests/KeymanHostTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KeymanHostTests.swift
@@ -1,0 +1,31 @@
+//
+//  MiscellaneousTests.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 7/21/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import XCTest
+@testable import KeymanEngine
+
+class KeymanHostTests: XCTestCase {
+  /**
+   * Ensures a test failure in case we accidentally leave `useLocal` enabled.
+   */
+  func testUseLocalDisabled() throws {
+    XCTAssertFalse(KeymanHosts.useLocal)
+  }
+
+  /**
+   * Ensures no accidental permanent edits to the .local variant URLs occur.
+   */
+  func testLocalSitesUnchanged() {
+    XCTAssertEqual(KeymanHosts.getApiSiteURL(forTier: .stable, useLocal: true),
+                   URL.init(string: "http://api.keyman.com.local"))
+    XCTAssertEqual(KeymanHosts.getHelpSiteURL(forTier: .stable, useLocal: true),
+                   URL.init(string: "http://help.keyman.com.local"))
+    XCTAssertEqual(KeymanHosts.getMainSiteURL(forTier: .stable, useLocal: true),
+                   URL.init(string: "http://keyman.com.local"))
+  }
+}


### PR DESCRIPTION
A first step to enabling tier-specific domain selection - actually having centralized definitions for those domains.

I'll follow this up with another PR once we've gotten the "staging" site architecture finalized and ready for use.