### PR TITLE
fix(windows): Import OSK wrong for European layouts

### DIFF
--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ImportKeyboardDLL.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ImportKeyboardDLL.pas
@@ -463,8 +463,13 @@ begin
     else if FRGFDeadKey[ss, False] then
     begin
       // It's a dead key
+      // This does not match the "Fill from layout" result because deadkeys are
+      // left blank in "Fill from layout". However, this is better because it
+      // matches the actual Windows layout. "Fill from layout" cannot deduce the
+      // character to put onto a deadkey currently (unlike Windows deadkeys,
+      // there is no isolated "default" for a Keyman deadkey).
       vkk := TVisualKeyboardKey.Create;
-      vkk.VKey := FVK;
+      vkk.VKey := MapScanCodeToUSVK(FSC);
       vkk.Text := st[1];
       vkk.Flags := [kvkkUnicode];
       vkk.Shift := KBDShiftStateToVisualKeyboardShiftState[ss];
@@ -486,7 +491,7 @@ begin
       begin
         // It's some characters; put 'em in there.
         vkk := TVisualKeyboardKey.Create;
-        vkk.VKey := FVK;
+        vkk.VKey := MapScanCodeToUSVK(FSC);
         vkk.Text := st;
         vkk.Flags := [kvkkUnicode];
         vkk.Shift := KBDShiftStateToVisualKeyboardShiftState[ss];


### PR DESCRIPTION
Fixes #3810.

Importing a Windows keyboard would not produce correct OSK for European layouts because it was based on virtual key instead of scan code. Mapping through the scan code back to "US" base layout resolves the issue.

Note that there is a slight difference between Import Windows Keyboard and Fill from Layout results, as deadkeys have slightly more information in the Import process, and can display the base deadkey, whereas Fill from Layout will result in a blank deadkey. This difference is by design.

This now also detects the presence of the 102nd key. Note that here also Fill from Layout may have a slightly different result, as the 102nd key is defined by kbdus.dll, and Fill from Layout will see the resulting rule in the .kmn and enable the 102nd key. This difference is also by design.

---

# kbdfr

Import Windows keyboard

![image](https://user-images.githubusercontent.com/4498365/98296826-9d3fdc00-2007-11eb-8ba8-3558d79f6d7f.png)

Fill from layout

![image](https://user-images.githubusercontent.com/4498365/98296811-9618ce00-2007-11eb-90ae-6514b89a190c.png)

(Difference is by design)

---

# kbdus

Import Windows keyboard

![image](https://user-images.githubusercontent.com/4498365/98296593-420de980-2007-11eb-9344-b337b4710f67.png)

Fill from layout

![image](https://user-images.githubusercontent.com/4498365/98297188-22c38c00-2008-11eb-98c4-381f75a18185.png)

(Difference is by design)
