### PR TITLE
fix(android/app): Switch system keyboard in KMPBrowserActivity

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -16,15 +16,18 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.util.KMPLink;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class KMPBrowserActivity extends AppCompatActivity {
+public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEventHandler.OnKeyboardEventListener {
   private static final String TAG = "KMPBrowserActivity";
 
   // URL for keyboard search web page presented to user when they add a keyboard in the app.
@@ -133,6 +136,8 @@ public class KMPBrowserActivity extends AppCompatActivity {
   @Override
   protected void onResume() {
     super.onResume();
+    KMManager.addKeyboardEventListener(this);
+
     if (webView != null) {
       webView.reload();
     }
@@ -141,11 +146,38 @@ public class KMPBrowserActivity extends AppCompatActivity {
   @Override
   protected void onPause() {
     super.onPause();
+    KMManager.removeKeyboardEventListener(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
+  }
+
+  @Override
+  public void onKeyboardLoaded(KMManager.KeyboardType keyboardType) {
+    // Mitigation for https://github.com/keymanapp/keyman/issues/1963
+    // Due to latency, switch from Keyman system keyboard to another
+    if (KMManager.getKMKeyboard(KMManager.KeyboardType.KEYBOARD_TYPE_SYSTEM) != null) {
+      Toast.makeText(getApplicationContext(), getString(R.string.switching_keyboard),
+        Toast.LENGTH_SHORT).show();
+      KMManager.advanceToNextInputMode();
+    }
+  }
+
+  @Override
+  public void onKeyboardChanged(String newKeyboard) {
+    // Do nothing
+  }
+
+  @Override
+  public void onKeyboardShown() {
+    //
+  }
+
+  @Override
+  public void onKeyboardDismissed() {
+    // Do nothing
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
   <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
   <string name="add_language_subtext" comment="Additional information for adding another language">(from keyboard package)</string>
 
+  <!-- Context: Keyman Settings "Install from keyman.com" menu -->
+  <string name="switching_keyboard" comment="Switching to another keyboard">Switching to another keyboard</string>
 
   <!-- Context: Select Package and Select Languages menu -->
   <string name="title_select_keyboard_package_list" comment="Select a keyboard package to add languages">Select Keyboard Package</string>


### PR DESCRIPTION
This is in the category of unpleasant mitigations for #1963 

Until we get a better grasp of why there's lag using a Keyman system keyboard in our internal WebView (e.g. embedded keyboard search), this PR has the Keyman system keyboard switch to another system keyboard.