### PR TITLE
fix(windows): help window centred on load

### DIFF
--- a/windows/src/desktop/kmshell/help/UfrmHelp.dfm
+++ b/windows/src/desktop/kmshell/help/UfrmHelp.dfm
@@ -3,6 +3,7 @@ inherited frmHelp: TfrmHelp
   BorderStyle = bsDialog
   ClientHeight = 288
   ClientWidth = 428
+  Position = poScreenCenter
   ExplicitWidth = 434
   ExplicitHeight = 317
   PixelsPerInch = 96


### PR DESCRIPTION
Fixes #4004.

Centres the help window when it first appears.

There is still a small resizing event but that will be handled with a separate PR for #3765.