### PR TITLE
refactor(web/engine): application of predictive suggestions

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -226,7 +226,9 @@ namespace com.keyman.text.prediction {
         let reversionPromise: Promise<Suggestion> = new Promise<Suggestion>(function(resolveFunc, rejectFunc) {
           wordbreakPromise.then(function(token) {
             let suggestion: Suggestion = {
-              displayAs: token,
+              // TODO:  This needs to be sourced from the lm-layer side, from the model's
+              // punctuation spec.  Hence the 'outer' TODO.
+              displayAs: '"' + token + '"',
               transform: reversionTranscription.transform,
               transformId: reversionTranscription.token
             }

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -186,6 +186,62 @@ namespace com.keyman.text.prediction {
       return this.predict_internal(transcription);
     }
 
+    public acceptSuggestion(suggestion: Suggestion, outputTarget: OutputTarget): Promise<Suggestion> {
+      if(!outputTarget) {
+        throw "Accepting suggestions requires a destination OutputTarget instance."
+      }
+      
+      // Find the state of the context at the time the suggestion was generated.
+      // This may refer to the context before an input keystroke or before application
+      // of a predictive suggestion.
+      let original = this.getPredictionState(suggestion.transformId);
+      if(!original) {
+        console.warn("Could not apply the Suggestion!");
+        return null;
+      } else {
+        // Apply the Suggestion!
+
+        // Step 1:  determine the final output text
+        let final = text.Mock.from(original.preInput);
+        final.apply(suggestion.transform);
+
+        // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
+        // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
+        // values as needed for use with their IME interfaces.
+        let transform = final.buildTransformFrom(outputTarget);
+        let wordbreakPromise = this.wordbreak(outputTarget); // Also build the display string for the reversion.
+        outputTarget.apply(transform);
+
+        // Build a 'reversion' Transcription that can be used to undo this apply() if needed,
+        // replacing the suggestion transform with the original input text.
+        let preApply = text.Mock.from(original.preInput);
+        preApply.apply(original.transform);
+
+        let reversionTranscription = preApply.buildTranscriptionFrom(outputTarget, null);
+        this.recordTranscription(reversionTranscription);
+
+        // TODO:  Also tell lm-layer we accepted the suggestion
+        // The 'reversion promise' should be returned from the lm-layer, not constructed here.
+        // (Needed for proper displayAs syntax!)
+        let reversionPromise: Promise<Suggestion> = new Promise<Suggestion>(function(resolveFunc, rejectFunc) {
+          wordbreakPromise.then(function(token) {
+            let suggestion: Suggestion = {
+              displayAs: token,
+              transform: reversionTranscription.transform,
+              transformId: reversionTranscription.token
+            }
+
+            resolveFunc(suggestion);
+          });
+        });
+
+        // Also, request new prediction set based on the resulting context.
+        this.predictFromTarget(outputTarget);
+
+        return reversionPromise;
+      }
+    }
+
     public predictFromTarget(outputTarget: OutputTarget): Promise<Suggestion[]> {
       if(!outputTarget) {
         return null;

--- a/web/source/dom/targets/outputTarget.ts
+++ b/web/source/dom/targets/outputTarget.ts
@@ -25,10 +25,12 @@ namespace com.keyman.dom.targets {
     apply(transform: Transform) {
       super.apply(transform);
 
-      let keyman = com.keyman.singleton;
+      // This class has non-integrated unit tests in which the `singleton` object doesn't exist.
+      // Thus, we need to test for this case.
+      let keyman = com.keyman['singleton'];
 
       // Signal the necessary text changes to the embedding app, if it exists.
-      if(keyman['oninserttext'] && keyman.isEmbedded) {
+      if(keyman && keyman['oninserttext'] && keyman.isEmbedded) {
         keyman['oninserttext'](transform.deleteLeft, transform.insert, transform.deleteRight);
       }
     }

--- a/web/source/dom/targets/outputTarget.ts
+++ b/web/source/dom/targets/outputTarget.ts
@@ -21,5 +21,16 @@ namespace com.keyman.dom.targets {
         elem.dispatchEvent(event);
       }
     }
+
+    apply(transform: Transform) {
+      super.apply(transform);
+
+      let keyman = com.keyman.singleton;
+
+      // Signal the necessary text changes to the embedding app, if it exists.
+      if(keyman['oninserttext'] && keyman.isEmbedded) {
+        keyman['oninserttext'](transform.deleteLeft, transform.insert, transform.deleteRight);
+      }
+    }
   }
 }


### PR DESCRIPTION
As KMW has existed until now, the application & reversion part of the code has been UI / DOM dependent.  These changes will bring it into a lower level, adapting it to fit within the `input-processor` core module.  This will allow the lm-layer to better assist with display text while also allowing KMW to better provide the lm-layer with acceptance/reversion/etc feedback about the state of the context.

Note that this PR aims only to refactor existing behavior; no new features have been added with these changes.  Those will come later.  We'll likely want a similar PR to refactor reversion as well, after which we can start implementing related features.