### PR TITLE
fix(windows): OSK toolbar sync

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.dfm
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.dfm
@@ -40,4 +40,11 @@ object frmKeyman7Main: TfrmKeyman7Main
     Left = 96
     Top = 104
   end
+  object tmrRefresh: TTimer
+    Enabled = False
+    Interval = 125
+    OnTimer = tmrRefreshTimer
+    Left = 440
+    Top = 40
+  end
 end

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -216,6 +216,7 @@ type
     FInUpdateOSKVisibility: Boolean;
     FOSKManuallyClosedThisSession: Boolean;
 
+    FLangSwitchRefreshWatcher: TThread;
     FLastFocus: THandle;
     FLastActive: THandle;
     //FLastKeymanID: Integer;
@@ -308,6 +309,7 @@ type
   protected
     procedure Notification(AComponent: TComponent; Operation: TOperation); override;
     procedure WndProc(var Message: TMessage); override;
+    procedure CreateWnd; override;
   public
     frmKeymanMenu: TfrmKeymanMenu;
     frmVisualKeyboard: TfrmVisualKeyboard;
@@ -418,6 +420,7 @@ uses
   Vcl.AxCtrls,
   Vcl.Buttons,
   Vcl.ComCtrls,
+  Windows8LanguageList,
   InterfaceHotkeys,
   utilhotkey,
   MessageIdentifiers,
@@ -528,19 +531,8 @@ begin
   Application.HookMainWindow(AppMessage);
 //  FRunningProduct := TRunningProduct.Create;
 
-  wm_test_keyman_functioning := RegisterWindowMessage('wm_test_keyman_functioning');
-  wm_keyman_globalswitch := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH');
-  wm_keyman_globalswitch_process := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH_PROCESS');
-  wm_keyman_control := RegisterWindowMessage('WM_KEYMAN_CONTROL');
-  wm_keyman_control_internal := RegisterWindowMessage('WM_KEYMAN_CONTROL_INTERNAL');   // I3933
   sMsg_TaskbarRestart := RegisterWindowMessage('TaskbarCreated');
-
-  ChangeWindowMessageFilter(wm_keyman_control, MSGFLT_ADD);
-  ChangeWindowMessageFilter(wm_keyman_globalswitch, MSGFLT_ADD);
-  ChangeWindowMessageFilter(wm_keyman_globalswitch_process, MSGFLT_ADD);
-  ChangeWindowMessageFilter(wm_keyman_control_internal, MSGFLT_ADD);   // I3933
   ChangeWindowMessageFilter(sMsg_TaskbarRestart, MSGFLT_ADD);
-  ChangeWindowMessageFilter(WM_USER_PlatformComms, MSGFLT_ADD);
 
   FInputPane := TFrameworkInputPane.Create;
 
@@ -554,6 +546,12 @@ end;}
 
 procedure TfrmKeyman7Main.FormDestroy(Sender: TObject);
 begin
+  if Assigned(FLangSwitchRefreshWatcher) then
+  begin
+    FLangSwitchRefreshWatcher.Terminate;
+    FLangSwitchRefreshWatcher := nil;
+  end;
+
   FreeAndNil(FInputPane);
 
   ClosePlatformComms64;
@@ -827,9 +825,18 @@ begin
       end;
     KMC_REFRESH:
       begin
+
         if VisualKeyboardVisible then
           frmVisualKeyboard.PreRefreshKeyman;
         kmcom.Refresh;
+        if wParam = 1 then
+        begin
+          FLangSwitchManager.Refresh(Pointer(lParam));
+        end
+        else
+        begin
+          FLangSwitchManager.Refresh(nil);
+        end;
         if VisualKeyboardVisible then
         begin
           frmVisualKeyboard.RefreshKeyman;
@@ -1356,7 +1363,7 @@ begin
       FLangSwitchManager.UpdateActive(FLangID, lsitWinKeyboard, val);   // I3949
       if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
       begin
-        FLangSwitchManager.Refresh;
+        FLangSwitchManager.Refresh(nil);
         FLangSwitchManager.UpdateActive(FLangID, lsitWinKeyboard, val);   // I3949
       end;
       FActiveHKL := val;   // I4359
@@ -1387,7 +1394,7 @@ begin
 
       if FLangSwitchManager.ActiveKeyboard = nil then   // I4715
       begin
-        FLangSwitchManager.Refresh;
+        FLangSwitchManager.Refresh(nil);
         FLangSwitchManager.UpdateActive(FLangID, lsitTIP, FClsid, FProfileGuid);
       end;
     end
@@ -1880,6 +1887,31 @@ begin
   SendPlatformComms64(PC_CLOSE, 0);
 end;
 
