### PR TITLE
refactor(common/models): LMLayer state management tweak, persistent ModelCompositor

### DIFF
--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -273,14 +273,13 @@ class LMLayerWorker {
    * @param model The loaded language model.
    */
   private transitionToReadyState(model: LexicalModel) {
+    let compositor = new ModelCompositor(model);
     this.state = {
       name: 'ready',
       handleMessage: (payload) => {
         switch(payload.message) {
           case 'predict':
             let {transform, context} = payload;
-            let compositor = new ModelCompositor(model); // Yeah, should probably use a persistent one eventually.
-
             let suggestions = compositor.predict(transform, context);
 
             // Now that the suggestions are ready, send them out!
@@ -303,8 +302,9 @@ class LMLayerWorker {
           default:
           throw new Error(`invalid message; expected one of {'predict', 'unload'} but got ${payload.message}`);
         }
-      }
-    };
+      },
+      compositor: compositor
+    } as LMLayerWorkerReadyState;
   }
 
   /**

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -304,7 +304,7 @@ class LMLayerWorker {
         }
       },
       compositor: compositor
-    } as LMLayerWorkerReadyState;
+    };
   }
 
   /**

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -118,6 +118,9 @@ interface WordbreakMessage {
   context: Context;
 }
 
+/**
+ * The LMLayer can be in one of the following states. The LMLayer can only produce predictions in the 'ready' state.
+ */
 type LMLayerWorkerState = LMLayerWorkerUnconfiguredState | LMLayerWorkerModellessState | LMLayerWorkerReadyState;
 
 /**
@@ -125,8 +128,6 @@ type LMLayerWorkerState = LMLayerWorkerUnconfiguredState | LMLayerWorkerModelles
  */
 interface LMLayerWorkerUnconfiguredState {
   /**
-   * Informative property. Name of the state. Currently, the LMLayerWorker can only
-   * be the following states:
    */
   name: 'unconfigured';
   handleMessage(payload: IncomingMessage): void;
@@ -137,8 +138,6 @@ interface LMLayerWorkerUnconfiguredState {
  */
 interface LMLayerWorkerModellessState {
   /**
-   * Informative property. Name of the state. Currently, the LMLayerWorker can only
-   * be the following states:
    */
   name: 'modelless';
   handleMessage(payload: IncomingMessage): void;
@@ -149,8 +148,6 @@ interface LMLayerWorkerModellessState {
  */
 interface LMLayerWorkerReadyState {
   /**
-   * Informative property. Name of the state. Currently, the LMLayerWorker can only
-   * be the following states:
    */
   name: 'ready';
   handleMessage(payload: IncomingMessage): void;

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -118,29 +118,42 @@ interface WordbreakMessage {
   context: Context;
 }
 
+type LMLayerWorkerState = LMLayerWorkerUnconfiguredState | LMLayerWorkerModellessState | LMLayerWorkerReadyState;
 
 /**
- * Represents a state in the LMLayer.
+ * Represents the unconfigured state of the LMLayer.
  */
-interface LMLayerWorkerState {
+interface LMLayerWorkerUnconfiguredState {
   /**
    * Informative property. Name of the state. Currently, the LMLayerWorker can only
    * be the following states:
    */
-  name: 'unconfigured' | 'modelless' | 'ready';
+  name: 'unconfigured';
   handleMessage(payload: IncomingMessage): void;
 }
 
 /**
- * Represents a state in the LMLayer.
+ * Represents the pre-model-load state of the LMLayer.
  */
-interface LMLayerWorkerReadyState extends LMLayerWorkerState {
+interface LMLayerWorkerModellessState {
+  /**
+   * Informative property. Name of the state. Currently, the LMLayerWorker can only
+   * be the following states:
+   */
+  name: 'modelless';
+  handleMessage(payload: IncomingMessage): void;
+}
+
+/**
+ * Represents the 'ready' state of the LMLayer.
+ */
+interface LMLayerWorkerReadyState {
   /**
    * Informative property. Name of the state. Currently, the LMLayerWorker can only
    * be the following states:
    */
   name: 'ready';
-
+  handleMessage(payload: IncomingMessage): void;
   compositor: ModelCompositor;
 }
 

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -131,6 +131,18 @@ interface LMLayerWorkerState {
   handleMessage(payload: IncomingMessage): void;
 }
 
+/**
+ * Represents a state in the LMLayer.
+ */
+interface LMLayerWorkerReadyState extends LMLayerWorkerState {
+  /**
+   * Informative property. Name of the state. Currently, the LMLayerWorker can only
+   * be the following states:
+   */
+  name: 'ready';
+
+  compositor: ModelCompositor;
+}
 
 /**
  * Constructors that return worker internal models.

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -127,8 +127,6 @@ type LMLayerWorkerState = LMLayerWorkerUnconfiguredState | LMLayerWorkerModelles
  * Represents the unconfigured state of the LMLayer.
  */
 interface LMLayerWorkerUnconfiguredState {
-  /**
-   */
   name: 'unconfigured';
   handleMessage(payload: IncomingMessage): void;
 }
@@ -137,8 +135,6 @@ interface LMLayerWorkerUnconfiguredState {
  * Represents the pre-model-load state of the LMLayer.
  */
 interface LMLayerWorkerModellessState {
-  /**
-   */
   name: 'modelless';
   handleMessage(payload: IncomingMessage): void;
 }
@@ -147,8 +143,6 @@ interface LMLayerWorkerModellessState {
  * Represents the 'ready' state of the LMLayer.
  */
 interface LMLayerWorkerReadyState {
-  /**
-   */
   name: 'ready';
   handleMessage(payload: IncomingMessage): void;
   compositor: ModelCompositor;


### PR DESCRIPTION
In order to proceed with edit-distance work, one of the first things that we have to do:  allow a persistent `ModelCompositor` that can store intermediate calculations, rather than reconstructing it every time.  

To facilitate this and to allow `ModelCompositor` to be accessible as an LMLayer property when in the correct state, the three states of the LMLayer have now been represented as a TS discriminated union.  The new `.compositor` properly is only accessible on the state object after condition-checking against `state.name == "ready"`.