### PR TITLE
fix(windows): show version with tag in setup

### DIFF
--- a/windows/src/desktop/setup/SetupStrings.pas
+++ b/windows/src/desktop/setup/SetupStrings.pas
@@ -85,6 +85,8 @@ type
     ssOptionsPackageLanguageAssociation,
     ssOptionsDefaultLanguage,
 
+    ssInstallerVersion,
+
     { Download dialog }
 
     ssDownloadingTitle,

--- a/windows/src/desktop/setup/UfrmInstallOptions.dfm
+++ b/windows/src/desktop/setup/UfrmInstallOptions.dfm
@@ -74,6 +74,13 @@ object frmInstallOptions: TfrmInstallOptions
     Font.Style = [fsBold]
     ParentFont = False
   end
+  object lblInstallerVersion: TLabel
+    Left = 8
+    Top = 358
+    Width = 102
+    Height = 16
+    Caption = 'lblInstallerVersion'
+  end
   object chkStartWithWindows: TCheckBox
     Left = 8
     Top = 100

--- a/windows/src/desktop/setup/UfrmInstallOptions.pas
+++ b/windows/src/desktop/setup/UfrmInstallOptions.pas
@@ -48,6 +48,7 @@ type
     lblDefaultKeymanSettings: TLabel;
     lblSelectModulesToInstall: TLabel;
     lblAssociatedKeyboardLanguage: TLabel;
+    lblInstallerVersion: TLabel;
     procedure FormCreate(Sender: TObject);
     procedure cmdOKClick(Sender: TObject);
   private
@@ -97,6 +98,7 @@ implementation
 
 uses
   bootstrapmain,
+  KeymanVersion,
   SetupStrings;
 
 { TfrmInstallOptions }
@@ -124,6 +126,8 @@ begin
   chkAutomaticallyReportUsage.Visible := FAllowOptions;
   chkCheckForUpdates.Visible := FAllowOptions;
   chkStartWithWindows.Visible := FAllowOptions;
+
+  lblInstallerVersion.Caption := FInstallInfo.Text(ssInstallerVersion, [KeymanVersion.CKeymanVersionInfo.VersionWithTag]);
 
   SetupDynamicOptions;
 end;

--- a/windows/src/desktop/setup/locale/en/strings.xml
+++ b/windows/src/desktop/setup/locale/en/strings.xml
@@ -55,6 +55,9 @@ Restart now?</string>
   <string name="ssOptionsUpgradeKeyboards">Upgrade keyboards installed with older versions to version $VERSION</string>
   <string name="ssOptionsAutomaticallyReportUsage">Share anonymous usage statistics with keyman.com</string>
 
+  <!-- Parameters: %0:s: version of installer (may differ from Keyman version) -->
+  <string name="ssInstallerVersion">Setup version: %0:s</string>
+
   <!-- Parameters: %0:s: version -->
   <string name="ssOptionsInstallKeyman">Install $APPNAME %0:s</string>
 

--- a/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
+++ b/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
@@ -89,8 +89,17 @@ begin
       FNewVersion := node.Values['version'].Value;
       FFileName := node.Values['file'].Value;
       FInstallURL := node.Values['url'].Value;
-      FInstallSize := (node.Values['size'] as TJSONNumber).AsInt64;
-      FStatus := ucrsUpdateReady;
+      if node.Values['size'] is TJSONNumber then
+      begin
+        FInstallSize := (node.Values['size'] as TJSONNumber).AsInt64;
+        FStatus := ucrsUpdateReady;
+      end
+      else
+      begin
+        FInstallSize := 0;
+        FStatus := ucrsNoUpdate;
+        FErrorMessage := 'No valid updates found.';
+      end;
     end
     else
     begin


### PR DESCRIPTION
Fixes #3680.
Fixes #3636.

Note that because the installer version may differ from the Keyman version that will actually be installed, the installer version number is a bit hidden away in the Options dialog, to try and reduce potential for confusion.

For example, if a user already has the installer downloaded, but a new version of Keyman is available, then by default the installer will try and download the new version rather than install the current version.