+type
+  TLangSwitchRefreshWatcher = class(TThread)
+  private
+    FOwnerHandle: THandle;
+    hTerminatedEvent: THandle;
+  protected
+    procedure Execute; override;
+    procedure TerminatedSet; override;
+  public
+    constructor Create(AOwnerHandle: THandle); reintroduce;
+    destructor Destroy; override;
+  end;
+
+procedure TfrmKeyman7Main.CreateWnd;
+begin
+  inherited;
+  if Assigned(FLangSwitchRefreshWatcher) then
+  begin
+    FLangSwitchRefreshWatcher.Terminate;
+  end;
+  FLangSwitchRefreshWatcher := TLangSwitchRefreshWatcher.Create(Handle);
+  FLangSwitchRefreshWatcher.FreeOnTerminate := True;
+  FLangSwitchRefreshWatcher.Start;
+end;
+
 procedure TfrmKeyman7Main.StartPlatformComms64;
 var
   dir, s: WideString;
@@ -2001,4 +2033,95 @@ begin
   FHotkeys.Clear;
 end;
 
+{ TLangSwitchRefreshWatcher }
+
+constructor TLangSwitchRefreshWatcher.Create(AOwnerHandle: THandle);
+begin
+  inherited Create(True);
+  FOwnerHandle := AOwnerHandle;
+  hTerminatedEvent := CreateEvent(nil, True, False, nil);
+end;
+
+destructor TLangSwitchRefreshWatcher.Destroy;
+begin
+  CloseHandle(hTerminatedEvent);
+  inherited Destroy;
+end;
+
+procedure TLangSwitchRefreshWatcher.Execute;
+var
+  hk: HKEY;
+  hEvent: THandle;
+  hEvents: array[0..1] of THandle;
+  FWin8Languages: TWindows8LanguageList;
+const
+  // We don't really know how long the changes are going to take
+  // so we'll wait 500 msec and then ask the main thread to reload
+  // the changes from the registry
+  ARBITRARY_WAIT_FOR_CHANGES = 1000;
+begin
+  if RegOpenKeyEx(HKEY_CURRENT_USER, PChar(SRegKey_ControlPanelInternationalUserProfile), 0,
+      KEY_NOTIFY, hk) <> ERROR_SUCCESS then
+    Exit;
+  try
+    hEvent := CreateEvent(nil, True, False, nil);
+    if hEvent = 0 then
+      Exit;
+    try
+      // Watch the registry key for any changes
+      if RegNotifyChangeKeyValue(hk, True, REG_NOTIFY_CHANGE_NAME or
+          REG_NOTIFY_CHANGE_LAST_SET, hEvent, True) <> ERROR_SUCCESS then
+        Exit;
+      repeat
+        // Wait for either the registry to change or for us to be terminated
+        hEvents[0] := hEvent;
+        hEvents[1] := hTerminatedEvent;
+        if WaitForMultipleObjects(2, @hEvents[0], False, INFINITE) <> WAIT_OBJECT_0 then
+          Exit;
+
+        // We'll wait a little bit because a bunch of changes are normally
+        // made at once, and we don't want to go crazy with refreshing
+        Sleep(ARBITRARY_WAIT_FOR_CHANGES);
+
+        // Ready to wait again
+        ResetEvent(hEvent);
+
+        // Start watching for changes again before requesting a refresh, so we
+        // don't miss any additional changes that come through
+        if RegNotifyChangeKeyValue(hk, True, REG_NOTIFY_CHANGE_NAME or
+            REG_NOTIFY_CHANGE_LAST_SET, hEvent, True) <> ERROR_SUCCESS then
+          Exit;
+
+        // Finally, tell the main form to process the refresh
+        FWin8Languages := TWindows8LanguageList.Create(True);
+        PostMessage(FOwnerHandle, wm_keyman_control, MAKELONG(KMC_REFRESH, 1), LParam(FWin8Languages));
+      until False;
+
+    finally
+      CloseHandle(hEvent);
+    end;
+  finally
+    RegCloseKey(hk);
+  end;
+
+end;
+
+procedure TLangSwitchRefreshWatcher.TerminatedSet;
+begin
+  inherited;
+  SetEvent(hTerminatedEvent);
+end;
+
+initialization
+  wm_test_keyman_functioning := RegisterWindowMessage('wm_test_keyman_functioning');
+  wm_keyman_globalswitch := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH');
+  wm_keyman_globalswitch_process := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH_PROCESS');
+  wm_keyman_control := RegisterWindowMessage('WM_KEYMAN_CONTROL');
+  wm_keyman_control_internal := RegisterWindowMessage('WM_KEYMAN_CONTROL_INTERNAL');   // I3933
+
+  ChangeWindowMessageFilter(wm_keyman_control, MSGFLT_ADD);
+  ChangeWindowMessageFilter(wm_keyman_globalswitch, MSGFLT_ADD);
+  ChangeWindowMessageFilter(wm_keyman_globalswitch_process, MSGFLT_ADD);
+  ChangeWindowMessageFilter(wm_keyman_control_internal, MSGFLT_ADD);   // I3933
+  ChangeWindowMessageFilter(WM_USER_PlatformComms, MSGFLT_ADD);
 end.

--- a/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
+++ b/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
@@ -182,7 +182,7 @@ type
     destructor Destroy; override;
     procedure UpdateActive(FLangID: Cardinal; FActiveItemType: TLangSwitchItemType; FHKL: HKL); overload;   // I3933
     procedure UpdateActive(FLangID: Cardinal; FActiveItemType: TLangSwitchItemType; FClsid, FProfileGuid: TGUID); overload;   // I3933
