### PR TITLE
chore(android/app): Add Obolo language from crowdin

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-ann/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-ann/strings.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- Context: Menu Action -->
+  <string name="action_share" comment="Menu action to send text content to another app">Che</string>
+  <!-- Context: Menu Action -->
+  <string name="action_web" comment="Menu action to open Keyman browser">Òwọlọ olik-etip</string>
+  <!-- Context: Menu Action -->
+  <string name="action_text_size" comment="Menu action to adjust text size">Okike inu-nge</string>
+  <!-- Context: Menu Action -->
+  <string name="action_overflow" comment="Show additional menu items">Ofifi</string>
+  <!-- Context: Menu Action -->
+  <string name="action_clear_text" comment="Menu action to erase text">Chọk inu-nge</string>
+  <!-- Context: Menu Action -->
+  <string name="action_info" comment="Menu action to display Keyman help page">Etip</string>
+  <!-- Context: Menu Action -->
+  <string name="action_settings" comment="Menu action to open Settings menu">Onineen̄</string>
+  <!-- Context: Menu Action -->
+  <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">Wop aya inu</string>
+  <!-- Context: Title -->
+  <string name="title_version" comment="Title of Keyman for Android version">Òsolek: %1$s</string>
+  <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
+  <string name="textview_hint" comment="Prompt to start typing">Bene ge me ere keyi&#8230;</string>
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <!-- Context: Text Size dialog -->
+  <string name="text_size" comment="Current text size (number)">Okike inu-nge: %1$d</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_up" comment="Make text bigger">Rọ inu-nge imin</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_down" comment="Make text smaller">Rọ inu-nge isip</string>
+  <!-- Context: Clear Text dialog -->
+  <string name="all_text_will_be_cleared" comment="Erase all the text">\nMêchọk otutuuk inu-nge\n</string>
+  <!-- Context: Get Started menu -->
+  <string name="get_started" comment="Menu for getting started">Bene si ikwaan̄</string>
+  <!-- Context: Get Started menu -->
+  <string name="add_a_keyboard" comment="Menu item to add a keyboard">Tap uwot-nge eyi usem kwun̄</string>
+  <!-- Context: Get Started menu -->
+  <string name="enable_system_keyboard" comment="Menu item to enable Keyman as system keyboard">Rọ mè Keyman ibene ikisi ikwaan̄ me otutuuk emen okwukwut</string>
+  <!-- Context: Get Started menu -->
+  <string name="set_keyman_as_default" comment="Menu item to set Keyman as default system keyboard">Rọ Keyman ire ọ̀kpọọn̄ uwot-nge</string>
+  <!-- Context: Get Started menu -->
+  <string name="more_info" comment="Open the Keyman for Android help page">Ofifi etip</string>
+  <!-- Context: Get Started menu -->
+  <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">Jeen̄ \"%1$s\" me ibebene</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">Ufuna òkọt òwop ekwu, nyi Keyman unye mè ifuk/ige inu me okwukwut.</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">Kpenyi unye ibe itap inu me emen ekwu. Ìkpokọt iwop ekwu uwot-nge</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="keyman_settings" comment="Settings menu title">Onineen̄</string>
+  <!-- Context: Keyman Settings menu -->
+  <plurals name="installed_languages">
+    <item quantity="one">Usem ewopbe (%1$d)</item>
+    <item quantity="other">Ebi kè usem ewopbe (%1$d)</item>
+  </plurals>
+  <!-- Context: Keyman Settings menu -->
+  <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">Wop Uwot-nge mè ìre Ikpa-usem</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner" comment="text suggestions banner">Kijeen̄ egop mgbọ geelek</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_on" comment="Description when toggle is on">Ọmọ me otitọt</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_off" comment="Description when toggle is off">Ire iniin̄, jeen̄ mgbọ echieekbe ibe òjeen̄ ikọ òkinunu</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report" comment="permission for sending crash reports">Tele ibe isa olik-etip iria etip òfolek ufialek ekwu</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_on" comment="Description when toggle is on">Ire ichili ito, môria erip òfolek ufialek ekwu</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_off" comment="Description when toggle is off">Ire ichit, ìkporia erip òfolek ufialek ekwu</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_keyman_dot_com" comment="Install package from Keyman server">Bọkọ me keyman.com wop</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_local_file" comment="Install package file from local device">San̄a me emen okwukwut wop</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_other_device" comment="Scan QR Code">Bọkọ me ofifi okwukwut wop</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_languages_to_installed_keyboard" comment="Install additional languages from a keyboard package">Tap usem sọkọ me lek uwot-nge ewopbe</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_language_subtext" comment="Additional information for adding another language">(inan̄a me ekwu eyi uwot-nge)</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_keyboard_package_list" comment="Select a keyboard package to add languages">Gobo Ekwu Uwot-nge</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_languages_for_package" comment="Select language names from the keyboard package">Gobo usem nyi %1$s</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">Mîtap usem %1$s me lek %2$s</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">Mîwuuk lek itap otutuuk usem iso</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_text" comment="Prompt to type in the browser search bar">Wèek sà ìre ge iman̄ akpatan̄</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="title_bookmarks" comment="Title for bookmarks">Iman̄-ikpa</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="no_bookmarks" comment="Text when bookmark list is empty">Kpunu iman̄-ikpa</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="add_bookmark" comment="Confirmation to add bookmark">Tap iman̄-ikpa</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_title" comment="Page title for saved bookmark">Ibot</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_url" comment="Page URL for saved bookmark">Iman̄ akpatan̄</string>
+  <!-- Context: KMP Package strings -->
+  <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Kpekọt iwop ekwu %1$s</string>
+  <!-- Context: KMP Package strings -->
+  <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">Mêkibọkọ ekwu uwot-nge itap\n%1$s&#8230;</string>
+  <!-- Context: KMP Package strings -->
+  <string name="failed_to_extract" comment="Notification that keyboard package failed to unzip">Kpekọt isan̄a isibi</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_keyboard_package" comment="Title to install keyboard package">Wop Uwot-nge</string>
+  <!-- Context: KMP Package welcome.htm title -->
+  <string name="welcome_package" comment="Title to welcome.htm page (name and version)">Onu me %1$s</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_predictive_text_package" comment="Title to install dictionary package">Wop Ikpa-usem</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">Ekwu uwot-nge ìkakaan̄ uwot-nge ekichabe ubọk eyi mêkọtbe iwop</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">Kpunu aya ikọ òkinunu eyi mêwopbe</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">Kpunu uwot-nge sà ìre aya ikọ òkinunu eyi mêwopbe</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">Uwot-nge ìkakaan̄ usem òje me lek eyi mêkọtbe iwop</string>
+  <!-- Context: KMP Package strings -->
+  <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Metadata òkup me ekwu îlọ/îchep</string>
+</resources>

