### PR TITLE
fix(ios): fixes accidental logo / cancel button overlap during package installation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -346,9 +346,8 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
 
     let dismissalBlock = {
       if let nvc = self.navigationController {
-        self.dismiss(animated: true) {
-          nvc.popToRootViewController(animated: true)
-        }
+        self.dismiss(animated: true)
+        nvc.popToRootViewController(animated: false)
       } else { // Otherwise, if the root view of a navigation controller, dismiss it outright.  (pop not available)
         self.dismiss(animated: true)
       }

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -110,14 +110,14 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // We have to gerry-rig this so that the framework-based SettingsViewController
     // can launch the app-based DocumentViewController.
     if #available(iOS 11.0, *) {
-      Manager.shared.fileBrowserLauncher = { _ in
+      Manager.shared.fileBrowserLauncher = { navVC in
         let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"],
                                               in: .import,
-                                              navVC: self.navigationController!)
+                                              navVC: navVC)
 
-        // Auto-dismiss the settings menu, then present the "install from file" browser.
-        self.navigationController!.topViewController!.dismiss(animated: true, completion: nil)
-        self.present(vc, animated: true)
+        // Present the "install from file" browser within the specified navigation view controller.
+        // (Allows displaying from within the Settings menu)
+        navVC.present(vc, animated: true)
       }
     }
   }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -85,18 +85,27 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
     let packageInstaller = AssociatingPackageInstaller(for: package,
                                                        withAssociators: associators) { status in
       if status == .starting {
-        // Start a spinner!
+        // Start a spinner!  Installation confirmed, but still in progress;
+        // there may be lexical models to download.
         activitySpinner.startAnimating()
-        self.view.addSubview(activitySpinner)
 
-        activitySpinner.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
-        activitySpinner.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
-        self.view.isUserInteractionEnabled = false
+        var pendingRootView: UIView
+        if let navVC = self.navVC, navVC.viewControllers.first?.view != nil {
+          pendingRootView = navVC.viewControllers.first!.view!
+        } else {
+          pendingRootView = self.view
+        }
+
+        pendingRootView.addSubview(activitySpinner)
+
+        activitySpinner.centerXAnchor.constraint(equalTo: pendingRootView.centerXAnchor).isActive = true
+        activitySpinner.centerYAnchor.constraint(equalTo: pendingRootView.centerYAnchor).isActive = true
+        pendingRootView.isUserInteractionEnabled = false
       } else if status == .complete {
-        // Report completion!   Only reached if installation actually happens.
+        // Report completion!   Only reached when installation is fully completed.
         activitySpinner.stopAnimating()
         activitySpinner.removeFromSuperview()
-        self.view.isUserInteractionEnabled = true
+        //self.view.isUserInteractionEnabled = true
 
         // Do not animate the dismissal:  the welcome-page's dismissal
         // already provides enough animation.

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -93,14 +93,15 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
         activitySpinner.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         self.view.isUserInteractionEnabled = false
       } else if status == .complete {
-        // Report completion!
+        // Report completion!   Only reached if installation actually happens.
         activitySpinner.stopAnimating()
         activitySpinner.removeFromSuperview()
         self.view.isUserInteractionEnabled = true
+
+        // Do not animate the dismissal:  the welcome-page's dismissal
+        // already provides enough animation.
         if let navVC = self.navVC {
-          navVC.dismiss(animated: true, completion: nil)
-        } else {
-          self.dismiss(animated: true, completion: nil)
+          navVC.dismiss(animated: false, completion: nil)
         }
       }
     }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -105,12 +105,11 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
         // Report completion!   Only reached when installation is fully completed.
         activitySpinner.stopAnimating()
         activitySpinner.removeFromSuperview()
-        //self.view.isUserInteractionEnabled = true
 
         // Do not animate the dismissal:  the welcome-page's dismissal
         // already provides enough animation.
         if let navVC = self.navVC {
-          navVC.dismiss(animated: false, completion: nil)
+          navVC.dismiss(animated: true, completion: nil)
         }
       }
     }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -97,7 +97,11 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
         activitySpinner.stopAnimating()
         activitySpinner.removeFromSuperview()
         self.view.isUserInteractionEnabled = true
-        self.dismiss(animated: true, completion: nil)
+        if let navVC = self.navVC {
+          navVC.dismiss(animated: true, completion: nil)
+        } else {
+          self.dismiss(animated: true, completion: nil)
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #4328.

The issue arose due to the view hierarchy in which the package installer was being displayed when using "Install From File" for package installation.  The old implementation had a "hard requirement" that it be displayed from the top-level view, which isn't ideal.  Reworking it to fully and properly accept an arbitrary `UINavigationView` root and then using the Settings menu's instance allows us to keep the top-level-only logo away from the package installer.

I've tested the UX via all three standard install paths:

1. Opened a .kmp from outside the Keyman app.  (Safari download, iOS Files app)
2. Used our "install from file" menu option from within the app
3. Downloaded from keyboard search

There was also an issue with the 'activity spinner' not displaying during installation from Install From File as well, so I rolled that into this PR.