### PR TITLE
feat(windows): select language at keyboard install

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -29,7 +29,8 @@ type
     class function RegisterTip(LangID: Integer; const KeyboardID, BCP47Tag: string): Boolean;
 
     /// <summary>Helper function to get default BCP47 tag for an installed keyboard</summary>
-    class function GetFirstLanguage(Keyboard: IKeymanKeyboardInstalled): string;
+    class function GetFirstLanguage(Keyboard: IKeymanKeyboardInstalled): string; overload;
+    class function GetFirstLanguage(Keyboard: IKeymanKeyboardFile): string; overload;
   private
     class function GetKeyboardLanguage(const KeyboardID,
       BCP47Tag: string): IKeymanKeyboardLanguageInstalled; static;
@@ -175,6 +176,13 @@ begin
   end
   else
     Result := False;
+end;
+
+class function TTIPMaintenance.GetFirstLanguage(Keyboard: IKeymanKeyboardFile): string;
+begin
+  if Keyboard.Languages.Count > 0
+    then Result := Keyboard.Languages[0].BCP47Code
+    else Result := TLanguageCodeUtils.TranslateWindowsLanguagesToBCP47(HKLToLanguageID(GetDefaultHKL));
 end;
 
 class function TTIPMaintenance.GetFirstLanguage(Keyboard: IKeymanKeyboardInstalled): string;

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -68,8 +68,8 @@ begin
   with TfrmInstallKeyboard.Create(Owner) do
   try
     Silent := ASilent;
+    DefaultBCP47Tag := BCP47;
     InstallFile := FileName;
-//TODO:    DefaultBCP47 := BCP47;
     if ModalResult = mrCancel then
       // failed to start install
       Result := False
@@ -77,7 +77,7 @@ begin
     begin
       if ASilent then
       begin
-        InstallKeyboard(LogFile);
+        InstallKeyboard(LogFile, BCP47);
         Result := True;
       end
       else

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -97,7 +97,7 @@ type
     procedure DeleteFileReferences;
     procedure CheckLogFileForWarnings(const Filename: string; Silent: Boolean);
     function CleanupPaths(var xml: string): string;
-    procedure InstallTipForPackage(const BCP47Tag: string);
+    procedure InstallTipForKeyboard(const BCP47Tag: string);
   protected
     procedure FireCommand(const command: WideString; params: TStringList); override;
   public
@@ -296,7 +296,7 @@ begin
           if WaitForElevatedConfiguration(Handle, '-log "'+t.Name+'" -s -i "'+FInstallFile+'='+BCP47Tag+'" -nowelcome') = 0 then
           begin
             // install the keyboard tip
-            InstallTipForPackage(BCP47Tag);
+            InstallTipForKeyboard(BCP47Tag);
             ModalResult := mrOk;
           end
           else
@@ -378,9 +378,7 @@ begin
         kmcom.Keyboards.Apply;
         kmcom.Keyboards.Refresh;
         FInstalledKeyboard := (FKeyboard as IKeymanKeyboardFile2).Install2(True);
-        // TODO: let user choose language
-        // GetFirstLanguage is a temporary function until we implement TODO above
-        TTIPMaintenance.DoInstall(FKeyboard.ID, TTIPMaintenance.GetFirstLanguage(FInstalledKeyboard));
+        InstallTipForKeyboard(BCP47Tag);
         CheckForMitigationWarningFor_Win10_1803(FSilent, ALogFile);
       end
       else
@@ -440,8 +438,7 @@ begin
 
         kmcom.Refresh;
 
-        // TODO: allow user to select language
-        InstallTipForPackage(BCP47Tag);
+        InstallTipForKeyboard(BCP47Tag);
 
         CheckForMitigationWarningFor_Win10_1803(FSilent, ALogFile);
       end;
@@ -467,7 +464,7 @@ begin
   ModalResult := mrOk;
 end;
 
-procedure TfrmInstallKeyboard.InstallTipForPackage(const BCP47Tag: string);
+procedure TfrmInstallKeyboard.InstallTipForKeyboard(const BCP47Tag: string);
 var
   i: Integer;
 begin

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -90,16 +90,19 @@ type
     FTempPath: string;
     FSilent: Boolean;
     PageTag: Integer;
+    FDefaultBCP47Tag: string;
     //FLanguageEnvironmentManager: TLanguageEnvironmentManager; // I1220
 
     procedure SetInstallFile(const Value: string);
     procedure DeleteFileReferences;
     procedure CheckLogFileForWarnings(const Filename: string; Silent: Boolean);
     function CleanupPaths(var xml: string): string;
