### PR TITLE
fix(ios): fixes nav bar issues when using "Install From File"

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -345,12 +345,10 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     self.completionHandler(selectedResources.map { $0.typedFullID })
 
     let dismissalBlock = {
-      // If it is not the root view of a navigationController, just pop it off the stack.
-      if let navVC = self.navigationController {
-       if navVC.viewControllers[0] != self {
-          self.dismiss(animated: true) // Needs TWO LAYERS of dismissal in this case.
+      if let nvc = self.navigationController {
+        self.dismiss(animated: true) {
+          nvc.popToRootViewController(animated: true)
         }
-        self.dismiss(animated: true)
       } else { // Otherwise, if the root view of a navigation controller, dismiss it outright.  (pop not available)
         self.dismiss(animated: true)
       }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -110,20 +110,10 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // can launch the app-based DocumentViewController.
     if #available(iOS 11.0, *) {
       Manager.shared.fileBrowserLauncher = { navController in
-        // Due to iOS design flaws, the UIDocumentPickerViewController auto-dismisses
-        // the PRESENTING VC whenever a file is selected - not even just itself!
-        //
-        // (As noted by https://stackoverflow.com/a/45505488)
-        //
-        // Thus, "intermediateNVC" serves as a dismissable intermediary.
-        let intermediateNVC = UINavigationController()
-        // Pass the 'master' VC to the package browser so that it can properly launch
-        // the installer.
         let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"], in: .import, navVC: navController)
-        intermediateNVC.pushViewController(vc, animated: false)
 
-        // The ACTUAL presentation.
-        navController.present(intermediateNVC, animated: true)
+        self.navigationController!.topViewController!.dismiss(animated: true, completion: nil)
+        self.present(vc, animated: true)
       }
     }
   }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -109,9 +109,12 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // We have to gerry-rig this so that the framework-based SettingsViewController
     // can launch the app-based DocumentViewController.
     if #available(iOS 11.0, *) {
-      Manager.shared.fileBrowserLauncher = { navController in
-        let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"], in: .import, navVC: navController)
+      Manager.shared.fileBrowserLauncher = { _ in
+        let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"],
+                                              in: .import,
+                                              navVC: self.navigationController!)
 
+        // Auto-dismiss the settings menu, then present the "install from file" browser.
         self.navigationController!.topViewController!.dismiss(animated: true, completion: nil)
         self.present(vc, animated: true)
       }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -29,6 +29,9 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
       delegate = self
 
       allowsMultipleSelection = false
+      self.title = NSLocalizedString("menu-settings-install-from-file",
+                                     bundle: Bundle(for: Manager.self),
+                                     comment: "")
 
       if #available(iOS 13.0, *) {
         // Easily dismissable without the extra button.


### PR DESCRIPTION
A tale of two devices, before & after style:

**Before**:
![Screen Shot 2020-12-09 at 12 02 18 PM](https://user-images.githubusercontent.com/25213402/101587380-abbe5080-3a16-11eb-9814-0f9c323813a2.png)

**After**:
![Screen Shot 2020-12-09 at 11 54 42 AM](https://user-images.githubusercontent.com/25213402/101587364-a6610600-3a16-11eb-8e50-83a236208b7b.png)

And for the device / OS version that _really_ motivated this...

**Before**:
![Screen Shot 2020-12-09 at 12 01 01 PM](https://user-images.githubusercontent.com/25213402/101587438-cb557900-3a16-11eb-8ca6-3b781171acde.png)

**After**:
![Screen Shot 2020-12-09 at 12 00 01 PM](https://user-images.githubusercontent.com/25213402/101587472-da3c2b80-3a16-11eb-940c-32be5a0b3b9b.png)

The main UI for file-system navigation was broken in iOS 11 & 12; apparently there are some rough edges in Apple's implementation of its `UIDocumentPickerViewController` class.

There's also the plus that the altered code is "simpler" than the original.
