### PR TITLE
fix(developer): Remove IE dependency from Developer Setup

### DIFF
--- a/windows/src/developer/setup/SetupStrings.pas
+++ b/windows/src/developer/setup/SetupStrings.pas
@@ -41,25 +41,16 @@ type
     ssErrorUnableToContactServer,
     ssErrorUnableToContactServerDetailed,
 
-    ssStatusCheckingWindowsInstaller,
-    ssStatusCheckingInternetExplorer,
-    ssStatusCheckingMSXML,
     ssStatusCheckingForUpdates,
     ssStatusInstalling,
     ssStatusComplete,
-
-    ssQueryUpdateWindowsInstaller,
-    ssQueryUpdateInternetExplorer,
-    ssQueryUpdateMSXML,
 
     ssQueryUpdateVersion,
 
     ssQueryRestart,
     ssErrorUnableToAutomaticallyRestart,
 
-    ssRedistIEUpdateRequired,
     ssMustRestart,
-    ssRedistRequired,
     ssCheckForUpdatesError
     );
 
@@ -80,16 +71,9 @@ const
     'Unable to contact server',
     'Unable to contact server, error was: %0:s',
 
-    'Checking Windows Installer version',
-    'Checking Internet Explorer version',
-    'Checking MSXML version',
     'Checking for updates online',
     'Installing Keyman Developer',
     'Installation Complete',
-
-    'An updated version of Windows Installer is required to install Keyman Developer.  Do you want to download and install it now?',
-    'Internet Explorer 5.5 or later is required to install Keyman Developer.  Do you want to download it now?',
-    'MSXML 3.0 is required to install Keyman Developer.  Do you want to download it now?',
 
     'Version %1:s of Keyman Developer has been released and is available for download.  This update is %0:dKB.  '+
       'Do you want to download and install the updated version (recommended)?',
@@ -97,11 +81,7 @@ const
     'You must restart Windows before Setup can complete.  When you restart Windows, Setup will continue.  Restart now?',
     'Windows was not able to be automatically restarted.  You should restart Windows before you try and start Keyman Developer.',
 
-    'Internet Explorer 5.5 or later is required to install Keyman Developer.',
-
     'You must restart Windows to complete Setup.  When you restart Windows, Setup will finish.',
-
-    'A redistributable %0:s is required but is not available in the install path.  This redistributable can be downloaded from the Keyman website.',
 
     'The online update check failed with an error: %0:s'
     );

--- a/windows/src/developer/setup/UfrmRun.pas
+++ b/windows/src/developer/setup/UfrmRun.pas
@@ -90,7 +90,6 @@ type
     procedure CheckNewVersion;
     function InstallMSI: Boolean;
     procedure Status(const Text: WideString = '');
-    function CheckDependencies: Boolean;
     procedure DownloadRedistFile(AOwner: TfrmDownloadProgress; var Result: Boolean);
     function InstallNewVersion: Boolean;
     function IsNewerVersionInstalled(const NewVersion: WideString): Boolean;
@@ -221,36 +220,6 @@ end;
 function TfrmRun.IsNewerVersionInstalled(const NewVersion: WideString): Boolean;
 begin
   Result := (FInstalledVersion.Version <> '') and (CompareVersions(NewVersion, FInstalledVersion.Version) >= 0);
-end;
-
-function TfrmRun.CheckDependencies: Boolean;
-const
-  SInternetExplorerHome = 'https://www.microsoft.com/ie/';
-begin
-  Result := False;
-
-  // Check Internet Explorer version
-  Status(FInstallInfo.Text(ssStatusCheckingInternetExplorer));
-  with TRegistryErrorControlled.Create do  // I2890
-  try
-    RootKey := HKEY_LOCAL_MACHINE;
-    if not OpenKeyReadOnly('Software\Microsoft\Internet Explorer') or not ValueExists('Version') or
-      (CompareVersions(ReadString('Version'), '9.0') > 0) then
-    begin
-      if FSilent or (MessageDlgW(FInstallInfo.Text(ssQueryUpdateInternetExplorer),
-        mtConfirmation, mbOkCancel, 0) = mrCancel) then
-      begin
-        LogError(FInstallInfo.Text(ssRedistIEUpdateRequired), False);
-        Exit;
-      end;
-      TUtilExecute.URL(SInternetExplorerHome);
-      Exit;
-    end;
-  finally
-    Free;
-  end;
-
-  Result := True;
 end;
 
 function TfrmRun.InstallNewVersion: Boolean;
@@ -423,8 +392,6 @@ end;
 
 function TfrmRun.DoInstall(Silent, PromptForReboot: Boolean): Boolean;  // I1901  // I3355   // I3500
 begin
-  Result := False;  // I1901
-
   FPromptForReboot := PromptForReboot;  // I3355   // I3500
   FSilent := Silent;
   
@@ -438,8 +405,6 @@ begin
     EnableWindow(GetDlgItem(Handle, IDC_CHECK1), False);
 
     StatusMax := 6;
-
-    if not CheckDependencies then Exit;
 
     SetupMSI;
 


### PR DESCRIPTION
Fixes #3832.

Removes the now-unneeded Internet Explorer dependency from Developer Setup, and corresponding strings (plus a couple of other unused strings).

I18n of these strings is a future project.