### PR TITLE
refactor(ios/engine): changes "install from file" to better match Apple guidelines

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -348,10 +348,9 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
       // If it is not the root view of a navigationController, just pop it off the stack.
       if let navVC = self.navigationController {
        if navVC.viewControllers[0] != self {
-        navVC.popViewController(animated: true)
-        } else {
-          self.dismiss(animated: true)
+          self.dismiss(animated: true) // Needs TWO LAYERS of dismissal in this case.
         }
+        self.dismiss(animated: true)
       } else { // Otherwise, if the root view of a navigation controller, dismiss it outright.  (pop not available)
         self.dismiss(animated: true)
       }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -110,8 +110,16 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // can launch the app-based DocumentViewController.
     if #available(iOS 11.0, *) {
       Manager.shared.fileBrowserLauncher = { navController in
-        let vc = PackageBrowserViewController()
-        navController.pushViewController(vc, animated: true)
+        // Due to iOS design flaws, the UIDocumentPickerViewController auto-dismisses
+        // the PRESENTING VC whenever a file is selected - not even just itself!
+        //
+        // Thus, "intermediateNVC" serves as a dismissable intermediary.
+        let intermediateNVC = UINavigationController()
+        let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"], in: .import, navVC: navController)
+        intermediateNVC.pushViewController(vc, animated: false)
+
+        // The ACTUAL presentation.
+        navController.present(intermediateNVC, animated: true)
       }
     }
   }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -113,6 +113,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
         // Due to iOS design flaws, the UIDocumentPickerViewController auto-dismisses
         // the PRESENTING VC whenever a file is selected - not even just itself!
         //
+        // (As noted by https://stackoverflow.com/a/45505488)
+        //
         // Thus, "intermediateNVC" serves as a dismissable intermediary.
         let intermediateNVC = UINavigationController()
         // Pass the 'master' VC to the package browser so that it can properly launch

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -115,6 +115,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
         //
         // Thus, "intermediateNVC" serves as a dismissable intermediary.
         let intermediateNVC = UINavigationController()
+        // Pass the 'master' VC to the package browser so that it can properly launch
+        // the installer.
         let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"], in: .import, navVC: navController)
         intermediateNVC.pushViewController(vc, animated: false)
 

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -29,6 +29,13 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
       delegate = self
 
       allowsMultipleSelection = false
+
+      self.navigationItem.setLeftBarButton(UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.doCancel)), animated: true)
+      self.modalPresentationStyle = .fullScreen
+  }
+
+  @objc func doCancel() {
+    self.dismiss(animated: true, completion: nil)
   }
 
   // MARK: UIDocumentPickerDelegate

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -30,7 +30,13 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
 
       allowsMultipleSelection = false
 
-      self.navigationItem.setLeftBarButton(UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.doCancel)), animated: true)
+      if #available(iOS 13.0, *) {
+        // Easily dismissable without the extra button.
+      } else {
+        self.navigationItem.setLeftBarButton(
+          UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.doCancel)),
+          animated: true)
+      }
       self.modalPresentationStyle = .fullScreen
   }
 

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -11,93 +11,82 @@ import SwiftUI
 import KeymanEngine
 
 @available(iOS 11.0, *)
