### PR TITLE
fix(developer): Map symbols for *LTREnter* and *LTRBkSp*

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -606,9 +606,11 @@ $(function () {
     '*RTLBkSp*':        0x72,
     '*ShiftLock*':      0x73,
     '*ShiftedLock*':    0x74,
-    '*ZWNJ*':           0x75, // If this one is specified, auto-detection will kick in.
-    '*ZWNJiOS*':        0x75, // The iOS version will be used by default, but the
-    '*ZWNJAndroid*':    0x76, // Android platform has its own default glyph.
+    '*ZWNJ*':           0x75, // * If this one is specified, auto-detection will kick in.
+    '*ZWNJiOS*':        0x75, //   The iOS version will be used by default, but the
+    '*ZWNJAndroid*':    0x76, //   Android platform has its own default glyph.
+    '*LTREnter*':       5,    // * Forces LTR shaping for the Enter/BkSp keys regardless
+    '*LTRBkSp*':        4,    //   of layout's directionality.
   };
 
   this.specialKeyNames = Object.entries(this.specialCharacters).map(ch => ch[0]);


### PR DESCRIPTION
Fixes #4015.

Maps `*LTREnter*` and `*LTRBkSp*` to the correct symbols on the touch layout builder.

![image](https://user-images.githubusercontent.com/4498365/102738032-0d7aa500-439d-11eb-9587-ada468abd0b6.png)
