### PR TITLE
fix(android/engine): Remove in-app keyboard Sentry log about fallback keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -157,6 +157,8 @@ final class KMKeyboard extends WebView {
           Toast.makeText(context, "Fatal Error with " + currentKeyboard +
             ". Loading default keyboard", Toast.LENGTH_LONG).show();
 
+          // Still send log about falling back to default keyboard (ignore language ID)
+          sendError(packageID, keyboardID, "");
           Keyboard firstKeyboard = KeyboardController.getInstance().getKeyboardInfo(0);
           if (firstKeyboard != null) {
             // Revert to first keyboard in the list

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1840,7 +1840,7 @@ public final class KMManager {
             // Revert to default (index 0) or fallback keyboard
             keyboardInfo = KMManager.getKeyboardInfo(context, 0);
             if (keyboardInfo == null) {
-              KMLog.LogError(TAG, "No keyboards installed. Reverting to fallback");
+              // Not logging to Sentry because some keyboard apps like FV don't install keyboards until the user chooses
               keyboardInfo = KMManager.getDefaultKeyboard(context);
             }
             if (keyboardInfo != null) {


### PR DESCRIPTION
Fixes #3922

Currently, we've been sending a Sentry report if KMManager doesn't have an installed keyboard to start. Some apps (like FV) don't install a keyboard until the user chooses to. FV also doesn't use the in-app keyboard.

@mcdurdin adds:
> The only time we want to know about falling back is if there is an error in another keyboard. If there's no default keyboard we probably don't need an error report

### Changes
* Removes the in-app keyboard Sentry log about not having a keyboard installed (left the system keyboard Sentry log at l. 2087)
* Send a Sentry log when having to fallback to a default keyboard (FV example in this Sentry [log](https://sentry.keyman.com/organizations/keyman/issues/2081/?project=21))