-class PackageBrowserViewController: UIDocumentBrowserViewController, UIDocumentBrowserViewControllerDelegate {
+class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPickerDelegate {
+  private weak var navVC: UINavigationController?
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+  init(documentTypes allowedUTIs: [String], in mode: UIDocumentPickerMode, navVC: UINavigationController) {
+    super.init(documentTypes: allowedUTIs, in: mode)
 
-        delegate = self
+    self.navVC = navVC
+  }
 
-        allowsDocumentCreation = false
-        allowsPickingMultipleItems = false
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
-        // Update the style of the UIDocumentBrowserViewController
-        // browserUserInterfaceStyle = .dark
-        // view.tintColor = .white
+  override func viewDidLoad() {
+      super.viewDidLoad()
+      delegate = self
 
-        // Specify the allowed content types of your application via the Info.plist.
+      allowsMultipleSelection = false
+  }
 
-        // Do any additional setup after loading the view.
+  // MARK: UIDocumentPickerDelegate
+
+  func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt documentURLs: [URL]) {
+      guard let sourceURL = documentURLs.first else { return }
+
+      doInstall(of: sourceURL)
+  }
+
+  // MARK: Package processing
+
+  func doInstall(of url: URL) {
+    // Once selected, start the standard install process.
+    let rfm = ResourceFileManager.shared
+
+    guard let destinationUrl = rfm.importFile(url) else {
+      return
     }
 
-    // MARK: UIDocumentBrowserViewControllerDelegate
-
-    func documentBrowser(_ controller: UIDocumentBrowserViewController, didPickDocumentsAt documentURLs: [URL]) {
-        guard let sourceURL = documentURLs.first else { return }
-
-        // Present the Document View Controller for the first document that was picked.
-        // If you support picking multiple items, make sure you handle them all.
-        doInstall(of: sourceURL)
-    }
-
-    func documentBrowser(_ controller: UIDocumentBrowserViewController,
-                         didImportDocumentAt sourceURL: URL,
-                         toDestinationURL destinationURL: URL) {
-        // Present the Document View Controller for the new newly created document
-        doInstall(of: destinationURL)
-    }
-
-    func documentBrowser(_ controller: UIDocumentBrowserViewController,
-                         failedToImportDocumentAt documentURL: URL,
-                         error: Error?) {
-        // Make sure to handle the failed import appropriately, e.g., by presenting an error message to the user.
-    }
-
-    // MARK: Document Presentation
-
-    func doInstall(of url: URL) {
-      // Once selected, start the standard install process.
-      let rfm = ResourceFileManager.shared
-
-      guard let destinationUrl = rfm.importFile(url) else {
-        return
-      }
-
-      if let package = rfm.prepareKMPInstall(from: destinationUrl, alertHost: self) {
-        // These type checks are necessary due to generic constraints.
-        if let kbdPackage = package as? KeyboardKeymanPackage {
-          doPrompt(for: kbdPackage, withAssociators: [.lexicalModels])
-        } else if let lmPackage = package as? LexicalModelKeymanPackage {
-          doPrompt(for: lmPackage)
-        }
+    if let package = rfm.prepareKMPInstall(from: destinationUrl, alertHost: self) {
+      // These type checks are necessary due to generic constraints.
+      if let kbdPackage = package as? KeyboardKeymanPackage {
+        doPrompt(for: kbdPackage, withAssociators: [.lexicalModels])
+      } else if let lmPackage = package as? LexicalModelKeymanPackage {
+        doPrompt(for: lmPackage)
       }
     }
+  }
 
-    private func doPrompt<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>>(
-        for package: Package,
-        withAssociators associators: [AssociatingPackageInstaller<Resource, Package>.Associator] = [])
-    where Resource.Package == Package {
-      let activitySpinner = Alerts.constructActivitySpinner()
-      activitySpinner.center = view.center
+  private func doPrompt<Resource: LanguageResource, Package: TypedKeymanPackage<Resource>>(
+      for package: Package,
+      withAssociators associators: [AssociatingPackageInstaller<Resource, Package>.Associator] = [])
+  where Resource.Package == Package {
+    let activitySpinner = Alerts.constructActivitySpinner()
+    activitySpinner.center = view.center
 
-      let packageInstaller = AssociatingPackageInstaller(for: package,
-                                                         withAssociators: associators) { status in
-        if status == .starting {
-          // Start a spinner!
-          activitySpinner.startAnimating()
-          self.view.addSubview(activitySpinner)
+    let packageInstaller = AssociatingPackageInstaller(for: package,
+                                                       withAssociators: associators) { status in
+      if status == .starting {
+        // Start a spinner!
+        activitySpinner.startAnimating()
+        self.view.addSubview(activitySpinner)
 
-          activitySpinner.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
-          activitySpinner.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
-          self.view.isUserInteractionEnabled = false
-        } else if status == .complete {
-          // Report completion!
-          activitySpinner.stopAnimating()
-          activitySpinner.removeFromSuperview()
-          self.view.isUserInteractionEnabled = true
-          self.dismiss(animated: true, completion: nil)
-        }
+        activitySpinner.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        activitySpinner.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
+        self.view.isUserInteractionEnabled = false
+      } else if status == .complete {
+        // Report completion!
+        activitySpinner.stopAnimating()
+        activitySpinner.removeFromSuperview()
+        self.view.isUserInteractionEnabled = true
+        self.dismiss(animated: true, completion: nil)
       }
-      packageInstaller.promptForLanguages(inNavigationVC: self.navigationController!)
     }
+
+    if let navVC = self.navVC {
+      packageInstaller.promptForLanguages(inNavigationVC: navVC)
+    }
+  }
 }


### PR DESCRIPTION
As seen at https://developer.apple.com/documentation/uikit/view_controllers/adding_a_document_browser_to_your_app:

> Important
>
>Always assign the document browser as your app's root view controller. Don't place the document browser in a navigation controller, tab bar, or split view, and don't present the document browser modally.
>
>If you want to present a document browser from another location in your view hierarchy, use a `UIDocumentPickerViewController` instead. 

The implementation we've been using until now was based on the `UIDocumentBrowserViewController` instead.  This PR contains the necessary tweaks for using the "correct" classes & patterns.  There was also a bit of an issue backing out of the document picker in iOS 12 (at least when run in the Simulator), so I've added a 'cancel' option to ensure that the view doesn't trap users on older versions of iOS.

Interestingly, the `UIDocumentPickerViewController` is apparently compatible with even older versions of iOS... but as I haven't tested with said older versions, I'm leaving the iOS 11+ check in at this time.  Not sure how it'd interact with versions of iOS from before the Files app was implemented.  (_Maybe_ there's a chance it could have use with 9.3.5 devices?  #4017 would need resolution first, almost certainly, though.)

Note that there are significant whitespace changes in one of the files; hiding those should help facilitate the review process.

------

While it was my hope that this also would help address #4017... sadly, it does not.  Maybe there's some subtle detail that I'm missing, but I've already tried a _**lot**_ of would-be subtle details to no avail.  At least these should be worthwhile code changes despite that.