### PR TITLE
docs(common): Clarify l10n readme

### DIFF
--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -1,12 +1,22 @@
 # Localization Maintenance
 
 Localization for Keyman is maintained at https://crowdin.com/project/keyman
-The Crowdin CLI (v3) tool is used to automate downloading and updating files
-between Keyman and Crowdin. The configuration file for all platforms is a YAML file named `/crowdin.yml`.
+
+Downloading and updating files between Keyman and Crowdin happens automatically
+on GitHub by way of the Crowdin git integration. The configuration file for all platforms
+is a YAML file named `/crowdin.yml`.
+
+The only thing that needs to be done manually is to update `crowdin.yml` if new files get added
+(and of course translating the strings on the [Crowdin website](https://crowdin.com/project/keyman)).
+
+## Manual up- and download with Crowdin CLI
+
+The following describes how alternatively the Crowdin CLI (v3) tool could be used to
+automate downloading and updating files between Keyman and Crowdin.
 
 On Windows, use `crowdin.bat` instead of `crowdin` for all the syntax below.
 
-## Add File
+### Add File
 
 When adding new files to https://crowdin.com/project/keyman/settings#files
 also go to the file "Settings" and edit **Resulting file after translations export:**.
@@ -19,12 +29,12 @@ For example, `android/KMEA/strings.xml` string uses
 /android/KMEA/app/src/main/res/values-%android_code%/strings.xml
 ```
 
-## Setup
+### Setup
 
 Install the [Crowdin CLI (v3)](https://support.crowdin.com/cli-tool-v3/) for your OS.
 Note, it has a prerequisite on Java 8.
 
-### Environment Variables
+#### Environment Variables
 
 In Crowdin, create a [personal access token](https://crowdin.com/settings#api-key)
 and set it as an environment variable `CROWDIN_PERSONAL_TOKEN`.
@@ -32,7 +42,7 @@ and set it as an environment variable `CROWDIN_PERSONAL_TOKEN`.
 Also copy the [project id](https://crowdin.com/project/keyman/settings#api)
 from API v2 and set it as an environment variable `CROWDIN_PROJECT_ID`.
 
-### Testing Crowdin CLI is Set Up Correctly
+#### Testing Crowdin CLI is Set Up Correctly
 
 To check your CLI setup, in the repo root folder,
 
@@ -43,7 +53,7 @@ crowdin list project
 You should see the CLI fetching project info and generating a list of files associated with the
 project.
 
-## Downloading from Crowdin
+### Downloading from Crowdin
 
 To download the latest translations from Crowdin (all platforms), open a command line at the repo
 root folder and run:
@@ -64,7 +74,7 @@ To display a list of latest translations from Crowdin:
 crowdin download --dryrun
 ```
 
-## Uploading to crowdin
+### Uploading to crowdin
 
 To upload source files to Crowdin:
 


### PR DESCRIPTION
Up- and download from Crowdin now happen automatically on GitHub
(at least once it's enabled again).