### PR TITLE
fix(windows): Keyman Configuration changes apply instantly

### DIFF
--- a/windows/src/desktop/kmshell/help/UfrmHelp.pas
+++ b/windows/src/desktop/kmshell/help/UfrmHelp.pas
@@ -131,7 +131,7 @@ begin
     then FQuery := Format('?keyboard=%s', [UrlEncode(FActiveKeyboard.Name)])
     else FQuery := '';
 
-  Content_Render(False, FQuery);
+  Content_Render(FQuery);
   inherited;
 end;
 

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -205,7 +205,7 @@ begin
     Data := TInstallKeyboardSharedData.Create(FXML, FTempPath, FPackagePath, FFiles);
     PageTag := modWebHttpServer.SharedData.Add(Data);
     FRenderPage := 'installkeyboard';
-    Content_Render(False, 'tag='+IntToStr(PageTag));
+    Content_Render('tag='+IntToStr(PageTag));
   finally
     Screen.Cursor := crDefault;
   end;

--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -47,7 +47,7 @@ uses
 type
   EOnlineUpdateCheck = class(Exception);
 
-  TOnlineUpdateCheckResult = (oucUnknown, oucShutDown, oucSuccess, oucNoUpdates, oucFailure, oucSuccessReboot, oucOffline);
+  TOnlineUpdateCheckResult = (oucUnknown, oucShutDown, oucSuccess, oucNoUpdates, oucFailure, oucOffline);
 
   TOnlineUpdateCheckParamsPackage = record
     ID: string;
@@ -194,7 +194,7 @@ function TOnlineUpdateCheck.Run: TOnlineUpdateCheckResult;
 begin
   Result := DoRun;
 
-  if Result in [oucShutDown, oucSuccess, oucSuccessReboot] then
+  if Result in [oucShutDown, oucSuccess] then
   begin
     kmcom.Keyboards.Refresh;
     kmcom.Keyboards.Apply;
@@ -487,9 +487,6 @@ begin
       end;
     end;
   end;
-
-  if (FParams.Result = oucSuccess) and kmcom.SystemInfo.RebootRequired then
-    FParams.Result := oucSuccessReboot;
 end;
 
 procedure TOnlineUpdateCheck.ShutDown;

--- a/windows/src/desktop/kmshell/main/UfrmKeepInTouch.pas
+++ b/windows/src/desktop/kmshell/main/UfrmKeepInTouch.pas
@@ -31,7 +31,7 @@ type
   private
     { Private declarations }
   protected
-    procedure Content_Render(FRefreshKeyman: Boolean = False; const Query: string = ''); override;
+    procedure Content_Render(const Query: string = ''); override;
     procedure FireCommand(const command: WideString; params: TStringList); override;
   public
     { Public declarations }
@@ -86,8 +86,7 @@ begin
   end;
 end;
 
-procedure TfrmKeepInTouch.Content_Render(FRefreshKeyman: Boolean;
-  const Query: string);
+procedure TfrmKeepInTouch.Content_Render(const Query: string);
 var
   FPath: string;
 begin

--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -309,7 +309,7 @@ begin
     FKeyboardXMLRenderer.FileReferences.ToStringArray
   );
 
-  Content_Render(FRefreshKeyman, 'tag='+IntToStr(FPageTag));
+  Content_Render('tag='+IntToStr(FPageTag));
 end;
 
 procedure TfrmMain.FireCommand(const command: WideString; params: TStringList);

--- a/windows/src/desktop/kmshell/main/UfrmOnlineUpdateNewVersion.pas
+++ b/windows/src/desktop/kmshell/main/UfrmOnlineUpdateNewVersion.pas
@@ -107,7 +107,7 @@ begin
   PageTag := modWebHttpServer.SharedData.Add(Data);
 
   FRenderPage := 'onlineupdate';
-  Content_Render(False, 'tag='+IntToStr(PageTag));
+  Content_Render('tag='+IntToStr(PageTag));
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -549,9 +549,6 @@ begin
 
   if FMode <> fmMain then
   begin
-    if kmcom.SystemInfo.RebootRequired then
-      RunReboot('Windows must be restarted for changes to complete.  Restart now?',
-        'Windows did not initiate the restart successfully.  You will need to restart manually.');
     ApplicationRunning := True;
     Application.Run;
     ApplicationRunning := False;

--- a/windows/src/desktop/kmshell/startup/UfrmSplash.pas
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.pas
@@ -278,10 +278,6 @@ begin
 
     until False;
 
-    if kmcom.SystemInfo.RebootRequired then
-      RunReboot('Windows must be restarted for changes to complete.  Restart now?',
-        'Windows did not initiate the restart successfully.  You will need to restart manually.');
-
     if kmcom.Options[KeymanOptionName(TUtilKeymanOption.koCheckForUpdates)].Value then
     begin
       if not kmcom.Control.IsOnlineUpdateCheckOpen then

--- a/windows/src/desktop/kmshell/util/utilkmshell.pas
+++ b/windows/src/desktop/kmshell/util/utilkmshell.pas
@@ -97,8 +97,6 @@ function ValidDirectory(const dir: string): string;
 
 function GetLongFile(APath:String):String;
 
