### PR TITLE
fix(windows): keyman desktop setup filename

### DIFF
--- a/windows/src/desktop/inst/download.in
+++ b/windows/src/desktop/inst/download.in
@@ -14,7 +14,7 @@ default:
 copyredist-desktop:
   -mkdir $(ROOT)\release\$Version
   copy /Y keymandesktop.msi $(ROOT)\release\$Version\keymandesktop.msi
-  copy /Y keymandesktop.exe $(ROOT)\release\$Version\keymandesktop-$Version.exe
+  copy /Y keymandesktop.exe $(ROOT)\release\$Version\keyman-$Version.exe
   copy /Y $(ROOT)\bin\desktop\setup.exe $(ROOT)\release\$Version\setup.exe
 
 prepareredist:


### PR DESCRIPTION
For now, we rename the final output executable to keyman-a.b.c.exe, and don't change the constructed filename during the build (there's no need). We also do not change the .msi filename because that has a bunch of cascading dependencies, and again it isn't that important.