### PR TITLE
fix(windows): improve version numbers

### DIFF
--- a/developer/js/README.md
+++ b/developer/js/README.md
@@ -52,10 +52,3 @@ How to run the tests
 
     ./build.sh -test
 
-
-How to update the package version
----------------------------------
-
-**NOTE**: this step should only be performed on the CI server:
-
-    ./build.sh -version MAJOR.MINOR.${BUILD_NUMBER} [-tier (alpha|beta)]

--- a/oem/firstvoices/windows/src/inst/download.in
+++ b/oem/firstvoices/windows/src/inst/download.in
@@ -20,5 +20,5 @@ clean:
 
 candle-desktop:
   $(WIXHEAT) dir ..\xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
-  $(WIXCANDLE) -dOEMNAME="$(OEMNAME)" -dPRODUCTNAME="$(PRODUCTNAME)" -dROOT="$(ROOT)" -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\xml firstvoices.wxs desktopui.wxs
+  $(WIXCANDLE) -dOEMNAME="$(OEMNAME)" -dPRODUCTNAME="$(PRODUCTNAME)" -dROOT="$(ROOT)" -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\xml firstvoices.wxs desktopui.wxs
 

--- a/oem/firstvoices/windows/src/inst/download.in
+++ b/oem/firstvoices/windows/src/inst/download.in
@@ -8,9 +8,9 @@ default:
   echo Please don't call this file directly -- used by Makefile
 
 copyredist-desktop:
-  -mkdir $(ROOT)\release\$VERSION
-  copy /Y firstvoices.msi $(ROOT)\release\$VERSION\firstvoices.msi
-  copy /Y firstvoices.exe $(ROOT)\release\$VERSION\firstvoices-$VERSION.exe
+  -mkdir $(ROOT)\release\$Version
+  copy /Y firstvoices.msi $(ROOT)\release\$Version\firstvoices.msi
+  copy /Y firstvoices.exe $(ROOT)\release\$Version\firstvoices-$VersionWithTag.exe
 
 prepareredist:
   rem prepareredist
@@ -20,5 +20,5 @@ clean:
 
 candle-desktop:
   $(WIXHEAT) dir ..\xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
-  $(WIXCANDLE) -dOEMNAME="$(OEMNAME)" -dPRODUCTNAME="$(PRODUCTNAME)" -dROOT="$(ROOT)" -dVERSION=$VERSION -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\xml firstvoices.wxs desktopui.wxs
+  $(WIXCANDLE) -dOEMNAME="$(OEMNAME)" -dPRODUCTNAME="$(PRODUCTNAME)" -dROOT="$(ROOT)" -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\xml firstvoices.wxs desktopui.wxs
 

--- a/oem/firstvoices/windows/src/localedef.dtd.in
+++ b/oem/firstvoices/windows/src/localedef.dtd.in
@@ -1,7 +1,7 @@
   <!ENTITY Company "">
   <!ENTITY ProductName "Keyman Desktop for FirstVoices">
   <!ENTITY Edition "">
-  <!ENTITY Version "$RELEASE">
+  <!ENTITY Version "$VersionRelease">
 
   <!ENTITY EvaluationPeriod "30">
 

--- a/windows/src/buildtools/inst/copydebug.in
+++ b/windows/src/buildtools/inst/copydebug.in
@@ -7,36 +7,36 @@ SIGNCODE_BUILD=1
 !include ..\..\Defines.mak
 
 copydebug:
-    -mkdir $(ROOT)\release\$VERSION
+    -mkdir $(ROOT)\release\$Version
 
     echo mkdir c:\kmsymbols > $(ROOT)\src\install.bat
-    echo mkdir c:\kmsymbols\$VERSION >> $(ROOT)\src\install.bat
-    echo copy *.tds c:\kmsymbols\$VERSION >> $(ROOT)\src\install.bat
-    echo copy *.dbg c:\kmsymbols\$VERSION >> $(ROOT)\src\install.bat
-    echo copy *.pdb c:\kmsymbols\$VERSION >> $(ROOT)\src\install.bat
+    echo mkdir c:\kmsymbols\$Version >> $(ROOT)\src\install.bat
+    echo copy *.tds c:\kmsymbols\$Version >> $(ROOT)\src\install.bat
+    echo copy *.dbg c:\kmsymbols\$Version >> $(ROOT)\src\install.bat
+    echo copy *.pdb c:\kmsymbols\$Version >> $(ROOT)\src\install.bat
     echo regedit /s tds.reg >> $(ROOT)\src\install.bat
     $(WZZIP) $(ROOT)\src\tds.zip $(ROOT)\src\install.bat $(ROOT)\src\buildtools\inst\tds.reg
 
     rem Disabling symsrv upload from the build agents (2018-06-19 mcdurdin)
