### PR TITLE
feat(web/engine): allows touch aliasing away from blank keys

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -936,7 +936,7 @@ namespace com.keyman.osk {
       this.touchCount = e.touches.length;
 
       // Get nearest key if touching a hidden key or the end of a key row
-      if((key && (key.className.indexOf('key-hidden') >= 0))
+      if((key && ((key.className.indexOf('key-hidden') >= 0) || (key.className.indexOf('key-blank') >= 0)))
         || t.className.indexOf('kmw-key-row') >= 0) {
         key = this.findNearestKey(e,t);
       }
@@ -1278,8 +1278,12 @@ namespace com.keyman.osk {
       // Find minimum distance from any key
       var k, k0=0, dx, dxMax=24, dxMin=100000, x1, x2;
       for(k = 0; k < t.childNodes.length; k++) {
-        let childNode = t.childNodes[k] as HTMLElement;
-        if(childNode.className !== undefined && childNode.className.indexOf('key-hidden') >= 0) {
+        let childNode = t.childNodes[k] as HTMLElement; // gets the .kmw-key-square containing a key
+        if(childNode.firstChild) {
+          childNode = childNode.firstChild as HTMLElement; // gets the actual key element.
+        }
+        if(childNode.className !== undefined  && (childNode.className.indexOf('key-hidden') >= 0)
+             || (childNode.className.indexOf('key-blank') >= 0)){
           continue;
         }
         x1 = childNode.offsetLeft;


### PR DESCRIPTION
Fixes #1111.

The OSK's touch handlers and `findNearestKey` algorithm now ignores `kmw-key-blank`-marked keys during its search for a nearest key.  Previous distance thresholds still apply.

### User Testing
@MakaraSok 

This image from the original issue provides a good hint for testing:

> Lost in spacing:
> ![image](https://user-images.githubusercontent.com/986339/44294895-9d0f6680-a26c-11e8-855b-8de8980a05c7.png)

Use of the standard `web/testing/unminified.html` test page is sufficient.
Keyboard:  `sil_cameroon_qwerty` (use "Add a keyboard by keyboard name")

- Use the 'abc' key to access the displayed layer.
- Try pressing a "key" about half a key's width away from a key that actually exists.
    - Keys on the same row within that distance should activate from such a keypress.
    - Keys on different rows will not activate. (It's a pre-existing design limitation.)