### PR TITLE
fix(android): Fix util to getting the tier on CI builds

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -277,7 +277,7 @@ public final class KMManager {
     if (versionName == null || versionName.isEmpty()) {
       versionName = com.tavultesoft.kmea.BuildConfig.VERSION_NAME;
     }
-    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)-(alpha|beta|stable)-.*");
+    Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)-(alpha|beta|stable).*");
     Matcher matcher = pattern.matcher(versionName);
     if (matcher.matches() && matcher.groupCount() >= 2) {
       switch (matcher.group(2)) {

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/KMManagerTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/KMManagerTest.java
@@ -48,13 +48,49 @@ public class KMManagerTest {
 
   @Test
   public void test_getTier() {
-    String versionName = "14.0.248-alpha-local";
+    String versionName = "14.0.248-alpha";
     KMManager.Tier tier = KMManager.getTier(versionName);
     Assert.assertEquals(KMManager.Tier.ALPHA, tier);
+
+    versionName = "14.0.248-alpha-test";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.ALPHA, tier);
+
+    versionName = "14.0.248-alpha-test-1234";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.ALPHA, tier);
+
+    versionName = "14.0.248-alpha-local";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.ALPHA, tier);
+
+    versionName = "14.0.248-beta";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.BETA, tier);
+
+    versionName = "14.0.248-beta-test";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.BETA, tier);
+
+    versionName = "14.0.248-beta-test-1234";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.BETA, tier);
 
     versionName = "14.0.248-beta-local";
     tier = KMManager.getTier(versionName);
     Assert.assertEquals(KMManager.Tier.BETA, tier);
+
+    versionName = "14.0.248-stable";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.STABLE, tier);
+
+    versionName = "14.0.248-stable-test";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.STABLE, tier);
+
+    versionName = "14.0.248-stable-test-1234";
+    tier = KMManager.getTier(versionName);
+    Assert.assertEquals(KMManager.Tier.STABLE, tier);
 
     versionName = "14.0.248-stable-local";
     tier = KMManager.getTier(versionName);


### PR DESCRIPTION
I noticed the Info page on Keyman 14.0.129-alpha was displaying "Page not found" because it was using the production host https://help.keyman.com instead of https://help.keyman-staging.com. This is because the regex in `KMManager.getTier()` was incorrect for CI versions because of an extra `-`.

A local development version string `14.0.248-alpha-local` would correctly return Tier.ALPHA, but a CI build `14.0.248-alpha` would return Tier.STABLE.

This PR fixes the regex and  adds additional unit test cases (adds PR test and CI version strings)
