### PR TITLE
fix(ios/engine): allows some language-code incomplete matches during package installation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -208,7 +208,21 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
                 withAssociators associators: [Associator] = [],
                 progressReceiver: @escaping ProgressReceiver) {
     self.package = package
-    self.defaultLgCode = defaultLanguageCode
+    if let defaultLanguageCode = defaultLanguageCode {
+      if package.languages.contains(where: { $0.id == defaultLanguageCode }) {
+        self.defaultLgCode = defaultLanguageCode
+      } else if let match = package.languages.first(where: { $0.id.contains(defaultLanguageCode) }) {
+        // The package specifies a more precise ID
+        self.defaultLgCode = match.id
+      } else if let match = package.languages.first(where: { defaultLanguageCode.contains($0.id) }) {
+        // The provided default language code is more precise than the id found in the package
+        self.defaultLgCode = match.id
+      } else {
+        self.defaultLgCode = nil
+      }
+    } else {
+      self.defaultLgCode = nil
+    }
 
     self.closureShared = ClosureShared(with: associators, downloadManager: downloadManager, receiver: progressReceiver)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -211,10 +211,10 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     if let defaultLanguageCode = defaultLanguageCode {
       if package.languages.contains(where: { $0.id == defaultLanguageCode }) {
         self.defaultLgCode = defaultLanguageCode
-      } else if let match = package.languages.first(where: { $0.id.contains(defaultLanguageCode) }) {
+      } else if let match = package.languages.first(where: { $0.id.hasPrefix(defaultLanguageCode) }) {
         // The package specifies a more precise ID
         self.defaultLgCode = match.id
-      } else if let match = package.languages.first(where: { defaultLanguageCode.contains($0.id) }) {
+      } else if let match = package.languages.first(where: { defaultLanguageCode.hasPrefix($0.id) }) {
         // The provided default language code is more precise than the id found in the package
         self.defaultLgCode = match.id
       } else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -150,7 +150,7 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
 
   public static func defaultDownloadClosure(downloadCompletionBlock: @escaping SearchDownloadHandler<FullKeyboardID>) -> SelectionCompletedHandler<FullKeyboardID> {
     return defaultDownloadClosure(withDownloadManager: ResourceDownloadManager.shared,
-                                              downloadCompletionBlock: downloadCompletionBlock)
+                                  downloadCompletionBlock: downloadCompletionBlock)
   }
 
   // For unit testing.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -204,39 +204,39 @@ public class ResourceFileManager {
         defaultLanguageCode: String? = nil,
         in rootVC: UIViewController,
         withAssociators associators: [AssociatingPackageInstaller<Resource, Package>.Associator] = [],
-        successHandler: ((KeymanPackage) -> Void)? = nil)
-    where Resource.Package == Package {
-      let activitySpinner = Alerts.constructActivitySpinner()
-      activitySpinner.center = rootVC.view.center
+        successHandler: ((KeymanPackage) -> Void)? = nil) where Resource.Package == Package {
+    let activitySpinner = Alerts.constructActivitySpinner()
+    activitySpinner.center = rootVC.view.center
 
-      let packageInstaller = AssociatingPackageInstaller(for: package,
-                                                         withAssociators: associators) { status in
-        if status == .starting {
-          // Start a spinner!
-          activitySpinner.startAnimating()
-          rootVC.view.addSubview(activitySpinner)
+    let packageInstaller = AssociatingPackageInstaller(for: package,
+                                                       defaultLanguageCode: defaultLanguageCode,
+                                                       withAssociators: associators) { status in
+      if status == .starting {
+        // Start a spinner!
+        activitySpinner.startAnimating()
+        rootVC.view.addSubview(activitySpinner)
 
-          activitySpinner.centerXAnchor.constraint(equalTo: rootVC.view.centerXAnchor).isActive = true
-          activitySpinner.centerYAnchor.constraint(equalTo: rootVC.view.centerYAnchor).isActive = true
-          rootVC.view.isUserInteractionEnabled = false
-        } else if status == .complete {
-          // Report completion!
-          activitySpinner.stopAnimating()
-          activitySpinner.removeFromSuperview()
-          rootVC.view.isUserInteractionEnabled = true
-          rootVC.dismiss(animated: true, completion: nil)
-          successHandler?(package)
-        }
-      }
-
-      if let navVC = rootVC as? UINavigationController {
-        packageInstaller.promptForLanguages(inNavigationVC: navVC)
-      } else {
-        let nvc = UINavigationController.init()
-        packageInstaller.promptForLanguages(inNavigationVC: nvc)
-        rootVC.present(nvc, animated: true, completion: nil)
+        activitySpinner.centerXAnchor.constraint(equalTo: rootVC.view.centerXAnchor).isActive = true
+        activitySpinner.centerYAnchor.constraint(equalTo: rootVC.view.centerYAnchor).isActive = true
+        rootVC.view.isUserInteractionEnabled = false
+      } else if status == .complete {
+        // Report completion!
+        activitySpinner.stopAnimating()
+        activitySpinner.removeFromSuperview()
+        rootVC.view.isUserInteractionEnabled = true
+        rootVC.dismiss(animated: true, completion: nil)
+        successHandler?(package)
       }
     }
+
+    if let navVC = rootVC as? UINavigationController {
+      packageInstaller.promptForLanguages(inNavigationVC: navVC)
+    } else {
+      let nvc = UINavigationController.init()
+      packageInstaller.promptForLanguages(inNavigationVC: nvc)
+      rootVC.present(nvc, animated: true, completion: nil)
+    }
+  }
 
   public func promptPackageInstall(of package: KeymanPackage,
                                    in rootVC: UIViewController,

--- a/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
@@ -326,7 +326,7 @@ class AssociatingPackageInstallerTests: XCTestCase {
     XCTAssertNil(Storage.active.userDefaults.userLexicalModels)
   }
 
-  func testPackageLanguageMismatch() throws {
+  func testPackageLangCodePartialMatch() throws {
     guard let strPackage = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.fvSencotenKMP) as? KeyboardKeymanPackage else {
       XCTFail()
       return

--- a/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
@@ -325,4 +325,35 @@ class AssociatingPackageInstallerTests: XCTestCase {
     XCTAssertNil(Storage.active.userDefaults.userKeyboards)
     XCTAssertNil(Storage.active.userDefaults.userLexicalModels)
   }
+
+  func testPackageLanguageMismatch() throws {
+    guard let strPackage = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.fvSencotenKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    guard let eurolatinPackage = try ResourceFileManager.shared.prepareKMPInstall(from: TestUtils.Keyboards.silEuroLatinKMP) as? KeyboardKeymanPackage else {
+      XCTFail()
+      return
+    }
+
+    let strInstaller = AssociatingPackageInstaller(for: strPackage,
+                                                defaultLanguageCode: "str", // correct code:  str-latn
+                                                downloadManager: downloadManager) { _ in
+    }
+
+    // Package does not contain "str", but does contain "str-latn"
+    XCTAssertEqual(strInstaller.defaultLgCode, "str-latn")
+
+    let eurolatinInstaller = AssociatingPackageInstaller(for: eurolatinPackage,
+                                                defaultLanguageCode: "en-fake-bcp", // correct code:  "en"
+                                                downloadManager: downloadManager) { _ in
+    }
+
+    // Package does not contain "en-fake-bcp", but does contain "en".
+    XCTAssertEqual(eurolatinInstaller.defaultLgCode, "en")
+
+    // Note:  the current naive approach isn't exactly BCP-47 subtag aware - it relies on one tag
+    // containing the entire other tag as a substring.
+  }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Keyboards.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Keyboards.swift
@@ -13,6 +13,7 @@ extension TestUtils {
   enum Keyboards {
     static let khmerAngkorKMP = TestUtils.keyboardsBundle.url(forResource: "khmer_angkor", withExtension: "kmp")!
     static let silEuroLatinKMP = TestUtils.keyboardsBundle.url(forResource: "sil_euro_latin", withExtension: "kmp")!
+    static let fvSencotenKMP = TestUtils.keyboardsBundle.url(forResource: "fv_sencoten", withExtension: "kmp")!
     
     static let khmer_angkor =  InstallableKeyboard(id: "khmer_angkor",
                                                    name: "Khmer Angkor",
@@ -43,5 +44,15 @@ extension TestUtils {
                                                    font: Font(family: "LatinWeb", source: ["DejaVuSans.ttf"], size: nil),
                                                    oskFont: nil,
                                                    isCustom: false)
+
+    static let fv_sencoten = InstallableKeyboard(id: "fv_sencoten",
+                                                 name: "SENĆOŦEN",
+                                                 languageID: "str-latn",
+                                                 languageName: "Salish, Straits (Latin)",
+                                                 version: "9.1",
+                                                 isRTL: false,
+                                                 font: nil,
+                                                 oskFont: nil,
+                                                 isCustom: false)
   }
 }


### PR DESCRIPTION
Fixes #3404.  Naively, but it should probably be enough for now.  (A better solution would be far more BCP-47 aware, but that would require a significantly more complex solution.)

Also fixes a bug / omission that prevented the default language code from actually being preselected.