### PR TITLE
fix(web): default attachment behavior

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1542,11 +1542,6 @@ namespace com.keyman.dom {
       opt['keyboards'] = fixPath(opt['keyboards']);
       opt['fonts'] = fixPath(opt['fonts']);    
 
-      // Set element attachment type    
-      if(opt['attachType'] == '') {
-        opt['attachType'] = 'auto';
-      }
-
       // Set default device options
       this.keyman.setDefaultDeviceOptions(opt);   
       


### PR DESCRIPTION
As noted on https://help.keyman.com/DEVELOPER/ENGINE/web/13.0/reference/core/init#init_options, the default attachment style on touch devices is supposed to be `'manual'`, not `'auto'`.  This is handled by `this.keyman.setDefaultDeviceOptions(opt)`:

https://github.com/keymanapp/keyman/blob/285319ba37f39d56b967d09930462b59639994be/web/source/kmwnative.ts#L27-L34

Caught during acceptance testing according to https://github.com/keymanapp/keyman/wiki/User-Testing-for-Web#tests in prep for Beta.