### PR TITLE
fix(windows): setup now allows choice of source

### DIFF
--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -200,7 +200,7 @@ begin
     then StatusMax := 6 + FInstallInfo.Packages.Count
     else StatusMax := FInstallInfo.Packages.Count;
 
-  msiLocation := FInstallInfo.BestMsi;
+  msiLocation := FInstallInfo.MsiInstallLocation;
   if Assigned(msiLocation) and FInstallInfo.ShouldInstallKeyman then
   begin
     if msiLocation.LocationType = iilOnline then
@@ -598,7 +598,7 @@ var
     begin
       if pack.ShouldInstall then
       begin
-        packLocation := pack.GetBestLocation;
+        packLocation := pack.InstallLocation;
         if Assigned(packLocation) then
         begin
           if packLocation.LocationType = iilOnline then
@@ -672,7 +672,7 @@ begin
     if CheckForUpdates then s := s + 'CheckForUpdates,';
     if AutomaticallyReportUsage then s := s + 'AutomaticallyReportUsage,';
 
-    msiLocation := FInstallInfo.BestMsi;
+    msiLocation := FInstallInfo.MsiInstallLocation;
     if Assigned(msiLocation) and (
         (FInstallInfo.InstalledVersion.Version = '') or (FInstallInfo.InstalledVersion.ProductCode <> msiLocation.ProductCode)
       ) then

--- a/windows/src/desktop/setup/SetupStrings.pas
+++ b/windows/src/desktop/setup/SetupStrings.pas
@@ -35,7 +35,7 @@ type
     ssActionInstallPackage,
     ssActionInstallPackageLanguage,
     ssActionNothingToInstall,
-    ssActionDownloadAndInstall,
+    ssActionDownload,
     ssActionInstall,
 
     ssFreeCaption,
@@ -68,6 +68,7 @@ type
     ssOptionsTitleDefaultKeymanSettings,
     ssOptionsTitleSelectModulesToInstall,
     ssOptionsTitleAssociatedKeyboardLanguage,
+    ssOptionsTitleLocation,
 
     ssOptionsStartWithWindows,
     ssOptionsStartAfterInstall,
@@ -76,13 +77,14 @@ type
     ssOptionsAutomaticallyReportUsage,
 
     ssOptionsInstallKeyman,
-    ssOptionsDownloadInstallKeyman,
     ssOptionsUpgradeKeyman,
-    ssOptionsDownloadUpgradeKeyman,
+    ssOptionsInstallKeymanVersion,
+    ssOptionsDownloadKeymanVersion,
     ssOptionsKeymanAlreadyInstalled,
 
     ssOptionsInstallPackage,
-    ssOptionsDownloadInstallPackage,
+    ssOptionsDownloadPackageVersion,
+    ssOptionsInstallPackageVersion,
     ssOptionsPackageLanguageAssociation,
     ssOptionsDefaultLanguage,
 

--- a/windows/src/desktop/setup/UfrmInstallOptions.dfm
+++ b/windows/src/desktop/setup/UfrmInstallOptions.dfm
@@ -9,67 +9,62 @@ object frmInstallOptions: TfrmInstallOptions
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
-  Font.Height = -13
+  Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
   OnCreate = FormCreate
-  DesignSize = (
-    646
-    386)
   PixelsPerInch = 96
-  TextHeight = 16
+  TextHeight = 13
   object lblInstallOptions: TLabel
     Left = 8
     Top = 8
-    Width = 179
-    Height = 16
+    Width = 159
+    Height = 13
     Caption = 'ssOptionsTitleInstallOptions'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
-    Font.Height = -13
+    Font.Height = -11
     Font.Name = 'Tahoma'
     Font.Style = [fsBold]
     ParentFont = False
   end
   object lblDefaultKeymanSettings: TLabel
     Left = 8
-    Top = 78
-    Width = 242
-    Height = 16
+    Top = 69
+    Width = 214
+    Height = 13
     Caption = 'ssOptionsTitleDefaultKeymanSettings'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
