### PR TITLE
fix(android/engine): Dismiss notification when touched

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -148,7 +148,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       channel.setDescription(description);
       // Register the channel with the system; you can't change the importance
       // or other notification behaviors after this
-      NotificationManager notificationManager = aContext.getSystemService(NotificationManager.class);
+      NotificationManager notificationManager = (NotificationManager) aContext.getSystemService(Context.NOTIFICATION_SERVICE);
       notificationManager.createNotificationChannel(channel);
     }
   }
@@ -428,6 +428,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       .setContentTitle(currentContext.getString(R.string.keyboard_updates_available))
       .setContentText(message)
       .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+      .setAutoCancel(true)
       .setContentIntent(startUpdateIntent)
       .setOngoing(true);
 

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android Version History
 
+## 2020-09-02 13.0.6218 stable
+* Bug fix:
+  * Dismiss notifications when touched (#3548)
+
 ## 2020-08-31 13.0.6217 stable
 * Bug fix:
   * Fix overflow menu for hdpi devices (#3536)


### PR DESCRIPTION
This addresses #3484 for stable-13.0 (similar to #3546)  

[setAutoCancel](https://developer.android.com/reference/android/app/Notification.Builder#setAutoCancel(boolean))(true) can make the notification automatically dismiss when the user touches it (choices are either cancel or download)
