### PR TITLE
fix(windows): icons missing in Configuration

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -277,6 +277,7 @@ var
   sharedDataIntf: IConfigMainSharedData;
   sharedData: TConfigMainSharedData;
   s: string;
+  xml: string;
 begin
   if FPageTag > 0 then
   begin
@@ -301,9 +302,10 @@ begin
     XMLEncode(TBaseKeyboards.GetName(kmcom.Options[KeymanOptionName(koBaseLayout)].Value))
   ]) + DefaultServersXMLTags + DefaultVersionXMLTags;
 
+  xml := FXMLRenderers.RenderToString(FRefreshKeyman, s);
   sharedData.Init(
     FXMLRenderers.TempPath,
-    FXMLRenderers.RenderToString(FRefreshKeyman, s),
+    xml,
     FKeyboardXMLRenderer.FileReferences.ToStringArray
   );
 


### PR DESCRIPTION
Fixes #3692.

Icons were missing in Configuration because the XML template was initialised out of order.

![image](https://user-images.githubusercontent.com/4498365/96397208-b9c0d380-1214-11eb-93e4-5ef2dc961e74.png)
