### PR TITLE
fix(web): default layout shift not changing layer

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -419,8 +419,12 @@ namespace com.keyman.keyboards {
               if(layerId.indexOf('shift') != -1) {
                 key['sp'] = buttonClasses['SHIFT-ON'];
               } 
-              if((formFactor != 'desktop') && (layerId != 'default')) {
-                key['nextlayer']='default';
+              if(formFactor != 'desktop') {
+                if(layerId != 'default') {
+                  key['nextlayer']='default';
+                } else {
+                  key['nextlayer']='shift';
+                }
               }
               break;
             case 'K_LCTRL':


### PR DESCRIPTION
While testing out recent predictive-text work, I discovered that "shift" wasn't functioning properly for keyboards with default layouts and mobile form factors.  Just shift, though.