### PR TITLE
feat(common/models): lexicon traversal

### DIFF
--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -1,4 +1,6 @@
 namespace models {
+  export const SENTINEL_CODE_UNIT = '\uFDD0';
+
   export function applyTransform(transform: Transform, context: Context): Context {
     // First, get the current context
     let fullLeftContext = context.left || '';
@@ -33,5 +35,29 @@ namespace models {
     if(prefix.deleteRight) {
       transform.deleteRight = (transform.deleteRight || 0) + prefix.deleteRight;
     }
+  }
+
+  /**
+   * Checks whether or not the specified UCS-2 character corresponds to a UTF-16 high surrogate.
+   * 
+   * @param char A single JavaScript (UCS-2) char corresponding to a single code unit.
+   */
+  export function isHighSurrogate(char: string): boolean;
+  /**
+   * Checks whether or not the specified UCS-2 character corresponds to a UTF-16 high surrogate.
+   * 
+   * @param codeUnit A code unit corresponding to a single UCS-2 char.
+   */
+  export function isHighSurrogate(codeUnit: number): boolean;
+  export function isHighSurrogate(codeUnit: string|number): boolean {
+    if(typeof codeUnit == 'string') {
+      codeUnit = codeUnit.charCodeAt(0);
+    }
+
+    return codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+  }
+
+  export function isSentinel(char: string): boolean {
+    return char == models.SENTINEL_CODE_UNIT;
   }
 }

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -175,7 +175,7 @@
         this.prefix = prefix;
       }
 
-      *children(): Generator<{key: string, traversal: () => LexiconTraversal}> {
+      *children(): Generator<{char: string, traversal: () => LexiconTraversal}> {
         let root = this.root;
 
         if(root.type == 'internal') {
@@ -196,7 +196,7 @@
                 for(let j = 0; j < entryNode.values.length; j++) {
                   let prefix = this.prefix + entry + internalNode.values[j];
                   yield {
-                    key: entry + entryNode.values[j],
+                    char: entry + entryNode.values[j],
                     traversal: function() { return new TrieModel.Traversal(internalNode.children[internalNode.values[j]], prefix) }
                   }
                 }
@@ -207,7 +207,7 @@
                 let prefix = this.prefix + entry;
 
                 yield {
-                  key: entry,
+                  char: entry,
                   traversal: function () {return new TrieModel.Traversal(entryNode, prefix)}
                 }
               }
@@ -216,7 +216,7 @@
             } else {
               let prefix = this.prefix + entry;
               yield {
-                key: entry,
+                char: entry,
                 traversal: function() { return new TrieModel.Traversal(entryNode, prefix)}
               }
             }
@@ -241,7 +241,7 @@
               nodeKey = nodeKey + key[prefix.length+1];
             }
             yield {
-              key: nodeKey,
+              char: nodeKey,
               traversal: function() { return new TrieModel.Traversal(root, prefix + nodeKey)}
             }
           };

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -162,7 +162,7 @@
       return this.getLastWord(context.left);
     }
 
