### PR TITLE
refactor(windows): refactor Dialog elements

### DIFF
--- a/windows/src/desktop/kmshell/xml/basekeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/basekeyboard.xsl
@@ -4,7 +4,7 @@
 
   <xsl:include href="elements.xsl"/>
 
-  <xsl:variable name="locale_basekeyboard" select="$locale/Dialog[@Id='BaseKeyboard'][1]" />
+  <xsl:variable name="dialoginfo_basekeyboard" select="$dialoginfo/Dialog[@Id='BaseKeyboard'][1]" />
 
   <xsl:template match="/">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -22,8 +22,8 @@ html {
  text-align:	justify;
  margin: 	 0px;
  padding: 0;
- width:    <xsl:value-of select="$locale_basekeyboard/@Width" />px;
- height:   <xsl:value-of select="$locale_basekeyboard/@Height" />px;
+ width:    <xsl:value-of select="$dialoginfo_basekeyboard/@Width" />px;
+ height:   <xsl:value-of select="$dialoginfo_basekeyboard/@Height" />px;
  overflow: hidden;
 }
 
@@ -32,8 +32,8 @@ body {
  text-align:	justify;
  padding: 0;
  margin:	 0px;
- width:    <xsl:value-of select="$locale_basekeyboard/@Width" />px;
- height:   <xsl:value-of select="$locale_basekeyboard/@Height" />px;
+ width:    <xsl:value-of select="$dialoginfo_basekeyboard/@Width" />px;
+ height:   <xsl:value-of select="$dialoginfo_basekeyboard/@Height" />px;
  overflow: hidden;
 }
 
@@ -55,8 +55,8 @@ div {
   position: absolute;
   left: 0;
   top: 0;
-  width: <xsl:value-of select="$locale_basekeyboard/@Width - 2" />px;
-  height: <xsl:value-of select="$locale_basekeyboard/@Height - 2" />px;
+  width: <xsl:value-of select="$dialoginfo_basekeyboard/@Width - 2" />px;
+  height: <xsl:value-of select="$dialoginfo_basekeyboard/@Height - 2" />px;
   }
 
 #content {
@@ -66,7 +66,7 @@ div {
 
 #footer {
   position: absolute;
-  top: expression(<xsl:value-of select="$locale_basekeyboard/@Height" /> - 36);
+  top: expression(<xsl:value-of select="$dialoginfo_basekeyboard/@Height" /> - 36);
   height: 36px;
   text-align: center;
   width: 100%;

--- a/windows/src/desktop/kmshell/xml/dialoginfo.xml
+++ b/windows/src/desktop/kmshell/xml/dialoginfo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<DialogInfo>
+  <Dialog Id="Keyman" Version="7.0.230.0" Width="740" Height="476">
+    <footerheight>40</footerheight>
+    <menuwidth>118</menuwidth>
+    <headerheight>40</headerheight>
+  </Dialog>
+
+  <Dialog Id="DownloadKeyboard" Width="740" Height="400">
+    <footerheight>40</footerheight>
+  </Dialog>
+
+  <Dialog Id="InstallKeyboard" Width="600" Height="300" />
+
+  <Dialog Id="ProxyConfiguration" Width="240" Height="176" />
+
+  <Dialog Id="BaseKeyboard" Width="512" Height="160" />
+
+  <Dialog Id="OnlineUpdate" Width="470" Height="260" />
+
+  <Dialog Id="Splash" Width="630" Height="450" />
+
+  <Dialog Id="Hint" Width="450" Height="300">
+    <footerheight>40</footerheight>
+    <headerheight>40</headerheight>
+  </Dialog>
+
+  <Dialog Id="Help" Width="450" Height="300"></Dialog>
+</DialogInfo>

--- a/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
@@ -4,7 +4,7 @@
 
   <xsl:include href="elements.xsl"/>
 
-  <xsl:variable name="locale_downloadkeyboard" select="$locale/Dialog[@Id='DownloadKeyboard'][1]" />
+  <xsl:variable name="dialoginfo_downloadkeyboard" select="$dialoginfo/Dialog[@Id='DownloadKeyboard'][1]" />
 
   <xsl:template match="/">
     <html xmlns="http://www.w3.org/1999/xhtml">
@@ -19,15 +19,15 @@
 
             body {
               padding: 0px; margin: 0px; overflow: hidden;
-              width: <xsl:value-of select="$locale_downloadkeyboard/@Width" />px;
-              height: <xsl:value-of select="$locale_downloadkeyboard/@Height" />px;
+              width: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Width" />px;
+              height: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Height" />px;
             }
             html { width: 100%; padding: 0px; margin: 0px; overflow: hidden }
 
             #size {
               position: absolute;
-              width: <xsl:value-of select="$locale_downloadkeyboard/@Width" />px;
-              height: <xsl:value-of select="$locale_downloadkeyboard/@Height" />px;
+              width: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Width" />px;
+              height: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Height" />px;
             }
 
             #contentframe {
