### PR TITLE
fix(web): default popup key selection, space highlight after popup

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1717,7 +1717,27 @@ namespace com.keyman.osk {
 
       // Highlight the duplicated base key (if a phone)
       if(device.formFactor == 'phone') {
-        var bk = <KeyElement> subKeys.childNodes[0].firstChild;
+        this.selectDefaultSubkey(e, subKeySpec, subKeys);
+      }
+    }
+
+    selectDefaultSubkey(baseKey: KeyElement, subkeys: OSKKeySpec[], popupBase: HTMLElement) {
+      var bk: KeyElement;
+      for(let i=0; i < subkeys.length; i++) {
+        let skSpec = subkeys[i];
+        let skElement = <KeyElement> popupBase.childNodes[i].firstChild;
+
+        // Preference order:
+        // #1:  subkey has same key ID and layer / modifier spec.
+        // #2:  if no perfect match exists, choose a subkey with the same key ID.
+        if(skSpec.id == baseKey.keyId && skSpec.layer == baseKey.key.layer) {
+          bk = skElement;
+        } else if(!bk && skSpec.id == baseKey.keyId) {
+          bk = skElement;
+        }
+      }
+
+      if(bk) {
         this.keyPending = bk;
         this.highlightKey(bk,true);//bk.className = bk.className+' kmw-key-touched';
       }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1732,6 +1732,7 @@ namespace com.keyman.osk {
         // #2:  if no perfect match exists, choose a subkey with the same key ID.
         if(skSpec.id == baseKey.keyId && skSpec.layer == baseKey.key.layer) {
           bk = skElement;
+          break; // Best possible match has been found.
         } else if(!bk && skSpec.id == baseKey.keyId) {
           bk = skElement;
         }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1728,13 +1728,16 @@ namespace com.keyman.osk {
         let skElement = <KeyElement> popupBase.childNodes[i].firstChild;
 
         // Preference order:
-        // #1:  subkey has same key ID and layer / modifier spec.
-        // #2:  if no perfect match exists, choose a subkey with the same key ID.
+        // #1:  if a default subkey has been specified, select it.  (pending, for 15.0+)
+        // #2:  if no default subkey is specified, default to a subkey with the same 
+        //      key ID and layer / modifier spec.
+        //if(skSpec.isDefault) { TODO for 15.0
+        //  bk = skElement;
+        //  break;
+        //} else
         if(skSpec.id == baseKey.keyId && skSpec.layer == baseKey.key.layer) {
           bk = skElement;
-          break; // Best possible match has been found.
-        } else if(!bk && skSpec.id == baseKey.keyId) {
-          bk = skElement;
+          break; // Best possible match has been found.  (Disable 'break' once above block is implemented.)
         }
       }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1715,7 +1715,7 @@ namespace com.keyman.osk {
       subKeys.shim.id = 'kmw-popup-shim';
       keyman.osk._Box.appendChild(subKeys.shim);
 
-      // Highlight the duplicated base key (if a phone)
+      // Highlight the duplicated base key or ideal subkey (if a phone)
       if(device.formFactor == 'phone') {
         this.selectDefaultSubkey(e, subKeySpec, subKeys);
       }


### PR DESCRIPTION
When reviewing this PR, it may be helpful to revisit #3718:
> This PR standardizes the popup keys by not pre-pending the base key in the popup array.

When we stopped prepending the base key for phone-oriented form factors... we forgot to stop auto-selecting the first subkey.  Before we disabled said prepending behavior, this had been intended to indicate that the base key was still selected... just as a subkey.

Of course, we still want to preserve this functionality if the keyboard specifies a subkey matching its base key.  However...

Also from #3718:
> This also fixes #3092 because now Keyboard creators can control if/where the base key appears in the popup keys.

So, we're given no guarantee for where the base key lies within the subkey array.

----

That said, there was an interesting feature that this enabled:

<img width="285" alt="Screen Shot 2021-01-21 at 12 17 10 PM" src="https://user-images.githubusercontent.com/25213402/105283234-9fffa580-5be2-11eb-84b4-75bbac460fe1.png">

There are some cases where it may be appropriate to auto-select a subkey that doesn't match its base key.  Due to the 'bug' left by #3718, this is behavior that's been in the 14.0 beta for a while, and it's pretty nifty for typing this language with a touch layout.

So, to preserve this 'nifty' behavior, I noticed and preserved a reasonable condition that developers could consider to deliberately allow this:  the base key's ID matches that of the subkey, but the _layer_ is different - the subkey highlighted above has `layer = 'shift'`.  So, I turned it into a selection rule - if there's no perfectly-matching subkey, we'll take the first "near-match".

----

Interestingly, this fixes point 2 of #2990!