### PR TITLE
fix(ios/engine): Proper associating-installer deinitialization, cancellation tests

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -197,7 +197,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
   // TODO:  deinit handling in case everything gets cancelled.
   // deinit { }
 
-  private func constructAssociationPickers() {
+  internal func constructAssociationPickers() {
     // We instantiate this now, indicating that language selection has begun.
     associationQueriers = []
 
@@ -225,11 +225,15 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     return { status in
       switch status {
         case .cancelled:
+          // Do not trigger installation or even _start_ attempting installation.
+          // Do a simple, graceful exit.
           closureShared.queryGroup.leave()
         // TODO:
         // case .inProgress(let queryCount, let associationsFound):
         //   break
         case .complete(_, let associationMap):
+          // Assumption:  .complete will only occur if 'picking' was not cancelled.
+          //              We know this holds true for the current LanguagePickAssociation implementation.
           let installer = closureShared.associationSpecs[specIndex].installer(downloadManager: closureShared.downloadManager)
           closureShared.associationInstallers[specIndex] = installer
 
@@ -267,7 +271,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     }
   }
 
-  private func initializeSynchronizationGroups() {
+  internal func initializeSynchronizationGroups() {
     let closureShared = self.closureShared
     closureShared.queryGroup.enter()
     closureShared.installGroup.enter()
@@ -284,7 +288,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     }
   }
 
-  private func coreInstallationClosure() -> ([Resource.FullID]?) -> Void {
+  internal func coreInstallationClosure() -> ([Resource.FullID]?) -> Void {
     // For use in closures called by other DispatchGroups.
     let packageKey = self.package.key
     let closureShared = self.closureShared

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -106,7 +106,6 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
 
   typealias AssociationInstallMap = [KeymanPackage.Key: PackageInstallResult]
 
-  // TODO:  Move more relevant class properties into the inner class below.
   private class ClosureShared {
     // Synchronization
     let queryGroup = DispatchGroup()
@@ -156,7 +155,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
         if complete {
           progressCallback(.complete)
         } else {
-          progressCallback(.inProgress)
+          //progressCallback(.inProgress)
         }
       }
     }
@@ -172,6 +171,26 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
   let defaultLgCode: String?
   var associationQueriers: [LanguagePickAssociator]?
 
+  /**
+   * Constructs an instance for installing the specified package alongside any detected packages containing specified types
+   * of associated resources for the languages that are selected for installation.
+   *
+   * - parameters:
+   *     - package: An already-download package to install.  Any language selection must choose languages supported by this package.
+   *     - defaultLanguageCode: The BCP-47 code for the default language to select when prompting the user for languages.
+   *     - withAssociators: A set of desired "language associations" to install alongside the package if they exist.
+   *       Currently supports the following options:
+   *       - `.lexicalModels`:  intended for use with keyboard packages.  Will query for and install lexical models for any
+   *       picked languages as part of the installation process.
+   *       - `.custom`:  allows specifying custom language associations.
+   *     - progressReceiver:  This will _always_ be called, even should picking never start before the class is deinitialized.
+   *       It will either receive `.cancelled` (exactly once) or a sequence like the following:
+   *       - `.starting` (exactly once)
+   *       - `.complete` (exactly once)
+   *
+   * In the future, `.inProgress` may be implemented; at that time, it will provide data for reporting installation progress and
+   * may be called multiple times between `.starting` and `.complete`.
+   */
   public convenience init(for package: Package,
                           defaultLanguageCode: String? = nil,
                           withAssociators associators: [Associator] = [],
@@ -194,8 +213,23 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     self.closureShared = ClosureShared(with: associators, downloadManager: downloadManager, receiver: progressReceiver)
   }
 
-  // TODO:  deinit handling in case everything gets cancelled.
-  // deinit { }
+  deinit {
+    // Ensure we send a 'cancel' signal IF this is a 'constructive cancellation'.
+    // That is, if no installs were triggered... even if picking never even started.
+    if !closureShared.pickingCompleted, self.associationQueriers != nil, !closureShared.isCancelled {
+       // Auto-dismiss any association queriers that might still be executing.
+       // Necessary for their closures to exit their DispatchGroups cleanly.
+      self.associationQueriers = nil
+
+      // Now we may safely send an artificial 'cancel'.
+      let installClosure = coreInstallationClosure()
+      installClosure(nil)
+    } else if self.associationQueriers == nil {
+      // We never started the associators or a picker, so bypass all of that and directly
+      // report cancellation.
+      closureShared.reportCancelled()
+    }
+  }
 
   internal func constructAssociationPickers() {
     // We instantiate this now, indicating that language selection has begun.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/LanguagePickAssociator.swift
@@ -271,9 +271,11 @@ public class LanguagePickAssociator {
   public func selectLanguages(_ languages: Set<String>) {
     let unsearched = languages.filter { !languageSetSearched.contains($0) }
 
-    languages.forEach {
-      closureShared.languageSet.insert($0)
-      languageSetSearched.insert($0)
+    languages.forEach { lgCode in
+      closureShared.querySyncQueue.sync {
+        _ = closureShared.languageSet.insert(lgCode)
+      }
+      languageSetSearched.insert(lgCode)
     }
 
     // Start fetch queries for any previously-unsearched language codes!
@@ -342,7 +344,9 @@ public class LanguagePickAssociator {
   }
 
   public func deselectLanguages(_ languages: Set<String>) {
-    languages.forEach { closureShared.languageSet.remove($0) }
+    closureShared.querySyncQueue.sync {
+      languages.forEach { closureShared.languageSet.remove($0) }
+    }
   }
 
   public func pickerDismissed() {
@@ -369,7 +373,7 @@ public class LanguagePickAssociator {
   }
 
   public var languagesPicked: Int {
-    return closureShared.languageSet.count
+    return closureShared.querySyncQueue.sync { closureShared.languageSet.count }
   }
 
   public var languagesQueried: Int {

--- a/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
@@ -71,6 +71,8 @@ class AssociatingPackageInstallerTests: XCTestCase {
         startExpectation.fulfill()
       } else if status == .complete {
         completeExpectation.fulfill()
+      } else if status == .cancelled {
+        XCTFail()
       }
     }
 
@@ -105,6 +107,8 @@ class AssociatingPackageInstallerTests: XCTestCase {
         startExpectation.fulfill()
       } else if status == .complete {
         completeExpectation.fulfill()
+      } else if status == .cancelled {
+        XCTFail()
       }
     }
 
@@ -146,6 +150,8 @@ class AssociatingPackageInstallerTests: XCTestCase {
         startExpectation.fulfill()
       } else if status == .complete {
         completeExpectation.fulfill()
+      } else if status == .cancelled {
+        XCTFail()
       }
     }
 
@@ -240,6 +246,81 @@ class AssociatingPackageInstallerTests: XCTestCase {
     installClosure(nil)
 
     wait(for: [cancelExpectation], timeout: 5)
+
+    XCTAssertNil(Storage.active.userDefaults.userKeyboards)
+    XCTAssertNil(Storage.active.userDefaults.userLexicalModels)
+  }
+
+  func testDeinitConstructiveCancellation() throws {
+    guard let package = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.silEuroLatinKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    // While the query should occur, the installation phase should never be reached.
+    // So, we don't mock the download.
+    let mockedQuery = TestUtils.Downloading.MockResult(location: TestUtils.Queries.model_case_en, error: nil)
+    let queryExpectation = XCTestExpectation()
+    mockedURLSession.queueMockResult(.data(mockedQuery), expectation: queryExpectation)
+
+    let cancelExpectation = XCTestExpectation()
+
+    do {
+      let installer = AssociatingPackageInstaller(for: package,
+                                                  defaultLanguageCode: "en",
+                                                  downloadManager: downloadManager,
+                                                  withAssociators: [.lexicalModels]) { status in
+        // When the user 'cancels' language selection, this installer should also
+        // signal cancellation.
+        if status == .cancelled {
+          // First, wait to ensure that the standard query did launch.
+          // Otherwise, we might accidentally skip the mocked query!
+          self.wait(for: [queryExpectation], timeout: 4)
+          cancelExpectation.fulfill()
+        } else {
+          XCTFail()
+        }
+      }
+
+      // Heavier white-box testing this time.
+      installer.initializeSynchronizationGroups()
+      installer.constructAssociationPickers()
+      installer.associationQueriers?.forEach {
+        $0.pickerInitialized()
+        $0.selectLanguages(Set(["en"])) // calls the expected query
+        // De-init will trigger the 'dismiss' signal.
+      }
+    }
+
+    wait(for: [cancelExpectation], timeout: 5)
+
+    XCTAssertNil(Storage.active.userDefaults.userKeyboards)
+    XCTAssertNil(Storage.active.userDefaults.userLexicalModels)
+  }
+
+  func testDeinitUnstarted() throws {
+    guard let package = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.silEuroLatinKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    let cancelExpectation = XCTestExpectation()
+
+    do {
+      let _ = AssociatingPackageInstaller(for: package,
+                                                  defaultLanguageCode: "en",
+                                                  downloadManager: downloadManager,
+                                                  withAssociators: [.lexicalModels]) { status in
+        // Since language-picking never began, no "cancelled" signal should occur.
+        if status == .cancelled {
+          cancelExpectation.fulfill()
+        } else {
+          XCTFail()
+        }
+      }
+    }
+
+    wait(for: [cancelExpectation], timeout: 1)
 
     XCTAssertNil(Storage.active.userDefaults.userKeyboards)
     XCTAssertNil(Storage.active.userDefaults.userLexicalModels)


### PR DESCRIPTION
Addresses a lingering `TODO` / comment from https://github.com/keymanapp/keyman/pull/3458#discussion_r466129228.  The `AssociatingPackageInstaller` now properly deinitializes and can better guarantee a nice 'contract' on its completion closure.

Also addresses a race condition that popped up during one test run by always synchronizing accesses to the affected variable.