### PR TITLE
fix(windows): uninstall language button z-index

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -540,6 +540,8 @@ table tr
 }
 .keyboard-language:hover a
 {
+  position: relative;
+  z-index: 10;
   visibility: visible;
 }
 


### PR DESCRIPTION
Fixes #4009.

Brings the uninstall language button above the text so it is clickable even when the text overlaps.