### PR TITLE
fix(windows): SizeOfImage header was wrong for dbg

### DIFF
--- a/windows/src/buildtools/build_standards_data/build_standards_data.dproj
+++ b/windows/src/buildtools/build_standards_data/build_standards_data.dproj
@@ -50,6 +50,7 @@
         <DCC_UsePackage>RESTComponents;FireDAC;FireDACSqliteDriver;soaprtl;FireDACIBDriver;soapmidas;FireDACCommon;RESTBackendComponents;soapserver;CloudService;FireDACCommonDriver;inet;$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>build_standards_data</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;bindcompdbx;IndyIPCommon;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACPgDriver;inetdb;DbxCommonDriver;fmx;fmxdae;xmlrtl;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;IndyIPClient;bindcompvcl;EmbeddedWebBrowser_XE;VCLRESTComponents;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;dsnapxml;FireDACMySQLDriver;dbrtl;inetdbxpress;IndyProtocols;keyman_components;FireDACCommonODBC;fmxase;$(DCC_UsePackage)</DCC_UsePackage>

--- a/windows/src/buildtools/buildpkg/Makefile
+++ b/windows/src/buildtools/buildpkg/Makefile
@@ -6,8 +6,8 @@
 
 build: version.res dirs
     $(DCC32) Buildpkg.dpr
-    $(TDS2DBG) buildpkg.exe
     $(SENTRYTOOL_DELPHIPREP) buildpkg.exe -dpr buildpkg.dpr
+    $(TDS2DBG) buildpkg.exe
     $(COPY) Buildpkg.exe $(PROGRAM)\online
     $(COPY) Buildpkg.exe $(PROGRAM)\buildtools
     if exist buildpkg.dbg $(COPY) buildpkg.dbg $(DEBUGPATH)\buildtools

--- a/windows/src/buildtools/buildpkg/buildpkg.dproj
+++ b/windows/src/buildtools/buildpkg/buildpkg.dproj
@@ -62,6 +62,7 @@
         <DCC_AssertionsAtRuntime>false</DCC_AssertionsAtRuntime>
         <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
         <Manifest_File>None</Manifest_File>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
@@ -212,8 +213,8 @@
                     <VersionInfoKeys Name="Comments"/>
                 </VersionInfoKeys>
                 <Excluded_Packages>
-                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k160.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
-                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp160.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k260.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp260.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
                 </Excluded_Packages>
             </Delphi.Personality>
             <Platforms>

--- a/windows/src/buildtools/sentrytool/sentrytool.dproj
+++ b/windows/src/buildtools/sentrytool/sentrytool.dproj
@@ -49,6 +49,7 @@
         <DCC_K>false</DCC_K>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>sentrytool</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;FireDAC;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACSqliteDriver;FireDACPgDriver;inetdb;CEF4Delphi;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;EmbeddedWebBrowser_XE;VCLRESTComponents;soapserver;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;keyman_components;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -76,7 +77,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>(None)</Manifest_File>
         <Debugger_CWD>C:\Projects\keyman\app\windows\src\engine\tsysinfox64</Debugger_CWD>

--- a/windows/src/desktop/insthelp/Makefile
+++ b/windows/src/desktop/insthelp/Makefile
@@ -6,8 +6,8 @@
 
 build: version.res dirs
     $(DCC32) insthelp.dpr
-    $(TDS2DBG) insthelp.exe
     $(SENTRYTOOL_DELPHIPREP) insthelp.exe -dpr insthelp.dpr
+    $(TDS2DBG) insthelp.exe
     $(COPY) insthelp.exe $(ROOT)\bin\desktop\insthelp.exe
 
 test-manifest:

--- a/windows/src/desktop/kmbrowserhost/Makefile
+++ b/windows/src/desktop/kmbrowserhost/Makefile
@@ -7,8 +7,8 @@
 build: version.res manifest.res dirs
     $(DELPHI_MSBUILD) kmbrowserhost.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmbrowserhost.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmbrowserhost.exe -dpr kmbrowserhost.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmbrowserhost.exe
     $(COPY) $(WIN32_TARGET_PATH)\kmbrowserhost.exe $(PROGRAM)\desktop
     if exist $(WIN32_TARGET_PATH)\kmbrowserhost.dbg $(COPY) $(WIN32_TARGET_PATH)\kmbrowserhost.dbg $(DEBUGPATH)\desktop
 

