### PR TITLE
fix(linux/config): Catch if kmp.json is invalid JSON

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -50,7 +50,7 @@ class KeyboardDetailsView(Gtk.Dialog):
             grid = Gtk.Grid()
             self.get_content_area().pack_start(grid, True, True, 12)
             lbl_invalid_metadata = Gtk.Label()
-            lbl_invalid_metadata.set_text(_("ERROR: Could not parse kmp.json in " + packageDir))
+            lbl_invalid_metadata.set_text(_("ERROR: Keyboard metadata is damaged.\nPlease \"Uninstall\" and then \"Install\" the keyboard."))
             lbl_invalid_metadata.set_halign(Gtk.Align.END)
             grid.add(lbl_invalid_metadata)
             self.resize(700, 200)

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -45,7 +45,17 @@ class KeyboardDetailsView(Gtk.Dialog):
         info, system, options, keyboards, files = parsemetadata(kmp_json)
 
         if info is None:
-            raise Exception(_("could not parse kmp.json"), kmp['packageID'], packageDir, kmp_json)
+            # Dialog when invalid metadata
+            self.add_button(_("_Close"), Gtk.ResponseType.CLOSE)
+            grid = Gtk.Grid()
+            self.get_content_area().pack_start(grid, True, True, 12)
+            lbl_invalid_metadata = Gtk.Label()
+            lbl_invalid_metadata.set_text(_("ERROR: Could not parse kmp.json in " + packageDir))
+            lbl_invalid_metadata.set_halign(Gtk.Align.END)
+            grid.add(lbl_invalid_metadata)
+            self.resize(700, 200)
+            self.show_all()
+            return
 
         kbdata = None
         jsonfile = os.path.join(packageDir, kmp['packageID'] + ".json")

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -446,7 +446,11 @@ def parsemetadata(jsonfile, verbose=False):
                 data = json.load(read_file)
             except JSONDecodeError as e:
                 logging.error("parsemetadata: " + jsonfile + " invalid")
-                sys.exit(1)
+                # Use empty details
+                data = {"nonexistent": "none"}
+                keyboards = []
+                files = []
+
             for x in data:
                 if x == 'info':
                     info = data[x]

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -7,6 +7,7 @@ import sys
 import os.path
 import magic
 from enum import Enum
+from json.decoder import JSONDecodeError
 
 
 class KMFileTypes(Enum):
@@ -441,7 +442,11 @@ def parsemetadata(jsonfile, verbose=False):
 
     if os.path.isfile(jsonfile):
         with open(jsonfile, "r") as read_file:
-            data = json.load(read_file)
+            try:
+                data = json.load(read_file)
+            except JSONDecodeError as e:
+                logging.error("parsemetadata: " + jsonfile + " invalid")
+                sys.exit(1)
             for x in data:
                 if x == 'info':
                     info = data[x]

--- a/linux/keyman-config/locale/keyman-config.pot
+++ b/linux/keyman-config/locale/keyman-config.pot
@@ -145,7 +145,9 @@ msgid "{name} keyboard"
 msgstr ""
 
 #: keyman_config/keyboard_details.py:53
-msgid "ERROR: Could not parse kmp.json in "
+msgid ""
+"ERROR: Keyboard metadata is damaged.\n"
+"Please \"Uninstall\" and then \"Install\" the keyboard."
 msgstr ""
 
 #: keyman_config/keyboard_details.py:74

--- a/linux/keyman-config/locale/keyman-config.pot
+++ b/linux/keyman-config/locale/keyman-config.pot
@@ -25,8 +25,8 @@ msgstr ""
 msgid "Download Keyman keyboards"
 msgstr ""
 
-#: keyman_config/downloadkeyboard.py:37 keyman_config/keyboard_details.py:327
-#: keyman_config/view_installed.py:205
+#: keyman_config/downloadkeyboard.py:37 keyman_config/keyboard_details.py:49
+#: keyman_config/keyboard_details.py:340 keyman_config/view_installed.py:205
 msgid "_Close"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Fonts:   "
 msgstr ""
 
-#: keyman_config/install_window.py:167 keyman_config/keyboard_details.py:91
+#: keyman_config/install_window.py:167 keyman_config/keyboard_details.py:96
 msgid "Package version:   "
 msgstr ""
 
@@ -144,62 +144,63 @@ msgstr ""
 msgid "{name} keyboard"
 msgstr ""
 
-#: keyman_config/keyboard_details.py:48
-msgid "could not parse kmp.json"
+#: keyman_config/keyboard_details.py:53
+msgid "ERROR: Could not parse kmp.json in "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:69
+#: keyman_config/keyboard_details.py:74
 msgid "Package name:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:80
+#: keyman_config/keyboard_details.py:85
 msgid "Package id:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:103
+#: keyman_config/keyboard_details.py:108
 msgid "Package description:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:116
+#: keyman_config/keyboard_details.py:121
 msgid "Package author:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:128
+#: keyman_config/keyboard_details.py:133
 msgid "Package copyright:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:161
+#: keyman_config/keyboard_details.py:174
 msgid "Keyboard filename:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:174
