### PR TITLE
fix(android/app): Remove unused intent ACTION_GET_USERDATA

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -111,7 +111,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   private static final String defaultDictionaryInstalled = "DefaultDictionaryInstalled";
   private static final String userTextKey = "UserText";
   private static final String userTextSizeKey = "UserTextSize";
-  protected static final String didCheckUserDataKey = "DidCheckUserData";
   private Toolbar toolbar;
   private Menu menu;
   private Uri data;
@@ -254,21 +253,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     textView.setTextSize((float) textSize);
     textView.setSelection(textView.getText().length());
 
-    boolean didCheckUserData = prefs.getBoolean(MainActivity.didCheckUserDataKey, false);
-    if (!didCheckUserData && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)) {
-      try {
-        Intent getUserdataIntent = new Intent("keyman.ACTION_GET_USERDATA");
-        startActivityForResult(getUserdataIntent, 0);
-      } catch (Exception e) {
-        KMLog.LogException(TAG, "", e);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(MainActivity.didCheckUserDataKey, true);
-        editor.commit();
-        checkGetStarted();
-      }
-    } else {
-      checkGetStarted();
-    }
+    checkGetStarted();
   }
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
@@ -280,7 +265,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
       checkGetStarted();
       return;
     } else {
-      boolean didFail = false;
       ClipData userdata = returnIntent.getClipData();
       int len = userdata.getItemCount();
       for (int i = 0; i < len; i++) {
@@ -312,15 +296,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           }
         } catch (Exception e) {
           KMLog.LogException(TAG, "", e);
-          didFail = true;
         }
-      }
-
-      if (!didFail) {
-        SharedPreferences prefs = getSharedPreferences(getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(MainActivity.didCheckUserDataKey, true);
-        editor.commit();
       }
 
       checkGetStarted();


### PR DESCRIPTION
This fixes the [ActivityNotFoundException](http://sentry.keyman.com/organizations/keyman/issues/390/?project=7&query=is%3Aunresolved) exceptions reported on Sentry.

Back when KMA and KMAPro were separate apps (predating Keyman for Android 2.8), KMA had an intent for "Keyman.ACTION_GET_USERDATA" while KMAPro did not.

This PR cleans up the calls to the unused activity.