### PR TITLE
fix(windows): Handle network errors when downloading keyboards

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
@@ -121,8 +121,13 @@ begin
 
       Stream := TFileStream.Create(FTempFilename, fmCreate);
       try
-        Response := Client.Get(FDownloadURL, Stream);
-        Result := Response.StatusCode = 200;
+        try
+          Response := Client.Get(FDownloadURL, Stream);
+          Result := Response.StatusCode = 200;
+        except
+          on E:ENetHTTPClientException do
+            Result := False;
+        end;
       finally
         Stream.Free;
       end;

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
@@ -229,10 +229,19 @@ begin
 
     Stream := TFileStream.Create(FTempFilename, fmCreate);
     try
-      Response := Client.Get(FDownloadURL, Stream);
-      Result := Response.StatusCode = 200;
-      FDownloadStatusText := Response.StatusText;
-      FDownloadStatusCode := Response.StatusCode;
+      try
+        Response := Client.Get(FDownloadURL, Stream);
+        Result := Response.StatusCode = 200;
+        FDownloadStatusText := Response.StatusText;
+        FDownloadStatusCode := Response.StatusCode;
+      except
+        on E:ENetHTTPClientException do
+        begin
+          FDownloadStatusText := E.Message;
+          FDownloadStatusCode := 0;
+          Result := False;
+        end;
+      end;
     finally
       Stream.Free;
     end;


### PR DESCRIPTION
Fixes #3993.
Fixes KEYMAN-WINDOWS-4P.

Handles network errors which caused an exception, e.g. connection timed out, or 12030 The connection with the server was terminated abnormally.