### PR TITLE
fix(windows): Settings refresh management

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -155,9 +155,11 @@ begin
       GetCurrentDir, childExitCode) or
     (childExitCode <> 0) then
   begin
+    kmcom.Refresh;
     Exit(False);
   end;
 
+  kmcom.Refresh;
   Result := True;
 end;
 

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -120,15 +120,14 @@ begin
   kmcom.Languages.Apply;
   AddDefaultLanguageHotkeys(InstalledKeyboards);
 
+  kmcom.Apply;
+
   if InstalledPackage <> nil then
   begin
     //if not ASilent then SelectLanguage(False);
     if not ASilent and not ANoWelcome then
       DoShowPackageWelcome(InstalledPackage, False);
   end;
-
-  {$MESSAGE HINT 'How do we correlate this with a Cancel in configuration? Do we change that to Close?' }
-  kmcom.Apply;
 end;
 
 /// <summary>

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -513,8 +513,10 @@ function TfrmInstallKeyboard.InstallTipForKeyboard(const BCP47Tag: string): Bool
 begin
   // Ensure keyboard is recorded in CU registry before we install the TIP, otherwise it will be marked as disabled by default,
   // as installing the TIP adds CU registry settings, potentially confusing the keyboard settings
-  kmcom.Refresh;
-  kmcom.Apply;
+
+  // Only do this for the keyboards, so we don't cause a global refresh
+  kmcom.Keyboards.Refresh;
+  kmcom.Keyboards.Apply;
 
   Result := DoInstallTipForKeyboard(BCP47Tag);
   if not Result then

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
@@ -159,6 +159,7 @@ begin
   else
     CheckForMitigationWarningFor_Win10_1803(Silent, '');
 
+  kmcom.Apply;
   Result := True;
 end;
 
@@ -265,7 +266,10 @@ begin
       Result := True;
     end
   ) then
+  begin
+    kmcom.Apply;
     ModalResult := mrOk;
+  end;
 end;
 
 procedure TfrmInstallKeyboardLanguage.editSearchChange(Sender: TObject);

