### PR TITLE
fix(web): Fix how layer is separated from key name

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -386,14 +386,19 @@ namespace com.keyman.text {
       osk.vkbd.keyPending = null;
 
       // Changes for Build 353 to resolve KMEI popup key issues      
-      keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
-      
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:core.keyboardProcessor.layerId);
-      keyName=t[t.length-1];
+      keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
+
+      // Can't just split on '-' because some layers like ctrl-shift contain it.
+      let separatorIndex = keyName.lastIndexOf('-');
+      var layer = core.keyboardProcessor.layerId;
+      if (separatorIndex > 0) {
+        layer = keyName.substring(0, separatorIndex);
+        keyName = keyName.substring(separatorIndex+1);
+      }
       if(layer == 'undefined') {
         layer=core.keyboardProcessor.layerId;
       }
-      
+
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
       var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=com.keyman.text.KeyboardProcessor.getModifierState(layer);


### PR DESCRIPTION
Fixes #3569

The touch layout keyboard in the issue accesses `ctrl-alt` and `shift-ctrl-alt` layers on some long-presses (e.g. "numeric" layer on the <kbd>[</kbd> key). KMW was just doing a `split('-')` to separate the layer from the key name.

This PR fixes that to account for layers that may contain '-'.

Q: Do we 🍒-pick to stable-13.0? 

## User Testing
Jotting a list of some touch-layout keyboards that contain `-` in the layer ("shift-alt", "shift-ctrl", "ctrl-alt", "rightalt-shift", etc)
* bangla_joy
    * on "rightalt" layer, press <kbd>৲</kbd>. This is `rightalt-shift-K_4`
    * on "rightalt" layer, press <kbd>৺</kbd>. This is `rightalt-shift-K_7`
    * on "rightalt" layer, press <kbd>৹</kbd>. This is `rightalt-shift-K_0`

* bangla_probhat
* basic_kbdarmph
* basic_kbdarmty
* basic_kbdcher
* basic_kbdcz1
    * on the "rightalt" layer, press <kbd>{</kbd>. This is `rightalt-shift-K_LBRKT`
    * on the "rightalt" layer, press <kbd>}</kbd>. This is `rightalt-shift-K_RBRKT`

* basic_kbdcz2
* basic_kbddzo
* sil_yoruba_bar
* sil_yoruba_dot
    * on "shift" layer, longpress <kbd>GB</kbd> and select <kbd>Q</kbd>. This is `rightalt-shift-K_Q`
    * on "shift" layer, longpress <kbd>S̩</kbd> and select <kbd>Z</kbd>. THis is `rightalt-shift-K_Z`
