### PR TITLE
fix(web): bulk renderer using video stream capture

### DIFF
--- a/web/bulk_rendering/README.md
+++ b/web/bulk_rendering/README.md
@@ -1,0 +1,18 @@
+# Bulk renderer
+
+This renderer loads all the cloud keyboards from api.keyman.com and renders each of them to the document, saving each render as an inline (data-url) PNG for easy comparison.
+
+## Using the bulk renderer
+
+1. `build.sh` to build the renderer (must have already built KeymanWeb in ../source/, `./build.sh -debug`).
+2. Open `index.html` (via http, not via file, as otherwise fonts will not be accessible).
+3. If you want a touch layout, use Developer Tools to select the appropriate emulation and then reload the page.
+3. Choose whether you wish to render all layers or just the default layer for each keyboard.
+4. If desired, filter out keyboards by id (regex).
+5. Run the render.
+6. Save the result to a .html file, either before.html or after.html.
+7. When swapping versions, don't forget to rebuild.
+
+## compare.html
+
+Compare allows you to load two runs of the renderer side-by-side (simply save the run to either before.html or after.html in this folder). It defaults to a width of 20% which you might need to tweak depending on the size of your display and the width of the OSK images.

--- a/web/bulk_rendering/compare.html
+++ b/web/bulk_rendering/compare.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+  This comparison page requires that you first generate the on screen keyboards using the
+  bulk renderer in index.html, then save the result to either before.html or after.html.
+  Then you can scroll the before results and the after results will scroll in sync.
+-->
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>KeymanWeb - On-Screen Keyboard Renders</title>
+  <style>
+    iframe { display: inline-block; width: 20%; height: 900px }
+  </style>
+  <script>
+    function matchScroll() {
+      document.getElementById('f2').contentWindow.document.documentElement.scrollTop =
+      document.getElementById('f2').contentWindow.pageYOffset = document.getElementById('f1').contentWindow.pageYOffset;
+    }
+
+    function attach() {
+      document.getElementById('f1').contentWindow.document.body.onscroll = matchScroll;
+    }
+  </script>
+</head>
+<body>
+  <iframe id='f1' src="before.html" onload="attach()"></iframe>
+  <iframe id='f2' src="after.html"></iframe>
+</body>
+</html>

--- a/web/bulk_rendering/index.html
+++ b/web/bulk_rendering/index.html
@@ -2,56 +2,67 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match phone and tablet device widths -->                         
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
 
     <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb - On-Screen Keyboard Renders</title>
 
-    <!-- Your page CSS --> 
-    <style type='text/css'>   
+    <!-- Your page CSS -->
+    <style type='text/css'>
       body {font-family: Tahoma,helvetica; margin-left: 0px}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
-    </style> 
- 
-    <!-- Insert unminified KeymanWeb source scripts -->              
+      h1 { font-size: 12px; font-weight: bold; color: darkred; }
+      h2 { font-size: 10px; background: blue; color: white; margin:  0; }
+      p { font-size: 10px; margin: 0; }
+
+    </style>
+
+    <!-- Insert unminified KeymanWeb source scripts -->
+    <!--<script src="https://s.keyman.com/kmw/engine/14.0.227/keymanweb.js" type="application/javascript"></script>-->
     <script src="../release/unminified/web/keymanweb.js" type="application/javascript"></script>
     <script src="../release/renderer/bulk_render.js" type="application/javascript"></script>
- 
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       var kmw=window.keyman;
       kmw.init({
         attachType:'auto'
         }).then(function() {
-          var renderer_poll = function() {
-            if(kmw.getKeyboards().length == 0) {
-              window.setTimeout(function() {
-                renderer_poll();
-              }, 1000);
-            } else {
-              kmw_renderer.run();
-            }
-          }
-
-          renderer_poll();
+          kmw.addKeyboards();
         });
-      kmw.addKeyboards();
 
-    </script> 
+
+      function runRenderer() {
+        var renderer_poll = function() {
+          if(kmw.getKeyboards().length == 0) {
+            // Waiting for KeymanWeb to load keyboards
+            window.setTimeout(function() {
+              renderer_poll();
+            }, 1000);
+          } else {
+            kmw_renderer.run(document.getElementById('allLayers').checked, document.getElementById('filter').value);
+          }
+        }
+
+        renderer_poll();
+      }
+    </script>
   </head>
 
-<!-- Sample page HTML -->  
   <body>
     <h1>KeymanWeb - Bulk On-Screen Keyboard Rendering</h1>
+    <input type='checkbox' id='allLayers' checked> <label for='allLayers'>All Layers</label>
+    <input type='text' id='filter' class='kmw-disabled' placeholder='Filter by ID'>
+    <input type='button' value='Start Render' onclick='runRenderer()'>
     <div id='deviceNotes'></div>
     <div id='renderList'></div>
 
-  </body>  
+  </body>
 </html>

--- a/web/bulk_rendering/tsconfig.json
+++ b/web/bulk_rendering/tsconfig.json
@@ -9,6 +9,7 @@
 	},
   "files": [
 		"../node_modules/@keymanapp/web-utils/src/index.ts",
+    "../node_modules/@keymanapp/web-environment/environment.inc.ts",
 		"../node_modules/@keymanapp/lexical-model-layer/message.d.ts",
 		"renderer_core.ts"
   ]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -449,15 +449,6 @@
       "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
       "dev": true
     },
-    "css-line-break": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.0.1.tgz",
-      "integrity": "sha1-GfIGOjPpX7KDG4ZEbAuAwYivRQo=",
-      "dev": true,
-      "requires": {
-        "base64-arraybuffer": "^0.1.5"
-      }
-    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -967,15 +958,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "html2canvas": {
-      "version": "1.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-alpha.12.tgz",
-      "integrity": "sha1-OxmS48mz9WBjw1/WIElPN+uohRM=",
-      "dev": true,
-      "requires": {
-        "css-line-break": "1.0.1"
-      }
     },
     "http-errors": {
       "version": "1.7.2",

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,6 @@
     "@sentry/cli": "^1.52.3",
     "chai": "^4.2.0",
     "google-closure-compiler-java": "^20200224.0.0",
-    "html2canvas": "^1.0.0-alpha.12",
     "karma": "^4.2.0",
     "karma-browserstack-launcher": "^1.5.1",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
Instead of using html2canvas which is only an approximation of the DOM, we now use the video capture API to get an exact capture of the OSK.

Removes html2canvas from web package.json as this is no longer used anywhere.

Sample results using compare.html:

![image](https://user-images.githubusercontent.com/4498365/105449567-c0a42a00-5ccc-11eb-84c5-affc9d2a919d.png)
