### PR TITLE
feat(linux): Small UI improvements

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -296,7 +296,7 @@ class InstallKmpWindow(Gtk.Dialog):
             if os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.debug(uri_path)
-                w = WelcomeView(self, uri_path, self.kbname)
+                w = WelcomeView(self, uri_path, self.kbname, True)
                 w.run()
                 w.destroy()
             else:

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -53,13 +53,8 @@ class KeyboardDetailsView(Gtk.Dialog):
             with open(jsonfile, "r") as read_file:
                 kbdata = json.load(read_file)
 
-        box = Gtk.Box(spacing=10)
-        # self.add(box)
         grid = Gtk.Grid()
         # grid.set_column_homogeneous(True)
-
-        box.add(grid)
-        # self.add(grid)
 
         # kbdatapath = os.path.join("/usr/local/share/keyman", kmp["id"], kmp["id"] + ".json")
 
@@ -144,6 +139,7 @@ class KeyboardDetailsView(Gtk.Dialog):
 
         divider_pkg = Gtk.HSeparator()
         grid.attach_next_to(divider_pkg, prevlabel, Gtk.PositionType.BOTTOM, 2, 1)
+        prevlabel = divider_pkg
 
         # Keyboard info for each keyboard
 
@@ -154,6 +150,13 @@ class KeyboardDetailsView(Gtk.Dialog):
                 if os.path.isfile(jsonfile):
                     with open(jsonfile, "r") as read_file:
                         kbdata = json.load(read_file)
+
+                # start with padding
+                lbl_pad = Gtk.Label()
+                lbl_pad.set_text("")
+                lbl_pad.set_halign(Gtk.Align.END)
+                grid.attach_next_to(lbl_pad, prevlabel, Gtk.PositionType.BOTTOM, 2, 1)
+                prevlabel = lbl_pad
 
                 # show the icon somewhere
 
@@ -326,6 +329,6 @@ class KeyboardDetailsView(Gtk.Dialog):
 
         self.add_button(_("_Close"), Gtk.ResponseType.CLOSE)
 
-        self.get_content_area().pack_start(box, True, True, 12)
+        self.get_content_area().pack_start(grid, True, True, 12)
         self.resize(800, 450)
         self.show_all()

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -159,19 +159,19 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         bbox_top.set_layout(Gtk.ButtonBoxStyle.START)
 
         self.uninstall_button = Gtk.Button.new_with_mnemonic(_("_Uninstall"))
-        self.uninstall_button.set_tooltip_text(_("Uninstall keyboard package"))
+        self.uninstall_button.set_tooltip_text(_("Uninstall keyboard"))
         self.uninstall_button.connect("clicked", self.on_uninstall_clicked)
         self.uninstall_button.set_sensitive(False)
         bbox_top.add(self.uninstall_button)
 
         self.about_button = Gtk.Button.new_with_mnemonic(_("_About"))
-        self.about_button.set_tooltip_text(_("About keyboard package"))
+        self.about_button.set_tooltip_text(_("About keyboard"))
         self.about_button.connect("clicked", self.on_about_clicked)
         self.about_button.set_sensitive(False)
         bbox_top.add(self.about_button)
 
         self.help_button = Gtk.Button.new_with_mnemonic(_("_Help"))
-        self.help_button.set_tooltip_text(_("Help for keyboard package"))
+        self.help_button.set_tooltip_text(_("Help for keyboard"))
         self.help_button.connect("clicked", self.on_help_clicked)
         self.help_button.set_sensitive(False)
         bbox_top.add(self.help_button)
@@ -188,17 +188,17 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         bbox_bottom.set_layout(Gtk.ButtonBoxStyle.END)
 
         button = Gtk.Button.new_with_mnemonic(_("_Refresh"))
-        button.set_tooltip_text(_("Refresh keyboard package list"))
+        button.set_tooltip_text(_("Refresh keyboard list"))
         button.connect("clicked", self.on_refresh_clicked)
         bbox_bottom.add(button)
 
         button = Gtk.Button.new_with_mnemonic(_("_Download"))
-        button.set_tooltip_text(_("Download and install a keyboard package from the Keyman website"))
+        button.set_tooltip_text(_("Download and install a keyboard from the Keyman website"))
         button.connect("clicked", self.on_download_clicked)
         bbox_bottom.add(button)
 
         button = Gtk.Button.new_with_mnemonic(_("_Install"))
-        button.set_tooltip_text(_("Install a keyboard package from a file"))
+        button.set_tooltip_text(_("Install a keyboard from a file"))
         button.connect("clicked", self.on_installfile_clicked)
         bbox_bottom.add(button)
 
