### PR TITLE
fix(windows): improve tsysinfo upload messages

### DIFF
--- a/windows/src/engine/tsysinfo/UfrmEmail.pas
+++ b/windows/src/engine/tsysinfo/UfrmEmail.pas
@@ -136,6 +136,11 @@ begin
       Request.UrlPath := API_Path_SubmitDiag;
 
       Upload;
+      if Response.StatusCode <> 200 then
+      begin
+        ShowMessage('The report was not successfully sent. An error was returned: '+IntToStr(Response.StatusCode));
+        Exit;
+      end;
       s := Trim(string(Response.MessageBodyAsString));
       if Copy(s,1,7) = '<error>' then
       begin


### PR DESCRIPTION
If tsysinfo fails to upload a diagnostic report, give more detail on what happened.