### PR TITLE
fix(developer): Project window and About window hardcoded urls

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -291,7 +291,8 @@ uses
   Sentry.Client.Vcl in '..\..\ext\sentry\Sentry.Client.Vcl.pas',
   sentry in '..\..\ext\sentry\sentry.pas',
   Keyman.System.KeymanSentryClient in '..\..\global\delphi\general\Keyman.System.KeymanSentryClient.pas',
-  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas';
+  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
+  Keyman.Developer.System.Project.UrlRenderer in 'project\Keyman.Developer.System.Project.UrlRenderer.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -546,6 +546,7 @@
         <DCCReference Include="..\..\ext\sentry\sentry.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.KeymanSentryClient.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
+        <DCCReference Include="project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/dialogs/UfrmAboutTike.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmAboutTike.dfm
@@ -520,10 +520,10 @@ inherited frmAboutTike: TfrmAboutTike
   object lblWebsite: TLabel
     Left = 125
     Top = 135
-    Width = 176
+    Width = 128
     Height = 13
     Cursor = crHandPoint
-    Caption = 'http://www.keyman.com/developer/'
+    Caption = '(url for keyman developer)'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clBlack
     Font.Height = -11

--- a/windows/src/developer/TIKE/dialogs/UfrmAboutTike.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmAboutTike.pas
@@ -79,14 +79,14 @@ procedure TfrmAboutTike.FormCreate(Sender: TObject);
 begin
   inherited;
   Caption := SCaption;
-  lblWebsite.Caption := MakeKeymanURL(URLPath_KeymanDeveloperHome);
+  lblWebsite.Caption := MakeKeymanURL(URLPath_KeymanDeveloperHome_Presentation);
   lblVersion.Caption := 'Version ' + GetVersionString;
   lblCopyright.Caption := GetVersionCopyright;
 end;
 
 procedure TfrmAboutTike.lblWebsiteClick(Sender: TObject);
 begin
-  TUtilExecute.URL(lblWebsite.Caption);  // I3349
+  TUtilExecute.URL(MakeKeymanURL(URLPath_KeymanDeveloperHome));  // I3349
 end;
 
 function TfrmAboutTike.GetHelpTopic: string;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -332,6 +332,7 @@ uses
   Keyman.Developer.System.Project.ProjectFileType,
   Keyman.Developer.System.Project.ProjectLoader,
   Keyman.Developer.System.Project.ProjectSaver,
+  Keyman.Developer.System.Project.UrlRenderer,
   RedistFiles,
   RegistryKeys,
   UMD5Hash,
@@ -881,6 +882,12 @@ begin
           userdoc := nil;
         end;
       end;
+
+      //
+      // Inject state URLs into the loaded file
+      //
+
+      TProjectUrlRenderer.AddUrls(doc.documentElement);
 
       xsl := MSXMLDOMDocumentFactory.CreateDOMDocument;
       try

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.UrlRenderer.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.UrlRenderer.pas
@@ -1,0 +1,45 @@
+unit Keyman.Developer.System.Project.UrlRenderer;
+
+interface
+
+uses
+  Winapi.msxml;
+
+type
+  TProjectUrlRenderer = class
+    class procedure AddUrls(root: IXMLDomNode);
+  end;
+
+implementation
+
+uses
+  Upload_Settings;
+
+{ TProjectUrlRenderer }
+
+class procedure TProjectUrlRenderer.AddUrls(root: IXMLDomNode);
+var
+  node: IXMLDomNode;
+
+  procedure AddUrl(const id, href: string);
+  var
+    urlNode: IXMLDOMElement;
+  begin
+    urlNode := root.ownerDocument.createElement('Url');
+    urlNode.setAttribute('id', id);
+    urlNode.setAttribute('href', MakeKeymanURL(href));
+    node.appendChild(urlNode);
+  end;
+begin
+  node := root.ownerDocument.createElement('DeveloperUrls');
+  AddUrl('help-keyboards', URLPath_KeymanDeveloper_HelpKeyboards);
+  AddUrl('help-packages', URLPath_KeymanDeveloper_HelpPackages);
+  AddUrl('help-mobile', URLPath_KeymanDeveloper_HelpMobile);
+  AddUrl('keymanweb', URLPath_KeymanDeveloper_KeymanWeb);
+  AddUrl('keyman-engine-home', URLPath_KeymanDeveloper_KeymanEngineHome);
+  AddUrl('home', URLPath_KeymanDeveloperHome);
+  AddUrl('home-presentation', URLPath_KeymanDeveloperHome_Presentation);
+  root.appendChild(node);
+end;
+
+end.

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.WelcomeRenderer.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.WelcomeRenderer.pas
@@ -17,6 +17,7 @@ uses
   Xml.Win.msxmldom,
 
   Keyman.Developer.System.Project.ProjectFile,
