### PR TITLE
fix(web): language menu key highlighting

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1066,9 +1066,13 @@ namespace com.keyman.osk {
       this.highlightKey(key,true);
 
       // Special function keys need immediate action
+      let _this = this;
       if(keyName == 'K_LOPT' || keyName == 'K_ROPT')      {
         window.setTimeout(function(this: VisualKeyboard){
           PreProcessor.clickKey(key);
+          // Because we immediately process the key, we need to re-highlight it after the click.
+          _this.highlightKey(key, true);
+          // Highlighting'll be cleared automatically later.
         }.bind(this),0);
         this.keyPending = null;
         this.touchPending = null;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1066,12 +1066,11 @@ namespace com.keyman.osk {
       this.highlightKey(key,true);
 
       // Special function keys need immediate action
-      let _this = this;
       if(keyName == 'K_LOPT' || keyName == 'K_ROPT')      {
         window.setTimeout(function(this: VisualKeyboard){
           PreProcessor.clickKey(key);
           // Because we immediately process the key, we need to re-highlight it after the click.
-          _this.highlightKey(key, true);
+          this.highlightKey(key, true);
           // Highlighting'll be cleared automatically later.
         }.bind(this),0);
         this.keyPending = null;


### PR DESCRIPTION
Fixes point 3 of #2990.

I'm kind of surprised the fix turned out to be so small.  I expected there to be extra changes required to drop the highlighting after the language menu is dismissed... but in my tests, this seems to automatically be handled?  Quite a pleasant surprise, assuming this holds on all affected platforms.

## User Testing

@MakaraSok 

I've tested a fair bit with iOS and through Chrome's mobile device emulation, but could also use some extra tests - especially for the Android app.  (Both in-app and as system keyboard)

Main things to check:
 - Does globe key highlighting 'feel' right?
 - Does it go away after the language-selection menu has been dismissed?