### PR TITLE
fix(windows): cleanup pointer to int typecasts

### DIFF
--- a/windows/src/.gitignore
+++ b/windows/src/.gitignore
@@ -32,3 +32,6 @@ global/delphi/cust/MessageIdentifierConsts.pas
 # Breakpad files generated for Sentry
 **/*.sym
 
+# Coverity intermediate folder and files
+cov-int/
+keyman-windows-coverity.tgz

--- a/windows/src/Makefile
+++ b/windows/src/Makefile
@@ -186,6 +186,39 @@ test-uiaccess:
     $(MAKE) test-uiaccess
     cd $(ROOT)\src
 
+#
+# Build Keyman projects for coverity; call this with
+#   make test-coverity
+# * Set environment variable COVBUILD to path to cov-build.exe
+# * tar must be on path
+#
+
+test-coverity:
+    cd $(ROOT)\src
+    if exist cov-int rd /s/q cov-int
+    if exist keyman-windows-coverity.tgz del keyman-windows-coverity.tgz
+    $(COVBUILD) --dir cov-int $(MAKE) test-coverity-internal
+    tar cvzf keyman-windows-coverity.tgz cov-int
+    rd /s/q cov-int
+    echo Manual upload keyman-windows-coverity.tgz to coverity
+    # TODO: automated upload as part of build
+
+test-coverity-internal:
+    cd $(ROOT)\src\developer\kmanalyze
+    $(MAKE) build
+    cd $(ROOT)\src\developer\kmcmpdll
+    $(MAKE) build
+    cd $(ROOT)\src\engine\keyman32
+    $(MAKE) build
+    cd $(ROOT)\src\engine\keyman64
+    $(MAKE) build
+    cd $(ROOT)\src\engine\keymanx64
+    $(MAKE) build
+    cd $(ROOT)\src\engine\kmtip
+    $(MAKE) build
+    cd $(ROOT)\src\engine\mcompile
+    $(MAKE) build
+
 # Build a release
 
 build-release-wrapper: clean-output global-versions

--- a/windows/src/developer/kmanalyze/kmanalyze.cpp
+++ b/windows/src/developer/kmanalyze/kmanalyze.cpp
@@ -158,7 +158,7 @@ BOOL LoadKeyboard(LPSTR fileName, LPKEYBOARD *lpKeyboard)
         if (sp->dwSystemID == TSS_COMPILEDVERSION)
         {
           char buf2[256];
-          wsprintf(buf2, "Wrong File Version: file version is %ls", ((PBYTE)kbp) + (DWORD)sp->dpString);
+          wsprintf(buf2, "Wrong File Version: file version is %ls", ((PBYTE)kbp) + (INT_PTR)sp->dpString);
           delete buf;
           Err(buf2);
           return FALSE;
@@ -219,7 +219,7 @@ BOOL VerifyChecksum(LPBYTE buf, LPDWORD CheckSum, DWORD sz)
 //}
 
 TESTS *DoGroupAnalysis(LPKEYBOARD kbd, LPGROUP gp, std::vector<LPGROUP> & tree, TEST *base_test) {
-  
+
   //
   // Prevent recursion
   //
@@ -282,9 +282,9 @@ TESTS *DoGroupAnalysis(LPKEYBOARD kbd, LPGROUP gp, std::vector<LPGROUP> & tree, 
     if (base_test) {
       std::wstring c1 = context.length() > base_test->context.length() ? context : base_test->context;
       //std::wstring c2 = context.length() > base_test->context.length() ? base_test->context : context;
-      
+
       //if(c1.compare(c1.length() - c2.length(), c2.length(), c2) != 0) {
-        // TODO: We are not comparing like with like ... so continue; but this naive test does not take into account 
+        // TODO: We are not comparing like with like ... so continue; but this naive test does not take into account
         // stores, which we need to, in order to make this work well.
       //}
 
@@ -315,12 +315,12 @@ TESTS *DoGroupAnalysis(LPKEYBOARD kbd, LPGROUP gp, std::vector<LPGROUP> & tree, 
         if (!new_tests) return NULL;
         // TODO: Then multiplying new_tests for each subsequent group I guess!?
         found = TRUE;
-        break; 
+        break;
       }
     }
     if (!found) {
       // TODO: Support use() in rule and use() in match
-      // check for use in match or extra 
+      // check for use in match or extra
       PWCHAR pc = gp->dpMatch;
       if (pc && *pc == UC_SENTINEL && *(pc + 1) == CODE_USE) {
         new_tests = DoGroupAnalysis(kbd, &kbd->dpGroupArray[*(pc + 2) - 1], tree, &t0);
@@ -437,7 +437,7 @@ std::wstring GetModifierName(UINT modifier) {
     if (str.size()) str += L" | ";
     str += buf;
   }
-  
+
   wsprintfW(buf, L" /* 0x%x */", originalModifier);
   if (!str.size()) str += L"0";
   str += buf;
@@ -493,7 +493,7 @@ void PrintTests(TESTS *tests, char *keyboardID, wchar_t *keyboardName, char *key
     fprintf(fp, "}%s\n", (i == tests->size() - 1 ? "" : ","));
   }
 
