### PR TITLE
fix(developer/compilers): fixes developer build breakage from #4291

### DIFF
--- a/windows/src/test/unit-tests/Makefile
+++ b/windows/src/test/unit-tests/Makefile
@@ -34,12 +34,6 @@ lexical-model-compiler:
     start /wait ./build.sh -test
 !endif
 
-# Revert any local changes to the original source; these changes can break
-# later sub-builds.
-    cd $(KEYMAN_ROOT)\developer\js
-		git restore package.json
-		git restore package-lock.json
-
 kmcomp-x64-structures:
 	cd $(ROOT)\src\test\unit-tests\group-helper-rsp19902
 	$(MAKE) $(TARGET)


### PR DESCRIPTION
Took quite a bit of digging, but I finally found the culprit.  Turns out, the big change from #4291 is actually a better solution to a problem addressed within https://github.com/keymanapp/keyman/pull/3836#issuecomment-727717729.  Unfortunately... the two solutions conflict with each other.  This is the "better solution" that [this comment](https://github.com/keymanapp/keyman/pull/3836#issuecomment-727791848) on the same PR was looking for:

> Wouldn't it be better to locate and fix the root cause of the version variance so that the version information being used is the same in all circumstances?

Now that _all_ in-repo packages are given identical versioning shifts during a Developer build, nothing breaks so long as those versions are kept consistent... which means no more package.json resetting after kmlmc unit tests.