### PR TITLE
fix(common/core/web): fixes revert event bug

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -367,7 +367,7 @@ namespace com.keyman.text.prediction {
 
     public tryRevertSuggestion(): boolean {
       let returnObj = {shouldSwallow: false};
-      this.emit('tryrevert', null, returnObj);
+      this.emit('tryrevert', returnObj);
 
       return returnObj.shouldSwallow;
     }


### PR DESCRIPTION
Fixes an error reported from Sentry:

```
TypeError: null is not an object (evaluating 'a.shouldSwallow=!1')
  at None (source/osk/banner.ts:671:7)
  at None ([native code])
  at None (source/osk/preProcessor.ts:86:21)
  at None (source/osk/preProcessor.ts:64:22)
  at None (source/osk/visualKeyboard.ts:961:9)
...
(4 additional frame(s) were not displayed)
```

This was because I overlooked something in #3702, a recently-accepted PR.  Figured I'd address it quickly before my memory of it went cold.