### PR TITLE
fix(web/ui): Add check for suggestion.tag

### DIFF
--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -546,7 +546,7 @@ namespace com.keyman.osk {
       this.revertAcceptancePromise = suggestion.apply();
       if(!this.revertAcceptancePromise) {
         // We get here either if suggestion acceptance fails or if it was a reversion.
-        if(suggestion.suggestion.tag == 'revert') {
+        if(suggestion.suggestion && suggestion.suggestion.tag == 'revert') {
           // Reversion state management
           this.recentAccept = false;
           this.doRevert = false;


### PR DESCRIPTION
Fixes #4079

This fixes the issue where clicking on a blank suggestion would throw the linked Sentry error.
``` javascript
Cannot read property 'tag' of null
```

### Testing
* Launch Keyman for Android (with the default English keyboard and nrc.en.mtnt model)
* Start typing
* For valid suggestions, click and verify suggestions are inserted
* Continue typing gibberish until 1-3 blank suggestions appear in the banner
* Click on a blank suggestion and verify nothing happens

I'm still unclear how reversions work. If I backspace enough times to get blank suggestions, it seems like I get in a state where suggestions are no longer generated

Scenario
1. Type "qwerty", <kbd>enter</kbd> "noooo"
![nooo](https://user-images.githubusercontent.com/7358010/101301771-6f4ef100-386c-11eb-914b-e83786da1954.png)
2. Backspace to "noo", and suggestions become blank
3. If I backspace all of "noooo", suggestions are still blank
4. If I then type a valid word "elephant", suggestions are still blank