-    Font.Height = -13
+    Font.Height = -11
     Font.Name = 'Tahoma'
     Font.Style = [fsBold]
     ParentFont = False
   end
   object lblSelectModulesToInstall: TLabel
     Left = 8
-    Top = 172
-    Width = 238
-    Height = 16
+    Top = 149
+    Width = 212
+    Height = 13
     Caption = 'ssOptionsTitleSelectModulesToInstall'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
-    Font.Height = -13
+    Font.Height = -11
     Font.Name = 'Tahoma'
     Font.Style = [fsBold]
     ParentFont = False
   end
   object lblAssociatedKeyboardLanguage: TLabel
-    Left = 322
-    Top = 172
-    Width = 287
-    Height = 16
-    Alignment = taRightJustify
-    Anchors = [akTop, akRight]
+    Left = 242
+    Top = 149
+    Width = 251
+    Height = 13
     Caption = 'ssOptionsTitleAssociatedKeyboardLanguage'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
-    Font.Height = -13
+    Font.Height = -11
     Font.Name = 'Tahoma'
     Font.Style = [fsBold]
     ParentFont = False
@@ -77,13 +72,26 @@ object frmInstallOptions: TfrmInstallOptions
   object lblInstallerVersion: TLabel
     Left = 8
     Top = 358
-    Width = 102
-    Height = 16
+    Width = 84
+    Height = 13
     Caption = 'lblInstallerVersion'
+  end
+  object lblTitleLocation: TLabel
+    Left = 497
+    Top = 149
+    Width = 128
+    Height = 13
+    Caption = 'ssOptionsTitleLocation'
+    Font.Charset = DEFAULT_CHARSET
+    Font.Color = clWindowText
+    Font.Height = -11
+    Font.Name = 'Tahoma'
+    Font.Style = [fsBold]
+    ParentFont = False
   end
   object chkStartWithWindows: TCheckBox
     Left = 8
-    Top = 100
+    Top = 88
     Width = 473
     Height = 17
     Caption = 'ssOptionsStartWithWindows'
@@ -91,7 +99,7 @@ object frmInstallOptions: TfrmInstallOptions
   end
   object chkStartAfterInstall: TCheckBox
     Left = 8
-    Top = 30
+    Top = 27
     Width = 473
     Height = 17
     Caption = 'ssOptionsStartAfterInstall'
@@ -99,7 +107,7 @@ object frmInstallOptions: TfrmInstallOptions
   end
   object chkCheckForUpdates: TCheckBox
     Left = 8
-    Top = 146
+    Top = 126
     Width = 473
     Height = 17
     Caption = 'ssOptionsCheckForUpdates'
@@ -107,7 +115,7 @@ object frmInstallOptions: TfrmInstallOptions
   end
   object chkUpgradeKeyman7: TCheckBox
     Left = 8
-    Top = 53
+    Top = 46
     Width = 473
     Height = 17
     Caption = 'ssOptionsUpgradeKeyboards'
@@ -135,7 +143,7 @@ object frmInstallOptions: TfrmInstallOptions
   end
   object chkAutomaticallyReportUsage: TCheckBox
     Left = 8
-    Top = 123
+    Top = 107
     Width = 473
     Height = 17
     Caption = 'ssOptionsAutomaticallyReportUsage'
@@ -143,9 +151,9 @@ object frmInstallOptions: TfrmInstallOptions
   end
   object sbTargets: TScrollBox
     Left = 6
-    Top = 192
+    Top = 168
     Width = 619
-    Height = 151
+    Height = 175
     BorderStyle = bsNone
     ParentBackground = True
     TabOrder = 5

--- a/windows/src/desktop/setup/UfrmInstallOptions.pas
+++ b/windows/src/desktop/setup/UfrmInstallOptions.pas
@@ -49,6 +49,7 @@ type
     lblSelectModulesToInstall: TLabel;
     lblAssociatedKeyboardLanguage: TLabel;
     lblInstallerVersion: TLabel;
+    lblTitleLocation: TLabel;
     procedure FormCreate(Sender: TObject);
     procedure cmdOKClick(Sender: TObject);
   private
