### PR TITLE
feat(mac): user-controllable legacy app list

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -125,6 +125,8 @@ typedef struct {
 - (NSString *)oskWindowTitle;
 - (void)postKeyboardEventWithSource: (CGEventSourceRef)source code:(CGKeyCode) virtualKey postCallback:(PostEventCallback)postEvent;
 - (KeymanVersionInfo)versionInfo;
+- (NSString *)keymanDataPath;
+- (NSArray *)legacyAppsUserDefaults;
 @end
 
 #endif /* KMInputMethodAppDelegate_h */


### PR DESCRIPTION
Fixes #1953.

Makes it possible to specify additional apps that need 'legacy' handling without requiring an updated build of Keyman for Mac. The list should be stored in user defaults under the `KMLegacyApps` key. It can be viewed with the command:

```
defaults read keyman.inputmethod.Keyman KMLegacyApps
```

And updated with:

```
defaults write keyman.inputmethod.Keyman KMLegacyApps -array value1 value2 ...
defaults write keyman.inputmethod.Keyman KMLegacyApps -array-add value1 value2 ...
```

Each entry should be a regex that matches the client app id.

For example:

```
defaults write keyman.inputmethod.Keyman KMLegacyApps -array com.microsoft.Word '^com.github.atom$'
```

(Note for purity, the `.` should be escaped in the regex but it'll actually be fine without...)

This commit also adds the `keymanDataPath` method on `KMInputMethodAppDelegate`, so we can place additional configuration data there in the future (as opposed to in the shared config which is less easy for users to edit.)

I've also gone ahead and disabled legacy for Word as I can't make it go wrong at present.