### PR TITLE
fix(common): improve increment-version robustness

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -4,11 +4,14 @@ set -e
 set -u
 
 #
-# Usage: increment-version.sh [commit base]
+# Usage: increment-version.sh [-f] [commit base]
 #
 # Increments the patch version on VERSION.md
 #
-# If -commit is specified, pushes the new version
+# If -f is specified, triggers a build even with
+# no detected changes.
+#
+# If commit is specified, pushes the new version
 # to the repository. base snould be either
 # master or beta.
 #
@@ -25,9 +28,17 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 gitbranch=`git branch --show-current`
 
+FORCE=0
+
+if [[ "$1" == "-f" ]]; then
+  FORCE=1
+  shift
+fi
+
 if [[ $# -gt 0 ]]; then
   # We want the action to specify the branch as a consistency check
   # for now at least.
+
   action=$1
   if [[ $# -gt 1 ]]; then
     base=$2
@@ -52,7 +63,8 @@ else
 fi
 
 if [[ $action == help ]]; then
-  echo "Usage: increment-version.sh [commit base]"
+  echo "Usage: increment-version.sh [-f] [commit base]"
+  echo "  -f  forces a build even with no changes"
   echo "  base must be either master or beta."
   echo "  base must be equal to currently checked-out"
   echo "  branch (this may not be required in future)"
@@ -74,15 +86,22 @@ popd > /dev/null
 
 pushd "$KEYMAN_ROOT" > /dev/null
 ABORT=0
-node resources/build/version/lib/index.js history version -t "$GITHUB_TOKEN" -b "$base" || ABORT=1
+node resources/build/version/lib/index.js history version -t "$GITHUB_TOKEN" -b "$base" || ABORT=$?
 
 if [[ $ABORT = 1 ]]; then
-  echo "Skipping version increment from $VERSION: no recently merged pull requests were found"
-  if [ ! -z "${TEAMCITY_VERSION-}" ]; then
-    # Send TeamCity a build status
-    echo "##teamcity[buildStatus status='SUCCESS' text='Skipping version increment from $VERSION: no recently merged pull requests were found']"
+  if [[ $FORCE = 0 ]]; then
+    echo "Skipping version increment from $VERSION: no recently merged pull requests were found"
+    if [ ! -z "${TEAMCITY_VERSION-}" ]; then
+      # Send TeamCity a build status
+      echo "##teamcity[buildStatus status='SUCCESS' text='Skipping version increment from $VERSION: no recently merged pull requests were found']"
+    fi
+    exit 0
+  else
+    echo "Force specified; building even though no changes were detected"
   fi
-  exit 0
+elif [[ $ABORT != 0 ]]; then
+  echo "Failed to complete version history check"
+  exit $ABORT
 fi
 popd > /dev/null
 
@@ -116,7 +135,6 @@ if [ "$action" == "commit" ]; then
   # Now that all version-related changes are ready and git-added, it's time to commit.
   git commit -m "$message"
   git push --tags origin "$branch"
-  hub pull-request -f --no-edit -b $base -l auto
   git checkout $base
 
   #
@@ -131,6 +149,14 @@ if [ "$action" == "commit" ]; then
   #
 
   triggerBuilds
+
+  #
+  # Now, create the PR on GitHub which will be merged when ready
+  #
+
+  cd "$KEYMAN_ROOT"
+  git checkout "$branch"
+  hub pull-request -f --no-edit -b $base -l auto
 
   #
   # Done
@@ -148,9 +174,6 @@ if [ "$action" == "commit" ]; then
   # latest history in it. We don't need to cleanup the branch because the CI will
   # do that for us.
   #
-
-  cd "$KEYMAN_ROOT"
-  git checkout "$branch"
 fi
 
 exit 0

--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -41,8 +41,7 @@ function triggerTeamCityBuild() {
   local TEAMCITY_SERVER=https://build.palaso.org
 
   local command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID,buildType:(id:$TEAMCITY_BUILDTYPE)'/></lastChanges></build>"
-
-  #debug echo "Call: $command"
+  echo "TeamCity Build Command: $command"
 
   # adjust indentation for output of curl
   echo -n "     "

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -32,9 +32,9 @@ const main = async (): Promise<void> => {
 
   const octokit: GitHub = new GitHub(argv.token);
 
-  // Pretend we have a single change. If we chain commands (as in normal usage), 
+  // Pretend we have a single change. If we chain commands (as in normal usage),
   // then we use the real history change count to determine if we continue.
-  let changeCount = 1; 
+  let changeCount = 1;
 
   const version = readFileSync('./VERSION.md', 'utf8').trim();
 
@@ -46,7 +46,7 @@ const main = async (): Promise<void> => {
     logInfo(`# Validating history for ${version}`);
     changeCount = await fixupHistory(octokit, argv.base);
     logInfo(`# ${changeCount} change(s) found for ${version}\n`);
-  } 
+  }
 
   //
   // Increment the version number if history has any entries
@@ -65,8 +65,8 @@ const main = async (): Promise<void> => {
 
 main().then(
   ()=>logInfo('Finished')
-) 
+)
 .catch((error: Error): void => {
   console.error(`An unexpected error occurred: ${error.message}, ${error.stack ?? 'no stack trace'}.`);
-  process.exit(1);
+  process.exit(2);
 });


### PR DESCRIPTION
Fixes #4061.

Four things:

1. Reorder the script steps so that builds are triggered before the PR is created. This should not really be necessary, but I am seeing some evidence that TeamCity is not respecting the commit sha we request to build. (This arose with 14.0.194 where a build agent became unavailable during a build and TC cancelled and restarted the build, but from a later revision... which this particular fix may not help, I guess...)
2. Add debug logging so we can see exactly which commit sha that we send to TeamCity
3. Handle errors in version increment by aborting the script with an error.
4. Add a -f force mode which we can use to trigger a build even if no changes are detected. This will need a corresponding patch in TC.