### PR TITLE
fix(developer): ci uses repo tier and version

### DIFF
--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -82,12 +82,10 @@ done
 
 # Dry run settings
 if (( should_dry_run )); then
-  DRY_RUN="echo dry run:"
+  DRY_RUN=--dry-run
 else
   DRY_RUN=
 fi
-
-# We now ignore the version and tier strings.
 
 publish_version=`cat "$KEYMAN_ROOT/VERSION.md"`
 publish_tier=`cat "$KEYMAN_ROOT/TIER.md"`
@@ -149,5 +147,5 @@ if (( should_publish )); then
   # a package in the @keymanapp scope on the public npm package index.
   #
   # See `npm help publish` for more details.
-  $DRY_RUN npm publish --access public --tag "${npm_dist_tag:=latest}" || fail "Could not publish ${npm_dist_tag} release."
+  npm publish $DRY_RUN --access public --tag "${npm_dist_tag:=latest}" || fail "Could not publish ${npm_dist_tag} release."
 fi

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -73,9 +73,9 @@ heat-model-compiler:
     cd $(KEYMAN_MODELCOMPILER_ROOT)
 
 !ifdef GIT_BASH_FOR_KEYMAN
-    $(GIT_BASH_FOR_KEYMAN) build.sh -version "$VERSION" -tier "$(TIER)"
+    $(GIT_BASH_FOR_KEYMAN) build.sh
 !else
-    start /wait .\build.sh -version "$VERSION" -tier "$(TIER)"
+    start /wait .\build.sh
 !endif
     # We use `npm pack` to extract only the aspects of the model-compiler actually needed for distribution.
     # While we could use npm-bundle or similar, that adds extra, unwanted cruft; our approach gives us more


### PR DESCRIPTION
Previously, the build would take the TeamCity TIER and VERSION, which are eliminated in favour of the repo sources (the details are populated correctly for alpha but are not needed given we have TIER.md and VERSION.md).