### PR TITLE
fix(android/app) Change UX to ensure package installation finishes

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -3,7 +3,6 @@
  */
 package com.tavultesoft.kmapro;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -17,7 +16,6 @@ import java.io.File;
 
 public class DownloadResultReceiver extends ResultReceiver {
   private Context context;
-  private ProgressDialog progressDialog;
 
   public DownloadResultReceiver(Handler handler, Context context) {
     super(handler);
@@ -25,20 +23,13 @@ public class DownloadResultReceiver extends ResultReceiver {
     this.context = context;
   }
 
-  public void setProgressDialog(ProgressDialog progressDialog) {
-    this.progressDialog = progressDialog;
-  }
-
   @Override
   protected void onReceiveResult(int resultCode, Bundle resultData) {
-    if (progressDialog != null && progressDialog.isShowing()) {
-      progressDialog.dismiss();
-    };
-    progressDialog = null;
     switch(resultCode) {
       case FileUtils.DOWNLOAD_ERROR :
         Toast.makeText(context, "Download failed",
           Toast.LENGTH_SHORT).show();
+        MainActivity.cleanupPackageInstall();
         break;
       case FileUtils.DOWNLOAD_SUCCESS :
         String downloadedFilename = resultData.getString("filename");

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -518,20 +518,22 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
 
         url = url.toLowerCase();
         try {
-          progressDialog = new ProgressDialog(MainActivity.this);
-          progressDialog.setMessage(String.format(getString(R.string.downloading_keyboard_package), filename));
-          progressDialog.setCancelable(false);
-          progressDialog.show();
+          if (progressDialog == null) {
+            progressDialog = new ProgressDialog(MainActivity.this);
+            progressDialog.setMessage(String.format(getString(R.string.downloading_keyboard_package), filename));
+            progressDialog.setCancelable(false);
+            progressDialog.show();
 
-          // Download the KMP to app cache
-          Intent downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
-          downloadIntent.putExtra("url", url);
-          downloadIntent.putExtra("filename", filename);
-          downloadIntent.putExtra("language", languageID);
-          downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
-          downloadIntent.putExtra("receiver", resultReceiver);
+            // Download the KMP to app cache
+            Intent downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
+            downloadIntent.putExtra("url", url);
+            downloadIntent.putExtra("filename", filename);
+            downloadIntent.putExtra("language", languageID);
+            downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
+            downloadIntent.putExtra("receiver", resultReceiver);
 
-          startService(downloadIntent);
+            startService(downloadIntent);
+          }
         } catch (Exception e) {
           KMLog.LogException(TAG, "", e);
           cleanupPackageInstall();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -223,6 +223,10 @@ public class WebViewFragment extends Fragment implements BlockingStep {
 
   @Override
   public void onBackClicked(StepperLayout.OnBackClickedCallback callback) {
+    if (callback.getStepperLayout().getCurrentStepPosition() == 0) {
+      // Cleanup after cancelling package installation
+      MainActivity.cleanupPackageInstall();
+    }
     callback.goToPrevStep();
   }
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -170,7 +170,7 @@ public class WebViewFragment extends Fragment implements BlockingStep {
 
     File[] files = (FileUtils.isReadmeFile(fileName)) ? tempPackagePath.listFiles(_readmeFilter) :
       tempPackagePath.listFiles(_welcomeFilter);
-    if (files.length > 0 && files[0].exists() && files[0].length() > 0) {
+    if (files != null && files.length > 0 && files[0].exists() && files[0].length() > 0) {
       webView.loadUrl("file:///" + files[0].getAbsolutePath());
     } else {
       // No readme.htm so display minimal package information

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -75,6 +75,14 @@
   <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">Show \"%1$s\" on startup</string>
 
 
+  <!-- Context: Android Storage Permission -->
+  <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">
+    To install keyboard packages, allow Keyman permission to read/write storage.</string>
+
+  <!-- Context: Android Storage Permission -->
+  <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">
+    Storage permission request was denied. May fail to install keyboard package</string>
+
   <!-- Context: Keyman Settings menu -->
   <string name="keyman_settings" comment="Settings menu title">Settings</string>
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -457,6 +457,24 @@ public final class KMManager {
     }
   }
 
+  /**
+   * Disables the In-App keyboard picker (like when installing keyboard/lexical-model packages)
+   */
+  public static void disableInAppGlobeKey() {
+    if (InAppKeyboard != null) {
+      InAppKeyboard.keyboardPickerEnabled = false;
+    }
+  }
+
+  /**
+   * Enables the In-App keyboard picker
+   */
+  public static void enableInAppGlobeKey() {
+    if (InAppKeyboard != null) {
+      InAppKeyboard.keyboardPickerEnabled = true;
+    }
+  }
+
   public static String getLanguagePredictionPreferenceKey(String langID) {
     return langID + predictionPrefSuffix;
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -457,24 +457,6 @@ public final class KMManager {
     }
   }
 
-  /**
-   * Disables the In-App keyboard picker (like when installing keyboard/lexical-model packages)
-   */
-  public static void disableInAppGlobeKey() {
-    if (InAppKeyboard != null) {
-      InAppKeyboard.keyboardPickerEnabled = false;
-    }
-  }
-
-  /**
-   * Enables the In-App keyboard picker
-   */
-  public static void enableInAppGlobeKey() {
-    if (InAppKeyboard != null) {
-      InAppKeyboard.keyboardPickerEnabled = true;
-    }
-  }
-
   public static String getLanguagePredictionPreferenceKey(String langID) {
     return langID + predictionPrefSuffix;
   }


### PR DESCRIPTION
Fixes #3895 where the user could interrupt a keyboard package installation by clicking the globe "keyboard picker" in between the package downloading and before the Stepper renders for the package installation.

This moves the Progress Dialog cleanup to block the user from accessing the keyboard picker until the package installation finishes or the package download fails.
![progress dialog](https://user-images.githubusercontent.com/7358010/101317839-daf78500-3891-11eb-8a7b-eee5b6b556eb.png)

This PR also guards against accidentally trying to install the same keyboard package multiple times in succession.

## Tested Scenarios
These involve searching for "sil_cameroon_qwerty" from keyman.com, before clicking the green button to install

### Failed download
1. From the Android settings, disable network connection
2. Click the green button to install
3. Verify keyboard download fails and the in-app keyboard is usable (not blocked by the progress dialog)
4. From the Android settings, re-enable network connection

### Cancelled package installation
1. Click the green button to install "sil_cameroon_qwerty"
2. On the Package installation stepper, hit the "< BACK" button on the bottom left to cancel
3. Verify in-app keyboard is usable

### Complete package installation
1. Click the green button to install "sil_cameroon_qwerty"
2. Go through the stepper to choose a language and install the keyboard
3. Verify in-app keyboard is set to sil_cameroon_qwerty and is usable

### Guard against downloading the same kmp multiple times
1. Quickly click the green button twice to install "sil_cameroon"qwerty"
2. Go through the stepper and choose a language and install the keyboard
3. Verify when the keyboard package finishes installing that there isn't another package Stepper to install
4. Verify inapp keyboard is set to sil_cameroon_qwerty and is usable