### PR TITLE
fix(android/browser): Fix slow input in embedded browser (WebViews)

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -237,15 +237,7 @@
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"></activity>
     <activity
-      android:name=".WebBrowserActivity"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
-      android:label="@string/app_name"></activity>
-    <activity
       android:name=".BookmarksActivity"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
-      android:label="@string/app_name"></activity>
-    <activity
-      android:name=".KMPBrowserActivity"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"></activity>
     <activity
@@ -298,6 +290,20 @@
       android:parentActivityName=".SelectPackageActivity"
       android:launchMode="singleTask"
       android:theme="@style/AppTheme.Base" />
+
+    <!-- Put other WebViewActivities in a separate process so the Keyboard WebView doesn't lag.
+    Ref https://stackoverflow.com/questions/40650643/timed-out-waiting-on-iinputcontextcallback-with-custom-keyboard-on-android -->
+    <activity
+      android:name=".WebBrowserActivity"
+      android:process=":WebBrowserActivity"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+      android:label="@string/app_name"></activity>
+    <activity
+      android:name=".KMPBrowserActivity"
+      android:process=":KMPBrowserActivity"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+      android:label="@string/app_name"></activity>
+
 
     <provider
       android:name="androidx.core.content.FileProvider"

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -17,12 +17,9 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.widget.Toast;
-
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.util.KMPLink;
 
 import java.util.regex.Matcher;
@@ -30,7 +27,7 @@ import java.util.regex.Pattern;
 
 import static android.app.Application.getProcessName;
 