+    procedure InstallTipForPackage(const BCP47Tag: string);
   protected
     procedure FireCommand(const command: WideString; params: TStringList); override;
   public
-    procedure InstallKeyboard(const ALogFile: string);
+    procedure InstallKeyboard(const ALogFile, BCP47Tag: string);
+    property DefaultBCP47Tag: string read FDefaultBCP47Tag write FDefaultBCP47Tag;
     property InstallFile: string read FInstallFile write SetInstallFile;
     property Silent: Boolean read FSilent write FSilent;
   end;
@@ -131,6 +134,7 @@ uses
   utilkmshell,
   utilsystem,
   utiluac,
+  utilxml,
   Xml.XmlDoc,
   Xml.XmlIntf;
 
@@ -196,6 +200,8 @@ begin
 
     FPackagePath := CleanupPaths(FXML);
 
+    FXML := FXML + '<DefaultBCP47Tag>' + XMLEncode(FDefaultBCP47Tag) + '</DefaultBCP47Tag>';
+
     Data := TInstallKeyboardSharedData.Create(FXML, FTempPath, FPackagePath, FFiles);
     PageTag := modWebHttpServer.SharedData.Add(Data);
     FRenderPage := 'installkeyboard';
@@ -255,16 +261,20 @@ end;
 procedure TfrmInstallKeyboard.FireCommand(const command: WideString; params: TStringList);
 var
   t: TTempFile;
+  BCP47Tag: string;
 begin
+  BCP47Tag := '';
   if (command = 'keyboard_install') and kmcom.SystemInfo.IsAdministrator then   // I4172
   begin
+    if params.Count = 1 then
+      BCP47Tag := params.ValueFromIndex[0];
     TfrmProgress.Execute(Self,
       function(Manager: IProgressManager): Boolean
       begin
         Manager.Title := 'Installing Keyboard';
         Manager.CanCancel := False;
         Manager.UpdateProgress('Installing Keyboard', 0, 0);
-        InstallKeyboard('');
+        InstallKeyboard('', BCP47Tag);
         Result := True;
       end
     );
@@ -273,6 +283,8 @@ begin
     ModalResult := mrCancel
   else if (command = 'keyboard_installallusers') or (command = 'keyboard_install') then   // I4172
   begin
+    if params.Count = 1 then
+      BCP47Tag := params.ValueFromIndex[0];
     TfrmProgress.Execute(Self,
       function(Manager: IProgressManager): Boolean
       begin
@@ -281,8 +293,12 @@ begin
         Manager.UpdateProgress('Installing Keyboard', 0, 0);
         t := TTempFileManager.Get('.log');
         try
-          if WaitForElevatedConfiguration(Handle, '-log "'+t.Name+'" -s -i "'+FInstallFile+'" -nowelcome') = 0 then
-            ModalResult := mrOk
+          if WaitForElevatedConfiguration(Handle, '-log "'+t.Name+'" -s -i "'+FInstallFile+'='+BCP47Tag+'" -nowelcome') = 0 then
+          begin
+            // install the keyboard tip
+            InstallTipForPackage(BCP47Tag);
+            ModalResult := mrOk;
+          end
           else
             ModalResult := mrCancel;
 
@@ -319,7 +335,7 @@ end;
  ------------------------------------------------------------------------------}
 
 // TODO: move this to TInstallFile
-procedure TfrmInstallKeyboard.InstallKeyboard(const ALogFile: string);
+procedure TfrmInstallKeyboard.InstallKeyboard(const ALogFile, BCP47Tag: string);
 var
   i: Integer;
   kbd: IKeymanKeyboardInstalled;
@@ -425,9 +441,7 @@ begin
         kmcom.Refresh;
 
         // TODO: allow user to select language
-        FInstalledPackage := kmcom.Packages[FPackage.ID];
-        for i := 0 to FInstalledPackage.Keyboards.Count - 1 do
-          TTIPMaintenance.DoInstall(FInstalledPackage.Keyboards[i].ID, TTIPMaintenance.GetFirstLanguage(FInstalledPackage.Keyboards[i] as IKeymanKeyboardInstalled));
+        InstallTipForPackage(BCP47Tag);
 
         CheckForMitigationWarningFor_Win10_1803(FSilent, ALogFile);
       end;
@@ -453,5 +467,25 @@ begin
   ModalResult := mrOk;
 end;
 
