### PR TITLE
fix(windows): sporadic 8087 control word corruption

### DIFF
--- a/windows/src/ext/sentry/Sentry.Client.pas
+++ b/windows/src/ext/sentry/Sentry.Client.pas
@@ -5,7 +5,6 @@ interface
 
 uses
   System.AnsiStrings,
-  System.Math,
   System.SysUtils,
   Winapi.ImageHlp,
   Winapi.Windows,
@@ -176,6 +175,25 @@ begin
 end;
 
 ///
+/// This is a thread-safe version of Set8087CW that avoids the global
+/// variable Default8087CW. We would get occasional situations where
+/// exceptions were raised on 2 threads simultaneously, which could lead to a
+/// race where the first thread set Default8087CW to $1340, and then the second
+/// thread would read that and think that is the default to keep. We want to
+/// avoid touching Default8087CW altogether here.
+///
+/// See also https://stackoverflow.com/a/39684636/1836776 and RSP-13643.
+///
+procedure Set8087CW_Threadsafe(ANewCW: Word);
+var
+  L8087CW: Word;
+asm
+  mov L8087CW, ANewCW
+  fnclex
+  fldcw L8087CW
+end;
+
+///
 /// First chance exception handler. We just want to take a copy of the raw
 /// stack here.
 ///
@@ -189,11 +207,12 @@ const
 {$ENDIF}
 var
   Skip: Integer;
-  LastMask: TArithmeticExceptionMask;
+  LastMask: WORD;
 begin
   // Floating point state may be broken here, so let's mask it out and continue
   // We'll restore state afterwards
-  LastMask := System.Math.SetExceptionMask([]);
+  LastMask := Get8087CW;
+  Set8087CW_Threadsafe($1332);
 
   if ExceptionInfo.ExceptionRecord.ExceptionCode = cDelphiException
     then Skip := DELPHI_FRAMES_TO_SKIP
@@ -201,7 +220,7 @@ begin
   CaptureStackTraceForException(ExceptionInfo.ExceptionRecord.ExceptionAddress, ExceptionInfo, Skip);
 
   // Restore FP state
-  System.Math.SetExceptionMask(LastMask);
+  Set8087CW_Threadsafe(LastMask);
 
   Result := 0; //EXCEPTION_CONTINUE_SEARCH;
 end;


### PR DESCRIPTION
This replaces vectored exception handler code which fixed up the 8087 CW with a thread-safe version of Set8087CW that avoids the global variable Default8087CW. We would get occasional situations where exceptions were raised on 2 threads simultaneously, which could lead to a race where the first thread set Default8087CW to $1340, and then the second thread would read that and think that is the default to keep. We want to avoid touching Default8087CW altogether here.

I believe that this could sometimes be visible to users with blank browser pages on reload (based on debugging experiences and noting floating point exceptions happening). Let's wait and see if that resolves that sporadic issue.

See also https://stackoverflow.com/a/39684636/1836776 and [RSP-13643](https://quality.embarcadero.com/browse/RSP-13643).