### PR TITLE
feat(common/models): correction thresholding, acceptance

### DIFF
--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -252,10 +252,8 @@ describe('Correction Distance Modeler', function() {
       
       firstSet = firstSet.value; // Retrieves <actual value>
       // No checks on the first set's cost.
-      assert.equal(firstSet[0].length, 1); // A single sequence ("ten") should be the best match.
-
-      let chars = firstSet[0][0].map(value => value.key);
-      assert.equal(chars.join(''), "ten");
+      assert.equal(firstSet.length, 1); // A single sequence ("ten") should be the best match.
+      assert.equal(firstSet[0].matchString, "ten");
 
       let secondBatch = [
         'beh',  'te',  'tec',
@@ -268,12 +266,10 @@ describe('Correction Distance Modeler', function() {
       assert.isFalse(secondSet.done);
       
       secondSet = secondSet.value; // Retrieves <actual value>
-      assert.isAbove(secondSet[1], firstSet[1]); // assert it 'costs more'.
-      assert.equal(secondSet[0].length, secondBatch.length);
+      assert.isAbove(secondSet[0].totalCost, firstSet[0].totalCost); // assert it 'costs more'.
+      assert.equal(secondSet.length, secondBatch.length);
 
-      let entries = secondSet[0].map(function(sequence) {
-        return sequence.map(value => value.key).join('');
-      }).sort();
+      let entries = secondSet.map(result => result.matchString).sort();
       assert.deepEqual(entries, secondBatch);
 
       let thirdBatch = [
@@ -288,12 +284,10 @@ describe('Correction Distance Modeler', function() {
       assert.isFalse(thirdSet.done);
       
       thirdSet = thirdSet.value; // Retrieves <actual value>
-      assert.isAbove(thirdSet[1], secondSet[1]); // assert it 'costs more'.
-      assert.equal(thirdSet[0].length, thirdBatch.length);
+      assert.isAbove(thirdSet[0].totalCost, secondSet[0].totalCost); // assert it 'costs more'.
+      assert.equal(thirdSet.length, thirdBatch.length);
 
-      entries = thirdSet[0].map(function(sequence) {
-        return sequence.map(value => value.key).join('');
-      }).sort();
+      entries = thirdSet.map(result => result.matchString).sort();
       assert.deepEqual(entries, thirdBatch);
     }
 

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -12,13 +12,18 @@ describe('ModelCompositor', function() {
       jsonFixture('tries/english-1000')
     );
     var composite = new ModelCompositor(model);
+    
+    // Initialize context
+    let context = {
+      //left: 'Th', startOfBuffer: false, endOfBuffer: true,
+      left: 'th', startOfBuffer: false, endOfBuffer: true,
+    };
+    composite.predict({insert: '', deleteLeft: 0}, context);
+
     // Pretend to fat finger "the" as "thr"
     var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
     var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
-    var suggestions = composite.predict([thr, the], {
-      //left: 'Th', startOfBuffer: false, endOfBuffer: true,
-      left: 'th', startOfBuffer: false, endOfBuffer: true,
-    });
+    var suggestions = composite.predict([thr, the], context);
 
     // Get the top suggest for 'the' and 'thr*'.
     var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -128,14 +128,19 @@ namespace correction {
 
       // Last entry:  may not be a 'delete' or a 'transpose' op.
       let tailIndex = editPath.length -1;
+      let ignorePenultimateMatch = false;
       if(editPath[tailIndex] == 'delete' || editPath[0].indexOf('transpose') >= 0) {
         return null;
       } else if(editPath[tailIndex] == 'insert') {
         pushedTail = true;
+      } else if(tailIndex > 0 && editPath[tailIndex-1] == 'insert' && editPath[tailIndex] == 'substitute') {
+        // Tends to happen when accepting suggestions.
+        pushedTail = true;
+        ignorePenultimateMatch = true;
       }
 
       // Now to check everything in-between:  should be exclusively 'match'es.
-      for(let index = 1; index < editPath.length - 2; index++) {
+      for(let index = 1; index < editPath.length - (ignorePenultimateMatch ? 2 : 1); index++) {
         if(editPath[index] != 'match') {
           return null;
         }

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -187,7 +187,20 @@ namespace correction {
     buildDeletionEdges(inputDistribution: Distribution<Transform>): SearchEdge[] {
       let edges: SearchEdge[] = [];
 
+      /* 
+       * If the probability of an input is less than the highest probability * the base edit-distance likelihood,
+       * don't build an edge for it; just rely on edits from the highest-probability edge.
+       * 
+       * We may be able to be stricter, but this should be a decent start.
+       * 
+       * Note:  thanks to ModelCompositor.predict, we know the distribution is pre-sorted.
+       */
       for(let probMass of inputDistribution) {
+        if(probMass.p < inputDistribution[0].p * Math.exp(-SearchSpace.EDIT_DISTANCE_COST_SCALE)) {
+          // Again, we're pre-sorted.  All further entries will be too low-cost to consider.
+          break;
+        }
+
         let edgeCalc = this.calculation;
         let transform = probMass.sample;
         if(transform.deleteLeft) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -154,6 +154,7 @@ class ModelCompositor {
       // TODO:  whitespace, backspace filtering.  Do it here.
       //        Whitespace is probably fine, actually.  Less sure about backspace.
 
+      let bestCorrectionCost: number;
       for(let correctionSet of searchSpace.getBestMatches()) {
         let [tokenizedCorrections, cost] = correctionSet;
         let corrections = tokenizedCorrections.map(function(tokenizedCorrection): [USVString, LexiconTraversal] {
@@ -180,6 +181,10 @@ class ModelCompositor {
             // TODO:  return type from getBestMatches() needs to return the final Transform's ID if possible.
           }
 
+          if(bestCorrectionCost === undefined) {
+            bestCorrectionCost = cost;
+          }
+
           // Hmm.  Getting the predictions here might actually be a bit tricky.
           return {
             sample: correctionTransform, 
@@ -195,6 +200,9 @@ class ModelCompositor {
         // it's technically possible that we return too few.
 
         if(rawPredictions.length >= ModelCompositor.MAX_SUGGESTIONS) {
+          break;
+        } else if(cost >= bestCorrectionCost + 4) { // e^-4 = 0.0183156388.  Allows "80%" of an extra edit.
+          // Very useful for stopping 'sooner' when words reach a sufficient length.
           break;
         }
       }


### PR DESCRIPTION
My current set of optimization tweaks for improving the performance of #3555.  It's definitely 'snappier' with these in place.

This also addresses some of the 'rough edges' noted on #3555:
- Suggestion 'acceptance' has been fixed, as well as some bugs that resulted within the context manager when applying suggestions.  (Kinda forgot about that case when designing its logic.)
- I've now more thoroughly tested continuous input; that concern has been alleviated.

The "new" biggest rough edges:
- Performance will take a serious hit when nonsense is input / when there is no reasonable corrective match.
     - I still need to determine a good threshold strategy for this case.
- Further optimizations would be wise.

That said... it's already working a lot better for "good input" use cases.