### PR TITLE
fix(developer/compilers): fixes dependency versioning on alpha, beta tiers

### DIFF
--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -251,6 +251,10 @@ set_version ( ) {
 #   set_npm_version VERSION_WITH_TIER
 #
 set_npm_version () {
+  if [ $# == 0 ]; then
+    fail "set_npm_version requires a specified version."
+  fi
+  
   local version=$1
   # We use --no-git-tag-version because our CI system controls version numbering and
   # already tags releases. We also want to have the version of this match the

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -257,7 +257,10 @@ set_npm_version () {
   # release of Keyman Developer -- these two versions should be in sync. Because this
   # is a large repo with multiple projects and build systems, it's better for us that
   # individual build systems don't take too much ownership of git tagging. :)
-  npm --no-git-tag-version --allow-same-version version "$version" || fail "Could not set package version to $version."
+  pushd . > /dev/null
+  cd "${KEYMAN_ROOT}"
+  npm run version "$version"  || fail "Could not set package versions to $version."
+  popd > /dev/null
 }
 
 # Initializes use of the npm `lerna` package within the repo.


### PR DESCRIPTION
Fixes #4288.

This reworks the `set_npm_version` resource script function to affect _all_ packages in the repo, not just the currently-active one.  As the `@keymanapp/lexical-model-compiler` package is dependent upon the `@keymanapp/models-types` package, it's important that `beta` versions of the former link to the matching `beta` version of the latter.  Otherwise... well, #4288.