### PR TITLE
fix(android/engine): Fix package filename when downloading from cloud

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
@@ -1,6 +1,7 @@
 package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
+import android.net.Uri;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -62,8 +63,17 @@ public class CloudKeyboardPackageDownloadCallback implements ICloudDownloadCallb
         try {
           if (_d.getCloudParams().target == CloudApiTypes.ApiTarget.KeyboardPackage) {
             installedKeyboards = new LinkedList<>();
+
+            // Parse url for the kmp filename
+            Uri uri = Uri.parse(_d.getCloudParams().url);
+            String packageID = uri.getLastPathSegment();
+            if (packageID == null || packageID.isEmpty()) {
+              KMLog.LogError(TAG, "Cloud URL " + _d.getCloudParams().url + " has null packageID");
+            }
+            String kmpFilename = String.format("%s%s", packageID, FileUtils.KEYMANPACKAGE);
+
             // Extract the kmp.
-            File kmpFile = new File(cacheDir, FileUtils.getFilename(_d.getCloudParams().url));
+            File kmpFile = new File(cacheDir, kmpFilename);
 
             FileUtils.copy(_d.getDestinationFile(), kmpFile);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
@@ -1,6 +1,7 @@
 package com.tavultesoft.kmea.cloud.impl;
 
 import android.content.Context;
+import android.net.Uri;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -56,8 +57,16 @@ public class CloudLexicalPackageDownloadCallback implements ICloudDownloadCallba
         try {
           if (_d.getCloudParams().target == CloudApiTypes.ApiTarget.LexicalModelPackage) {
             installedLexicalModels = new LinkedList<>();
+
+            // Parse url for the kmp filename
+            Uri uri = Uri.parse(_d.getCloudParams().url);
+            String kmpFilename = uri.getLastPathSegment();
+            if (kmpFilename == null || kmpFilename.isEmpty()) {
+              KMLog.LogError(TAG, "Cloud URL " + _d.getCloudParams().url + " has null model package");
+            }
+
             // Extract the kmp. Validate it contains only lexical models, and then process the lexical model package
-            File kmpFile = new File(cacheDir, FileUtils.getFilename(_d.getCloudParams().url));
+            File kmpFile = new File(cacheDir, kmpFilename);
 
             FileUtils.copy(_d.getDestinationFile(), kmpFile);
 


### PR DESCRIPTION
Fixes #3530 

When downloading keyboard package updates, the cloud API uses links such as
https://keyman-staging.com/go/package/download/sil_euro_latin?version=1.9.1&update=1

Currently, keyboard package updates would be saved with an invalid filename `sil_euro_latin?version=1.9.1&update=1`.
The cloud keyboard package download callback need to be updated to convert that path to a filename `sil_euro_latin.kmp`.

I updated CloudLexicalPackageDownloadCallback.java to use the same pattern to keep things similar. 

Note, downloads from keyboard searches (https://keyman-staging.com/keyboards/...)  don't use the background downloader, so MainActivity is triggered with the correct filename "sil_euro_latin.kmp".
