### PR TITLE
fix(windows): Rename to Keyman in help files

### DIFF
--- a/windows/src/desktop/help/about/history.xml
+++ b/windows/src/desktop/help/about/history.xml
@@ -2,7 +2,7 @@
 <section id="about_history">
   <title>Version History</title>
 
-  <para>A frequently updated changelog for Keyman Desktop is kept at <ulink url="https://help.keyman.com/products/desktop/versionhistory.php">https://help.keyman.com/products/desktop/versionhistory.php</ulink> on the Keyman Help website.</para>
+  <para>A frequently updated changelog for Keyman is kept at <ulink url="https://help.keyman.com/products/desktop/version-history">https://help.keyman.com/products/desktop/version-history</ulink> on the Keyman Help website.</para>
 
   <bridgehead>Related Topics</bridgehead>
   <itemizedlist>

--- a/windows/src/desktop/help/about/requirements.xml
+++ b/windows/src/desktop/help/about/requirements.xml
@@ -2,7 +2,7 @@
 <section id="about_requirements">
   <title>System Requirements</title>
   <bridgehead>Supported Windows Operating Systems</bridgehead>
-  <para>Keyman Desktop 10.0 fully supports 32-bit <emphasis>and</emphasis> 64-bit versions of the following Windows operating systems:</para>
+  <para>Keyman fully supports 32-bit <emphasis>and</emphasis> 64-bit versions of the following Windows operating systems:</para>
   <itemizedlist>
     <listitem>
       <para>Windows 7</para>
@@ -23,8 +23,8 @@
       <para>Windows Server 2012 and 2012 R2</para>
     </listitem>
   </itemizedlist>
-  <note>Keyman Desktop works slightly differently in different versions of Windows. Older versions of Windows have more language limitations and need extra configuration.</note>  
+  <note>Keyman works slightly differently in different versions of Windows. Older versions of Windows have more language limitations and need extra configuration.</note>  
   <bridgehead>Resource Requirements</bridgehead>
-  <para>Keyman Desktop 10.0 has minimal resource requirements. Any computer that can run Windows 7 should be able to run Keyman Desktop without trouble.</para>
+  <para>Keyman has minimal resource requirements. Any computer that can run Windows 7 should be able to run Keyman without trouble.</para>
 	
 </section>

--- a/windows/src/desktop/help/about/welcome.xml
+++ b/windows/src/desktop/help/about/welcome.xml
@@ -1,16 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="about_welcome">
-  <title>Welcome to Keyman Desktop 10.0</title>
+  <title>Welcome to Keyman</title>
 
-  <para>Thank you for installing Keyman Desktop 10.0. Whether you're a new or returning user, we believe you will appreciate the significant enhancements in this latest version of Keyman Desktop.</para>
-  <para>We've added many new features to our market-leading keyboard application and our redesigned Keyman Desktop Help should assist you in getting around.</para>
+  <para>Thank you for installing Keyman. Whether you're a new or returning user, we believe you will appreciate the significant enhancements in this latest version of Keyman.</para>
   
-  <bridgehead>What is Keyman Desktop?</bridgehead>
-  <para>Keyman Desktop is a keyboard application that makes it easy for you to type in your language in all your favourite Windows programs and across the Web. Keyman Desktop is used by more than a million people to type in over 1000 languages and counting.</para>
-  <para>Keyman Desktop remaps your hardware keyboard to any one of hundreds of virtual keyboards, available for download from the <ulink url="https://www.keyman.com/">Keyman Website</ulink> and around the Web. If you cannot find a keyboard for your language, we offer the companion application <ulink url="https://keyman.com/developer/">Keyman Developer</ulink>. Keyman Developer is a powerful software solution for creating the perfect Keyman keyboard to suit your needs.</para>
-  <para>Keyman Desktop features seamless integration with your Windows operating system and the Windows language bar. You can use Keyman keyboards with Keyman Desktop in almost any Windows or Web application. Try it in office software like Word or Excel; browsers like Firefox or Internet Explorer; design programs like Adobe InDesign; and email services like Outlook or Gmail.</para>
-  <para>Keyman Desktop fully supports <ulink url="http://www.unicode.org/">Unicode</ulink> and legacy standards and can be used with all standard hardware keyboards, making it the perfect solution for typing in any language on your computer.</para>
-  <para>A list of features in Keyman Desktop 10.0 is available <link linkend="about_whatsnew">here</link>.</para>
+  <bridgehead>What is Keyman?</bridgehead>
+  <para>Keyman is a keyboard application that makes it easy for you to type in your language in all your favourite Windows programs and across the Web. Keyman is used by more than a million people to type in over 1000 languages and counting.</para>
+  <para>Keyman remaps your hardware keyboard to any one of hundreds of virtual keyboards, available for download from the <ulink url="https://keyman.com/">Keyman Website</ulink> and around the Web. If you cannot find a keyboard for your language, we offer the companion application <ulink url="https://keyman.com/developer/">Keyman Developer</ulink>. Keyman Developer is a powerful software solution for creating the perfect Keyman keyboard to suit your needs.</para>
+  <para>Keyman features seamless integration with your Windows operating system and the Windows language bar. You can use Keyman keyboards with Keyman in almost any Windows or Web application. Try it in office software like Word or Excel; browsers like Firefox or Internet Explorer; design programs like Adobe InDesign; and email services like Outlook or Gmail.</para>
+  <para>Keyman fully supports <ulink url="http://www.unicode.org/">Unicode</ulink> and legacy standards and can be used with all standard hardware keyboards, making it the perfect solution for typing in any language on your computer.</para>
+  <para>A list of features in Keyman is available <link linkend="about_whatsnew">here</link>.</para>
   <para>
     <inlinemediaobject>
       <imageobject>

--- a/windows/src/desktop/help/about/whatsnew.xml
+++ b/windows/src/desktop/help/about/whatsnew.xml
@@ -2,12 +2,24 @@
 <section id="about_whatsnew">
   <title>What's New</title>
   
-  <para>Here are some of the great things we have added to Keyman Desktop 10.0. </para>
+  <para>Here are some of the great things we have added to Keyman 14.0.</para>
   <itemizedlist>
