### PR TITLE
feat(common/models): casing for suggestions with partial replacement

### DIFF
--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -142,8 +142,7 @@ declare interface LexicalModel {
 
   /**
    * Generates predictive suggestions corresponding to the state of context after the proposed
-   * transform is applied to it.  Each returned `Suggestion` should replace the entire 
-   * word / text token, rather than leaving part of it unaltered.
+   * transform is applied to it.
    * 
    * This method should NOT attempt to perform any form of correction; this is modeled within a
    * separate component of the LMLayer predictive engine.  That is, "th" + "e" should not be

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -10,7 +10,7 @@ var ModelCompositor = require('../../build/intermediate').ModelCompositor;
 
 describe('ModelCompositor', function() {
   describe('Prediction with 14.0+ models', function() {
-    describe.only('applySuggestionCasing', function() {
+    describe('applySuggestionCasing', function() {
       let plainApplyCasing = function(caseToApply, text) {
         switch(caseToApply) {
           case 'lower':

--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -127,6 +127,7 @@ describe('ModelCompositor', function() {
           displayAs: 'therefore'
         };
 
+        // When integrated, the 'the' string comes from a wordbreak operation on the current context.
         compositor.applySuggestionCasing(suggestion, 'the', 'initial');
         assert.equal(suggestion.displayAs, 'Therefore');
         assert.equal(suggestion.transform.insert, 'Therefore');


### PR DESCRIPTION
As noted by https://github.com/keymanapp/keyman/pull/3770#discussion_r520108961, initial implementation for adaptively casing predictions was made easier by assuming that any suggestions a model produces replace the entire word.  (That assumption holds true for the `TrieModel`.)  With a little extra work, we can relax the assumption and restore the original `predict` spec to its original form.

To facilitate unit testing, I've also moved the casing-application code into its own, isolated function.  Integrated tests will come later with their own pathway, but at least this provides some initial LMLayer test coverage for the new feature.