### PR TITLE
fix(android/engine): Remove notification after installing kbd package

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -521,7 +521,15 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
   @Override
   public void onPackageInstalled(List<Map<String, String>> keyboardsInstalled) {
-    // Do nothing
+    if (! openUpdates.isEmpty() && keyboardsInstalled != null) {
+      for (Map<String, String> k : keyboardsInstalled) {
+        String _langid = k.get(KMManager.KMKey_LanguageID);
+        String _kbid = k.get(KMManager.KMKey_KeyboardID);
+        removeOpenUpdate(createKeyboardId(_langid, _kbid));
+      }
+    }
+
+    tryFinalizeUpdate();
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -147,7 +147,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       channel.setDescription(description);
       // Register the channel with the system; you can't change the importance
       // or other notification behaviors after this
-      NotificationManager notificationManager = aContext.getSystemService(NotificationManager.class);
+      NotificationManager notificationManager = (NotificationManager) aContext.getSystemService(Context.NOTIFICATION_SERVICE);
       notificationManager.createNotificationChannel(channel);
     }
   }
@@ -427,6 +427,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       .setContentTitle(currentContext.getString(R.string.keyboard_updates_available))
       .setContentText(message)
       .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+      .setAutoCancel(true)
       .setContentIntent(startUpdateIntent)
       .setOngoing(true);
 


### PR DESCRIPTION
This addresses #3484 for 14.0.
Since cloud keyboards now download packages instead of individual files, the handler ResourceUpdateTool.onPackageInstalled() needed to cleanup the system notification. (Refer to onKeyboardDownloadFinished at l.506)

Will still need to investigate why 13.0 notifications aren't getting dismissed...

(update):
[setAutoCancel](https://developer.android.com/reference/android/app/Notification.Builder#setAutoCancel(boolean))(true) can make the notification automatically dismiss when the user touches it (choices are either cancel or download)