### PR TITLE
feat(common/models): use of applyCasing for suggestions

### DIFF
--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -142,8 +142,8 @@ declare interface LexicalModel {
 
   /**
    * Generates predictive suggestions corresponding to the state of context after the proposed
-   * transform is applied to it.  This transform may correspond to a 'correction' of a recent 
-   * keystroke rather than one actually received.
+   * transform is applied to it.  Each returned `Suggestion` should replace the entire 
+   * word / text token, rather than leaving part of it unaltered.
    * 
    * This method should NOT attempt to perform any form of correction; this is modeled within a
    * separate component of the LMLayer predictive engine.  That is, "th" + "e" should not be
@@ -152,7 +152,9 @@ declare interface LexicalModel {
    * 
    * However, addition of diacritics to characters (which may transform the underlying char code 
    * when Unicode-normalized) is permitted.  For example, "pur" + "e" may reasonably predict
-   * "purée", where "e" has been transformed to "é" as part of the suggestion.
+   * "purée", where "e" has been transformed to "é" as part of the suggestion.  When possible, 
+   * it is recommended to accomplish this by defining a `toKey` (`searchTermToKey` in model
+   * source) instead.
    * 
    * When both prediction and correction are permitted, said component (the `ModelCompositor`) will 
    * generally call this method once per 'likely' generated corrected state of the context, 
@@ -160,8 +162,7 @@ declare interface LexicalModel {
    * @param transform A Transform corresponding to a recent input keystroke
    * @param context A depiction of the context to which `transform` is applied.
    * @returns A probability distribution (`Distribution<Suggestion>`) on the resulting `Suggestion` 
-   * space for use in determining the most optimal overall suggestions.  Each returned `Suggestion`
-   * should replace the entire word / text token, rather than leaving part of it unaltered.
+   * space for use in determining the most optimal overall suggestions.  
    */
   predict(transform: Transform, context: Context): Distribution<Suggestion>;
 

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -2,71 +2,274 @@
  * Integration tests for the model compositor with the trie model.
  */
 
-const { models } = require('../../build/intermediate');
+const { models, wordBreakers } = require('../../build/intermediate');
 
 var assert = require('chai').assert;
 var TrieModel = require('../../build/intermediate').models.TrieModel;
 var ModelCompositor = require('../../build/intermediate').ModelCompositor;
 
 describe('ModelCompositor', function() {
-  it('should compose suggestions from a fat-fingered keypress (no keying needed)', function () {
-    var model = new TrieModel(
-      jsonFixture('tries/english-1000')
-    );
-    var composite = new ModelCompositor(model);
+  describe('Prediction with 14.0+ models', function() {
+    describe('Model uses default-style keying, no casing', function () {
+      var uncasedModel = new TrieModel(
+        jsonFixture('tries/english-1000'), {
+          languageUsesCasing: false,
+          wordBreaker: wordBreakers.default,
+          searchTermToKey: function(text) {
+            // We're dealing with very simple English text; without casing, there's no keying to be done
+            // for such simple data.  No need to normalize or remove diacritics here.
+            return text;
+          }
+        }
+      );
+
+      it('should produce suggestions from uncased input', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'th', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
     
-    // Initialize context
-    let context = {
-      left: 'th', startOfBuffer: false, endOfBuffer: true,
-    };
-    composite.predict({insert: '', deleteLeft: 0}, context);
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // Get the top suggest for 'the' and 'thr*'.
+        var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
+        var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+    
+        // Sanity check: do we have actual real-valued probabilities?
+        assert.isAbove(thrSuggestion.p, 0.0);
+        assert.isBelow(thrSuggestion.p, 1.0);
+        assert.isAbove(theSuggestion.p, 0.0);
+        assert.isBelow(theSuggestion.p, 1.0);
+        // 'the' should be the intended the result here.
+        assert.isAbove(theSuggestion.p, thrSuggestion.p);
+      });
 
-    // Pretend to fat finger "the" as "thr"
-    var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
-    var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
-    var suggestions = composite.predict([thr, the], context);
+      it('should not produce suggestions from cased input', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'TH', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
+    
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'R', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'E', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // We should only receive a 'keep' suggestion.
+        assert.equal(suggestions.length, 1);
+        assert.equal(suggestions[0].tag, 'keep');
+      });
+    });
 
-    // Get the top suggest for 'the' and 'thr*'.
-    var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
-    var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+    describe('Model uses default-style keying, provides casing', function () {
+      let applyCasing = function(caseToApply, text) {
+        switch(caseToApply) {
+          case 'lower':
+            return text.toLowerCase();
+          case 'upper':
+            return text.toUpperCase();
+          case 'initial':
+            return applyCasing('upper', text.charAt(0)) . concat(text.substring(1));
+          default:
+            return text;
+        }
+      };
 
-    // Sanity check: do we have actual real-valued probabilities?
-    assert.isAbove(thrSuggestion.p, 0.0);
-    assert.isBelow(thrSuggestion.p, 1.0);
-    assert.isAbove(theSuggestion.p, 0.0);
-    assert.isBelow(theSuggestion.p, 1.0);
-    // 'the' should be the intended the result here.
-    assert.isAbove(theSuggestion.p, thrSuggestion.p);
+      var uncasedModel = new TrieModel(
+        jsonFixture('tries/english-1000'), {
+          languageUsesCasing: true,
+          applyCasing: applyCasing,
+          wordBreaker: wordBreakers.default,
+          searchTermToKey: function(text) {
+            // We're dealing with very simple English text; no need to normalize or remove diacritics here.
+            return applyCasing('lower', text);
+          }
+        }
+      );
+
+      it('should produce suggestions from uncased input', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'th', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
+    
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // Get the top suggest for 'the' and 'thr*'.
+        var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
+        var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+    
+        // Sanity check: do we have actual real-valued probabilities?
+        assert.isAbove(thrSuggestion.p, 0.0);
+        assert.isBelow(thrSuggestion.p, 1.0);
+        assert.isAbove(theSuggestion.p, 0.0);
+        assert.isBelow(theSuggestion.p, 1.0);
+        // 'the' should be the intended the result here.
+        assert.isAbove(theSuggestion.p, thrSuggestion.p);
+      });
+
+      it('should produce capitalized suggestions from fully-uppercased input', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'TH', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
+    
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'R', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'E', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // Get the top suggest for 'the' and 'thr*'.
+        var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'THE' || s.displayAs === '“THE”'; })[0];
+        var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('THR'); })[0];
+    
+        // Sanity check: do we have actual real-valued probabilities?
+        assert.isAbove(thrSuggestion.p, 0.0);
+        assert.isBelow(thrSuggestion.p, 1.0);
+        assert.isAbove(theSuggestion.p, 0.0);
+        assert.isBelow(theSuggestion.p, 1.0);
+        // 'the' should be the intended the result here.
+        assert.isAbove(theSuggestion.p, thrSuggestion.p);
+      });
+
+      it('should produce "initial-case" suggestions from input with an initial capital', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'Th', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
+    
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // Get the top suggest for 'the' and 'thr*'.
+        var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'The' || s.displayAs === '“The”'; })[0];
+        var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('Thr'); })[0];
+    
+        // Sanity check: do we have actual real-valued probabilities?
+        assert.isAbove(thrSuggestion.p, 0.0);
+        assert.isBelow(thrSuggestion.p, 1.0);
+        assert.isAbove(theSuggestion.p, 0.0);
+        assert.isBelow(theSuggestion.p, 1.0);
+        // 'the' should be the intended the result here.
+        assert.isAbove(theSuggestion.p, thrSuggestion.p);
+      });
+
+      it('also from input with partial capitalization when including an initial capital', function() {
+        let model = uncasedModel;
+        var composite = new ModelCompositor(model);
+        
+        // Initialize context
+        let context = {
+          left: 'TH', startOfBuffer: false, endOfBuffer: true,
+        };
+        composite.predict({insert: '', deleteLeft: 0}, context);
+    
+        // Pretend to fat finger "the" as "thr"
+        var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+        var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+        var suggestions = composite.predict([thr, the], context);
+    
+        // Get the top suggest for 'the' and 'thr*'.
+        var theSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('The'); })[0];
+        var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('Thr'); })[0];
+    
+        // Sanity check: do we have actual real-valued probabilities?
+        assert.isAbove(thrSuggestion.p, 0.0);
+        assert.isBelow(thrSuggestion.p, 1.0);
+        assert.isAbove(theSuggestion.p, 0.0);
+        assert.isBelow(theSuggestion.p, 1.0);
+      });
+    });
   });
 
