### PR TITLE
fix(windows): remove obsolete releaseCapture calls

### DIFF
--- a/oem/firstvoices/windows/src/xml/menu.js
+++ b/oem/firstvoices/windows/src/xml/menu.js
@@ -1,5 +1,5 @@
 var menudiv = null, global_menu_elem_name = null;
-  
+
   function RightButtonMenu( menuid ) {
     if( (event.clientX + 180) > document.body.clientWidth ) {
       ShowMenu( menuid,'right', event.clientX, event.clientY );
@@ -7,7 +7,7 @@ var menudiv = null, global_menu_elem_name = null;
       ShowMenu( menuid,'left', event.clientX, event.clientY );
     }
   }
-  
+
   function PageOffset(e)
   {
     var pt = {x: 0, y: 0};
@@ -18,7 +18,7 @@ var menudiv = null, global_menu_elem_name = null;
     }
     return pt;
   }
-        
+
   function ShowMenu(name,align,xpos,ypos) {
     global_menu_elem_name = name;
     var q;
@@ -27,19 +27,19 @@ var menudiv = null, global_menu_elem_name = null;
 
     menudiv.innerHTML = menu.innerHTML;
     menudiv.style.width = menu.offsetWidth + 'px';
-    
+
     (function(m) {
       for(var i = 0; i < m.children.length; i++) {
         if(m.children[i].id != '') { m.children[i].id = 'Popup_'+m.children[i].id; }
       }
     })(menudiv);
-    
+
     var pb = PageOffset(button);
     var pm = PageOffset(menu.offsetParent);
 
     menudiv.style.zIndex=100;
     menudiv.style.visibility='visible';
-    
+
     if( xpos && ypos ) {
       if(align=='right')
         menudiv.style.left = (xpos-menudiv.offsetWidth) + 'px';
@@ -48,21 +48,19 @@ var menudiv = null, global_menu_elem_name = null;
       menudiv.style.top = ypos + 'px';
     } else {
       if(align=='right') menudiv.style.left = (pb.x+button.offsetWidth-menudiv.offsetWidth) + 'px';
-        else menudiv.style.left = pb.x + 'px'; 
+        else menudiv.style.left = pb.x + 'px';
       menudiv.style.top = (pb.y+button.offsetHeight) + 'px';
     }
-    
-    
+
+
     q = menudiv.children[0];
     q.focus();
-//menudiv.setCapture(false);  // I1828
   }
-  
+
   function HideMenu() {
     if(event.srcElement != menudiv) {
       global_menu_elem_name = null;
       menudiv.style.visibility='hidden';
-      document.releaseCapture();
       try {
         if(lastfocus_item != null) lastfocus_item.focus();
       } catch(e) {
@@ -72,7 +70,7 @@ var menudiv = null, global_menu_elem_name = null;
   }
 
   function menuitem_keydown(n)
-  { 
+  {
     switch(event.keyCode) {
       case 27:  // esc
         /* esc */
@@ -84,7 +82,7 @@ var menudiv = null, global_menu_elem_name = null;
       case 32:  // enter, spacebar
         HideMenu();
         menuitemdown(true);
-        event.cancelBubble = true; 
+        event.cancelBubble = true;
         event.returnValue = false;
         return true;
 
@@ -100,7 +98,7 @@ var menudiv = null, global_menu_elem_name = null;
           elem.children[i].focus();
           break;
         }
-        
+
       }
       break;
     case 38:    // up
@@ -109,7 +107,7 @@ var menudiv = null, global_menu_elem_name = null;
         event.cancelBubble=true;
         return true;
       }
-      
+
       // find prev list element
       var elem = event.srcElement.parentElement;
       for(var i = 0; i < elem.children.length; i++) {
@@ -134,7 +132,7 @@ var menudiv = null, global_menu_elem_name = null;
         event.cancelBubble=true;
         return true;
       }
-      
+
       // find next file element
       var elem = event.srcElement.parentElement;
       for(var i = 0; i < elem.children.length; i++) {
@@ -185,7 +183,7 @@ var menudiv = null, global_menu_elem_name = null;
       event.cancelBubble = true;
     }
   }
-  
+
   function menu_doAttachEvent(obj, e, f)
   {
     if(obj.attachEvent) return obj.attachEvent('on'+e, f);
@@ -199,5 +197,4 @@ var menudiv = null, global_menu_elem_name = null;
     document.body.appendChild(menudiv);
   }
   menu_doAttachEvent(window, 'load', menusetup);
-  
-  
+

--- a/windows/src/desktop/kmshell/xml/menu.js
+++ b/windows/src/desktop/kmshell/xml/menu.js
@@ -1,5 +1,5 @@
 var menudiv = null, global_menu_elem_name = null;
-  
+
   function RightButtonMenu( menuid ) {
     if( (event.clientX + 180) > document.body.clientWidth ) {
       ShowMenu( menuid,'right', event.clientX, event.clientY );
@@ -7,7 +7,7 @@ var menudiv = null, global_menu_elem_name = null;
       ShowMenu( menuid,'left', event.clientX, event.clientY );
     }
   }
-  
+
   function PageOffset(e)
   {
     var pt = {x: 0, y: 0};
@@ -18,7 +18,7 @@ var menudiv = null, global_menu_elem_name = null;
     }
     return pt;
   }