-function RunReboot(const msg, failuremsg: WideString): Boolean;
-
 function TSFInstalled: Boolean;
 
 function GetLongFileName(const fname: string): string;
@@ -506,61 +504,6 @@ begin
   end;
 
   while (s <> '') and CharInSet(s[1], [' ', #9, #13, #10]) do Delete(s,1,1);  // I3310
-end;
-
-function RunReboot(const msg, failuremsg: WideString): Boolean;
-var
-  hToken: THandle;
-  tkp: TTokenPrivileges;
-  len: DWord;
-begin
-  Result := False;
-  KL.Log('RunReboot - enter');
-  if (msg <> '') and (MessageDlg(msg, mtWarning, mbOkCancel, 0) = mrCancel) then
-  begin
-    KL.Log('RunReboot - cancelled');
-    Exit;
-  end;
-
-  // Get a token for this process.
-  if not OpenProcessToken(GetCurrentProcess, TOKEN_ADJUST_PRIVILEGES or TOKEN_QUERY, hToken) then
-  begin
-    KL.Log('RunReboot - failed to OpenProcessToken');
-    ShowMessage(failuremsg);
-    Exit;
-  end;
-
-  // Get the LUID for the shutdown privilege.
-
-  LookupPrivilegeValue(nil, PCHAR('SeShutdownPrivilege') {SE_SHUTDOWN_NAME}, tkp.Privileges[0].Luid);
-
-  tkp.PrivilegeCount := 1;  // one privilege to set
-  tkp.Privileges[0].Attributes := SE_PRIVILEGE_ENABLED;
-
-  // Get the shutdown privilege for this process.
-
-  AdjustTokenPrivileges(hToken, False, tkp, 0, nil, len);
-
-  // Cannot test the return value of AdjustTokenPrivileges.
-
-  if GetLastError() <> ERROR_SUCCESS then
-  begin
-    KL.Log('RunReboot - failed to AdjustTokenPrivileges');
-    ShowMessage(failuremsg);
-    Exit;
-  end;
-
-  // Shut down the system
-  if not ExitWindowsEx(EWX_REBOOT, 0) then
-  begin
-    KL.Log('RunReboot - failed to ExitWindowsEx');
-    ShowMessage(failuremsg);
-    Exit;
-  end;
-
-  KL.Log('RunReboot - restarting now');
-
-  Result := True;
 end;
 
 function GetLongFile(APath:String):String;

--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -128,6 +128,12 @@
   border-right: 1px solid #6D6C6F;
 }
 
+.footer_instant {
+  font-size: 12px;
+  padding-top: 3px;
+  padding-right: 3px;
+}
+
 input[type='submit'], input[type='button'], button
 {
   background: #F68924;

--- a/windows/src/desktop/kmshell/xml/keyman_footer.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_footer.xsl
@@ -9,28 +9,18 @@
   <xsl:template name="footerframe">
     <div id='footer-top'></div>
     <div style="float:right; padding: 2px 12px">
+      <div class='footer_instant'><xsl:value-of select="$locale/string[@name='S_Footer_ChangesImmediate']"/></div>
+    </div>
+    <div id="keyboards_control" style="float:left">
       <xsl:call-template name="button">
-        <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_OK']"/></xsl:with-param>
-				<xsl:with-param name="default">1</xsl:with-param>
-        <xsl:with-param name="command">keyman:footer_ok</xsl:with-param>
-        <xsl:with-param name="width">70px</xsl:with-param>
+        <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_InstallKeyboard']"/></xsl:with-param>
+        <xsl:with-param name="command">keyman:keyboard_install</xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="button">
-        <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_Cancel']"/></xsl:with-param>
-        <xsl:with-param name="command">keyman:footer_cancel</xsl:with-param>
-        <xsl:with-param name="width">70px</xsl:with-param>
+        <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_DownloadKeyboard']"/></xsl:with-param>
+        <xsl:with-param name="command">keyman:keyboard_download</xsl:with-param>
       </xsl:call-template>
     </div>
-      <div id="keyboards_control" style="float:left">
-        <xsl:call-template name="button">
-          <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_InstallKeyboard']"/></xsl:with-param>
-          <xsl:with-param name="command">keyman:keyboard_install</xsl:with-param>
-        </xsl:call-template>
-        <xsl:call-template name="button">
-          <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_DownloadKeyboard']"/></xsl:with-param>
-          <xsl:with-param name="command">keyman:keyboard_download</xsl:with-param>
-        </xsl:call-template>
-      </div>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -268,14 +268,17 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Caption_Copyright" comment="Keyboard download window, etc. - term for copyright">Copyright:</string>
 
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Footer_ChangesImmediate" comment="Short-term (14.0) message explaining why Ok and Cancel buttons are no longer present">Changes are applied immediately</string>
   
-
-  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">Install keyboard...</string>
 
-  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Button_DownloadKeyboard" comment="Keyboard Layouts - download keyboard button">Download keyboard...</string>
@@ -567,7 +570,6 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_Diagnostics_Diagnostics" comment="Support button submenu - performs a diagnostic report">Diagnostics</string>
 
-  
   
 
   <!-- Context: Download Keyboard Dialog -->

--- a/windows/src/engine/kmcomapi/com/system/keymansysteminfo.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymansysteminfo.pas
@@ -99,13 +99,13 @@ end;
 
 procedure TKeymanSystemInfo.SetReboot;
 begin
-  FWantReboot := True;
-  KL.Log('TKeymanErrors.SetReboot.');
+  KL.Log('TKeymanErrors.SetReboot is no longer supported.');
 end;
 
 function TKeymanSystemInfo.Get_RebootRequired: WordBool;
 begin
-  Result := FWantReboot;
+  KL.Log('TKeymanErrors.RebootRequired always returns False.');
+  Result := False;
 end;
 
 end.

--- a/windows/src/engine/kmcomapi/processes/kpbase.pas
+++ b/windows/src/engine/kmcomapi/processes/kpbase.pas
@@ -30,7 +30,6 @@ type
     procedure ErrorFmt(ErrorCode: Cardinal; Args: OleVariant);
     procedure Warn(WarnCode: Cardinal);
     procedure WarnFmt(WarnCode: Cardinal; Args: OleVariant);
-    procedure SetReboot; deprecated;
   public
     constructor Create(AContext: TKeymanContext);
     destructor Destroy; override;
@@ -64,11 +63,6 @@ end;
 procedure TKPBase.ErrorFmt(ErrorCode: Cardinal; Args: OleVariant);
 begin
   (FContext as TKeymanContext).Errors.AddFmt(ErrorCode, Args, kesError);
-end;
-
-procedure TKPBase.SetReboot;
-begin
-  (FContext as TKeymanContext).SystemInfo.SetReboot;
 end;
 
 procedure TKPBase.Warn(WarnCode: Cardinal);

--- a/windows/src/engine/kmcomapi/util/internalinterfaces.pas
+++ b/windows/src/engine/kmcomapi/util/internalinterfaces.pas
@@ -89,8 +89,6 @@ type
   IIntKeymanPackagesInstalled = IIntKeymanCollection;
 
   IIntKeymanSystemInfo = interface(IIntKeymanInterface)
-    ['{90E3F800-E232-4C12-B7B0-7EFE43B71585}']
-    procedure SetReboot; safecall;
   end;
 
   IIntKeymanOptions = IIntKeymanCollection;

--- a/windows/src/global/delphi/hints/UfrmHint.pas
+++ b/windows/src/global/delphi/hints/UfrmHint.pas
@@ -104,7 +104,7 @@ begin
   ]);
 
   FRenderPage := 'hint';
