### PR TITLE
fix(windows): add transient profile support to keyman32

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -68,16 +68,17 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateKeyboard(GUID *profile) 
       for(int j = 0; j < _td->lpKeyboards[i].nProfiles; j++) {
         if(IsEqualGUID(_td->lpKeyboards[i].Profiles[j].Guid, *profile)) {
           SelectKeyboard(_td->lpKeyboards[i].KeymanID);   // I3594
-          break;
+          ReportActiveKeyboard(_td, PC_UPDATE);   // I3961
+          return TRUE;
         }
       }
     }
-  } else {
-    SelectKeyboard(KEYMANID_NONKEYMAN);   // I3594
   }
-  
+
+  SendDebugMessage(0, sdmAIDefault, 0, "TIPActivateKeyboard: Could not find profile");
+  SelectKeyboard(KEYMANID_NONKEYMAN);   // I3594
   ReportActiveKeyboard(_td, PC_UPDATE);   // I3961
-  return TRUE;
+  return FALSE;
 }
 
 extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateEx(BOOL FActivate) {  // I3581

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -224,7 +224,7 @@ typedef struct tagINTKEYBOARDOPTIONS
 
 typedef struct tagINTKEYBOARDPROFILE
 {
-  WCHAR Locale[LOCALE_NAME_MAX_LENGTH];
+  //WCHAR Locale[LOCALE_NAME_MAX_LENGTH]; This is not currently used in keyman32/64 so we won't load it
   LANGID LangID;
   GUID Guid;
 } INTKEYBOARDPROFILE, *LPINTKEYBOARDPROFILE;

--- a/windows/src/global/inc/registry.h
+++ b/windows/src/global/inc/registry.h
@@ -90,7 +90,10 @@
 #define REGSZ_KeymanError		"keyman error"
    // I3613
 #define REGSZ_LanguageProfiles "Language Profiles"
+#define REGSZ_TransientLanguageProfiles "Transient Language Profiles"
 #define REGSZ_ProfileGUID   "profile guid"
+#define REGWSZ_ProfileGUID L"" ## REGSZ_ProfileGUID
+#define REGSZ_LanguageProfiles_LangID "LangID"
 
 #define REGSZ_LayoutID			"layout id"
 


### PR DESCRIPTION
Keyman32/keyman64 were not reading the new 'Transient Language Profiles'
key which is needed with Keyman 14. Minor tweak to ensure we don't scan
through more profiles than necessary when activating tip in aiTIP.cpp also.