### PR TITLE
fix(web): ci uses repo tier and version

### DIFF
--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -32,6 +32,7 @@ run_tests=0
 install_dependencies=1
 should_publish=0
 npm_dist_tag=
+should_dry_run=0
 
 # Process command-line arguments
 while [[ $# -gt 0 ]] ; do

--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -17,72 +17,60 @@ EX_USAGE=64
 
 
 display_usage ( ) {
-  echo "Usage: $0 [-test] [-version version] [-tier tier]"
+  echo "Usage: $0 [-test] [-publish-to-npm]"
   echo "       $0 -help"
   echo
   echo "  -help               displays this screen and exits"
-  echo "  -version version    sets the package version before building"
   echo "  -test               runs tests"
   echo "  -publish-to-npm     publishes the current version to the npm package index"
-  echo "  -tier tier          also sets the package version tier and npm tag (alpha, beta, stable) before building or publishing"
-  echo "                      If version has 4 components, only first three are used."
+  echo "  -dry-run            do test, etc, but don't actually publish"
 }
 
 ################################ Main script ################################
 
 run_tests=0
 install_dependencies=1
-publish_version=
-publish_tier=
-lastkey=
 should_publish=0
 npm_dist_tag=
 
 # Process command-line arguments
 while [[ $# -gt 0 ]] ; do
   key="$1"
-  if [[ -z "$lastkey" ]]; then
-    case $key in
-      -help|-h)
-        display_usage
-        exit
-        ;;
-      -test)
-        run_tests=1
-        install_dependencies=0
-        ;;
-      -version)
-        lastkey=$key
-        ;;
-      -tier)
-        lastkey=$key
-        ;;
-      -publish-to-npm)
-        should_publish=1
-        ;;
-      *)
-        echo "$0: invalid option: $key"
-        display_usage
-        exit $EX_USAGE
-    esac
-  else
-    case $lastkey in
-      -version)
-        publish_version=$key
-        ;;
-      -tier)
-        publish_tier=$key
-        ;;
-      *)
-        # Should be impossible to reach ;-)
-        echo "$0: invalid option: $lastkey"
-        display_usage
-        exit $EX_USAGE
-    esac
-    lastkey=
-  fi
+  case $key in
+    -help|-h)
+      display_usage
+      exit
+      ;;
+    -test)
+      run_tests=1
+      install_dependencies=0
+      ;;
+    -version)
+      echo "Warning: -version is now ignored"
+      ;;
+    -tier)
+      echo "Warning: -tier is now ignored"
+      ;;
+    -publish-to-npm)
+      should_publish=1
+      ;;
+    *)
+      echo "$0: invalid option: $key"
+      display_usage
+      exit $EX_USAGE
+  esac
   shift # past the processed argument
 done
+
+# Dry run settings
+if (( should_dry_run )); then
+  DRY_RUN=--dry-run
+else
+  DRY_RUN=
+fi
+
+publish_version=`cat "$KEYMAN_ROOT/VERSION.md"`
+publish_tier=`cat "$KEYMAN_ROOT/TIER.md"`
 
 # Validate the publish_version
 if [ ! -z "$publish_version" ]; then
@@ -145,5 +133,5 @@ if (( should_publish )); then
   # a package in the @keymanapp scope on the public npm package index.
   #
   # See `npm help publish` for more details.
-  npm publish --access public --tag "${npm_dist_tag:=latest}" || fail "Could not publish ${npm_dist_tag} release."
+  npm publish $DRY_RUN --access public --tag "${npm_dist_tag:=latest}" || fail "Could not publish ${npm_dist_tag} release."
 fi

--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -42,6 +42,9 @@ while [[ $# -gt 0 ]] ; do
       display_usage
       exit
       ;;
+    -dry-run)
+      should_dry_run=1
+      ;;
     -test)
       run_tests=1
       install_dependencies=0


### PR DESCRIPTION
Previously, the build would take the TeamCity TIER and VERSION, which are eliminated in favour of the repo sources (the details are populated correctly for alpha but are not needed given we have TIER.md and VERSION.md).

This is analogous to #3670.