### PR TITLE
fix(windows): Update mitigation for Keyman 14 and Windows 10 19597

### DIFF
--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguageinstalled.pas
@@ -145,7 +145,7 @@ function TKeymanKeyboardLanguageInstalled.FindInstallationLangID(
   out RegistrationRequired: WordBool; Flags: tagKeymanInstallFlags): WordBool;
 var
   kp: TKPInstallKeyboardLanguage;
-  s: string;
+  BCP47Code, s: string;
   KPFlags: TKPInstallKeyboardLanguageFlags;
 begin
   LangID := Self.Get_LangID;
@@ -160,7 +160,8 @@ begin
     KPFlags := [];
     if (Flags and kifInstallTransientLanguage) <> 0 then
       Include(KPFlags, ilkInstallTransientLanguage);
-    Result := kp.FindInstallationLangID(Self.Get_BCP47Code, LangID, s, KPFlags);
+    BCP47Code := Self.Get_BCP47Code;
+    Result := kp.FindInstallationLangID(BCP47Code, LangID, s, KPFlags);
 
     // We only need to register a TIP for user custom installations of languages:
     // languages that are suggested already have a TIP registered, and the

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesfile.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesfile.pas
@@ -3,10 +3,18 @@ unit keymankeyboardlanguagesfile;
 interface
 
 uses
-  Windows, ActiveX, ComObj, keymanapi_TLB, StdVcl, keymanautoobject, KeymanContext,
+  System.Win.ComObj,
+  System.Win.StdVCL,
+  Winapi.ActiveX,
+  Winapi.Windows,
+
+  internalinterfaces,
+  keymanapi_TLB,
+  keymanautoobject,
+  KeymanContext,
   keymanerrorcodes,
-  PackageInfo,
-  internalinterfaces;
+  kmxfile,
+  PackageInfo;
 
 type
   TKeymanKeyboardLanguageFileList = TAutoObjectList;
@@ -22,7 +30,8 @@ type
     function Get_Items(Index: Integer): IKeymanKeyboardLanguage; safecall;
     function IndexOfBCP47Code(const BCP47Code: string): Integer;
   public
-    constructor Create(AContext: TKeymanContext; AOwner: IKeymanKeyboardFile; APackageKeyboardLanguages: TPackageKeyboardLanguageList);
+    constructor Create(AContext: TKeymanContext; AOwner: IKeymanKeyboardFile; APackageKeyboardLanguages: TPackageKeyboardLanguageList;
+      AKeyboardInfo: PKeyboardInfo);
     destructor Destroy; override;
   end;
 
@@ -37,31 +46,62 @@ uses
 
   BCP47Tag,
   keymankeyboardlanguagefile,
+  Keyman.System.MitigateWin10_1803LanguageInstall,
   Keyman.System.CanonicalLanguageCodeUtils,
+  Keyman.System.LanguageCodeUtils,
   KLog,
   RegistryKeys,
   utilkeyman;
 
 { TKeymanKeyboardLanguagesFile }
 
-constructor TKeymanKeyboardLanguagesFile.Create(AContext: TKeymanContext; AOwner: IKeymanKeyboardFile; APackageKeyboardLanguages: TPackageKeyboardLanguageList);
+constructor TKeymanKeyboardLanguagesFile.Create(AContext: TKeymanContext; AOwner: IKeymanKeyboardFile; APackageKeyboardLanguages: TPackageKeyboardLanguageList;
+  AKeyboardInfo: PKeyboardInfo);
 var
   i: Integer;
   FCanonicalBCP47Tag: string;
+  langs: TArray<Integer>;
+  lang: Integer;
+  ml: TMitigateWin10_1803.TMitigatedLanguage;
+  FCanonicalBCP4Tag: string;
+  FLangID: Integer;
 begin
   _SetContext(AContext);
   FOwner := AOwner;
   FLanguages := TKeymanKeyboardLanguageFileList.Create;
   inherited Create(AContext, IKeymanKeyboardLanguagesInstalled, FLanguages);
   // Just fill the list here because we never need to refresh static data anyway
-  if not Assigned(APackageKeyboardLanguages) then
-    Exit;
-  for i := 0 to APackageKeyboardLanguages.Count - 1 do
+  if Assigned(APackageKeyboardLanguages) then
   begin
