### PR TITLE
fix(android/oem): Check keyboard selected  before allowing setup

### DIFF
--- a/oem/firstvoices/android/.editorconfig
+++ b/oem/firstvoices/android/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+; applies to all files
+[*]
+indent_style = space
+
+[*.{java, sh, css, html, xml}]
+indent_size = 4

--- a/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
+++ b/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
@@ -17,19 +17,19 @@
 }
 
 html, body{
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	padding: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    padding: 0;
 }
 
 html{
-	margin: 0;
-	min-height: 100%;
-	position: relative;
+    margin: 0;
+    min-height: 100%;
+    position: relative;
 }
 
 body{
-	background: #f7511e;
+    background: #f7511e;
     background: -moz-linear-gradient(25deg,  #f7511e 0%, #aa1225 55%, #9f031f 100%);
     background: -webkit-gradient(linear, left bottom, right top, color-stop(0%,#f7511e), color-stop(55%,#aa1225), color-stop(100%,#9f031f));
     background: -webkit-linear-gradient(25deg,  #f7511e 0%,#aa1225 55%,#9f031f 100%);
@@ -37,19 +37,19 @@ body{
     background: -ms-linear-gradient(25deg,  #f7511e 0%,#aa1225 55%,#9f031f 100%);
     /*background: linear-gradient(25deg,  #f7511e 0%,#aa1225 55%,#9f031f 100%);*/
 
-	color: #fff;
-	font-family: 'Open Sans';
-	margin: 0 0 200px 0;
+    color: #fff;
+    font-family: 'Open Sans';
+    margin: 0 0 200px 0;
 }
 
 #instructions{
-	padding: 0 30px 10px;
-	width: calc(100% - 60px);
+    padding: 0 30px 10px;
+    width: calc(100% - 60px);
 }
 
 #instructions p{
-	font-size: 0.875em;
-	margin: 15px 0;
+    font-size: 0.875em;
+    margin: 15px 0;
 }
 
 #logo {
@@ -59,8 +59,8 @@ body{
 }
 
 #logo img{
-	max-width: 400px;
-	width: 100%;
+    max-width: 400px;
+    width: 100%;
 }
 
 #logo p{
@@ -73,44 +73,44 @@ body{
 }
 
 h2{
-	color: #ffd988;
-	font-family: 'Nunito';
-	font-size: 1.25em;
-	font-weight: normal;
+    color: #ffd988;
+    font-family: 'Nunito';
+    font-size: 1.25em;
+    font-weight: normal;
 }
 
 .steps{
-	display: table;
-	width: 100%;
+    display: table;
+    width: 100%;
 }
 
 .step{
-	display: table-row;
+    display: table-row;
 }
 
 .step-number, .step-instruction{
-	border-bottom: 1px solid #A0BC76;
-	display: table-cell;
-	vertical-align: top;
+    border-bottom: 1px solid #A0BC76;
+    display: table-cell;
+    vertical-align: top;
 }
 
 .step-number{
-	width: 80px;
+    width: 80px;
 }
 
 .step-number img{
-	display: block;
-	height: 30px;
-	margin: 15px auto;
-	width: 30px;
-	-webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
-	filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
+    display: block;
+    height: 30px;
+    margin: 15px auto;
+    width: 30px;
+    -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
+    filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
 }
 
 .step-number span {
     display: block;
     height: 30px;
-    line-height: 15px;
+    line-height: 25px;
     margin: 15px auto;
     width: 30px;
     -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
@@ -128,34 +128,49 @@ h2{
 }
 
 .steps.use .step-number, .steps.use .step-instruction{
-	border-bottom: 0 none;
+    border-bottom: 0 none;
 }
 
 .step-instruction{
-	margin-top: 10px;
+    margin-top: 10px;
 }
 
 .step-instruction img{
-	-webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
-	filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
-	height: 30px;
-	margin-right: 5px;
-	vertical-align: top;
-	width: 30px;
-	opacity: 0.25;
+    -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
+    filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
+    height: 30px;
+    margin-right: 5px;
+    vertical-align: top;
+    width: 30px;
+    opacity: 0.25;
 }
 
 .step-instruction input[type="button"]{
-	background-color: #DDDDDD;
-	border: 0 none;
-	border-radius: 5px;
-	color: #333;
-	-webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
-	filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
-	height: 30px;
-	line-height: 30px;
-	text-transform: uppercase;
-	width: 180px;
+    background-color: #DDDDDD;
+    border: 0 none;
+    border-radius: 5px;
+    color: #333;
+    -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
+    filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
+    height: 30px;
+    line-height: 30px;
+    width: 150px;
+}
+
+.checkIconOff {
+    alt: 'CheckBoxOff';
+    background: url('check-off.png');
+    opacity: 0.25;
+}
+
+.checkIconOn {
+    alt: 'CheckBoxOn';
+    background: url('check-on.png');
+    opacity: 1.0;
+}
+
+#button2:disabled {
+    opacity: 0.25;
 }
 
 #supporters{
@@ -207,9 +222,9 @@ h2{
 }
 
 #footer{
-	background-color: #605E4B;
-	color: #CFCEC8;
-	height: 200px;
+    background-color: #605E4B;
+    color: #CFCEC8;
+    height: 200px;
     bottom: 0;
     left: 0;
     position: absolute;
@@ -218,15 +233,15 @@ h2{
 }
 
 #footer h2, #footer a{
-	color: #CFCEC8;
+    color: #CFCEC8;
 }
 
 #footer p{
-	font-size: 0.875em;
-	margin: 5px 0;
+    font-size: 0.875em;
+    margin: 5px 0;
 }
 
 #footer img{
-	height: auto;
-	width: 50px;
+    height: auto;
+    width: 50px;
 }

