### PR TITLE
fix(ios): package-internal links should be considered internal

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
@@ -90,7 +90,12 @@ class PackageWebViewController: UIViewController, WKNavigationDelegate {
                decidePolicyFor navigationAction: WKNavigationAction,
                decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     if let link = navigationAction.request.url {
-      if UniversalLinks.isExternalLink(link) {
+      if link.path.hasPrefix(self.package.sourceFolder.path) {
+        // Links from within the package will show up as 'external' in the condition below!
+        // So, we check against package-internal links first.
+        decisionHandler(.allow)
+        return
+      } else if UniversalLinks.isExternalLink(link) {
         decisionHandler(.cancel)
 
         // Kick this link out to an external Safari process.


### PR DESCRIPTION
Turns out that #3889 had some rather unexpected interactions with the display of package welcome.htm pages; welcome.htm was being improperly detected as an 'external' link, which consistently resulted in the display of a blank welcome screen.