### PR TITLE
fix(windows): Improve refresh reliablilty

### DIFF
--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -103,7 +103,6 @@ type
   private
     wm_keyman_control: UINT;
     wm_kmselectlang: UINT;
-    RefreshHandle: THandle;
     FAutoApply: Boolean;
     FKeymanCustomisation: IKeymanCustomisation;
     FLastRefreshToken: IntPtr;
@@ -359,47 +358,20 @@ begin
   Result := FLastRefreshToken;
 end;
 
+type
+  TRefreshThread = class(TThread)
+  private
+    FLastRefreshToken: Integer;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(ALastRefreshToken: Integer);
+  end;
+
 procedure TKeymanControl.ApplyToRunningKeymanEngine;
 begin
-  // This convoluted way of refreshing keyman ensures that km is init for the thread.
-  // Other methods would work but this is easiest
-  TThread.CreateAnonymousThread(
-    procedure
-    const
-      KR_REQUEST_REFRESH = 0;
-      KR_SETTINGS_CHANGED = 3;
-    var
-      msg: TMsg;
-      wm_keyman_refresh: UINT;
-    begin
-      wm_keyman_refresh := RegisterWindowMessage('WM_KEYMANREFRESH');
-      RefreshHandle := AllocateHWnd(nil);
-
-      // We currently have two announcements because the KR_REQUEST_REFRESH
-      // announcement is actioned only when Keyman Engine is running, while we
-      // still need to tell any apps listening for changes that the settings
-      // have changed. In future, we should probably refactor this to use a
-      // single broadcast.
-
-      // We use a random number here to so that multiple processes can generate
-      // hopefully unique tokens for refresh, and we share this token with our
-      // current consumer so they can ignore notifications that they have
-      // generated
-
-      // First, post out a KR_SETTINGS_CHANGED for the benefit of Keyman
-      // Configuration and other apps that want it
-      FLastRefreshToken := Random(MaxInt);
-      PostMessage(HWND_BROADCAST, wm_keyman_refresh, KR_SETTINGS_CHANGED, FLastRefreshToken);
-
-      // Then, post out a refresh to Keyman Engine and process it in this
-      // thread so that Keyman Engine will grab it and broadcast it, if it is
-      // currently running
-      PostMessage(RefreshHandle, wm_keyman_refresh, KR_REQUEST_REFRESH, 0);
-      GetMessage(msg, RefreshHandle, wm_keyman_refresh, wm_keyman_refresh);
-      DispatchMessage(msg);
-      DeallocateHWnd(RefreshHandle);
-    end
-  ).Start;
+  FLastRefreshToken := Random(MaxInt);
+  TRefreshThread.Create(FLastRefreshToken).Start;
 end;
 
 constructor TKeymanControl.Create(AContext: TKeymanContext);
@@ -759,5 +731,57 @@ begin
   end;
 end;
 {$ENDIF}
+
+{ TRefreshThread}
+
+constructor TRefreshThread.Create(ALastRefreshToken: Integer);
+begin
+  inherited Create(True);
+  FreeOnTerminate := True;
+  FLastRefreshToken := ALastRefreshToken;
+end;
+
+procedure TRefreshThread.Execute;
+const
+  KR_REQUEST_REFRESH = 0;
+  KR_SETTINGS_CHANGED = 3;
+var
+  msg: TMsg;
+  wm_keyman_refresh: UINT;
+  RefreshHandle: THandle;
+begin
+  // This convoluted way of refreshing keyman ensures that km is init for the thread.
+  // Other methods would work but this is easiest
+
+  wm_keyman_refresh := RegisterWindowMessage('WM_KEYMANREFRESH');
+  RefreshHandle := AllocateHWnd(nil);
+
+  // We currently have two announcements because the KR_REQUEST_REFRESH
+  // announcement is actioned only when Keyman Engine is running, while we
+  // still need to tell any apps listening for changes that the settings
+  // have changed. In future, we should probably refactor this to use a
+  // single broadcast.
+
+  // We use a random number here to so that multiple processes can generate
+  // hopefully unique tokens for refresh, and we share this token with our
+  // current consumer so they can ignore notifications that they have
+  // generated
+
+  // First, post out a KR_SETTINGS_CHANGED for the benefit of Keyman
+  // Configuration and other apps that want it
+  PostMessage(HWND_BROADCAST, wm_keyman_refresh, KR_SETTINGS_CHANGED, FLastRefreshToken);
+
+  // Then, post out a refresh to Keyman Engine and process it in this
+  // thread so that Keyman Engine will grab it and broadcast it, if it is
+  // currently running
+  PostMessage(RefreshHandle, wm_keyman_refresh, KR_REQUEST_REFRESH, 0);
+
+  // Flush the queue but don't stall the thread
+  while PeekMessage(msg, 0, 0, 0, PM_REMOVE) do
+  begin
+    DispatchMessage(msg);
+  end;
+  DeallocateHWnd(RefreshHandle);
+end;
 
 end.


### PR DESCRIPTION
This change has three fixes to improve the reliability of notifying Keyman Engine of updates to settings or keyboard installs:

1. It removes the closure pattern of the refresh thread, because that was closing on a variable on a different thread (`RefreshHandle`) and that could cause races and/or exceptions in the case of early free. What's more, the closure was actually unnecessary as the variable was really only used by the refresh thread!

2. It moves responsibility for setting the refresh token to the calling thread so that the caller can depend on the token being the one that is actually sent, removing a race.

3. Most important, the refresh thread now flushes all messages in its queue, as there may be multiple messages relating to the window construction that need to be processed before the wm_keyman_refresh message can be handled. This greatly improves the chance of the notification actually being sent!