### PR TITLE
fix(windows): tweak scrolling in keyboard menu

### DIFF
--- a/windows/src/engine/keyman/UfrmKeymanMenu.pas
+++ b/windows/src/engine/keyman/UfrmKeymanMenu.pas
@@ -430,10 +430,10 @@ begin
   // Do we need scrollable keyboard list? Only if it's greater than 75% of screen height
   //
 
-  ScrollableView := TotalKeyboardHeight > (Screen.Height * 1 div 5);
+  ScrollableView := TotalKeyboardHeight > (Screen.Height * 3 div 4);
   if ScrollableView then
   begin
-    TotalKeyboardHeight := Screen.Height * 1 div 5;
+    TotalKeyboardHeight := Screen.Height * 3 div 4;
 
     // Calculate the maximum scroll
     TempItemHeight := 0;


### PR DESCRIPTION
Fixes #3694.

The keyboard menu would sometimes scroll too far, which could be confusing for the end user. This fix stops the scroll once the last item is in view; it also tweaks the down arrow key handler to ensure that the current item is correctly scrolled into view.