### PR TITLE
feat(developer/compilers): logging errors and warnings in the lexical model compiler

### DIFF
--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Error codes. Use these when logging messages.
+ * 
+ * Extends https://github.com/keymanapp/keyman/blob/99db3c0d2448f448242e6397f9d72e9a7ccee4b9/windows/src/global/inc/Comperr.h
+ */
+export enum KeymanCompilerError {
+  CERR_LEXICAL_MODEL_MIN = 0x0800,
+  CERR_LEXICAL_MODEL_MAX = 0x08FF,
+
+  CERR_FATAL = 0x8000,
+  CERR_ERROR = 0x4000,
+  CERR_WARNING = 0x2000,
+  CERR_MEMORY = 0x1000,  // N.B., probably unused in TypeScript
+
+  CERR_FATAL_LM = CERR_FATAL | CERR_LEXICAL_MODEL_MIN,
+  /* Place all fatal LM compiler errors here! */
+
+  CERR_ERROR_LM = CERR_ERROR | CERR_LEXICAL_MODEL_MIN,
+  /* Place all recoverable LM compiler errors here! */
+
+  CERR_WARN_LM = CERR_WARNING | CERR_LEXICAL_MODEL_MIN,
+  /* Place all LM compiler warnings here! */
+  MixedNormalizationForms,
+}
+
+const LOG_LEVEL_TITLE = {
+  [0]: '',
+  [KeymanCompilerError.CERR_WARNING]: 'Warning',
+  [KeymanCompilerError.CERR_ERROR]: 'Error',
+  [KeymanCompilerError.CERR_FATAL]: 'Fatal Error',
+};
+
+interface FilenameAndLineNo {
+  readonly filename: string;
+  readonly lineno: number;
+}
+
+/**
+ * Logs compiler messages (warnings, errors, logs).
+ * 
+ * @param code Error code
+ * @param message A helpful message!
+ * @param source [optional] the filename/line number in the source that induced this error
+ * 
+ * @see https://github.com/keymanapp/keyman/blob/99db3c0d2448f448242e6397f9d72e9a7ccee4b9/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLog.pas#L60-L77
+ */
+export function log(code: KeymanCompilerError, message: string, source?: FilenameAndLineNo) {
+  let sourceStr = source ? `${source.filename} (${source.lineno}):` : '';
+  let prefix = determineLogLevelTitle(code);
+  if (prefix)
+    prefix = `${prefix}: `;
+
+  console.error(`${sourceStr} ${prefix}${h(code)} ${message}`)
+}
+
+function determineLogLevelTitle(code: KeymanCompilerError): string {
+  let level = code & 0xF000;
+  return LOG_LEVEL_TITLE[level];
+}
+
+/**
+ * Format a number as a zero-padded 4 digit hexadecimal.
+ */
+function h(n: number) {
+  let formatted = n.toString(16).toUpperCase();
+  if (formatted.length < 4) {
+    formatted = '0'.repeat(4 - formatted.length);
+  }
+
+  return formatted; 
+}

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -37,6 +37,11 @@ const LOG_LEVEL_TITLE = {
 };
 
 /**
+ * Direct where log messages go.
+ */
+let _logHandler: (log: LogMessage) => void = printLogs;
+
+/**
  * Logs compiler messages (warnings, errors, logs).
  * 
  * @param code Error code
@@ -50,7 +55,30 @@ export function log(code: KeymanCompilerError, message: string, source?: Filenam
     ? new LogMessageFromSource(code, message, source)
     : new LogMessage(code, message);
 
-  console.error(logMessage.format());
+  _logHandler(logMessage)
+}
+
+/**
+ * Override where log messages go.
+ * 
+ * @param fn The desired log message handler.
+ */
+export function redirectLogMessagesTo(fn: (log: LogMessage) => void) {
+  _logHandler = fn;
+}
+
+/**
+ * Reset the log message handler to the default.
+ */
+export function resetLogMessageHandler() {
+  _logHandler = printLogs;
+}
+
+/**
+ * Prints log messages to stderr. The default log action.
+ */
+export function printLogs(log: LogMessage): void {
+  console.error(log.format());
 }
 
 /**

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -21,6 +21,7 @@ export enum KeymanCompilerError {
   CERR_WARN_LM = CERR_WARNING | CERR_LEXICAL_MODEL_MIN,
   /* Place all LM compiler warnings here! */
   MixedNormalizationForms,
