### PR TITLE
change(android/engine): Allow swipe to dismiss update notifications

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -428,8 +428,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       .setContentText(message)
       .setPriority(NotificationCompat.PRIORITY_DEFAULT)
       .setAutoCancel(true)
-      .setContentIntent(startUpdateIntent)
-      .setOngoing(true);
+      .setContentIntent(startUpdateIntent);
 
     notificationManager.notify(notification_id,builder.build());
   }


### PR DESCRIPTION
Fixes item 2 of #4252 
> 2. We should be able to left-swipe an update notification to dismiss it -- there's no reason for it to be persistent :)

Yah for 1-line changes

I tested with a custom build that had an older version of sil_euro_latin.kmp (version 1.8.1).
When the app loaded, the update notification appeared.
I could then swipe to dismiss it.