### PR TITLE
fix(ios): better handling of scoped vs non-scoped package URLs

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -92,15 +92,16 @@ public class ResourceFileManager {
       try fileManager.removeItem(at: destination)
     }
 
-    // Throws an error if the destination file already exists, and there's no
-    // built-in override parameter.  Hence, the previous if-block.
-    if source.startAccessingSecurityScopedResource() {
-      defer { source.stopAccessingSecurityScopedResource() }  // The Swift version of 'finally'.
+    // If we've been provided a security-scoped resource URL,
+    // it needs special handling.  This function needs to accept
+    // both scoped & non-scoped URLs.
+    if source.startAccessingSecurityScopedResource() { // only succeeds if scoped
+      // The Swift version of 'finally'.
+      defer { source.stopAccessingSecurityScopedResource() }
       try fileManager.copyItem(at: source, to: destination)
     } else {
-      // We _could_ get more specific, as it's due to issues with security-scoped resources...
-      // but this ought be fine for now.
-      throw KMPError.copyFiles
+      // Not scoped?  No problem!
+      try fileManager.copyItem(at: source, to: destination)
     }
   }
 


### PR DESCRIPTION
Fixes #4281.

Rework of #4095, which was not properly implemented.  Turns out not everything needs to be security-scoped.