### PR TITLE
fix(web): Remove base key from popup keys

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -40,7 +40,7 @@ namespace com.keyman.osk {
     }
   };
 
-  // iOS now relies upon native-mode popup key management, so we only implement these hybrid-targetted
+  // iOS now relies upon native-mode popup key management, so we only implement these hybrid-targeted
   // methods when embedding in Android.
   let device = com.keyman.singleton.util.device;
 
@@ -56,10 +56,8 @@ namespace com.keyman.osk {
       if(key['subKeys'] && (typeof(window['oskCreatePopup']) == 'function')) {
         var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
             yBase = dom.Utils.getAbsoluteY(key);
-        
-        if(util.device.formFactor == 'phone') {
-          this.prependBaseKey(key);
-        }
+
+        // No longer prepend base key to subkey array
 
         this.popupBaseKey = key;
         this.popupPending=true;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -57,7 +57,7 @@ namespace com.keyman.osk {
         var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
             yBase = dom.Utils.getAbsoluteY(key);
 
-        // No longer prepend base key to subkey array
+        // #3718: No longer prepend base key to subkey array
 
         this.popupBaseKey = key;
         this.popupPending=true;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1596,43 +1596,7 @@ namespace com.keyman.osk {
       }
     }
 
-    /**
-     * Prepend the base key to the touch-hold key array (for phones)
-     *
-     * @param {Object}  e   base key object
-     */
-    prependBaseKey(e: KeyElement) {
-      // This is a tag we set on the key element during its construction.
-      let subKeys: OSKKeySpec[] = e['subKeys'];
-      let keyman = com.keyman.singleton;
 
-      if(e && typeof(e.id) != 'undefined') {
-        //TODO: refactor this, it's pretty messy...
-        var i,
-          idx = e.id.split('-'),
-          baseId = e['keyId'],
-          layer = e['key'].spec['layer'],
-          sp = e['key'].spec['sp'],
-          nextlayer = e['key'].spec['nextlayer'];
-
-        if(typeof subKeys != 'undefined' && subKeys.length > 0 && (subKeys[0].id != baseId || subKeys[0].layer != layer)) {
-          var eCopy = new OSKKeySpec(baseId, '', undefined, sp, nextlayer);  // {'id':baseId,'layer':'','key':undefined};
-          if(layer != '') {
-            eCopy['layer'] = layer;
-          }
-
-          for(i = 0; i < e.childNodes.length; i++) {
-            if(keyman.util.hasClass(<HTMLElement> e.childNodes[i], 'kmw-key-text')) {
-              break;
-            }
-          }
-          if(i < e.childNodes.length) {
-            eCopy['text'] = e.childNodes[i].textContent;
-          }
-          subKeys.splice(0, 0, eCopy);
-        }
-      }
-    }
     //#endregion
 
     /**

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1509,10 +1509,7 @@ namespace com.keyman.osk {
       subKeys.id='kmw-popup-keys';
       this.popupBaseKey = e;
 
-      // Does the popup array include the base key?   *** condition for phone only ***
-      if(device.formFactor == 'phone') {
-        this.prependBaseKey(e);
-      }
+      // No longer prepend base key to popup array
 
       // Must set position dynamically, not in CSS
       var ss=subKeys.style;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1509,7 +1509,7 @@ namespace com.keyman.osk {
       subKeys.id='kmw-popup-keys';
       this.popupBaseKey = e;
 
-      // No longer prepend base key to popup array
+      // #3718: No longer prepend base key to popup array
 
       // Must set position dynamically, not in CSS
       var ss=subKeys.style;


### PR DESCRIPTION
Fixes #1113 

atm, Keyman for Android on phones includes the base key in the list of popup keys.

This PR standardizes the popup keys by not pre-pending the base key in the popup array.

This also fixes #3092 because now Keyboard creators can control if/where the base key appears in the popup keys.

## Screenshots

### Mobile viewport
![desktop f popup](https://user-images.githubusercontent.com/7358010/96397191-2925cb80-11f3-11eb-9ad3-8ec45cdd1b95.png)

### Android emulator
![android f popup](https://user-images.githubusercontent.com/7358010/96397204-304cd980-11f3-11eb-9908-227226d27e34.png)
