### PR TITLE
fix(ios/engine): requests security for imported files

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /**
  * This class stores common methods used for installing language resources, regardless of source.
@@ -93,7 +94,14 @@ public class ResourceFileManager {
 
     // Throws an error if the destination file already exists, and there's no
     // built-in override parameter.  Hence, the previous if-block.
-    try fileManager.copyItem(at: source, to: destination)
+    if source.startAccessingSecurityScopedResource() {
+      defer { source.stopAccessingSecurityScopedResource() }  // The Swift version of 'finally'.
+      try fileManager.copyItem(at: source, to: destination)
+    } else {
+      // We _could_ get more specific, as it's due to issues with security-scoped resources...
+      // but this ought be fine for now.
+      throw KMPError.copyFiles
+    }
   }
 
   /**


### PR DESCRIPTION
Recently, it seems that our "Install From File" functionality stopped working correctly.  After a bit of digging, it turns out this is due to how file-system security in iOS now (?) works, and it seems this may be more stringent on actual devices than on Simulator.

This fixes the issues my test devices had when attempting to address [this Community site issue](https://community.software.sil.org/t/ios-keyboard-package-cannot-be-installed-in-the-keyman-app-keyboard-testable-properly-in-phone-browser/4112/14).  It's not yet clear whether or not the root cause of that issue matches that from my repro attempts.

Note that this is currently a dependent PR of #4089.  I ran into an interesting issue when attempting to rebase against `master` that _might_ be due to new Swift / Xcode requirements on one of the types involved, though I'm not sure.  I could invest time in deciphering that if needed; there's a chance we may be able to 🍒-pick this if so _and_ if this is the same underlying cause as what the user reported in that Community posting.

This fix is entirely separate from the iOS 12.0 install-from-file issue, unfortunately.