### PR TITLE
fix(ios/engine): package installation language-picker improvements

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -380,10 +380,40 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
       cell.selectedBackgroundView = selectionColor
     }
 
+    cell.selectionStyle = .default
+    cell.isUserInteractionEnabled = true
+    cell.backgroundColor = .none
+    var isAlreadyInstalled: Bool = false
+
+    // Check:  is the language ALREADY installed?
+    let language = languages[indexPath.row].id
+    if let installedResources: [Resource] = Storage.active.userDefaults.userResources(ofType: Resource.self) {
+      installedResources.forEach { resource in
+        if resource.packageKey == package.key {
+          // The resource is from this package.
+          if resource.languageID == language {
+            cell.selectionStyle = .none
+            cell.isUserInteractionEnabled = false
+            cell.accessoryType = .checkmark
+            isAlreadyInstalled = true
+          }
+        }
+      }
+    }
+
     switch indexPath.section {
       case 0:
         let index = indexPath.row
         cell.detailTextLabel?.text = languages[index].name
+        if isAlreadyInstalled {
+          cell.detailTextLabel?.textColor = .gray // helps indicate 'disabled'
+        } else {
+          if #available(*, iOS 13.0) {
+            cell.detailTextLabel?.textColor = .label
+          } else {
+            cell.detailTextLabel?.textColor = .black
+          }
+        }
         return cell
       default:
         return cell
@@ -391,6 +421,15 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   }
 
   public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    guard let cell = tableView.cellForRow(at: indexPath) else {
+      return
+    }
+
+    guard cell.isUserInteractionEnabled == true else {
+      tableView.deselectRow(at: indexPath, animated: false)
+      return
+    }
+
     navigationItem.rightBarButtonItem?.isEnabled = true
     tableView.cellForRow(at: indexPath)?.accessoryType = .checkmark
 
@@ -398,6 +437,15 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   }
 
   public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+    guard let cell = tableView.cellForRow(at: indexPath) else {
+      return
+    }
+
+    guard cell.isUserInteractionEnabled == true else {
+      tableView.deselectRow(at: indexPath, animated: false)
+      return
+    }
+
     if languageTable.indexPathsForSelectedRows?.count ?? 0 == 0 {
       rightNavigationMode = .none
     } else {


### PR DESCRIPTION
Already-installed resources from a package were previously set to be installable upon download / install-from-file.  These should be pre-marked.  (Note the greyed options.)

Additionally, if a package supports multiple languages for a resource and the first language is already installed, the default selection shifts to the first language not currently paired with the resource.

<img width="559" alt="Screen Shot 2020-09-28 at 10 04 54 AM" src="https://user-images.githubusercontent.com/25213402/94386510-1418c800-0172-11eb-8070-5e17e8beb67b.png">

Previously-installed language pairings may be selected for reinstallation:

<img width="559" alt="Screen Shot 2020-09-28 at 10 02 30 AM" src="https://user-images.githubusercontent.com/25213402/94386568-2d217900-0172-11eb-82d0-dfc9279a4a9d.png">

This _should_ reinstall _all_ possible resource pairings for that language, even if some were manually removed.  Otherwise, only currently-installed resource pairings will be updated.  If the resource is then deselected, the grayed-out formatting will be restored.

"Install" will still be selectable even if no _new_ selections have been made... as long as at least one resource pairing from the package has already been installed.

<img width="559" alt="Screen Shot 2020-09-28 at 10 08 43 AM" src="https://user-images.githubusercontent.com/25213402/94386762-9acda500-0172-11eb-8cd8-eba235ce45cb.png">

If nothing has been previously installed from the package _and_ nothing is marked for installation, then the "Install" button will be unselectable.  (Even if something was previously picked; this aspect hadn't been working correctly before.)

<img width="559" alt="Screen Shot 2020-09-28 at 10 09 16 AM" src="https://user-images.githubusercontent.com/25213402/94386872-d7999c00-0172-11eb-92a6-0bf9d42cf87e.png">
