### PR TITLE
fix(android/app): Allow uninstalling sil_euro_latin for non-default languages

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
@@ -125,7 +125,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     infoList.add(hashMap);
 
     // If not default keyboard, display uninstall keyboard
-    if (!kbID.equalsIgnoreCase(KMManager.KMDefault_KeyboardID)) {
+    if (!(kbID.equalsIgnoreCase(KMManager.KMDefault_KeyboardID) &&
+        languageID.equalsIgnoreCase(KMManager.KMDefault_LanguageID))) {
       hashMap = new HashMap<>();
       hashMap.put(titleKey, getString(R.string.uninstall_keyboard));
       hashMap.put(subtitleKey, "");


### PR DESCRIPTION
Keyman has checks to prevent the default keyboard (sil_euro_latin) from being uninstalled. 

We should still allow non-default language IDs to be uninstalled with sil_euro_latin.


