### PR TITLE
feat(common/models): disables "keep" when word is not suggestion otherwise

### DIFF
--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -242,6 +242,16 @@ interface Reversion extends Suggestion {
   tag: 'revert';
 }
 
+interface Keep extends Suggestion {
+  tag: 'keep';
+
+  /**
+   * Notes whether or not the Suggestion may actually be suggested by the model.
+   * Should be `false` if the model does not actually predict the current text.
+   */
+  matchesModel: boolean;
+}
+
 /**
  * A tag indicating the nature of the current suggestion.
  * 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -530,7 +530,7 @@ namespace com.keyman.osk {
     private initNewContext: boolean = true;
 
     private currentSuggestions: Suggestion[] = [];
-    private keepSuggestion: Suggestion;
+    private keepSuggestion: Keep;
     private revertSuggestion: Reversion;
 
     private currentTranscriptionID: number;
@@ -700,7 +700,9 @@ namespace com.keyman.osk {
     private doUpdate() {
       let suggestions = [];
       // Insert 'current text' if/when valid as the leading option.
-      if(this.activateKeep() && this.keepSuggestion) {
+      // Since we don't yet do auto-corrections, we only show 'keep' whenever it's
+      // a valid word (according to the model).
+      if(this.activateKeep() && this.keepSuggestion && this.keepSuggestion.matchesModel) {
         suggestions.push(this.keepSuggestion);
       } else if(this.doRevert) {
         suggestions.push(this.revertSuggestion);
@@ -752,7 +754,7 @@ namespace com.keyman.osk {
       // and prevent it from being hidden after reversion operations.
       for(let s of suggestions) {
         if(s.tag == 'keep') {
-          this.keepSuggestion = s;
+          this.keepSuggestion = s as Keep;
         }
       }
 


### PR DESCRIPTION
Fixes #3056.

Disables display of the "keep" suggestion except when the suggestion matches a model prediction.

Not a model prediction:

<img width="286" alt="Screen Shot 2020-10-12 at 12 59 55 PM" src="https://user-images.githubusercontent.com/25213402/95710442-e744d480-0c8a-11eb-9009-b08c85f3fdef.png">

When it is a model prediction:

<img width="290" alt="Screen Shot 2020-10-12 at 1 01 26 PM" src="https://user-images.githubusercontent.com/25213402/95710534-1b1ffa00-0c8b-11eb-8531-e5d933ffa794.png">

For these examples, note "tying" is a far less frequent word than "thing" and "think", which is why the prediction engine wants to 'correct' away from it.  However, once the word is fully typed, the fact that the word is a perfect match "overrides" that probability, as it's now a "keep" suggestion.

--------

As usual, since the suggestion matches an entry in the `LexicalModel`, no quote-style marks are displayed for the "keep" in this scenario.