--- a/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
+++ b/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
@@ -110,7 +110,7 @@ h2{
 .step-number span {
     display: block;
     height: 30px;
-    line-height: 30px;
+    line-height: 15px;
     margin: 15px auto;
     width: 30px;
     -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.2));
@@ -123,7 +123,7 @@ h2{
     color: white;
     text-align: center;
     font-family: 'Nunito';
-    font-size: 1.5em;
+    font-size: 1.0em;
     font-weight: bold;
 }
 
@@ -155,7 +155,7 @@ h2{
 	height: 30px;
 	line-height: 30px;
 	text-transform: uppercase;
-	width: 150px;
+	width: 180px;
 }
 
 #supporters{

--- a/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
+++ b/oem/firstvoices/android/app/src/main/assets/setup/android-instructions.css
@@ -1,17 +1,17 @@
 @font-face {
    font-family: "Nunito";
-   src: url("nunito-regular-webfont.eot"); 
+   src: url("nunito-regular-webfont.eot");
    src: url("nunito-regular-webfont.ttf") format("truetype"),
-     url("nunito-regular-webfont.otf") format("opentype"), 
+     url("nunito-regular-webfont.otf") format("opentype"),
      url("nunito-regular-webfont.woff") format("woff"),
      url("nunito-regular-webfont.svg#nunitoregular") format("svg");
 }
 
 @font-face {
    font-family: "Open Sans";
-   src: url("opensans-regular-webfont.eot"); 
+   src: url("opensans-regular-webfont.eot");
    src: url("opensans-regular-webfont.ttf") format("truetype"),
-     url("opensans-regular-webfont.otf") format("opentype"), 
+     url("opensans-regular-webfont.otf") format("opentype"),
      url("opensans-regular-webfont.woff") format("woff"),
      url("opensans-regular-webfont.svg#open_sansregular") format("svg");
 }
@@ -135,14 +135,14 @@ h2{
     margin-top: 10px;
 }
 
-.step-instruction img{
+.step-instruction span{
+    display: inline-block;
     -webkit-filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
     filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.1));
     height: 30px;
     margin-right: 5px;
     vertical-align: top;
     width: 30px;