-    procedure Refresh(ANewWin8Languages: TWindows8LanguageList = nil);
+    procedure Refresh;
     function FindKeyboard(FHKL: HKL; FProfileGuid: TGUID): TLangSwitchKeyboard; overload;
     function FindKeyboard(id: string): TLangSwitchKeyboard; overload;
     property Languages[Index: Integer]: TLangSwitchLanguage read GetLanguage;
@@ -406,7 +406,7 @@ begin
   TDebugLogClient.Instance.WriteMessage('[EnumTSFKeyboards] EXIT ---------------', []);
 end;
 
-procedure TLangSwitchManager.Refresh(ANewWin8Languages: TWindows8LanguageList);   // I3933
+procedure TLangSwitchManager.Refresh;   // I3933
 var
   i: Integer;
   j: Integer;
@@ -419,13 +419,7 @@ var
 //  templang: array[0..5] of TLangSwitchLanguage;   // I4715
 //  tempkbd: array[0..15] of TLangSwitchKeyboard;   // I4715
 begin
-  if Assigned(ANewWin8Languages) then
-  begin
-    FWin8Languages.Free;
-    FWin8Languages := ANewWin8Languages;
-  end
-  else
-    FWin8Languages.Refresh;
+  FWin8Languages.Refresh;
 
   FActiveItemType := lsitUnknown;
   FActiveLangID := 0;

--- a/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
+++ b/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
@@ -1,18 +1,18 @@
 (*
   Name:             LangSwitchManager
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      22 Oct 2010
 
   Modified Date:    12 Sep 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          22 Oct 2010 - mcdurdin - I2522 - Initial version of language switch window
                     30 Nov 2010 - mcdurdin - I2543 - Support switching to TSF addins in Language Switch Window
                     17 Dec 2010 - mcdurdin - I2575 - Wrong keyboard layout selected for default language
@@ -182,7 +182,7 @@ type
     destructor Destroy; override;
     procedure UpdateActive(FLangID: Cardinal; FActiveItemType: TLangSwitchItemType; FHKL: HKL); overload;   // I3933
     procedure UpdateActive(FLangID: Cardinal; FActiveItemType: TLangSwitchItemType; FClsid, FProfileGuid: TGUID); overload;   // I3933
-    procedure Refresh;
+    procedure Refresh(ANewWin8Languages: TWindows8LanguageList = nil);
     function FindKeyboard(FHKL: HKL; FProfileGuid: TGUID): TLangSwitchKeyboard; overload;
     function FindKeyboard(id: string): TLangSwitchKeyboard; overload;
     property Languages[Index: Integer]: TLangSwitchLanguage read GetLanguage;
@@ -406,7 +406,7 @@ begin
   TDebugLogClient.Instance.WriteMessage('[EnumTSFKeyboards] EXIT ---------------', []);
 end;
 
-procedure TLangSwitchManager.Refresh;   // I3933
+procedure TLangSwitchManager.Refresh(ANewWin8Languages: TWindows8LanguageList);   // I3933
 var
   i: Integer;
   j: Integer;
@@ -419,7 +419,13 @@ var
 //  templang: array[0..5] of TLangSwitchLanguage;   // I4715
 //  tempkbd: array[0..15] of TLangSwitchKeyboard;   // I4715
 begin
-  FWin8Languages.Refresh;
+  if Assigned(ANewWin8Languages) then
+  begin
+    FWin8Languages.Free;
+    FWin8Languages := ANewWin8Languages;
+  end
+  else
+    FWin8Languages.Refresh;
 
   FActiveItemType := lsitUnknown;
   FActiveLangID := 0;
@@ -992,7 +998,7 @@ begin
 
   FLanguageToggle := '3';
   FLayoutToggle := '3';
-  
+
   FReset := False;
 
   with TRegistryErrorControlled.Create do  // I2890


### PR DESCRIPTION
As Keyman now monitors the Windows keyboard list from Control Panel, it is no longer sufficient to refresh the toolbar only when a Keyman keyboard is updated, as at that point Windows has not refreshed its own language list in the registry. Instead, we need to monitor changes to the relevant registry key and then refresh when those changes are 'complete'.

There is a problem: there does not appear to be a good way to monitor for changes to Windows language settings. `WM_SETTINGCHANGE` is sent when a language is added by the user in Settings, but the actual change happens asynchronously, and we are not notified when the changes are complete.

We also do not get notifications when languages are added via APIs.

Given the async nature of the language profile changes, this leads to race conditions when we try to refresh the OSK toolbar. My preferred solution is to monitor the relevant key in a separate thread, and when changes are received we could refresh every 125msec for 5 seconds after the last change is detected. It's a bit yuck perf-wise but would probably be pretty transparent to the user. (We reset that poll timer every time a change is detected)

In testing, this looks good. It means the changes appear as soon as ready, without substantial delays or performance issues. Polling this makes me feel a bit dirty, but I'll just take a shower and be okay.

# User Testing

@MakaraSok can you try enabling/disabling keyboards, adding/removing keyboards and/or languages, and monitor the OSK toolbar to see if it reflects the changes reasonably quickly?