### PR TITLE
fix(windows): keyboard help missing

### DIFF
--- a/windows/src/desktop/kmshell/help/UfrmHelp.pas
+++ b/windows/src/desktop/kmshell/help/UfrmHelp.pas
@@ -128,7 +128,7 @@ var
 begin
   FormStyle := fsStayOnTop;   // I4209
   if FActiveKeyboard <> nil
-    then FQuery := Format('?keyboard=%s', [UrlEncode(FActiveKeyboard.Name)])
+    then FQuery := Format('keyboard=%s', [UrlEncode(FActiveKeyboard.Name)])
     else FQuery := '';
 
   Content_Render(FQuery);


### PR DESCRIPTION
Fixes #4057.

Keyboard help link was missing from the help dialog when instantiated from Keyman menu or OSK.