### PR TITLE
fix(windows): Handle failure on task creation

### DIFF
--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -63,7 +63,7 @@ begin
 
     // Create or open the Keyman task folder
     try
-      pTaskFolder := pService.GetFolder('\*' + CTaskFolderName);
+      pTaskFolder := pService.GetFolder('\' + CTaskFolderName);
     except
       on E:EOleException do
       begin

--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -16,7 +16,9 @@ type
 implementation
 
 uses
+  System.SysUtils,
   System.Variants,
+  System.Win.ComObj,
   Winapi.ActiveX,
   Winapi.Windows,
 
@@ -24,6 +26,8 @@ uses
   KeymanPaths,
   KeymanVersion,
   RegistryKeys,
+  Keyman.System.KeymanSentryClient,
+  Sentry.Client,
   TaskScheduler_TLB;
 
 { TKeymanStartTask }
@@ -53,42 +57,75 @@ var
   pEventTrigger: IEventTrigger;
   pAction: IExecAction;
 begin
-  pService := CoTaskScheduler_.Create;
-  pService.Connect(EmptyParam, EmptyParam, EmptyParam, EmptyParam);
-
-  // Create or open the Keyman task folder
   try
-    pTaskFolder := pService.GetFolder('\' + CTaskFolderName);
+    pService := CoTaskScheduler_.Create;
+    pService.Connect(EmptyParam, EmptyParam, EmptyParam, EmptyParam);
+
+    // Create or open the Keyman task folder
+    try
+      pTaskFolder := pService.GetFolder('\*' + CTaskFolderName);
+    except
+      on E:EOleException do
+      begin
+        // Don't report if the folder doesn't exist, because we need to create it
+        if E.ErrorCode <> HResultFromWin32(ERROR_FILE_NOT_FOUND) then
+          TKeymanSentryClient.ReportHandledException(E, 'Failed to get task folder');
+
+        try
+          pTaskFolder := pService.GetFolder('\').CreateFolder(CTaskFolderName, EmptyParam);
+        except
+          on E:EOleException do
+          begin
+            // Don't report if we might have a race (someone else created it at
+            // the same time we did)
+            if E.ErrorCode <> HResultFromWin32(ERROR_ALREADY_EXISTS) then
+              TKeymanSentryClient.ReportHandledException(E, 'Failed to create task folder');
+
+            // well let's try one last time to get the folder
+            try
+              pTaskFolder := pService.GetFolder('\' + CTaskFolderName);
+            except
+              on E:EOleException do
+              begin
+                TKeymanSentryClient.ReportHandledException(E, 'Failed to get task folder, second try');
+                Exit;
+              end;
+            end;
+          end;
+        end;
+      end;
+    end;
+
+    // Create a new task
+    pTask := pService.NewTask(0);
+
+    pRegInfo := pTask.RegistrationInfo;
+    pRegInfo.Author := CTaskAuthor;
+    pRegInfo.Description := CTaskDescription;
+    pRegInfo.Version := CKeymanVersionInfo.VersionWithTag;
+
+    pSettings := pTask.Settings;
+    pSettings.DisallowStartIfOnBatteries := False;
+    pSettings.StopIfGoingOnBatteries := False;
+    pSettings.ExecutionTimeLimit := 'PT0S'; // no time limit
+    pSettings.Priority := 4; // https://github.com/microsoft/WinDev/issues/55
+
+    // Start the task when Keyman event 256 is logged
+    pEventTrigger := pTask.Triggers.Create(TASK_TRIGGER_EVENT) as IEventTrigger;
+    pEventTrigger.Id := CTaskEventTriggerId;
+    pEventTrigger.Subscription := CTaskTrigger;
+
+    // Action is to run keyman.exe as login user
+    pAction := pTask.Actions.Create(TASK_ACTION_EXEC) as IExecAction;
+    pAction.Path := TKeymanPaths.KeymanEngineInstallPath(TKeymanPaths.S_KeymanExe);
+    pAction.Arguments := CKeymanExeStartArguments;
+
+    pTaskFolder.RegisterTaskDefinition(CTaskName, pTask, TASK_CREATE_OR_UPDATE or TASK_IGNORE_REGISTRATION_TRIGGERS,
+      EmptyParam, EmptyParam, TASK_LOGON_NONE, EmptyParam);
   except
-    pTaskFolder := pService.GetFolder('\').CreateFolder(CTaskFolderName, EmptyParam);
+    on E:Exception do
+      TKeymanSentryClient.ReportHandledException(E, 'Failed to create task');
   end;
-
-  // Create a new task
-  pTask := pService.NewTask(0);
-
-  pRegInfo := pTask.RegistrationInfo;
-  pRegInfo.Author := CTaskAuthor;
-  pRegInfo.Description := CTaskDescription;
-  pRegInfo.Version := CKeymanVersionInfo.VersionWithTag;
-
-  pSettings := pTask.Settings;
-  pSettings.DisallowStartIfOnBatteries := False;
-  pSettings.StopIfGoingOnBatteries := False;
-  pSettings.ExecutionTimeLimit := 'PT0S'; // no time limit
-  pSettings.Priority := 4; // https://github.com/microsoft/WinDev/issues/55
-
-  // Start the task when Keyman event 256 is logged
-  pEventTrigger := pTask.Triggers.Create(TASK_TRIGGER_EVENT) as IEventTrigger;
-  pEventTrigger.Id := CTaskEventTriggerId;
-  pEventTrigger.Subscription := CTaskTrigger;
-
-  // Action is to run keyman.exe as login user
-  pAction := pTask.Actions.Create(TASK_ACTION_EXEC) as IExecAction;
-  pAction.Path := TKeymanPaths.KeymanEngineInstallPath(TKeymanPaths.S_KeymanExe);
-  pAction.Arguments := CKeymanExeStartArguments;
-
-  pTaskFolder.RegisterTaskDefinition(CTaskName, pTask, TASK_CREATE_OR_UPDATE or TASK_IGNORE_REGISTRATION_TRIGGERS,
-    EmptyParam, EmptyParam, TASK_LOGON_NONE, EmptyParam);
 end;
 
 class procedure TKeymanStartTask.DeleteTask;
@@ -96,25 +133,39 @@ var
   pService: ITaskService;
   pTaskFolder: ITaskFolder;
 begin
-  pService := CoTaskScheduler_.Create;
-  pService.Connect(EmptyParam, EmptyParam, EmptyParam, EmptyParam);
   try
-    pTaskFolder := pService.GetFolder('\'+CTaskFolderName);
-  except
-    // Assume that the folder doesn't exist, nothing to do
-    Exit;
-  end;
+    pService := CoTaskScheduler_.Create;
+    pService.Connect(EmptyParam, EmptyParam, EmptyParam, EmptyParam);
+    try
+      pTaskFolder := pService.GetFolder('\'+CTaskFolderName);
+    except
+      on E:EOleException do
+      begin
+        if E.ErrorCode = HResultFromWin32(ERROR_FILE_NOT_FOUND) then
+          // Assume that the folder doesn't exist, nothing to do
+          Exit;
+      end;
+    end;
 
-  try
-    pTaskFolder.DeleteTask(CTaskName, 0);
-  except
-    // We'll assume that the task doesn't exist, and continue
-  end;
+    try
+      pTaskFolder.DeleteTask(CTaskName, 0);
+    except
+      on E:EOleException do
+      begin
+        if E.ErrorCode = HResultFromWin32(ERROR_FILE_NOT_FOUND) then
+          // Assume that the task doesn't exist, nothing to do
+          Exit;
+      end;
+    end;
 
-  if pTaskFolder.GetTasks(0).Count = 0 then
-  begin
-    pTaskFolder := nil;
-    pService.GetFolder('\').DeleteFolder(CTaskFolderName, 0);
+    if pTaskFolder.GetTasks(0).Count = 0 then
+    begin
+      pTaskFolder := nil;
+      pService.GetFolder('\').DeleteFolder(CTaskFolderName, 0);
+    end;
+  except
+    on E:Exception do
+      TKeymanSentryClient.ReportHandledException(E, 'Failed to delete task');
   end;
 end;
 

--- a/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -4,6 +4,7 @@ interface
 
 uses
   System.Classes,
+  System.SysUtils,
   Sentry.Client;
 
 type
@@ -31,6 +32,8 @@ type
 
     class procedure Validate(Force: Boolean = False);
 
+    class procedure ReportHandledException(E: Exception; const Message: string = ''; IncludeStack: Boolean = True);
+
     class procedure Start(SentryClientClass: TSentryClientClass; AProject: TKeymanSentryClientProject; const ALogger: string; AFlags: TKeymanSentryClientFlags = [kscfCaptureExceptions, kscfShowUI, kscfTerminate]);
     class procedure Stop;
     class property Client: TSentryClient read FClient;
@@ -51,7 +54,7 @@ uses
   System.Generics.Collections,
   System.JSON,
   System.StrUtils,
-  System.SysUtils,
+  System.Win.ComObj,
   System.Win.Registry,
 {$IF NOT DEFINED(CONSOLE)}
 {$IF NOT DEFINED(SENTRY_NOVCL)}
@@ -176,6 +179,25 @@ begin
     if kscfTerminate in FFlags then
       EventAction := sceaTerminate;
   end;
+end;
+
+class procedure TKeymanSentryClient.ReportHandledException(E: Exception;
+  const Message: string = ''; IncludeStack: Boolean = True);
+var
+  text: string;
+begin
+  if Message <> ''
+    then text := Message + ': '
+    else text := '';
+
+  if E is EOleException then
+    text := Format('%s(%x): %s%s', [E.ClassName, (E as EOleException).ErrorCode, text, E.Message])
+  else if E is EOSError then
+    text := Format('%s(%d): %s%s', [E.ClassName, (E as EOSError).ErrorCode, text, E.Message])
+  else
+    text := Format('%s: %s%s', [E.ClassName, text, E.Message]);
+
+  Client.MessageEvent(TSentryLevel.SENTRY_LEVEL_WARNING, text, IncludeStack);
 end;
 
 procedure TKeymanSentryClient.ReportRemoteErrors(const childEventID: string);


### PR DESCRIPTION
Fixes #3797.
Fixes KEYMAN-WINDOWS-5H.

Report unexpected errors creating or deleting scheduled task, and ignore expected errors better, handling a potential race condition where two processes both attempt to create a folder at the same time.

Note that creating the task should not be a race because we use the `TASK_CREATE_OR_UPDATE` flag.