-        
+
   function ShowMenu(name,align,xpos,ypos) {
     global_menu_elem_name = name;
     var q;
@@ -27,19 +27,19 @@ var menudiv = null, global_menu_elem_name = null;
 
     menudiv.innerHTML = menu.innerHTML;
     menudiv.style.width = menu.offsetWidth + 'px';
-    
+
     (function(m) {
       for(var i = 0; i < m.children.length; i++) {
         if(m.children[i].id != '') { m.children[i].id = 'Popup_'+m.children[i].id; }
       }
     })(menudiv);
-    
+
     var pb = PageOffset(button);
     var pm = PageOffset(menu.offsetParent);
 
     menudiv.style.zIndex=100;
     menudiv.style.visibility='visible';
-    
+
     if( xpos && ypos ) {
       if(align=='right')
         menudiv.style.left = (xpos-menudiv.offsetWidth) + 'px';
@@ -48,21 +48,19 @@ var menudiv = null, global_menu_elem_name = null;
       menudiv.style.top = ypos + 'px';
     } else {
       if(align=='right') menudiv.style.left = (pb.x+button.offsetWidth-menudiv.offsetWidth) + 'px';
-        else menudiv.style.left = pb.x + 'px'; 
+        else menudiv.style.left = pb.x + 'px';
       menudiv.style.top = (pb.y+button.offsetHeight) + 'px';
     }
-    
-    
+
+
     q = menudiv.children[0];
     q.focus();
-//menudiv.setCapture(false);  // I1828
   }
-  
+
   function HideMenu() {
     if(event.srcElement != menudiv) {
       global_menu_elem_name = null;
       menudiv.style.visibility='hidden';
-      document.releaseCapture();
       try {
         if(lastfocus_item != null) lastfocus_item.focus();
       } catch(e) {
@@ -72,7 +70,7 @@ var menudiv = null, global_menu_elem_name = null;
   }
 
   function menuitem_keydown(n)
-  { 
+  {
     switch(event.keyCode) {
       case 27:  // esc
         /* esc */
@@ -84,7 +82,7 @@ var menudiv = null, global_menu_elem_name = null;
       case 32:  // enter, spacebar
         HideMenu();
         menuitemdown(true);
-        event.cancelBubble = true; 
+        event.cancelBubble = true;
         event.returnValue = false;
         return true;
 
@@ -100,7 +98,7 @@ var menudiv = null, global_menu_elem_name = null;
           elem.children[i].focus();
           break;
         }
-        
+
       }
       break;
     case 38:    // up
@@ -109,7 +107,7 @@ var menudiv = null, global_menu_elem_name = null;
         event.cancelBubble=true;
         return true;
       }
-      
+
       // find prev list element
       var elem = event.srcElement.parentElement;
       for(var i = 0; i < elem.children.length; i++) {
@@ -134,7 +132,7 @@ var menudiv = null, global_menu_elem_name = null;
         event.cancelBubble=true;
         return true;
       }
-      
+
       // find next file element
       var elem = event.srcElement.parentElement;
       for(var i = 0; i < elem.children.length; i++) {
@@ -185,7 +183,7 @@ var menudiv = null, global_menu_elem_name = null;
       event.cancelBubble = true;
     }
   }
-  
+
   function menu_doAttachEvent(obj, e, f)
   {
     if(obj.attachEvent) return obj.attachEvent('on'+e, f);
@@ -199,5 +197,4 @@ var menudiv = null, global_menu_elem_name = null;
     document.body.appendChild(menudiv);
   }
   menu_doAttachEvent(window, 'load', menusetup);
-  
-  
+


### PR DESCRIPTION
Fixes #3361. Remove obsolete releaseCapture calls from Keyman Config.