### PR TITLE
fix(developer): Incorrect script:language map

### DIFF
--- a/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
+++ b/windows/src/developer/TIKE/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
@@ -156,7 +156,7 @@ var
   t: string;
 begin
   inherited;
-  tag.Language := TKMXFileLanguages.TranslateISO6393ToBCP47(cbLanguageTag.Text);
+  tag.Tag := TKMXFileLanguages.TranslateISO6393ToBCP47(cbLanguageTag.Text);
   t := TCanonicalLanguageCodeUtils.FindBestTag(Tag.Tag, False);
   if t <> '' then
   begin


### PR DESCRIPTION
Fixes #1584.

In the "Select BCP 47 Tag" dialog, when the user starts typing a language tag, e.g. "hi" for Hindi, the "h" would match "ha" for Hausa, and set the script to "Latn". When the "i" was then typed, the script box would not be cleared, giving an incorrect result of "hi-Latn" instead of just plain "hi".

The earlier issue of "yo-Brai" has already been resolved.