### PR TITLE
fix(android/app): Inject meta viewport tag for viewing help

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -109,7 +109,6 @@ public class WebViewFragment extends Fragment implements BlockingStep {
     webView.getSettings().setLoadWithOverviewMode(true);
     webView.getSettings().setBuiltInZoomControls(true);
     webView.getSettings().setSupportZoom(true);
-    webView.getSettings().setTextZoom(200);
     webView.setVerticalScrollBarEnabled(true);
     webView.setHorizontalScrollBarEnabled(true);
     webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
@@ -135,6 +134,17 @@ public class WebViewFragment extends Fragment implements BlockingStep {
 
       @Override
       public void onPageFinished(WebView view, String url) {
+        // Inject a meta viewport tag into the head of the file if it doesn't exist
+        webView.loadUrl(
+          "javascript:(function() {" +
+            "if(!document.querySelectorAll('meta[name=viewport]').length) {"+
+            "let meta=document.createElement('meta');"+
+            "meta.name='viewport';"+
+            "meta.content='width=device-width, initial-scale=1';"+
+            "document.head.appendChild(meta);"+
+            "}"+
+            "})()"
+        );
       }
     });
 


### PR DESCRIPTION
Fixes #3522 by injecting a meta viewport tag if the help document in WebViewFragment doesn't contain it.
This replaces the 200% zoom.

Screenshots

## khmer_angkor
generated readme.htm
![khmer readme](https://user-images.githubusercontent.com/7358010/91376433-3bb10380-e847-11ea-9567-02408f569b39.png)

display welcome.htm
![khmer welcome](https://user-images.githubusercontent.com/7358010/91376448-423f7b00-e847-11ea-9073-54499e1a88e7.png)

## sil_cameroon_qwerty
display readme.htm
![cameroon readme](https://user-images.githubusercontent.com/7358010/91376552-83d02600-e847-11ea-99a5-66010df7344e.png)

display welcome.htm
![cameroon welcome](https://user-images.githubusercontent.com/7358010/91376558-8763ad00-e847-11ea-9cd6-4de50c36fc77.png)

## nrc.str.sencoten.model
generated readme.htm
![sencoten readme](https://user-images.githubusercontent.com/7358010/91376566-8af73400-e847-11ea-8b18-264ef5cee4b4.png)

generated (blank) welcome.htm
![sencoten welcome](https://user-images.githubusercontent.com/7358010/91376508-6438fd80-e847-11ea-8595-6ebdb65c8883.png)
