### PR TITLE
fix(windows): keyboard menu could get out of sync

### DIFF
--- a/windows/src/engine/keyman/Menu_KeyboardItems.pas
+++ b/windows/src/engine/keyman/Menu_KeyboardItems.pas
@@ -293,6 +293,9 @@ begin
   FMenu.Items.Clear;
   FNextMenuItemIsBreak := False;
 
+  FKeyman.Refresh;
+  frmKeyman7Main.LangSwitchManager.Refresh;
+
   with kmint.KeymanCustomisation do
     for i := 1 to CustMenuItems.Count do {$MESSAGE HINT 'This indexing needs to be sorted out'}
     begin


### PR DESCRIPTION
Fixes #3725.
Fixes #3783.

In some situations, the keyboard menu would either display empty or would not refresh to get all installed keyboards.