### PR TITLE
fix(windows): Improve refresh performance

### DIFF
--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -725,9 +725,10 @@ void HandleRefresh(int code, LONG tag)
     // All threads need to have their keyboard list
     // refreshed after an update, but only once per
     // refresh request
-    //if (UpdateRefreshTag(tag)) {
-    ScheduleRefresh();
-    //}
+    if (UpdateRefreshTag(tag)) {
+      // We'll update when we are called into action
+      ScheduleRefresh();
+    }
     break;
 	}
 }

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -223,7 +223,8 @@ typedef struct tagKEYMAN64THREADDATA
   BOOL TIPFUpdateable, TIPFPreserved;   // I4290
 
   BOOL FInRefreshKeyboards;
-  LONG RefreshTag_Process;
+  BOOL RefreshRequired;
+  LONG RefreshTag_Process; // TODO: we may be able to eliminate this with our delayed refresh pattern?
 
   /* Addin Globals */
 

--- a/windows/src/engine/keyman32/kmhook_callwndproc.cpp
+++ b/windows/src/engine/keyman32/kmhook_callwndproc.cpp
@@ -163,6 +163,7 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
 		  {
 		  case WM_KILLFOCUS:
         {
+          CheckScheduledRefresh();
           HWND hwnd = IsLanguageSwitchWindowVisible();   // I4326
           if(hwnd != NULL && !Globals::IsControllerProcess()) SendToLanguageSwitchWindow(hwnd, VK_ESCAPE, 0); // I3025
 
@@ -177,6 +178,7 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         }
 			  break;
       case WM_SETFOCUS:
+        CheckScheduledRefresh();
         if (IsSysTrayWindow(cp->hwnd))      // I2443 - always do the focus change now? really unsure about this one
           SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsSysTrayWindow");
         else if (Globals::IsControllerWindow(cp->hwnd))
@@ -193,10 +195,11 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
       case WM_ACTIVATE:
         if(cp->wParam == WA_ACTIVE || cp->wParam == WA_CLICKACTIVE)
         {
-          
+          CheckScheduledRefresh();
         }
         break;
 		  case WM_INPUTLANGCHANGE:
+        CheckScheduledRefresh();
         SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_INPUTLANGCHANGE %x %x Hwnd=%x Parent=%x Focus=%x Active=%x", cp->wParam, cp->lParam, cp->hwnd, GetParent(cp->hwnd), GetFocus(), GetActiveWindow());
           ReportActiveKeyboard(PC_UPDATE);   // I4288
 

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -149,7 +149,7 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 
   if ((mp->message == WM_KEYDOWN || mp->message == WM_SYSKEYDOWN || mp->message == WM_KEYUP || mp->message == WM_SYSKEYUP)) {   // I4642
     BYTE scan = KEYMSG_LPARAM_SCAN(mp->lParam);
-
+    CheckScheduledRefresh();
     _td->LastScanCode = scan;
     _td->LastKey = mp->wParam;
 

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -359,6 +359,8 @@ void _OutputThreadDebugString(char *s);
 void HandleRefresh(int code, LONG tag);
 void RefreshKeyboards(BOOL Initialising);
 void ReleaseKeyboards(BOOL Lock);
+void CheckScheduledRefresh();
+void ScheduleRefresh();
 
 /* Glossary conversion functions */
 


### PR DESCRIPTION
When a keyboard is installed, Keyman will now only refresh its internal state on a given thread when that thread receives focus and/or input, rather than immediately. This will dramatically reduce the chatter caused by Keyman Engine when a keyboard is installed or settings are changed.

# User testing

@MakaraSok, after installing this version, we need to verify that keyboards are correctly activated and usable in a target application after installing the keyboard, or when any settings are changed.