### PR TITLE
fix(developer): make touch layout editor source view fonts consistent

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
@@ -177,7 +177,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     Top = 0
     Width = 1043
     Height = 645
-    ActivePage = pageDetails
+    ActivePage = pageTouchLayout
     Align = alClient
     Font.Charset = ANSI_CHARSET
     Font.Color = clWindowText
@@ -698,7 +698,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
             Top = 22
             Width = 482
             Height = 13
-            Caption =
+            Caption = 
               'In Keyman 10, language metadata should now be managed in the pac' +
               'kage, not the keyboard.'
           end
@@ -721,6 +721,9 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     object pageLayout: TTabSheet
       Caption = 'Layout'
       ImageIndex = 5
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
       object pagesLayout: TPageControl
         Left = 0
         Top = 0
@@ -735,6 +738,10 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageLayoutDesign: TTabSheet
           Caption = 'Design'
           ImageIndex = -1
+          ExplicitLeft = 0
+          ExplicitTop = 0
+          ExplicitWidth = 0
+          ExplicitHeight = 0
           object panLayoutSimple: TPanel
             Left = 0
             Top = 0
@@ -1015,9 +1022,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     object pageTouchLayout: TTabSheet
       Caption = 'Touch Layout'
       ImageIndex = 16
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object pagesTouchLayout: TPageControl
         Left = 0
         Top = 0
@@ -1032,10 +1036,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageTouchLayoutDesign: TTabSheet
           Caption = 'Design'
           ImageIndex = -1
-          ExplicitLeft = 0
-          ExplicitTop = 0
-          ExplicitWidth = 0
-          ExplicitHeight = 0
         end
         object pageTouchLayoutCode: TTabSheet
           Caption = 'Code'
@@ -1078,6 +1078,9 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     object pageCompile: TTabSheet
       Caption = 'Build'
       ImageIndex = 1
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
       object Panel1: TPanel
         Left = 0
         Top = 0
@@ -1093,7 +1096,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
           Top = 13
           Width = 333
           Height = 13
-          Caption =
+          Caption = 
             'The keyboard must be compiled in order to distribute or install ' +
             'it'
         end
@@ -1142,7 +1145,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
           object lblInstallHint: TLabel
             Left = 9
             Top = 39
-            Width = 259
+            Width = 213
             Height = 13
             Caption = 'You can install the keyboard into Keyman:'
           end
@@ -1297,7 +1300,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
   end
   object dlgBrowseBitmap: TOpenPictureDialog
     DefaultExt = 'ico'
-    Filter =
+    Filter = 
       'All supported files (*.ico, *.bmp)|*.ico;*.bmp|Icon files (*.ico' +
       ')|*.ico|Bitmap files (*.bmp)|*.bmp|All files (*.*)|*.*'
     Options = [ofHideReadOnly, ofCreatePrompt, ofEnableSizing]
@@ -1307,7 +1310,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
   end
   object dlgSaveExport: TSaveDialog
     DefaultExt = 'kmn'
-    Filter =
+    Filter = 
       'Keyman 5.0 Keyboard Wizard (*.kmn)|*.kmn|Windows NT/2000/XP keyb' +
       'oard (*.dll)|*.dll|Windows 95/98/Me keyboard (*.kbd)|*.kbd'
     Options = [ofOverwritePrompt, ofHideReadOnly, ofPathMustExist, ofEnableSizing]

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -816,6 +816,8 @@ procedure TfrmKeymanWizard.CodeFontChanged;
 begin
   inherited;
   frameSource.CodeFont := CodeFont;
+  frameTouchLayoutSource.CodeFont := CodeFont;
+  frameOSK.CodeFont := CodeFont;
 end;
 
 {-----------------------------------------------------------------------------}
@@ -2819,6 +2821,18 @@ begin
           if pagesTouchLayout.ActivePage = pageTouchLayoutDesign
             then frameTouchLayout.FontInfo[Index] := NewValue   // I4872
             else UpdateTouchLayoutSourceFont;
