### PR TITLE
fix(android/browser): Improve how embedded browser handles input

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     android:icon="@drawable/ic_launcher"
     android:label="@string/app_name"
     android:roundIcon="@drawable/ic_launcher_round"
+    android:usesCleartextTraffic="true"
     android:theme="@style/AppTheme"
     android:supportsRtl="true">
     <receiver android:name=".NetworkStateReceiver">

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -323,7 +323,10 @@ public class WebBrowserActivity extends AppCompatActivity {
           try {
             new URL(urlStr);
           } catch (MalformedURLException e) {
-            KMLog.LogException(TAG, "", e);
+            // Intentionally not logging "No protocol" exception because it may be a query
+            if (e != null && !e.getMessage().startsWith("no protocol:")) {
+              KMLog.LogException(TAG, "", e);
+            }
 
             if (Patterns.WEB_URL.matcher(String.format("%s%s", "http://", urlStr)).matches()) {
               urlStr = String.format("%s%s", "http://", urlStr);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -4,8 +4,11 @@
 
 package com.tavultesoft.kmapro;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.KMPLink;
@@ -320,21 +323,31 @@ public class WebBrowserActivity extends AppCompatActivity {
           InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
           imm.hideSoftInputFromWindow(addressField.getWindowToken(), 0);
           String urlStr = v.getText().toString();
-          try {
-            new URL(urlStr);
-          } catch (MalformedURLException e) {
-            // Intentionally not logging "No protocol" exception because it may be a query
-            if (e != null && !e.getMessage().startsWith("no protocol:")) {
-              KMLog.LogException(TAG, "", e);
-            }
 
-            if (Patterns.WEB_URL.matcher(String.format("%s%s", "http://", urlStr)).matches()) {
-              urlStr = String.format("%s%s", "http://", urlStr);
-            } else {
-              urlStr = String.format("https://www.google.com/search?q=%s", urlStr);
+          boolean valid = false;
+          String originalUrl = urlStr;
+          while(!valid) {
+            try {
+              new URL(urlStr);
+              valid = true;
+            } catch (MalformedURLException e) {
+              // Intentionally not logging exception because it may be a query
+
+              if (Patterns.WEB_URL.matcher("http://" + urlStr).matches()) {
+                urlStr = "http://" + originalUrl;
+                valid = true;
+              } else {
+                try {
+                  urlStr = String.format("https://www.google.com/search?q=%s",
+                    URLEncoder.encode(originalUrl, StandardCharsets.UTF_8.displayName()));
+                  valid = true; // no need to test again; we'll assume it's valid this time
+                } catch (UnsupportedEncodingException ue) {
+                  urlStr = String.format("https://www.google.com/search?q=%s", originalUrl);
+                  break;
+                }
+              }
             }
           }
-
           webView.loadUrl(urlStr);
           addressField.clearFocus();
           handled = true;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -334,7 +334,7 @@ public class WebBrowserActivity extends AppCompatActivity {
               // Intentionally not logging exception because it may be a query
 
               if (Patterns.WEB_URL.matcher("http://" + urlStr).matches()) {
-                urlStr = "http://" + originalUrl;
+                urlStr = "http://" + urlStr;
                 valid = true;
               } else {
                 try {


### PR DESCRIPTION
While checking Sentry logs for #3721, I noticed a large amount of [MalformedURLExceptions](http://sentry.keyman.com/organizations/keyman/issues/484/?project=7&query=is%3Aunresolved).

(edited)
This PR adds the following fixes to `WebBrowserActivity`:
* Don't log `MalformedURLExceptions` since it may be a query
* URLEncode the string if it seems to be a URL
* Set `android:usesCleartextTraffic="true"` which allows http traffic (API 23+)