-  it('should compose suggestions from a fat-fingered keypress (keying needed)', function () {
-    var model = new TrieModel(
-      jsonFixture('tries/english-1000')
-    );
-    var composite = new ModelCompositor(model);
-    
-    // Initialize context
-    let context = {
-      left: 'Th', startOfBuffer: false, endOfBuffer: true,
-    };
-    composite.predict({insert: '', deleteLeft: 0}, context);
-
-    // Pretend to fat finger "the" as "thr"
-    var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
-    var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
-    var suggestions = composite.predict([thr, the], context);
-
-    // Get the top suggest for 'the' and 'thr*'.
-    var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'The' || s.displayAs === '“The”'; })[0];
-    var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
-
-    // Sanity check: do we have actual real-valued probabilities?
-    assert.isAbove(thrSuggestion.p, 0.0);
-    assert.isBelow(thrSuggestion.p, 1.0);
-    assert.isAbove(theSuggestion.p, 0.0);
-    assert.isBelow(theSuggestion.p, 1.0);
-    // 'the' should be the intended the result here.
-    assert.isAbove(theSuggestion.p, thrSuggestion.p);
+  describe('Prediction with legacy Models (12.0 / 13.0)', function() {
+    it('should compose suggestions from a fat-fingered keypress (no keying needed)', function () {
+      var model = new TrieModel(
+        jsonFixture('tries/english-1000')
+      );
+      var composite = new ModelCompositor(model);
+      
+      // Initialize context
+      let context = {
+        left: 'th', startOfBuffer: false, endOfBuffer: true,
+      };
+      composite.predict({insert: '', deleteLeft: 0}, context);
+  
+      // Pretend to fat finger "the" as "thr"
+      var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+      var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+      var suggestions = composite.predict([thr, the], context);
+  
+      // Get the top suggest for 'the' and 'thr*'.
+      var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the' || s.displayAs === '“the”'; })[0];
+      var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+  
+      // Sanity check: do we have actual real-valued probabilities?
+      assert.isAbove(thrSuggestion.p, 0.0);
+      assert.isBelow(thrSuggestion.p, 1.0);
+      assert.isAbove(theSuggestion.p, 0.0);
+      assert.isBelow(theSuggestion.p, 1.0);
+      // 'the' should be the intended the result here.
+      assert.isAbove(theSuggestion.p, thrSuggestion.p);
+    });
+  
+    it('should compose suggestions from a fat-fingered keypress (keying needed)', function () {
+      var model = new TrieModel(
+        jsonFixture('tries/english-1000')
+      );
+      var composite = new ModelCompositor(model);
+      
+      // Initialize context
+      let context = {
+        left: 'Th', startOfBuffer: false, endOfBuffer: true,
+      };
+      composite.predict({insert: '', deleteLeft: 0}, context);
+  
+      // Pretend to fat finger "the" as "thr"
+      var the = { sample: { insert: 'r', deleteLeft: 0}, p: 0.45 };
+      var thr = { sample: { insert: 'e', deleteLeft: 0}, p: 0.55 };
+      var suggestions = composite.predict([thr, the], context);
+  
+      // Get the top suggest for 'the' and 'thr*'.
+      var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'The' || s.displayAs === '“The”'; })[0];
+      var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
+  
+      // Sanity check: do we have actual real-valued probabilities?
+      assert.isAbove(thrSuggestion.p, 0.0);
+      assert.isBelow(thrSuggestion.p, 1.0);
+      assert.isAbove(theSuggestion.p, 0.0);
+      assert.isBelow(theSuggestion.p, 1.0);
+      // 'the' should be the intended the result here.
+      assert.isAbove(theSuggestion.p, thrSuggestion.p);
+    });
   });
 
   // The nomenclature's a minor sneak-peek from child PRs.

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -198,6 +198,11 @@ class LMLayerWorker {
         configuration.rightContextCodePoints = this._platformCapabilities.maxRightContextCodePoints || 0;
       }
 
