### PR TITLE
chore(android/engine): Remove use of lexical-model catalog

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -242,10 +242,9 @@ public final class KMManager {
   protected static final String KMFilename_Osk_Ttf_Font = "keymanweb-osk.ttf";
   protected static final String KMFilename_Osk_Woff_Font = "keymanweb-osk.woff";
 
-  public static final String KMFilename_Installed_LexicalModelsList = "lexical_models_list.json";
-
-  // Deprecated by KMFilename_Installed_KeyboardsList and KMFilename_InstalledLexicalModelsList above
+  // Deprecated by KeyboardController.KMFilename_Installed_KeyboardsList
   public static final String KMFilename_KeyboardsList = "keyboards_list.dat";
+
   public static final String KMFilename_LexicalModelsList = "lexical_models_list.dat";
 
   private static Context appContext;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -133,7 +133,6 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
 
   protected void ensureInitCloudReturn(Context aContext, Dataset aDataSet, CloudCatalogDownloadReturns jsonTuple)
   {
-    jsonTuple.keyboardJSON = ensureInit(aContext,aDataSet,jsonTuple.keyboardJSON);
     jsonTuple.lexicalModelJSON = ensureInit(aContext,aDataSet, jsonTuple.lexicalModelJSON);
     jsonTuple.packagesJSON = ensureInit(aContext, aDataSet, jsonTuple.packagesJSON);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadReturns.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadReturns.java
@@ -11,22 +11,17 @@ import java.util.List;
  * Result type for catalogue download.
  */
 public class CloudCatalogDownloadReturns {
-  public JSONObject keyboardJSON; // TODO: remove
   public JSONArray lexicalModelJSON;
   public JSONObject packagesJSON;
 
   // Used by the CloudCatalogDownloadTask, as it fits well with doInBackground's param structure.
   public CloudCatalogDownloadReturns(List<CloudApiTypes.CloudApiReturns> returns) {
-    JSONObject kbd = null;
     JSONArray lex = null;
     JSONObject pkg = null;
 
     //TODO: Seems to be wrong because only the last result for each type will be processed
     for(CloudApiTypes.CloudApiReturns ret: returns) {
       switch(ret.target) {
-        case Keyboards:
-          kbd = ret.jsonObject;
-          break;
         case LexicalModels:
           lex = ret.jsonArray;
           break;
@@ -37,22 +32,19 @@ public class CloudCatalogDownloadReturns {
     }
 
     // Errors are thrown if we try to do this assignment within the loop.
-    this.keyboardJSON = kbd;
     this.lexicalModelJSON = lex;
     this.packagesJSON = pkg;
   }
 
   public CloudCatalogDownloadReturns(JSONObject keyboardJSON, JSONArray lexicalModelJSON, JSONObject packagesJSON) {
-    this.keyboardJSON = keyboardJSON;
     this.lexicalModelJSON = lexicalModelJSON;
     this.packagesJSON = packagesJSON;
   }
 
   public boolean isEmpty() {
-    boolean emptyKbd = keyboardJSON == null || keyboardJSON.length() == 0;
     boolean emptyLex = lexicalModelJSON == null || lexicalModelJSON.length() == 0;
     boolean emptyPkg = packagesJSON == null || packagesJSON.length() == 0;
 
-    return emptyKbd && emptyLex && emptyPkg;
+    return emptyLex && emptyPkg;
   }
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -40,8 +40,6 @@ public class CloudRepository {
   public static final String API_PRODUCTION_HOST = "api.keyman.com";
   public static final String API_STAGING_HOST = "api.keyman-staging.com";
 
-  public static final String API_MODEL_QUERY = "?q";
-  public static final String API_MODEL_FORMATSTR = "https://%s/model%s";
   public static final String API_MODEL_LANGUAGE_FORMATSTR = "https://%s/model?q=bcp47:%s";
   public static final String API_PACKAGE_VERSION_FORMATSTR = "https://%s/package-version?platform=android%s%s";
 
@@ -181,7 +179,7 @@ public class CloudRepository {
     }
   }
 
-  private CloudApiTypes.CloudApiParam prepareResourcesUpdateQuerty(Context aContext) {
+  private CloudApiTypes.CloudApiParam prepareResourcesUpdateQuery(Context aContext) {
     // Keyman cloud keyboard
     // Append each keyboard id
     String keyboardQuery = "";
@@ -205,29 +203,6 @@ public class CloudRepository {
     String queryURL = String.format(API_PACKAGE_VERSION_FORMATSTR, getHost(), keyboardQuery, lexicalModelQuery);
     return new CloudApiTypes.CloudApiParam(
       CloudApiTypes.ApiTarget.PackageVersion, queryURL).setType(CloudApiTypes.JSONType.Object);
-  }
-
-  private CloudApiTypes.CloudApiParam prepareLexicalModelUpdateQuery(Context aContext)
-  {
-    // This allows us to directly get the full lexical model catalog.
-    // TODO:  Remove and replace with commented-out code below once the proper multi-language
-    //        query is ready!
-    String lexicalURL = String.format(API_MODEL_FORMATSTR, getHost(), API_MODEL_QUERY);
-
-    return new CloudApiTypes.CloudApiParam(CloudApiTypes.ApiTarget.LexicalModels, lexicalURL)
-      .setType(CloudApiTypes.JSONType.Array);
-
-    // TODO: We want a list of lexical models for every language with an installed resource (kbd, lex model)
-
-//      String lexicalURL = String.format(API_MODEL_FORMATSTR, getHost(), "?q=bcp47:");
-//
-//      for(String lgCode: languageCodes) {
-//        lexicalURL = String.format("%s%s,", lexicalURL, lgCode);
-//      }
-//
-//      lexicalURL = lexicalURL.substring(0, lexicalURL.lastIndexOf(','));
-
-    /* do what's possible here, rather than in the Task */
   }
 
   public static String prepareLexicalModelQuery(String languageID) {
@@ -406,8 +381,7 @@ public class CloudRepository {
     List<CloudApiTypes.CloudApiParam> cloudQueries = new ArrayList<>(2);
 
     if (!cacheValid) {
-      cloudQueries.add(prepareLexicalModelUpdateQuery(context));
-      cloudQueries.add(prepareResourcesUpdateQuerty(context));
+      cloudQueries.add(prepareResourcesUpdateQuery(context));
     }
 
     int cloudQueryEntries = cloudQueries.size();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Dataset.java
@@ -340,7 +340,7 @@ public class Dataset extends ArrayAdapter<Dataset.LanguageDataset> implements Li
     this.languageMetadata.clear();
   }
 
-  // TODO:  Do we need to override any of this class's menbers in case someone SOMEHOW constructs
+  // TODO:  Do we need to override any of this class's members in case someone SOMEHOW constructs
   //        a LanguageDataset from outside the Dataset class?
 
   @Override


### PR DESCRIPTION
This is the low-hanging-fruit 🍏  portion of #3777 by removing the use of the lexical-model catalog. `CloudRepository.prepareLexicalModelUpdateQuery` is also no longer needed.

* Also clarify deprecation comments since `KMManager.KMFilename_LexicalModelsList` is still in use.
* Fix typo `prepareResourcesUpdateQuerty` to `prepareResourcesUpdateQuery`

This change does affect ModelPickerActivity since there's no longer a lexical-model catalog available to display available models to install. The UX will be updated in a separate PR.

As a test, I verified I could install the fv_sencoten keyboard, and the app would find the associated dictionary and download it.
