### PR TITLE
fix(windows): Show full version with tag in Setup

### DIFF
--- a/windows/src/desktop/inst/download.in
+++ b/windows/src/desktop/inst/download.in
@@ -31,7 +31,7 @@ candle: candle-desktop candle-cef candle-locale
 
 candle-desktop:
   $(WIXHEAT) dir ..\kmshell\xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
-  $(WIXCANDLE) -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
+  $(WIXCANDLE) -dVERSION_WITH_TAG=$VersionWithTag -dVERSION=$VersionWin -dRELEASE=$VersionRelease -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=..\kmshell\xml keymandesktop.wxs desktopui.wxs
 
 #
 # Chromium Embedded Framework

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -301,5 +301,7 @@
     <Property Id="ARPURLUPDATEINFO" Value="http://www.keyman.com/" />
     <Property Id="ARPHELPLINK" Value="http://help.keyman.com/" />
 
+    <Property Id="VersionWithTag" Value="$(var.VERSION_WITH_TAG)" />
+
   </Product>
 </Wix>

--- a/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
@@ -45,6 +45,7 @@ type
     FVersion: string;
     FPath: string;
     FProductCode: string;
+    FVersionWithTag: string;
   public
     constructor Create(ALocationType: TInstallInfoLocationType); virtual;
     procedure UpgradeToLocalPath(const ARootPath: string);
@@ -53,6 +54,7 @@ type
     property Path: string read FPath write FPath;
     property Url: string read FUrl write FUrl;
     property ProductCode: string read FProductCode write FProductCode; // used only by msi
+    property VersionWithTag: string read FVersionWithTag write FVersionWithTag; // used only by msi
     property Version: string read FVersion write FVersion;
   end;
 
@@ -243,6 +245,7 @@ var
   pack: TInstallInfoPackage;
   packLocation: TInstallInfoPackageFileLocation;
   FVersion, FMSIFileName: string;
+  FVersionWithTag: string;
 begin
   FInSetup := False;
   FInPackages := False;
@@ -291,12 +294,13 @@ begin
 
     if System.SysUtils.FileExists(FMSIFileName) then  // I3476
     begin
-      FVersion := GetMsiVersion(FMSIFileName);
+      FVersion := GetMsiVersion(FMSIFileName, FVersionWithTag);
       if FVersion <> '' then
       begin
         location := TInstallInfoFileLocation.Create(iilLocal);
         location.Path := FMSIFileName;
         location.Version := FVersion;
+        location.VersionWithTag := FVersionWithTag;
         FMsiLocations.Add(location);
       end;
     end;

--- a/windows/src/desktop/setup/Keyman.Setup.System.MsiUtils.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.MsiUtils.pas
@@ -2,7 +2,7 @@ unit Keyman.Setup.System.MsiUtils;
 
 interface
 
-function GetMsiVersion(const Filename: string): string;
+function GetMsiVersion(const Filename: string; var VersionWithTag: string): string;
 
 implementation
 
@@ -13,7 +13,7 @@ uses
   jwamsi,
   jwamsiquery;
 
-function GetMsiVersion(const Filename: string): string;
+function GetMsiVersion(const Filename: string; var VersionWithTag: string): string;
 var
   sz: DWord;
   buf: array[0..64] of WideChar;
@@ -25,6 +25,14 @@ begin
     sz := 64;
     if MsiGetProductPropertyW(hProduct, 'ProductVersion', buf, @sz) = ERROR_SUCCESS then
       Result := buf;
+
+    sz := 64;
+    if MsiGetProductPropertyW(hProduct, 'VersionWithTag', buf, @sz) = ERROR_SUCCESS then
+      VersionWithTag := buf;
+
+    if VersionWithTag = '' then
+      VersionWithTag := Result;
+
     MsiCloseHandle(hProduct);
   end;
 end;

--- a/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.OnlineResourceCheck.pas
@@ -95,6 +95,7 @@ begin
       location.URL := ucr.InstallURL;
       location.Path := ucr.FileName;
       location.Version := ucr.NewVersion;
+      location.VersionWithTag := ucr.NewVersionWithTag;
       location.Size := ucr.InstallSize;
       AInstallInfo.MsiLocations.Add(location);
     end;

--- a/windows/src/desktop/setup/UfrmInstallOptions.pas
+++ b/windows/src/desktop/setup/UfrmInstallOptions.pas
@@ -260,23 +260,10 @@ begin
     if FInstallInfo.IsInstalled
       then Text := FInstallInfo.Text(ssOptionsUpgradeKeyman)
       else Text := FInstallInfo.Text(ssOptionsInstallKeyman);
