### PR TITLE
chore(linux): Improve version number for debian package

### DIFF
--- a/linux/scripts/debian.sh
+++ b/linux/scripts/debian.sh
@@ -29,6 +29,7 @@ for proj in ${projects}; do
     downloadSource debianpackage
 
     cd ${proj}-${version}
+    dch -v ${version}-1 "Re-release to Debian"
     debuild -d -S -sa -Zxz
     cd ${BASEDIR}
 done

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -39,8 +39,8 @@ function downloadSource() {
         make clean
     fi
 
-    # Update tier in Debian watch files (replacing any previously set tier)
-    sed "s/\$tier\|alpha\|beta\|stable/${TIER}/g" $BASEDIR/scripts/watch.in > debian/watch
+    # Update tier in Debian watch files (replacing any previously set tier) and remove comment
+    sed -e "s/\$tier\|alpha\|beta\|stable/${TIER}/g" -e "s/^# .*$//" $BASEDIR/scripts/watch.in > debian/watch
 
     version=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -)
     dirversion=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-url/text()" - | cut -d/ -f6)

--- a/linux/scripts/watch.in
+++ b/linux/scripts/watch.in
@@ -1,3 +1,3 @@
 version=4
-# Tier set by launchpad.sh script
+# Tier replaced by package-build.inc.sh script
 https://downloads.keyman.com/linux/$tier/@ANY_VERSION@/@PACKAGE@@ANY_VERSION@@ARCHIVE_EXT@ debian uupdate


### PR DESCRIPTION
This change switches the package version number for packages that are intended for the Debian package repo to match the Debian policies.

It also removes the comment from the watch file.