### PR TITLE
chore(common): improve build README.md

### DIFF
--- a/resources/build/README.md
+++ b/resources/build/README.md
@@ -1,3 +1,15 @@
+# Release builds
+
+A release is triggered nightly whenever a pull request has been merged to the branch; it
+runs from a TeamCity build configuration that runs `increment-version.sh` and then uploads
+the resulting `HISTORY.md` to https://downloads.keyman.com/history/HISTORY.md.
+
+To manually make a release (for example if a build falls over for a transient error or
+there was a build configuration problem), create a new PR that targets the branch,
+merge it, and then run the **Trigger Release Builds** build configuration for that 
+branch. If you have no changes, see that as an opportunity to improve documentation,
+including this file...
+
 # Various tools
 
 vswhere.exe is used by Keyman Core to select a Visual Studio version on Windows.


### PR DESCRIPTION
The background reason for this is to test a fix to the web build, where s.keyman.com resources were not being updated since we refactored the build configurations (sadly, the build did not die when it should have).