### PR TITLE
feat(android/app): Associate app with /keyboards/install links

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -194,7 +194,6 @@
 
       <intent-filter android:autoVerify="true">
         <!-- KMPBrowserActivity converts cloud keyboard package links from http(s)://{HOST}/keyboards/install into /go/package/download
-             KMAPro should be able to handle both links.
              Use {HOST} as defined in KMPLink.java
              Also note, Manifest will OR all the scheme/host/pathPrefix combinations -->
         <action android:name="android.intent.action.VIEW" />
@@ -211,6 +210,15 @@
           android:host="keyman.com"
           android:scheme="https"
           android:pathPrefix="/go/package/download" />
+
+      </intent-filter>
+
+      <intent-filter>
+        <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
 
         <data
           android:host="keyman-staging.com"

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -193,8 +193,10 @@
       </intent-filter>
 
       <intent-filter android:autoVerify="true">
-        <!-- cloud keyboard package download links https://{HOST}/go/package/download/
-             Use {HOST} as defined in KMPLink.java -->
+        <!-- KMPBrowserActivity converts cloud keyboard package links from http(s)://{HOST}/keyboards/install into /go/package/download
+             KMAPro should be able to handle both links.
+             Use {HOST} as defined in KMPLink.java
+             Also note, Manifest will OR all the scheme/host/pathPrefix combinations -->
         <action android:name="android.intent.action.VIEW" />
 
         <category android:name="android.intent.category.DEFAULT" />
@@ -202,7 +204,7 @@
 
         <data
           android:host="keyman-staging.com"
-          android:scheme="https"
+          android:scheme="http"
           android:pathPrefix="/go/package/download" />
 
         <data
@@ -210,8 +212,20 @@
           android:scheme="https"
           android:pathPrefix="/go/package/download" />
 
+        <data
+          android:host="keyman-staging.com"
+          android:scheme="http"
+          android:pathPrefix="/keyboards/install" />
+
+        <data
+          android:host="keyman.com"
+          android:scheme="https"
+          android:pathPrefix="/keyboards/install" />
+
       </intent-filter>
+
     </activity>
+
     <activity
       android:name=".InfoActivity"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -358,6 +358,11 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           break;
         case "http" :
         case "https" :
+          // Might need to modify link like KMPBrowserActivity
+          String link = data.toString();
+          if (KMPLink.isKeymanInstallLink(link)) {
+            data = KMPLink.getKeyboardDownloadLink(link);
+          }
           downloadKMP(scheme);
           break;
         case "keyman" :


### PR DESCRIPTION
Follow-on to #3343 and circling back to a [point](https://github.com/keymanapp/keyman/pull/3343/files#r455287611) @mcdurdin raised in the review 😞 
> That is, if I visit that link from Chrome, will it open Keyman? (It shouldn't -- only the /keyboards/install/ links should)

At the moment, KMPBrowserActivity converts `/keyboards/install` links to the necessary `/go/package/download` for the main app to process.

This PR updates the Android Manifest to associate the Keyman app with `/keyboards/install` links in case an external browser is generating the Keyman keyboard search. This way, the intent routes through the main app to create the `/go/package/download` link and install the keyboard package.

Also tweaks the scheme to include 'http' (all the scheme/host combinations will end up in the merged Manifest file).