### PR TITLE
fix(android/engine): Only get keyboard version for cloud/

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -466,8 +466,13 @@ final class KMKeyboard extends WebView {
     }
 
     boolean retVal = true;
-    String keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
-    if (!KMManager.shouldAllowSetKeyboard() || keyboardVersion == null) {
+    // keyboardVersion only needed for legacy cloud/ keyboards.
+    // Otherwise, no need for the JSON overhead of determining the keyboard version from kmp.json
+    String keyboardVersion = packageID.equals(KMManager.KMDefault_UndefinedPackageID) ?
+      KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
+
+    if (!KMManager.shouldAllowSetKeyboard() ||
+        (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
       sendError(packageID, keyboardID, languageID);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
@@ -478,13 +483,13 @@ final class KMKeyboard extends WebView {
       kFont = kbInfo.getFont();
       kOskFont = kbInfo.getOSKFont();
       retVal = false;
+
+      // Keyboard changed, so determine version again
+      keyboardVersion = packageID.equals(KMManager.KMDefault_UndefinedPackageID) ?
+        KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
     }
 
     String kbKey = String.format("%s_%s", languageID, keyboardID);
-    //if (kbKey.equals(currentKeyboard))
-    //  return false;
-
-    keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
 
     setKeyboardRoot(packageID);
     String keyboardPath = makeKeyboardPath(packageID, keyboardID, keyboardVersion);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -432,18 +432,26 @@ final class KMKeyboard extends WebView {
       return false;
 
     boolean retVal = true;
-    String keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
-    if (!KMManager.shouldAllowSetKeyboard() || keyboardVersion == null) {
+    // keyboardVersion only needed for legacy cloud/ keyboards.
+    // Otherwise, no need for the JSON overhead of determining the keyboard version from kmp.json
+    String keyboardVersion = packageID.equals(KMManager.KMDefault_UndefinedPackageID) ?
+      KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
+
+    if (!KMManager.shouldAllowSetKeyboard() ||
+        (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
       sendError(packageID, keyboardID, languageID);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
       keyboardID = kbInfo.getKeyboardID();
       languageID = kbInfo.getLanguageID();
       retVal = false;
+
+      // Keyboard changed, so determine version again
+      keyboardVersion = packageID.equals(KMManager.KMDefault_UndefinedPackageID) ?
+        KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
+
     }
     String kbKey = String.format("%s_%s", languageID, keyboardID);
-
-    keyboardVersion = KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID);
 
     setKeyboardRoot(packageID);
 


### PR DESCRIPTION
Helps improve startup-time for #2811 

On app startup, we want to avoid parsing kmp.json files if we can.

This updates `KMManager.prepareKeyboardSwitch()` and `KMKeyboard.setKeyboard()` to only determine the keyboard version for `cloud/` keyboards (since the version string is only appended to cloud/ keyboard files). This avoids the JSON overhead of parsing kmp.json files to get a keyboard version that isn't used.

While there's a lot of similarity between KMKeyboard.prepareKeyboardSwitch() and KMKeyboard.setKeyboard() from #2296, I'm not planning to refactor that at this time.