--- a/windows/src/desktop/kmshell/install/uninstall.pas
+++ b/windows/src/desktop/kmshell/install/uninstall.pas
@@ -1,18 +1,18 @@
 (*
   Name:             uninstall
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      27 Mar 2008
 
   Modified Date:    1 Jan 2013
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          27 Mar 2008 - mcdurdin - Initial version
                     28 Aug 2008 - mcdurdin - I1609 - Uninstall requires administrator if installed by admin
                     12 Mar 2010 - mcdurdin - I2216 - Show currently installed fonts in package details
@@ -100,7 +100,7 @@ begin
     if WaitForElevatedConfiguration(Handle, '-up "'+pkgID+'" -s') = 0 then
     begin
       kmcom.Refresh;
-      kmcom.Keyboards.Apply;
+      kmcom.Apply;
       Result := True;
     end;
     Exit;
@@ -154,8 +154,8 @@ begin
     kbd := nil;
     if WaitForElevatedConfiguration(Handle, '-uk "'+kbdID+'" -s') = 0 then
     begin
-      kmcom.Keyboards.Refresh;
-      kmcom.Keyboards.Apply;
+      kmcom.Refresh;
+      kmcom.Apply;
       Result := True;
     end;
     Exit;
@@ -164,7 +164,7 @@ begin
   kmcom.Keyboards.Apply;
   kbd.Uninstall;
   kbd := nil;
-  kmcom.Keyboards.Refresh;
+  kmcom.Refresh;
   kmcom.Apply;
   Result := True;
 end;

--- a/windows/src/desktop/kmshell/install/uninstall.pas
+++ b/windows/src/desktop/kmshell/install/uninstall.pas
@@ -99,7 +99,7 @@ begin
     pkg := nil;
     if WaitForElevatedConfiguration(Handle, '-up "'+pkgID+'" -s') = 0 then
     begin
-      kmcom.Keyboards.Refresh;
+      kmcom.Refresh;
       kmcom.Keyboards.Apply;
       Result := True;
     end;
@@ -119,8 +119,8 @@ begin
   UninstallPackageTips(pkg);
   pkg.Uninstall(True);
   pkg := nil;
-  kmcom.Keyboards.Refresh;
-  kmcom.Keyboards.Apply;
+  kmcom.Refresh;
+  kmcom.Apply;
   Result := True;
 end;
 
@@ -165,7 +165,7 @@ begin
   kbd.Uninstall;
   kbd := nil;
   kmcom.Keyboards.Refresh;
-  kmcom.Keyboards.Apply;
+  kmcom.Apply;
   Result := True;
 end;
 
@@ -199,6 +199,7 @@ begin
   kbdlang.Uninstall;
   kbdlang := nil;
   kmcom.Keyboards.Refresh;
+  kmcom.Apply;
   Result := True;
 end;
 

--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -347,6 +347,7 @@ begin
   FPackage := nil;
 
   kmcom.Refresh;
+  kmcom.Apply;
   SysUtils.DeleteFile(Package.SavePath);
 end;
 

--- a/windows/src/desktop/kmshell/main/UImportOlderVersionSettings.pas
+++ b/windows/src/desktop/kmshell/main/UImportOlderVersionSettings.pas
@@ -188,9 +188,9 @@ begin
             SameText(kmcom.Keyboards[i].OwnerPackage.ID, p) then
           kmcom.Keyboards[i].Loaded := False;
     end;
-    kmcom.Apply;
   end;
 
+  kmcom.Apply;
   Result := True;
 end;
 

--- a/windows/src/desktop/kmshell/main/UfrmBaseKeyboard.pas
+++ b/windows/src/desktop/kmshell/main/UfrmBaseKeyboard.pas
@@ -32,6 +32,8 @@ begin
   with TfrmBaseKeyboard.Create(nil) do
   try
     Result := ShowModal = mrOk;
+    if Result then
+      kmcom.Apply;
   finally
     Free;
   end;

--- a/windows/src/desktop/kmshell/main/UfrmKeepInTouch.pas
+++ b/windows/src/desktop/kmshell/main/UfrmKeepInTouch.pas
@@ -112,7 +112,7 @@ end;
 procedure TfrmKeepInTouch.TntFormShow(Sender: TObject);
 begin
   inherited;
-  Do_Content_Render(False);
+  Do_Content_Render;
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/UfrmMain.dfm
+++ b/windows/src/desktop/kmshell/main/UfrmMain.dfm
@@ -15,4 +15,9 @@ inherited frmMain: TfrmMain
   ExplicitHeight = 533
   PixelsPerInch = 96
   TextHeight = 13
+  object AppEvents: TApplicationEvents
+    OnMessage = AppEventsMessage
+    Left = 416
+    Top = 256
+  end
 end

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -370,7 +370,7 @@ var
         else Result := KeyboardFileNames[3];
     end;
 begin
-  kmcom.AutoApply := True;
+  kmcom.AutoApply := False;
 
   FMutex := nil;  // I2720
 
@@ -494,9 +494,13 @@ begin
         else ExitCode := 1;
 
     fmInstallTipsForPackages:
-      if TTipMaintenance.InstallTipsForPackages(KeyboardFileNames)
-        then ExitCode := 0
-        else ExitCode := 1;
+      if TTipMaintenance.InstallTipsForPackages(KeyboardFileNames) then
+      begin
+        kmcom.Apply;
+        ExitCode := 0;
+      end
+      else
+        ExitCode := 1;
 
     fmUninstallKeyboard:            { I1201 - Fix crash uninstalling admin-installed keyboards and packages }
       if UninstallKeyboard(nil, FirstKeyboardFileName, FSilent)

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -496,6 +496,7 @@ begin
     fmInstallTipsForPackages:
       if TTipMaintenance.InstallTipsForPackages(KeyboardFileNames) then
       begin
+        // TTIPMaintenance never does a kmcom.Apply to notify
         kmcom.Apply;
         ExitCode := 0;
       end

--- a/windows/src/desktop/kmshell/render/GenericXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/GenericXMLRenderer.pas
@@ -28,7 +28,7 @@ type
   private
     FXML: WideString;
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   public
     constructor Create(AOwner: TXMLRenderers; const AXML: WideString = '');
   end;
@@ -43,7 +43,7 @@ begin
   FXML := AXML;
 end;
 
-function TGenericXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TGenericXMLRenderer.XMLData: WideString;
 begin
   Result := FXML;
 end;

--- a/windows/src/desktop/kmshell/render/HotkeysXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/HotkeysXMLRenderer.pas
@@ -27,7 +27,7 @@ uses
 type
   THotkeysXMLRenderer = class(TXMLRenderer)
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   end;
 
 implementation
@@ -63,7 +63,7 @@ begin
   Result := s;
 end;
 
-function THotkeysXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function THotkeysXMLRenderer.XMLData: WideString;
 var
   FValue, i, j: Integer;
 begin

--- a/windows/src/desktop/kmshell/render/KeyboardListXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/KeyboardListXMLRenderer.pas
@@ -34,7 +34,7 @@ type
     FFileReferences: TStrings;
     procedure DeleteFileReferences;
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   public
     constructor Create(AOwner: TXMLRenderers);
     destructor Destroy; override;
@@ -76,7 +76,7 @@ begin
   inherited Destroy;
 end;
 
-function TKeyboardListXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TKeyboardListXMLRenderer.XMLData: WideString;
     function AddKeyboard(kbd: IKeymanKeyboardInstalled): WideString;
     var
       References: OleVariant;
@@ -105,12 +105,6 @@ var
   I: Integer;
 begin
   DeleteFileReferences;
-
-  if FRefreshKeyman then
-  begin
-    kmcom.Keyboards.Refresh;
-    kmcom.Packages.Refresh;
-  end;
 
   { Add unpackaged keyboards }
   for I := 0 to kmcom.Keyboards.Count - 1 do

--- a/windows/src/desktop/kmshell/render/LanguagesXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/LanguagesXMLRenderer.pas
@@ -27,7 +27,7 @@ uses
 type
   TLanguagesXMLRenderer = class(TXMLRenderer)
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   end;
 
 implementation
@@ -38,12 +38,10 @@ uses
 
 { TLanguagesXMLRenderer }
 
-function TLanguagesXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TLanguagesXMLRenderer.XMLData: WideString;
 var
   References: OleVariant;
 begin
-  if FRefreshKeyman then
-    kmcom.Languages.Refresh;
   References := Null;   // I2678
   Result := kmcom.Languages.SerializeXML(0, '', References);
 end;

--- a/windows/src/desktop/kmshell/render/OptionsXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/OptionsXMLRenderer.pas
@@ -33,7 +33,7 @@ uses
 type
   TOptionsXMLRenderer = class(TXMLRenderer)
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   public
     constructor Create(AOwner: TXMLRenderers);
   end;
@@ -54,7 +54,7 @@ begin
   inherited Create(AOwner);
 end;
 
-function TOptionsXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TOptionsXMLRenderer.XMLData: WideString;
 var
   References: OleVariant;
   i: Integer;
@@ -69,8 +69,6 @@ var
     end;
 begin
   References := Null;  // I2678
-  if FRefreshKeyman then
-    kmcom.Options.Refresh;
   Result := kmcom.Options.SerializeXML(0, '', References);
   FGroups := TStringList.Create;
   try

--- a/windows/src/desktop/kmshell/render/SupportXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/SupportXMLRenderer.pas
@@ -30,7 +30,7 @@ uses
 type
   TSupportXMLRenderer = class(TXMLRenderer)
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   end;
 
 implementation
@@ -47,7 +47,7 @@ uses
 
 { TSupportXMLRenderer }
 
-function TSupportXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TSupportXMLRenderer.XMLData: WideString;
 begin
   //kmcom.SystemInfo.EngineVersion
   Result := '<support>'+

--- a/windows/src/desktop/kmshell/render/WelcomeXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/WelcomeXMLRenderer.pas
@@ -28,7 +28,7 @@ uses
 type
   TWelcomeXMLRenderer = class(TXMLRenderer)
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; override;
+    function XMLData: WideString; override;
   end;
 
 implementation
@@ -42,7 +42,7 @@ uses
 
 { TWelcomeXMLRenderer }
 
-function TWelcomeXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
+function TWelcomeXMLRenderer.XMLData: WideString;
 
     function AddPackage(pkg: IKeymanPackageInstalled): WideString;
     var
@@ -63,9 +63,6 @@ function TWelcomeXMLRenderer.XMLData(FRefreshKeyman: Boolean): WideString;
 var
   I: Integer;
 begin
-  if FRefreshKeyman then
-    kmcom.Packages.Refresh;
-
   { Add packaged keyboards }
   for I := 0 to kmcom.Packages.Count - 1 do
   begin

--- a/windows/src/desktop/kmshell/settings/Keyman.Configuration.UI.UfrmSettingsManager.pas
+++ b/windows/src/desktop/kmshell/settings/Keyman.Configuration.UI.UfrmSettingsManager.pas
@@ -73,6 +73,8 @@ uses
   System.UITypes,
   System.Win.Registry,
 
+  kmint,
+
   Keyman.System.SettingsManager,
   Keyman.System.SettingsManagerFile,
   Keyman.Configuration.UI.UfrmSettingsAddTSFApp,
@@ -193,6 +195,12 @@ begin
   gridDebugOption.Invalidate;
   FWasSaved := True;
   EnableControls;
+
+  // Because we change settings directly in registry, Keyman COM API
+  // will now have invalid values, so let's refresh them before we
+  // apply and broadcast the change
+  kmcom.Refresh;
+  kmcom.Apply;
 end;
 
 procedure TfrmSettingsManager.cmdTSFApplicationSettingsClick(

--- a/windows/src/desktop/kmshell/startup/UfrmSplash.pas
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.pas
@@ -132,13 +132,13 @@ end;
 procedure TfrmSplash.TntFormShow(Sender: TObject);
 begin
   FRenderPage := 'splash';
-  Do_Content_Render(False);
+  Do_Content_Render;
   inherited;
 end;
 
 procedure TfrmSplash.WMUser(var Message: TMessage);
 begin
-  Do_Content_Render(False);
+  Do_Content_Render;
 end;
 
 procedure TfrmSplash.WMUser_FormShown(var Message: TMessage);
@@ -156,14 +156,14 @@ begin
   if FShowConfigurationOnLoad then
   begin
     Main(Self);
-    Do_Content_Render(True);
+    Do_Content_Render;
   end;
 end;
 
 procedure TfrmSplash.FireCommand(const command: WideString; params: TStringList);
 begin
   if command = 'start' then Command_Start
-  else if command = 'config' then begin Main(Self); Do_Content_Render(True); end   // I4393   // I4396
+  else if command = 'config' then begin Main(Self); Do_Content_Render; end   // I4393   // I4396
   else if command = 'hidesplash' then FShouldDisplay := False
   else if command = 'showsplash' then FShouldDisplay := True
   else if command = 'exit' then Command_Exit

--- a/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
+++ b/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
@@ -460,9 +460,6 @@ begin
   CheckKeyboardFonts(False);
 end;
 
-const
-  KR_REFRESH = 2;
-
 {------------------------------------------------------------------------------------------------}
 
 procedure TfrmTextEditor.editorSelectionChange(Sender: TObject);

--- a/windows/src/desktop/kmshell/util/kmint.pas
+++ b/windows/src/desktop/kmshell/util/kmint.pas
@@ -43,6 +43,8 @@ function LoadKMCOM: Boolean;
 
 const
   KEYMAN_LAYOUT_CUSTOM = $000005FE;
+  KR_REFRESH = 2;
+  KR_SETTINGS_CHANGED = 3;
 
 const
   KMC_REFRESH = 4;

--- a/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
+++ b/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
@@ -262,7 +262,7 @@ begin
   if PageTag <> '' then
     PageTag := '<PageTag>'+PageTag+'</PageTag>';
 
-  FXML := FXMLRenderers.RenderToString(False, s + PageTag + DefaultServersXMLTags + DefaultVersionXMLTags);
+  FXML := FXMLRenderers.RenderToString(s + PageTag + DefaultServersXMLTags + DefaultVersionXMLTags);
 
   FResponseInfo.ContentStream := TStringStream.Create(FXML, TEncoding.UTF8);
   FResponseInfo.FreeContentStream := True;

--- a/windows/src/engine/keyman/kmint.pas
+++ b/windows/src/engine/keyman/kmint.pas
@@ -1,18 +1,18 @@
 (*
   Name:             kmint
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    14 Sep 2006
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     14 Sep 2006 - mcdurdin - Remove Refresh-Keyman function
 *)
@@ -49,7 +49,8 @@ uses
 
 const
   KR_REQUEST_REFRESH = 0;  // Send this to any window, which will make Keyman post a KR_REFRESH to all top-level windows
-  KR_REFRESH = 2;       // Finally this message get sent to all the other top-level windows in the system.
+  KR_REFRESH = 2;          // Finally this message get sent to all the other top-level windows in the system.
+  KR_SETTINGS_CHANGED = 3;
 
 function KeymanCustomisation: IKeymanCustomisation;
 begin

--- a/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
@@ -349,7 +349,13 @@ begin
       kotBool: FBoolValue := reg.ReadBool(FRegistryName);
       kotLong: FIntValue := StrToIntDef('$'+reg.ReadString(FRegistryName), 0);
       kotString: FStringValue := reg.ReadString(FRegistryName);
-    end;
+    end
+  else
+    case FOptionType of
+      kotBool: FBoolValue := FDefaultBoolValue;
+      kotLong: FIntValue := FDefaultIntValue;
+      kotString: FStringValue := FDefaultStringValue;
+    end
 end;
 
 procedure TUtilKeymanOptionEntry.Save(AContext: TKeymanContext; reg: TRegistryErrorControlled);  // I2890

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -34,6 +34,8 @@ type
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;
 
     procedure DiagnosticTestException; safecall;
+
+    function LastRefreshToken: IntPtr; safecall;
   end;
 
 implementation

--- a/windows/src/global/delphi/ui/UfrmWebContainer.pas
+++ b/windows/src/global/delphi/ui/UfrmWebContainer.pas
@@ -93,7 +93,7 @@ type
     property DialogName: WideString read FDialogName;
 
 
-    procedure Do_Content_Render(FRefreshKeyman: Boolean); virtual;
+    procedure Do_Content_Render; virtual;
   end;
 
 procedure CreateForm(InstanceClass: TComponentClass; var Reference);
@@ -148,7 +148,7 @@ begin
   cef.Navigate(modWebHttpServer.Host + '/page/'+FRenderPage+IfThen(Query='','','?'+Query));
 end;
 
-procedure TfrmWebContainer.Do_Content_Render(FRefreshKeyman: Boolean);
+procedure TfrmWebContainer.Do_Content_Render;
 begin
   Content_Render;   // I4088
 end;
@@ -249,7 +249,7 @@ var
 begin
   UILanguageID := params.Values['value'];
   kmint.KeymanCustomisation.CustMessages.LanguageCode := UILanguageID;
-  Do_Content_Render(True);
+  Do_Content_Render;
 end;
 
 procedure TfrmWebContainer.cefLoadEnd(Sender: TObject);
@@ -301,7 +301,7 @@ end;
 
 procedure TfrmWebContainer.WMUser_ContentRender(var Message: TMessage);
 begin
-  Do_Content_Render(True);
+  Do_Content_Render;
 end;
 
 procedure TfrmWebContainer.WMUser_FormShown(var Message: TMessage);

--- a/windows/src/global/delphi/ui/XMLRenderer.pas
+++ b/windows/src/global/delphi/ui/XMLRenderer.pas
@@ -63,13 +63,13 @@ type
     FXMLFileName: WideString;
     function Getkmcom: IKeyman;
   protected
-    function XMLData(FRefreshKeyman: Boolean): WideString; virtual; abstract;
+    function XMLData: WideString; virtual; abstract;
     function Stylesheet: WideString; virtual;
     property kmcom: IKeyman read Getkmcom;
   public
     constructor Create(AOwner: TXMLRenderers);
     function Render: Boolean;
-    function GetXMLData(FRefreshKeyman: Boolean): WideString;
+    function GetXMLData: WideString;
     property Owner: TXMLRenderers read FOwner;
     property XMLFileName: WideString read FXMLFileName;
   end;
@@ -85,7 +85,7 @@ type
     function Getkmcom: IKeyman;
   public
     constructor Create;
-    function RenderToString(FRefreshKeyman: Boolean; const AdditionalData: WideString = ''): string;
+    function RenderToString(const AdditionalData: WideString = ''): string;
     function TemplateExists: Boolean;
     property kmcom: IKeyman read Getkmcom;
     property Items[Index: Integer]: TXMLRenderer read GetItem write SetItem; default;
@@ -128,9 +128,9 @@ begin
   Result := FOwner.kmcom;
 end;
 
-function TXMLRenderer.GetXMLData(FRefreshKeyman: Boolean): WideString;
+function TXMLRenderer.GetXMLData: WideString;
 begin
-  Result := XMLData(FRefreshKeyman);
+  Result := XMLData;
 end;
 
 function TXMLRenderer.Render: Boolean;
@@ -183,7 +183,7 @@ begin
   end;
 end;
 
-function TXMLRenderers.RenderToString(FRefreshKeyman: Boolean; const AdditionalData: WideString): string;
+function TXMLRenderers.RenderToString(const AdditionalData: WideString): string;
 var
   i: Integer;
   FOutput: TStrings;
@@ -218,7 +218,7 @@ begin
         '<localepath>'+XMLEncode(s)+'</localepath>');
 
     for i := 0 to Count - 1 do
-      FOutput.Add(Items[i].GetXMLData(FRefreshKeyman));
+      FOutput.Add(Items[i].GetXMLData);
     FOutput.Add('</Keyman>');
 
     doc := TXMLDocument.Create(nil);

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -1,18 +1,18 @@
 /*
   Name:             Keyman64
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    9 Aug 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Remove HWND parameter from SelectKeyboard
                     23 Aug 2006 - mcdurdin - Add version 7.0 system stores - VISUALKEYBOARD, KMW_RTL, KMW_HELPFILE, KMW_HELPTEXT, KMW_EMBEDJS
                     14 Sep 2006 - mcdurdin - Add IsSysTrayWindow function
@@ -60,7 +60,7 @@
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
 #endif
 
-#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT 
+#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT 1
 #endif
 
@@ -98,11 +98,12 @@
 #define ERROR_KEYMAN_KEYBOARD_NOT_ACTIVE (ERROR_APP_MASK | 0x00000009L)
 #define ERROR_KEYMAN_TOO_MANY_CONTROLLERS (ERROR_APP_MASK | 0x0000000AL)
 
-/* RefreshKeyboards message parameters */ 
+/* RefreshKeyboards message parameters */
 
-#define KR_REQUEST_REFRESH	0
-#define KR_PRE_REFRESH	1
-#define KR_REFRESH		2
+#define KR_REQUEST_REFRESH  0
+#define KR_PRE_REFRESH      1
+#define KR_REFRESH          2
+#define KR_SETTINGS_CHANGED 3   // Broadcast when Keyman Configuration settings change
 
 /* WM_KEY* message analysis */
 
@@ -132,17 +133,17 @@
 //#define KM_GETUISTATE	3
 #define KM_FOCUSCHANGED	5		// Never use this flag: internal to Keyman
 #define KM_ACTIVECHANGED 6  // Never use this flag: internal to Keyman
-#define KM_EXITFLUSH  8 // Disconnects GetMessage hook 
+#define KM_EXITFLUSH  8 // Disconnects GetMessage hook
 
 #define KMF_WINDOWCHANGED 1
 
-/***************************************************************************/ 
+/***************************************************************************/
 
 typedef struct tagSTORE
 {
 	DWORD dwSystemID;
 	PWSTR dpName;
-	PWSTR dpString;		
+	PWSTR dpString;
 } STORE, *LPSTORE;
 
 
@@ -151,8 +152,8 @@ typedef struct tagKEY
 	WCHAR Key;
 	DWORD Line;
 	DWORD ShiftFlags;
-	PWSTR dpOutput;		
-	PWSTR dpContext;	
+	PWSTR dpOutput;
+	PWSTR dpContext;
 } KEY, *LPKEY;
 
 
