### PR TITLE
fix(windows): Remove double refresh

### DIFF
--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -92,7 +92,9 @@ public:
 
 	static DWORD *ShiftState();
 
+#ifndef _WIN64
   static LONG *RefreshTag();
+#endif
 
 	static HHOOK get_hhookGetMessage();
 	static HHOOK get_hhookCallWndProc();

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -69,9 +69,6 @@
 /*                                                                         */
 /***************************************************************************/
 
-//__declspec(align(4)) LONG RefreshTag_Process = 0;
-//__declspec(align(4)) LONG FInRefreshKeyboards = 0;
-
 UINT 
   //TODO: consolidate these messages -- they are probably not all required now
   wm_keyman = 0,						// user message - ignore msg   // I3594
@@ -280,8 +277,10 @@ static wchar_t
 __declspec(align(8)) static UINT
   f_vk_prefix = 0;
 
+#ifndef _WIN64
 __declspec(align(8)) static LONG
   f_RefreshTag = 0;
+#endif
 
 static BOOL 
   f_debug_KeymanLog = FALSE, 
@@ -321,7 +320,9 @@ DWORD *Globals::InitialisingThread()  { return &f_InitialisingThread; }   // I43
 
 DWORD *Globals::ShiftState()          { return &f_ShiftState;         }
 
+#ifndef _WIN64
 LONG *Globals::RefreshTag()           { return &f_RefreshTag;         }
+#endif
 
 HHOOK Globals::get_hhookCallWndProc()   { return f_hhookCallWndProc;   }
 HHOOK Globals::get_hhookGetMessage()    { return f_hhookGetMessage;    }
@@ -440,7 +441,9 @@ BOOL Globals::ResetControllers()  // I3092
   f_FSingleThread = FALSE;
   f_hwndIM = 0;
 	f_hwndIMAlways = 0;
+#ifndef _WIN64
   f_RefreshTag = 0;
+#endif
 
   Globals::Unlock();
 


### PR DESCRIPTION
Both the win32 and the win64 keyman engine libraries would receive a refresh notification, and then they'd both broadcast the change. This change limits the broadcast responsibility to the 32-bit engine.