### PR TITLE
fix(common/core/web): predictive context reset

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -240,7 +240,7 @@
     function updateKMSelectionRange(start, end) {
       var ta = document.getElementById('ta');
       var kmw = window['keyman'];
-      var resetContext = (ta.selectionStart != pos || ta.selectionEnd != pos + length);
+      var resetContext = (ta.selectionStart != start || ta.selectionEnd != end);
       ta.selectionStart = ta._KeymanWebSelectionStart = start;
       ta.selectionEnd = ta._KeymanWebSelectionEnd = end;
       kmw['setActiveElement'](ta);

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -240,9 +240,13 @@
     function updateKMSelectionRange(start, end) {
       var ta = document.getElementById('ta');
       var kmw = window['keyman'];
+      var resetContext == (ta.selectionStart != pos || ta.selectionEnd != pos + length);
       ta.selectionStart = ta._KeymanWebSelectionStart = start;
       ta.selectionEnd = ta._KeymanWebSelectionEnd = end;
       kmw['setActiveElement'](ta);
+      if(resetContext) {
+        kmw.resetContext();
+      }
     }
 
     function oskCreateKeyPreview(x,y,w,h,t) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -228,8 +228,13 @@
       }
       var ta = document.getElementById('ta');
       var kmw = window['keyman'];
+      var resetContext = ta.value != text;
       ta.value = text;
       kmw['setActiveElement'](ta);
+
+      if(resetContext) {
+        kmw.resetContext();
+      }
     }
 
     function updateKMSelectionRange(start, end) {

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -240,7 +240,7 @@
     function updateKMSelectionRange(start, end) {
       var ta = document.getElementById('ta');
       var kmw = window['keyman'];
-      var resetContext == (ta.selectionStart != pos || ta.selectionEnd != pos + length);
+      var resetContext = (ta.selectionStart != pos || ta.selectionEnd != pos + length);
       ta.selectionStart = ta._KeymanWebSelectionStart = start;
       ta.selectionEnd = ta._KeymanWebSelectionEnd = end;
       kmw['setActiveElement'](ta);

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -183,9 +183,9 @@ namespace com.keyman.text {
       return ruleBehavior;
     }
 
-    public resetContext() {
+    public resetContext(outputTarget?: OutputTarget) {
       this.keyboardProcessor.resetContext();
-      this.languageProcessor.invalidateContext();
+      this.languageProcessor.invalidateContext(outputTarget);
     }
   }
 }

--- a/common/predictive-text/docs/worker-communication-protocol.md
+++ b/common/predictive-text/docs/worker-communication-protocol.md
@@ -113,7 +113,7 @@ An asynchronous message to predict after typing 'D':
 Message types
 -------------
 
-Currently there are four message types:
+Currently there are a whole bunch of message types:
 
 Message         | Direction          | Parameters          | Expected reply      | Uses token
 ----------------|--------------------|---------------------|---------------------|---------------

--- a/common/predictive-text/docs/worker-communication-protocol.md
+++ b/common/predictive-text/docs/worker-communication-protocol.md
@@ -115,21 +115,22 @@ Message types
 
 Currently there are four message types:
 
-Message       | Direction          | Parameters          | Expected reply      | Uses token
---------------|--------------------|---------------------|---------------------|---------------
-`config`      | LMLayer → worker   | capabilities        | No                  | No
-`load`        | keyboard → LMLayer | model               | Yes — `ready`       | No
-`unload`      | keyboard → LMLayer | none                | No                  | No 
-`ready`       | LMLayer → keyboard | configuration       | No                  | No
-`predict`     | keyboard → LMLayer | transform, context  | Yes — `suggestions` | Yes
-`suggestions` | LMLayer → keyboard | suggestions         | No                  | Yes
-`wordbreak`   | LMLayer → worker   | context             | Yes - `currentword` | Yes
-`currentword` | LMLayer → keyboard | string              | No                  | Yes
-`accept`      | keyboard → LMLayer | suggestion,         | Yes - `postaccept`  | Yes
-                                   | context, transform  |                     |
-`postaccept`  | LMLayer → keyboard | reversion           | No                  | Yes
-`revert`      | keyboard → LMLayer | reversion, context  | Yes - `reversion`   | Yes
-`postrevert`  | LMLayer → keyboard | suggestions         | No                  | Yes
+Message         | Direction          | Parameters          | Expected reply      | Uses token
+----------------|--------------------|---------------------|---------------------|---------------
+`config`        | LMLayer → worker   | capabilities        | No                  | No
+`load`          | keyboard → LMLayer | model               | Yes — `ready`       | No
+`unload`        | keyboard → LMLayer | none                | No                  | No 
+`ready`         | LMLayer → keyboard | configuration       | No                  | No
+`predict`       | keyboard → LMLayer | transform, context  | Yes — `suggestions` | Yes
+`suggestions`   | LMLayer → keyboard | suggestions         | No                  | Yes
+`wordbreak`     | LMLayer → worker   | context             | Yes - `currentword` | Yes
+`currentword`   | LMLayer → keyboard | string              | No                  | Yes
+`accept`        | keyboard → LMLayer | suggestion,         | Yes - `postaccept`  | Yes
+                                     | context, transform  |                     |
+`postaccept`    | LMLayer → keyboard | reversion           | No                  | Yes
+`revert`        | keyboard → LMLayer | reversion, context  | Yes - `reversion`   | Yes
+`postrevert`    | LMLayer → keyboard | suggestions         | No                  | Yes
+`reset-context` | keyboard → LMLayer | context             | No                  | No
               
 
 ### Message: `config`
@@ -512,12 +513,38 @@ generated.
 
 ### Message: `postaccept`
 
-The `postaccept` message is sent from the keyboard to the LMLayer.  This
+The `postaccept` message is sent from the LMLayer to the keyboard.  This
 message sends a `reversion` capable of undoing acceptance of the `suggestion`
 just accepted by the triggering `accept` message.
 
 This message **MUST** be in response to a `postaccept` message, and it
 **MUST** respond with the corresponding [token][Tokens].
+
+### Message: `revert`
+
+The `revert` message is sent from the keyboard to the LMLayer.
+
+The keyboard **MUST** send a `reversion` - the one previously returned by a
+`postaccept` message in response to an `accept` message.  This message tells
+the predictive text engine to _revert_ the engine's tracked context to the
+original `context` parameter sent as part of that `accept` message.
+
+The keyboard must also send the _current_ `context` state, as it can be used
+to determine the original context should the predictive engine have lost track
+of the original state in the meantime.
+
+### Message: `postrevert`
+
+The `postrevert` message is sent from the LMLayer to the keyboard.  This
+message sends an array of `suggestions` corresponding to the newly-restored
+`context` requested by the `revert` message.
+
+### Message: `reset-context`
+
+The `reset-context` message is sent from the keyboard to the LMLayer.  This
+message sends information on the new `context` to be used for prediction,
+telling the predictive engine to disregard all previously-tracked information
+that is context-dependent.
 
 #### Examples
 

--- a/common/predictive-text/index.ts
+++ b/common/predictive-text/index.ts
@@ -179,6 +179,13 @@ namespace com.keyman.text.prediction {
       });
     }
 