+  Keyman.Developer.System.Project.UrlRenderer,
   RegistryKeys,
   VersionInfo,
   utilsystem;
@@ -55,6 +56,8 @@ begin
       node := doc.createElement('Version');
       node.appendChild(doc.createTextNode(GetVersionString));
       root.appendChild(node);
+
+      TProjectUrlRenderer.AddUrls(root);
 
       xsl := MSXMLDOMDocumentFactory.CreateDOMDocument;
       try

--- a/windows/src/developer/TIKE/xml/project/distribution.xsl
+++ b/windows/src/developer/TIKE/xml/project/distribution.xsl
@@ -11,11 +11,11 @@
             <h3>Quick Links</h3>
 
             <ul>
-              <li><a href="https://keyman.com/go/developer/10.0/help-keyboards">Share source and add to Keyman keyboard repositories</a></li>
-              <li><a href="https://keyman.com/go/developer/10.0/help-packages">Windows and macOS distribution</a></li>
-              <li><a href="https://keyman.com/go/developer/10.0/help-mobile">iPhone, iPad and Android distribution</a></li>
-              <li><a href="https://keyman.com/go/developer/10.0/keymanweb">Web soft keyboard</a></li>
-              <li><a href="https://keyman.com/go/developer/10.0/keyman-engine-home">Keyman Engine</a></li>
+              <li><a><xsl:attribute name="href"><xsl:value-of select='KeymanDeveloperProject/DeveloperUrls/Url[@id="help-keyboards"]/@href' /></xsl:attribute>Share source and add to Keyman keyboard repositories</a></li>
+              <li><a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-packages"]/@href' /></xsl:attribute>Keyboard distribution</a></li>
+              <li><a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-mobile"]/@href' /></xsl:attribute>Distribution tips for mobile devices</a></li>
+              <li><a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="keymanweb"]/@href' /></xsl:attribute>Web soft keyboard</a></li>
+              <li><a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="keyman-engine-home"]/@href' /></xsl:attribute>Keyman Engine</a></li>
             </ul>
           </div>
         </div>
@@ -30,16 +30,16 @@
 
           <ul>
             <li>Add your keyboard to the Keyman Keyboard Repositories. In order to do this, you must share the source code of your keyboard.
-                <b>Recommended option!</b> &#160; <a href='https://keyman.com/go/developer/10.0/help-keyboards'>Learn more</a></li>
-            <li>Share a package file yourself: just give a .kmp file to any Keyman user, on Windows, macOS, iOS or Android and they can install it. Or put the .kmp file onto a website for users to download.
-                <a href='https://keyman.com/go/developer/10.0/help-packages'>Learn more</a></li>
+                <b>Recommended option!</b> &#160; <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-keyboards"]/@href' /></xsl:attribute>Learn more</a></li>
+            <li>Share a package file yourself: just give a .kmp file to any Keyman user, on Windows, macOS, iOS, Android or Linux and they can install it. Or put the .kmp file onto a website for users to download.
+                <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-packages"]/@href' /></xsl:attribute>Learn more</a></li>
             <li>Sharing package files to mobile devices can be more complex. Learn about specific techniques for distribution to mobile devices.
-                <a href='https://keyman.com/go/developer/10.0/help-mobile'>Learn more</a></li>
+                <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-mobile"]/@href' /></xsl:attribute>Learn more</a></li>
             <li>Add your keyboard to a website using KeymanWeb
