### PR TITLE
feat(ios/engine): Associating package installer

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		CE97866224C7DD1A00C5DCBC /* KeyboardSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE97866124C7DD1A00C5DCBC /* KeyboardSearchTests.swift */; };
 		CE99350E24D7CCFC00202DA3 /* LanguagePickAssociator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99350D24D7CCFC00202DA3 /* LanguagePickAssociator.swift */; };
 		CE99351024D8018B00202DA3 /* LanguagePickAssociatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99350F24D8018B00202DA3 /* LanguagePickAssociatorTests.swift */; };
+		CE9A7A7924DA55D5007CCB5F /* AssociatingPackageInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9A7A7824DA55D5007CCB5F /* AssociatingPackageInstaller.swift */; };
 		CE9B440C23FE49F000499CAB /* Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9B440B23FE49F000499CAB /* Migrations.swift */; };
 		CE9B440F23FE4E7500499CAB /* 12.0 Ad-hoc Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE9B440D23FE4E7400499CAB /* 12.0 Ad-hoc Migration.bundle */; };
 		CE9B441023FE4E7500499CAB /* Simple 12.0 Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE9B440E23FE4E7500499CAB /* Simple 12.0 Migration.bundle */; };
@@ -501,6 +502,7 @@
 		CE97866124C7DD1A00C5DCBC /* KeyboardSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSearchTests.swift; sourceTree = "<group>"; };
 		CE99350D24D7CCFC00202DA3 /* LanguagePickAssociator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagePickAssociator.swift; sourceTree = "<group>"; };
 		CE99350F24D8018B00202DA3 /* LanguagePickAssociatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagePickAssociatorTests.swift; sourceTree = "<group>"; };
+		CE9A7A7824DA55D5007CCB5F /* AssociatingPackageInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatingPackageInstaller.swift; sourceTree = "<group>"; };
 		CE9B440B23FE49F000499CAB /* Migrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migrations.swift; sourceTree = "<group>"; };
 		CE9B440D23FE4E7400499CAB /* 12.0 Ad-hoc Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "12.0 Ad-hoc Migration.bundle"; sourceTree = "<group>"; };
 		CE9B440E23FE4E7500499CAB /* Simple 12.0 Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "Simple 12.0 Migration.bundle"; sourceTree = "<group>"; };
@@ -910,6 +912,7 @@
 				CE71705E23A9C97F00A924A1 /* PackageInstallViewController.swift */,
 				CE99350D24D7CCFC00202DA3 /* LanguagePickAssociator.swift */,
 				C0E30C8B1FC40D0400C80416 /* Storage.swift */,
+				CE9A7A7824DA55D5007CCB5F /* AssociatingPackageInstaller.swift */,
 			);
 			path = "Resource Management";
 			sourceTree = "<group>";
@@ -1572,6 +1575,7 @@
 				C075EB061F8EFF870041F4BD /* String+Helpers.swift in Sources */,
 				1645D5952036C6FF0076C51B /* KeymanPackage.swift in Sources */,
 				9A079E40223B602B00581263 /* LexicalModel.swift in Sources */,
+				CE9A7A7924DA55D5007CCB5F /* AssociatingPackageInstaller.swift in Sources */,
 				C0E30C8C1FC40D0400C80416 /* Storage.swift in Sources */,
 				C045148A1F85DF9100D88416 /* InputViewController.swift in Sources */,
 				CE22DFBA230B94DB00A4551C /* ResourceDownloadQueue.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		CE97866224C7DD1A00C5DCBC /* KeyboardSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE97866124C7DD1A00C5DCBC /* KeyboardSearchTests.swift */; };
 		CE99350E24D7CCFC00202DA3 /* LanguagePickAssociator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99350D24D7CCFC00202DA3 /* LanguagePickAssociator.swift */; };
 		CE99351024D8018B00202DA3 /* LanguagePickAssociatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE99350F24D8018B00202DA3 /* LanguagePickAssociatorTests.swift */; };
+		CE9A749A24DBA576003C3B65 /* AssociatingPackageInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9A749924DBA576003C3B65 /* AssociatingPackageInstallerTests.swift */; };
 		CE9A7A7924DA55D5007CCB5F /* AssociatingPackageInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9A7A7824DA55D5007CCB5F /* AssociatingPackageInstaller.swift */; };
 		CE9B440C23FE49F000499CAB /* Migrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9B440B23FE49F000499CAB /* Migrations.swift */; };
 		CE9B440F23FE4E7500499CAB /* 12.0 Ad-hoc Migration.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CE9B440D23FE4E7400499CAB /* 12.0 Ad-hoc Migration.bundle */; };
