### PR TITLE
fix(windows): setup status showed only 'removing older versions'

### DIFF
--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -511,9 +511,8 @@ begin
     end
     else
     begin
-      Status('Removing older versions');
       // Remove older versions of Keyman now. We'll still get the upgrade desired
-      // because we've backed up the relevant keys for reapplication post-install
+      // because we've backed up the relevant keys for reapplication post-install.
       // Version 11 and later do not need this treatment as they are upgraded in-place
       // with the file and registry locations remaining static
       if (MsiGetProductCode(ProductCode_Keyman7_1Light, pcode) = ERROR_SUCCESS) or // Keyman 7.1 Light
@@ -522,11 +521,11 @@ begin
          (MsiGetProductCode(ProductCode_Keyman9, pcode) = ERROR_SUCCESS) or // Keyman 9.0
          (MsiGetProductCode(ProductCode_Keyman10, pcode) = ERROR_SUCCESS) then // Keyman 10.0
       begin
+        Status(FInstallInfo.Text(ssStatusRemovingOlderVersions));
         MsiConfigureProduct(pcode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_ABSENT);
         // We'll ignore errors ...
       end;
     end;
-
 
     { Log the install to the diag folder }
 
@@ -539,6 +538,7 @@ begin
 
     FCacheFileName := CacheMSIFile(msiLocation);  // I3476
 
+    Status(FInstallInfo.Text(ssStatusInstalling));
     res := MsiInstallProductW(PWideChar(FCacheFileName), PWideChar(ReinstallMode));
 
     FinishCacheMSIFile(msiLocation,  // I3476

--- a/windows/src/desktop/setup/SetupStrings.pas
+++ b/windows/src/desktop/setup/SetupStrings.pas
@@ -49,6 +49,7 @@ type
     ssExitButton,
 
     ssStatusInstalling,
+    ssStatusRemovingOlderVersions,
     ssStatusComplete,
 
     ssQueryRestart,

--- a/windows/src/desktop/setup/locale/en/strings.xml
+++ b/windows/src/desktop/setup/locale/en/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+﻿<resources>
   <string name="ssLanguageName">English</string>
   <string name="ssApplicationTitle">$APPNAME $VERSION Setup</string>
   <string name="ssTitle">Install $APPNAME $VERSION</string>
@@ -28,6 +28,7 @@
   <string name="ssExitButton">E&amp;xit</string>
 
   <string name="ssStatusInstalling">Installing $APPNAME</string>
+  <string name="ssStatusRemovingOlderVersions">Removing older versions</string>
   <string name="ssStatusComplete">Installation Complete</string>
 
   <string name="ssQueryRestart">You must restart Windows before Setup can complete.  When you restart Windows, Setup will continue.


### PR DESCRIPTION
Fixes #3690.

This applies an 'Installing Keyman' label during the install. While Windows Installer does supply some status messages, at present we are not using those. Also fixed a missing i18n string.