### PR TITLE
chore(windows/resources): Address missing links in help

### DIFF
--- a/windows/src/desktop/help/TODO.md
+++ b/windows/src/desktop/help/TODO.md
@@ -5,3 +5,4 @@
 - search for \n\n- (gaps between bullets)
 - search for ^**...**$
 - search for keyboard references and use <kbd></kbd>
+- implement `troubleshooting_hidden` page (desired by windows/src/desktop/help/basic/keyboard_tasks/enable_keyboard.md)

--- a/windows/src/desktop/help/TODO.md
+++ b/windows/src/desktop/help/TODO.md
@@ -2,7 +2,6 @@
 - search for title: ... {...}
 - search for "(desktop_images"
 - search for "](#"
-- search for "[???]"
 - search for \n\n- (gaps between bullets)
 - search for ^**...**$
 - search for keyboard references and use <kbd></kbd>

--- a/windows/src/desktop/help/basic/config_tasks/config_menu.md
+++ b/windows/src/desktop/help/basic/config_tasks/config_menu.md
@@ -23,12 +23,12 @@ To open Keyman Configuration:
 
 For more information on using Keyman Configuration, see:
 
--   [???](#start_locale)
+- [How To - Set the Language for Keyman for Windows Menus](../../start/locale)
 
--   [???](#basic_keyboards_tab)
+- [Keyboards Layout Tab](keyboards_tab)
 
--   [???](#basic_options_tab)
+- [Options Tab](options_tab)
 
--   [???](#basic_hotkeys_tab)
+- [Hotkeys Tab](hotkeys_tab)
 
--   [???](#basic_support_tab)
+- [Support Tab](support_tab)

--- a/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.md
+++ b/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.md
@@ -24,7 +24,7 @@ To open the Hotkeys tab of Keyman Configuration:
 **Setting Hotkeys**
 
 For help setting hotkeys in the Hotkeys tab of Keyman Configuration,
-see: [???](#start_hotkey_set)
+see: [Set Hotkeys for Keyman, Keyman Keyboards and Windows Languages](../../start/hotkey_set)
 
 **Note:**
 By default, hotkeys only turn on a function or keyboard. If you prefer
@@ -85,8 +85,8 @@ currently installed Windows languages.
 
 **Related Topics**
 
--   [???](#start_hotkey_set)
+- [Set Hotkeys for Keyman, Keyman Keyboards and Windows Languages](../../start/hotkey_set)
 
--   [???](#basic_config_menu)
+- [Keyman Configuration Menu](../config_tasks/config_menu)
 
--   [???](#basic_options_tab)
+- [Keyman Configuration - Options Tab](options_tab)

--- a/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.md
+++ b/windows/src/desktop/help/basic/config_tasks/hotkeys_tab.md
@@ -38,8 +38,6 @@ following hotkeys will toggle with this option enabled:
 
 -   Show On Screen Keyboard Pane
 
--   Show Keyboard Usage Pane
-
 -   Show Font Helper Pane
 
 -   Show Character Map Pane
@@ -61,9 +59,6 @@ functions:
 
 -   Show On Screen Keyboard Pane --- Opens or shows the [On Screen
     Keyboard](#basic_osk) tool of the Keyman Toolbox.
-
--   Show Keyboard Usage Pane --- Opens or shows the [Keyboard
-    Usage](#basic_usage) tool of the Keyman Toolbox.
 
 -   Show Font Helper Pane --- Opens or shows the [Font
     Helper](#basic_fonthelper) tool of the Keyman Toolbox.

--- a/windows/src/desktop/help/basic/config_tasks/keyboards_tab.md
+++ b/windows/src/desktop/help/basic/config_tasks/keyboards_tab.md
@@ -38,12 +38,12 @@ Layouts tab of Keyman Configuration:
 **Uninstalling a Keyboard**
 
 To uninstall a Keyman keyboard from the Keyboard Layouts tab of Keyman
-Configuration, see: [???](#basic_uninstall_keyboard)
+Configuration, see: [Uninstall a Keyboard](../keyboard_tasks/uninstall_keyboard)
 
 **Enabling and Disabling a Keyboard**
 
 To enable or disable a Keyman keyboard from the Keyboard Layouts tab of
-Keyman Configuration, see: [???](#basic_disable_keyboard)
+Keyman Configuration, see: [Disable a Keyboard](../keyboard_tasks/disable_keyboard)
 
 **Setting a Hotkey**
 
@@ -143,8 +143,8 @@ Code.
 All Keyman keyboards are associated with a Windows language by default.
 To change the association, or add a new association, see the following:
 
--   [???](#start_configure_computer)
+-   [Configure Computer](../../start/configure_computer)
 
 **Related Topics**
 
--   [???](#basic_config_menu)
+-   [Keyman Configuration Menu](config_menu)

--- a/windows/src/desktop/help/basic/config_tasks/options_tab.md
+++ b/windows/src/desktop/help/basic/config_tasks/options_tab.md
@@ -188,6 +188,6 @@ To open the Options tab of Keyman Configuration:
 
 **Related Topics**
 
--   [???](#basic_config_menu)
+-   [Keyman Configuration Menu](config_menu)
 
--   [???](#basic_hotkeys_tab)
+-   [Hotkeys Tab](hotkeys_tab)

--- a/windows/src/desktop/help/basic/config_tasks/support_tab.md
+++ b/windows/src/desktop/help/basic/config_tasks/support_tab.md
@@ -56,6 +56,6 @@ Configuration. In the Support tab you will see:
 
 **Related Topics**
 
--   [???](#basic_config_menu)
+-   [Keyman Configuration Menu](config_menu)
 
--   [???](#start_download-install_keyman)
+-   [Download and Install Keyman](../../start/download-install_keyman)

--- a/windows/src/desktop/help/basic/engine_tasks/update.md
+++ b/windows/src/desktop/help/basic/engine_tasks/update.md
@@ -35,4 +35,4 @@ it again from the [Keyman Website](https://keyman.com/).
 
 **Related Topics**
 
--   [???](#advanced_proxy_config)
+-   [Proxy Configuration](../../advanced/proxy_config)

--- a/windows/src/desktop/help/basic/index.md
+++ b/windows/src/desktop/help/basic/index.md
@@ -12,7 +12,7 @@ title: Basic Help
 * [uninstall_keyboard](uninstall_keyboard)
 
 * [traymenu](traymenu)
-* [toolbox](toolbox)
+* [The Keyman Toolbox](toolbox)
 * [osk](osk)
 * [fonthelper](fonthelper)
 * [charactermap](charactermap)

--- a/windows/src/desktop/help/basic/index.md
+++ b/windows/src/desktop/help/basic/index.md
@@ -14,7 +14,6 @@ title: Basic Help
 * [traymenu](traymenu)
 * [toolbox](toolbox)
 * [osk](osk)
-* [usage](usage)
 * [fonthelper](fonthelper)
 * [charactermap](charactermap)
 

--- a/windows/src/desktop/help/basic/index.md
+++ b/windows/src/desktop/help/basic/index.md
@@ -2,29 +2,29 @@
 title: Basic Help
 ---
 
-* [newways](newways)
+* [New Ways to Use Keyman](newways)
 
-* [update](update)
-* [uninstall](uninstall)
+* [Software Task - Update Keyman](update)
+* [Software Task - Uninstall Keyman](uninstall)
 
-* [enable_keyboard](enable_keyboard)
-* [disable_keyboard](disable_keyboard)
-* [uninstall_keyboard](uninstall_keyboard)
+* [Keyboard Task - Turn on a Keyboard](enable_keyboard)
+* [Keyboard Task - Enable and Disable a Keyboard](disable_keyboard)
+* [Keyboard Task - Uninstall a Keyboard](uninstall_keyboard)
 
-* [traymenu](traymenu)
+* [The Keyman Menu](traymenu)
 * [The Keyman Toolbox](toolbox)
-* [osk](osk)
-* [fonthelper](fonthelper)
-* [charactermap](charactermap)
+* [Keyman Toolbox - On Screen Keyboard](osk)
+* [Keyman Toolbox - Font Helper](fonthelper)
+* [Keyman Toolbox - Character Map](charactermap)
 
-* [languageswitcher](languageswitcher)
+* [Language Switcher](languageswitcher)
 
-* [text_editor](text_editor)
+* [The Keyman Text Editor](text_editor)
 
-* [config_menu](config_menu)
-* [keyboards_tab](keyboards_tab)
-* [options_tab](options_tab)
-* [hotkeys_tab](hotkeys_tab)
-* [support_tab](support_tab)
+* [Keyman Configuration](config_menu)
+* [Keyman Configuration - Keyboard Layouts Tab](keyboards_tab)
+* [Keyman Configuration - Options Tab](options_tab)
+* [Keyman Configuration - Hotkeys Tab](hotkeys_tab)
+* [Keyman Configuration - Support Tab](support_tab)
 
-* [help](help)
+* [The Keyman Help Menu](help)

--- a/windows/src/desktop/help/basic/keyboard_tasks/disable_keyboard.md
+++ b/windows/src/desktop/help/basic/keyboard_tasks/disable_keyboard.md
@@ -61,8 +61,8 @@ To enable a Keyman keyboard:
 
 **Related Topics**
 
--   [???](#basic_uninstall_keyboard)
+-   [Uninstall a Keyboard](uninstall_keyboard)
 
--   [???](#basic_enable_keyboard)
+-   [Turn on a Keyboard](enable_keyboard)
 
--   [???](#basic_keyboards_tab)
+-   [Keyboard Layouts Tab](../config_tasks/keyboards_tab)

--- a/windows/src/desktop/help/basic/keyboard_tasks/enable_keyboard.md
+++ b/windows/src/desktop/help/basic/keyboard_tasks/enable_keyboard.md
@@ -117,18 +117,18 @@ choose the keyboard you want to use.
 
 **Related Topics**
 
--   [???](#basic_traymenu)
+-   [The Keyman for Windows Menu](../traymenu)
 
--   [???](#basic_toolbox)
+-   [Keyman for Windows Toolbox](../toolbox_tasks/toolbox)
 
--   [???](#basic_languageswitcher)
+-   [Language Switcher](../languageswitcher)
 
--   [???](#basic_hotkeys_tab)
+-   [Keyman Configuration - Hotkeys Tab](../config_tasks/hotkeys_tab)
 
--   [???](#basic_keyboards_tab)
+-   [Keyman Configuration - Keyboard Layouts Tab](../config_tasks/keyboards_tab)
 
--   [???](#start_download-install_keyboard)
+-   [Download and Install Keyboard](../../start/download-install_keyboard)
 
--   [???](#basic_disable_keyboard)
+-   [Keyboard Task - Enable and Disable Keyboard](disable_keyboard)
 
 -   [???](#troubleshooting_hidden)

--- a/windows/src/desktop/help/basic/keyboard_tasks/uninstall_keyboard.md
+++ b/windows/src/desktop/help/basic/keyboard_tasks/uninstall_keyboard.md
@@ -36,8 +36,8 @@ The Keyman keyboard is now removed from Keyman.
 
 **Related Topics**
 
--   [???](#basic_disable_keyboard)
+-   [Enable and Disable a Keyboard](disable_keyboard)
 
--   [???](#basic_enable_keyboard)
+-   [Turn on a Keyboard](enable_keyboard)
 
--   [???](#start_download-install_keyboard)
+-   [Download and Install a Keyboard](../../start/download-install_keyboard)

--- a/windows/src/desktop/help/basic/toolbox_tasks/charactermap.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/charactermap.md
@@ -312,4 +312,4 @@ Character Map.
 
 **Related Topics**
 
--   [Toolbox](toolbox)
+-   [The Keyman Toolbox](toolbox)

--- a/windows/src/desktop/help/basic/toolbox_tasks/charactermap.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/charactermap.md
@@ -312,4 +312,4 @@ Character Map.
 
 **Related Topics**
 
--   [???](#basic_toolbox)
+-   [Toolbox](toolbox)

--- a/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.md
@@ -43,6 +43,6 @@ the fonts you need.
 
 **Related Topics**
 
--   [???](#basic_toolbox)
+-   [Toolbox](toolbox)
 
--   [???](#basic_enable_keyboard)
+-   [Turn on a Keyboard](../keyboard_tasks/enable_keyboard)

--- a/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/fonthelper.md
@@ -43,6 +43,6 @@ the fonts you need.
 
 **Related Topics**
 
--   [Toolbox](toolbox)
+-   [The Keyman Toolbox](toolbox)
 
 -   [Turn on a Keyboard](../keyboard_tasks/enable_keyboard)

--- a/windows/src/desktop/help/basic/toolbox_tasks/osk.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/osk.md
@@ -68,6 +68,6 @@ keyboards designed phonetically, this is because there is not a simple
 
 **Related Topics**
 
--   [Toolbox](toolbox)
+-   [The Keyman Toolbox](toolbox)
 
 -   [Options Tab](../config_tasks/options_tab)

--- a/windows/src/desktop/help/basic/toolbox_tasks/osk.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/osk.md
@@ -8,12 +8,7 @@ shows the currently selected Keyman keyboard or Windows layout.
 ![](desktop_images/osk-tibetan.png)
 
 **Note:**
-Some Keyman keyboards do not contain an On Screen Keyboard view. You can
-find more help for those keyboards from the
-
-Keyboard Usage tool
-
-of the Keyman Toolbox.
+Some Keyman keyboards do not contain an On Screen Keyboard view.
 
 **Opening the On Screen Keyboard**
 
@@ -68,9 +63,7 @@ characters of your active Windows layout.
 **Note:**
 Some Keyman keyboards do not have an On Screen Keyboard view. For
 keyboards designed phonetically, this is because there is not a simple
-1-1 correspondence between each key and the letter you want to type. The
-Keyboard Usage tool is often helpful for these keyboards and Keyman will switch to this view
-by default. This option can be changed in Keyman Configuration.
+1-1 correspondence between each key and the letter you want to type.
 
 
 **Related Topics**

--- a/windows/src/desktop/help/basic/toolbox_tasks/osk.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/osk.md
@@ -75,8 +75,6 @@ by default. This option can be changed in Keyman Configuration.
 
 **Related Topics**
 
--   [???](#basic_toolbox)
+-   [Toolbox](toolbox)
 
--   [???](#basic_usage)
-
--   [???](#basic_options_tab)
+-   [Options Tab](../config_tasks/options_tab)

--- a/windows/src/desktop/help/basic/toolbox_tasks/toolbox.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/toolbox.md
@@ -399,10 +399,8 @@ of Keyman Configuration and click Reset Hints.
 
 **Related Topics**
 
--   [???](#basic_osk)
+-   [On Screen Keyboard](osk)
 
--   [???](#basic_usage)
+-   [Font Helper](fonthelper)
 
--   [???](#basic_fonthelper)
-
--   [???](#basic_charactermap)
+-   [Character Map](charactermap)

--- a/windows/src/desktop/help/basic/toolbox_tasks/usage.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/usage.md
@@ -55,8 +55,8 @@ Keyman keyboard:
 
 **Related Topics**
 
--   [???](#basic_toolbox)
+-   [Toolbox](toolbox)
 
--   [???](#basic_osk)
+-   [On Screen Keyboard](osk)
 
--   [???](#basic_enable_keyboard)
+-   [Turn on a Keyboard](../keyboard_tasks/enable_keyboard)

--- a/windows/src/desktop/help/basic/toolbox_tasks/usage.md
+++ b/windows/src/desktop/help/basic/toolbox_tasks/usage.md
@@ -55,7 +55,7 @@ Keyman keyboard:
 
 **Related Topics**
 
--   [Toolbox](toolbox)
+-   [The Keyman Toolbox](toolbox)
 
 -   [On Screen Keyboard](osk)
 

--- a/windows/src/desktop/help/start/rtl.md
+++ b/windows/src/desktop/help/start/rtl.md
@@ -17,11 +17,11 @@ get started.
     To do this, simply associate the keyboard with a right-to-left
     Windows language (like Arabic). For instructions on associating a
     Keyman keyboard with a Windows language, see:
-    [???](#start_configure_computer)
+    [How To - Set up Your Computer for a Keyman Keyboard](configure_computer)
 
 2.  If you will be using MS Office programs like Word, you should
     configure MS Office for your right-to-left language. For
-    instructions, see: [???](#start_configure_office)
+    instructions, see: [How To - Set up MS Office for a Keyman Keyboard](configure_office)
 
 3.  Each time you start typing with a right-to-left Keyman keyboard, you
     may need to change the typing direction in the program you are

--- a/windows/src/desktop/help/start/tutorial.md
+++ b/windows/src/desktop/help/start/tutorial.md
@@ -124,10 +124,7 @@ To learn how to type with your new Keyman keyboard, open the On Screen
 Keyboard tool of the Keyman Toolbox. You can open the On Screen Keyboard
 tool from the On Screen Keyboard link in the Keyman menu.
 
-**Tip:** Some Keyman keyboards do not include an On Screen Keyboard. You can
-usually find help for these keyboards from the Keyboard Usage tool of
-the Keyman Toolbox. You can open the Keyboard Usage tool from the
-Keyboard Usage link in the Keyman menu.
+**Tip:** Some Keyman keyboards do not include an On Screen Keyboard.
 
 ## Step 8
 

--- a/windows/src/desktop/help/troubleshooting/font.md
+++ b/windows/src/desktop/help/troubleshooting/font.md
@@ -2,7 +2,7 @@
 title: How To - Fix Font Issues
 ---
 
-If you are having font issues, you should first try: [???](#start_font)
+If you are having font issues, you should first try: [How To - Find the Best Fonts for a Keyman Keyboard](../start/font)
 
 ## Fix Characters Appearing Smaller than the Selected Font Size
 


### PR DESCRIPTION
Continues to address help TODOs started in #4307 

* This updates nearly all of the missing `[???]` links.
* Also start removing references to Keyboard usage since that's a breaking change in 14.0
> Keyman Engine no longer supports the keyboard usage page (usage.htm).