### PR TITLE
chore(windows): sentrytool param file support

### DIFF
--- a/windows/src/buildtools/sentrytool/Keyman.System.SentryTool.SentryToolMain.pas
+++ b/windows/src/buildtools/sentrytool/Keyman.System.SentryTool.SentryToolMain.pas
@@ -20,31 +20,158 @@ var
   FInfile, FOutfile, FProjectFile, FRootPath, FIncludePath: string;
   FDelphiSearchFile: TDelphiSearchFile = nil;
 
+  CmdParams: array of string;
+
+// Note: this is lifted from System.pas, which doesn't
+// make GetParamStr a public symbol, sadly.
+function GetParamStr(P: PChar; var Param: string): PChar;
+var
+  i, Len: Integer;
+  Start, S: PChar;
+begin
+  // U-OK
+  while True do
+  begin
+    while (P[0] <> #0) and (P[0] <= ' ') do
+      Inc(P);
+    if (P[0] = '"') and (P[1] = '"') then Inc(P, 2) else Break;
+  end;
+  Len := 0;
+  Start := P;
+  while P[0] > ' ' do
+  begin
+    if P[0] = '"' then
+    begin
+      Inc(P);
+      while (P[0] <> #0) and (P[0] <> '"') do
+      begin
+        Inc(Len);
+        Inc(P);
+      end;
+      if P[0] <> #0 then
+        Inc(P);
+    end
+    else
+    begin
+      Inc(Len);
+      Inc(P);
+    end;
+  end;
+
+  SetLength(Param, Len);
+
+  P := Start;
+  S := Pointer(Param);
+  i := 0;
+  while P[0] > ' ' do
+  begin
+    if P[0] = '"' then
+    begin
+      Inc(P);
+      while (P[0] <> #0) and (P[0] <> '"') do
+      begin
+        S[i] := P^;
+        Inc(P);
+        Inc(i);
+      end;
+      if P[0] <> #0 then Inc(P);
+    end
+    else
+    begin
+      S[i] := P^;
+      Inc(P);
+      Inc(i);
+    end;
+  end;
+
+  Result := P;
+end;
+
+function LoadParamsFromFile(const Filename: string): Boolean;
+var
+  p: PChar;
+  cmd, s: string;
+  str: TStringList;
+begin
+  cmd := '';
+  str := TStringList.Create;
+  try
+    str.LoadFromFile(Filename);
+    for s in str do
+      cmd := cmd + Trim(s) + ' ';
+  finally
+    str.Free;
+  end;
+  p := PChar(cmd);
+  while p <> #0 do
+  begin
+    p := GetParamStr(p, s);
+    if s <> '' then
+    begin
+      SetLength(CmdParams, Length(CmdParams)+1);
+      CmdParams[High(CmdParams)] := s;
+    end;
+  end;
+  Result := True;
+end;
+
+function LoadParamsFromCmdline: Boolean;
+var
+  i: Integer;
+begin
+  SetLength(CmdParams, ParamCount);
+  for i := 0 to ParamCount - 1 do
+    CmdParams[i] := ParamStr(i+1);
+  Result := True;
+end;
+
+function CmdParamStr(n: Integer): string;
+begin
+  Assert(n >= 0);
+  if n = 0 then
+    Result := ParamStr(0)
+  else if n > Length(CmdParams)
+    then Result := ''
+    else Result := CmdParams[n-1];
+end;
+
+function CmdParamCount: Integer;
+begin
+  Result := Length(CmdParams);
+end;
+
 function ParseParams: Boolean;
 var
   n: Integer;
 begin
+  if Copy(ParamStr(1), 1, 1) = '@' then
+  begin
+    if not LoadParamsFromFile(Copy(ParamStr(1), 2, MaxInt)) then Exit(False);
+  end
+  else
+    if not LoadParamsFromCmdline then Exit(False);
+
   n := 1;
-  FDebug := ParamStr(n) = '-v';
+  FDebug := CmdParamStr(n) = '-v';
   if FDebug then Inc(n);
-  if ParamStr(n) <> 'delphiprep' then Exit(False);
+  if CmdParamStr(n) <> 'delphiprep' then Exit(False);
   Inc(n);
 
-  while n <= ParamCount do
+  while n <= CmdParamCount do
   begin
-    if ParamStr(n) = '-dpr' then
-      FProjectFile := ParamStr(n+1)
-    else if ParamStr(n) = '-i' then
-      FIncludePath := ParamStr(n+1)
-    else if ParamStr(n) = '-o' then
-      FOutFile := ParamStr(n+1)
-    else if ParamStr(n) = '-r' then
-      FRootPath := ParamStr(n+1)
+    if CmdParamStr(n) = '-dpr' then
+      FProjectFile := CmdParamStr(n+1)
+    else if CmdParamStr(n) = '-i' then
+      FIncludePath := CmdParamStr(n+1)
+    else if CmdParamStr(n) = '-o' then
+      FOutFile := CmdParamStr(n+1)
+    else if CmdParamStr(n) = '-r' then
+      FRootPath := CmdParamStr(n+1)
     else
     begin
       if FInfile = '' then
       begin
-        FInfile := ParamStr(n);
+        FInfile := CmdParamStr(n);
         Inc(n);
         Continue;
       end;


### PR DESCRIPTION
The maximum command line length in Windows is 2047 characters. In Delphi it appears to be 1024 characters. In debugging, I hit that 1024 character limit which was pretty annoying.

So this patch allows us to use an `@file` parameter to put command line parameters into a text file and read from that instead. It's probably a little hacked together and could be turned into a class that we could usefully reuse in all our other command line apps.

I looked around for a generic Delphi solution but did not find an existing one that was any good.

Low priority, not required for beta, but putting it up because I've done the work already.