### PR TITLE
fix(linux): Don't fail installation if restarting ibus fails (v13)

### DIFF
--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -14,10 +14,14 @@ case "$1" in
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        sudo -H -u "$ibususer" ibus exit
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus exit || true
+        fi
       else
-        ibususer=`ps -C ibus-daemon -o user=`
-        sudo -H -u "$ibususer" ibus restart
+        ibususer=`ps -C ibus-daemon -o user=|uniq`
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus restart || true
+        fi
       fi
     fi
   ;;

--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -13,15 +13,15 @@ case "$1" in
       ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
-        ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        if [ "x$ibususer" != "x" ]; then
+        ibususers=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
+        for ibususer in $ibususers; do
           sudo -H -u "$ibususer" ibus exit || true
-        fi
+        done
       else
-        ibususer=`ps -C ibus-daemon -o user=|uniq`
-        if [ "x$ibususer" != "x" ]; then
+        ibususers=`ps -C ibus-daemon -o user=|uniq`
+        for ibususer in $ibususers; do
           sudo -H -u "$ibususer" ibus restart || true
-        fi
+        done
       fi
     fi
   ;;

--- a/linux/ibus-keyman/debian/postrm
+++ b/linux/ibus-keyman/debian/postrm
@@ -14,10 +14,14 @@ case "$1" in
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        sudo -H -u "$ibususer" ibus exit
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus exit || true
+        fi
       else
-        ibususer=`ps -C ibus-daemon -o user=`
-        sudo -H -u "$ibususer" ibus restart
+        ibususer=`ps -C ibus-daemon -o user=|uniq`
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus restart || true
+        fi
       fi
     fi
   ;;

--- a/linux/ibus-keyman/debian/postrm
+++ b/linux/ibus-keyman/debian/postrm
@@ -13,15 +13,15 @@ case "$1" in
       ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
-        ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        if [ "x$ibususer" != "x" ]; then
+        ibususers=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
+        for ibususer in $ibususers; do
           sudo -H -u "$ibususer" ibus exit || true
-        fi
+        done
       else
-        ibususer=`ps -C ibus-daemon -o user=|uniq`
-        if [ "x$ibususer" != "x" ]; then
+        ibususers=`ps -C ibus-daemon -o user=|uniq`
+        for ibususer in $ibususers; do
           sudo -H -u "$ibususer" ibus restart || true
-        fi
+        done
       fi
     fi
   ;;


### PR DESCRIPTION
If (re-)starting ibus fails for whatever reason we should simply ignore the failure instead of failing the entire installation/uninstallation.

This fixes #3902.