### PR TITLE
fix(mac): codesign resilience

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -996,7 +996,7 @@
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				OTHER_CODE_SIGN_FLAGS = "--timestamp";
+				OTHER_CODE_SIGN_FLAGS = "--timestamp --verbose";
 				PRODUCT_BUNDLE_IDENTIFIER = "keyman.inputmethod.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PRODUCT_VERSION = 0.0.1;
@@ -1036,7 +1036,7 @@
 				INFOPLIST_FILE = Keyman4MacIM/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				OTHER_CODE_SIGN_FLAGS = "--timestamp";
+				OTHER_CODE_SIGN_FLAGS = "--timestamp --verbose";
 				PRODUCT_BUNDLE_IDENTIFIER = "keyman.inputmethod.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PRODUCT_VERSION = 0.0.1;

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -286,8 +286,17 @@ execBuildCommand() {
     typeset ret_code
 
     displayInfo "Building $component:" "$cmnd"
+    set +e
     eval $cmnd
+    set -e
     ret_code=$?
+    if [ $ret_code == 65 ]; then
+        # This is often a codesign failure, possibly due to a timeout. We'll retry once before failing
+        displayInfo "Failed to build with code 65, possibly codesign failure. Retrying build of $component:" "$cmnd"
+        eval $cmnd
+        ret_code=$?
+    fi
+
     if [ $ret_code != 0 ]; then
         fail "Build of $component failed! Error: [$ret_code] when executing command: '$cmnd'"
     fi

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -288,8 +288,8 @@ execBuildCommand() {
     displayInfo "Building $component:" "$cmnd"
     set +e
     eval $cmnd
-    set -e
     ret_code=$?
+    set -e
     if [ $ret_code == 65 ]; then
         # This is often a codesign failure, possibly due to a timeout. We'll retry once before failing
         displayInfo "Failed to build with code 65, possibly codesign failure. Retrying build of $component:" "$cmnd"


### PR DESCRIPTION
This PR tries to make codesign more resilient to failure, by retrying a build step that falls over with code 65. This code is not limited to codesign but most frequently happens with it.

A more complete answer would be to do the codesigning step in build.sh instead of in the project, which would give us more control of the outcome, and maybe simplify the build process somewhat, but I will leave that for now, because it is usually better to leave that to XCode.