### PR TITLE
fix(developer): disable TSentryClient on WINE

### DIFF
--- a/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -27,6 +27,7 @@ type
     procedure NestedValidateAccessViolation;
     procedure NestedValidateDelphiException;
     procedure NestedValidateFloatingPointException;
+    class function GetEnabled: Boolean; static;
   public
     destructor Destroy; override;
 
@@ -37,6 +38,7 @@ type
     class procedure Start(SentryClientClass: TSentryClientClass; AProject: TKeymanSentryClientProject; const ALogger: string; AFlags: TKeymanSentryClientFlags = [kscfCaptureExceptions, kscfShowUI, kscfTerminate]);
     class procedure Stop;
     class property Client: TSentryClient read FClient;
+    class property Enabled: Boolean read GetEnabled;
     class property Instance: TKeymanSentryClient read FInstance;
     class property OnBeforeShutdown: TNotifyEvent read FOnBeforeShutdown write FOnBeforeShutdown;
   public
@@ -186,6 +188,9 @@ class procedure TKeymanSentryClient.ReportHandledException(E: Exception;
 var
   text: string;
 begin
+  if not Enabled then
+    Exit;
+
   if Message <> ''
     then text := Message + ': '
     else text := '';
@@ -285,6 +290,9 @@ begin
   FProject := AProject;
   FFlags := AFlags;
 
+  if not Enabled then
+    Exit;
+
   sentry_set_library_path(FindSentryDLL);
 
   o.Debug := False;
@@ -346,6 +354,11 @@ begin
   inherited Destroy;
 end;
 
+class function TKeymanSentryClient.GetEnabled: Boolean;
+begin
+  Result := TSentryClient.Enabled;
+end;
+
 class procedure TKeymanSentryClient.Start(SentryClientClass: TSentryClientClass; AProject: TKeymanSentryClientProject; const ALogger: string; AFlags: TKeymanSentryClientFlags);
 begin
   TKeymanSentryClient.Create(SentryClientClass, AProject, ALogger, AFlags);
@@ -367,6 +380,9 @@ end;
 //
 class procedure TKeymanSentryClient.Validate(Force: Boolean);
 begin
+  if not Enabled then
+    Exit;
+
   TKeymanSentryClient.Instance.NestedValidate(Force);
 end;
 


### PR DESCRIPTION
Under WINE, on macOS at least, `TSentryClient` is crashing at startup, e.g. when calling `SymInitialise`. In order to have a working kmcomp.exe on macOS/Linux, we'll just disable Sentry altogether for now.

I have tested this succesfully on Catalina with version 4.1.2 of WINE. Version 5.0 and 5.7 continue to struggle with other crashes. We need to do more investigation to find out why later versions are crashing.

Furthermore, WINE by default still does not include wine32on64 which is needed for kmcomp.exe, so we should add kmcomp.x64.exe to the keyboards repository and use that instead (see corresponding fix keymanapp/keyboards#1439 which adds that as well as fixing the modification date calculation). I'll add kmcomp.x64.exe (and latest version of kmcomp.exe) in a separate PR on keyboards once this PR hits beta.