### PR TITLE
fix(android/app,oem/fv/android): Sanitize Sentry navigation breadcrumbs

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -90,6 +90,7 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import io.sentry.SentryLevel;
 import io.sentry.android.core.SentryAndroid;
 
 public class MainActivity extends AppCompatActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener,
@@ -129,6 +130,23 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     checkSendCrashReport();
     if (KMManager.getMaySendCrashReport()) {
       SentryAndroid.init(context, options -> {
+        options.setBeforeBreadcrumb((breadcrumb, hint) -> {
+          String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-(.)*$";
+          if ("navigation".equals(breadcrumb.getCategory()) && breadcrumb.getLevel() == SentryLevel.INFO &&
+            ((breadcrumb.getData("from") != null) || (breadcrumb.getData("to") != null)) ) {
+            // Sanitize navigation breadcrumbs
+            String dataFrom = String.valueOf(breadcrumb.getData("from"));
+            dataFrom = dataFrom.replaceAll(NAVIGATION_PATTERN, "$1$2");
+            breadcrumb.setData("from", dataFrom);
+            String dataTo = String.valueOf(breadcrumb.getData("to"));
+            dataTo = dataTo.replaceAll(NAVIGATION_PATTERN, "$1$2");
+            breadcrumb.setData("to", dataTo);
+
+            return breadcrumb;
+          } else {
+            return breadcrumb;
+          }
+        });
         options.setRelease("release-" + com.tavultesoft.kmapro.BuildConfig.VERSION_NAME);
         options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
       });

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -131,7 +131,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     if (KMManager.getMaySendCrashReport()) {
       SentryAndroid.init(context, options -> {
         options.setBeforeBreadcrumb((breadcrumb, hint) -> {
-          String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-(.)*$";
+          String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";
           if ("navigation".equals(breadcrumb.getCategory()) && breadcrumb.getLevel() == SentryLevel.INFO &&
             ((breadcrumb.getData("from") != null) || (breadcrumb.getData("to") != null)) ) {
             // Sanitize navigation breadcrumbs


### PR DESCRIPTION
Fixes #3997

This sanitizes the Sentry navigation breadcrumbs so they don't include key information.

For testing the breadcrumb, I manually created breadcrumbs in `KMManager.shouldOverrideUrlLoading()` for "showKeyPreview"
```
        Breadcrumb breadcrumb = new Breadcrumb();
        breadcrumb.setCategory("navigation");
        breadcrumb.setType("navigation");
        breadcrumb.setData("from", url);
        breadcrumb.setData("to", url);
        breadcrumb.setLevel(SentryLevel.INFO);
        Sentry.addBreadcrumb(breadcrumb);
```

Reference

