### PR TITLE
feat(common/models): naive correction-algorithm timer

### DIFF
--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -329,7 +329,7 @@ describe('Correction Distance Modeler', function() {
       searchSpace.addInput(synthDistribution2);
       searchSpace.addInput(synthDistribution3);
 
-      let iter = searchSpace.getBestMatches();
+      let iter = searchSpace.getBestMatches(0); // disables the correction-search timeout.
       checkResults_teh(iter);
 
       // Debugging method:  a simple loop for printing out the generated sets, in succession.
@@ -380,12 +380,12 @@ describe('Correction Distance Modeler', function() {
       searchSpace.addInput(synthDistribution2);
       searchSpace.addInput(synthDistribution3);
 
-      let iter = searchSpace.getBestMatches();
+      let iter = searchSpace.getBestMatches(0); // disables the correction-search timeout.
       checkResults_teh(iter);
 
       // The key: do we get the same results the second time?
       // Reset the iterator first...
-      let iter2 = searchSpace.getBestMatches();
+      let iter2 = searchSpace.getBestMatches(0); // disables the correction-search timeout.
       checkResults_teh(iter2);
     });
 


### PR DESCRIPTION
To keep things snappy, this adds a (by default) 33ms timer on the correction algorithm.  It will automatically return results after that time, whether or not any valid corrections have been found.

Note: this time will not be cut short if/when a new keystroke is received.  That's why I'm labelling it 'naive'.  See #3580 for notes toward a more robust (but also markedly more complex) design... the 'complex' part being why we're going 'naive' for now.