### PR TITLE
fix(windows): remove obsolete option 'Switch to OSK/Help'

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman_options.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_options.xsl
@@ -14,7 +14,7 @@
 					<xsl:sort select="sort" />
           <div class="options_list_header"><xsl:value-of select="$locale/string[@name=current()/name]"/></div>
           <xsl:for-each select="//KeymanOption[group=current()/name]">
-            <xsl:if test="optiontype = 1">
+            <xsl:if test="optiontype = 1 and id != 'koAutoSwitchOSKPages'">
               <xsl:call-template name="option" />
             </xsl:if>
           </xsl:for-each>


### PR DESCRIPTION
Fixes #4113.

The option "Switch to On Screen Keyboard/Help automatically when a keyboard is selected" is obsolete and we should remove it from the UI.

Note that this does not remove the API surface, just hides the option from view, as there may be apps relying on the API value.

Not touching help just now as that will be addressed in a help update in the future.