### PR TITLE
feat(common/models): Edit path derivation

### DIFF
--- a/common/predictive-text/unit_tests/headless/edit-distance/classical-calculation.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/classical-calculation.js
@@ -475,7 +475,7 @@ describe('Classical Damerau-Levenshtein edit-distance calculation', function() {
       let editSequence = [
       //  a     c     c     o     m
         op.m, op.m, op.m, op.m, op.m,
-      // *m    o      d     a     t    e
+      // +m    o      d     a     t    e
         op.i, op.m, op.m, op.m, op.m, op.m
       ];
 

--- a/common/predictive-text/worker/correction/classical-calculation.ts
+++ b/common/predictive-text/worker/correction/classical-calculation.ts
@@ -177,15 +177,15 @@ namespace correction {
       let insertParentCost = this.getCostAt(row, col-1);
       let deleteParentCost = this.getCostAt(row-1, col);
       let substitutionParentCost = this.getCostAt(row-1, col-1);
-      let transposeParent = ClassicalDistanceCalculation.getTransposeParent(this, row, col);
-      if(transposeParent[0] >= 0 && transposeParent[1] >= 0) {
+      let [lastInputIndex, lastMatchIndex] = = ClassicalDistanceCalculation.getTransposeParent(this, row, col);
+      if(lastInputIndex >= 0 && lastMatchIndex >= 0) {
         // OK, a transposition source is quite possible.  Still need to do more vetting, to be sure.
         let expectedCost = 1;
 
         // This transposition includes either 'transpose-insert' or 'transpose-delete' operations.
         ops = ['transpose-start']; // always needs a 'start'.
-        if(transposeParent[0] != row-1) {
-          let count = row - transposeParent[0] - 1;
+        if(lastInputIndex != row-1) {
+          let count = row - lastInputIndex - 1;
           ops = ops.concat( Array(count).fill('transpose-delete') );
           expectedCost += count;
         } else {
@@ -196,10 +196,10 @@ namespace correction {
         ops.push('transpose-end');
 
         // Double-check our expectations.
-        if(this.getCostAt(transposeParent[0]-1, transposeParent[1]-1) != currentCost - expectedCost) {
+        if(this.getCostAt(lastInputIndex-1, lastMatchIndex-1) != currentCost - expectedCost) {
           ops = null;
         }
-        parent = [transposeParent[0]-1, transposeParent[1]-1];
+        parent = [lastInputIndex-1, lastMatchIndex-1];
       }
 
       if(ops) {

--- a/common/predictive-text/worker/correction/classical-calculation.ts
+++ b/common/predictive-text/worker/correction/classical-calculation.ts
@@ -177,7 +177,7 @@ namespace correction {
       let insertParentCost = this.getCostAt(row, col-1);
       let deleteParentCost = this.getCostAt(row-1, col);
       let substitutionParentCost = this.getCostAt(row-1, col-1);
-      let [lastInputIndex, lastMatchIndex] = = ClassicalDistanceCalculation.getTransposeParent(this, row, col);
+      let [lastInputIndex, lastMatchIndex] = ClassicalDistanceCalculation.getTransposeParent(this, row, col);
       if(lastInputIndex >= 0 && lastMatchIndex >= 0) {
         // OK, a transposition source is quite possible.  Still need to do more vetting, to be sure.
         let expectedCost = 1;
@@ -189,7 +189,7 @@ namespace correction {
           ops = ops.concat( Array(count).fill('transpose-delete') );
           expectedCost += count;
         } else {
-          let count = col - transposeParent[1] - 1;
+          let count = col - lastMatchIndex - 1;
           ops = ops.concat( Array(count).fill('transpose-insert') );
           expectedCost += count;
         }


### PR DESCRIPTION
One feature that the initial edit-distance implementation was lacking:  the ability to trace the path used to find the minimum edit distance.  While not strictly necessary for the core search algorithm, it's useful for diagnosing any issues that may arise when debugging, etc.

As it turns out, it looks like this algorithm will be quite useful for 'aligning' contexts as the user continues typing.  A specialized, hand-written version was looking to be tricky to hand-code properly due to the wide variance of possible control paths, so I bumped up the priority of this previously-missing feature.

Note that a pair of `'transpose-start'` and `'transpose-end'` constitute a _single unit_ of edit distance.  It took me a little bit to settle on this representation, as this is a bit odd... but it does allow for perfect replication of the edits without a need to specify indices within either of the input or match sequences.