### PR TITLE
fix(windows): add back support for disabling keyboards

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -158,6 +158,7 @@ begin
   begin
     try
       kmcom.Keyboards.Refresh;
+      kmcom.Keyboards.Apply;
 
       FilenameBCP47 := Filenames[i].Split(['=']);
       Filename := FilenameBCP47[0];

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmInstallKeyboard
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    1 May 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     01 Aug 2006 - mcdurdin - Check if keyboard is already installed and uninstall if so
                     06 Oct 2006 - mcdurdin - Display welcome after package install
@@ -468,7 +468,11 @@ procedure TfrmInstallKeyboard.InstallTipForKeyboard(const BCP47Tag: string);
 var
   i: Integer;
 begin
+  // Ensure keyboard is recorded in CU registry before we install the TIP, otherwise it will be marked as disabled by default,
+  // as installing the TIP adds CU registry settings, potentially confusing the keyboard settings
   kmcom.Refresh;
+  kmcom.Apply;
+  // Install the TIP for the current user
   if Assigned(FKeyboard) then
   begin
     if BCP47Tag <> ''

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
@@ -283,11 +283,50 @@ begin
 end;
 
 procedure TKeymanKeyboardInstalled.Set_Loaded(Value: WordBool);
+var
+  i: Integer;
+  lang: IKeymanKeyboardLanguageInstalled2;
+  LangID: Integer;
+  TemporaryKeyboardID: WideString;
+  RegistrationRequired: WordBool;
 begin
-  // TODO: Keyman 14.0 this is currently a no-op. Instead, remove Windows
-  // language associations in order to enable and disable a keyboard. But we
-  // will need to re-implement this so users can still unload keyboards without
-  // uninstalling them completely.
+  if Value then
+  begin
+    FRegKeyboard.Enabled := True;
+    for i := 0 to Get_Languages.Count - 1 do
+    begin
+      lang := Get_Languages[i] as IKeymanKeyboardLanguageInstalled2;
+      if lang.IsInstalled then
+      begin
+        if lang.FindInstallationLangID(LangID, TemporaryKeyboardID, RegistrationRequired, kifInstallTransientLanguage) then
+        begin
+          if not RegistrationRequired then
+            lang.InstallTip(LangID, TemporaryKeyboardID)
+          else
+          begin
+            // The registration for the keyboard TIP has somehow disappeared; this is unexpected.
+            // We don't want to crash, so we'll just try and clean it up. The user will have to
+            // reinstall it, which is not the end of the world.
+            lang.Uninstall;
+          end;
+        end;
+      end;
+    end;
+  end
+  else
+  begin
+    FRegKeyboard.Enabled := False;
+    for i := 0 to Get_Languages.Count - 1 do
+    begin
+      lang := Get_Languages[i] as IKeymanKeyboardLanguageInstalled2;
+      if lang.IsInstalled then
+      begin
+        (lang as IIntKeymanKeyboardLanguage).Disable;
+      end;
+    end;
+  end;
+
+  (Context.Keyboards as IKeymanKeyboardsInstalled).Apply;
 end;
 
 function TKeymanKeyboardInstalled.Get_IconFilename: WideString;   // I3581

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
@@ -298,17 +298,15 @@ begin
       lang := Get_Languages[i] as IKeymanKeyboardLanguageInstalled2;
       if lang.IsInstalled then
       begin
-        if lang.FindInstallationLangID(LangID, TemporaryKeyboardID, RegistrationRequired, kifInstallTransientLanguage) then
+        if lang.FindInstallationLangID(LangID, TemporaryKeyboardID, RegistrationRequired, kifInstallTransientLanguage) and
+            not RegistrationRequired then
+          lang.InstallTip(LangID, TemporaryKeyboardID)
+        else
         begin
-          if not RegistrationRequired then
-            lang.InstallTip(LangID, TemporaryKeyboardID)
-          else
-          begin
-            // The registration for the keyboard TIP has somehow disappeared; this is unexpected.
-            // We don't want to crash, so we'll just try and clean it up. The user will have to
-            // reinstall it, which is not the end of the world.
-            lang.Uninstall;
-          end;
+          // The registration for the keyboard TIP has somehow disappeared; this is unexpected.
+          // We don't want to crash, so we'll just try and clean it up. The user will have to
+          // reinstall it, which is not the end of the world.
+          lang.Uninstall;
         end;
       end;
     end;

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardsinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardsinstalled.pas
@@ -161,14 +161,21 @@ end;
 
 procedure TKeymanKeyboardsInstalled.Apply;
 var
