### PR TITLE
fix(windows): update CI for publishing desktop help

### DIFF
--- a/windows/src/buildtools/help-keyman-com.sh
+++ b/windows/src/buildtools/help-keyman-com.sh
@@ -5,6 +5,15 @@
 #
 SHLVL=0
 
+set -e
+set -u
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 #
 # Allows us to check for existence of subfolders in help/
 #
@@ -19,18 +28,12 @@ shopt -s nullglob
 # These are passed via environment:
 #
 # HELP_KEYMAN_COM = the home of the help.keyman.com repository
-# MAJOR_VERSION = 10.0, 11.0, etc
 #
 # That repo must have push to origin configured and logged in
 #
 
 if [ -z ${HELP_KEYMAN_COM+x} ]; then
   >&2 echo "Not uploading documentation: must set HELP_KEYMAN_COM in environment."
-  exit 1
-fi
-
-if [ -z ${MAJOR_VERSION+x} ]; then
-  >&2 echo "Not uploading documentation: must set MAJOR_VERSION in environment."
   exit 1
 fi
 
@@ -82,7 +85,7 @@ function upload_keyman_desktop_help {
     return 0
   fi
 
-  local dstpath="$HELP_KEYMAN_COM/products/desktop/$MAJOR_VERSION/docs"
+  local dstpath="$HELP_KEYMAN_COM/products/desktop/$VERSION_RELEASE/docs"
 
   mkdir -p "$dstpath"
 
@@ -92,6 +95,7 @@ function upload_keyman_desktop_help {
 
 #
 # Commit and push to the help.keyman.com repo
+# TODO: turn this into a pull request
 #
 
 function commit_and_push {
@@ -100,7 +104,7 @@ function commit_and_push {
   pushd $HELP_KEYMAN_COM
   git config user.name "Keyman Build Server"
   git config user.email "keyman-server@users.noreply.github.com"
-  git add products/desktop/$MAJOR_VERSION/docs || return 1
+  git add products/desktop/$VERSION_RELEASE/docs || return 1
   git diff --cached --no-ext-diff --quiet --exit-code && {
     # if no changes then don't do anything.
     echo "No changes to commit"


### PR DESCRIPTION
This updates the build script to use the version data available in the repository rather than relying on environment.