### PR TITLE
feat(ios/engine): go/package use for model pkg downloads

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceDownloadManager.swift
@@ -101,10 +101,19 @@ public class ResourceDownloadManager {
     baseURL.appendPathComponent("download")
     baseURL.appendPathComponent(packageKey.id)
 
+    var typeForEndpoint: String
+    switch(packageKey.type) {
+      case .keyboard:
+        typeForEndpoint = "keyboard"
+      case .lexicalModel:
+        typeForEndpoint = "model"
+    }
+
     var urlComponents = URLComponents(string: baseURL.absoluteString)!
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "platform", value: "ios"),
-      URLQueryItem(name: "tier", value: (Version.currentTagged.tier ?? .stable).rawValue)
+      URLQueryItem(name: "tier", value: (Version.currentTagged.tier ?? .stable).rawValue),
+      URLQueryItem(name: "type", value: typeForEndpoint)
     ]
 
     if let version = version {
@@ -130,9 +139,6 @@ public class ResourceDownloadManager {
                                                                 completionBlock: CompletionHandler<FullID.Resource.Package>?)
   where FullID.Resource.Package: TypedKeymanPackage<FullID.Resource> {
     let packageKey = KeymanPackage.Key(id: fullID.id, type: fullID.type)
-    // TODO:  Currently invalid for model downloads.
-    //
-    //        Fortunately, this currently only affects legacy APIs.
     let packageURL = defaultDownloadURL(forPackage: KeymanPackage.Key(id: fullID.id, type: fullID.type),
                                         andResource: fullID,
                                         asUpdate: asUpdate)
@@ -257,11 +263,11 @@ public class ResourceDownloadManager {
         log.info("Fetched lexical model list for "+languageID+".")
 
         let closure = completionClosure ?? self.standardLexicalModelInstallCompletionBlock(forFullID: lmFullID)
-        // Its format is not yet supported for lexical models.
-//        let downloadURL = self.defaultDownloadURL(forPackage: lexicalModel.packageKey,
-//                                                  andResource: lexicalModel.fullID,
-//                                                  asUpdate: false)
-        self.downloadPackage(withKey: lexicalModel.packageKey, from: results[0].1, completionBlock: closure)
+        let downloadURL = self.defaultDownloadURL(forPackage: lexicalModel.packageKey,
+                                                  andResource: lexicalModel.fullID,
+                                                  asUpdate: false)
+
+        self.downloadPackage(withKey: lexicalModel.packageKey, from: downloadURL, completionBlock: closure)
       }
     }
   }

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceDownloadManagerTests.swift
@@ -32,7 +32,7 @@ class ResourceDownloadManagerTests: XCTestCase {
     }
   }
 
-  func testDefaultDownloadURL() {
+  func testDefaultKeyboardDownloadURL() {
     let tier = Version.currentTagged.tier ?? .stable
     let root = "/go/package/download"
 
@@ -45,6 +45,9 @@ class ResourceDownloadManagerTests: XCTestCase {
     XCTAssertTrue(basic_khmer_angkor_components.queryItems!.contains { item in
       return item.name == "tier" && item.value == tier.rawValue
     })
+    XCTAssertTrue(basic_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "type" && item.value == "keyboard"
+    })
 
     let adv_khmer_angkor_url = downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.khmer_angkor, andResource: TestUtils.Keyboards.khmer_angkor.fullID, withVersion: Version("1.0.6"), asUpdate: true)
     let adv_khmer_angkor_components = URLComponents(string: adv_khmer_angkor_url.absoluteString)!
@@ -56,6 +59,9 @@ class ResourceDownloadManagerTests: XCTestCase {
       return item.name == "tier" && item.value == tier.rawValue
     })
     XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
+      return item.name == "type" && item.value == "keyboard"
+    })
+    XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
       return item.name == "update" && item.value == "1"
     })
     XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
@@ -64,6 +70,11 @@ class ResourceDownloadManagerTests: XCTestCase {
     XCTAssertTrue(adv_khmer_angkor_components.queryItems!.contains { item in
       return item.name == "bcp47" && item.value == "km"
     })
+  }
+
+  func testDefaultLexicalModelDownloadURL() {
+    let tier = Version.currentTagged.tier ?? .stable
+    let root = "/go/package/download"
 
     let basic_mtnt_components = URLComponents(string: downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt).absoluteString)!
 
@@ -73,6 +84,31 @@ class ResourceDownloadManagerTests: XCTestCase {
     })
     XCTAssertTrue(basic_mtnt_components.queryItems!.contains { item in
       return item.name == "tier" && item.value == tier.rawValue
+    })
+    XCTAssertTrue(basic_mtnt_components.queryItems!.contains { item in
+      return item.name == "type" && item.value == "model"
+    })
+
+    let adv_mtnt_url = downloadManager!.defaultDownloadURL(forPackage: TestUtils.Packages.Keys.nrc_en_mtnt, andResource: TestUtils.LexicalModels.mtnt.fullID, withVersion: Version(TestUtils.LexicalModels.mtnt.version), asUpdate: true)
+    let adv_mtnt_components = URLComponents(string: adv_mtnt_url.absoluteString)!
+    XCTAssertEqual(adv_mtnt_components.path, "\(root)/nrc.en.mtnt")
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "platform" && item.value == "ios"
+    })
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "tier" && item.value == tier.rawValue
+    })
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "type" && item.value == "model"
+    })
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "update" && item.value == "1"
+    })
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "version" && item.value == TestUtils.LexicalModels.mtnt.version
+    })
+    XCTAssertTrue(adv_mtnt_components.queryItems!.contains { item in
+      return item.name == "bcp47" && item.value == "en"
     })
   }
 


### PR DESCRIPTION
Since https://github.com/keymanapp/keyman.com/pull/162 has been merged, our iOS code may now target use of go/package links for lexical model packages.