### PR TITLE
fix(android/app): Only copy asset .kmp file if it doesn't exist

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -624,8 +624,13 @@ public final class KMManager {
 
         // Copy asset KMP files
         if (isPackageFile) {
-          copyAsset(context, assetFile, "", true);
           kmpFile = new File(getResourceRoot(), assetFile);
+          if (kmpFile.exists()) {
+            // Skip if kmp file already exists.
+            // Admittedly, we'll miss out on kmp updates with Keyman upgrades
+            continue;
+          }
+          copyAsset(context, assetFile, "", true);
           tempPackagePath = kmpProcessor.unzipKMP(kmpFile);
 
           // Determine package info


### PR DESCRIPTION
Fixes #3521

Update `KMManager.copyAssets` so asset kmp files only get copied if they don't exist. This avoids unzipping the packages on every startup.