### PR TITLE
fix(windows): sentrytool should fail build on exception and access violation when rewriting executables

### DIFF
--- a/windows/src/buildtools/sentrytool/Keyman.System.AddPdbToPe.pas
+++ b/windows/src/buildtools/sentrytool/Keyman.System.AddPdbToPe.pas
@@ -265,6 +265,9 @@ begin
     s.SetSize(SectionOffset + SectionRawSize);
     FillChar((PByte(s.Memory) + SectionOffset)^, SectionRawSize, 0);
 
+    nh32 := PImageNtHeaders(NativeUInt(nh32)-NativeUInt(dh)+NativeUInt(s.Memory));
+    section := PImageSectionHeader(NativeUInt(section)-NativeUInt(dh)+NativeUInt(s.Memory));
+
     // Increment the number of sections
     Inc(nh32.FileHeader.NumberOfSections);
 
@@ -323,6 +326,9 @@ begin
     // Allocate a new section for the debug directory
     s.SetSize(SectionOffset + SectionRawSize);
     FillChar((PByte(s.Memory) + SectionOffset)^, SectionRawSize, 0);
+
+    nh64 := PImageNtHeaders64(NativeUInt(nh64)-NativeUInt(dh)+NativeUInt(s.Memory));
+    section := PImageSectionHeader(NativeUInt(section)-NativeUInt(dh)+NativeUInt(s.Memory));
 
     // Increment the number of sections
     Inc(nh64.FileHeader.NumberOfSections);

--- a/windows/src/buildtools/sentrytool/sentrytool.dpr
+++ b/windows/src/buildtools/sentrytool/sentrytool.dpr
@@ -16,6 +16,9 @@ begin
     ExitCode := main;
   except
     on E: Exception do
+    begin
       Writeln(E.ClassName, ': ', E.Message);
+      ExitCode := 1;
+    end;
   end;
 end.

--- a/windows/src/desktop/kmconfig/Makefile
+++ b/windows/src/desktop/kmconfig/Makefile
@@ -6,7 +6,7 @@
 
 build: version.res manifest.res #icons
     $(DELPHI_MSBUILD) kmconfig.dproj /p:Platform=Win32
-    $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmconfig.exe -dpr kmconfig.exe
+    $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\kmconfig.exe -dpr kmconfig.dpr
     $(TDS2DBG) $(WIN32_TARGET_PATH)\kmconfig.exe
     $(COPY) $(WIN32_TARGET_PATH)\kmconfig.exe $(PROGRAM)\desktop
     if exist $(WIN32_TARGET_PATH)\kmconfig.dbg $(COPY) $(WIN32_TARGET_PATH)\kmconfig.dbg $(DEBUGPATH)\desktop


### PR DESCRIPTION
Fixes #4002.

Examining the logs shows that sentrytool is failing with an access violation when running on the build agent, although it works on my local machine. 

Fixes three separate issues relating to sentrytool:

1. Build should be failing if sentrytool fails.
2. Access violation when rewriting executable in some cases (originally missed due to point 1).
3. Typo in sentrytool call meant it wasn't working for kmconfig.exe (originally missed due to point 1).
