### PR TITLE
feat(common/core/web): selective wordbreak swallowing after accepting suggestions

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -209,7 +209,6 @@ namespace com.keyman.text.prediction {
         // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
         // values as needed for use with their IME interfaces.
         let transform = final.buildTransformFrom(outputTarget);
-        let wordbreakPromise = this.wordbreak(outputTarget); // Also build the display string for the reversion.
         outputTarget.apply(transform);
 
         // Build a 'reversion' Transcription that can be used to undo this apply() if needed,
@@ -355,14 +354,22 @@ namespace com.keyman.text.prediction {
       this._mayCorrect = flag;
     }
 
+    public get wordbreaksAfterSuggestions() {
+      return this.configuration.wordbreaksAfterSuggestions;
+    }
+
     public tryAcceptSuggestion(source: string): boolean {
-      // Handlers of this event should return 'false' when the 'try' is successful.
-      return !this.emit('tryaccept', source);
+      let returnObj = {shouldSwallow: false};
+      this.emit('tryaccept', source, returnObj);
+
+      return returnObj.shouldSwallow;
     }
 
     public tryRevertSuggestion(): boolean {
-      // Handlers of this event should return 'false' when the 'try' is successful.
-      return !this.emit('tryrevert', null);
+      let returnObj = {shouldSwallow: false};
+      this.emit('tryrevert', null, returnObj);
+
+      return returnObj.shouldSwallow;
     }
   }
 }

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -369,6 +369,16 @@ declare interface Configuration {
   rightContextCodePoints: number;
   /** deprecated; use `leftContextCodePoints` instead! */
   rightContextCodeUnits?: number,
+
+  /**
+   * Whether or not the model appends characters to Suggestions for
+   * wordbreaking purposes.  (These characters need not be whitespace
+   * or actual wordbreak characters.)
+   * 
+   * If not specified, this will be auto-detected based on the model's
+   * punctuation properties (if they exist).
+   */
+  wordbreaksAfterSuggestions?: boolean
 }
 
 

--- a/common/predictive-text/docs/worker-communication-protocol.md
+++ b/common/predictive-text/docs/worker-communication-protocol.md
@@ -245,6 +245,13 @@ interface ReadyMessage {
      * bisect graphical clusters.
      */
     rightContextCodePoints: number,
+
+    /**
+     * Whether or not the model appends characters to Suggestions for
+     * wordbreaking purposes.  (These characters need not be whitespace
+     * or actual wordbreak characters.)
+     */
+    wordbreaksAfterSuggestions: boolean
   };
 }
 ```

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -198,7 +198,12 @@ class LMLayerWorker {
         configuration.rightContextCodePoints = this._platformCapabilities.maxRightContextCodePoints || 0;
       }
 
-      this.transitionToReadyState(model);
+      let compositor = this.transitionToReadyState(model);
+      // This test allows models to directly specify the property without it being auto-overridden by
+      // this default.
+      if(configuration.wordbreaksAfterSuggestions === undefined) {
+        configuration.wordbreaksAfterSuggestions = (compositor.punctuation.insertAfterWord != '');
+      }
       this.cast('ready', { configuration });
     } catch (err) {
       this.error("loadModel failed!", err);
@@ -272,7 +277,7 @@ class LMLayerWorker {
    *
    * @param model The loaded language model.
    */
-  private transitionToReadyState(model: LexicalModel) {
+  private transitionToReadyState(model: LexicalModel): ModelCompositor {
     let compositor = new ModelCompositor(model);
     this.state = {
       name: 'ready',
@@ -314,6 +319,8 @@ class LMLayerWorker {
       },
       compositor: compositor
     };
+
+    return compositor;
   }
 
   /**

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -5,7 +5,7 @@ class ModelCompositor {
   private lexicalModel: LexicalModel;
   private contextTracker?: correction.ContextTracker;
   private static readonly MAX_SUGGESTIONS = 12;
-  private readonly punctuation: LexicalModelPunctuation;
+  readonly punctuation: LexicalModelPunctuation;
 
   constructor(lexicalModel: LexicalModel) {
     this.lexicalModel = lexicalModel;

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -634,15 +634,20 @@ namespace com.keyman.osk {
      * Should return 'false' if the current state allows accepting a suggestion and act accordingly.
      * Otherwise, return true.
      */
-    tryAccept: (source: string) => boolean = function(this: SuggestionManager, source: string): boolean {
+    tryAccept: (source: string) => boolean = function(this: SuggestionManager, source: string, returnObj: {shouldSwallow: boolean}) {
+      let keyman = com.keyman.singleton;
+
       if(!this.recentAccept && this.selected) {
         this.doAccept(this.selected);
-        return false;
+        returnObj.shouldSwallow = true;
       } else if(this.recentAccept && source == 'space') {
         this.recentAccept = false;
-        return false; // Swallows a single space post-accept.
+        // If the model doesn't insert wordbreaks, don't swallow the space.  If it does, 
+        // we consider that insertion to be the results of the first post-accept space.
+        returnObj.shouldSwallow = !!keyman.core.languageProcessor.wordbreaksAfterSuggestions;
+      } else {
+        returnObj.shouldSwallow = false;
       }
-      return true;  // Not yet implemented
     }.bind(this);
 
     /**
@@ -650,7 +655,7 @@ namespace com.keyman.osk {
      * Should return 'false' if the current state allows reverting a recently-applied suggestion and act accordingly.
      * Otherwise, return true.
      */
-    tryRevert: () => boolean = function(this: SuggestionManager): boolean {
+    tryRevert: () => boolean = function(this: SuggestionManager, returnObj: {shouldSwallow: boolean}) {
       // Has the revert keystroke (BKSP) already been sent once since the last accept?
       if(this.doRevert) {
         // If so, clear the 'revert' option and start doing normal predictions again.
@@ -662,7 +667,9 @@ namespace com.keyman.osk {
         this.swallowPrediction = true;
       }
 
-      return true;
+      // We don't yet actually do key-based reversions.
+      returnObj.shouldSwallow = false;
+      return;
     }.bind(this);
 
     /**


### PR DESCRIPTION
Fixes #2851.

As it turns out, the space-swallowing code has actually been broken since the KMW core refactor, as the newer event-handling style (the Node-style `.emit` stuff) doesn't actually return the response value from its handlers.  So, this includes a bug fix for that aspect, too.

Now for the main purpose of this PR.  Whenever a model is loaded, it now returns a flag indicating whether or not it appends wordbreak characters after suggestions as _part_ of the `Configuration` object we've always been returning.  This flag may then be used by KMW to selectively enable wordbreak-squashing behavior in predictive contexts.

I've tested this with a local modification to one of the test models; `K_SPACE` is no longer squashed when the model does not append extra characters to suggestions via the model `Punctuation` spec.