### PR TITLE
fix(windows): menu scroll positions need reset at popup

### DIFF
--- a/windows/src/engine/keyman/UfrmKeymanMenu.pas
+++ b/windows/src/engine/keyman/UfrmKeymanMenu.pas
@@ -401,6 +401,7 @@ begin
 
   for i := 0 to Fmnu.Items.Count - 1 do
   begin
+    FItemOffsets[i] := 0;
     if Fmnu.Items[i] is TKeymanMenuItem then
     begin
       kmi := Fmnu.Items[i] as TKeymanMenuItem;


### PR DESCRIPTION
Fixes #4012.

If the menu previously was scrollable, then it would potentially show items at the wrong offset because the offsets were not reset when the menu popup was called if no scroll was needed.