@@ -275,13 +275,13 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         model, treeiter = selection.get_selected()
         if treeiter is not None:
             self.uninstall_button.set_tooltip_text(
-                _("Uninstall keyboard package {package}").format(package=model[treeiter][1]))
+                _("Uninstall keyboard {package}").format(package=model[treeiter][1]))
             self.help_button.set_tooltip_text(
-                _("Help for keyboard package {package}").format(package=model[treeiter][1]))
+                _("Help for keyboard {package}").format(package=model[treeiter][1]))
             self.about_button.set_tooltip_text(
-                _("About keyboard package {package}").format(package=model[treeiter][1]))
+                _("About keyboard {package}").format(package=model[treeiter][1]))
             self.options_button.set_tooltip_text(
-                _("Settings for keyboard package {package}").format(package=model[treeiter][1]))
+                _("Settings for keyboard {package}").format(package=model[treeiter][1]))
             logging.debug("You selected %s version %s", model[treeiter][1], model[treeiter][2])
             self.about_button.set_sensitive(True)
             if model[treeiter][4] == InstallArea.IA_USER:
@@ -301,10 +301,10 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             else:
                 self.options_button.set_sensitive(False)
         else:
-            self.uninstall_button.set_tooltip_text(_("Uninstall keyboard package"))
-            self.help_button.set_tooltip_text(_("Help for keyboard package"))
-            self.about_button.set_tooltip_text(_("About keyboard package"))
-            self.options_button.set_tooltip_text(_("Settings for keyboard package"))
+            self.uninstall_button.set_tooltip_text(_("Uninstall keyboard"))
+            self.help_button.set_tooltip_text(_("Help for keyboard"))
+            self.about_button.set_tooltip_text(_("About keyboard"))
+            self.options_button.set_tooltip_text(_("Settings for keyboard"))
             self.uninstall_button.set_sensitive(False)
             self.about_button.set_sensitive(False)
             self.help_button.set_sensitive(False)
@@ -346,9 +346,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             logging.info("Uninstall keyboard " + model[treeiter][3] + "?")
             dialog = Gtk.MessageDialog(
                 self, 0, Gtk.MessageType.QUESTION,
-                Gtk.ButtonsType.YES_NO, _("Uninstall keyboard?"))
+                Gtk.ButtonsType.YES_NO, _("Uninstall keyboard package?"))
             dialog.format_secondary_text(
-                _("Are you sure that you want to uninstall the {keyboard} keyboard?")
+                _("Are you sure that you want to uninstall the {keyboard} keyboard and its fonts?")
                 .format(keyboard=model[treeiter][1]))
             response = dialog.run()
             dialog.destroy()

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -16,9 +16,12 @@ from keyman_config.accelerators import bind_accelerator, init_accel
 
 class WelcomeView(Gtk.Dialog):
 
-    def __init__(self, parent, welcomeurl, keyboardname):
+    def __init__(self, parent, welcomeurl, keyboardname, newlyInstalled=False):
         self.accelerators = None
-        kbtitle = _("{name} installed").format(name=keyboardname)
+        if newlyInstalled:
+            kbtitle = _("{name} installed").format(name=keyboardname)
+        else:
+            kbtitle = keyboardname
         self.welcomeurl = welcomeurl
         Gtk.Dialog.__init__(self, kbtitle, parent)
         init_accel(self)


### PR DESCRIPTION
- Remove "package" from the tooltips text since that might be
  confusing to users.
- Also make title of Welcome (Help) dialog optionally say "installed"
  instead of always so that we open that dialog via the Help button
  we just display the keyboard name.
- Refactor Keyboard Details dialog to remove an unnecessary box.
- Add padding after keyboard details in Keyboard Details dialog.

Tooltip before:

![image](https://user-images.githubusercontent.com/181336/90870795-69570200-e39a-11ea-94ac-9583ae679695.png)

Tooltip after:

![image](https://user-images.githubusercontent.com/181336/90870827-74aa2d80-e39a-11ea-8504-9607256b5ab9.png)

Help dialog before:

![image](https://user-images.githubusercontent.com/181336/90870889-8e4b7500-e39a-11ea-971a-080128355f1c.png)

Help dialog after:

![image](https://user-images.githubusercontent.com/181336/90870914-94415600-e39a-11ea-9219-452c0b6c1a30.png)

Keyboard Details dialog before:

![image](https://user-images.githubusercontent.com/181336/90870958-a02d1800-e39a-11ea-8288-66bb8b8edced.png)

Keyboard Details dialog after:

![image](https://user-images.githubusercontent.com/181336/90870974-a622f900-e39a-11ea-8f56-16fff7144493.png)

