### PR TITLE
fix(windows): Splash button sizes

### DIFF
--- a/windows/src/desktop/kmshell/xml/splash.css
+++ b/windows/src/desktop/kmshell/xml/splash.css
@@ -50,7 +50,11 @@ div {
 }
 
 #version {
-  position: absolute; font-size: 0.8em; right: 90px; bottom: 10px; color: #F68924
+  position: absolute;
+  font-size: 0.8em;
+  right: 120px;
+  bottom: 10px;
+  color: #F68924;
 }
 
 #beta {
@@ -66,7 +70,7 @@ div {
   height: 84px;
   max-height: 84px;
   overflow-y: auto;
-  width: 400px;
+  width: 360px;
   padding: 0 16px 0 0;
 }
 
@@ -143,17 +147,27 @@ a.button {
 #tasks div { margin-bottom: 2px; margin-left: 4px }
 
 #startNow {
-  left: 434px;
+  right: 12px;
   top: 332px;
   height: 1.2em;
 }
 
+#startNow .btn,
+#config .btn {
+  width: 180px;
+  text-overflow: ellipsis;
+}
+
 #config {
-  left: 434px;
+  right: 12px;
   top: 372px;
 }
 
 #exit { right: 12px; bottom: 12px; }
+
+#exit .btn-small {
+  width: 90px;
+}
 
 #tasks div#showAtStartupBox { margin-top: 6px; margin-left: 0; }
 #tasks a, #showAtStartupLabel { color: #F68924; text-decoration: none; }


### PR DESCRIPTION
Fixes #4265.

This adjusts the button sizes of the splash screen to accommodate longer strings such as found in the Khmer translation. We could go to a more flexible layout model to allow for the buttons to stretch as needed, but that's a lot more work and I don't really want to try for that right now.

![image](https://user-images.githubusercontent.com/4498365/105941347-4f3fef00-60b1-11eb-8926-1f54456b1890.png)

(ignore the missing Version string -- that's not related and not a problem, only on my dev machine)

![image](https://user-images.githubusercontent.com/4498365/105941412-7eeef700-60b1-11eb-8299-01ae47165a7d.png)