-    opacity: 0.25;
 }
 
 .step-instruction input[type="button"]{
@@ -160,12 +160,14 @@ h2{
 .checkIconOff {
     alt: 'CheckBoxOff';
     background: url('check-off.png');
-    opacity: 0.25;
+    background-size: contain;
+    opacity: 0;
 }
 
 .checkIconOn {
     alt: 'CheckBoxOn';
     background: url('check-on.png');
+    background-size: contain;
     opacity: 1.0;
 }
 

--- a/oem/firstvoices/android/app/src/main/assets/setup/main.html
+++ b/oem/firstvoices/android/app/src/main/assets/setup/main.html
@@ -15,52 +15,40 @@
                 window.jsInterface.showRegionList();
             }
 
-            function setCheckBox1On() {
-                var checkbox1 = document.getElementById("checkbox1");
-                if (checkbox1.src != "check-on.png") {
-                    checkbox1.src = "check-on.png";
-                    checkbox1.style.opacity = 1.0;
-                }
+            function setCheckBoxOn(id) {
+                var checkbox = document.getElementById(id);
+                if (checkbox) {
+                    if (checkbox.className != "checkIconOn") {
+                    checkbox.className = "checkIconOn";
+                    }
 
-                enableButton2();
+                    if (id == "checkbox1") {
+                        enableButton2();
+                    }
+                }
             }
 
-            function setCheckBox1Off() {
-                var checkbox1 = document.getElementById("checkbox1");
-                if (checkbox1.src != "check-off.png") {
-                    checkbox1.src = "check-off.png";
-                    checkbox1.style.opacity = 0.25;
-                }
+            function setCheckBoxOff(id) {
+                var checkbox = document.getElementById(id);
+                if (checkbox) {
+                    if (checkbox.className != "checkIconOff") {
+                        checkbox.className = "checkIconOff";
+                    }
 
-                disableButton2();
+                    if (id == "checkbox1") {
+                        disableButton2();
+                    }
+                }
             }
 
             function disableButton2() {
                 var button2 = document.getElementById("button2");
                 button2.disabled = true;
-                button2.style.opacity = 0.25;
             }
 
             function enableButton2() {
                 var button2 = document.getElementById("button2");
                 button2.disabled = false;
-                button2.style.opacity = 1.0;
-            }
-
-            function setCheckBox2On() {
-                var checkbox2 = document.getElementById("checkbox2");
-                if (checkbox2.src != "check-on.png") {
-                    checkbox2.src = "check-on.png";
-                    checkbox2.style.opacity = 1.0;
-                }
-            }
-
-            function setCheckBox2Off() {
-                var checkbox2 = document.getElementById("checkbox2");
-                if (checkbox2.src != "check-off.png") {
-                    checkbox2.src = "check-off.png";
-                    checkbox2.style.opacity = 0.25;
-                }
             }
         </script>
     </head>
@@ -78,14 +66,16 @@
                 <div class="step">
                     <div class="step-number"><span>1</span></div>
                     <div class="step-instruction">
-                        <p><input type="button" value="Select keyboards" onclick="showRegionList()" id="button1" /> <img src="check-off.png" alt="CheckBox" class="checkicon" id="checkbox1" /></p>
+                        <p><input type="button" value="Select keyboards" onclick="showRegionList()" id="button1" /> 
+                            <img class="checkIconOff" id="checkbox1" /></p>
                     </div>
                 </div>
                 <div class="step">
                     <div class="step-number"><span>2</span></div>
                     <div class="step-instruction">
+                        <!-- Setup disabled until a keyboard is selected -->
                         <p><input type="button" value="Setup" onclick="showSetup()" id="button2" disabled />
-                             <img src="check-off.png" alt="CheckBox" class="checkicon" id="checkbox2" /></p>
+                             <img class="checkIconOff" id="checkbox2" /></p>
                     </div>
                 </div>
             </div>
@@ -109,7 +99,7 @@
             <h2>Developed by</h2>
             <img src="keyman.svg" alt="" />
             <p>SIL International</p>
-            <p><a href="http://www.keyman.com">www.keyman.com</a></p>
+            <p><a href="https://www.keyman.com">www.keyman.com</a></p>
         </div>
 
     </body>

--- a/oem/firstvoices/android/app/src/main/assets/setup/main.html
+++ b/oem/firstvoices/android/app/src/main/assets/setup/main.html
@@ -66,8 +66,8 @@
                 <div class="step">
                     <div class="step-number"><span>1</span></div>
                     <div class="step-instruction">
-                        <p><input type="button" value="Select keyboards" onclick="showRegionList()" id="button1" /> 
-                            <img class="checkIconOff" id="checkbox1" /></p>
+                        <p><input type="button" value="Select keyboards" onclick="showRegionList()" id="button1" />
+                            <span class="checkIconOff" id="checkbox1"></span></p>
                     </div>
                 </div>
                 <div class="step">
@@ -75,7 +75,7 @@
                     <div class="step-instruction">
                         <!-- Setup disabled until a keyboard is selected -->
                         <p><input type="button" value="Setup" onclick="showSetup()" id="button2" disabled />
-                             <img class="checkIconOff" id="checkbox2" /></p>
+                             <span class="checkIconOff" id="checkbox2"></span></p>
                     </div>
                 </div>
             </div>

--- a/oem/firstvoices/android/app/src/main/assets/setup/main.html
+++ b/oem/firstvoices/android/app/src/main/assets/setup/main.html
@@ -1,61 +1,77 @@
 <!DOCTYPE html>
 
 <html>
-	<head>
-	    <title>FirstVoices Keyboards installation</title>
-	    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-	    <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport">
-	    <link rel="stylesheet" type="text/css" href="android-instructions.css" />
-	    <script language="JavaScript">
-	        function showSetup() {
-	            window.jsInterface.showSetup();
-	        }
+    <head>
+        <title>FirstVoices Keyboards installation</title>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport">
+        <link rel="stylesheet" type="text/css" href="android-instructions.css" />
+        <script language="JavaScript">
+            function showSetup() {
+                window.jsInterface.showSetup();
+            }
 
-	        function showRegionList() {
-	            window.jsInterface.showRegionList();
-	        }
+            function showRegionList() {
+                window.jsInterface.showRegionList();
+            }
 
-	        function setCheckBox1On() {
-	            var checkbox1 = document.getElementById("checkbox1");
-	            if (checkbox1.src != "check-on.png") {
-	                checkbox1.src = "check-on.png";
-	                checkbox1.style.opacity = 1.0;
-	            }
-	        }
+            function setCheckBox1On() {
+                var checkbox1 = document.getElementById("checkbox1");
+                if (checkbox1.src != "check-on.png") {
+                    checkbox1.src = "check-on.png";
+                    checkbox1.style.opacity = 1.0;
+                }
 
-	        function setCheckBox1Off() {
-	            var checkbox1 = document.getElementById("checkbox1");
-	            if (checkbox1.src != "check-off.png") {
-	                checkbox1.src = "check-off.png";
-	                checkbox1.style.opacity = 0.25;
-	            }
-	        }
+                enableButton2();
+            }
 
-	        function setCheckBox2On() {
-	            var checkbox2 = document.getElementById("checkbox2");
-	            if (checkbox2.src != "check-on.png") {
-	                checkbox2.src = "check-on.png";
-	                checkbox2.style.opacity = 1.0;
-	            }
-	        }
+            function setCheckBox1Off() {
+                var checkbox1 = document.getElementById("checkbox1");
+                if (checkbox1.src != "check-off.png") {
+                    checkbox1.src = "check-off.png";
+                    checkbox1.style.opacity = 0.25;
+                }
 
-	        function setCheckBox2Off() {
-	            var checkbox2 = document.getElementById("checkbox2");
-	            if (checkbox2.src != "check-off.png") {
-	                checkbox2.src = "check-off.png";
-	                checkbox2.style.opacity = 0.25;
-	            }
-	        }
-	    </script>
-	</head>
+                disableButton2();
+            }
 
-	<body>
+            function disableButton2() {
+                var button2 = document.getElementById("button2");
+                button2.disabled = true;
+                window.console.log("Disabling button2");
+            }
 
-		<div id="instructions">
-			<div id="logo">
-				<img src="firstvoices-logo.gif" alt="FirstVoices" />
-				<p>Keyboards</p>
-			</div>
+            function enableButton2() {
+                var button2 = document.getElementById("button2");
+                button2.disabled = false;
+                window.console.log("Enabling button2");
+            }
+
+            function setCheckBox2On() {
+                var checkbox2 = document.getElementById("checkbox2");
+                if (checkbox2.src != "check-on.png") {
+                    checkbox2.src = "check-on.png";
+                    checkbox2.style.opacity = 1.0;
+                }
+            }
+
+            function setCheckBox2Off() {
+                var checkbox2 = document.getElementById("checkbox2");
+                if (checkbox2.src != "check-off.png") {
+                    checkbox2.src = "check-off.png";
+                    checkbox2.style.opacity = 0.25;
+                }
+            }
+        </script>
+    </head>
+
+    <body>
+
+        <div id="instructions">
+            <div id="logo">
+                <img src="firstvoices-logo.gif" alt="FirstVoices" />
+                <p>Keyboards</p>
+            </div>
 
             <h2>Installation instructions</h2>
             <div class="steps">
@@ -68,32 +84,33 @@
                 <div class="step">
                     <div class="step-number"><span>2</span></div>
                     <div class="step-instruction">
-                        <p><input type="button" value="Setup" onclick="showSetup()" id="button2" /> <img src="check-off.png" alt="CheckBox" class="checkicon" id="checkbox2" /></p>
+                        <p><input type="button" value="Setup" onclick="showSetup()" id="button2" disabled />
+                             <img src="check-off.png" alt="CheckBox" class="checkicon" id="checkbox2" /></p>
                     </div>
                 </div>
             </div>
-			<h2>To use FirstVoices Keyboards</h2>
-				<p>After completing these steps above, selected FirstVoices keyboards will be available on your Android device.</p>
-		</div>
+            <h2>To use FirstVoices Keyboards</h2>
+                <p>After completing these steps above, selected FirstVoices keyboards will be available on your Android device.</p>
+        </div>
 
-		<div id="supporters">
-			<p>FirstVoices gratefully acknowledges the following supporters of this project:</p>
-			<a href="http://www.newrelationshiptrust.ca/"><img src="nrt.svg" alt="" /></a>
-			<a href="http://www.fpcc.ca/"><img src="fpcc.svg" alt="" /></a>
-			<a href="http://www.languagegeek.com/"><img src="languagegeek.png" alt="" /></a>
-		</div>
+        <div id="supporters">
+            <p>FirstVoices gratefully acknowledges the following supporters of this project:</p>
+            <a href="http://www.newrelationshiptrust.ca/"><img src="nrt.svg" alt="" /></a>
+            <a href="http://www.fpcc.ca/"><img src="fpcc.svg" alt="" /></a>
+            <a href="http://www.languagegeek.com/"><img src="languagegeek.png" alt="" /></a>
+        </div>
 
-		<div id="donation">
-			<p>If you like this app please consider supporting FirstVoices by donating to the First Peoples' Cultural Foundation</p>
-			<p><a href="http://fpcf.ca/donate-now/">Donate</a></p>
-		</div>
+        <div id="donation">
+            <p>If you like this app please consider supporting FirstVoices by donating to the First Peoples' Cultural Foundation</p>
+            <p><a href="http://fpcf.ca/donate-now/">Donate</a></p>
+        </div>
 
-		<div id="footer">
-			<h2>Developed by</h2>
-			<img src="keyman.svg" alt="" />
-			<p>SIL International</p>
-			<p><a href="http://www.keyman.com">www.keyman.com</a></p>
-		</div>
+        <div id="footer">
+            <h2>Developed by</h2>
+            <img src="keyman.svg" alt="" />
+            <p>SIL International</p>
+            <p><a href="http://www.keyman.com">www.keyman.com</a></p>
+        </div>
 
-	</body>
+    </body>
 </html>

--- a/oem/firstvoices/android/app/src/main/assets/setup/main.html
+++ b/oem/firstvoices/android/app/src/main/assets/setup/main.html
@@ -38,13 +38,13 @@
             function disableButton2() {
                 var button2 = document.getElementById("button2");
                 button2.disabled = true;
-                window.console.log("Disabling button2");
+                button2.style.opacity = 0.25;
             }
 
             function enableButton2() {
                 var button2 = document.getElementById("button2");
                 button2.disabled = false;
-                window.console.log("Enabling button2");
+                button2.style.opacity = 1.0;
             }
 
             function setCheckBox2On() {

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -10,6 +10,8 @@ import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import io.sentry.android.core.SentryAndroid;
@@ -184,8 +186,13 @@ public class MainActivity extends AppCompatActivity {
         @SuppressWarnings("unused")
         @JavascriptInterface
         public void showSetup() {
-            Intent setupIntent = new Intent(context, SetupActivity.class);
-            context.startActivity(setupIntent);
+            // Ensure a keyboard has been selected first
+            if (didCompleteSelectKeyboard()) {
+              Intent setupIntent = new Intent(context, SetupActivity.class);
+              context.startActivity(setupIntent);
+            } else {
+              Toast.makeText(context, context.getString(R.string.select_keyboard_first), Toast.LENGTH_SHORT).show();
+            }
         }
 
         @SuppressWarnings("unused")
@@ -197,7 +204,7 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private boolean didCompleteSelectKeyboard() {
+    private static boolean didCompleteSelectKeyboard() {
         return FVShared.getInstance().activeKeyboardCount() > 0;
     }
 

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -10,7 +10,6 @@ import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -186,13 +185,8 @@ public class MainActivity extends AppCompatActivity {
         @SuppressWarnings("unused")
         @JavascriptInterface
         public void showSetup() {
-            // Ensure a keyboard has been selected first
-            if (didCompleteSelectKeyboard()) {
-              Intent setupIntent = new Intent(context, SetupActivity.class);
-              context.startActivity(setupIntent);
-            } else {
-              Toast.makeText(context, context.getString(R.string.select_keyboard_first), Toast.LENGTH_SHORT).show();
-            }
+            Intent setupIntent = new Intent(context, SetupActivity.class);
+            context.startActivity(setupIntent);
         }
 
         @SuppressWarnings("unused")

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -121,14 +121,14 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onPageFinished(WebView view, String url) {
                 if (didCompleteSelectKeyboard())
-                    view.loadUrl("javascript:setCheckBox1On();");
+                    view.loadUrl("javascript:setCheckBoxOn('checkbox1');");
                 else
-                    view.loadUrl("javascript:setCheckBox1Off();");
+                    view.loadUrl("javascript:setCheckBoxOff('checkbox1');");
 
                 if (didCompleteSetup())
-                    view.loadUrl("javascript:setCheckBox2On();");
+                    view.loadUrl("javascript:setCheckBoxOn('checkbox2');");
                 else
-                    view.loadUrl("javascript:setCheckBox2Off();");
+                    view.loadUrl("javascript:setCheckBoxOff('checkbox2');");
             }
         });
 
@@ -142,14 +142,14 @@ public class MainActivity extends AppCompatActivity {
         WebView webView = findViewById(R.id.webView);
         if (webView != null) {
             if (didCompleteSelectKeyboard())
-                webView.loadUrl("javascript:setCheckBox1On();");
+                webView.loadUrl("javascript:setCheckBoxOn('checkbox1');");
             else
-                webView.loadUrl("javascript:setCheckBox1Off();");
+                webView.loadUrl("javascript:setCheckBoxOff('checkbox1');");
 
             if (didCompleteSetup())
-                webView.loadUrl("javascript:setCheckBox2On();");
+                webView.loadUrl("javascript:setCheckBoxOn('checkbox2');");
             else
-                webView.loadUrl("javascript:setCheckBox2Off();");
+                webView.loadUrl("javascript:setCheckBoxOff('checkbox2');");
         }
     }
 

--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="setup">Setup</string>
     <string name="regions">Regions</string>
     <string name="keyboards">Keyboards</string>
+
+    <!-- Context: Installation Instructions -->
+    <string name="select_keyboard_first">Select Keyboard first</string>
 </resources>

--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,4 @@
     <string name="setup">Setup</string>
     <string name="regions">Regions</string>
     <string name="keyboards">Keyboards</string>
-
-    <!-- Context: Installation Instructions -->
-    <string name="select_keyboard_first">Select Keyboard first</string>
 </resources>


### PR DESCRIPTION
Fixes #3922

Currently, the FV UX allows a user to set FV as a system keyboard before a keyboard has been selected.
This was causing a lot of Sentry issues as the app had to fallback to the sil_euro_latin keyboard.

This PR adds disables the "Setup" button until a keyboard is selected.

### Updated screenshots (final)
CSS updated to fix button and text layout

**2 Setup** button disabled when a language isn't selected
![Screenshot_1606349630](https://user-images.githubusercontent.com/7358010/100293753-4a7a9400-2fb7-11eb-9920-0d8b2e99cc3a.png)

**2 Setup** button enabled when a language has been selected
![Screenshot_1606349642](https://user-images.githubusercontent.com/7358010/100293765-51a1a200-2fb7-11eb-9797-79cdc4472345.png)

**2 checkbox** after setup complete
![Screenshot_1606349671](https://user-images.githubusercontent.com/7358010/100293773-56665600-2fb7-11eb-9e6a-66373d7af263.png)
