### PR TITLE
fix(ios/engine): banner inconsistency

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -130,6 +130,9 @@ private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
     }
     let topBarDelta = hideBanner ? 0 : InputViewController.topBarHeight
 
+    // Sets height before the constraints, as it's the height constraint that triggers OSK resizing.
+    keymanWeb.setBannerHeight(to: Int(InputViewController.topBarHeight))
+
     portraitConstraint?.constant = topBarDelta + keymanWeb.constraintTargetHeight(isPortrait: true)
     landscapeConstraint?.constant = topBarDelta + keymanWeb.constraintTargetHeight(isPortrait: false)
 
@@ -141,8 +144,6 @@ private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
       portraitConstraint?.isActive = false
       landscapeConstraint?.isActive = true
     }
-
-    keymanWeb.setBannerHeight(to: Int(InputViewController.topBarHeight))
   }
 }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1868,7 +1868,7 @@ namespace com.keyman.osk {
         this.hkKey=this.getSpecialKey(nLayer,'K_ROPT');
 
         // Always adjust screen height if iPhone or iPod, to take account of viewport changes
-        if(device.OS == 'iOS' && device.formFactor == 'phone') {
+        if(device.OS == 'iOS') {
           this.adjustHeights();
         }
       }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1868,6 +1868,8 @@ namespace com.keyman.osk {
         this.hkKey=this.getSpecialKey(nLayer,'K_ROPT');
 
         // Always adjust screen height if iPhone or iPod, to take account of viewport changes
+        // Do NOT condition upon form-factor; this line prevents a bug with displaying
+        // the predictive-text banner on the initial keyboard load.  (Issue #2907)
         if(device.OS == 'iOS') {
           this.adjustHeights();
         }


### PR DESCRIPTION
Fixes #2907.

These changes ensure that the banner always displays correctly upon initial load of the keyboard.