### PR TITLE
fix(windows): refresh configuration after changes

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -303,7 +303,7 @@ begin
 
   sharedData.Init(
     FXMLRenderers.TempPath,
-    FXMLRenderers.RenderToString(False, s),
+    FXMLRenderers.RenderToString(FRefreshKeyman, s),
     FKeyboardXMLRenderer.FileReferences.ToStringArray
   );
 


### PR DESCRIPTION
Fixes #3178. (Does not apply the "Close" button remodelling, which is a bigger job which I have split into a separate issue #3518). Part of #3512.