@@ -56,11 +57,13 @@ type
       Package: TInstallInfoPackage;
       Location: TInstallInfoPackageFileLocation;
       CheckBox: TCheckBox;
-      ComboBox: TComboBox;
+      ComboBoxLocation: TComboBox;
+      ComboBoxLanguage: TComboBox;
       function IsValid: Boolean;
     end;
   private
     chkInstallKeyman: TCheckBox;
+    cbKeymanLocation: TComboBox;
     FPackages: array of TPackageControl;
     function GetCanUpgradeKeyman7: Boolean;
     function GetCheckForUpdates: Boolean;
@@ -79,8 +82,8 @@ type
     procedure chkInstallKeyboardClick(Sender: TObject);
     procedure chkInstallKeymanClick(Sender: TObject);
     procedure EnableControls;
-    procedure AddCheckboxPanel(const Text: string; AddCombo: Boolean;
-      var pt: TPoint; var chk: TCheckBox; var cb: TComboBox);
+    procedure AddCheckboxPanel(const Text: string; AddLanguageCombo: Boolean;
+      var pt: TPoint; var chk: TCheckBox; var cbLocation, cbLanguage: TComboBox);
     { Private declarations }
   public
     { Public declarations }
@@ -120,6 +123,7 @@ begin
   lblDefaultKeymanSettings.Caption := FInstallInfo.Text(ssOptionsTitleDefaultKeymanSettings);
   lblSelectModulesToInstall.Caption := FInstallInfo.Text(ssOptionsTitleSelectModulesToInstall);
   lblAssociatedKeyboardLanguage.Caption := FInstallInfo.Text(ssOptionsTitleAssociatedKeyboardLanguage);
+  lblTitleLocation.Caption := FInstallInfo.Text(ssOptionsTitleLocation);
 
   FAllowOptions := not FInstallInfo.IsInstalled and FInstallInfo.IsNewerAvailable;
   lblDefaultKeymanSettings.Visible := FAllowOptions;
@@ -192,18 +196,19 @@ begin
   chkUpgradeKeyman7.Checked := Value;
 end;
 
-procedure TfrmInstallOptions.AddCheckboxPanel(const Text: string; AddCombo: Boolean; var pt: TPoint; var chk: TCheckBox; var cb: TComboBox);
+procedure TfrmInstallOptions.AddCheckboxPanel(const Text: string; AddLanguageCombo: Boolean; var pt: TPoint; var chk: TCheckBox; var cbLocation, cbLanguage: TComboBox);
 var
   pan: TPanel;
 begin
   pan := TPanel.Create(Self);
   chk := TCheckBox.Create(Self);
-  cb := TComboBox.Create(Self);
+  cbLocation := TComboBox.Create(Self);
+  cbLocation.Font := Font;
 
   pan.Left := pt.X;
   pan.Top := pt.Y;
-  pan.Width := sbTargets.ClientWidth - GetSystemMetrics(SM_CXVSCROLL);
-  pan.Height := cb.Height + 4;
+  pan.Width := sbTargets.Width - GetSystemMetrics(SM_CXVSCROLL);
+  pan.Height := cbLocation.Height;
   pan.BevelKind := bkTile;
   pan.BevelOuter := bvNone;
   pan.Caption := '';
@@ -211,21 +216,26 @@ begin
   sbTargets.InsertControl(pan);
 
   chk.Left := 2;
-  chk.Top := 4;
-  chk.Width := 2 * sbTargets.ClientWidth div 3 + 1;
+  chk.Top := 2;
+  chk.Width := sbTargets.ClientWidth div 3 + 1;
   chk.Caption := Text;
   pan.InsertControl(chk);
 
-  if AddCombo then
+  if AddLanguageCombo then
   begin
