### PR TITLE
chore(linux): Fix launchpad build (closes #3875)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ lerna-debug.log
 
 # Cached/auto-compiled Python bytecode
 *.pyc
+
+# Debian watch file - we generate it from watch.in
+watch

--- a/common/core/desktop/debian/watch
+++ b/common/core/desktop/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/keyman-keyboardprocessor-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-keyman/debian/watch
+++ b/linux/ibus-keyman/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/ibus-keyman-(.+)\.tar\.gz debian uupdate

--- a/linux/ibus-kmfl/debian/watch
+++ b/linux/ibus-kmfl/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/ibus-kmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/keyman-config/debian/watch
+++ b/linux/keyman-config/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/keyman_config-(.+)\.tar\.gz debian uupdate

--- a/linux/kmflcomp/debian/watch
+++ b/linux/kmflcomp/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/kmflcomp-(.+)\.tar\.gz debian uupdate

--- a/linux/libkmfl/debian/watch
+++ b/linux/libkmfl/debian/watch
@@ -1,3 +1,0 @@
-version=4
-# Tier set by launchpad.sh script
-https://downloads.keyman.com/linux/$tier/(\d\S+)/libkmfl-(.+)\.tar\.gz debian uupdate

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -37,7 +37,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-if [ ! `which xmllint` ]; then
+if [ ! $(which xmllint) ]; then
     echo "you must install xmllint (libxml2-utils package) to use this script"
     exit 1
 fi
@@ -61,7 +61,7 @@ else
 fi
 
 
-BASEDIR=`pwd`
+BASEDIR=$(pwd)
 
 rm -rf launchpad
 mkdir -p launchpad
@@ -72,30 +72,28 @@ for proj in ${projects}; do
     else
        cd ${proj}
     fi
+
     if [ "${proj}" == "keyman-config" ]; then
-        tarname="keyman_config"
         make clean
-    else
-        tarname="${proj}"
     fi
 
     # Update tier in Debian watch files (replacing any previously set tier)
-    sed -i "s/\$tier\|alpha\|beta\|stable/${TIER}/g" debian/watch
+    sed "s/\$tier\|alpha\|beta\|stable/${TIER}/g" $BASEDIR/scripts/watch.in > debian/watch
 
-    version=`uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -`
-    dirversion=`uscan --report --dehs|xmllint --xpath "//dehs/upstream-url/text()" - | cut -d/ -f6`
+    version=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -)
+    dirversion=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-url/text()" - | cut -d/ -f6)
     echo "${proj} version is ${version}"
     uscan
     cd ..
     mv ${proj}-${version} ${BASEDIR}/launchpad
     mv ${proj}_${version}.orig.tar.gz ${BASEDIR}/launchpad
-    mv ${tarname}-${version}.tar.gz ${BASEDIR}/launchpad
+    mv ${proj}-${version}.tar.gz ${BASEDIR}/launchpad
     rm ${proj}*.debian.tar.xz
     cd ${BASEDIR}/launchpad
     wget -N https://downloads.keyman.com/linux/${TIER}/${dirversion}/SHA256SUMS
-    sha256sum -c --ignore-missing SHA256SUMS |grep ${tarname}
+    sha256sum -c --ignore-missing SHA256SUMS |grep ${proj}
     cd ${proj}-${version}
-    echo `pwd`
+    echo $(pwd)
     cp debian/changelog ../${proj}-changelog
     #TODO separate source builds and dputs for each of $dists?
     for dist in ${distributions}; do

--- a/linux/scripts/watch.in
+++ b/linux/scripts/watch.in
@@ -1,0 +1,3 @@
+version=4
+# Tier set by launchpad.sh script
+https://downloads.keyman.com/linux/$tier/@ANY_VERSION@/@PACKAGE@@ANY_VERSION@@ARCHIVE_EXT@ debian uupdate


### PR DESCRIPTION
This change fixes the launchpad build script and also improves updating the watch file.

If we use the variables that `uscan` provides we don't have to hard-code the package name in the watch file. This makes it possible to use a generic one for all packages.