### PR TITLE
fix(windows): invalid character in text content opening help

### DIFF
--- a/windows/src/desktop/kmshell/help/UfrmHelp.pas
+++ b/windows/src/desktop/kmshell/help/UfrmHelp.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmHelp
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      27 Mar 2008
 
   Modified Date:    1 May 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          27 Mar 2008 - mcdurdin - I1251 - Integrate keyboard help with Keyman help
                     14 Jun 2008 - mcdurdin - Go directly to help if the help template does not exist
                     28 Jul 2008 - mcdurdin - I1510 - Context help fix
@@ -25,16 +25,26 @@ unit UfrmHelp;  // I3306
 interface
 
 uses
-  Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls, Forms,
-  Dialogs, UfrmWebContainer,
-  keymanapi_TLB, UfrmKeymanBase, UserMessages;
+  System.Classes,
+  System.SysUtils,
+  System.Variants,
+  Vcl.Controls,
+  Vcl.Dialogs,
+  Vcl.Forms,
+  Vcl.Graphics,
+  Winapi.Messages,
+  Winapi.Windows,
+
+  UfrmWebContainer,
+  UfrmKeymanBase,
+  UserMessages;
 
 type
   THelpFormHelpTarget = (htNone, htProduct, htKeyboard, htTutorial);
   TfrmHelp = class(TfrmWebContainer)
     procedure TntFormCreate(Sender: TObject);
   private
-    FActiveKeyboard: IKeymanKeyboardInstalled;
+    FActiveKeyboardID: string;
     FHelpTarget: THelpFormHelpTarget;
     FHelpJump: WideString;
     procedure DoHelpTarget(Target: THelpFormHelpTarget);
@@ -48,7 +58,6 @@ type
     class procedure Execute(const Context, ActiveKeyboardID: string);
     procedure OpenKeyboardHelp;
     procedure OpenProductHelp;
-    property ActiveKeyboard: IKeymanKeyboardInstalled read FActiveKeyboard write FActiveKeyboard;
     property HelpTarget: THelpFormHelpTarget read FHelpTarget;
     property HelpJump: WideString read FHelpJump write FHelpJump;
   end;
@@ -59,6 +68,7 @@ implementation
 
 uses
   help,
+  keymanapi_TLB,
   kmint,
   MessageIdentifierConsts,
   MessageIdentifiers,
@@ -73,9 +83,7 @@ begin
   with TfrmHelp.Create(nil) do   // I1251 - Combine help with keyboard help
   try
     HelpJump := Context;
-    if ActiveKeyboardID = ''
-      then ActiveKeyboard := nil
-      else ActiveKeyboard := kmint.kmcom.Keyboards.Items[ActiveKeyboardID];
+    FActiveKeyboardID := ActiveKeyboardID;
 
     ShowModal;
 
@@ -127,8 +135,8 @@ var
   FQuery: string;
 begin
   FormStyle := fsStayOnTop;   // I4209
-  if FActiveKeyboard <> nil
-    then FQuery := Format('keyboard=%s', [UrlEncode(FActiveKeyboard.Name)])
+  if FActiveKeyboardID <> ''
+    then FQuery := Format('keyboard=%s', [UrlEncode(FActiveKeyboardID)])
     else FQuery := '';
 
   Content_Render(FQuery);
@@ -139,7 +147,7 @@ procedure TfrmHelp.OpenKeyboardHelp;
 var
   kbd: IKeymanKeyboardInstalled;
 begin
-  kbd := FActiveKeyboard;
+  kbd := kmint.kmcom.Keyboards.Items[FActiveKeyboardID];
   if not Assigned(kbd) then Exit;
   kmcom.Control.ShowKeyboardWelcome(kbd);
 end;

--- a/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
+++ b/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
@@ -63,6 +63,7 @@ uses
   System.StrUtils,
   System.SysUtils,
 
+  keymanapi_tlb,
   BaseKeyboards,
   Keyman.Configuration.System.HttpServer.App.TextEditorFonts,
   KeymanVersion,
@@ -195,9 +196,14 @@ end;
 procedure TAppHttpResponder.ProcessPageHelp(const Params: TStrings);
 var
   s: string;
+  kbd: IKeymanKeyboardInstalled;
 begin
   if Params.Values['keyboard'] <> ''
-    then s := Format('<Keyboard Name="%s" />', [XMLEncode(Params.Values['keyboard'])])
+    then kbd := FXMLRenderers.kmcom.Keyboards.Items[Params.Values['keyboard']]
+    else kbd := nil;
+
+  if Assigned(kbd)
+    then s := Format('<Keyboard Name="%s" />', [XMLEncode(kbd.Name)])
     else s := '';
   FXMLRenderers.RenderTemplate := 'Help.xsl';
   ProcessXMLPage(s);


### PR DESCRIPTION
Fixes #4205.

Avoids encoding UTF-8 in the URL which has patchy support in some of our libraries.