### PR TITLE
refactor(ios/engine): package installer tweaks

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -229,6 +229,10 @@ public class KeymanPackage {
     return Key(for: self)
   }
 
+  public var name: String {
+    return self.metadata.info?.name?.description ?? id
+  }
+
   public func isKeyboard() -> Bool {
     return metadata.packageType == .Keyboard
   }
@@ -288,15 +292,23 @@ public class KeymanPackage {
   }
   
   public func infoHtml() -> String {
-    let welcomePath = self.sourceFolder.appendingPathComponent("welcome.htm")
-    
-    if FileManager.default.fileExists(atPath: welcomePath.path) {
-      if let html = try? String(contentsOfFile: welcomePath.path, encoding: String.Encoding.utf8) {
+    if let welcomeURL = self.welcomePageURL {
+      if let html = try? String(contentsOfFile: welcomeURL.path, encoding: String.Encoding.utf8) {
         return html
       }
     }
   
     return defaultInfoHtml()
+  }
+
+  public var welcomePageURL: URL? {
+    let welcomeURL = self.sourceFolder.appendingPathComponent("welcome.htm")
+
+    if FileManager.default.fileExists(atPath: welcomeURL.path) {
+      return welcomeURL
+    } else {
+      return nil
+    }
   }
 
   public var version: Version {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -472,6 +472,7 @@ public class KeymanPackage {
  */
 public class TypedKeymanPackage<TypedLanguageResource: LanguageResource>: KeymanPackage {
   public private(set) var installables: [[TypedLanguageResource]] = []
+  typealias Resource = TypedLanguageResource
 
   internal func setInstallableResourceSets<Resource: KMPResource>(for kmpResources: [Resource]) where
       TypedLanguageResource: KMPInitializableLanguageResource {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -47,10 +47,15 @@ public class PackageInstallViewController: UIViewController {
 
     navigationItem.leftBarButtonItem = cancelBtn
     navigationItem.rightBarButtonItem = installBtn
+    navigationItem.title = package.name
   }
 
   override public func viewWillAppear(_ animated: Bool) {
-    wkWebView?.loadHTMLString(package.infoHtml(), baseURL: nil)
+    if let welcomeURL = package.welcomePageURL {
+      wkWebView?.loadFileURL(welcomeURL, allowingReadAccessTo: package.sourceFolder)
+    } else {
+      wkWebView?.loadHTMLString(package.infoHtml(), baseURL: nil)
+    }
   }
 
   @objc func cancelBtnHandler() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -209,8 +209,12 @@ public class ResourceFileManager {
 
       if let fullIDs = fullIDs {
         do {
-          //try ResourceFileManager.shared.finalizePackageInstall(self.package, isCustom: self.isCustom)
           try ResourceFileManager.shared.install(resourcesWithIDs: fullIDs, from: package)
+
+          if package is KeyboardKeymanPackage {
+            // TODO(?): We might should attempt an automatic download + install of lexical models
+            // for the specified language codes.
+          }
         } catch {
           if let kmpError = error as? KMPError {
             let alert = self.buildKMPError(kmpError)


### PR DESCRIPTION
Aside from the design changes, there are a couple of bug fixes included with these changes:
- Images in a package's welcome.htm now display properly.
    - Previously,  the keyboard images in the screenshot below simply never appeared.
- Package-internal links (to pages, pdfs, etc) now work correctly.

Minor additional feature:
- the name of the package is now displayed in the package installer's title bar.  If no "pretty" name is specified within the kmp.json's data (info->name->description), it'll display the package's ID instead.
    - Before, the "Khmer Angkor" text between Cancel and Install did not exist.  This is from the name of the _package_, which _may_ (but does not _have to_) correspond to hosted resources.

![Screen Shot 2020-07-27 at 1 43 00 PM](https://user-images.githubusercontent.com/25213402/88511506-1b571480-d00f-11ea-9d89-8da4f647ece2.png)

-----

Finally, the "refactor" component of this PR.  As we've talked about displaying a prompt for the user to select the languages to use for newly-downloaded keyboards, a modificatios to the package-install prompt is in order.  In particular, the prompt no longer directly installs the package, instead leaving that to a closure provided by external code.  This gives external code more direct access to the context of any potential errors while also providing users of the class with richer, more meaningful information about what the user has chosen to install.  

Toward that end, the set of `FullID`s to install - _with their language tags_ - are 'returned' from the prompt.  In the case that a user is installing the package via universal link, these language tags will also be of use for downloading associated lexical models.

The plan for subsequent PRs:  
* to allow the user to select the language pairings to install, rather than merely choosing a default set.
* to display this prompt when installing a package from keyboard search under the following conditions:
    - The package is not language-tagged
    - The package supports more than one language
    - Note that currently, this view does not appear as part of the keyboard search UX.
        - To integrate it there will require a bit of work due to interactions with how chained lexical models are currently implemented. (A motivating factor toward the 'refactor' component of this PR.)