### PR TITLE
refactor(common/models): extract Outcome type

### DIFF
--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -86,9 +86,9 @@ namespace models {
    * @param transform 
    */
   export function transformToSuggestion(transform: Transform): Suggestion;
-  export function transformToSuggestion(transform: Transform, p: number): Suggestion & {p: number}; 
-  export function transformToSuggestion(transform: Transform, p?: number): Suggestion & {p?: number} {
-    let suggestion: Suggestion & {p?: number} = {
+  export function transformToSuggestion(transform: Transform, p: number): WithOutcome<Suggestion>; 
+  export function transformToSuggestion(transform: Transform, p?: number): Outcome<Suggestion> {
+    let suggestion: Outcome<Suggestion> = {
       transform: transform,
       transformId: transform.id,
       displayAs: transform.insert

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -137,7 +137,7 @@
 
       /* Helper */
 
-      function makeDistribution(suggestions: (Suggestion & {p: number})[]): Distribution<Suggestion> {
+      function makeDistribution(suggestions: WithOutcome<Suggestion>[]): Distribution<Suggestion> {
         let distribution: Distribution<Suggestion> = [];
 
         for(let s of suggestions) {

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -320,6 +320,27 @@ interface ProbabilityMass<T> {
 
 declare type Distribution<T> = ProbabilityMass<T>[];
 
+/**
+ * A type augmented with an optional probability.
+ */
+type Outcome<T> = T & {
+  /**
+   * [optional] probability of this outcome.
+   */
+  p?: number;
+};
+
+/**
+ * A type augmented with a probability.
+ */
+type WithOutcome<T> = T & {
+  /**
+   * Probability of this outcome.
+   */
+  p: number;
+};
+
+
 
 /******************************** Messaging ********************************/
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -316,18 +316,18 @@ class ModelCompositor {
     return suggestions;
   }
 
-  private toAnnotatedSuggestion(suggestion: Suggestion & {p?: number}, 
+  private toAnnotatedSuggestion(suggestion: Outcome<Suggestion>, 
     annotationType: SuggestionTag,
-    quoteBehavior?: models.QuoteBehavior): Suggestion & {p?: number};
-  private toAnnotatedSuggestion(suggestion: Suggestion & {p?: number},
+    quoteBehavior?: models.QuoteBehavior): Outcome<Suggestion>;
+  private toAnnotatedSuggestion(suggestion: Outcome<Suggestion>,
     annotationType: 'keep',
-    quoteBehavior?: models.QuoteBehavior): Keep & {p?: number};
-  private toAnnotatedSuggestion(suggestion: Suggestion & {p?: number}, 
+    quoteBehavior?: models.QuoteBehavior): Outcome<Keep>;
+  private toAnnotatedSuggestion(suggestion: Outcome<Suggestion>, 
     annotationType: 'revert',
-    quoteBehavior?: models.QuoteBehavior): Reversion & {p?: number};
-  private toAnnotatedSuggestion(suggestion: Suggestion & {p?: number}, 
+    quoteBehavior?: models.QuoteBehavior): Outcome<Reversion>;
+  private toAnnotatedSuggestion(suggestion: Outcome<Suggestion>, 
                                 annotationType: SuggestionTag,
-                                quoteBehavior: models.QuoteBehavior = models.QuoteBehavior.default): Suggestion & {p?: number} {
+                                quoteBehavior: models.QuoteBehavior = models.QuoteBehavior.default): Outcome<Suggestion> {
     // A method-internal 'import' of the enum.
     let QuoteBehavior = models.QuoteBehavior;
 


### PR DESCRIPTION
`& { p?: number }` was being used often enough, I thought it might as well be its own type. This is `Outcome` — but perhaps it should be named `Sample`? `WithOutcome` is the same type, but the `p` is _required_.