### PR TITLE
chore(android/app,oem/fv/android): Revert #4025

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -90,7 +90,6 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import io.sentry.SentryLevel;
 import io.sentry.android.core.SentryAndroid;
 
 public class MainActivity extends AppCompatActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener,
@@ -130,23 +129,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     checkSendCrashReport();
     if (KMManager.getMaySendCrashReport()) {
       SentryAndroid.init(context, options -> {
-        options.setBeforeBreadcrumb((breadcrumb, hint) -> {
-          String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";
-          if ("navigation".equals(breadcrumb.getCategory()) && breadcrumb.getLevel() == SentryLevel.INFO &&
-            ((breadcrumb.getData("from") != null) || (breadcrumb.getData("to") != null)) ) {
-            // Sanitize navigation breadcrumbs
-            String dataFrom = String.valueOf(breadcrumb.getData("from"));
-            dataFrom = dataFrom.replaceAll(NAVIGATION_PATTERN, "$1$2");
-            breadcrumb.setData("from", dataFrom);
-            String dataTo = String.valueOf(breadcrumb.getData("to"));
-            dataTo = dataTo.replaceAll(NAVIGATION_PATTERN, "$1$2");
-            breadcrumb.setData("to", dataTo);
-
-            return breadcrumb;
-          } else {
-            return breadcrumb;
-          }
-        });
         options.setRelease("release-" + com.tavultesoft.kmapro.BuildConfig.VERSION_NAME);
         options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
       });

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -13,7 +13,6 @@ import android.webkit.WebViewClient;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import io.sentry.SentryLevel;
 import io.sentry.android.core.SentryAndroid;
 
 import com.tavultesoft.kmea.*;
@@ -29,23 +28,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         SentryAndroid.init(this, options -> {
-            options.setBeforeBreadcrumb((breadcrumb, hint) -> {
-                String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-(.)*$";
-                if ("navigation".equals(breadcrumb.getCategory()) && breadcrumb.getLevel() == SentryLevel.INFO &&
-                    ((breadcrumb.getData("from") != null) || (breadcrumb.getData("to") != null)) ) {
-                    // Sanitize navigation breadcrumbs
-                    String dataFrom = String.valueOf(breadcrumb.getData("from"));
-                    dataFrom = dataFrom.replaceAll(NAVIGATION_PATTERN, "$1$2");
-                    breadcrumb.setData("from", dataFrom);
-                    String dataTo = String.valueOf(breadcrumb.getData("to"));
-                    dataTo = dataTo.replaceAll(NAVIGATION_PATTERN, "$1$2");
-                    breadcrumb.setData("to", dataTo);
-
-                    return breadcrumb;
-                } else {
-                    return breadcrumb;
-                }
-            });
             options.setRelease("release-"+com.firstvoices.keyboards.BuildConfig.VERSION_NAME);
             options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
         });


### PR DESCRIPTION
From https://github.com/keymanapp/keyman/pull/4071#issuecomment-737704988

> can you remove the java code that is unnecessary?
> ...sentry-android is not going to receive navigation events to sanitize.

Since Sentry navigation breadcrumbs are handled by embedded KMW sentry-manager, the sentry-android change in #4025 need to be reverted.