### PR TITLE
fix(common/core/web): meta key handling

### DIFF
--- a/common/core/desktop/src/kmx/kmx_file.h
+++ b/common/core/desktop/src/kmx/kmx_file.h
@@ -205,7 +205,9 @@ namespace kmx {
 #define K_CTRLFLAG    0x0020    // Either ctrl flag
 #define K_ALTFLAG   0x0040    // Either alt flag
 //#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
-                                // Used internally to ensure Meta-key shortcuts safely bypass rules
+                                // Used internally (currently, only by KMW) to ensure Meta-key 
+                                // shortcuts safely bypass rules
+                                // Meta key = Command key on macOS, Windows key on Windows
 #define CAPITALFLAG   0x0100    // Caps lock on
 #define NOTCAPITALFLAG  0x0200    // Caps lock NOT on
 #define NUMLOCKFLAG   0x0400    // Num lock on

--- a/common/core/desktop/src/kmx/kmx_file.h
+++ b/common/core/desktop/src/kmx/kmx_file.h
@@ -204,6 +204,8 @@ namespace kmx {
 #define K_SHIFTFLAG   0x0010    // Either shift flag
 #define K_CTRLFLAG    0x0020    // Either ctrl flag
 #define K_ALTFLAG   0x0040    // Either alt flag
+//#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
+                                // Used internally to ensure Meta-key shortcuts safely bypass rules
 #define CAPITALFLAG   0x0100    // Caps lock on
 #define NOTCAPITALFLAG  0x0200    // Caps lock NOT on
 #define NUMLOCKFLAG   0x0400    // Num lock on

--- a/common/core/web/keyboard-processor/src/text/codes.ts
+++ b/common/core/web/keyboard-processor/src/text/codes.ts
@@ -9,6 +9,7 @@ namespace com.keyman.text {
       "SHIFT":0x0010,
       "CTRL":0x0020,
       "ALT":0x0040,
+      "META":0x0080, // Represents command keys, which some OSes use for shortcuts we don't want to block.
       "CAPS":0x0100,
       "NO_CAPS":0x0200,
       "NUM_LOCK":0x0400,

--- a/common/core/web/keyboard-processor/src/text/codes.ts
+++ b/common/core/web/keyboard-processor/src/text/codes.ts
@@ -1,6 +1,7 @@
 namespace com.keyman.text {
   export var Codes = {
     // Define Keyman Developer modifier bit-flags (exposed for use by other modules)
+    // Compare against /common/core/desktop/src/kmx/kmx_file.h.  CTRL+F "#define LCTRLFLAG" to find the secton.
     modifierCodes: {
       "LCTRL":0x0001,
       "RCTRL":0x0002,

--- a/common/core/web/keyboard-processor/src/text/codes.ts
+++ b/common/core/web/keyboard-processor/src/text/codes.ts
@@ -9,14 +9,19 @@ namespace com.keyman.text {
       "SHIFT":0x0010,
       "CTRL":0x0020,
       "ALT":0x0040,
-      "META":0x0080, // Represents command keys, which some OSes use for shortcuts we don't want to block.
+      // TENTATIVE:  Represents command keys, which some OSes use for shortcuts we don't
+      // want to block.  No rule will ever target a modifier set with this bit set to 1. 
+      "META":0x0080,
       "CAPS":0x0100,
       "NO_CAPS":0x0200,
       "NUM_LOCK":0x0400,
       "NO_NUM_LOCK":0x0800,
       "SCROLL_LOCK":0x1000,
       "NO_SCROLL_LOCK":0x2000,
-      "VIRTUAL_KEY":0x4000
+      "VIRTUAL_KEY":0x4000,
+      // Reserved:  is VIRTUALCHARKEY on Windows.  All our platforms use the same
+      // code definitions.
+      "VIRTUAL_CHAR_KEY":0x8000
     },
 
     modifierBitmasks: {

--- a/common/core/web/keyboard-processor/src/text/codes.ts
+++ b/common/core/web/keyboard-processor/src/text/codes.ts
@@ -3,26 +3,24 @@ namespace com.keyman.text {
     // Define Keyman Developer modifier bit-flags (exposed for use by other modules)
     // Compare against /common/core/desktop/src/kmx/kmx_file.h.  CTRL+F "#define LCTRLFLAG" to find the secton.
     modifierCodes: {
-      "LCTRL":0x0001,
-      "RCTRL":0x0002,
-      "LALT":0x0004,
-      "RALT":0x0008,
-      "SHIFT":0x0010,
-      "CTRL":0x0020,
-      "ALT":0x0040,
+      "LCTRL":0x0001,           // LCTRLFLAG
+      "RCTRL":0x0002,           // RCTRLFLAG
+      "LALT":0x0004,            // LALTFLAG
+      "RALT":0x0008,            // RALTFLAG
+      "SHIFT":0x0010,           // K_SHIFTFLAG
+      "CTRL":0x0020,            // K_CTRLFLAG
+      "ALT":0x0040,             // K_ALTFLAG
       // TENTATIVE:  Represents command keys, which some OSes use for shortcuts we don't
       // want to block.  No rule will ever target a modifier set with this bit set to 1. 
-      "META":0x0080,
-      "CAPS":0x0100,
-      "NO_CAPS":0x0200,
-      "NUM_LOCK":0x0400,
-      "NO_NUM_LOCK":0x0800,
-      "SCROLL_LOCK":0x1000,
-      "NO_SCROLL_LOCK":0x2000,
-      "VIRTUAL_KEY":0x4000,
-      // Reserved:  is VIRTUALCHARKEY on Windows.  All our platforms use the same
-      // code definitions.
-      "VIRTUAL_CHAR_KEY":0x8000
+      "META":0x0080,            // K_METAFLAG
+      "CAPS":0x0100,            // CAPITALFLAG
+      "NO_CAPS":0x0200,         // NOTCAPITALFLAG
+      "NUM_LOCK":0x0400,        // NUMLOCKFLAG
+      "NO_NUM_LOCK":0x0800,     // NOTNUMLOCKFLAG
+      "SCROLL_LOCK":0x1000,     // SCROLLFLAG
+      "NO_SCROLL_LOCK":0x2000,  // NOTSCROLLFLAG
+      "VIRTUAL_KEY":0x4000,     // ISVIRTUALKEY
+      "VIRTUAL_CHAR_KEY":0x8000 // VIRTUALCHARKEY // Unused by KMW, but reserved for use by other Keyman engines.
     },
 
     modifierBitmasks: {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMBinaryFileFormat.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMBinaryFileFormat.h
@@ -117,6 +117,10 @@ struct COMP_STORE {
 #define K_SHIFTFLAG     0x0010      // Either shift flag
 #define K_CTRLFLAG      0x0020      // Either ctrl flag
 #define K_ALTFLAG       0x0040      // Either alt flag
+//#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
+                                // Used internally (currently, only by KMW) to ensure Meta-key 
+                                // shortcuts safely bypass rules
+                                // Meta key = Command key on macOS, Windows key on Windows
 #define CAPITALFLAG     0x0100      // Caps lock on
 #define NOTCAPITALFLAG  0x0200      // Caps lock NOT on
 #define NUMLOCKFLAG     0x0400      // Num lock on
@@ -189,9 +193,6 @@ struct COMP_KEY {
 #define KVKS_RCTRL              0x10
 #define KVKS_LALT               0x20
 #define KVKS_RALT               0x40
-//#define KVKS_META               0x80    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
-                                          // Used internally to ensure Meta-key shortcuts safely bypass rules
-
 
 /*
 PWSTR incxstr(PWSTR p) {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMBinaryFileFormat.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMBinaryFileFormat.h
@@ -189,6 +189,8 @@ struct COMP_KEY {
 #define KVKS_RCTRL              0x10
 #define KVKS_LALT               0x20
 #define KVKS_RALT               0x40
+//#define KVKS_META               0x80    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
+                                          // Used internally to ensure Meta-key shortcuts safely bypass rules
 
 
 /*

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -149,6 +149,14 @@ namespace com.keyman.dom {
           ((curModState & (modifierCodes['LALT'] | modifierCodes['RALT']))   ? 0x40 : 0); 
       }
 
+
+      /* Tweak the modifiers if an OS meta key is detected; this will allow meta-key-based 
+       * hotkeys to bypass Keyman processing.  We do this AFTER the chiral modifier filtering
+       * because some keyboards specify their own modifierBitmask, which won't include it.
+       * We don't currently use that reference in this method, but that may change in the future.
+       */
+      s.Lmodifiers |= (e.metaKey ? modifierCodes['META']: 0);
+
       // Mnemonic handling.
       if(activeKeyboard && activeKeyboard.isMnemonic) {
         // The following will never set a code corresponding to a modifier key, so it's fine to do this,

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -269,6 +269,8 @@
 #define K_SHIFTFLAG		0x0010		// Either shift flag
 #define K_CTRLFLAG		0x0020		// Either ctrl flag
 #define K_ALTFLAG		0x0040		// Either alt flag
+//#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
+                                // Used internally to ensure Meta-key shortcuts safely bypass rules
 #define CAPITALFLAG		0x0100		// Caps lock on
 #define NOTCAPITALFLAG	0x0200		// Caps lock NOT on
 #define NUMLOCKFLAG		0x0400		// Num lock on

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -270,7 +270,9 @@
 #define K_CTRLFLAG		0x0020		// Either ctrl flag
 #define K_ALTFLAG		0x0040		// Either alt flag
 //#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
-                                // Used internally to ensure Meta-key shortcuts safely bypass rules
+                                // Used internally (currently, only by KMW) to ensure Meta-key 
+                                // shortcuts safely bypass rules
+                                // Meta key = Command key on macOS, Windows key on Windows
 #define CAPITALFLAG		0x0100		// Caps lock on
 #define NOTCAPITALFLAG	0x0200		// Caps lock NOT on
 #define NUMLOCKFLAG		0x0400		// Num lock on


### PR DESCRIPTION
Fixes #3814.

Following the work in #3848, I noted that the shortcuts were failing for a different reason on Mac, where they are command-key based instead of CTRL-based.  On that platform, the engine does nothing to note when the `metaKey` is currently active; tracking this is enough to allow mac-based hotkeys to pass through.  Do let me know if the new `META` modifier code needs to be changed to something else.

As keyboard rules require exact modifier state matches to succeed, applying the `META` modifier code to keystrokes will bypass any rules not explicitly targeting modifier states that include the `Meta` state.