### PR TITLE
fix(developer): debug.log created unexpectedly

### DIFF
--- a/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
+++ b/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
@@ -92,6 +92,7 @@ begin
 
   GlobalCEFApp.CheckCEFFiles := False;
 
+  GlobalCEFApp.LogFile := TKeymanPaths.ErrorLogPath + ExtractFileName(ChangeFileExt(ParamStr(0),''))+'-cef.log';
   GlobalCEFApp.LogSeverity := LOGSEVERITY_ERROR;
 
   // We run in debug mode when TIKE debug mode flag is set, so that we can


### PR DESCRIPTION
Fixes #4110.

CEF will create a debug.log file in the current folder if it encounters an error. Instead, it should be written to Keyman's diag folder. This fix is for both Keyman Developer and Keyman for Windows.