### PR TITLE
fix(web): OSK loading efficiency

### DIFF
--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -888,14 +888,10 @@ namespace com.keyman.osk {
      *
      *  @return {boolean}
      */
-    loadCookie() {
+    loadCookie(): void {
       let util = com.keyman.singleton.util;
 
       var c = util.loadCookie('KeymanWeb_OnScreenKeyboard');
-      if(typeof(c) == 'undefined' || c == null) {
-        this.userPositioned=false;
-        return false;
-      }
 
       this._Enabled = util.toNumber(c['visible'], 1) == 1;
       this.userPositioned = util.toNumber(c['userSet'], 0) == 1;
@@ -941,8 +937,6 @@ namespace com.keyman.osk {
       if(this.userPositioned && this._Box) {
         this.setPos({'left': this.x, 'top': this.y});
       }
-
-      return true;
     }
 
     private setSize(width?: number, height?: number, pending?: boolean) {

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -956,26 +956,6 @@ namespace com.keyman.osk {
       }
     }
 
-    getWidthFromCookie(): number {
-      let util = com.keyman.singleton.util;
-
-      var c = util.loadCookie('KeymanWeb_OnScreenKeyboard');
-      if(typeof(c) == 'undefined' || c == null) {
-        return screen.width * 0.3;
-      }
-
-      // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
-      var newWidth=util.toNumber(c['width'], 0.3 * screen.width); // Default - 30% of screen's width.
-
-      if(newWidth < 0.2*screen.width) {
-        newWidth = 0.2*screen.width;
-      } else if(newWidth > 0.9*screen.width) {
-        newWidth=0.9*screen.width;
-      }
-
-      return newWidth;
-    }
-
     /**
      * Get the wanted height of the banner (does not include the keyboard)
      *  @return   {number}    height in pixels

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -38,13 +38,16 @@ namespace com.keyman.osk {
 
     // OSK positioning fields
     userPositioned: boolean = false;
-    width: number;
-    height: number;
     x: number;
     y: number;
     noDrag: boolean = false;
     dfltX: string;
     dfltY: string;
+
+    // Fields used to store target OSK size when no keyboard has been loaded
+    // If a keyboard has been loaded, the VisualKeyboard values override these.
+    _baseWidth: number;
+    _baseHeight: number;
 
     // OSK resizing-event state fields
     resizing: boolean;
@@ -279,6 +282,22 @@ namespace com.keyman.osk {
 
       if(this._Enabled) {
         this._Show();
+      }
+    }
+
+    private get width(): number {
+      if(this.vkbd) {
+        return this.vkbd.width;
+      } else {
+        return this.width;
+      }
+    }
+
+    private get height(): number {
+      if(this.vkbd) {
+        return this.vkbd.height;
+      } else {
+        return this.height;
       }
     }
 
@@ -587,8 +606,7 @@ namespace com.keyman.osk {
       }
 
       var r=this.getRect();
-      this.width = r.width;
-      this.height = r.height;
+      this.setSize(r.width, r.height, true);
       e.cancelBubble = true;
       return false;
     }.bind(this);
@@ -791,8 +809,7 @@ namespace com.keyman.osk {
         }
 
         var r=this.getRect();
-        this.width=r.width;
-        this.height=r.height;
+        this.setSize(r.width, r.height, true);
         this.x = r.left;
         this.y = r.top;
         e.cancelBubble = true;
@@ -928,16 +945,14 @@ namespace com.keyman.osk {
       return true;
     }
 
-    private setSize(width?: number, height?: number) {
+    private setSize(width?: number, height?: number, pending?: boolean) {
       if(width && height) {
-        this.width = width;
-        this.height = height;
+        this._baseWidth = width;
+        this._baseHeight = height;
       }
 
       if(this.vkbd) {
-        this.vkbd.kbdDiv.style.width=this.width+'px';
-        this.vkbd.kbdDiv.style.height=this.height+'px';
-        this.vkbd.kbdDiv.style.fontSize=(this.height/8)+'px';
+        this.vkbd.setSize(width, height, pending);
       }
     }
 
@@ -1125,7 +1140,7 @@ namespace com.keyman.osk {
             w=0.9*screen.width;
           }
           ds.width=w+'px';
-          this.width=w;
+          this.setSize(w, this.height, true);
         }
 
         // Set height, but limit to reasonable value
@@ -1141,7 +1156,7 @@ namespace com.keyman.osk {
             h=0.5*screen.height;
           }
           ds.height=h+'px'; ds.fontSize=(h/8)+'px';
-          this.height=h;
+          this.setSize(this.width, h, true);
         }
 
         // Fix or release user resizing
@@ -1318,9 +1333,8 @@ namespace com.keyman.osk {
         }
         this._Enabled=true;
         this._Visible=true;
-        if(this.vkbd && this.vkbd.kbdDiv) {
-          this.width=this.vkbd.kbdDiv.offsetWidth;
-          this.height=this.vkbd.kbdDiv.offsetHeight;
+        if(this.vkbd) {
+          this.vkbd.refit();
         }
 
         this.saveCookie();
@@ -1365,9 +1379,8 @@ namespace com.keyman.osk {
       }
 
       // Save current size if visible
-      if(this._Box && this._Box.style.display == 'block' && this.vkbd && this.vkbd.kbdDiv) {
-        this.width = this.vkbd.kbdDiv.offsetWidth;
-        this.height = this.vkbd.kbdDiv.offsetHeight;
+      if(this._Box && this._Box.style.display == 'block' && this.vkbd) {
+        this.vkbd.refit();
       }
 
       if(hiddenByUser) {

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -289,7 +289,7 @@ namespace com.keyman.osk {
       if(this.vkbd) {
         return this.vkbd.width;
       } else {
-        return this.width;
+        return this._baseWidth;
       }
     }
 
@@ -297,7 +297,7 @@ namespace com.keyman.osk {
       if(this.vkbd) {
         return this.vkbd.height;
       } else {
-        return this.height;
+        return this._baseHeight;
       }
     }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -683,7 +683,8 @@ namespace com.keyman.osk {
       if(this._width) {
         return this._width;
       } else {
-        return this.loadSizeFromCookie().width;
+        this.loadSizeFromCookie();
+        return this.width;
       }
     }
 
@@ -691,41 +692,39 @@ namespace com.keyman.osk {
       if(this._height) {
         return this._height;
       } else {
-        return this.loadSizeFromCookie().height;
+        this.loadSizeFromCookie();
+        return this.height;
       }
     }
 
-    protected loadSizeFromCookie(): {width: number, height: number} {
+    protected loadSizeFromCookie() {
       let keyman = com.keyman.singleton;
       let util = keyman.util;
 
+      // If no prior cookie exists, it merely returns an empty object / cookie.
       var c = util.loadCookie('KeymanWeb_OnScreenKeyboard');
       var newWidth: number, newHeight: number;
-      if(typeof(c) == 'undefined' || c == null) {
-        newWidth = screen.width * 0.3;
-        newHeight = 144; // 16 * 8; 16 is our preferred default font size.
-      } else {
-        // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
-        newWidth=util.toNumber(c['width'], 0.3 * screen.width); // Default - 30% of screen's width.
 
-        if(newWidth < 0.2*screen.width) {
-          newWidth = 0.2*screen.width;
-        } else if(newWidth > 0.9*screen.width) {
-          newWidth=0.9*screen.width;
-        }
+      // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
+      newWidth=util.toNumber(c['width'], 0.333 * screen.width); // Default - 1/3rd of screen's width.
 
-        newHeight=util.toNumber(c['height'],0.15*screen.height);
+      if(newWidth < 0.2*screen.width) {
+        newWidth = 0.2*screen.width;
+      } else if(newWidth > 0.9*screen.width) {
+        newWidth=0.9*screen.width;
+      }
+  
+      // Default height decision made here: 
+      // https://github.com/keymanapp/keyman/pull/4279#discussion_r560453929
+      newHeight=util.toNumber(c['height'], 0.333 * newWidth);
 
-        if(newHeight > 0.5*screen.height) {
-          newHeight=0.5*screen.height;
-        }
+      if(newHeight < 0.15*screen.height) {
+        newHeight = 0.15 * screen.height;
+      } else if(newHeight > 0.5*screen.height) {
+        newHeight=0.5*screen.height;
       }
 
       this.setSize(newWidth, newHeight);
-      return {
-        width: newWidth,
-        height: newHeight
-      }
     }
 
     /**
@@ -735,10 +734,8 @@ namespace com.keyman.osk {
      * @param pending Set to `true` if called during a resizing interaction
      */
     public setSize(width: number, height: number, pending?: boolean) {
-      //if(width && height) {
       this._width = width;
       this._height = height;
-      //}
 
       if(!pending && this.kbdDiv) {
         this.kbdDiv.style.width=this._width+'px';

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -683,7 +683,7 @@ namespace com.keyman.osk {
       if(this._width) {
         return this._width;
       } else {
-        return this.setSizeFromCookie().width;
+        return this.loadSizeFromCookie().width;
       }
     }
 
@@ -691,11 +691,11 @@ namespace com.keyman.osk {
       if(this._height) {
         return this._height;
       } else {
-        return this.setSizeFromCookie().height;
+        return this.loadSizeFromCookie().height;
       }
     }
 
-    protected setSizeFromCookie(): {width: number, height: number} {
+    protected loadSizeFromCookie(): {width: number, height: number} {
       let keyman = com.keyman.singleton;
       let util = keyman.util;
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -578,6 +578,9 @@ namespace com.keyman.osk {
     kbdHelpDiv: HTMLDivElement;
     styleSheet: HTMLStyleElement;
 
+    width: number;
+    height: number;
+
     // Style-related properties
     fontFamily: string;
     fontSize: string;
@@ -677,6 +680,34 @@ namespace com.keyman.osk {
       } else {
         Lkbd.className = device.formFactor + ' kmw-osk-inner-frame';
       }
+    }
+
+    /**
+     * Sets & tracks the size of the VisualKeyboard's primary element.
+     * @param width 
+     * @param height 
+     * @param pending Set to `true` if called during a resizing interaction
+     */
+    public setSize(width: number, height: number, pending?: boolean) {
+      //if(width && height) {
+      this.width = width;
+      this.height = height;
+      //}
+
+      if(!pending) {
+        this.kbdDiv.style.width=this.width+'px';
+        this.kbdDiv.style.height=this.height+'px';
+        this.kbdDiv.style.fontSize=(this.height/8)+'px';
+      }
+    }
+
+    /**
+     * Called by OSKManager after resize operations in order to determine the final
+     * size actually used by the visual keyboard.
+     */
+    public refit() {
+      this.width=this.kbdDiv.offsetWidth;
+      this.height=this.kbdDiv.offsetHeight;
     }
 
     /**


### PR DESCRIPTION
Upon investigation of #4240, I noticed that a large amount of time was being spent constantly reloading OSK properties via KMW's web cookie.  This PR reworks those parts of the code, greatly reducing the amount of time spent cookie-parsing.

In terms of before-and-after feel, the OSK now loads much faster than before; I'd say the load time is halved at a minimum.

May also help mitigate https://github.com/keymanapp/keyman/issues/3294 a bit.  Definitely not a full fix, though.