### PR TITLE
fix(android/app): Handle keyman protocol from external browser

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -38,7 +38,6 @@ import com.tavultesoft.kmea.util.KMPLink;
 
 import android.Manifest;
 import android.app.ProgressDialog;
-import android.content.ComponentName;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
@@ -256,13 +255,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     KMKeyboardDownloaderActivity.addKeyboardDownloadEventListener(this);
     PackageActivity.addKeyboardDownloadEventListener(this);
 
-    // Get calling activity
-    ComponentName component = this.getCallingActivity();
-    String caller = null;
-    if (component != null) {
-      caller = component.getClassName();
-    }
-
     Intent intent = getIntent();
     data = intent.getData();
 
@@ -285,10 +277,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
           downloadKMP(scheme);
           break;
         case "keyman" :
-          // Only accept download links from Keyman browser activities
-          if (KMPLink.isKeymanDownloadLink(data.toString()) && caller != null &&
-            (caller.equalsIgnoreCase("com.tavultesoft.kmea.KMPBrowserActivity") ||
-             caller.equalsIgnoreCase("com.tavultesoft.kmapro.WebBrowserActivity"))) {
+          // TODO: Only accept download links from Keyman browser activities when universal links work
+          if (KMPLink.isKeymanDownloadLink(data.toString())) {
 
             // Convert opaque URI to hierarchical URI so the query parameters can be parsed
             Builder builder = new Uri.Builder();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -288,6 +288,10 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
               .encodedQuery(data.getEncodedQuery());
             data = Uri.parse(builder.build().toString());
             downloadKMP(scheme);
+          } else if (KMPLink.isLegacyKeymanDownloadLink(data.toString())) {
+            link = data.toString();
+            data = KMPLink.getLegacyKeyboardDownloadLink(link);
+            downloadKMP(scheme);
           } else {
             String msg = "Unrecognized scheme: " + scheme;
             KMLog.LogError(TAG, msg);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
@@ -36,7 +36,7 @@ public final class KMPLink {
   private static final Pattern downloadPattern = Pattern.compile(downloadPatternFormatStr);
 
   private static final String LEGACY_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR = "^keyman://localhost/open\\?(.+)?$";
-  private static final Pattern legacyDownloadPattermPattern = Pattern.compile(LEGACY_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR);
+  private static final Pattern legacyDownloadPattern = Pattern.compile(LEGACY_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR);
 
   // Keyman 14.0+ generated URL for keyboard download links
   private static final String KMP_DOWNLOAD_KEYBOARDS_FORMATSTR = "https://%s/go/package/download/%s";
@@ -87,7 +87,7 @@ public final class KMPLink {
     if (url == null || url.isEmpty()) {
       return status;
     }
-    Matcher legacyMatcher = legacyDownloadPattermPattern.matcher(url);
+    Matcher legacyMatcher = legacyDownloadPattern.matcher(url);
     if (legacyMatcher.matches() && legacyMatcher.group(1) != null) {
       Uri data = Uri.parse(url);
       String keyboard = data.getQueryParameter("keyboard");
@@ -171,7 +171,7 @@ public final class KMPLink {
       return uri;
     }
 
-    Matcher matcher = legacyDownloadPattermPattern.matcher(url);
+    Matcher matcher = legacyDownloadPattern.matcher(url);
     // Validate deep link with package ID and optional bcp47 tag
     if (matcher.matches() && matcher.group(1) != null) {
       Uri installUri = Uri.parse(url);


### PR DESCRIPTION
Fixes #4247 and reverts some of a0d1cb0307891fa469064a62228f6450773263c0

* This updates the app to handle `keyman://` links from the internal and external (Chrome) browser.
* This involves converting the legacy `keyman://localhost` link to a kmp install link.

## User Testing
Follow the steps from the reported issue:

> Attempting to install the Keyman Amharic keyboard does not work from https://keyman.com/amharic or https://keyman-staging.com/amharic

> To Reproduce
>
>Go to either url above
>Click on 'Download for Android'
>Select 'Yes - Install Keyboard'

- [ ] Verify Keyman for Android downloads and installs the keyboard package.

