### PR TITLE
fix(android/engine): Fix undetermined lexical model package ID

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -964,7 +964,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
         }
 
         // Check if associated model is not already installed
-        if (KMManager.getAssociatedLexicalModel(languageID) == null) {
+        if ((KMManager.getAssociatedLexicalModel(languageID) == null) && KMManager.hasConnection(context)) {
           String _downloadid = CloudLexicalModelMetaDataDownloadCallback.createDownloadId(languageID);
           CloudLexicalModelMetaDataDownloadCallback _callback = new CloudLexicalModelMetaDataDownloadCallback();
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -4,6 +4,7 @@
 package com.tavultesoft.kmea.data;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -45,14 +46,14 @@ public class LexicalModel extends LanguageResource implements Serializable {
       String packageID = "";
       if (lexicalModelJSON.has(KMManager.KMKey_PackageID)) {
         packageID = lexicalModelJSON.getString(KMManager.KMKey_PackageID);
-      } else if (kmp != null && FileUtils.hasLexicalModelPackageExtension(kmp)) {
-        // Extract package ID from packageFilename
-        String filename = FileUtils.getFilename(kmp);
-        // Truncate .model.kmp file extension
-        packageID = filename.replace(FileUtils.MODELPACKAGE, "");
+      } else if (kmp != null) {
+        Uri uri = Uri.parse(kmp);
+        // Extract package ID from uri
+        packageID = uri.getLastPathSegment();
       } else {
         // Invalid Package ID
-        KMLog.LogError(TAG, "Invalid package ID");
+        KMLog.LogExceptionWithData(TAG, "Invalid package ID with lexicalModelJSON",
+          "lexicalModelJSON", lexicalModelJSON.toString(4), null);
       }
 
       String resourceID = lexicalModelJSON.getString(KMManager.KMKey_ID);


### PR DESCRIPTION
This addresses the Sentry error [invalid package ID](http://sentry.keyman.com/organizations/keyman/issues/898/?project=7&query=is%3Aunresolved)

One side effect of keymanapp/api.keyman.com#105 is that "packageFilename" no longer ends in "model.kmp". This cleans up the logic in determining the lexical model package ID.