@@ -35,15 +35,15 @@
               left: 0;
               top: 0;
               width: 100%;
-              height: <xsl:value-of select="$locale_downloadkeyboard/@Height - $locale_downloadkeyboard/footerheight" />px;
+              height: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Height - $dialoginfo_downloadkeyboard/footerheight" />px;
               border-bottom: 2px solid #888888;
               overflow: scroll;
               }
             #footerframe {
               position: absolute;
               left: 0px;
-              top: <xsl:value-of select="$locale_downloadkeyboard/@Height - $locale_downloadkeyboard/footerheight" />px;
-              height: <xsl:value-of select="$locale_downloadkeyboard/footerheight" />px;
+              top: <xsl:value-of select="$dialoginfo_downloadkeyboard/@Height - $dialoginfo_downloadkeyboard/footerheight" />px;
+              height: <xsl:value-of select="$dialoginfo_downloadkeyboard/footerheight" />px;
               width: 100%;
               overflow: hidden;
               background: #dcdcdc;

--- a/windows/src/desktop/kmshell/xml/elements.xsl
+++ b/windows/src/desktop/kmshell/xml/elements.xsl
@@ -6,11 +6,12 @@
 
   <!-- I978 - locale was not reliably selected due to undefined order of document() loading and | processing -->
   <xsl:variable name="prilocale" select="document(/Keyman/localepath)/Locale" />
-  <xsl:variable name="altlocale" select="document(/Keyman/defaultlocalepath)/Locale/*[not(@Id = $prilocale//@Id)]" />
+  <xsl:variable name="altlocale" select="document('locale.xml')/Locale/*[not(@Id = $prilocale//@Id)]" />
   <xsl:variable name="comlocale">
       <xsl:copy-of select="$prilocale/*" />
       <xsl:copy-of select="$altlocale" />
   </xsl:variable>
+  <xsl:variable name="dialoginfo" select="document('dialoginfo.xml')/DialogInfo" />
   <xsl:variable name="locale" select="msxsl:node-set($comlocale)" />
 
   <!--

--- a/windows/src/desktop/kmshell/xml/help.xsl
+++ b/windows/src/desktop/kmshell/xml/help.xsl
@@ -4,7 +4,7 @@
 
 	<xsl:include href="elements.xsl"/>
 
-	<xsl:variable name="locale_help" select="$locale/Dialog[@Id='Help'][1]" />
+	<xsl:variable name="dialoginfo_help" select="$dialoginfo/Dialog[@Id='Help'][1]" />
 
 	<xsl:template match="/">
 
@@ -19,8 +19,8 @@
 					* { font-family: <xsl:value-of select="($locale/String[@Id='SK_UIFontName'])[1]" />, "Segoe UI"; font-size: 13.3px; }
 
 					body { padding: 0px; margin: 0px; overflow: hidden;
-					width: <xsl:value-of select="$locale_help/@Width" />px;
-					height: <xsl:value-of select="$locale_help/@Height" />px;
+					width: <xsl:value-of select="$dialoginfo_help/@Width" />px;
+					height: <xsl:value-of select="$dialoginfo_help/@Height" />px;
 					background: white; border: none; }
 					html { padding: 0px; margin: 0px; overflow: hidden; }
 
@@ -30,8 +30,8 @@
 					}
 
 					#size { position: absolute; left: 0; top: 0;
