### PR TITLE
fix(linux/config): Check if file exists before creating hard links

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -136,13 +136,17 @@ def install_kmp_shared(inputfile, online=False, language=None):
                 logging.info("Installing %s as documentation", f['name'])
                 if not os.path.isdir(kmpdocdir):
                     os.makedirs(kmpdocdir)
-                os.link(fpath, os.path.join(kmpdocdir, f['name']))
+                kmpdocpath = os.path.join(kmpdocdir, f['name'])
+                if not os.path.isfile(kmpdocpath):
+                    os.link(fpath, kmpdocpath)
             elif ftype == KMFileTypes.KM_FONT:
                 # Special handling of font to hard link it into font dir
                 logging.info("Installing %s as font", f['name'])
                 if not os.path.isdir(kmpfontdir):
                     os.makedirs(kmpfontdir)
-                os.link(fpath, os.path.join(kmpfontdir, f['name']))
+                kmpfontpath = os.path.join(kmpfontdir, f['name'])
+                if not os.path.isfile(kmpfontpath):
+                    os.link(fpath, kmpfontpath)
             elif ftype == KMFileTypes.KM_SOURCE:
                 # TODO for the moment just leave it for ibus-kmfl to ignore if it doesn't load
                 logging.info("Installing %s as keyman file", f['name'])
@@ -208,7 +212,9 @@ def install_kmp_user(inputfile, online=False, language=None):
                 fontsdir = os.path.join(user_keyman_font_dir(), packageID)
                 if not os.path.isdir(fontsdir):
                     os.makedirs(fontsdir)
-                os.link(fpath, os.path.join(fontsdir, f['name']))
+                fontpath = os.path.join(fontsdir, f['name'])
+                if not os.path.isfile(fontpath):
+                    os.link(fpath, fontpath)
                 logging.info("Installing %s as font", f['name'])
             elif ftype == KMFileTypes.KM_OSK:
                 # Special handling to convert kvk into LDML


### PR DESCRIPTION
During KMP installation, hard links to some of the keyboard files are created.
This throws [FileExistsError](https://sentry.keyman.com/organizations/keyman/issues/874/?environment=alpha&project=12) if the file already exists

Before this fix, here's the steps to trigger the error:
1. Load keyman-config
2. "Download" to install sil_euro_latin.kmp from keyman.com 
(A hard link is created at `~/.local/share/fonts/keyman/sil_euro_latin/DejaVuSans.ttf`)
3. In a browser, download the keyboard package from https://downloads.keyman.com/keyboards/sil_euro_latin/1.9.2/sil_euro_latin.kmp
4. From keyman-config, "Install" the local sil_euro_latin.kmp file.
This tries to make the hard link to the existing font file, and the FileExistsError is reported to the terminal
