### PR TITLE
chore(common/resources): Fix dest paths for crowdin strings

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -28,7 +28,7 @@ files:
   # Android files
 
   - source: /android/KMEA/app/src/main/res/values/strings.xml
-    dest: /android/engine/strings.xml
+    dest: /master/android/engine/strings.xml
     translation: /android/KMEA/app/src/main/res/values-%android_code%/strings.xml
     languages_mapping:
       # Prevent invalid region pap-rPAP
@@ -36,7 +36,7 @@ files:
         pap: pap
 
   - source: /android/KMAPro/kMAPro/src/main/res/values/strings.xml
-    dest: /android/app/strings.xml
+    dest: /master/android/app/strings.xml
     translation: /android/KMAPro/kMAPro/src/main/res/values-%android_code%/strings.xml
     languages_mapping:
       # Prevent invalid region pap-rPAP
@@ -47,37 +47,37 @@ files:
   # Note: we use type: android for the Windows project files
 
   - source: /windows/src/desktop/kmshell/xml/strings.xml
-    dest: /windows/strings.xml
+    dest: /master/windows/strings.xml
     translation: /windows/src/desktop/kmshell/locale/%locale%/%original_file_name%
     type: android
 
-  - source: /window/src/desktop/setup/locale/en/strings.xml
-    dest: /windows/setup/strings.xml
+  - source: /windows/src/desktop/setup/locale/en/strings.xml
+    dest: /master/windows/setup/strings.xml
     translation: /windows/src/desktop/setup/locale/%locale%/%original_file_name%
     type: android
 
   # iOS files
 
-  - source: /ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/en.lproj/ResourceInfoView.strings
-    dest: /ios/engine/ResourceInfoView.strings
+  - source: /ios/engine/KMEI/KeymanEngine/Classes/en.lproj/ResourceInfoView.strings
+    dest: /master/ios/engine/ResourceInfoView.strings
     translation: /ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/%osx_code%/%original_file_name%
 
   - source: /ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
-    dest: /ios/engine/Localizable.strings
+    dest: /master/ios/engine/Localizable.strings
     translation: /ios/engine/KMEI/KeymanEngine/%osx_code%/%original_file_name%
 
   - source: /ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.stringsdict
-    dest: /ios/engine/Localizable.stringsdict
+    dest: /master/ios/engine/Localizable.stringsdict
     translation: /ios/engine/KMEI/KeymanEngine/%osx_code%/%original_file_name%
 
   - source: /ios/keyman/Keyman/Keyman/en.lproj/Localizable.strings
-    dest: /ios/app/Localizable.strings
+    dest: /master/ios/app/Localizable.strings
     translation: /ios/keyman/Keyman/Keyman/%osx_code%/%original_file_name%
 
   # Linux files
 
   - source: /linux/keyman-config/locale/keyman-config.pot
-    dest: /linux/keyman-config.pot
+    dest: /master/linux/keyman-config.pot
     translation: /linux/keyman-config/locale/%locale_with_underscore%.po
     type: gettext
     update_option: update_as_unapproved

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,8 +7,8 @@
 #
 project_id_env: "CROWDIN_PROJECT_ID"
 api_token_env: "CROWDIN_PERSONAL_TOKEN"
-base_path: . # local base path
-base_url: https://api.crowdin.com
+base_path: "." # local base path
+base_url: "https://api.crowdin.com"
 
 #
 # Choose file structure in Crowdin

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -28,7 +28,7 @@ files:
   # Android files
 
   - source: /android/KMEA/app/src/main/res/values/strings.xml
-    dest: /master/android/engine/strings.xml
+    dest: /android/engine/strings.xml
     translation: /android/KMEA/app/src/main/res/values-%android_code%/strings.xml
     languages_mapping:
       # Prevent invalid region pap-rPAP
@@ -36,7 +36,7 @@ files:
         pap: pap
 
   - source: /android/KMAPro/kMAPro/src/main/res/values/strings.xml