-public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEventHandler.OnKeyboardEventListener {
+public class KMPBrowserActivity extends AppCompatActivity {
   private static final String TAG = "KMPBrowserActivity";
 
   // URL for keyboard search web page presented to user when they add a keyboard in the app.
@@ -151,7 +148,6 @@ public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEve
   @Override
   protected void onResume() {
     super.onResume();
-    KMManager.addKeyboardEventListener(this);
 
     if (webView != null) {
       webView.reload();
@@ -161,41 +157,11 @@ public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEve
   @Override
   protected void onPause() {
     super.onPause();
-    KMManager.removeKeyboardEventListener(this);
   }
 
   @Override
   protected void onDestroy() {
     super.onDestroy();
-  }
-
-  @Override
-  public void onKeyboardLoaded(KMManager.KeyboardType keyboardType) {
-    // Mitigation for https://github.com/keymanapp/keyman/issues/1963
-    // Due to latency, switch from Keyman system keyboard to another
-    /*
-    if (KMManager.getKMKeyboard(KMManager.KeyboardType.KEYBOARD_TYPE_SYSTEM) != null) {
-      Toast.makeText(getApplicationContext(), getString(R.string.switching_keyboard),
-        Toast.LENGTH_SHORT).show();
-      KMManager.advanceToNextInputMode();
-    }
-
-     */
-  }
-
-  @Override
-  public void onKeyboardChanged(String newKeyboard) {
-    // Do nothing
-  }
-
-  @Override
-  public void onKeyboardShown() {
-    //
-  }
-
-  @Override
-  public void onKeyboardDismissed() {
-    // Do nothing
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -60,7 +60,6 @@ public class KMPBrowserActivity extends AppCompatActivity {
       if (!didSetDataDirectorySuffix) {
         String processName = getProcessName();
         WebView.setDataDirectorySuffix(processName);
-        Log.d(TAG, "process name: " + processName);
         didSetDataDirectorySuffix = true;
       }
     }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -26,6 +27,8 @@ import com.tavultesoft.kmea.util.KMPLink;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static android.app.Application.getProcessName;
 
 public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEventHandler.OnKeyboardEventListener {
   private static final String TAG = "KMPBrowserActivity";
@@ -46,12 +49,24 @@ public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEve
   private WebView webView;
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
+  private static boolean didSetDataDirectorySuffix = false;
 
   @SuppressLint({"SetJavaScriptEnabled", "InflateParams"})
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     final Context context = this;
+
+    // Difference processes in the same application cannot directly share WebView-related data
+    // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      if (!didSetDataDirectorySuffix) {
+        String processName = getProcessName();
+        WebView.setDataDirectorySuffix(processName);
+        Log.d(TAG, "process name: " + processName);
+        didSetDataDirectorySuffix = true;
+      }
+    }
 
     setContentView(R.layout.activity_kmp_browser);
 
@@ -158,11 +173,14 @@ public class KMPBrowserActivity extends AppCompatActivity implements KeyboardEve
   public void onKeyboardLoaded(KMManager.KeyboardType keyboardType) {
     // Mitigation for https://github.com/keymanapp/keyman/issues/1963
     // Due to latency, switch from Keyman system keyboard to another
+    /*
     if (KMManager.getKMKeyboard(KMManager.KeyboardType.KEYBOARD_TYPE_SYSTEM) != null) {
       Toast.makeText(getApplicationContext(), getString(R.string.switching_keyboard),
         Toast.LENGTH_SHORT).show();
       KMManager.advanceToNextInputMode();
     }
+
+     */
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -46,7 +46,7 @@ import android.webkit.WebViewClient;
 import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.tavultesoft.kmea.util.KMLog;
+import static android.app.Application.getProcessName;
 
 public class WebBrowserActivity extends AppCompatActivity {
   private static final String TAG = "WebBrowserActivity";
@@ -60,12 +60,25 @@ public class WebBrowserActivity extends AppCompatActivity {
   private String loadedFont;
   private boolean isLoading = false;
   private boolean didFinishLoading = false;
+  private static boolean didSetDataDirectorySuffix = false;
 
   @SuppressLint({"SetJavaScriptEnabled", "InflateParams"})
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     final Context context = this;
+
+    // Difference processes in the same application cannot directly share WebView-related data
+    // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+       Log.d(TAG, "didSetDataDirectorySuffix: " + didSetDataDirectorySuffix);
+       if (!didSetDataDirectorySuffix) {
+         String processName = getProcessName();
+         WebView.setDataDirectorySuffix(processName);
+         Log.d(TAG, "process name: " + processName);
+         didSetDataDirectorySuffix = true;
+       }
+    }
 
     setContentView(R.layout.activity_web_browser);
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebBrowserActivity.java
@@ -71,11 +71,9 @@ public class WebBrowserActivity extends AppCompatActivity {
     // Difference processes in the same application cannot directly share WebView-related data
     // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-       Log.d(TAG, "didSetDataDirectorySuffix: " + didSetDataDirectorySuffix);
        if (!didSetDataDirectorySuffix) {
          String processName = getProcessName();
          WebView.setDataDirectorySuffix(processName);
-         Log.d(TAG, "process name: " + processName);
          didSetDataDirectorySuffix = true;
        }
     }

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -112,9 +112,6 @@
   <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
   <string name="add_language_subtext" comment="Additional information for adding another language">(from keyboard package)</string>
 
-  <!-- Context: Keyman Settings "Install from keyman.com" menu -->
-  <string name="switching_keyboard" comment="Switching to another keyboard">Switching to another keyboard</string>
-
   <!-- Context: Select Package and Select Languages menu -->
   <string name="title_select_keyboard_package_list" comment="Select a keyboard package to add languages">Select Keyboard Package</string>
 


### PR DESCRIPTION
This fixes #1963 where typing in the embedded browser (a WebView) with the SystemKeyboard (also a WebView) was timeout out between each keystroke.

The fix from https://stackoverflow.com/questions/40650643/timed-out-waiting-on-iinputcontextcallback-with-custom-keyboard-on-android was to put extra WebViews in a separate process. (this affects WebBrowserActivity and KMPBrowserActivity where a user interacts with the webview).

Having the webViews in a separate process also brought up a complication in Android P (API 29+) where the data directory also needs to be separate.
Ref: https://stackoverflow.com/questions/51843546/android-pie-9-0-webview-in-multi-process

Finally, with a responsive system keyboard in the webView, we can revert the workaround in #3648 (no longer need to override the System Keyboard when searching for a keyboard).