--- a/windows/src/desktop/kmbrowserhost/kmbrowserhost.dproj
+++ b/windows/src/desktop/kmbrowserhost/kmbrowserhost.dproj
@@ -62,6 +62,7 @@
         <DCC_Define>SENTRY_NOVCL;$(DCC_Define)</DCC_Define>
         <VerInfo_Locale>3081</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;bindcompdbx;IndyIPCommon;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACPgDriver;inetdb;CEF4Delphi;DbxCommonDriver;fmx;fmxdae;xmlrtl;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;IndyIPClient;bindcompvcl;EmbeddedWebBrowser_XE;VCLRESTComponents;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;dsnapxml;FireDACMySQLDriver;dbrtl;inetdbxpress;IndyProtocols;keyman_components;FireDACCommonODBC;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -70,7 +71,6 @@
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>(None)</Manifest_File>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;bindcompdbx;IndyIPCommon;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;dsnapcon;FireDACADSDriver;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;vcltouch;vcldb;bindcompfmx;FireDACPgDriver;inetdb;DbxCommonDriver;fmx;fmxdae;xmlrtl;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;IndyIPClient;bindcompvcl;VCLRESTComponents;dbxcds;VclSmp;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;dsnapxml;FireDACMySQLDriver;dbrtl;inetdbxpress;IndyProtocols;FireDACCommonODBC;fmxase;$(DCC_UsePackage)</DCC_UsePackage>

--- a/windows/src/desktop/kmconfig/Makefile
+++ b/windows/src/desktop/kmconfig/Makefile
@@ -6,10 +6,10 @@
 
 build: version.res manifest.res #icons
     $(DELPHI_MSBUILD) kmconfig.dproj /p:Platform=Win32
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmconfig.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmconfig.exe -dpr kmconfig.exe
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmconfig.exe
     $(COPY) $(WIN32_TARGET_PATH)\kmconfig.exe $(PROGRAM)\desktop
-    if exist $(WIN32_TARGET_PATH)\kmconfig.exe $(COPY) $(WIN32_TARGET_PATH)\kmconfig.exe $(DEBUGPATH)\desktop
+    if exist $(WIN32_TARGET_PATH)\kmconfig.dbg $(COPY) $(WIN32_TARGET_PATH)\kmconfig.dbg $(DEBUGPATH)\desktop
 
 #icons:
     #rc icons.rc

--- a/windows/src/desktop/kmconfig/kmconfig.dproj
+++ b/windows/src/desktop/kmconfig/kmconfig.dproj
@@ -58,6 +58,7 @@
         <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
         <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
         <SanitizedProjectName>kmconfig</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;FireDAC;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACSqliteDriver;FireDACPgDriver;inetdb;CEF4Delphi;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;EmbeddedWebBrowser_XE;VCLRESTComponents;soapserver;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;keyman_components;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -87,7 +88,6 @@
         <DCC_ConsoleTarget>true</DCC_ConsoleTarget>
         <DCC_MapFile>3</DCC_MapFile>
         <Debugger_RunParams>reset engine.compatibility.text_services_framework.notepad.exe 0</Debugger_RunParams>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <DCC_Description>Keyman Config</DCC_Description>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
@@ -107,7 +107,6 @@
         <DCC_Description>Keyman Config</DCC_Description>
         <DCC_ConsoleTarget>true</DCC_ConsoleTarget>
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/windows/src/desktop/kmshell/Makefile
+++ b/windows/src/desktop/kmshell/Makefile
@@ -6,8 +6,8 @@
 
 build: version.res manifest.res icons xml
     $(DCC32) kmshell.dpr
-    $(TDS2DBG) kmshell.exe
     $(SENTRYTOOL_DELPHIPREP) kmshell.exe -dpr kmshell.dpr
+    $(TDS2DBG) kmshell.exe
     $(COPY) kmshell.exe $(PROGRAM)\desktop
     if exist kmshell.dbg $(COPY) kmshell.dbg $(DEBUGPATH)\desktop
 

--- a/windows/src/desktop/setup/Makefile
+++ b/windows/src/desktop/setup/Makefile
@@ -6,8 +6,8 @@
 
 build: version.res manifest.res icons locale
     $(DCC32) setup.dpr
-    $(TDS2DBG) setup.exe
     $(SENTRYTOOL_DELPHIPREP) setup.exe -dpr setup.dpr
+    $(TDS2DBG) setup.exe
     $(COPY) setup.exe $(PROGRAM)\desktop
 
 locale:

--- a/windows/src/desktop/setup/setup.dproj
+++ b/windows/src/desktop/setup/setup.dproj
@@ -65,6 +65,7 @@
         <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
         <ImageDebugInfo>true</ImageDebugInfo>
         <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <Icon_MainIcon>setup_Icon.ico</Icon_MainIcon>
@@ -90,7 +91,6 @@
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DCC_DebugInfoInExe>false</DCC_DebugInfoInExe>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -7,8 +7,8 @@
 build: version.res manifest.res icons dirs xml
     cd $(ROOT)\src\developer\tike
     $(DCC32) tike.dpr
-    $(TDS2DBG) tike.exe
     $(SENTRYTOOL_DELPHIPREP) tike.exe -dpr tike.dpr
+    $(TDS2DBG) tike.exe
     $(COPY) tike.exe $(PROGRAM)\developer
     $(COPY) kmlmc.cmd $(PROGRAM)\developer
     if exist tike.dbg $(COPY) tike.dbg $(DEBUGPATH)\developer

--- a/windows/src/developer/kmanalyze/Makefile
+++ b/windows/src/developer/kmanalyze/Makefile
@@ -7,6 +7,7 @@
 build: version.res dirs
     $(MSBUILD) kmanalyze.sln $(MSBUILD_BUILD)
     $(COPY) $(TARGET_PATH)\kmanalyze.exe $(PROGRAM)\developer
+    $(COPY) $(TARGET_PATH)\kmanalyze.pdb $(DEBUGPATH)\developer
 
 clean: def-clean
     $(MSBUILD) kmanalyze.sln $(MSBUILD_CLEAN)

--- a/windows/src/developer/kmcomp/Makefile
+++ b/windows/src/developer/kmcomp/Makefile
@@ -11,8 +11,8 @@ TARGET_GROUP=developer
 build: version.res manifest.res dirs icons
     $(DELPHI_MSBUILD) kmcomp.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmcomp.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmcomp.exe -dpr kmcomp.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmcomp.exe
     $(COPY) $(WIN32_TARGET_PATH)\kmcomp.exe $(PROGRAM)\developer
     if exist $(WIN32_TARGET_PATH)\kmcomp.dbg $(COPY) $(WIN32_TARGET_PATH)\kmcomp.dbg $(DEBUGPATH)\developer
 
@@ -25,7 +25,7 @@ build: version.res manifest.res dirs icons
     if exist $(WIN64_TARGET_PATH)\kmcomp.x64.map del $(WIN64_TARGET_PATH)\kmcomp.x64.map
     ren $(WIN64_TARGET_PATH)\kmcomp.map kmcomp.x64.map
 
-    $(SENTRYTOOL_DELPHIPREP) $(WIN64_TARGET_PATH)\kmcomp.x64.exe -dpr kmcomp.dpr
+    # $(SENTRYTOOL_DELPHIPREP) $(WIN64_TARGET_PATH)\kmcomp.x64.exe -dpr kmcomp.dpr
     $(COPY) $(WIN64_TARGET_PATH)\kmcomp.x64.exe $(PROGRAM)\developer\kmcomp.x64.exe
     if exist $(WIN64_TARGET_PATH)\kmcomp.dbg $(COPY) $(WIN64_TARGET_PATH)\kmcomp.dbg $(DEBUGPATH)\developer\kmcomp.x64.dbg
 

--- a/windows/src/developer/kmconvert/Makefile
+++ b/windows/src/developer/kmconvert/Makefile
@@ -7,8 +7,8 @@
 build: version.res manifest.res dirs icons
     $(DELPHI_MSBUILD) kmconvert.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmconvert.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmconvert.exe -dpr kmconvert.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmconvert.exe
     $(COPY) $(WIN32_TARGET_PATH)\kmconvert.exe $(PROGRAM)\developer
     if exist $(WIN32_TARGET_PATH)\kmconvert.dbg $(COPY) $(WIN32_TARGET_PATH)\kmconvert.dbg $(DEBUGPATH)\developer
 