-    dest: /master/android/app/strings.xml
+    dest: /android/app/strings.xml
     translation: /android/KMAPro/kMAPro/src/main/res/values-%android_code%/strings.xml
     languages_mapping:
       # Prevent invalid region pap-rPAP
@@ -47,37 +47,37 @@ files:
   # Note: we use type: android for the Windows project files
 
   - source: /windows/src/desktop/kmshell/xml/strings.xml
-    dest: /master/windows/strings.xml
+    dest: /windows/strings.xml
     translation: /windows/src/desktop/kmshell/locale/%locale%/%original_file_name%
     type: android
 
   - source: /windows/src/desktop/setup/locale/en/strings.xml
-    dest: /master/windows/setup/strings.xml
+    dest: /windows/setup/strings.xml
     translation: /windows/src/desktop/setup/locale/%locale%/%original_file_name%
     type: android
 
   # iOS files
 
   - source: /ios/engine/KMEI/KeymanEngine/Classes/en.lproj/ResourceInfoView.strings
-    dest: /master/ios/engine/ResourceInfoView.strings
+    dest: /ios/engine/ResourceInfoView.strings
     translation: /ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/%osx_code%/%original_file_name%
 
   - source: /ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
-    dest: /master/ios/engine/Localizable.strings
+    dest: /ios/engine/Localizable.strings
     translation: /ios/engine/KMEI/KeymanEngine/%osx_code%/%original_file_name%
 
   - source: /ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.stringsdict
-    dest: /master/ios/engine/Localizable.stringsdict
+    dest: /ios/engine/Localizable.stringsdict
     translation: /ios/engine/KMEI/KeymanEngine/%osx_code%/%original_file_name%
 
   - source: /ios/keyman/Keyman/Keyman/en.lproj/Localizable.strings
-    dest: /master/ios/app/Localizable.strings
+    dest: /ios/app/Localizable.strings
     translation: /ios/keyman/Keyman/Keyman/%osx_code%/%original_file_name%
 
   # Linux files
 
   - source: /linux/keyman-config/locale/keyman-config.pot
-    dest: /master/linux/keyman-config.pot
+    dest: /linux/keyman-config.pot
     translation: /linux/keyman-config/locale/%locale_with_underscore%.po
     type: gettext
     update_option: update_as_unapproved

--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -4,7 +4,7 @@ Localization for Keyman is maintained at https://crowdin.com/project/keyman
 
 Downloading and updating files between Keyman and Crowdin happens automatically
 on GitHub by way of the Crowdin git integration. The configuration file for all platforms
-is a YAML file named `/crowdin.yml`.
+is a YAML file named `/crowdin.yml`. Currently, the git integration tracks the `master` branch.
 
 The only thing that needs to be done manually is to update `crowdin.yml` if new files get added
 (and of course translating the strings on the [Crowdin website](https://crowdin.com/project/keyman)).
@@ -54,24 +54,25 @@ You should see the CLI fetching project info and generating a list of files asso
 project.
 
 ### Downloading from Crowdin
+Since Crowdin is tracking the `master` branch, download translations will be zipped into a `master` folder.
 
 To download the latest translations from Crowdin (all platforms), open a command line at the repo
 root folder and run:
 
 ```bash
-crowdin download
+crowdin download -b master
 ```
 
 To download latest translations for the specific language:
 
 ```bash
-crowdin download -l {language_code}
+crowdin download -b master -l {language_code}
 ```
 
 To display a list of latest translations from Crowdin:
 
 ```bash
-crowdin download --dryrun
+crowdin download -b master --dryrun
 ```
 
 ### Uploading to crowdin


### PR DESCRIPTION
This is in preparation of updating our UI strings via crowdin.

Refer to resources/build/l10n/README.md

Some cleanup first in `crowind.yml`
* ~Use the "master" folder on translate.keyman.com for Alpha pre-release strings~
* Fix paths for windows and ios

@jahorton and @mcdurdin are the "translation" paths still correct for your platforms?

TODO:
- [x] When I run `crowdin.bat download`, crowdin CLI says it downloads translations, but I'm not seeing any new files 😕 