@@ -160,8 +161,8 @@ typedef struct tagGROUP
 {
 	PWSTR dpName;
 	LPKEY dpKeyArray;		// [LPKEY] address of first item in key array
-	PWSTR dpMatch;		
-	PWSTR dpNoMatch;		
+	PWSTR dpMatch;
+	PWSTR dpNoMatch;
 	DWORD cxKeyArray;		// in array entries
 	BOOL  fUsingKeys;		// group(xx) [using keys] <-- specified or not
 } GROUP, *LPGROUP;
@@ -172,7 +173,7 @@ typedef struct tagKEYBOARD
 	DWORD dwIdentifier;		// Keyman compiled keyboard id
 
 	DWORD dwFileVersion;	// Version of the file - Keyman 4.0 is 0x0400
-	
+
 	DWORD dwCheckSum;		// As stored in keyboard
 	DWORD xxkbdlayout;    	// as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
 	DWORD IsRegistered;		// layout id, from same registry key
@@ -183,7 +184,7 @@ typedef struct tagKEYBOARD
 
 	LPSTORE dpStoreArray;	// [LPSTORE] address of first item in store array, from start of file
 	LPGROUP dpGroupArray;	// [LPGROUP] address of first item in group array, from start of file
-	
+
 	DWORD StartGroup[2];	// index of starting groups [2 of them]
 							// Ansi=0, Unicode=1
 
