### PR TITLE
feat(common/models):  actual priority queue for Trie models

### DIFF
--- a/common/models/templates/src/priority-queue.ts
+++ b/common/models/templates/src/priority-queue.ts
@@ -85,7 +85,8 @@ namespace models {
      * @param elements 
      */
     enqueueAll(elements: Type[]) {
-      for(let element of elements) {this.enqueue(element);
+      for(let element of elements) {
+        this.enqueue(element);
       }
     }
 

--- a/common/models/templates/src/priority-queue.ts
+++ b/common/models/templates/src/priority-queue.ts
@@ -1,0 +1,143 @@
+/**
+ * @file priority-queue.ts
+ *
+ * Defines a mildly abstracted priority queue implementation.
+ */
+
+namespace models {
+  /**
+   * Used to compare two instances of a type.
+   * @returns 
+   * - value < 0 if `a` should come before `b`
+   * - value > 0 if `b` should come before `a`
+   * - 0 if they should be treated equally.
+   */
+  export type Comparator<Type> = (a: Type, b: Type) => number;
+
+  export class PriorityQueue<Type> {
+
+    private comparator: Comparator<Type>;
+    private heap: Type[] = [];
+
+    /**
+     * Constructs an empty priority queue.
+     * @param comparator A `Comparator` returning negative values when and only when
+     * the first parameter should precede the second parameter.
+     */
+    constructor(comparator: Comparator<Type>) {
+      // TODO: We may wish to allow options specifying a limit or threshold for adding
+      // items to the priority queue.  Possibly both.
+      this.comparator = comparator;
+    }
+
+    private static leftChildIndex(index: number): number {
+      return index * 2 + 1;
+    }
+
+    private static rightChildIndex(index: number): number {
+      return index * 2 + 2;
+    }
+
+    private static parentIndex(index: number): number {
+      return Math.floor((index-1)/2);
+    }
+
+    /**
+     * Returns the number of elements currently held by the priority queue.
+     */
+    get count(): number {
+      return this.heap.length;
+    }
+
+    /**
+     * Returns the highest-priority item within the priority queue.
+     * <p>
+     * Is O(1).
+     */
+    peek() {
+      return this.heap[0];  // undefined if it doesn't exist... which is completely correct.
+    }
+
+    /**
+     * Inserts a new element into the priority queue, placing it in order.
+     * <p>
+     * Is O(log N), where N = # of items in the priority queue.
+     * @param element 
+     */
+    enqueue(element: Type) {
+      let index = this.heap.length;
+      this.heap.push(element);
+
+      let parent = PriorityQueue.parentIndex;
+      let parentIndex = parent(index);
+      while(index !== 0 && this.comparator(this.heap[index], this.heap[parentIndex]) < 0) {
+        let a = this.heap[index];
+        this.heap[index] = this.heap[parentIndex];
+        this.heap[parentIndex] = a;
+
+        index = parentIndex;
+        parentIndex = parent(index);
+      }
+    }
+
+    /**
+     * Convenience function:  lazily calls enqueue for each element of the specified array.
+     * @param elements 
+     */
+    enqueueAll(elements: Type[]) {
+      for(let element of elements) {this.enqueue(element);
+      }
+    }
+
+    /**
+     * Removes the highest-priority element from the queue, returning it.
+     * <p>
+     * Is O(log N), where N = number of items in the priority queue.
+     */
+    dequeue(): Type {
+      if(this.count == 0) {
+        return undefined;
+      }
+
+      const root = this.heap[0];
+      let tail = this.heap.pop();
+      if(this.heap.length > 0) {
+        this.heap[0] = tail;
+        this.heapify(0);
+      }
+
+      return root;
+    }
+
+    /**
+     * Compares the entry at the specified index against its children,
+     * propagating it downward within the heap until heap requirements are specified.
+     * <p>
+     * Is O(log N), where N = number of items in the priority queue.
+     * 
+     * @param index The index of the top-most node that must be examined
+     * for repositioning.
+     */
+    private heapify(index: number) {
+      let leftIndex = PriorityQueue.leftChildIndex(index);
+      let rightIndex = PriorityQueue.rightChildIndex(index);
+      let topMostIndex = index;
+
+      if(leftIndex < this.heap.length && this.comparator(this.heap[leftIndex], this.heap[topMostIndex]) < 0) {
+        topMostIndex = leftIndex;
+      }
+
+      if(rightIndex < this.heap.length && this.comparator(this.heap[rightIndex], this.heap[topMostIndex]) < 0) {
+        topMostIndex = rightIndex;
+      }
+
+      if(topMostIndex != index) {
+        let a = this.heap[index];
+        this.heap[index] = this.heap[topMostIndex];
+        this.heap[topMostIndex] = a;
+
+        this.heapify(topMostIndex);
+      }
+    }
+  }
+}

--- a/common/models/templates/test/test-priority-queue.js
+++ b/common/models/templates/test/test-priority-queue.js
@@ -1,0 +1,81 @@
+/*
+ * Unit tests for the priority queue.
+ */
+
+var assert = require('chai').assert;
+var PriorityQueue = require('../').models.PriorityQueue;
+
+describe('Priority queue', function() {
+  it('can act as a min-heap', function () {
+    let input = [1, 10, 2, 9, 3, 8, 4, 7, 5, 6];
+    
+    let queue = new PriorityQueue((a, b) => a - b);
+    input.forEach((input) => queue.enqueue(input));
+
+    assert.equal(queue.peek(), 1);
+    assert.equal(queue.count, 10);
+
+    for(let i = 1; i <= 10; i++) {
+      assert.equal(queue.dequeue(), i);
+    }
+
+    assert.equal(queue.count, 0);
+  });
+
+  it('can act as a max-heap', function () {
+    let input = [1, 10, 2, 9, 3, 8, 4, 7, 5, 6];
+    
+    let queue = new PriorityQueue((a, b) => b - a);
+    input.forEach((input) => queue.enqueue(input));
+
+    assert.equal(queue.peek(), 10);
+    assert.equal(queue.count, 10);
+
+    for(let i = 10; i >= 1; i--) {
+      assert.equal(queue.dequeue(), i);
+    }
+
+    assert.equal(queue.count, 0);
+  });
+
+  it('operates correctly when used interactively', function() {
+    // min-heap version.
+    let queue = new PriorityQueue((a, b) => a - b);
+
+    queue.enqueueAll([1, 10, 3, 8, 5]);
+    assert.equal(queue.count, 5);
+
+    assert.equal(queue.dequeue(), 1);
+    assert.equal(queue.count, 4);
+
+    queue.enqueue(2);
+    assert.equal(queue.count, 5);
+
+    assert.equal(queue.dequeue(), 2);
+    assert.equal(queue.count, 4);
+
+    queue.enqueue(7);
+    queue.enqueue(6);
+    assert.equal(queue.count, 6);
+
+    assert.equal(queue.dequeue(), 3);
+    assert.equal(queue.count, 5);
+
+    queue.enqueue(13);
+    queue.enqueue(0);
+    assert.equal(queue.count, 7);
+
+    assert.equal(queue.dequeue(), 0);
+    assert.equal(queue.count, 6);
+
+    queue.enqueue(1);
+    queue.enqueue(1);
+    assert.equal(queue.count, 8);
+
+    assert.equal(queue.dequeue(), 1);
+    assert.equal(queue.count, 7);
+
+    assert.equal(queue.dequeue(), 1);
+    assert.equal(queue.count, 6);
+  })
+});


### PR DESCRIPTION
Addresses this old comment: https://github.com/keymanapp/keyman/blob/32df4035a5a2dcc8c0ecded1abf8e9367eab103c/common/models/templates/src/trie-model.ts#L383-L385

As it turns out, a proper priority queue will _also_ be quite helpful for a correction algorithm using edit-distance calculations to search across a lexicon.  So... two birds, one stone.  That algorithm will want a 'min-heap' style queue instead of the Trie's 'max-heap' style queue, so it's been abstracted to take a comparator tailored to each use-case.
- Accordingly, the class is now defined outside of the `TrieModel` class, though still within the `models` namespace.

Immediate benefits:
- Predictions should be snappier, particularly when many are available.
    - Drops from O(N^2 log N) to O(N log N), an order of magnitude faster for larger prediction counts.

------

If we prefer, there is an npm package ([`tinyqueue`](https://www.npmjs.com/package/tinyqueue)) that exists that should act similarly.  Either way. 
- [`js-priority-queue`](https://www.npmjs.com/package/js-priority-queue) also exists, but is less optimized and less time-efficient.  Which probably led to `tinyqueue` as mentioned above.
- However, it's worth noting that if we wish to 'extend' the priority-queue with any additional functionality, like thresholds and max-count limitations... we'll need our own version then anyway.

Noting another comment from before:
https://github.com/keymanapp/keyman/blob/32df4035a5a2dcc8c0ecded1abf8e9367eab103c/common/models/templates/src/trie-model.ts#L387

Would currently be 'maintained' as:
https://github.com/keymanapp/keyman/blob/c14e06e270aba715260139c57abd716ad7cc5fdc/common/models/templates/src/priority-queue.ts#L28-L29