### PR TITLE
feat(common/models): context reversion modeling

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -232,7 +232,7 @@ namespace com.keyman.text.prediction {
             // the input will be automatically rewound to the preInput state.
             transform: original.transform,
             // The ID part is critical; the reversion can't be applied without it.
-            transformId: -original.token, // reversions use the additive inverse.
+            transformId: original.token, // reversions use the additive inverse.
             displayAs: reversion.displayAs,  // The real reason we needed to call the LMLayer.
             id: reversion.id,
             tag: reversion.tag

--- a/common/predictive-text/docs/worker-communication-protocol.md
+++ b/common/predictive-text/docs/worker-communication-protocol.md
@@ -128,6 +128,8 @@ Message       | Direction          | Parameters          | Expected reply      |
 `accept`      | keyboard → LMLayer | suggestion,         | Yes - `postaccept`  | Yes
                                    | context, transform  |                     |
 `postaccept`  | LMLayer → keyboard | reversion           | No                  | Yes
+`revert`      | keyboard → LMLayer | reversion, context  | Yes - `reversion`   | Yes
+`postrevert`  | LMLayer → keyboard | suggestions         | No                  | Yes
               
 
 ### Message: `config`

--- a/common/predictive-text/message.d.ts
+++ b/common/predictive-text/message.d.ts
@@ -30,8 +30,8 @@ type Token = number;
 /**
  * The valid outgoing message kinds.
  */
-type OutgoingMessageKind = 'error' | 'ready' | 'suggestions' | 'currentword' | 'postaccept';
-type OutgoingMessage = ErrorMessage | ReadyMessage | SuggestionMessage | CurrentWordMessage | PostAcceptMessage;
+type OutgoingMessageKind = 'error' | 'ready' | 'suggestions' | 'currentword' | 'postaccept' | 'postrevert';
+type OutgoingMessage = ErrorMessage | ReadyMessage | SuggestionMessage | CurrentWordMessage | PostAcceptMessage | PostRevertMessage;
 
 interface ErrorMessage {
   message: 'error';
@@ -95,7 +95,7 @@ interface PostAcceptMessage {
 
   /**
    * Opaque, unique token that pairs this message
-   * with the wordbreak message that initiated it.
+   * with the accept message that initiated it.
    */
   token: Token;
 
@@ -103,6 +103,22 @@ interface PostAcceptMessage {
    * A 'Reversion' that will return the context to its prior state.
    */
   reversion: Reversion;
+}
+
+interface PostRevertMessage {
+  message: 'postrevert';
+
+  /**
+   * Opaque, unique token that pairs this message
+   * with the revert message that initiated it.
+   */
+  token: Token;
+
+  /**
+   * The original set of Suggestions returned that included the
+   * reverted Suggestion
+   */
+  suggestions: Suggestion[];
 }
 
 /**

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -181,6 +181,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
@@ -223,6 +224,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
@@ -258,6 +260,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
@@ -300,6 +303,7 @@ describe('ModelCompositor', function() {
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       // Check #1:  Does the returned reversion properly revert the context to its pre-application state?
@@ -316,6 +320,155 @@ describe('ModelCompositor', function() {
 
       let angledReversion = acceptanceTest(angledPunctuation, baseSuggestion, baseContext, postTransform);
       assert.equal(angledReversion.displayAs, "«hi»");
+    });
+  });
+
+  describe('acceptReversion', function() {
+    let executeAcceptance = function(model, suggestion, context, postTransform) {
+      let compositor = new ModelCompositor(model);
+
+      return {compositor: compositor, reversion: compositor.acceptSuggestion(suggestion, context, postTransform)};
+    }
+
+    let englishPunctuation = {
+      quotesForKeepSuggestion: { open: `“`, close: `”`},
+      insertAfterWord: ' '
+    };
+
+    // While this isn't a state the LMLayer should ever operate within, this provides
+    // a useful base state for developing further tests against the method.
+    it('model without traversals: returns appropriate suggestions upon reversion', function() {
+      // This setup matches 'acceptSuggestion' the test case
+      // it('first word of context + postTransform provided, .deleteLeft > 0')
+      // seen earlier in the file.
+
+      let baseSuggestion = {
+        transform: {
+          insert: 'hello ',
+          deleteLeft: 2,
+          id: 0
+        },
+        transformId: 0,
+        id: 0,
+        displayAs: 'hello'
+      };
+  
+      let baseContext = {
+        left: 'he', startOfBuffer: true, endOfBuffer: true
+      }
+    
+      // Represents the keystroke that triggered the suggestion.  It's not technically part
+      // of the Context when the suggestion is built.
+      let postTransform = {
+        insert: 'i',
+        deleteLeft: 1
+      }
+
+      let model = new models.DummyModel({punctuation: englishPunctuation});
+      let compositor = new ModelCompositor(model);
+
+      let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
+      assert.equal(reversion.id, -baseSuggestion.id);
+
+      let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
+      assert.equal(appliedContext.left, "hello ");
+
+      let suggestions = compositor.applyReversion(reversion, appliedContext);
+      
+      // As this test is a bit... 'hard-wired', we only get the 'keep' suggestion.
+      // It should still be accurate, though.
+      assert.equal(suggestions.length, 1);
+
+      let expectedTransform = {
+        insert: '',  // Keeps current context the same.
+        deleteLeft: 0
+      }
+      assert.deepEqual(suggestions[0].transform, expectedTransform);
+    });
+
+    it('model with traversals: returns appropriate suggestions upon reversion', function() {
+      // This setup matches 'acceptSuggestion' the test case
+      // it('first word of context + postTransform provided, .deleteLeft > 0')
+      // seen earlier in the file.
+  
+      let baseContext = {
+        left: 'he', startOfBuffer: true, endOfBuffer: true
+      }
+    
+      // Represents the keystroke that triggered the suggestion.  It's not technically part
+      // of the Context when the suggestion is built.
+      let postTransform = {
+        insert: 'i',
+        deleteLeft: 1,
+        id: 13
+      }
+
+      let model = new models.TrieModel(jsonFixture('tries/english-1000'), {punctuation: englishPunctuation});
+      let compositor = new ModelCompositor(model);
+
+      let initialSuggestions = compositor.predict(postTransform, baseContext);
+      let keepSuggestion = initialSuggestions[0];
+      assert.equal(keepSuggestion.tag, 'keep'); // corresponds to `postTransform`, but the transform isn't equal.
+
+      let baseSuggestion = initialSuggestions[1];
+      let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
+      assert.equal(reversion.id, -baseSuggestion.id);
+
+      let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
+      let reversionSuggestions = compositor.applyReversion(reversion, appliedContext);
+      
+      // The returned suggestion list should match the original suggestion list.
+      assert.deepEqual(reversionSuggestions, initialSuggestions);
+    });
+
+    it('model with traversals: properly tracks context state', function() {
+      // Could be merged with the previous test case, but I think it's good to have the error
+      // sets flagged separately.
+  
+      let baseContext = {
+        left: 'he', startOfBuffer: true, endOfBuffer: true
+      }
+    
+      // Represents the keystroke that triggered the suggestion.  It's not technically part
+      // of the Context when the suggestion is built.
+      let postTransform = {
+        insert: 'i',
+        deleteLeft: 1,
+        id: 13
+      }
+
+      let model = new models.TrieModel(jsonFixture('tries/english-1000'), {punctuation: englishPunctuation});
+      let compositor = new ModelCompositor(model);
+
+      let initialSuggestions = compositor.predict(postTransform, baseContext);
+      let keepSuggestion = initialSuggestions[0];
+      assert.equal(keepSuggestion.tag, 'keep'); // corresponds to `postTransform`, but the transform isn't equal.
+
+      let baseContextState = compositor.contextTracker.analyzeState(model, baseContext);
+      assert.equal(compositor.contextTracker.count, 1);
+
+      let baseSuggestion = initialSuggestions[1];
+      let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
+      assert.equal(reversion.transformId, baseSuggestion.transformId);
+      assert.equal(reversion.id, -baseSuggestion.id);
+
+      // Accepting the suggestion adds an extra context state.
+      assert.equal(compositor.contextTracker.count, 2);
+
+      // The replacement should be marked on the context-tracking token.
+      assert.isOk(baseContextState.tail.replacement);
+
+      let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
+      compositor.applyReversion(reversion, appliedContext);
+
+      // Reverting the suggestion should remove that extra state.
+      assert.equal(compositor.contextTracker.count, 1);
+      assert.equal(compositor.contextTracker.item(0), baseContextState);
+
+      // The replacement should no longer be marked for the context-tracking token.
+      assert.isNotOk(baseContextState.tail.replacement);
     });
   });
 });

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -35,7 +35,6 @@ namespace correction {
 
     revert() {
       delete this.activeReplacementId;
-      delete this.replacements;
     }
   }
 
@@ -188,7 +187,7 @@ namespace correction {
         return undefined;
       }
 
-      return this.item[0];
+      return this.item(0);
     }
 
     get newest(): Item {
@@ -196,7 +195,7 @@ namespace correction {
         return undefined;
       }
 
-      return this.item[this.count - 1];
+      return this.item(this.count - 1);
     }
 
     enqueue(item: Item): Item {
@@ -224,6 +223,21 @@ namespace correction {
       }
     }
 
+    popNewest(): Item {
+      if(this.currentTail == this.currentHead) {
+        return null;
+      } else {
+        let item = this.circle[this.currentHead];
+        this.currentHead = (this.currentHead - 1 + this.maxCount) % this.maxCount;
+        return item;
+      }
+    }
+
+    /**
+     * Returns items contained within the circular array, ordered from 'oldest' to 'newest' -
+     * the same order in which the items will be dequeued.
+     * @param index 
+     */
     item(index: number) {
       if(index >= this.count) {
         throw "Invalid array index";

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -280,7 +280,7 @@ class LMLayerWorker {
         switch(payload.message) {
           case 'predict':
             var {transform, context} = payload;
-            let suggestions = compositor.predict(transform, context);
+            var suggestions = compositor.predict(transform, context);
 
             // Now that the suggestions are ready, send them out!
             this.cast('suggestions', {
@@ -308,8 +308,17 @@ class LMLayerWorker {
               reversion: reversion
             });
             break;
+          case 'revert':
+              var {reversion, context} = payload;
+              var suggestions: Suggestion[] = compositor.applyReversion(reversion, context);
+
+              this.cast('postrevert', {
+                token: payload.token,
+                suggestions: suggestions
+              });
+              break;
           default:
-          throw new Error(`invalid message; expected one of {'predict', 'wordbreak', 'accept', 'unload'} but got ${payload.message}`);
+            throw new Error(`invalid message; expected one of {'predict', 'wordbreak', 'accept', 'revert', 'unload'} but got ${payload.message}`);
         }
       },
       compositor: compositor

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -434,6 +434,49 @@ class ModelCompositor {
 
     return reversion;
   }
+
+  applyReversion(reversion: Reversion, context: Context): Suggestion[] {
+    // If we are unable to track context (because the model does not support LexiconTraversal),
+    // we need a "fallback" strategy.
+    let compositor = this;
+    let fallbackSuggestions = function() {
+      let revertedContext = models.applyTransform(reversion.transform, context);
+      return compositor.predict({ insert: '', deleteLeft: 0}, revertedContext);
+    }
+
+    if(!this.contextTracker) {
+      return fallbackSuggestions();
+    }
+
+    // When the context is tracked, we prefer the tracked information.
+    let contextMatchFound = false;
+    for(let c = this.contextTracker.count - 1; c >= 0; c--) {
+      let contextState = this.contextTracker.item(c);
+
+      if(contextState.tail.activeReplacementId == -reversion.id) {
+        contextMatchFound = true;
+        break;
+      }
+    }
+
+    if(!contextMatchFound) {
+      return fallbackSuggestions();
+    }
+
+    // Remove all contexts more recent than the one we're reverting to.
+    while(this.contextTracker.newest.tail.activeReplacementId != -reversion.id) {
+      this.contextTracker.popNewest();
+    }
+
+    this.contextTracker.newest.tail.revert();
+
+    // Will need to be modified a bit if/when phrase-level suggestions are implemented.
+    // Those will be tracked on the first token of the phrase, which won't be the tail
+    // if they cover multiple tokens.
+    return this.contextTracker.newest.tail.replacements.map(function(trackedSuggestion) {
+      return trackedSuggestion.suggestion;
+    });
+  }
 }
 
 /**

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -410,10 +410,10 @@ class ModelCompositor {
     // Since we're outside of the standard `predict` control path, we'll need to
     // set the Reversion's ID directly.
     let reversion = this.toAnnotatedSuggestion(firstConversion, 'revert');
-    if(suggestion.transformId || suggestion.transformId === 0) {
+    if(suggestion.transformId != null) {
       reversion.transformId = suggestion.transformId;
     }
-    if(suggestion.id || suggestion.id === 0) {
+    if(suggestion.id != null) {
       // Since a reversion inverts its source suggestion, we set its ID to be the 
       // additive inverse of the source suggestion's ID.  Makes easy mapping /
       // verification later.

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -410,7 +410,10 @@ class ModelCompositor {
     // Since we're outside of the standard `predict` control path, we'll need to
     // set the Reversion's ID directly.
     let reversion = this.toAnnotatedSuggestion(firstConversion, 'revert');
-    if(suggestion.id) {
+    if(suggestion.transformId || suggestion.transformId === 0) {
+      reversion.transformId = suggestion.transformId;
+    }
+    if(suggestion.id || suggestion.id === 0) {
       // Since a reversion inverts its source suggestion, we set its ID to be the 
       // additive inverse of the source suggestion's ID.  Makes easy mapping /
       // verification later.

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -38,8 +38,8 @@ type ImportScripts = typeof DedicatedWorkerGlobalScope.prototype.importScripts;
 /**
  * The valid incoming message kinds.
  */
-type IncomingMessageKind = 'config' | 'load' | 'predict' | 'unload' | 'wordbreak' | 'accept';
-type IncomingMessage = ConfigMessage | LoadMessage | PredictMessage | UnloadMessage | WordbreakMessage | AcceptMessage;
+type IncomingMessageKind = 'config' | 'load' | 'predict' | 'unload' | 'wordbreak' | 'accept' | 'revert';
+type IncomingMessage = ConfigMessage | LoadMessage | PredictMessage | UnloadMessage | WordbreakMessage | AcceptMessage | RevertMessage;
 
 /**
  * The structure of a config message.  It should include the platform's supported
@@ -147,6 +147,27 @@ interface AcceptMessage {
    * thus likely to differ.)
    */
   postTransform?: Transform;
+}
+
+interface RevertMessage {
+  message: 'revert';
+
+  /**
+   * Opaque, unique token that pairs this accept message with its return message.
+   */
+  token: Token;
+
+  /**
+   * The Reversion being applied.  The ID must be assigned and should be the additive inverse
+   * of the Suggestion being reverted.
+   */
+  reversion: Reversion;
+
+  /**
+   * The Context being reverted, which should be the same context as resulted from applying the
+   * corresponding Suggestion.
+   */
+  context: Context;
 }
 
 /**

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -317,15 +317,6 @@ namespace com.keyman.text {
     keymanweb.modelManager.register(model);
   };
 
-  keymanweb['showNewSuggestions'] = function() {
-    let keyman = com.keyman.singleton;
-
-    if(keyman['osk'].banner['activeBanner'] instanceof com.keyman.osk.SuggestionBanner) {
-      let banner = keyman['osk'].banner['activeBanner'];
-      banner.rotateSuggestions();
-    }
-  }
-
   /**
    * Function called by Android and iOS when a device-implemented keyboard popup is displayed or hidden
    * 


### PR DESCRIPTION
This PR will get reversion working fully with the newer correction algorithm while also providing a nice new benefit:

- Reversions restore the original state of the input, even remembering the probability of each keystroke for use in further predictions after extra typing.
- The tracked context state will be fully rewound to before the reverted Suggestion was applied.

Note:  to simplify the implementation, I dropped unused code that was intended to support suggestion rotation.  Let me know if that's an issue and I can look at restoring it in a cleaner way.