-    FCanonicalBCP47Tag := TCanonicalLanguageCodeUtils.FindBestTag(APackageKeyboardLanguages[i].ID, True);
-    if (FCanonicalBCP47Tag <> '') and (IndexOfBCP47Code(FCanonicalBCP47Tag) < 0) then
-      FLanguages.Add(TKeymanKeyboardLanguageFile.Create(AContext, AOwner, FCanonicalBCP47Tag, 0,
-        APackageKeyboardLanguages[i].Name));
+    for i := 0 to APackageKeyboardLanguages.Count - 1 do
+    begin
+      FCanonicalBCP47Tag := TCanonicalLanguageCodeUtils.FindBestTag(APackageKeyboardLanguages[i].ID, True);
+      if (FCanonicalBCP47Tag <> '') and (IndexOfBCP47Code(FCanonicalBCP47Tag) < 0) then
+        FLanguages.Add(TKeymanKeyboardLanguageFile.Create(AContext, AOwner, FCanonicalBCP47Tag, 0,
+          APackageKeyboardLanguages[i].Name));
+    end;
+  end
+  else if Assigned(AKeyboardInfo) then
+  begin
+    langs := GetLanguageCodesFromKeyboard(AKeyboardInfo^);
+    for lang in langs do
+    begin
+      if TMitigateWin10_1803.IsMitigationRequired(lang, ml) then
+      begin
+        FCanonicalBCP4Tag := ml.NewLanguage.BCP47;
+        FLangID := ml.NewLanguage.Code;
+      end
+      else
+      begin
+        FCanonicalBCP47Tag := TLanguageCodeUtils.TranslateWindowsLanguagesToBCP47(lang);
+        FLangID := lang;
+      end;
+
+      if FCanonicalBCP47Tag <> '' then
+      begin
+        FLanguages.Add(TKeymanKeyboardLanguageFile.Create(AContext, AOwner, FCanonicalBCP47Tag, FLangID, ''));
+      end;
+    end;
   end;
   Refresh;
 end;

--- a/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
+++ b/windows/src/engine/kmcomapi/com/keyboardlanguages/keymankeyboardlanguagesinstalled.pas
@@ -69,6 +69,7 @@ uses
 
   Keyman.System.CanonicalLanguageCodeUtils,
   Keyman.System.LanguageCodeUtils,
+  Keyman.System.MitigateWin10_1803LanguageInstall,
   Keyman.System.Process.KPInstallKeyboardLanguage,
   BCP47Tag,
   keymankeyboardlanguageinstalled,
@@ -85,15 +86,22 @@ var
   FKeyboardLanguage: TKeymanKeyboardLanguageInstalled;
   FCanonicalBCP47Tag: string;
   i: Integer;
+  ml: TMitigateWin10_1803.TMitigatedLanguage;
 begin
   // This adds an in-memory item to the array so that it can be installed
   FCanonicalBCP47Tag := TCanonicalLanguageCodeUtils.FindBestTag(BCP47Tag, True);
   if FCanonicalBCP47Tag = '' then
     Exit(nil);
 
+  if TMitigateWin10_1803.IsMitigationRequired(FCanonicalBCP47Tag, ml) then
+  begin
+    FCanonicalBCP47Tag := ml.NewLanguage.BCP47;
+    (Context as TKeymanContext).Errors.AddFmt(KMN_W_ProfileInstall_Win10_1803_MitigationApplied, VarArrayOf([ml.OriginalLanguage.Name, ml.NewLanguage.Name]), kesWarning);
+  end;
+
   for i := 0 to FLanguages.Count - 1 do
     if SameText((FLanguages[i] as IKeymanKeyboardLanguageInstalled).BCP47Code, FCanonicalBCP47Tag) then
-      Exit(nil);
+      Exit(FLanguages[i] as IKeymanKeyboardLanguageInstalled);
 
   FKeyboardLanguage := TKeymanKeyboardLanguageInstalled.Create(Context, FOwner, FCanonicalBCP47Tag, 0, GUID_NULL, '');
   FLanguages.Add(FKeyboardLanguage);

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
@@ -24,17 +24,20 @@ type
       NewLanguage: TLanguageReference;
     end;
 