+      // Ensures that default casing rules exist for custom models that request casing rules but don't define them.
+      if(model.languageUsesCasing && !model.applyCasing) {
+        model.applyCasing = models.defaultApplyCasing;
+      }
+
       let compositor = this.transitionToReadyState(model);
       // This test allows models to directly specify the property without it being auto-overridden by
       // this default.

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -291,7 +291,7 @@ class ModelCompositor {
 
     // Apply 'after word' punctuation and casing (when applicable).  Also, set suggestion IDs.  
     // We delay until now so that utility functions relying on the unmodified Transform may execute properly.
-    let currentCasing: CasingEnum = null;
+    let currentCasing: CasingForm = null;
     if(lexicalModel.languageUsesCasing) {
       currentCasing = this.detectCurrentCasing(postContext);
     }
@@ -519,7 +519,7 @@ class ModelCompositor {
     }
   }
 
-  private detectCurrentCasing(context: Context): CasingEnum {
+  private detectCurrentCasing(context: Context): CasingForm {
     let model = this.lexicalModel;
 
     let text = this.wordbreak(context);

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -281,6 +281,7 @@ class ModelCompositor {
         // We still condition on 'p' existing so that test cases aren't broken.
         value.sample['p'] = value.p;
       }
+      //
       return value.sample;
     });
 
