### PR TITLE
fix(android): Popup misalignments and compatibility with WeChat, Telegram

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -22,11 +22,13 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.widget.FrameLayout;
 
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.Sentry;
@@ -177,6 +179,16 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   }
 
   @Override
+  public void onConfigureWindow(Window win, boolean isFullscreen, boolean isCandidatesOnly) {
+    super.onConfigureWindow(win, isFullscreen, isCandidatesOnly);
+
+    // We don't currently use isFullscreen or isCandidatesOnly; we always want to MATCH_PARENT,
+    // unlike the default for height which is WRAP_CONTENT. We then adjust the touchable area
+    // in `onCalculateInsets`
+    win.setLayout(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+  }
+
+  @Override
   public void onComputeInsets(InputMethodService.Insets outInsets) {
     super.onComputeInsets(outInsets);
 
@@ -192,6 +204,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     int bannerHeight = KMManager.getBannerHeight(this);
     int kbHeight = KMManager.getKeyboardHeight(this);
     outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
+    outInsets.visibleTopInsets = outInsets.contentTopInsets;
     outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_REGION;
     outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -420,21 +420,19 @@ public final class KMManager {
    * @param keyboard KeyboardType
    * @return RelativeLayout.LayoutParams
    */
-  private static RelativeLayout.LayoutParams getKeyboardLayoutParams(KeyboardType keyboard) {
+  private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
     int bannerHeight = getBannerHeight(appContext);
     int kbHeight = getKeyboardHeight(appContext);
     RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
       RelativeLayout.LayoutParams.MATCH_PARENT, bannerHeight + kbHeight);
-    if (keyboard == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
-    }
+    params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
    return params;
   }
 
   private static void initInAppKeyboard(Context appContext) {
     if (InAppKeyboard == null) {
       InAppKeyboard = new KMKeyboard(appContext, KeyboardType.KEYBOARD_TYPE_INAPP);
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_INAPP);
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.setVerticalScrollBarEnabled(false);
       InAppKeyboard.setHorizontalScrollBarEnabled(false);
@@ -447,7 +445,7 @@ public final class KMManager {
   private static void initSystemKeyboard(Context appContext) {
     if (SystemKeyboard == null) {
       SystemKeyboard = new KMKeyboard(appContext, KeyboardType.KEYBOARD_TYPE_SYSTEM);
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.setVerticalScrollBarEnabled(false);
       SystemKeyboard.setHorizontalScrollBarEnabled(false);
@@ -537,12 +535,12 @@ public final class KMManager {
   public static void onConfigurationChanged(Configuration newConfig) {
     // KMKeyboard
     if (InAppKeyboard != null) {
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_INAPP);
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.onConfigurationChanged(newConfig);
     }
     if (SystemKeyboard != null) {
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.onConfigurationChanged(newConfig);
     }
@@ -723,7 +721,7 @@ public final class KMManager {
    *
    * At some point, we might migrate /cloud/ keyboards into packages
    * 5) For now, delete cloud/sil_euro_latin*.js
-   * 
+   *
    * Assumption: No legacy keyboards exist in /packages/*.js
    * @param context
    */
@@ -1061,12 +1059,12 @@ public final class KMManager {
 
     RelativeLayout.LayoutParams params;
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
-      params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_INAPP);
+      params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
-      params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+      params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
@@ -1278,9 +1276,9 @@ public final class KMManager {
         currentBanner = KMManager.KM_BANNER_STATE_BLANK;
 
       if(result1)
-        InAppKeyboard.setLayoutParams(getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_INAPP));
+        InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
       if(result2)
-        SystemKeyboard.setLayoutParams(getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_SYSTEM));
+        SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
 
     registerAssociatedLexicalModel(languageID);
@@ -2005,7 +2003,7 @@ public final class KMManager {
         }
         currentBanner = (isModelActive && modelPredictionPref) ?
           KM_BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
-        RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_INAPP);
+        RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         InAppKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {
         // URL has actual path to the keyboard.html file as a prefix!  We need to replace
@@ -2273,7 +2271,7 @@ public final class KMManager {
         }
         currentBanner = (isModelActive && modelPredictionPref) ?
           KM_BANNER_STATE_SUGGESTION : KM_BANNER_STATE_BLANK;
-        RelativeLayout.LayoutParams params = getKeyboardLayoutParams(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+        RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
         SystemKeyboard.setLayoutParams(params);
       } else if (url.indexOf("suggestPopup") >= 0) {
         // URL has actual path to the keyboard.html file as a prefix!  We need to replace

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -14,11 +14,13 @@ import java.util.HashMap;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.widget.FrameLayout;
 
 public class SystemKeyboard extends InputMethodService implements OnKeyboardEventListener {
 

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -158,6 +158,16 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   }
 
   @Override
+  public void onConfigureWindow(Window win, boolean isFullscreen, boolean isCandidatesOnly) {
+    super.onConfigureWindow(win, isFullscreen, isCandidatesOnly);
+
+    // We don't currently use isFullscreen or isCandidatesOnly; we always want to MATCH_PARENT,
+    // unlike the default for height which is WRAP_CONTENT. We then adjust the touchable area
+    // in `onCalculateInsets`
+    win.setLayout(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+  }
+
+  @Override
   public void onComputeInsets(InputMethodService.Insets outInsets) {
     super.onComputeInsets(outInsets);
 
@@ -173,6 +183,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     int bannerHeight = KMManager.getBannerHeight(this);
     int kbHeight = KMManager.getKeyboardHeight(this);
     outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
+    outInsets.visibleTopInsets = outInsets.contentTopInsets;
     outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_REGION;
     outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);
   }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -11,11 +11,13 @@ import android.view.Display;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.widget.FrameLayout;
 
 import com.tavultesoft.kmea.KMHardwareKeyboardInterpreter;
 import com.tavultesoft.kmea.KMManager;

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -163,6 +163,16 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
     }
 
     @Override
+    public void onConfigureWindow(Window win, boolean isFullscreen, boolean isCandidatesOnly) {
+        super.onConfigureWindow(win, isFullscreen, isCandidatesOnly);
+
+        // We don't currently use isFullscreen or isCandidatesOnly; we always want to MATCH_PARENT,
+        // unlike the default for height which is WRAP_CONTENT. We then adjust the touchable area
+        // in `onCalculateInsets`
+        win.setLayout(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+    }
+
+    @Override
     public void onComputeInsets(Insets outInsets) {
         super.onComputeInsets(outInsets);
 
@@ -182,6 +192,7 @@ public class SystemKeyboard extends InputMethodService implements KeyboardEventH
         int bannerHeight = KMManager.getBannerHeight(this);
         int kbHeight = KMManager.getKeyboardHeight(this);
         outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
+        outInsets.visibleTopInsets = outInsets.contentTopInsets;
         outInsets.touchableInsets = Insets.TOUCHABLE_INSETS_REGION;
         outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);
     }


### PR DESCRIPTION
Fixes #4019.
Rolls back #3009 and fixes base issue in alternative manner.

The core issue here was twofold:

1. We needed to set the window size to the whole screen in order for the popups to visible and touchable. We implement this in `onConfigureWindow`.
2. Once our window size is the whole screen, we need to tell the apps which part of the window is our keyboard UI, in `onComputeInsets`. This is the only part of the window which impacts the layout of the underlying app. We had not set the `visibleTopInsets` property and this caused the WeChat problems.

Finally, in order for this to work, we roll back the original fix in #3009 as that one breaks the full-screen layout requirement.

Tested with a wide range of apps on Android 10, including WeChat and Telegram. If @kienwt, @ericjding have capacity, would love to know if this fix works for them also.

Note that this fix requires changes to consumers of Keyman Engine, so sample and FV Keyboards updated accordingly.