-  pInputProcessorProfiles: ITfInputProcessorProfiles;
+  i, n: Integer;
 begin
-  OleCheck(CoCreateInstance(CLASS_TF_InputProcessorProfiles, nil, CLSCTX_INPROC_SERVER,
-                          IID_ITfInputProcessorProfiles, pInputProcessorProfiles));
   with TRegKeyboardList.Create do
   try
     Load(True);
-    // May do some cleanup
+
+    for i := 0 to FKeyboards.Count - 1 do
+    begin
+      n := IndexOfName((FKeyboards[i] as IKeymanKeyboard).ID);
+      if n >= 0 then
+      begin
+        Items[n].ApplySettings((FKeyboards[i] as IIntKeymanKeyboardInstalled).RegKeyboard);
+      end;
+    end;
+
     Save;
   finally
     Free;

--- a/windows/src/engine/kmcomapi/keymanapi_TLB.pas
+++ b/windows/src/engine/kmcomapi/keymanapi_TLB.pas
@@ -12,7 +12,7 @@ unit keymanapi_TLB;
 // ************************************************************************ //
 
 // $Rev: 52393 $
-// File generated on 2/09/2020 8:08:53 AM from Type Library described below.
+// File generated on 23/09/2020 5:09:37 PM from Type Library described below.
 
 // ************************************************************************  //
 // Type Lib: C:\Projects\keyman\app\windows\src\engine\kmcomapi\kmcomapi (1)
@@ -1704,7 +1704,9 @@ type
     procedure RegisterTip(LangID: Integer); safecall;
     procedure InstallTip(LangID: Integer; const TemporaryKeyboardToRemove: WideString); safecall;
     function Get_IsRegistered: WordBool; safecall;
+    function Get_WindowsBCP47Code: WideString; safecall;
     property IsRegistered: WordBool read Get_IsRegistered;
+    property WindowsBCP47Code: WideString read Get_WindowsBCP47Code;
   end;
 
 // *********************************************************************//
@@ -1719,6 +1721,7 @@ type
     procedure RegisterTip(LangID: Integer); dispid 405;
     procedure InstallTip(LangID: Integer; const TemporaryKeyboardToRemove: WideString); dispid 406;
     property IsRegistered: WordBool readonly dispid 501;
+    property WindowsBCP47Code: WideString readonly dispid 502;
     property OwnerKeyboard: IKeymanKeyboardInstalled readonly dispid 4;
     property ProfileGUID: {NOT_OLEAUTO(TGUID)}OleVariant readonly dispid 5;
     procedure Uninstall; dispid 6;

--- a/windows/src/engine/kmcomapi/kmcomapi.ridl
+++ b/windows/src/engine/kmcomapi/kmcomapi.ridl
@@ -6,7 +6,7 @@
 // However, when applying changes via the Editor this file will be regenerated
 // and comments or formatting changes will be lost.
 // ************************************************************************ //
