### PR TITLE
fix(ios/engine): deletion for selected text at the context start

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -346,6 +346,16 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     if numCharsToDelete <= 0 {
       textDocumentProxy.insertText(newText)
+
+      // A full-context deletion will report numCharsToDelete == 0 and won't
+      // otherwise delete selected text.
+      if #available(iOSApplicationExtension 11.0, *) {
+        if let selected = textDocumentProxy.selectedText {
+          if selected.count > 0 {
+            textDocumentProxy.deleteBackward()
+          }
+        }
+      }
       return
     }
 


### PR DESCRIPTION
Fixes #3986.

Sad that it doesn't work before iOS 11, but it gets the job done pretty nicely.  I don't see any way to double-check that there is pre-existing selected text otherwise.