### PR TITLE
feat(common/models):  context tracking of accepted Suggestions

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -240,6 +240,7 @@ namespace com.keyman.text.prediction {
             // The ID part is critical; the reversion can't be applied without it.
             transformId: reversionTranscription.token,
             displayAs: reversion.displayAs,
+            id: reversion.id,
             tag: reversion.tag
           }
           // // If using the version from lm-layer:

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -217,6 +217,14 @@ declare interface Suggestion {
   transformId?: number;
 
   /**
+   * A unique identifier for the Suggestion itself, not shared with any others -
+   * even for Suggestions sourced from the same Transform. 
+   * 
+   * The lm-layer is responsible for setting this field, not models.
+   */
+  id?: number;
+
+  /**
    * The suggested update to the buffer. Note that this transform should
    * be applied AFTER the instigating transform, if any.
    */

--- a/common/predictive-text/unit_tests/headless/edit-distance/context-tracker.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/context-tracker.js
@@ -1,5 +1,7 @@
 var assert = require('chai').assert;
 var ContextTracker = require('../../../build/intermediate/index').correction.ContextTracker;
+var ModelCompositor = require('../../../build/intermediate/index').ModelCompositor;
+var models = require('../../../build/intermediate/index').models;
 
 describe('ContextTracker', function() {
   function toWrapperDistribution(transform) {
@@ -99,6 +101,72 @@ describe('ContextTracker', function() {
 
       let state = ContextTracker.modelContextState(context);
       assert.deepEqual(state.tokens.map(token => token.raw), rawTokens);
+    });
+  });
+
+  describe('suggestion acceptance tracking', function() {
+    let englishPunctuation = {
+      quotesForKeepSuggestion: { open: `“`, close: `”`},
+      insertAfterWord: ' '
+    };
+
+    it('tracks an accepted suggestion', function() {
+      let baseSuggestion = {
+        transform: {
+          insert: 'world ',
+          deleteLeft: 3,
+          id: 0
+        },
+        transformId: 0,
+        id: 1,
+        displayAs: 'world'
+      };
+  
+      let baseContext = {
+        left: 'hello wor', startOfBuffer: true, endOfBuffer: true
+      };
+    
+      // Represents the keystroke that triggered the suggestion.  It's not technically part
+      // of the Context when the suggestion is built.
+      let postTransform = {
+        insert: 'l',
+        deleteLeft: 0
+      };
+
+      let options = {
+        punctuation: englishPunctuation
+      };
+
+      let model = new models.TrieModel(jsonFixture('tries/english-1000'), options);
+      let compositor = new ModelCompositor(model);
+      let baseContextState = compositor.contextTracker.analyzeState(model, baseContext);
+
+      baseContextState.tail.replacements = [{
+        suggestion: baseSuggestion,
+        tokenWidth: 1
+      }];
+
+      let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
+
+      // Actual test assertion - was the replacement tracked?
+      assert.equal(baseContextState.tail.activeReplacementId, baseSuggestion.id);
+      assert.equal(reversion.id, -baseSuggestion.id);
+
+      // Next step - on the followup context, is the replacement still active?
+      let postContext = models.applyTransform(baseSuggestion.transform, baseContext);
+
+      let postContextState = compositor.contextTracker.analyzeState(model, postContext);
+
+      // The non-wordbreak token before the tail in the newer TrackedContextState should deep-equal
+      // the tail token of the original TrackedContextState, but the two tokens should be different instances.
+      assert.notEqual(postContextState.tokens[postContextState.tokens.length - 3], baseContextState.tail);
+      assert.deepEqual(postContextState.tokens[postContextState.tokens.length - 3], baseContextState.tail);
+
+      // Penultimate token corresponds to whitespace, which does not have a 'raw' representation.
+      assert.isNull(postContextState.tokens[postContextState.tokens.length - 2].raw);
+
+      // Final token is empty (follows a wordbreak)
+      assert.equal(postContextState.tail.raw, '');
     });
   });
 });

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -165,6 +165,7 @@ describe('ModelCompositor', function() {
           id: 0
         },
         transformId: 0,
+        id: 1,
         displayAs: 'hello'
       };
   
@@ -180,6 +181,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
       //            Does this include characters not considered when the Suggestion was built?
@@ -205,6 +207,7 @@ describe('ModelCompositor', function() {
           id: 0
         },
         transformId: 0,
+        id: 0,
         displayAs: 'world'
       };
   
@@ -220,6 +223,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
       //            Does this include characters not considered when the Suggestion was built?
@@ -245,6 +249,7 @@ describe('ModelCompositor', function() {
           id: 0
         },
         transformId: 0,
+        id: 0,
         displayAs: 'world'
       };
   
@@ -253,6 +258,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext);
+      assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
       //            Does this include characters not considered when the Suggestion was built?