-    cb.Left := pan.ClientWidth - pan.ClientWidth div 3 - 1;
-    cb.Top := 0;
-    cb.Width := pan.ClientWidth div 3;
-    cb.Style := csDropDownList;
-    pan.InsertControl(cb);
-  end
-  else
-    FreeAndNil(cb);
+    cbLanguage := TComboBox.Create(Self);
+    cbLanguage.Left := pan.ClientWidth div 3 + 1;
+    cbLanguage.Top := 0;
+    cbLanguage.Width := pan.ClientWidth div 3;
+    cbLanguage.Style := csDropDownList;
+    pan.InsertControl(cbLanguage);
+  end;
+
+  cbLocation.Left := pan.ClientWidth - pan.ClientWidth div 3 - 1;
+  cbLocation.Top := 0;
+  cbLocation.Width := pan.ClientWidth div 3;
+  cbLocation.Style := csDropDownList;
+  pan.InsertControl(cbLocation);
 
   Inc(pt.Y, pan.Height - 2);
 end;
@@ -236,16 +246,22 @@ var
   packLocation: TInstallInfoPackageFileLocation;
   chk: TCheckBox;
   pt: TPoint;
-  cb: TComboBox;
+  cbLocation, cbLanguage: TComboBox;
   n: Integer;
   Text: string;
   selectedLang, lang: TInstallInfoPackageLanguage;
+  location: TInstallInfoFileLocation;
 begin
   pt.x := 0;
   pt.y := 0;
 
   if FInstallInfo.IsNewerAvailable then
   begin
+    if FInstallInfo.IsInstalled
+      then Text := FInstallInfo.Text(ssOptionsUpgradeKeyman)
+      else Text := FInstallInfo.Text(ssOptionsInstallKeyman);
+
+{
     if not FInstallInfo.IsInstalled then
       case FInstallInfo.BestMsi.LocationType of
         iilLocal:  Text := FInstallInfo.Text(ssOptionsInstallKeyman, [FInstallInfo.BestMsi.Version]);
@@ -256,6 +272,7 @@ begin
         iilLocal:  Text := FInstallInfo.Text(ssOptionsUpgradeKeyman, [FInstallInfo.BestMsi.Version]);
         iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadUpgradeKeyman, [FInstallInfo.BestMsi.Version, FormatFileSize(FInstallInfo.BestMsi.Size)]);
       end;
+}
   end
   else if FInstallInfo.IsInstalled then
   begin
@@ -267,64 +284,89 @@ begin
     Assert(False, 'Offline, Keyman is not installed, and no msi is available');
   end;
 
-  AddCheckboxPanel(Text, False, pt, chkInstallKeyman, cb);
+  AddCheckboxPanel(Text, False, pt, chkInstallKeyman, cbKeymanLocation, cbLanguage);
+
+  for location in FInstallInfo.MsiLocations do
+  begin
+    case location.LocationType of
+      iilLocal: Text := FInstallInfo.Text(ssOptionsInstallKeymanVersion, [location.Version]);
+      iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadKeymanVersion, [location.Version, FormatFileSize(location.Size)]);
+    end;
+    cbKeymanLocation.Items.AddObject(Text, location);
+  end;
+  cbKeymanLocation.ItemIndex := cbKeymanLocation.Items.IndexOfObject(FInstallInfo.MsiInstallLocation);
+
   chkInstallKeyman.Checked := FInstallInfo.ShouldInstallKeyman;
-  chkInstallKeyman.Enabled := FInstallInfo.IsNewerAvailable and FInstallInfo.IsInstalled;
   chkInstallKeyman.OnClick := chkInstallKeymanClick;
+  chkInstallKeyman.Enabled := FInstallInfo.IsNewerAvailable and FInstallInfo.IsInstalled;
+  cbKeymanLocation.Enabled := chkInstallKeyman.Enabled and (cbKeymanLocation.Items.Count > 1);
+
+  lblTitleLocation.Left := cbKeymanLocation.Left + sbTargets.Left;
 
   n := 0;
   SetLength(FPackages, FInstallInfo.Packages.Count);
   for pack in FInstallInfo.Packages do
   begin
-    packLocation := pack.GetBestLocation;
-    if Assigned(packLocation) then
+    packLocation := pack.InstallLocation;
+    if not Assigned(packLocation) then Continue;
+
+    Text := FInstallInfo.Text(ssOptionsInstallPackage, [packLocation.GetNameOrID(pack.ID)]);
+    AddCheckboxPanel(Text, True, pt, chk, cbLocation, cbLanguage);
+    chk.Checked := pack.ShouldInstall;
+    chk.OnClick := chkInstallKeyboardClick;
+
+    for location in pack.Locations DO
     begin
