### PR TITLE
feat(ios/engine): LanguagePickAssociator progress tracking, base integration with package lang picker

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -357,6 +357,10 @@ public class KeymanPackage {
     fatalError("abstract base method went unimplemented by derived class")
   }
 
+  public func installableResources(forLanguage lgCode: String) -> [AnyLanguageResource] {
+    return installableResourceSets.flatMap { $0.filter { $0.languageID == lgCode }}
+  }
+
   /**
    * Parses a decompressed KMP's metadata file, producing the typed KeymanPackage instance corresponding to it.
    *
@@ -508,6 +512,10 @@ public class TypedKeymanPackage<TypedLanguageResource: LanguageResource>: Keyman
   // See https://forums.swift.org/t/confusing-limitations-on-covariant-overriding/16252
   public override var installableResourceSets: [[AnyLanguageResource]] {
     return installables
+  }
+
+  public func installables(forLanguage lgCode: String) -> [TypedLanguageResource] {
+    return super.installableResources(forLanguage: lgCode) as! [TypedLanguageResource]
   }
 
   public func findResource(withID fullID: TypedLanguageResource.FullID) -> TypedLanguageResource? {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -36,7 +36,8 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   @IBOutlet weak var ipadTagWidthConstraint: NSLayoutConstraint?
 
   // iPhone layout only
-  @IBOutlet weak var iphoneTabViewController: UITabBarController!
+  // Do _NOT_ use `weak` here - things break otherwise.
+  @IBOutlet var iphoneTabViewController: UITabBarController!
 
   let package: Resource.Package
   var wkWebView: WKWebView?

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -219,6 +219,7 @@ public class ResourceFileManager {
           if let kmpError = error as? KMPError {
             let alert = self.buildKMPError(kmpError)
             rootVC.present(alert, animated: true, completion: nil)
+            return
           }
         }
 


### PR DESCRIPTION
Following from #3451, this PR implements the progress-tracking infrastructure needed for the ideas noted as "future thoughts" in the description.  It requires a shift in the callback's signature, so it's best to get it out of the way before 14.0 lands.

This also gives us more fine-grained info for use in `LanguagePickAssociator`'s unit tests, and the new information itself is easily unit-testable.

Basic integration with the `PackageInstallViewController` has also been added, though no code yet actually provides it with associators.  That's left to future work.