### PR TITLE
fix(common/core/web): fixes no-output logic check, arrow keys

### DIFF
--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -48,7 +48,7 @@ namespace com.keyman.text {
         //   case Codes.keyCodes['K_TABFWD']:
         //     return '\t';
           default:
-           return '';
+           return null;
         }
       }
     }


### PR DESCRIPTION
Fixes the Windows aspect of #3814.

The core of the issue was a mishandled return value.  As it turns out, `'' != null`, despite `! '' == true`.  (Thank you, JS.)  Noting this, `DefaultOutput.forAny` should return `null` instead of `''` so that its return value is handled properly within `KeyboardProcessor`.  This also better matches the other key-code output/handling checks of `DefaultOutput`.

The code block affected by this return value:  https://github.com/keymanapp/keyman/blob/866e12481ffb9a2e0bff2f0e625d53ddcfd53bf8/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts#L152-L169

Since we were returning `''` for "no default output", the condition on line 153 was always `true`, meaning the `else` block from 162-164 was never evaluated.  That `else` block is the pathway needed to let the keystroke patterns mentioned in #3814 pass through the engine unhindered. (Note lines 159 - 161 for comparison.)