### PR TITLE
fix(android/app): Fix Info page title size

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -49,7 +49,7 @@ public class InfoActivity extends AppCompatActivity {
     getSupportActionBar().setTitle(null);
     getSupportActionBar().setDisplayUseLogoEnabled(true);
     getSupportActionBar().setDisplayShowHomeEnabled(true);
-    getSupportActionBar().setLogo(R.drawable.keyman_logo);
+    //getSupportActionBar().setLogo(R.drawable.keyman_logo);
     getSupportActionBar().setDisplayShowTitleEnabled(false);
     getSupportActionBar().setDisplayShowCustomEnabled(true);
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -44,7 +44,7 @@ public class InfoActivity extends AppCompatActivity {
 
     setContentView(R.layout.activity_info);
 
-    Toolbar toolbar = findViewById(R.id.info_toolbar);
+    Toolbar toolbar = findViewById(R.id.titlebar);
     setSupportActionBar(toolbar);
     getSupportActionBar().setTitle(null);
     getSupportActionBar().setDisplayUseLogoEnabled(true);
@@ -53,9 +53,8 @@ public class InfoActivity extends AppCompatActivity {
     getSupportActionBar().setDisplayShowTitleEnabled(false);
     getSupportActionBar().setDisplayShowCustomEnabled(true);
 
-    TextView version = new TextView(this);
+    TextView version = findViewById(R.id.bar_title);
     version.setWidth((int) getResources().getDimension(R.dimen.label_width));
-    version.setTextSize(getResources().getDimension(R.dimen.titlebar_label_textsize));
     version.setGravity(Gravity.CENTER);
 
     // Parse app version string to create a version title (Not using KMManager.getVersion() because that's for KMEA)
@@ -63,7 +62,6 @@ public class InfoActivity extends AppCompatActivity {
 
     String versionTitle = String.format(getString(R.string.title_version), versionStr);
     version.setText(versionTitle);
-    getSupportActionBar().setCustomView(version);
 
     // Extract the the major minor version from the full version string
     String[] versionArray = versionStr.split("\\.", 3);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -7,12 +7,10 @@ package com.tavultesoft.kmapro;
 import com.tavultesoft.kmea.BuildConfig;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.FormFactor;
-import com.tavultesoft.kmea.util.KMLog;
 
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.view.Gravity;
 import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -20,10 +18,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.TextView;
 import android.annotation.SuppressLint;
-import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.app.AppCompatActivity;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager.NameNotFoundException;
 
 public class InfoActivity extends AppCompatActivity {
   private final static String TAG = "InfoActivity";
@@ -44,18 +39,7 @@ public class InfoActivity extends AppCompatActivity {
 
     setContentView(R.layout.activity_info);
 
-    Toolbar toolbar = findViewById(R.id.titlebar);
-    setSupportActionBar(toolbar);
-    getSupportActionBar().setTitle(null);
-    getSupportActionBar().setDisplayUseLogoEnabled(true);
-    getSupportActionBar().setDisplayShowHomeEnabled(true);
-    //getSupportActionBar().setLogo(R.drawable.keyman_logo);
-    getSupportActionBar().setDisplayShowTitleEnabled(false);
-    getSupportActionBar().setDisplayShowCustomEnabled(true);
-
-    TextView version = findViewById(R.id.bar_title);
-    version.setWidth((int) getResources().getDimension(R.dimen.label_width));
-    version.setGravity(Gravity.CENTER);
+    TextView version = findViewById(R.id.infoVersion);
 
     // Parse app version string to create a version title (Not using KMManager.getVersion() because that's for KMEA)
     String versionStr = BuildConfig.VERSION_NAME;

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context=".InfoActivity" >
 
-    <include layout="@layout/titlebar" />
-
     <WebView
         android:id="@+id/infoWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_marginBottom="?attr/actionBarSize" />
 
-</LinearLayout>
+    <!-- Version string on the bottom of the page -->
+    <include
+        layout="@layout/titlebar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentBottom="true" />
+
+</RelativeLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
@@ -6,14 +6,7 @@
     android:orientation="vertical"
     tools:context=".InfoActivity" >
 
-    <androidx.appcompat.widget.Toolbar
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/info_toolbar"
-        android:minHeight="?attr/actionBarSize"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        android:background="?attr/colorPrimary" />
+    <include layout="@layout/titlebar" />
 
     <WebView
         android:id="@+id/infoWebView"

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
@@ -10,13 +10,19 @@
         android:id="@+id/infoWebView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="?attr/actionBarSize" />
+        android:layout_marginBottom="@dimen/info_label_height"/>
 
     <!-- Version string on the bottom of the page -->
-    <include
-        layout="@layout/titlebar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:layout_alignParentBottom="true" />
+    <TextView
+      android:id="@+id/infoVersion"
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/info_label_height"
+      android:layout_gravity="center_horizontal"
+      android:gravity="center"
+      android:ellipsize="end"
+      android:singleLine="true"
+      android:text="@string/title_version"
+      android:textSize="@dimen/info_label_textsize"
+      android:layout_alignParentBottom="true" />
 
 </RelativeLayout>

--- a/android/KMAPro/kMAPro/src/main/res/values-land/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-land/dimens.xml
@@ -4,6 +4,6 @@
          Customize dimensions originally defined in res/values/dimens.xml (such as
          screen margins) for landscape here.
     -->
-
+    <dimen name="label_width">400dp</dimen>
     <dimen name="update_indicator_bg_margin">10dp</dimen>
 </resources>

--- a/android/KMAPro/kMAPro/src/main/res/values-sw600dp/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-sw600dp/dimens.xml
@@ -4,12 +4,12 @@
          Customize dimensions originally defined in res/values/dimens.xml (such as
          screen margins) for sw600dp devices (e.g. 7" tablets) here.
     -->
-    <dimen name="label_width">400dp</dimen>
-    <dimen name="titlebar_label_textsize">6.75sp</dimen>
+    <dimen name="label_width">450dp</dimen>
+    <dimen name="titlebar_label_textsize">28sp</dimen>
     <dimen name="product_logo_bottom">196dp</dimen>
     <dimen name="checkbox_margin">18dp</dimen>
     <dimen name="checkbox_margin_left">12dp</dimen>
     <dimen name="checkbox_padding">10dp</dimen>
     <dimen name="preference_icon">32dp</dimen>
-  <dimen name="update_indicator_bg_margin">10dp</dimen>
+    <dimen name="update_indicator_bg_margin">10dp</dimen>
 </resources>

--- a/android/KMAPro/kMAPro/src/main/res/values-sw600dp/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-sw600dp/dimens.xml
@@ -6,6 +6,8 @@
     -->
     <dimen name="label_width">450dp</dimen>
     <dimen name="titlebar_label_textsize">28sp</dimen>
+    <dimen name="info_label_textsize">14sp</dimen>
+    <dimen name="info_label_height">34dp</dimen>
     <dimen name="product_logo_bottom">196dp</dimen>
     <dimen name="checkbox_margin">18dp</dimen>
     <dimen name="checkbox_margin_left">12dp</dimen>

--- a/android/KMAPro/kMAPro/src/main/res/values-sw720dp/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-sw720dp/dimens.xml
@@ -5,7 +5,6 @@
          screen margins) for sw720dp devices (e.g. 10" tablets) here.
     -->
     <dimen name="label_width">500dp</dimen>
-    <dimen name="titlebar_label_textsize">18sp</dimen>
     <dimen name="package_label_width">650dp</dimen>
     <dimen name="product_logo_bottom">196dp</dimen>
     <dimen name="checkbox_margin">8dp</dimen>

--- a/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
@@ -6,7 +6,7 @@
     <dimen name="activity_splash_textsize">20sp</dimen>
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="label_width">250dp</dimen>
+    <dimen name="label_width">350dp</dimen>
     <dimen name="titlebar_label_textsize">16sp</dimen>
     <dimen name="titlebar_button_height">24dp</dimen>
     <dimen name="package_label_width">350dp</dimen>

--- a/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
@@ -6,7 +6,7 @@
     <dimen name="activity_splash_textsize">20sp</dimen>
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="label_width">200dp</dimen>
+    <dimen name="label_width">250dp</dimen>
     <dimen name="titlebar_label_textsize">16sp</dimen>
     <dimen name="titlebar_button_height">24dp</dimen>
     <dimen name="package_label_width">350dp</dimen>

--- a/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/dimens.xml
@@ -8,7 +8,8 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="label_width">350dp</dimen>
     <dimen name="titlebar_label_textsize">16sp</dimen>
-    <dimen name="titlebar_button_height">24dp</dimen>
+    <dimen name="info_label_textsize">12sp</dimen>
+    <dimen name="info_label_height">30dp</dimen>
     <dimen name="package_label_width">350dp</dimen>
     <dimen name="keyman_bar_height">8dp</dimen>
     <dimen name="checkbox_margin">8dp</dimen>


### PR DESCRIPTION
Fixes #3566 

This updates the Info page to reuse the titlebar styling.
Since the Info page includes the online help.keyman.com banner, I also commented out the logo in the titlebar.

## Screenshots
(Updated screenshots with version string moved to bottom of page)
Except for Nexus S, all screens from emulated devices show portrait and landscape orientation.

## Nexus S
![nexus s](https://user-images.githubusercontent.com/7358010/93038935-75b83d00-f670-11ea-897e-ec3e9748f1dc.png)

## Pixel 2
![pixel 2](https://user-images.githubusercontent.com/7358010/93039001-9b454680-f670-11ea-83a3-a4771eab0c52.png)

![pixel 2 land](https://user-images.githubusercontent.com/7358010/93039012-9ed8cd80-f670-11ea-86d3-1d70383e28fc.png)

## Nexus 7 [7" device]
![nexus 7](https://user-images.githubusercontent.com/7358010/93039125-e9f2e080-f670-11ea-9201-3d29b826f1b0.png)
 
![nexus 7 land](https://user-images.githubusercontent.com/7358010/93039132-ed866780-f670-11ea-9e94-569dab4f072d.png)

## Nexus 10 [10" device]
![nexus 10](https://user-images.githubusercontent.com/7358010/93039149-f70fcf80-f670-11ea-983d-250339fae0d0.png)

![nexus 10 land](https://user-images.githubusercontent.com/7358010/93039156-fa0ac000-f670-11ea-841a-f502f2ab80e6.png)



