### PR TITLE
fix(web/engine): blocks key previews for blank/hidden keys

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1664,11 +1664,20 @@ namespace com.keyman.osk {
       var classes=key.className, cs = ' kmw-key-touched';
 
       // For phones, use key preview rather than highlighting the key,
-      // except for space, bksp, enter, shift and popup keys
-      var usePreview = ((this.keytip != null)
-        && (classes.indexOf('kmw-key-shift') < 0)
-        && (classes.indexOf('kmw-spacebar') < 0)
-        && (key.id.indexOf('popup') < 0 ));
+      var usePreview = ((this.keytip != null) && (key.id.indexOf('popup') < 0 ));
+
+      if(usePreview) {
+        // Previews are not permitted for keys using any of the following CSS styles.
+        var excludedClasses = ['kmw-key-shift',    // special keys
+                               'kmw-key-shift-on', // active special keys (shift, when in shift layer
+                               'kmw-spacebar',     // space
+                               'kmw-key-blank',    // Keys that are only used for layout control
+                               'kmw-key-hidden'];
+
+        for(let c=0; c < excludedClasses.length; c++) {
+          usePreview = usePreview && (classes.indexOf(excludedClasses[c]) < 0);
+        }
+      }
 
       if(usePreview) {
         this.showKeyTip(key,on);


### PR DESCRIPTION
Addresses a sub-issue noted on #1111.

As noted in [this comment](https://github.com/keymanapp/keyman/issues/1111#issuecomment-589977307) from that issue:

> In Chrome emulation, they [_blank/hidden keys_] do still show the popup pentagon [_key preview_].

The preview is pretty simple to turn off, and we were already disabling it for a few CSS classes.  This PR just adds a few extra to the blacklist.

With these changes in place, key previews for blank/hidden keys now know their place, even during Chrome emulation, and no longer appear.