### PR TITLE
feat(windows): map installed bcp47

### DIFF
--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
@@ -85,11 +85,16 @@ uses
 constructor TKeymanKeyboardLanguageInstalled.Create(AContext: TKeymanContext;
   AOwner: IKeymanKeyboardInstalled; const ABCP47Code: string;
   ALangID: Integer; AProfileGUID: TGUID; const AName: string);
+var
+  BCP47Code: string;
 begin
   FOwner := AOwner;
   FProfileGUID := AProfileGUID;
-  FIsInstalled := IsTIPInstalledForCurrentUser(aBCP47Code, ALangID, AProfileGUID);
-  inherited Create(AContext, AOwner, ABCP47Code, ALangID, AName);
+  BCP47Code := ABCP47Code;
+  // Note, if the TIP is installed, the BCP47Code may be modified to match the
+  // canonicalization that Windows gives it.
+  FIsInstalled := IsTIPInstalledForCurrentUser(BCP47Code, ALangID, AProfileGUID);
+  inherited Create(AContext, AOwner, BCP47Code, ALangID, AName);
 end;
 
 function TKeymanKeyboardLanguageInstalled.FindInstallationLangID(

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
@@ -180,7 +180,7 @@ procedure TKeymanKeyboardLanguagesInstalled.DoRefresh;
         regLM.ValueExists(SRegValue_KeymanProfileGUID) then
       begin
         FGUID := StringToGUID(regLM.ReadString(SRegValue_KeymanProfileGUID));
-        BCP47Tag := GetBCP47ForTransientTIP(LangID, FGUID);
+        BCP47Tag := GetBCP47ForInstalledTIP(LangID, FGUID);
         if (BCP47Tag <> '') and (IndexOfBCP47Code(BCP47Tag) < 0) then
         begin
           FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, BCP47Tag, LangID, FGUID, BCP47Tag); // TODO: get language name

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
@@ -22,7 +22,7 @@ type
     /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
     /// <param name="BCP47Tag">This should be a BCP47 tag that is currently installed</param>
-    procedure UninstallTip(const KeyboardID, BCP47Tag: string); overload;
+    procedure UninstallTip(KeyboardID, BCP47Tag: string); overload;
 
     /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
@@ -196,7 +196,7 @@ begin
   DoUnregisterTip(KeyboardID, BCP47Tag, GetInputProcessorProfileMgr);
 end;
 
-procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID, BCP47Tag: string);
+procedure TKPUninstallKeyboardLanguage.UninstallTip(KeyboardID, BCP47Tag: string);
 var
   reg: TRegistry;
   FIsAdmin: Boolean;
@@ -247,7 +247,7 @@ var
   reg: TRegistry;
   FIsAdmin: Boolean;
   guid: TGUID;
-  FLayoutInstallString: string;
+  BCP47Tag, FLayoutInstallString: string;
   RootPath: string;
 begin
   if not KeyboardInstalled(KeyboardID, FIsAdmin) then
@@ -283,7 +283,9 @@ begin
   // This scenario can arise if the user has removed the TIP through Windows
   // UI/APIs after we install it.
   //
-  if not IsTipInstalledForCurrentUser('', langid, guid) then
+
+  BCP47Tag := '';
+  if not IsTipInstalledForCurrentUser(BCP47Tag, langid, guid) then
     Exit;
 
   //

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -263,6 +263,10 @@ const
 
   SRegKey_ControlPanelInternationalUserProfile = 'Control Panel\International\User Profile'; // CU
 
+  SRegValue_CPIUP_Languages = 'Languages';
+  SRegValue_CPIUP_TransientLangId = 'TransientLangId';
+  SRegValue_CPIUP_CachedLanguageName = 'CachedLanguageName';
+
   { User profile keys }
 
   //SRegKey_NTProfileList = 'Software\Microsoft\Windows NT\CurrentVersion\ProfileList';

--- a/windows/src/global/delphi/general/Windows8LanguageList.pas
+++ b/windows/src/global/delphi/general/Windows8LanguageList.pas
@@ -96,25 +96,24 @@ begin
   Clear;
   with TRegistry.Create do
   try
-    // TODO: move key and value names to RegistryKeys.pas
-    FIsSupported := OpenKeyReadOnly('Control Panel\International\User Profile') and ValueExists('Languages');
+    FIsSupported := OpenKeyReadOnly(SRegKey_ControlPanelInternationalUserProfile) and ValueExists(SRegValue_CPIUP_Languages);
     if FIsSupported then
     begin
       FLanguageNames := TStringList.Create;
       FValueNames := TStringList.Create;
       try