-    class function IsMitigationRequired(Code: LANGID; var lang: TMitigateWin10_1803.TMitigatedLanguage): Boolean;
+    class function IsMitigationRequired(Code: LANGID; var lang: TMitigateWin10_1803.TMitigatedLanguage): Boolean; overload;
+    class function IsMitigationRequired(BCP47Tag: string; var lang: TMitigateWin10_1803.TMitigatedLanguage): Boolean; overload;
   end;
 
 implementation
 
+uses
+  System.SysUtils;
 
 const
   MitigatedLanguages: array[0..2] of TMitigateWin10_1803.TMitigatedLanguage = (
-    (OriginalLanguage: (Code: $005E; Name: 'Amharic'); NewLanguage: (BCP47: 'gez-Ethi-ET'; Name: 'Geez')),
-    (OriginalLanguage: (Code: $0073; Name: 'Tigrinya'); NewLanguage: (BCP47: 'gez-Ethi-ET'; Name: 'Geez')),
-    (OriginalLanguage: (Code: $005B; Name: 'Sinhala'); NewLanguage: (Code: $0409; Name: 'English (US)'))
+    (OriginalLanguage: (Code: $005E; BCP47: 'am'; Name: 'Amharic'); NewLanguage: (BCP47: 'gez-Ethi-ET'; Name: 'Geez')),
+    (OriginalLanguage: (Code: $0073; BCP47: 'ti'; Name: 'Tigrinya'); NewLanguage: (BCP47: 'gez-Ethi-ET'; Name: 'Geez')),
+    (OriginalLanguage: (Code: $005B; BCP47: 'si'; Name: 'Sinhala'); NewLanguage: (Code: $0409; Name: 'English (US)'))
   );
 
 { TMitigateWin10_1803 }
@@ -78,6 +81,31 @@ begin
   Code := PRIMARYLANGID(Code);
   for I := Low(MitigatedLanguages) to High(MitigatedLanguages) do
     if MitigatedLanguages[I].OriginalLanguage.Code = Code then