-      case packLocation.LocationType of
-        iilLocal:  Text := FInstallInfo.Text(ssOptionsInstallPackage, [packLocation.GetNameOrID(pack.ID), packLocation.Version]);
-        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadInstallPackage, [packLocation.GetNameOrID(pack.ID), packLocation.Version, FormatFileSize(packLocation.Size)]);
+      case location.LocationType of
+        iilLocal:  Text := FInstallInfo.Text(ssOptionsInstallPackageVersion, [location.Version]);
+        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadPackageVersion, [location.Version, FormatFileSize(location.Size)]);
       end;
-
-      AddCheckboxPanel(Text, True, pt, chk, cb);
-      chk.Checked := pack.ShouldInstall;
-      chk.OnClick := chkInstallKeyboardClick;
-      cb.OnClick := cbInstallKeyboardClick;
-      cb.Hint := FInstallInfo.Text(ssOptionsPackageLanguageAssociation, [packLocation.GetNameOrID(pack.ID)]);
-      cb.ShowHint := True;
-
-      selectedLang := nil;
-      for lang in packLocation.Languages do
-      begin
-        cb.Items.AddObject(lang.Name + ' ('+lang.BCP47+')', lang);
-        if SameText(pack.BCP47, lang.BCP47) then selectedLang := lang;
-      end;
-
-      if cb.Items.Count = 0 then
-        cb.Items.AddObject(FInstallInfo.Text(ssOptionsDefaultLanguage), nil);
-
-      cb.Sorted := True;
-      cb.ItemIndex := cb.Items.IndexOfObject(selectedLang);
-      if cb.ItemIndex < 0 then
-        cb.ItemIndex := 0;
-
-      FPackages[n].Package := pack;
-      FPackages[n].Location := packLocation;
-      FPackages[n].CheckBox := chk;
-      FPackages[n].ComboBox := cb;
-      Inc(n);
+      cbLocation.Items.AddObject(Text, location);
     end;
+    cbLocation.ItemIndex := cbLocation.Items.IndexOfObject(packLocation);
+    cbLocation.OnClick := cbInstallKeyboardClick;
+
+    cbLanguage.OnClick := cbInstallKeyboardClick;
+    cbLanguage.Hint := FInstallInfo.Text(ssOptionsPackageLanguageAssociation, [packLocation.GetNameOrID(pack.ID)]);
+    cbLanguage.ShowHint := True;
+
+    selectedLang := nil;
+    for lang in packLocation.Languages do
+    begin
+      cbLanguage.Items.AddObject(lang.Name + ' ('+lang.BCP47+')', lang);
+      if SameText(pack.BCP47, lang.BCP47) then selectedLang := lang;
+    end;
+
+    if cbLanguage.Items.Count = 0 then
+      cbLanguage.Items.AddObject(FInstallInfo.Text(ssOptionsDefaultLanguage), nil);
+
+    cbLanguage.Sorted := True;
+    cbLanguage.ItemIndex := cbLanguage.Items.IndexOfObject(selectedLang);
+    if cbLanguage.ItemIndex < 0 then
+      cbLanguage.ItemIndex := 0;
+
+    FPackages[n].Package := pack;
+    FPackages[n].Location := packLocation;
+    FPackages[n].CheckBox := chk;
+    FPackages[n].ComboBoxLanguage := cbLanguage;
+    FPackages[n].ComboBoxLocation := cbLocation;
+    Inc(n);
+
+    lblAssociatedKeyboardLanguage.Left := cbLanguage.Left + sbTargets.Left;
   end;
+
+  EnableControls;
+
+  lblAssociatedKeyboardLanguage.Visible := FInstallInfo.Packages.Count > 0;
 
   // Special case: if there are no options to change, don't present them
   if (FInstallInfo.Packages.Count = 0) and not chkInstallKeyman.Enabled then
   begin
     sbTargets.Visible := False;
     lblSelectModulesToInstall.Visible := False;
