### PR TITLE
fix(windows): crash with package online update

### DIFF
--- a/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
@@ -283,7 +283,7 @@ begin
     kpil.RegisterTip(KeyboardID, BCP47Tag, KeyboardName, Langs[0], IconFileName, '');
     kpil.InstallTip(KeyboardID, BCP47Tag, Langs[0], guid);
   finally
-    Free;
+    kpil.Free;
   end;
 end;
 
@@ -304,7 +304,7 @@ begin
       Result := True;
     end;
   finally
-    Free;
+    kpil.Free;
   end;
 end;
 


### PR DESCRIPTION
Fixes #4005.
Fixes #3938.
Fixes KEYMAN-WINDOWS-5V.

The wrong object was being freed which caused an access violation internally.