### PR TITLE
feat(common/models):  low-level correction-algorithm infrastructure

### DIFF
--- a/common/predictive-text/unit_tests/headless/edit-distance/classical-calculation.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/classical-calculation.js
@@ -1,5 +1,4 @@
 var assert = require('chai').assert;
-let baseNS = require('../../../build/intermediate');
 var ClassicalDistanceCalculation = require('../../../build/intermediate').correction.ClassicalDistanceCalculation;
 
 function prettyPrintMatrix(matrix) {

--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -23,7 +23,7 @@ function findEdgeWithChars(edgeArray, input, match) {
   return results[0];
 }
 
-describe.only('Correction Distance Modeler', function() {
+describe('Correction Distance Modeler', function() {
   describe('Search Node + Search Edge', function() {
     var testModel;
 

--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -11,12 +11,12 @@ function edgeHasChars(edge, input, match) {
     return false;
   }
 
-  return edge.calculation.lastMatchEntry.char == match;
+  return edge.calculation.lastMatchEntry.key == match;
 }
 
 function findEdgeWithChars(edgeArray, input, match) {
   let results = edgeArray.filter(function(value) {
-    return value.calculation.lastMatchEntry.char == match && value.optimalInput[value.optimalInput.length - 1].sample.insert == input;
+    return value.calculation.lastMatchEntry.key == match && value.optimalInput[value.optimalInput.length - 1].sample.insert == input;
   });
 
   assert.equal(results.length, 1);
@@ -45,7 +45,7 @@ describe.only('Correction Distance Modeler', function() {
       for(let child of rootTraversal.children()) {
         expectedChildCount++;
 
-        let childEdge = edges.filter(value => value.calculation.lastMatchEntry.char == child.char)[0];
+        let childEdge = edges.filter(value => value.calculation.lastMatchEntry.key == child.char)[0];
         assert.isOk(childEdge);
         assert.isEmpty(childEdge.optimalInput);
         assert.isEmpty(childEdge.calculation.inputSequence);
@@ -111,7 +111,7 @@ describe.only('Correction Distance Modeler', function() {
           let matchingEdge = findEdgeWithChars(edges, mass.sample.insert, child.char);
 
           // Substitution - matching char
-          if(mass.sample.insert == matchingEdge.calculation.lastMatchEntry.char) {
+          if(mass.sample.insert == matchingEdge.calculation.lastMatchEntry.key) {
             assert.equal(matchingEdge.currentCost, 1 - mass.p);
           } else {
             // not matching char.
@@ -127,18 +127,18 @@ describe.only('Correction Distance Modeler', function() {
 
       let firstEdge = queue.dequeue();
       assert.equal(firstEdge.optimalInput[0].sample.insert, 't');
-      assert.equal(firstEdge.calculation.lastMatchEntry.char, 't');
+      assert.equal(firstEdge.calculation.lastMatchEntry.key, 't');
       assert.equal(firstEdge.currentCost, 0.25);
 
       let secondEdge = queue.dequeue();
       assert.equal(secondEdge.optimalInput[0].sample.insert, 'h');
-      assert.equal(secondEdge.calculation.lastMatchEntry.char, 'h');
+      assert.equal(secondEdge.calculation.lastMatchEntry.key, 'h');
       assert.equal(secondEdge.currentCost, 0.75);
 
       // After this, a 't' input without a matching char.
       let nextEdge = queue.dequeue();
       assert.equal(nextEdge.optimalInput[0].sample.insert, 't');
-      assert.notEqual(nextEdge.calculation.lastMatchEntry.char, 't');
+      assert.notEqual(nextEdge.calculation.lastMatchEntry.key, 't');
       assert.equal(nextEdge.currentCost, 1.25);
     });
 
@@ -194,7 +194,7 @@ describe.only('Correction Distance Modeler', function() {
       // Find the first result with an actual word directly represented.
       do {
         edge = layer3Queue.dequeue();
-      } while(edge.calculation.lastMatchEntry.tag.entries.length == 0);
+      } while(edge.calculation.lastMatchEntry.traversal.entries.length == 0);
 
       assertEdgeChars(edge, 'n', 'n'); // 'ten' - perfect edit distance of 0, though less-likely input sequence.
       assert(edge.currentCost, 1);
@@ -202,7 +202,7 @@ describe.only('Correction Distance Modeler', function() {
       var edge;
       do {
         edge = layer3Queue.dequeue();
-      } while(edge.calculation.lastMatchEntry.tag.entries.length == 0);
+      } while(edge.calculation.lastMatchEntry.traversal.entries.length == 0);
 
       // Both have a raw edit distance of 1 while using the same input-sequence root. ('th')
       let tenFlag = edgeHasChars(edge, 'h', 'n'); // subs out the 'h' entirely.  Could also occur with 'a', but is too unlikely.
@@ -213,7 +213,7 @@ describe.only('Correction Distance Modeler', function() {
 
       do {
         edge = layer3Queue.dequeue();
-      } while(edge.calculation.lastMatchEntry.tag.entries.length == 0);
+      } while(edge.calculation.lastMatchEntry.traversal.entries.length == 0);
 
       tenFlag = tenFlag || edgeHasChars(edge, 'h', 'n');
       theFlag = theFlag || edgeHasChars(edge, 'h', 'e');

--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -1,0 +1,130 @@
+var assert = require('chai').assert;
+let models = require('../../../build/intermediate').models;
+let correction = require('../../../build/intermediate').correction;
+
+describe.only('Correction Distance Modeler', function() {
+  describe('Search Node + Search Edge', function() {
+    var testModel;
+
+    before(function() {
+      testModel = new models.TrieModel(jsonFixture('tries/english-1000'));
+    });
+
+    it('SearchNode.buildInsertionEdges() - from root', function() {
+      let rootTraversal = testModel.traverseFromRoot();
+      assert.isNotEmpty(rootTraversal);
+
+      let rootNode = new correction.SearchNode(rootTraversal);
+      assert.equal(rootNode.calculation.getHeuristicFinalCost(), 0);
+
+      let edges = rootNode.buildInsertionEdges();
+      assert.isAbove(edges.length, 0);
+
+      let expectedChildCount = 0;
+      for(let child of rootTraversal.children()) {
+        expectedChildCount++;
+
+        let childEdge = edges.filter(value => value.calculation.lastMatchEntry.char == child.char)[0];
+        assert.isOk(childEdge);
+        assert.isEmpty(childEdge.optimalInput);
+        assert.isEmpty(childEdge.calculation.inputSequence);
+        assert.equal(childEdge.currentCost, 1);
+      }
+
+      assert.equal(edges.length, expectedChildCount);
+    });
+
+    it('SearchNode.buildDeletionEdges() - from root', function() {
+      let rootTraversal = testModel.traverseFromRoot();
+      assert.isNotEmpty(rootTraversal);
+
+      let rootNode = new correction.SearchNode(rootTraversal);
+      assert.equal(rootNode.calculation.getHeuristicFinalCost(), 0);
+
+      let synthDistribution = [
+        {sample: {insert: 't', deleteLeft: 0}, p: 0.75}, // Transform, probability
+        {sample: {insert: 'h', deleteLeft: 0}, p: 0.25}
+      ];
+
+      let edges = rootNode.buildDeletionEdges(synthDistribution);
+      assert.equal(edges.length, 2);
+
+      for(let edge of edges) {
+        assert.isNotEmpty(edge.optimalInput);
+        assert.isEmpty(edge.calculation.matchSequence);
+
+        if(edge.optimalInput[0].p == 0.75) {
+          // 't'.
+          // 1.25:  assumes p = .75 ==> transform to input string cost of .25.
+          assert.equal(edge.currentCost, 1.25);
+        } else if(edge.optimalInput[0].p == 0.25) {
+          // 'h'
+        } else {
+          assert.fail();
+          assert.equal(edge.currentCost, 1.75);
+        }
+      }
+    });
+
+    it('SearchNode.buildSubstitutionEdges() - from root', function() {
+      // The combinatorial effect here is a bit much to fully test.
+      let rootTraversal = testModel.traverseFromRoot();
+      assert.isNotEmpty(rootTraversal);
+
+      let rootNode = new correction.SearchNode(rootTraversal);
+      assert.equal(rootNode.calculation.getHeuristicFinalCost(), 0);
+
+      let synthDistribution = [
+        {sample: {insert: 't', deleteLeft: 0}, p: 0.75}, // Transform, probability
+        {sample: {insert: 'h', deleteLeft: 0}, p: 0.25}
+      ];
+
+      let edges = rootNode.buildSubstitutionEdges(synthDistribution);
+      assert.isAbove(edges.length, 0);
+
+      let expectedChildCount = 0;
+      for(let child of rootTraversal.children()) {
+        for(let mass of synthDistribution) {
+          expectedChildCount++;
+          
+          let matchingEdge = edges.filter(function(value) {
+            return value.calculation.lastMatchEntry.char == child.char &&
+                   value.optimalInput[0] == mass;
+          });
+
+          assert.equal(matchingEdge.length, 1); // An array is returned, but should only hold the one entry.
+          matchingEdge = matchingEdge[0]; // Array -> that one entry.
+
+          // Substitution - matching char
+          if(mass.sample.insert == matchingEdge.calculation.lastMatchEntry.char) {
+            assert.equal(matchingEdge.currentCost, 1 - mass.p);
+          } else {
+            // not matching char.
+            assert.equal(matchingEdge.currentCost, 2 - mass.p);
+          }
+        }
+      }
+
+      assert.equal(edges.length, expectedChildCount);
+
+      // One final bit, which is a bit of integration - we know the top two nodes that should result.
+      let queue = new models.PriorityQueue(correction.QUEUE_EDGE_COMPARATOR, edges);
+
+      let firstEdge = queue.dequeue();
+      assert.equal(firstEdge.optimalInput[0].sample.insert, 't');
+      assert.equal(firstEdge.calculation.lastMatchEntry.char, 't');
+      assert.equal(firstEdge.currentCost, 0.25);
+
+      let secondEdge = queue.dequeue();
+      assert.equal(secondEdge.optimalInput[0].sample.insert, 'h');
+      assert.equal(secondEdge.calculation.lastMatchEntry.char, 'h');
+      assert.equal(secondEdge.currentCost, 0.75);
+
+      // After this, a 't' input without a matching char.
+      let nextEdge = queue.dequeue();
+      assert.equal(nextEdge.optimalInput[0].sample.insert, 't');
+      assert.notEqual(nextEdge.calculation.lastMatchEntry.char, 't');
+      assert.equal(nextEdge.currentCost, 1.25);
+    });
+  });
+});

--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -24,7 +24,7 @@ function findEdgeWithChars(edgeArray, input, match) {
 }
 
 describe('Correction Distance Modeler', function() {
-  describe('Search Node + Search Edge', function() {
+  describe('SearchNode + SearchEdge', function() {
     var testModel;
 
     before(function() {

--- a/common/predictive-text/worker/correction/classical-calculation.ts
+++ b/common/predictive-text/worker/correction/classical-calculation.ts
@@ -451,6 +451,10 @@ namespace correction {
       return inputString + models.SENTINEL_CODE_UNIT + matchString + models.SENTINEL_CODE_UNIT + this.diagonalWidth;
     }
 
+    get lastInputEntry(): TInput {
+      return this.inputSequence[this.inputSequence.length-1];
+    }
+
     get lastMatchEntry(): TMatch {
       return this.matchSequence[this.matchSequence.length-1];
     }

--- a/common/predictive-text/worker/correction/classical-calculation.ts
+++ b/common/predictive-text/worker/correction/classical-calculation.ts
@@ -446,10 +446,13 @@ namespace correction {
     }
 
     get mapKey(): string {
-      // TODO:  assumes TUnit == string.  Fine for us for now, though.
       let inputString = this.inputSequence.map((value) => value.key).join('');
       let matchString =  this.matchSequence.map((value) => value.key).join('');
-      return inputString + models.SENTINEL_CODE_UNIT + matchString;
+      return inputString + models.SENTINEL_CODE_UNIT + matchString + models.SENTINEL_CODE_UNIT + this.diagonalWidth;
+    }
+
+    get lastMatchEntry(): TMatch {
+      return this.matchSequence[this.matchSequence.length-1];
     }
   }
 }

--- a/common/predictive-text/worker/correction/classical-calculation.ts
+++ b/common/predictive-text/worker/correction/classical-calculation.ts
@@ -444,5 +444,12 @@ namespace correction {
         }
       }
     }
+
+    get mapKey(): string {
+      // TODO:  assumes TUnit == string.  Fine for us for now, though.
+      let inputString = this.inputSequence.map((value) => value.key).join('');
+      let matchString =  this.matchSequence.map((value) => value.key).join('');
+      return inputString + models.SENTINEL_CODE_UNIT + matchString;
+    }
   }
 }

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -18,24 +18,6 @@ namespace correction {
     return arg1.currentCost - arg2.currentCost;
   }
 
-  // const QUEUE_END_NODE_COMPARATOR: models.Comparator<SearchNode> = function(arg1, arg2) {
-  //   return arg1.knownCost - arg2.knownCost;
-  // }
-
-  export const QUEUE_SPACE_COMPARATOR: models.Comparator<SearchSpaceTier> = function(space1, space2) {
-    let node1 = space1.correctionQueue.peek();
-    let node2 = space2.correctionQueue.peek();
-    
-    // Guards, just in case one of the search spaces ever has an empty node.
-    if(node1 && node2) {
-      return node1.currentCost - node2.currentCost;
-    } else if(node2) {
-      return 1;
-    } else {
-      return -1;
-    }
-  }
-
   // Represents an 'edge' to a potential 'node' on the (conceptual) graph used to search for best-fitting
   // corrections by the correction-search algorithm.  Stores the cost leading to the new node, though it may be
   // an overestimate when the edit distance is greater than the current search threshold.
@@ -214,83 +196,4 @@ namespace correction {
       return edges;
     }
   } 
-
-  /*
-   * NOTE:  Everything after this point is EXTREMELY rough-draft. 
-   */
-
-  class SearchSpaceTier {
-    correctionQueue: models.PriorityQueue<SearchEdge>;
-    operation: SearchOperation;
-
-    processed: SearchNode[] = [];
-
-    constructor(operation: SearchOperation) {
-      this.operation = operation;
-      this.correctionQueue = new models.PriorityQueue<SearchEdge>(QUEUE_EDGE_COMPARATOR);
-    }
-  }
-
-  // The set of search spaces corresponding to the same 'context' for search.
-  // Whenever a wordbreak boundary is crossed, a new instance should be made.
-  export class SearchSpace {
-    private cachedSpaces: {[id: string]: SearchSpaceTier} = {};
-    private selectionQueue: models.PriorityQueue<SearchSpaceTier>;
-
-    // TODO:  Fix; is not quite right.  We want the results corresponding to the node
-    // that will let us build the next tier's SearchNodes when new input arrives.
-    //
-    // We use an array and not a PriorityQueue b/c batch-heapifying at a single point in time 
-    // is cheaper than iteratively building a priority queue.
-    private extractedResults: SearchNode[] = [];
-
-    constructor() {
-      this.selectionQueue = new models.PriorityQueue<SearchSpaceTier>(QUEUE_SPACE_COMPARATOR);
-    }
-
-    processNode(node: SearchEdge): SearchNode[] {
-      let sourceCalc = node.calculation;
-
-      // TODO:  Lots of things.
-      return [];
-    }
-
-    addInput(input: Distribution<Transform>) {
-
-    }
-  }
-
-  export class DistanceModelerOptions {
-    minimumPredictions: number;
-  }
-
-  export class DistanceModeler {
-    private options: DistanceModelerOptions;
-    public static readonly DEFAULT_OPTIONS: DistanceModelerOptions = {
-      minimumPredictions: 3
-    }
-
-    // Keep as a 'rotating cache'.  Includes search spaces corresponding to 'revert' commands.
-    private searchSpaces: SearchSpace[] = [];
-
-    private inputs: Distribution<USVString>[] = [];
-    private lexiconRoot: LexiconTraversal;
-
-    constructor(lexiconRoot: LexiconTraversal, options: DistanceModelerOptions = DistanceModeler.DEFAULT_OPTIONS) {
-      this.lexiconRoot = lexiconRoot;
-      this.options = options;
-    }
-
-    addInput(input: Distribution<Transform>) {
-      // TODO:  add 'addInput' operation
-      //        do search space things
-    }
-
-    // Current best guesstimate of how compositor will retrieve ideal corrections.
-    getBestMatches(): Generator<[string, number][]> { // might should also include a 'base cost' parameter of sorts?
-      // Duplicates underlying Priority Queue, iterates progressively through sets of evenly-costed
-      // corrections until satisfied.
-      return null;
-    }
-  }
 }

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -9,6 +9,11 @@ namespace correction {
 
   type RealizedInput = ProbabilityMass<Transform>[];
 
+  type TraversableToken<TUnit> = {
+    key: TUnit,
+    traversal: LexiconTraversal
+  }
+
   export const QUEUE_EDGE_COMPARATOR: models.Comparator<SearchEdge> = function(arg1, arg2) {
     return arg1.currentCost - arg2.currentCost;
   }
@@ -40,7 +45,7 @@ namespace correction {
   // heuristic.
   class SearchEdge {
     // Existing calculation from prior rounds to use as source.
-    calculation: ClassicalDistanceCalculation;
+    calculation: ClassicalDistanceCalculation<string, EditToken<string>, TraversableToken<string>>;
 
     // The sequence of input 'samples' taken from specified input distributions.
     optimalInput: RealizedInput;
@@ -88,7 +93,7 @@ namespace correction {
   // Most of the actual calculations occur as part of this process.
   //
   export class SearchNode {
-    calculation: ClassicalDistanceCalculation;
+    calculation: ClassicalDistanceCalculation<string, EditToken<string>, TraversableToken<string>>;
     
     currentTraversal: LexiconTraversal;
     priorInput: RealizedInput;
@@ -112,7 +117,7 @@ namespace correction {
         let edge = obj as SearchEdge;
 
         this.calculation = edge.calculation;
-        this.currentTraversal = edge.calculation.matchSequence[edge.calculation.matchSequence.length-1]['traversal']
+        this.currentTraversal = edge.calculation.matchSequence[edge.calculation.matchSequence.length-1].traversal;
         this.priorInput = edge.optimalInput;
       } else {
         // Assume it's a LexiconTraversal instead.
@@ -209,6 +214,10 @@ namespace correction {
       return edges;
     }
   } 
+
+  /*
+   * NOTE:  Everything after this point is EXTREMELY rough-draft. 
+   */
 
   class SearchSpaceTier {
     correctionQueue: models.PriorityQueue<SearchEdge>;

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -75,7 +75,7 @@ namespace correction {
     get mapKey(): string {
       // TODO:  correct, as Transforms don't convert nicely to strings.
       let inputString = this.optimalInput.map((value) => value.sample).join('');
-      let matchString =  this.calculation.matchSequence.map((value) => value.char).join('');
+      let matchString =  this.calculation.matchSequence.map((value) => value.key).join('');
       // TODO:  might should also track diagonalWidth.
       return inputString + models.SENTINEL_CODE_UNIT + matchString;
     }
@@ -112,7 +112,7 @@ namespace correction {
         let edge = obj as SearchEdge;
 
         this.calculation = edge.calculation;
-        this.currentTraversal = edge.calculation.matchSequence[edge.calculation.matchSequence.length-1].tag
+        this.currentTraversal = edge.calculation.matchSequence[edge.calculation.matchSequence.length-1]['traversal']
         this.priorInput = edge.optimalInput;
       } else {
         // Assume it's a LexiconTraversal instead.
@@ -128,8 +128,8 @@ namespace correction {
 
       for(let lexicalChild of this.currentTraversal.children()) {
         let matchToken = {
-          char: lexicalChild.char,
-          tag: lexicalChild.traversal()
+          key: lexicalChild.char,
+          traversal: lexicalChild.traversal()
         }
 
         // TODO:  Check against cache(s) & cache results.
@@ -167,9 +167,8 @@ namespace correction {
             char = char + transform.insert[i];
           }
 
-          // TODO:  Drop 'matchCost' as a thing.
           // TODO:  Check against cache, write results to that cache.
-          edgeCalc = edgeCalc.addInputChar({char: char, matchCost: 1});
+          edgeCalc = edgeCalc.addInputChar({key: char});
         }
 
         let childEdge = new SearchEdge();
@@ -192,8 +191,8 @@ namespace correction {
       for(let lexicalChild of this.currentTraversal.children()) {
         for(let edge of intermediateEdges) {
           let matchToken = {
-            char: lexicalChild.char,
-            tag: lexicalChild.traversal()
+            key: lexicalChild.char,
+            traversal: lexicalChild.traversal()
           }
   
           // TODO:  Check against cache(s), cache results.

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -41,13 +41,14 @@ namespace correction {
       minimumPredictions: 3
     }
 
-    // Keep as a 'rotating cache'?
+    // Keep as a 'rotating cache'.  Includes search spaces corresponding to 'revert' commands.
+    private cachedSpaces: {[id: string]: SearchSpace} = {};
+    private cachedIDs: string[];
+
     private searchSpaces: SearchSpace[] = [];
     static readonly QUEUE_COMPARATOR: models.Comparator<SearchNode> = function(arg1, arg2) {
       return arg1.currentCost - arg2.currentCost;
     }
-
-    private operations: SearchOperation[] = [];
 
     private inputs: InputToken[] = [];
     private lexiconRoot: LexiconTraversal;
@@ -59,7 +60,15 @@ namespace correction {
 
     // TODO:  Define the type more properly.
     addInput(input: {char: string}) {
+      // TODO:  add 'addInput' operation
+      //        do search space things
+    }
 
+    // Current best guesstimate of how compositor will retrieve ideal corrections.
+    getBestMatches(): Generator<[string, number][]> {
+      // Duplicates underlying Priority Queue, iterates progressively through sets of evenly-costed
+      // corrections until satisfied.
+      return null;
     }
   }
 }

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -1,0 +1,65 @@
+/// <reference path="classical-calculation.ts" />
+
+namespace correction {
+  enum SearchOperation {
+    addInput,
+    addMatch,
+    expandDiagonal
+  }
+
+  class SearchNode {
+    calculation: ClassicalDistanceCalculation
+    
+    get currentCost(): number {
+      return this.calculation.getHeuristicFinalCost();
+    }
+
+    get mapKey(): string {
+      return this.calculation.matchSequence.map((value) => value.char).join('');
+    }
+  }
+
+  class SearchSpace {
+    queue: models.PriorityQueue<SearchNode>
+    operation: SearchOperation
+
+    processed: SearchNode[] = [];
+
+    constructor(operation: SearchOperation) {
+      this.operation = operation;
+      this.queue = new models.PriorityQueue<SearchNode>(DistanceModeler.QUEUE_COMPARATOR);
+    }
+  }
+
+  export class DistanceModelerOptions {
+    minimumPredictions: number;
+  }
+
+  export class DistanceModeler {
+    private options: DistanceModelerOptions;
+    public static readonly DEFAULT_OPTIONS: DistanceModelerOptions = {
+      minimumPredictions: 3
+    }
+
+    // Keep as a 'rotating cache'?
+    private searchSpaces: SearchSpace[] = [];
+    static readonly QUEUE_COMPARATOR: models.Comparator<SearchNode> = function(arg1, arg2) {
+      return arg1.currentCost - arg2.currentCost;
+    }
+
+    private operations: SearchOperation[] = [];
+
+    private inputs: InputToken[] = [];
+    private lexiconRoot: LexiconTraversal;
+
+    constructor(lexiconRoot: LexiconTraversal, options: DistanceModelerOptions = DistanceModeler.DEFAULT_OPTIONS) {
+      this.lexiconRoot = lexiconRoot;
+      this.options = options;
+    }
+
+    // TODO:  Define the type more properly.
+    addInput(input: {char: string}) {
+
+    }
+  }
+}

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -1,5 +1,5 @@
 /// <reference path="../node_modules/@keymanapp/models-templates/src/index.ts" />
-/// <reference path="correction/classical-calculation.ts" />
+/// <reference path="correction/distance-modeler.ts" />
 
 class ModelCompositor {
   private lexicalModel: LexicalModel;

--- a/common/predictive-text/worker/tsconfig.json
+++ b/common/predictive-text/worker/tsconfig.json
@@ -6,7 +6,8 @@
     "outFile": "../build/intermediate/index.js",
     "sourceMap": true,
     "lib": ["webworker", "es6"],
-    "target": "es5"
+    "target": "es5",
+    "downlevelIteration": true
   },
   "include": [
     "../node_modules/@keymanapp/web-environment/environment.inc.ts",


### PR DESCRIPTION
Following from #3526, this PR starts integrating use of Damerau-Levenshtein-based edit-distance for use with modeling/generating 'corrections'.  In particular, two "low-level" classes are introduced:  `SearchEdge` and `SearchNode`.  Part of addressing #2223.

After significant analysis and work, I've noticed that the overall algorithm will effectively be an implementation of the A* algorithm over a virtualized search graph with directed edges.  (Said graph will be _mostly_ tree-like, though some branches may converge.  The graph will be acyclical, at least.)

Inputs:  
- a list of probability distributions over the possible input tokens
    - This allows us to, in theory, search over _**all**_ possible input sequences.
- a `LexiconTraversal` object, allowing efficient search throughout a lexical model's underlying lexicon.
    - Refer to #3479.

Combined, these inputs theoretically allow us to perform edit distance calculations across all pairs of inputs + words in the lexicon.  Of course, this is combinatoric and quickly becomes prohibitively expensive to exhaustively do.  That's where the A* comes in - we'll only search over the most likely and promising corrections offered by a model's lexicon.  The planned search may stop under two conditions.

1. Enough corrections have been generated.
    - If there are already 3 very likely corrections and we've finished evaluating all possibilities of equal probability, why keep going?
        - Or 12, or whatever number is preferred.
2. A cost threshold has been reached.
    - We should be able to determine a reasonable cutoff to prevent nonsense corrections/predictions from being given to users.
       - Probably something like `0.6 * (input sequence length) + 2`.  The constant provides a buffer in case of 'leading' mistakes, and using the string's actual length provides a bit of buffer in case of unlikely keystrokes and occasional mistakes.
       - Naturally, coefficients/constants subject to tweaking/change.  We could allow users to indirectly adjust them as part of a setting.

The implementation of `SearchEdge` combined with `SearchNode` will allow a search algorithm to dynamically generate _only_ the parts of the search-space graph actually needed for evaluation.  I've added one test case as a "hand-driven" example of how an algorithm might use these classes to search a lexicon; the actual algorithm's driving code will come later.

-----

@ddaspit - this is but a part of the eventual graph-searching algorithm we'll be using for predictive text.  Unfortunately, it's  a bit harder to make properly abstract at this time.  

Abstraction difficulties:

- Note that the correction algorithm's input will _not_ be the same as the edit-distance algorithm's input.  Input mapping (from `Transform[]` to what is effectively `string[]`) is necessary and would have to be specified as part of an abstracted version of the final algorithm.
    - For context, one `Transform` corresponds to the results of a single keystroke, which may emit multiple characters (thus, multiple input tokens) and/or delete adjacent context.  Or it may just be a single character.
    - Also note that we'd want a way for _both_ types of input to be 'hashable' in some manner; hash table caching will be very useful for us.
- While no match-sequence mapping is necessary, there's a different problem there.  We'll be storing data on the "match token" that is used to generate edges to all entries of the lexicon prefixed by an edge's source node.  (Again, since the graph is dynamically built.)
    - It may be worth examining the `LexiconTraversal` class and seeing if an abstracted version of _that_ might be possible for your potential use cases.
    - If it's possible to build an object pattern that allows string-by-string iteration across possible translations, using an existing 'prefix' to enumerate all strings one token longer than said prefix, the existing abstraction should work... after being further abstracted (so that it's not string-reliant).
