### PR TITLE
fix(developer): Respect tab editor option

### DIFF
--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -23,6 +23,7 @@ async function loadSettings() {
   let params = (new URL(location)).searchParams;
   let filename = params.get('filename');
   let mode = params.get('mode');
+  let isWordlistTsv = false;
 
   if(!mode) {
     mode = 'keyman';
@@ -50,7 +51,7 @@ async function loadSettings() {
     // Create editor and load source file
     //
 
-    let isWordlistTsv = (mode == 'wordlisttsv');
+    isWordlistTsv = (mode == 'wordlisttsv');
     if(isWordlistTsv) {
       mode = 'text';
     }
@@ -332,11 +333,10 @@ async function loadSettings() {
 
       monaco.editor.setTheme(themeName);
 
-      editor.updateOptions({
-        useTabStops: _settings.useTabChar
-      });
-
       editor.model.updateOptions({
+        insertSpaces:
+          !_settings.useTabChar && // user pref
+          !isWordlistTsv, // We always use tabs for TSV files
         tabSize: _settings.indentSize
       });
     });


### PR DESCRIPTION
Fixes #1692.

The wrong option was being set -- not sure how this was missed earlier!

Also ensures that TSV files will always use Tabs, regardless of the global setting.