### PR TITLE
feat(ios/engine): download queue concurrency

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -615,20 +615,26 @@ public class ResourceDownloadManager {
 
   // MARK - Notifications
   internal func resourceDownloadStarted(withKey packageKey: KeymanPackage.Key) {
-    NotificationCenter.default.post(name: Notifications.packageDownloadStarted,
-                                    object: self,
-                                    value: packageKey)
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: Notifications.packageDownloadStarted,
+                                      object: self,
+                                      value: packageKey)
+    }
   }
 
   internal func resourceDownloadCompleted(with package: KeymanPackage) {
-    NotificationCenter.default.post(name: Notifications.packageDownloadCompleted,
-                                    object: self,
-                                    value: package)
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: Notifications.packageDownloadCompleted,
+                                      object: self,
+                                      value: package)
+    }
   }
 
   internal func resourceDownloadFailed(withKey packageKey: KeymanPackage.Key, with error: Error) {
-    NotificationCenter.default.post(name: Notifications.packageDownloadFailed,
-                                    object: self,
-                                    value: PackageDownloadFailedNotification(packageKey: packageKey, error: error))
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: Notifications.packageDownloadFailed,
+                                      object: self,
+                                      value: PackageDownloadFailedNotification(packageKey: packageKey, error: error))
+    }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -255,10 +255,14 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     }
   }
 
+  // ---- CRITICAL SECTION FIELDS ----
+  // Any writes to these must be performed on `queueThread`.
+  // Async reads are permitted.
   private var queueRoot: DownloadQueueFrame
   private var queueStack: [DownloadQueueFrame]
+  // ------------- END ---------------
+
   private var queueThread: DispatchQueue
-  
   private var downloader: HTTPDownloader?
   private var reachability: Reachability?
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadQueue.swift
@@ -231,28 +231,33 @@ private class DownloadQueueFrame {
   }
 }
 
-// The other half of ResourceDownloadManager, this class is responsible for executing the downloads
-// and handling the results.
+/**
+ * The other half of ResourceDownloadManager, this class is responsible for executing the downloads
+ * and handling the results.  Internally manages its own single-threaded `DispatchQueue`, which
+ * handles all necessary synchronization.
+ *
+ * At present, submissions to this class will be evaluated sequentially by its `DispatchQueue`, though
+ * this may change at a later time.  (The 'sequential' aspect is due to legacy design decisions from
+ * before concurrency was a consideration.)
+ */
 class ResourceDownloadQueue: HTTPDownloadDelegate {
   enum QueueState: String {
     case clear
-    case busy
     case noConnection
 
     var error: Error? {
       switch(self) {
         case .clear:
           return nil
-        case .busy:
-          return NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "No internet connection"])
         case .noConnection:
-          return NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "Download queue is busy"])
+          return NSError(domain: "Keyman", code: 0, userInfo: [NSLocalizedDescriptionKey: "No internet connection"])
       }
     }
   }
 
   private var queueRoot: DownloadQueueFrame
   private var queueStack: [DownloadQueueFrame]
+  private var queueThread: DispatchQueue
   
   private var downloader: HTTPDownloader?
   private var reachability: Reachability?
@@ -278,6 +283,10 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
 
     queueRoot = DownloadQueueFrame()
     queueStack = [queueRoot] // queueRoot will always be the bottom frame of the stack.
+
+    // Creates a single-threaded DispatchQueue, facilitating concurrency at this class's
+    // critical sections.
+    queueThread = DispatchQueue(label: "com.keyman.ResourceDownloadQueue")
   }
   
   public func hasConnection() -> Bool {
@@ -287,11 +296,6 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
   public var state: QueueState {
     guard hasConnection() else {
       return .noConnection
-    }
-    
-    // At this stage, we now have everything needed to generate download requests.
-    guard currentBatch == nil else { // Original behavior - only one download operation is permitted at a time.
-      return .busy
     }
     
     return .clear
@@ -315,6 +319,12 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     }
   }
 
+  // ---------- CRITICAL SECTION:  START -----------
+  // IMPORTANT: These functions should only ever be referenced from `queueThread`.
+  //            as they maintain synchronization for the queue's critical
+  //            tracking fields.
+  //
+  // As a result, these functions are intentionally and explicitly `private`.
   private func finalizeCurrentBatch(withError error: Error? = nil) {
     let frame = queueStack[queueStack.count - 1]
     
@@ -333,7 +343,7 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
       frame.index += 1
     }
   }
-  
+
   private func executeNext() {
     let frame = queueStack[queueStack.count - 1]
     
@@ -374,15 +384,6 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     }
   }
 
