### PR TITLE
fix(android/app): Install keyboard packages w/o welcome.htm

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -212,8 +212,15 @@ public class WebViewFragment extends Fragment implements BlockingStep {
 
   @Override
   public void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback) {
+    // Send data to calling Activity (1-step stepper)
+    if (isInstallButton) {
+     this.callback.onInstallClicked(pkgTarget, packageID);
+    }
+
+    // Cleanup
     getActivity().finish();
   }
+
   @Override
   public void onBackClicked(StepperLayout.OnBackClickedCallback callback) {
     callback.goToPrevStep();


### PR DESCRIPTION
Fixes #3873

The stepper adapter determines how many steps (dots) are involved in the .kmp keyboard package installation.

In the case of a 1-step install (only 1 associated language, no readme.htm or welcome.htm included), the "Install" button was registering as `onCompleteClicked` and the WebViewFragment finished the activity without installing the keyboard.

This adds a check to handle the 1-step scenario.

### Tests performed
Verified keyboard packages install for these scenarios:
Engineering package of chirality keyboard (1 language, no readme.htm or welcome.htm) - 1 step
khmer_angkor (1 language, contains welcome.htm) - 2 steps
sil_cameroon_qwerty (multiple languages to select, contains welcome.htm) - 3 steps

After all the packages installed, I went back to the "Add languages to installed keyboard" menu and verified that worked.
For chirality and khmer_angkor, the app notifies  "All languages already installed"

For sil_cameroon_qwerty, it installed the added languages.