### PR TITLE
fix(mac): improve robustness of altool call

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -458,6 +458,12 @@ if $PREPRELEASE || $NOTARIZE; then
       sleep 30
       xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || (
         ALTOOL_CODE=$?
+        ALTOOL_PRODUCT_ERROR=$(/usr/libexec/PlistBuddy -c "Print product-errors:0:code" "$ALTOOL_LOG_PATH")
+        if [ "$ALTOOL_PRODUCT_ERROR" == 1519 ]; then
+            # Could not find the RequestUUID; this is a temporary error sometimes returned by Apple.
+            # We'll just keep retrying.
+            continue;
+        fi
         cat "$ALTOOL_LOG_PATH"
         fail "altool failed with code $ALTOOL_CODE"
       )


### PR DESCRIPTION
Fixes #3331.

Handles temporary failures calling altool where Apple servers return "Could not find the RequestUUID" for a few minutes post-upload.

Example log we are handling:

```
[04:50:44][Step 5/5] Zipping Keyman.app for notarization to /Users/mcdurdin/buildAgent/work/99b311828f4ee7c/keyman/mac/Keyman4MacIM/build/Release/Keyman.zip
[04:50:44][Step 5/5] Uploading Keyman.zip to Apple for notarization
[04:51:23][Step 5/5] <?xml version="1.0" encoding="UTF-8"?>
[04:51:23][Step 5/5] <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
[04:51:23][Step 5/5] <plist version="1.0">
[04:51:23][Step 5/5] <dict>
[04:51:23][Step 5/5] 	<key>notarization-upload</key>
[04:51:23][Step 5/5] 	<dict>
[04:51:23][Step 5/5] 		<key>RequestUUID</key>
[04:51:23][Step 5/5] 		<string>fd45e30c-5a96-4d02-9196-0923d4e5e90f</string>
[04:51:23][Step 5/5] 	</dict>
[04:51:23][Step 5/5] 	<key>os-version</key>
[04:51:23][Step 5/5] 	<string>10.15.3</string>
[04:51:23][Step 5/5] 	<key>success-message</key>
[04:51:23][Step 5/5] 	<string>No errors uploading '/Users/mcdurdin/buildAgent/work/99b311828f4ee7c/keyman/mac/Keyman4MacIM/build/Release/Keyman.zip'.</string>
[04:51:23][Step 5/5] 	<key>tool-path</key>
[04:51:23][Step 5/5] 	<string>/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework</string>
[04:51:23][Step 5/5] 	<key>tool-version</key>
[04:51:23][Step 5/5] 	<string>4.01.1182</string>
[04:51:23][Step 5/5] </dict>
[04:51:23][Step 5/5] </plist>
[04:51:23][Step 5/5]
[04:51:23][Step 5/5] Waiting 30 seconds for status
[04:51:55][Step 5/5] <?xml version="1.0" encoding="UTF-8"?>
[04:51:55][Step 5/5] <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
[04:51:55][Step 5/5] <plist version="1.0">
[04:51:55][Step 5/5] <dict>
[04:51:55][Step 5/5] 	<key>os-version</key>
[04:51:55][Step 5/5] 	<string>10.15.3</string>
[04:51:55][Step 5/5] 	<key>product-errors</key>
[04:51:55][Step 5/5] 	<array>
[04:51:55][Step 5/5] 		<dict>
[04:51:55][Step 5/5] 			<key>code</key>
[04:51:55][Step 5/5] 			<integer>1519</integer>
[04:51:55][Step 5/5] 			<key>message</key>
[04:51:55][Step 5/5] 			<string>Could not find the RequestUUID.</string>
[04:51:55][Step 5/5] 			<key>userInfo</key>
[04:51:55][Step 5/5] 			<dict>
[04:51:55][Step 5/5] 				<key>NSLocalizedDescription</key>
[04:51:55][Step 5/5] 				<string>Could not find the RequestUUID.</string>
[04:51:55][Step 5/5] 				<key>NSLocalizedFailureReason</key>
[04:51:55][Step 5/5] 				<string>Apple Services operation failed.</string>
[04:51:55][Step 5/5] 				<key>NSLocalizedRecoverySuggestion</key>
[04:51:55][Step 5/5] 				<string>Could not find the RequestUUID.</string>
[04:51:55][Step 5/5] 			</dict>
[04:51:55][Step 5/5] 		</dict>
[04:51:55][Step 5/5] 	</array>
[04:51:55][Step 5/5] 	<key>tool-path</key>
[04:51:55][Step 5/5] 	<string>/Applications/Xcode.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework</string>
[04:51:55][Step 5/5] 	<key>tool-version</key>
[04:51:55][Step 5/5] 	<string>4.01.1182</string>
[04:51:55][Step 5/5] </dict>
[04:51:55][Step 5/5] </plist>
[04:51:55][Step 5/5]
[04:51:55][Step 5/5] altool failed with code 1
```