+procedure TfrmInstallKeyboard.InstallTipForPackage(const BCP47Tag: string);
+var
+  i: Integer;
+begin
+  kmcom.Refresh;
+  if Assigned(FKeyboard) then
+  begin
+    if BCP47Tag <> ''
+      then TTIPMaintenance.DoInstall(FKeyboard.ID, BCP47Tag)
+      else TTIPMaintenance.DoInstall(FKeyboard.ID, TTIPMaintenance.GetFirstLanguage(FKeyboard));
+  end
+  else
+  begin
+    if (FPackage.Keyboards.Count = 1) and (BCP47Tag <> '') then
+      TTIPMaintenance.DoInstall(FPackage.Keyboards[0].ID, BCP47Tag)
+    else
+      for i := 0 to FPackage.Keyboards.Count - 1 do
+        TTIPMaintenance.DoInstall(FPackage.Keyboards[i].ID, TTIPMaintenance.GetFirstLanguage(FPackage.Keyboards[i] as IKeymanKeyboardFile));
+  end;
+end;
 
 end.

--- a/windows/src/desktop/kmshell/xml/installkeyboard.css
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.css
@@ -1,4 +1,4 @@
-html, body { 
+html, body {
   overflow: hidden;
 }
 
@@ -6,31 +6,31 @@ div {
   position: absolute;
 }
 
-#background { 
-  background: #79C3DA; z-index: 1; left: 0; top: 0; 
+#background {
+  background: #79C3DA; z-index: 1; left: 0; top: 0;
 }
 
-#foreground { 
-  z-index: 2; left: 0; top: 0; 
+#foreground {
+  z-index: 2; left: 0; top: 0;
 }
 
 #frame {
-  top: 0; left: 0; 
-  height: 244px; 
-  padding: 10px; 
+  top: 0; left: 0;
+  height: 244px;
+  padding: 10px;
 }
 
 #image {
