### PR TITLE
chore(android): Add script to find unused strings. Manually remove them

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -82,9 +82,7 @@
   <string name="install_predictive_text_package">Install Predictive Text Package %1$s</string>
   <string name="no_new_touch_keyboards_to_install">No new touch-optimized keyboards to install</string>
   <string name="no_new_predictive_text_to_install">No new predictive text to install</string>
-  <string name="no_valid_touch_keyboards_to_install">No valid touch-optimized keyboards to install</string>
   <string name="no_targets_to_install">No keyboards or predictive text to install</string>
-  <string name="missing_metadata" comment="kmp.json file is missing from the keyboard package">kmp.json does not exist</string>
-  <string name="invalid_metadata">Invalid metadata in package</string>
+  <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Invalid/Missing metadata in package</string>
 
 </resources>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/LanguageSettingsActivity.java
@@ -166,7 +166,7 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
 
     layout = (RelativeLayout)findViewById(R.id.model_picker);
     textView = (TextView) layout.findViewById(R.id.text1);
-    textView.setText(getString(R.string.model));
+    textView.setText(getString(R.string.model_label));
 
     lexicalModelTextView = layout.findViewById(R.id.text2);
 

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -33,9 +33,6 @@
     <string name="confirm_delete_keyboard">Would you like to delete this keyboard?</string>
     <string name="confirm_download_keyboard">Would you like to download the latest version of this keyboard?</string>
     <string name="confirm_update">Would you like to update keyboards and dictionaries now?</string>
-    <string name="custom_keyboard">Custom Keyboard</string>
-    <string name="font_failed_to_download">Warning: Font failed to download</string>
-    <string name="keyboard_failed_to_download">Error: Keyboard failed to download</string>
     <string name="keyboard_updates_channel">Resource Updates</string>
     <string name="keyboard_updates_available">Resource Updates Available</string>
     <string name="update_available">%1$s (Update Available)</string>
@@ -79,7 +76,7 @@
     <!-- Language Settings menu strings -->
     <string name="enable_corrections">Enable corrections</string>
     <string name="enable_predictions">Enable predictions</string>
-    <string name="model">Dictionary</string>
+    <string name="model_label">Dictionary</string>
     <string name="model_info_header" comment="Dictionary name">Dictionary: %1$s</string>
     <string name="model_picker_header">%1$s dictionaries</string>
     <string name="manage_dictionary">Manage dictionary</string>

--- a/android/utility/.gitignore
+++ b/android/utility/.gitignore
@@ -1,0 +1,3 @@
+detail.md
+summary.md
+strings.txt

--- a/android/utility/i18n-check-unused-strings.sh
+++ b/android/utility/i18n-check-unused-strings.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Based on /windows/src/test/i18n-check-unused-strings
 #
 # This script finds all references to strings in strings.xml in order to make sure that old
 # strings do not proliferate over time. The script generates the following files:
@@ -51,7 +52,6 @@ while IFS= read -r string; do
   count=$(grep -Inr \
     --exclude=strings.xml \
     --exclude-dir=utility \
-    --exclude-dir=__history \
     "$string" \
     "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/res/layout" "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/res/menu" "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/java" \
     "$KEYMAN_ROOT/android/KMEA/app/src/main/res/layout" "$KEYMAN_ROOT/android/KMEA/app/src/main/java" | tee -a detail.md | wc -l)

--- a/android/utility/i18n-check-unused-strings.sh
+++ b/android/utility/i18n-check-unused-strings.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#
+# This script finds all references to strings in strings.xml in order to make sure that old
+# strings do not proliferate over time. The script generates the following files:
+#
+# * strings.txt: A plain-text list of all string identifiers found in strings.xml.
+# * summary.md: A summary of number of matches for each string found.
+# * details.md: List of every reference to each string found
+#
+# Note that you should review the results with care; some strings may not ever be found,
+# because they may be metadata such as "author of translation", or they may have been
+# added as part of upcoming functionality; they may also be found in temporary files and
+# build artifacts. Because of this, and because the script takes a little while to run,
+# I'm not adding the script to the standard build at this time.
+#
+# Note: strings that aren't expected to be found generally should have `translateable="false"`` so they don't get 
+# translated in crowdin.
+#
+
+set -e # die on non-zero exit code
+set -u # die on undefined variables
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# Preparation
+
+echo "# List of localized string usage" > detail.md
+echo "Collected at: $(date)" >> detail.md
+echo >> detail.md
+
+echo "# Summary of localized string usage" | tee summary.md
+echo "Collected at: $(date)" | tee -a summary.md
+echo | tee -a summary.md
+echo " Count | String | Flag" | tee -a summary.md
+echo "-------|--------|------" | tee -a summary.md
+
+# Lazy extract all identifiers from strings.xml into local strings.txt
+# Note that this relies on the XML following a single line per string pattern
+# (up to the name attribute, anyway) but this is good enough for now.
+
+grep -oP '<string.+name="(.+?)"' \
+  "$KEYMAN_ROOT/android/KMEA/app/src/main/res/values/strings.xml" "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/res/values/strings.xml" | grep -oP 'name="(.+?)"' | awk -F[\"] '{print $2}' > strings.txt
+
+while IFS= read -r string; do
+  echo "## $string" >> detail.md
+  count=$(grep -Inr \
+    --exclude=strings.xml \
+    --exclude-dir=utility \
+    --exclude-dir=__history \
+    "$string" \
+    "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/res/layout" "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/res/menu" "$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/java" \
+    "$KEYMAN_ROOT/android/KMEA/app/src/main/res/layout" "$KEYMAN_ROOT/android/KMEA/app/src/main/java" | tee -a detail.md | wc -l)
+  echo >> detail.md
+
+  # Write summary
+  if [ $count -eq 0 ]; then
+    echo "**0** | **$string** | **Not found**" | tee -a summary.md
+  else
+    echo "$count | $string" | tee -a summary.md
+  fi
+
+done < strings.txt


### PR DESCRIPTION
Similar to #3412

1. Adds a similar script from Windows to identify unused Android strings (from KMAPro and KMEA strings.xml)
2. Remove the unused strings from strings.xml

As part of the manual cleanup, consolidated the strings `missing_metadata` and `invalid_metadata`.

Also changed string name `model` to a more specific  `model_label`