### PR TITLE
fix(web): OSK key preview positioning

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2365,7 +2365,8 @@ namespace com.keyman.osk {
       canvas.height = 2.3 * xHeight;
 
       kts.top = 'auto';
-      kts.bottom = (y0 + h0 - xTop - xHeight)+'px';
+      // Matches how the subkey positioning is set.
+      kts.bottom = (parseInt(key.style.bottom, 10))+'px';
       kts.textAlign = 'center';   kts.overflow = 'visible';
       kts.fontFamily = util.getStyleValue(kc,'font-family');
       kts.width = canvas.width+'px';


### PR DESCRIPTION
Fixes #3953.

This changes the key preview positioning logic to better parallel the subkey-display positioning logic, as only the former was affected by the bug being fixed.