### PR TITLE
fix(mac): turn on legacy mode for Java apps

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -65,6 +65,7 @@ NSRange _previousSelRange;
             [clientAppId isEqual: @"com.adobe.AfterEffects"] ||
             [clientAppId isEqual: @"com.microsoft.VSCode"] ||
             [clientAppId isEqual: @"com.google.Chrome"] ||
+            [clientAppId hasPrefix: @"net.java"] ||
             [clientAppId isEqual: @"com.Keyman.test.legacyInput"]
                /*||[clientAppId isEqual: @"ro.sync.exml.Oxygen"] - Oxygen has worse problems */);
 


### PR DESCRIPTION
Relates to #3935, #174, #458, #3243. (Not marking as fixed because it depends on external changes.)

This switches Java apps into legacy mode. However, Java itself will need patching to support Keyman, as it makes assumptions about input methods, including matching specific input methods by name, before enabling its complex text support.

I think we should consider backporting to 13.0 if the Java fix is accepted in reasonable time.

I have submitted a bug report but submitting a patch to the OpenJDK project looks [tiresome and convoluted](https://stackoverflow.com/questions/29379425/where-to-report-issues-of-openjdk-when-youre-not-a-openjdk-developer). It requires a change to a single file, [AWTView.m](https://github.com/openjdk/jdk/blob/6329de45045da3ce937cd22d82e74c3f142ea3f2/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m), with the following diff (against JDK 16.0):

```diff
diff --git a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
index 3e80b5a6cf3..2ae1f4f3f12 100644
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -263,6 +263,16 @@ - (void) keyDown: (NSEvent *)event {
     fProcessingKeystroke = YES;
     fKeyEventsNeeded = YES;

+    if([(NSString *)kbdLayout containsString:@"keyman"]) {
+        // Keyman handles all key events; none should be
+        // passed through as default before Keyman processes them
+        fKeyEventsNeeded = NO;
+    }
     // Allow TSM to look at the event and potentially send back NSTextInputClient messages.
     [self interpretKeyEvents:[NSArray arrayWithObject:event]];

@@ -960,7 +989,9 @@ - (void) insertText:(id)aString replacementRange:(NSRange)replacementRange

     if ((utf16Length > 2) ||
         ((utf8Length > 1) && [self isCodePointInUnicodeBlockNeedingIMEvent:codePoint]) ||
-        ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"]))) {
+        ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"])) ||
+        ([(NSString *)kbdLayout containsString:@"keyman"])
+        ) {
         aStringIsComplex = YES;
     }
```

# References

https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8195675

JDK currently has a number of bugs in its IM handling; see:
* https://bugs.openjdk.java.net/browse/JDK-8214578
* https://bugs.openjdk.java.net/browse/JDK-8234786
* https://bugs.openjdk.java.net/browse/JDK-8248532

It's not clear to me exactly which versions of Java currently experience these issues. The fix introduced by 8214578 made things worse, not better, and has an incredibly specific patch for a single IM and single character.

# Testing

I have successfully tested this fix with a source build of ELAN (#3243).

```
export JAVA_HOME=~mcdurdin/Documents/Projects/jdk/build/macosx-x86_64-server-slowdebug/images/jdk
mvn test
```

I have not yet tested the other apps but it looks hopeful.