### PR TITLE
fix(developer): Allow unhandled keys to go through to debugger memo

### DIFF
--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -166,7 +166,7 @@ BOOL ProcessHook()
       _td->app->QueueAction(QIT_VSHIFTUP, Globals::get_ShiftState());
       fOutputKeystroke = FALSE;
     }
-    else if (!_td->TIPFUpdateable) {
+		else if (!_td->TIPFUpdateable) {
       //
       // #2759: kmtip calls this function twice for each keystroke, first to
       // determine if we are doing processing work (IsUpdateable() == FALSE),
@@ -177,6 +177,17 @@ BOOL ProcessHook()
       //
       fOutputKeystroke = FALSE;
     }
+  }
+
+  if (fOutputKeystroke && _td->app->DebugControlled()) {
+		// The debug memo does not receive default key events because
+		// we capture them all here. So we synthesize the key event for
+		// the debugger.
+    _td->app->QueueAction(QIT_VSHIFTDOWN, Globals::get_ShiftState());
+    _td->app->QueueAction(QIT_VKEYDOWN, _td->state.vkey);
+    _td->app->QueueAction(QIT_VKEYUP, _td->state.vkey);
+    _td->app->QueueAction(QIT_VSHIFTUP, Globals::get_ShiftState());
+    fOutputKeystroke = FALSE;
   }
 
 	if(*Globals::hwndIM() == 0 || *Globals::hwndIMAlways())


### PR DESCRIPTION
Fixes #2690.
Fixes #3082.

In the debugger, key events such as <kbd>Enter</kbd>, <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Ctrl</kbd>+<kbd>V</kbd> were being swallowed by the debug engine if they did not have rules within the keyboard. This change emits the key events so the debug memo can process them normally.

## Test scenarios

A sample keyboard which allows us to test the various scenarios:

```
store(&VERSION) '10.0'
store(&NAME) 'test debug default keys'
store(&TARGETS) 'any'

begin Unicode > use(main)

group(main) using keys

'a' + [K_ENTER] > 'axb'
'b' + [K_ENTER] > 'bx' use(emit)
+ 'c' > 'xyz'

group(emit) using keys
```

1. Handled key: press <kbd>c</kbd>: should emit `xyz`
2. Unhandled key: press <kbd>Enter</kbd>: should emit `\n` (where `\n` is a new line)
3. Handled key which is sometimes unhandled: press <kbd>a</kbd>, <kbd>Enter</kbd>: should emit `axb`
4. Handled key which should be emitted: press <kbd>b</kbd>, <kbd>Enter</kbd>: should emit `bx\n`
5. Press <kbd>Ctrl</kbd>+<kbd>a</kbd> to select all.