### PR TITLE
fix(android/engine): Update in-app TextView context on pageLoaded

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1847,6 +1847,11 @@ public final class KMManager {
         InAppKeyboard.callJavascriptAfterLoad();
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_INAPP, EventType.KEYBOARD_LOADED, null);
+
+        // Special handling for in-app TextView context keymanapp/keyman#3809
+        if (KMTextView.activeView != null && KMTextView.activeView.getClass() == KMTextView.class) {
+          KMTextView.updateTextContext();
+        }
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
@@ -56,6 +56,19 @@ public final class KMTextView extends AppCompatEditText {
     init(context);
   }
 
+  /**
+   * Method to update and reset the in-app context.
+   * Assumption: InAppKeyboardLoaded is true
+   */
+  public static void updateTextContext() {
+    KMTextView textView = (KMTextView) activeView;
+    int selStart = textView.getSelectionStart();
+    int selEnd = textView.getSelectionEnd();
+    KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
+    KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
+    KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
+  }
+
   private void init(final Context context) {
     this.context = context;
     this.hardwareKeyboardInterpreter = new KMHardwareKeyboardInterpreter(context, KeyboardType.KEYBOARD_TYPE_INAPP);
@@ -107,12 +120,7 @@ public final class KMTextView extends AppCompatEditText {
         if (hasFocus) {
           activeView = v;
           if (KMManager.InAppKeyboardLoaded) {
-            KMTextView textView = (KMTextView) activeView;
-            int selStart = textView.getSelectionStart();
-            int selEnd = textView.getSelectionEnd();
-            KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
-            KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
-            KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
+            updateTextContext();
           }
           showKeyboard();
         } else {
@@ -179,11 +187,7 @@ public final class KMTextView extends AppCompatEditText {
 
       if (activeView != null && activeView.equals(this)) {
         if (KMManager.InAppKeyboardLoaded) {
-          KMTextView textView = (KMTextView) activeView;
-          int selStart = textView.getSelectionStart();
-          int selEnd = textView.getSelectionEnd();
-          KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
-          KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
+          updateTextContext();
         }
 
         if (keyboardVisible) {


### PR DESCRIPTION
Fixes #3809

This fixes the race condition where the in-app TextView would load before the in-app keyboard is loaded. The TextView would fail to get existing context.

* Consolidates some WET code to `updateTextContext()`