@@ -502,6 +503,7 @@
 		CE97866124C7DD1A00C5DCBC /* KeyboardSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSearchTests.swift; sourceTree = "<group>"; };
 		CE99350D24D7CCFC00202DA3 /* LanguagePickAssociator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagePickAssociator.swift; sourceTree = "<group>"; };
 		CE99350F24D8018B00202DA3 /* LanguagePickAssociatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagePickAssociatorTests.swift; sourceTree = "<group>"; };
+		CE9A749924DBA576003C3B65 /* AssociatingPackageInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatingPackageInstallerTests.swift; sourceTree = "<group>"; };
 		CE9A7A7824DA55D5007CCB5F /* AssociatingPackageInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatingPackageInstaller.swift; sourceTree = "<group>"; };
 		CE9B440B23FE49F000499CAB /* Migrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migrations.swift; sourceTree = "<group>"; };
 		CE9B440D23FE4E7400499CAB /* 12.0 Ad-hoc Migration.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = "12.0 Ad-hoc Migration.bundle"; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				CE4459CD23FBBA8D003151FD /* AppDelegate.swift */,
 				CEF888D423FE786C00667693 /* KeyboardScaleTests.swift */,
 				CE97866124C7DD1A00C5DCBC /* KeyboardSearchTests.swift */,
+				CE9A749924DBA576003C3B65 /* AssociatingPackageInstallerTests.swift */,
 				CE99350F24D8018B00202DA3 /* LanguagePickAssociatorTests.swift */,
 				CEDFEF8E23FE43B700BECF39 /* MigrationTests.swift */,
 				CE973D842484A71700F66045 /* KMPJSONTests.swift */,
@@ -1485,6 +1488,7 @@
 				CE5C8BE524B5BD1C00FAFB7F /* QueryModelTests.swift in Sources */,
 				CEA9670F24BEF05A0035AACF /* Updates.swift in Sources */,
 				CE97866224C7DD1A00C5DCBC /* KeyboardSearchTests.swift in Sources */,
