### PR TITLE
refactor(ios/engine): builds package download links

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -41,6 +41,10 @@ public class ResourceDownloadManager {
   
   // MARK - Downloading resources
 
+  /**
+   * Generates a download link for the specified package.  The resulting link is planned to be evergreen, with redirects as
+   * necessary to support it long, long into the future.
+   */
   public func defaultDownloadURL(forPackage packageKey: KeymanPackage.Key,
                                  andResource resourceKey: AnyLanguageResourceFullID? = nil,
                                  withVersion version: Version? = nil,
@@ -79,9 +83,6 @@ public class ResourceDownloadManager {
                                                                 asUpdate: Bool? = nil,
                                                                 completionBlock: CompletionHandler<FullID.Resource.Package>?)
   where FullID.Resource.Package: TypedKeymanPackage<FullID.Resource> {
-    // Note:  in this case, someone knows the "full ID" of the resource already, but NOT its location.
-    //        We can use the package-version query to attempt a lookup for a .kmp location
-    //        for download.
     let packageKey = KeymanPackage.Key(id: fullID.id, type: fullID.type)
     let packageURL = defaultDownloadURL(forPackage: KeymanPackage.Key(id: fullID.id, type: fullID.type),
                                         andResource: fullID,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -41,55 +41,72 @@ public class ResourceDownloadManager {
   
   // MARK - Downloading resources
 
+  public func defaultDownloadURL(forPackage packageKey: KeymanPackage.Key,
+                                 andResource resourceKey: AnyLanguageResourceFullID? = nil,
+                                 withVersion version: Version? = nil,
+                                 asUpdate: Bool? = nil) -> URL {
+    var baseURL = KeymanHosts.KEYMAN_COM
+    baseURL.appendPathComponent("go")
+    baseURL.appendPathComponent("package")
+    baseURL.appendPathComponent("download")
+    baseURL.appendPathComponent(packageKey.id)
+
+    var urlComponents = URLComponents(string: baseURL.absoluteString)!
+    var queryItems: [URLQueryItem] = [
+      URLQueryItem(name: "platform", value: "ios"),
+      URLQueryItem(name: "tier", value: (Version.currentTagged.tier ?? .stable).rawValue)
+    ]
+
+    if let version = version {
+      queryItems.append(URLQueryItem(name: "version", value: version.description))
+    }
+
+    if let resourceKey = resourceKey {
+      queryItems.append(URLQueryItem(name: "bcp47", value: resourceKey.languageID))
+    }
+
+    if let asUpdate = asUpdate {
+      queryItems.append(URLQueryItem(name: "update", value: asUpdate ? "1" : "0"))
+    }
+
+    urlComponents.queryItems = queryItems
+    return urlComponents.url!
+  }
+
   // Used to maintain legacy API:  downloadKeyboard and downloadLexicalModel (based on ID, language ID)
   private func downloadResource<FullID: LanguageResourceFullID>(withFullID fullID: FullID,
                                                                 sendNotifications: Bool,
+                                                                asUpdate: Bool? = nil,
                                                                 completionBlock: CompletionHandler<FullID.Resource.Package>?)
   where FullID.Resource.Package: TypedKeymanPackage<FullID.Resource> {
     // Note:  in this case, someone knows the "full ID" of the resource already, but NOT its location.
     //        We can use the package-version query to attempt a lookup for a .kmp location
     //        for download.
     let packageKey = KeymanPackage.Key(id: fullID.id, type: fullID.type)
-    Queries.PackageVersion.fetch(for: [packageKey], withSession: session) { result, error in
-      guard let result = result, error == nil else {
-        log.info("Error occurred requesting location for \(fullID.description)")
-        self.resourceDownloadFailed(withKey: packageKey, with: error ?? .noData)
-        try? completionBlock?(nil, error ?? .noData)
-        return
-      }
+    let packageURL = defaultDownloadURL(forPackage: KeymanPackage.Key(id: fullID.id, type: fullID.type),
+                                        andResource: fullID,
+                                        asUpdate: asUpdate)
 
-      guard case let .success(data) = result.entryFor(packageKey) else {
-        if case let .failure(errorEntry) = result.entryFor(packageKey) {
-          if let errorEntry = errorEntry {
-            log.info("Query reported error: \(String(describing: errorEntry.error))")
-          }
-        }
-        self.resourceDownloadFailed(withKey: packageKey, with: Queries.ResultError.unqueried)
-        try? completionBlock?(nil, Queries.ResultError.unqueried)
-        return
-      }
-
-      // Perform common 'can download' check.  We need positive reachability and no prior download queue.
-      guard self.downloader.state == .clear else {
-        let err = self.downloader.state.error ??
-          NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "Already busy downloading something"])
-        self.resourceDownloadFailed(withKey: packageKey, with: err)
-        try? completionBlock?(nil, err)
-        return
-      }
-
-      let completionClosure: CompletionHandler<FullID.Resource.Package> = completionBlock ?? { package, error in
-        // If the caller doesn't specify a completion block, this will carry out a default installation.
-        if let package = package {
-          try? ResourceFileManager.shared.install(resourceWithID: fullID, from: package)
-        }
-      }
-
-      self.downloadPackage(withKey: packageKey,
-                           from: URL.init(string: data.packageURL)!,
-                           withNotifications: sendNotifications,
-                           completionBlock: completionClosure)
+    // Perform common 'can download' check.  We need positive reachability and no prior download queue.
+    guard self.downloader.state == .clear else {
+      let err = self.downloader.state.error ??
+        NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "Already busy downloading something"])
+      self.resourceDownloadFailed(withKey: packageKey, with: err)
+      try? completionBlock?(nil, err)
+      return
     }
+
+    let completionClosure: CompletionHandler<FullID.Resource.Package> = completionBlock ?? { package, error in
+      // If the caller doesn't specify a completion block, this will carry out a default installation.
+      if let package = package {
+        try? ResourceFileManager.shared.install(resourceWithID: fullID, from: package)
+      }
+    }
+
+    self.downloadPackage(withKey: packageKey,
+                         from: packageURL,
+                         withNotifications: sendNotifications,
+                         completionBlock: completionClosure)
   }
 
   /// Asynchronously fetches the .js file for the keyboard with given IDs.

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -1,5 +1,5 @@
 //
-//  ResourceDownloadManagement.swift
+//  ResourceDownloadManagerTests.swift
 //  KeymanEngineTests
 //
 //  Created by Joshua Horton on 6/29/20.

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -32,6 +32,50 @@ class ResourceDownloadManagerTests: XCTestCase {
     }
   }
 
+  func testDefaultDownloadURL() {
+    let tier = Version.currentTagged.tier ?? .stable
+    let root = "/go/package/download"
+
+    let basic_khmer_angkor_components = URLComponents(string: downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.khmer_angkor).absoluteString)!
+
+    XCTAssertEqual(basic_khmer_angkor_components.path, "\(root)/khmer_angkor")
+    XCTAssertTrue(basic_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "platform" && item.value == "ios"
+    })
+    XCTAssertTrue(basic_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "tier" && item.value == tier.rawValue
+    })
+
+    let adv_khmer_angkor_url = downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.khmer_angkor, andResource: TestUtils.Keyboards.khmer_angkor.fullID, withVersion: Version("1.0.6"), asUpdate: true)
+    let adv_khmer_angkor_components = URLComponents(string: adv_khmer_angkor_url.absoluteString)!
+    XCTAssertEqual(adv_khmer_angkor_components.path, "\(root)/khmer_angkor")
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "platform" && item.value == "ios"
+    })
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "tier" && item.value == tier.rawValue
+    })
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "update" && item.value == "1"
+    })
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "version" && item.value == "1.0.6"
+    })
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "bcp47" && item.value == "km"
+    })
+
+    let basic_mtnt_components = URLComponents(string: downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt).absoluteString)!
+
+    XCTAssertEqual(basic_mtnt_components.path, "\(root)/nrc.en.mtnt")
+    XCTAssertTrue(basic_mtnt_components.queryItems!.contains { item in
+      return item.name == "platform" && item.value == "ios"
+    })
+    XCTAssertTrue(basic_mtnt_components.queryItems!.contains { item in
+      return item.name == "tier" && item.value == tier.rawValue
+    })
+  }
+
   func testDownloadPackageForKeyboard() throws {
     let expectation = XCTestExpectation(description: "Mocked \"download\" should complete successfully.")
     let packageKey = TestUtils.Keyboards.khmer_angkor.packageKey
@@ -138,10 +182,8 @@ class ResourceDownloadManagerTests: XCTestCase {
     // run this integration test otherwise.
     downloadManager = ResourceDownloadManager(session: mockedURLSession!, autoExecute: true)
 
-    let mockedQuery = TestUtils.Downloading.MockResult(location: TestUtils.Queries.package_version_km, error: nil)
     let mockedDownload = TestUtils.Downloading.MockResult(location: TestUtils.Keyboards.khmerAngkorKMP, error: nil)
 
-    mockedURLSession?.queueMockResult(.data(mockedQuery))
     mockedURLSession?.queueMockResult(.download(mockedDownload))
 
     let khmer_angkor_id = TestUtils.Keyboards.khmer_angkor.fullID
@@ -168,10 +210,8 @@ class ResourceDownloadManagerTests: XCTestCase {
     // run this integration test otherwise.
     downloadManager = ResourceDownloadManager(session: mockedURLSession!, autoExecute: true)
     
-    let mockedQuery = TestUtils.Downloading.MockResult(location: TestUtils.Queries.package_version_case_mtnt, error: nil)
     let mockedDownload = TestUtils.Downloading.MockResult(location: TestUtils.LexicalModels.mtntKMP, error: nil)
 
-    mockedURLSession?.queueMockResult(.data(mockedQuery))
     mockedURLSession?.queueMockResult(.download(mockedDownload))
 
     let mtnt_id = TestUtils.LexicalModels.mtnt.fullID


### PR DESCRIPTION
Since we're moving to use of an 'evergreen' link format for package downloads, we can safely drop any package-version query usage solely used to find a valid location for the package.

This also allows us to receive a bit more metadata for analytics, as it's specified as part of the URL.

Not done in this PR:
- queries for lexical models return a different link
- package-version queries return different links

While both of the above are planned to be converted to use of the same 'evergreen' link type, it may be worth ignoring those in favor of use of the new `defaultDownloadURL` method, as the app has the most direct access to any relevant analytics metadata.