-  fprintf(fp, 
+  fprintf(fp,
     "  }\n"
     "}"/*);\n"
     "})();\n"*/
@@ -504,7 +504,7 @@ void PrintTests(TESTS *tests, char *keyboardID, wchar_t *keyboardName, char *key
 
 void RemoveDuplicateTests(TESTS *tests) {
   // TODO: sort tests by key, modifier, context
-  
+
   // Then remove duplicates
 }
 
@@ -564,16 +564,16 @@ void PrintRule(LPKEYBOARD kbd, LPKEY kp) {
   for (PWCHAR pc = kp->dpContext; pc && *pc; pc = incxstr(pc)) {
     if (*pc == UC_SENTINEL) {
       switch (*(pc + 1)) {
-      case CODE_ANY:			
+      case CODE_ANY:
         sp = &kbd->dpStoreArray[*(pc + 2) - 1];
         context.push_back(NextUTF32(sp->dpString));
         break;
-      case CODE_NOTANY:   
+      case CODE_NOTANY:
         assert(FALSE); //TODO
-      case CODE_INDEX:		
+      case CODE_INDEX:
         assert(FALSE); //TODO
       case CODE_DEADKEY:
-        
+
         case CODE_EXTENDED:		p += 2; while (*p != UC_SENTINEL_EXTENDEDEND) p++; return p + 1;
         case CODE_CLEARCONTEXT: return p + 1;
         case CODE_CALL:			return p + 1;

--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             Compiler
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    25 Oct 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     23 Aug 2006 - mcdurdin - Add VISUALKEYBOARD, KMW_RTL, KMW_HELPFILE, KMW_HELPTEXT, KMW_EMBEDJS system stores
                     14 Sep 2006 - mcdurdin - Support icons in version 7
@@ -96,7 +96,7 @@ BOOL IsValidCallStore(PFILE_STORE fs);
 BOOL IsSameToken(PWSTR *p, PWSTR token);
 DWORD GetRHS(PFILE_KEYBOARD fk, PWSTR p, PWSTR buf, int bufsize, int offset, int IsUnicode);
 PWSTR GetDelimitedString(PWSTR *p, PWSTR Delimiters, WORD Flags);
-DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int max, int offset, PWSTR *newp, int isVKey, 
+DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int max, int offset, PWSTR *newp, int isVKey,
 	int isUnicode);
 
 int GetGroupNum(PFILE_KEYBOARD fk, PWSTR p);
@@ -150,17 +150,17 @@ const PWCHAR LineTokens[] = {
 #define SSN__PREFIX		L"&"
 
 const PWCHAR StoreTokens[TSS__MAX+2] = {
-	L"", 
-	SSN__PREFIX L"BITMAP", 
+	L"",
+	SSN__PREFIX L"BITMAP",
 	SSN__PREFIX L"COPYRIGHT",
-	SSN__PREFIX L"HOTKEY", 
-	SSN__PREFIX L"LANGUAGE", 
+	SSN__PREFIX L"HOTKEY",
+	SSN__PREFIX L"LANGUAGE",
 	SSN__PREFIX L"LAYOUT",
-	SSN__PREFIX L"MESSAGE", 
-	SSN__PREFIX L"NAME", 
+	SSN__PREFIX L"MESSAGE",
+	SSN__PREFIX L"NAME",
 	SSN__PREFIX L"VERSION",
-	SSN__PREFIX L"CAPSONONLY", 
-	SSN__PREFIX L"CAPSALWAYSOFF", 
+	SSN__PREFIX L"CAPSONONLY",
+	SSN__PREFIX L"CAPSALWAYSOFF",
 	SSN__PREFIX L"SHIFTFREESCAPS",
 	SSN__PREFIX L"LANGUAGENAME",
 	L"",
@@ -247,7 +247,7 @@ BOOL AddCompileString(LPSTR buf)
     (*msgproc)(currentLine+1, CWARN_Info, buf);
 	return FALSE;
 }
-	
+
 BOOL AddCompileMessage(DWORD msg)
 {
 	char szText[SZMAX_ERRORTEXT+1+280];
@@ -282,7 +282,7 @@ BOOL AddCompileMessage(DWORD msg)
 
 	return FALSE;
 }
-	
+
 extern "C" BOOL __declspec(dllexport) CompileKeyboardFile(PSTR pszInfile, PSTR pszOutfile, BOOL ASaveDebug, BOOL ACompilerWarningsAsErrors, BOOL AWarnDeprecatedCode, CompilerMessageProc pMsgProc)   // I4865   // I4866
 {
 	HANDLE hInfile = INVALID_HANDLE_VALUE, hOutfile = INVALID_HANDLE_VALUE;
@@ -301,8 +301,8 @@ extern "C" BOOL __declspec(dllexport) CompileKeyboardFile(PSTR pszInfile, PSTR p
 	PSTR p;
 	if(p = strrchr(pszInfile, '\\'))
 	{
-		strncpy_s(CompileDir, _countof(CompileDir), pszInfile, (int)(p-pszInfile+1));  // I3481
-		CompileDir[(int)(p-pszInfile+1)] = 0;
+		strncpy_s(CompileDir, _countof(CompileDir), pszInfile, (INT_PTR)(p-pszInfile+1));  // I3481
+		CompileDir[(INT_PTR)(p-pszInfile+1)] = 0;
 	}
 	else
 		CompileDir[0] = 0;
@@ -335,7 +335,7 @@ extern "C" BOOL __declspec(dllexport) CompileKeyboardFile(PSTR pszInfile, PSTR p
   {
     return CERR_CannotCreateTempfile;
   }
-	
+
 	hOutfile = CreateFileA(pszOutfile, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
 	if(hOutfile == INVALID_HANDLE_VALUE) SetError(CERR_CannotCreateOutfile);
 
@@ -351,7 +351,7 @@ extern "C" BOOL __declspec(dllexport) CompileKeyboardFile(PSTR pszInfile, PSTR p
 	}
 	else
 		AddCompileMessage(CERR_InvalidValue);
-	
+
 	CloseHandle(hInfile);
 	CloseHandle(hOutfile);
 
@@ -385,8 +385,8 @@ extern "C" BOOL __declspec(dllexport) CompileKeyboardFileToBuffer(PSTR pszInfile
 	PSTR p;
 	if(p = strrchr(pszInfile, '\\'))
 	{
-		strncpy_s(CompileDir, _countof(CompileDir), pszInfile, (int)(p-pszInfile+1));  // I3481
-		CompileDir[(int)(p-pszInfile+1)] = 0;
+		strncpy_s(CompileDir, _countof(CompileDir), pszInfile, (INT_PTR)(p-pszInfile+1));  // I3481
+		CompileDir[(INT_PTR)(p-pszInfile+1)] = 0;
 	}
 	else
 		CompileDir[0] = 0;
@@ -442,7 +442,7 @@ void GetVersionInfo(DWORD *VersionMajor, DWORD *VersionMinor)
 BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 {
 	PWSTR str, p;
-	
+
 	DWORD msg;
 
 	FMnemonicLayout = FALSE;
@@ -475,7 +475,7 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 	fk->dwBitmapSize = 0;
 	fk->dwHotKey = 0;
 
-	/* Add a store for the Keyman 6.0 copyright information string */ 
+	/* Add a store for the Keyman 6.0 copyright information string */
 
 	DWORD vmajor, vminor;
 	GetVersionInfo(&vmajor, &vminor);
@@ -488,7 +488,7 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 	//delete pw;
 
 	/* Add a system store for the Keyman edition number */
-	
+
 	swprintf(str, LINESIZE, L"%d", 0);  // I3481
 	AddStore(fk, TSS_CUSTOMKEYMANEDITION, str);
 	PWSTR tbuf = strtowstr((char*) "Keyman");
@@ -525,13 +525,13 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 	SetFilePointer(hInfile, 2, NULL, FILE_BEGIN);
 	currentLine = 0;
 
-	/* Reindex the list of codeconstants after stores added */ 
+	/* Reindex the list of codeconstants after stores added */
 
 	CodeConstants->reindex();
 
-	/* ReadLine will automatically skip over $Keyman lines, and parse wrapped lines */ 
+	/* ReadLine will automatically skip over $Keyman lines, and parse wrapped lines */
 	while((msg = ReadLine(hInfile, str, FALSE)) == CERR_None)
-    { 
+    {
 		if(GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
 		msg = ParseLine(fk, str);
 		if(msg != CERR_None) SetError(msg);
@@ -543,7 +543,7 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
 
 	if(FSaveDebug) RecordDeadkeyNames(fk);
 
-	/* Add the compiler version as a system store */ 
+	/* Add the compiler version as a system store */
 	if((msg = AddCompilerVersionStore(fk)) != CERR_None) SetError(msg);
 
   if((msg = BuildVKDictionary(fk)) != CERR_None) SetError(msg);  // I3438
@@ -578,7 +578,7 @@ DWORD ProcessBeginLine(PFILE_KEYBOARD fk, PWSTR p)
 	else if(*p != '>') return CERR_InvalidToken;
 	else BeginMode = BEGIN_ANSI;
 
-	if((msg = GetRHS(fk, p, tstr, 80, (int)(p-pp), FALSE)) != CERR_None) return msg;
+	if((msg = GetRHS(fk, p, tstr, 80, (int)(INT_PTR)(p-pp), FALSE)) != CERR_None) return msg;
 
 	if(tstr[0] != UC_SENTINEL || tstr[1] != CODE_USE) return CERR_InvalidBegin;
 
@@ -619,7 +619,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 
 	p = str;
 	pp = str;
-	
+
 	switch(LineTokenType(&p))
     {
 	case T_BLANK:
@@ -648,7 +648,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
 		if( !q ) return CERR_InvalidName;
-		
+
 		if((msg = AddStore(fk, TSS_NAME, q)) != CERR_None) return msg;
 		break;
 
@@ -659,7 +659,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 
 		if((msg = AddStore(fk, TSS_COPYRIGHT, q)) != CERR_None) return msg;
 		break;
-	
+
   case T_MESSAGE:
     WarnDeprecatedHeader();   // I4866
 		q = GetDelimitedString(&p, L"\"\"", 0);
@@ -696,12 +696,12 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
     WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_CAPSALWAYSOFF, L"1")) != CERR_None) return msg;
 		break;
-	
+
 	case T_CAPSON:
     WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_CAPSONONLY, L"1")) != CERR_None) return msg;
 		break;
-	
+
 	case T_SHIFT:
     WarnDeprecatedHeader();   // I4866
 		if((msg = AddStore(fk, TSS_SHIFTFREESCAPS, L"1")) != CERR_None) return msg;
@@ -748,7 +748,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		if(fk->currentGroup == 0xFFFFFFFF) return CERR_CodeInvalidInThisSection;
 		{
 		  PWCHAR buf = new WCHAR[GLOBAL_BUFSIZE];
-		  if((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE-1, (int)(p-pp), IsUnicode)) != CERR_None)
+		  if((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(p-pp), IsUnicode)) != CERR_None)
 		  {
 		    delete buf;
 		    return msg;
@@ -758,12 +758,12 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
         delete buf;
         return msg;
       }
-      
+
       gp = &fk->dpGroupArray[fk->currentGroup];
-		
+
 		  gp->dpMatch = new WCHAR[wcslen(buf) + 1];
 		  wcscpy_s(gp->dpMatch, wcslen(buf)+1, buf);  // I3481
-		  
+
 		  delete buf;
 
 		  if(FSaveDebug)
@@ -786,7 +786,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 		if(fk->currentGroup == 0xFFFFFFFF) return CERR_CodeInvalidInThisSection;
 		{
 		  PWCHAR buf = new WCHAR[GLOBAL_BUFSIZE];
-      if((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE, (int)(p-pp), IsUnicode)) != CERR_None) 
+      if((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE, (int)(INT_PTR)(p-pp), IsUnicode)) != CERR_None)
       {
         delete buf;
         return msg;
@@ -798,10 +798,10 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
       }
 
 		  gp = &fk->dpGroupArray[fk->currentGroup];
-		
+
 		  gp->dpNoMatch = new WCHAR[wcslen(buf) + 1];
 		  wcscpy_s(gp->dpNoMatch, wcslen(buf)+1, buf);  // I3481
-		  
+
 		  delete buf;
 
 		  if(FSaveDebug)
@@ -830,13 +830,13 @@ DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p)
 
 	gp = new FILE_GROUP[fk->cxGroupArray + 1];
 	if(!gp) return CERR_CannotAllocateMemory;
-	
+
 	if(fk->dpGroupArray)
     {
 		memcpy(gp, fk->dpGroupArray, sizeof(FILE_GROUP) * fk->cxGroupArray);
 		delete fk->dpGroupArray;
 	}
-	
+
 	fk->dpGroupArray = gp;
 	gp = &fk->dpGroupArray[fk->cxGroupArray];
 	fk->cxGroupArray++;
@@ -851,7 +851,7 @@ DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p)
 
 	gp->fUsingKeys = FALSE;
 	if(IsSameToken(&p, L"using") && IsSameToken(&p, L"keys")) gp->fUsingKeys = TRUE;
-	
+
 	safe_wcsncpy(gp->szName, q, SZMAX_GROUPNAME);
 
 	if(FSaveDebug)
@@ -894,7 +894,7 @@ WCHAR VKToChar(WORD keyCode, UINT shiftFlags)
 		n = keyCode - '0';
 		return ((shiftFlags & K_SHIFTFLAG) ? shiftedDigit[n] : keyCode);
 	}
-	
+
 	if(keyCode >= 'A' && keyCode <= 'Z')
 	{
 		Shift = (shiftFlags & K_SHIFTFLAG);
@@ -912,7 +912,7 @@ WCHAR VKToChar(WORD keyCode, UINT shiftFlags)
 
 	switch(keyCode)
 	{
-	case VK_ACCENT:	
+	case VK_ACCENT:
 		return Shift ? '~' : '`';
 	case VK_HYPHEN:
 		return Shift ? '_' : '-';
@@ -970,11 +970,11 @@ DWORD ProcessGroupFinish(PFILE_KEYBOARD fk)
 {
 	PFILE_GROUP gp;
 
-	if(fk->currentGroup == 0xFFFFFFFF) return CERR_None; 
+	if(fk->currentGroup == 0xFFFFFFFF) return CERR_None;
 		// Just got to first group - so nothing to finish yet
 
 	gp = &fk->dpGroupArray[fk->currentGroup];
-	
+
 	// Finish off the previous group stuff!
 	qsort(gp->dpKeyArray, gp->cxKeyArray, sizeof(FILE_KEY), cmpkeys);
 
@@ -1007,13 +1007,13 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
 
 	sp = new FILE_STORE[fk->cxStoreArray+1];
 	if(!sp) return CERR_CannotAllocateMemory;
-	
+
 	if(fk->dpStoreArray)
     {
 		memcpy(sp, fk->dpStoreArray, sizeof(FILE_STORE) * fk->cxStoreArray);
 		delete fk->dpStoreArray;
 	}
-	
+
 	fk->dpStoreArray = sp;
 	sp = &fk->dpStoreArray[fk->cxStoreArray];
 
@@ -1028,7 +1028,7 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
   {
     PWCHAR temp = new WCHAR[GLOBAL_BUFSIZE];
 
-	  if((msg = GetXString(fk, p, L"c\n", temp, GLOBAL_BUFSIZE-1, (int)(p-pp), &p, FALSE, TRUE)) != CERR_None)
+	  if((msg = GetXString(fk, p, L"c\n", temp, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(p-pp), &p, FALSE, TRUE)) != CERR_None)
 	  {
 	    delete temp;
 	    return msg;
@@ -1037,11 +1037,11 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
   	sp->dwSystemID = i;
 	  sp->dpString = new WCHAR[wcslen(temp)+1];
 	  wcscpy_s(sp->dpString, wcslen(temp)+1, temp);  // I3481
-	  
+
 	  delete temp;
 	}
 
-	if(xstrlen(sp->dpString) == 1 && *sp->dpString != UC_SENTINEL && 
+	if(xstrlen(sp->dpString) == 1 && *sp->dpString != UC_SENTINEL &&
 		sp->dwSystemID == 0 && (fk->version >= VERSION_60 || fk->version == 0))
 	{
     // In this case, we want to change behaviour for older versioned keyboards so that
@@ -1059,7 +1059,7 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
 
 	fk->cxStoreArray++;	// increment now, because GetXString refers to stores
 
-	if(i > 0) 
+	if(i > 0)
 		if((msg = ProcessSystemStore(fk, i, sp)) != CERR_None) return msg;
 
 	return CERR_None;
@@ -1071,13 +1071,13 @@ DWORD AddStore(PFILE_KEYBOARD fk, DWORD SystemID, PWSTR str, DWORD *dwStoreID)
 
 	sp = new FILE_STORE[fk->cxStoreArray+1];
 	if(!sp) return CERR_CannotAllocateMemory;
-	
+
 	if(fk->dpStoreArray)
 	{
 		memcpy(sp, fk->dpStoreArray, sizeof(FILE_STORE) * fk->cxStoreArray);
 		delete fk->dpStoreArray;
 	}
-  
+
 	fk->dpStoreArray = sp;
 	sp = &fk->dpStoreArray[fk->cxStoreArray];
 
@@ -1111,7 +1111,7 @@ DWORD AddDebugStore(PFILE_KEYBOARD fk, PWSTR str)
 
 	sp = new FILE_STORE[fk->cxStoreArray+1];
 	if(!sp) return CERR_CannotAllocateMemory;
-	
+
 	if(fk->dpStoreArray)
 	{
 		memcpy(sp, fk->dpStoreArray, sizeof(FILE_STORE) * fk->cxStoreArray);
@@ -1146,45 +1146,45 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
 	DWORD msg;
 	PWSTR p, q;
 	char *pp;
-	
+
 	if(!pssBuf) pssBuf = new WCHAR[GLOBAL_BUFSIZE];
 	PWCHAR buf = pssBuf;
 
 	switch(SystemID)
 	{
 	case TSS_BITMAP:
-		if((msg = ImportBitmapFile(fk, sp->dpString, &fk->dwBitmapSize, &fk->lpBitmap)) != CERR_None) 
+		if((msg = ImportBitmapFile(fk, sp->dpString, &fk->dwBitmapSize, &fk->lpBitmap)) != CERR_None)
 			return msg;
 		break;
-	
+
 	case TSS_CALLDEFINITION:
 		break;
-	
+
 	case TSS_CALLDEFINITION_LOADFAILED:
 		break;
-	
+
 	case TSS_CAPSALWAYSOFF:
 		if(*sp->dpString == L'1') fk->dwFlags |= KF_CAPSALWAYSOFF;
 		break;
-	
+
 	case TSS_CAPSONONLY:
 		if(*sp->dpString == L'1') fk->dwFlags |= KF_CAPSONONLY;
 		break;
-	
+
 	case TSS_COMPILEDVERSION:
 		break;
 
 	case TSS_COPYRIGHT:
 		break;
-	
+
 	case TSS_DEBUG_LINE:
 		break;
-	
+
 	case TSS_ETHNOLOGUECODE:
     VERIFY_KEYBOARD_VERSION(fk, VERSION_60, CERR_60FeatureOnly_EthnologueCode);
     if((msg = ProcessEthnologueStore(sp->dpString)) != CERR_None) return msg;  // I2646
 		break;
-	
+
 	case TSS_HOTKEY:
 		if((msg = ProcessHotKey(sp->dpString, &fk->dwHotKey)) != CERR_None) return msg;
 
@@ -1205,7 +1205,7 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
 		delete pp;
     CodeConstants->reindex();   // I4982
 		break;
-	
+
 	case TSS_LANGUAGE:
     {
       wchar_t *context = NULL;
@@ -1222,12 +1222,12 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
       }
       else
   		  j = xatoi(&q);
-  		
+
 	    if(i < 1 || j < 1 || i > 0x3FF || j > 0x3F) return CERR_InvalidLanguageLine;
 		  if(i >= 0x200 || j >= 0x20) AddWarning(CWARN_CustomLanguagesNotSupported);
-		
+
 		  fk->KeyboardID = (DWORD) MAKELANGID(i, j);
-    
+
 		  swprintf(buf, GLOBAL_BUFSIZE, L"%x %x", i, j);  // I3481
 		  delete sp->dpString;
 		  sp->dpString = new WCHAR[wcslen(buf)+1];
@@ -1272,7 +1272,7 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
     if (wcstof(p, NULL) < 5.0) {
       AddWarning(CWARN_OldVersion);
     }
-		
+
 		if(wcsncmp(p, L"3.0", 3) == 0)       fk->version = VERSION_50;   //0x0a0b000n= a.bn
 		else if(wcsncmp(p, L"3.1", 3) == 0)  fk->version = VERSION_50;   //all versions < 5.0
 		else if(wcsncmp(p, L"3.2", 3) == 0)  fk->version = VERSION_50;   //we compile as if
@@ -1345,7 +1345,7 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
 
 		    j = SUBLANGID(n);
 		    i = PRIMARYLANGID(n);
-  		
+
 	      if(i < 1 || j < 1 || i > 0x3FF || j > 0x3F) return CERR_InvalidLanguageLine;
 
         swprintf(r, szQ - (size_t)(r-q), L"x%04.4x ", n);  // I3481
@@ -1394,8 +1394,8 @@ BOOL IsValidKeyboardVersion(WCHAR *dpString) {   // I4140
     while(iswdigit(*dpString)) {
       dpString++;
     }
-    if(*dpString == '.') { 
-      dpString++; 
+    if(*dpString == '.') {
+      dpString++;
       if(!iswdigit(*dpString)) {
         return FALSE;
       }
@@ -1460,7 +1460,7 @@ DWORD CheckStatementOffsets(PFILE_KEYBOARD fk, PFILE_GROUP gp, PWSTR context, PW
 			  for(q = context, i = 1; *q && i < contextOffset; q=incxstr(q), i++);
 
 			  if(*q == 0)	{
-				  if(!gp->fUsingKeys) 
+				  if(!gp->fUsingKeys)
             // no key in the rule, so offset is past end of context
             return CERR_IndexDoesNotPointToAny;
 				  if(i < contextOffset) // I4914
@@ -1470,7 +1470,7 @@ DWORD CheckStatementOffsets(PFILE_KEYBOARD fk, PFILE_GROUP gp, PWSTR context, PW
 			  }
 
 			  // find the any
-			  if(*q != UC_SENTINEL || *(q+1) != CODE_ANY) 
+			  if(*q != UC_SENTINEL || *(q+1) != CODE_ANY)
           return CERR_IndexDoesNotPointToAny;
 
         int anyStore = *(q+2) - 1;
@@ -1511,7 +1511,7 @@ DWORD ProcessKeyLine(PFILE_KEYBOARD fk, PWSTR str, BOOL IsUnicode)
 	PFILE_GROUP gp;
 	PFILE_KEY kp;
   PWCHAR pklIn, pklKey, pklOut;
-	
+
 	pklIn = new WCHAR[GLOBAL_BUFSIZE];    // I2432 - Allocate buffers each line -- slightly slower but safer than keeping a single buffer
 	pklKey = new WCHAR[GLOBAL_BUFSIZE];
 	pklOut = new WCHAR[GLOBAL_BUFSIZE];
@@ -1526,19 +1526,19 @@ DWORD ProcessKeyLine(PFILE_KEYBOARD fk, PWSTR str, BOOL IsUnicode)
 	  pp = str;
 
 	  if(gp->fUsingKeys) {
-		  if((msg = GetXString(fk, str, L"+", pklIn, GLOBAL_BUFSIZE-1, (int)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
+		  if((msg = GetXString(fk, str, L"+", pklIn, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
 
 		  str = p + 1;
-		  if((msg = GetXString(fk, str, L">", pklKey, GLOBAL_BUFSIZE-1, (int)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
+		  if((msg = GetXString(fk, str, L">", pklKey, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
 		  if(pklKey[0] == 0) return CERR_ZeroLengthString;
 		  if(xstrlen(pklKey) > 1) AddWarning(CWARN_KeyBadLength);
 	  } else {
-		  if((msg = GetXString(fk, str, L">", pklIn, GLOBAL_BUFSIZE-1, (int)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
+		  if((msg = GetXString(fk, str, L">", pklIn, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
 		  if(pklIn[0] == 0) return CERR_ZeroLengthString;
 	  }
 
 	  str = p + 1;
-	  if((msg = GetXString(fk, str, L"c\n", pklOut, GLOBAL_BUFSIZE-1, (int)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
+	  if((msg = GetXString(fk, str, L"c\n", pklOut, GLOBAL_BUFSIZE-1, (int)(INT_PTR)(str-pp), &p, TRUE, IsUnicode)) != CERR_None) return msg;
 
 	  if(pklOut[0] == 0) return CERR_ZeroLengthString;
 
@@ -1555,7 +1555,7 @@ DWORD ProcessKeyLine(PFILE_KEYBOARD fk, PWSTR str, BOOL IsUnicode)
 		  memcpy(kp, gp->dpKeyArray, gp->cxKeyArray * sizeof(FILE_KEY));
 		  delete gp->dpKeyArray;
 	  }
-  	
+
 	  gp->dpKeyArray = kp;
 	  kp = &gp->dpKeyArray[gp->cxKeyArray];
 	  gp->cxKeyArray++;
@@ -1629,9 +1629,9 @@ DWORD ExpandKp_ReplaceIndex(PFILE_KEYBOARD fk, PFILE_KEY k, DWORD keyIndex, int 
         {
 			s = &fk->dpStoreArray[*(pIndex+2) - 1];
 			for(i = 0, pStore = s->dpString; i < nAnyIndex; i++, pStore = incxstr(pStore));
-			PWSTR qStore = incxstr(pStore); 
+			PWSTR qStore = incxstr(pStore);
 
-			int w = (int)(qStore - pStore);
+			int w = (int)(INT_PTR)(qStore - pStore);
 			if(w > 4)
 			{
 				*pIndex = UC_SENTINEL;
@@ -1668,7 +1668,7 @@ DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, DWORD storeIndex)
 	keyIndex = xstrlen(dpContext) + 1;
 
 	/*
-	 Now we change them to plain characters in the output in multiple rules, 
+	 Now we change them to plain characters in the output in multiple rules,
 	 and set the keystroke to the appropriate character in the store.
 	*/
 
@@ -1676,7 +1676,7 @@ DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, DWORD storeIndex)
 	if(!k) return CERR_CannotAllocateMemory;
 	memcpy(k, gp->dpKeyArray, gp->cxKeyArray * sizeof(FILE_KEY));
 
-	kpp = &k[(int)(kpp - gp->dpKeyArray)];
+	kpp = &k[(INT_PTR)(kpp - gp->dpKeyArray)];
 
 	delete gp->dpKeyArray;
 	gp->dpKeyArray = k;
@@ -1767,7 +1767,7 @@ LinePrefixType GetLinePrefixType(PWSTR *p)
   while(iswspace(*s)) s++;
 
   PWSTR q = s;
-	
+
 	if(*s != '$') return lptNone;
 
   /* I1569 - fix named constants at the start of the line */
@@ -1837,7 +1837,7 @@ int LineTokenType(PWSTR *str)
 	return T_UNKNOWN;
 }
 
-const PWSTR DeadKeyChars = 
+const PWSTR DeadKeyChars =
 	L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
 BOOL strvalidchrs(PWSTR q, PWSTR chrs)
@@ -1856,14 +1856,14 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 	BOOL finished = FALSE;
 	WCHAR c;
 	PSTR codename;
-	
+
   PWCHAR tstr = NULL;
   int tstrMax = 0;
 
   tstr = new WCHAR[max];    // I2432 - Allocate buffers each line -- slightly slower but safer than keeping a single buffer - GetXString is re-entrant with if()
   tstrMax = max;
 
-  __try 
+  __try
   {
     *tstr = 0;
 
@@ -1876,7 +1876,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 		  while(iswspace(*p) && !wcschr(token, *p)) p++;
 		  if(!*p) break;
 
-		  ErrChr = (int)(p - str) + offset + 1;
+		  ErrChr = (int)(INT_PTR)(p - str) + offset + 1;
 
   /*
   char *tokenTypes[] = {
@@ -1948,20 +1948,20 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 		  case 1:
 			  q = wcschr(p+1, '\"');
 			  if(!q) return CERR_UnterminatedString;
-			  if((int)(q-p) - 1 + mx > max) return CERR_UnterminatedString;
+			  if((INT_PTR)(q-p) - 1 + mx > max) return CERR_UnterminatedString;
 			  if(sFlag) return CERR_StringInVirtualKeySection;
-		      wcsncat_s(tstr, max, p+1, (int)(q-p)-1);  // I3481
-			  mx += (int)(q-p)-1;
+		      wcsncat_s(tstr, max, p+1, (INT_PTR)(q-p)-1);  // I3481
+			  mx += (int)(INT_PTR)(q-p)-1;
 			  tstr[mx] = 0;
 			  p = q+1;
 			  continue;
 		  case 2:
 			  q = wcschr(p+1, '\'');
 			  if(!q) return CERR_UnterminatedString;
-			  if((int)(q-p) - 1 + mx > max) return CERR_UnterminatedString;
+			  if((INT_PTR)(q-p) - 1 + mx > max) return CERR_UnterminatedString;
 			  if(sFlag) return CERR_StringInVirtualKeySection;
-			  wcsncat_s(tstr, max, p+1, (int)(q-p)-1);  // I3481
-			  mx += (int)(q-p)-1;
+			  wcsncat_s(tstr, max, p+1, (INT_PTR)(q-p)-1);  // I3481
+			  mx += (int)(INT_PTR)(q-p)-1;
 			  tstr[mx] = 0;
 			  p = q+1;
 			  continue;
@@ -1977,7 +1977,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 				  if(_wcsicmp(q, fk->dpStoreArray[i].szName) == 0) break;
 			  }
 			  if(i == fk->cxStoreArray) return CERR_StoreDoesNotExist;
-  			
+
 			  if(!*fk->dpStoreArray[i].dpString) return CERR_ZeroLengthString;
         CheckStoreUsage(fk, i, TRUE, FALSE, FALSE);
 
@@ -2066,7 +2066,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 				  if(_wcsicmp(q, fk->dpStoreArray[i].szName) == 0) break;
 			  }
 			  if(i == fk->cxStoreArray) return CERR_StoreDoesNotExist;
-  			
+
         CheckStoreUsage(fk, i, TRUE, FALSE, FALSE);
 
 			  for(q = fk->dpStoreArray[i].dpString; *q; q++)
@@ -2276,7 +2276,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
         // version to 10.0. This makes an assumption that if we are using these features in a keyboard and it has no version specified, that we want to use the features
         // in the web target platform, even if there are platform() rules excluding this possibility. In that (rare) situation, the keyboard developer should simply specify
         // the &version to be 9.0 or whatever to avoid this behaviour.
-        if (sFlag & (LCTRLFLAG | LALTFLAG | RCTRLFLAG | RALTFLAG | CAPITALFLAG | NOTCAPITALFLAG | NUMLOCKFLAG | NOTNUMLOCKFLAG | SCROLLFLAG | NOTSCROLLFLAG) && 
+        if (sFlag & (LCTRLFLAG | LALTFLAG | RCTRLFLAG | RALTFLAG | CAPITALFLAG | NOTCAPITALFLAG | NUMLOCKFLAG | NOTNUMLOCKFLAG | SCROLLFLAG | NOTSCROLLFLAG) &&
             CompileTarget == CKF_KEYMANWEB &&
             fk->dwFlags & KF_AUTOMATICVERSION) {
           VERIFY_KEYBOARD_VERSION(fk, VERSION_100, 0);
@@ -2310,11 +2310,11 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 					  q++;
 					  while(iswspace(*q)) q++;
 					  if(*q != ']') return CERR_InvalidToken;
-					  break; /* out of while loop */ 
+					  break; /* out of while loop */
 				  }
-  	
+
 				  for(j = 0; !iswspace(*q) && *q != ']' && *q != 0; q++, j++);
-  			
+
 				  if(*q == 0) return CERR_InvalidToken;
 
           WCHAR vkname[SZMAX_VKDICTIONARYNAME];  // I3438
@@ -2349,7 +2349,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
           tstr[mx++] = (int)i;
 
 					if(FMnemonicLayout && (i <= VK__MAX) && VKeyMayBeVCKey[i]) AddWarning(CWARN_VirtualKeyWithMnemonicLayout);  // I3438
-  
+
 				  while(iswspace(*q)) q++;
 			  }
 			  tstr[mx++] = UC_SENTINEL_EXTENDEDEND;
@@ -2468,7 +2468,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
 		  ErrChr = 0;
       return CERR_None;
     }
-  
+
   }
   __finally
   {
@@ -2517,7 +2517,7 @@ DWORD process_if_synonym(DWORD dwSystemID, PFILE_KEYBOARD fk, LPWSTR q, LPWSTR t
   tstr[(*mx)++] = UC_SENTINEL;
   tstr[(*mx)++] = (WCHAR) CODE_IFSYSTEMSTORE;
   tstr[(*mx)++] = (WCHAR)(dwSystemID+1);   // I4785
-  tstr[(*mx)++] = 2; 
+  tstr[(*mx)++] = 2;
   tstr[(*mx)++] = (WCHAR)(dwStoreID+1);
   tstr[(*mx)] = 0;
 
@@ -2534,12 +2534,12 @@ DWORD process_if(PFILE_KEYBOARD fk, LPWSTR q, LPWSTR tstr, int *mx)  // I3431
   while(*s && *s != L' ' && *s != L'!' && *s != L'=') s++;
   r = s;
   while(*s == L' ') s++;
-  if(*s == L'!') 
+  if(*s == L'!')
   {
     s++;
     not = TRUE;
   }
-    
+
   if(*s != '=') return CERR_InvalidIf;
   s++;
   while(*s == ' ') s++;
@@ -2589,7 +2589,7 @@ DWORD process_if(PFILE_KEYBOARD fk, LPWSTR q, LPWSTR tstr, int *mx)  // I3431
   tstr[(*mx)++] = UC_SENTINEL;
   tstr[(*mx)++] = (WCHAR) code;
   tstr[(*mx)++] = (WCHAR)(i+1);
-  tstr[(*mx)++] = not ? 1 : 2; 
+  tstr[(*mx)++] = not ? 1 : 2;
   tstr[(*mx)++] = (WCHAR)(dwStoreID+1);
   tstr[(*mx)] = 0;
 
@@ -2777,8 +2777,8 @@ DWORD ProcessEthnologueStore(PWSTR p) // I2646
   while(*p)
   {
     while(wcschr(L" ,;", *p))
-    { 
-      if(*p != ' ') res = CWARN_PunctuationInEthnologueCode; 
+    {
+      if(*p != ' ') res = CWARN_PunctuationInEthnologueCode;
       p++;
     }
     if(q == p) return CERR_InvalidEthnologueCode;
@@ -2834,8 +2834,8 @@ DWORD ProcessHotKey(PWSTR p, DWORD *hk)
         {
 			while(iswspace(*q)) q++;
 
-			if(_wcsnicmp(q, L"ALT", 3) == 0) sFlag |= HK_ALT, q += 3; 
-			else if(_wcsnicmp(q, L"CTRL", 4) == 0) sFlag |= HK_CTRL, q += 4; 
+			if(_wcsnicmp(q, L"ALT", 3) == 0) sFlag |= HK_ALT, q += 3;
+			else if(_wcsnicmp(q, L"CTRL", 4) == 0) sFlag |= HK_CTRL, q += 4;
 			else if(_wcsnicmp(q, L"SHIFT", 5) == 0) sFlag |= HK_SHIFT, q += 5;
 			else if(towupper(*q) != 'K') return CERR_InvalidToken;
 		} while(towupper(*q) != 'K');
@@ -2849,11 +2849,11 @@ DWORD ProcessHotKey(PWSTR p, DWORD *hk)
 		}
 		else return CERR_NoTokensFound;
 
-		j = (int) (r-q);
+		j = (int)(INT_PTR) (r-q);
 
 		for(i = 0; i <= VK__MAX; i++)  // I3438
 			if( j == (int)wcslen(VKeyNames[i]) && _wcsnicmp(q, VKeyNames[i], j) == 0) break;
-		
+
 		if(i == VK__MAX + 1) return CERR_InvalidToken;  // I3438
 
 		*hk = i | sFlag;
@@ -2925,11 +2925,11 @@ DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, HANDLE hOutfile)
 
 	// Calculate how much memory to allocate
 
-	size = sizeof(COMP_KEYBOARD) + 
-			fk->cxGroupArray * sizeof(COMP_GROUP) +  
+	size = sizeof(COMP_KEYBOARD) +
+			fk->cxGroupArray * sizeof(COMP_GROUP) +
 			fk->cxStoreArray * sizeof(COMP_STORE) +
-			/*wcslen(fk->szName)*2 + 2 + 
-			wcslen(fk->szCopyright)*2 + 2 + 
+			/*wcslen(fk->szName)*2 + 2 +
+			wcslen(fk->szCopyright)*2 + 2 +
 			wcslen(fk->szLanguageName)*2 + 2 +
 			wcslen(fk->szMessage)*2 + 2 +*/
 			fk->dwBitmapSize;
@@ -2943,7 +2943,7 @@ DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, HANDLE hOutfile)
 			size += wcslen(fkp->dpOutput)*2 + 2;
 			size += wcslen(fkp->dpContext)*2 + 2;
 		}
-		
+
 		if( fgp->dpMatch ) size += wcslen(fgp->dpMatch)*2 + 2;
 		if( fgp->dpNoMatch ) size += wcslen(fgp->dpNoMatch)*2 + 2;
 	}
@@ -2970,7 +2970,7 @@ DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, HANDLE hOutfile)
 	ck->StartGroup[0] = fk->StartGroup[0];
 	ck->StartGroup[1] = fk->StartGroup[1];
 	ck->dwHotKey = fk->dwHotKey;
-	
+
 	ck->dwFlags = fk->dwFlags;
 
 	offset = sizeof(COMP_KEYBOARD);
@@ -3098,7 +3098,7 @@ DWORD ReadLine(HANDLE hInfile, PWSTR wstr, BOOL PreProcess)
 	if(SetFilePointer(hInfile, 0, NULL, FILE_CURRENT) == GetFileSize(hInfile, NULL))
 		// Always a "\r\n" to the EOF, avoids funny bugs
 		wcscat_s(str, _countof(str), L"\r\n");  // I3481
-	
+
 	if(len == 0) return CERR_EndOfFile;
 
 	for(p = str, n = 0; n < len; n++, p++)
@@ -3106,7 +3106,7 @@ DWORD ReadLine(HANDLE hInfile, PWSTR wstr, BOOL PreProcess)
 		if(currentQuotes != 0)
     {
 			if( *p == L'\n' )
-      { 
+      {
         *p = 0;  // I2525
          wcscpy_s(wstr, LINESIZE, str);  // I3481
          return (PreProcess ? CERR_None : CERR_UnterminatedString);
@@ -3124,9 +3124,9 @@ DWORD ReadLine(HANDLE hInfile, PWSTR wstr, BOOL PreProcess)
 			*p = L' ';
 			continue;
 		}
-		if( LineCarry ) 
+		if( LineCarry )
 		{
-			switch( *p ) 
+			switch( *p )
 			{
 			case L' ':
 			case L'\t':
@@ -3175,7 +3175,7 @@ DWORD ReadLine(HANDLE hInfile, PWSTR wstr, BOOL PreProcess)
 
 	if( *p == L'\n' ) currentLine++;
 
-	SetFilePointer(hInfile, -(int)(len*2 - (DWORD)(p-str)*2 - 2), NULL, FILE_CURRENT);
+	SetFilePointer(hInfile, -(int)(len*2 - (INT_PTR)(p-str)*2 - 2), NULL, FILE_CURRENT);
 
 	p--;
 	while(p >= str && iswspace(*p)) p--;
@@ -3419,10 +3419,10 @@ BOOL IsValidCallStore(PFILE_STORE fs)
 	PWSTR p;
 	for(i = 0, p = fs->dpString; *p; p++)
 		if(*p == ':') i++;
-		else if(!((*p >= 'a' && *p <= 'z') || 
-				  (*p >= 'A' && *p <= 'Z') || 
-				  (*p >= '0' && *p <= '9') || 
-				  *p == '.' || 
+		else if(!((*p >= 'a' && *p <= 'z') ||
+				  (*p >= 'A' && *p <= 'Z') ||
+				  (*p >= '0' && *p <= '9') ||
+				  *p == '.' ||
 				  *p == '_'))
 			return FALSE;
 
@@ -3434,7 +3434,7 @@ HANDLE CreateTempFile()
 	char szTempPathBuffer[MAX_PATH], szTempFileName[MAX_PATH];   // I3228   // I3510
   if(!GetTempPath(MAX_PATH, szTempPathBuffer)) return INVALID_HANDLE_VALUE;
 	if(!GetTempFileName(szTempPathBuffer, "kmx", 0, szTempFileName)) return INVALID_HANDLE_VALUE;     // I3228   // I3510
-	return CreateFile(szTempFileName, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 
+	return CreateFile(szTempFileName, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
 	FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
 }
 
@@ -3467,18 +3467,18 @@ HANDLE UTF16TempFromUTF8(HANDLE hInfile, BOOL hasPreamble)
     p = buf;
     poutbuf = outbuf;
     if (hasPreamble) {
-      // We have a preamble, so we attempt to read as UTF-8 and allow conversion errors to be filtered. This is not great for a 
+      // We have a preamble, so we attempt to read as UTF-8 and allow conversion errors to be filtered. This is not great for a
       // compiler but matches existing behaviour -- in future versions we may not do lenient conversion.
       ConversionResult cr = ConvertUTF8toUTF16(&p, &buf[len2], (UTF16 **)&poutbuf, (const UTF16 *)&outbuf[len], lenientConversion);
-      WriteFile(hOutfile, outbuf, (int)(poutbuf - outbuf) * 2, &len2, NULL);
+      WriteFile(hOutfile, outbuf, (DWORD)(INT_PTR)(poutbuf - outbuf) * 2, &len2, NULL);
     }
     else {
       // No preamble, so we attempt to read as strict UTF-8 and fall back to ANSI if that fails
       ConversionResult cr = ConvertUTF8toUTF16(&p, &buf[len2], (UTF16 **)&poutbuf, (const UTF16 *)&outbuf[len], strictConversion);
       if (cr == sourceIllegal) {
         // Not a valid UTF-8 file, so fall back to ANSI
-        //AddCompileMessage(CINFO_NonUnicodeFile); 
-        // note, while this message is defined, for now we will not emit it 
+        //AddCompileMessage(CINFO_NonUnicodeFile);
+        // note, while this message is defined, for now we will not emit it
         // because we don't support HINT/INFO messages yet and we don't want
         // this to cause a blocking compile at this stage
         poutbuf = strtowstr((PSTR)buf);
@@ -3486,7 +3486,7 @@ HANDLE UTF16TempFromUTF8(HANDLE hInfile, BOOL hasPreamble)
         delete poutbuf;
       }
       else {
-        WriteFile(hOutfile, outbuf, (int)(poutbuf - outbuf) * 2, &len2, NULL);
+        WriteFile(hOutfile, outbuf, (DWORD)(INT_PTR)(poutbuf - outbuf) * 2, &len2, NULL);
       }
     }
   }

--- a/windows/src/developer/kmdecomp/kmdecomp.cpp
+++ b/windows/src/developer/kmdecomp/kmdecomp.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmdecomp
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      12 Oct 2012
 
   Modified Date:    12 Oct 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          12 Oct 2012 - mcdurdin - I3467 - V9.0 - Upgrade KMDECOMP to compile with KM9 source tree
 */
 
@@ -71,7 +71,7 @@ int run(int argc, char *argv[])
 	_makepath_s(buf2, _MAX_PATH, drive, dir, filename, ".bmp");
 
 	int n = SaveKeyboardSource(kbd, lpBitmap, cbBitmap, buf, buf2);
-	
+
 	if(lpBitmap) delete lpBitmap;
 
 	delete kbd;
@@ -137,29 +137,29 @@ BOOL LoadKeyboard(LPSTR fileName, LPKEYBOARD *lpKeyboard, LPBYTE *lpBitmap, DWOR
 
 	if(kbp->dwIdentifier != FILEID_COMPILED) { delete buf; Err("errNotFileID"); return FALSE; }
 
-	/* Check file version */ 
+	/* Check file version */
 
-	if(ckbp->dwFileVersion < VERSION_MIN || 
-	   ckbp->dwFileVersion > VERSION_MAX) 
-	{ 
-		/* Old or new version -- identify the desired program version */ 
-		if(VerifyChecksum(buf, &kbp->dwCheckSum, sz)) 
-		{ 
+	if(ckbp->dwFileVersion < VERSION_MIN ||
+	   ckbp->dwFileVersion > VERSION_MAX)
+	{
+		/* Old or new version -- identify the desired program version */
+		if(VerifyChecksum(buf, &kbp->dwCheckSum, sz))
+		{
 			kbp->dpStoreArray = (LPSTORE) (buf + ckbp->dpStoreArray);
 			for(sp = kbp->dpStoreArray, i = 0; i < kbp->cxStoreArray; i++, sp++)
 				if(sp->dwSystemID == TSS_COMPILEDVERSION)
 				{
 					char buf2[256];
-					wsprintf(buf2, "Wrong File Version: file version is %ls", ((PBYTE)kbp) + (DWORD)sp->dpString);
+					wsprintf(buf2, "Wrong File Version: file version is %ls", ((PBYTE)kbp) + (INT_PTR)sp->dpString);
 					delete buf;
 					Err(buf2);
 					return FALSE;
 				}
 		}
 		delete buf; Err("Unknown File Version: try using the latest version of KMDECOMP");
-		return FALSE; 
+		return FALSE;
 	}
-	
+
 	if(!VerifyChecksum(buf, &kbp->dwCheckSum, sz)) { delete buf; Err("Bad Checksum in file"); return FALSE; }
 
 	kbp->dpStoreArray = (LPSTORE) (buf + ckbp->dpStoreArray);
@@ -169,7 +169,7 @@ BOOL LoadKeyboard(LPSTR fileName, LPKEYBOARD *lpKeyboard, LPBYTE *lpBitmap, DWOR
 	//kbp->dpCopyright = (PWSTR) (buf + ckbp->dpCopyright);
 	//kbp->dpMessage = (PWSTR) (buf + ckbp->dpMessage);
 	//kbp->dpLanguageName = (PWSTR) (buf + ckbp->dpLanguageName);
-		
+
 	if(ckbp->dwBitmapSize > 0)
 	{
 	  *lpBitmap = new BYTE[ckbp->dwBitmapSize];

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             aiTIP
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      19 Jun 2007
 
   Modified Date:    23 Feb 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          19 Jun 2007 - mcdurdin - I890 - Fix deadkeys in TSF
                     13 Jul 2007 - mcdurdin - I934 - Prep for x64
                     27 Jan 2009 - mcdurdin - I1797 - Add fallback for AIWin2000 app integration
@@ -98,7 +98,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateEx(BOOL FActivate) {  //
 void ProcessToggleChange(UINT key) {   // I4793
   UINT flag = 0;
 
-  switch(key) {  
+  switch(key) {
     case VK_CAPITAL: flag = CAPITALFLAG; break;
     case VK_NUMLOCK: flag = NUMLOCKFLAG; break;
     default: return;
@@ -156,7 +156,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
 		  return FALSE;
 	  }
   }
-	  
+
   DWORD LocalShiftState = Globals::get_ShiftState();
 
   if(!Preserved) {
@@ -164,14 +164,14 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
     case VK_CAPITAL:
       if(!isUp) ProcessToggleChange((UINT) wParam);   // I4793
       if (!Updateable) {
-        // We only want to process the Caps Lock key event once -- 
+        // We only want to process the Caps Lock key event once --
         // in the first pass (!Updateable).
         KeyCapsLockPress(isUp);   // I4548
       }
       return FALSE;
     case VK_SHIFT:
       if (!Updateable) {
-        // We only want to process the Shift key event once -- 
+        // We only want to process the Shift key event once --
         // in the first pass (!Updateable).
         KeyShiftPress(isUp);   // I4548
       }
@@ -193,7 +193,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
     SendDebugMessageFormat(0, sdmGlobal, 0, "TIPProcessKey: TSFShiftToShift start with %x, include %x", LocalShiftState, NewShiftState);
     *Globals::ShiftState() = (LocalShiftState & K_NOTMODIFIERFLAG) | NewShiftState;   // I3588
   }
-	
+
 	_td->TIPFUpdateable = Updateable;
   _td->TIPFPreserved = Preserved;   // I4290
 
@@ -276,7 +276,7 @@ BOOL AITIP::CanHandleWindow(HWND ahwnd) {
   return TRUE;   // I3574
 }
 
-BOOL AITIP::HandleWindow(HWND ahwnd) { 
+BOOL AITIP::HandleWindow(HWND ahwnd) {
   FIsDebugControlWindow = IsDebugControlWindow(ahwnd);
   return AIWin2000Unicode::HandleWindow(ahwnd);   // I3574
 }
@@ -285,7 +285,7 @@ BOOL AITIP::IsWindowHandled(HWND ahwnd) {
   return AIWin2000Unicode::IsWindowHandled(ahwnd);   // I3574
 }
 
-BOOL AITIP::IsUnicode() { 
+BOOL AITIP::IsUnicode() {
 	return TRUE;
 }
 
@@ -337,7 +337,7 @@ void AITIP::MergeContextWithCache(PWSTR buf, AppContext *local_context) {   // I
   SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::MergeContextWithCache TIP:'%s' Context:'%s' DKContext:'%s'",
       mc1, mc2, mc3);
 
-  delete mc1; 
+  delete mc1;
   delete mc2;
   delete mc3;
 #endif
@@ -371,7 +371,7 @@ void AITIP::ReadContext() {
       SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::ReadContext: full context [Updateable=%d] %s", _td->TIPFUpdateable, Debug_UnicodeString(buf));
     }
     useLegacy = FALSE;   // I3575
-		
+
     // If the text content of the context is identical, inject the deadkeys
     // Otherwise, reset the cachedContext to match buf, no deadkeys
 
@@ -390,7 +390,7 @@ void AITIP::ReadContext() {
 
 AppContextWithStores::AppContextWithStores(int nKeyboardOptions) : AppContext() {   // I4978
   this->nKeyboardOptions = nKeyboardOptions;
-  KeyboardOptions = new INTKEYBOARDOPTIONS[nKeyboardOptions]; 
+  KeyboardOptions = new INTKEYBOARDOPTIONS[nKeyboardOptions];
   memset(KeyboardOptions, 0, sizeof(INTKEYBOARDOPTIONS) * nKeyboardOptions);
 }
 
@@ -518,7 +518,7 @@ BOOL AITIP::PostKeys() {
 
   int bk=0;
 	WCHAR *OutBuf = new WCHAR[QueueSize+1], *p = OutBuf;   // I4272
-	
+
   *OutBuf = 0;
 
 	for(int n = 0; n < QueueSize; n++) {
@@ -542,8 +542,8 @@ BOOL AITIP::PostKeys() {
 	}
 
 	if(_td->TIPProcessOutput && (bk > 0 || OutBuf[0])) {
-  	SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::PostKeys: output bk=%d outcount=%d", bk, (int)(p-OutBuf));
-		(*_td->TIPProcessOutput)(bk, OutBuf, (int)(p - OutBuf));
+  	SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::PostKeys: output bk=%d outcount=%d", bk, (INT_PTR)(p-OutBuf));
+		(*_td->TIPProcessOutput)(bk, OutBuf, (int)(INT_PTR)(p - OutBuf));
   } else {
     SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::PostKeys: no output");
   }
@@ -671,7 +671,7 @@ BOOL AITIP::QueueDebugInformation(int ItemType, LPGROUP Group, LPKEY Rule, PWSTR
 	di.Group = Group;			// LPGROUP
 	di.Output = foutput;		// PWSTR
 	di.Flags = dwExtraFlags;	// DWORD
-	
+
 	if(di.Rule) FillStoreOffsets(&di);
 
 	// data required

--- a/windows/src/engine/keyman32/appint/appint.cpp
+++ b/windows/src/engine/keyman32/appint/appint.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             appint
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      5 Nov 2007
 
   Modified Date:    23 Jun 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          05 Nov 2007 - mcdurdin - I1129 - Fix irregular behaviour with context rules in debugger
                     27 Jan 2009 - mcdurdin - I1797 - Add fallback for AIWin2000 app integration
                     11 Dec 2009 - mcdurdin - I934 - x64 - Initial version
@@ -75,9 +75,9 @@ WCHAR *AppContext::BufMax(int n)  // Used only by IMX DLLs
 	if(CurContext == p || n == 0) return p; /* empty context or 0 characters requested, return pointer to end of context */  // I3091
 
   WCHAR *q = p;  // I3091
-	for(; p > CurContext && (int)(q-p) < n; p = decxstr(p, CurContext));  // I3091
+	for(; p > CurContext && (INT_PTR)(q-p) < n; p = decxstr(p, CurContext));  // I3091
 
-  if((int)(q-p) > n) p = incxstr(p); /* Copes with deadkey or supplementary pair at start of returned buffer making it too long */  // I3091
+  if((INT_PTR)(q-p) > n) p = incxstr(p); /* Copes with deadkey or supplementary pair at start of returned buffer making it too long */  // I3091
 
   return p;  // I3091
 }
@@ -112,9 +112,9 @@ void AppContext::Get(WCHAR *buf, int bufsize)
 		*buf = *p; buf++;
 		if(*p >= 0xD800 && *p <= 0xDBFF) { *buf = *(++p); bufsize--; buf++; }
 	}
-	//wcsncpy(buf, CurContext, bufsize); 
+	//wcsncpy(buf, CurContext, bufsize);
 	*buf = 0;
-	//buf[bufsize-1] = 0; 
+	//buf[bufsize-1] = 0;
 }
 
 void AppContext::CopyFrom(AppContext *source)   // I3575
@@ -129,21 +129,21 @@ void AppContext::Set(const WCHAR *buf)
 {
 	const WCHAR *p;
 	WCHAR *q;
-	for(p = buf, q = CurContext; *p && (int)(q-CurContext) < MAXCONTEXT - 1; p++, q++)
+	for(p = buf, q = CurContext; *p && (INT_PTR)(q-CurContext) < MAXCONTEXT - 1; p++, q++)
 	{
 		*q = *p;
 		if(*p >= 0xD800 && *p <= 0xDBFF) { *(++q) = *(++p); }
 	}
 	*q = 0;
-  pos = (int)(q-CurContext);  // I1129 - Irregular behaviour with context rules
-	CurContext[MAXCONTEXT-1] = 0; 
+  pos = (int)(INT_PTR)(q-CurContext);  // I1129 - Irregular behaviour with context rules
+	CurContext[MAXCONTEXT-1] = 0;
 }
 
 BOOL AppContext::CharIsDeadkey()
 {
 	if(pos < 3) // code_sentinel, deadkey, #, 0
 		return FALSE;
-	return CurContext[pos-3] == UC_SENTINEL && 
+	return CurContext[pos-3] == UC_SENTINEL &&
 		   CurContext[pos-2] == CODE_DEADKEY;
 }
 
@@ -159,7 +159,7 @@ BOOL AppContext::CharIsSurrogatePair()
 /* AppActionQueue */
 
 AppActionQueue::AppActionQueue()
-{ 
+{
 	ResetQueue();
 }
 

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmprocess
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      14 Sep 2006
 
   Modified Date:    28 Mar 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          14 Sep 2006 - mcdurdin - Remove NoSetShift flag
                     04 Jan 2007 - mcdurdin - Add CODE_NOTANY
                     22 Jan 2007 - mcdurdin - Fix for K_NPENTER
@@ -128,7 +128,7 @@ BOOL ProcessHook()
       SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, "Key pressed: %s Context '%s'",
         Debug_VirtualKey(_td->state.vkey), getcontext_debug());
     }
-	
+
 		AIDEBUGKEYINFO keyinfo;
 		keyinfo.shiftFlags = Globals::get_ShiftState();
 		keyinfo.VirtualKey = _td->state.vkey;
@@ -228,7 +228,7 @@ BOOL ProcessGroup(LPGROUP gp)
 	for(i = 0; i < _td->state.lpkb->cxGroupArray; i++)
 		if(gp == &_td->state.lpkb->dpGroupArray[i])
 		{
-			if(_td->state.msg.message == wm_keymankeydown && ShouldDebug(sdmKeyboard)) 
+			if(_td->state.msg.message == wm_keymankeydown && ShouldDebug(sdmKeyboard))
 				SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, "Entering group %d of %d, context '%s'", i+1, _td->state.lpkb->cxGroupArray, getcontext_debug());
 			sdmfI = i;
 			break;
@@ -258,7 +258,7 @@ BOOL ProcessGroup(LPGROUP gp)
 	*/
 
   if(ShouldDebug(sdmKeyboard))
-	  SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, "state.vkey: %s shiftFlags: %x; charCode: %X", 
+	  SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, "state.vkey: %s shiftFlags: %x; charCode: %X",
       Debug_VirtualKey(_td->state.vkey), Globals::get_ShiftState(), _td->state.charCode);   // I4582
 
 	if(gp)
@@ -270,12 +270,12 @@ BOOL ProcessGroup(LPGROUP gp)
 			{
 				if(kkp->dpContext[0] != 0) break; else continue;
 			}
-	
+
 			//if(kkp->Key == state.vkey)
-			//SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard, 0, "kkp->Key: %d kkp->ShiftFlags: %x", 
+			//SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard, 0, "kkp->Key: %d kkp->ShiftFlags: %x",
 			//	kkp->Key, kkp->ShiftFlags);
 
-			/* Keyman 6.0: support Virtual Characters */ 
+			/* Keyman 6.0: support Virtual Characters */
 			if(IsEquivalentShift(kkp->ShiftFlags, Globals::get_ShiftState()))
 			{
         if(kkp->Key > VK__MAX && kkp->Key == _td->state.vkey) break;	// I3438   // I4582
@@ -298,7 +298,7 @@ BOOL ProcessGroup(LPGROUP gp)
 		 Context is not kept for virtual keys being output.
 		*/
 
-		if(_td->state.msg.message == wm_keymankeydown && ShouldDebug(sdmKeyboard)) SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, 
+		if(_td->state.msg.message == wm_keymankeydown && ShouldDebug(sdmKeyboard)) SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0,
 			"No match was found in group %d of %d", sdmfI, _td->state.lpkb->cxGroupArray);
 
 		if(!gp || (_td->state.charCode == 0 && gp->fUsingKeys))   // I4585
@@ -307,7 +307,7 @@ BOOL ProcessGroup(LPGROUP gp)
       BOOL fIsBackspace = _td->state.vkey == VK_BACK && (Globals::get_ShiftState() & (LCTRLFLAG|RCTRLFLAG|LALTFLAG|RALTFLAG)) == 0;   // I4128
 
       if(/*_td->app->DebugControlled() &&*/ fIsBackspace) {   // I4838   // I4933
-        	//if(_td->state.msg.message == wm_keymankeydown) 
+        	//if(_td->state.msg.message == wm_keymankeydown)
 				  //	_td->app->QueueAction(QIT_BACK, BK_BACKSPACE);
 				if(_td->state.msg.message == wm_keymankeydown) {   // I4933
           if(!_td->app->IsLegacy()) {   // I4933
@@ -383,14 +383,14 @@ BOOL ProcessGroup(LPGROUP gp)
 		}
 		else if (gp->dpNoMatch != NULL && *gp->dpNoMatch != 0 && _td->state.msg.message != wm_keymankeyup)
 		{
-			/* NoMatch rule found, and is a character key */ 
+			/* NoMatch rule found, and is a character key */
 			_td->app->QueueDebugInformation(QID_NOMATCH_ENTER, gp, NULL, NULL, gp->dpNoMatch, 0);
 			PostString(gp->dpNoMatch, &_td->state.msg, _td->state.lpkb, NULL);
 			_td->app->QueueDebugInformation(QID_NOMATCH_EXIT, gp, NULL, NULL, gp->dpNoMatch, 0);
 		}
 		else if (_td->state.charCode != 0 && _td->state.charCode != 0xFFFF && _td->state.msg.message != wm_keymankeyup && gp->fUsingKeys)
 		{
-			/* No rule found, is a character key */ 
+			/* No rule found, is a character key */
 			// 7.0.239.0: I994 - Workaround output order issues - we will use the TSF to output all characters...
 			// if(app->Type1() == AIType_TIP) { fOutputKeystroke = TRUE; return FALSE; } // Don't swallow keystroke
 
@@ -448,7 +448,7 @@ BOOL ProcessGroup(LPGROUP gp)
 			    case CODE_DEADKEY: _td->app->QueueAction(QIT_BACK, BK_DEADKEY); break;
 					case CODE_NUL: break;	// 11 Aug 2003 - I25(v6) - mcdurdin - CODE_NUL context support
         }
-      else 
+      else
 			{
 				_td->app->QueueAction(QIT_BACK, 0);
 			}
@@ -478,7 +478,7 @@ BOOL ProcessGroup(LPGROUP gp)
 }
 
 /*
-*	int PostString( LPSTR str, BOOL *useMode, LPMSG mp, 
+*	int PostString( LPSTR str, BOOL *useMode, LPMSG mp,
 *	LPKEYBOARD lpkb );
 *
 *	Parameters:	str		Pointer to string to send
@@ -513,7 +513,7 @@ int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr)
             {
 		    case CODE_EXTENDED:				// Start of a virtual key section w/shift codes
 			    p++;
-				
+
 				shift = *p; //(*p<<8) | *(p+1);
 				_td->app->QueueAction(QIT_VSHIFTDOWN, shift);
 
@@ -523,7 +523,7 @@ int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr)
 				_td->app->QueueAction(QIT_VKEYUP, *p);
 
 				_td->app->QueueAction(QIT_VSHIFTUP, shift);
-				
+
 				p++; // CODE_EXTENDEDEND
 				////// CODE_EXTENDEDEND will be incremented by loop
 
@@ -561,7 +561,7 @@ int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr)
 				CallDLL(_td->lpActiveKeyboard, *p-1);
 			    if(_td->state.StopOutput) return psrPostMessages;
 				FoundUse = TRUE;
-				break; 
+				break;
 			case CODE_USE:					// use another group
 			  p++;
 			  ProcessGroup(&lpkb->dpGroupArray[*p-1]);
@@ -676,7 +676,7 @@ BOOL ContextMatch(LPKEY kkp)
   if(!_td) return FALSE;
 
 	memset(_td->IndexStack, 0, GLOBAL_ContextStackSize*sizeof(WORD));  // I3158   // I3524
-	
+
 	p = kkp->dpContext;
 
 	if(*p == 0)
@@ -701,7 +701,7 @@ BOOL ContextMatch(LPKEY kkp)
     {
     	s = &_td->lpActiveKeyboard->Keyboard->dpStoreArray[(*(pp+2))-1];  // I2590
       t = &_td->lpActiveKeyboard->Keyboard->dpStoreArray[(*(pp+4))-1];  // I2590
-      
+
       bEqual = wcscmp(s->dpString, t->dpString) == 0;
       if(*(pp+3) == 1 && bEqual) return FALSE;  // I2590
       if(*(pp+3) == 2 && !bEqual) return FALSE;  // I2590
@@ -731,7 +731,7 @@ BOOL ContextMatch(LPKEY kkp)
           bEqual = wcscmp(ss, t->dpString) == 0;
         }
       }
-      
+
       if(*(pp+3) == 1 && bEqual) return FALSE;  // I2590
       if(*(pp+3) == 2 && !bEqual) return FALSE;  // I2590
     }
@@ -770,14 +770,14 @@ BOOL ContextMatch(LPKEY kkp)
 
         temp = xstrchr(s->dpString, q);
 
-        /*SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard ,kkp->Line, "ContextMatch: CODE_ANY [%x %x %x %x %x %x %x %x %x %x] [%x %x %x] %d", 
-          s->dpString[0], s->dpString[1], s->dpString[2], 
-          s->dpString[3], s->dpString[4], s->dpString[5], 
-          s->dpString[6], s->dpString[7], s->dpString[8], 
+        /*SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard ,kkp->Line, "ContextMatch: CODE_ANY [%x %x %x %x %x %x %x %x %x %x] [%x %x %x] %d",
+          s->dpString[0], s->dpString[1], s->dpString[2],
+          s->dpString[3], s->dpString[4], s->dpString[5],
+          s->dpString[6], s->dpString[7], s->dpString[8],
           s->dpString[9],
           q[0], q[1], q[2],
-          (temp ? (int)(temp-s->dpString) : 0));*/
-        
+          (temp ? (INT_PTR)(temp-s->dpString) : 0));*/
+
         if(temp != NULL)  // I1622
           *indexp = (WORD) xstrpos(temp, s->dpString);
 
@@ -790,7 +790,7 @@ BOOL ContextMatch(LPKEY kkp)
 	      s = &_td->lpActiveKeyboard->Keyboard->dpStoreArray[(*(p+2))-1];
 
         if((temp = xstrchr(s->dpString, q)) != NULL)   // I1622
-          return FALSE; 
+          return FALSE;
 
 				//if((temp = xstrchr(s->dpString, GetSuppChar(q))) != NULL)
 				//  return FALSE;
@@ -801,7 +801,7 @@ BOOL ContextMatch(LPKEY kkp)
 
 				for(temp = s->dpString; *temp && n > 0; temp = incxstr(temp), n--);
 				if(n != 0) return FALSE;
-				if(xchrcmp(temp, q) != 0) return FALSE; 
+				if(xchrcmp(temp, q) != 0) return FALSE;
         ////if(GetSuppChar(temp) != GetSuppChar(q)) return FALSE; // I1622
 				break;
 			case CODE_CONTEXTEX:
@@ -819,7 +819,7 @@ BOOL ContextMatch(LPKEY kkp)
 				return FALSE;
 			}
 		}
-		else if(xchrcmp(p, q) != 0) //GetSuppChar(p) != GetSuppChar(q)) 
+		else if(xchrcmp(p, q) != 0) //GetSuppChar(p) != GetSuppChar(q))
 		{
     	//SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard, kkp->Line, "ContextMatch: [%d] FAIL: %s", kkp->Line, format_unicode_debug(p));
 	    //SendDebugMessageFormat(state.msg.hwnd, sdmKeyboard, kkp->Line, "ContextMatch: [%d] FAIL: %s", kkp->Line, format_unicode_debug(q));

--- a/windows/src/engine/mcompile/mc_syskbdnt32.cpp
+++ b/windows/src/engine/mcompile/mc_syskbdnt32.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             syskbdnt32
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      10 Sep 2008
 
   Modified Date:    4 May 2010
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          10 Sep 2008 - mcdurdin - I1635 - Initial version
                     11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
                     30 Nov 2009 - mcdurdin - I934 - Prep for x64 - change UINT to WORD for vkeys
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */ 
+#include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
 
 
 typedef PKBDTABLES (WINAPI *PKBDLAYERDESCRIPTORFUNC)(VOID);
@@ -40,9 +40,9 @@ BOOL LoadNewLibrary_NT(PWSTR filename) {
   if(hKbdLibrary) FreeLibrary(hKbdLibrary);
 
 	hKbdLibrary = LoadLibrary(filename);
-	if(!hKbdLibrary) { 	
+	if(!hKbdLibrary) {
 	  LogError(L"LoadNewLibrary: Exit -- could not load library");
-		return FALSE; 
+		return FALSE;
 	}
 
   PKBDLAYERDESCRIPTORFUNC KbdLayerDescriptorFunc = (PKBDLAYERDESCRIPTORFUNC) GetProcAddress(hKbdLibrary, "KbdLayerDescriptor");
@@ -53,7 +53,7 @@ BOOL LoadNewLibrary_NT(PWSTR filename) {
 			return TRUE;
     }
 	}
-				
+
 	FreeLibrary(hKbdLibrary);
 
 	hKbdLibrary = NULL;
@@ -67,39 +67,39 @@ WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE pvt;
 	int i;
-	
-	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */ 
+
+	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */
 
   if(IsNumberPadKey(VKey)) {
     return 0;
   }
 
-	/* Get the appropriate table column for shift state */ 
+	/* Get the appropriate table column for shift state */
 
 	int shift = -1, shiftidx = 0, capslockbit = 0;
 
 	for(PVK_TO_BIT pvtb = KbdTables->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
 		switch(pvtb->Vk) {
-		case VK_MENU:    
+		case VK_MENU:
 			if(ShiftFlags & (LALTFLAG|RALTFLAG)) shiftidx |= pvtb->ModBits; break;
 		case VK_SHIFT:
 			if(ShiftFlags & CAPITALFLAG) capslockbit = pvtb->ModBits;
 			if(ShiftFlags & (K_SHIFTFLAG)) shiftidx |= pvtb->ModBits; break;
-		case VK_CONTROL: 
+		case VK_CONTROL:
 			if(ShiftFlags & (LCTRLFLAG|RCTRLFLAG)) shiftidx |= pvtb->ModBits; break;
 		}
   }
 
-	/* If the shift modifier is unused, don't produce a character */ 
+	/* If the shift modifier is unused, don't produce a character */
 
-	if(shiftidx > KbdTables->pCharModifiers->wMaxModBits || 
+	if(shiftidx > KbdTables->pCharModifiers->wMaxModBits ||
 			KbdTables->pCharModifiers->ModNumber[shiftidx] == 0xF) {
 		return 0;
 	}
 
 	shift = KbdTables->pCharModifiers->ModNumber[shiftidx];
 
-	/* Get the appropriate virtual key */ 
+	/* Get the appropriate virtual key */
 
 	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++) {
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;) {
@@ -108,32 +108,32 @@ WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 					return 0;
         }
 
-				/* Check for Caps Lock */ 
+				/* Check for Caps Lock */
 				if(ShiftFlags & CAPITALFLAG) {
 					if(pv->Attributes & CAPLOK) {
-						/* Invert the state of the SHIFT key */ 
-						shift = KbdTables->pCharModifiers->ModNumber[shiftidx ^ capslockbit]; 
+						/* Invert the state of the SHIFT key */
+						shift = KbdTables->pCharModifiers->ModNumber[shiftidx ^ capslockbit];
           } else if(pv->Attributes & SGCAPS) {
-						pv++; /* Next keystroke has the appropriate capitalised character */ 
+						pv++; /* Next keystroke has the appropriate capitalised character */
           }
 				}
 
-				/* Found the keystroke combination, return the appropriate character (if existing) */ 
+				/* Found the keystroke combination, return the appropriate character (if existing) */
 				switch(pv->wch[shift]) {
 				case WCH_DEAD:
 					pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
           *PDeadKey = pv->wch[shift];
-					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */ 
+					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */
 				case WCH_NONE:
-					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */ 
+					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */
 				}
 
-				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */ 
+				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */
 			}
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -169,20 +169,20 @@ WORD CharToUSVK_NT(WORD ch, WORD *shift)
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE pvt;
 	int i, j;
-	
-	/* Find the appropriate keyboard tables */ 
 
-	if(!KbdTables) return 0;				/* Could not load keyboard DLL */ 
+	/* Find the appropriate keyboard tables */
 
-	/* Map the character back to the virtual key */ 
+	if(!KbdTables) return 0;				/* Could not load keyboard DLL */
+
+	/* Map the character back to the virtual key */
 
 	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++)
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;)
 		{
 			for(j = 0; j < pvt->nModifications; j++)
-				if(pv->wch[j] == ch) 
+				if(pv->wch[j] == ch)
 				{
-					/* Return the new virtual key */ 
+					/* Return the new virtual key */
           *shift = ModificationToShift_NT(j);
           if(*shift == 0xFFFF) return 0;
           return pv->VirtualKey;
@@ -190,7 +190,7 @@ WORD CharToUSVK_NT(WORD ch, WORD *shift)
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 
-	/* Remapping not found */ 
+	/* Remapping not found */
 	return 0;
 }
 
@@ -210,19 +210,19 @@ int GetDeadkeys_NT(WORD DeadKey, WORD *OutputPairs) {
 		}
 	}
   *p = 0;
-  return (int)(p-OutputPairs);
+  return (INT_PTR)(p-OutputPairs);
 }
 
 WORD VKUSToVKUnderlyingLayout_NT(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
 
   if(VKey > 255) return VKey;
 
@@ -232,15 +232,15 @@ WORD VKUSToVKUnderlyingLayout_NT(WORD VKey) {
 }
 
 WORD VKUnderlyingLayoutToVKUS_NT(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
 
   UINT scan;
   for(scan = 1; scan <= KbdTables->bMaxVSCtoVK; scan++) {

--- a/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/syskbdnt32.cpp
+++ b/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/syskbdnt32.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             syskbdnt32
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      10 Sep 2008
 
   Modified Date:    4 May 2010
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          10 Sep 2008 - mcdurdin - I1635 - Initial version
                     11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
                     30 Nov 2009 - mcdurdin - I934 - Prep for x64 - change UINT to WORD for vkeys
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include "../../../../engine/keyman32/kbd.h"	/* DDK kbdlayout */ 
+#include "../../../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
 
 
 typedef PKBDTABLES (WINAPI *PKBDLAYERDESCRIPTORFUNC)(VOID);
@@ -40,9 +40,9 @@ BOOL LoadNewLibrary_NT(PWSTR filename) {
   if(hKbdLibrary) FreeLibrary(hKbdLibrary);
 
 	hKbdLibrary = LoadLibrary(filename);
-	if(!hKbdLibrary) { 	
+	if(!hKbdLibrary) {
 	  LogError(L"LoadNewLibrary: Exit -- could not load library");
-		return FALSE; 
+		return FALSE;
 	}
 
   PKBDLAYERDESCRIPTORFUNC KbdLayerDescriptorFunc = (PKBDLAYERDESCRIPTORFUNC) GetProcAddress(hKbdLibrary, "KbdLayerDescriptor");
@@ -53,7 +53,7 @@ BOOL LoadNewLibrary_NT(PWSTR filename) {
 			return TRUE;
     }
 	}
-				
+
 	FreeLibrary(hKbdLibrary);
 
 	hKbdLibrary = NULL;
@@ -67,39 +67,39 @@ WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE pvt;
 	int i;
-	
-	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */ 
+
+	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */
 
   if(IsNumberPadKey(VKey)) {
     return 0;
   }
 
-	/* Get the appropriate table column for shift state */ 
+	/* Get the appropriate table column for shift state */
 
 	int shift = -1, shiftidx = 0, capslockbit = 0;
 
 	for(PVK_TO_BIT pvtb = KbdTables->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
 		switch(pvtb->Vk) {
-		case VK_MENU:    
+		case VK_MENU:
 			if(ShiftFlags & (LALTFLAG|RALTFLAG)) shiftidx |= pvtb->ModBits; break;
 		case VK_SHIFT:
 			if(ShiftFlags & CAPITALFLAG) capslockbit = pvtb->ModBits;
 			if(ShiftFlags & (K_SHIFTFLAG)) shiftidx |= pvtb->ModBits; break;
-		case VK_CONTROL: 
+		case VK_CONTROL:
 			if(ShiftFlags & (LCTRLFLAG|RCTRLFLAG)) shiftidx |= pvtb->ModBits; break;
 		}
   }
 
-	/* If the shift modifier is unused, don't produce a character */ 
+	/* If the shift modifier is unused, don't produce a character */
 
-	if(shiftidx > KbdTables->pCharModifiers->wMaxModBits || 
+	if(shiftidx > KbdTables->pCharModifiers->wMaxModBits ||
 			KbdTables->pCharModifiers->ModNumber[shiftidx] == 0xF) {
 		return 0;
 	}
 
 	shift = KbdTables->pCharModifiers->ModNumber[shiftidx];
 
-	/* Get the appropriate virtual key */ 
+	/* Get the appropriate virtual key */
 
 	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++) {
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;) {
@@ -108,32 +108,32 @@ WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 					return 0;
         }
 
-				/* Check for Caps Lock */ 
+				/* Check for Caps Lock */
 				if(ShiftFlags & CAPITALFLAG) {
 					if(pv->Attributes & CAPLOK) {
-						/* Invert the state of the SHIFT key */ 
-						shift = KbdTables->pCharModifiers->ModNumber[shiftidx ^ capslockbit]; 
+						/* Invert the state of the SHIFT key */
+						shift = KbdTables->pCharModifiers->ModNumber[shiftidx ^ capslockbit];
           } else if(pv->Attributes & SGCAPS) {
-						pv++; /* Next keystroke has the appropriate capitalised character */ 
+						pv++; /* Next keystroke has the appropriate capitalised character */
           }
 				}
 
-				/* Found the keystroke combination, return the appropriate character (if existing) */ 
+				/* Found the keystroke combination, return the appropriate character (if existing) */
 				switch(pv->wch[shift]) {
 				case WCH_DEAD:
 					pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
           *PDeadKey = pv->wch[shift];
-					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */ 
+					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */
 				case WCH_NONE:
-					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */ 
+					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */
 				}
 
-				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */ 
+				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */
 			}
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -169,20 +169,20 @@ WORD CharToUSVK_NT(WORD ch, WORD *shift)
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE pvt;
 	int i, j;
-	
-	/* Find the appropriate keyboard tables */ 
 
-	if(!KbdTables) return 0;				/* Could not load keyboard DLL */ 
+	/* Find the appropriate keyboard tables */
 
-	/* Map the character back to the virtual key */ 
+	if(!KbdTables) return 0;				/* Could not load keyboard DLL */
+
+	/* Map the character back to the virtual key */
 
 	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++)
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;)
 		{
 			for(j = 0; j < pvt->nModifications; j++)
-				if(pv->wch[j] == ch) 
+				if(pv->wch[j] == ch)
 				{
-					/* Return the new virtual key */ 
+					/* Return the new virtual key */
           *shift = ModificationToShift_NT(j);
           if(*shift == 0xFFFF) return 0;
           return pv->VirtualKey;
@@ -190,7 +190,7 @@ WORD CharToUSVK_NT(WORD ch, WORD *shift)
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 
-	/* Remapping not found */ 
+	/* Remapping not found */
 	return 0;
 }
 
@@ -210,19 +210,19 @@ int GetDeadkeys_NT(WORD DeadKey, WORD *OutputPairs) {
 		}
 	}
   *p = 0;
-  return (int)(p-OutputPairs);
+  return (INT_PTR)(p-OutputPairs);
 }
 
 WORD VKUSToVKUnderlyingLayout_NT(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
 
   if(VKey > 255) return VKey;
 
@@ -232,15 +232,15 @@ WORD VKUSToVKUnderlyingLayout_NT(WORD VKey) {
 }
 
 WORD VKUnderlyingLayoutToVKUS_NT(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
 
   UINT scan;
   for(scan = 1; scan <= KbdTables->bMaxVSCtoVK; scan++) {

--- a/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/syskbdnt64.cpp
+++ b/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/syskbdnt64.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             syskbdnt64
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      10 Sep 2008
 
   Modified Date:    4 May 2010
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          10 Sep 2008 - mcdurdin - I1635 - Initial version
                     11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
                     30 Nov 2009 - mcdurdin - I934 - Prep for x64 - change UINT to WORD for vkeys
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include "../../../../engine/keyman32/kbd.h"	/* DDK kbdlayout */ 
+#include "../../../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
 
 typedef struct {
     PVK_TO_BIT pVkToBit;     // Virtual Keys -> Mod bits
@@ -128,9 +128,9 @@ BOOL LoadNewLibrary_NT_x64(PWSTR filename) {
   if(hKbdLibrary_x64) FreeLibrary(hKbdLibrary_x64);
 
 	hKbdLibrary_x64 = LoadLibrary(filename);
-	if(!hKbdLibrary_x64) { 	
+	if(!hKbdLibrary_x64) {
 	  LogError(L"LoadNewLibrary_x64: Exit -- could not load library");
-		return FALSE; 
+		return FALSE;
 	}
 
   PKBDLAYERDESCRIPTORFUNC KbdLayerDescriptorFunc = (PKBDLAYERDESCRIPTORFUNC) GetProcAddress(hKbdLibrary_x64, "KbdLayerDescriptor");
@@ -141,7 +141,7 @@ BOOL LoadNewLibrary_NT_x64(PWSTR filename) {
 			return TRUE;
     }
 	}
-				
+
 	FreeLibrary(hKbdLibrary_x64);
 
 	hKbdLibrary_x64 = NULL;
@@ -155,39 +155,39 @@ WCHAR CharFromVK_NT_x64(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE_x64 pvt;
 	int i;
-	
-	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */ 
+
+	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */
 
   if(IsNumberPadKey(VKey)) {
     return 0;
   }
 
-	/* Get the appropriate table column for shift state */ 
+	/* Get the appropriate table column for shift state */
 
 	int shift = -1, shiftidx = 0, capslockbit = 0;
 
 	for(PVK_TO_BIT pvtb = KbdTables_x64->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
 		switch(pvtb->Vk) {
-		case VK_MENU:    
+		case VK_MENU:
 			if(ShiftFlags & (LALTFLAG|RALTFLAG)) shiftidx |= pvtb->ModBits; break;
 		case VK_SHIFT:
 			if(ShiftFlags & CAPITALFLAG) capslockbit = pvtb->ModBits;
 			if(ShiftFlags & (K_SHIFTFLAG)) shiftidx |= pvtb->ModBits; break;
-		case VK_CONTROL: 
+		case VK_CONTROL:
 			if(ShiftFlags & (LCTRLFLAG|RCTRLFLAG)) shiftidx |= pvtb->ModBits; break;
 		}
   }
 
-	/* If the shift modifier is unused, don't produce a character */ 
+	/* If the shift modifier is unused, don't produce a character */
 
-	if(shiftidx > KbdTables_x64->pCharModifiers->wMaxModBits || 
+	if(shiftidx > KbdTables_x64->pCharModifiers->wMaxModBits ||
 			KbdTables_x64->pCharModifiers->ModNumber[shiftidx] == 0xF) {
 		return 0;
 	}
 
 	shift = KbdTables_x64->pCharModifiers->ModNumber[shiftidx];
 
-	/* Get the appropriate virtual key */ 
+	/* Get the appropriate virtual key */
 
 	for(i = 0, pvt = KbdTables_x64->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++) {
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;) {
@@ -196,32 +196,32 @@ WCHAR CharFromVK_NT_x64(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
 					return 0;
         }
 
-				/* Check for Caps Lock */ 
+				/* Check for Caps Lock */
 				if(ShiftFlags & CAPITALFLAG) {
 					if(pv->Attributes & CAPLOK) {
-						/* Invert the state of the SHIFT key */ 
-						shift = KbdTables_x64->pCharModifiers->ModNumber[shiftidx ^ capslockbit]; 
+						/* Invert the state of the SHIFT key */
+						shift = KbdTables_x64->pCharModifiers->ModNumber[shiftidx ^ capslockbit];
           } else if(pv->Attributes & SGCAPS) {
-						pv++; /* Next keystroke has the appropriate capitalised character */ 
+						pv++; /* Next keystroke has the appropriate capitalised character */
           }
 				}
 
-				/* Found the keystroke combination, return the appropriate character (if existing) */ 
+				/* Found the keystroke combination, return the appropriate character (if existing) */
 				switch(pv->wch[shift]) {
 				case WCH_DEAD:
 					pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
           *PDeadKey = pv->wch[shift];
-					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */ 
+					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */
 				case WCH_NONE:
-					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */ 
+					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */
 				}
 
-				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */ 
+				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */
 			}
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -257,20 +257,20 @@ WORD CharToUSVK_NT_x64(WORD ch, WORD *shift)
 	PVK_TO_WCHARS1 pv;
 	PVK_TO_WCHAR_TABLE_x64 pvt;
 	int i, j;
-	
-	/* Find the appropriate keyboard tables */ 
 
-	if(!KbdTables_x64) return 0;				/* Could not load keyboard DLL */ 
+	/* Find the appropriate keyboard tables */
 
-	/* Map the character back to the virtual key */ 
+	if(!KbdTables_x64) return 0;				/* Could not load keyboard DLL */
+
+	/* Map the character back to the virtual key */
 
 	for(i = 0, pvt = KbdTables_x64->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++)
 		for(pv = pvt->pVkToWchars; pv->VirtualKey;)
 		{
 			for(j = 0; j < pvt->nModifications; j++)
-				if(pv->wch[j] == ch) 
+				if(pv->wch[j] == ch)
 				{
-					/* Return the new virtual key */ 
+					/* Return the new virtual key */
           *shift = ModificationToShift_NT_x64(j);
           if(*shift == 0xFFFF) return 0;
           return pv->VirtualKey;
@@ -278,7 +278,7 @@ WORD CharToUSVK_NT_x64(WORD ch, WORD *shift)
 			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
 		}
 
-	/* Remapping not found */ 
+	/* Remapping not found */
 	return 0;
 }
 
@@ -298,19 +298,19 @@ int GetDeadkeys_NT_x64(WORD DeadKey, WORD *OutputPairs) {
 		}
 	}
   *p = 0;
-  return (int)(p-OutputPairs);
+  return (INT_PTR)(p-OutputPairs);
 }
 
 WORD VKUSToVKUnderlyingLayout_NT_x64(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables_x64)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables_x64)				/* Could not load keyboard DLL */
+		return VKey;
 
   if(VKey > 255) return VKey;
 
@@ -320,15 +320,15 @@ WORD VKUSToVKUnderlyingLayout_NT_x64(WORD VKey) {
 }
 
 WORD VKUnderlyingLayoutToVKUS_NT_x64(WORD VKey) {
-	
+
 	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
 
 	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
 
-	/* Find the appropriate keyboard tables */ 
+	/* Find the appropriate keyboard tables */
 
-	if(!KbdTables_x64)				/* Could not load keyboard DLL */ 
-		return VKey;  
+	if(!KbdTables_x64)				/* Could not load keyboard DLL */
+		return VKey;
 
   UINT scan;
   for(scan = 1; scan <= KbdTables_x64->bMaxVSCtoVK; scan++) {
@@ -347,7 +347,7 @@ WORD VKUnderlyingLayoutToVKUS_NT_x64(WORD VKey) {
 
 typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
 
-LPFN_ISWOW64PROCESS 
+LPFN_ISWOW64PROCESS
 fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(GetModuleHandle(L"kernel32"),"IsWow64Process");
 BOOL fStored = FALSE;
 BOOL bIsWow64 = FALSE;
@@ -359,7 +359,7 @@ BOOL IsWow64() {
   if(NULL != fnIsWow64Process) {
     if(!fnIsWow64Process(GetCurrentProcess(),&bIsWow64)){
       // handle error
-      return FALSE;   
+      return FALSE;
     }
   }
   fStored = TRUE;


### PR DESCRIPTION
Fixes #3084.

This does two things:

1. Cleans up a bunch of places where we used to use `(int)` typecasts for pointer math, which was problematic. We now use `(INT_PTR)` per MSDN https://docs.microsoft.com/en-us/windows/win32/winprog64/rules-for-using-pointers and then cast that down to `(int)` where necessary, e.g. when storing string lengths which are never going to be more than a few hundred characters! Doing this explicitly helps to clarify that we are aware of the typecast and believe it to be safe.

2. Adds in some build infrastructure for future use of Coverity Scan https://scan.coverity.com/ which we plan to use for further code quality updates. I have submitted the project to Coverity and are now waiting for approval so we can check results. Once we have approval, I do plan to add this to the nightly build (we need to keep submissions under 3 builds/day).

Note: I have not yet added Keyman Core (Windows) to this project, nor are we currently building Keyman Core (macOS) or Keyman for Linux, but we should consider adding those in future.