### PR TITLE
fix(web): uses CSS line-height to vertically center oversized OSK keycaps

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -69,6 +69,7 @@ namespace com.keyman.osk {
   export abstract class OSKKey {
     spec: OSKKeySpec;
     formFactor: string;
+    cap: HTMLDivElement;
 
     /**
      * The layer of the OSK on which the key is displayed.
@@ -361,6 +362,7 @@ namespace com.keyman.osk {
 
       let kDiv=util._CreateElement('div');
       kDiv.className='kmw-key-square';
+      this.cap = kDiv;
 
       let ks=kDiv.style;
       ks.width=this.objectGeometry(spec['widthpc']);
@@ -464,12 +466,13 @@ namespace com.keyman.osk {
       }
     }
 
-    construct(osk: VisualKeyboard, baseKey: HTMLDivElement, topMargin: boolean): HTMLDivElement {
+    construct(osk: VisualKeyboard, baseKey: KeyElement, topMargin: boolean): HTMLDivElement {
       let spec = this.spec;
 
       let kDiv=document.createElement('div');
       let tKey = osk.getDefaultKeyObject();
       let ks=kDiv.style;
+      this.cap = kDiv;
 
       for(var tp in tKey) {
         if(typeof spec[tp] != 'string') {
@@ -496,8 +499,12 @@ namespace com.keyman.osk {
       btn.id = this.getId(osk);
 
       // Must set button size (in px) dynamically, not from CSS
+      let baseCap = baseKey.key.cap;
       let bs=btn.style;
       bs.height=ks.height;
+      if(baseCap) { // null guard, just to be safe.
+        bs.lineHeight=baseCap.style.lineHeight;
+      }
       bs.width=ks.width;
 
       // Must set position explicitly, at least for Android
@@ -1588,7 +1595,7 @@ namespace com.keyman.osk {
         }
 
         let keyGenerator = new com.keyman.osk.OSKSubKey(subKeySpec[i], e['key'].layer, device.formFactor);
-        let kDiv = keyGenerator.construct(this, <HTMLDivElement> e, needsTopMargin);
+        let kDiv = keyGenerator.construct(this, <KeyElement> e, needsTopMargin);
 
         subKeys.appendChild(kDiv);
       }
@@ -1990,7 +1997,7 @@ namespace com.keyman.osk {
           if(!this.isStatic) {
             rs.bottom=bottom+'px';
           }
-          rs.maxHeight=rs.height=rowHeight+'px';
+          rs.maxHeight=rs.lineHeight=rs.height=rowHeight+'px';
 
           // Calculate the exact vertical coordinate of the row's center.
           this.layout.layer[nLayer].row[nRow].proportionalY = ((oskHeight - bottom) - rowHeight/2) / oskHeight;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -69,7 +69,6 @@ namespace com.keyman.osk {
   export abstract class OSKKey {
     spec: OSKKeySpec;
     formFactor: string;
-    cap: HTMLDivElement;
 
     /**
      * The layer of the OSK on which the key is displayed.
@@ -362,7 +361,6 @@ namespace com.keyman.osk {
 
       let kDiv=util._CreateElement('div');
       kDiv.className='kmw-key-square';
-      this.cap = kDiv;
 
       let ks=kDiv.style;
       ks.width=this.objectGeometry(spec['widthpc']);
@@ -383,8 +381,6 @@ namespace com.keyman.osk {
           ks.bottom=rowStyle.bottom;
         }
         ks.height=rowStyle.height;  // must be specified in px for rest of layout to work correctly
-        ks.lineHeight=rowStyle.height; // helps ensure that text is vertically-centered, even if overflowing
-                                       // due to use of oversized font scales
 
         // Set distinct phone and tablet button position properties
         btn.style.left=ks.left;
@@ -472,7 +468,6 @@ namespace com.keyman.osk {
       let kDiv=document.createElement('div');
       let tKey = osk.getDefaultKeyObject();
       let ks=kDiv.style;
-      this.cap = kDiv;
 
       for(var tp in tKey) {
         if(typeof spec[tp] != 'string') {
@@ -499,12 +494,9 @@ namespace com.keyman.osk {
       btn.id = this.getId(osk);
 
       // Must set button size (in px) dynamically, not from CSS
-      let baseCap = baseKey.key.cap;
       let bs=btn.style;
       bs.height=ks.height;
-      if(baseCap) { // null guard, just to be safe.
-        bs.lineHeight=baseCap.style.lineHeight;
-      }
+      bs.lineHeight=baseKey.style.lineHeight;
       bs.width=ks.width;
 
       // Must set position explicitly, at least for Android
@@ -2040,7 +2032,7 @@ namespace com.keyman.osk {
         if(!this.isStatic) {
           ks.bottom=bottom+'px';
         }
-        ks.height=ks.minHeight=(rowHeight-pad)+'px';
+        ks.height=ks.lineHeight=ks.minHeight=(rowHeight-pad)+'px';
 
         // Rescale keycap labels on iPhone (iOS 7)
         if(resizeLabels && (j > 0)) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -380,7 +380,9 @@ namespace com.keyman.osk {
         if(!osk.isStatic) {
           ks.bottom=rowStyle.bottom;
         }
-        ks.height=rowStyle.height;  //must be specified in px for rest of layout to work correctly
+        ks.height=rowStyle.height;  // must be specified in px for rest of layout to work correctly
+        ks.lineHeight=rowStyle.height; // helps ensure that text is vertically-centered, even if overflowing
+                                       // due to use of oversized font scales
 
         // Set distinct phone and tablet button position properties
         btn.style.left=ks.left;


### PR DESCRIPTION
Fixes #4026.

A quick comparison via Chrome's device emulation mode:

**Before**

<img width="431" alt="Screen Shot 2021-01-14 at 3 39 02 PM" src="https://user-images.githubusercontent.com/25213402/104565823-71804880-567f-11eb-9d36-dd74df6d4943.png">

**After**

<img width="434" alt="Screen Shot 2021-01-14 at 3 39 17 PM" src="https://user-images.githubusercontent.com/25213402/104565838-780ec000-567f-11eb-9976-d2a6c4c0c3cd.png">

Note:  I used an artificially low-res device to replicate the scenario reported in #4026 without any code/resource modifications to the testing page.

Shrinking the page further:

**Before**
<img width="334" alt="Screen Shot 2021-01-14 at 3 57 36 PM" src="https://user-images.githubusercontent.com/25213402/104567319-3da62280-5681-11eb-8f0b-ef4e394f3d12.png">

**After**
<img width="333" alt="Screen Shot 2021-01-14 at 3 52 45 PM" src="https://user-images.githubusercontent.com/25213402/104566755-945f2c80-5680-11eb-9287-a0df0cca9bd7.png">

Note how the resulting OSK is an, uh, "equal-opportunity offender", chopping off the tops of tall characters as well as the bottom of characters with 'descenders' in this scenario.

And, for a particularly extreme example:

**After**
<img width="272" alt="Screen Shot 2021-01-14 at 4 04 27 PM" src="https://user-images.githubusercontent.com/25213402/104568124-3df2ed80-5682-11eb-9179-24850ef819e4.png">

----

This change ensures that the text on a key is always vertically centered... even if that means letting the text "overflow" past the key's boundaries in all directions.  Since the OSK's code directly _prescribes_ the height of its keys, we can set the text's `line-height` to the same value, resulting in a nice, clean vertical centering.

Using the default `line-height` value (generally defaults to `1.2em`) instead results in overflow past the bottom of the host element if necessary for the font size, _regardless_ of any `vertical-align` style settings.  As a result, setting to a constant `em` value will result in the same overflow pattern if the resulting line-height is greater than the actual height allotted to the element.  Fortunately, setting an exact, pixel-based height avoids the issue entirely.