-        ReadMultiString('Languages', FLanguageNames);
+        ReadMultiString(SRegValue_CPIUP_Languages, FLanguageNames);
 
         for i := 0 to FLanguageNames.Count - 1 do
         begin
           Language := TWindows8Language.Create(FLanguageNames[i]);
           Add(Language);
-          if OpenKeyReadOnly('\Control Panel\International\User Profile\'+FLanguageNames[i]) then
+          if OpenKeyReadOnly('\' + SRegKey_ControlPanelInternationalUserProfile + '\'+FLanguageNames[i]) then
           begin
-            if ValueExists('TransientLangId') then
-              Language.FLangId := ReadInteger('TransientLangId');
-            if ValueExists('CachedLanguageName') then
-              Language.FLocaleName := LoadIndirectString(ReadString('CachedLanguageName'));
+            if ValueExists(SRegValue_CPIUP_TransientLangId) then
+              Language.FLangId := ReadInteger(SRegValue_CPIUP_TransientLangId);
+            if ValueExists(SRegValue_CPIUP_CachedLanguageName) then
+              Language.FLocaleName := LoadIndirectString(ReadString(SRegValue_CPIUP_CachedLanguageName));
 
             FValueNames.Clear;
             GetValueNames(FValueNames);

--- a/windows/src/global/delphi/general/utiltsf.pas
+++ b/windows/src/global/delphi/general/utiltsf.pas
@@ -23,8 +23,8 @@ unit utiltsf;
 interface
 
 function TSFInstalled: Boolean;
-function IsTIPInstalledForCurrentUser(BCP47Tag: string; LangID: Integer; guidProfile: TGUID): Boolean;
-function GetBCP47ForTransientTIP(LangID: Integer; guidProfile: TGUID): string;
+function IsTIPInstalledForCurrentUser(var BCP47Tag: string; LangID: Integer; guidProfile: TGUID): Boolean;
+function GetBCP47ForInstalledTIP(LangID: Integer; guidProfile: TGUID): string;
 function IsTransientLanguageID(LangID: Integer): Boolean;
 function GetLayoutInstallString(LangID: Integer; guidProfile: TGUID): string;
 
@@ -62,35 +62,25 @@ begin
   ]);
 end;
 
-function IsTIPInstalledForCurrentUser(BCP47Tag: string; LangID: Integer; guidProfile: TGUID): Boolean;
+function IsTIPInstalledForCurrentUser(var BCP47Tag: string; LangID: Integer; guidProfile: TGUID): Boolean;
 var
-  FLayoutInstallString: string;
-  reg: TRegistryErrorControlled;
+  s: string;
 begin
-  if BCP47Tag <> '' then
-  begin
-    reg := TRegistryErrorControlled.Create(KEY_READ);
-    try
-      FLayoutInstallString := GetLayoutInstallString(LangID, guidProfile);
-      Result :=
-        reg.OpenKeyReadOnly(SRegKey_ControlPanelInternationalUserProfile + '\' + BCP47Tag) and
-        reg.ValueExists(FLayoutInstallString);
-    finally
-      reg.Free;
-    end;
-  end
-  else
-  begin
-    Result := GetBCP47ForTransientTIP(LangID, guidProfile) <> '';
-  end;
+  s := GetBCP47ForInstalledTIP(LangID, guidProfile);
+  Result := s <> '';
+  if Result then
+    BCP47Tag := s;
 end;
 
-function GetBCP47ForTransientTIP(LangID: Integer; guidProfile: TGUID): string;
+function GetBCP47ForInstalledTIP(LangID: Integer; guidProfile: TGUID): string;
 var
   tag, FLayoutInstallString: string;
   reg: TRegistryErrorControlled;
   tags: TStringList;
 begin
+  // TODO: we could cache this data so we don't have to read and compare for
+  // every installed language -- but let's get the algorithm solid before
+  // optimising.
   Result := '';
 
   reg := TRegistryErrorControlled.Create(KEY_READ);


### PR DESCRIPTION
Fixes #1282.
Fixes #1719.

This PR handles the case where Windows installs a BCP 47 tag that may not match our tag 100% precisely. In this case, Keyman maps the Windows BCP 47 tag to the in-memory data for consistency. It also allows for install of more complex tags.

Part of #3512.