### PR TITLE
fix(ios): prevents crash from failed legacy-resource-wrapping attempt

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Migrations.swift
@@ -686,7 +686,10 @@ public enum Migrations {
 
     // Each wrapper package contains only a single resource.  .installables[0] returns all
     // LanguageResource pairings for that script resource.
-    let wrappedResources: [Resource] = wrapperPackages.flatMap { $0.installables[0] }
+    let wrappedResources: [Resource] = wrapperPackages.flatMap { package in
+      // Just in case the 'wrapping' process goes wrong, this will prevent a fatal error.
+      package.installables.count > 0 ? package.installables[0] : []
+    }
 
     let mappedResources: [Resource] = wrappedResources.compactMap { resource in
       if resources.contains(where: { $0.typedFullID == resource.typedFullID}) {


### PR DESCRIPTION
Should something go wrong in the migration process, it's (unfortunately) possible for the results to report a package without either a keyboard or a lexical model.  This can cause startup crashes within the Keyman app and may be related to #4051, though it's hard to say for certain.

I'll need a repro for creating the erroneous state in order to address the root issue, but that's currently lacking.  It's likely possible to find one, but _that_ looks to be a quite time-consuming process... and there are currently higher priorities to address.