### PR TITLE
fix(windows): lookup language name on create

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -91,7 +91,6 @@ begin
   if lang = nil then
     Exit(False);
 
-  // TODO: handle errors
   (lang as IKeymanKeyboardLanguageInstalled2).InstallTip(LangID, KeyboardToRemove);
   Result := True;
 end;
@@ -105,7 +104,6 @@ begin
   if lang = nil then
     Exit(False);
 
-  // TODO: handle errors
   (lang as IKeymanKeyboardLanguageInstalled2).RegisterTip(LangID);
   Result := True;
 end;

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
@@ -95,7 +95,7 @@ begin
     if SameText((FLanguages[i] as IKeymanKeyboardLanguageInstalled).BCP47Code, FCanonicalBCP47Tag) then
       Exit(nil);
 
-  FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, FCanonicalBCP47Tag, 0, GUID_NULL, BCP47Tag);
+  FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, FCanonicalBCP47Tag, 0, GUID_NULL, '');
   FLanguages.Add(FKeyboardLanguage);
   Result := FKeyboardLanguage;
 end;
@@ -187,7 +187,7 @@ procedure TKeymanKeyboardLanguagesInstalled.DoRefresh;
         BCP47Tag := GetBCP47ForTransientTIP(LangID, FGUID);
         if (BCP47Tag <> '') and (IndexOfBCP47Code(BCP47Tag) < 0) then
         begin
-          FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, BCP47Tag, LangID, FGUID, BCP47Tag); // TODO: get language name
+          FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, BCP47Tag, LangID, FGUID, '');
           FLanguages.Add(FKeyboardLanguage);
         end;
       end;


### PR DESCRIPTION
Lookup a language name from various sources rather than using the BCP 47 code, where possible.

Relates to #3512.