--- a/windows/src/developer/kmconvert/kmconvert.dproj
+++ b/windows/src/developer/kmconvert/kmconvert.dproj
@@ -56,6 +56,7 @@
         <DCC_UsePackage>RESTComponents;FireDAC;FireDACSqliteDriver;soaprtl;FireDACIBDriver;soapmidas;FireDACCommon;RESTBackendComponents;soapserver;CloudService;FireDACCommonDriver;inet;$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>kmconvert</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;bindcompdbx;IndyIPCommon;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACPgDriver;inetdb;CEF4Delphi;DbxCommonDriver;fmx;fmxdae;xmlrtl;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;IndyIPClient;bindcompvcl;EmbeddedWebBrowser_XE;VCLRESTComponents;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;dsnapxml;FireDACMySQLDriver;dbrtl;inetdbxpress;IndyProtocols;keyman_components;FireDACCommonODBC;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -66,7 +67,6 @@
         <DCC_ConsoleTarget>true</DCC_ConsoleTarget>
         <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
         <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <Manifest_File>(None)</Manifest_File>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">

--- a/windows/src/developer/setup/Makefile
+++ b/windows/src/developer/setup/Makefile
@@ -6,8 +6,8 @@
 
 build: version.res manifest.res icons
     $(DCC32) setup.dpr
-    $(TDS2DBG) setup.exe
     $(SENTRYTOOL_DELPHIPREP) setup.exe -dpr setup.dpr
+    $(TDS2DBG) setup.exe
     $(COPY) setup.exe $(PROGRAM)\developer
     if exist setup.dbg $(COPY) setup.dbg $(DEBUGPATH)\developer\devsetup.dbg
     -del devsetup.dbg

--- a/windows/src/engine/inst/insthelper/Makefile
+++ b/windows/src/engine/inst/insthelper/Makefile
@@ -8,9 +8,10 @@ VERSION_TXT_PATH=..\..
 
 build: dirs version.res
     $(DCC32) insthelper.dpr
-    $(TDS2DBG) insthelper.dll
     $(SENTRYTOOL_DELPHIPREP) insthelper.dll -dpr insthelper.dpr
+    $(TDS2DBG) insthelper.dll
     $(COPY) insthelper.dll $(PROGRAM)\inst
+    $(COPY) insthelper.dbg $(DEBUGPATH)\inst
 
 clean: def-clean
     -del *.dll

--- a/windows/src/engine/keyman/Makefile
+++ b/windows/src/engine/keyman/Makefile
@@ -7,8 +7,8 @@
 build: version.res manifest.res keymanmenuitem.res icons.res osktoolbar.res dirs
     rc langswitch\langswitchmanager.rc
     $(DCC32) keyman.dpr
-    $(TDS2DBG) keyman.exe
     $(SENTRYTOOL_DELPHIPREP) keyman.exe -dpr keyman.dpr
+    $(TDS2DBG) keyman.exe
     $(COPY) keyman.exe $(PROGRAM)\engine
     if exist keyman.dbg $(COPY) keyman.dbg $(DEBUGPATH)\engine
 

--- a/windows/src/engine/kmcomapi/Makefile
+++ b/windows/src/engine/kmcomapi/Makefile
@@ -8,8 +8,8 @@ build: version.res manifest.res kbd_noicon.res dirs
     gentlb -Tkmcomapi.tlb kmcomapi.ridl
     $(DELPHI_MSBUILD) kmcomapi.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmcomapi.dll
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmcomapi.dll -dpr kmcomapi.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\kmcomapi.dll
     $(COPY) $(WIN32_TARGET_PATH)\kmcomapi.dll $(PROGRAM)\engine
     if exist $(WIN32_TARGET_PATH)\kmcomapi.dbg $(COPY) $(WIN32_TARGET_PATH)\kmcomapi.dbg $(DEBUGPATH)\engine
 

--- a/windows/src/engine/kmcomapi/kmcomapi.dproj
+++ b/windows/src/engine/kmcomapi/kmcomapi.dproj
@@ -84,7 +84,6 @@
         <DCC_UsePackage>vclie50;Vcl50;Inetdb50;Inet50;Vcldb50;Vclx50;Vclbde50;proide50;keyman_components;$(DCC_UsePackage)</DCC_UsePackage>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <DebugSourcePath>C:\keyman\7.0\src\keyman\kmshell\startup\;$(DebugSourcePath)</DebugSourcePath>
-        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
         <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
         <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
@@ -137,6 +136,7 @@
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <Debugger_HostApplication>C:\Projects\keyman\open\windows\src\test\test-kmcomapi-win64\Win64\Debug\kmcomapi_win64_host.exe</Debugger_HostApplication>
         <Debugger_RunParams>-r:Keyman.Test.Console.KeymanAPIHost.TKeymanAPITest.Test_IKeymanPackageInstalled,Keyman.Test.Console.KeymanAPIHost.TKeymanAPITest.Test_IKeymanPackageFile</Debugger_RunParams>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/windows/src/engine/tsysinfo/Makefile
