### PR TITLE
fix(web): better font-wait null guards

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2590,14 +2590,14 @@ namespace com.keyman.osk {
       let keymanweb = com.keyman.singleton;
       let util = keymanweb.util;
 
-      if(typeof(kfd) == 'undefined' && typeof(ofd) == 'undefined') {
-        return true;
-      }
+      let fontDefined = !!(kfd && kfd['files']);
+      kfd = fontDefined ? kfd : undefined;
 
-      if(typeof(kfd['files']) == 'undefined' && typeof(ofd['files']) == 'undefined') {
-        return true;
-      }
+      let oskFontDefined = !!(ofd && ofd['files']);
+      ofd = oskFontDefined ? ofd : undefined;
 
+      // Automatically 'ready' if the descriptor is explicitly `undefined`.
+      // Thus, also covers the case where both are undefined.
       var kReady=util.checkFontDescriptor(kfd), oReady=util.checkFontDescriptor(ofd);
       if(kReady && oReady) {
         return true;


### PR DESCRIPTION
Fixes #4285.

While the explicit `fontDefined` and `oskFontDefined` variables are unnecessary, they do help with clarity when debugging.