-						width: <xsl:value-of select="$locale_help/@Width" />px;
-						height: <xsl:value-of select="$locale_help/@Height" />px;
+						width: <xsl:value-of select="$dialoginfo_help/@Width" />px;
+						height: <xsl:value-of select="$dialoginfo_help/@Height" />px;
           }
 
           #captionBox {

--- a/windows/src/desktop/kmshell/xml/hint.xsl
+++ b/windows/src/desktop/kmshell/xml/hint.xsl
@@ -4,7 +4,7 @@
 
 	<xsl:include href="elements.xsl"/>
 
-	<xsl:variable name="locale_hint" select="$locale/Dialog[@Id='Hint'][1]" />
+	<xsl:variable name="dialoginfo_hint" select="$dialoginfo/Dialog[@Id='Hint'][1]" />
 	<xsl:variable name="HintTitle">HintTitle_<xsl:value-of select="/Keyman/Hint/@ID" /></xsl:variable>
 	<xsl:variable name="Hint">Hint_<xsl:value-of select="/Keyman/Hint/@ID" /></xsl:variable>
 
@@ -23,8 +23,8 @@
             font-family: <xsl:value-of select="($locale/String[@Id='SK_UIFontName'])[1]" />, "Segoe UI";
           }
 					#container {
-  					width: <xsl:value-of select="$locale_hint/@Width" />px;
-	  				height: <xsl:value-of select="$locale_hint/@Height" />px;
+  					width: <xsl:value-of select="$dialoginfo_hint/@Width" />px;
+	  				height: <xsl:value-of select="$dialoginfo_hint/@Height" />px;
           }
 
         </style>

--- a/windows/src/desktop/kmshell/xml/installkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.xsl
@@ -4,7 +4,7 @@
 
   <xsl:include href="elements.xsl" />
 
-  <xsl:variable name="locale_installkeyboard" select="$locale/Dialog[@Id='InstallKeyboard'][1]" />
+  <xsl:variable name="dialoginfo_installkeyboard" select="$dialoginfo/Dialog[@Id='InstallKeyboard'][1]" />
 
   <xsl:template match="/">
     <html>
@@ -21,20 +21,20 @@
           }
 
           #background {
-            width: <xsl:value-of select="$locale_installkeyboard/@Width" />px;
-            height: <xsl:value-of select="$locale_installkeyboard/@Height" />px;
+            width: <xsl:value-of select="$dialoginfo_installkeyboard/@Width" />px;
+            height: <xsl:value-of select="$dialoginfo_installkeyboard/@Height" />px;
           }
           #foreground {
-            width: <xsl:value-of select="$locale_installkeyboard/@Width" />px;
-            height: <xsl:value-of select="$locale_installkeyboard/@Height" />px;
+            width: <xsl:value-of select="$dialoginfo_installkeyboard/@Width" />px;
+            height: <xsl:value-of select="$dialoginfo_installkeyboard/@Height" />px;
           }
 
           #frame {
-            width: <xsl:value-of select="$locale_installkeyboard/@Width - 20" />px;
+            width: <xsl:value-of select="$dialoginfo_installkeyboard/@Width - 20" />px;
           }
 
           #footer {
-            width: <xsl:value-of select="$locale_installkeyboard/@Width - 16" />px;
+            width: <xsl:value-of select="$dialoginfo_installkeyboard/@Width - 16" />px;
           }
         </style>
         <script src="/app/installkeyboard.js"></script>

--- a/windows/src/desktop/kmshell/xml/locale.xml
+++ b/windows/src/desktop/kmshell/xml/locale.xml
@@ -38,13 +38,6 @@ Create a user interface translation for Keyman for Windows at https://crowdin.co
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <String Group="Configuration Dialog" Type="PlainText" Id="S_ConfigurationTitle" Version="7.0.230.0" Description="Configuration dialog title, which includes the product name">&Name; Configuration</String>
-
-<Dialog Id="Keyman" Version="7.0.230.0" Width="740" Height="476">
-  <footerheight>40</footerheight>
-  <menuwidth>118</menuwidth>
-  <headerheight>40</headerheight>
-</Dialog>
-
 <String Group="Configuration Dialog" Type="PlainText" Id="S_Caption_Help" Version="7.0.239.0" Description="Configuration dialog link to Help">Help</String>
 
 <!-- Tab names and shortcut keys -->
