### PR TITLE
fix(mac): support page and copyright

### DIFF
--- a/mac/Keyman4Mac/Keyman4Mac/Info.plist
+++ b/mac/Keyman4Mac/Keyman4Mac/Info.plist
@@ -10,6 +10,8 @@
 	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleGetInfoString</key>
+	<string>.</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -40,6 +42,8 @@
 		<string>-alpha-local</string>
 		<key>VersionWithTag</key>
 		<string>$(PRODUCT_VERSION)-alpha-local</string>
+		<key>VersionRelease</key>
+		<string>x.y</string>
 	</dict>
 </dict>
 </plist>

--- a/mac/Keyman4MacIM/Keyman4MacIM/Info.plist
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Info.plist
@@ -68,6 +68,8 @@
 		<string>-alpha-local</string>
 		<key>VersionWithTag</key>
 		<string>$(PRODUCT_VERSION)-alpha-local</string>
+		<key>VersionRelease</key>
+		<string>x.y</string>
 	</dict>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
@@ -30,14 +30,9 @@
     
     // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
     [self.window setBackgroundColor:[NSColor whiteColor]];
-    NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *build = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleVersionKey];
-    if ([version isEqualToString:build]) {
-        [self.versionLabel setStringValue:[NSString stringWithFormat:@"Version %@", version]];
-    }
-    else {
-        [self.versionLabel setStringValue:[NSString stringWithFormat:@"Version %@ (build %@)", version, build]];
-    }
+
+    KeymanVersionInfo versionInfo = [[self AppDelegate] versionInfo];
+    [self.versionLabel setStringValue:[NSString stringWithFormat:@"Version %@", versionInfo.versionWithTag]];
          
     NSMutableString *copyrightInfo = [[NSMutableString alloc] initWithString: [[[NSBundle mainBundle] infoDictionary] objectForKey:@"NSHumanReadableCopyright"]];
     [self.copyrightLabel setStringValue:copyrightInfo];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -57,9 +57,12 @@
     [_tableView registerForDraggedTypes:@[NSFilenamesPboardType]];
     _lastReloadDate = [NSDate date];
     [self startTimer];
+
+    KeymanVersionInfo versionInfo = [[self AppDelegate] versionInfo];
+    NSString *versionUrl = [NSString stringWithFormat:@"https://%@/products/mac/%@", versionInfo.helpKeymanCom, versionInfo.versionRelease];
     
     [self.webView setFrameLoadDelegate:(id<WebFrameLoadDelegate>)self];
-    [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://help.keyman.com/products/macosx/"]]];
+    [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString: versionUrl]]];
 
     [self.alwaysShowOSKCheckBox setState:(self.AppDelegate.alwaysShowOSK ? NSOnState : NSOffState)];
     [self.useVerboseLoggingCheckBox setState:(self.AppDelegate.useVerboseLogging ? NSOnState : NSOffState)];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMDownloadKeyboard/KMDownloadKBWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMDownloadKeyboard/KMDownloadKBWindowController.m
@@ -27,7 +27,8 @@
     [self.webView setPolicyDelegate:(id<WebPolicyDelegate>)self];
     
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *url = [NSString stringWithFormat:@"https://keyman.com/go/macos/10.0/download-keyboards/?version=%@", version];
+    KeymanVersionInfo keymanVersionInfo = [[self AppDelegate] versionInfo];
+    NSString *url = [NSString stringWithFormat:@"https://%@/go/macos/14.0/download-keyboards/?version=%@", keymanVersionInfo.keymanCom, version];
     if (self.AppDelegate.debugMode)
         NSLog(@"KMDownloadKBWindowController opening url = %@, version = '%@'", url, version);
     [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
@@ -156,7 +156,9 @@
 
         NSString *linkFormat = @"<a href='%@'>%@</a>";
         NSString *packageId = [self.packagePath lastPathComponent];
-        NSString *shareUrl = [NSString stringWithFormat:@"https://keyman.com/go/keyboard/%@/share", packageId];
+
+        KeymanVersionInfo keymanVersionInfo = [[self AppDelegate] versionInfo];
+        NSString *shareUrl = [NSString stringWithFormat:@"https://%@/go/keyboard/%@/share", keymanVersionInfo.keymanCom, packageId];
         NSString *name = [[self.infoDict objectForKey:kName] objectAtIndex:0];
         if (name == nil)
             name = @"Unknown Keyboard Package";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -44,6 +44,16 @@ extern NSString *const kReadMeFile;
 extern NSString *const kVersion;
 extern NSString *const kWebSite;
 
+typedef struct {
+    NSString *sentryEnvironment;
+    NSString *versionRelease;
+    NSString *versionWithTag;
+    NSString *tier;
+    NSString *keymanCom;
+    NSString *helpKeymanCom;
+    NSString *apiKeymanCom;
+} KeymanVersionInfo;
+
 @interface KMInputMethodAppDelegate : NSObject
 #define USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE 1
 #ifdef USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE
@@ -113,7 +123,7 @@ extern NSString *const kWebSite;
 - (NSString *)kvkFilePathFromFilename:(NSString *)kvkFilename;
 - (NSString *)oskWindowTitle;
 - (void)postKeyboardEventWithSource: (CGEventSourceRef)source code:(CGKeyCode) virtualKey postCallback:(PostEventCallback)postEvent;
-
+- (KeymanVersionInfo)versionInfo;
 @end
 
 #endif /* KMInputMethodAppDelegate_h */

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -110,17 +110,38 @@ id _lastServerWithOSKShowing = nil;
     return self;
 }
 