-  internal func step() {
-    executeNext()
-  }
-
-  // Exposes useful information for runtime mocking.  Used by some automated tests.
-  internal func topLevelNodes() -> [DownloadNode] {
-    return queueRoot.nodes
-  }
-
   private func innerExecute(_ node: DownloadNode) {
     switch(node) {
       case .simpleBatch(let batch):
@@ -410,16 +411,36 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
         innerExecute(batch.tasks[0])
     }
   }
-  
+
+  // ----------- CRITICAL SECTION:  END ------------
+
+  // The next two functions are used as queueThread's "API".
+  // Internally, they must perform `sync` / `async` operations when
+  // writing to the critical tracking fields.
   public func queue(_ node: DownloadNode) {
-    queueRoot.nodes.append(node)
-    
-    // If the queue was empty before this...
-    if queueRoot.nodes.count == 1 && autoExecute {
-      executeNext()
+    // `sync` is particularly important here for some automated testing checks
+    // when `autoExecute == `false`.
+    queueThread.sync {
+      self.queueRoot.nodes.append(node)
+    }
+
+    queueThread.async {
+      // If the queue was empty before this...
+      if self.queueRoot.nodes.count == 1 && self.autoExecute {
+        self.executeNext()
+      }
     }
   }
-  
+
+  internal func step() {
+    queueThread.async { self.executeNext() }
+  }
+
+  // Exposes useful information for runtime mocking.  Used by some automated tests.
+  internal func topLevelNodes() -> [DownloadNode] {
+    return queueRoot.nodes
+  }
+
   // MARK - helper methods for ResourceDownloadManager
   
   // TODO:  Eliminate this property coompletely.
@@ -445,17 +466,25 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     let batch = queue.userInfo[Key.downloadBatch] as! AnyDownloadBatch
 
     let packagePath = batch.tasks[0].file
+    var err: Error? = nil
     do {
       try batch.completeWithPackage(fromKMP: packagePath)
-      // Completing the queue means having completed a batch.  We should only move forward in this class's
-      // queue at this time, once a batch's task queue is complete.
-      finalizeCurrentBatch()
     } catch {
-      finalizeCurrentBatch(withError: error)
+      err = error
     }
 
-    if autoExecute {
-      executeNext()
+    queueThread.async {
+      if let error = err {
+        self.finalizeCurrentBatch(withError: error)
+      } else {
+        // Completing the queue means having completed a batch.  We should only move forward in this class's
+        // queue at this time, once a batch's task queue is complete.
+        self.finalizeCurrentBatch()
+      }
+
+      if self.autoExecute {
+        self.executeNext()
+      }
     }
   }
   
@@ -463,12 +492,14 @@ class ResourceDownloadQueue: HTTPDownloadDelegate {
     if case .simpleBatch(let batch) = self.currentBatch {
       try? batch.completeWithCancellation()
     }
-    
-    // In case we're part of a 'composite' operation, we should still keep the queue moving.
-    finalizeCurrentBatch()
 
-    if autoExecute {
-      executeNext()
+    queueThread.async {
+      // In case we're part of a 'composite' operation, we should still keep the queue moving.
+      self.finalizeCurrentBatch()
+
+      if self.autoExecute {
+        self.executeNext()
+      }
     }
   }
 


### PR DESCRIPTION
Man, this keyboard-search rework really is "the gift that keeps on giving."

As it turns out, the "simplest" way to provide nice, clean callbacks from the keyboard-search (see #3384)... kinda requires a bit of concurrency support.  Why?
- Callback 1:  The keyboard search _immediately_ knows what package a user's selected for download.  Easy.
- Callback 2:  It does _not_ immediately know what lexical model best matches that package.  An async model-query fetch is _required_.

While we _could_ wait on the model-query fetch to return before 'returning' from keyboard-search, a poor connection or loss of data could spell a poor user experience.  They'd have to wait for the async fetch to complete... and _then_ have to wait on both downloads.  Also sequential.  This would also be a "hard and fast" requirement for anything using the keyboard search.

But why is this?  As it turns out, in parallel:
- We may immediately start downloading the keyboard package.
- Simultaneously, we can safely query for a matching lexical model package.
    - Once that completes, if a match exists, we may then start downloading the lexical model.

If those top two bullet points are run in parallel, there is nothing already in `KeymanEngine` that could handle the resulting race condition:  the lexical model package download could be queued before the keyboard package download completes.  So, either we use a cumbersome forced-serial approach... or we make things a little more concurrency-compatible.

Turns out, Swift provides some pretty sweet concurrency classes, so it wasn't even that much of an edit to support!  Also, the result will keep things _much_ cleaner in the keyboard search implementation than they would have been otherwise... also allowing code that uses the resulting keyboard-search module to _choose_ which parts they perform synchronous waits against.  "more responsive UI" == "better".