### PR TITLE
feat(ios/engine): support for deferred chaining of lexical model downloads

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -29,6 +29,34 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     case error(Error?)
   }
 
+  public enum DelayedLanguageSelection {
+    case none
+    case tag(String)
+  }
+
+  public enum SearchResult<FullID: LanguageResourceFullID> {
+    /**
+     * Indicates that the user cancelled the search.
+     */
+    case cancelled
+
+    /**
+     * Indicates that a package has been selected for download, but we don't know what language
+     * they wish to use it for.  This case will never be specified for the lexical-model selection closure.
+     *
+     * Once a target language has been identified, call the third parameter's closure to start a search
+     * for associated lexical models (or to indicate that none should occur).  Otherwise, the lexical model
+     * search closure provided to the keyboard search will never evaluate.
+     */
+    case untagged(KeymanPackage.Key, URL, (DelayedLanguageSelection) -> Void)
+
+    /**
+     * Indicates that a package has been selected for download and is already associated with a
+     * language tag.
+     */
+    case tagged(KeymanPackage.Key, URL, FullID)
+  }
+
   // Useful documentation regarding certain implementation details:
   // https://docs.google.com/document/d/1rhgMeJlCdXCi6ohPb_CuyZd0PZMoSzMqGpv1A8cMFHY/edit
 
@@ -38,7 +66,8 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
    * 2. The Keyman cloud URL from which that package may be downloaded.  Will be nil if and only if the first parameter is nil.
    * 3. The unique identifier for the resource WITHIN that package to install.  Useful when a package's resource(s) support multiple languages.
    */
-  public typealias SelectionCompletedHandler<FullID: LanguageResourceFullID> = (KeymanPackage.Key?, URL?, FullID?) -> Void
+  public typealias SelectionCompletedHandler<FullID: LanguageResourceFullID> = (SearchResult<FullID>) -> Void
+  internal typealias DeferredLexicalModelSearch = (DelayedLanguageSelection) -> Void
 
   private let keyboardSelectionClosure: SelectionCompletedHandler<FullKeyboardID>!
   private let lexicalModelSelectionClosure: SelectionCompletedHandler<FullLexicalModelID>!
@@ -131,40 +160,54 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
 
   internal func finalize(with keyboard_id: String, for lang_id: String?) {
     let packageKey = KeymanPackage.Key(id: keyboard_id, type: .keyboard)
-    var resourceKey: FullKeyboardID? = nil
 
     // If we have a language ID AND do not yet have a model for it.
     if let lang_id = lang_id {
-      resourceKey = FullKeyboardID(keyboardID: keyboard_id, languageID: lang_id)
+      let resourceKey = FullKeyboardID(keyboardID: keyboard_id, languageID: lang_id)
+      let kbdURL = ResourceDownloadManager.shared.defaultDownloadURL(forPackage: packageKey, andResource: resourceKey, asUpdate: false)
+      performLanguageSearch(languageID: lang_id)
+      self.keyboardSelectionClosure(.tagged(packageKey, kbdURL, resourceKey))
+    } else {
+      // No language ID?  Defer the language search!
+      let deferredModelClosure: DeferredLexicalModelSearch = { arg in
+        if case let .tag(lgCode) = arg {
+          self.performLanguageSearch(languageID: lgCode)
+        } else {
+          self.lexicalModelSelectionClosure(.cancelled)
+        }
+      }
+      let kbdURL = ResourceDownloadManager.shared.defaultDownloadURL(forPackage: packageKey, asUpdate: false)
+      self.keyboardSelectionClosure(.untagged(packageKey, kbdURL, deferredModelClosure))
+    }
+  }
 
