### PR TITLE
chore(mac): use new keyboard install page

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMDownloadKeyboard/KMDownloadKBWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMDownloadKeyboard/KMDownloadKBWindowController.m
@@ -34,18 +34,57 @@
     [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
 }
 
+- (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request newFrameName:(NSString *)frameName decisionListener:(id<WebPolicyDecisionListener>)listener {
+    [[NSWorkspace sharedWorkspace] openURL:[actionInformation objectForKey:WebActionOriginalURLKey]];
+    [listener ignore];
+}
+
 - (void)webView:(WebView *)webView decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener {
-    NSString* url = [[request URL] description];
+    NSString* url = [[request URL] absoluteString];
     if (self.AppDelegate.debugMode)
         NSLog(@"decidePolicyForNavigationAction, navigating to %@", url);
     
-    if ([request.URL.absoluteString startsWith:@"keyman:"]) {
-        if ([request.URL.absoluteString startsWith:@"keyman:link?url="])
+    // The pattern for matching links matches work in #3602
+    NSString* urlPathMatchKeyboardsInstall = @"^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/keyboards/install/([^?/]+)(?:\\?(.+))?$";
+                                             // e.g. https://keyman.com/keyboards/install/foo
+    NSString* urlPathMatchKeyboardsRoot = @"^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/keyboards([/?].*)?$";
+                                          // http://keyman.com.local/keyboards/foo
+    NSString* urlPathMatchKeyboardsGo = @"^http(?:s)?://keyman(?:-staging)?\\.com(?:\\.local)?/go/macos/[^/]+/download-keyboards";
+                                        // https://keyman-staging.com/go/macos/14.0/download-keyboards?version=14.0.146.0
+    NSRange range = NSMakeRange(0, url.length);
+
+    NSError* error;
+    NSRegularExpression* regexInstall = [NSRegularExpression regularExpressionWithPattern: urlPathMatchKeyboardsInstall options: 0 error: &error];
+    NSRegularExpression* regexRoot = [NSRegularExpression regularExpressionWithPattern: urlPathMatchKeyboardsRoot options: 0 error: &error];
+    NSRegularExpression* regexGo = [NSRegularExpression regularExpressionWithPattern: urlPathMatchKeyboardsGo options: 0 error: &error];
+
+    NSArray* matchesInstall = [regexInstall matchesInString:url options:0 range:range];
+
+    if(matchesInstall.count > 0) {
+        if (self.AppDelegate.debugMode)
+            NSLog(@"Farming out download to app delegate.");
+        [listener ignore];
+        NSTextCheckingResult* match = (NSTextCheckingResult*) matchesInstall[0];
+        NSString* matchKeyboardId = [url substringWithRange:[match rangeAtIndex:1]];
+        // Install keyboard link
+        [self.AppDelegate downloadKeyboardFromKeyboardId:matchKeyboardId];
+        //[self.AppDelegate processURL:url];
+    }
+    else if([regexRoot numberOfMatchesInString:url options:0 range:range] > 0 ||
+        [regexGo numberOfMatchesInString:url options:0 range:range] > 0) {
+        // allow https://keyman.com/keyboards* to go through
+        // allow https://keyman.com/go/macos/download-keyboards to go through
+        if (self.AppDelegate.debugMode)
+            NSLog(@"Accepting link in this browser.");
+       [listener use];
+    }
+    else if([url startsWith:@"keyman:"]) {
+        if ([url startsWith:@"keyman:link?url="])
         {
+            if (self.AppDelegate.debugMode)
+                NSLog(@"Opening keyman:link URL in default browser: %@", url);
             [listener ignore];
             url = [request.URL.absoluteString substringFromIndex:[@"keyman:link?url=" length]];
-            if (self.AppDelegate.debugMode)
-                NSLog(@"Opening URL in default browser: %@", url);
             [[NSWorkspace sharedWorkspace] openURL: [[NSURL alloc] initWithString:url]];
         }
         else {
@@ -57,9 +96,11 @@
     }
     else
     {
+        // Open in external browser
         if (self.AppDelegate.debugMode)
-            NSLog(@"Normal navigation in webview.");
-        [listener use];
+            NSLog(@"Opening URL in default browser: %@", url);
+        [listener ignore];
+        [[NSWorkspace sharedWorkspace] openURL: [[NSURL alloc] initWithString:url]];
     }
 }
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -113,6 +113,7 @@ typedef struct {
 - (NSWindowController *)infoWindow_;
 - (NSWindowController *)kbHelpWindow_;
 - (void)processURL:(NSString*)rawUrl;
+- (void)downloadKeyboardFromKeyboardId:(NSString *)keyboardId;
 - (NSString *)kmxFilePathAtIndex:(NSUInteger)index;
 - (NSString *)packagePathAtIndex:(NSUInteger)index;
 - (NSInteger)indexForPackageFolder:(NSString *)packageFolder;


### PR DESCRIPTION
Fixes #3898.

This reworks the keyboard download window to use the new keyboard install page and url pattern. Some refactoring of the downloadKeyboard method was required to handle the new download patterns.

We need to start looking at moving the Configuration dialog into a model where it runs as a separate process, so it does not need to be floating and can be accessed through the dock or Cmd+Tab etc. Right now, clicking an external link opens in the browser, but the browser is stuck behind the window. This is a separate job though.

![image](https://user-images.githubusercontent.com/4498365/99751628-b7fd6f00-2b36-11eb-9a4e-db34445c5dd9.png)

![image](https://user-images.githubusercontent.com/4498365/99751660-c51a5e00-2b36-11eb-8b58-d45d1a3cf4f9.png)

![image](https://user-images.githubusercontent.com/4498365/99751686-d19eb680-2b36-11eb-8c73-fc7e600f086e.png)