-    public getRootTraversal(): LexiconTraversal {
+    public traverseFromRoot(): LexiconTraversal {
       return new TrieModel.Traversal(this._trie['root'], '');
     }
 

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -235,16 +235,16 @@
 
       get entries(): string[] {
         if(this.root.type == 'leaf') {
-          console.log("leaf, prefix " + this.prefix);
-          return this.root.entries.map(function(value) { return value.content });
+          if(this.root.entries[0].key == this.prefix) {
+            return this.root.entries.map(function(value) { return value.content });
+          } else {
+            return undefined;
+          }
         } else {
-          console.log("not leaf, prefix " + this.prefix);
           let matchingLeaf = this.root.children['\uFDD0'];
           if(matchingLeaf && matchingLeaf.type == 'leaf') {
-            console.log("matched leaf");
             return matchingLeaf.entries.map(function(value) { return value.content });
           } else {
-            console.log("big meanie");
             return undefined;
           }
         }

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -223,29 +223,41 @@
           }
 
           return;
-        } else {
-          let fullText = root.entries[0].key;
+        } else { // type == 'leaf'
           let prefix = this.prefix;
-          if(prefix.length < fullText.length) {
-            let key = fullText[prefix.length];
-            let charCode = fullText.charCodeAt(prefix.length);
+
+          let children = root.entries.filter(function(entry) {
+            return entry.key != prefix && prefix.length < entry.key.length;
+          })
+
+          for(let i = 0; i < children.length; i++) {
+            let entry = children[i];
+            let key = entry.key;
+            let nodeKey = entry.key[prefix.length]
+            let charCode = nodeKey.charCodeAt(0);
+
             if(charCode >= 0xD800 && charCode <= 0xDBFF) {
               // Merge the other half of an SMP char in!
-              key = key + fullText[prefix.length+1];
+              nodeKey = nodeKey + key[prefix.length+1];
             }
             yield {
-              key: key,
-              traversal: function() { return new TrieModel.Traversal(root, prefix + key)}
+              key: nodeKey,
+              traversal: function() { return new TrieModel.Traversal(root, prefix + nodeKey)}
             }
-          }
+          };
           return;
         }
       }
 
       get entries(): string[] {
         if(this.root.type == 'leaf') {
-          if(this.root.entries[0].key == this.prefix) {
-            return this.root.entries.map(function(value) { return value.content });
+          let prefix = this.prefix;
+
+          let matches = this.root.entries.filter(function(entry) {
+            return entry.key == prefix;
+          })
+          if(matches.length > 0) {
+            return matches.map(function(value) { return value.content });
           } else {
             return undefined;
           }

--- a/common/models/templates/test/fixtures/tries/smp-apple.json
+++ b/common/models/templates/test/fixtures/tries/smp-apple.json
@@ -1,0 +1,47 @@
+{
+  "totalWeight":2,
+  "root": {
+    "type":"internal","weight":1,
+    "values":["\ud835"],
+    "children": {
+      "\ud835": {
+        "type":"internal",
+        "weight":1,
+        "values":["\uddba"],
+        "children":{
+          "\uddba": {
+            "type":"internal",
+            "weight":1,
+            "values":["\ud835"],
+            "children":{
+              "\ud835": {
+                "type":"internal",
+                "weight":1,
+                "values":["\uddc9"],
+                "children": {
+                  "\uddc9":{
+                    "type":"internal",
+                    "weight":1,
+                    "values":["p","\ud835"],
+                    "children":{
+                      "p": {
+                        "type":"leaf",
+                        "weight":1,
+                        "entries":[{"key":"𝖺𝗉pl𝖾","weight":1,"content":"𝖺𝗉pl𝖾"}]
+                      },
+                      "\ud835": {
+                        "type":"leaf",
+                        "weight":1,
+                        "entries":[{"key":"𝖺𝗉𝗉𝗅𝖾","weight":1,"content":"𝖺𝗉𝗉𝗅𝖾"}]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -77,5 +77,67 @@ describe('Trie traversal abstractions', function() {
     assert.isEmpty(eKeys);
   });
 
-  // Next test:  "tro" + "uble" - only "tro" has actual representation!
+  it('iteration over compact leaf node', function() {
+    var model = new TrieModel(jsonFixture('tries/english-1000'));
+
+    let rootTraversal = model.getRootTraversal();
+    assert.isDefined(rootTraversal);
+
+    // 't', 'r', 'o' have siblings, but these don't.
+    let leafChildSequence = ['u', 'b', 'l', 'e'];
+    let eSuccess = false;
+    for(child of rootTraversal.children()) {
+      if(child.key == 't') {
+        let traversalInner1 = child.traversal();
+        assert.isDefined(traversalInner1);
+        assert.isUndefined(child.entries);
+
+        for(tChild of traversalInner1.children()) {
+          if(tChild.key == 'r') { 
+            let traversalInner2 = tChild.traversal();
+            assert.isDefined(traversalInner2);
+            assert.isUndefined(tChild.entries);
+
+            for(rChild of traversalInner2.children()) {
+              if(rChild.key == 'o') {
+                let curChild = rChild;
+
+                // At this point, we're already at the trie's actual leaf node for "trouble".
+                // But for edit-distance trie traversal, we want to decompress this and model
+                // an uncompacted Trie.
+                do {
+                  assert.isNotEmpty(leafChildSequence);
+
+                  let oIter = curChild.traversal().children();
+                  let curr = oIter.next();
+                  curChild = curr.value;
+
+                  // Test generator behavior - there should be one child, then the 'done' state.
+                  assert.isDefined(curChild);
+                  assert.equal(curChild.key, leafChildSequence[0]);
+                  curr = oIter.next();
+                  assert.isTrue(curr.done);
+
+                  // Prepare for iteration.
+                  leafChildSequence.shift();
+
+                  // Conditional test - if that was not the final character, entries should be undefined.
+                  if(leafChildSequence.length > 0) {
+                    assert.isUndefined(curChild.traversal().entries);
+                  } else {
+                    let finalTraversal = curChild.traversal();
+                    assert.isDefined(finalTraversal.entries);
+                    assert.equal(finalTraversal.entries[0], 'trouble');
+                    eSuccess = true;
+                  }
+                } while (leafChildSequence.length > 0);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    assert.isTrue(eSuccess);
+  });
 });

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -17,7 +17,7 @@ describe('Trie traversal abstractions', function() {
   it('root-level iteration over child nodes', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
 
-    let rootTraversal = model.getRootTraversal();
+    let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
 
     let rootKeys = ['t', 'o', 'a', 'i', 'w', 'h', 'f', 'b', 'n', 'y', 's', 'm',
@@ -35,7 +35,7 @@ describe('Trie traversal abstractions', function() {
   it('traversal with simple internal nodes', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
 
-    let rootTraversal = model.getRootTraversal();
+    let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
 
     let eKeys = ['y', 'r', 'i', 'm', 's', 'n', 'o'];
@@ -48,14 +48,16 @@ describe('Trie traversal abstractions', function() {
         tSuccess = true;
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
-        assert.isUndefined(child.entries);
+        assert.isArray(child.traversal().entries);
+        assert.isEmpty(child.traversal().entries);
 
         for(tChild of traversalInner1.children()) {
           if(tChild.char == 'h') { 
             hSuccess = true;
             let traversalInner2 = tChild.traversal();
             assert.isDefined(traversalInner2);
-            assert.isUndefined(tChild.entries);
+            assert.isEmpty(tChild.traversal().entries);
+            assert.isArray(tChild.traversal().entries);
 
             for(hChild of traversalInner2.children()) {
               if(hChild.char == 'e') {
@@ -88,7 +90,7 @@ describe('Trie traversal abstractions', function() {
   it('traversal over compact leaf node', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
 
-    let rootTraversal = model.getRootTraversal();
+    let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
 
     // 't', 'r', 'o' have siblings, but these don't.
@@ -98,13 +100,15 @@ describe('Trie traversal abstractions', function() {
       if(child.char == 't') {
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
-        assert.isUndefined(child.entries);
+        assert.isArray(child.traversal().entries);
+        assert.isEmpty(child.traversal().entries);
 
         for(tChild of traversalInner1.children()) {
           if(tChild.char == 'r') { 
             let traversalInner2 = tChild.traversal();
             assert.isDefined(traversalInner2);
-            assert.isUndefined(tChild.entries);
+            assert.isArray(tChild.traversal().entries);
+            assert.isEmpty(tChild.traversal().entries);
 
             for(rChild of traversalInner2.children()) {
               if(rChild.char == 'o') {
@@ -131,7 +135,8 @@ describe('Trie traversal abstractions', function() {
 
                   // Conditional test - if that was not the final character, entries should be undefined.
                   if(leafChildSequence.length > 0) {
-                    assert.isUndefined(curChild.traversal().entries);
+                    assert.isArray(curChild.traversal().entries);
+                    assert.isEmpty(curChild.traversal().entries);
                   } else {
                     let finalTraversal = curChild.traversal();
                     assert.isDefined(finalTraversal.entries);
@@ -155,7 +160,7 @@ describe('Trie traversal abstractions', function() {
     // One solely uses SMP characters, the other of which uses a mix of SMP and standard.
     var model = new TrieModel(jsonFixture('tries/smp-apple'));
 
-    let rootTraversal = model.getRootTraversal();
+    let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
 
     let smpA = smpForUnicode(0x1d5ba);
@@ -176,14 +181,16 @@ describe('Trie traversal abstractions', function() {
         aSuccess = true;
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
-        assert.isUndefined(child.entries);
+        assert.isArray(child.traversal().entries);
+        assert.isEmpty(child.traversal().entries);
 
         for(aChild of traversalInner1.children()) {
           if(aChild.char == smpP) { 
             pSuccess = true;
             let traversalInner2 = aChild.traversal();
             assert.isDefined(traversalInner2);
-            assert.isUndefined(aChild.entries);
+            assert.isArray(aChild.traversal().entries);
+            assert.isEmpty(aChild.traversal().entries);
 
             for(pChild of traversalInner2.children()) {
               let keyIndex = pKeys.indexOf(pChild.char);
@@ -193,7 +200,8 @@ describe('Trie traversal abstractions', function() {
               if(pChild.char == 'p') { // We'll test traversal with the 'mixed' entry from here.
                 let traversalInner3 = pChild.traversal();
                 assert.isDefined(traversalInner3);
-                assert.isUndefined(pChild.entries);
+                assert.isArray(pChild.traversal().entries);
+                assert.isEmpty(pChild.traversal().entries);
 
                 // Now to handle the rest, knowing it's backed by a leaf node.
                 let curChild = pChild;
@@ -219,7 +227,8 @@ describe('Trie traversal abstractions', function() {
 
                   // Conditional test - if that was not the final character, entries should be undefined.
                   if(leafChildSequence.length > 0) {
-                    assert.isUndefined(curChild.traversal().entries);
+                    assert.isArray(curChild.traversal().entries);
+                    assert.isEmpty(curChild.traversal().entries);
                   } else {
                     let finalTraversal = curChild.traversal();
                     assert.isDefined(finalTraversal.entries);

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -24,7 +24,7 @@ describe('Trie traversal abstractions', function() {
                     'u', 'c', 'd', 'l', 'e', 'j', 'p', 'g', 'v', 'k', 'r', 'q']
 
     for(child of rootTraversal.children()) {
-      let keyIndex = rootKeys.indexOf(child.key);
+      let keyIndex = rootKeys.indexOf(child.char);
       assert.notEqual(keyIndex, -1);
       rootKeys.splice(keyIndex, 1);
     }
@@ -44,21 +44,21 @@ describe('Trie traversal abstractions', function() {
     let hSuccess = false;
     let eSuccess = false;
     for(child of rootTraversal.children()) {
-      if(child.key == 't') {
+      if(child.char == 't') {
         tSuccess = true;
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
         assert.isUndefined(child.entries);
 
         for(tChild of traversalInner1.children()) {
-          if(tChild.key == 'h') { 
+          if(tChild.char == 'h') { 
             hSuccess = true;
             let traversalInner2 = tChild.traversal();
             assert.isDefined(traversalInner2);
             assert.isUndefined(tChild.entries);
 
             for(hChild of traversalInner2.children()) {
-              if(hChild.key == 'e') {
+              if(hChild.char == 'e') {
                 eSuccess = true;
                 let traversalInner3 = hChild.traversal();
                 assert.isDefined(traversalInner3);
@@ -67,8 +67,8 @@ describe('Trie traversal abstractions', function() {
                 assert.equal(traversalInner3.entries[0], "the");
 
                 for(eChild of traversalInner3.children()) {
-                  let keyIndex = eKeys.indexOf(eChild.key);
-                  assert.notEqual(keyIndex, -1, "Did not find char '" + eChild.key + "' in array!");
+                  let keyIndex = eKeys.indexOf(eChild.char);
+                  assert.notEqual(keyIndex, -1, "Did not find char '" + eChild.char + "' in array!");
                   eKeys.splice(keyIndex, 1);
                 }
               }
@@ -95,19 +95,19 @@ describe('Trie traversal abstractions', function() {
     let leafChildSequence = ['u', 'b', 'l', 'e'];
     let eSuccess = false;
     for(child of rootTraversal.children()) {
-      if(child.key == 't') {
+      if(child.char == 't') {
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
         assert.isUndefined(child.entries);
 
         for(tChild of traversalInner1.children()) {
-          if(tChild.key == 'r') { 
+          if(tChild.char == 'r') { 
             let traversalInner2 = tChild.traversal();
             assert.isDefined(traversalInner2);
             assert.isUndefined(tChild.entries);
 
             for(rChild of traversalInner2.children()) {
-              if(rChild.key == 'o') {
+              if(rChild.char == 'o') {
                 let curChild = rChild;
 
                 // At this point, we're already at the trie's actual leaf node for "trouble".
@@ -122,7 +122,7 @@ describe('Trie traversal abstractions', function() {
 
                   // Test generator behavior - there should be one child, then the 'done' state.
                   assert.isDefined(curChild);
-                  assert.equal(curChild.key, leafChildSequence[0]);
+                  assert.equal(curChild.char, leafChildSequence[0]);
                   curr = iter.next();
                   assert.isTrue(curr.done);
 
@@ -172,25 +172,25 @@ describe('Trie traversal abstractions', function() {
     let pSuccess = false;
     let eSuccess = false;
     for(child of rootTraversal.children()) {
-      if(child.key == smpA) {
+      if(child.char == smpA) {
         aSuccess = true;
         let traversalInner1 = child.traversal();
         assert.isDefined(traversalInner1);
         assert.isUndefined(child.entries);
 
         for(aChild of traversalInner1.children()) {
-          if(aChild.key == smpP) { 
+          if(aChild.char == smpP) { 
             pSuccess = true;
             let traversalInner2 = aChild.traversal();
             assert.isDefined(traversalInner2);
             assert.isUndefined(aChild.entries);
 
             for(pChild of traversalInner2.children()) {
-              let keyIndex = pKeys.indexOf(pChild.key);
-              assert.notEqual(keyIndex, -1, "Did not find char '" + pChild.key + "' in array!");
+              let keyIndex = pKeys.indexOf(pChild.char);
+              assert.notEqual(keyIndex, -1, "Did not find char '" + pChild.char + "' in array!");
               pKeys.splice(keyIndex, 1);
 
-              if(pChild.key == 'p') { // We'll test traversal with the 'mixed' entry from here.
+              if(pChild.char == 'p') { // We'll test traversal with the 'mixed' entry from here.
                 let traversalInner3 = pChild.traversal();
                 assert.isDefined(traversalInner3);
                 assert.isUndefined(pChild.entries);
@@ -210,7 +210,7 @@ describe('Trie traversal abstractions', function() {
 
                   // Test generator behavior - there should be one child, then the 'done' state.
                   assert.isDefined(curChild);
-                  assert.equal(curChild.key, leafChildSequence[0]);
+                  assert.equal(curChild.char, leafChildSequence[0]);
                   curr = iter.next();
                   assert.isTrue(curr.done);
 

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -1,0 +1,81 @@
+/*
+ * Unit tests for the Trie prediction model.
+ */
+
+var assert = require('chai').assert;
+var TrieModel = require('../').models.TrieModel;
+
+describe('Trie traversal abstractions', function() {
+  it('root-level iteration over child nodes', function() {
+    var model = new TrieModel(jsonFixture('tries/english-1000'));
+
+    let rootTraversal = model.getRootTraversal();
+    assert.isDefined(rootTraversal);
+
+    let rootKeys = ['t', 'o', 'a', 'i', 'w', 'h', 'f', 'b', 'n', 'y', 's', 'm',
+                    'u', 'c', 'd', 'l', 'e', 'j', 'p', 'g', 'v', 'k', 'r', 'q']
+
+    for(child of rootTraversal.children()) {
+      let keyIndex = rootKeys.indexOf(child.key);
+      assert.notEqual(keyIndex, -1);
+      rootKeys.splice(keyIndex, 1);
+    }
+
+    assert.isEmpty(rootKeys);
+  });
+
+  it('iteration over simple internal node', function() {
+    var model = new TrieModel(jsonFixture('tries/english-1000'));
+
+    let rootTraversal = model.getRootTraversal();
+    assert.isDefined(rootTraversal);
+
+    let eKeys = ['y', 'r', 'i', 'm', 's', 'n', 'o'];
+
+    let tSuccess = false;
+    let hSuccess = false;
+    let eSuccess = false;
+    for(child of rootTraversal.children()) {
+      if(child.key == 't') {
+        tSuccess = true;
+        let traversalInner1 = child.traversal();
+        assert.isDefined(traversalInner1);
+        assert.isUndefined(child.entries);
+
+        for(tChild of traversalInner1.children()) {
+          if(tChild.key == 'h') { 
+            hSuccess = true;
+            let traversalInner2 = tChild.traversal();
+            assert.isDefined(traversalInner2);
+            assert.isUndefined(tChild.entries);
+
+            for(hChild of traversalInner2.children()) {
+              if(hChild.key == 'e') {
+                eSuccess = true;
+                let traversalInner3 = hChild.traversal();
+                assert.isDefined(traversalInner3);
+                
+                assert.isDefined(traversalInner3.entries);
+                assert.equal(traversalInner3.entries[0], "the");
+
+                for(eChild of traversalInner3.children()) {
+                  let keyIndex = eKeys.indexOf(eChild.key);
+                  assert.notEqual(keyIndex, -1, "Did not find char '" + eChild.key + "' in array!");
+                  eKeys.splice(keyIndex, 1);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    assert.isTrue(tSuccess);
+    assert.isTrue(hSuccess);
+    assert.isTrue(eSuccess);
+
+    assert.isEmpty(eKeys);
+  });
+
+  // Next test:  "tro" + "uble" - only "tro" has actual representation!
+});

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -17,6 +17,11 @@
  */	
 declare type USVString = string;
 
+declare interface LexiconTraversal {
+  children(): Generator<{key: USVString, traversal: () => LexiconTraversal}>;
+  entries: USVString[];
+}
+
 /**
  * The model implementation, within the Worker.
  */
@@ -78,6 +83,13 @@ declare interface LexicalModel {
    * @see LexicalModelPunctuation
    */
   readonly punctuation?: LexicalModelPunctuation;
+
+  /**
+   * Lexical models _may_ provide a LexiconTraversal object usable to enhance 
+   * prediction and correction results.  The returned object represents the
+   * unfiltered lexicon (with an empty prefix).
+   */
+  getRootTraversal?(): LexiconTraversal;
 }
 
 /**

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -115,7 +115,7 @@ declare interface LexicalModel {
    * prediction and correction results.  The returned object represents the
    * unfiltered lexicon (with an empty prefix).
    */
-  getRootTraversal?(): LexiconTraversal;
+  traverseFromRoot?(): LexiconTraversal;
 }
 
 /**

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -17,8 +17,33 @@
  */	
 declare type USVString = string;
 
+/**
+ * Used to facilitate edit-distance calculations by allowing the LMLayer to
+ * efficiently search the model's lexicon in a Trie-like manner.
+ */
 declare interface LexiconTraversal {
+  /**
+   * Provides an iterable pattern used to search for words with a prefix matching
+   * the current traversal state's prefix when a new character is appended.
+   * 
+   * For example, if the current traversal state corresponds to 'th', children() may return
+   * an iterator with states corresponding 'e' (for 'the', 'then', 'there'),
+   * 'a' (for 'than', 'that'), etc.
+   * 
+   * @param key       The character suffixed to the existing lookup-prefix's string
+   * @param traversal A closure providing an iterable over the possible child states
+   * of the resulting state.
+   */
   children(): Generator<{key: USVString, traversal: () => LexiconTraversal}>;
+
+  /**
+   * Any entries directly keyed by the currently-represented lookup prefix.  Entries and
+   * children may exist simultaneously, but `entries` must always exist when no children are
+   * available in the returned `children()` iterable.
+   * 
+   * For example, with a search prefix of 'the', entries should return ['the'] even if 'then'
+   * and 'there' also exist within the lexicon.
+   */
   entries: USVString[];
 }
 

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -24,16 +24,27 @@ declare type USVString = string;
 declare interface LexiconTraversal {
   /**
    * Provides an iterable pattern used to search for words with a prefix matching
-   * the current traversal state's prefix when a new character is appended.
+   * the current traversal state's prefix when a new character is appended.  Iterating
+   * across `children` provides 'breadth' to a lexical search.
    * 
-   * For example, if the current traversal state corresponds to 'th', children() may return
-   * an iterator with states corresponding 'e' (for 'the', 'then', 'there'),
-   * 'a' (for 'than', 'that'), etc.
+   * For an example with English, if the current traversal state corresponds to 'th', 
+   * children() may return an iterator with states corresponding 'e' 
+   * (for 'the', 'then', 'there'), 'a' (for 'than', 'that'), etc.
    * 
-   * @param char      The character suffixed to the existing lookup-prefix's string after
-   *                  any 'keying' transformations are applied.
-   * @param traversal A closure providing an iterable over the possible child states
-   * of the resulting state.
+   * @param char      A full character (a UTF-16 code point, which may be comprised of two
+   *                  code units) corresponding to the child node, appended to the current
+   *                  node's prefix to produce the child node's prefix.
+   * <p>
+   *                  Example: if the current traversal's represented prefix is 'th', 
+   *                  char = 'e' would indicate a child node with prefix = 'the'.
+   * @param traversal a LexiconTraversal starting from (or "rooted at") the child node.  Use
+   *                  of the returned object provides 'depth' to a lexical search.
+   * <p>
+   *                  Example:
+   * 
+   * - Suppose our current LexiconTraversal represents a prefix of 'th'.
+   * - If `char` = 'e', the child represents a prefix of 'the'.
+   * - Then `traversal` allows traversing the part of the lexicon prefixed by 'the'.
    */
   children(): Generator<{char: USVString, traversal: () => LexiconTraversal}>;
 
@@ -42,8 +53,20 @@ declare interface LexiconTraversal {
    * children may exist simultaneously, but `entries` must always exist when no children are
    * available in the returned `children()` iterable.
    * 
-   * For example, with a search prefix of 'the', entries should return ['the'] even if 'then'
-   * and 'there' also exist within the lexicon.
+   * Examples for English:
+   * - search prefix of 'th':  [] - an empty array.  'th' is not a valid English word.
+   * - search prefix of 'the': ['the'].  'then' and 'there' may also exist within the lexicon,
+   *   but they most directly belong to deeper traversal states.
+   * 
+   * May contain multiple children if a lexical model performs 'keying' operations, such as
+   * may result from stripping accent markers from Spanish or French.  In this case, all entries
+   * transformed to the same 'key' should be listed by their key's traversal node.
+   * 
+   * Example using French "accent homographs", where keying operations strip accents:
+   * 
+   * - prefix of 'acre': ['acre', 'âcre']
+   * - prefix of 'crepe': ['crêpe', 'crêpé']
+   * - other examples:  https://www.thoughtco.com/french-accent-homographs-1371072
    */
   entries: USVString[];
 }

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -30,11 +30,12 @@ declare interface LexiconTraversal {
    * an iterator with states corresponding 'e' (for 'the', 'then', 'there'),
    * 'a' (for 'than', 'that'), etc.
    * 
-   * @param key       The character suffixed to the existing lookup-prefix's string
+   * @param char      The character suffixed to the existing lookup-prefix's string after
+   *                  any 'keying' transformations are applied.
    * @param traversal A closure providing an iterable over the possible child states
    * of the resulting state.
    */
-  children(): Generator<{key: USVString, traversal: () => LexiconTraversal}>;
+  children(): Generator<{char: USVString, traversal: () => LexiconTraversal}>;
 
   /**
    * Any entries directly keyed by the currently-represented lookup prefix.  Entries and


### PR DESCRIPTION
While our currently-published model template is a Trie-based wordlist, it's important to note that we may support other model templates in the future.  When it comes to examining the lexicon for possible words, the important thing for an edit-distance based search is that we can search the lexicon '_like_' a Trie, not necessarily that the full model itself is Trie-based.

For highly agglutinative languages, it may be more efficient to reconstruct the words from morphemes (as needed) than to actually store every possible word within a Trie.  Furthermore, edit distance doesn't care whether or not a model's backing Trie stores probabilities on a per-word basis or uses some alternate function.  It only cares what words 'neighbor' the current word it's examining.

----

Past that... it turns out that even our current Trie-wordlist's Trie storage's interface doesn't quite match what I'm wanting for use with my edit-distance search plans.

For example, suppose a user has typed "trou" and is looking to type the word "trouble."  With the super-basic test model (See `english-1000.json`), we have the node for "tro"... that jumps straight to the leaf node for "trouble".  For searching, it's best if we have a "virtual" node for "trou".
- "trou" vs "tro":  edit distance 1
- "trou" vs "trou": edit distance 0
- "trou" vs "trouble": edit distance 3

That same model also supports:
- "trou" vs "tru": edit distance 1
- "trou" vs "true": edit distance 2
- "trou" vs "truth": edit distance 3

If a "trou" node is not available, any suggestions prefixed by either "tro" or "tru" will be given equal weight.  With a "trou" node, we know to prioritize "trou" entries over "tru" entries due to the edit distance difference.  

To be a bit more explicit about my thought process:
- Once a compatible edit-distance based search is available, the original `predict()` method would be used to find suggestions based on the closest-matching prefixes.
    - That is, edit-distance search is largely for 'correction'.
    - Of course, if a prefix is a word itself, that's great!
- For the average case, we're not likely to compute edit distance against all common prefixes / nodes of a Trie, let alone every word in the lexicon.
    - If we find that "edit distance = 1" provides 12+ suggestions and everything else left to search is at least edit distance 2... why search further?
    - I may add an extra `LexiconTraversal` field:  `representedCount`.  This would help the search to track how many suggestions are already available without the need to even call `predict`.
    - That said, it may be the case that `representedCount`'s only uses would be at times we'd look to call `predict` anyway, so... I'm holding off on that for now.
- Between inputs, we would save all precomputed intermediate calculations.  Part of this is _also_ saving the traversal state.
    - These would be fed into a priority queue to perform breadth-first search... and without a need to re-traverse the lexicon unnecessarily.

-------

Finally... please feel free to critique the nomenclature this PR introduces.  I struggled to get it to its current state, and I'm still not entirely happy with the current terminology.