### PR TITLE
fix(android/samples): Add dependency on androidx.preference

### DIFF
--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     api(name: 'keyman-engine', ext: 'aar')
     implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
 }

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -43,4 +43,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     api (name:'keyman-engine', ext:'aar')
     implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
 }

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -50,4 +50,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     api (name:'keyman-engine', ext:'aar')
     implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
 }


### PR DESCRIPTION
Well this is slightly embarrassing 😞 

Right after fixing the Sentry dependency for sample apps in #4267, I introduced a globe-button crash when 
#4261 adds a dependency on `implementation 'androidx.preference:preference:1.1.1'` for KMEA consumers.

I've added a note in the 13.0 to 14.0 migration (wiki), and this PR updates the Sample and Test apps.

Fortunately, FV already has the dependency.