@@ -207,7 +208,7 @@ typedef struct tagIMDLLHOOK
 	DWORD storeno;
 	IMDLLHOOKProc function;
 } IMDLLHOOK, *LPIMDLLHOOK;
-	
+
 typedef struct tagIMDLL
 {
 	char        Filename[256];
@@ -351,13 +352,15 @@ BOOL ShouldDebug_1(); // TSDMState state);
 #define OutputThreadDebugString(s) _OutputThreadDebugString(s)
 void _OutputThreadDebugString(char *s);
 #else
-#define OutputThreadDebugString(s) 
+#define OutputThreadDebugString(s)
 #endif
 
-/* Keyboard selection functions */ 
+/* Keyboard selection functions */
 
 void HandleRefresh(int code, LONG tag);
 void RefreshKeyboards(BOOL Initialising);
+void CheckScheduledRefresh();
+void ScheduleRefresh();
 void ReleaseKeyboards(BOOL Lock);
 
 /* Glossary conversion functions */


### PR DESCRIPTION
Fixes #4011.
Fixes #4039.
Fixes #4121.
Fixes #4119.
Fixes KEYMAN-WINDOWS-6A.
Fixes KEYMAN-WINDOWS-6B.
Fixes KEYMAN-WINDOWS-4B.
Fixes KEYMAN-WINDOWS-4C.

I am sorry that this touches as many files as it does. Hopefully, most of the changes are relatively simple and clear.

This change completes the immediate-change model for Keyman Configuration, by refactoring the refresh of settings out of the render phase and more appropriately splitting applying and refreshing. It adds a new message flag for `wm_keyman_refresh`, `KR_SETTINGS_CHANGED`, which uses a random token approach broadcast to all applications on the desktop to ensure that the refresh is received and multiple notifications for the same event can be appropriately coalesced.

Most of the files touched are stripping out the refresh flags from the render phase.

There is one small bug resolved at the same time with the options properties, which were not reset to default if they had been deleted from the registry prior to a refresh (see utilkeymanoption.pas).

It would possibly be better to split the `Apply` and "notify" operations, but that is a substantial change to the behaviour of the program which I am not willing to do during a beta phase, and would possibly impact other users of the Keyman API.

# User testing

@MakaraSok:

For each operation, watch to see that:

- [ ] the keyboard menu is updated.
- [ ] the On Screen Toolbar is updated.
- [ ] Keyman Configuration reflects the changed settings accurately.

Try the following:

1. Installing a package from File Explorer while Keyman Configuration is open
2. Install a package from Keyman COnfiguration
3. Download a package from Keyman Configuration
4. Uninstall package
5. Enable and disable a keyboard
6. Adding and remove keyboard languages
7. Change various options in the Options tab
8. Change keyboard hotkeys