### PR TITLE
fix(android): Update KMPBrowser to pass external links to user browser

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -44,7 +44,7 @@ public class KMPBrowserActivity extends AppCompatActivity {
   // Patterns for determining if a link should be opened in external browser
   // 1. Host isn't keyman.com (production/staging)
   // 2. Host is keyman.com but not /keyboards/
-  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(\\/)?(.+)?$";
+  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/)?(.+)?$";
   private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
     KMPLink.KMP_PRODUCTION_HOST,
     KMPLink.KMP_STAGING_HOST);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -44,7 +44,7 @@ public class KMPBrowserActivity extends AppCompatActivity {
   // Patterns for determining if a link should be opened in external browser
   // 1. Host isn't keyman.com (production/staging)
   // 2. Host is keyman.com but not /keyboards/
-  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/.*)?$";
+  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/?.*)?$";
   private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
     KMPLink.KMP_PRODUCTION_HOST,
     KMPLink.KMP_STAGING_HOST);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -44,7 +44,7 @@ public class KMPBrowserActivity extends AppCompatActivity {
   // Patterns for determining if a link should be opened in external browser
   // 1. Host isn't keyman.com (production/staging)
   // 2. Host is keyman.com but not /keyboards/
-  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/?.*)?$";
+  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards([/?].*)?$";
   private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
     KMPLink.KMP_PRODUCTION_HOST,
     KMPLink.KMP_STAGING_HOST);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -40,6 +40,16 @@ public class KMPBrowserActivity extends AppCompatActivity {
   // URL for keyboard search web page presented to user when they add a keyboard in the app.
   private static final String KMP_SEARCH_KEYBOARDS_FORMATSTR = "https://%s/go/android/%s/download-keyboards%s";
   private static final String KMP_SEARCH_KEYBOARDS_LANGUAGES = "/languages/%s";
+
+  // Patterns for determining if a link should be opened in external browser
+  // 1. Host isn't keyman.com (production/staging)
+  // 2. Host is keyman.com but not /keyboards/
+  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(\\/)?(.+)?$";
+  private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
+    KMPLink.KMP_PRODUCTION_HOST,
+    KMPLink.KMP_STAGING_HOST);
+  private static final Pattern keyboardPattern = Pattern.compile(keyboardPatternFormatStr);
+
   private WebView webView;
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
@@ -88,6 +98,13 @@ public class KMPBrowserActivity extends AppCompatActivity {
 
           // Finish activity
           finish();
+        } else if (!isKeymanKeyboardsLink(url)) {
+          Uri uri = Uri.parse(url);
+
+          // All links that aren't internal Keyman keyboard links open in user's browser
+          Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+          startActivity(intent);
+          return true;
         }
         if (lowerURL.startsWith("keyman:")) {
           // Warn for unsupported keyman schemes
@@ -168,4 +185,21 @@ public class KMPBrowserActivity extends AppCompatActivity {
     }
   }
 
+  /**
+   * Check if a URL is a valid internal Keyman keyboard link
+   * @param url String of the URL to parse
+   * @return boolean
+   */
+  public boolean isKeymanKeyboardsLink(String url) {
+    boolean status = false;
+    if (url == null || url.isEmpty()) {
+      return status;
+    }
+    Matcher matcher = keyboardPattern.matcher(url);
+    if (matcher.matches()) {
+      status = true;
+    }
+
+    return status;
+  }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMPBrowserActivity.java
@@ -44,7 +44,7 @@ public class KMPBrowserActivity extends AppCompatActivity {
   // Patterns for determining if a link should be opened in external browser
   // 1. Host isn't keyman.com (production/staging)
   // 2. Host is keyman.com but not /keyboards/
-  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/)?(.+)?$";
+  private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards(/.*)?$";
   private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
     KMPLink.KMP_PRODUCTION_HOST,
     KMPLink.KMP_STAGING_HOST);


### PR DESCRIPTION
KMPBrowserActivity should only be handling Keyman `/keyboards/` links. All other links should go to the user's browser.

### User Testing
@MakaraSok 
Install and launch Keyman
- [x] Verify keyboard installs
1. Access keyboards search via Settings --> "Install Keyboard or Dictionary" --> "Install from keyman.com"
2. Search for a keyboard (e.g. khmer_angkor) and click on the resulting keyboard
3. Click the green button and install the keyboard
4. Verify the keyboard installs

- [x] Verify external links launch user browser (e.g. Chrome)
1. Access keyboards search via "Settings" --> "Install Keyboard or Dictionary" --> "Install from keyman.com"
2. Search for another keyboard (e.g. basic_kbdkni) and click on the resulting keyboard
3. Do not install the keyboard. Instead, scroll down to "Keyboard Details" and click Documentation: "Keyboard help"
4. Verify the help link opens in an external user browser (should see browser bar that you can edit)