-// File generated on 2/09/2020 8:20:10 AM (- $Rev: 12980 $, 129133765).
+// File generated on 23/09/2020 5:25:25 PM (- $Rev: 12980 $, 651560046).
 
 [
   uuid(F16E2A9A-DA46-4EA3-BFF3-BA46B480C961),
@@ -990,6 +990,8 @@ library keymanapi
     HRESULT _stdcall InstallTip([in] long LangID, [in] BSTR TemporaryKeyboardToRemove);
     [propget, id(0x000001F5)]
     HRESULT _stdcall IsRegistered([out, retval] VARIANT_BOOL* Value);
+    [propget, id(0x000001F6)]
+    HRESULT _stdcall WindowsBCP47Code([out, retval] BSTR* Value);
   };
 
   [

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPInstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPInstallKeyboardLanguage.pas
@@ -451,6 +451,17 @@ begin
 
   if not InstallLayoutOrTip(PChar(FLayoutInstallString), 0) then   // I4302
     ErrorFmt(KMN_E_ProfileInstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
+
+  //
+  // Record the installation of the language
+  //
+  reg := TRegistry.Create;
+  try
+    if reg.OpenKey(BuildKeyboardLanguagesKey_CU(KeyboardID), True) then
+      reg.WriteString(BCP47Tag, FLayoutInstallString);
+  finally
+    reg.Free;
+  end;
 end;
 
 function TKPInstallKeyboardLanguage.InstallBCP47Language(const FLocaleName: string): Boolean;

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
@@ -252,7 +252,8 @@ begin
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
 
   //
-  // Record the installation of the language
+  // Remove the language from our current user Keyman settings (unless we are
+  // actually just disabling the keyboard, not uninstalling it)
   //
   if RemoveCURegistry then
     UninstallCURegistry(KeyboardID, FLayoutInstallString);
@@ -287,9 +288,8 @@ begin
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
 
   //
-  // Record the installation of the language. We need to match on the layout
-  // install string because the BCP47Tag is not necessarily identical after
-  // Windows canonicalizes it according to its internal rules
+  // Remove the language from our current user Keyman settings (unless we are
+  // actually just disabling the keyboard, not uninstalling it)
   //
   if RemoveCURegistry then
     UninstallCURegistry(KeyboardID, FLayoutInstallString);

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPUninstallKeyboardLanguage.pas
@@ -22,17 +22,26 @@ type
     /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
     /// <param name="LangID">The transient profile to uninstall, $2000, $2400, $2800, $2C00</param>
-    procedure UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID); overload;
+    /// <param name="RemoveCURegistry">If we are actually 'disabling' the Keyman keyboard,
+    /// this should be False, otherwise for a full uninstall set to True because we do want
+    /// to remove the Keyman registry settings</param>
+    procedure UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID; RemoveCURegistry: Boolean); overload;
 
     /// <summary>Uninstalls all TIPs for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
-    procedure UninstallTip(const KeyboardID: string); overload;
+    /// <param name="RemoveCURegistry">If we are actually 'disabling' the Keyman keyboard,
+    /// this should be False, otherwise for a full uninstall set to True because we do want
+    /// to remove the Keyman registry settings</param>
+    procedure UninstallTip(const KeyboardID: string; RemoveCURegistry: Boolean); overload;
 
   protected
     /// <summary>Uninstalls a TIP for the current user for a given keyboard</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
     /// <param name="BCP47Tag">This should be a BCP47 tag that is currently installed</param>
-    procedure UninstallTip(KeyboardID, BCP47Tag: string); overload;
+    /// <param name="RemoveCURegistry">If we are actually 'disabling' the Keyman keyboard,
+    /// this should be False, otherwise for a full uninstall set to True because we do want
+    /// to remove the Keyman registry settings</param>
+    procedure UninstallTip(KeyboardID, BCP47Tag: string; RemoveCURegistry: Boolean); overload;
 
     /// <summary>Unregisters a TIP from the Local Machine registry</summary>
     /// <param name="KeyboardID">The ID of the keyboard</param>
@@ -48,6 +57,8 @@ type
     procedure DoUnregisterTip(const KeyboardID, BCP47Tag: string; pInputProcessorProfileMgr: ITfInputProcessorProfileMgr);
     procedure DoUnregisterTipTransientProfile(const KeyboardID: string; LangID: Word; pInputProcessorProfileMgr: ITfInputProcessorProfileMgr);
     function GetInputProcessorProfileMgr: ITfInputProcessorProfileMgr;
+    procedure UninstallCURegistry(const KeyboardID,
+      LayoutInstallString: string);
   end;
 
 implementation
@@ -196,7 +207,7 @@ begin
   DoUnregisterTip(KeyboardID, BCP47Tag, GetInputProcessorProfileMgr);
 end;
 
-procedure TKPUninstallKeyboardLanguage.UninstallTip(KeyboardID, BCP47Tag: string);
+procedure TKPUninstallKeyboardLanguage.UninstallTip(KeyboardID, BCP47Tag: string; RemoveCURegistry: Boolean);
 var
   reg: TRegistry;
   FIsAdmin: Boolean;
@@ -239,9 +250,15 @@ begin
 
   if not InstallLayoutOrTip(PChar(FLayoutInstallString), ILOT_UNINSTALL) then   // I4302
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
+
+  //
+  // Record the installation of the language
+  //
+  if RemoveCURegistry then
+    UninstallCURegistry(KeyboardID, FLayoutInstallString);
 end;
 
-procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID);
+procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string; LangID: Integer; ProfileGUID: TGUID; RemoveCURegistry: Boolean);
 var
   FIsAdmin: Boolean;
   BCP47Tag, FLayoutInstallString: string;
