### PR TITLE
chore(android/samples): Remove old sample keyboard loaded code

### DIFF
--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -112,9 +112,6 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
   @Override
   public void onKeyboardLoaded(KeyboardType keyboardType) {
     // Handle Keyman keyboard loaded event here if needed
-    // We can set our custom keyboard here
-    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "ta");
-    KMManager.setKeyboard(this, kbIndex);
   }
 
   @Override

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -193,9 +193,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   @Override
   public void onKeyboardLoaded(KeyboardType keyboardType) {
     // Handle Keyman keyboard loaded event here if needed
-    // We can set our custom keyboard here
-    int kbIndex = KMManager.getKeyboardIndex(this, "tamil99m", "ta");
-    KMManager.setKeyboard(this, kbIndex);
   }
 
   @Override


### PR DESCRIPTION
This cleans up `onKeyboardLoaded()` in the Android sample apps .

1. The old keyboard id `tamil99m` is no longer used when the sample apps changed from `tamil99m` to `basic_kbdtam99.kmp` (#2935)
2. The sample onKeyboardLoaded() code actually interferes with the globe button if the user adds more than 1 keyboard in the app. (First keyboard index always gets selected)

KMManager already sets the keyboard when it's added.