### PR TITLE
fix(ios/engine): adds check for keyboard load success, auto-reset on load failure

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -288,6 +288,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     setOuterConstraints()
     inputView?.setNeedsUpdateConstraints()
+
+    keymanWeb.verifyLoaded()
   }
 
   open override func viewWillDisappear(_ animated: Bool) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -976,6 +976,7 @@ extension KeymanWebViewController {
    * Implemented as a workaround for a weird bug (likely within iOS) in which the
    * InputViewController and KeymanWebViewController constructors (and thus, `loadView`)
    * are sometimes completely bypassed during system-keyboard use.
+   * See https://github.com/keymanapp/keyman/issues/3985
    */
   func verifyLoaded() {
     // Test: are we currently loading?  If so, don't worry 'bout a thing.

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -59,6 +59,8 @@ class KeymanWebViewController: UIViewController {
   /// when predictive text is not active
   private var bannerImgPath: String = ""
 
+  var isLoading: Bool = false
+
   init(storage: Storage) {
     self.storage = storage
     super.init(nibName: nil, bundle: nil)
@@ -555,6 +557,7 @@ extension KeymanWebViewController: KeymanWebDelegate {
   func keyboardLoaded(_ keymanWeb: KeymanWebViewController) {
     delegate?.keyboardLoaded(keymanWeb)
 
+    isLoading = false
     log.info("Loaded keyboard.")
 
     resizeKeyboard()
@@ -963,9 +966,22 @@ extension KeymanWebViewController {
   // MARK: - Show/hide views
   func reloadKeyboard() {
     webView!.loadFileURL(Storage.active.kmwURL, allowingReadAccessTo: Storage.active.baseDir)
+    isLoading = true
 
     // Check for a change of "always show banner" state
     updateShowBannerSetting()
+  }
+
+  /*
+   * Implemented as a workaround for a weird bug (likely within iOS) in which the
+   * InputViewController and KeymanWebViewController constructors (and thus, `loadView`)
+   * are sometimes completely bypassed during system-keyboard use.
+   */
+  func verifyLoaded() {
+    // Test: are we currently loading?  If so, don't worry 'bout a thing.
+    if !isLoading {
+      webView!.evaluateJavaScript("verifyLoaded()", completionHandler: nil)
+    }
   }
 
   @objc func showHelpBubble() {

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -52,6 +52,15 @@
                     
                 //});
             }
+
+            function verifyLoaded() {
+              // During proper loads of KMW, a keyboard will be set very early on.
+              // There's a chance that the keyboard is still loading, so we double-check
+              // against the stub count.
+              if(!keyman.core.activeKeyboard && keyman.keyboardManager.keyboardStubs.length == 0) {
+                location.reload();
+              }
+            }
         
             function showBanner(flag) {
               console.log("Setting banner display for dictionaryless keyboards to " + flag);


### PR DESCRIPTION
Fixes #3985.  Likely by working around some sort of iOS bug... that I haven't found any online mention of.  Yay.

After identifying a 100% reproduction-rate sequence for #3985 (see [this comment](https://github.com/keymanapp/keyman/issues/3985#issuecomment-736274186) for details), I was finally able to start reliably debugging the issue.  After diving through the related call stacks, I noticed some _very_ peculiar behavior going on.

When the error occurs, it's because the system keyboard's constructors and `loadView` functions... were never called.  They're new and distinct instances, but our code never constructed them.  I thoroughly documented reference values and exact breakpoint locations to come to this conclusion, as it's a pretty serious accusation to make against iOS and/or the Swift compiler.

This matters because our keyboard makes the necessary calls to display the OSK... only after a successful load of the keyboard (see `keyboardLoaded`), which itself relies on `reloadKeyboard`, which is only called by `loadView`.  Since `loadView` is completely bypassed, the necessary event chain is bypassed, and the keyboard remains blank.

As a rough workaround, this solution implements a couple of simple checks in an attempt to detect and fix this scenario.  The checks aren't perfect, but I've written then in such a way that we'll only get "false negatives" that will result in an unnecessary reset.  You see, there's a race condition between the point where the keyboard's view appears and when the `resetKeyboard` callback (set within `keyboardLoaded`) is triggered to set the actual keyboard - this window of time will result in said 'false negative'.  While not optimal... since we don't know what mechanism is bypassing the constructors, and it "smells" like a deep-copy scenario... I'm not sure how to check for this window without introducing the possibility of false positives.