### PR TITLE
feat(windows): major version upgrades

### DIFF
--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -544,6 +544,10 @@ begin
       ShowUI := not FSilent;
       Fields.Add('version', ansistring(CKeymanVersionInfo.Version));
       Fields.Add('tier', ansistring(CKeymanVersionInfo.Tier));
+      if FForce
+        then Fields.Add('manual', '1')
+        else Fields.Add('manual', '0');
+
       for i := 0 to kmcom.Packages.Count - 1 do
       begin
         pkg := kmcom.Packages[i];

--- a/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
@@ -49,6 +49,7 @@ begin
     http.Fields.Add('version', AnsiString(currentVersion));
     http.Fields.Add('tier', AnsiString(AInstallInfo.Tier));
     http.Fields.Add('update', '0'); // This is probably a fresh install of a package, not an update
+    http.Fields.Add('manual', '1'); // Treat this as a manual update so the staggered rollout doesn't apply
     for pack in AInstallInfo.Packages do
       http.Fields.Add(AnsiString('package_'+pack.ID), AnsiString(pack.Locations.LatestVersion));
 


### PR DESCRIPTION
Relates to #1635.

This goes with keymanapp/api.keyman.com#122, and ensures that major upgrades are offered regardless of the rollout schedule, if they are available, when the user manually checks for an update.