+    resetContext(context: Context) {
+      this._worker.postMessage({
+        message: 'reset-context',
+        context: context
+      });
+    }
+
     // TODO: asynchronous close() method.
     //       Worker code must recognize message and call self.close().
 

--- a/common/predictive-text/worker/index.ts
+++ b/common/predictive-text/worker/index.ts
@@ -344,16 +344,20 @@ class LMLayerWorker {
             });
             break;
           case 'revert':
-              var {reversion, context} = payload;
-              var suggestions: Suggestion[] = compositor.applyReversion(reversion, context);
+            var {reversion, context} = payload;
+            var suggestions: Suggestion[] = compositor.applyReversion(reversion, context);
 
-              this.cast('postrevert', {
-                token: payload.token,
-                suggestions: suggestions
-              });
-              break;
+            this.cast('postrevert', {
+              token: payload.token,
+              suggestions: suggestions
+            });
+            break;
+          case 'reset-context':
+            var {context} = payload;
+            compositor.resetContext(context);
+            break;
           default:
-            throw new Error(`invalid message; expected one of {'predict', 'wordbreak', 'accept', 'revert', 'unload'} but got ${payload.message}`);
+            throw new Error(`invalid message; expected one of {'predict', 'wordbreak', 'accept', 'revert', 'reset-context', 'unload'} but got ${payload.message}`);
         }
       },
       compositor: compositor

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -150,6 +150,7 @@ class ModelCompositor {
         if(this.isEmpty(inputTransform) || this.isWhitespace(inputTransform)) {
           newEmptyToken = true;
           prefixTransform = inputTransform;
+          context = postContext; // Ensure the whitespace token is preapplied!
         }
       }
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -534,6 +534,14 @@ class ModelCompositor {
     }
   }
 