+				CE9A749A24DBA576003C3B65 /* AssociatingPackageInstallerTests.swift in Sources */,
 				CEF888D523FE786C00667693 /* KeyboardScaleTests.swift in Sources */,
 				CEA9670924BEC4030035AACF /* ResourceUpdateTests.swift in Sources */,
 				CE07E3D6247E41DB00DFA9D2 /* URLSessionMock.swift in Sources */,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -61,7 +61,6 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
       switch self {
         case .lexicalModels:
           return { associatedLexicalModelMap, completionClosure in
-            // TODO:  Stuff!
             associatedLexicalModelMap.forEach { packageKey, association in
               let url = association.url
               let lgCodes = association.languageCodes

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 
+/**
+ * Given a `KeymanPackage` that KeymanEngine knows how to install, this class facilitates language selection as part of the
+ * package installation process.
+ *
+ * "Associations" may also be specified to look up 'associated' resources for the selected language codes and have them install alongside
+ * the base package.  For example, installing the `sil_euro_latin` keyboard for `en` (English) with the `.lexicalModels` association
+ * will query for `en` models and install them as well as the `sil_euro_latin` package.
+ *
+ * At the time of writing, this will return the `nrc.en.mtnt` model and will install it for use with `en`
+ * before indicating that overall package installation is complete.
+ */
 public class AssociatingPackageInstaller<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>> where Resource.Package == Package {
 
   // The second parameter should be used to report on installation success on a per-package basis.
@@ -23,7 +34,14 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
    * Defines behaviors for finding and installing resources associated with the set of languages selected for installation.
    */
   public enum Associator {
+    /**
+     * Facilitates installing lexical models for the languages being installed.
+     */
     case lexicalModels
+
+    /**
+     * Designed to allow framework users to specify their own associations if desired.
+     */
     case custom(AssociatorBuilder, AssociationInstaller)
 
     internal func instance(for installer: AssociatingPackageInstaller,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -1,0 +1,137 @@
+//
+//  AssociatingPackageInstaller.swift
+//  KeymanEngine
+//
+//  Created by Joshua Horton on 8/5/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import Foundation
+
+public class AssociatingPackageInstaller<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>> where Resource.Package == Package {
+  // TODO:  extra parameter for error / success tracking
+  //        Receives a map, so we should track per-package progress.
+  public typealias AssociationInstaller = (LanguagePickAssociator.AssociationMap) -> Void
+
+  public typealias AssociatorBuilder = (AssociatingPackageInstaller,
+                                        LanguagePickAssociator.AssociationReceiver)
+                                        -> LanguagePickAssociator
+  /**
+   * Defines behaviors for finding and installing resources associated with the set of languages selected for installation.
+   */
+  public enum Associator {
+    case lexicalModels
+    case custom(AssociatorBuilder, AssociationInstaller)
+
+    internal func instance(for installer: AssociatingPackageInstaller,
+                           withReceiver receiver: @escaping LanguagePickAssociator.AssociationReceiver)
+                           -> LanguagePickAssociator {
+      switch self {
+        case .lexicalModels:
+          return LanguagePickAssociator(searchWith: LanguagePickAssociator.lexicalModelSearcher,
+                                        progressClosure: receiver)
+        case .custom(let constructor, _):
+          return constructor(installer, receiver)
+      }
+    }
+
+    internal func installer() -> AssociationInstaller {
+      switch self {
+        case .lexicalModels:
+          return { associatedLexicalModelMap in
+            // TODO:  Stuff!
+            associatedLexicalModelMap.forEach { packageKey, association in
+              let url = association.url
+              let lgCodes = association.languageCodes
+
+              ResourceDownloadManager.shared.downloadPackage(withKey: packageKey, from: url) {
+                (package: LexicalModelKeymanPackage?, error: Error?) in
+                guard error == nil, let package = package else {
+                  // TODO:  Error handling, progress tracking
+                  return
+                }
+
+                let associatedResources = lgCodes.flatMap { package.installableResources(forLanguage: $0) } as! [InstallableLexicalModel]
+                let associatedResourceIDs = associatedResources.map { $0.typedFullID }
+
+                // TODO:  Error handling, related progress tracking.
+                try? ResourceFileManager.shared.install(resourcesWithIDs: associatedResourceIDs, from: package)
+              }
+            }
+          }
+        case .custom(_, let closure):
+          return closure
+      }
+    }
+  }
+
+  let package: Package
+  let defaultLgCode: String?
+  var associationSpecs: [Associator]
+  var associationQueriers: [LanguagePickAssociator]?
+  var associationInstallers: [Int: AssociationInstaller] = [:]
+
+  public init(for package: Package,
+              defaultLanguageCode: String? = nil,
+              withAssociators associators: [Associator] = []) {
+    self.package = package
+    self.defaultLgCode = defaultLanguageCode
+    self.associationSpecs = associators
+  }
+
+  private func constructAssociationPickers() {
+    // We instantiate this now, indicating that language selection has begun.
+    self.associationQueriers = []
+
+    // Using a classical for-loop allows us to 'map' receivers (within their closures) to their associators.
+    for i in 0 ... associationSpecs.count-1 {
+      let associationSpec = associationSpecs[i]
+
+      let receiver: LanguagePickAssociator.AssociationReceiver = { status in
+        // TODO: implement handling for the various progress states.
+        switch status {
+          // TODO:
+          //case .inProgress(let queryCount, let associationsFound):
+          // TODO:  use of first parameter for progress tracking.
+          case .complete(_, let associationMap):
+            let installer = self.associationSpecs[i].installer()
+            self.associationInstallers[i] = installer
+
+            // TODO:  tracking, error handling.
+            installer(associationMap)
+          default:
+            break
+        }
+      }
+      self.associationQueriers!.append(associationSpec.instance(for: self, withReceiver: receiver))
+    }
+  }
+
+  public func promptForLanguages(inNavigationVC navVC: UINavigationController) {
+    guard self.associationQueriers == nil else {
+      fatalError("Invalid state - language picking has already been triggered.")
+    }
+
+    constructAssociationPickers()
+
+    let baseResourceReceiver: PackageInstallViewController<Resource>.CompletionHandler = { fullIDs in
+      guard let fullIDs = fullIDs else {
+        // TODO:  cancellation handling
+        return
+      }
+
+      // TODO:  error handling, progress tracking.
+      try? ResourceFileManager.shared.install(resourcesWithIDs: fullIDs, from: self.package)
+    }
+
+    let pickerPrompt = PackageInstallViewController<Resource>(for: package,
+                                                              defaultLanguageCode: defaultLgCode,
+                                                              languageAssociators: associationQueriers!,
+                                                              completionHandler: baseResourceReceiver)
+
+    navVC.pushViewController(pickerPrompt, animated: true)
+  }
+
+  // TODO: a programmatic version with the approximate signature seen below.
+  // public func selectLanguages(withCodes languageIDs: Set<String>)
+}

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -9,9 +9,11 @@
 import Foundation
 
 public class AssociatingPackageInstaller<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>> where Resource.Package == Package {
-  // TODO:  extra parameter for error / success tracking
-  //        Receives a map, so we should track per-package progress.
-  public typealias AssociationInstaller = (LanguagePickAssociator.AssociationMap) -> Void
+
+  // The second parameter should be used to report on installation success on a per-package basis.
+  public typealias AssociationInstaller = (LanguagePickAssociator.AssociationMap,
+                                           @escaping (KeymanPackage.Key, PackageInstallResult) -> Void)
+                                           -> Void
 
   public typealias AssociatorBuilder = (AssociatingPackageInstaller,
                                         LanguagePickAssociator.AssociationReceiver)
@@ -38,7 +40,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     internal func installer() -> AssociationInstaller {
       switch self {
         case .lexicalModels:
-          return { associatedLexicalModelMap in
+          return { associatedLexicalModelMap, completionClosure in
             // TODO:  Stuff!
             associatedLexicalModelMap.forEach { packageKey, association in
               let url = association.url
@@ -54,8 +56,12 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
                 let associatedResources = lgCodes.flatMap { package.installableResources(forLanguage: $0) } as! [InstallableLexicalModel]
                 let associatedResourceIDs = associatedResources.map { $0.typedFullID }
 
-                // TODO:  Error handling, related progress tracking.
-                try? ResourceFileManager.shared.install(resourcesWithIDs: associatedResourceIDs, from: package)
+                do {
+                  try ResourceFileManager.shared.install(resourcesWithIDs: associatedResourceIDs, from: package)
+                  completionClosure(packageKey, .complete)
+                } catch {
+                  completionClosure(packageKey, .error(error))
+                }
               }
             }
           }
@@ -65,66 +71,176 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     }
   }
 
+  public enum PackageInstallResult {
+    case error(Error)
+    case complete
+  }
+
+  typealias AssociationInstallMap = [KeymanPackage.Key: PackageInstallResult]
+
+  // TODO:  Move more relevant class properties into the inner class below.
+  private class ClosureShared {
+    // Synchronization
+    let queryGroup = DispatchGroup()
+    let installGroup = DispatchGroup()
+    let progressQueue = DispatchQueue(label: "com.keyman.associatingPackageInstaller")
+
+    // Specifications needed across multiple threads.
+    let associationSpecs: [Associator]
+    var associationInstallers: [Int: AssociationInstaller] = [:]
+
+    // Holds data needed for progress tracking.
+    var pickingCompleted: Bool = false
+    var associationQueryProgress: [Int: LanguagePickAssociator.Progress] = [:]
+    var installProgressMap: [KeymanPackage.Key: PackageInstallResult?] = [:]
+
+    var isCancelled = false
+
+    init(with associationSpecs: [Associator]) {
+      self.associationSpecs = associationSpecs
+    }
+  }
+
+  private let closureShared: ClosureShared
+
   let package: Package
   let defaultLgCode: String?
-  var associationSpecs: [Associator]
   var associationQueriers: [LanguagePickAssociator]?
-  var associationInstallers: [Int: AssociationInstaller] = [:]
 
+  // TODO:  Add progress-report callback closure parameter.
   public init(for package: Package,
               defaultLanguageCode: String? = nil,
               withAssociators associators: [Associator] = []) {
     self.package = package
     self.defaultLgCode = defaultLanguageCode
-    self.associationSpecs = associators
+
+    self.closureShared = ClosureShared(with: associators)
   }
 
   private func constructAssociationPickers() {
     // We instantiate this now, indicating that language selection has begun.
     self.associationQueriers = []
 
+    let closureShared = self.closureShared
     // Using a classical for-loop allows us to 'map' receivers (within their closures) to their associators.
-    for i in 0 ... associationSpecs.count-1 {
-      let associationSpec = associationSpecs[i]
+    for i in 0 ... closureShared.associationSpecs.count-1 {
+      let associationSpec = closureShared.associationSpecs[i]
 
+      closureShared.queryGroup.enter()
+      // TODO:  Define in separate method.
       let receiver: LanguagePickAssociator.AssociationReceiver = { status in
-        // TODO: implement handling for the various progress states.
         switch status {
-          // TODO:
+          case .cancelled:
+            // TODO:  anything else to do if cancelled?
+            closureShared.queryGroup.leave()
+            // TODO:
           //case .inProgress(let queryCount, let associationsFound):
-          // TODO:  use of first parameter for progress tracking.
           case .complete(_, let associationMap):
-            let installer = self.associationSpecs[i].installer()
-            self.associationInstallers[i] = installer
+            let installer = closureShared.associationSpecs[i].installer()
+            closureShared.associationInstallers[i] = installer
 
-            // TODO:  tracking, error handling.
-            installer(associationMap)
+            // Since completions will be signaled once per package,
+            // we enter the install group once per package.
+            associationMap.forEach { _, _ in closureShared.installGroup.enter() }
+            closureShared.queryGroup.leave()
+
+            installer(associationMap) { packageKey, result in
+              closureShared.progressQueue.async {
+                closureShared.installProgressMap[packageKey] = result
+
+                // TODO:  compute & report progress.
+
+                // Last thing in this closure.
+                closureShared.installGroup.leave()
+              }
+            }
           default:
             break
+        }
+
+        closureShared.progressQueue.async {
+          closureShared.associationQueryProgress[i] = status
+
+          if case let .complete(_, associationMap) = status {
+            associationMap.forEach { (key, _) in
+              // Allows tracking install-completion progress.
+              closureShared.installProgressMap[key] = nil  // indicates 'downloading'.
+            }
+          }
+
+          // TODO:  trigger a 'progress report' if in the right state. (isCancelled == false is part of that.)
         }
       }
       self.associationQueriers!.append(associationSpec.instance(for: self, withReceiver: receiver))
     }
   }
 
+  private func initializeSynchronizationGroups() {
+    let closureShared = self.closureShared
+    closureShared.queryGroup.enter()
+    closureShared.installGroup.enter()
+
+    // All queries must have returned in order for us to be sure all
+    // needed installations have occurrred.
+    closureShared.queryGroup.notify(queue: closureShared.progressQueue) {
+      closureShared.installGroup.leave() // ?
+    }
+
+    closureShared.installGroup.notify(queue: DispatchQueue.main) {
+      // TODO:  The final 'progress report' / completion signaller.
+    }
+  }
+
   public func promptForLanguages(inNavigationVC navVC: UINavigationController) {
-    guard self.associationQueriers == nil else {
+    guard self.associationQueriers == nil, !closureShared.pickingCompleted else {
       fatalError("Invalid state - language picking has already been triggered.")
     }
 
+    initializeSynchronizationGroups()
     constructAssociationPickers()
 
+    let closureShared = self.closureShared
+    // For use in closures called by other DispatchGroups.
+    let packageKey = self.package.key
+
+    // TODO:  Move contents to their own method so that this may be shared with a future
+    //        programmatic installation method.
+    //
+    // Is triggered from UI, so is in the standard, main UI thread / DispatchGroup.
     let baseResourceReceiver: PackageInstallViewController<Resource>.CompletionHandler = { fullIDs in
       guard let fullIDs = fullIDs else {
-        // TODO:  cancellation handling
+        closureShared.isCancelled = true
+        closureShared.queryGroup.leave()
+
         return
       }
 
-      // TODO:  error handling, progress tracking.
-      try? ResourceFileManager.shared.install(resourcesWithIDs: fullIDs, from: self.package)
+      closureShared.progressQueue.sync {
+        // Indicates a transition to 'installing' state.
+        closureShared.pickingCompleted = true
+        closureShared.installProgressMap[packageKey] = nil
+      }
+      closureShared.installGroup.enter()  // Enter the 'install' group before exiting the 'query' group, to be safe.
+      closureShared.queryGroup.leave()
+
+      var result: PackageInstallResult
+      do {
+        try ResourceFileManager.shared.install(resourcesWithIDs: fullIDs, from: self.package)
+        result = .complete
+      } catch {
+        result = .error(error)
+      }
+
+      closureShared.progressQueue.async {
+        closureShared.installProgressMap[packageKey] = result
+
+        // TODO:  report on installation progress?
+      }
+
+      closureShared.installGroup.leave()
     }
 
-    let pickerPrompt = PackageInstallViewController<Resource>(for: package,
+    let pickerPrompt = PackageInstallViewController<Resource>(for: self.package,
                                                               defaultLanguageCode: defaultLgCode,
                                                               languageAssociators: associationQueriers!,
                                                               completionHandler: baseResourceReceiver)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
@@ -42,7 +42,7 @@ public class LanguagePickAssociator {
      * Indicates that all generated association queries have returned.  Reports the total number of queries that occurred,
      * followed by a map of package keys to the corresponding URL and language codes to install from the package.
      */
-    case complete(Int, [KeymanPackage.Key: Association])
+    case complete(Int, AssociationMap)
   }
   /**
    * A callback that returns available packages corresponding to provided language codes.
@@ -61,6 +61,8 @@ public class LanguagePickAssociator {
    * * When either occurs, it will be the final call to the `AssociationReceiver`.
    */
   public typealias AssociationReceiver = (Progress) -> Void
+
+  public typealias AssociationMap = [KeymanPackage.Key: Association]
 
   public struct Association {
     public let url: URL

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
@@ -327,8 +327,12 @@ public class LanguagePickAssociator {
           let finishedCodeSet = Set(finishedCodeList)
           let selectedSet = finishedCodeSet.intersection(closureShared.languageSet)
 
+          let packagesToInstall = closureShared.packageMap.filter { (key, value) in
+            return selectedSet.intersection(value.languageCodes).count > 0
+          }
+
           // Report progress.
-          closureShared.progressClosure(.inProgress(closureShared.queriesComplete, selectedSet.count))
+          closureShared.progressClosure(.inProgress(closureShared.queriesComplete, packagesToInstall.count))
         }
 
         // We leave this dispatch group AFTER collating all relevant install requests.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -282,15 +282,20 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   }
 
   @objc func installBtnHandler() {
-    dismiss(animated: true, completion: {
-      let selectedItems = self.languageTable.indexPathsForSelectedRows ?? []
-      let selectedLanguageCodes = selectedItems.map { self.languages[$0.row].id }
+    // If it is not the root view of a navigationController, just pop it off the stack.
+    if let navVC = self.navigationController, navVC.viewControllers[0] != self {
+      navVC.popViewController(animated: true)
+    } else { // Otherwise, if the root view of a navigation controller, dismiss it outright.  (pop not available)
+      dismiss(animated: true)
+    }
 
-      let selectedResources = self.package.installableResourceSets.flatMap { $0.filter { selectedLanguageCodes.contains($0.languageID) }} as! [Resource]
+    let selectedItems = self.languageTable.indexPathsForSelectedRows ?? []
+    let selectedLanguageCodes = selectedItems.map { self.languages[$0.row].id }
 
-      self.completionHandler(selectedResources.map { $0.typedFullID })
-      self.associators.forEach { $0.pickerFinalized() }
-    })
+    let selectedResources = self.package.installableResourceSets.flatMap { $0.filter { selectedLanguageCodes.contains($0.languageID) }} as! [Resource]
+
+    self.completionHandler(selectedResources.map { $0.typedFullID })
+    self.associators.forEach { $0.pickerFinalized() }
   }
 
   public func tableView(_ tableView: UITableView, titleForHeaderInSection: Int) -> String? {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -251,10 +251,14 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   }
 
   @objc func cancelBtnHandler() {
-    dismiss(animated: true, completion: {
-      self.completionHandler(nil)
-      self.associators.forEach { $0.pickerDismissed() }
-    })
+    // If it is not the root view of a navigationController, just pop it off the stack.
+    if let navVC = self.navigationController, navVC.viewControllers[0] != self {
+      navVC.popViewController(animated: true)
+    } else { // Otherwise, if the root view of a navigation controller, dismiss it outright.  (pop not available)
+      dismiss(animated: true)
+    }
+    self.completionHandler(nil)
+    self.associators.forEach { $0.pickerDismissed() }
   }
 
   @objc func backBtnHandler() {

--- a/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
@@ -1,0 +1,168 @@
+//
+//  AssociatingPackageInstallerTests.swift
+//  KeymanEngineTests
+//
+//  Created by Joshua Horton on 8/6/20.
+//  Copyright © 2020 SIL International. All rights reserved.
+//
+
+import XCTest
+@testable import KeymanEngine
+
+class AssociatingPackageInstallerTests: XCTestCase {
+  var mockedURLSession: TestUtils.Downloading.URLSessionMock!
+  var downloadManager: ResourceDownloadManager!
+
+  let mockedSearchCallback: LanguagePickAssociator.AssociationSearcher = { lgCodes, callback in
+    var searchResult: [String: (KeymanPackage.Key, URL)?] = [:]
+
+    // We aren't downloading these models, so a placeholder URL is fine.
+    let placeholderURL = URL.init(string: "http://place.holder.com")!
+
+    lgCodes.forEach { lgCode in
+      switch lgCode {
+        case "en":
+          searchResult["en"] = (TestUtils.Packages.Keys.nrc_en_mtnt, placeholderURL)
+        case "str":
+          searchResult["str"] = (TestUtils.Packages.Keys.nrc_str_sencoten, placeholderURL)
+        default:
+          searchResult[lgCode] = nil
+      }
+    }
+
+    callback(searchResult)
+  }
+
+  override func setUp() {
+    // Resets resource directories for a clean slate.
+    // We'll be testing against actually-installed packages.
+    TestUtils.standardTearDown()
+    
+    mockedURLSession = TestUtils.Downloading.URLSessionMock()
+    downloadManager = ResourceDownloadManager(session: mockedURLSession!, autoExecute: true)
+  }
+
+  override func tearDownWithError() throws {
+    TestUtils.standardTearDown()
+
+    let queueWasCleared = mockedURLSession!.queueIsEmpty
+    mockedURLSession = nil
+
+    if !queueWasCleared {
+      throw NSError(domain: "Keyman",
+                    code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "A test did not fully utilize its queued mock results!"])
+    }
+  }
+
+  func testKeyboardNoAssociations() throws {
+    guard let package = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.silEuroLatinKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    let startExpectation = XCTestExpectation()
+    let completeExpectation = XCTestExpectation()
+
+    let installer = AssociatingPackageInstaller(for: package,
+                                                defaultLanguageCode: "en",
+                                                downloadManager: downloadManager) { status in
+      if status == .starting {
+        startExpectation.fulfill()
+      } else if status == .complete {
+        completeExpectation.fulfill()
+      }
+    }
+
+    installer.pickLanguages(withCodes: Set(["en"]))
+
+    wait(for: [startExpectation, completeExpectation], timeout: 5)
+
+    guard let userKeyboards = Storage.active.userDefaults.userKeyboards else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertTrue(userKeyboards.contains { $0.fullID == TestUtils.Keyboards.sil_euro_latin.fullID })
+    XCTAssertNil(Storage.active.userDefaults.userLexicalModels)
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.sil_euro_latin), .installed)
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt), .none)
+  }
+
+  func testLexicalModelNoAssociations() throws {
+    guard let package = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.LexicalModels.mtntKMP) as? LexicalModelKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    let startExpectation = XCTestExpectation()
+    let completeExpectation = XCTestExpectation()
+
+    let installer = AssociatingPackageInstaller(for: package,
+                                                defaultLanguageCode: "en",
+                                                downloadManager: downloadManager) { status in
+      if status == .starting {
+        startExpectation.fulfill()
+      } else if status == .complete {
+        completeExpectation.fulfill()
+      }
+    }
+
+    installer.pickLanguages(withCodes: Set(["en"]))
+
+    wait(for: [startExpectation, completeExpectation], timeout: 5)
+
+    guard let userLexicalModels = Storage.active.userDefaults.userLexicalModels else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertTrue(userLexicalModels.contains { $0.fullID == TestUtils.LexicalModels.mtnt.fullID })
+    XCTAssertNil(Storage.active.userDefaults.userKeyboards)
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt), .installed)
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.sil_euro_latin), .none)
+  }
+
+  func testKeyboardWithAssociatedLexicalModels() throws {
+    let mockedQuery = TestUtils.Downloading.MockResult(location: TestUtils.Queries.model_case_en, error: nil)
+    let mockedDownload = TestUtils.Downloading.MockResult(location: TestUtils.LexicalModels.mtntKMP, error: nil)
+
+    mockedURLSession.queueMockResult(.data(mockedQuery))
+    mockedURLSession.queueMockResult(.download(mockedDownload))
+
+    guard let package = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.silEuroLatinKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    let startExpectation = XCTestExpectation()
+    let completeExpectation = XCTestExpectation()
+
+    let installer = AssociatingPackageInstaller(for: package,
+                                                defaultLanguageCode: "en",
+                                                downloadManager: downloadManager,
+                                                withAssociators: [ .lexicalModels ]) { status in
+      if status == .starting {
+        startExpectation.fulfill()
+      } else if status == .complete {
+        completeExpectation.fulfill()
+      }
+    }
+
+    installer.pickLanguages(withCodes: Set(["en"]))
+
+    wait(for: [startExpectation, completeExpectation], timeout: 5)
+
+    guard let userKeyboards = Storage.active.userDefaults.userKeyboards,
+          let userLexicalModels = Storage.active.userDefaults.userLexicalModels else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertTrue(userKeyboards.contains { $0.fullID == TestUtils.Keyboards.sil_euro_latin.fullID })
+    XCTAssertTrue(userLexicalModels.contains { $0.fullID == TestUtils.LexicalModels.mtnt.fullID} )
+
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.sil_euro_latin), .installed)
+    XCTAssertEqual(ResourceFileManager.shared.installState(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt), .installed)
+  }
+}

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -68,14 +68,9 @@ class PackageBrowserViewController: UIDocumentBrowserViewController, UIDocumentB
           let packageInstaller = AssociatingPackageInstaller(for: kbdPackage,
                                                              withAssociators: [.lexicalModels])
           packageInstaller.promptForLanguages(inNavigationVC: self.navigationController!)
-        } else {
-          // We choose to prompt the user for comfirmation, rather
-          // than automatically installing the package.
-          rfm.promptPackageInstall(of: package, in: self, isCustom: true, successHandler: { _ in
-            // Auto-dismiss the document browser upon successful KMP install.
-            // It's likely quite rare that someone would want to install 2+ at once.
-            self.navigationController?.popViewController(animated: true)
-          })
+        } else if let lmPackage = package as? LexicalModelKeymanPackage {
+          let packageInstaller = AssociatingPackageInstaller(for: lmPackage)
+          packageInstaller.promptForLanguages(inNavigationVC: self.navigationController!)
         }
       }
     }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -64,13 +64,19 @@ class PackageBrowserViewController: UIDocumentBrowserViewController, UIDocumentB
       }
 
       if let package = rfm.prepareKMPInstall(from: destinationUrl, alertHost: self) {
-        // We choose to prompt the user for comfirmation, rather
-        // than automatically installing the package.
-        rfm.promptPackageInstall(of: package, in: self, isCustom: true, successHandler: { _ in
-          // Auto-dismiss the document browser upon successful KMP install.
-          // It's likely quite rare that someone would want to install 2+ at once.
-          self.navigationController?.popViewController(animated: true)
-        })
+        if let kbdPackage = package as? KeyboardKeymanPackage {
+          let packageInstaller = AssociatingPackageInstaller(for: kbdPackage,
+                                                             withAssociators: [.lexicalModels])
+          packageInstaller.promptForLanguages(inNavigationVC: self.navigationController!)
+        } else {
+          // We choose to prompt the user for comfirmation, rather
+          // than automatically installing the package.
+          rfm.promptPackageInstall(of: package, in: self, isCustom: true, successHandler: { _ in
+            // Auto-dismiss the document browser upon successful KMP install.
+            // It's likely quite rare that someone would want to install 2+ at once.
+            self.navigationController?.popViewController(animated: true)
+          })
+        }
       }
     }
 }


