### PR TITLE
fix(common/models): proper RTL quote ordering

### DIFF
--- a/common/models/templates/src/quote-behavior.ts
+++ b/common/models/templates/src/quote-behavior.ts
@@ -28,14 +28,6 @@ namespace models {
         case QuoteBehavior.useQuotes:
           let {open, close} = punctuation.quotesForKeepSuggestion;
   
-          // TODO:  Is this the right thing to do under RTL?
-          //        We need an extra pass over this section to validate it.
-          if(punctuation.isRTL) {
-            let temp = close;
-            close = open;
-            open = temp;
-          }
-  
           // This part's simple enough, at least.
           return open + text + close;
         default:

--- a/common/models/templates/test/test-quote-behavior.js
+++ b/common/models/templates/test/test-quote-behavior.js
@@ -31,7 +31,18 @@ describe('Quote behaviors', function() {
     });
 
     it.skip('RTL', function() {
-      // TODO:
+      let englishPunctuation = {
+        quotesForKeepSuggestion: { open: `”`, close: `“`},
+        insertAfterWord: " ",
+        isRTL: false
+      }
+
+      var plainQuotedHello;
+      plainQuotedHello = QuoteBehavior.apply(QuoteBehavior.useQuotes, "hello", englishPunctuation, QuoteBehavior.useQuotes);
+      assert.equal(plainQuotedHello, "”hello“");
+
+      // That said... it's very hard to get an assertion in place regarding the
+      // resulting visual appearance of this test.
     });
   });
 


### PR DESCRIPTION
Fixes the output ordering of quotation-style punctuation characters for RTL languages.