### PR TITLE
fix(developer): debug window inherits editor font

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -1171,8 +1171,7 @@ begin
   if FFont = nil then
   begin
     FDefaultFont := True;
-    //TODO:FFont := EditorMemo.AltFont;
-    FFont := Font;  //TODO scrap this
+    FFont := EditorMemo.CharFont;
   end
   else
     FDefaultFont := False;

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -2884,9 +2884,7 @@ begin
   FDebugForm.OnClearBreakpoint := DebugClearBreakpoint;
   FDebugForm.OnUpdateExecutionPoint := DebugUpdateExecutionPoint;
   FDebugForm.Visible := True;
-
-
-// TODO:  FDebugForm.EditorMemo := frameSource.memo;
+  FDebugForm.EditorMemo := frameSource;
 
   FDebugStatusForm := TfrmDebugStatus.Create(Self);
   FDebugStatusForm.BorderStyle := bsNone;


### PR DESCRIPTION
Fixes #3827.

The debugger was not inheriting the editor font -- this is a regression from when we replaced TPlusMemo with Monaco editor.