### PR TITLE
fix(windows): simplify profile uninstall

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -412,14 +412,21 @@ function TfrmMain.GetKeyboardLanguageFromParams(params: TStringList; out kbdlang
 var
   n: Integer;
   kbd: IKeymanKeyboardInstalled;
+  bcp47code: string;
 begin
   n := kmcom.Keyboards.IndexOf(params.Values['id']);
   if n < 0 then Exit(False);
   kbd := kmcom.Keyboards[n];
-  n := StrToIntDef(params.Values['index'], -1);
-  if (n < 0) or (n >= kbd.Languages.Count) then Exit(False);
-  kbdlang := kbd.Languages[n];
-  Result := True;
+  bcp47code := params.Values['bcp47code'];
+  for n := 0 to kbd.Languages.Count - 1 do
+  begin
+    if kbd.Languages[n].BCP47Code = bcp47code then
+    begin
+      kbdlang := kbd.Languages[n];
+      Exit(True);
+    end;
+  end;
+  Result := False;
 end;
 
 function TfrmMain.GetPackageFromParams(params: TStringList; out pkg: IKeymanPackageInstalled): Boolean;

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -503,7 +503,6 @@ begin
         else ExitCode := 1;
 
     fmInstallTip:
-      // TODO: handle when not enough parameters
       if TTipMaintenance.InstallTip(StrToIntDef('$'+FirstKeyboardFilename, 0), SecondKeyboardFileName, ThirdKeyboardFileName, FourthKeyboardFileName)
         then ExitCode := 0
         else ExitCode := 1;

--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -314,7 +314,7 @@
   <xsl:template match="KeymanKeyboardLanguageInstalled">
     <div class='keyboard-language'>
       <a>
-        <xsl:attribute name="href">keyman:keyboardlanguage_uninstall?id=<xsl:value-of select='../../id'/>&amp;index=<xsl:value-of select="position()-1"/></xsl:attribute>
+        <xsl:attribute name="href">keyman:keyboardlanguage_uninstall?id=<xsl:value-of select='../../id'/>&amp;bcp47code=<xsl:value-of select="bcp47code"/></xsl:attribute>
         <img src="/app/cross.png">
           <xsl:attribute name="title"><xsl:value-of select="$locale/string[@name='S_Languages_Uninstall']"/></xsl:attribute>
         </img>

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
@@ -208,9 +208,7 @@ begin
   if Get_IsInstalled then
     with TKPUninstallKeyboardLanguage.Create(Context) do
     try
-      if IsTransientLanguageID(Get_LangID)
-        then UninstallTip(FOwner.ID, Get_LangID)
-        else UninstallTip(FOwner.ID, Get_BCP47Code);
+      UninstallTip(FOwner.ID, Get_LangID, Get_ProfileGUID);
     finally
       Free;
     end;

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
@@ -21,19 +21,19 @@ type
 
     /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
-    /// <param name="BCP47Tag">This should be a BCP47 tag that is currently installed</param>
-    procedure UninstallTip(KeyboardID, BCP47Tag: string); overload;
-
-    /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
-    /// <param name="KeyboardID">The ID of the keyboard</param>
     /// <param name="LangID">The transient profile to uninstall, $2000, $2400, $2800, $2C00</param>
-    procedure UninstallTip(const KeyboardID: string; LangID: Word); overload;
+    procedure UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID); overload;
 
     /// <summary>Uninstalls all TIPs for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
     procedure UninstallTip(const KeyboardID: string); overload;
 
   protected
+    /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
+    /// <param name="KeyboardID">The ID of the keyboard</param>
+    /// <param name="BCP47Tag">This should be a BCP47 tag that is currently installed</param>
+    procedure UninstallTip(KeyboardID, BCP47Tag: string); overload;
+
     /// <summary>Unregisters a TIP from the Local Machine registry</summary>
     /// <param name="BCP47Tag">This should be a BCP47 tag</param>
     /// <param name="KeyboardID">The ID of the keyboard</param>
@@ -241,39 +241,13 @@ begin
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
 end;
 
-procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string;
-  LangID: Word);
+procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID);
 var
-  reg: TRegistry;
   FIsAdmin: Boolean;
-  guid: TGUID;
   BCP47Tag, FLayoutInstallString: string;
-  RootPath: string;
 begin
   if not KeyboardInstalled(KeyboardID, FIsAdmin) then
     ErrorFmt(KMN_E_ProfileUninstall_KeyboardNotFound, VarArrayOf([KeyboardID]));
-
-  if not IsTransientLanguageID(LangID) then
-    ErrorFmt(KMN_E_ProfileUninstall_NotATransientLanguageCode, VarArrayOf([KeyboardID, LangID]));
-
-  reg := TRegistry.Create(KEY_READ);
-  try
-    reg.RootKey := HKEY_LOCAL_MACHINE;
-    RootPath := GetRegistryKeyboardInstallKey_LM(KeyboardID) + SRegSubKey_TransientLanguageProfiles;
-    if not reg.OpenKeyReadOnly(RootPath + '\' + IntToHex(LangID, 4)) then
-      // We'll assume it's not installed
-      Exit;
-
-    if not reg.ValueExists(SRegValue_KeymanProfileGUID) then
-    begin
-      WarnFmt(KMN_W_ProfileUninstall_RegistryCorrupt, VarArrayOf([KeyboardID]));
-      Exit;
-    end;
-
-    guid := StringToGuid(reg.ReadString(SRegValue_KeymanProfileGUID));
-  finally
-    reg.Free;
-  end;
 
   //
   // We need to check if the TIP is installed before attempting to remove it,
@@ -285,13 +259,13 @@ begin
   //
 
   BCP47Tag := '';
-  if not IsTipInstalledForCurrentUser(BCP47Tag, langid, guid) then
+  if not IsTipInstalledForCurrentUser(BCP47Tag, langid, ProfileGUID) then
     Exit;
 
   //
   // Uninstall the TIP from Windows current user
   //
-  FLayoutInstallString := GetLayoutInstallString(LangID, guid);
+  FLayoutInstallString := GetLayoutInstallString(LangID, ProfileGUID);
   if not InstallLayoutOrTip(PChar(FLayoutInstallString), ILOT_UNINSTALL) then   // I4302
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
 end;


### PR DESCRIPTION
This does two things:

1. It fixes an issue where uninstall of a profile would fail because of registered-but-not-installed profiles in the same list.
2. It simplifies referencing the profile to be uninstalled so we can avoid looking up in the registry again, given we already have the active data.

There is another round of refactoring that we can do in Keyman Configuration relating to profile uninstallation, but as it is working at present, I am holding off to fix other issues. May return and refactor if time permits.

Part of #3512