### PR TITLE
feat(ios/engine): launches external links outside the app

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
@@ -84,4 +84,21 @@ class PackageWebViewController: UIViewController, WKNavigationDelegate {
       """
     );
   }
+
+  // Used to intercept links that should be handled externally.
+  public func webView(_ webView: WKWebView,
+               decidePolicyFor navigationAction: WKNavigationAction,
+               decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    if let link = navigationAction.request.url {
+      if UniversalLinks.isExternalLink(link) {
+        decisionHandler(.cancel)
+
+        // Kick this link out to an external Safari process.
+        UniversalLinks.externalLinkLauncher?(link)
+        return
+      }
+    }
+
+    decisionHandler(.allow)
+  }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -121,6 +121,12 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
         self.navigationController?.popViewController(animated: true) // Rewind UI
         finalize(with: parsedLink)
         return
+      } else if UniversalLinks.isExternalLink(link) {
+        decisionHandler(.cancel)
+
+        // Kick this link out to an external Safari process.
+        UniversalLinks.externalLinkLauncher?(link)
+        return
       }
     }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/UniversalLinks.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/UniversalLinks.swift
@@ -18,7 +18,18 @@ public class UniversalLinks {
     }
   }
 
-  private static let KEYBOARD_INSTALL_LINK_REGEX = try! NSRegularExpression(pattern: "^http(?:s)?:\\/\\/[^\\/]+\\/keyboards\\/install\\/([^?\\/]+)(?:\\?(.+))?$")
+  // The standard technique for launching URLs externally is dependent upon being
+  // within an app, not in an app-extension.  Furthermore, that distinction is made
+  // at bundle compile-time... so we simply CAN'T condition on that within the framework.
+  // It's thus up to the app to define this method-field when desired.
+  public static var externalLinkLauncher: ((URL) -> Void)? = nil
+
+  // e.g. https://keyman.com/keyboards/install/foo
+  private static let KEYBOARD_INSTALL_LINK_REGEX = try! NSRegularExpression(pattern: "^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/keyboards/install/([^?/]+)(?:\\?(.+))?$")
+  // e.g. http://keyman.com.local/keyboards/foo
+  private static let KEYBOARD_MATCH_ROOT_REGEX = try! NSRegularExpression(pattern: "^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/keyboards([/?].*)?$");
+  // e.g. https://keyman-staging.com/go/windows/14.0/download-keyboards?version=14.0.146.0
+  private static let KEYBOARD_MATCH_GO_REGEX = try! NSRegularExpression(pattern: "^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/go/windows/[^/]+/download-keyboards")
 
   public static func tryParseKeyboardInstallLink(_ link: URL) -> ParsedKeyboardInstallLink? {
     let linkString = link.absoluteString
@@ -41,5 +52,31 @@ public class UniversalLinks {
     } else {
       return nil
     }
+  }
+
+  /**
+   * Returns `true` for links that should be opened externally, rather than in an app-hosted WebView.
+   * `false` is returned for links we consider to be 'internal' within the Keyman ecosystem.
+   */
+  public static func isExternalLink(_ link: URL) -> Bool {
+    let linkString = link.absoluteString
+    let linkRange = NSRange(location: 0, length: linkString.utf16.count)
+
+    // Case 1:  the link captured for keyboard search
+    if let _ = tryParseKeyboardInstallLink(link) {
+      return false
+    } else if let _ = KEYBOARD_MATCH_ROOT_REGEX.firstMatch(in: linkString,
+                                                           options: [],
+                                                           range: linkRange) {
+      return false
+    } else if let _ = KEYBOARD_MATCH_GO_REGEX.firstMatch(in: linkString,
+                                                         options: [],
+                                                         range: linkRange) {
+      return false
+    } else if linkString.starts(with: "keyman: ") {
+      return false
+    }
+
+    return true
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/UniversalLinks.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/UniversalLinks.swift
@@ -73,7 +73,7 @@ public class UniversalLinks {
                                                          options: [],
                                                          range: linkRange) {
       return false
-    } else if linkString.starts(with: "keyman: ") {
+    } else if linkString.starts(with: "keyman:") {
       return false
     }
 

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -55,6 +55,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     SentryManager.start()
 
+    UniversalLinks.externalLinkLauncher = { url in
+      UIApplication.shared.openURL(url)
+    }
+
     #if DEBUG
       KeymanEngine.log.outputLevel = .debug
       log.outputLevel = .debug


### PR DESCRIPTION
Designed to parallel #3602... assuming I interpreted its changes correctly.  I'm not 100% sure that I did.

This is more complicated than might be desired due to Swift restrictions on the method for launching URLs externally.  Those complications motivated the `private static var` approach as a workaround.