-    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\debug\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $VERSION" /c "Release $VERSION"
-    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\bin\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $VERSION" /c "Release $VERSION"
+    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\debug\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $Version" /c "Release $Version"
+    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\bin\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $Version" /c "Release $Version"
 
     # ping localhost  # delay for a few seconds
     # $(WZSE) $(ROOT)\src\tds.zip -setup -t $(ROOT)\src\buildtools\inst\tds_dialog.txt -c .\install.bat
-    copy $(ROOT)\src\tds.zip $(ROOT)\release\$VERSION\tds-$VERSION.zip
+    copy $(ROOT)\src\tds.zip $(ROOT)\release\$Version\tds-$Version.zip
     -del $(ROOT)\src\tds.zip
 
     del $(ROOT)\src\install.bat
 
     # wait 1 second -- gives winzip time to finish
     # ping -n 2 127.0.0.1
-    # copy $(ROOT)\src\tds.exe $(ROOT)\release\$VERSION\tds-$VERSION.exe
+    # copy $(ROOT)\src\tds.exe $(ROOT)\release\$Version\tds-$Version.exe
     cd $(BUILD)
-    $(WZZIP) -r $(ROOT)\release\$VERSION\debug-$VERSION.zip *.zip
+    $(WZZIP) -r $(ROOT)\release\$Version\debug-$Version.zip *.zip
 
 
 uploadsymbols:
     rem Disabling symsrv upload from the build agents (2018-06-19 mcdurdin)
-    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\debug\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $VERSION" /c "Release $VERSION"
-    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\bin\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $VERSION" /c "Release $VERSION"
+    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\debug\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $Version" /c "Release $Version"
+    # "C:\Program Files (x86)\Windows Kits\8.0\Debuggers\x86\symstore" add /r /f $(ROOT)\bin\*.* /s c:\Tavultesoft\Debug\Symbols /t "Keyman" /v "Build $Version" /c "Release $Version"
 

--- a/windows/src/buildtools/inst/srcbackup.in
+++ b/windows/src/buildtools/inst/srcbackup.in
@@ -5,6 +5,6 @@
 !include ..\..\Defines.mak
 
 srcbackup:
-    -mkdir $(ROOT)\release\$VERSION
+    -mkdir $(ROOT)\release\$Version
     cd $(ROOT)\src
-    $(WZZIP) -r -x!*.ipch -x!*.sdf -x!*.db $(ROOT)\release\$VERSION\src-$VERSION.zip *.*
+    $(WZZIP) -r -x!*.ipch -x!*.sdf -x!*.db $(ROOT)\release\$Version\src-$Version.zip *.*

--- a/windows/src/desktop/help/install.in
+++ b/windows/src/desktop/help/install.in
@@ -6,5 +6,5 @@
 
 install:
   if not exist $(KEYMAN_SITE_ROOT)\help.keyman.com\products\desktop exit 1
-  -rd /s/q $(KEYMAN_SITE_ROOT)\help.keyman.com\products\desktop\$RELEASE\docs
-  xcopy /s/q/y $(ROOT)\bin\help\php\desktop\* $(KEYMAN_SITE_ROOT)\help.keyman.com\products\desktop\$RELEASE\docs\ #
+  -rd /s/q $(KEYMAN_SITE_ROOT)\help.keyman.com\products\desktop\$VersionRelease\docs
+  xcopy /s/q/y $(ROOT)\bin\help\php\desktop\* $(KEYMAN_SITE_ROOT)\help.keyman.com\products\desktop\$VersionRelease\docs\ #

--- a/windows/src/desktop/inst/download.in
+++ b/windows/src/desktop/inst/download.in
@@ -31,7 +31,7 @@ candle: candle-desktop candle-cef candle-locale
 
 candle-desktop:
   $(WIXHEAT) dir ..\kmshell\xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
-  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
 
 #
 # Chromium Embedded Framework
@@ -47,7 +47,7 @@ heat-cef:
   -rmdir /s/q $(KEYMAN_WIX_TEMP_CEF)
 
 candle-cef: heat-cef
-  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
 
 #
 # Locale files