+#: keyman_config/keyboard_details.py:187
 msgid "Keyboard name:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:185
+#: keyman_config/keyboard_details.py:198
 msgid "Keyboard id:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:196
+#: keyman_config/keyboard_details.py:209
 msgid "Keyboard version:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:208
+#: keyman_config/keyboard_details.py:221
 msgid "Keyboard author:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:219
+#: keyman_config/keyboard_details.py:232
 msgid "Keyboard license:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:230
+#: keyman_config/keyboard_details.py:243
 msgid "Keyboard description:   "
 msgstr ""
 
-#: keyman_config/keyboard_details.py:321
+#: keyman_config/keyboard_details.py:334
+#, python-brace-format
 msgid ""
 "Scan this code to load this keyboard\n"
-"on another device or share online"
+"on another device or <a href='{uri}'>share online</a>"
 msgstr ""
 
 #: keyman_config/options.py:24
@@ -240,7 +241,7 @@ msgid "_Uninstall"
 msgstr ""
 
 #: keyman_config/view_installed.py:162 keyman_config/view_installed.py:304
-msgid "Uninstall keyboard package"
+msgid "Uninstall keyboard"
 msgstr ""
 
 #: keyman_config/view_installed.py:167
@@ -248,7 +249,7 @@ msgid "_About"
 msgstr ""
 
 #: keyman_config/view_installed.py:168 keyman_config/view_installed.py:306
-msgid "About keyboard package"
+msgid "About keyboard"
 msgstr ""
 
 #: keyman_config/view_installed.py:173
@@ -256,14 +257,14 @@ msgid "_Help"
 msgstr ""
 
 #: keyman_config/view_installed.py:174 keyman_config/view_installed.py:305
-msgid "Help for keyboard package"
+msgid "Help for keyboard"
 msgstr ""
 
 #: keyman_config/view_installed.py:179
 msgid "_Options"
 msgstr ""
 
-#: keyman_config/view_installed.py:180
+#: keyman_config/view_installed.py:180 keyman_config/view_installed.py:307
 msgid "Settings for keyboard"
 msgstr ""
 
@@ -272,7 +273,7 @@ msgid "_Refresh"
 msgstr ""
 
 #: keyman_config/view_installed.py:191
-msgid "Refresh keyboard package list"
+msgid "Refresh keyboard list"
 msgstr ""
 
 #: keyman_config/view_installed.py:195
@@ -280,11 +281,11 @@ msgid "_Download"
 msgstr ""
 
 #: keyman_config/view_installed.py:196
-msgid "Download and install a keyboard package from the Keyman website"
+msgid "Download and install a keyboard from the Keyman website"
 msgstr ""
 
 #: keyman_config/view_installed.py:201
-msgid "Install a keyboard package from a file"
+msgid "Install a keyboard from a file"
 msgstr ""
 
 #: keyman_config/view_installed.py:206
@@ -293,50 +294,46 @@ msgstr ""
 
 #: keyman_config/view_installed.py:278
 #, python-brace-format
-msgid "Uninstall keyboard package {package}"
+msgid "Uninstall keyboard {package}"
 msgstr ""
 
 #: keyman_config/view_installed.py:280
 #, python-brace-format
-msgid "Help for keyboard package {package}"
+msgid "Help for keyboard {package}"
 msgstr ""
 
 #: keyman_config/view_installed.py:282
 #, python-brace-format
-msgid "About keyboard package {package}"
+msgid "About keyboard {package}"
 msgstr ""
 
 #: keyman_config/view_installed.py:284
 #, python-brace-format
-msgid "Settings for keyboard package {package}"
-msgstr ""
-
-#: keyman_config/view_installed.py:307
-msgid "Settings for keyboard package"
+msgid "Settings for keyboard {package}"
 msgstr ""
 
 #: keyman_config/view_installed.py:349
-msgid "Uninstall keyboard?"
+msgid "Uninstall keyboard package?"
 msgstr ""
 
 #: keyman_config/view_installed.py:351
 #, python-brace-format
-msgid "Are you sure that you want to uninstall the {keyboard} keyboard?"
+msgid "Are you sure that you want to uninstall the {keyboard} keyboard and its fonts?"
 msgstr ""
 
-#: keyman_config/welcome.py:21
+#: keyman_config/welcome.py:22
 #, python-brace-format
 msgid "{name} installed"
 msgstr ""
 
-#: keyman_config/welcome.py:37
+#: keyman_config/welcome.py:40
 msgid "Open in _Web browser"
 msgstr ""
 
-#: keyman_config/welcome.py:39
+#: keyman_config/welcome.py:42
 msgid "Open in the default web browser to do things like printing"
 msgstr ""
 
-#: keyman_config/welcome.py:42
+#: keyman_config/welcome.py:45
 msgid "_OK"
 msgstr ""


### PR DESCRIPTION
This catches [JSONDecodeError](https://sentry.keyman.com/organizations/keyman/issues/873/?environment=alpha&project=12) when kmp.json is invalid JSON.

Question: Is it appropriate to exit out? The Keyman config dialog can't really handle if kmp.json is invalid.