### PR TITLE
fix(windows): download error dialog could be blank

### DIFF
--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -205,8 +205,12 @@ begin
   begin
     if msiLocation.LocationType = iilOnline then
     begin
+      LogInfo('Downloading '+msiLocation.Url);
       if not TResourceDownloader.Execute(FInstallInfo, msiLocation, FSilent) then
+      begin
+        LogInfo('Failed to download '+msiLocation.Url);
         Exit(False);
+      end;
     end;
 
     Status(FInstallInfo.Text(ssStatusInstalling));
@@ -602,9 +606,9 @@ var
             LogInfo('Downloading '+packLocation.Url);
             if not TResourceDownloader.Execute(FInstallInfo, packLocation, FSilent) then
             begin
-              LogInfo('Failed to download '+packLocation.Url); // TODO: can we get more detail?
+              LogInfo('Failed to download '+packLocation.Url);
               pack.ShouldInstall := False;
-              Continue; //
+              Continue;
             end;
           end;
 

--- a/windows/src/desktop/setup/UfrmDownloadProgress.pas
+++ b/windows/src/desktop/setup/UfrmDownloadProgress.pas
@@ -106,9 +106,13 @@ begin
       then ModalResult := mrOk
       else ModalResult := mrCancel;
   except
-    on E:Exception do
+    on E:EHTTPUploader do
     begin
       ShowMessage(E.Message);
+      ModalResult := mrCancel;
+    end;
+    on E:EHTTPUploaderCancel do
+    begin
       ModalResult := mrCancel;
     end;
   end;


### PR DESCRIPTION
Fixes #3688.

If a user cancelled the download dialog, a blank error dialog would be shown.