### PR TITLE
feat(ios/engine): keyboard-menu scroll indicator now flashes when opened

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardMenuView.swift
@@ -142,6 +142,10 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
     fatalError("init(coder:) has not been implemented")
   }
 
+  func flashScrollIndicators() {
+    tableView?.flashScrollIndicators()
+  }
+
   override func draw(_ rect: CGRect) {
     let keyWidth = keyFrame.width
     let keyHeight = keyFrame.height

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -1088,6 +1088,7 @@ extension KeymanWebViewController {
         self.keyboardMenuView = KeyboardMenuView(keyFrame: keyFrame, inputViewController: ic,
                                                  closeButtonTitle: closeButtonTitle)
         parentView?.addSubview(self.keyboardMenuView!)
+        self.keyboardMenuView!.flashScrollIndicators()
       }
     }
   }


### PR DESCRIPTION
Fixes #4018.

![Screen Shot 2020-12-01 at 2 56 54 PM](https://user-images.githubusercontent.com/25213402/100712720-ca549400-33e5-11eb-8d27-bd58e7b8791b.png)

The scroll indicator's flash lasts about a second - plenty of time to indicate the potential to scroll.  It flashes regardless of whether or not there's a need to scroll, as seen here:

![Screen Shot 2020-12-01 at 3 02 33 PM](https://user-images.githubusercontent.com/25213402/100713010-418a2800-33e6-11eb-8a04-a2a01bab0062.png)

![Screen Shot 2020-12-01 at 3 05 04 PM](https://user-images.githubusercontent.com/25213402/100713268-9e85de00-33e6-11eb-8790-b4e4c1ea4a30.png)

It's nothing intrusive or ugly, so I think that having it flash in these scenarios is "fine."