### PR TITLE
fix(android, ios): adds null guard to refreshLayouts call

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -77,7 +77,9 @@
         oskHeight = h;
       }
       var kmw=window['keyman'];
-      kmw.core.activeKeyboard.refreshLayouts();
+      if(kmw && kmw.core && kmw.core.activeKeyboard) {
+        kmw.core.activeKeyboard.refreshLayouts();
+      }
       kmw['correctOSKTextSize']();
     }
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -90,7 +90,9 @@
             function setOskHeight(height) {
                 var kmw=window['keyman'];
                 oskHeight = height;
-                kmw.core.activeKeyboard.refreshLayouts();
+                if(kmw && kmw.core && kmw.core.activeKeyboard) {
+                    kmw.core.activeKeyboard.refreshLayouts();
+                }
                 kmw.osk.show(true);
                 kmw['correctOSKTextSize']();
             }


### PR DESCRIPTION
Fixes [this Sentry error report](https://sentry.keyman.com/organizations/keyman/issues/1866/?environment=local&project=11&referrer=alert_email).

Basically, I forgot to add a null-guard to some of the new lines in #3909.  (Within both `keyboard.html` files)