### PR TITLE
fix(windows): crash installing package with a race

### DIFF
--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -222,23 +222,26 @@ begin
   Result := '';
   doc := LoadXMLData(xml);
 
-  node := doc.DocumentElement.ChildNodes.FindNode('readme');
-  if Assigned(node) then
+  if Assigned(doc.DocumentElement) then
   begin
-    Result := node.NodeValue;
-    node.NodeValue := ExtractFileName(Result);
-    Result := ExtractFilePath(Result);
-  end;
+    node := doc.DocumentElement.ChildNodes.FindNode('readme');
+    if Assigned(node) then
+    begin
+      Result := node.NodeValue;
+      node.NodeValue := ExtractFileName(Result);
+      Result := ExtractFilePath(Result);
+    end;
 
-  node := doc.DocumentElement.ChildNodes.FindNode('graphic');
-  if Assigned(node) then
-  begin
-    Result := node.NodeValue;
-    node.NodeValue := ExtractFileName(Result);
-    Result := ExtractFilePath(Result);
-  end;
+    node := doc.DocumentElement.ChildNodes.FindNode('graphic');
+    if Assigned(node) then
+    begin
+      Result := node.NodeValue;
+      node.NodeValue := ExtractFileName(Result);
+      Result := ExtractFilePath(Result);
+    end;
 
-  doc.SaveToXML(xml);
+    doc.SaveToXML(xml);
+  end;
 end;
 
 procedure TfrmInstallKeyboard.TntFormDestroy(Sender: TObject);

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardfile.pas
@@ -259,7 +259,8 @@ end;
 
 function TKeymanKeyboardFile.Serialize(Flags: TOleEnum; const ImagePath: WideString; References: TStrings): WideString;
 var
-  FBitmap, FEncodings: WideString;
+  FBitmap, FEncodings: string;
+  TempBitmapLockFile: string;
 begin
   FEncodings := '';
   if (Get_Encodings and keymanapi_TLB.keUnicode) = keymanapi_TLB.keUnicode then
@@ -283,7 +284,7 @@ begin
     (Assigned(FKeyboardInfo.Icon) or
     Assigned(FKeyboardInfo.Bitmap)) then
   begin
-    FBitmap := XMLImageTempName(ImagePath, References);
+    FBitmap := XMLImageTempName(ImagePath, TempBitmapLockFile, References);
     with TBitmap.Create do
     try
       Width := 16;
@@ -295,6 +296,7 @@ begin
     finally
       Free;
     end;
+    DeleteFile(TempBitmapLockFile); // delete after bitmap is saved to avoid races
     Result := Result + '<bitmap>'+ExtractFileName(FBitmap)+'</bitmap>';
   end;
 end;

--- a/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymankeyboardinstalled.pas
@@ -211,7 +211,8 @@ end;
 function TKeymanKeyboardInstalled.Serialize(Flags: TOleEnum; const ImagePath: WideString; References: TStrings): WideString;
 var
   FHasVisualKeyboard: Boolean;
-  FBitmap, FEncodings: WideString;
+  FBitmap, FEncodings: string;
+  TempBitmapLockFile: string;
 begin
   FEncodings := '';
   if (Get_Encodings and keymanapi_TLB.keUnicode) = keymanapi_TLB.keUnicode then
@@ -240,7 +241,7 @@ begin
 
   if ((Flags and ksfExportImages) = ksfExportImages) and Assigned(FRegKeyboard.Icon) then
   begin
-    FBitmap := XMLImageTempName(ImagePath, References);
+    FBitmap := XMLImageTempName(ImagePath, TempBitmapLockFile, References);
     with Vcl.Graphics.TBitmap.Create do
     try
       Width := 16;
@@ -250,6 +251,7 @@ begin
     finally
       Free;
     end;
+    DeleteFile(TempBitmapLockFile); // delete after bitmap is saved to avoid races
     Result := Result + '<bitmap>'+ExtractFileName(FBitmap)+'</bitmap>';
   end;
 

--- a/windows/src/global/delphi/general/utilxml.pas
+++ b/windows/src/global/delphi/general/utilxml.pas
@@ -30,7 +30,7 @@ uses
 
 function XMLEncode(const s: WideString): WideString;
 function XMLFormat(const Args: array of const): WideString;
-function XMLImageTempName(const ImagePath: WideString; References: TStrings): WideString;
+function XMLImageTempName(const ImagePath: string; var TempLockFile: string; References: TStrings): string;
 
 implementation
 
@@ -138,7 +138,7 @@ begin
   end;
 end;
 
-function XMLImageTempName(const ImagePath: WideString; References: TStrings): WideString;
+function XMLImageTempName(const ImagePath: string; var TempLockFile: string; References: TStrings): string;
 var
   s: string;
   buf: array[0..260] of char;
@@ -146,8 +146,8 @@ begin
   s := ExcludeTrailingPathDelimiter(ImagePath);
   if GetTempFileName(PChar(s), 'kmn', 0, buf) = 0 then
     RaiseLastOSError;
-  DeleteFile(buf);
-  Result := ChangeFileExt(buf, '.bmp');
+  TempLockFile := buf;
+  Result := ChangeFileExt(TempLockFile, '.bmp');
   References.Add(ExtractFileName(Result));
 end;
 


### PR DESCRIPTION
Fixes #3801.
Fixes #3802.
Fixes KEYMAN-WINDOWS-5M.
Fixes KEYMAN-WINDOWS-5N.

This is a two-part fix for Keyman Configuration where it appears there was a race with creating a temporary file, and which caused a cascading exception.

The first part resolves the race; the second part (in UfrmInstallKeyboard.pas) adds a little extra robustness (probably not totally necessary).