+
+          if Index = kfontTouchLayoutPhone then
+          begin
+            f := TFont.Create;
+            try
+              f.Name := Value.Name;
+              f.Size := StrToIntDef(Value.Size, 12);
+              frameTouchLayoutSource.CharFont := f;
+            finally
+              f.Free;
+            end;
+          end;
         end;
       end;
   end;

--- a/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.dfm
+++ b/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.dfm
@@ -24,6 +24,10 @@ inherited frameOnScreenKeyboardEditor: TframeOnScreenKeyboardEditor
     object pageDesign: TTabSheet
       Caption = 'Design'
       ImageIndex = -1
+      ExplicitLeft = 0
+      ExplicitTop = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
       object panVK: TPanel
         Left = 0
         Top = 0
@@ -366,6 +370,10 @@ inherited frameOnScreenKeyboardEditor: TframeOnScreenKeyboardEditor
     object pageCode: TTabSheet
       Caption = 'Code'
       ImageIndex = -1
+      ExplicitLeft = 0
+      ExplicitTop = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
     end
   end
   object dlgVKImportXML: TOpenDialog

--- a/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
@@ -182,7 +182,9 @@ type
     procedure SetKeyFont(const Value: TFont);
     function DoesKeyboardSupportXMLVisualKeyboard: Boolean;
     function TransferDesignToSource: Boolean;
-    function TransferSourceToDesign(ASilent: Boolean): Boolean;   // I4057
+    function TransferSourceToDesign(ASilent: Boolean): Boolean;
+    function GetCodeFont: TFont;
+    procedure SetCodeFont(const Value: TFont);   // I4057
   protected
     function GetHelpTopic: string; override;
   public
@@ -192,6 +194,7 @@ type
     procedure UpdateControls;
     procedure SetFocus; override;
     property UnderlyingLayout: HKL read GetUnderlyingLayout write SetUnderlyingLayout;
+    property CodeFont: TFont read GetCodeFont write SetCodeFont;
     property KeyFont: TFont read GetKeyFont write SetKeyFont;   // I4057
     property VKModified: Boolean read FVKModified write SetVKModified;
     property VKUnicode: Boolean read FVKUnicode write SetVKUnicode;
@@ -255,6 +258,11 @@ procedure TframeOnScreenKeyboardEditor.TntFormDestroy(Sender: TObject);
 begin
   inherited;
   FreeAndNil(FVK);  // I2794
+end;
+
+procedure TframeOnScreenKeyboardEditor.SetCodeFont(const Value: TFont);
+begin
+  frameSource.CodeFont := Value;
 end;
 
 procedure TframeOnScreenKeyboardEditor.SetFocus;
@@ -985,6 +993,8 @@ begin
   VKkeySample.DataFont := FFont;
   VKkeySample.DataFont.Color := clBlack;
   VKkeySample.Repaint;
+
+  frameSource.CharFont := FFont;
 end;
 
 function TframeOnScreenKeyboardEditor.VK_GetCurrentKey: TVisualKeyboardKey;
@@ -1263,6 +1273,11 @@ begin
   finally
     Free;
   end;
+end;
+
+function TframeOnScreenKeyboardEditor.GetCodeFont: TFont;
+begin
+  Result := frameSource.CodeFont;
 end;
 
 function TframeOnScreenKeyboardEditor.GetHelpTopic: string;

--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -282,7 +282,15 @@ async function loadSettings() {
       document.head.appendChild(fontCss);
     }
 
-    fontCss.innerHTML = ".mtk20, .mtk8 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+    if(mode == 'keyman') {
+      fontCss.innerHTML = ".mtk20, .mtk8 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+    } else if(mode == 'xml') {
+      fontCss.innerHTML = ".mtk1 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+    } else if(mode == 'json') {
+      fontCss.innerHTML = ".mtk5 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+    } else {
+      fontCss.innerHTML = ".mtk1 { font-size: " + fonts.charFont.size + "px; font-family: \"" + fonts.charFont.name + "\"; }";
+    }
 
     // Calculate the appropriate line height based on the maximum from the two fonts set
 


### PR DESCRIPTION
Fixes #1724.

Note: character font in touch layout source editor uses charFont from phone layout only at present.