### PR TITLE
fix(windows): Proxy Configuration window size

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmProxyConfiguration.dfm
+++ b/windows/src/desktop/kmshell/main/UfrmProxyConfiguration.dfm
@@ -2,11 +2,11 @@ inherited frmProxyConfiguration: TfrmProxyConfiguration
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'frmProxyConfiguration'
-  ClientHeight = 288
-  ClientWidth = 428
+  ClientHeight = 176
+  ClientWidth = 240
   Position = poScreenCenter
-  ExplicitWidth = 434
-  ExplicitHeight = 317
+  ExplicitWidth = 246
+  ExplicitHeight = 205
   PixelsPerInch = 96
   TextHeight = 13
 end

--- a/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
+++ b/windows/src/desktop/kmshell/xml/proxyconfiguration.xsl
@@ -103,7 +103,7 @@ div {
   <div id='content'>
     <div class='form' id="ProxyServerLabel"><xsl:value-of select="$locale/string[@name='S_ProxyConfiguration_Server']" /></div>
     <div class='form' id="ProxyServer">
-      <input type="text" id="Form_ProxyServer">
+      <input autofocus="autofocus" type="text" id="Form_ProxyServer">
         <xsl:attribute name="value"><xsl:value-of select="/Keyman/Proxy/Server"/></xsl:attribute>
       </input>
     </div>


### PR DESCRIPTION
Fixes #4007.

Proxy Configuration window is now the right size and focuses the Server text box appropriately.

![image](https://user-images.githubusercontent.com/4498365/102281933-f0506b80-3f83-11eb-9ed4-c604901d54ba.png)
