### PR TITLE
fix(ios): autosets + autodisplays keyboard after a package install

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -364,6 +364,10 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
       do {
         try ResourceFileManager.shared.install(resourcesWithIDs: fullIDs, from: self.package)
         result = .complete
+
+        if let kbdID = fullIDs.first(where: { $0.type == .keyboard }) {
+          _ = Manager.shared.setKeyboard(withFullID: kbdID as! FullKeyboardID)
+        }
       } catch {
         result = .error(error)
       }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -393,6 +393,9 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
   @objc private func onWelcomeDismissed() {
     self.dismissalBlock?()
     self.dismissalBlock = nil
+
+    // The user will be on the main screen after this, so we should resummon the keyboard.
+    Manager.shared.showKeyboard()
   }
 
   public func tableView(_ tableView: UITableView, titleForHeaderInSection: Int) -> String? {


### PR DESCRIPTION
This fixes a regression from 13.0 stable that resulted from the installation rework.

Fixes #3982.