+  public resetContext(context: Context) {
+    if(this.contextTracker) {
+      let tokenizedContext = models.tokenize(this.lexicalModel.wordbreaker || wordBreakers.default, context);
+      let contextState = correction.ContextTracker.modelContextState(tokenizedContext.left, this.lexicalModel);
+      this.contextTracker.enqueue(contextState);
+    }
+  }
+
   private detectCurrentCasing(context: Context): CasingForm {
     let model = this.lexicalModel;
 

--- a/common/predictive-text/worker/worker-interfaces.ts
+++ b/common/predictive-text/worker/worker-interfaces.ts
@@ -38,8 +38,8 @@ type ImportScripts = typeof DedicatedWorkerGlobalScope.prototype.importScripts;
 /**
  * The valid incoming message kinds.
  */
-type IncomingMessageKind = 'config' | 'load' | 'predict' | 'unload' | 'wordbreak' | 'accept' | 'revert';
-type IncomingMessage = ConfigMessage | LoadMessage | PredictMessage | UnloadMessage | WordbreakMessage | AcceptMessage | RevertMessage;
+type IncomingMessageKind = 'config' | 'load' | 'predict' | 'unload' | 'wordbreak' | 'accept' | 'revert' | 'reset-context';
+type IncomingMessage = ConfigMessage | LoadMessage | PredictMessage | UnloadMessage | WordbreakMessage | AcceptMessage | RevertMessage | ResetContextMessage;
 
 /**
  * The structure of a config message.  It should include the platform's supported
@@ -187,6 +187,15 @@ interface RevertMessage {
   /**
    * The Context being reverted, which should be the same context as resulted from applying the
    * corresponding Suggestion.
+   */
+  context: Context;
+}
+
+interface ResetContextMessage {
+  message: 'reset-context';
+
+  /**
+   * The new context to be used as a base for future context mutations and predictions.
    */
   context: Context;
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -229,7 +229,7 @@ extension KeymanWebViewController {
   }
   
   func resetContext() {
-    webView!.evaluateJavaScript("keyman.interface.resetContext();", completionHandler: nil)
+    webView!.evaluateJavaScript("keyman.core.resetContext();", completionHandler: nil)
   }
 
   func setDeviceType(_ idiom: UIUserInterfaceIdiom) {
@@ -573,7 +573,7 @@ extension KeymanWebViewController: KeymanWebDelegate {
     if let cursorRange = self.currentCursorRange {
       self.setCursorRange(cursorRange)
     }
-    
+
     setDeviceType(UIDevice.current.userInterfaceIdiom)
     
     let shouldReloadKeyboard = Manager.shared.shouldReloadKeyboard

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -273,7 +273,7 @@
                 var ta = document.getElementById('ta');
                 var kmw = window['keyman'];
 
-                let resetContext = ta.value != text
+                var resetContext = ta.value != text;
                 ta.value = text;
                 kmw['setActiveElement'](ta);
                 if(resetContext) {

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -272,8 +272,13 @@
                 if(undefined == text) text = '';
                 var ta = document.getElementById('ta');
                 var kmw = window['keyman'];
+
+                let resetContext = ta.value != text
                 ta.value = text;
                 kmw['setActiveElement'](ta);
+                if(resetContext) {
+                  kmw.resetContext();
+                }
                 return ta.value;
             }
             

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -262,9 +262,13 @@
             function setCursorRange(pos, length) {
                 var ta = document.getElementById('ta');
                 var kmw = window['keyman'];
+                var resetContext = (ta.selectionStart != pos || ta.selectionEnd != pos + length);
                 ta.selectionStart = ta._KeymanWebSelectionStart = pos;
                 ta.selectionEnd = ta._KeymanWebSelectionEnd = pos + length;
                 kmw['setActiveElement'](ta);
+                if(resetContext) {
+                  kmw.resetContext();
+                }
                 return ta.selectionEnd;
             }
             

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -479,7 +479,7 @@ namespace com.keyman {
       if(outputTarget) {
         outputTarget.resetContext();
       }
-      this.core.resetContext();
+      this.core.resetContext(outputTarget);
     };
 
     /**

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -690,6 +690,7 @@ namespace com.keyman.osk {
 
       // Do we have a keep suggestion?  If so, remove it from the list so that we can control its display position
       // and prevent it from being hidden after reversion operations.
+      this.keepSuggestion = null;
       for(let s of suggestions) {
         if(s.tag == 'keep') {
           this.keepSuggestion = s as Keep;


### PR DESCRIPTION
Fixes #3981.

May have "interesting" interactions with Android; extra user testing is advised.

### User Testing

- Test against "Clear Text" operations within the mobile apps.  Do reasonable predictions (as if the text had always been blank) occur, or does it seem like old, cleared text is still remembered?  Or something else entirely?
- Test against cursor / caret movement
- On the system keyboard level, find an app (or web page) with 2+ input fields.  Type text in both, then swap between them mid-word.  What sort of predictions arise then?