### PR TITLE
fix(android): Update sentry plugin to remove obsolete API  use

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.31'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.35'
         classpath 'name.remal:gradle-plugins:1.0.157'
     }
 }

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
         // io.sentry:sentry-android-gradle-plugin not available for library project
-        classpath 'io.sentry:sentry-android:2.0.1'
+        classpath 'io.sentry:sentry-android:2.3.0'
         classpath 'name.remal:gradle-plugins:1.0.157'
     }
 }

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.google.gms:google-services:4.3.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.31'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.35'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Fixes #3460

Update the sentry plugin versions for KMEA, kMAPRo, and FV app to remove build warnings of obsolete API use.
(Fixed in [sentry-android-gradle-plugin-1.7.32](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/v1.7.32))