@@ -268,9 +285,44 @@ begin
   FLayoutInstallString := GetLayoutInstallString(LangID, ProfileGUID);
   if not InstallLayoutOrTip(PChar(FLayoutInstallString), ILOT_UNINSTALL) then   // I4302
     WarnFmt(KMN_W_ProfileUninstall_InstallLayoutOrTipFailed, VarArrayOf([KeyboardID]));
+
+  //
+  // Record the installation of the language. We need to match on the layout
+  // install string because the BCP47Tag is not necessarily identical after
+  // Windows canonicalizes it according to its internal rules
+  //
+  if RemoveCURegistry then
+    UninstallCURegistry(KeyboardID, FLayoutInstallString);
 end;
 
-procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string);
+procedure TKPUninstallKeyboardLanguage.UninstallCURegistry(const KeyboardID, LayoutInstallString: string);
+var
+  reg: TRegistry;
+  str: TStringList;
+  name: string;
+begin
+  str := TStringList.Create;
+  reg := TRegistry.Create;
+  try
+    if reg.OpenKey(BuildKeyboardLanguagesKey_CU(KeyboardID), True) then
+    begin
+      reg.GetValueNames(str);
+      for name in str do
+      begin
+        if reg.ReadString(name) = LayoutInstallString then
+        begin
+          reg.DeleteValue(name);
+          Exit;
+        end;
+      end;
+    end;
+  finally
+    reg.Free;
+    str.Free;
+  end;
+end;
+
+procedure TKPUninstallKeyboardLanguage.UninstallTip(const KeyboardID: string; RemoveCURegistry: Boolean);
 var
   sLocales: TStrings;
   sLocale: string;
@@ -298,7 +350,7 @@ begin
 
     for sLocale in sLocales do
       // Note: if TIP is not installed, this still succeeds
-      UninstallTip(KeyboardID, sLocale);
+      UninstallTip(KeyboardID, sLocale, RemoveCURegistry);
   finally
     sLocales.Free;
   end;

--- a/windows/src/engine/kmcomapi/util/internalinterfaces.pas
+++ b/windows/src/engine/kmcomapi/util/internalinterfaces.pas
@@ -73,6 +73,7 @@ type
 
   IIntKeymanKeyboardLanguage = interface   // I4376
     ['{81C18942-3C81-4F50-A64A-35A4FE863177}']
+    procedure Disable;
   end;
 
   IIntKeymanKeyboardsInstalled = interface(IIntKeymanCollection)   // I4381

--- a/windows/src/global/delphi/general/RegistryKeys.pas
+++ b/windows/src/global/delphi/general/RegistryKeys.pas
@@ -193,6 +193,7 @@ const
   SRegKey_ActiveKeyboards_CU = SRegKey_KeymanEngine_CU + '\Active Keyboards';                   // CU
 
   SRegSubKey_KeyboardOptions = 'Options';  // CU\ActiveKeyboards\<id>\Options
+  SRegSubKey_KeyboardLanguages = 'Languages'; //CU\ActiveKeyboards\<id>\Disabled Languages
 
   SRegValue_KeymanID            = 'keyman id';                                      // CU
   SRegValue_Legacy_KeymanInstalledLanguage = 'keyman installed language';                  // CU   // I4220
@@ -468,6 +469,7 @@ const
 function BuildKeyboardOptionKey_CU(const KeyboardID: string): string;
 function BuildKeyboardLanguageProfilesKey_LM(const KeyboardID: string): string;
 function BuildKeyboardSuggestedLanguagesKey_LM(const KeyboardID: string): string;
+function BuildKeyboardLanguagesKey_CU(const KeyboardID: string): string;
 
 implementation
 
@@ -484,6 +486,11 @@ end;
 function BuildKeyboardSuggestedLanguagesKey_LM(const KeyboardID: string): string;
 begin
   Result := SRegKey_InstalledKeyboards_LM + '\' + KeyboardID + '\' + SRegSubKey_SuggestedLanguages;
+end;
+
+function BuildKeyboardLanguagesKey_CU(const KeyboardID: string): string;
+begin
+  Result := SRegKey_ActiveKeyboards_CU + '\' + KeyboardID + '\' + SRegSubKey_KeyboardLanguages;
 end;
 
 end.


### PR DESCRIPTION
Fixes #3560. This reworks the functionality for disabling keyboards to work with the new TIP registration pattern. Much of the code is the same as in Keyman 13, but there are some significant differences, so it all needs to be reviewed.