### PR TITLE
fix(ios/engine): changes image-banner display logic

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -604,10 +604,10 @@ extension KeymanWebViewController: KeymanWebDelegate {
   func updateShowBannerSetting() {
     let userData = Storage.active.userDefaults
     let alwaysShow = userData.bool(forKey: Key.optShouldShowBanner)
-    if Manager.shared.isSystemKeyboard || alwaysShow {
-      showBanner(true)
-    } else {
+    if !Manager.shared.isSystemKeyboard {
       showBanner(false)
+    } else {
+      showBanner(alwaysShow)
     }
   }
   


### PR DESCRIPTION
Fixes #2836.

The "image banner" will now only display when "Always show banner" is selected _**and**_ the system keyboard is active.

Honestly, I was surprised at just how simple the change turned out to be.  I get the feeling that #3909 may have prevented would-be complications.

In regard to #2907, key previews / popup keys seem to display properly, though sometimes the predictive-text banner will not display upon initial load of the system keyboard.  So, that issue isn't fully resolved yet, though at least #2836 will be.