+    lblAssociatedKeyboardLanguage.Visible := False;
+    lblTitleLocation.Visible := False;
   end;
-
-  lblAssociatedKeyboardLanguage.Visible := FInstallInfo.Packages.Count > 0;
-
-
-  EnableControls;
 end;
 
 procedure TfrmInstallOptions.cmdOKClick(Sender: TObject);
@@ -332,15 +374,17 @@ var
   pack: TPackageControl;
 begin
   FInstallInfo.ShouldInstallKeyman := chkInstallKeyman.Checked;
+  FInstallInfo.MsiInstallLocation := cbKeymanLocation.Items.Objects[cbKeymanLocation.ItemIndex] as TInstallInfoFileLocation;
 
   for pack in FPackages do
     if pack.IsValid then
     begin
       pack.Package.ShouldInstall := pack.CheckBox.Checked;
-      if (pack.ComboBox.ItemIndex < 0) or
-          not Assigned(pack.ComboBox.Items.Objects[pack.ComboBox.ItemIndex])
+      if (pack.ComboBoxLanguage.ItemIndex < 0) or
+          not Assigned(pack.ComboBoxLanguage.Items.Objects[pack.ComboBoxLanguage.ItemIndex])
         then pack.Package.BCP47 := ''
-        else pack.Package.BCP47 := (pack.ComboBox.Items.Objects[pack.ComboBox.ItemIndex] as TInstallInfoPackageLanguage).BCP47;
+        else pack.Package.BCP47 := (pack.ComboBoxLanguage.Items.Objects[pack.ComboBoxLanguage.ItemIndex] as TInstallInfoPackageLanguage).BCP47;
+      pack.Package.InstallLocation := pack.ComboBoxLocation.Items.Objects[pack.ComboBoxLocation.ItemIndex] as TInstallInfoPackageFileLocation;
     end;
 
   ModalResult := mrOk;
@@ -366,12 +410,17 @@ var
   i: Integer;
   e: Boolean;
 begin
+  chkInstallKeyman.Enabled := FInstallInfo.IsNewerAvailable and FInstallInfo.IsInstalled;
+
   e := chkInstallKeyman.Checked;
+  cbKeymanLocation.Enabled := e and (cbKeymanLocation.Items.Count > 1);
+
   for i := 0 to High(FPackages) do
   begin
     if FPackages[i].IsValid then
     begin
-      FPackages[i].ComboBox.Enabled := FPackages[i].CheckBox.Checked;
+      FPackages[i].ComboBoxLanguage.Enabled := FPackages[i].CheckBox.Checked and (FPackages[i].ComboBoxLanguage.Items.Count > 1);
+      FPackages[i].ComboBoxLocation.Enabled := FPackages[i].CheckBox.Checked and (FPackages[i].ComboBoxLocation.Items.Count > 1);
       e := e or FPackages[i].CheckBox.Checked;
     end;
   end;

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -605,13 +605,13 @@ begin
   s := '';
   if FInstallInfo.ShouldInstallKeyman then
   begin
-    FLocationType := FInstallInfo.BestMsi.LocationType;
+    FLocationType := FInstallInfo.MsiInstallLocation.LocationType;
 
     if FLocationType = iilOnline
-      then downloadSize := '('+FormatFileSize(FInstallInfo.BestMsi.Size)+')'
+      then downloadSize := FInstallInfo.Text(ssActionDownload, [FormatFileSize(FInstallInfo.MsiInstallLocation.Size)])
       else downloadSize := '';
 
-    s := s + FInstallInfo.Text(ssActionInstallKeyman, [FInstallInfo.BestMsi.Version, downloadSize]) + #13#10;
+    s := s + FInstallInfo.Text(ssActionInstallKeyman, [FInstallInfo.MsiInstallLocation.Version, downloadSize]) + #13#10;
 
     Found := True;
   end
@@ -622,7 +622,7 @@ begin
   begin
     if pack.ShouldInstall then
     begin
