### PR TITLE
fix(android/app): Fix environment portion of app version string

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -30,10 +30,10 @@ android {
         //dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
         //println "===END DUMP==="
 
-        // VERSION_CODE and VERSION_NAME from version.gradle
+        // VERSION strings from version.gradle
         versionCode VERSION_CODE as Integer
         versionName VERSION_NAME
-        buildConfigField "String", "VERSION_ENVIRONMENT", "\""+VERSION_ENVIRONMENT+"\""
+        buildConfigField 'String', 'VERSION_ENVIRONMENT', '"'+VERSION_ENVIRONMENT+'"'
     }
 
     String env_release_store_file = System.getenv("release_store_file")

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -59,17 +59,7 @@ public class InfoActivity extends AppCompatActivity {
     version.setGravity(Gravity.CENTER);
 
     // Parse app version string to create a version title (Not using KMManager.getVersion() because that's for KMEA)
-    String versionStr = "";
-    PackageInfo pInfo;
-    try {
-      pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
-      versionStr = pInfo.versionName;
-    } catch (NameNotFoundException e) {
-      KMLog.LogException(TAG, "", e);
-
-      // Fallback to a "current" version. This does not need to be maintained
-      versionStr = "12.0.0.0";
-    }
+    String versionStr = BuildConfig.VERSION_NAME;
 
     String versionTitle = String.format(getString(R.string.title_version), versionStr);
     version.setText(versionTitle);

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -22,6 +22,7 @@ def getVersionName = { ->
     String env_version = System.getenv("VERSION_WITH_TAG")
     if (env_version != null) {
         // If building from script, we have build number in VERSION_WITH_TAG
+        println "Using build $env_version from VERSION_WITH_TAG"
         return "$env_version"
     } else {
         // Building probably from IDE, so let's use VERSION.md and TIER.md directly
@@ -38,9 +39,11 @@ def getVersionEnvironment = { ->
     String env_environment = System.getenv("VERSION_ENVIRONMENT")
     if (env_environment != null) {
         // If building from script, we have build number in VERSION_ENVIRONMENT
+        println "Using $env_environment from VERSION_ENVIRONMENT"
         return "$env_environment"
     } else {
         // Building probably from IDE, so use "local"
+        println "Using local environment"
         return "local"
     }
 }

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -93,7 +93,9 @@ function findVersion() {
         fi
     fi
 
-    VERSION_WITH_TAG="$VERSION$VERSION_TAG"
+    # export these two so version.gradle can access them
+    export VERSION_ENVIRONMENT
+    export VERSION_WITH_TAG="$VERSION$VERSION_TAG"
 
     readonly VERSION
     readonly VERSION_MAJOR

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script sets build environment variables:
+# This script sets build environment variables. VERSION vars are also exported:
 #   VERSION:          Full current build version, e.g. "14.0.1"
 #   VERSION_WIN:      Full current build version for Windows, e.g. "14.0.1.0"
 #   VERSION_RELEASE:  Current release version, e.g. "14.0"
@@ -93,9 +93,7 @@ function findVersion() {
         fi
     fi
 
-    # export these two so version.gradle can access them
-    export VERSION_ENVIRONMENT
-    export VERSION_WITH_TAG="$VERSION$VERSION_TAG"
+    VERSION_WITH_TAG="$VERSION$VERSION_TAG"
 
     readonly VERSION
     readonly VERSION_MAJOR
@@ -106,6 +104,17 @@ function findVersion() {
     readonly VERSION_TAG
     readonly VERSION_WITH_TAG
     readonly VERSION_ENVIRONMENT
+
+    # Export version strings so places like version.gradle can access them
+    export VERSION
+    export VERSION_MAJOR
+    export VERSION_MINOR
+    export VERSION_PATCH
+    export VERSION_RELEASE
+    export VERSION_WIN
+    export VERSION_TAG
+    export VERSION_WITH_TAG
+    export VERSION_ENVIRONMENT
 }
 
 function findTier() {


### PR DESCRIPTION
When displaying the Info page of alpha builds from the Play Store, we noticed the version string displayed the wrong environment:
`14.0.X-alpha-local` (CI builds should have ended with `-alpha`).

It turns out  the `VERSION_` shell variables  from `build-utils.sh` aren't visible in `version.gradle` (though CI environment variables like `build_counter` are visible).

This PR:
* Exports the two VERSION strings needed in version.gradle
* Updates the Info page to simply display `BuildConfig.VERSION_NAME`