### PR TITLE
fix(android/engine,android/app) Notify when invalid keyboard package fails to install

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -111,6 +111,17 @@ public class PackageActivity extends AppCompatActivity implements
     // lexical-model packages will be 0
     final int languageCount = kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0);
 
+    // Sanity check for keyboard packages
+    if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
+      if (keyboardCount == 0) {
+        showErrorToast(context, getString(R.string.no_new_touch_keyboards_to_install));
+        finish();
+      } else if (languageCount == 0) {
+        showErrorToast(context, getString(R.string.no_associated_languages));
+        finish();
+      }
+    }
+
     // Silent installation (skip displaying welcome.htm and user confirmation)
     if (silentInstall) {
       installPackage(context, pkgTarget, pkgId, languageList, true);
@@ -178,7 +189,7 @@ public class PackageActivity extends AppCompatActivity implements
 
   @Override
   public void onError(VerificationError verificationError) {
-    Toast.makeText(this, verificationError.getErrorMessage(), Toast.LENGTH_SHORT).show();
+    Toast.makeText(this, verificationError.getErrorMessage(), Toast.LENGTH_LONG).show();
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -115,10 +115,8 @@ public class PackageActivity extends AppCompatActivity implements
     if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
       if (keyboardCount == 0) {
         showErrorToast(context, getString(R.string.no_new_touch_keyboards_to_install));
-        finish();
       } else if (languageCount == 0) {
         showErrorToast(context, getString(R.string.no_associated_languages));
-        finish();
       }
     }
 
@@ -235,6 +233,7 @@ public class PackageActivity extends AppCompatActivity implements
     // Setting result to 1 so calling activity will finish too
     setResult(1);
     cleanup();
+    finish();
   }
 
   /**

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
   <string name="install_predictive_text_package" comment="Title to install dictionary package">Install Dictionary</string>
 
   <!-- Context: KMP Package strings -->
-  <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">No new touch-optimized keyboards to install</string>
+  <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">Keyboard package has no touch-optimized keyboards to install</string>
 
   <!-- Context: KMP Package strings -->
   <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">No new predictive text to install</string>

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -179,6 +179,9 @@
   <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">No keyboards or predictive text to install</string>
 
   <!-- Context: KMP Package strings -->
+  <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">Keyboard package has no associated languages to install</string>
+
+  <!-- Context: KMP Package strings -->
   <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Invalid/Missing metadata in package</string>
 
 </resources>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -298,13 +298,15 @@ public class PackageProcessor {
         for (int f = 0; f < files.length(); f++) {
           JSONObject file = files.getJSONObject(f);
           String filename = file.getString(PP_FILES_NAME_KEY);
-          if (FileUtils.hasJavaScriptExtension(filename) && filename.equals(expectedKeyboardFilename)) {
+          if (filename != null && filename.equals(expectedKeyboardFilename)) {
             count++;
             break;
           }
         }
       }
     } catch (JSONException e) {
+      // Setting count to 0 due to invalid package
+      count = 0;
       KMLog.LogException(TAG, "", e);
     }
 


### PR DESCRIPTION
Fixes #3958 

Some of the legacy keyboard packages are invalid because they
* don't include .JS touch-optimized keyboard
* don't have languages assigned in kmp.json

This adds additional checks during a package installation and provides the notification when a keyboard package fails

### Screenshot
![Screenshot_1606369371](https://user-images.githubusercontent.com/7358010/100312460-f7b7d100-2fe4-11eb-9057-24ee39005bf2.png)


### Testing
Test by attempting to install "mbsindhi" keyboard.

