### PR TITLE
fix(windows): sentry range check error

### DIFF
--- a/windows/src/ext/sentry/Sentry.Client.pas
+++ b/windows/src/ext/sentry/Sentry.Client.pas
@@ -556,7 +556,7 @@ begin
       Continue;
     end;
 
-    raw_frames[n] := frame.AddrPC.Offset;
+    raw_frames[n] := NativeUInt(frame.AddrPC.Offset);
     Inc(n);
   end;
 


### PR DESCRIPTION
In some circumstances, Sentry would get a range check error while processing the call stack due to `DWORD` being defined as `NativeInt`, not `NativeUInt`, in old JWA libraries. This would mask the original exception, and could cause the app to hang.