### PR DESCRIPTION
This PR aims to merge handling for all forms of package installation into a shiny, specialized class - the `AssociatingPackageInstaller`.  KeymanEngine users may specify which, if any, types of language associations should be made for installing packages on a per-use basis of the class.  Currently, only lexical-model associations have a default implementation, with 'custom' associations also having a supported pathway.  This association must be specified for associated lexical models to be automatically installed upon keyboard package installation.

This class will track the query and installation process for resources for the selected language to install alongside the 'base' package.  It's designed to support number-backed progress reporting, though this initial implementation will only worry about "complete" vs "not complete".

---

Missing but intended for future PRs:
- Progress %age reporting (if we have the time/space for it)
- Integration with other installation pathways.  
    - Currently only works from the file browser.
    - While integration with most other pathways will be simple, I'll need to rip out now-redundant parts of the KeyboardSearchViewController, which'll take a bit of time.

Notes:
- tested with a solid internet connection - no issues
- tested with a disabled internet connection - file-based keyboard installation returned quickly.
- have _not_ tested against a 'spotty' connection, though spinner behavior itself has been tested.

Also...
- will likely be 'rough around the edges' regarding errors that arise during package installation itself.
    - Since we may be installing multiple packages, that's the "hard part" for progress tracking and a considerable part of why that aspect's being delayed.
- does not report if an error arises from installing the base package itself.
    - probably should get _at least_ this in... though the exact best way to handle this isn't super clear.
    - likely similar to a cancellation, but needs to report the base package error
    - ... and then there would be the UI ties for that.
    - I'm currently considering this to be less urgent than actually integrating the installer into keyboard search and universal link stuff, though.