### PR TITLE
fix(web): unexpected errors in OSK / banner position calculations

### DIFF
--- a/web/source/dom/uiTouchHandlerBase.ts
+++ b/web/source/dom/uiTouchHandlerBase.ts
@@ -425,7 +425,7 @@ namespace com.keyman.dom {
         // Cancel touch if moved up and off keyboard, unless popup keys visible
       } else {
         let base = this.baseElement;
-        let parent = this.baseElement.parentElement;
+        let parent = base.parentElement; // parentElement is _Box
         let top = base.offsetTop;
         if(parent) {
           top += parent.offsetTop;

--- a/web/source/dom/uiTouchHandlerBase.ts
+++ b/web/source/dom/uiTouchHandlerBase.ts
@@ -425,7 +425,11 @@ namespace com.keyman.dom {
         // Cancel touch if moved up and off keyboard, unless popup keys visible
       } else {
         let base = this.baseElement;
-        let top = (base.offsetParent as HTMLElement).offsetTop + base.offsetTop;
+        let parent = this.baseElement.parentElement;
+        let top = base.offsetTop;
+        if(parent) {
+          top += parent.offsetTop;
+        }
         let height = base.offsetHeight;
         let yMin = Math.max(5, top - 0.25 * height);
         let yMax = (top + height) + 0.25 * height;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1208,7 +1208,8 @@ namespace com.keyman.osk {
         // Cancel touch if moved up and off keyboard, unless popup keys visible
       } else {
         // _Box has (most of) the useful client values.
-        let _Box = this.kbdDiv.offsetParent as HTMLElement; // == osk._Box
+        let keyman = com.keyman.singleton;
+        let _Box = this.kbdDiv.parentElement ? this.kbdDiv.parentElement : keyman.osk._Box;
         let height = (this.kbdDiv.firstChild as HTMLElement).offsetHeight; // firstChild == layer-group, has height info.
         // We need to adjust the offset properties by any offsets related to the active banner.
 


### PR DESCRIPTION
Fixes #3991.

As noted by https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent,

> `offsetParent` returns null in the following situations:
>
>    * The element or its parent element has the `display` property set to `none`.
>    * The element has the position property set to fixed (firefox returns `<body>`).
>    * The element is `<body>` or `<html>`.

The `_Box` element certainly uses the `fixed` position property, and noting that we've seen cases with opacity at 0, it's not a _huge_ stretch to imagine that said cases could be treated the same way as `display = 'none'` from the first point above.

Both the banner and the keyboard layer group elements are direct children of `_Box`, so we'd be better off relying on that fact and just using `parentElement` instead of `offsetParent`.  Along with a couple of null-guards and failsafe assignments, for extra robustness.