### PR TITLE
fix(web/engine): fixes OSK rotation

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -77,6 +77,7 @@
         oskHeight = h;
       }
       var kmw=window['keyman'];
+      kmw.core.activeKeyboard.refreshLayouts();
       kmw['correctOSKTextSize']();
     }
 

--- a/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -349,6 +349,18 @@ namespace com.keyman.keyboards {
       }
     }
 
+    public refreshLayouts() {
+      let formFactors = [ utils.FormFactor.Desktop, utils.FormFactor.Phone, utils.FormFactor.Tablet ];
+
+      let _this = this;
+
+      formFactors.forEach(function(form) {
+        // Currently doesn't work if we reset it to POLYFILLED, likely due to how 'calibration'
+        // currently works.
+        _this.layoutStates[form] = LayoutState.NOT_LOADED;
+      });
+    }
+
     public markLayoutCalibrated(formFactor: utils.FormFactor) {
       if(this.layoutStates[formFactor] != LayoutState.NOT_LOADED) {
         this.layoutStates[formFactor] = LayoutState.CALIBRATED;

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -90,6 +90,7 @@
             function setOskHeight(height) {
                 var kmw=window['keyman'];
                 oskHeight = height;
+                kmw.core.activeKeyboard.refreshLayouts();
                 kmw.osk.show(true);
                 kmw['correctOSKTextSize']();
             }

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -464,6 +464,7 @@ namespace com.keyman.keyboards {
             
             // Re-initializate OSK before returning if required
             if(this.keymanweb.mustReloadKeyboard) {
+              activeKeyboard.refreshLayouts();
               osk._Load();
             }
             return Promise.resolve();
@@ -489,6 +490,9 @@ namespace com.keyman.keyboards {
       for(Ln=0; Ln<this.keyboards.length; Ln++) { // I1511 - array prototype extended
         if(this.keyboards[Ln]['KI'] == PInternalName) {
           keyman.core.activeKeyboard = new Keyboard(this.keyboards[Ln]);
+          // As a rotation may have occurred since the keyboard was swapped out,
+          // we should refresh its layouts.
+          keyman.core.activeKeyboard.refreshLayouts();
           this.keymanweb.domManager._SetTargDir(this.keymanweb.domManager.getLastActiveElement());  // I2077 - LTR/RTL timing
         
           // and update the active stub
@@ -503,6 +507,7 @@ namespace com.keyman.keyboards {
         }
       }
 
+      // If we've reached this point, this is the first load request for the requested keyboard.
       if(keyman.core.activeKeyboard == null) {
         for(Ln=0; Ln<this.keyboardStubs.length; Ln++) { // I1511 - array prototype extended
           if((this.keyboardStubs[Ln]['KI'] == PInternalName) 

--- a/web/source/kmwrotation.ts
+++ b/web/source/kmwrotation.ts
@@ -47,6 +47,8 @@ namespace com.keyman {
       var osk = this.keyman.osk;
       // TODO:  Reattach later in the refactoring process!
       //osk.hideLanguageList();
+      // Force a re-layout for the active keyboard's currently-utilized layout.
+      this.keyman.core.activeKeyboard.refreshLayouts();
       osk._Load();
       if(this.oskVisible) {
         osk._Show();


### PR DESCRIPTION
Fixes #3049.

In my zeal to make OSK rendering more efficient during the KMW core refactor, the optimizations kind of neglected how OSK rotation works when deciding to reuse layout calcuations; a rebuild of the OSK layer group had always been required to properly adjust OSK dimensions.  This PR provides a pathway to restore recomputation/reconstruction of the layer group whenever a rotation occurs:  `Keyboard.refreshLayouts()`.

Once this method is called on a keyboard, the next `VisualKeyboard._Load()` call against an OSK for it will be forced to recalculate its layout information and thus will readjust its dimensions to the currently-expected values in the same manner it always did before.  While 'better' approaches may be possible in the future, this is a simple and safe way to fix the issue for now.