### PR TITLE
feat(common/models): efficient batch-enqueue

### DIFF
--- a/common/models/templates/src/priority-queue.ts
+++ b/common/models/templates/src/priority-queue.ts
@@ -86,11 +86,6 @@ namespace models {
           }
         }
       } else {
-        // Quick safety-check.
-        if(this.count == 0) {
-          return;
-        }
-
         this.heapify(0, this.count - 1);
       }
     }
@@ -142,11 +137,12 @@ namespace models {
      * @param elements A group of elements to enqueue simultaneously.
      */
     enqueueAll(elements: Type[]) {
-      let firstIndex = this.count > 0 ? this.count : 1; // parent of 0 is -1, which is illegal.
+      let firstIndex = this.count 
       this.heap = this.heap.concat(elements);
-      let lastIndex = this.count - 1;
+      let firstParent = PriorityQueue.parentIndex(firstIndex);
 
-      this.heapify(PriorityQueue.parentIndex(firstIndex), PriorityQueue.parentIndex(lastIndex));
+      // The 'parent' of index 0 will return -1, which is illegal.
+      this.heapify(firstParent >= 0 ? firstParent : 0, PriorityQueue.parentIndex(this.count-1));
     }
 
     /**

--- a/common/models/templates/src/priority-queue.ts
+++ b/common/models/templates/src/priority-queue.ts
@@ -58,35 +58,35 @@ namespace models {
     private heapify(): void;
     private heapify(start: number, end: number): void;
     private heapify(start?: number, end?: number): void {
-      if(typeof start == 'number' && typeof end == 'number') {
-        // Use of 'indices' here is a bit of a customization.
-        // At the cost of (temporary) extra storage space, we can more efficiently enqueue
-        // multiple elements simultaneously.
-        let queuedIndices: number[] = [];
-        let lastParent = -1;
-
-        for(let i = end; i >= start; i--) {
-          let parent = PriorityQueue.parentIndex(i);
-          if(this.siftDown(i) && parent < start && lastParent != parent) {
-            // We only need to queue examination for a heap node if its children have changed
-            // and it isn't already being examined.
-            queuedIndices.push(parent);
-            lastParent = parent;
-          }
-        }
-
-        lastParent = -1;
-        while(queuedIndices.length > 0) {
-          let index = queuedIndices.shift();
-          let parent = PriorityQueue.parentIndex(index);
-          if(this.siftDown(index) && parent >= 0 && lastParent != parent) {
-              // We only need to queue examination for a heap node if its children have changed.
-            queuedIndices.push(parent);
-            lastParent = parent;
-          }
-        }
-      } else {
+      if(start == undefined || end == undefined) {
         this.heapify(0, this.count - 1);
+      }
+
+      // Use of 'indices' here is a bit of a customization.
+      // At the cost of (temporary) extra storage space, we can more efficiently enqueue
+      // multiple elements simultaneously.
+      let queuedIndices: number[] = [];
+      let lastParent = -1;
+
+      for(let i = end; i >= start; i--) {
+        let parent = PriorityQueue.parentIndex(i);
+        if(this.siftDown(i) && parent < start && lastParent != parent) {
+          // We only need to queue examination for a heap node if its children have changed
+          // and it isn't already being examined.
+          queuedIndices.push(parent);
+          lastParent = parent;
+        }
+      }
+
+      lastParent = -1;
+      while(queuedIndices.length > 0) {
+        let index = queuedIndices.shift();
+        let parent = PriorityQueue.parentIndex(index);
+        if(this.siftDown(index) && parent >= 0 && lastParent != parent) {
+            // We only need to queue examination for a heap node if its children have changed.
+          queuedIndices.push(parent);
+          lastParent = parent;
+        }
       }
     }
 

--- a/common/models/templates/test/test-priority-queue.js
+++ b/common/models/templates/test/test-priority-queue.js
@@ -22,6 +22,23 @@ describe('Priority queue', function() {
     assert.equal(queue.count, 0);
   });
 
+  it('initializes well from pre-existing values', function() {
+    let input = [1, 10, 2, 9, 3, 8, 4, 7, 5, 6];
+    let originalInput = Array.from(input);
+    let queue = new PriorityQueue((a, b) => a - b, input);
+
+    assert.deepEqual(input, originalInput);
+
+    assert.equal(queue.peek(), 1);
+    assert.equal(queue.count, 10);
+
+    for(let i = 1; i <= 10; i++) {
+      assert.equal(queue.dequeue(), i);
+    }
+
+    assert.equal(queue.count, 0);
+  });
+
   it('can act as a max-heap', function () {
     let input = [1, 10, 2, 9, 3, 8, 4, 7, 5, 6];
     
@@ -77,5 +94,23 @@ describe('Priority queue', function() {
 
     assert.equal(queue.dequeue(), 1);
     assert.equal(queue.count, 6);
-  })
+  });
+
+  it('properly batch-enqueues', function() {
+    let queue = new PriorityQueue((a, b) => a - b);
+
+    queue.enqueueAll([1, 10, 3, 8, 5]);
+    assert.equal(queue.count, 5);
+
+    assert.equal(queue.dequeue(), 1);
+    assert.equal(queue.count, 4);
+
+    let batch2 = [2, 7, 6, 13, 0, 1, 1];
+    queue.enqueueAll(batch2);
+
+    let correctOrder = [0, 1, 1, 2, 3, 5, 6, 7, 8, 10, 13];
+    while(correctOrder.length > 0) {
+      assert.equal(queue.dequeue(), correctOrder.shift());
+    }
+  });
 });


### PR DESCRIPTION
Looking more closely at what will be need for edit-distance based correction searches, it looks like a more efficient batch-enqueue method is in order.  This corrects the 'lazy' approach previously noted and also facilitates O(N) heap construction from existing arrays.