@@ -180,10 +173,6 @@ Create a user interface translation for Keyman for Windows at https://crowdin.co
 <!-- Download Keyboard Layout Dialog   -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<Dialog Id="DownloadKeyboard" Width="740" Height="400">
-  <footerheight>40</footerheight>
-</Dialog>
-
 <String Group="Download Keyboard Dialog" Type="PlainText" Id="S_DownloadKeyboard_Title" Version="7.0.230.0" Description="Download keyboard layout from keyman.com dialog title">Download Keyboard From keyman.com</String>
 <String Group="Download Keyboard Dialog" Type="PlainText" Id="S_DownloadKeyboard_DownloadOnlyCheckbox" Version="7.0.230.0" Description="Download only option checkbox">Don't install, just download</String>
 
@@ -192,8 +181,6 @@ Create a user interface translation for Keyman for Windows at https://crowdin.co
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <!-- Note: this dialog uses captions from the Configuration dialog as well -->
-
-<Dialog Id="InstallKeyboard" Width="600" Height="300" />
 
 <String Group="Install Keyboard Dialog" Type="PlainText" Id="S_InstallKeyboard_Title" Version="7.0.230.0" Description="Install keyboard/package dialog title">Install Keyboard/Package</String>
 
@@ -206,8 +193,6 @@ Create a user interface translation for Keyman for Windows at https://crowdin.co
 <!-- Proxy Configuration Dialog        -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<Dialog Id="ProxyConfiguration" Width="240" Height="176" />
-
 <String Group="Proxy Configuration Dialog" Type="PlainText" Id="S_ProxyConfiguration_Title" Version="7.0.230.0" Description="Proxy configuration dialog title">Proxy Server Configuration</String>
 
 <String Group="Proxy Configuration Dialog" Type="PlainText" Id="S_ProxyConfiguration_Server" Version="7.0.230.0" Description="Proxy dialog - fillable-field server">Server: </String>
@@ -218,8 +203,6 @@ Create a user interface translation for Keyman for Windows at https://crowdin.co
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Base Keyboard Dialog        -->
 <!-- - - - - - - - - - - - - - - - - - -->
-
-<Dialog Id="BaseKeyboard" Width="512" Height="160" />
 
 <String Group="Base Keyboard Dialog" Type="PlainText" Id="S_BaseKeyboard_Title" Version="9.0.445.0" Description="Base keyboard dialog title">Set Base Keyboard</String>
 <String Group="Base Keyboard Dialog" Type="PlainText" Id="S_BaseKeyboard_Text" Version="9.0.445.0" Description="Base keyboard dialog description">Select the base Latin script
@@ -241,8 +224,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Online Update Dialog              -->
 <!-- - - - - - - - - - - - - - - - - - -->
-
-<Dialog Id="OnlineUpdate" Width="470" Height="260" />
 
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_Title" Version="7.0.230.0" Description="Update dialog title, where &Name; = product name">Updated &Name; Components Available</String>
 
@@ -273,8 +254,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
 <!-- Splash Dialog                     -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<Dialog Id="Splash" Width="630" Height="450" />
-
 <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_Name" Version="8.0.288.0" Description="Splash major title">&Name;</String>
 
 <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_Start" Version="8.0.294.0" Description="Start Keyman button">Start &Name;</String>
@@ -301,11 +280,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
 <!-- Hints                             -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<Dialog Id="Hint" Width="450" Height="300">
-	<footerheight>40</footerheight>
-	<headerheight>40</headerheight>
-</Dialog>
-
 <String Group="Hints" Type="PlainText" Id="S_Button_ResetHints" Version="7.0.244.0" Description="Hint - options tab button to reset hints">Reset Hints</String>
 <String Group="Hints" Type="PlainText" Id="SKHintsReset" Version="7.0.244.0" Description="Hint - options tab dialog confirming reset of hints">All hint messages have been reset and will be displayed again.</String>
 
@@ -322,7 +296,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
 <!-- Help                              -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<Dialog Id="Help" Width="450" Height="300"></Dialog>
 <String Group="Help Dialog" Type="PlainText" Id="S_HelpTitle" Version="7.0.230.0" Description="Help - product name help">&Name; Help</String>
 <String Group="Help Dialog" Type="PlainText" Id="S_Help_Product" Version="7.0.230.0" Description="Help - help contents link title">Help Contents</String>
 

