### PR TITLE
fix(developer): Debug character grid performance

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebug.dfm
+++ b/windows/src/developer/TIKE/child/UfrmDebug.dfm
@@ -12,6 +12,7 @@ inherited frmDebug: TfrmDebug
   Position = poDefault
   OnClose = FormClose
   OnDestroy = FormDestroy
+  OnResize = FormResize
   ExplicitWidth = 771
   ExplicitHeight = 171
   PixelsPerInch = 96


### PR DESCRIPTION
The character grid in the debugger would become very slow as the number of characters increased, with substantial flickering. This refactor removes the unnecessary recalculations of the grid cell count and thus resolves performance problems.