-<listitem>Keyman Desktop 10 is completely free and <link xref="https://keyman.com/free">open source</link>!</listitem>
-<listitem>Support for custom BCP-47 language codes: you can now associate a keyboard with any valid language code in Windows 8 and later</listitem>
-<listitem><link xref="https://help.keyman.com/developer/engine/desktop/10.0/api/">Keyman API</link> extensively rewritten and improved</listitem>
-<listitem>Additional user interface language - Turkish (translation done by Stevan Vanderwerf)</listitem>
+    <listitem>Renamed from Keyman Desktop to Keyman for Windows</listitem>
+    <listitem>Keyman keyboards are no longer hidden from the Windows language picker when you exit Keyman. Rather, if you select a Keyman keyboard, Keyman will be restarted for you automatically.</listitem>
+    <listitem>Simpler and Smoother Keyboard Search</listitem>
+    <listitem>Localizable UI through <link xref="https://translate.keyman.com/">translate.keyman.com</link></listitem>
+    <listitem>Added user interface for configuring all Keyman system-level options (#3733)</listitem>
+    <listitem>Refreshed user interface no longer depends on Internet Explorer (#1720)</listitem>
+    <listitem>Smoother and more reliable installation of keyboard languages (#3509)</listitem>
+    <listitem>Choose associated language when keyboard is installed (#3524)</listitem>
+    <listitem>Much improved keyboard download experience (#3326)</listitem>
+    <listitem>Improved BCP 47 tag support (#3529)</listitem>
+    <listitem>Much improved initial download and installation experience including bundled keyboards (#3304)</listitem>
+    <listitem>Keyman Configuration changes now apply instantly (#3753)</listitem>
+    <listitem>Improved user experience when many keyboards installed (#3626, #3627)</listitem>
+    <listitem>Improved bootstrap installer</listitem>
+    <listitem>Now uses Chromium to host all web-based UI (e.g. Keyman Configuration)</listitem>
+    <listitem>Breaking change: Keyman Engine no longer supports the keyboard usage page (usage.htm)</listitem>
   </itemizedlist>
 
   <bridgehead>Related Topics</bridgehead>

--- a/windows/src/desktop/help/advanced/proxy_config.xml
+++ b/windows/src/desktop/help/advanced/proxy_config.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="advanced_proxy_config">
   <title>Proxy Configuration</title>
-  <para>The Proxy Configuration dialog allows you to enter HTTP proxy details for Keyman Desktop Configuration.</para>
+  <para>The Proxy Configuration dialog allows you to enter HTTP proxy details for Keyman Configuration.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -11,7 +11,7 @@
   </para>
   <para>Most users do not need to change their proxy configuration.  Proxy configuration is used only in networked environments, and if a proxy server is present,
   your network administrator will be able to provide you with the details required.</para>
-  <para>Proxy details are used when checking for updates online and when downloading a keyboard layout.  If no proxy details are entered, Keyman Desktop Configuration 
+  <para>Proxy details are used when checking for updates online and when downloading a keyboard layout.  If no proxy details are entered, Keyman Configuration 
   will use the proxy settings from Internet Explorer.</para>
   <bridgehead>Related Topics</bridgehead>
   <itemizedlist>

--- a/windows/src/desktop/help/advanced/text_services_framework.xml
+++ b/windows/src/desktop/help/advanced/text_services_framework.xml
@@ -17,13 +17,12 @@
   
   <!--need double-check, I don't if the second sentence is true.-->
   <para>With Keyman Desktop 9 and later versions, all keyboards are registered through the Windows interfaces, and the
-  key advantage is that Keyman Desktop now automatically detects applications that have support for TSF and upgrades the experience for those applications.</para>
-  <para>For those applications that support TSF, the most important advantage is that Keyman Desktop can read the current 'context' from the application. The 
-  'context' is the characters on the screen around the insertion point. Earlier versions of Keyman Desktop remembered the context while inputting text, but as
-  soon as an arrow key was pressed,   or the mouse clicked, Keyman Desktop would forget the context. This means that existing text can be edited in a   
+  key advantage is that Keyman now automatically detects applications that have support for TSF and upgrades the experience for those applications.</para>
+  <para>For those applications that support TSF, the most important advantage is that Keyman can read the current 'context' from the application. The 
+  'context' is the characters on the screen around the insertion point. Earlier versions of Keyman remembered the context while inputting text, but as
+  soon as an arrow key was pressed,   or the mouse clicked, Keyman would forget the context. This means that existing text can be edited in a   
   much more intuitive manner when using TSF.</para>
   <bridgehead>What applications support TSF?</bridgehead><!--update needed-->
-  <para>At the time of the release of Keyman Desktop 9.0, TSF was fully supported by some Windows Vista and Windows 7 components, along with Microsoft Word and
-  Microsoft Publisher. Other applications support TSF to a varying degree.</para>
+  <para>TSF is supported by a wide range of software and Windows components.</para>
  
 </section>

--- a/windows/src/desktop/help/basic/config_tasks/config_menu.xml
+++ b/windows/src/desktop/help/basic/config_tasks/config_menu.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_config_menu">
-  <title>Keyman Desktop Configuration</title>
-  <para>Keyman Configuration is the central control panel for Keyman Desktop. Use Keyman Configuration to purchase and activate Keyman Desktop, switch the language of Keyman Desktop menus, install and uninstall keyboards, change options, set hotkeys, disable addins, associate languages, check for updates and run support diagnostics.</para> 
+  <title>Keyman Configuration</title>
+  <para>Keyman Configuration is the central control panel for Keyman. Use Keyman Configuration to purchase and activate Keyman, switch the language of Keyman menus, install and uninstall keyboards, change options, set hotkeys, disable addins, associate languages, check for updates and run support diagnostics.</para> 
    <para>
     <inlinemediaobject>
       <imageobject>
@@ -14,10 +14,10 @@
   <para>To open Keyman Configuration:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
   </orderedlist>
 

--- a/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.xml
+++ b/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.xml
@@ -2,7 +2,7 @@
 <section id="basic_hotkeys_tab" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Keyman Configuration - Hotkeys Tab</title>
   
-<para>The Hotkeys tab of Keyman Configuration lets you set hotkeys for Keyman Desktop functions, Keyman keyboards and Windows languages.</para>
+<para>The Hotkeys tab of Keyman Configuration lets you set hotkeys for Keyman functions, Keyman keyboards and Windows languages.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -15,10 +15,10 @@
   <para>To open the Hotkeys tab of Keyman Configuration:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select the Hotkeys tab.</para>
@@ -50,13 +50,13 @@
 	</note>
   
   <bridgehead>About Hotkeys</bridgehead>
-  <para>The General Hotkeys section of the Hotkeys tab lists hotkeys for Keyman Desktop functions:</para>
+  <para>The General Hotkeys section of the Hotkeys tab lists hotkeys for Keyman functions:</para>
   <itemizedlist>
 	<listitem>
-		<para>Switch Keyman Desktop Off — Switches all Keyman Desktop keyboards off, but does not exit Keyman Desktop.</para>
+		<para>Switch Keyman Off — Switches to your default Windows keyboard, but does not exit Keyman.</para>
     </listitem>
 	<listitem>
-		<para>Open Keyboard Menu — Opens the  <link linkend='basic_traymenu'>Keyman Desktop Menu</link>.</para>
+		<para>Open Keyboard Menu — Opens the  <link linkend='basic_traymenu'>Keyman Menu</link>.</para>
     </listitem>
 	<listitem>
 		<para>Open Language Switcher — Opens the <link linkend='basic_languageswitcher'>Language Switcher</link>.</para>

--- a/windows/src/desktop/help/basic/config_tasks/keyboards_tab.xml
+++ b/windows/src/desktop/help/basic/config_tasks/keyboards_tab.xml
@@ -14,10 +14,10 @@
   <para>To open the Keyboard Layouts tab of Keyman Configuration:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select the Keyboard Layouts tab.</para>
@@ -32,7 +32,7 @@
 		<para>To install a keyboard layout from a local folder, see: <link linkend='install_folder'>Installing a Keyman keyboard from a Folder on Your Computer</link></para>
 	</listitem>
 	<listitem>
-		<para>To install a keyboard layout online, see: <link linkend='install_tav'>Downloading &amp; Installing a Keyman Keyboard within Keyman Desktop</link></para>
+		<para>To install a keyboard layout online, see: <link linkend='install_tav'>Downloading &amp; Installing a Keyman Keyboard within Keyman</link></para>
 	</listitem>
    </itemizedlist>
 

--- a/windows/src/desktop/help/basic/config_tasks/options_tab.xml
+++ b/windows/src/desktop/help/basic/config_tasks/options_tab.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_options_tab">
   <title>Keyman Configuration - Options Tab</title>
-  <para>The Options tab of Keyman Configuration includes the Keyman Desktop application options. You can use the Options tab to set general, startup, Keyman Toolbox On Screen Keyboard and advanced options.</para>
+  <para>The Options tab of Keyman Configuration includes the Keyman application options. You can use the Options tab to set general, startup, Keyman Toolbox On Screen Keyboard and advanced options.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -14,10 +14,10 @@
   <para>To open the Options tab of Keyman Configuration:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select the Options tab.</para>
@@ -45,7 +45,7 @@
     </listitem>
     <listitem>
       <para>Select keyboard layout for all applications</para>
-      <para>Unlike Windows default behaviour, Keyman Desktop allows you to select one Windows language and Keyman keyboard for all open applications and text fields across your entire system. Tick this option to select one Windows language and Keyman keyboard across your entire system. Untick this option to select Windows language and Keyman keyboards independently for different programs.</para>
+      <para>Unlike Windows default behaviour, Keyman allows you to select one Windows language and Keyman keyboard for all open applications and text fields across your entire system. Tick this option to select one Windows language and Keyman keyboard across your entire system. Untick this option to select Windows language and Keyman keyboards independently for different programs.</para>
       <para>On Windows 8, 8.1, 10 and later versions, this checkbox is disabled because Windows has this functionality built in. The setting can be changed in Windows, with the following steps:</para>
       <itemizedlist>
         <listitem>Open Control Panel</listitem>
@@ -55,7 +55,7 @@
     </listitem>
     <listitem>
       <para>Show hint messages</para>
-      <para>You can turn on and off the beginner hint messages which appear while using Keyman Desktop. Tick this option to show all hint messages. Untick this option to hide all hint messages.</para>
+      <para>You can turn on and off the beginner hint messages which appear while using Keyman. Tick this option to show all hint messages. Untick this option to hide all hint messages.</para>
 	  <note>You can also hide hint messages on a case-by-case bases by ticking <inlinemediaobject><imageobject><imagedata fileref="desktop_images/options-hint.png" /></imageobject></inlinemediaobject> at the bottom of each hint.</note> 
     </listitem>
     <listitem>
@@ -74,20 +74,20 @@
   <itemizedlist>
     <listitem>
       <para>Start when Windows starts</para>
-      <para>You can have Keyman Desktop start when Windows starts. Tick this option to have Keyman Desktop start when Windows starts. Untick this option to start Keyman Desktop manually.</para>
+      <para>You can have Keyman start when Windows starts. Tick this option to have Keyman start when Windows starts. Untick this option to start Keyman manually.</para>
     </listitem>
     <listitem>
       <para>Show splash screen</para>
-      <para>You can turn on and off the Keyman Desktop splash screen that appears when Keyman Desktop starts. Tick this option to show the splash screen on startup. Untick this option to remove the splash screen.</para>
+      <para>You can turn on and off the Keyman splash screen that appears when Keyman starts. Tick this option to show the splash screen on startup. Untick this option to remove the splash screen.</para>
     </listitem>
     <listitem>
       <para>Automatically check www.keyman.com weekly for updates.</para>
-      <para>Keyman Desktop can automatically check for application and keyboard updates once a week. No personally identifiable information is sent to Keyman in this process. Tick this option to have Keyman Desktop automatically check weekly for updates to Keyman Desktop and the keyboards you have installed. Untick this option to check for updates manually.</para>
-	  <note>Keyman Desktop can be updated manually through the Support tab in the Configuration menu.</note>
+      <para>Keyman can automatically check for application and keyboard updates once a week. No personally identifiable information is sent to Keyman in this process. Tick this option to have Keyman automatically check weekly for updates to Keyman and the keyboards you have installed. Untick this option to check for updates manually.</para>
+	  <note>Keyman can be updated manually through the Support tab in the Configuration menu.</note>
     </listitem>
     <listitem>
-      <para>Test for conflicting applications when Keyman Desktop starts</para>
-      <para>Some applications are not written according to the Windows software development standards and can cause problems with Keyman keyboard input. Tick this option to have Keyman Desktop detect problem applications and work around them. Untick this option to prevent Keyman Desktop from working around problem applications.</para>
+      <para>Test for conflicting applications when Keyman starts</para>
+      <para>Some applications are not written according to the Windows software development standards and can cause problems with Keyman keyboard input. Tick this option to have Keyman detect problem applications and work around them. Untick this option to prevent Keyman from working around problem applications.</para>
     </listitem>
   </itemizedlist>
   <bridgehead>Using On Screen Keyboard Options</bridgehead>
@@ -109,7 +109,7 @@
     </listitem>
     <listitem>
       <para>Switch to appropriate On Screen Keyboard/Help automatically when a keyboard is selected</para>
-      <para>Each time you turn on a Keyman keyboard, Keyman Desktop can automatically detect and switch to the Keyman Toolbox tool which is best for that Keyman keyboard: either the On Screen Keyboard or Keyboard Usage. Tick this option to have Keyman Desktop automatically detect and display the best view for your Keyman keyboard. Untick this option to prevent Keyman Desktop from switching its display automatically.</para>
+      <para>Each time you turn on a Keyman keyboard, Keyman can automatically detect and switch to the Keyman Toolbox tool which is best for that Keyman keyboard: either the On Screen Keyboard or Keyboard Usage. Tick this option to have Keyman automatically detect and display the best view for your Keyman keyboard. Untick this option to prevent Keyman from switching its display automatically.</para>
     </listitem>
   </itemizedlist>
   <bridgehead>Using Advanced Options</bridgehead>
@@ -123,8 +123,8 @@
   <itemizedlist>
     <listitem>
       <para>Debugging</para>
-      <para>If you are having issues with Keyman Desktop, you can create a debug log for Keyman Desktop. A debug log contains information to help Keyman Technical Support resolve compatibility issues and improve Keyman Desktop. Tick this option to begin a debug log. You should not need to use this option unless you are requested to do so by Keyman Technical Support in relation to an issue you are experiencing.</para>
-      <para>The debug log files are created in <guilabel>%LOCALAPPDATA%\Keyman\Diag</guilabel>, and called <guilabel>system#.etl</guilabel>, where # is a number from 0 to 15. Each time you start Keyman Desktop, a new log file will be created, up to <guilabel>system15.etl</guilabel>, after which it will wrap around and start again at <guilabel>system0.etl</guilabel>.  Untick this option to stop collecting a debug log.</para>
+      <para>If you are having issues with Keyman, you can create a debug log for Keyman. A debug log contains information to help Keyman Technical Support resolve compatibility issues and improve Keyman. Tick this option to begin a debug log. You should not need to use this option unless you are requested to do so by Keyman Technical Support in relation to an issue you are experiencing.</para>
+      <para>The debug log files are created in <guilabel>%LOCALAPPDATA%\Keyman\Diag</guilabel>, and called <guilabel>system#.etl</guilabel>, where # is a number from 0 to 15. Each time you start Keyman, a new log file will be created, up to <guilabel>system15.etl</guilabel>, after which it will wrap around and start again at <guilabel>system0.etl</guilabel>.  Untick this option to stop collecting a debug log.</para>
       <para>Debug log files will be sent to Keyman Technical Support when you send a diagnostic report to us with the Keyman System Information tool.</para>
       <para>Debug log files are in binary format and can be imported into Windows Event Viewer for viewing, or Microsoft Message Analyzer (recommended).</para>
       <note>

--- a/windows/src/desktop/help/basic/config_tasks/support_tab.xml
+++ b/windows/src/desktop/help/basic/config_tasks/support_tab.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="basic_support_tab" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Keyman Configuration - Support Tab</title>
-  <para>The Support tab of Keyman Configuration displays Keyman Desktop version information and support tools. You can use the Support tab to send a support request, check Windows language settings, check for updates, and view Keyman Desktop version information.</para>
+  <para>The Support tab of Keyman Configuration displays Keyman version information and support tools. You can use the Support tab to send a support request, check Windows language settings, check for updates, and view Keyman version information.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -13,10 +13,10 @@
   <para>To open the Support tab of Keyman Configuration:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select the Support tab.</para>
@@ -30,7 +30,7 @@
 
 
   <bridgehead>Checking for Updates</bridgehead>
-	<para>To check for Keyman Desktop updates, from the Support tab of Keyman Configuration click the 'Check for Updates' link. You can also download and install Keyman Desktop again from the Keyman website.</para>
+	<para>To check for Keyman updates, from the Support tab of Keyman Configuration click the 'Check for Updates' link. You can also download and install Keyman again from the Keyman website.</para>
 	
   
   <bridgehead>About Version Information</bridgehead>
@@ -38,9 +38,9 @@
    <itemizedlist>
     <listitem>Version Detals
     <itemizedlist>
-      <listitem><para>Edition — Details on your current edition of Keyman Desktop.</para>
+      <listitem><para>Edition — Details on your current edition of Keyman.</para>
       </listitem>
-      <listitem><para>Version — The current Keyman Desktop version number</para></listitem>
+      <listitem><para>Version — The current Keyman version number</para></listitem>
     </itemizedlist>
     </listitem>
    </itemizedlist>

--- a/windows/src/desktop/help/basic/engine_tasks/uninstall.xml
+++ b/windows/src/desktop/help/basic/engine_tasks/uninstall.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_uninstall">
-  <title>Software Task - Uninstall Keyman Desktop</title>
-  <para>To uninstall Keyman Desktop:</para>
+  <title>Software Task - Uninstall Keyman</title>
+  <para>To uninstall Keyman:</para>
    <orderedlist>
 	<listitem>
-	 <para>Close Keyman Desktop.</para>
+	 <para>Close Keyman.</para>
 	</listitem>
     <listitem>
 	 <para>Open Windows Control Panel.</para>
@@ -13,7 +13,7 @@
 	 <para>Select 'Add or Remove Programs' or 'Programs and Features' or 'Uninstall a program'.</para>
 	</listitem>
 	<listitem>
-	 <para>Click Keyman Desktop 10.0 in the list.</para>
+	 <para>Click Keyman in the list.</para>
 	</listitem>
 	<listitem>
 	 <para>Click <guibutton>Remove</guibutton> or <guibutton>Uninstall</guibutton> or right-click 'Uninstall'.</para>

--- a/windows/src/desktop/help/basic/engine_tasks/update.xml
+++ b/windows/src/desktop/help/basic/engine_tasks/update.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_update">
-  <title>Software Task - Update Keyman Desktop</title>
+  <title>Software Task - Update Keyman</title>
   <bridgehead>Check for Updates Automatically</bridgehead>
-  <para>Keyman Desktop can check for updates automatically once a week. Here's how:</para>
+  <para>Keyman can check for updates automatically once a week. Here's how:</para>
    <orderedlist>
     <listitem>
-	 <para>Open Keyman Desktop.</para>
+	 <para>Open Keyman.</para>
 	</listitem>
 	<listitem>
 	 <para>Open Keyman Configuration, from the Keyman menu (on the Windows Taskbar near the clock).</para>
@@ -28,7 +28,7 @@
      </para>	 
 	</listitem>
 	<listitem>
-     <para>Tick 'Automatically check www.keyman.com weekly for updates.'</para>
+     <para>Tick 'Automatically check keyman.com weekly for updates.'</para>
 	</listitem>
 	<listitem>
 	 <para>Click <guibutton>OK</guibutton> to apply changes.</para>
@@ -46,7 +46,7 @@
      </para> 
 	 
    <bridgehead>Updating Manually</bridgehead>
-   <para>You can manually update Keyman Desktop at any time by downloading and installing it again from the <ulink url="https://www.keyman.com/">Keyman Website</ulink>.</para>  
+   <para>You can manually update Keyman at any time by downloading and installing it again from the <ulink url="https://keyman.com/">Keyman Website</ulink>.</para>  
 	
   <bridgehead>Related Topics</bridgehead>
   <itemizedlist>

--- a/windows/src/desktop/help/basic/help.xml
+++ b/windows/src/desktop/help/basic/help.xml
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_help">
-  <title>The Keyman Desktop Help Menu</title>
-  <para>The Keyman Desktop Help menu gives you comprehensive help for every aspect of Keyman Desktop.</para> 
+  <title>The Keyman Help Menu</title>
+  <para>The Keyman Help menu gives you comprehensive help for every aspect of Keyman.</para> 
   
-  <tip>All of the help available through the Keyman Desktop Help menu is also available online through the <ulink url='http://help.keyman.com/products/desktop/10.0/'>Help Documentation</ulink> section of the Keyman Desktop help site.</tip>
+  <tip>All of the help available through the Keyman Help menu is also available online through the <ulink url='http://help.keyman.com/products/windows/'>Help Documentation</ulink> section of the Keyman help site.</tip>
 
   <bridgehead>Opening Help</bridgehead>
   <!--there seem be no popup dialogue box as such in v10.0-->
-  <para>To open Keyman Desktop Help:</para>
+  <para>To open Keyman Help:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Help…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Help…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select Help Contents.</para>
@@ -28,15 +28,15 @@
   </orderedlist>
  
   <bridgehead>Using Help</bridgehead>
-  <para>Keyman Desktop Help is divided into seven sections:</para>
+  <para>Keyman Help is divided into seven sections:</para>
   <orderedlist>
-   <listitem><para>About Keyman Desktop — Provides general information and licensing details about the current version of Keyman Desktop.</para></listitem> 
-   <listitem><para>Getting Started — Includes all the help you need to start using Keyman Desktop quickly.</para></listitem> 
-   <listitem><para>Basic Help — Gives a detailed overview of all of the basic features of Keyman Desktop.</para></listitem> 
-   <listitem><para>Advanced Help — Gives an overview of more advanced Keyman Desktop features.</para></listitem> 
+   <listitem><para>About Keyman — Provides general information and licensing details about the current version of Keyman.</para></listitem> 
+   <listitem><para>Getting Started — Includes all the help you need to start using Keyman quickly.</para></listitem> 
+   <listitem><para>Basic Help — Gives a detailed overview of all of the basic features of Keyman.</para></listitem> 
+   <listitem><para>Advanced Help — Gives an overview of more advanced Keyman features.</para></listitem> 
    <listitem><para>Common Questions — Includes a selection of the most frequently asked questions.</para></listitem> 
    <listitem><para>Troubleshooting Index — Provides reference guides for specific issues.</para></listitem> 
-   <listitem><para>Context Help — Links context-sensitive help (accesible throughout Keyman Desktop using <keycap>F1</keycap>) to the correct help topics.</para></listitem> 
+   <listitem><para>Context Help — Links context-sensitive help (accesible throughout Keyman using <keycap>F1</keycap>) to the correct help topics.</para></listitem> 
   </orderedlist>
   
   <bridgehead>Related Topics</bridgehead>

--- a/windows/src/desktop/help/basic/keyboard_tasks/disable_keyboard.xml
+++ b/windows/src/desktop/help/basic/keyboard_tasks/disable_keyboard.xml
@@ -16,10 +16,10 @@
   <para>To disable a Keyman keyboard:</para>
   <orderedlist>
     <listitem>
-      <para>Open <application>Keyman Desktop</application>.</para>
+      <para>Open <application>Keyman</application>.</para>
 	</listitem>
 	<listitem>
-	  <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+	  <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
       <para>
         <inlinemediaobject>
           <imageobject>
@@ -54,10 +54,10 @@
  <para>To enable a Keyman keyboard:</para>
   <orderedlist>
     <listitem>
-      <para>Open <application>Keyman Desktop</application>.</para>
+      <para>Open <application>Keyman</application>.</para>
 	</listitem>
 	<listitem>
-	  <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+	  <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
       <para>
         <inlinemediaobject>
           <imageobject>

--- a/windows/src/desktop/help/basic/keyboard_tasks/enable_keyboard.xml
+++ b/windows/src/desktop/help/basic/keyboard_tasks/enable_keyboard.xml
@@ -13,10 +13,10 @@
 	<note>You need to have an application open for your Keyman keyboard to load correctly.</note>
    </listitem>
    <listitem>
-    <para>Start Keyman Desktop.</para>
+    <para>Start Keyman.</para>
    </listitem>
    <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     <para>
         <inlinemediaobject>
           <imageobject>
@@ -37,10 +37,10 @@
     <para>Open an application to type in, like MS Word.</para>
    </listitem>
    <listitem>
-    <para>Start Keyman Desktop.</para>
+    <para>Start Keyman.</para>
    </listitem>
    <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     <para>
         <inlinemediaobject>
           <imageobject>
@@ -72,7 +72,7 @@
 	<note>You need to have an application open for your Keyman keyboard to load correctly.</note>
    </listitem>
    <listitem>
-    <para>Start Keyman Desktop.</para>
+    <para>Start Keyman.</para>
    </listitem>
    <listitem>
     <para>Press the Language Switcher hotkey to bring up the Language Switcher. If you are using the default Language Switcher hotkey (<keycap>Left.Alt</keycap> + <keycap>Shift</keycap>) or another hotkey with <keycap>Alt</keycap>, you will need to press and HOLD the <keycap>Alt</keycap> part of the hotkey and press and RELEASE the last key in the hotkey to use the Language Switcher. When you release <keycap>Alt</keycap>, the Language Switcher will close.</para>
@@ -100,7 +100,7 @@
     <para>Open an application to type in, like MS Word.</para>
    </listitem>
    <listitem>
-    <para>Start Keyman Desktop.</para>
+    <para>Start Keyman.</para>
    </listitem>
    <listitem>
     <para>Press and release the hotkey for your Keyman keyboard.</para>

--- a/windows/src/desktop/help/basic/keyboard_tasks/uninstall_keyboard.xml
+++ b/windows/src/desktop/help/basic/keyboard_tasks/uninstall_keyboard.xml
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_uninstall_keyboard">
   <title>Keyboard Task - Uninstall a Keyboard</title>
-  <para>Uninstalling a Keyman keyboard removes it from Keyman Desktop. If you want to use the Keyman keyboard again it must be reinstalled.</para>
+  <para>Uninstalling a Keyman keyboard removes it from Keyman. If you want to use the Keyman keyboard again it must be reinstalled.</para>
   <note>You can disable a keyboard temporarily, instead of uninstalling it. For more help, see: <xref linkend='basic_disable_keyboard'></xref></note>
   <para>To uninstall a Keyman keyboard:</para>
   <orderedlist>
     <listitem>
-      <para>Open <application>Keyman Desktop</application>.</para>
+      <para>Open <application>Keyman</application>.</para>
 	</listitem>
 	<listitem>
-	  <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+	  <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
       <para>
         <inlinemediaobject>
           <imageobject>
@@ -41,7 +41,7 @@
       <para>Click <guibutton>OK</guibutton>.</para>
     </listitem>
   </orderedlist>
-  <para>The Keyman keyboard is now removed from Keyman Desktop.</para>
+  <para>The Keyman keyboard is now removed from Keyman.</para>
   
   <bridgehead>Related Topics</bridgehead>
   <itemizedlist>

--- a/windows/src/desktop/help/basic/languageswitcher.xml
+++ b/windows/src/desktop/help/basic/languageswitcher.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <section id="basic_languageswitcher" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Language Switcher</title>
-  <para>The Keyman Desktop Language Switcher is a single popup menu to let you rapidly switch between any installed Keyman keyboard, Windows language or Windows layout.</para>
+  <para>The Keyman Language Switcher is a single popup menu to let you rapidly switch between any installed Keyman keyboard, Windows language or Windows layout.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -12,7 +12,7 @@
   </para>  
  
   <bridgehead>Opening and Using the Language Switcher</bridgehead>
-  <para>To open and use the Keyman Desktop Language Switcher </para>
+  <para>To open and use the Keyman Language Switcher </para>
   <orderedlist>
   <listitem>
     <para>Press the Language Switcher hotkey to bring up the Language Switcher. If you are using the default Language Switcher hotkey (<keycap>Left.Alt</keycap> + <keycap>Shift</keycap>) or another hotkey with <keycap>Alt</keycap>, you will need to press and HOLD the <keycap>Alt</keycap> part of the hotkey and press and RELEASE the last key in the hotkey to use the Language Switcher. When you release <keycap>Alt</keycap>, the Language Switcher will close.</para>

--- a/windows/src/desktop/help/basic/newways.xml
+++ b/windows/src/desktop/help/basic/newways.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <section id="basic_newways" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>New Ways to Use Keyman Desktop</title>
+  <title>New Ways to Use Keyman</title>
   
-  <para>If you are an existing user of Keyman Desktop, you will notice that some parts of the program have changed. This 
-  topic describes some of the new ways you can or should access some of Keyman Desktop's features. These changes have been 
-  implemented as part of enhancing how Keyman Desktop integrates with modern versions of Windows.</para>
+  <para>If you are an existing user of Keyman, you will notice that some parts of the program have changed. This 
+  topic describes some of the new ways you can or should access some of Keyman's features. These changes have been 
+  implemented as part of enhancing how Keyman integrates with modern versions of Windows.</para>
   
-  <!--New ways in Keyman Desktop 10.0 should replace this section.-->
+  <para>Keyman Configuration no longer requires you to click the <guibutton>OK</guibutton> to save changes. All changes are applied instantly.</para>
+
+  <para>Keyman keyboards are no longer hidden from the Windows language picker when you exit Keyman. Rather, if you select a Keyman keyboard, Keyman will be restarted for you automatically.</para>
+
+  <!--New ways in Keyman 10.0 should replace this section.-->
   <para>The key change in your usage will be how you access keyboard layouts. With version 9.0 and later, all keyboard layouts are
   registered as Windows Text Services, and are always available through Windows language interfaces as well as with the
   <link linkend="basic_traymenu">Keyman menu</link>, 
@@ -14,16 +18,18 @@
   <link linkend="basic_hotkeys_tab">hotkeys</link>.</para>
   
   <para><xref linkend="basic_enable_keyboard"></xref></para>
+
+  <para>Most of the following changes were made in Keyman 10.0</para>
   
   <para>When you install a keyboard layout, it will be registered under the language for which the keyboard has been designed,
   or if this has not been specified by the keyboard designer, then it will be installed under your default language. You can
   always change the language registration in the <link linkend="basic_keyboards_tab">Keyboards tab</link>.</para>
   
-  <para>In earlier versions of Keyman Desktop, language association was controlled in the Languages tab in Keyman Desktop Configuration.
+  <para>In earlier versions of Keyman, language association was controlled in the Languages tab in Keyman Configuration.
   With the new model of keyboard registration, all language association is controlled in the Keyboards tab. Each keyboard can be associated with multiple languages.</para>
   
   <para>The keyboard menu now shows all Windows languages and keyboards, and not just Keyman keyboards. This reflects the tight integration
-  with Windows languages that Keyman Desktop 10 provides.</para>
+  with Windows languages that Keyman 10+ provides.</para>
   
   <para>You may be using a non-US hardware keyboard, which we call the Base Layout.  For example, you may be using a French, or German, or
   other European Latin-script keyboard.  You can change the base layout in the Options tab, which will allow Keyman to automatically

--- a/windows/src/desktop/help/basic/text_editor.xml
+++ b/windows/src/desktop/help/basic/text_editor.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_text_editor" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>The Keyman Desktop Text Editor</title>
+  <title>The Keyman Text Editor</title>
   <para>The Keyman Text Editor is a basic text editor for testing your Keyman keyboards.</para>
   
   <para>
@@ -11,16 +11,16 @@
     </inlinemediaobject>
   </para>  
   
-  <note>You do not need to use the Keyman Text Editor to type with Keyman Desktop. You can use Keyman Desktop in almost any application on your computer that accepts keyboard input.</note>
+  <note>You do not need to use the Keyman Text Editor to type with Keyman. You can use Keyman in almost any application on your computer that accepts keyboard input.</note>
   
   <bridgehead>Opening the Text Editor</bridgehead>
   <para>To open the Keyman Text Editor:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Text Editor…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Text Editor…</guilabel>.</para>
     </listitem>
   </orderedlist>
 

--- a/windows/src/desktop/help/basic/toolbox_tasks/charactermap.xml
+++ b/windows/src/desktop/help/basic/toolbox_tasks/charactermap.xml
@@ -14,10 +14,10 @@
   <para>To open the Keyman Character Map:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Character Map</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Character Map</guilabel>.</para>
     </listitem>
   </orderedlist>
   

--- a/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.xml
+++ b/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.xml
@@ -15,10 +15,10 @@
   <para>To open the Font Helper:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Font Helper</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Font Helper</guilabel>.</para>
     </listitem>
   </orderedlist>  
   
@@ -32,8 +32,8 @@
       <para>Open the Font Helper.</para>
     </listitem>
   </orderedlist>   
-  <para>Each font listed in the Font Helper includes a percentage value.  This value indicates how many characters in the current Keyman Desktop keyboard are available from the font.  Most of the time, fonts with greater than 90% coverage will work for nearly all texts.</para>
-  <para>In addition to percentage values, Keyman Desktop also includes a complete Character Chart with all the keyboard characters supported by the font. The Character Chart will allow you to see exactly which characters your font supports. It will also allow you to see how the same characters look in different fonts.</para>
+  <para>Each font listed in the Font Helper includes a percentage value.  This value indicates how many characters in the current Keyman keyboard are available from the font.  Most of the time, fonts with greater than 90% coverage will work for nearly all texts.</para>
+  <para>In addition to percentage values, Keyman also includes a complete Character Chart with all the keyboard characters supported by the font. The Character Chart will allow you to see exactly which characters your font supports. It will also allow you to see how the same characters look in different fonts.</para>
   <tip>If no fonts are listed in the Font Helper, check the documentation of the keyboard layout to see if it includes information on where to obtain the fonts you need.</tip>
   
 <bridgehead>Related Topics</bridgehead>

--- a/windows/src/desktop/help/basic/toolbox_tasks/osk.xml
+++ b/windows/src/desktop/help/basic/toolbox_tasks/osk.xml
@@ -17,10 +17,10 @@
   <para>To open the On Screen Keyboard:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>On Screen Keyboard</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>On Screen Keyboard</guilabel>.</para>
     </listitem>
   </orderedlist>
 
@@ -58,7 +58,7 @@
   </orderedlist>
       <para>When a Keyman keyboard is on, the black font on the keycaps shows the characters assigned to each key. The blue font on the keycaps shows the characters of the Windows layout currently associated with the Keyman keyboard.</para>
 	  <para>When no Keyman keyboard is on, the blue font on the keycaps shows the characters of your active Windows layout.</para>
-	  <note>Some Keyman keyboards do not have an On Screen Keyboard view. For keyboards designed phonetically, this is because there is not a simple 1-1 correspondence between each key and the letter you want to type. The <link linkend="basic_usage">Keyboard Usage tool</link> is often helpful for these keyboards and Keyman Desktop will switch to this view by default. This option can be changed in <link linkend="basic_options_tab">Keyman Configuration</link>.</note> 
+	  <note>Some Keyman keyboards do not have an On Screen Keyboard view. For keyboards designed phonetically, this is because there is not a simple 1-1 correspondence between each key and the letter you want to type. The <link linkend="basic_usage">Keyboard Usage tool</link> is often helpful for these keyboards and Keyman will switch to this view by default. This option can be changed in <link linkend="basic_options_tab">Keyman Configuration</link>.</note> 
 	  
 <bridgehead>Related Topics</bridgehead>
  <itemizedlist>

--- a/windows/src/desktop/help/basic/toolbox_tasks/toolbox.xml
+++ b/windows/src/desktop/help/basic/toolbox_tasks/toolbox.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_toolbox">
-  <title>The Keyman Desktop Toolbox</title>
-  <para>The Keyman Toolbox contains a collection of tools for working with Keyman Desktop.</para>
+  <title>The Keyman Toolbox</title>
+  <para>The Keyman Toolbox contains a collection of tools for working with Keyman.</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -14,10 +14,10 @@
   <para>To display the Keyman Toolbox:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>On Screen Keyboard</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>On Screen Keyboard</guilabel>.</para>
     </listitem>
   </orderedlist>
   <note>The Keyman Toolbox is displayed by default in the last position it was used. It will be displayed initially in the bottom right hand corner of the screen.</note>
@@ -149,7 +149,7 @@
             <para>Open Help</para>
           </entry>
           <entry>
-            <para>Opens <link linkend='basic_help'>Keyman Desktop Help</link>.</para>
+            <para>Opens <link linkend='basic_help'>Keyman Help</link>.</para>
           </entry>
         </row>
         <row>
@@ -166,7 +166,7 @@
             <para>Close Keyman Toolbox</para>
           </entry>
           <entry>
-            <para>Closes the Keyman Toolbox but does not exit Keyman Desktop.  The Keyman Toolbox can be displayed again by following the instructions at the top of this help topic.</para>
+            <para>Closes the Keyman Toolbox but does not exit Keyman.  The Keyman Toolbox can be displayed again by following the instructions at the top of this help topic.</para>
           </entry>
         </row>
       </tbody>
@@ -237,7 +237,7 @@
       </imageobject>
     </inlinemediaobject>
   </para>   
-  <para>At the bottom of the Keyman Toolbox, a hint bar shows handy tips on how to use Keyman Desktop and access some of the more       advanced features available.  The hint bar will slowly cycle through the available hints, or you can use the arrow buttons on the right of the hint bar to cycle through the hints yourself.</para>
+  <para>At the bottom of the Keyman Toolbox, a hint bar shows handy tips on how to use Keyman and access some of the more       advanced features available.  The hint bar will slowly cycle through the available hints, or you can use the arrow buttons on the right of the hint bar to cycle through the hints yourself.</para>
   <para>You can close the hint bar by clicking the X icon on the right hand side of the hint bar.  This X icon is not the same as the Close Keyman Toolbox button at the top of the window!</para>
   <para>To access the hint bar again, open the <link linkend="basic_options_tab">Options tab</link> of Keyman Configuration and click <guibutton>Reset Hints</guibutton>.</para>
   

--- a/windows/src/desktop/help/basic/toolbox_tasks/usage.xml
+++ b/windows/src/desktop/help/basic/toolbox_tasks/usage.xml
@@ -2,8 +2,8 @@
 <section id="basic_usage">
   <title>Keyman Toolbox - Keyboard Usage</title>
   
-  <para>The Keyboard Usage tool of the <link linkend="basic_toolbox">Keyman Toolbox</link> shows helpful hints on how to use the currently selected Keyman Desktop keyboard.</para>
-  <para>The Keyman Desktop 10.0 allows you to select either Keyboard Usage or the On-Screen Keyboard</para>
+  <para>The Keyboard Usage tool of the <link linkend="basic_toolbox">Keyman Toolbox</link> shows helpful hints on how to use the currently selected Keyman keyboard.</para>
+  <para>Keyman allows you to select either Keyboard Usage or the On-Screen Keyboard</para>
   <para>
     <inlinemediaobject>
       <imageobject>
@@ -16,15 +16,15 @@
   <para>To open the Keyboard Usage tool:</para>
   <orderedlist>
     <listitem>
-    <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+    <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Keyboard Usage</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Keyboard Usage</guilabel>.</para>
     </listitem>
   </orderedlist>
   
   <bridgehead>Using Keyboard Usage</bridgehead>
-  <para>The content of the Keyboard Usage tool changes depending on the active Keyman Desktop keyboard:</para>
+  <para>The content of the Keyboard Usage tool changes depending on the active Keyman keyboard:</para>
 	<itemizedlist>
 		<listitem>
 			<para>Some keyboards include dynamic help in Keyboard Usage. This help allows you to click on a letter to insert it into your document directly.</para>

--- a/windows/src/desktop/help/basic/traymenu.xml
+++ b/windows/src/desktop/help/basic/traymenu.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="basic_traymenu">
-  <title>The Keyman Desktop Menu</title>
-  <bridgehead>Opening the Keyman Desktop Menu</bridgehead>
-  <para>When you start <application>Keyman Desktop</application>, the Keyman icon (<inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>) is displayed on the Windows Taskbar near the clock. This area is called the System Tray or System Notification Area.</para>
+  <title>The Keyman Menu</title>
+  <bridgehead>Opening the Keyman Menu</bridgehead>
+  <para>When you start <application>Keyman</application>, the Keyman icon (<inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>) is displayed on the Windows Taskbar near the clock. This area is called the System Tray or System Notification Area.</para>
   <para>
 	<inlinemediaobject>
 		<imageobject>
@@ -10,7 +10,7 @@
 		</imageobject>
 	</inlinemediaobject>
   </para>
-  <para>To display the Keyman Desktop menu, click on the Keyman icon.</para>
+  <para>To display the Keyman menu, click on the Keyman icon.</para>
   <para>
     <inlinemediaobject>
         <imageobject>
@@ -18,10 +18,10 @@
         </imageobject>
     </inlinemediaobject>
   </para>
-  <note>If you cannot find the Keyman Desktop menu or Keyman icon, for more help see: <link linkend='findmenu'>Finding a Missing Keyman Desktop Menu</link></note>
+  <note>If you cannot find the Keyman menu or Keyman icon, for more help see: <link linkend='findmenu'>Finding a Missing Keyman Menu</link></note>
  
-  <bridgehead>Using the Keyman Desktop Menu</bridgehead>
-  <para>Click the Keyman icon (<inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>) with either mouse button to bring up the Keyman Desktop menu.</para>
+  <bridgehead>Using the Keyman Menu</bridgehead>
+  <para>Click the Keyman icon (<inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>) with either mouse button to bring up the Keyman menu.</para>
   <para>
         <inlinemediaobject>
           <imageobject>
@@ -29,11 +29,11 @@
           </imageobject>
         </inlinemediaobject>
   </para>
-  <para>The left side of the Keyman Desktop menu lists the Keyman keyboards currently installed and enabled on your computer. Click on a keyboard to turn it on and start using it.</para>
-  <note>You can add more Keyman keyboards to the Keyman Desktop menu through the <link linkend='basic_keyboards_tab'>Keyboard Layouts tab</link> of Keyman Configuration.</note>
+  <para>The left side of the Keyman menu lists the Keyman keyboards currently installed and enabled on your computer. Click on a keyboard to turn it on and start using it.</para>
+  <note>You can add more Keyman keyboards to the Keyman menu through the <link linkend='basic_keyboards_tab'>Keyboard Layouts tab</link> of Keyman Configuration.</note>
   <note>To use a Keyman keyboard, the keyboard must be enabled in the Keyboard Layouts tab of Keyman Configuration. For help enabling your keyboard, see: <xref linkend='basic_disable_keyboard'></xref></note> 
   
-  <para>The right side of the Keyman Desktop menu contains links to tools and features in Keyman Desktop:</para>
+  <para>The right side of the Keyman menu contains links to tools and features in Keyman:</para>
   <itemizedlist>
 				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-osk.png"></imagedata></imageobject></inlinemediaobject> – Opens or closes the <link linkend='basic_osk'>On Screen Keyboard tool</link>.</listitem>
 				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-usage.png"></imagedata></imageobject></inlinemediaobject> – Opens or closes the <link linkend='basic_usage'>Keyboard Usage tool</link>.</listitem>
@@ -42,11 +42,11 @@
 				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-texteditor.png"></imagedata></imageobject></inlinemediaobject> – Opens the <link linkend='basic_text_editor'>Keyman Text Editor</link>.</listitem>
 				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-config.png"></imagedata></imageobject></inlinemediaobject> – Opens <link linkend='basic_config_menu'>Keyman Configuration</link>.</listitem>
 				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-help.png"></imagedata></imageobject></inlinemediaobject> – Opens <link linkend='basic_help'>Keyman Help</link>.</listitem>
-				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-exit.png"></imagedata></imageobject></inlinemediaobject> – Exits Keyman Desktop.</listitem>
+				<listitem><inlinemediaobject><imageobject><imagedata fileref="desktop_images/menuicon-exit.png"></imagedata></imageobject></inlinemediaobject> – Exits Keyman.</listitem>
 			</itemizedlist>
   
-  <bridgehead><anchor id="findmenu"></anchor>Finding a Missing Keyman Desktop Menu</bridgehead>
-  <para>If you cannot find the Keyman icon for the Keyman Desktop menu, it may be in the hidden notifications area of the Windows Taskbar. Check for the Keyman icon by clicking the arrow or triangle next to the Windows clock.</para>
+  <bridgehead><anchor id="findmenu"></anchor>Finding a Missing Keyman Menu</bridgehead>
+  <para>If you cannot find the Keyman icon for the Keyman menu, it may be in the hidden notifications area of the Windows Taskbar. Check for the Keyman icon by clicking the arrow or triangle next to the Windows clock.</para>
   <para>If the Keyman icon is in the hidden notifications area, you should move the Keyman icon permanently to the Windows Taskbar. Here's how to move the icon:</para>
 							<itemizedlist>
 								<listitem>
@@ -69,7 +69,7 @@
 												</para>
 											</listitem>
 											<listitem>
-												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman Desktop icon will now always appear in the Windows Taskbar near the clock, if Keyman Desktop is on.</para>
+												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman icon will now always appear in the Windows Taskbar near the clock, if Keyman is on.</para>
 											</listitem>
 										</orderedlist>									
 								</listitem>
@@ -110,7 +110,7 @@
 												</para>
                       </listitem>
 											<listitem>
-												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman Desktop icon will now always appear in the Windows Taskbar near the clock, if Keyman Desktop is on.</para>
+												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman icon will now always appear in the Windows Taskbar near the clock, if Keyman is on.</para>
 											</listitem>
 											<listitem>
 												<para>Continue on to <link linkend='tutorial_step5'>Step 5</link> of this guide.</para>
@@ -120,7 +120,7 @@
 							</itemizedlist>
 
 							 
-  <para>If the Keyman icon is not in the hidden notifications area and not on the Windows Taskbar near the clock, make sure Keyman Desktop has been started. If you still cannot locate the Keyman icon and menu, visit the <ulink url="https://community.software.sil.org/c/keyman">SIL Keyman Community</ulink> for further assistance.</para>
+  <para>If the Keyman icon is not in the hidden notifications area and not on the Windows Taskbar near the clock, make sure Keyman has been started. If you still cannot locate the Keyman icon and menu, visit the <ulink url="https://community.software.sil.org/c/keyman">SIL Keyman Community</ulink> for further assistance.</para>
  <bridgehead>Related Topics</bridgehead>
  <itemizedlist>
   <listitem>

--- a/windows/src/desktop/help/common/adware.xml
+++ b/windows/src/desktop/help/common/adware.xml
@@ -3,5 +3,5 @@
 <section id="common_adware">
   <title>Does Keyman include adware or spyware?</title>
   <para>No!</para>
-  <para>We never have and never will include adware or spyware components. Keyman Desktop does contact the keyman.com website periodically to check for updates for both Keyman Desktop and the keyboards you have installed. In this process, the only information communicated is the current version of Keyman Desktop and the version of the keyboards. You can switch this option off in Keyman Configuration.</para>
+  <para>We never have and never will include adware or spyware components. Keyman does contact the keyman.com website periodically to check for updates for both Keyman and the keyboards you have installed. In this process, the only information communicated is the current version of Keyman and the version of the keyboards. You can switch this option off in Keyman Configuration.</para>
 </section>

--- a/windows/src/desktop/help/common/editions.xml
+++ b/windows/src/desktop/help/common/editions.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="common_editions">
-  <title>What is new in  Keyman Desktop 10.0?</title>
-  <para>Keyman Desktop 10 brings a number of features which are not available in the Free edition of the previous Keyman Desktop. These features are:</para>
+  <title>What is new in  Keyman 10.0?</title>
+  <para>Keyman 10 brings a number of features which are not available in the Free edition of the previous Keyman. These features are:</para>
  <itemizedlist>
   <listitem>
    <para><link linkend='basic_enable_keyboard'>Unlimited active keyboards</link></para>
@@ -23,7 +23,7 @@
   </listitem>
  </itemizedlist>
  <para>
-  You can review the full feature list of Keyman Desktop 10.0 online: <ulink url="http://www.keyman.com/desktop/">Keyman Website</ulink>.
+  You can review the full feature list of Keyman 10.0 online: <ulink url="http://www.keyman.com/desktop/">Keyman Website</ulink>.
  </para>
  
 </section>

--- a/windows/src/desktop/help/common/free.xml
+++ b/windows/src/desktop/help/common/free.xml
@@ -2,5 +2,5 @@
 
 <section id="common_free">
   <title>Is Keyman now Free?</title>
-  <para>Keyman Desktop 10.0 is now available under the open source MIT license. You can access the source on GitHub.</para>
+  <para>Keyman 10.0 and later versions are now available under the open source MIT license. You can access the source on GitHub.</para>
 </section>

--- a/windows/src/desktop/help/common/linux.xml
+++ b/windows/src/desktop/help/common/linux.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <section id="common_linux">
-  <title>Does Keyman Desktop run on Linux?</title>
-  <para>While Keyman Desktop is a Windows product, we have an input method manager for Linux called <ulink url="https://help.keyman.com/kb/58">KMFL</ulink>.</para>
+  <title>Does Keyman run on Linux?</title>
+  <para>Yes. <ulink url="https://keyman.com/linux">Keyman for Linux</ulink>.</para>
 </section>

--- a/windows/src/desktop/help/common/mac.xml
+++ b/windows/src/desktop/help/common/mac.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="common_mac">
-  <title>Does Keyman Desktop run on a Mac?</title>
+  <title>Does Keyman run on a Mac?</title>
   <para>Yes. Please visit <ulink url="https://keyman.com/macos/">Keyman for macOS</ulink> for more information. Also note that there are two other ways you can use Keyman keyboards on a Mac:</para>
   <orderedlist>
-    <listitem><para>If you are running Windows on your Mac (through a program like Fusion, Parallels or BootCamp) you can use Keyman Desktop through Windows.</para></listitem>
+    <listitem><para>If you are running Windows on your Mac (through a program like Fusion, Parallels or BootCamp) you can use Keyman through Windows.</para></listitem>
     <listitem>
       <para>We offer a web-based typing application, KeymanWeb. It works in all major browsers (Firefox, Safari, Chrome, etc), on any OS that supports those browsers. You can use KeymanWeb at <ulink href="https://keymanweb.com/">https://keymanweb.com</ulink>.</para>
     </listitem>

--- a/windows/src/desktop/help/common/old_version.xml
+++ b/windows/src/desktop/help/common/old_version.xml
@@ -2,5 +2,5 @@
 
 <section id="common_old_version">
   <title>I am a registered Keyman 7.1 or Keyman Desktop 8 or Keyman Desktop 9 user. Can I still download Keyman 7.1 or Keyman Desktop 8 or Keyman Desktop 9?</title>
-  <para>If you are a registered user of Keyman 7.1 or Keyman Desktop 8 or Keyman Desktop 9, you can download the most recent version these programs from <ulink url='http://www.keyman.com/archive/downloads.php'>www.keyman.com/archive/downloads</ulink>.</para>>
+  <para>If you are a registered user of Keyman 7.1 or Keyman Desktop 8 or Keyman Desktop 9, you can download the most recent version these programs from <ulink url='http://keyman.com/downloads/archive/'>keyman.com/downloads/archive/</ulink>.</para>>
 </section>

--- a/windows/src/desktop/help/common/os.xml
+++ b/windows/src/desktop/help/common/os.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <section id="common_os">
-  <title>What operating systems does Keyman Desktop 10 support?</title>
+  <title>What operating systems does Keyman support?</title>
     <!--this needs to be updated.-->
- <para>Just like Keyman Desktop 9.0, Keyman Desktop 10.0 fully supports 32-bit <emphasis>and</emphasis> 64-bit versions of the following Windows operating systems:</para>
+ <para>Keyman fully supports 32-bit <emphasis>and</emphasis> 64-bit versions of the following Windows operating systems:</para>
   <itemizedlist>
     <listitem>
       <para>Windows Server 2008</para>
@@ -24,5 +24,5 @@
       <para>Windows Server 2012 and 2012 R2</para>
     </listitem>
   </itemizedlist>
-  <note>Keyman Desktop works slightly differently in different versions of Windows. Older versions of Windows have more language limitations and need extra configuration. Windows Vista and later versions of Windows include added security measures and some configuration actions will require you to confirm security prompts.</note>  
+  <note>Keyman works slightly differently in different versions of Windows. Older versions of Windows have more language limitations and need extra configuration. Windows Vista and later versions of Windows include added security measures and some configuration actions will require you to confirm security prompts.</note>  
 </section>

--- a/windows/src/desktop/help/common/requirements.xml
+++ b/windows/src/desktop/help/common/requirements.xml
@@ -3,5 +3,5 @@
 <section id="common_requirements">
   <!--double check needed-->
   <title>What are Keyman's hardware requirements?</title>
-  <para>Keyman Desktop 10.0 has minimal resource requirements. Any computer that can run Windows Vista or later should be able to run Keyman Desktop without trouble.</para>
+  <para>Keyman has minimal resource requirements. Any computer that can run Windows 7 or later should be able to run Keyman without trouble.</para>
 </section>

--- a/windows/src/desktop/help/common/support.xml
+++ b/windows/src/desktop/help/common/support.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <section id="common_support">
-  <title>What support do I get with my Keyman Desktop?</title>
-  <para>Keyman Desktop 10 includes web support via our <ulink url="https://community.software.sil.org/c/keyman">community forums</ulink>.</para>
+  <title>What support do I get with my Keyman?</title>
+  <para>Keyman includes community-based web support via our <ulink url="https://community.software.sil.org/c/keyman">community forums</ulink>.</para>
 </section>

--- a/windows/src/desktop/help/common/unicode.xml
+++ b/windows/src/desktop/help/common/unicode.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <section id="common_unicode">
-  <title>Does Keyman Desktop support Unicode?</title>
-  <para>Yes, since Keyman Desktop 5, Keyman fully supports the Unicode Standard, up to and including Unicode 10.0. We also update Keyman Desktop with each new release of the Unicode Standard.</para>
+  <title>Does Keyman support Unicode?</title>
+  <para>Yes, since Keyman 5, Keyman fully supports the Unicode Standard, up to and including Unicode 13.0. We also update Keyman with each new release of the Unicode Standard.</para>
 </section>

--- a/windows/src/desktop/help/context/keyman.xml
+++ b/windows/src/desktop/help/context/keyman.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="context_keyman">
- <title>Keyman Desktop Configuration</title>
+ <title>Keyman Configuration</title>
    <redirect url="basic_config_menu" />
 </section>

--- a/windows/src/desktop/help/context/manualactivate.xml
+++ b/windows/src/desktop/help/context/manualactivate.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="context_manualactivate">
-  <title>Manually Activate Keyman Desktop</title>
+  <title>Manually Activate Keyman</title>
   <redirect url="basic_manual_activate" />
 </section>

--- a/windows/src/desktop/help/context/onlineupdate.xml
+++ b/windows/src/desktop/help/context/onlineupdate.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="context_onlineupdate">
- <title>Update Keyman Desktop</title>
+ <title>Update Keyman</title>
    <redirect url="basic_update" />
 </section>

--- a/windows/src/desktop/help/context/onscreenkeyboard.xml
+++ b/windows/src/desktop/help/context/onscreenkeyboard.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="context_onscreenkeyboard">
-  <title>The Keyman Desktop Toolbox</title>
+  <title>The Keyman Toolbox</title>
     <redirect url="basic_toolbox" />
 </section>

--- a/windows/src/desktop/help/context/selectlanguage.xml
+++ b/windows/src/desktop/help/context/selectlanguage.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="context_selectlanguage">
-  <title>Set Language for Keyman Desktop Menus</title>
+  <title>Set Language for Keyman Menus</title>
     <redirect url="start_locale" />
 </section>

--- a/windows/src/desktop/help/context/splash.xml
+++ b/windows/src/desktop/help/context/splash.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="context_splash">
-  <title>The Keyman Desktop Splash Screen</title>
+  <title>The Keyman Splash Screen</title>
 
   <para>
     <inlinemediaobject>
@@ -14,5 +14,5 @@
 
   <para>You can stop the splash screen from showing by deselecting the option 'Show this screen at startup'.</para>
 
-  <para>Note: when Keyman Desktop starts with Windows, the splash screen is not shown.</para>
+  <para>Note: when Keyman starts with Windows, the splash screen is not shown.</para>
 </section>

--- a/windows/src/desktop/help/context/traymenu.xml
+++ b/windows/src/desktop/help/context/traymenu.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="context_traymenu">
-  <title>The Keyman Desktop Menu</title>
+  <title>The Keyman Menu</title>
    <redirect url="basic_traymenu" />
 </section>

--- a/windows/src/desktop/help/context/tutorial.xml
+++ b/windows/src/desktop/help/context/tutorial.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="context_tutorial">
-  <title>Getting Started with Keyman Desktop</title>
+  <title>Getting Started with Keyman</title>
     <redirect url="start_tutorial" />
 </section>

--- a/windows/src/desktop/help/index.xml
+++ b/windows/src/desktop/help/index.xml
@@ -4,12 +4,12 @@
                  [<!ENTITY % xinclude SYSTEM "../../global/xml/xinclude.mod"> %xinclude;]
 ><!-- http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd -->
 <book xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>Keyman Desktop User Guide</title>
+  <title>Keyman User Guide</title>
 
    <!-- About -->
 
   <chapter id="about">
-    <title>About Keyman Desktop</title>
+    <title>About Keyman</title>
     <xi:include href="about/welcome.xml" />
     <xi:include href="about/whatsnew.xml" />
     <xi:include href="about/requirements.xml" />

--- a/windows/src/desktop/help/start/configure_computer.xml
+++ b/windows/src/desktop/help/start/configure_computer.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="start_configure_computer">
   <title>How To - Set up Your Computer for a Keyman Keyboard</title>
-   <para>Keyman Desktop will automatically set up your computer for best performance with most Keyman keyboards. However, for best performance on some keyboards you may need to manually associate your Keyman keyboard with a Windows language and layout.</para>
+   <para>Keyman will automatically set up your computer for best performance with most Keyman keyboards. However, for best performance on some keyboards you may need to manually associate your Keyman keyboard with a Windows language and layout.</para>
 
    <bridgehead>Benefits of Association</bridgehead>
    <para>Correctly associating your Keyman keyboard has three main benefits.</para>
@@ -29,13 +29,13 @@
 	</orderedlist>
   
   <bridgehead>Association instructions</bridgehead>
-  <note><para>Keyman Desktop allows you to associate multiple Windows languages to a keyboard.</para></note>
+  <note><para>Keyman allows you to associate multiple Windows languages to a keyboard.</para></note>
 	<orderedlist>
 		<listitem>
-      <para>Click on the <guiicon>Keyman Desktop</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
+      <para>Click on the <guiicon>Keyman</guiicon> icon <inlinemediaobject><imageobject><imagedata fileref="desktop_images/icon-keyman.png" /></imageobject></inlinemediaobject>, on the Windows Taskbar near the clock.</para>
     </listitem>
     <listitem>
-      <para>From the Keyman Desktop menu, select <guilabel>Configuration…</guilabel>.</para>
+      <para>From the Keyman menu, select <guilabel>Configuration…</guilabel>.</para>
     </listitem>
     <listitem>
       <para>Select the Keyboard Layouts tab.</para>

--- a/windows/src/desktop/help/start/configure_office.xml
+++ b/windows/src/desktop/help/start/configure_office.xml
@@ -1,15 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="start_configure_office">
   <title>How To - Set up MS Office for a Keyman Keyboard</title>
-   <para>Keyman Desktop will automatically set up your Microsoft Office programs for best performance with most Keyman keyboards. However, you may need to manually adjust your MS Office language settings for some Keyman keyboards.</para>
+   <para>Keyman will automatically set up your Microsoft Office programs for best performance with most Keyman keyboards. However, you may need to manually adjust your MS Office language settings for some Keyman keyboards.</para>
   <bridgehead>Benefits to Configuring Language Settings for MS Office</bridgehead>
    <para>The Microsoft Office language settings control spell checking, autocorrection, and other language-specific features for the programs in the Microsoft Office suite (including Word, Excel, PowerPoint, Outlook, Publisher, Access, OneNote, Groove, and InfoPath). If you will be using any of the MS Office programs with your Keyman keyboard, in order to enjoy these features you will need to configure MS Office language settings.</para>
 
   <bridgehead>Setting up MS Office 2003</bridgehead>
-   <para>To set up Microsoft Office 2003 for your Keyman keyboard:</para>	<orderedlist>
+   <para>To set up Microsoft Office 2003 for your Keyman keyboard:</para>
+	<orderedlist>
 		<listitem>
 			<para>Open the All Programs menu from the Windows Start menu.</para>
-		</listitem>		<listitem>
+		</listitem>
+		<listitem>
 			<para>Select Microsoft Office › Microsoft Office Tools › Microsoft Office 2003 Language Settings.</para>
 		</listitem>
 		<listitem>
@@ -24,7 +26,8 @@
 		<listitem>
 			<para>Restart your Office applications.</para>
 		</listitem>
-	</orderedlist>   
+	</orderedlist>
+   
   <bridgehead>Setting up MS Office 2007</bridgehead>
    <para>To set up Microsoft Office 2007 for your Keyman keyboard:</para>
 	<orderedlist>

--- a/windows/src/desktop/help/start/download-install_keyboard.xml
+++ b/windows/src/desktop/help/start/download-install_keyboard.xml
@@ -2,14 +2,14 @@
 <section id="start_download-install_keyboard">
   <title>How To - Download and Install a Keyman Keyboard</title>
   
-  <para>You must have a Keyman keyboard installed to type with Keyman Desktop in your language. You can download and install a Keyman keyboard at the same time you download and install Keyman Desktop. For more information, see:  <xref linkend="start_download-install_keyman"></xref>.</para>
-  <para>You can also add keyboards to Keyman Desktop after you have installed Keyman Desktop. For more information, keep reading.</para>
+  <para>You must have a Keyman keyboard installed to type with Keyman in your language. You can download and install a Keyman keyboard at the same time you download and install Keyman. For more information, see:  <xref linkend="start_download-install_keyman"></xref>.</para>
+  <para>You can also add keyboards to Keyman after you have installed Keyman. For more information, keep reading.</para>
   
-  <bridgehead><anchor id="install_tav"></anchor>Downloading &amp; Installing a Keyman Keyboard within Keyman Desktop</bridgehead>
-  <para>Here's how to download and install a Keyman keyboard within Keyman Desktop:</para>
+  <bridgehead><anchor id="install_tav"></anchor>Downloading &amp; Installing a Keyman Keyboard within Keyman</bridgehead>
+  <para>Here's how to download and install a Keyman keyboard within Keyman:</para>
   <orderedlist>
     <listitem>
-      <para>Start Keyman Desktop.</para>
+      <para>Start Keyman.</para>
 	</listitem>
 	<listitem>
 	  <para>Open Keyman Configuration, from the Keyman menu (on the Windows Taskbar near the clock).</para>
@@ -63,7 +63,7 @@
 	    </itemizedlist>
 	  </tip>
 	  <note><para><guibutton>Install</guibutton> installs the keyboard for anyone who can log on to your computer.  You may be prompted by User Account Control to allow Keyman to make changes to your computer -- click 'Yes'.</para></note>
-      <note>If a keyboard with the same name is already installed, Keyman Desktop will ask you if you want to replace the old keyboard or cancel the installation.</note>
+      <note>If a keyboard with the same name is already installed, Keyman will ask you if you want to replace the old keyboard or cancel the installation.</note>
 
 	</listitem>
 	<listitem>
@@ -76,7 +76,7 @@
    
    <bridgehead><anchor id="install_folder"></anchor>Installing a Keyman Keyboard from a Folder on Your Computer</bridgehead> 
    <para>There are two ways you can install a Keyman keyboard from a folder on your computer. The easiest way is to find the keyboard on your computer and double-click to install it. Keyman keyboards have a file name that ends with .KMX or .KMP.</para>
-   <para>You can also install a keyboard from your computer within Keyman Desktop. Here's how:</para>
+   <para>You can also install a keyboard from your computer within Keyman. Here's how:</para>
   <orderedlist>
     <listitem>
       <para>Start Keyman</para>
@@ -116,7 +116,7 @@
 	    </itemizedlist>
 	  </tip>
 	  <note><para><guibutton>Install</guibutton> installs the keyboard for anyone who can log on to your computer.</para></note>
-      <note>If a keyboard with the same name is already installed, Keyman Desktop will ask you if you want to replace the old keyboard or cancel the installation.</note>
+      <note>If a keyboard with the same name is already installed, Keyman will ask you if you want to replace the old keyboard or cancel the installation.</note>
 	</listitem>
 	<listitem>
       <para>Click <guibutton>OK</guibutton> if asked to configure you computer to work with your new keyboard.</para>

--- a/windows/src/desktop/help/start/download-install_keyman.xml
+++ b/windows/src/desktop/help/start/download-install_keyman.xml
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="start_download-install_keyman">
-  <title>How To - Download and Install Keyman Desktop</title>
+  <title>How To - Download and Install Keyman</title>
 
-<bridgehead>Downloading Keyman Desktop</bridgehead>
-  <para>You can download Keyman Desktop with a keyboard for your language from the <ulink url='https://keyman.com/desktop/'>Keyman Website</ulink>.</para>
+<bridgehead>Downloading Keyman</bridgehead>
+  <para>You can download Keyman with a keyboard for your language from the <ulink url='https://keyman.com/desktop/'>Keyman Website</ulink>.</para>
   
-<bridgehead>Installing Keyman Desktop</bridgehead>
-  <para>After you download Keyman Desktop 10.0, to install the program:</para>
+<bridgehead>Installing Keyman</bridgehead>
+  <para>After you download Keyman, to install the program:</para>
 	<orderedlist>
-		<listitem>Find the Keyman Desktop executable file on your computer. The name of the file begins with 'keymandesktop-10' and ends with '.exe'.</listitem>
+		<listitem>Find the Keyman executable file on your computer. The name of the file begins with 'keyman-' and ends with '.exe'.</listitem>
 		<listitem>Double-click the file to begin installation. </listitem>
 		<listitem><para>You will be asked to allow the installer to access your system. Click <guibutton>Yes</guibutton> to continue.</para>
 				<para>
@@ -19,7 +19,7 @@
 					</inlinemediaobject>
 				</para>		
 		</listitem>		
-		<listitem><para>Once you have read and agree to the license terms, click <guibutton>Install Keyman Desktop</guibutton> to continue.</para>
+		<listitem><para>Once you have read and agree to the license terms, click <guibutton>Install Keyman</guibutton> to continue.</para>
 				<para>
 					<inlinemediaobject>
 						<imageobject>
@@ -29,7 +29,7 @@
 				</para>
 				<note>You can select advanced installation options from the Install Options link on the bottom left.</note>
 		</listitem>
-		<listitem><para>At the end of the installation, click <guibutton>Start Keyman Desktop</guibutton> to begin using Keyman or click <guibutton>Take the tour</guibutton> for the Getting Started tutorial.</para>
+		<listitem><para>At the end of the installation, click <guibutton>Start Keyman</guibutton> to begin using Keyman or click <guibutton>Take the tour</guibutton> for the Getting Started tutorial.</para>
 				<para>
 					<inlinemediaobject>
 						<imageobject>
@@ -39,7 +39,7 @@
 				</para>		
 		</listitem>		
     </orderedlist>
-  <para>When you finish your installation of Keyman, you can delete or move the installation's executable file. It doesn't need to remain on your computer for Keyman Desktop to work.</para>
+  <para>When you finish your installation of Keyman, you can delete or move the installation's executable file. It doesn't need to remain on your computer for Keyman to work.</para>
 	  
   <bridgehead>Related Topics</bridgehead>
   <itemizedlist>

--- a/windows/src/desktop/help/start/hotkey_set.xml
+++ b/windows/src/desktop/help/start/hotkey_set.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="start_hotkey_set" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>How To - Set Hotkeys for Keyman Desktop, Keyman Keyboards and Windows Languages</title>
+  <title>How To - Set Hotkeys for Keyman, Keyman Keyboards and Windows Languages</title>
 
-  <para>A hotkey is a keyboard shortcut. In <application>Keyman Desktop</application> these are used to turn on and off Keyman Desktop functions, Keyman keyboards and Windows languages.</para>
-  <para>To set the hotkey for a <application>Keyman Desktop</application> function, Keyman keyboard or Windows language:</para>
+  <para>A hotkey is a keyboard shortcut. In <application>Keyman</application> these are used to turn on and off Keyman functions, Keyman keyboards and Windows languages.</para>
+  <para>To set the hotkey for a <application>Keyman</application> function, Keyman keyboard or Windows language:</para>
   <orderedlist>
     <listitem>
       <para>Open Keyman Configuration, from the Keyman menu in the Windows taskbar.</para>

--- a/windows/src/desktop/help/start/locale.xml
+++ b/windows/src/desktop/help/start/locale.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <section id="start_locale">
-  <title>How To - Set the Language for Keyman Desktop Menus</title>
-  <bridgehead>Setting a Language for Keyman Desktop Menus</bridgehead>
-   <para>If you would like the menus in Keyman Desktop to be in a language other than English: </para>
+  <title>How To - Set the Language for Keyman Menus</title>
+  <bridgehead>Setting a Language for Keyman Menus</bridgehead>
+   <para>If you would like the menus in Keyman to be in a language other than English: </para>
    <orderedlist>
     <listitem>
 	  <para>Open Keyman Configuration, from the Keyman menu in the Windows taskbar.</para>
@@ -22,7 +22,7 @@
 	  <note>If your language is not available online, you can write your own translation for your language using our locale editor. For more information, see <xref linkend="advanced_locale_edit"></xref>.</note>
     </listitem>
 	<listitem>
-	  <para>Restart Keyman Desktop for the language changes to take effect for the entire program.</para>
+	  <para>Restart Keyman for the language changes to take effect for the entire program.</para>
 	</listitem>
   </orderedlist>
 

--- a/windows/src/desktop/help/start/rtl.xml
+++ b/windows/src/desktop/help/start/rtl.xml
@@ -4,7 +4,7 @@
   <para>If you will be typing in a right-to-left language (like Arabic, Farsi, Hebrew, or Yiddish) there are three things you should know before you get started.</para>
   <orderedlist>
 	<listitem>
-	  <para>Your computer must be set up for right-to-left language support. Keyman Desktop will automatically set up your computer for most Keyman keyboards that need right-to-left language support. However, you may need to manually adjust your settings for some Keyman keyboards. Otherwise, without right-to-left language support, letters in your right-to-left language might appear in the wrong order, not join correctly, or change after the spacebar is pressed.</para>
+	  <para>Your computer must be set up for right-to-left language support. Keyman will automatically set up your computer for most Keyman keyboards that need right-to-left language support. However, you may need to manually adjust your settings for some Keyman keyboards. Otherwise, without right-to-left language support, letters in your right-to-left language might appear in the wrong order, not join correctly, or change after the spacebar is pressed.</para>
 	  <para>To do this, simply associate the keyboard with a right-to-left Windows language (like Arabic). For instructions on associating a Keyman keyboard with a Windows language, see: <xref linkend="start_configure_computer"></xref></para>
 	</listitem>
 	<listitem>

--- a/windows/src/desktop/help/start/tutorial.xml
+++ b/windows/src/desktop/help/start/tutorial.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="start_tutorial">
-  <title>Getting Started with Keyman Desktop</title>
-  <para>Follow these steps for a basic introduction to Keyman Desktop:</para>
-   <note><application>Keyman Desktop</application> must be installed first. For help on installing <application>Keyman Desktop</application>, please see: <xref linkend="start_download-install_keyman"></xref>.</note> 
+  <title>Getting Started with Keyman</title>
+  <para>Follow these steps for a basic introduction to Keyman:</para>
+   <note><application>Keyman</application> must be installed first. For help on installing <application>Keyman</application>, please see: <xref linkend="start_download-install_keyman"></xref>.</note> 
 
 			<bridgehead>Step 1</bridgehead>
 			
@@ -12,11 +12,11 @@
 					</imageobject>
 				</inlinemediaobject>
 				
-			<para>Check the Windows Taskbar near the clock to see if Keyman Desktop is running. If it is running you will see the Keyman Desktop icon: <inlinemediaobject><imageobject><imagedata fileref='desktop_images/icon-keyman.png'></imagedata></imageobject></inlinemediaobject></para>
+			<para>Check the Windows Taskbar near the clock to see if Keyman is running. If it is running you will see the Keyman icon: <inlinemediaobject><imageobject><imagedata fileref='desktop_images/icon-keyman.png'></imagedata></imageobject></inlinemediaobject></para>
 		 
 			<bridgehead><anchor id="tutorial_step2"></anchor>Step 2</bridgehead>
 			
-			<para>If the Keyman Desktop icon is in the Windows Taskbar near the clock, continue on to <link linkend='tutorial_step5'>Step 5</link>.</para>
+			<para>If the Keyman icon is in the Windows Taskbar near the clock, continue on to <link linkend='tutorial_step5'>Step 5</link>.</para>
 			<para>
 				<inlinemediaobject>
 					<imageobject>
@@ -24,13 +24,13 @@
 					</imageobject>
 				</inlinemediaobject>
 			</para>
-			<para>If the Keyman Desktop icon is not on the Windows Taskbar near the clock, click the arrow or triangle next to the clock:</para>
+			<para>If the Keyman icon is not on the Windows Taskbar near the clock, click the arrow or triangle next to the clock:</para>
 					<itemizedlist>
 					 <listitem>
-						<para>You will see a collection of icons. If the Keyman Desktop icon (<inlinemediaobject><imageobject><imagedata fileref='desktop_images/icon-keyman.png'></imagedata></imageobject></inlinemediaobject>) is not in this collection, Keyman Desktop is not running. Read steps 3 and 4 to learn how to start Keyman Desktop.</para> 
+						<para>You will see a collection of icons. If the Keyman icon (<inlinemediaobject><imageobject><imagedata fileref='desktop_images/icon-keyman.png'></imagedata></imageobject></inlinemediaobject>) is not in this collection, Keyman is not running. Read steps 3 and 4 to learn how to start Keyman.</para> 
 					 </listitem>
 					 <listitem>
-						<para>If the Keyman Desktop icon is in this collection, you should move it permanently to the Windows Taskbar. Here's how:</para>
+						<para>If the Keyman icon is in this collection, you should move it permanently to the Windows Taskbar. Here's how:</para>
 							<itemizedlist>
 								<listitem>
 									<para>On Windows 7:</para>
@@ -52,7 +52,7 @@
 												</para>
 											</listitem>
 											<listitem>
-												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman Desktop icon will now always appear in the Windows Taskbar near the clock, if Keyman Desktop is on.</para>
+												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman icon will now always appear in the Windows Taskbar near the clock, if Keyman is on.</para>
 											</listitem>
 											<listitem>
 												<para>Continue on to <link linkend='tutorial_step5'>Step 5</link> of this guide.</para>
@@ -96,7 +96,7 @@
 												</para>
                       </listitem>
 											<listitem>
-												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman Desktop icon will now always appear in the Windows Taskbar near the clock, if Keyman Desktop is on.</para>
+												<para>Click <guibutton>OK</guibutton> to apply changes. The Keyman icon will now always appear in the Windows Taskbar near the clock, if Keyman is on.</para>
 											</listitem>
 											<listitem>
 												<para>Continue on to <link linkend='tutorial_step5'>Step 5</link> of this guide.</para>
@@ -140,7 +140,7 @@
 												</para>
                       </listitem>
 											<listitem>
-												<para>The Keyman Desktop icon will now always appear in the Windows Taskbar near the clock, if Keyman Desktop is on.</para>
+												<para>The Keyman icon will now always appear in the Windows Taskbar near the clock, if Keyman is on.</para>
 											</listitem>
 											<listitem>
 												<para>Continue on to <link linkend='tutorial_step5'>Step 5</link> of this guide.</para>
@@ -153,7 +153,7 @@
        
 			<bridgehead>Step 3</bridgehead>
 		
-			<para>To Start Keyman Desktop, click on the Windows Start Menu, select All Programs, and select Keyman Desktop.</para>
+			<para>To Start Keyman, click on the Windows Start Menu, select All Programs, and select Keyman.</para>
   
         
 			<bridgehead>Step 4</bridgehead>
@@ -164,7 +164,7 @@
 					</imageobject>
 				</inlinemediaobject>
 				
-		    <para>Keyman Desktop will now be running and the Keyman Desktop icon will be on the Windows Taskbar near the clock.</para>
+		    <para>Keyman will now be running and the Keyman icon will be on the Windows Taskbar near the clock.</para>
         
 			<bridgehead><anchor id="tutorial_step5"></anchor>Step 5</bridgehead>
 			
@@ -205,7 +205,7 @@
         
 			<bridgehead>Step 9</bridgehead>
           
-		    <para>To return to using your normal keyboard, open the Keyman menu and click 'Switch Keyman Desktop Off'.</para>
+		    <para>To return to using your normal keyboard, open the Keyman menu and click 'Switch Keyman Off'.</para>
 
 
   <bridgehead>Related Topics</bridgehead>

--- a/windows/src/desktop/help/troubleshooting/bootstrapper.xml
+++ b/windows/src/desktop/help/troubleshooting/bootstrapper.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="troubleshooting_bootstrapper">
-  <title>How To - Use the Keyman Desktop Setup Bootstrapper</title>
+  <title>How To - Use the Keyman Setup Bootstrapper</title>
 	<bridgehead>About the Bootstrapper</bridgehead>
 
-<para>The Keyman Desktop installation bootstrapper is a self-extracting executable file that contains a Windows Installer technology MSI file, and optionally keyboards.</para>
+<para>The Keyman installation bootstrapper is a self-extracting executable file that contains a Windows Installer technology MSI file, and optionally keyboards.</para>
 
 <para>The bootstrapper:</para>
 <orderedlist>
 	<listitem><para>Checks the system before starting the installation to ensure that all prerequisites are met, and optionally downloads and installs the prerequisites.</para></listitem>
-	<listitem><para>Optionally checks online for an updated version of Keyman Desktop before installing.</para></listitem>
-    <listitem><para>Starts the Keyman Desktop Windows Installer MSI package.</para></listitem>
+	<listitem><para>Optionally checks online for an updated version of Keyman before installing.</para></listitem>
+    <listitem><para>Starts the Keyman Windows Installer MSI package.</para></listitem>
 	<listitem><para>Installs any keyboards included.</para></listitem>
-    <listitem><para>Starts Keyman Desktop after the install completes.</para></listitem>
+    <listitem><para>Starts Keyman after the install completes.</para></listitem>
 </orderedlist>
 	
 <bridgehead>Command Line Options</bridgehead>

--- a/windows/src/desktop/help/troubleshooting/excel.xml
+++ b/windows/src/desktop/help/troubleshooting/excel.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="troubleshooting_excel">
-  <title>How To - Use Keyman Desktop in Excel</title>
+  <title>How To - Use Keyman in Excel</title>
 	<bridgehead>Using Keyman in Excel with the / Key</bridgehead>
 
 	<para>Keyboard layouts which rely on the '/' key cause difficulty in Microsoft Excel. In order to provide legacy compatibility with Lotus 1-2-3, by default using the '/' key in Excel activates keyboard shortcuts. There are two solutions to this problem.</para>

--- a/windows/src/desktop/help/troubleshooting/hidden.xml
+++ b/windows/src/desktop/help/troubleshooting/hidden.xml
@@ -5,14 +5,14 @@
 
 	<para>You may experience an issue in Windows 7 where:</para>
 	<itemizedlist>
-    <listitem>Keyman Desktop is on; and</listitem>
+    <listitem>Keyman is on; and</listitem>
     <listitem>your Keyman keyboard is active, with its icon showing in the Keyman menu; but</listitem>
     <listitem>your Keyman keyboard does not work.</listitem>
     </itemizedlist>
 	
 	<bridgehead>Resolution</bridgehead>
 
-	<para>Unhide the Keyman Desktop menu as described in <link linkend='tutorial_step2'>Step 2</link> of the Getting Started tutorial.</para>
+	<para>Unhide the Keyman menu as described in <link linkend='tutorial_step2'>Step 2</link> of the Getting Started tutorial.</para>
   <para>This can also be resolved by switching language using the Windows Language Bar or the Language Icon</para>
 	
 	<bridgehead>Background</bridgehead>

--- a/windows/src/desktop/help/troubleshooting/securitysoftware.xml
+++ b/windows/src/desktop/help/troubleshooting/securitysoftware.xml
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <section id="troubleshooting_securitysoftware">
   <title>How To - Resolve Security Software Conflicts with keyman32.dll</title>
-	<para>Certain security softwares impair or prevent the use of the Keyman Desktop library file keyman32.dll. This file is completely safe and is necessary for the running of Keyman Desktop. Should your security software question you about this file, you will need to allow the file to continue running Keyman Desktop.</para>
+	<para>Certain security softwares impair or prevent the use of the Keyman library file keyman32.dll. This file is completely safe and is necessary for the running of Keyman. Should your security software question you about this file, you will need to allow the file to continue running Keyman.</para>
 
     <para>If for any reason you are concerned that keyman32.dll may have been tampered with, you may check the file's digital signature here:</para>
 
 	<orderedlist>
     <listitem><para>Open the Windows Start menu.</para></listitem>
     <listitem><para>In the search or run box, type %commonprogramfiles% or, in Windows 64-bit, %commonprogramfiles(x86)%.</para></listitem>
-    <listitem><para>Open the Tavultesoft folder.</para></listitem>
+    <listitem><para>Open the Keyman folder.</para></listitem>
     <listitem><para>Open the Keyman Engine folder.</para></listitem>
     <listitem><para>Right-click on keyman32.dll.</para></listitem>
     <listitem><para>Select Properties from the menu.</para></listitem>
     <listitem><para>Select the Digital Signature tab.</para></listitem>
-    <listitem><para>Select Tavultesoft in the signature list, and click <guibutton>Details</guibutton>.</para></listitem>
+    <listitem><para>Select SUMMER INSTITUTE OF LINGUSTICS, INC. in the signature list, and click <guibutton>Details</guibutton>.</para></listitem>
     <listitem><para>You should see the message 'This digital signature is OK'. If you receive any other message, please let us know.</para></listitem>
 	</orderedlist>
 	
-  <para>If you need any assistance using Keyman Desktop with your security software you should use the <ulink url="https://community.software.sil.org/c/keyman">community</ulink>.</para>
+  <para>If you need any assistance using Keyman with your security software you should use the <ulink url="https://community.software.sil.org/c/keyman">community</ulink>.</para>
 </section>


### PR DESCRIPTION
Relates to #4003.

Some minor edits have been made but the help files need a revisit before stable release as there is much out of date content.

There will be some inconsistencies; the priority for this PR is to remove the "Desktop" name where appropriate.