### PR TITLE
fix(android/app): Remove network check on "Get Started" menu

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -113,11 +113,9 @@ public class GetStartedActivity extends AppCompatActivity {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         if (position == 0) {
-          if (KMManager.hasConnection(context)) {
-            // Keyman Settings install activity
-            Intent i = new Intent(context, KeymanSettingsInstallActivity.class);
-            context.startActivity(i);
-          }
+          // Keyman Settings install activity
+          Intent i = new Intent(context, KeymanSettingsInstallActivity.class);
+          context.startActivity(i);
         } else if (position == 1) {
           startActivity(new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS));
         } else if (position == 2) {


### PR DESCRIPTION
I was reviewing the [User Testing for Android](https://github.com/keymanapp/keyman/wiki/User-Testing-for-Android) procedures for Friday's test meeting.

Originally, the **Get Started** menu option "Add a keyboard for your language" required network access to keyman.com to install a keyboard.

The option now accesses the Keyman Settings menu "Install Keyboard or Dictionary" which offers two options for installing offline keyboard packages. (The first option "Install from keyman.com" has the check for network).

This small PR just removes the network check on the "Get Started" menu.