+  DuplicateWordInSameFile,
 }
 
 const LOG_LEVEL_TITLE = {
@@ -45,12 +46,12 @@ interface FilenameAndLineNo {
  * @see https://github.com/keymanapp/keyman/blob/99db3c0d2448f448242e6397f9d72e9a7ccee4b9/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLog.pas#L60-L77
  */
 export function log(code: KeymanCompilerError, message: string, source?: FilenameAndLineNo) {
-  let sourceStr = source ? `${source.filename} (${source.lineno}):` : '';
+  let sourceStr = source ? `${source.filename} (${source.lineno}): ` : '';
   let prefix = determineLogLevelTitle(code);
   if (prefix)
     prefix = `${prefix}: `;
 
-  console.error(`${sourceStr} ${prefix}${h(code)} ${message}`)
+  console.error(`${sourceStr}${prefix}${h(code)} ${message}`)
 }
 
 function determineLogLevelTitle(code: KeymanCompilerError): string {

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -53,7 +53,7 @@ let _logHandler: (log: LogMessage) => void = printLogs;
 export function log(code: KeymanCompilerError, message: string, source?: FilenameAndLineNo) {
   let logMessage = source
     ? new LogMessageFromSource(code, message, source)
-    : new LogMessage(code, message);
+    : new OrdinaryLogMessage(code, message);
 
   _logHandler(logMessage)
 }
@@ -92,7 +92,18 @@ interface FilenameAndLineNo {
 /**
  * A log message that knows how to format itself.
  */
-class LogMessage {
+export interface LogMessage {
+  readonly code: KeymanCompilerError;
+  readonly logLevel: KeymanCompilerError;
+  readonly message: string;
+
+  format(): string;
+}
+
+/**
+ * Concrete implementation of the log message.
+ */
+class OrdinaryLogMessage implements LogMessage {
   readonly code: KeymanCompilerError;
   readonly message: string;
 
@@ -121,7 +132,7 @@ class LogMessage {
 /**
  * A log message with a filename and line number.
  */
-class LogMessageFromSource extends LogMessage {
+class LogMessageFromSource extends OrdinaryLogMessage {
   readonly filename: string;
   readonly lineno: number;
 

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -84,10 +84,10 @@ export function resetLogMessageHandler() {
 }
 
 /**
- * Prints log messages to stderr. The default log action.
+ * Prints log messages to stdout. The default log action.
  */
 export function printLogs(log: LogMessage): void {
-  console.error(log.format());
+  console.log(log.format());
 }
 
 /**

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -53,11 +53,6 @@ export function log(code: KeymanCompilerError, message: string, source?: Filenam
   console.error(logMessage.format());
 }
 
-function determineLogLevelTitle(code: KeymanCompilerError): string {
-  let level = code & 0xF000;
-  return LOG_LEVEL_TITLE[level];
-}
-
 class LogMessage {
   readonly code: KeymanCompilerError;
   readonly message: string;
@@ -68,7 +63,7 @@ class LogMessage {
   }
 
   format(): string {
-    let prefix = determineLogLevelTitle(this.code);
+    let prefix = this.determineLogLevelTitle();
     if (prefix)
       prefix = `${prefix}: `;
 
@@ -77,6 +72,10 @@ class LogMessage {
 
   get logLevel(): KeymanCompilerError {
     return this.code & 0xF000;
+  }
+
+  determineLogLevelTitle(): string {
+    return LOG_LEVEL_TITLE[this.logLevel] || '';
   }
 }
 

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -8,7 +8,7 @@ export enum LogLevel {
   CERR_FATAL = 0x8000,
   CERR_ERROR = 0x4000,
   CERR_WARNING = 0x2000,
-  CERR_MEMORY = 0x1000,  // N.B., probably unused in TypeScript
+  // Note: 0x01000 is a memory error, but that is never raised in TypeScript
   CERR_INFO = 0x0000,  // N.B., not in widespread use
 };
 
@@ -29,8 +29,8 @@ export enum KeymanCompilerError {
 
   CERR_WARN_LM = LogLevel.CERR_WARNING | CERR_LEXICAL_MODEL_MIN,
   /* Place all LM compiler warnings here! */
-  MixedNormalizationForms,
-  DuplicateWordInSameFile,
+  CWARN_MixedNormalizationForms = 0x2801,
+  CWARN_DuplicateWordInSameFile = 0x2802,
 }
 
 /**
@@ -43,7 +43,6 @@ const LOG_LEVEL_TITLE: {[level in LogLevel]: string} = {
   [LogLevel.CERR_WARNING]: 'Warning',
   [LogLevel.CERR_ERROR]: 'Error',
   [LogLevel.CERR_FATAL]: 'Fatal Error',
-  [LogLevel.CERR_MEMORY]: '???',
 };
 
 /**

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -24,17 +24,17 @@ export enum KeymanCompilerError {
   DuplicateWordInSameFile,
 }
 
+/**
+ * Human-readable titles for the various log levels.
+ * 
+ * Taken from https://github.com/keymanapp/keyman/blob/d83cfffe511ce65b781f919e89e3693146844849/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLog.pas#L39-L46
+ */
 const LOG_LEVEL_TITLE = {
   [0]: '',
   [KeymanCompilerError.CERR_WARNING]: 'Warning',
   [KeymanCompilerError.CERR_ERROR]: 'Error',
   [KeymanCompilerError.CERR_FATAL]: 'Fatal Error',
 };
-
-interface FilenameAndLineNo {
-  readonly filename: string;
-  readonly lineno: number;
-}
 
 /**
  * Logs compiler messages (warnings, errors, logs).
@@ -53,6 +53,17 @@ export function log(code: KeymanCompilerError, message: string, source?: Filenam
   console.error(logMessage.format());
 }
 
+/**
+ * Duct tapes together a filename and a line number of a log.
+ */
+interface FilenameAndLineNo {
+  readonly filename: string;
+  readonly lineno: number;
+}
+
+/**
+ * A log message that knows how to format itself.
+ */
 class LogMessage {
   readonly code: KeymanCompilerError;
   readonly message: string;
@@ -62,14 +73,6 @@ class LogMessage {
     this.message = message;
   }
 
-  format(): string {
-    let prefix = this.determineLogLevelTitle();
-    if (prefix)
-      prefix = `${prefix}: `;
-
-    return `${prefix}${h(this.code)} ${this.message}`   
-  }
-
   get logLevel(): KeymanCompilerError {
     return this.code & 0xF000;
   }
@@ -77,8 +80,19 @@ class LogMessage {
   determineLogLevelTitle(): string {
     return LOG_LEVEL_TITLE[this.logLevel] || '';
   }
+
+  format(): string {
+    let prefix = this.determineLogLevelTitle();
+    if (prefix)
+      prefix = `${prefix}: `;
+
+    return `${prefix}${h(this.code)} ${this.message}`   
+  }
 }
 
+/**
+ * A log message with a filename and line number.
+ */
 class LogMessageFromSource extends LogMessage {
   readonly filename: string;
   readonly lineno: number;

--- a/developer/js/source/errors.ts
+++ b/developer/js/source/errors.ts
@@ -81,28 +81,20 @@ class LogMessage {
 }
 
 class LogMessageFromSource extends LogMessage {
-  readonly source: FilenameAndLineNo;
+  readonly filename: string;
+  readonly lineno: number;
 
   constructor(code: KeymanCompilerError, message: string, source: FilenameAndLineNo) {
     super(code, message);
-    this.source = source;
+    this.filename = source.filename;
+    this.lineno = source.lineno;
   }
 
   format(): string {
     let originalMessage = super.format();
     return `${this.filename} (${this.lineno}): ${originalMessage}`;
   }
-
-  get filename(): string {
-    return this.source.filename;
-  }
-
-  get lineno(): number {
-    return this.source.lineno;
-  }
 }
-
-
 
 /**
  * Format a number as a zero-padded 4 digit hexadecimal.

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -87,6 +87,8 @@ export function parseWordListFromContents(wordlist: WordList, contents: string):
 function _parseWordList(wordlist: WordList, source:  WordListSource): void {
   const TAB = "\t";
 
+  let wordsSeenInThisFile = new Set<string>();
+
   for (let [lineno, line] of source.lines()) {
     // Remove the byte-order mark (BOM) from the beginning of the string.
     // Because `contents` can be the concatenation of several files, we have to remove
@@ -124,6 +126,17 @@ function _parseWordList(wordlist: WordList, source:  WordListSource): void {
       // Treat it like a hapax legonmenom -- it exist, but only once.
       count = 1;
     }
+
+    if (wordsSeenInThisFile.has(wordform)) {
+      // The same word seen across multiple files is fine,
+      // but a word seen multiple times in one file is a problem!
+      log(
+        KeymanCompilerError.DuplicateWordInSameFile,
+        `duplicate word “${wordform}” found in same file; summing counts`,
+        {filename: source.name, lineno}
+      )
+    }
+    wordsSeenInThisFile.add(wordform);
 
     wordlist[wordform] = (wordlist[wordform] || 0) + count;
   }

--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -109,7 +109,7 @@ function _parseWordList(wordlist: WordList, source:  WordListSource): void {
     if (original !== wordform) {
       // Mixed normalization forms are yucky! Warn about it.
       log(
-        KeymanCompilerError.MixedNormalizationForms,
+        KeymanCompilerError.CWARN_MixedNormalizationForms,
         `“${wordform}” is not in Unicode NFC. Automatically converting to NFC.`,
         {filename: source.name, lineno}
       )
@@ -131,7 +131,7 @@ function _parseWordList(wordlist: WordList, source:  WordListSource): void {
       // The same word seen across multiple files is fine,
       // but a word seen multiple times in one file is a problem!
       log(
-        KeymanCompilerError.DuplicateWordInSameFile,
+        KeymanCompilerError.CWARN_DuplicateWordInSameFile,
         `duplicate word “${wordform}” found in same file; summing counts`,
         {filename: source.name, lineno}
       )

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -124,7 +124,14 @@ export function compileModelSourceCode(code: string) {
  * Enables one to query log messages after they have been logged.
  */
 export class LogHoarder {
-  readonly messages: LogMessage[] = [];
+  private messages: LogMessage[] = [];
+
+  /**
+   * Get rid of all log messages seen.
+   */
+  clear() {
+    this.messages = [];
+  }
   
   /**
    * Hoards a log message for later perusal.

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -5,7 +5,7 @@
  */
 import * as path from 'path';
 import {assert} from 'chai';
-import {LogMessage, KeymanCompilerError, redirectLogMessagesTo, resetLogMessageHandler} from '../../dist/errors';
+import {LogMessage, KeymanCompilerError, redirectLogMessagesTo, resetLogMessageHandler, LogLevel} from '../../dist/errors';
 
 export interface CompilationResult {
   hasSyntaxError: boolean;
@@ -144,7 +144,7 @@ export class LogHoarder {
    * Has an error message with this code been witnessed?
    */
   hasSeenCode(code: KeymanCompilerError): boolean {
-    return !!this.messages.find(log => log.code === code);
+    return Boolean(this.messages.find(log => log.code === code));
   }
 
   /**
@@ -152,7 +152,7 @@ export class LogHoarder {
    */
   hasSeenWarnings(): boolean {
     return this.messages
-      .filter(log => log.logLevel === KeymanCompilerError.CERR_WARNING)
+      .filter(log => log.level === LogLevel.CERR_WARNING)
       .length > 0;
   }
 

--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -121,13 +121,13 @@ export function compileModelSourceCode(code: string) {
 }
 
 /**
- * Keeps log messages
+ * Enables one to query log messages after they have been logged.
  */
 export class LogHoarder {
   readonly messages: LogMessage[] = [];
   
   /**
-   * Hoards a log message for later perusal
+   * Hoards a log message for later perusal.
    */
   handleLog(log: LogMessage) {
     this.messages.push(log);
@@ -150,7 +150,10 @@ export class LogHoarder {
   }
 
   /**
-   * Install the log hoarder.
+   * Overrides the global log handler, allowing one to browse log messages
+   * later.
+   * 
+   * Remember to uninstall the log handler afterwards!
    */
   install(): this {
     redirectLogMessagesTo(this.handleLog.bind(this));
@@ -159,6 +162,9 @@ export class LogHoarder {
 
   /**
    * Return the log message handler to its default.
+   * 
+   * Note: You MUST uninstall the hoarder after use!
+   * It's recommended you put this in an afterEach() callback.
    */
   uninstall() {
     resetLogMessageHandler()

--- a/developer/js/tests/test-error-logger.ts
+++ b/developer/js/tests/test-error-logger.ts
@@ -28,5 +28,11 @@ describe('error logger', function () {
     assert.isTrue(this.logHoarder.hasSeenCode(
       KeymanCompilerError.CWARN_TooManyErrorsOrWarnings
     ));
+
+    // Log a DIFFERENT error -- it should not appear in the log
+    log(KeymanCompilerError.CWARN_MixedNormalizationForms, "fake error");
+    assert.isFalse(this.logHoarder.hasSeenCode(
+      KeymanCompilerError.CWARN_MixedNormalizationForms
+    ));
   })
 })

--- a/developer/js/tests/test-error-logger.ts
+++ b/developer/js/tests/test-error-logger.ts
@@ -1,0 +1,32 @@
+import { MAX_MESSAGES, KeymanCompilerError, log } from "../dist/errors"
+import { LogHoarder } from "./helpers"
+import { assert } from "chai"
+
+describe('error logger', function () {
+  beforeEach(function () {
+    this.logHoarder = (new LogHoarder).install()
+  })
+
+  afterEach(function () {
+    this.logHoarder.uninstall();
+    delete this.logHoarder;
+  })
+
+  it('should stop logging messages **after** a maximum', function () {
+    for (let i = 0; i < MAX_MESSAGES; i++) {
+      log(KeymanCompilerError.CWARN_DuplicateWordInSameFile, "fake error");
+    }
+
+    // We've logged *just enough messages. This error should not be found:
+    assert.isFalse(this.logHoarder.hasSeenCode(
+      KeymanCompilerError.CWARN_TooManyErrorsOrWarnings
+    ));
+
+    // Log just one too many:
+    log(KeymanCompilerError.CWARN_DuplicateWordInSameFile, "fake error");
+
+    assert.isTrue(this.logHoarder.hasSeenCode(
+      KeymanCompilerError.CWARN_TooManyErrorsOrWarnings
+    ));
+  })
+})

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -106,5 +106,22 @@ describe('parsing a word list', function () {
     assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.DuplicateWordInSameFile));
     // helló and hello + U+0301 have both been seen:
     assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.MixedNormalizationForms));
+
+    // Let's parse another file:
+
+    this.logHoarder.clear();
+    // Now, parse a DIFFERENT file, but with an NFD entry.
+    parseWordListFromContents(repeatedWords, "hello\u0301\t5\n");
+    assert.isTrue(this.logHoarder.hasSeenWarnings())
+    // hello + U+0301 (NFD) has been seen, but...
+    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.MixedNormalizationForms));
+    // BUT! We have not seen a duplicate **within the same file**
+    assert.isFalse(this.logHoarder.hasSeenCode(KeymanCompilerError.DuplicateWordInSameFile));
+
+    assert.deepEqual(repeatedWords, {
+      hello: expected['hello'],
+      // should have seen more of this entry:
+      "hell\u00f3": expected["hell\u00f3"] + 5,
+    });
   });
 });

--- a/developer/js/tests/test-parse-wordlist.ts
+++ b/developer/js/tests/test-parse-wordlist.ts
@@ -103,9 +103,9 @@ describe('parsing a word list', function () {
     
     assert.isTrue(this.logHoarder.hasSeenWarnings());
     // hello has been seen multiple times:
-    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.DuplicateWordInSameFile));
+    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.CWARN_DuplicateWordInSameFile));
     // helló and hello + U+0301 have both been seen:
-    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.MixedNormalizationForms));
+    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.CWARN_MixedNormalizationForms));
 
     // Let's parse another file:
 
@@ -114,9 +114,9 @@ describe('parsing a word list', function () {
     parseWordListFromContents(repeatedWords, "hello\u0301\t5\n");
     assert.isTrue(this.logHoarder.hasSeenWarnings())
     // hello + U+0301 (NFD) has been seen, but...
-    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.MixedNormalizationForms));
+    assert.isTrue(this.logHoarder.hasSeenCode(KeymanCompilerError.CWARN_MixedNormalizationForms));
     // BUT! We have not seen a duplicate **within the same file**
-    assert.isFalse(this.logHoarder.hasSeenCode(KeymanCompilerError.DuplicateWordInSameFile));
+    assert.isFalse(this.logHoarder.hasSeenCode(KeymanCompilerError.CWARN_DuplicateWordInSameFile));
 
     assert.deepEqual(repeatedWords, {
       hello: expected['hello'],

--- a/windows/src/global/delphi/general/CompileErrorCodes.pas
+++ b/windows/src/global/delphi/general/CompileErrorCodes.pas
@@ -19,6 +19,7 @@
                     04 May 2015 - mcdurdin - I4688 - V9.0 - Add build path to project settings
                     24 Aug 2015 - mcdurdin - I4872 - OSK font and Touch Layout font should be the same in Developer
                     28 Feb 2018 - jahorton - Imported the "SomewhereIGotItWrong" error code for use in KMW compilation
+                    22 Jul 2020 - eddieantonio - Add lexical model range https://github.com/keymanapp/keyman/pull/3385
 *)
 unit CompileErrorCodes;
 
@@ -29,6 +30,9 @@ const
   CWARN_FLAG = $2000;
   CERR_FLAG = $4000;
   CFATAL_FLAG = $8000;
+
+  CERR_LEXICAL_MODEL_MIN = $0800;
+  CERR_LEXICAL_MODEL_MAX = $08FF;
 
   CERR_NotSupportedInKeymanWebContext =               $4054;
   CERR_NotSupportedInKeymanWebOutput =                $4055;

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -17,6 +17,7 @@
                     25 May 2010 - mcdurdin - I1632 - Keyboard Options
                     21 Feb 2014 - mcdurdin - I4061 - V9.0 - KeymanWeb compiler needs defined codes for some errors
                     06 Mar 2014 - mcdurdin - I4118 - V9.0 - KMW compiler should warn when extended shift flags are used
+                    22 Jul 2020 - eddieantonio - Add lexical model range https://github.com/keymanapp/keyman/pull/3385
 */
    // I4061
 #ifndef _COMPERR_H
@@ -26,6 +27,10 @@
 #define CERR_ERROR						0x00004000
 #define CERR_WARNING					0x00002000
 #define CERR_MEMORY						0x00001000
+
+// Any messages from the lexical model compiler occupy this range:
+#define CERR_LEXICAL_MODEL_MIN			0x00000800
+#define CERR_LEXICAL_MODEL_MAX			0x000008FF
 
 #define CERR_None						0x00000000
 #define CERR_EndOfFile					0x00000001


### PR DESCRIPTION
Adds a logging message mechanism to the lexical model compiler.

So now, given a wordlist like this:

```tsv
# this is a comment
hello   1
helló   2
helló   3
 hello  4
hello   5
```

...we generate the following log messages:

```
wordlist.tsv (3): Warning: 2801 “helló” is not in Unicode NFC. Automatically converting to NFC.
wordlist.tsv (4): Warning: 2802 duplicate word “helló” found in same file; summing counts
wordlist.tsv (5): Warning: 2802 duplicate word “hello” found in same file; summing counts
wordlist.tsv (6): Warning: 2802 duplicate word “hello” found in same file; summing counts
```

I've implemented two new warnings: Mixed normalization forms (which is really just being consistent in using NFC), and duplicate words within the same file. More warnings should be added/adjusted given the guidelines in "Reviewing Predictive Text Submissions", as authored by D. Rowe.

Fixes #3377