### PR TITLE
fix(web): toolbar and loading optimisations

### DIFF
--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -12,9 +12,9 @@ namespace com.keyman.keyboards {
     }
 
     toString(): string {
-      var kbid=this.id; 
-      var lgid=''; 
-      var kvid='';  
+      var kbid=this.id;
+      var lgid='';
+      var kvid='';
 
       if(this.language) {
         kbid=kbid+'@'+this.language;
@@ -27,7 +27,7 @@ namespace com.keyman.keyboards {
         }
       }
 
-      //TODO: add specifier validation... 
+      //TODO: add specifier validation...
 
       return kbid;
     }
@@ -74,7 +74,7 @@ namespace com.keyman.keyboards {
 
   export interface KeyboardChangeData {
     ['internalName']: string;
-    ['languageCode']: string; 
+    ['languageCode']: string;
     ['indirect']: boolean;
   }
 
@@ -92,13 +92,13 @@ namespace com.keyman.keyboards {
     deferredKRS = [];          // Array of pending keyboard stubs from KRS, to register after initialization
     deferredKR = [];           // Array of pending keyboards, to be installed at end of initialization
 
-    // The following was not actually utilized within KeymanWeb; I think it's handled via different logic.  
+    // The following was not actually utilized within KeymanWeb; I think it's handled via different logic.
     // See setDefaultKeyboard() below.
     dfltStub = null;           // First keyboard stub loaded - default for touch-screen devices, ignored on desktops
 
     keyboards: any[] = [];
 
-    
+
     languageList: any[] = null; // List of keyboard languages available for KeymanCloud
     languagesPending: any[] = [];     // Array of languages waiting to be registered
 
@@ -122,18 +122,18 @@ namespace com.keyman.keyboards {
         return this.activeStub['KLC'];
       }
     }
-        
+
     /**
      * Get an associative array of keyboard identification strings
-     *   This was defined as an array, so is kept that way, but  
-     *   Javascript treats it as an object anyway 
-     *    
+     *   This was defined as an array, so is kept that way, but
+     *   Javascript treats it as an object anyway
+     *
      * @param       {Object}    Lkbd       Keyboard object
      * @return      {Object}               Copy of keyboard identification strings
-     * 
-     */    
+     *
+     */
     private _GetKeyboardDetail = function(Lkbd) { // I2078 - Full keyboard detail
-      var Lr={};  
+      var Lr={};
       Lr['Name'] = Lkbd['KN'];
       Lr['InternalName'] =  Lkbd['KI'];
       Lr['LanguageName'] = Lkbd['KL'];  // I1300 - Add support for language names
@@ -144,32 +144,32 @@ namespace com.keyman.keyboards {
       Lr['CountryCode'] = Lkbd['KCC'];
       Lr['KeyboardID'] = Lkbd['KD'];
       Lr['Font'] = Lkbd['KFont'];
-      Lr['OskFont'] = Lkbd['KOskFont'];  
+      Lr['OskFont'] = Lkbd['KOskFont'];
       return Lr;
     }
 
     /**
-     * Get array of available keyboard stubs 
-     * 
+     * Get array of available keyboard stubs
+     *
      * @return   {Array}     Array of available keyboards
-     * 
-     */    
+     *
+     */
     getDetailedKeyboards() {
       var Lr = [], Ln, Lstub, Lrn;
 
       for(Ln=0; Ln < this.keyboardStubs.length; Ln++)  // I1511 - array prototype extended
-      {    
+      {
         Lstub = this.keyboardStubs[Ln];
         Lrn = this._GetKeyboardDetail(Lstub);  // I2078 - Full keyboard detail
         Lr=this.keymanweb._push(Lr,Lrn); // TODO:  Resolve without need for the cast.
-      } 
+      }
       return Lr;
     }
 
     registerDeferredStubs() {
       this.addKeyboardArray(this.deferredStubs);
-        
-      // KRS stubs (legacy format registration)    
+
+      // KRS stubs (legacy format registration)
       for(var j=0; j<this.deferredKRS.length; j++) {
         this._registerStub(this.deferredKRS[j]);
       }
@@ -182,11 +182,11 @@ namespace com.keyman.keyboards {
     }
 
     /**
-     * Register a fully specified keyboard (add meta-data for each language) immediately 
-     * 
+     * Register a fully specified keyboard (add meta-data for each language) immediately
+     *
      * @param  {Object}  arg
-     * @returns {boolean}   
-     **/              
+     * @returns {boolean}
+     **/
     addStub(arg: any): boolean {
       if(typeof(arg['id']) != 'string') {
         return false;
@@ -200,7 +200,7 @@ namespace com.keyman.keyboards {
       if(typeof(arg['languages']) == 'undefined') {
         return false;
       }
-      
+
       // Default the keyboard name to its id, capitalized
       if(typeof(arg['name']) != 'string') {
         arg['name'] = arg['id'].replace('_',' ');
@@ -230,9 +230,9 @@ namespace com.keyman.keyboards {
 
     /**
      *  Create or update a keyboard meta-data 'stub' during keyboard registration
-     * 
+     *
      *  Cross-reference with https://help.keyman.com/developer/engine/web/11.0/reference/core/addKeyboards.
-     *  
+     *
      *  @param  {Object}  kp  (partial) keyboard meta-data object (`spec` object)
      *  @param  {Object}  lp  language object (`spec.languages` object)
      *  @param  {Object}  options   KeymanCloud callback options
@@ -279,11 +279,11 @@ namespace com.keyman.keyboards {
         if(!rx.test(sp['KF'])) {
           sp['KF'] = options['keyboardBaseUri']+sp['KF'];
         }
-      } 
-      
+      }
+
       // Font path defined by cloud entry
       var fontPath=options['fontBaseUri'];
-      
+
       // or overridden locally, in page source
       if(this.keymanweb.options['fonts'] != '') {
         fontPath=this.keymanweb.options['fonts'];
@@ -301,7 +301,7 @@ namespace com.keyman.keyboards {
       else {
         this.keymanweb.options.fonts=fontPath;
       }
-      
+
       // Add font specifiers where necessary and not overridden by user
       if(typeof(lp['font']) != 'undefined') {
         sp['KFont'] = (typeof sp['KFont'] === 'undefined') ? new KeyboardFont(lp['font'], fontPath) : sp['KFont'];
@@ -310,15 +310,15 @@ namespace com.keyman.keyboards {
       // Fixed OSK font issue Github #7 (9/1/2015)
       if(typeof(lp['oskFont']) != 'undefined') {
         sp['KOskFont'] = (typeof sp['KOskFont'] === 'undefined') ? new KeyboardFont(lp['oskFont'], fontPath) : sp['KOskFont'];
-      }           
+      }
 
-      // Update the UI 
+      // Update the UI
       this.doKeyboardRegistered(sp['KI'],sp['KL'],sp['KN'],sp['KLC'],sp['KP']);
 
       // If we have no activeStub because there were no stubs, set the new keyboard as active.
       // Do not trigger on merges.
-      if(!this.activeStub && isNew && this.keyboardStubs.length == 1) {
-        // #676: We call _SetActiveKeyboard so we can avoid overwriting 
+      if(!this.activeStub && isNew && this.keyboardStubs.length == 1 && this.keymanweb.options['setActiveOnRegister']=='true') {
+        // #676: We call _SetActiveKeyboard so we can avoid overwriting
         // cookies that determine our active keyboard at page load time
         this.doBeforeKeyboardChange(sp['KI'], sp['KLC']);
         this._SetActiveKeyboard(sp['KI'], sp['KLC'], false);
@@ -328,11 +328,11 @@ namespace com.keyman.keyboards {
 
     /**
      *  Find a keyboard stub by id in the registered keyboards list
-     *  
+     *
      *  @param  {string}  kid   internal keyboard id (without 'Keyboard_' prefix)
      *  @param  {string}  lgid  language code
-     *  
-     **/                 
+     *
+     **/
     findStub(kid: string, lgid: string): KeyboardStub {
       var i;
       for(i=0; i<this.keyboardStubs.length; i++) {
@@ -357,22 +357,22 @@ namespace com.keyman.keyboards {
 
     /**
      * Allow to change active keyboard by (internal) keyboard name
-     * 
+     *
      * @param       {string}    PInternalName   Internal name
      * @param       {string}    PLgCode         Language code
-     */    
+     */
     setActiveKeyboard(PInternalName: string, PLgCode: string): Promise<void> {
       //TODO: This does not make sense: the callbacks should be in _SetActiveKeyboard, not here,
       //      since this is always called FROM the UI, which should not need notification.
-      //      If UI callbacks are needed at all, they should be within _SetActiveKeyboard 
+      //      If UI callbacks are needed at all, they should be within _SetActiveKeyboard
 
       // Skip on embedded which namespaces packageID::Keyboard_keyboardID
       if(!this.keymanweb.isEmbedded && PInternalName && PInternalName.indexOf("Keyboard_") != 0) {
         PInternalName = "Keyboard_" + PInternalName;
       }
 
-      this.doBeforeKeyboardChange(PInternalName,PLgCode);     
-      let p: Promise<void> = this._SetActiveKeyboard(PInternalName,PLgCode,true);    
+      this.doBeforeKeyboardChange(PInternalName,PLgCode);
+      let p: Promise<void> = this._SetActiveKeyboard(PInternalName,PLgCode,true);
       if(this.keymanweb.domManager.getLastActiveElement() != null) {
         this.keymanweb.domManager.focusLastActiveElement(); // TODO:  Resolve without need for the cast.
       }
@@ -393,22 +393,22 @@ namespace com.keyman.keyboards {
 
       return p;
     }
-    
+
     /**
      * Change active keyboard to keyboard selected by (internal) name and language code
-     * 
+     *
      *  Test if selected keyboard already loaded, and simply update active stub if so.
      *  Otherwise, insert a script to download and insert the keyboard from the repository
-     *  or user-indicated file location. 
-     * 
+     *  or user-indicated file location.
+     *
      * Note that the test-case oriented 'recorder' stubs this method to provide active
      * keyboard stub information.  If changing this function, please ensure the recorder is
      * not affected.
-     * 
+     *
      * @param       {string}    PInternalName
      * @param       {string=}    PLgCode
-     * @param       {boolean=}   saveCookie   
-     */    
+     * @param       {boolean=}   saveCookie
+     */
     _SetActiveKeyboard(PInternalName: string, PLgCode?: string, saveCookie?: boolean): Promise<void> {
       var n, Ln;
 
@@ -421,7 +421,7 @@ namespace com.keyman.keyboards {
 
       // Set default language code
       if(arguments.length < 2 || (!PLgCode)) {
-        PLgCode='---'; 
+        PLgCode='---';
       }
 
       // Check that the saved keyboard is currently registered
@@ -435,7 +435,7 @@ namespace com.keyman.keyboards {
       if(util.device.touchable && (PInternalName == '' || PInternalName == null || n >= this.keyboardStubs.length)) {
         if(this.keyboardStubs.length != 0) {
           PInternalName=this.keyboardStubs[0]['KI'];
-          PLgCode=this.keyboardStubs[0]['KLC'];   
+          PLgCode=this.keyboardStubs[0]['KLC'];
         }
       }
 
@@ -445,23 +445,23 @@ namespace com.keyman.keyboards {
       }
 
       // Check if requested keyboard and stub are currently active
-      if(this.activeStub && activeKeyboard && activeKeyboard.id == PInternalName 
+      if(this.activeStub && activeKeyboard && activeKeyboard.id == PInternalName
         && this.activeStub['KI'] == PInternalName     //this part of test should not be necessary, but keep anyway
-        && this.activeStub['KLC'] == PLgCode && !this.keymanweb.mustReloadKeyboard                                 
-        ) return Promise.resolve();   
+        && this.activeStub['KLC'] == PLgCode && !this.keymanweb.mustReloadKeyboard
+        ) return Promise.resolve();
 
       // Check if current keyboard matches requested keyboard, but not stub
       if(activeKeyboard && (activeKeyboard.id == PInternalName)) {
         // If so, simply update the active stub
         for(Ln=0; Ln<this.keyboardStubs.length; Ln++) {
-          if((this.keyboardStubs[Ln]['KI'] == PInternalName) 
+          if((this.keyboardStubs[Ln]['KI'] == PInternalName)
             && (this.keyboardStubs[Ln]['KLC'] == PLgCode)) {
-            this.activeStub = this.keyboardStubs[Ln]; 
-            
-            // Append a stylesheet for this keyboard for keyboard specific styles 
+            this.activeStub = this.keyboardStubs[Ln];
+
+            // Append a stylesheet for this keyboard for keyboard specific styles
             // or if needed to specify an embedded font
             osk.vkbd.appendStyleSheet();
-            
+
             // Re-initializate OSK before returning if required
             if(this.keymanweb.mustReloadKeyboard) {
               activeKeyboard.refreshLayouts();
@@ -477,7 +477,7 @@ namespace com.keyman.keyboards {
 
       // Hide OSK and do not update keyboard list if using internal keyboard (desktops)
       if(PInternalName == '') {
-        osk._Hide(false); 
+        osk._Hide(false);
 
         if(!this.keymanweb.isEmbedded) {
           util.wait(false);
@@ -494,12 +494,12 @@ namespace com.keyman.keyboards {
           // we should refresh its layouts.
           keyman.core.activeKeyboard.refreshLayouts();
           this.keymanweb.domManager._SetTargDir(this.keymanweb.domManager.getLastActiveElement());  // I2077 - LTR/RTL timing
-        
+
           // and update the active stub
           for(var Ls=0; Ls<this.keyboardStubs.length; Ls++) {
-            if((this.keyboardStubs[Ls]['KI'] == PInternalName) && 
+            if((this.keyboardStubs[Ls]['KI'] == PInternalName) &&
               (this.keyboardStubs[Ls]['KLC'] == PLgCode || PLgCode == '---')) {
-              this.activeStub = this.keyboardStubs[Ls]; 
+              this.activeStub = this.keyboardStubs[Ls];
               break;
             }
           }
@@ -510,18 +510,18 @@ namespace com.keyman.keyboards {
       // If we've reached this point, this is the first load request for the requested keyboard.
       if(keyman.core.activeKeyboard == null) {
         for(Ln=0; Ln<this.keyboardStubs.length; Ln++) { // I1511 - array prototype extended
-          if((this.keyboardStubs[Ln]['KI'] == PInternalName) 
+          if((this.keyboardStubs[Ln]['KI'] == PInternalName)
             && ((this.keyboardStubs[Ln]['KLC'] == PLgCode) || (PLgCode == '---'))) {
             // Force OSK display for CJK keyboards (keyboards using a pick list)
             if(this.isCJK(this.keyboardStubs[Ln]) || util.device.touchable) {
               osk._Enabled = true;
             }
 
-            // Create a script to load from the server - when it finishes loading, it will register itself, 
+            // Create a script to load from the server - when it finishes loading, it will register itself,
             //  detect that it is active, and focus as appropriate. The second test is needed to allow recovery from a failed script load
 
             // Ensure we're not already loading the keyboard.
-            if(!this.keyboardStubs[Ln].asyncLoader) {   
+            if(!this.keyboardStubs[Ln].asyncLoader) {
               // Always (temporarily) hide the OSK when loading a new keyboard, to ensure that a failure to load doesn't leave the current OSK displayed
               if(osk.ready) {
                 osk._Hide(false);
@@ -538,8 +538,8 @@ namespace com.keyman.keyboards {
               // Setup our default error-messaging callback if it should be implemented.
               loadingStub.asyncLoader.callback = function(altString, msgType) {
                 var msg = altString || 'Sorry, the '+kbdName+' keyboard for '+lngName+' is not currently available.';
-                
-                // Thanks, Closure errors.  
+
+                // Thanks, Closure errors.
                 if(!this.keymanweb.isEmbedded) {
                   util.wait(false);
                   util.alert(altString || msg, function() {
@@ -565,11 +565,11 @@ namespace com.keyman.keyboards {
 
               loadingStub.asyncLoader.timer = window.setTimeout(loadingStub.asyncLoader.callback, 10000);
 
-              //Display the loading delay bar (Note: only append 'keyboard' if not included in name.) 
+              //Display the loading delay bar (Note: only append 'keyboard' if not included in name.)
               if(!this.keymanweb.isEmbedded) {
                 util.wait('Installing keyboard<br/>' + kbdName);
               }
-              
+
               // Installing the script immediately does not work reliably if two keyboards are
               // loaded in succession if there is any delay in downloading the script.
               // It works much more reliably if deferred (KMEW-101, build 356)
@@ -592,7 +592,7 @@ namespace com.keyman.keyboards {
       if(Pk !== null)  // I3363 (Build 301)
         Pk = Pk.scriptObject;
         String.kmwEnableSupplementaryPlane(Pk && ((Pk['KS'] && (Pk['KS'] == 1)) || (Pk['KN'] == 'Hieroglyphic'))); // I3319
-      
+
       // Initialize the OSK (provided that the base code has been loaded)
       osk._Load();
       return Promise.resolve();
@@ -601,10 +601,10 @@ namespace com.keyman.keyboards {
     /**
      * Install a keyboard script that has been downloaded from a keyboard server
      * Operates as the core of a Promise, hence the 'resolve' and 'reject' parameters.
-     * 
+     *
      *  @param  {Object}  kbdStub   keyboard stub to be loaded.
-     *    
-     **/      
+     *
+     **/
     installKeyboard(resolve: () => void, reject: () => void, kbdStub: KeyboardStub) {
       var util = this.keymanweb.util;
       var osk = this.keymanweb.osk;
@@ -640,7 +640,7 @@ namespace com.keyman.keyboards {
         reject();
       }, false);
 
-      
+
       // The load event will activate a newly-loaded keyboard if successful and report an error if it is not.
       Lscript.addEventListener('load', function() {
         if(kbdStub.asyncLoader.timer !== null) {
@@ -653,7 +653,7 @@ namespace com.keyman.keyboards {
         // Test if keyboard already loaded
         var kbd = manager.getKeyboardByID(kbdStub['KI']), Li;
         if(kbd) {  // Is cleared upon a successful load.
-          
+
           //Activate keyboard, if it's still the active stub.
           if(kbdStub == manager.activeStub) {
             manager.doBeforeKeyboardChange(kbd['KI'],kbdStub['KLC']);
@@ -666,22 +666,22 @@ namespace com.keyman.keyboards {
 
             String.kmwEnableSupplementaryPlane(kbd && ((kbd['KS'] && kbd['KS'] == 1) || kbd['KN'] == 'Hieroglyphic')); // I3319 - SMP extension, I3363 (Build 301)
             manager.saveCurrentKeyboard(kbd['KI'], kbdStub['KLC']);
-          
+
             // Prepare and show the OSK for this keyboard
             osk._Load();
-          } 
-  
+          }
+
           // Remove the wait message, if defined
           if(!manager.keymanweb.isEmbedded) {
             util.wait(false);
           }
 
-          kbdStub.asyncLoader = null; 
+          kbdStub.asyncLoader = null;
           resolve();
           // A handler portion for cases where the new <script> block loads, but fails to process.
         } else {  // Output error messages even when embedded - they're useful when debugging the apps and KMEA/KMEI engines.
           kbdStub.asyncLoader.callback('Error registering the ' + kbdName + ' keyboard for ' + kbdLang + '.', 'error');
-          kbdStub.asyncLoader = null; 
+          kbdStub.asyncLoader = null;
           reject();
         }
       }, false);
@@ -700,18 +700,18 @@ namespace com.keyman.keyboards {
         } catch(ex2) {
           reject();
         }
-      }            
+      }
     }
 
-    /* TODO: why not use util.loadCookie and saveCookie?? */  
-    
+    /* TODO: why not use util.loadCookie and saveCookie?? */
+
     /**
      * Function     saveCurrentKeyboard
      * Scope        Private
      * @param       {string}    PInternalName       name of keyboard
-     * @param       {string}    PLgCode             language code   
+     * @param       {string}    PLgCode             language code
      * Description Saves current keyboard as a cookie
-     */    
+     */
     private saveCurrentKeyboard(PInternalName: string, PLgCode: string) {
       var s = "current="+PInternalName+":"+PLgCode;
       this.keymanweb.util.saveCookie('KeymanWeb_Keyboard',{'current':PInternalName+':'+PLgCode});
@@ -726,7 +726,7 @@ namespace com.keyman.keyboards {
 
     /**
      * Restore the most recently used keyboard, if still available
-     */    
+     */
     restoreCurrentKeyboard() {
       var stubs = this.keyboardStubs, i, n=stubs.length;
       let core = com.keyman.singleton.core;
@@ -735,11 +735,11 @@ namespace com.keyman.keyboards {
       if(stubs.length < 1) return;
 
       // If no saved keyboard, default to US English, else first loaded stub
-      var d=this.getSavedKeyboard();            
-      var t=d.split(':'); 
+      var d=this.getSavedKeyboard();
+      var t=d.split(':');
 
       // Identify the stub with the saved keyboard
-      t=d.split(':'); 
+      t=d.split(':');
       if(t.length < 2) t[1]='';
 
       // This loop is needed to select the correct stub when several apply to a given keyboard
@@ -748,7 +748,7 @@ namespace com.keyman.keyboards {
       {
         if(stubs[i]['KI'] == t[0] && (stubs[i]['KLC'] == t[1] || t[1] == '')) break;
       }
-    
+
       // Sets the default stub (as specified with the `getSavedKeyboard` call) as active.
       // if((i < n) || (device.touchable && (this.activeKeyboard == null)))
       if((i < n) || (core.activeKeyboard == null))
@@ -763,18 +763,18 @@ namespace com.keyman.keyboards {
 
     /**
      * Gets the cookie for the name and language code of the most recently active keyboard
-     * 
-     *  Defaults to US English, but this needs to be user-set in later revision (TODO)      
-     * 
-     * @return      {string}          InternalName:LanguageCode 
-     **/    
-    getSavedKeyboard(): string {  
+     *
+     *  Defaults to US English, but this needs to be user-set in later revision (TODO)
+     *
+     * @return      {string}          InternalName:LanguageCode
+     **/
+    getSavedKeyboard(): string {
       var v = this.keymanweb.util.loadCookie('KeymanWeb_Keyboard');
-      
+
       if(typeof(v['current']) != 'string') {
         return 'Keyboard_us:eng';
       }
-      
+
       // Check that the requested keyboard is included in the available keyboard stubs
       var n, stubs = this.keyboardStubs,kd;
 
@@ -788,12 +788,12 @@ namespace com.keyman.keyboards {
         kd=stubs[n]['KI']+':'+stubs[n]['KLC'];
         if(kd == 'Keyboard_us:eng') return kd;
       }
-      
+
       // Otherwise use the first keyboard stub
       if(stubs.length > 0) {
         return stubs[0]['KI']+':'+stubs[0]['KLC'];
       }
-      
+
       // Or US English if no stubs loaded (should never happen)
       return 'Keyboard_us:eng';
     }
@@ -801,11 +801,11 @@ namespace com.keyman.keyboards {
     /**
      * Function    isCJK
      * Scope       Public
-     * @param      {Object=}  k0 
+     * @param      {Object=}  k0
      * @return     {boolean}
      * Description Tests if the keyboard stub uses a pick list (Chinese, Japanese, Korean, etc.)
-     *             (This function accepts either keyboard structure.)   
-     */    
+     *             (This function accepts either keyboard structure.)
+     */
     isCJK(k: KeyboardStub) { // I3363 (Build 301)
       var lg: string;
       if(typeof(k['KLC']) != 'undefined') {
@@ -813,7 +813,7 @@ namespace com.keyman.keyboards {
       } else if(typeof(k['LanguageCode']) != 'undefined') {
         lg = k['LanguageCode'];
       }
-      
+
       return ((lg == 'cmn') || (lg == 'jpn') || (lg == 'kor'));
     }
 
@@ -837,7 +837,7 @@ namespace com.keyman.keyboards {
 
     /* ------------------------------------------------------------
     *  Definitions for adding, removing, and requesting keyboards.
-    *  ------------------------------------------------------------ 
+    *  ------------------------------------------------------------
     */
 
     /**
@@ -864,10 +864,10 @@ namespace com.keyman.keyboards {
 
     /**
      * Build 362: addKeyboardArray() link to Cloud. One or more arguments may be used
-     * 
+     *
      * @param {string|Object} x keyboard name string or keyboard metadata JSON object
-     * 
-     */  
+     *
+     */
     addKeyboardArray(x: any[] | IArguments): void {
       // Store all keyboard meta-data for registering later if called before initialization
       if(!this.keymanweb.initialized) {
@@ -881,7 +881,7 @@ namespace com.keyman.keyboards {
       if(x.length == 0) {
         return;
       }
-    
+
       // Create a temporary array of metadata objects from the arguments used
       var i,j,kp,kbid,lgid,kvid,cmd='',comma='';
       var cloudList: CloudRequestEntry[] = [];
@@ -923,7 +923,7 @@ namespace com.keyman.keyboards {
           // - no request will be sent to cloud
           var stub: KeyboardStub = <KeyboardStub> x[i];
 
-          if(typeof(x[i]['filename']) == 'string') {                                                   
+          if(typeof(x[i]['filename']) == 'string') {
             if(!this.addStub(x[i])) {
               alert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
             }
@@ -934,7 +934,7 @@ namespace com.keyman.keyboards {
             }
 
             lList=x[i]['languages'];
-                
+
             //Array or single entry?
             if(typeof(lList.length) == 'number') {
               for(j=0; j<lList.length; j++) {
@@ -952,7 +952,7 @@ namespace com.keyman.keyboards {
           }
         }
       }
-      
+
       // Return if all keyboards being registered are local and fully specified
       if(cloudList.length == 0) {
         return;
@@ -960,31 +960,31 @@ namespace com.keyman.keyboards {
 
       // Update the keyboard metadata list from keyman.com - build the command
       cmd='&keyboardid=';
-      for(i=0; i<cloudList.length; i++) {      
+      for(i=0; i<cloudList.length; i++) {
         cmd=cmd+comma+cloudList[i].toString();
         comma=',';
-      }  
-      
+      }
+
       // Request keyboard metadata from the Keyman Cloud keyboard metadata server
       this.keymanCloudRequest(cmd,false);
     }
 
-    /** 
+    /**
      *  Register a keyboard for each associated language
-     *  
-     *  @param  {Object}  kp  Keyboard Object or Object array      
+     *
+     *  @param  {Object}  kp  Keyboard Object or Object array
      *  @param  {Object}  options   keymanCloud callback options
-     *  @param  {number}  nArg  keyboard index in argument array   
-     *       
-     **/   
+     *  @param  {number}  nArg  keyboard index in argument array
+     *
+     **/
     registerLanguagesForKeyboard(kp, options, nArg:number) {
       var i,j,id,nDflt=0,kbId='';
-      
+
       // Do not attempt to process badly formatted requests
       if(typeof(kp) == 'undefined') {
         return;
       }
-      
+
       if(typeof(options['keyboardid']) == 'string') {
         kbId = options['keyboardid'].split(',')[nArg];
       }
@@ -992,13 +992,13 @@ namespace com.keyman.keyboards {
       // When keyboards requested by language code, several keyboards may be returned as an array
       if(typeof(kp.length) == 'number') {
         // If language code is suffixed by $, register all keyboards for this language
-        if(kp.length == 1 || kbId.substr(-1,1) == '$' || kbId == '') {      
+        if(kp.length == 1 || kbId.substr(-1,1) == '$' || kbId == '') {
           for(i=0; i<kp.length; i++) {
             this.registerLanguagesForKeyboard(kp[i],options,nArg);
           }
         }
         // Register the default keyboard for the language code
-        // Until a default is defined, the default will be the Windows keyboard, 
+        // Until a default is defined, the default will be the Windows keyboard,
         // that is, the keyboard named for the language (exception: English:US), or the
         // first keyboard found.
         else {
@@ -1013,18 +1013,18 @@ namespace com.keyman.keyboards {
                 nDflt = i;
                 break;
               }
-            }          
+            }
           }
 
           this.registerLanguagesForKeyboard(kp[nDflt],options,nArg);
         }
-      } else { // Otherwise, process a single keyboard for the specified languages 
+      } else { // Otherwise, process a single keyboard for the specified languages
         // May need to filter returned stubs by language
         var lgCode=kbId.split('@')[1];
         if(typeof(lgCode) == 'string') {
           lgCode=lgCode.replace(/\$$/,'');
         }
-        
+
         // Can only add keyboard stubs for defined languages
         var ll=kp['languages'];
         if(typeof(ll) != 'undefined') {
@@ -1038,22 +1038,22 @@ namespace com.keyman.keyboards {
             this.mergeStub(kp,ll,options);
           }
         }
-      }                              
+      }
     }
 
     /**
      * Call back from cloud for adding keyboard metadata
-     * 
+     *
      * @param {Object}    x   metadata object
-     **/                  
+     **/
     register(x) {
       var options=x['options'];
-    
+
       // Always clear the timer associated with this callback
       if(x['timerid']) {
         window.clearTimeout(x['timerid']);
       }
-      
+
       // Indicate if unable to register keyboard
       if(typeof(x['error']) == 'string') {
         var badName='';
@@ -1064,7 +1064,7 @@ namespace com.keyman.keyboards {
         this.serverUnavailable(badName+' keyboard not found.');
         return;
       }
-      
+
       // Ignore callback unless the context is defined
       if(typeof(options) == 'undefined' || typeof(options['context']) == 'undefined') {
         return;
@@ -1086,20 +1086,20 @@ namespace com.keyman.keyboards {
         if(this.languagesPending) {
           this.addLanguageKeyboards(this.languagesPending);
         }
-        this.languagesPending = [];      
+        this.languagesPending = [];
       }
     }
 
     /**
      *  Add default or all keyboards for a given language
-     *  
+     *
      *  @param  {Object}   languages    Array of language names
-     **/           
+     **/
     addLanguageKeyboards(languages) {
       var i, j, lgName, cmd, first, addAll;
-      
+
       // Defer registering keyboards by language until the language list has been loaded
-      if(this.languageList == null) {                       
+      if(this.languageList == null) {
         first = (this.languagesPending.length == 0);
 
         for(i=0; i<languages.length; i++) {
@@ -1108,12 +1108,12 @@ namespace com.keyman.keyboards {
 
         if(first) {
           this.keymanCloudRequest('',true);
-        }   
+        }
       } else { // Identify and register each keyboard by language name
         cmd = '';
         for(i=0; i<languages.length; i++) {
           lgName = languages[i].toLowerCase();
-          addAll = (lgName.substr(-1,1) == '$'); 
+          addAll = (lgName.substr(-1,1) == '$');
           if(addAll) {
             lgName = lgName.substr(0,lgName.length-1);
           }
@@ -1145,43 +1145,43 @@ namespace com.keyman.keyboards {
 
     /**
      *  Request keyboard metadata from the Keyman Cloud keyboard metadata server
-     *   
+     *
      *  @param  {string}   cmd        command string
-     *  @param  {boolean?} byLanguage if true, context=languages, else context=keyboards 
+     *  @param  {boolean?} byLanguage if true, context=languages, else context=keyboards
      **/
-    keymanCloudRequest(cmd: string, byLanguage?: boolean) {         
-      var URL='https://api.keyman.com/cloud/4.0/', tFlag, 
+    keymanCloudRequest(cmd: string, byLanguage?: boolean) {
+      var URL='https://api.keyman.com/cloud/4.0/', tFlag,
         Lscript = this.keymanweb.util._CreateElement('script');
-      
+
       URL = URL + ((arguments.length > 1) && byLanguage ? 'languages' : 'keyboards')
         +'?jsonp=keyman.register&languageidtype=bcp47&version='+this.keymanweb['version'];
 
       var kbdManager = this;
-      
+
       // Set callback timer
       tFlag='&timerid='+window.setTimeout(
         function(){
           kbdManager.serverUnavailable(cmd);
         }
-        ,10000);    
-    
-      Lscript.charset="UTF-8";                     
-      Lscript.src = URL+cmd+tFlag;       
-      Lscript.type = 'text/javascript';       
-      try {                                  
-        document.body.appendChild(Lscript);  
+        ,10000);
+
+      Lscript.charset="UTF-8";
+      Lscript.src = URL+cmd+tFlag;
+      Lscript.type = 'text/javascript';
+      try {
+        document.body.appendChild(Lscript);
         }
-      catch(ex) {                                                     
+      catch(ex) {
         document.getElementsByTagName('head')[0].appendChild(Lscript);
-        }                  
+        }
     }
 
     /**
      *  Display warning if Keyman Cloud server fails to respond
-     * 
+     *
      *  @param  {string}  cmd command string sent to Cloud
-     *          
-     **/       
+     *
+     **/
     private serverUnavailable(cmd) {
       this.keymanweb.util.alert(cmd == '' ? 'Unable to connect to Keyman Cloud server!' : cmd);
       this.keymanweb.warned=true;
@@ -1189,11 +1189,11 @@ namespace com.keyman.keyboards {
 
     /**
      * Build 362: removeKeyboards() remove keyboard from list of available keyboards
-     * 
+     *
      * @param {string}  x      keyboard name string
      * @param {boolean} force  When true, also drops the cached keyboard object
-     * 
-     */  
+     *
+     */
     removeKeyboards(x: string, force?: boolean) {
       if(arguments.length == 0) {
         return false;
@@ -1202,9 +1202,9 @@ namespace com.keyman.keyboards {
       var i, j;
       var success = true, activeRemoved = false, anyRemoved = false;;
 
-      for(i=0; i<arguments.length; i++) {           
+      for(i=0; i<arguments.length; i++) {
         for(j=this.keyboardStubs.length-1; j>=0; j--) {
-          if('Keyboard_'+arguments[i] == this.keyboardStubs[j]['KI']) {                 
+          if('Keyboard_'+arguments[i] == this.keyboardStubs[j]['KI']) {
             if('Keyboard_'+arguments[i] == this.getActiveKeyboardName()) {
               activeRemoved = true;
             }
@@ -1245,16 +1245,16 @@ namespace com.keyman.keyboards {
         // Update the UI keyboard menu
         this.doKeyboardUnregistered();
       }
-        
+
       return success;
     }
 
     /**
-     * Function     _registerKeyboard  KR                    
+     * Function     _registerKeyboard  KR
      * Scope        Public
      * @param       {Object}      Pk      Keyboard  object
      * Description  Register and load the keyboard
-     */    
+     */
     _registerKeyboard(Pk) {
       // If initialization not yet complete, list the keyboard to be registered on completion of initialization
       if(!this.keymanweb.initialized) {
@@ -1268,7 +1268,7 @@ namespace com.keyman.keyboards {
       } else {
         Pk['_kmw'] = new KeyboardTag();
       }
-      
+
       var Li,Lstub;
 
       // For package namespacing with KMEA/KMEI.
@@ -1280,7 +1280,7 @@ namespace com.keyman.keyboards {
 
       var Ps=this.activeStub;
       var savedActiveStub = this.activeStub;
-      if(!Ps || !('KI' in Ps) || (Ps['KI'] != Pk['KI'])) {         
+      if(!Ps || !('KI' in Ps) || (Ps['KI'] != Pk['KI'])) {
         // Find the first stub for this keyboard
         for(Lstub=0; Lstub < this.keyboardStubs.length; Lstub++) { // I1511 - array prototype extended
           Ps=this.keyboardStubs[Lstub];
@@ -1290,15 +1290,15 @@ namespace com.keyman.keyboards {
 
           Ps=null;
         }
-      } 
-      
-      // Build 369: ensure active stub defined when loading local keyboards 
+      }
+
+      // Build 369: ensure active stub defined when loading local keyboards
       if(this.activeStub == null && Ps != null) {
         this.activeStub = Ps;
       }
-      
+
       // Register the stub for this language (unless it is already registered)
-      // keymanweb.KRS(Ps?Ps:Pk); 
+      // keymanweb.KRS(Ps?Ps:Pk);
 
       // Test if keyboard already loaded
       for(Li=0; Li<this.keyboards.length; Li++) {
@@ -1306,7 +1306,7 @@ namespace com.keyman.keyboards {
           return;
         }
       }
-    
+
       // Append to keyboards array
       this.keyboards=this.keymanweb._push(this.keyboards, Pk); // TODO:  Resolve without need for the cast.
 
@@ -1319,16 +1319,16 @@ namespace com.keyman.keyboards {
 
     /**
      * Add the basic keyboard parameters (keyboard stub) to the array of keyboard stubs
-     * If no language code is specified in a keyboard it cannot be registered, 
-     * and a keyboard stub must be registered before the keyboard is loaded 
+     * If no language code is specified in a keyboard it cannot be registered,
+     * and a keyboard stub must be registered before the keyboard is loaded
      * for the keyboard to be usable.
-     * 
+     *
      * @param       {Object}      Pstub     Keyboard stub object
      * @return      {?number}               1 if already registered, else null
      */
     _registerStub(Pstub): number {
       var Lk;
-      
+
       // In initialization not complete, list the stub to be registered on completion of initialization
       if(!this.keymanweb.initialized) {
         this.deferredKRS.push(Pstub);
@@ -1360,20 +1360,20 @@ namespace com.keyman.keyboards {
           }
         }
       }
-    
+
       // Register stub (add to KeyboardStubs array)
       this.keyboardStubs=this.keymanweb._push(this.keyboardStubs, Pstub); // TODO:  Resolve without need for the cast.
 
       // TODO: Need to distinguish between initial loading of a large number of stubs and any subsequent loading.
       //   UI initialization should not be needed for each registration, only at end.
-      // Reload this keyboard if it was the last active keyboard and 
+      // Reload this keyboard if it was the last active keyboard and
       // make any changes needed by UI for new keyboard stub
       // (Uncommented for Build 360)
       this.doKeyboardRegistered(Pstub['KI'],Pstub['KL'],Pstub['KN'],Pstub['KLC'],Pstub['KP']);
 
       // If we have no activeStub because there were no stubs, set the new keyboard as active.
       // Do not trigger on merges.
-      if(!this.activeStub && this.dfltStub == Pstub && this.keyboardStubs.length == 1) {
+      if(!this.activeStub && this.dfltStub == Pstub && this.keyboardStubs.length == 1 && this.keymanweb.options['setActiveOnRegister']=='true') {
         this.setActiveKeyboard(Pstub['KI'], Pstub['KLC']);
       }
 
@@ -1386,61 +1386,61 @@ namespace com.keyman.keyboards {
 
     /**
      * Execute external (UI) code needed on registering keyboard, used
-     * to update each UIs language menu   
-     *    
+     * to update each UIs language menu
+     *
      * Note that the argument object is not at present used by any UI,
-     * since the menu is always fully recreated when needed, but the arguments   
+     * since the menu is always fully recreated when needed, but the arguments
      * remain defined to allow for possible use in future (Aug 2014)
-     *    
+     *
      * @param       {string}            _internalName
      * @param       {string}            _language
      * @param       {string}            _keyboardName
      * @param       {string}            _languageCode
      * @param       {string=}           _packageID        Used by KMEA/KMEI to track .kmp related info.
      * @return      {boolean}
-     */       
+     */
     doKeyboardRegistered(_internalName: string, _language: string, _keyboardName: string,
         _languageCode: string, _packageID?: string): boolean {
       var p={'internalName':_internalName,'language':_language,'keyboardName':_keyboardName,'languageCode':_languageCode};
-      
+
       // Utilized only by our embedded codepaths.
       if(_packageID) {
         p['package'] = _packageID;
       }
       return this.keymanweb.util.callEvent('kmw.keyboardregistered',p);
     }
-    
+
     /**
      * Execute external (UI) code to rebuild menu when deregistering keyboard
-     *    
-     * @return      {boolean}   
-     */       
+     *
+     * @return      {boolean}
+     */
 
     doKeyboardUnregistered(): boolean {
-      var p={};     
-      return this.keymanweb.util.callEvent('kmw.keyboardregistered',p);    
+      var p={};
+      return this.keymanweb.util.callEvent('kmw.keyboardregistered',p);
     }
-    
+
     /**
      * Execute external (UI) code needed on loading keyboard
-     * 
+     *
      * @param       {string}            _internalName
-     * @return      {boolean}   
-     */       
+     * @return      {boolean}
+     */
     doKeyboardLoaded(_internalName: string): boolean {
       var p={};
-      p['keyboardName']=_internalName; 
+      p['keyboardName']=_internalName;
       return this.keymanweb.util.callEvent('kmw.keyboardloaded', p);
     }
-      
+
     /**
      * Function     doBeforeKeyboardChange
      * Scope        Private
      * @param       {string}            _internalName
      * @param       {string}            _languageCode
-     * @return      {boolean}   
+     * @return      {boolean}
      * Description  Execute external (UI) code needed before changing keyboard
-     */       
+     */
     doBeforeKeyboardChange(_internalName: string, _languageCode: string): boolean {
       var p={};
       p['internalName']=_internalName;
@@ -1450,13 +1450,13 @@ namespace com.keyman.keyboards {
 
     /**
      * Execute external (UI) code needed *after* changing keyboard
-     * 
+     *
      * @param       {string}            _internalName
      * @param       {string}            _languageCode
      * @param       {boolean=}           _indirect
-     * @return      {boolean}   
-     */       
-    doKeyboardChange(_internalName: string, _languageCode: string, _indirect?:boolean): boolean {                      
+     * @return      {boolean}
+     */
+    doKeyboardChange(_internalName: string, _languageCode: string, _indirect?:boolean): boolean {
       var p: KeyboardChangeData = {
         'internalName': _internalName,
         'languageCode': _languageCode,

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -79,15 +79,16 @@ namespace com.keyman {
       'keyboards':'',
       'fonts':'',
       'attachType':'',
-      'ui':null
+      'ui':null,
+      'setActiveOnRegister':'true'
     };
 
 
     // Stub functions (defined later in code only if required)
-    setDefaultDeviceOptions(opt){}     
+    setDefaultDeviceOptions(opt){}
     getStyleSheetPath(s){return s;}
     getKeyboardPath(f, p?){return f;}
-    KC_(n, ln, Pelem){return '';} 
+    KC_(n, ln, Pelem){return '';}
     handleRotationEvents(){}
     // Will serve as an API function for a workaround, in case of future touch-alignment issues.
     ['alignInputs'](eleList?: HTMLElement[]){}
@@ -120,7 +121,7 @@ namespace com.keyman {
       } else {
         baseLayout = 'us';
       }
-      this._BrowserIsSafari = (navigator.userAgent.indexOf('AppleWebKit') >= 0);  // I732 END - Support for European underlying keyboards #1      
+      this._BrowserIsSafari = (navigator.userAgent.indexOf('AppleWebKit') >= 0);  // I732 END - Support for European underlying keyboards #1
 
       this.core = new text.InputProcessor({
         baseLayout: baseLayout,
@@ -129,7 +130,7 @@ namespace com.keyman {
 
       // Used by the embedded apps.
       this['interface'] = this.core.keyboardInterface;
-      
+
       this.modelManager = new text.prediction.ModelManager();
       this.osk = this['osk'] = new com.keyman.osk.OSKManager();
 
@@ -197,10 +198,10 @@ namespace com.keyman {
     /**
      * Expose font testing to allow checking that SpecialOSK or custom font has
      * been correctly loaded by browser
-     * 
+     *
      *  @param  {string}  fName   font-family name
      *  @return {boolean}         true if available
-     **/         
+     **/
     ['isFontAvailable'](fName: string): boolean {
       return this.util.checkFont({'family':fName});
     }
@@ -212,19 +213,19 @@ namespace com.keyman {
      * @param       {function(Event)}   func      event handler function
      * @return      {boolean}                     value returned by util.addEventListener
      * Description  Wrapper function to add and identify KeymanWeb-specific event handlers
-     */       
+     */
     ['addEventListener'](event: string, func): boolean {
       return this.util.addEventListener('kmw.'+event, func);
     }
 
       /**
      * Function     _GetEventObject
-     * Scope        Private   
+     * Scope        Private
      * @param       {Event=}     e     Event object if passed by browser
-     * @return      {Event|null}       Event object              
+     * @return      {Event|null}       Event object
      * Description Gets the event object from the window when using Internet Explorer
-     *             and handles getting the event correctly in frames 
-     */     
+     *             and handles getting the event correctly in frames
+     */
     _GetEventObject<E extends Event>(e: E) {  // I2404 - Attach to controls in IFRAMEs
       if (!e) {
         e = window.event as E;
@@ -239,23 +240,23 @@ namespace com.keyman {
             if(!win) {
               return null;
             }
-            
+
             e = win.event as E;
           }
         }
       }
-      
-      return e;    
+
+      return e;
     }
 
     /**
      * Function     _push
-     * Scope        Private   
-     * @param       {Array}     Parray    Array   
-     * @param       {*}         Pval      Value to be pushed or appended to array   
+     * Scope        Private
+     * @param       {Array}     Parray    Array
+     * @param       {*}         Pval      Value to be pushed or appended to array
      * @return      {Array}               Returns extended array
-     * Description  Push (if possible) or append a value to an array 
-     */  
+     * Description  Push (if possible) or append a value to an array
+     */
     _push<T>(Parray: T[], Pval: T) {
       if(Parray.push) {
         Parray.push(Pval);
@@ -271,8 +272,8 @@ namespace com.keyman {
      * Function     attachToControl
      * Scope        Public
      * @param       {Element}    Pelem       Element to which KMW will be attached
-     * Description  Attaches KMW to control (or IFrame) 
-     */  
+     * Description  Attaches KMW to control (or IFrame)
+     */
     ['attachToControl'](Pelem: HTMLElement) {
       this.domManager.attachToControl(Pelem);
     }
@@ -281,18 +282,18 @@ namespace com.keyman {
      * Function     detachFromControl
      * Scope        Public
      * @param       {Element}    Pelem       Element from which KMW will detach
-     * Description  Detaches KMW from a control (or IFrame) 
-     */  
+     * Description  Detaches KMW from a control (or IFrame)
+     */
     ['detachFromControl'](Pelem: HTMLElement) {
       this.domManager.detachFromControl(Pelem);
     }
 
     /**
      * Exposed function to load keyboards by name. One or more arguments may be used
-     * 
+     *
      * @param {string|Object} x keyboard name string or keyboard metadata JSON object
-     * 
-     */  
+     *
+     */
     ['addKeyboards'](x) {
       if(arguments.length == 0) {
         this.keyboardManager.keymanCloudRequest('',false);
@@ -300,52 +301,52 @@ namespace com.keyman {
         this.keyboardManager.addKeyboardArray(arguments);
       }
     }
-    
+
     /**
      *  Add default or all keyboards for a given language
-     *  
+     *
      *  @param  {string}   arg    Language name (multiple arguments allowed)
-     **/           
+     **/
     ['addKeyboardsForLanguage'](arg) {
       this.keyboardManager.addLanguageKeyboards(arguments);
     }
-    
+
     /**
      * Call back from cloud for adding keyboard metadata
-     * 
+     *
      * @param {Object}    x   metadata object
-     **/                  
-    ['register'](x) {                     
+     **/
+    ['register'](x) {
       this.keyboardManager.register(x);
     }
 
     /**
      * Build 362: removeKeyboards() remove keyboard from list of available keyboards
-     * 
+     *
      * @param {string}  x      keyboard name string
      * @param {boolean} force  When true, also drops the cached keyboard object
-     * 
-     */  
+     *
+     */
     ['removeKeyboards'](x, force?) {
       return this.keyboardManager.removeKeyboards(x);
     }
 
     /**
      * Allow to change active keyboard by (internal) keyboard name
-     * 
+     *
      * @param       {string}    PInternalName   Internal name
      * @param       {string}    PLgCode         Language code
-     */    
+     */
     ['setActiveKeyboard'](PInternalName: string, PLgCode: string): Promise<void> {
       return this.keyboardManager.setActiveKeyboard(PInternalName,PLgCode);
     }
-    
+
     /**
      * Function     getActiveKeyboard
      * Scope        Public
      * @return      {string}      Name of active keyboard
      * Description  Return internal name of currently active keyboard
-     */    
+     */
     ['getActiveKeyboard'](): string {
       return this.keyboardManager.getActiveKeyboardName();
     }
@@ -356,7 +357,7 @@ namespace com.keyman {
      * @param      {boolean=}        true to retrieve full language name, false/undefined to retrieve code.
      * @return     {string}         language code
      * Description Return language code for currently selected language
-     */    
+     */
     ['getActiveLanguage'](fullName?: boolean): string {
       return this.keyboardManager.getActiveLanguage(fullName);
     }
@@ -368,13 +369,13 @@ namespace com.keyman {
     /**
      * Function    isCJK
      * Scope       Public
-     * @param      {Object=}  k0 
+     * @param      {Object=}  k0
      * @return     {boolean}
-     * Description Tests if active keyboard (or specified keyboard script object, as optional argument) 
+     * Description Tests if active keyboard (or specified keyboard script object, as optional argument)
      *             uses a pick list (Chinese, Japanese, Korean, etc.)
-     *             (This function accepts either keyboard structure.)   
-     */    
-    ['isCJK'](k0?) { 
+     *             (This function accepts either keyboard structure.)
+     */
+    ['isCJK'](k0?) {
       var kbd: keyboards.Keyboard;
       if(k0) {
         kbd = new keyboards.Keyboard(k0);
@@ -404,12 +405,12 @@ namespace com.keyman {
 
     /**
      * Get keyboard meta data for the selected keyboard and language
-     * 
+     *
      * @param       {string}    PInternalName     Internal name of keyboard
      * @param       {string=}   PlgCode           language code
-     * @return      {Object}                      Details of named keyboard 
-     *                                            
-     **/    
+     * @return      {Object}                      Details of named keyboard
+     *
+     **/
     ['getKeyboard'](PInternalName: string, PlgCode?: string) {
       var Ln, Lrn;
 
@@ -418,7 +419,7 @@ namespace com.keyman {
       for(Ln=0; Ln < kbdList.length; Ln++) {
         Lrn = kbdList[Ln];
 
-        if(Lrn['InternalName'] == PInternalName || Lrn['InternalName'] == "Keyboard_" + PInternalName) { 
+        if(Lrn['InternalName'] == PInternalName || Lrn['InternalName'] == "Keyboard_" + PInternalName) {
           if(arguments.length < 2) {
             return Lrn;
           }
@@ -426,39 +427,39 @@ namespace com.keyman {
           if(Lrn['LanguageCode'] == PlgCode) {
             return Lrn;
           }
-        } 
+        }
       }
 
       return null;
     }
-    
+
     /**
-     * Get array of available keyboard stubs 
-     * 
+     * Get array of available keyboard stubs
+     *
      * @return   {Array}     Array of available keyboards
-     * 
-     */    
+     *
+     */
     ['getKeyboards']() {
       return this.keyboardManager.getDetailedKeyboards();
     }
 
     /**
      * Gets the cookie for the name and language code of the most recently active keyboard
-     * 
-     *  Defaults to US English, but this needs to be user-set in later revision (TODO)      
-     * 
-     * @return      {string}          InternalName:LanguageCode 
-     */    
+     *
+     *  Defaults to US English, but this needs to be user-set in later revision (TODO)
+     *
+     * @return      {string}          InternalName:LanguageCode
+     */
     ['getSavedKeyboard']() {
-      return this.keyboardManager.getSavedKeyboard();  
+      return this.keyboardManager.getSavedKeyboard();
     }
 
     /**
      * Function     Initialization
      * Scope        Public
      * @param       {Object}  arg     object array of user-defined properties
-     * Description  KMW window initialization  
-     */    
+     * Description  KMW window initialization
+     */
     ['init'](arg): Promise<any> {
       return this.domManager.init(arg);
     }
@@ -467,7 +468,7 @@ namespace com.keyman {
      * Function     resetContext
      * Scope        Public
      * @param       {Object} e      The element whose context should be cleared.  If null, the currently-active element will be chosen.
-     * Description  Reverts the OSK to the default layer, clears any processing caches and modifier states, 
+     * Description  Reverts the OSK to the default layer, clears any processing caches and modifier states,
      *              and clears deadkeys and prediction-processing states on the active element (if it exists)
      */
     ['resetContext'](e?: HTMLElement) {
@@ -495,8 +496,8 @@ namespace com.keyman {
      * Function     disableControl
      * Scope        Public
      * @param       {Element}      Pelem       Element to be disabled
-     * Description  Disables a KMW control element 
-     */    
+     * Description  Disables a KMW control element
+     */
     ['disableControl'](Pelem: HTMLElement) {
       this.domManager.disableControl(Pelem);
     }
@@ -505,28 +506,28 @@ namespace com.keyman {
      * Function     enableControl
      * Scope        Public
      * @param       {Element}      Pelem       Element to be disabled
-     * Description  Disables a KMW control element 
-     */    
+     * Description  Disables a KMW control element
+     */
     ['enableControl'](Pelem: HTMLMapElement) {
       this.domManager.enableControl(Pelem);
     }
-    
+
     /**
      * Function     setKeyboardForControl
-     * Scope        Public   
-     * @param       {Element}    Pelem    Control element 
-     * @param       {string|null=}    Pkbd     Keyboard (Clears the set keyboard if set to null.)  
+     * Scope        Public
+     * @param       {Element}    Pelem    Control element
+     * @param       {string|null=}    Pkbd     Keyboard (Clears the set keyboard if set to null.)
      * @param       {string|null=}     Plc      Language Code
-     * Description  Set default keyboard for the control 
-     */    
+     * Description  Set default keyboard for the control
+     */
     ['setKeyboardForControl'](Pelem: HTMLElement, Pkbd?: string, Plc?: string) {
       this.domManager.setKeyboardForControl(Pelem, Pkbd, Plc);
     }
 
     /**
      * Function     getKeyboardForControl
-     * Scope        Public   
-     * @param       {Element}    Pelem    Control element 
+     * Scope        Public
+     * @param       {Element}    Pelem    Control element
      * @return      {string|null}         The independently-managed keyboard for the control.
      * Description  Returns the keyboard ID of the current independently-managed keyboard for this control.
      *              If it is currently following the global keyboard setting, returns null instead.
@@ -537,8 +538,8 @@ namespace com.keyman {
 
     /**
      * Function     getLanguageForControl
-     * Scope        Public   
-     * @param       {Element}    Pelem    Control element 
+     * Scope        Public
+     * @param       {Element}    Pelem    Control element
      * @return      {string|null}         The independently-managed keyboard for the control.
      * Description  Returns the language code used with the current independently-managed keyboard for this control.
      *              If it is currently following the global keyboard setting, returns null instead.
@@ -549,25 +550,25 @@ namespace com.keyman {
 
     /**
      * Set focus to last active target element (browser-dependent)
-     */    
+     */
     ['focusLastActiveElement']() {
       this.domManager.focusLastActiveElement();
     }
-    
+
     /**
      * Get the last active target element *before* KMW activated (I1297)
-     * 
-     * @return      {Object}        
-     */    
+     *
+     * @return      {Object}
+     */
     ['getLastActiveElement']() {
       return this.domManager.getLastActiveElement();
     }
 
     /**
-     *  Set the active input element directly optionally setting focus 
-     * 
+     *  Set the active input element directly optionally setting focus
+     *
      *  @param  {Object|string} e         element id or element
-     *  @param  {boolean=}      setFocus  optionally set focus  (KMEW-123) 
+     *  @param  {boolean=}      setFocus  optionally set focus  (KMEW-123)
      **/
     ['setActiveElement'](e: string|HTMLElement, setFocus: boolean) {
       return this.domManager.setActiveElement(e, setFocus);
@@ -575,9 +576,9 @@ namespace com.keyman {
 
     /**
      * Move focus to user-specified element
-     * 
+     *
      *  @param  {string|Object}   e   element or element id
-     *           
+     *
      **/
     ['moveToElement'](e: string|HTMLElement) {
       this.domManager.moveToElement(e);
@@ -608,24 +609,24 @@ namespace com.keyman {
 
     /**
      * Function     getUIState
-     * Scope        Public   
+     * Scope        Public
      * @return      {Object.<string,(boolean|number)>}
      * Description  Return object with activation state of UI:
      *                activationPending (bool):   KMW being activated
-     *                activated         (bool):   KMW active    
-     */    
+     *                activated         (bool):   KMW active
+     */
     ['getUIState'](): UIState {
       return this.uiManager.getUIState();
     }
 
     /**
      * Set or clear the IsActivatingKeymanWebUI flag (exposed function)
-     * 
+     *
      * @param       {(boolean|number)}  state  Activate (true,false)
      */
     ['activatingUI'](state: boolean) {
       this.uiManager.setActivatingUI(state);
-    } 
+    }
 
     // Functions that might be added later
     ['beepKeyboard']: () => void;
@@ -655,8 +656,8 @@ namespace com.keyman {
 /**
  * Determine path and protocol of executing script, setting them as
  * construction defaults.
- *    
- * This can only be done during load when the active script will be the  
+ *
+ * This can only be done during load when the active script will be the
  * last script loaded.  Otherwise the script must be identified by name.
 */
 var scripts = document.getElementsByTagName('script');
@@ -669,9 +670,9 @@ KeymanBase._srcPath = sPath;
 KeymanBase._rootPath = sPath.replace(/(https?:\/\/)([^\/]*)(.*)/,'$1$2/');
 KeymanBase._protocol = sPath.replace(/(.{3,5}:)(.*)/,'$1');
 
-/**  
- * Base code: Declare major component namespaces, instances, and utility functions 
- */  
+/**
+ * Base code: Declare major component namespaces, instances, and utility functions
+ */
 
 // If a copy of the script is already loaded, detect this and prevent re-initialization / data reset.
 if(!window['keyman'] || !window['keyman']['loaded']) {
@@ -680,7 +681,7 @@ if(!window['keyman'] || !window['keyman']['loaded']) {
     /* The base object call may need to be moved into a separate, later file eventually.
      * It will be necessary to override methods with kmwnative.ts and kmwembedded.ts before the
      * affected objects are initialized.
-     * 
+     *
      * We only recreate the 'keyman' object if it's not been loaded.
      * As this is the base object, not creating it prevents a KMW system reset.
      */

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -6,7 +6,7 @@
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!window['keyman']['ui']['name']) { 
+if(!window['keyman']['ui']['name']) {
   /********************************/
   /*                              */
   /* Toolbar User Interface       */
@@ -20,7 +20,7 @@ if(!window['keyman']['ui']['name']) {
    * Instead, use the --output-wrapper command during optimization, which will
    * add the anonymous function to enclose all code, including those optimized
    * variables which would otherwise have global scope.
-   **/  
+   **/
 
   try {
 
@@ -29,22 +29,22 @@ if(!window['keyman']['ui']['name']) {
 
     // Disable UI for touch devices
     if(util['isTouchDevice']()) throw '';
-    
+
     // User interface local variables
     keymanweb['ui'] = {
       init: false,
       toolbarNode: null,
-      backgroundNode: null, 
-      browseMapNode: null, 
+      backgroundNode: null,
+      browseMapNode: null,
       keyboardsButtonNode: null,
-      languageButtonsNode: null, 
-      offButtonNode: null, 
-      offBarNode: null, 
-      oskButtonNode: null, 
+      languageButtonsNode: null,
+      offButtonNode: null,
+      offBarNode: null,
+      oskButtonNode: null,
       oskBarNode: null,
-      selectorNode: null, 
-      regionLanguageListNodes: [], 
-      regionNodes: null, 
+      selectorNode: null,
+      regionLanguageListNodes: [],
+      regionNodes: null,
       langKeyboardNodes: [],
       langKeyboardListNodes: [],
       selectedRegion: 'as',
@@ -63,10 +63,10 @@ if(!window['keyman']['ui']['name']) {
       lgText: ''          // language name in toolbar
     }
 
-    // User Interface object 
+    // User Interface object
     var ui=keymanweb['ui'];
     ui['name'] = 'toolbar';
-    
+
     ui.ToolBar_Text = {
       Keyboards: 'Languages',
       OffTitle: 'Turn off KeymanWeb keyboards',
@@ -74,12 +74,12 @@ if(!window['keyman']['ui']['name']) {
       ShowOSK: 'Show On Screen Keyboard',
       LanguageSelector: 'Select language'
       };
-    
+
     ui.ToolBar_Text['SelectKeyboardPre']='Select ';
     ui.ToolBar_Text['SelectKeyboardSuf']='keyboard';
     ui.ToolBar_Text['AltKeyboardsPre']='Alternate keyboards for ';
     ui.ToolBar_Text['AltKeyboardsSuf']='';
-    
+
     ui.ToolBar_Text['ca']='Central America';
     ui.ToolBar_Text['sa']='South America';
     ui.ToolBar_Text['na']='Americas';
@@ -90,18 +90,18 @@ if(!window['keyman']['ui']['name']) {
     ui.ToolBar_Text['oc']='Oceania';
 
 
-    var controller=document.getElementById('KeymanWebControl');        
+    var controller=document.getElementById('KeymanWebControl');
   /**
      * Create some of the controls but don't insert them into the document yet
      * This does not need or want to prevent loss of focus, so uses document.createElement
-     * rather than util.createElement.      
-     * 
+     * rather than util.createElement.
+     *
      * @param       {string}  tag
      * @param       {?string=}  id
      * @param       {?string=}  className
-     * @param       {string=}  innerHTML               
-     * @return      {Node|null}   
-     */       
+     * @param       {string=}  innerHTML
+     * @return      {Node|null}
+     */
     ui.createNode = function(tag, id, className, innerHTML)
     {
       //var node = util['createElement'](tag);
@@ -109,44 +109,44 @@ if(!window['keyman']['ui']['name']) {
       if(id) node.id = id;
       if(className) node.className = className;
       if(innerHTML) node.innerHTML = innerHTML;
-      
+
       // The following is OK for IE and for F3.5 and later - should simply be ignored for others
-      // first tried preventDefault() as suggested by many on web, which worked but interfered with keyboard and OSK enabling        
+      // first tried preventDefault() as suggested by many on web, which worked but interfered with keyboard and OSK enabling
       if(tag == 'a' || tag == 'area' || tag == 'map') node.ondragstart = function(){return false;}
       return node;
     }
-    
+
     /**
      * Initialize toolbar UI
-     */       
+     */
     ui['initialize'] = ui.initToolbarUI = function()
     {
       if(!keymanweb['initialized'] || ui.init) return;
-    
+
       // Find the controller DIV, insert at top of body if undefined
-      var e = document.getElementById('KeymanWebControl');    
-      if(!e) 
+      var e = document.getElementById('KeymanWebControl');
+      if(!e)
       {
         if(document.body == null)
           return;
         else
         {
           e=document.createElement('DIV');
-          e.id='KeymanWebControl';  
+          e.id='KeymanWebControl';
           document.body.insertBefore(e,document.body.firstChild);
           ui._insertedElem = e;
         }
       }
-      
+
       // Hide toolbar until elements fully drawn, to prevent spurious text displays
       e.style.visibility='hidden'; e.style.maxHeight='35px';
 
       ui.init = true;
-      
+
       if(util['isTouchDevice']()) return;
 
       util['linkStyleSheet'](util['getOption']('resources')+'ui/toolbar/kmwuitoolbar.css');
-        
+
       ui.regions = {};
       //ui.regions['ca'] = {t: ui.ToolBar_Text['ca'], m: '49,52,65,54,68,57,71,56,73,59,75,60,93,61,94,58,97,58,101,59,107,60,114,64,115,68,114,77,104,74,98,75,96,78,95,82,90,81,85,80,82,76,78,74,74,73,65,68,57,61' },
       //ui.regions['sa'] = {t: ui.ToolBar_Text['sa'], m: '82,82,95,82,96,78,98,75,104,74,114,77,120,79,124,83,126,87,141,90,142,97,138,103,135,113,127,116,123,124,115,131,112,132,109,138,117,139,140,141,141,146,134,148,114,145,109,148,100,148,91,143,91,130,96,111,89,102,83,95,77,89' },
@@ -156,15 +156,15 @@ if(!window['keyman']['ui']['name']) {
       ui.regions['as'] = {t: ui.ToolBar_Text['as'], m: '219,1,221,6,228,12,231,16,231,33,227,34,225,35,225,37,227,39,229,45,232,48,239,48,240,49,239,53,242,60,243,65,249,70,252,81,259,87,271,87,278,95,289,100,303,101,311,98,320,98,323,98,323,84,311,81,308,73,307,65,317,57,330,50,334,44,348,36,364,38,375,34,375,8,355,8,336,5,292,1,285,0,219,0' },
       ui.regions['oc'] = {t: ui.ToolBar_Text['oc'], m: '288,117,289,107,303,101,311,98,323,98,323,84,333,77,344,73,362,80,369,88,375,96,375,141,352,143,323,142,316,136,310,130,291,130' }
       ui.regions['un'] = {t: ui.ToolBar_Text['un'], m: '205,52,202,48,203,45,208,43,215,43,218,44,223,46,227,48,232,48,239,48,240,49,239,53,242,60,243,65,237,76,231,77,229,75,221,75,207,53' },
-      
+
       ui.toolbarNode = ui.createNode('div', 'kmw_controls');
       ui.toolbarNode.style.display='block';
-      
-      var tbNode = ui.createNode('a', 'kmw_controls_start', null, ' '); 
+
+      var tbNode = ui.createNode('a', 'kmw_controls_start', null, ' ');
       tbNode.href = "https://keyman.com/developer/keymanweb/";
       tbNode.target="_blank";
       ui.toolbarNode.appendChild(tbNode);
-      
+
       /* Keyboards button */
       ui.keyboardsButtonNode = ui.createNode('div','kmw_btn_keyboards','kmw_button');
       ui.keyboardsButtonNode.title=ui.ToolBar_Text.LanguageSelector;
@@ -178,14 +178,14 @@ if(!window['keyman']['ui']['name']) {
 
       /* Keyboards popup */
       ui.selectorNode = ui.createNode('div', 'kmw_selector');
-      ui.regionsNode = ui.createNode('div', 'kmw_selector_regions');    
+      ui.regionsNode = ui.createNode('div', 'kmw_selector_regions');
       var imgNode;
       ui.browseMapNode = ui.createNode('div', 'kmw_browsemap');
       imgNode = ui.createNode('img', 'kmw_region_browsemap');
       imgNode.src= util['getOption']('resources')+'ui/toolbar/blank.gif';
       imgNode.useMap = '#kmw_worldgrey16';
       ui.browseMapNode.appendChild(imgNode);
-    
+
       var areaNode, mapNode = ui.createNode('map', 'kmw_worldgrey16');
       mapNode.name='kmw_worldgrey16';
       for(var i in ui.regions)
@@ -202,7 +202,7 @@ if(!window['keyman']['ui']['name']) {
         areaNode.coords = ui.regions[i].m;
         mapNode.appendChild(areaNode);
       }
-      
+
       areaNode = ui.createNode('area');
       areaNode.shape = 'default';
       areaNode.nohref = 'true';
@@ -225,14 +225,14 @@ if(!window['keyman']['ui']['name']) {
         itemNode.appendChild(ui.regionNodes[i]);
         listNode.appendChild(itemNode);
       }
-      ui.regionsNode.appendChild(listNode);    
+      ui.regionsNode.appendChild(listNode);
       ui.selectorNode.appendChild(ui.regionsNode);
       ui.keyboardsButtonNode.appendChild(ui.selectorNode);
       ui.toolbarNode.appendChild(ui.keyboardsButtonNode);
 
-      // Separator and Keyboard Off Button       
+      // Separator and Keyboard Off Button
       ui.toolbarNode.appendChild(ui.offBarNode = ui.createNode('div', 'kmw_bar_off', 'kmw_bar'));
-  
+
       ui.offButtonNode = ui.createNode('div', 'kmw_btn_off', 'kmw_button_selected');
       aNode = ui.createNode('a', null, 'kmw_button_a');
       aNode.href = '#';
@@ -242,13 +242,13 @@ if(!window['keyman']['ui']['name']) {
       aNode.appendChild(ui.createNode('div', null, 'kmw_a', ui.ToolBar_Text.Off));
       ui.offButtonNode.appendChild(aNode);
       ui.toolbarNode.appendChild(ui.offButtonNode);
-      
-      // Keyboard buttons       
-      ui.toolbarNode.appendChild(ui.languageButtonsNode = ui.createNode('div', 'kmw_control_keyboards', 'kmw_button'));    
-      
-      // Separator and On Screen Keyboard Button       
+
+      // Keyboard buttons
+      ui.toolbarNode.appendChild(ui.languageButtonsNode = ui.createNode('div', 'kmw_control_keyboards', 'kmw_button'));
+
+      // Separator and On Screen Keyboard Button
       ui.toolbarNode.appendChild(ui.oskBarNode = ui.createNode('div', 'kmw_bar_osk', 'kmw_bar'));
-        
+
       ui.oskButtonNode = ui.createNode('div', 'kmw_btn_osk', 'kmw_button');//was 'kmw_button_selected'
       aNode = ui.createNode('a', null, 'kmw_button_a');
       aNode.href = '#';
@@ -258,32 +258,32 @@ if(!window['keyman']['ui']['name']) {
       //aNode.appendChild(ui.createNode('div', null, 'kmw_a', 'On Screen Keyboard'));
       ui.oskButtonNode.appendChild(aNode);
       ui.toolbarNode.appendChild(ui.oskButtonNode);
-    
+
       ui.toolbarNode.appendChild(ui.createNode('div', 'kmw_controls_end', null, ' '));
-    
+
       var img = ui.createNode('div');
       img.id = 'kmw_map_preload';
       ui.toolbarNode.appendChild(img);
-    
+
       ui.toolbarNode.appendChild(ui.createNode('br', null, 'kmw_clear'));
-    
-      // Append toolbar node to controller      
-      e.appendChild(ui.toolbarNode);    
-    
+
+      // Append toolbar node to controller
+      e.appendChild(ui.toolbarNode);
+
       // Initialize map array, using a timer to allow restarting if necessary after keyboards loaded
       // Note that toolbar will be displayed and enabled on completion of timeout routine
       ui.updateMap = true;
       if(ui.startTimer) clearTimeout(ui.startTimer);
-      ui.startTimer = setTimeout(ui.addKeyboardsToMap,2000);
-    
+      ui.startTimer = setTimeout(ui.addKeyboardsToMap,0);
+
       // Ensure that popups are hidden by clicking elsewhere on document
       util['attachDOMEvent'](document.body,'click',ui.hideAllPopups,false);
 
-      // Set Europe to be the default region 
+      // Set Europe to be the default region
       ui.selectedRegion = 'eu';
 
       // Restore focus
-      keymanweb['focusLastActiveElement']();  
+      keymanweb['focusLastActiveElement']();
     }
 
     ui.shutdown = function() {
@@ -301,22 +301,22 @@ if(!window['keyman']['ui']['name']) {
     /**
      * Fill the map with available keyboards when the Keyboards selector is clicked
      *    after all keyboard stubs have been registered
-    **/     
+    **/
     ui.addKeyboardsToMap = function()
     {
       // Do nothing unless a keyboard has been installed since map created
       if(ui.updateMap) ui.updateMap=false; else return;
 
-      var n = 0;  
+      var n = 0;
       ui.regionLanguageListNodes = {};
-    
-      // Build list of keyboards by region and language       
+
+      // Build list of keyboards by region and language
       var Keyboards = keymanweb['getKeyboards']();
-      
+
       // Sort the keyboards by region and language
       Keyboards.sort(ui.sortKeyboards);
 
-      // Always rebuild the map, so remove any previously created language lists 
+      // Always rebuild the map, so remove any previously created language lists
       for(n=ui.regionsNode.childNodes.length; n>0; n--)
       {
         if(ui.regionsNode.childNodes[n-1].className == 'kmw_selector_region')
@@ -324,15 +324,15 @@ if(!window['keyman']['ui']['name']) {
           ui.regionsNode.removeChild(ui.regionsNode.childNodes[n-1]);
         }
       }
-      
+
       for(var i in ui.regions)
-      {      
-      
+      {
+
         ui.regionLanguageListNodes[i] = ui.createNode('div', null, 'kmw_selector_region');
         var colNode = ui.createNode('div', null, 'kmw_keyboard_col');
         var max = 0, count = 0, languageCode = '';
-    
-        // Get number of languages for the region         
+
+        // Get number of languages for the region
         for(var j=0; j<Keyboards.length; j++) {
           // REVERT:  ensures that keyboards without visible map region get displayed SOMEWHERE.
           var kbdRegion = Keyboards[j]['RegionCode'];
@@ -351,12 +351,12 @@ if(!window['keyman']['ui']['name']) {
           languageCode = bcpSubtags[0];
 
           max++;
-        }   
+        }
         max = Number(((max+3)/4).toFixed(0));   // Get number of entries per column
-  
+
         // Add language list to columns for the region
         languageCode='';
-        for(var j=0; j<Keyboards.length; j++) {           
+        for(var j=0; j<Keyboards.length; j++) {
           // REVERT:  ensures that keyboards without visible map region get displayed SOMEWHERE.
           var kbdRegion = Keyboards[j]['RegionCode'];
           if(!ui.regions[kbdRegion]) {
@@ -382,52 +382,57 @@ if(!window['keyman']['ui']['name']) {
 
             continue;
           }
-          
-          // Add a new language entry          
-          languageCode = bcpSubtags[0]; 
+
+          // Add a new language entry
+          languageCode = bcpSubtags[0];
           ui.languages[languageCode] = { id: Keyboards[j]['LanguageCode'], name: Keyboards[j]['LanguageName'], keyboards: [Keyboards[j]] };
-  
-          // Start a new column if necessary          
+
+          // Start a new column if necessary
           if(count % max == 0 && count > 0)
           {
             ui.regionLanguageListNodes[i].appendChild(colNode);
-            colNode = ui.createNode('div', null, count/max == 3 ? 'kmw_keyboard_col_right' : 'kmw_keyboard_col');   
+            colNode = ui.createNode('div', null, count/max == 3 ? 'kmw_keyboard_col_right' : 'kmw_keyboard_col');
           }
           count++;
-          
-          // Add the language to the column          
+
+          // Add the language to the column
           var langNode = ui.createNode('div', null, 'kmw_language');
           var aNode = ui.createNode('a', null, null, Keyboards[j]['LanguageName']);
           aNode.href='#';
           aNode.onclick = (function(lang) { return function(event) { return ui.selectLanguage(event, lang); }; })(ui.languages[languageCode]);
           langNode.appendChild(aNode);
           colNode.appendChild(langNode);
-          
+
           n++;
         }
-        // Finish the last column and close the list        
+        // Finish the last column and close the list
         ui.regionLanguageListNodes[i].appendChild(colNode);
         ui.regionLanguageListNodes[i].appendChild(ui.createNode('div', null, 'kmw_clear'));
         ui.regionsNode.appendChild(ui.regionLanguageListNodes[i]);
       }
       ui.loadCookie();
-      
+
       // Ensure that the correct region has been selected
       ui.selectRegion(null, ui.selectedRegion);
-      ui.enableControls();  
-      
+      ui.enableControls();
+
+      // When a keyboard is activated before init is complete,
+      // the toolbar needs to refresh the loaded keyboard
+      if(ui.lastSelectedKeyboard) {
+        ui.changeKeyboardEvent(ui.lastSelectedKeyboard);
+      }
+
       // Restore focus
       keymanweb['focusLastActiveElement']();
-
     }
-          
+
     /**
      * Sort keyboards array returned from keymanweb by region and language
-     * 
+     *
      * @param       {Object}  a
      * @param       {Object}  b
-     * @return      {number}   
-     **/   
+     * @return      {number}
+     **/
     ui.sortKeyboards = function(a,b)
     {
       if(a['RegionCode'] < b['RegionCode']) return -2;
@@ -436,14 +441,14 @@ if(!window['keyman']['ui']['name']) {
       if(a['LanguageName'] > b['LanguageName']) return 1;
       return 0;
     }
-      
+
     /* KeymanWeb Interfaces */
 
     /**
      * Function     findListedKeyboard
      * Scope        Private
      * @param       {Object}  lang
-     * @return      {?number}   
+     * @return      {?number}
      * Description  Test if a keyboard is still shown on the toolbar.  Returns index of keyboard in listedKeyboards or null if not found
      */
     ui.findListedKeyboard = function(lang)
@@ -455,27 +460,27 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * Add a keyboard to the list of keyboards available for a language
-     * 
+     *
      * @param       {Object}  lang
      * @param       {Object}  kbd
-     **/       
+     **/
     ui.addKeyboardToList = function(lang,kbd)
     {
       var found = ui.findListedKeyboard(lang);
       if(found == null)
       {
-        // Add the button 
+        // Add the button
         if(ui.listedKeyboards.length >= ui.maxListedKeyboards)
         {
           var oldestPriority = 0x7fffffff, oldestFound = null;
-          
+
           for(var i = 0; i < ui.listedKeyboards.length; i++)
             if(ui.listedKeyboards[i].priority < oldestPriority)
             {
               oldestFound = i;
               oldestPriority = ui.listedKeyboards[i].priority;
             }
-            
+
           // delete the oldest used control
           if(oldestFound != null)
           {
@@ -494,20 +499,20 @@ if(!window['keyman']['ui']['name']) {
         var buttonNode = ui.createNode('div', null/*'kmw_button_keyboard_'+lang.id*/, 'kmw_button');
         var aNode = ui.createNode('a', null, 'kmw_button_a'+(lang.keyboards.length>1 ? ' kmw_norightgap' : ''));
         aNode.href='#';
-        
+
         var p1=ui.ToolBar_Text['SelectKeyboardPre']+kbd['Name'],p2=ui.ToolBar_Text['SelectKeyboardSuf'];
         if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) p1=p1+' '+ p2;
         aNode.title = p1;
         aNode.onclick = function(event) { return ui.selectLanguage(event, lang) };
         aNode.appendChild(ui.createNode('div', 'kmw_img_kbd', 'kmw_img'));
-        
+
         ui.lgText=ui.truncate(lang.name,28);
         aNode.appendChild(ui.createNode('div', null, 'kmw_a', ui.lgText));
         buttonNode.appendChild(aNode);
-        
+
         var thisANode = aNode;
-        
-        if(lang.keyboards.length > 1) { 
+
+        if(lang.keyboards.length > 1) {
           aNode = ui.createNode('a', null, 'kmw_button_a kmw_noleftgap');
           aNode.href = '#';
           aNode.title = ui.ToolBar_Text['AltKeyboardsPre']+lang.name+ui.ToolBar_Text['AltKeyboardsSuf'];
@@ -518,10 +523,10 @@ if(!window['keyman']['ui']['name']) {
           aNode.appendChild(divNode);
           aNode.appendChild(ui.createNode('div', null, 'kmw_drop'));
           buttonNode.appendChild(aNode);
-          
+
           ui.langKeyboardListNodes[lang.id] = ui.createNode('ul', null, 'kmw_selector_kbd');
           ui.langKeyboardListNodes[lang.id].style.display='none';
-          
+
           for(var n in lang.keyboards) {
             var itemNode = ui.createNode('li');
             kbdText = lang.keyboards[n]['Name'].replace(/\s?keyboard/i,'');
@@ -530,30 +535,30 @@ if(!window['keyman']['ui']['name']) {
             aNode = ui.createNode('a', null, null, kbdText);
             aNode.href = '#';
             aNode.title = '';
-            aNode.onclick = (function(lang,kbd) { return function(event) { return ui.selectKeyboard(event, lang, kbd); } })(lang, lang.keyboards[n]);
+            aNode.onclick = (function(lang,kbd) { return function(event) { return ui.selectKeyboard(event, lang, kbd, true); } })(lang, lang.keyboards[n]);
 
             itemNode.appendChild(aNode);
             ui.langKeyboardListNodes[lang.id].appendChild(itemNode);
           }
           buttonNode.appendChild(ui.langKeyboardListNodes[lang.id]);
         }
-        
+
         ui.languageButtonsNode.appendChild(buttonNode);
-        
+
         var thisLang = lang, thisButtonNode = buttonNode;
         ui.listedKeyboards.push({priority: ui.keyboardListPriority++, lang:thisLang, keyboard:kbd, buttonNode:thisButtonNode, aNode:thisANode});
       }
       else
-      {    
+      {
         ui.listedKeyboards[found].priority = ui.keyboardListPriority++;
         ui.listedKeyboards[found].keyboard = kbd;
         var e = ui.langKeyboardNodes[lang.id];
-        if(e) 
+        if(e)
         {
           var kbdText=kbd['Name'].replace(/\s?keyboard/i,'');
           e.innerHTML = ui.truncate(kbdText,40-ui.lgText.length);
         }
-        if(ui.listedKeyboards[found].aNode) 
+        if(ui.listedKeyboards[found].aNode)
         {
           var p1=ui.ToolBar_Text['SelectKeyboardPre']+kbd['Name'],p2=ui.ToolBar_Text['SelectKeyboardSuf'];
           if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) p1=p1+' '+ p2;
@@ -562,43 +567,43 @@ if(!window['keyman']['ui']['name']) {
       }
     }
 
-    /** 
+    /**
      *  Truncate a long name and add an ellipsis
-     *  
+     *
      *  @param  {string}  PName   string that may need to be truncated
      *  @param  {number}  PLen    max non-truncated length
      *  @return {string}          string, truncated with ellipsis if necessary
-     *                
+     *
      **/
     ui.truncate = function(PName,PLen)
     {
       if(PName.length <=PLen) return PName;
       return PName.substr(0,PLen-1)+'\u2026';
     }
-        
+
     /**
-     * Rebuild the entire keyboard list whenever a keyboard is installed 
+     * Rebuild the entire keyboard list whenever a keyboard is installed
      * (without necessarily loading the keyboard)
-     * 
+     *
      * @param       {Object}  p Keyboard metadata object
-     **/    
+     **/
     ui.registerKeyboard = function(p)
     {
-      ui.updateMap = true; 
+      ui.updateMap = true;
       if(ui.startTimer) clearTimeout(ui.startTimer);
-      ui.startTimer = setTimeout(ui.addKeyboardsToMap,2000);
+      ui.startTimer = setTimeout(ui.addKeyboardsToMap,0);
     }
-    keymanweb['addEventListener']('keyboardregistered',ui.registerKeyboard);   
-    
+    keymanweb['addEventListener']('keyboardregistered',ui.registerKeyboard);
+
     var keyboardsForLangPopup = null;
-    
+
     /**
      * Function     hideKeyboardsForLanguage
      * Scope        Private
      * @param       {Object}  event
-     * @return      {boolean} 
+     * @return      {boolean}
      * Description  Hide the list of keyboards for this language
-     **/    
+     **/
     ui.hideKeyboardsForLanguage = function(event)
     {
       var e = ui.keyboardsForLangPopup;
@@ -609,12 +614,12 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * Display the list of keyboards for this language
-     * 
+     *
      * @param       {Object}  event
      * @param       {Object}  lang
-     * @return      {boolean} 
-     * 
-     **/    
+     * @return      {boolean}
+     *
+     **/
     ui.showKeyboardsForLanguage = function(event, lang)
     {
       ui.hideKeyboardsPopup(event);
@@ -628,15 +633,15 @@ if(!window['keyman']['ui']['name']) {
       }
       return ui.eventCapture(event);
     }
-      
+
     /**
      * Select the language, and either select the keyboard (if unique) or display the list of keyboards
      * available for this language
-     * 
+     *
      * @param       {Object}  event
-     * @param       {Object}  lang   
-     * @return      {boolean} 
-     **/    
+     * @param       {Object}  lang
+     * @return      {boolean}
+     **/
     ui.selectLanguage = function(event, lang)
     {
       var found=ui.findListedKeyboard(lang), kbd = null;
@@ -647,18 +652,19 @@ if(!window['keyman']['ui']['name']) {
         kbd = ui.listedKeyboards[found].keyboard;
       if(!kbd) return false;
 
-      return ui.selectKeyboard(event,lang,kbd);
+      return ui.selectKeyboard(event,lang,kbd,true);
     }
 
     /**
-     * Enable a selected keyboard 
-     * 
+     * Enable a selected keyboard
+     *
      * @param       {Object}  event
      * @param       {Object}  lang
-     * @param       {Object}  kbd    
-     * @return      {boolean} 
-     **/  
-    ui.selectKeyboard = function(event,lang,kbd) {
+     * @param       {Object}  kbd
+     * @param       {boolean} updateKeyman
+     * @return      {boolean}
+     **/
+    ui.selectKeyboard = function(event,lang,kbd,updateKeyman:boolean) {
       if(ui.selectedLanguage) {
         var found = ui.findListedKeyboard(ui.selectedLanguage);
         if(found != null) {
@@ -671,53 +677,55 @@ if(!window['keyman']['ui']['name']) {
       ui.selectedKeyboard = kbd;
 
       // In 12.0, this UI class has only been partially converted to BCP-47.
-      // `lang.id` refers to the base language identifier and will NOT include 
+      // `lang.id` refers to the base language identifier and will NOT include
       // any subtags.  We want the FULL language identifier here, with subtags.
       ui.SelectedLanguage = kbd.LanguageCode;
 
-      // Return focus to input area and activate the selected keyboard 
+      // Return focus to input area and activate the selected keyboard
       ui.setLastFocus(); //*****this seems out of sequence???
       ui.addKeyboardToList(lang, kbd);
-      keymanweb['setActiveKeyboard'](kbd['InternalName'], kbd['LanguageCode']);
+      if(updateKeyman) {
+        keymanweb['setActiveKeyboard'](kbd['InternalName'], kbd['LanguageCode']);
+      }
       ui.listedKeyboards[ui.findListedKeyboard(lang)].buttonNode.className = 'kmw_button_selected';
-    
+
       // Always save current state when selecting a keyboard
       ui.saveCookie();
       ui.enableControls();
       return ui.hideKeyboardsPopup(event) || ui.hideKeyboardsForLanguage(event);
-    }  
+    }
 
     /**
      * Enable all UI controls
-     * 
-     * @return      {boolean} 
-     **/    
+     *
+     * @return      {boolean}
+     **/
     ui.enableControls = function()
     {
       var elems=[ui.offButtonNode, ui.offBarNode, ui.oskButtonNode, ui.oskBarNode],hideOskButton=false;
 
       if(keymanweb['isCJK'](ui.selectedKeyboard)) hideOskButton = true;
       else if(ui.selectedKeyboard == null) hideOskButton = (elems[2].style.display == 'none')
-    
+
       if(ui.selectedKeyboard != null || ui.listedKeyboards.length > 0)
-      {        
-        for(var i = 0; i < elems.length; i++) 
+      {
+        for(var i = 0; i < elems.length; i++)
           elems[i].style.display='';
       }
       else
       {
-        for(var i = 0; i < elems.length; i++) 
+        for(var i = 0; i < elems.length; i++)
           elems[i].style.display='none';
-      }      
+      }
 
       if(hideOskButton)
         ui.oskButtonNode.style.display = ui.oskBarNode.style.display = 'none';
 
       else if(ui.selectedKeyboard == null)
         ui.oskButtonNode.className='kmw_button_disabled';
-      //else 
+      //else
       //  ui.oskButtonNode.className=(osk && osk['isEnabled']() ? 'kmw_button_selected' : 'kmw_button');
-      
+
       // Display the toolbar if still hidden
       ui.toolbarNode.parentNode.style.visibility='visible';
       return true;
@@ -725,26 +733,26 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * Restore the focus to the last focused element
-     **/    
+     **/
     ui.setLastFocus = function()
     {
       keymanweb['focusLastActiveElement']();
     }
 
     /**
-     * Display or hide the OSK according to user control. This will always force 
-     * the focus to the last active element if currently unfocused, which is  
-     * preferable to not having the OSK appear when the OSK button is clicked.      
-     * 
+     * Display or hide the OSK according to user control. This will always force
+     * the focus to the last active element if currently unfocused, which is
+     * preferable to not having the OSK appear when the OSK button is clicked.
+     *
      * @param       {Object}  event
-     * @return      {boolean} 
-     **/    
+     * @return      {boolean}
+     **/
     ui.showOSK = function(event)
-    { 
+    {
       //Toggle OSK on or off
       if(osk && keymanweb['getActiveKeyboard']() != '')
       {
-        if(osk['isEnabled']()) osk['hide'](); else osk['show'](true);      
+        if(osk['isEnabled']()) osk['hide'](); else osk['show'](true);
       }
       ui.setLastFocus();
       return ui.eventCapture(event);
@@ -754,11 +762,11 @@ if(!window['keyman']['ui']['name']) {
      * Function     offButtonClickEvent
      * Scope        Private
      * @param       {Object}  event
-     * @return      {boolean} 
+     * @return      {boolean}
      * Description  Update the UI when all keyboards disabled by user
-     **/    
+     **/
     ui.offButtonClickEvent = function(event)
-    { 
+    {
       if(ui.toolbarNode.className != 'kmw_controls_disabled')
       {
         ui.hideKeyboardsForLanguage(null);
@@ -773,10 +781,10 @@ if(!window['keyman']['ui']['name']) {
         ui.offButtonNode.className = 'kmw_button_selected';
       }
       // Return the focus to the input area and set the active keyboard to nothing
-      ui.setLastFocus();     
+      ui.setLastFocus();
       keymanweb['setActiveKeyboard']('','');
-      
-      //Save current state when deselecting a keyboard (may not be needed) 
+
+      //Save current state when deselecting a keyboard (may not be needed)
       ui.saveCookie();
       ui.enableControls();
       return ui.eventCapture(event);
@@ -786,32 +794,32 @@ if(!window['keyman']['ui']['name']) {
      * Function     eventCapture
      * Scope        Private
      * @param       {Object}  event
-     * @return      {boolean} 
+     * @return      {boolean}
      * Description  Browser-independent event capture
-     **/    
+     **/
     ui.eventCapture = function(event)
     {
       if(!event) event = window.event;
       if(window.event) window.event.returnValue = false;
       if(event) event.cancelBubble = true;
-      
+
       return false;
     }
-        
+
     /**
      * Function     selectRegion
      * Scope        Private
      * @param       {Object}  event
-     * @param       {string}  region   
-     * @return      {boolean} 
+     * @param       {string}  region
+     * @return      {boolean}
      * Description  Select the region for which to list languages
-     **/    
+     **/
     ui.selectRegion = function(event, region)
-    {                     
+    {
       var e = ui.browseMapNode;
       if(!e) return ui.eventCapture(event);
-      e.className = 'kmw_browsemap_'+region;      
-      if(typeof(ui.regionLanguageListNodes[region]) == 'undefined') 
+      e.className = 'kmw_browsemap_'+region;
+      if(typeof(ui.regionLanguageListNodes[region]) == 'undefined')
       {
         ui.updateMap = true; ui.addKeyboardsToMap();
       }
@@ -831,40 +839,40 @@ if(!window['keyman']['ui']['name']) {
      * Function     unhoverRegion
      * Scope        Private
      * @param       {Object}  event
-     * @param       {string}  region   
-     * @return      {boolean} 
+     * @param       {string}  region
+     * @return      {boolean}
      * Description  Remove highlighting from a region
-     **/    
+     **/
     ui.unhoverRegion = function(event, region)
     {
       ui.browseMapNode.className = (ui.selectedRegion == null ? '' : 'kmw_browsemap_'+ui.selectedRegion);
       ui.regionNodes[region].className=(ui.selectedRegion==region?'selected':'');
       return ui.eventCapture(event);
     }
-      
+
     /**
      * Function     hoverRegion
      * Scope        Private
      * @param       {Object}  event
-     * @param       {string}  region 
-     * @return      {boolean} 
+     * @param       {string}  region
+     * @return      {boolean}
      * Description  Highlight a hovered region
-     **/    
+     **/
     ui.hoverRegion = function(event, region)
     {
       ui.browseMapNode.className = 'kmw_browsemap_'+region+'_sel';
       ui.regionNodes[region].className='hover';
       return ui.eventCapture(event);
     }
-    
+
     /**
      * Function     pluck
      * Scope        Private
      * @param       {Object}  elem
-     * @param       {string}  property   
-     * @return      {*} 
+     * @param       {string}  property
+     * @return      {*}
      * Description  Get the value of an element property
-     **/    
+     **/
     ui.pluck = function(elem, property) {
         return elem.getAttribute ? elem.getAttribute(property) || elem[property] : elem[property];
       };
@@ -873,14 +881,14 @@ if(!window['keyman']['ui']['name']) {
      * Function     focusControlEvent
      * Scope        Private
      * @param       {Object}  params    Object containing Target element (or frame)
-     * @return      {boolean}   
+     * @return      {boolean}
      * Description  UI code to be executed on receiving focus
      */
     ui.focusControlEvent = function(params)
-    {      
+    {
       if(!ui.init) return true;
 
-      var t=params.target;      
+      var t=params.target;
       if(t.tagName.toLowerCase() == 'textarea' || (t.tagName.toLowerCase() == 'input' && t.type.toLowerCase() == 'text'))
       {
         ui.lastActiveControl = t;
@@ -893,7 +901,7 @@ if(!window['keyman']['ui']['name']) {
         {
           if(ui.selectedKeyboard != null)
           {
-            if(keymanweb['isCJK']()) 
+            if(keymanweb['isCJK']())
             {
               ui.oskButtonNode.style.display = ui.oskBarNode.style.display = 'none';
             }
@@ -902,35 +910,35 @@ if(!window['keyman']['ui']['name']) {
               ui.oskButtonNode.className = (osk && osk['isEnabled']()) ? 'kmw_button_selected' : 'kmw_button';
             }
           }
-            
+
           if(ui.toolbarNode.className != '') ui.toolbarNode.className = '';
-          
+
           var offsetX, offsetY;
           if(t.KMW_HelpOffsetX) offsetX = t.KMW_HelpOffsetX; else offsetX = 64;
           if(t.KMW_HelpOffsetY) offsetY = t.KMW_HelpOffsetY; else offsetY = 0;
           ui.helpOffsetX = util['getAbsoluteX'](t)+offsetX;
-          ui.helpOffsetY = util['getAbsoluteY'](t)+t.offsetHeight+offsetY;          
+          ui.helpOffsetY = util['getAbsoluteY'](t)+t.offsetHeight+offsetY;
         }
-      }   
+      }
       return true;
     }
     keymanweb['addEventListener']('controlfocused',ui.focusControlEvent);
-  
+
     /**
      * Function     oncontrolblurred
      * Scope        Private
      * Parameters   {Object}  params  Object containing event
      * @return      {boolean}
-     * Description  UI code to be executed on losing focus 
-     */  
+     * Description  UI code to be executed on losing focus
+     */
     ui.blurControlEvent = function(params)
     {
       if(!ui.init) return true;
 
       // Must disable OSK button when not focused
       if(ui.oskButtonNode.style.display != 'none') ui.oskButtonNode.className='kmw_button_disabled';
-      
-      if(!params.event) return true;   // I2404 - Manage IE events in IFRAMEs      
+
+      if(!params.event) return true;   // I2404 - Manage IE events in IFRAMEs
       return true;
     }
     keymanweb['addEventListener']('controlblurred',ui.blurControlEvent);
@@ -938,32 +946,34 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * UI action required when keyboard changed indirectly
-     * 
+     *
      * @param       {Object}  p   keyboard selection object
-     * @return      {boolean}   
-     **/    
+     * @return      {boolean}
+     **/
+
+    ui.lastSelectedKeyboard = null;
+
     ui.changeKeyboardEvent = function(p)
-    {                   
-      //if(p['indirect']) 
-      //{          
-        var kbName=p['internalName'],
-            lgName=p['languageCode'];
-        if(lgName != '' && kbName != '')
+    {
+      ui.lastSelectedKeyboard = null;
+      var kbName=p['internalName'],
+          lgName=keymanweb['util']['getLanguageCodes'](p['languageCode'])[0];
+      if(lgName != '' && kbName != '')
+      {
+        var lg = ui.languages[lgName];
+        if(lg != null)
         {
-          var lg = ui.languages[lgName];
-          if(lg != null)
+          for(var j=0; j<lg.keyboards.length; j++)
           {
-            for(var j=0; j<lg.keyboards.length; j++)
+            if(lg.keyboards[j]['InternalName'] == kbName)
             {
-              if(lg.keyboards[j]['InternalName'] == kbName)
-              {
-                ui.selectKeyboard(null, lg, lg.keyboards[j]);
-                window.focus(); ui.setLastFocus();                       
-              }
+              ui.selectKeyboard(null, lg, lg.keyboards[j], false);
+              return true;
             }
           }
         }
-      //}
+        ui.lastSelectedKeyboard = {...p};
+      }
       return true;
     }
     keymanweb['addEventListener']('keyboardchange',ui.changeKeyboardEvent);
@@ -971,48 +981,48 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * UI action when OSK displayed: restore to or update the saved OSK position
-     * 
+     *
      * @param       {Object}  oskPosition
-     * @return      {Object} 
-     **/    
+     * @return      {Object}
+     **/
     ui.onShowOSK = function(oskPosition)
-    { 
+    {
       if(ui.init) ui.oskButtonNode.className = 'kmw_button_selected';
       //The return valu is not currently useful, but allows for the possibility of the OSK restricting or limiting
       //a UI-set position, and returning the corrected position to the UI
       return oskPosition;
-    } 
+    }
     osk['addEventListener']('show',ui.onShowOSK);
 
     /**
      * Update appearance of OSK button whenever the OSK is hidden by the user
-     * 
+     *
      * @param       {Object}  p
-     **/    
+     **/
     ui.onHideOSK = function(p)
     {
       if(ui.init && p['HiddenByUser']) ui.oskButtonNode.className = 'kmw_button';
-    }  
+    }
     osk['addEventListener']('hide',ui.onHideOSK);
-    
+
     /**
      * Function     showKeyboardsPopup
      * Scope        Private
      * @param       {Object}  event
-     * @return      {boolean} 
+     * @return      {boolean}
      * Description  Update the map when displayed
-     **/    
+     **/
     ui.showKeyboardsPopup = function(event)
-    {                 
+    {
       // Add any newly available keyboards to the map
       ui.addKeyboardsToMap();
-      
+
       if(ui.toolbarNode.className == 'kmw_controls_disabled') return ui.eventCapture(event);
       ui.hideKeyboardsForLanguage(null);
       if(ui.selectorNode.className=='kmw_over') return ui.hideKeyboardsPopup(event);
       ui.selectorNode.className='kmw_over';
       ui.keyboardsButtonNode.className='kmw_button_selected';
-      
+
       ui.SetupPopupDismissal(ui.selectorNode, ui.hideKeyboardsPopup);
       return ui.eventCapture(event);
     }
@@ -1021,9 +1031,9 @@ if(!window['keyman']['ui']['name']) {
      * Function     hideKeyboardsPopup
      * Scope        Private
      * @param       {Object}  event
-     * @return      {boolean} 
+     * @return      {boolean}
      * Description  Hide the list of keyboards for this language
-     **/    
+     **/
     ui.hideKeyboardsPopup = function(event)
     {
       ui.selectorNode.className='';
@@ -1031,52 +1041,52 @@ if(!window['keyman']['ui']['name']) {
       ui.CancelPopupDismissal(ui.hideKeyboardsPopup);
       return ui.eventCapture(event);
     }
-    
+
     /**
      * Hide both language and keyboard selection popups on body click
      * @param   {Object}  event
-     * @return  {boolean}      
-    **/       
+     * @return  {boolean}
+    **/
     ui.hideAllPopups = function(event)
     {
       var e = ui.keyboardsForLangPopup;
       if((!e || (e.style.display =='none')) && (ui.selectorNode.className == '')) return true;
       ui.hideKeyboardsPopup(event);
       ui.hideKeyboardsForLanguage(event);
-      return ui.eventCapture(event);    
+      return ui.eventCapture(event);
     }
-      
+
     var dismissalCallback = null, popupElement = null, lastDismissalCallback = null;
-    
+
     /**
      * Function     PopupDismissal
      * Scope        Private
      * @param       {Object}  event
-     * @return      {Object} 
+     * @return      {Object}
      * Description  Carry out action when popup dismissed
-     **/    
+     **/
     ui.PopupDismissal = function(event)
-    {               
+    {
       var t = (event && event.target) || (window.event && window.event.srcElement);
       if(t)
-      {            
+      {
         while(t.parentNode)
         {
           if (t == popupElement) return null;
           t = t.parentNode;
         }
-      }    
+      }
       if(t.nodeName == '#document') ui.hideAllPopups(event); //KMEW-41, fixed for build 356.
       return dismissalCallback;
     }
-    
+
     /**
      * Function     SetupPopupDismissal
      * Scope        Private
-     * @param       {Object}            element    
+     * @param       {Object}            element
      * @param       {function(Object)}  callback
      * Description  Prepare for callback dismissal
-     **/    
+     **/
     ui.SetupPopupDismissal = function(element, callback)
     {
       if(ui.PopupDismissal == document.onclick)
@@ -1086,13 +1096,13 @@ if(!window['keyman']['ui']['name']) {
       lastDismissalCallback = document.onclick;
       document.onclick = ui.PopupDismissal;
     }
-    
+
     /**
      * Function     CancelPopupDismissal
      * Scope        Private
      * @param       {?function(Object)}  callback
      * Description  Cancel callback dismissal
-     **/    
+     **/
     ui.CancelPopupDismissal = function(callback)
     {
       if(ui.PopupDismissal == document.onclick)
@@ -1103,23 +1113,23 @@ if(!window['keyman']['ui']['name']) {
         popupElement = null;
       }
     }
-    
+
     /**
      * Load the previous state from the KeymanWeb_Keyboard and KeymanWeb_Toolbar cookies
      **/
     ui.loadCookie = function()
     {
-      var currentKeyboard='',currentLgCode='',c=util['loadCookie']("KeymanWeb_Keyboard");          
+      var currentKeyboard='',currentLgCode='',c=util['loadCookie']("KeymanWeb_Keyboard");
       if(c['current'] != undefined) currentKeyboard = c['current'].split(':')[0];
-      c=util['loadCookie']("KeymanWeb_Toolbar"); 
+      c=util['loadCookie']("KeymanWeb_Toolbar");
 
       if(c['region'] != undefined) ui.selectedRegion = c['region'];
       if(c['maxrecent'] != undefined)
       {
         for(var i=0; i<c['maxrecent']; i++)
         {
-          if(c['recent'+i] != undefined)    
-          { 
+          if(c['recent'+i] != undefined)
+          {
             var r=c['recent'+i].split(',');
             if(r.length == 2)
             {
@@ -1132,11 +1142,11 @@ if(!window['keyman']['ui']['name']) {
                   {
                     ui.addKeyboardToList(k, k.keyboards[j]);
                     if(k.keyboards[j]['InternalName'] == currentKeyboard)
-                    { 
-                      ui.selectKeyboard(null, k, k.keyboards[j]);
+                    {
+                      ui.selectKeyboard(null, k, k.keyboards[j], true);
                       window.focus(); ui.setLastFocus();
-                      break;                      
-                    }  
+                      break;
+                    }
                     break;
                   }
                 }
@@ -1145,8 +1155,8 @@ if(!window['keyman']['ui']['name']) {
           }
         }
       }
-      // If language list and keyboard list have not yet been saved as a cookie, 
-      // initialize to the current (default) language and keyboard, if set by KMW 
+      // If language list and keyboard list have not yet been saved as a cookie,
+      // initialize to the current (default) language and keyboard, if set by KMW
       else
       {
         var kbName=keymanweb['getActiveKeyboard'](),
@@ -1160,8 +1170,8 @@ if(!window['keyman']['ui']['name']) {
             {
               if(lg.keyboards[j]['InternalName'] == kbName)
               {
-                ui.selectKeyboard(null, lg, lg.keyboards[j]);
-                window.focus(); ui.setLastFocus();                       
+                ui.selectKeyboard(null, lg, lg.keyboards[j], true);
+                window.focus(); ui.setLastFocus();
               }
             }
           }
@@ -1171,21 +1181,21 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * Save the current UI state in the KeymanWeb_Toolbar cookie
-     **/  
+     **/
     ui.saveCookie = function()
     {
       var vs={};
       vs['region'] = ui.selectedRegion;
-      vs['maxrecent'] = ''+ui.listedKeyboards.length; 
+      vs['maxrecent'] = ''+ui.listedKeyboards.length;
       for(var i=0; i<ui.listedKeyboards.length; i++)
         vs['recent'+i] = ui.listedKeyboards[i].lang.id+","+ui.listedKeyboards[i].keyboard['InternalName'];
       util['saveCookie']('KeymanWeb_Toolbar',vs);
     }
 
     // Initialize when everything defined (replaces unreliable onload event handler)
-    // ui.initToolbarUI(); 
+    // ui.initToolbarUI();
     // No, initialization must not be done before KMW is ready!
     // ui.initialize() is now called by keymanweb when document is ready and kmw initialization completed
-      
+
   } catch(ex){}
 }


### PR DESCRIPTION
There are a number of changes here to improve the performance of KeymanWeb and the toolbar and reduce unnecessary requests:

1. (kmwbase.ts and kmwkeyboards.ts) Added option `setActiveOnRegister`, default `'true'`; if set to `'false'` then will never attempt to activate the first registered keyboard. Note that this property is a string because the `options` object currently supports only string types, which is not ideal, but out of scope for this PR.

2. (kmwuitoolbar.ts) fixed issue with toolbar not matching correctly on full BCP 47 code (line 960) after keyboard change notification.

3. (kmwuitoolbar.ts) fixed issue with toolbar not showing active keyboard if the keyboard is activated before init is complete (see `ui.lastSelectedKeyboard` references).

4. (kmwuitoolbar.ts) avoided re-entrancy for `ui.changeKeyboardEvent` by ensuring that `ui.selectKeyboard` does not attempt to set the active keyboard again for keymanweb; note that this was being caught by the event dispatcher in keymanweb but it was still not ideal.

5. (kmwuitoolbar.ts) with above changes, able to remove appalling two second timeout on load (yay!)

These changes will be useful immediately with keymanweb.com.