-      packLocation := pack.GetBestLocation;
+      packLocation := pack.InstallLocation;
       if Assigned(packLocation) then
       begin
         if pack.BCP47 <> ''
@@ -630,7 +630,7 @@ begin
           else langname := '';
 
         if packLocation.LocationType = iilOnline
-          then downloadSize := '('+FormatFileSize(packLocation.Size)+')'
+          then downloadSize := FInstallInfo.Text(ssActionDownload, [FormatFileSize(packLocation.Size)])
           else downloadSize := '';
 
         if langname <> ''
@@ -649,13 +649,13 @@ begin
 
   if not Found then
     s := FInstallInfo.Text(ssActionNothingToInstall)
-  else if FLocationType = iilOnline then
-    s := FInstallInfo.Text(ssActionDownloadAndInstall)+#13#10+s
   else
     s := FInstallInfo.Text(ssActionInstall)+#13#10+s;
 
   lblActions.Caption := s.Trim;
   lblActions.Top := panContent.ClientHeight - lblActions.Height - 4;
+  lblActions.Invalidate;
+  panContent.Invalidate;
 end;
 
 procedure TfrmRunDesktop.FormKeyDown(Sender: TObject; var Key: Word;

--- a/windows/src/desktop/setup/bootstrapmain.pas
+++ b/windows/src/desktop/setup/bootstrapmain.pas
@@ -191,18 +191,20 @@ BEGIN
             Exit;
           end;
 
+          FInstallInfo.CheckPackageLocations;
+
           // If the user is trying to install on downlevel version of Windows (Vista or earlier),
           // we can simplify their life by installing the packages into an existing Keyman
           // install, or point them to the old version of Keyman otherwise.
           if CheckForOldVersionScenario then   // I4460
             Exit;
 
-          TRunTools.CheckInstalledVersion(FInstallInfo.BestMsi);
+          TRunTools.CheckInstalledVersion(FInstallInfo.MsiInstallLocation);
 
           // Looks for installation state for Keyman, and determines best packages for installation.
           // If no .msi can be found, and Keyman is not installed, this will show/log an error and
           // abort installation.
-          if not FInstallInfo.CheckMsiAndPackageUpgradeScenarios then
+          if not FInstallInfo.CheckMsiUpgradeScenarios then
           begin
             // TODO: this should be refactored together with the retry strategy for online check above
             // TODO: Delineate between log messages and dialogs.
@@ -331,7 +333,7 @@ procedure InstallKeyboardsInOldVersion(const ShellPath: string);   // I4460
   var
     location: TInstallInfoPackageFileLocation;
   begin
-    location := pack.GetBestLocation;
+    location := pack.InstallLocation;
     if Assigned(location) and pack.ShouldInstall then
     begin
       if location.LocationType = iilOnline then

--- a/windows/src/desktop/setup/locale/en/strings.xml
+++ b/windows/src/desktop/setup/locale/en/strings.xml
@@ -5,16 +5,17 @@
   <string name="ssInstallSuccess">$APPNAME $VERSION has been installed successfully.</string>
   <string name="ssCancelQuery">Are you sure you want to cancel the installation of $APPNAME?</string>
 
-  <!-- Parameters: %0:s: version, %1:s: (size) -->
+  <!-- Parameters: %0:s: version, %1:s: ssActionDownload -->
   <string name="ssActionInstallKeyman">• $APPNAME %0:s %1:s</string>
 
-  <!-- Parameters: %0:s: package name %1:s: version %2:s: (size) -->
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: ssActionDownload -->
   <string name="ssActionInstallPackage">• %0:s %1:s %2:s</string>
 
-  <!-- Parameters: %0:s: package name %1:s: version %2:s: language %3:s: (size) -->
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: language %3:s: ssActionDownload -->
   <string name="ssActionInstallPackageLanguage">• %0:s %1:s for %2:s %3:s</string>
   <string name="ssActionNothingToInstall">There is nothing to install.</string>
-  <string name="ssActionDownloadAndInstall">Setup will download and install:</string>
+  <!-- Parameters: %0:s download size -->
+  <string name="ssActionDownload">(%0:s download)</string>
   <string name="ssActionInstall">Setup will install:</string>
 
   <string name="ssFreeCaption">$APPNAME $VERSION is free and open source</string>
@@ -47,8 +48,9 @@ Restart now?</string>
 
   <string name="ssOptionsTitleInstallOptions">Installation options</string>
   <string name="ssOptionsTitleDefaultKeymanSettings">Default $APPNAME settings</string>
-  <string name="ssOptionsTitleSelectModulesToInstall">Select modules to install or upgrade</string>
+  <string name="ssOptionsTitleSelectModulesToInstall">Modules to install or upgrade</string>
   <string name="ssOptionsTitleAssociatedKeyboardLanguage">Associated Keyboard Language</string>
+  <string name="ssOptionsTitleLocation">Version to install</string>
 
   <string name="ssOptionsStartWithWindows">Start $APPNAME when Windows starts</string>
   <string name="ssOptionsStartAfterInstall">Start $APPNAME when installation completes</string>
@@ -59,26 +61,25 @@ Restart now?</string>
   <!-- Parameters: %0:s: version of installer (may differ from Keyman version) -->
   <string name="ssInstallerVersion">Setup version: %0:s</string>
 
-  <!-- Parameters: %0:s: version -->
-  <string name="ssOptionsInstallKeyman">Install $APPNAME %0:s</string>
-
-  <!-- Parameters: %0:s: version, %1:s: size -->
-  <string name="ssOptionsDownloadInstallKeyman">Download and install $APPNAME %0:s (%1:s)</string>
-
-  <!-- Parameters: %0:s: version -->
-  <string name="ssOptionsUpgradeKeyman">Upgrade $APPNAME to %0:s</string>
-
-  <!-- Parameters: %0:s: version, %1:s: size -->
-  <string name="ssOptionsDownloadUpgradeKeyman">Download and upgrade $APPNAME to %0:s (%1:s)</string>
+  <string name="ssOptionsInstallKeyman">Install $APPNAME</string>
+  <string name="ssOptionsUpgradeKeyman">Upgrade $APPNAME</string>
 
   <!-- Parameters: %0:s: installed version -->
   <string name="ssOptionsKeymanAlreadyInstalled">$APPNAME %0:s is already installed.</string>
 
-  <!-- Parameters: %0:s: package name %1:s: package version -->
-  <string name="ssOptionsInstallPackage">Install %0:s %1:s</string>
+  <!-- Parameters: %0:s: version, %1:s: size -->
+  <string name="ssOptionsDownloadKeymanVersion">Download version %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: version -->
+  <string name="ssOptionsInstallKeymanVersion">Version %0:s</string>
 
-  <!-- Parameters: %0:s: package name %1:s: package version %2:s package size -->
-  <string name="ssOptionsDownloadInstallPackage">Download and install %0:s %1:s (%2:s)</string>
+
+  <!-- Parameters: %0:s: package name %1:s -->
+  <string name="ssOptionsInstallPackage">Install %0:s</string>
+
+  <!-- Parameters: %0:s: package version %1:s package size -->
+  <string name="ssOptionsDownloadPackageVersion">Download version %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: package version -->
+  <string name="ssOptionsInstallPackageVersion">Version %0:s</string>
 
   <!-- Parameters: %0:s package name -->
   <string name="ssOptionsPackageLanguageAssociation">Select the language that you wish to associate with %0:s keyboard</string>


### PR DESCRIPTION
Where more than one source of a file is available, e.g. a local keymandesktop.msi which is older than the current published version online, then Setup will choose the newer, online version by default, but allows the user to change the install source in the Options dialog to have an offline setup if they prefer.

This means that the 'best' location is now chosen at startup, and then the user can override that.

Relates to #3689.

# New Install Options dialog

![image](https://user-images.githubusercontent.com/4498365/97510569-1f614c80-19d9-11eb-8aa0-d2e13c694251.png)

(Note some options are hidden because they are not relevant)

# Old Install Options dialog

![image](https://user-images.githubusercontent.com/4498365/97510696-65b6ab80-19d9-11eb-939a-207362ee5261.png)
