### PR TITLE
fix(android/engine): Check asset package version before installing

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -428,14 +428,14 @@ public class PackageProcessor {
   }
 
   /**
-   * Determines if installing the .kmp would result in a downgrade.  For testing only.
+   * Determines if installing the .kmp would result in a downgrade.
    * @param kmpPath The path to the .kmp to be installed.
    * @param preExtracted Indicates use of a temporary testing 'kmp' that is pre-extracted.
    * @return <code><b>true</b></code> if installing would be a downgrade, otherwise <code><b>false</b></code>.
    * @throws IOException
    * @throws JSONException
    */
-  boolean isDowngrade(File kmpPath, boolean preExtracted) throws IOException, JSONException {
+  public boolean isDowngrade(File kmpPath, boolean preExtracted) throws IOException, JSONException {
     return internalCompareKMPVersion(kmpPath, preExtracted,-1);
   }
 


### PR DESCRIPTION
Fixes #3500

When KMManager is copying asset kmp files, check if the asset package is a downgrade before installing it.