-
-{
-    if not FInstallInfo.IsInstalled then
-      case FInstallInfo.BestMsi.LocationType of
-        iilLocal:  Text := FInstallInfo.Text(ssOptionsInstallKeyman, [FInstallInfo.BestMsi.Version]);
-        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadInstallKeyman, [FInstallInfo.BestMsi.Version, FormatFileSize(FInstallInfo.BestMsi.Size)]);
-      end
-    else
-      case FInstallInfo.BestMsi.LocationType of
-        iilLocal:  Text := FInstallInfo.Text(ssOptionsUpgradeKeyman, [FInstallInfo.BestMsi.Version]);
-        iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadUpgradeKeyman, [FInstallInfo.BestMsi.Version, FormatFileSize(FInstallInfo.BestMsi.Size)]);
-      end;
-}
   end
   else if FInstallInfo.IsInstalled then
   begin
-    Text := FInstallInfo.Text(ssOptionsKeymanAlreadyInstalled, [FInstallInfo.InstalledVersion.Version]);
+    Text := FInstallInfo.Text(ssOptionsKeymanAlreadyInstalled, [FInstallInfo.InstalledVersion.Version]);//TODO VersionWithTag?
   end
   else
   begin
@@ -289,8 +276,8 @@ begin
   for location in FInstallInfo.MsiLocations do
   begin
     case location.LocationType of
-      iilLocal: Text := FInstallInfo.Text(ssOptionsInstallKeymanVersion, [location.Version]);
-      iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadKeymanVersion, [location.Version, FormatFileSize(location.Size)]);
+      iilLocal: Text := FInstallInfo.Text(ssOptionsInstallKeymanVersion, [location.VersionWithTag]);
+      iilOnline: Text := FInstallInfo.Text(ssOptionsDownloadKeymanVersion, [location.VersionWithTag, FormatFileSize(location.Size)]);
     end;
     cbKeymanLocation.Items.AddObject(Text, location);
   end;

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -611,7 +611,7 @@ begin
       then downloadSize := FInstallInfo.Text(ssActionDownload, [FormatFileSize(FInstallInfo.MsiInstallLocation.Size)])
       else downloadSize := '';
 
-    s := s + FInstallInfo.Text(ssActionInstallKeyman, [FInstallInfo.MsiInstallLocation.Version, downloadSize]) + #13#10;
+    s := s + FInstallInfo.Text(ssActionInstallKeyman, [FInstallInfo.MsiInstallLocation.VersionWithTag, downloadSize]) + #13#10;
 
     Found := True;
   end;

--- a/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
+++ b/windows/src/global/delphi/general/Keyman.System.UpdateCheckResponse.pas
@@ -38,6 +38,7 @@ type
     FInstallSize: Int64;
     FInstallURL: string;
     FNewVersion: string;
+    FNewVersionWithTag: string;
     FStatus: TUpdateCheckResponseStatus;
     FErrorMessage: string;
     FCurrentVersion: string;
@@ -50,6 +51,7 @@ type
 
     property CurrentVersion: string read FCurrentVersion;
     property NewVersion: string read FNewVersion;
+    property NewVersionWithTag: string read FNewVersionWithTag;
     property FileName: string read FFileName;
     property InstallURL: string read FInstallURL;
     property InstallSize: Int64 read FInstallSize;
@@ -87,6 +89,9 @@ begin
     if CompareVersions(node.Values['version'].Value, FCurrentVersion) < 0 then
     begin
       FNewVersion := node.Values['version'].Value;
+      FNewVersionWithTag := FNewVersion;
+      if (node.Values['stability'] <> nil) and (node.Values['stability'].Value <> '') then
+        FNewVersionWithTag := FNewVersionWithTag + '-' + node.Values['stability'].Value;
       FFileName := node.Values['file'].Value;
       FInstallURL := node.Values['url'].Value;
       if node.Values['size'] is TJSONNumber then


### PR DESCRIPTION
Fixes #4041.

Show the version with tier and build flags in Setup so that it is clear which version of Keyman will be installed, as the Keyman version can be distinct from the setup.exe version.

Constructs the version tag from `version`+`stability` data in the `UpdateCheckResponse` and uses a new MSI property called `VersionWithTag` for Windows Installers. Older MSIs will still show `a.b.c.d` versions instead of the tagged version if they are checked locally (as opposed to online), because the new `VersionWithTag` property will not be present.

![image](https://user-images.githubusercontent.com/4498365/102442811-5f5bbc00-4079-11eb-93e5-37547c1866af.png)

![image](https://user-images.githubusercontent.com/4498365/102442875-83b79880-4079-11eb-8454-ca4239520de7.png)