+    begin
+      lang := MitigatedLanguages[I];
+      Exit(True);
+    end;
+  // lang value undefined.
+  Result := False;
+end;
+
+class function TMitigateWin10_1803.IsMitigationRequired(BCP47Tag: string;
+  var lang: TMitigateWin10_1803.TMitigatedLanguage): Boolean;
+var
+  I: Integer;
+begin
+  if not IsWindows10_1803_OrGreater then
+    Exit(False);
+
+  // We only want to look at the primary language tag for comparison
+  // And we assume that the tag has been canonicalized from ISO639-3 first
+  BCP47Tag := LowerCase(BCP47Tag);
+  I := Pos('-', BCP47Tag);
+  if I > 0 then
+    BCP47Tag := Copy(BCP47Tag, 1, I-1);
+
+  for I := Low(MitigatedLanguages) to High(MitigatedLanguages) do
+    if MitigatedLanguages[I].OriginalLanguage.BCP47 = BCP47Tag then
     begin
       lang := MitigatedLanguages[I];
       Exit(True);

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
@@ -98,7 +98,10 @@ class function TMitigateWin10_1803.IsMitigationRequired(BCP47Tag: string;
 var
   I: Integer;
 begin
-  if not IsWindows10_1803_OrGreater then
+  if not IsWindows10_OrGreater_Build(WINDOWS_10_BUILDNUMBER_WithFailure) then
+    Exit(False);
+
+  if IsWindows10_OrGreater_Build(WINDOWS_10_BUILDNUMBER_Fixed) then
     Exit(False);
 
   // We only want to look at the primary language tag for comparison

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.MitigateWin10_1803LanguageInstall.pas
@@ -45,9 +45,10 @@ const
 const
   WINDOWS_10_MAJORVERSION = 10;
   WINDOWS_10_MINORVERSION = 0;
-  WINDOWS_10_BUILDNUMBER = 17134;
+  WINDOWS_10_BUILDNUMBER_WithFailure = 17134;
+  WINDOWS_10_BUILDNUMBER_Fixed = 19597;
 
-function IsWindows10_1803_OrGreater: BOOL; inline;
+function IsWindows10_OrGreater_Build(Build: DWORD): BOOL; inline;
 var
   osvi: OSVERSIONINFOEXW;
   dwlConditionMask: DWORDLONG;
@@ -66,7 +67,7 @@ begin
 
   osvi.dwMajorVersion := WINDOWS_10_MAJORVERSION;
   osvi.dwMinorVersion := WINDOWS_10_MINORVERSION;
-  osvi.dwBuildNumber := WINDOWS_10_BUILDNUMBER;
+  osvi.dwBuildNumber := Build;
 
   Result := VerifyVersionInfoW(osvi, VER_MAJORVERSION or VER_MINORVERSION or VER_BUILDNUMBER, dwlConditionMask) <> False;
 end;
@@ -75,7 +76,10 @@ class function TMitigateWin10_1803.IsMitigationRequired(Code: LANGID; var lang: 
 var
   I: Integer;
 begin
-  if not IsWindows10_1803_OrGreater then
+  if not IsWindows10_OrGreater_Build(WINDOWS_10_BUILDNUMBER_WithFailure) then
+    Exit(False);
+
+  if IsWindows10_OrGreater_Build(WINDOWS_10_BUILDNUMBER_Fixed) then
     Exit(False);
 
   Code := PRIMARYLANGID(Code);

--- a/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPInstallKeyboardLanguage.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/Keyman.System.Process.KPInstallKeyboardLanguage.pas
@@ -185,7 +185,16 @@ begin
     end;
 
     if LangID <> 0 then
+    begin
+      // We have found a LangID, so the search is done.
       Exit(True);
+    end;
+
+    // While `ConvertBCP47TagToLangID` only ever returns `True` if the
+    // `LangID` parameter is set to non-zero on exit, TMitigateWin10_1803 may
+    // cause `LangID` to be reset to zero, indicating that we need to install
+    // a transient lang id for the corresponding replacement `BCP47Tag` that
+    // was located, after all.
   end;
 
   if not (ilkInstallTransientLanguage in Flags) then

--- a/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
+++ b/windows/src/engine/kmcomapi/processes/keyboard/kpinstallkeyboard.pas
@@ -313,12 +313,8 @@ end;
 procedure TKPInstallKeyboard.RegisterProfiles(const FileName, PackageID: string;
   FInstallOptions: TKPInstallKeyboardOptions; PackageLanguageMetadata: TPackageKeyboardLanguageList);
 var
-  FAllLanguagesW: WideString;
-  FAllLanguages: string;
-  FLanguage: string;
-  FLanguages: array of Integer;
+  FLanguages: TArray<Integer>;
   FLanguageInstalled: Boolean;
-  FLanguageID: Integer;
   ki: TKeyboardInfo;
   kbdname: string;
   FDestPath: string;
@@ -351,6 +347,7 @@ type
   var
     i: Integer;
   begin
+
     for i := 0 to High(FLanguages) do
       if FLanguages[i] = FLanguageID then
         Exit;
@@ -452,35 +449,19 @@ begin
     end
     else
     begin
-      //
-      // Use keyboard-defined default profile first   // I4607
-      //
-      if ki.KeyboardID <> 0 then
-      begin
-        AddLanguage(ki.KeyboardID);
-      end;
-
-      //
-      // Then enumerate all defined languages to try next   // I4607
-      //
-      GetSystemStore(ki.MemoryDump.Memory, TSS_WINDOWSLANGUAGES, FAllLanguagesW);
-
-      FAllLanguages := FAllLanguagesW;
-      while FAllLanguages <> '' do
-      begin
-        FLanguage := StrToken(FAllLanguages, ' ');
-        Delete(FLanguage, 1, 1); // 'x'
-        if TryStrToInt('$'+FLanguage, FLanguageID) then
-        begin
-          AddLanguage(FLanguageID);
-        end;
-      end;
+      FLanguages := GetLanguageCodesFromKeyboard(ki);
 
       //
       // Final fallback is to install against default language for system   // I4607
       //
       if Length(FLanguages) = 0 then
         AddLanguage(HKLToLanguageID(FDefaultHKL));
+
+      for i := 0 to High(Flanguages) do
+        if TMitigateWin10_1803.IsMitigationRequired(FLanguages[i], ml) then
+        begin
+          FLanguages[i] := ml.NewLanguage.Code;
+        end;
 
       if ikLegacyRegisterAndInstallProfiles in FInstallOptions then
       begin


### PR DESCRIPTION
Fixes #1285.
Fixes #4184.

First, the keyboard profile and registration strategy was not taking into account the mitigation for Win10 1803 (#1285) and this meant that the Amharic, Tigrigna and Sinhala keyboards would not install correctly.

Second, with Windows 10 build 19597, the installation should work correctly for all three languages.