@@ -56,4 +56,4 @@ candle-cef: heat-cef
 candle-locale:
   # locale files are in desktop/locale/*
   $(WIXHEAT) dir ..\kmshell\locale -o locale.wxs -ag -cg Locale -dr INSTALLDIR -var var.LOCALESOURCE -wx -nologo
-  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dLOCALESOURCE=..\kmshell\locale locale.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dPRODUCTID=$GUID1 -dLOCALESOURCE=..\kmshell\locale locale.wxs

--- a/windows/src/desktop/inst/download.in
+++ b/windows/src/desktop/inst/download.in
@@ -12,10 +12,10 @@ default:
   echo Please don't call this file directly -- used by Makefile
 
 copyredist-desktop:
-  -mkdir $(ROOT)\release\$VERSION
-  copy /Y keymandesktop.msi $(ROOT)\release\$VERSION\keymandesktop.msi
-  copy /Y keymandesktop.exe $(ROOT)\release\$VERSION\keymandesktop-$VERSION.exe
-  copy /Y $(ROOT)\bin\desktop\setup.exe $(ROOT)\release\$VERSION\setup.exe
+  -mkdir $(ROOT)\release\$Version
+  copy /Y keymandesktop.msi $(ROOT)\release\$Version\keymandesktop.msi
+  copy /Y keymandesktop.exe $(ROOT)\release\$Version\keymandesktop-$VersionWithTag.exe
+  copy /Y $(ROOT)\bin\desktop\setup.exe $(ROOT)\release\$Version\setup.exe
 
 prepareredist:
   rem prepareredist
@@ -31,7 +31,7 @@ candle: candle-desktop candle-cef candle-locale
 
 candle-desktop:
   $(WIXHEAT) dir ..\kmshell\xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
-  $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
 
 #
 # Chromium Embedded Framework
@@ -47,7 +47,7 @@ heat-cef:
   -rmdir /s/q $(KEYMAN_WIX_TEMP_CEF)
 
 candle-cef: heat-cef
-  $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
 
 #
 # Locale files
@@ -56,4 +56,4 @@ candle-cef: heat-cef
 candle-locale:
   # locale files are in desktop/locale/*
   $(WIXHEAT) dir ..\kmshell\locale -o locale.wxs -ag -cg Locale -dr INSTALLDIR -var var.LOCALESOURCE -wx -nologo
-  $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dLOCALESOURCE=..\kmshell\locale locale.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$RELEASE -dPRODUCTID=$GUID1 -dLOCALESOURCE=..\kmshell\locale locale.wxs

--- a/windows/src/desktop/insthelp/manifest.in
+++ b/windows/src/desktop/insthelp/manifest.in
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="tavultesoft.keymandeveloper.insthelp"
-    version="$VERSION"
+    version="$VersionWin"
     processorArchitecture="x86"/>
   <description>Keyman Engine Installation Assistant</description>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/windows/src/desktop/kmbrowserhost/manifest.in
+++ b/windows/src/desktop/kmbrowserhost/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="sil.keyman.kmbrowserhost" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="sil.keyman.kmbrowserhost" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop Browser Host Process</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/desktop/kmshell/localedef.dtd.in
+++ b/windows/src/desktop/kmshell/localedef.dtd.in
@@ -1,7 +1,7 @@
   <!ENTITY Company "">
   <!ENTITY ProductName "Keyman Desktop">
   <!ENTITY Edition "">
-  <!ENTITY Version "$RELEASE">
+  <!ENTITY Version "$VersionRelease">
   
   <!ENTITY EvaluationPeriod "30">
 

--- a/windows/src/desktop/kmshell/manifest.in
+++ b/windows/src/desktop/kmshell/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.kmshell" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.kmshell" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/desktop/setup/debug-manifest.in
+++ b/windows/src/desktop/setup/debug-manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.setup" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.setup" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop Setup</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/desktop/setup/manifest.in
+++ b/windows/src/desktop/setup/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.setup" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandesktop.setup" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop Setup</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/developer/TIKE/manifest.in
+++ b/windows/src/developer/TIKE/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.tike" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.tike" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Developer</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -1,7 +1,7 @@
 !include ..\..\Defines.mak
 
 ##
-## In this file, $VERSION and $RELEASE will be replaced by mkver. These are not
+## In this file, $Version, $VersionWin and $VersionRelease will be replaced by mkver. These are not
 ## Make variables, but mkver variables.
 ##
 