-                <a href='https://keyman.com/go/developer/10.0/keymanweb'>Learn more</a></li>
+                <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="keymanweb"]/@href' /></xsl:attribute>Learn more</a></li>
           </ul>
 
-          <p>You can also create your own custom keyboarding product based on Keyman: <a href='https://keyman.com/go/developer/10.0/keyman-engine-home'>Learn more</a></p>
+          <p>You can also create your own custom keyboarding product based on Keyman: <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="keyman-engine-home"]/@href' /></xsl:attribute>Learn more</a></p>
 
         </div>
       </div>

--- a/windows/src/developer/TIKE/xml/project/globalwelcome.xsl
+++ b/windows/src/developer/TIKE/xml/project/globalwelcome.xsl
@@ -14,7 +14,7 @@
         <div id="pageheader">
             <div class='pagetext'>
               <p><img src='res/keymandeveloper.png' alt='Keyman Developer' /></p>
-              <p id='header-link'><a target='_blank' href='https://keyman.com/go/developer/12.0/home'>https://keyman.com/developer/</a></p>
+              <p id='header-link'><a><xsl:attribute name="href"><xsl:value-of select='/Data/DeveloperUrls/Url[@id="home"]/@href' /></xsl:attribute><xsl:value-of select='/Data/DeveloperUrls/Url[@id="home-presentation"]/@href' /></a></p>
               <p id='header-version'>Version <xsl:value-of select="/Data/Version" /></p>
               <div id='header-sil'>
                 <img src='res/sil.png' />

--- a/windows/src/developer/TIKE/xml/project/keyboards.xsl
+++ b/windows/src/developer/TIKE/xml/project/keyboards.xsl
@@ -45,7 +45,7 @@
           </ul>
 
           <p>
-            It's a good idea to read <a href='https://keyman.com/go/developer/10.0/help-keyboards'>Developing Open Source Keyboards</a> for guidelines
+            It's a good idea to read <a><xsl:attribute name="href"><xsl:value-of select='/KeymanDeveloperProject/DeveloperUrls/Url[@id="help-keyboards"]/@href' /></xsl:attribute>Developing Open Source Keyboards</a> for guidelines
             on preparing open source keyboards for sharing through the Keyman keyboard repositories. Also see the Distribution tab for more on
             distributing your completed keyboards.
           </p>

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -112,14 +112,15 @@ uses
   Keyman.Developer.System.Project.modelTsProjectFileAction in '..\TIKE\project\Keyman.Developer.System.Project.modelTsProjectFileAction.pas',
   Keyman.Developer.System.LexicalModelCompile in '..\..\global\delphi\lexicalmodels\Keyman.Developer.System.LexicalModelCompile.pas',
   Keyman.System.LexicalModelUtils in '..\..\global\delphi\lexicalmodels\Keyman.System.LexicalModelUtils.pas',
-  Keyman.Developer.System.Project.ProjectLogConsole in 'Keyman.Developer.System.Project.ProjectLogConsole.pas' {$R icons.RES},
+  Keyman.Developer.System.Project.ProjectLogConsole in 'Keyman.Developer.System.Project.ProjectLogConsole.pas',
   Sentry.Client in '..\..\ext\sentry\Sentry.Client.pas',
   Sentry.Client.Console in '..\..\ext\sentry\Sentry.Client.Console.pas',
   sentry in '..\..\ext\sentry\sentry.pas',
   Keyman.System.KeymanSentryClient in '..\..\global\delphi\general\Keyman.System.KeymanSentryClient.pas',
   KeymanPaths in '..\..\global\delphi\general\KeymanPaths.pas',
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
-  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas';
+  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
+  Keyman.Developer.System.Project.UrlRenderer in '..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -277,6 +277,7 @@
         <DCCReference Include="..\..\global\delphi\general\KeymanPaths.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
