### PR TITLE
fix(windows): Enter and Spacebar handling in Configuration

### DIFF
--- a/windows/src/desktop/kmshell/xml/menu-frame.js
+++ b/windows/src/desktop/kmshell/xml/menu-frame.js
@@ -1,5 +1,5 @@
   var menuframe_activeindex=0, menuframe_items = [];
-          
+
   function menuframe_add(path, name, description, hotkey)
   {
     var n = menuframe_items.length;
@@ -13,18 +13,18 @@
     menuframe_items[n].menu_hotkey = hotkey;
     menuframe_items[n].menu_name = name;
   }
-  
+
   function menuframe_activate(n)
   {
     var p = menuframe_items[menuframe_activeindex], c = menuframe_items[n];
     var itemtype, blah;
-    
-    p.className='menuframe'; 
-    c.className='menuframe_active'; 
+
+    p.className='menuframe';
+    c.className='menuframe_active';
     menuframe_activeindex=n;
     document.getElementById('content_'+p.menu_name).style.display = 'none';
     document.getElementById('content_'+c.menu_name).style.display = 'block';
-    
+
     save_state();
 
     if(!loading_state) {
@@ -32,19 +32,19 @@
       for(var i = 0; i < q.length; i++) {
         blah = q[i].id;
         itemtype = blah.substr(0, 5);
-        
+
         if( itemtype == "list_" ) {
           q[i].focus();
           break;
         }
       }
     }
-    
+
     if(typeof window['menuframe_activate_'+c.menu_name] != 'undefined') {
       window['menuframe_activate_'+c.menu_name]();
     }
   }
-  
+
   function menuframe_keydown(event)
   //document.onkeydown = function()
   {
@@ -80,16 +80,11 @@
         }
         break;
       case 13:    // enter
-        if( event.target.id.substring(0,6) != 'button' && event.target.tagName != 'TEXTAREA' ) {
-          event.cancelBubble = true; event.returnValue = false;
-          location.href='keyman:footer_ok';
-          break;
-        }
-        event.cancelBubble = true; event.returnValue = true;
+        event.cancelBubble = true;
+        event.returnValue = event.target.id.substring(0,6) == 'button' || event.target.tagName == 'TEXTAREA';
         break;
       case 27:    // esc
         event.cancelBubble = true; event.returnValue = false;
-        location.href='keyman:footer_cancel';
         break;
       case 32:    // spacebar
         switch(event.srcElement.tagName.toLowerCase()) {
@@ -103,18 +98,18 @@
             document.getElementById(k).focus();
             break;
           case 'input': return true;
-          case 'div': 
-          case 'span': 
+          case 'div':
+          case 'span':
             if(event.srcElement.parentElement) {
               switch(event.srcElement.parentElement.id) {
                 case 'keyboards':
-                  keyboard_checkclick(event.srcElement.id.substring(5),true);
+                  keyboard_checkclick(event.srcElement.id.substring('list_keyboard_'.length),true);
                   break;
                 case 'options':
-                  options_updatecheck(event.srcElement.id.substring(5),true);
+                  options_updatecheck(event.srcElement.id.substring('list_option_'.length),true);
                   break;
-                case 'hotkeys':
-                  location.href='keyman:hotkey_set?index=hotkey_' + event.srcElement.id.substring(5);
+                case 'subcontent_hotkeys':
+                  location.href='keyman:hotkey_set?index=hotkey_' + event.srcElement.id.substring('list_hotkey_'.length);
                   break;
                 default:
                   break;
@@ -124,13 +119,13 @@
         }
         event.cancelBubble = true; event.returnValue = false; event.preventDefault(); break;
         break;
-      default: 
+      default:
         for(var i = 0; i < menuframe_items.length; i++)
           if(menuframe_items[i].menu_hotkey.charCodeAt(0) == event.keyCode && event.altKey)
           {
               event.cancelBubble = true; event.returnValue = false; menuframe_activate(i); break;
           }
-            
+
     }
   }
 
@@ -138,5 +133,4 @@
     document.onkeydown = menuframe_keydown;
   }
   doAttachEvent(window, 'load', menuframe_setup);
-  
- 
+


### PR DESCRIPTION
Fixes #4186.
Fixes #4183.
Fixes [KEYMAN-WINDOWS-7X](https://sentry.keyman.com/organizations/keyman/issues/2802/?referrer=github_integration).
Fixes [KEYMAN-WINDOWS-6Y](https://sentry.keyman.com/organizations/keyman/issues/2305/?referrer=github_integration).

The Enter and Spacebar key handlers had not been updated for the new layout and so threw errors in use.