-      if Storage.active.userDefaults.userLexicalModels?.contains(where: { $0.languageID == lang_id }) == nil {
-        Queries.LexicalModel.fetchModels(forLanguageCode: resourceKey!.languageID,
-                                         withSession: session) { results, error in
-          if let results = results {
-            if results.count == 0 {
-              self.lexicalModelSelectionClosure(nil, nil, nil)
-            } else {
-              let lexicalModel = results[0].0
-              self.lexicalModelSelectionClosure(lexicalModel.packageKey, results[0].1, lexicalModel.fullID)
-            }
+  internal func performLanguageSearch(languageID: String) {
+    if Storage.active.userDefaults.userLexicalModels?.contains(where: { $0.languageID == languageID }) == nil {
+      Queries.LexicalModel.fetchModels(forLanguageCode: languageID,
+                                       withSession: session) { results, error in
+        if let results = results {
+          if results.count == 0 {
+            self.lexicalModelSelectionClosure(.cancelled)
           } else {
-            self.lexicalModelSelectionClosure(nil, nil, nil)
+            let lexicalModel = results[0].0
+            self.lexicalModelSelectionClosure(.tagged(lexicalModel.packageKey, results[0].1, lexicalModel.fullID))
+          }
+        } else {
+          // .cancelled because if we already errored once, a redo of the query is likely
+          // to raise an error again.  We -could- defer as if there were no language tag, though.
+          self.lexicalModelSelectionClosure(.cancelled)
 
-            if let error = error {
-              log.error("Could not find a lexical model for language id \"\(lang_id)\" due to error: \(String(describing: error))")
-            }
+          if let error = error {
+            log.error("Could not find a lexical model for language id \"\(languageID)\" due to error: \(String(describing: error))")
           }
         }
-      } else {
-        self.lexicalModelSelectionClosure(nil, nil, nil)
       }
-    } else { // No language ID?  No model download possible.
-      self.lexicalModelSelectionClosure(nil, nil, nil)
+    } else {
+      // We already have a lexical model for the language.  No need to download a new one.
+      self.lexicalModelSelectionClosure(.cancelled)
     }
-
-    let kbdURL = ResourceDownloadManager.shared.defaultDownloadURL(forPackage: packageKey, andResource: resourceKey, asUpdate: false)
-    self.keyboardSelectionClosure(packageKey, kbdURL, resourceKey)
   }
+
 
   public static func defaultKeyboardInstallationClosure(installCompletionBlock: ((DefaultInstallationResult) -> Void)? = nil) -> SelectionCompletedHandler<FullKeyboardID> {
     return defaultKeyboardInstallationClosure(withDownloadManager: ResourceDownloadManager.shared,
@@ -189,38 +232,67 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
       dispatchGroup?.leave() // "fulfill" this closure's aspect of the group's synchronization scheme.
     }
 
-    return { packageKey, packageURL, resourceKey in
-      if let packageKey = packageKey, let packageURL = packageURL {
-        let downloadClosure: ResourceDownloadManager.CompletionHandler<KeyboardKeymanPackage> = { package, error in
-          guard let package = package, error == nil else {
-            let errString = error != nil ? String(describing: error) : "<unknown error>"
-            let message = "Could not download package \(packageKey): \(errString)"
+    return { searchResult in
+      var packageKey: KeymanPackage.Key
+      var packageURL: URL
 
-            finalize(as: .error(error), noCallbackLog: message)
-            return
+      switch searchResult {
+        case .cancelled:
+          finalize(as: .cancelled)
+          return
+        case .untagged(let key, let url, _):
+          packageKey = key
+          packageURL = url
+        case .tagged(let key, let url, _):
+          packageKey = key
+          packageURL = url
+      }
+
+      let downloadClosure: ResourceDownloadManager.CompletionHandler<KeyboardKeymanPackage> = { package, error in
+        guard let package = package, error == nil else {
+          let errString = error != nil ? String(describing: error) : "<unknown error>"
+          let message = "Could not download package \(packageKey): \(errString)"
+
+          finalize(as: .error(error), noCallbackLog: message)
+          if case let .untagged(_, _, deferredLexicalModelSearch) = searchResult {
+            deferredLexicalModelSearch(.none)
           }
+          return
+        }
 
-          do {
-            if let resourceKey = resourceKey {
-              try ResourceFileManager.shared.install(resourceWithID: resourceKey, from: package)
-              finalize(as: .success(resourceKey))
-            } else {
+        switch searchResult {
+          case .untagged(_, _, let deferredLexicalModelSearch):
+            do {
               // TODO:  We don't know which resource the user actually wants.  Prompt them.
               // But for now, the old 'default' installation.
               try ResourceFileManager.shared.finalizePackageInstall(package, isCustom: false)
+              // Whatever solution we put in place should return (at least) one of these:
+              let resourceKey = package.installables.first!.first!.fullID
+
               // Yeah, it's ugly... but it's best to fix as part of resolution of the TODO above.
               // That's "the first language pairing of the first keyboard in the package."
-              finalize(as: .success(package.installables.first!.first!.fullID))
+              finalize(as: .success(resourceKey))
+              deferredLexicalModelSearch(.tag(resourceKey.languageID))
+            } catch {
+              finalize(as: .error(error), noCallbackLog: "Could not install package \(packageKey): \(error)")
+              deferredLexicalModelSearch(.none)
+              throw error // For more accurate notifications
             }
-          } catch {
-            finalize(as: .error(error), noCallbackLog: "Could not install package \(packageKey): \(error)")
-          }
+          case .tagged(_, _, let resourceKey):
+            do {
+              try ResourceFileManager.shared.install(resourceWithID: resourceKey, from: package)
+              finalize(as: .success(resourceKey))
+            } catch {
+              finalize(as: .error(error), noCallbackLog: "Could not install package \(packageKey): \(error)")
+              throw error // For more accurate notifications
+            }
+          default:
+            // Illegal state - we already checked this.
+            fatalError()
         }
-
-        downloadManager.downloadPackage(withKey: packageKey, from: packageURL, withNotifications: true, completionBlock: downloadClosure)
-      } else {
-        finalize(as: .cancelled)
       }
+
+      downloadManager.downloadPackage(withKey: packageKey, from: packageURL, withNotifications: true, completionBlock: downloadClosure)
     }
   }
 
@@ -246,30 +318,35 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
       dispatchGroup?.leave() // "fulfill" this closure's aspect of the group's synchronization scheme.
     }
 
-    return { packageKey, packageURL, resourceKey in
-      if let packageKey = packageKey, let packageURL = packageURL, let resourceKey = resourceKey {
-        var lmInstallClosure: ResourceDownloadManager.CompletionHandler<LexicalModelKeymanPackage>
-        lmInstallClosure = { package, error in
-          if let package = package, error == nil {
-            //  perform the actual installation
-            do {
-              try ResourceFileManager.shared.install(resourceWithID: resourceKey, from: package)
-              finalize(as: .success(resourceKey))
-            } catch {
-              finalize(as: .error(error), noCallbackLog: "Could not install \(resourceKey) from package \(packageKey): \(error)")
+    return { searchResult in
+      switch searchResult {
+        case .cancelled:
+          finalize(as: .cancelled)
+          return
+        case .tagged(let packageKey, let packageURL, let resourceKey):
+          var lmInstallClosure: ResourceDownloadManager.CompletionHandler<LexicalModelKeymanPackage>
+          lmInstallClosure = { package, error in
+            if let package = package, error == nil {
+              //  perform the actual installation
+              do {
+                try ResourceFileManager.shared.install(resourceWithID: resourceKey, from: package)
+                finalize(as: .success(resourceKey))
+              } catch {
+                finalize(as: .error(error), noCallbackLog: "Could not install \(resourceKey) from package \(packageKey): \(error)")
+                throw error
+              }
+            } else {
+              let errString = error != nil ? String(describing: error) : "<unknown error>"
+              let message = "Could not download package \(packageKey): \(errString)"
+
+              finalize(as: .error(error), noCallbackLog: message)
+              throw error ?? NSError()
             }
-          } else {
-            let errString = error != nil ? String(describing: error) : "<unknown error>"
-            let message = "Could not download package \(packageKey): \(errString)"
-
-            finalize(as: .error(error), noCallbackLog: message)
-            return
           }
-        }
 
-        downloadManager.downloadPackage(withKey: packageKey, from: packageURL, withNotifications: true, completionBlock: lmInstallClosure)
-      } else {
-        finalize(as: .cancelled)
+          downloadManager.downloadPackage(withKey: packageKey, from: packageURL, withNotifications: true, completionBlock: lmInstallClosure)
+        case .untagged(_, _, _):
+          fatalError() // Explicitly illegal state, as documented in the enum's definition.
       }
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -353,7 +353,13 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
   
   private func keyboardDownloadFailed() {
     log.info("keyboardDownloadFailed: InstalledLanguagesViewController")
+
+    if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
+      toolbar.displayStatus("Download unsuccessful", withIndicator: false, duration: 3.0)
+    }
     restoreNavigation()
+
+    navigationController?.popToRootViewController(animated: true)
   }
   
   private func lexicalModelDownloadFailed() {


### PR DESCRIPTION
Addresses a noted issue on #3384.

Sometimes we won't know the language tag to use for a package's resources until after it's been downloaded.  For these cases, we need a way to trigger the lexical model "search" after installation, rather than before.  (Admittedly, this was the standard case before #3384 anyway...)  An ideal solution would still allow us to trigger the lexical model "search" before installation when we do have foreknowledge of the language tag... and this PR makes that dream a reality.

When the `keyboardSelectionClosure` denotes an `.untagged` search result, it is provided with a custom-made closure that may be called after the package is installed.
- Providing it with `.none` (which should be used for installation failures) will abort the lexical-model search, calling the `lexicalModelSelectionClosure` with `.cancelled`.  
    - Allows code to be written that expects said closure to _always_ be called, which is one of my design goals for the `KeyboardSearchViewController`.
- Providing it with `.tag("km")` (as an example) will trigger a model search for the language tag `km`.

One big, overarching theme in this PR:  discriminated unions "for fun and profit."

----

There are two "throw-in"s:  
- During testing, a unique opportunity arose to test the engine's error-notification handling when a successfully downloaded package _unsuccessfully_ attempts an installation.
    - As error notification handling also needs to be addressed for #3384, I felt it to be "related enough".)
- The base PR previously neglected to call the closures when the view was dismissed manually; `.cancelled` is now sent for these cases.