+++ b/windows/src/engine/tsysinfo/Makefile
@@ -17,8 +17,8 @@ build: version.res manifest.res dirs
     del tsysinfox64.bin
 
     $(DCC32) tsysinfo.dpr
-    $(TDS2DBG) tsysinfo.exe
     $(SENTRYTOOL_DELPHIPREP) tsysinfo.exe -dpr tsysinfo.dpr
+    $(TDS2DBG) tsysinfo.exe
     $(COPY) tsysinfo.exe $(PROGRAM)\engine
     if exist tsysinfo.dbg $(COPY) tsysinfo.dbg $(DEBUGPATH)\engine
 

--- a/windows/src/engine/tsysinfox64/Makefile
+++ b/windows/src/engine/tsysinfox64/Makefile
@@ -6,7 +6,7 @@
 
 build: version.res manifest.res dirs
     $(DELPHI_MSBUILD) tsysinfox64.dproj /p:Platform=Win64
-    $(SENTRYTOOL_DELPHIPREP) $(WIN64_TARGET_PATH)\tsysinfox64.exe -dpr tsysinfox64.dpr
+    #$(SENTRYTOOL_DELPHIPREP) $(WIN64_TARGET_PATH)\tsysinfox64.exe -dpr tsysinfox64.dpr
     $(COPY) $(WIN64_TARGET_PATH)\tsysinfox64.exe $(PROGRAM)\engine
 
 clean: def-clean

--- a/windows/src/ext/sentry/test/Makefile
+++ b/windows/src/ext/sentry/test/Makefile
@@ -8,10 +8,10 @@ build: dirs # version.res manifest.res
     $(DELPHI_MSBUILD) SentryClientTest.dproj /p:Platform=Win32
     $(DELPHI_MSBUILD) SentryClientVclTest.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\SentryClientTest.exe
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\SentryClientVclTest.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\SentryClientTest.exe -dpr SentryClientTest.dpr
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\SentryClientVclTest.exe -dpr SentryClientVclTest.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\SentryClientTest.exe
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\SentryClientVclTest.exe
 
 upload-symbols:
     sentry-cli upload-dif -p keyman-windows --wait --include-sources .

--- a/windows/src/ext/sentry/test/SentryClientTest.dproj
+++ b/windows/src/ext/sentry/test/SentryClientTest.dproj
@@ -55,6 +55,7 @@
         <DCC_K>false</DCC_K>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>SentryClientTest</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;FireDAC;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACSqliteDriver;FireDACPgDriver;inetdb;CEF4Delphi;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;EmbeddedWebBrowser_XE;VCLRESTComponents;soapserver;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;keyman_components;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -85,7 +86,6 @@
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>..\..\..\..\..\..\sentry-native\sentry-delphi-test\(None)</Manifest_File>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
@@ -94,7 +94,6 @@
         <DCC_DebugInformation>0</DCC_DebugInformation>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>..\..\..\..\..\..\sentry-native\sentry-delphi-test\(None)</Manifest_File>

--- a/windows/src/ext/sentry/test/SentryClientVclTest.dproj
+++ b/windows/src/ext/sentry/test/SentryClientVclTest.dproj
@@ -58,6 +58,7 @@
         <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
         <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
         <SanitizedProjectName>SentryClientVclTest</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;IndyIPCommon;RESTComponents;bindcompdbx;DBXInterBaseDriver;vcl;IndyIPServer;vclactnband;vclFireDAC;IndySystem;tethering;svnui;mbColorLibD10;dsnapcon;FireDACADSDriver;scFontCombo;DCPdelphi2009;FireDACMSAccDriver;fmxFireDAC;vclimg;Jcl;FireDAC;vcltouch;JvCore;vcldb;bindcompfmx;svn;FireDACSqliteDriver;FireDACPgDriver;inetdb;CEF4Delphi;soaprtl;DbxCommonDriver;fmx;FireDACIBDriver;fmxdae;xmlrtl;soapmidas;fmxobj;vclwinx;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;dbexpress;IndyCore;vclx;bindcomp;appanalytics;dsnap;FireDACCommon;IndyIPClient;bindcompvcl;RESTBackendComponents;EmbeddedWebBrowser_XE;VCLRESTComponents;soapserver;dbxcds;VclSmp;JvDocking;adortl;JclVcl;vclie;bindengine;DBXMySQLDriver;CloudService;dsnapxml;FireDACMySQLDriver;dbrtl;IndyProtocols;inetdbxpress;keyman_components;FireDACCommonODBC;FireDACCommonDriver;inet;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
