### PR TITLE
fix(windows): glitch in keyboard menu

### DIFF
--- a/windows/src/engine/keyman/UfrmKeymanMenu.pas
+++ b/windows/src/engine/keyman/UfrmKeymanMenu.pas
@@ -341,6 +341,9 @@ begin
     end;
   end;
 
+  if not ScrollableView then
+    Exit;
+
   for i := 0 to 1 do
   begin
     if FSelectedScrollRect = i


### PR DESCRIPTION
Fixes #4112.

Glitch in keyboard menu from scrollable buttons being drawn at top-left -- when the menu was not scrollable.