### PR TITLE
fix(web): disables predictive text on Opera mini

### DIFF
--- a/web/source/dom/domOverrides.ts
+++ b/web/source/dom/domOverrides.ts
@@ -8,6 +8,9 @@ namespace com.keyman.dom {
     } else if(keyman.util.getIEVersion() < 10) {
       console.warn("WebWorkers are not supported in this version of IE.");
       return false;
+    } else if(typeof Worker != 'function') {
+      console.warn("WebWorkers are not supported by this browser.");
+      return false;
     }
 
     return true;


### PR DESCRIPTION
Also, other browsers without access to the WebWorker `Worker` constructor.

Fixes #4242.
Fixes KEYMANWEB-COM-V.
