### PR TITLE
fix(windows): upgrading transitional profiles

### DIFF
--- a/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
@@ -109,6 +109,7 @@ uses
   kmxfileconsts,
   utilicon,
   utilstr,
+  utiltsf,
   keymanapi_TLB;
 
 procedure TKPInstallKeyboard.Execute(const FileName, PackageID: string; FInstallOptions: TKPInstallKeyboardOptions; Languages: TPackageKeyboardLanguageList; Force: Boolean);
@@ -403,7 +404,7 @@ begin
               r.WriteString(BCP47Tag, PackageLanguageMetadata[i].Name);
               kpil := TKPInstallKeyboardLanguage.Create(Context);
               try
-                if kpil.FindInstallationLangID(BCP47Tag, LangID, TemporaryKeyboardID, []) then
+                if kpil.FindInstallationLangID(BCP47Tag, LangID, TemporaryKeyboardID, []) and not IsTransientLanguageID(LangID) then
                   kpil.RegisterTip(kbdname, BCP47Tag, ki.KeyboardName, LangID, FIconFileName, PackageLanguageMetadata[i].Name);
               finally
                 kpil.Free;


### PR DESCRIPTION
Relates to #3561.

If a keyboard is installed for a transitional profile but another keyboard is already installed for that profile, then Keyman would crash, expecting the transitional profile to be missing.

Note that this does not introduce support for upgrading transitional language profiles, but simply resolves the related crash. Upgrading transitional language profiles (and disabled keyboards) will be added in an upcoming PR.