### PR TITLE
fix(ios): reloads keyboard after package updates

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -279,8 +279,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   open override func viewWillAppear(_ animated: Bool) {
-    // Just seeing if it's actually called.
     super.viewWillAppear(animated)
+
+    if Manager.shared.shouldReloadKeyboard {
+      self.reload()
+    }
   }
 
   open override func viewDidAppear(_ animated: Bool) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -277,7 +277,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     //
     // We MUST NOT shortcut this method as a result; doing so may (rarely) result in the infamous
     // blank keyboard bug!
-    if kb.fullID == currentKeyboardID && !self.isSystemKeyboard {
+    if kb.fullID == currentKeyboardID && !self.isSystemKeyboard && !self.shouldReloadKeyboard {
       log.info("Keyboard unchanged: \(kb.fullID)")
       return false
      // throw KeyboardError.unchanged

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -752,9 +752,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     // true source of the problems.
     viewController.dismiss(animated: false)
     showKeyboard()
-    if shouldReloadKeyboard {
-      inputViewController.reload()
-    }
+    
     NotificationCenter.default.post(name: Notifications.keyboardPickerDismissed, object: self, value: ())
   }
     

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -342,6 +342,8 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
 
     let selectedResources = self.package.installableResourceSets.flatMap { $0.filter { selectedLanguageCodes.contains($0.languageID) }} as! [Resource]
 
+    // Always reload after installing or updating resources.
+    Manager.shared.shouldReloadKeyboard = true
     self.completionHandler(selectedResources.map { $0.typedFullID })
 
     let dismissalBlock = {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -308,7 +308,6 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
 
       switch(package.resourceType()) {
         case .keyboard:
-          Manager.shared.shouldReloadKeyboard = true
           msg = NSLocalizedString("notification-download-success-keyboard", bundle: engineBundle, comment: "")
         case .lexicalModel:
           msg = NSLocalizedString("notification-download-success-lexical-model", bundle: engineBundle, comment: "")


### PR DESCRIPTION
Fixes #2757.

- Re-installing a package that has already been previously installed will automatically load the newly re-installed version, regardless of identical package filenames, relative package versions, etc.

----

With the first commit, the severity of the bug is downgraded for both cases:

> If I take care to ensure no automatic [package filename] renaming occurs behind the scenes, this does reproduce exactly. It gets tricky though, as various ways of importing .kmp files for testing will result in automatic `-1`, `-2`, etc renaming by iOS / Simulator / whatever.

- Now only requires swapping in and out of the keyboard.  There's no need to force-close & restart the app.

> If I slip up and let automatic renaming occur, merely swapping in and out of the keyboard is sufficient for a refresh; force-closing the app is not required. It is still required if system-level automatic renaming is prevented.

- Now 100% fixed; the keyboard will auto-refresh without issue so long as the actual package filename is different, even if only due to automatic iOS renaming.

----

The second commit fully resolves the bug, even for the first case.  As it turns out, the actual `reload()` method was never called until the keyboard picker was dismissed - the problem being that this required _summoning_ the picker, which isn't part of the package install pipeline.

It did make one assumption:  _the keyboard must always be hidden during a package install & redisplayed after it's fully complete_.  As the install process now always sets `shouldReloadKeyboard`, the keyboard's `viewWillAppear` method is sufficient for detecting that for needed reloads.

Unfortunately, attempting to immediately reload the keyboard (instead of using `shouldReloadKeyboard` to defer the reload until keyboard re-display) is prone to causing a blank keyboard bug.  As a result, I think it's safer to rely upon the assumption above for now; that assumption _is_ the "correct" control flow for the app, after all.