### PR TITLE
fix(windows): simplify profile repair

### DIFF
--- a/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
+++ b/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
@@ -31,8 +31,6 @@ uses
 
 type
   TKeyboardTIPCheck = class
-  private
-    class procedure ReinstallProfile(pInputProcessorProfileMgr: ITfInputProcessorProfileMgr; kmkbd: IKeymanKeyboardInstalled; kmlang: IKeymanKeyboardLanguageInstalled);
   public
     class function CheckKeyboardTIPInstallStatus: Boolean;
   end;
@@ -84,90 +82,13 @@ begin
       begin
         if kmcom.SystemInfo.IsAdministrator then
         begin
-          ReinstallProfile(ippm, k, k.Languages[j]);
+          (k.Languages[j] as IKeymanKeyboardLanguageInstalled2).RegisterTip(k.Languages[j].LangID);
         end
         else
           Result := False;
       end;
     end;
   end;
-end;
-
-function GetKeyboardIconFileName(const KeyboardFileName: string): string;   // I3599
-begin
-  Result := ChangeFileExt(KeyboardFileName, '.kmx.ico');   // I3581
-end;
-
-class procedure TKeyboardTIPCheck.ReinstallProfile(pInputProcessorProfileMgr: ITfInputProcessorProfileMgr;
-  kmkbd: IKeymanKeyboardInstalled; kmlang: IKeymanKeyboardLanguageInstalled);
-var
-  IconFileName: string;
-  IconIndex: Integer;
-  guidProfile: TGUID;
-  FLayoutInstallString: string;
-begin
-  IconFileName := GetKeyboardIconFileName(kmkbd.Filename);
-  if not FileExists(IconFileName) then
-    IconFileName := '';
-
-  if IconFileName = '' then   // I4555
-  begin
-    IconFileName := TKeymanPaths.KeymanEngineInstallPath(TKeymanPaths.S_KeymanExe);
-    IconIndex := 1;
-  end
-  else
-    IconIndex := 0;
-
-  guidProfile := kmlang.ProfileGUID;
-
-  OleCheck(pInputProcessorProfileMgr.RegisterProfile(   // I3743
-    c_clsidKMTipTextService,
-    kmlang.LangID,
-    guidProfile,
-    PWideChar(kmkbd.Name),
-    Length(kmkbd.Name),
-    PWideChar(IconFileName),
-    Length(IconFileName),
-    IconIndex,
-    0,
-    0,
-    1,
-    0));
-
-  FLayoutInstallString := Format('%04.4x:%s%s', [kmlang.LangID, GuidToString(c_clsidKMTipTextService),   // I4244
-    GuidToString(guidProfile)]);
-
-  (*
-  pInputProcessorProfilesEx := pInputProcessorProfiles as ITfInputProcessorProfilesEx;
-  ResPath := 'c:\temp\res.dll';
-  OleCheck(pInputProcessorProfilesEx.SetLanguageProfileDisplayName(c_clsidKMTipTextService, nLocale, guid, ResPath, Length(ResPath), 101));
-  *)
-(*
-  { Save TIP to registry }   // I4244
-
-  try   // I4494
-    if not InstallLayoutOrTip(PChar(FLayoutInstallString), 0) then   // I4302
-      ErrorFmt(KMN_E_ProfileInstall_KeyboardNotFound, VarArrayOf(['bogus2'])); //TODO FIX CODE
-  except
-    on E:EOleException do
-    begin
-      WarnFmt(KMN_W_TSF_COMError, VarArrayOf(['EOleException: '+E.Message+' ('+E.Source+', '+IntToHex(E.ErrorCode,8)+')']));
-    end;
-    on E:EOleSysError do
-    begin
-      WarnFmt(KMN_W_TSF_COMError, VarArrayOf(['EOleSysError: '+E.Message+' ('+IntToHex(E.ErrorCode,8)+')']));
-    end;
-    on E:Exception do
-    begin
-      WarnFmt(KMN_W_TSF_COMError, VarArrayOf([E.Message]));
-    end;
-  end;
-*)
-
-
-
-//      k.Languages[j].ProfileGUID
-
 end;
 
 end.


### PR DESCRIPTION
Now that we have an idempotent function to register a TIP for a language, it makes sense to use that to repair existing profiles, rather than the prior, rather WET code (which also was not quite right for the new design, anyway).

Relates to #3512.