### PR TITLE
feat(android): Add app association to keyman.com

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -192,7 +192,7 @@
 
       </intent-filter>
 
-      <intent-filter>
+      <intent-filter android:autoVerify="true">
         <!-- cloud keyboard package download links https://{HOST}/go/package/download/
              Use {HOST} as defined in KMPLink.java -->
         <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Following the reference from https://developer.android.com/training/app-links/verify-site-associations

> When `android:autoVerify="true"` is present on any one of your intent filters, installing your app on devices with Android 6.0 and higher causes the system to attempt to verify all hosts associated with the URLs in any of your app's intent filters.