### PR TITLE
fix(windows): Upgrading keyboards with transient profiles

### DIFF
--- a/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
@@ -17,8 +17,6 @@ uses
   Keyman.System.Standards.LangTagsRegistry,
   System.SysUtils;
 
-// TODO: Make this a COM API function so we aren't shipping 3+MB of standards data multiple times
-
 ///
 ///<summary>Find a language code with appropriate script and region subtags</summary>
 ///<remarks>


### PR DESCRIPTION
Relates to #3561.

If a keyboard has languages installed under one of the four transient language profiles, then we need to jump through some additional hoops to upgrade it to the 14.0 model.

This does not yet handle all scenarios around installed but non-loaded keyboards.