-  top: 0; 
-  left: 0; 
-  height: 250px; 
-  width: 140px; 
+  top: 0;
+  left: 0;
+  height: 250px;
+  width: 140px;
   padding: 5px
 }
 
 .content {
-  left: 150px; top: 0px; 
-  width: 438px; 
+  left: 150px; top: 0px;
+  width: 438px;
   padding: 4px;
   background: white;
   border-left: 2px solid #888888;
@@ -42,20 +42,20 @@ div {
 }
 
 .has_readme .content {
-  height: 226px; 
+  height: 226px;
   visibility: hidden;
 }
 
 .content_selected {
-  left: 150px; top: 0px; 
-  width: 438px; 
+  left: 150px; top: 0px;
+  width: 438px;
   padding: 4px;
   background: white;
   border-left: 2px solid #888888;
   border-top: 2px solid #888888;
   border-right: 2px solid #888888;
   overflow-y: auto;
-  height: 226px; 
+  height: 226px;
   visibility: visible
 }
 
@@ -98,7 +98,7 @@ div {
 }
 
 #footer {
-  top: 260px; 
+  top: 260px;
   left: 0;
   height: 26px;
   vertical-align: middle;
@@ -119,7 +119,7 @@ div {
   font-size: 13.3px;
   padding-right: 10px;
   margin: 1px;
-  vertical-align: top;
+  vertical-align: middle;
 }
 .otherdetails {
   font-size: 13.3px;

--- a/windows/src/desktop/kmshell/xml/installkeyboard.js
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.js
@@ -25,7 +25,7 @@ function genkeydown(event) {
   } else {
     return true;
   }
-  event.cancelBubble = true; 
+  event.cancelBubble = true;
   event.returnValue = false;
   return false;
 }
@@ -35,7 +35,7 @@ function framekeydown() {
 }
 
 document.onkeydown = function() {
-  return genkeydown(event); 
+  return genkeydown(event);
 }
 
 function setupframehotkeys() {
@@ -47,8 +47,14 @@ function setupframehotkeys() {
 
 window.onload = function() {
   setupframehotkeys();
-  
+
   if(document.getElementById('tabs') != null) {
     tabClick(document.getElementById('tabDetails'));
   }
+}
+
+function keyboard_install(elevate) {
+  let href = elevate ? 'keyman:keyboard_installallusers?' : 'keyman:keyboard_install?';
+  let keyboards = Array.from(document.querySelectorAll('select.keyboardLanguage'));
+  location.href = href + keyboards.map((e) => e.id.substring('keyboardLanguage_'.length) + '=' + e.value).join('&');
 }

--- a/windows/src/desktop/kmshell/xml/installkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.xsl
@@ -104,7 +104,7 @@
 						<xsl:if test="/Keyman/canelevate">
 							<xsl:call-template name="button">
 								<xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_InstallKeyboard_Button_Install']"/></xsl:with-param>
-								<xsl:with-param name="command">keyman:keyboard_installallusers</xsl:with-param>
+								<xsl:with-param name="command">javascript:keyboard_install(true)</xsl:with-param>
 								<xsl:with-param name="width">120px</xsl:with-param>
                 <xsl:with-param name="shield">1</xsl:with-param>
 							</xsl:call-template>
@@ -113,7 +113,7 @@
               <xsl:call-template name="button">
                 <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_InstallKeyboard_Button_Install']"/></xsl:with-param>
                 <xsl:with-param name="default">1</xsl:with-param>
-                <xsl:with-param name="command">keyman:keyboard_install</xsl:with-param>
+                <xsl:with-param name="command">javascript:keyboard_install(false)</xsl:with-param>
                 <xsl:with-param name="width">70px</xsl:with-param>
               </xsl:call-template>
             </xsl:if>
@@ -128,8 +128,26 @@
     </html>
   </xsl:template>
 
-  <xsl:template match="/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile/name">
-    <xsl:value-of select="."/><br />
+  <xsl:template match="KeymanKeyboardLanguage">
+    <option>
+      <xsl:attribute name="value"><xsl:value-of select="bcp47code" /></xsl:attribute>
+      <xsl:if test="bcp47code = /Keyman/DefaultBCP47Tag"><xsl:attribute name="selected">selected</xsl:attribute></xsl:if>
+      <xsl:value-of select="langname" />
+    </option>
+  </xsl:template>
+  <xsl:template match="/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile">
+    <xsl:value-of select="name"/>
+    <!-- This test presents the selection for keyboard language only for packages with a single keyboard and more than one language option. In future, we could consider extending
+         it for packages with more than one keyboard, but that would take more plumbing for implementation. -->
+    <xsl:if test="count(/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile) = 1 and count(KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage) > 1">:
+      <select class="keyboardLanguage">
+        <xsl:attribute name="id">keyboardLanguage_<xsl:value-of select="id"/></xsl:attribute>
+        <xsl:apply-templates select="KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage">
+          <xsl:sort select="langname" />
+        </xsl:apply-templates>
+      </select>
+    </xsl:if>
+    <br />
   </xsl:template>
 
   <xsl:template match="/Keyman/KeymanPackageFile/Fonts/Font/name">
@@ -170,7 +188,7 @@
   <xsl:template match="/Keyman/KeymanPackageFile">
     <tr>
       <td class="detailheader"><xsl:value-of select="$locale/string[@name='S_Caption_Keyboards']"/></td>
-      <td class="otherdetails"><xsl:apply-templates select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile/name" /></td>
+      <td class="otherdetails"><xsl:apply-templates select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile" /></td>
     </tr>
 
     <xsl:if test="Fonts/Font">

--- a/windows/src/desktop/kmshell/xml/installkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.xsl
@@ -135,19 +135,18 @@
       <xsl:value-of select="langname" />
     </option>
   </xsl:template>
-  <xsl:template match="/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile">
-    <xsl:value-of select="name"/>
-    <!-- This test presents the selection for keyboard language only for packages with a single keyboard and more than one language option. In future, we could consider extending
-         it for packages with more than one keyboard, but that would take more plumbing for implementation. -->
-    <xsl:if test="count(/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile) = 1 and count(KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage) > 1">:
-      <select class="keyboardLanguage">
-        <xsl:attribute name="id">keyboardLanguage_<xsl:value-of select="id"/></xsl:attribute>
-        <xsl:apply-templates select="KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage">
-          <xsl:sort select="langname" />
-        </xsl:apply-templates>
-      </select>
-    </xsl:if>
-    <br />
+
+  <xsl:template mode="language-picker" match="/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile">
+    <select class="keyboardLanguage">
+      <xsl:attribute name="id">keyboardLanguage_<xsl:value-of select="id"/></xsl:attribute>
+      <xsl:apply-templates select="KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage">
+        <xsl:sort select="langname" />
+      </xsl:apply-templates>
+    </select>
+  </xsl:template>
+
+  <xsl:template mode="keyboard-name" match="/Keyman/KeymanPackageFile/KeymanPackageContentKeyboardsFile/KeymanKeyboardFile">
+    <xsl:value-of select="name"/><br />
   </xsl:template>
 
   <xsl:template match="/Keyman/KeymanPackageFile/Fonts/Font/name">
@@ -186,10 +185,29 @@
   </xsl:template>
 
   <xsl:template match="/Keyman/KeymanPackageFile">
-    <tr>
-      <td class="detailheader"><xsl:value-of select="$locale/string[@name='S_Caption_Keyboards']"/></td>
-      <td class="otherdetails"><xsl:apply-templates select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile" /></td>
-    </tr>
+    <xsl:choose>
+      <xsl:when test="count(KeymanPackageContentKeyboardsFile/KeymanKeyboardFile) = 1">
+        <tr>
+          <td class="detailheader"><xsl:value-of select="$locale/string[@name='S_Caption_Keyboard']"/></td>
+          <td class="otherdetails"><xsl:apply-templates mode="keyboard-name" select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile" /></td>
+        </tr>
+        <xsl:if test="count(KeymanPackageContentKeyboardsFile/KeymanKeyboardFile/KeymanKeyboardLanguagesFile/KeymanKeyboardLanguage) > 1">
+          <!-- This test presents the selection for keyboard language only for packages with a single keyboard and 
+               more than one language option. In future, we could consider extending it for packages with more than 
+               one keyboard, but that would take more plumbing for implementation. -->
+          <tr>
+            <td class="detailheader"><xsl:value-of select="$locale/string[@name='S_Caption_KeyboardLanguage']"/></td>
+            <td class="otherdetails"><xsl:apply-templates mode="language-picker" select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile" /></td>
+          </tr>
+        </xsl:if>
+      </xsl:when>
+      <xsl:otherwise>
+        <tr>
+          <td class="detailheader"><xsl:value-of select="$locale/string[@name='S_Caption_Keyboards']"/></td>
+          <td class="otherdetails"><xsl:apply-templates mode="keyboard-name" select="KeymanPackageContentKeyboardsFile/KeymanKeyboardFile" /></td>
+        </tr>
+      </xsl:otherwise>
+    </xsl:choose>
 
     <xsl:if test="Fonts/Font">
       <tr>

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -178,6 +178,16 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Caption_Keyboards" comment="Keyboard download window, etc. - term for keyboard layouts">Keyboard Layouts:</string>
 
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_Keyboard" comment="Keyboard install dialog - term for a single keyboard layout">Keyboard Layout:</string>
+
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_KeyboardLanguage" comment="Keyboard install dialog - term for caption for language selector a single keyboard layout">Keyboard Language:</string>
+
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
@@ -78,18 +78,20 @@ type
 implementation
 
 uses
-  Graphics,
+  System.SysUtils,
+  System.Variants,
+  Vcl.Graphics,
+
+  internalinterfaces,
   keymanerrorcodes,
   keymanhotkey,
   kmxfileusedchars,
   kpinstallkeyboard,
   Keyman.System.LanguageCodeUtils,
-  SysUtils,
   utilkeyman,
   utilolepicture,
   utilstr,
-  utilxml,
-  Variants;
+  utilxml;
 
 { TKeymanKeyboardFile }
 
@@ -275,6 +277,8 @@ begin
     'layoutpositional', Get_LayoutType = kltPositional
   ]);
 
+  Result := Result + (FLanguages as IIntKeymanInterface).DoSerialize(Flags, ImagePath, References);
+
   if ((Flags and ksfExportImages) = ksfExportImages) and
     (Assigned(FKeyboardInfo.Icon) or
     Assigned(FKeyboardInfo.Bitmap)) then
@@ -291,7 +295,7 @@ begin
     finally
       Free;
     end;
-      Result := Result + '<bitmap>'+ExtractFileName(FBitmap)+'</bitmap>';
+    Result := Result + '<bitmap>'+ExtractFileName(FBitmap)+'</bitmap>';
   end;
 end;
 


### PR DESCRIPTION
For packages with a single keyboard, we now make it possible to select a language at install time.

Fixes #1456.  Part of omnibus #3512.

# Screenshots

## Single keyboard / single language, and multi keyboard

These are the same as before.

![image](https://user-images.githubusercontent.com/4498365/91382944-3fa44c00-e86e-11ea-9c55-aff9c7dddaf1.png)

![image](https://user-images.githubusercontent.com/4498365/91383000-6793af80-e86e-11ea-83e7-2a0d02f5fa68.png)

## Single keyboard / multiple languages

The combo is pre-filled with the bcp47 tag found in the search.

![image](https://user-images.githubusercontent.com/4498365/91382965-4e8afe80-e86e-11ea-841a-ed9de1853a4c.png)

![image](https://user-images.githubusercontent.com/4498365/91383016-70848100-e86e-11ea-9d98-5defbb30833e.png)

![image](https://user-images.githubusercontent.com/4498365/91383023-75493500-e86e-11ea-994e-27718eaf4fab.png)
