### PR TITLE
fix(android/app): Change install intent to MainActivity

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -8,31 +8,21 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.Color;
-import android.graphics.PorterDuff.Mode;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.ImageButton;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.KMManager.Tier;
 import com.tavultesoft.kmea.util.KMPLink;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.tavultesoft.kmea.util.KMPLink.KMP_PRODUCTION_HOST;
-import static com.tavultesoft.kmea.util.KMPLink.KMP_STAGING_HOST;
 
 public class KMPBrowserActivity extends AppCompatActivity {
   private static final String TAG = "KMPBrowserActivity";
@@ -93,8 +83,9 @@ public class KMPBrowserActivity extends AppCompatActivity {
           Uri downloadURI = KMPLink.getKeyboardDownloadLink(url);
 
           // Create intent with keyboard download link for KMAPro main activity to handle
-          Intent intent = new Intent(Intent.ACTION_VIEW, downloadURI);
-          startActivityForResult(intent, 1);
+          Intent intent = new Intent(context, MainActivity.class);
+          intent.setData(downloadURI);
+          startActivity(intent);
 
           // Finish activity
           finish();


### PR DESCRIPTION
Fixes #3595

With the refactoring in #3614, KMPBrowserActivity can now start an intent for MainActivity to install the kmp.

Screenshots of the workflow:

Pressing the "Install Keyboard" button
![install sencoten](https://user-images.githubusercontent.com/7358010/94122571-ea635680-fe7c-11ea-926b-b11960394225.png)

starts the kmp download
![download sencoten](https://user-images.githubusercontent.com/7358010/94122624-fcdd9000-fe7c-11ea-8c22-d35c6cab744b.png)

kmp install shows readme.htm
![readme sencoten](https://user-images.githubusercontent.com/7358010/94122649-049d3480-fe7d-11ea-8953-2e3e89a2396b.png)

after keyboard (and dictionary) installed
![sencoten installed](https://user-images.githubusercontent.com/7358010/94122660-0b2bac00-fe7d-11ea-9ed2-37f694fe932e.png)