+- (KeymanVersionInfo)versionInfo {
+    KeymanVersionInfo result;
+    // Get version information from Info.plist, which is filled in 
+    // by build.sh.
+    NSDictionary *keymanInfo =[[[NSBundle mainBundle] infoDictionary] objectForKey:@"Keyman"];
+    result.sentryEnvironment = [keymanInfo objectForKey:@"SentryEnvironment"];
+    result.tier = [keymanInfo objectForKey:@"Tier"];
+    result.versionRelease = [keymanInfo objectForKey:@"VersionRelease"];
+    result.versionWithTag = [keymanInfo objectForKey:@"VersionWithTag"];
+    if([result.tier isEqualToString:@"stable"]) {
+        result.keymanCom = @"keyman.com";
+        result.helpKeymanCom = @"help.keyman.com";
+        result.apiKeymanCom = @"api.keyman.com";
+    } 
+    else {
+        result.keymanCom = @"keyman-staging.com";
+        result.helpKeymanCom = @"help.keyman-staging.com";
+        result.apiKeymanCom = @"api.keyman-staging.com";
+    }
+    return result;
+}
+
 -(void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{ @"NSApplicationCrashOnExceptions": @YES }];
 
-    NSDictionary *keymanInfo =[[[NSBundle mainBundle] infoDictionary] objectForKey:@"Keyman"];
-    NSString *sentryEnvironment = [keymanInfo objectForKey:@"SentryEnvironment"];
-    NSString *releaseName = [NSString stringWithFormat:@"release-%@", [keymanInfo objectForKey:@"VersionWithTag"]];
+    KeymanVersionInfo keymanVersionInfo = [self versionInfo];
+    NSString *releaseName = [NSString stringWithFormat:@"release-%@", keymanVersionInfo.versionWithTag];
     
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"https://960f8b8e574c46e3be385d60ce8e1fea@sentry.keyman.com/9";
         options.releaseName = releaseName;
-        options.environment = sentryEnvironment;
+        options.environment = keymanVersionInfo.sentryEnvironment;
         // options.debug = @YES; 
     }];
     

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/Info.plist
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/Info.plist
@@ -32,6 +32,8 @@
 		<string>-alpha-local</string>
 		<key>VersionWithTag</key>
 		<string>$(PRODUCT_VERSION)-alpha-local</string>
+		<key>VersionRelease</key>
+		<string>x.y</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(COPYRIGHT_STRING_RIGHTS)</string>

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -305,9 +305,11 @@ execBuildCommand() {
 updatePlist() {
 	if $UPDATE_VERSION_IN_PLIST ; then
 		KM_PLIST="$1"
+        APPNAME="$2"
 		if [ ! -f "$KM_PLIST" ]; then
 			fail "File not found: $KM_PLIST"
 		fi
+        local YEAR=`date "+%Y"`
         echo "Setting version and related fields to $VERSION_WITH_TAG in $KM_PLIST"
         /usr/libexec/Plistbuddy -c "Set CFBundleVersion $VERSION" "$KM_PLIST"
         /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $VERSION" "$KM_PLIST"
@@ -315,6 +317,9 @@ updatePlist() {
         /usr/libexec/Plistbuddy -c "Set :Keyman:Tier $TIER" "$KM_PLIST"
         /usr/libexec/Plistbuddy -c "Set :Keyman:VersionTag $VERSION_TAG" "$KM_PLIST"
         /usr/libexec/Plistbuddy -c "Set :Keyman:VersionWithTag $VERSION_WITH_TAG" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionRelease $VERSION_RELEASE" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set CFBundleGetInfoString $APPNAME $VERSION_WITH_TAG for macOS, Copyright © 2017-$YEAR SIL International." "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set NSHumanReadableCopyright Copyright © 2017-$YEAR SIL International." "$KM_PLIST"
 	fi
 }
 
@@ -324,7 +329,7 @@ if $DO_KEYMANENGINE ; then
     echo_heading "Building Keyman Engine"
     execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS $BUILD_ACTIONS $TEST_ACTION -scheme $ENGINE_NAME"
     execBuildCommand "$ENGINE_NAME dSYM file" "dsymutil \"$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework/Versions/A/$ENGINE_NAME\" -o \"$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework.dSYM\""
-    updatePlist "$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework/Resources/Info.plist"
+    updatePlist "$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework/Resources/Info.plist" "Keyman Engine"
 fi
 
 ### Build Keyman.app (Input Method and Configuration app) ###
@@ -341,7 +346,7 @@ if $DO_KEYMANIM ; then
     		execBuildCommand "$IM_NAME tests" "xcodebuild $TEST_ACTION -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS -scheme Keyman SYMROOT=\"$KM4MIM_BASE_PATH/build\""
     	fi
     fi
-    updatePlist "$KM4MIM_BASE_PATH/build/$CONFIG/Keyman.app/Contents/Info.plist"
+    updatePlist "$KM4MIM_BASE_PATH/build/$CONFIG/Keyman.app/Contents/Info.plist" "Keyman"
 
     # Upload symbols
 
@@ -366,7 +371,7 @@ fi
 if $DO_KEYMANTESTAPP ; then
     echo_heading "Building test app"
     execBuildCommand $TESTAPP_NAME "xcodebuild -project \"$KMTESTAPP_PROJECT_PATH\" $BUILD_OPTIONS $BUILD_ACTIONS"
-    updatePlist "$KMTESTAPP_BASE_PATH/build/$CONFIG/$TESTAPP_NAME.app/Contents/Info.plist"
+    updatePlist "$KMTESTAPP_BASE_PATH/build/$CONFIG/$TESTAPP_NAME.app/Contents/Info.plist" "Keyman Test App"
 fi
 
 ### Notarize the app for preprelease ###


### PR DESCRIPTION
Fixes #3849.

* Uses keyman-staging.com when on alpha or beta
* Updates copyright year at build time
* Fixes link to help documentation (/mac, not /macosx)