### PR TITLE
fix(windows): bootstrap package install specified language bugs

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -79,7 +79,9 @@ begin
   if pack.Keyboards.Count = 0 then
     Exit(False);
 
-  Result := DoInstall(pack.Keyboards[0].ID, BCP47Tag);
+  if BCP47Tag = ''
+    then Result := DoInstall(pack.Keyboards[0].ID, GetFirstLanguage(pack.Keyboards[0] as IKeymanKeyboardInstalled))
+    else Result := DoInstall(pack.Keyboards[0].ID, BCP47Tag);
 end;
 
 class function TTIPMaintenance.InstallTip(LangID: Integer; const KeyboardID, BCP47Tag,

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -14,7 +14,7 @@ type
       Keyboard: IKeymanKeyboardInstalled); static;
     class procedure AddDefaultLanguageHotkeys(
       InstalledKeyboards: array of IKeymanKeyboardInstalled); static;
-    class procedure InstallKeyboardPackageLanguage(
+    class procedure RegisterKeyboardPackageLanguage(
       FPackage: IKeymanPackageInstalled; const BCP47: string); static;
   public
     class function BrowseAndInstallKeyboardFromFile(Owner: TComponent): Boolean; static;
@@ -168,8 +168,9 @@ begin
       begin
         FPackage := (kmcom.Packages as IKeymanPackagesInstalled2).Install2(FileName, True);
         if Length(FilenameBCP47) > 1
-          then InstallKeyboardPackageLanguage(FPackage, FilenameBCP47[1])
-          else InstallKeyboardPackageLanguage(FPackage, '');
+          then RegisterKeyboardPackageLanguage(FPackage, FilenameBCP47[1])
+          else RegisterKeyboardPackageLanguage(FPackage, '');
+          // The keyboard will be installed for current user as a separate step
       end
       else
       begin
@@ -221,7 +222,7 @@ begin
   end;
 end;
 
-class procedure TInstallFile.InstallKeyboardPackageLanguage(FPackage: IKeymanPackageInstalled; const BCP47: string);
+class procedure TInstallFile.RegisterKeyboardPackageLanguage(FPackage: IKeymanPackageInstalled; const BCP47: string);
 var
   DefaultBCP47Language: string;
   i: Integer;
@@ -237,11 +238,11 @@ begin
       DefaultBCP47Language := FPackage.Keyboards[i].DefaultBCP47Languages;
       if DefaultBCP47Language.Contains(' ') then
         DefaultBCP47Language := DefaultBCP47Language.Split([' '])[0];
-      TTIPMaintenance.DoInstall(FPackage.Keyboards[i].ID, DefaultBCP47Language);
+      TTIPMaintenance.DoRegister(FPackage.Keyboards[i].ID, DefaultBCP47Language);
     end;
   end
   else if FPackage.Keyboards.Count > 0 then
-    TTIPMaintenance.DoInstall(FPackage.Keyboards[0].ID, BCP47);
+    TTIPMaintenance.DoRegister(FPackage.Keyboards[0].ID, BCP47);
 end;
 
 class procedure TInstallFile.AddDefaultLanguageHotkey(Keyboard: IKeymanKeyboardInstalled);


### PR DESCRIPTION
If the user does not specify a language in the bootstrap install, then the package would be installed without any language selection. This happens, for example, in a bundled installer run without parameters, or if there are additional .kmp files in the same folder as the setup.exe that are to be installed, and the user does not open the Setup Options dialog to choose languages for each package.

Also, the elevated portion of the language install was doing a register and install instead of just register. This was not particularly harmful but was unwanted for scenarios where the elevated user is different to the login user.