-  Content_Render(False, query);
+  Content_Render(query);
   inherited;
 end;
 

--- a/windows/src/global/delphi/ui/UfrmWebContainer.pas
+++ b/windows/src/global/delphi/ui/UfrmWebContainer.pas
@@ -81,7 +81,7 @@ type
 
     function IsLocalUrl(const url: string): Boolean;
 
-    procedure Content_Render(FRefreshKeyman: Boolean = False; const Query: string = ''); virtual;
+    procedure Content_Render(const Query: string = ''); virtual;
     procedure WndProc(var Message: TMessage); override;  // I2720
   public
     constructor Create(AOwner: TComponent); override;
@@ -123,8 +123,7 @@ begin
   Application.CreateForm(InstanceClass, Reference);
 end;
 
-procedure TfrmWebContainer.Content_Render(FRefreshKeyman: Boolean;
-  const Query: string);
+procedure TfrmWebContainer.Content_Render(const Query: string);
 var
   FWidth, FHeight: Integer;
 begin
@@ -147,7 +146,7 @@ end;
 
 procedure TfrmWebContainer.Do_Content_Render(FRefreshKeyman: Boolean);
 begin
-  Content_Render(FRefreshKeyman);   // I4088
+  Content_Render;   // I4088
 end;
 
 constructor TfrmWebContainer.Create(AOwner: TComponent);


### PR DESCRIPTION
Fixes #3518.

This is a multi-part PR, with base cleanup in separate commits. Recommend reviewing each commit separately as that will clarify the intent of the changes.

---

Changes in Keyman Configuration will now apply immediately. This removes the OK and Cancel buttons from the dialog and means that all actions are consistent in when they are applied, unlike previously. This also matches the Windows 10 Settings metaphor and metaphors for most modern apps and devices.

For now, I have placed a message where the OK and Buttons were previously, to help existing users understand the change. In time, I expect us to be able to remove that message entirely.

---

Cleanup includes: removing reboot check, removing unused file dialogs, deleting unreachable code, removing unused parameters.

For future consideration:
* Moving Keyman Configuration dialog data management to the back end http server thread (as changes are applied immediately, there is no longer any need to maintain shared data state)
* Making updates more granular -- only writing the changes that have been made rather than batching them all
* Refreshing when changes in configuration that may be made by other apps are received