### PR TITLE
fix(linux): Improve robustness when installing ibus-keyman

### DIFF
--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -14,10 +14,14 @@ case "$1" in
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        sudo -H -u "$ibususer" ibus exit
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus exit
+        fi
       else
         ibususer=`ps -C ibus-daemon -o user=|uniq`
-        sudo -H -u "$ibususer" ibus restart
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus restart
+        fi
       fi
     fi
   ;;


### PR DESCRIPTION
If for whatever reason ibus wasn't running for the current user
the installation failed previously, leaving the user in a broken
state until he reboots and tries the installation again. This change
detects this situation and skips restarting ibus.