### PR TITLE
fix(windows): Buffer overrun in firstrun

### DIFF
--- a/windows/src/ext/sentry/Sentry.Client.pas
+++ b/windows/src/ext/sentry/Sentry.Client.pas
@@ -247,6 +247,15 @@ begin
   if sentry_init(options) = 0 then
     FSentryInit := True;
 
+  {$WARN SYMBOL_PLATFORM OFF} // W1002 Symbol 'CmdLine' is specific to a platform
+  if CmdLine <> nil then
+  begin
+    sentry_set_tag('keyman.commandline', PAnsiChar(AnsiString(string(CmdLine))));
+  end;
+  {$WARN SYMBOL_PLATFORM DEFAULT}
+
+  sentry_set_tag('keyman.executable', PAnsiChar(AnsiString(ParamStr(0))));
+
   if scfCaptureExceptions in AFlags then
   begin
     // This allows us to capture call stacks from the original exception context

--- a/windows/src/global/delphi/general/Keyman.System.UILanguageManager.pas
+++ b/windows/src/global/delphi/general/Keyman.System.UILanguageManager.pas
@@ -33,7 +33,7 @@ begin
 
   if GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, @ulNumLanguages, nil, @cchLanguagesBuffer) then
   begin
-    pwszLanguagesBuffer := AllocMem(cchLanguagesBuffer);
+    pwszLanguagesBuffer := AllocMem(cchLanguagesBuffer * sizeof(Char));
     try
       if GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, @ulNumLanguages, pwszLanguagesBuffer, @cchLanguagesBuffer) then
       begin


### PR DESCRIPTION
Fixes #3633.

Memory allocation was half its required size due to missing
`sizeof(Char)` calculation.

Also added extra tags to Sentry events for command line and executable,
which made tracing this issue so much easier.