### PR TITLE
chore: don't add tag to version in filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@
 
 # /developer/inst/
 /windows/src/developer/inst/*.wixpdb
+/windows/src/developer/inst/download.mak
 /windows/src/developer/inst/copydev.mak
 
 # /developer/kmcmpdll/

--- a/oem/firstvoices/windows/src/inst/download.in
+++ b/oem/firstvoices/windows/src/inst/download.in
@@ -10,7 +10,7 @@ default:
 copyredist-desktop:
   -mkdir $(ROOT)\release\$Version
   copy /Y firstvoices.msi $(ROOT)\release\$Version\firstvoices.msi
-  copy /Y firstvoices.exe $(ROOT)\release\$Version\firstvoices-$VersionWithTag.exe
+  copy /Y firstvoices.exe $(ROOT)\release\$Version\firstvoices-$Version.exe
 
 prepareredist:
   rem prepareredist

--- a/windows/src/desktop/inst/download.in
+++ b/windows/src/desktop/inst/download.in
@@ -14,7 +14,7 @@ default:
 copyredist-desktop:
   -mkdir $(ROOT)\release\$Version
   copy /Y keymandesktop.msi $(ROOT)\release\$Version\keymandesktop.msi
-  copy /Y keymandesktop.exe $(ROOT)\release\$Version\keymandesktop-$VersionWithTag.exe
+  copy /Y keymandesktop.exe $(ROOT)\release\$Version\keymandesktop-$Version.exe
   copy /Y $(ROOT)\bin\desktop\setup.exe $(ROOT)\release\$Version\setup.exe
 
 prepareredist:

--- a/windows/src/developer/inst/Makefile
+++ b/windows/src/developer/inst/Makefile
@@ -15,15 +15,15 @@ setup:
     #
 
     cd $(ROOT)\src\developer\inst
-    $(MKVER_U) copydev.in copydev.mak
+    $(MKVER_U) download.in download.mak
 
     #
     # Build the installation archive
     #
 
-    $(MAKE) -fcopydev.mak candle
+    $(MAKE) -fdownload.mak candle
     $(WIXLIGHT) -sice:ICE91 -sice:ICE60 -dWixUILicenseRtf=License.rtf -out keymandeveloper.msi -ext WixUIExtension $(DEVELOPER_FILES)
-    $(MAKE) -fcopydev.mak clean-heat
+    $(MAKE) -fdownload.mak clean-heat
 
     #
     # Sign the installation archive
@@ -36,7 +36,7 @@ setup:
     #
 
     cd $(ROOT)\src\developer\inst
-    $(MAKE) -fcopydev.mak
+    $(MAKE) -fdownload.mak
 
 build:
     @rem
@@ -49,7 +49,7 @@ backup:
 
 clean:
     cd $(ROOT)\src\developer\inst
-    -del /Q copydev.mak
+    -del /Q download.mak
     -del /Q *.msi
     -del /Q *.msp
     -del /Q *.wixobj
@@ -66,9 +66,9 @@ clean:
 
 test-releaseexists:
     cd $(ROOT)\src\developer\inst
-    $(MKVER_U) copydev.in copydev.mak
+    $(MKVER_U) download.in download.mak
 
-    $(MAKE) -fcopydev.mak test-releaseexists
+    $(MAKE) -fdownload.mak test-releaseexists
 
 install:
     @rem

--- a/windows/src/developer/inst/download.in
+++ b/windows/src/developer/inst/download.in
@@ -1,7 +1,7 @@
 !include ..\..\Defines.mak
 
 ##
-## In this file, $Version, $VersionWin, $VersionRelease and $Version will be replaced by mkver. These are not
+## In this file, $Version, $VersionWin, and $VersionRelease will be replaced by mkver. These are not
 ## Make variables, but mkver variables.
 ##
 

--- a/windows/src/developer/inst/download.in
+++ b/windows/src/developer/inst/download.in
@@ -1,7 +1,7 @@
 !include ..\..\Defines.mak
 
 ##
-## In this file, $Version, $VersionWin, $VersionRelease and $VersionWithTag will be replaced by mkver. These are not
+## In this file, $Version, $VersionWin, $VersionRelease and $Version will be replaced by mkver. These are not
 ## Make variables, but mkver variables.
 ##
 
@@ -24,7 +24,7 @@ KEYMAN_MODELCOMPILER_ROOT=$(KEYMAN_ROOT)\developer\js
 copykmdev: makeinstaller
     -mkdir $(ROOT)\release\$Version
     copy /Y $(ROOT)\src\developer\inst\keymandeveloper.msi $(ROOT)\release\$Version\keymandeveloper.msi
-    copy /Y $(ROOT)\src\developer\inst\keymandeveloper-$VersionWithTag.exe $(ROOT)\release\$Version\keymandeveloper-$VersionWithTag.exe
+    copy /Y $(ROOT)\src\developer\inst\keymandeveloper-$Version.exe $(ROOT)\release\$Version\keymandeveloper-$Version.exe
 
 test-releaseexists:
     if exist $(ROOT)\release\$Version\keymandeveloper*.msi echo. & echo Release $Version already exists. Delete it or update VERSION.md and try again & exit 1
@@ -145,5 +145,5 @@ makeinstaller:
     echo MSIFileName=keymandeveloper.msi >> setup.inf
     echo Title=Keyman Developer $VersionRelease >>setup.inf
     $(WZZIP) setup.zip keymandeveloper.msi setup.inf
-    copy /b $(ROOT)\bin\developer\setup.exe + setup.zip keymandeveloper-$VersionWithTag.exe
-    $(SIGNCODE) /d "Keyman Developer" keymandeveloper-$VersionWithTag.exe
+    copy /b $(ROOT)\bin\developer\setup.exe + setup.zip keymandeveloper-$Version.exe
+    $(SIGNCODE) /d "Keyman Developer" keymandeveloper-$Version.exe

--- a/windows/src/engine/inst/download.in
+++ b/windows/src/engine/inst/download.in
@@ -9,7 +9,7 @@ default:
 
 copyredist:
   -mkdir $(ROOT)\release\$Version
-  copy /Y $(ROOT)\src\engine\inst\keymanengine.msm $(ROOT)\release\$Version\keymanengine-$VersionWithTag.msm
+  copy /Y $(ROOT)\src\engine\inst\keymanengine.msm $(ROOT)\release\$Version\keymanengine-$Version.msm
 
 prepareredist:
   rem


### PR DESCRIPTION
While it might be nice to add the tag to versions in filenames, this creates a lot of work on the website where we make some filename assumptions. So, this PR winds that detail of filename changes back, and renames copydev.in to download.in to make it consistent with the other download.in files.