@@ -84,7 +85,6 @@
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
         <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
         <DCC_MapFile>3</DCC_MapFile>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
@@ -98,7 +98,6 @@
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
         <AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
         <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <DCC_MapFile>3</DCC_MapFile>
         <DCC_DebugInformation>2</DCC_DebugInformation>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>

--- a/windows/src/support/oskbulkrenderer/Makefile
+++ b/windows/src/support/oskbulkrenderer/Makefile
@@ -7,8 +7,8 @@
 build: version.res dirs
     $(DELPHI_MSBUILD) oskbulkrenderer.dproj /p:Platform=Win32
 
-    $(TDS2DBG) $(WIN32_TARGET_PATH)\oskbulkrenderer.exe
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\oskbulkrenderer.exe -dpr oskbulkrenderer.dpr
+    $(TDS2DBG) $(WIN32_TARGET_PATH)\oskbulkrenderer.exe
     $(COPY) $(WIN32_TARGET_PATH)\oskbulkrenderer.exe $(PROGRAM)\support
     if exist $(WIN32_TARGET_PATH)\oskbulkrenderer.dbg $(COPY) $(WIN32_TARGET_PATH)\oskbulkrenderer.dbg $(DEBUGPATH)\support
 

--- a/windows/src/support/oskbulkrenderer/oskbulkrenderer.dproj
+++ b/windows/src/support/oskbulkrenderer/oskbulkrenderer.dproj
@@ -66,6 +66,7 @@
         <DCC_UsePackage>RESTComponents;FireDAC;FireDACSqliteDriver;soaprtl;FireDACIBDriver;soapmidas;FireDACCommon;RESTBackendComponents;soapserver;CloudService;FireDACCommonDriver;inet;$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>oskbulkrenderer</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android64)'!=''">
         <Base_Android>true</Base_Android>
@@ -118,7 +119,6 @@
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
         <Debugger_RunParams>-f -x .kvks .</Debugger_RunParams>
         <Debugger_CWD>c:\temp\x\kbdus\source</Debugger_CWD>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>(None)</Manifest_File>
         <DCC_MapFile>3</DCC_MapFile>
@@ -130,7 +130,6 @@
         <DCC_DebugInformation>0</DCC_DebugInformation>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <Manifest_File>(None)</Manifest_File>
         <DCC_MapFile>3</DCC_MapFile>

--- a/windows/src/support/unload_keyboards/unloadkeyboards.dproj
+++ b/windows/src/support/unload_keyboards/unloadkeyboards.dproj
@@ -57,6 +57,7 @@
         <DCC_F>false</DCC_F>
         <DCC_K>false</DCC_K>
         <SanitizedProjectName>unloadkeyboards</SanitizedProjectName>
+        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>IndyCore160;vcldbx;frx16;TeeDB;IndyProtocols160;EmbeddedWebBrowser_XE;tb2k_d12;vclib;inetdbbde;Tee;Rave100VCL;svnui;ibxpress;vclimg;DCPdelphi2009;frxDB16;intrawebdb_120_160;fmi;mbColorLibD10;fs16;vclactnband;FMXTee;vcldb;TeeUI;bindcompvcl;vcldsnap;vclie;vcltouch;Intraweb_120_160;websnap;vclribbon;VclSmp;frxe16;fsDB16;vcl;PBFolderDialogPackRun;CloudService;CodeSiteExpressPkg;IndySystem160;FmxTeeUI;dsnapcon;vclx;VCLZipD2009_4;webdsnap;svn;keyman_components;bdertl;SpTBXLib_d16;adortl;$(DCC_UsePackage)</DCC_UsePackage>
@@ -90,7 +91,6 @@
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
         <BT_BuildType>Debug</BT_BuildType>
-        <DCC_DebugInfoInTds>true</DCC_DebugInfoInTds>
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Locale>1033</VerInfo_Locale>


### PR DESCRIPTION
Fixes #3831.

This fixes both issues reported in the bug (dproj changes ensure separate .tds, and Makefile changes fix order of execution so that dbg is generated after sentryprep's cleanup).

Note that unit tests and other unpublished executables do not need updating for this.