### PR TITLE
fix(linux): Don't fail installation if restarting ibus fails

### DIFF
--- a/linux/ibus-keyman/debian/postinst
+++ b/linux/ibus-keyman/debian/postinst
@@ -15,12 +15,12 @@ case "$1" in
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
         if [ "x$ibususer" != "x" ]; then
-          sudo -H -u "$ibususer" ibus exit
+          sudo -H -u "$ibususer" ibus exit || true
         fi
       else
         ibususer=`ps -C ibus-daemon -o user=|uniq`
         if [ "x$ibususer" != "x" ]; then
-          sudo -H -u "$ibususer" ibus restart
+          sudo -H -u "$ibususer" ibus restart || true
         fi
       fi
     fi

--- a/linux/ibus-keyman/debian/postrm
+++ b/linux/ibus-keyman/debian/postrm
@@ -14,10 +14,14 @@ case "$1" in
       if [ "x$gspid" != "x" ]; then
         # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
         ibususer=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
-        sudo -H -u "$ibususer" ibus exit
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus exit || true
+        fi
       else
         ibususer=`ps -C ibus-daemon -o user=|uniq`
-        sudo -H -u "$ibususer" ibus restart
+        if [ "x$ibususer" != "x" ]; then
+          sudo -H -u "$ibususer" ibus restart || true
+        fi
       fi
     fi
   ;;


### PR DESCRIPTION
If (re-)starting ibus fails for whatever reason we should simply ignore the failure instead of failing the entire installation/uninstallation.

This fixes #3902.