### PR TITLE
fix(windows): align title to top in Install Keyboard

### DIFF
--- a/windows/src/desktop/kmshell/xml/installkeyboard.css
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.css
@@ -119,7 +119,7 @@ div {
   font-size: 13.3px;
   padding-right: 10px;
   margin: 1px;
-  vertical-align: middle;
+  vertical-align: top;
 }
 .otherdetails {
   font-size: 13.3px;


### PR DESCRIPTION
Fixes #4179.