### PR TITLE
fix(linux): Lookup language tag from keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -246,6 +246,9 @@ def install_kmp_user(inputfile, online=False, language=None):
         raise InstallError(InstallStatus.Abort, message)
 
 
+# The implementation of this method is a hack.
+# TODO: reimplement normalization according to langtags.json. See implementation for Windows once
+# that is in place.
 def _normalize_language(supportedLanguages, language):
     if len(supportedLanguages) <= 0:
         return ''

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -246,7 +246,25 @@ def install_kmp_user(inputfile, online=False, language=None):
         raise InstallError(InstallStatus.Abort, message)
 
 
+def _normalize_language(supportedLanguages, language):
+    if len(supportedLanguages) <= 0:
+        return ''
+
+    if not language:
+        return language
+
+    for supportedLanguage in supportedLanguages:
+        id = supportedLanguage['id']
+        if id == language or id.startswith(language + '-'):
+            return id
+    return None
+
+
 def install_keyboards(keyboards, packageDir, language=None):
+    firstKeyboard = keyboards[0]
+    if firstKeyboard and 'languages' in firstKeyboard and len(firstKeyboard['languages']) > 0:
+        language = _normalize_language(firstKeyboard['languages'], language)
+
     if is_gnome_shell():
         install_keyboards_to_gnome(keyboards, packageDir, language)
     else:

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -2,7 +2,8 @@
 import unittest
 from unittest.mock import patch, ANY
 
-from keyman_config.install_kmp import install_keyboards_to_ibus, install_keyboards_to_gnome
+from keyman_config.install_kmp import install_keyboards_to_ibus, install_keyboards_to_gnome, \
+    _normalize_language
 
 
 class InstallKmpTests(unittest.TestCase):
@@ -173,6 +174,37 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'de:fooDir/foo1.kmx')])
         self.mockRestartIbus.assert_not_called()
+
+    def test_normalizeLanguage(self):
+        # Setup
+        languages = [
+            {'id': 'de'},
+            {'id': 'esi-Latn'},
+        ]
+
+        for data in [
+            {'given': 'de', 'expected': 'de'},
+            {'given': 'esi', 'expected': 'esi-Latn'},
+            {'given': 'esi-Latn', 'expected': 'esi-Latn'},
+            {'given': 'es', 'expected': None},
+            {'given': 'en', 'expected': None},
+            {'given': None, 'expected': None},
+        ]:
+            # Execute
+            result = _normalize_language(languages, data['given'])
+
+            # Verify
+            self.assertEqual(result, data['expected'])
+
+    def test_normalizeLanguage_noLanguages(self):
+        # Setup
+        languages = []
+
+        # Execute
+        result = _normalize_language(languages, 'en')
+
+        # Verify
+        self.assertEqual(result, '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

When installing a keyboard with a bcp47 tag we now look up the
language tag in the keyboard kmp.json file. This fixes #3399 in
case a script subtag is required for the language and will cause
the keyboard to properly show up in the Linux keyboard selection
list.