--- a/android/KMEA/app/src/main/res/values-ann/strings.xml
+++ b/android/KMEA/app/src/main/res/values-ann/strings.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Device type  -->
+    <!-- Application name (Keyman Engine for Android) -->
+    <!-- Context: Title for list -->
+    <plurals name="title_keyboards">
+        <item quantity="one">Uwot-nge</item>
+        <item quantity="other">Ebi kè uwot-nge</item>
+    </plurals>
+    <!-- Context: Title for list -->
+    <string name="title_add_keyboard" comment="Add a new keyboard">Tap aya uwot-nge gbaalek</string>
+    <!-- Context: Title for list -->
+    <string name="title_languages_settings" comment="List of installed languages">Ebi kè usem ewopbe</string>
+    <!-- Context: Title for list -->
+    <string name="title_language_settings" comment="Keyman Settings for a language">%1$s Onineen̄</string>
+    <!-- Context: Button label -->
+    <string name="label_add" comment="Button to add an item">Tap sọkọ</string>
+    <!-- Context: Button label -->
+    <string name="label_back" comment="Button to go back">Gwu kom</string>
+    <!-- Context: Button label -->
+    <string name="label_cancel" comment="Button to cancel an action">Gwak</string>
+    <!-- Context: Button label -->
+    <string name="label_close" comment="Close a dialog">Chit</string>
+    <!-- Context: Button label -->
+    <string name="label_close_keyman" comment="Close the Keyman application">Chit Keyman</string>
+    <!-- Context: Button label -->
+    <string name="label_download" comment="Button to confirm downloading an item">Bọkọ tap</string>
+    <!-- Context: Button label -->
+    <string name="label_install" comment="Confirmation to install a package">Wop</string>
+    <!-- Context: Button label -->
+    <string name="label_later" comment="Do an action at a later time">Ofifi mgbọ</string>
+    <!-- Context: Button label -->
+    <string name="label_next" comment="Go to the next screen">Eyi ògọọk</string>
+    <!-- Context: Button label -->
+    <string name="label_ok" comment="Button to acknowledge a dialog">ÎSO</string>
+    <!-- Context: Button label -->
+    <string name="label_update" comment="Dialog button to update a resource">Bọkọ aya</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="cannot_connect" comment="Error message when network connection fails">\nKpekọt itibi itet akpatan̄ Keyman!\n</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_delete_keyboard" comment="Confirmation to delete a keyboard">Ìre oweek ichọchọk uwot-nge yi isan̄a?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_download_keyboard" comment="Confirmation to download a keyboard update">Ìre oweek ibọbọkọ aya òsolek uwot-nge yi itap?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_update" comment="Confirmation to update several resources">Ìre owu môma inwenwene uwot-nge mè ikpa-usem itap me eyi ayaya mgbọ keyi?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_channel">Irọrọ inu-ikwaan̄ iso usen</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_available" comment="Notification when resource updates are available">Aya inu-ikwaan̄ ọmọ wa</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="update_available" comment="Currently installed version of a resource with an available update">%1$s (Aya Ọmọwa)</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_update_message" comment="language name: keyboard name">      Aya Uwot-nge Ọmọwa %1$s: %2$s </string>
+    <!-- Context: Keyboard Updates -->
+    <string name="dictionary_update_message">Aya Ikpa-usem Ọmọwa %1$s: %2$s </string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_version" comment="Label for keyboard version">Òsolek uwot-nge</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="help_link" comment="Label for help link">Ugọbọ ntap-ubọk</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="uninstall_keyboard" comment="Label for uninstalling keyboard">Jibi uwot-nge</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_picker_new_keyboard" comment="Mark a language name that's newly installed in keyboard list">[aya] %1$s</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_qr_code" comment="QR Code description">      Gwuku iman̄ yi kè òbọkọ\nuwot-nge yi me ofifi okwukwut</string>
+    <!-- Context: Query for associated dictionary -->
+    <string name="query_associated_model" comment="Check if there's an available dictionary to download">Wèek ikpa-usem òje me lek bọkọ tap</string>
+    <!-- Context: Model Updates -->
+    <string name="confirm_download_model" comment="Confirmation to download a dictionary update">Ìre oweek ibọbọkọ aya òsolek ikpa-usem yi itap?</string>
+    <!-- Context: No associated dictionary found -->
+    <string name="no_associated_model" comment="Confirmation there's no available dictionary to download">Kpunu ikpa-usem mêbọkọbe itap</string>
+    <!-- Context: Model Updates -->
+    <string name="catalog_unavailable" comment="Notification that the cloud resource catalog can't be updated">Kpunu onineen̄ inu-ikwaan̄</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_start_in_background" comment="Notification that the resource catalog update will begin">Mîbene ikirọ inu-ikwaan̄ iso usen me udun̄-oyet</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_is_running_in_background" comment="Notification that the resource catalog update is still downloading">Mêkibọkọ onineen̄ inu-ikwaan̄ itap; soso yaka sa me mgbidim mgbọ!</string>
+    <!-- Context: Background download messages-->
+    <string name="progress_message_checking_resource_is_running" comment="Progress notification that the check for a resource is still running ">Mêkiweek inu-ikwaan̄</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_start_in_background" comment="Notification that a keyboard download has started">Ibọbọkọ uwot-nge itap îbene me Udun̄</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_is_running_in_background" comment="Notification that a keyboard download is still running">Mîwuuk lek ibene ikibọkọ uwot-nge egobobe ya itap; soso neke sa lek me mgbidim mgbọ!</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_finished" comment="Notification that a keyboard download has finished">Mîbọkọ uwot-nge itap inan̄a!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_start_in_background" comment="Notification that a dictionary download has started">Ibọbọkọ ikpa-usem itap îbene me Udun̄</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">Mîwuuk lek ibene ikibọkọ ikpa-usem egobobe ya itap; soso neke sa lek me mgbidim mgbọ!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Mîbọkọ ikpa-usem itap inan̄a.</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_unavailable" comment="Error message when a Keyman server can't be reached">Kpekọt ibọkọ etip me akpatan̄!</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_current" comment="Notification that all resources are up to date">"Otutuuk inu-ikwaan̄ mîso usen!"</string>
+    <!-- Context: Model Info -->
+    <string name="model_version" comment="Title for a dictionary version">Òsolek Ikpa-usem</string>
+    <!-- Context: Model Info -->
+    <string name="uninstall_model" comment="Label to uninstall a dictionary">Jibi ikpa-usem</string>
+    <!-- Context: Model Info -->
+    <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">Ìre oweek ichọchọk ikpa-usem yi isan̄a?</string>
+    <!-- Context: Language Settings Keyboard install strings -->
+    <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">Mîbọkọ uwot-nge %1$s itap</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_corrections" comment="Enable corrections from the suggestion banner">Rọ ikinen̄e ige</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_predictions" comment="Enable predictions from the suggestion banner">Rọ ikibak ikọ onu-misi</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_label">Ikpa-usem</string>
+    <!-- Context: Language Settings menu substring - Check for available dictionary -->
+    <string name="check_available_model" comment="Check for available dictionary">Kpọ ikpa-usem òkukup</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_info_header" comment="Dictionary name">Ikpa-usem: %1$s</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_picker_header" comment="Dictionaries for a specified language">Ikpa-usem %1$s</string>
+    <!-- Context: Language Settings menu strings -->
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_install_toast" comment="Notification when a dictionary is installed">Ikpa-usem ebọkọbe itap</string>
+    <!-- Context: Language Settings menu strings -->
+    <plurals name="keyboard_count">
+        <item quantity="one">(uwot-nge %1$d)</item>
+        <item quantity="other">(Ebi kè uwot-nge %1$d)</item>
+    </plurals>
+    <!-- Context: Content descriptions -->
+    <!-- Context: Content descriptions -->
+    <!-- Context: Popup menu labels -->
+    <string name="label_delete" comment="Confirmation to delete an item">Chọk</string>
+    <!-- Context: Shared preferences name -->
+    <!-- Context: Other strings -->
+    <string name="help_bubble_text">Chak ubọk me ere keyi sa nwene uwot-nge</string>
+</resources>


### PR DESCRIPTION
Manually check in Android files from crowdin for Obolo (`ann-latn`).
Can't use crowdin CLI because it doesn't handle custom languages
https://support.crowdin.com/api/language-codes/

Due to how Android localization only handles language and region codes. So we'll configure these as `ann`.

The code for Keyman for Android to change display language to Obolo will be handled on a separate PR.