### PR TITLE
feat(common/models): Correction improvement

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -419,8 +419,12 @@ namespace com.keyman.keyboards {
               if(layerId.indexOf('shift') != -1) {
                 key['sp'] = buttonClasses['SHIFT-ON'];
               } 
-              if((formFactor != 'desktop') && (layerId != 'default')) {
-                key['nextlayer']='default';
+              if(formFactor != 'desktop') {
+                if(layerId != 'default') {
+                  key['nextlayer']='default';
+                } else {
+                  key['nextlayer']='shift';
+                }
               }
               break;
             case 'K_LCTRL':

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -96,6 +96,10 @@
       };
     }
 
+    toKey(text: USVString): USVString {
+      return this._trie.toKey(text);
+    }
+
     predict(transform: Transform, context: Context): Distribution<Suggestion> {
       // Special-case the empty buffer/transform: return the top suggestions.
       if (!transform.insert && context.startOfBuffer && context.endOfBuffer) {

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -91,6 +91,18 @@ declare interface LexicalModel {
   configure(capabilities: Capabilities): Configuration;
 
   /**
+   * Indicates a mapping function used by the model to simplify lookup operations
+   * within the lexicon.  This is expected to result in a many-to-one mapping.
+   * 
+   * Example usages:  
+   * - converting any upper-case characters into lowercase
+   * - removing accent marks that may be difficult to type on standard keyboard layouts
+   * 
+   * @param text 
+   */
+  toKey?(text: USVString): USVString;
+
+  /**
    * Generates predictive suggestions corresponding to the state of context after the proposed
    * transform is applied to it.  This transform may correspond to a 'correction' of a recent 
    * keystroke rather than one actually received.

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -92,13 +92,22 @@ declare interface LexicalModel {
 
   /**
    * Indicates a mapping function used by the model to simplify lookup operations
-   * within the lexicon.  This is expected to result in a many-to-one mapping.
+   * within the lexicon.  This is expected to result in a many-to-one mapping, transforming
+   * the input text into a common, simplified 'index'/'key' form shared by all
+   * text forms that a person might reasonably interpret as "the same".
    * 
    * Example usages:  
-   * - converting any upper-case characters into lowercase
+   * - converting any upper-case characters into lowercase.
+   *   - For English, 'CAT' and 'Cat' might be keyed as 'cat', since users expect all
+   *     three to be treated as the same word.
    * - removing accent marks that may be difficult to type on standard keyboard layouts
+   *   - For French, users may wish to type "jeune" instead of "jeûne" when lazy or 
+   *     if accent marks cannot be easily input.
    * 
-   * @param text 
+   * Providing a function targetted for your language can greatly improve a user's experience
+   * using your dictionary.
+   * @param text The original input text.
+   * @returns The 'keyed' form of that text.
    */
   toKey?(text: USVString): USVString;
 

--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -296,7 +296,7 @@ describe('Correction Distance Modeler', function() {
       let rootTraversal = testModel.traverseFromRoot();
       assert.isNotEmpty(rootTraversal);
 
-      let searchSpace = new correction.SearchSpace(rootTraversal);
+      let searchSpace = new correction.SearchSpace(testModel);
 
       let iter = searchSpace.getBestMatches();
       let firstSet = iter.next();
@@ -308,7 +308,7 @@ describe('Correction Distance Modeler', function() {
       let rootTraversal = testModel.traverseFromRoot();
       assert.isNotEmpty(rootTraversal);
 
-      let searchSpace = new correction.SearchSpace(rootTraversal);
+      let searchSpace = new correction.SearchSpace(testModel);
 
       // VERY artificial distributions.
       let synthDistribution1 = [
@@ -359,7 +359,7 @@ describe('Correction Distance Modeler', function() {
       let rootTraversal = testModel.traverseFromRoot();
       assert.isNotEmpty(rootTraversal);
 
-      let searchSpace = new correction.SearchSpace(rootTraversal);
+      let searchSpace = new correction.SearchSpace(testModel);
 
       // VERY artificial distributions.
       let synthDistribution1 = [
@@ -394,7 +394,7 @@ describe('Correction Distance Modeler', function() {
       let rootTraversal = testModel.traverseFromRoot();
       assert.isNotEmpty(rootTraversal);
 
-      let searchSpace = new correction.SearchSpace(rootTraversal);
+      let searchSpace = new correction.SearchSpace(testModel);
       let iter = searchSpace.getBestMatches();
 
       // While there's no input, insertion operations can produce suggestions.

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -7,7 +7,7 @@ var TrieModel = require('../../build/intermediate').models.TrieModel;
 var ModelCompositor = require('../../build/intermediate').ModelCompositor;
 
 describe('ModelCompositor', function() {
-  it('should compose suggestions from a fat-fingered keypress', function () {
+  it('should compose suggestions from a fat-fingered keypress (no keying needed)', function () {
     var model = new TrieModel(
       jsonFixture('tries/english-1000')
     );
@@ -15,8 +15,37 @@ describe('ModelCompositor', function() {
     
     // Initialize context
     let context = {
-      //left: 'Th', startOfBuffer: false, endOfBuffer: true,
       left: 'th', startOfBuffer: false, endOfBuffer: true,
+    };
+    composite.predict({insert: '', deleteLeft: 0}, context);
+
+    // Pretend to fat finger "the" as "thr"
+    var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+    var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+    var suggestions = composite.predict([thr, the], context);
+
+    // Get the top suggest for 'the' and 'thr*'.
+    var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
+    var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+
+    // Sanity check: do we have actual real-valued probabilities?
+    assert.isAbove(thrSuggestion.p, 0.0);
+    assert.isBelow(thrSuggestion.p, 1.0);
+    assert.isAbove(theSuggestion.p, 0.0);
+    assert.isBelow(theSuggestion.p, 1.0);
+    // 'the' should be the intended the result here.
+    assert.isAbove(theSuggestion.p, thrSuggestion.p);
+  });
+
+  it('should compose suggestions from a fat-fingered keypress (keying needed)', function () {
+    var model = new TrieModel(
+      jsonFixture('tries/english-1000')
+    );
+    var composite = new ModelCompositor(model);
+    
+    // Initialize context
+    let context = {
+      left: 'Th', startOfBuffer: false, endOfBuffer: true,
     };
     composite.predict({insert: '', deleteLeft: 0}, context);
 

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -55,7 +55,7 @@ describe('ModelCompositor', function() {
     var suggestions = composite.predict([thr, the], context);
 
     // Get the top suggest for 'the' and 'thr*'.
-    var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
+    var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'The' || s.displayAs === '“The”'; })[0];
     var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
 
     // Sanity check: do we have actual real-valued probabilities?

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -179,10 +179,8 @@ namespace correction {
   }
 
   export class ContextTracker extends CircularArray<TrackedContextState> {
-    // TODO:  Rework to accept the lexical model directly instead.  Needed to properly construct SearchSpace.
     static attemptMatchContext(tokenizedContext: USVString[], 
                                matchState: TrackedContextState,
-                               rootTraversal: LexiconTraversal,
                                transformDistribution?: Distribution<Transform>,): TrackedContextState {
       // Map the previous tokenized state to an edit-distance friendly version.
       let matchContext: USVString[] = matchState.toRawTokenization();
@@ -355,7 +353,7 @@ namespace correction {
 
       if(tokenizedContext.length > 0) {
         for(let i = this.count - 1; i >= 0; i--) {
-          let resultState = ContextTracker.attemptMatchContext(tokenizedContext, this.item(i), model.traverseFromRoot(), transformDistribution);
+          let resultState = ContextTracker.attemptMatchContext(tokenizedContext, this.item(i), transformDistribution);
 
           if(resultState) {
             resultState.taggedContext = context;

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -290,7 +290,7 @@ namespace correction {
       return state;
     }
 
-    static modelContextState(tokenizedContext: USVString[], traversalRoot: LexiconTraversal): TrackedContextState {
+    static modelContextState(tokenizedContext: USVString[], lexicalModel: LexicalModel): TrackedContextState {
       let baseTokens = tokenizedContext.map(function(entry) {
         let token = new TrackedContextToken();
         token.raw = entry;
@@ -314,6 +314,7 @@ namespace correction {
       });
 
       // And now build the final context state object, which includes whitespace 'tokens'.
+      let traversalRoot = lexicalModel.traverseFromRoot();
       let state = new TrackedContextState(traversalRoot);
 
       if(baseTokens.length > 0) {
@@ -368,7 +369,7 @@ namespace correction {
       //
       // Assumption:  as a caret needs to move to context before any actual transform distributions occur,
       // this state is only reached on caret moves; thus, transformDistribution is actually just a single null transform.
-      let state = ContextTracker.modelContextState(tokenizedContext, model.traverseFromRoot());
+      let state = ContextTracker.modelContextState(tokenizedContext, model);
       state.taggedContext = context;
       this.enqueue(state);
       return state;

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -176,6 +176,7 @@ namespace correction {
   }
 
   export class ContextTracker extends CircularArray<TrackedContextState> {
+    // TODO:  Rework to accept the lexical model directly instead.  Needed to properly construct SearchSpace.
     static attemptMatchContext(tokenizedContext: USVString[], 
                                matchState: TrackedContextState,
                                rootTraversal: LexiconTraversal,

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -65,7 +65,7 @@ namespace correction {
       if(this._inputCost !== undefined) {
         return this._inputCost;
       } else {
-        let MIN_P = 0.0001;
+        let MIN_P = SearchSpace.MIN_KEYSTROKE_PROBABILITY;
         // Should technically re-normalize the sampling distribution.
         // -ln(p) is smaller for larger probabilities, as ln(p) is always <= 0.  Approaches infinity as p => 0.
 
@@ -265,10 +265,10 @@ namespace correction {
   // The set of search spaces corresponding to the same 'context' for search.
   // Whenever a wordbreak boundary is crossed, a new instance should be made.
   export class SearchSpace {
-
     private QUEUE_SPACE_COMPARATOR: models.Comparator<SearchSpaceTier>;
 
     static readonly EDIT_DISTANCE_COST_SCALE = 5;
+    static readonly MIN_KEYSTROKE_PROBABILITY = 0.0001;
 
     private tierOrdering: SearchSpaceTier[] = [];
     private selectionQueue: models.PriorityQueue<SearchSpaceTier>;
@@ -287,8 +287,10 @@ namespace correction {
     private processedEdgeSet: {[mapKey: string]: boolean} = {};
 
     constructor(model: LexicalModel) {
-      if(!model || !model.traverseFromRoot) {
-        throw "The provided model does not meet the requirements needed to support robust correction searching.";
+      if(!model) {
+        throw "The LexicalModel parameter must not be null / undefined.";
+      } else if(!model.traverseFromRoot) {
+        throw "The provided model does not implement the `traverseFromRoot` function, which is needed to support robust correction searching.";
       }
 
       // Constructs the comparator needed for the following line.

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -286,11 +286,15 @@ namespace correction {
     // Signals that the edge has already been processed.
     private processedEdgeSet: {[mapKey: string]: boolean} = {};
 
-    constructor(traversalRoot: LexiconTraversal, toKey?: (USVString) => USVString) {
+    constructor(model: LexicalModel) {
+      if(!model || !model.traverseFromRoot) {
+        throw "The provided model does not meet the requirements needed to support robust correction searching.";
+      }
+
       // Constructs the comparator needed for the following line.
       this.buildQueueSpaceComparator();
       this.selectionQueue = new models.PriorityQueue<SearchSpaceTier>(this.QUEUE_SPACE_COMPARATOR);
-      this.rootNode = new SearchNode(traversalRoot, toKey);
+      this.rootNode = new SearchNode(model.traverseFromRoot(), model.toKey ? model.toKey.bind(model) : null);
 
       this.completedPaths = [this.rootNode];
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -216,7 +216,7 @@ class ModelCompositor {
       // Combine duplicate samples.
       let displayText = prediction.sample.displayAs;
 
-      if(displayText == keepOptionText || lexicalModel.toKey && displayText == lexicalModel.toKey(keepOptionText)) {
+      if(displayText == keepOptionText || (lexicalModel.toKey && displayText == lexicalModel.toKey(keepOptionText)) ) {
         keepOption = prediction.sample;
         // Ensure we keep any original casing, etc that may have been stripped.
         keepOption.transform.insert = keepOptionText + punctuation.insertAfterWord;

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -216,8 +216,11 @@ class ModelCompositor {
       // Combine duplicate samples.
       let displayText = prediction.sample.displayAs;
 
-      if(displayText == keepOptionText) {
+      if(displayText == keepOptionText || lexicalModel.toKey && displayText == lexicalModel.toKey(keepOptionText)) {
         keepOption = prediction.sample;
+        // Ensure we keep any original casing, etc that may have been stripped.
+        keepOption.transform.insert = keepOptionText + punctuation.insertAfterWord;
+        keepOption.displayAs = keepOptionText;
         // Specifying 'keep' helps uses of the LMLayer find it quickly
         // if/when desired.
         keepOption.tag = 'keep';

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -172,8 +172,7 @@ class ModelCompositor {
             finalInput = inputTransform;  // A fallback measure.  Greatly matters for empty contexts.
           }
 
-          // For now, a 'hacked' re-use of the model's existing `.predict()` method.
-          // Ideally, we'd just use the prefix to look up possible words.
+          // Replace the existing context with the correction.
           let correctionTransform: Transform = {
             insert: correction,  // insert correction string
             deleteLeft: lexicalModel.wordbreak(context).length, // remove actual token string


### PR DESCRIPTION
Note:  to facilitate testing some of the new logic, this also includes the changes seen in #3754.  (Kinda hard to test the case-matching 'keep' if you can't type it.)

Adds two features:
1. If a model uses a 'keying' function, it may now expose it as part of the lexical model interface.  The corrective search may then use it to 'key' corrective searches in the same manner.
2. Adds a minimum threshold for search-path cost to the correction algorithm to help keep things 'snappier'. 