### PR TITLE
fix(windows): Online Update dialog layout was messy

### DIFF
--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -396,6 +396,7 @@ begin
     if ShowModal <> mrYes then
     begin
       Self.FParams.Result := oucUnknown;
+      Self.FErrorMessage := '';
       Exit;
     end;
 

--- a/windows/src/desktop/kmshell/xml/onlineupdate.xsl
+++ b/windows/src/desktop/kmshell/xml/onlineupdate.xsl
@@ -24,7 +24,7 @@ body {
  font-size:		11px;
  text-align:	justify;
  margin:	0px;
- width:         482px;
+ width:         469px;
  overflow: hidden;
 }
 
@@ -46,8 +46,8 @@ div {
 
 #border {
   border: none;
-  width: <xsl:value-of select="$dialoginfo_onlineupdate/@Width - 2" />px;
-  height: <xsl:value-of select="$dialoginfo_onlineupdate/@Height - 2" />px;
+  width: 469px;
+  height: 375px;
   }
 
 #header { background: white;  }
@@ -65,7 +65,7 @@ div {
 }
 
 #UpdateContainer {
-	height: 76px;
+	height: 220px;
 	overflow-y: auto;
 	border: solid 1px gray;
 	margin: 12px 8px;


### PR DESCRIPTION
Fixes #4040.

![image](https://user-images.githubusercontent.com/4498365/102172104-4245b280-3eec-11eb-96e0-6957a66a78b6.png)

Also now prevents the spurious "no updates are available" message from appearing when the user cancels the update dialog.