@@ -288,10 +289,20 @@ class ModelCompositor {
       suggestions = [ keepOption as Suggestion ].concat(suggestions);
     }
 
-    // Apply 'after word' punctuation and set suggestion IDs.  
+    // Apply 'after word' punctuation and casing (when applicable).  Also, set suggestion IDs.  
     // We delay until now so that utility functions relying on the unmodified Transform may execute properly.
+    let currentCasing: CasingEnum = null;
+    if(lexicalModel.languageUsesCasing) {
+      currentCasing = this.detectCurrentCasing(postContext);
+    }
+
     let compositor = this;
     suggestions.forEach(function(suggestion) {
+      if(currentCasing && currentCasing != 'lower') {
+        suggestion.transform.insert = lexicalModel.applyCasing(currentCasing, suggestion.transform.insert);
+        suggestion.displayAs = lexicalModel.applyCasing(currentCasing, suggestion.displayAs);
+      }
+
       if (suggestion.transform.insert.length > 0) {
         suggestion.transform.insert += punctuation.insertAfterWord;
 
@@ -505,6 +516,35 @@ class ModelCompositor {
       // Since the model relies on custom wordbreaking behavior, we need to use the
       // old, deprecated wordbreaking pattern.
       return model.wordbreak(context);
+    }
+  }
+
+  private detectCurrentCasing(context: Context): CasingEnum {
+    let model = this.lexicalModel;
+
+    let text = this.wordbreak(context);
+
+    if(!model.languageUsesCasing) {
+      throw "Invalid attempt to detect casing: languageUsesCasing is set to false";
+    }
+
+    if(!model.applyCasing) {
+      // The worker should automatically 'sub in' default behavior during the model's load if that
+      // function isn't defined explicitly as part of the model.
+      throw "Invalid LMLayer state:  languageUsesCasing is set to true, but no applyCasing function exists";
+    }
+
+    if(model.applyCasing('lower', text) == text) {
+      return 'lower';
+    } else if(model.applyCasing('upper', text) == text) {
+      // If only a single character has been input, assume we're in 'initial' mode.
+      return text.kmwLength() > 1 ? 'upper' : 'initial';
+    } else if(model.applyCasing('initial', text) == text) {
+      // We check 'initial' last, as upper-case input is indistinguishable.
+      return 'initial';
+    } else {
+      // 'null' is returned when no casing pattern matches the input.
+      return null;
     }
   }
 }


### PR DESCRIPTION
When combined with #3770, implements most of the spec defined within #3720.

The new `applyCasing` function may now be utilized to enhance suggestions.  The predictive engine will now detect the casing pattern used by the current context (when `languageUsesCasing == true`) and will transform suggestion text to match said casing when is not the default (`lower`) casing pattern or an unknown one.

-----

While this does need a proper set of compiled-model unit tests, that's best left to a follow-up PR.  It would be a _very_ good idea to maintain some integration tests for the new feature, as the compilation infrastructure involved is definitely _not_ trivial.  (The "pseudoclosure" thing seen in #3770, in particular.)  The issue is that #3836 adds infrastructure needed to facilitate the tests, and that PR's branch is currently completely separate from this PR set.

So, followups to make:
- [ ] automated integration tests for use of applyCasing
  - I have a local branch mostly ready for this, but it's unreviewable until the two required development paths are (mostly) merged.  (Two base branches, with each based on a different `master` commit.)
- [x] revert #3770's extra restriction [(see discussion)](https://github.com/keymanapp/keyman/pull/3770#discussion_r520232035) on `LexicalModel.predict`
  - see #3845.
  - also adds isolated unit tests for application of casing rules