### PR TITLE
fix(web): Fix layer how layer is separated from key name

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -120,12 +120,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation "com.google.firebase:firebase-analytics:17.2.1"
+    implementation "com.google.firebase:firebase-analytics:17.6.0"
     implementation "com.google.firebase:firebase-messaging:20.0.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
     implementation 'androidx.preference:preference:1.1.0'
 
     // Add dependency for generating QR Codes

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -76,11 +76,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3.1'
 
     /* We only want these Firebase Crashlytics dependencies for KMEA */
-    implementation 'com.google.firebase:firebase-analytics:17.2.1'
+    implementation 'com.google.firebase:firebase-analytics:17.6.0'
     implementation 'com.google.firebase:firebase-crash:16.2.1'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
 
     // Generate QR Codes
     implementation ('com.github.kenglxn.QRGen:android:2.6.0') {

--- a/android/README.md
+++ b/android/README.md
@@ -165,12 +165,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.1'
     implementation 'com.google.android.material:material:1.0.0'
     api (name:'keyman-engine', ext:'aar')
-    implementation "com.google.firebase:firebase-analytics:17.2.1"
+    implementation "com.google.firebase:firebase-analytics:17.6.0"
     implementation "com.google.firebase:firebase-messaging:20.0.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
 
     // Include this if you want to have QR Codes displayed on Keyboard Info
     implementation ('com.github.kenglxn.QRGen:android:2.6.0') {

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -33,7 +33,4 @@ dependencies {
     api(name: 'keyman-engine', ext: 'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
 }

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -32,7 +32,4 @@ dependencies {
     api (name:'keyman-engine', ext:'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
     }
-}

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -33,7 +33,4 @@ dependencies {
     api (name:'keyman-engine', ext:'aar')
     implementation "com.google.firebase:firebase-core:17.2.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
 }

--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,11 @@
 # Keyman for Android Version History
 
+## 2020-10-07 13.0.6219 stable
+* Bug fix:
+  * Fix how layer is separated from key name (updated Keyman Web Engine #3674)
+* Change:
+  * Remove deprecated Crashlytics SDK from build (#3674)
+
 ## 2020-09-02 13.0.6218 stable
 * Bug fix:
   * Dismiss notifications when touched (#3548)

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -117,9 +117,6 @@ dependencies {
     implementation "com.google.firebase:firebase-analytics:17.2.1"
     implementation "com.google.firebase:firebase-messaging:20.0.1"
     implementation "com.google.firebase:firebase-crash:16.2.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
     implementation 'androidx.preference:preference:1.1.0'
 }
 

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -10,8 +10,6 @@ import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import com.crashlytics.android.Crashlytics;
-import io.fabric.sdk.android.Fabric;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.tavultesoft.kmea.*;
@@ -22,7 +20,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Fabric.with(this, new Crashlytics());
         setContentView(R.layout.activity_main);
 
         new FVShared(this);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -403,13 +403,19 @@ namespace com.keyman.text {
       osk.vkbd.keyPending = null;
 
       // Changes for Build 353 to resolve KMEI popup key issues      
-      keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)      
-      
-      var t=keyName.split('-'),layer=(t.length>1?t[0]:osk.vkbd.layerId);
-      keyName=t[t.length-1];
-      if(layer == 'undefined') layer=osk.vkbd.layerId;
-      
-      
+      keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
+
+      // Can't just split on '-' because some layers like ctrl-shift contain it.
+      let separatorIndex = keyName.lastIndexOf('-');
+      var layer = osk.vkbd.layerId;
+      if (separatorIndex > 0) {
+        layer = keyName.substring(0, separatorIndex);
+        keyName = keyName.substring(separatorIndex+1);
+      }
+      if(layer == 'undefined') {
+        layer=osk.vkbd.layerId;
+      }
+
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
       var Lelem=keymanweb.domManager.getLastActiveElement(),Lkc,keyShiftState=processor.getModifierState(layer);


### PR DESCRIPTION
Cherry-pick of #3659 to stable-13.0 by fixing how the layer is separated from the key name.

In order for stable-13.0 to build, I also had to remove the deprecated Crashlytics SDK