+        <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/developer/kmconvert/kmconvert.dpr
+++ b/windows/src/developer/kmconvert/kmconvert.dpr
@@ -83,13 +83,14 @@ uses
   CompileErrorCodes in '..\..\global\delphi\general\CompileErrorCodes.pas',
   Keyman.Developer.System.ModelProjectTemplate in 'Keyman.Developer.System.ModelProjectTemplate.pas',
   Keyman.Developer.System.Project.modelTsProjectFile in '..\TIKE\project\Keyman.Developer.System.Project.modelTsProjectFile.pas',
-  Keyman.Developer.System.Project.wordlistTsvProjectFile in '..\TIKE\project\Keyman.Developer.System.Project.wordlistTsvProjectFile.pas',
+  Keyman.Developer.System.Project.wordlistTsvProjectFile in '..\TIKE\project\Keyman.Developer.System.Project.wordlistTsvProjectFile.pas' {$R icons.RES},
   Sentry.Client in '..\..\ext\sentry\Sentry.Client.pas',
   Sentry.Client.Console in '..\..\ext\sentry\Sentry.Client.Console.pas',
   sentry in '..\..\ext\sentry\sentry.pas',
   Keyman.System.KeymanSentryClient in '..\..\global\delphi\general\Keyman.System.KeymanSentryClient.pas',
   KeymanPaths in '..\..\global\delphi\general\KeymanPaths.pas',
-  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas';
+  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
+  Keyman.Developer.System.Project.UrlRenderer in '..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmconvert/kmconvert.dproj
+++ b/windows/src/developer/kmconvert/kmconvert.dproj
@@ -198,6 +198,7 @@
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.KeymanSentryClient.pas"/>
         <DCCReference Include="..\..\global\delphi\general\KeymanPaths.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
+        <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/global/delphi/general/Upload_Settings.pas
+++ b/windows/src/global/delphi/general/Upload_Settings.pas
@@ -48,6 +48,13 @@ const
   URLPath_KeymanLanguageLookup = '/go/developer/'+SKeymanVersion+'/language-lookup';
   URLPath_KeymanDeveloperDocumentation = '/go/developer/'+SKeymanVersion+'/docs';
   URLPath_KeymanDeveloperHome = '/go/developer/'+SKeymanVersion+'/home';
+  URLPath_KeymanDeveloperHome_Presentation = '/developer';
+
+  URLPath_KeymanDeveloper_HelpKeyboards = '/go/developer/'+SKeymanVersion+'/help-keyboards';
+  URLPath_KeymanDeveloper_HelpPackages = '/go/developer/'+SKeymanVersion+'/help-packages';
+  URLPath_KeymanDeveloper_HelpMobile = '/go/developer/'+SKeymanVersion+'/help-mobile';
+  URLPath_KeymanDeveloper_KeymanWeb = '/go/developer/'+SKeymanVersion+'/keymanweb';
+  URLPath_KeymanDeveloper_KeymanEngineHome = '/go/developer/'+SKeymanVersion+'/keyman-engine-home';
 
   URLPath_KeymanDeveloper_KeymanForAndroidDownload = '/go/developer/'+SKeymanVersion+'/android-app';
   URLPath_KeymanDeveloper_KeymanForIosDownload = '/go/developer/'+SKeymanVersion+'/ios-app';

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
@@ -98,7 +98,8 @@ uses
   TextFileFormat in '..\..\developer\TIKE\main\TextFileFormat.pas',
   Keyman.System.LexicalModelUtils in '..\..\global\delphi\lexicalmodels\Keyman.System.LexicalModelUtils.pas',
   Keyman.System.PackageInfoRefreshLexicalModels in '..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshLexicalModels.pas',
-  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas';
+  Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
+  Keyman.Developer.System.Project.UrlRenderer in '..\..\developer\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
+++ b/windows/src/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
@@ -178,6 +178,7 @@
         <DCCReference Include="..\..\global\delphi\lexicalmodels\Keyman.System.LexicalModelUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshLexicalModels.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
+        <DCCReference Include="..\..\developer\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
Relates to #3394.

Fixes all remaining hardcoded URLs in the Project / Welcome and the About window in Keyman Developer.