### PR TITLE
fix(android/app): Wrap preference screen titles

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -93,6 +93,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
 
     setSystemKeyboardPreference = new CheckBoxPreference(context);
     setSystemKeyboardPreference.setTitle(R.string.enable_system_keyboard);
+    setSystemKeyboardPreference.setSingleLineTitle(false);
     setSystemKeyboardPreference.setDefaultValue(SystemIMESettings.isEnabledAsSystemKB(context));
     setSystemKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
       @Override
@@ -105,6 +106,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
 
     setDefaultKeyboardPreference = new CheckBoxPreference(context);
     setDefaultKeyboardPreference.setTitle(R.string.set_keyman_as_default);
+    setDefaultKeyboardPreference.setSingleLineTitle(false);
     setDefaultKeyboardPreference.setDefaultValue(SystemIMESettings.isDefaultKB(context));
     setDefaultKeyboardPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
       @Override


### PR DESCRIPTION
Fixes #4260 so the preference screen titles (checkboxes) aren't truncated. 
* Enable Keyman as system-wide keyboard
* Set Keyman as default keyboard

Fortunately, we don't need to support Holo theme anymore

Android 5,0 (API 21)
![preference api 21](https://user-images.githubusercontent.com/7358010/105661674-9935a300-5f00-11eb-86e9-2d0d6b416c66.png)

Android 9.0 (API 28)
![preference api 28](https://user-images.githubusercontent.com/7358010/105661687-9f2b8400-5f00-11eb-98ff-12d972cc08cd.png)
