### PR TITLE
fix(windows): exception handling list error

### DIFF
--- a/windows/src/engine/kmcomapi/com/hotkeys/keymanhotkeys.pas
+++ b/windows/src/engine/kmcomapi/com/hotkeys/keymanhotkeys.pas
@@ -66,7 +66,7 @@ begin
   if (Index < Get_Count) and (Index >= 0) then
     Result := FHotkeys[Index] as IKeymanHotkey
   else
-    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([IntToStr(Index)]));
 end;
 
 procedure TKeymanHotkeys.Apply;

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
@@ -260,7 +260,7 @@ begin
   if (Index < Get_Count) and (Index >= 0) then
     Result := FLanguages[Index] as IKeymanKeyboardLanguageInstalled
   else
-    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
+    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([IntToStr(Index)]));
 end;
 
 function TKeymanKeyboardLanguagesInstalled.IndexOfBCP47Code(

--- a/windows/src/engine/kmcomapi/com/keyboardoptions/keymankeyboardoptions.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardoptions/keymankeyboardoptions.pas
@@ -95,7 +95,7 @@ begin
     i := Index;
     if (i < 0) or (i >= Get_Count) then
     begin
-      ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+      ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
       Exit;
     end;
   end;

--- a/windows/src/engine/kmcomapi/com/keyboards/keymanpackagecontentkeyboards.pas
+++ b/windows/src/engine/kmcomapi/com/keyboards/keymanpackagecontentkeyboards.pas
@@ -87,7 +87,7 @@ begin
   if (i < Get_Count) and (i >= 0) then
     Result := FKeyboards[i] as IKeymanKeyboard
   else
-    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
 end;
 
 function TKeymanPackageContentKeyboards.IndexOf(const ID: WideString): Integer;

--- a/windows/src/engine/kmcomapi/com/languages/keymanlanguages.pas
+++ b/windows/src/engine/kmcomapi/com/languages/keymanlanguages.pas
@@ -85,7 +85,7 @@ begin
   if (Index < Get_Count) and (Index >= 0) then
     Result := FLanguages[Index] as IKeymanLanguage
   else
-    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([IntToStr(Index)]));
 end;
 
    // I4220

--- a/windows/src/engine/kmcomapi/com/options/keymanoptions.pas
+++ b/windows/src/engine/kmcomapi/com/options/keymanoptions.pas
@@ -96,7 +96,7 @@ begin
 
   if (i < Get_Count) and (i >= 0)
     then Result := FKeymanOptions[i] as IKeymanOption
-    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
 end;
 
 function TKeymanOptions.IndexOf(const ID: WideString): Integer;

--- a/windows/src/engine/kmcomapi/com/packages/keymanpackagecontentfiles.pas
+++ b/windows/src/engine/kmcomapi/com/packages/keymanpackagecontentfiles.pas
@@ -66,7 +66,7 @@ begin
 
   if (i < Get_Count) and (i >= 0)
     then Result := FContentFiles[i] as IKeymanPackageContentFile
-    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
 end;
 
 function TKeymanPackageContentFiles.IndexOf(const Filename: WideString): Integer;

--- a/windows/src/engine/kmcomapi/com/packages/keymanpackagecontentfonts.pas
+++ b/windows/src/engine/kmcomapi/com/packages/keymanpackagecontentfonts.pas
@@ -80,7 +80,7 @@ begin
 
   if (i < Get_Count) and (i >= 0)
     then Result := FFonts[i] as IKeymanPackageContentFont
-    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
 end;
 
 function TKeymanPackageContentFonts.IndexOf(const Filename: WideString): Integer;

--- a/windows/src/engine/kmcomapi/com/packages/keymanpackagesinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/packages/keymanpackagesinstalled.pas
@@ -93,7 +93,7 @@ begin
 
   if (i < Get_Count) and (i >= 0)
     then Result := FPackages[i] as IKeymanPackageInstalled
-    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([Index]));
+    else ErrorFmt(KMN_E_Collection_InvalidIndex, VarArrayOf([VarToStr(Index)]));
 end;
 
 function TKeymanPackagesInstalled.IndexOf(const ID: WideString): Integer;


### PR DESCRIPTION
Fixes #4006.
Fixes KEYMAN-WINDOWS-4C.

This fixes the list error exception which was masking the actual cause of #4006, which is already fixed by #4164.

Related issue #4119 is also fixed by #4164.