### PR TITLE
chore: exclude parens if no scope in commit msg

### DIFF
--- a/resources/git-hooks/prepare-commit-msg
+++ b/resources/git-hooks/prepare-commit-msg
@@ -96,7 +96,12 @@ function prepend_scope() {
     else
       postfix=""
     fi
-    prefix="$TYPE($SCOPE): $EXTRA_WHITESPACE"
+
+    if [ -z "$SCOPE" ]; then
+      prefix="$TYPE: $EXTRA_WHITESPACE"
+    else
+      prefix="$TYPE($SCOPE): $EXTRA_WHITESPACE"
+    fi
 
     # Reuse any existing message text, wrapping it in our conventional commit formatting before
     # presenting it to the user for any final edits.


### PR DESCRIPTION
If no scope is found in the branch name, then don't include the parentheses around the scope, as this breaks automatic merge messages and the parentheses are unnecessary.