@@ -278,6 +284,7 @@ describe('ModelCompositor', function() {
           id: 0
         },
         transformId: 0,
+        id: 0,
         displayAs: 'hello'
       };
   
@@ -293,6 +300,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
       //            Does this include characters not considered when the Suggestion was built?

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -90,6 +90,14 @@ namespace correction {
       }
     }
 
+    get head(): TrackedContextToken {
+      return this.tokens[0];
+    }
+
+    get tail(): TrackedContextToken {
+      return this.tokens[this.tokens.length - 1];
+    }
+
     popHead() {
       this.tokens.splice(0, 2);
       this.indexOffset -= 1;
@@ -121,7 +129,7 @@ namespace correction {
     }
 
     updateTail(transformDistribution: Distribution<Transform>, tokenText?: USVString) {
-      let editedToken = this.tokens[this.tokens.length - 1];
+      let editedToken = this.tail;
       
       // Preserve existing text if new text isn't specified.
       tokenText = tokenText || (tokenText === '' ? '' : editedToken.raw);
@@ -284,7 +292,7 @@ namespace correction {
         if(ignorePenultimateMatch) {
           // For this case, we were likely called by ModelCompositor.acceptSuggestion(), which
           // would have marked the accepted suggestion.
-          matchState.tokens[matchState.tokens.length - 1].replacementText = tokenizedContext[tokenizedContext.length-2];
+          matchState.tail.replacementText = tokenizedContext[tokenizedContext.length-2];
         }
 
         state = new TrackedContextState(matchState);

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -9,8 +9,8 @@ namespace correction {
   export class TrackedContextToken {
     raw: string;
     transformDistributions: Distribution<Transform>[] = [];
-    replacements: TrackedContextSuggestion;
-    activeReplacement: number = -1;
+    replacements: TrackedContextSuggestion[];
+    activeReplacementId: number = -1;
 
     get isNew(): boolean {
       return this.transformDistributions.length == 0;
@@ -44,7 +44,7 @@ namespace correction {
           let copy = new TrackedContextToken();
           copy.raw = token.raw;
           copy.replacements = token.replacements
-          copy.activeReplacement = token.activeReplacement;
+          copy.activeReplacementId = token.activeReplacementId;
           copy.transformDistributions = token.transformDistributions;
   
           return copy;

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -333,6 +333,13 @@ namespace correction {
         state.pushTail(baseTokens.splice(0, 1)[0]);
       }
 
+      if(state.tokens.length == 0) {
+        let token = new TrackedContextToken();
+        token.raw = '';
+
+        state.pushTail(token);
+      }
+
       return state;
     }
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -307,7 +307,12 @@ class ModelCompositor {
     // Store the suggestions on the final token of the current context state (if it exists).
     // Or, once phrase-level suggestions are possible, on whichever token serves as each prediction's root.
     if(contextState) {
-      // TODO:  context tracking enhancements
+      contextState.tokens[contextState.tokens.length - 1].replacements = suggestions.map(function(suggestion) {
+        return {
+          suggestion: suggestion,
+          tokenWidth: 1
+        }
+      });
     }
 
     return suggestions;
@@ -386,7 +391,7 @@ class ModelCompositor {
     }
 
     let postContextTokens = this.lexicalModel.tokenize(context); //.wordbreak(postContext);
-    let revertedPrefix = postContextTokens[postContextTokens.length - 1];
+    let revertedPrefix = postContextTokens[postContextTokens.length - 1] || '';
 
     let firstConversion = models.transformToSuggestion(reversionTransform);
     firstConversion.displayAs = revertedPrefix;

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -400,8 +400,15 @@ class ModelCompositor {
     // Since we're outside of the standard `predict` control path, we'll need to
     // set the Reversion's ID directly.
     let reversion = this.toAnnotatedSuggestion(firstConversion, 'revert');
-    reversion.id = this.SUGGESTION_ID_SEED;
-    this.SUGGESTION_ID_SEED++;
+    if(suggestion.id) {
+      // Since a reversion inverts its source suggestion, we set its ID to be the 
+      // additive inverse of the source suggestion's ID.  Makes easy mapping /
+      // verification later.
+      reversion.id = -suggestion.id;
+    } else {
+      reversion.id = -this.SUGGESTION_ID_SEED;
+      this.SUGGESTION_ID_SEED++;
+    }
     
     // Step 3:  if we track Contexts, update the tracking data as appropriate.
     if(this.contextTracker) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -7,6 +7,8 @@ class ModelCompositor {
   private static readonly MAX_SUGGESTIONS = 12;
   private readonly punctuation: LexicalModelPunctuation;
 
+  private SUGGESTION_ID_SEED = 0;
+
   constructor(lexicalModel: LexicalModel) {
     this.lexicalModel = lexicalModel;
     if(lexicalModel.traverseFromRoot) {
@@ -297,6 +299,9 @@ class ModelCompositor {
           suggestion.transform.deleteRight = mergedTransform.deleteRight;
         }
       }
+
+      suggestion.id = compositor.SUGGESTION_ID_SEED;
+      compositor.SUGGESTION_ID_SEED++;
     });
 
     // Store the suggestions on the final token of the current context state (if it exists).
@@ -390,10 +395,13 @@ class ModelCompositor {
     // Since we're outside of the standard `predict` control path, we'll need to
     // set the Reversion's ID directly.
     let reversion = this.toAnnotatedSuggestion(firstConversion, 'revert');
+    reversion.id = this.SUGGESTION_ID_SEED;
+    this.SUGGESTION_ID_SEED++;
     
     // Step 3:  if we track Contexts, update the tracking data as appropriate.
     if(this.contextTracker) {
-      // TODO:  implement.
+      let contextState = this.contextTracker.analyzeState(this.lexicalModel, context);
+      contextState.tokens[contextState.tokens.length - 1].activeReplacementId = suggestion.id;
     }
 
     return reversion;

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -310,7 +310,7 @@ class ModelCompositor {
     // Store the suggestions on the final token of the current context state (if it exists).
     // Or, once phrase-level suggestions are possible, on whichever token serves as each prediction's root.
     if(contextState) {
-      contextState.tokens[contextState.tokens.length - 1].replacements = suggestions.map(function(suggestion) {
+      contextState.tail.replacements = suggestions.map(function(suggestion) {
         return {
           suggestion: suggestion,
           tokenWidth: 1
@@ -420,9 +420,8 @@ class ModelCompositor {
       if(!contextState) {
         contextState = this.contextTracker.analyzeState(this.lexicalModel, context);
       }
-      let lastToken = contextState.tokens[contextState.tokens.length - 1];
       
-      lastToken.activeReplacementId = suggestion.id;
+      contextState.tail.activeReplacementId = suggestion.id;
       let acceptedContext = models.applyTransform(suggestion.transform, context);
       this.contextTracker.analyzeState(this.lexicalModel, acceptedContext);
     }

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -284,6 +284,7 @@ class ModelCompositor {
 
     // Apply 'after word' punctuation and set suggestion IDs.  
     // We delay until now so that utility functions relying on the unmodified Transform may execute properly.
+    let compositor = this;
     suggestions.forEach(function(suggestion) {
       if (suggestion.transform.insert.length > 0) {
         suggestion.transform.insert += punctuation.insertAfterWord;

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -129,7 +129,7 @@ interface AcceptMessage {
   /**
    * The Suggestion being accepted.  The ID must be assigned.
    */
-  suggestion: Suggestion;
+  suggestion: Suggestion & {id: number};
 
   /**
    * The context (text to the left and text to right) at the


### PR DESCRIPTION
This PR adds internal tracking of user manipulations to the context state.  In particular, whenever a user 'accepts' a `Suggestion`, this will be noted within the `ContextTracker` to provide enhanced information to subsequent prediction efforts.  (All such tracking is worker-internal and only for the user's local use.)  This was previously part of #3647, but the changes were distinct enough to merit splitting it in twain - hence this now being reviewable separately.

- Tracked context now notes any accepted suggestions and the resulting token text, maintaining both the original and replaced versions of each token.
- Fixes some related internal context tracking bugs that hadn't yet been caught due to lack of external impact.  (Arguably, it may be more of an "incomplete implementation" scenario.)
- 'Reversions' will still seem a bit broken for now - part of that whole "incomplete implementation" bit.
    - That said, once work is complete, these changes will add extra polish beyond what was available in prior versions of Keyman's predictive text.

Related upcoming features:
- Whenever a user chooses to "revert" a `Suggestion`, the _full_ original context will be restored.
    - The system will remember all calculations for the context, thus allowing the original keystroke probabilities to drive  predictions when extending typed context from a reversion!
    - At the time of reversion, we'll be able to immediately return the original set of predictions, rather than recomputing them from scratch.
- If handled correctly, KMW should be able to 'revert' any deadkeys that were originally 'consumed' when accepting Suggestions.
    - Of course, it's quite debatable whether or not we want to actually do this.
- Debatably, we may be getting close to a point where we _**could**_ experiment with some auto-correction behavior.
    - It's far safer when when no information about the prior state is lost _and_ when it can be easily restored.
    - This particular point will be its own PR if and when we choose to pursue it.

All of this tracking data is _also_ designed for further extensions in the far future, beyond 14.0:
- If we ever wish to allow phrase-level suggestions, the tokenized context tracking is designed to facilitate this.
    - Everything I can foresee such a feature needing will be available there.
    - Also handy for catching cases where 'whitespace typos' occur, which 14.0 predictive text assumes to be impossible.

While a bit more test development probably "wouldn't hurt," there is a test now, so I'm comfortable moving this out of draft.