@@ -22,19 +22,19 @@ KEYMAN_DEVELOPER_TEMPLATES_ROOT=$(ROOT)\src\developer\kmconvert\data
 KEYMAN_MODELCOMPILER_ROOT=$(KEYMAN_ROOT)\developer\js
 
 copykmdev: makeinstaller
-    -mkdir $(ROOT)\release\$VERSION
-    copy /Y $(ROOT)\src\developer\inst\keymandeveloper.msi $(ROOT)\release\$VERSION\keymandeveloper.msi
-    copy /Y $(ROOT)\src\developer\inst\keymandeveloper-$VERSION.exe $(ROOT)\release\$VERSION\keymandeveloper-$VERSION.exe
+    -mkdir $(ROOT)\release\$Version
+    copy /Y $(ROOT)\src\developer\inst\keymandeveloper.msi $(ROOT)\release\$Version\keymandeveloper.msi
+    copy /Y $(ROOT)\src\developer\inst\keymandeveloper-$VersionWithTag.exe $(ROOT)\release\$Version\keymandeveloper-$VersionWithTag.exe
 
 test-releaseexists:
-    if exist $(ROOT)\release\$VERSION\keymandeveloper*.msi echo. & echo Release $VERSION already exists. Delete it or update src\version.txt and try again & exit 1
+    if exist $(ROOT)\release\$Version\keymandeveloper*.msi echo. & echo Release $Version already exists. Delete it or update src\version.txt and try again & exit 1
 
 candle: heat-cef heat-xml heat-templates heat-model-compiler
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE kmdev.wxs
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dXmlSourceDir=$(ROOT)\src\developer\TIKE\xml xml.wxs
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dTemplatesSourceDir=$(KEYMAN_DEVELOPER_TEMPLATES_ROOT) templates.wxs
-    $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -dModelCompilerSourceDir=$(KEYMAN_WIX_TEMP_MODELCOMPILER) kmlmc.wxs
+    $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease kmdev.wxs
+    $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dXmlSourceDir=$(ROOT)\src\developer\TIKE\xml xml.wxs
+    $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dCefSourceDir=$(KEYMAN_CEF4DELPHI_ROOT) cef.wxs
+    $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dTemplatesSourceDir=$(KEYMAN_DEVELOPER_TEMPLATES_ROOT) templates.wxs
+    $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dModelCompilerSourceDir=$(KEYMAN_WIX_TEMP_MODELCOMPILER) kmlmc.wxs
 
 clean-heat: clean-heat-model-compiler
 
@@ -141,9 +141,9 @@ clean-heat-model-compiler:
 makeinstaller:
     cd $(ROOT)\src\developer\inst
     echo [Setup] > setup.inf
-    echo Version=$VERSION >> setup.inf
+    echo Version=$Version >> setup.inf
     echo MSIFileName=keymandeveloper.msi >> setup.inf
-    echo Title=Keyman Developer $RELEASE >>setup.inf
+    echo Title=Keyman Developer $VersionRelease >>setup.inf
     $(WZZIP) setup.zip keymandeveloper.msi setup.inf
-    copy /b $(ROOT)\bin\developer\setup.exe + setup.zip keymandeveloper-$VERSION.exe
-    $(SIGNCODE) /d "Keyman Developer" keymandeveloper-$VERSION.exe
+    copy /b $(ROOT)\bin\developer\setup.exe + setup.zip keymandeveloper-$VersionWithTag.exe
+    $(SIGNCODE) /d "Keyman Developer" keymandeveloper-$VersionWithTag.exe

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -1,7 +1,7 @@
 !include ..\..\Defines.mak
 
 ##
-## In this file, $Version, $VersionWin and $VersionRelease will be replaced by mkver. These are not
+## In this file, $Version, $VersionWin, $VersionRelease and $VersionWithTag will be replaced by mkver. These are not
 ## Make variables, but mkver variables.
 ##
 

--- a/windows/src/developer/inst/copydev.in
+++ b/windows/src/developer/inst/copydev.in
@@ -27,7 +27,7 @@ copykmdev: makeinstaller
     copy /Y $(ROOT)\src\developer\inst\keymandeveloper-$VersionWithTag.exe $(ROOT)\release\$Version\keymandeveloper-$VersionWithTag.exe
 
 test-releaseexists:
-    if exist $(ROOT)\release\$Version\keymandeveloper*.msi echo. & echo Release $Version already exists. Delete it or update src\version.txt and try again & exit 1
+    if exist $(ROOT)\release\$Version\keymandeveloper*.msi echo. & echo Release $Version already exists. Delete it or update VERSION.md and try again & exit 1
 
 candle: heat-cef heat-xml heat-templates heat-model-compiler
     $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease kmdev.wxs

--- a/windows/src/developer/kmcomp/manifest.in
+++ b/windows/src/developer/kmcomp/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.kmcomp" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.kmcomp" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Developer Command Line Compiler</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/developer/kmconvert/manifest.in
+++ b/windows/src/developer/kmconvert/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.kmconvert" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.kmconvert" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Developer Conversion Utility</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/developer/setup/manifest.in
+++ b/windows/src/developer/setup/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.setup" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.setup" version="$$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop Setup</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/developer/setup/manifest.in
+++ b/windows/src/developer/setup/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.setup" version="$$VersionWin" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymandeveloper.setup" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Desktop Setup</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/inst/download.in
+++ b/windows/src/engine/inst/download.in
@@ -8,8 +8,8 @@ default:
   echo Please don't call this file directly -- used by Makefile
 
 copyredist:
-  -mkdir $(ROOT)\release\$VERSION
-  copy /Y $(ROOT)\src\engine\inst\keymanengine.msm $(ROOT)\release\$VERSION\keymanengine-$VERSION.msm
+  -mkdir $(ROOT)\release\$Version
+  copy /Y $(ROOT)\src\engine\inst\keymanengine.msm $(ROOT)\release\$Version\keymanengine-$VersionWithTag.msm
 
 prepareredist:
   rem
@@ -18,4 +18,4 @@ clean:
   rem
 
 candle:
-  $(WIXCANDLE) -dVERSION=$VERSION -dRELEASE=$RELEASE -ext WixUtilExtension keymanengine.wxs components.wxs
+  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -ext WixUtilExtension keymanengine.wxs components.wxs

--- a/windows/src/engine/keyman/debug-manifest.in
+++ b/windows/src/engine/keyman/debug-manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="keyman" version="$VERSiON" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="keyman" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/keyman/manifest.in
+++ b/windows/src/engine/keyman/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.keyman" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.keyman" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/keymanx64/manifest.in
+++ b/windows/src/engine/keymanx64/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.keymanx64" version="$VERSION" processorArchitecture="amd64"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.keymanx64" version="$VersionWin" processorArchitecture="amd64"/>
 	<description>Keyman Engine x64</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/kmcomapi/manifest.in
+++ b/windows/src/engine/kmcomapi/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.kmcomapi" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.kmcomapi" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine API</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/mcompile/manifest.in
+++ b/windows/src/engine/mcompile/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.mcompile" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.mcompile" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine x64</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/tsysinfo/manifest.in
+++ b/windows/src/engine/tsysinfo/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.tsysinfo" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.tsysinfo" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine Diagnostics</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/engine/tsysinfox64/manifest.in
+++ b/windows/src/engine/tsysinfox64/manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.tsysinfox64" version="$VERSION" processorArchitecture="x86"/>
+	<assemblyIdentity type="win32" name="tavultesoft.keymanengine.tsysinfox64" version="$VersionWin" processorArchitecture="x86"/>
 	<description>Keyman Engine Diagnostics x64</description>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>

--- a/windows/src/global/help/version.in
+++ b/windows/src/global/help/version.in
@@ -1,5 +1,5 @@
 <?php
-  $COPYRIGHT = "Copyright &copy;1994-2001 Tavultesoft";
-  $KEYMANVERSION = "$VERSION";
+  $COPYRIGHT = "Copyright &copy;1994-2020 SIL International";
+  $KEYMANVERSION = "$Version";
   $DOCVERSION = "$DATE";
 ?>

--- a/windows/src/support/kmkb0045/manifest.in
+++ b/windows/src/support/kmkb0045/manifest.in
@@ -5,7 +5,7 @@
   <assemblyIdentity
     type="win32"
     name="tavultesoft.keymanengine.kmkb0045"
-    version="$VERSION"
+    version="$VersionWin"
     processorArchitecture="x86"/>
 
   <description>Tavultesoft KMKB0045</description>


### PR DESCRIPTION
Release build executables should have 3 component version numbers with the version tag appended, e.g. keymandesktop-14.0.155-alpha-local.exe.

Potentially coming later, rename keymandesktop-version.exe to keyman-version.exe.