--- a/windows/src/desktop/kmshell/xml/onlineupdate.xsl
+++ b/windows/src/desktop/kmshell/xml/onlineupdate.xsl
@@ -4,7 +4,7 @@
 
   <xsl:include href="elements.xsl"/>
 
-  <xsl:variable name="locale_onlineupdate" select="$locale/Dialog[@Id='OnlineUpdate'][1]" />
+  <xsl:variable name="dialoginfo_onlineupdate" select="$dialoginfo/Dialog[@Id='OnlineUpdate'][1]" />
 
   <xsl:template match="/">
 
@@ -46,8 +46,8 @@ div {
 
 #border {
   border: none;
-  width: <xsl:value-of select="$locale_onlineupdate/@Width - 2" />px;
-  height: <xsl:value-of select="$locale_onlineupdate/@Height - 2" />px;
+  width: <xsl:value-of select="$dialoginfo_onlineupdate/@Width - 2" />px;
+  height: <xsl:value-of select="$dialoginfo_onlineupdate/@Height - 2" />px;
   }
 
 #header { background: white;  }

--- a/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
+++ b/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
@@ -4,7 +4,7 @@
 
   <xsl:include href="elements.xsl"/>
 
-  <xsl:variable name="locale_proxyconfiguration" select="$locale/Dialog[@Id='ProxyConfiguration'][1]" />
+  <xsl:variable name="dialoginfo_proxyconfiguration" select="$dialoginfo/Dialog[@Id='ProxyConfiguration'][1]" />
 
   <xsl:template match="/">
 
@@ -20,8 +20,8 @@ html {
  font-size:		 13px;
  text-align:	justify;
  margin: 	 0px;
- width:    <xsl:value-of select="$locale_proxyconfiguration/@Width" />px;
- height:   <xsl:value-of select="$locale_proxyconfiguration/@Height" />px;
+ width:    <xsl:value-of select="$dialoginfo_proxyconfiguration/@Width" />px;
+ height:   <xsl:value-of select="$dialoginfo_proxyconfiguration/@Height" />px;
  overflow: hidden;
 }
 
@@ -29,8 +29,8 @@ body {
  font-size:	 	 13px;
  text-align:	justify;
  margin:	 0px;
- width:    <xsl:value-of select="$locale_proxyconfiguration/@Width" />px;
- height:   <xsl:value-of select="$locale_proxyconfiguration/@Height" />px;
+ width:    <xsl:value-of select="$dialoginfo_proxyconfiguration/@Width" />px;
+ height:   <xsl:value-of select="$dialoginfo_proxyconfiguration/@Height" />px;
  overflow: hidden;
 }
 
@@ -45,8 +45,8 @@ div {
 
 #border {
   border: 1px solid #AD4A29;
-  width: <xsl:value-of select="$locale_proxyconfiguration/@Width - 2" />px;
-  height: <xsl:value-of select="$locale_proxyconfiguration/@Height - 2" />px;
+  width: <xsl:value-of select="$dialoginfo_proxyconfiguration/@Width - 2" />px;
+  height: <xsl:value-of select="$dialoginfo_proxyconfiguration/@Height - 2" />px;
   }
 #content {
  padding: 10px;

--- a/windows/src/desktop/kmshell/xml/splash.xsl
+++ b/windows/src/desktop/kmshell/xml/splash.xsl
@@ -3,7 +3,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:include href="elements.xsl"/>
-  <xsl:variable name="locale_splash" select="$locale/Dialog[@Id='Splash'][1]" />
+  <xsl:variable name="locale_splash" select="$dialoginfo/Dialog[@Id='Splash'][1]" />
   <xsl:template match="/">
 
 <html>


### PR DESCRIPTION
Removes Dialog elements from locale.xml and places them in dialoginfo.xml. These may be eliminated entirely at some point.

The next step is to convert locale.xml to strings.xml, now that the non-string data has been removed from locale.xml. (Again, I don't need to do this with the translations because that will be cleaned up automatically when we do the conversion.)