### PR TITLE
fix(android/samples): Fix Sentry dependencies

### DIFF
--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'io.sentry.android.gradle'
+}
 
 android {
     compileSdkVersion 29
@@ -40,5 +43,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'com.google.android.material:material:1.2.1'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:2.3.0'
+    implementation 'io.sentry:sentry-android:3.1.0'
 }

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'io.sentry:sentry-android:2.0.1'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'io.sentry.android.gradle'
+}
 
 android {
     compileSdkVersion 29
@@ -39,5 +42,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'com.google.android.material:material:1.2.1'
     api (name:'keyman-engine', ext:'aar')
-    implementation 'io.sentry:sentry-android:2.3.0'
+    implementation 'io.sentry:sentry-android:3.1.0'
 }

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'io.sentry:sentry-android:2.0.1'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'io.sentry.android.gradle'
+}
 
 ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
@@ -46,5 +49,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'com.google.android.material:material:1.2.1'
     api (name:'keyman-engine', ext:'aar')
-    implementation 'io.sentry:sentry-android:2.3.0'
+    implementation 'io.sentry:sentry-android:3.1.0'
 }

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'io.sentry:sentry-android:2.0.1'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The Sample apps were migrated from Crashlytics to Sentry in #2778

I don't know when it started happening, but a user tried to build the latest 14.0.222 beta KMSample2 project and got runtime exceptions
```
  Process: com.keyman.kmsample2, PID: 13914
     java.lang.NoClassDefFoundError: Failed resolution of:
Lio/sentry/Sentry;
```

It seems only KMSample1 and KMSample2 are affected.