### PR TITLE
fix(web, android, iOS): OSK 'tab' support when embedded

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -180,7 +180,10 @@ namespace com.keyman.text {
       //        once THOSE are properly relocated.  (They're too DOM-heavy to remain in web-core.)
 
       // Only return true (for the eventual event handler's return value) if we didn't match a rule.
-      return ruleBehavior;
+
+      // Alas, the above notes are the goal, and will be separately addressed by #3695.  For now, a hacky
+      // workaround in order to not break default behaviors.
+      return ruleBehavior && !ruleBehavior.triggerKeyDefault;  // return `true` if the key is considered fully handled.
     }
 
     public resetContext(outputTarget?: OutputTarget) {

--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -194,13 +194,11 @@ namespace com.keyman.text {
           return Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
         } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
           return Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
-          // Filter out unembedded desktop scenarios; we need browser-default behavior to go through then.
-        } else if((Lkc.device.formFactor != utils.FormFactor.Desktop || Lkc.device.embedded) && 
-                  n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
+        } else if(n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
           // If TAB may be treated as a 'command key', it'll have been filtered out before this point.
           return '\t';
         }
-      } catch (e) {
+       } catch (e) {
         if(ruleBehavior) {
           ruleBehavior.errorLog = "Error detected with default mapping for key:  code = " + n + ", shift state = " + (keyShiftState == 1 ? 'shift' : 'default');
         }

--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -194,6 +194,9 @@ namespace com.keyman.text {
           return Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
         } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
           return Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
+        } else if(n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
+          // If TAB may be treated as a 'command key', it'll have been filtered out before this point.
+          return '\t';
         }
       } catch (e) {
         if(ruleBehavior) {

--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -37,19 +37,7 @@ namespace com.keyman.text {
       } else if((char = DefaultOutput.forBaseKeys(Lkc)) != null) {
         return char;
       } else {
-        // // For headless and embeddded, we may well allow '\t'.  It's DOM mode that has other uses.
-        // // Not originally defined for text output within defaultKeyOutput.
-        // // We can't enable it yet, as it'll cause hardware keystrokes in the DOM to output '\t' rather
-        // // than rely on the browser-default handling.
-        let code = DefaultOutput.codeForEvent(Lkc);
-        switch(code) {
-        //   case Codes.keyCodes['K_TAB']:
-        //   case Codes.keyCodes['K_TABBACK']:
-        //   case Codes.keyCodes['K_TABFWD']:
-        //     return '\t';
-          default:
-           return null;
-        }
+        return null;
       }
     }
 

--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -194,7 +194,9 @@ namespace com.keyman.text {
           return Codes.codesUS[keyShiftState][1][n-Codes.keyCodes['K_COLON']];
         } else if(n >= Codes.keyCodes['K_LBRKT'] && n <= Codes.keyCodes['K_QUOTE']) {
           return Codes.codesUS[keyShiftState][2][n-Codes.keyCodes['K_LBRKT']];
-        } else if(n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
+          // Filter out unembedded desktop scenarios; we need browser-default behavior to go through then.
+        } else if((Lkc.device.formFactor != utils.FormFactor.Desktop || Lkc.device.embedded) && 
+                  n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
           // If TAB may be treated as a 'command key', it'll have been filtered out before this point.
           return '\t';
         }

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -984,12 +984,15 @@ namespace com.keyman.text {
       var matched = this.activeKeyboard.process(outputTarget, keystroke);
       this.activeTargetOutput = null;
 
-      if(!matched) {
-        return null;
-      }
-
       // Finalize the rule's results.
       this.ruleBehavior.transcription = outputTarget.buildTranscriptionFrom(preInput, keystroke);
+
+      // `matched` refers to whether or not the FINAL rule (from any group) matched, rather than
+      // whether or not ANY rule matched.  If the final rule doesn't match, we trigger the key's
+      // default behavior (if appropriate).
+      //
+      // See https://github.com/keymanapp/keyman/pull/4350#issuecomment-768753852
+      this.ruleBehavior.triggerKeyDefault = !matched;
 
       // Clear our result-tracking variable to prevent any possible pollution for future processing.
       let behavior = this.ruleBehavior;

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -225,7 +225,7 @@ namespace com.keyman.text {
         matchBehavior = this.keyboardInterface.processKeystroke(outputTarget, keyEvent);
       }
 
-      if(!matchBehavior) {
+      if(matchBehavior.triggerKeyDefault) {
         // Restore the virtual key code if a mnemonic keyboard is being used
         // If no vkCode value was stored, maintain the original Lcode value.
         keyEvent.Lcode=keyEvent.vkCode || keyEvent.Lcode;
@@ -236,7 +236,11 @@ namespace com.keyman.text {
 
         // Match against the 'default keyboard' - rules to mimic the default string output when typing in a browser.
         // Many keyboards rely upon these 'implied rules'.
-        matchBehavior = this.defaultRuleBehavior(keyEvent);
+        let defaultBehavior = this.defaultRuleBehavior(keyEvent);
+        if(defaultBehavior) {
+          matchBehavior.mergeInDefaults(defaultBehavior);
+          matchBehavior.triggerKeyDefault = false; // We've triggered it successfully.
+        } // If null, we must rely on something else (like the browser, in DOM-aware code) to fulfill the default.
 
         this.keyboardInterface.activeTargetOutput = null;
       }

--- a/common/core/web/keyboard-processor/tests/cases/engine/unmatched_final_group.js
+++ b/common/core/web/keyboard-processor/tests/cases/engine/unmatched_final_group.js
@@ -1,0 +1,45 @@
+var assert = require('chai').assert;
+let fs = require('fs');
+let vm = require('vm');
+
+let KeyboardProcessor = require('../../../dist');
+let KMWRecorder = require('../../../../tools/recorder/dist/nodeProctor');
+
+// Required initialization setup.
+global.com = KeyboardProcessor.com; // exports all keyboard-processor namespacing.
+
+describe('Engine - Unmatched Final Groups', function() {
+  let testJSONtext = fs.readFileSync('../tests/resources/json/engine_tests/ghp_enter.json');
+  // Common test suite setup.
+  let testSuite = new KMWRecorder.KeyboardTest(JSON.parse(testJSONtext));
+
+  var keyboard;
+  let device = {
+    formFactor: 'desktop',
+    OS: 'windows',
+    browser: 'native'
+  }
+
+  before(function() {
+    // -- START: Standard Recorder-based unit test loading boilerplate --
+    // Load the keyboard.  We'll need a KeyboardProcessor instance as an intermediary.
+    let kp = new KeyboardProcessor();
+
+    // These two lines will load a keyboard from its file; headless-mode `registerKeyboard` will
+    // automatically set the keyboard as active.
+    var script = new vm.Script(fs.readFileSync('../tests/' + testSuite.keyboard.filename));
+    script.runInThisContext();
+
+    keyboard = kp.activeKeyboard;
+    assert.equal(keyboard.id, "Keyboard_" + testSuite.keyboard.id);
+    // --  END:  Standard Recorder-based unit test loading boilerplate --
+
+    // This part provides extra assurance that the keyboard properly loaded.
+    assert.equal(keyboard.id, "Keyboard_galaxie_hebrew_positional");
+  });
+
+  it('Emits default tab AND matches rule from early group', function() {
+    let proctor = new KMWRecorder.NodeProctor(keyboard, device, assert.equal);
+    testSuite.test(proctor);
+  });
+});

--- a/common/core/web/tests/resources/fixtures/singleTextArea.html
+++ b/common/core/web/tests/resources/fixtures/singleTextArea.html
@@ -1,0 +1,2 @@
+<!--That ID is explicitly looked up as the input target.-->
+<textarea id="singleton"/>

--- a/common/core/web/tests/resources/json/engine_tests/ghp_enter.json
+++ b/common/core/web/tests/resources/json/engine_tests/ghp_enter.json
@@ -1,0 +1,41 @@
+{
+  "specVersion": "14.0",
+  "keyboard": {
+    "id": "galaxie_hebrew_positional",
+    "name": "Galaxie Hebrew (Positional)",
+    "filename": "resources/keyboards/galaxie_hebrew_positional-2.2.js",
+    "languages": [
+      {
+        "id": "he",
+        "name": "Hebrew",
+        "region": "Asia"
+      }
+    ]
+  },
+  "inputTestSets": [
+    {
+      "constraint": {
+        "target": "desktop",
+        "validOSList": null,
+        "validBrowsers": null
+      },
+      "testSet": [
+        {
+          "inputs": [
+            {
+              "type": "osk",
+              "layer": "default",
+              "keyName": "K_M"
+            },
+            {
+              "type": "osk",
+              "layer": "default",
+              "keyName": "K_ENTER"
+            }
+          ],
+          "output": "ם\n"
+        }
+      ]
+    }
+  ]
+}

--- a/common/core/web/tests/resources/json/keyboards/galaxie_hebrew_positional.json
+++ b/common/core/web/tests/resources/json/keyboards/galaxie_hebrew_positional.json
@@ -1,0 +1,10 @@
+{
+  "id": "galaxie_hebrew_positional",
+  "name":"Galaxie Hebrew (Positional)",
+  "languages":{
+    "id":"he",
+    "name": "Hebrew",
+    "region": 3
+  },
+  "filename":"resources/keyboards/galaxie_hebrew_positional-2.2.js"
+}

--- a/common/core/web/tests/resources/keyboards/galaxie_hebrew_positional-2.2.js
+++ b/common/core/web/tests/resources/keyboards/galaxie_hebrew_positional-2.2.js
@@ -1,0 +1,521 @@
+if (typeof keyman === 'undefined') {
+  console.log('Keyboard requires KeymanWeb 10.0 or later');
+  if (typeof tavultesoft !== 'undefined')
+      tavultesoft.keymanweb.util.alert("This keyboard requires KeymanWeb 10.0 or later");
+} else {
+  KeymanWeb.KR(new Keyboard_galaxie_hebrew_positional());
+}
+function Keyboard_galaxie_hebrew_positional() {
+  this.KI = "Keyboard_galaxie_hebrew_positional";
+  this.KN = "Galaxie Hebrew (Positional)";
+  this.KMINVER = "10.0";
+  this.KV = {
+      F: ' 1em "Arial"',
+      K102: 0
+  };
+  this.KDU = 0;
+  this.KV.KLS = {
+      "default": ["", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "־", "◌ְ", "", "", "", "ק", "ו", "ךֵ", "ר", "ת", "י", "ע", "ך", "וֹ", "פ", "ף", "", "◌ּ", "", "", "", "א", "ס", "ד", "ט", "ג", "ה", "ח", "כ", "ל", "ךָ", "'", "", "", "", "", "", "", "ז", "צ", "שׂ", "שׁ", "ב", "נ", "מ", ",", "׃", "ן", "", "", "", "", "", ""],
+      "shift": ["~", "◌ִ", "◌ֵ", "◌ֶ", "◌ֱ", "◌ֻ", "◌ַ", "◌ֲ", "◌ָ", "◌ֳ", "◌ֹ", "◌ֿ", "+", "", "", "", "קּ", "וּ", "ךְ", "רּ", "תּ", "יּ", "עּ", "ךּ", "וֹּ", "פּ", "ףּ", "שּּ", "|", "", "", "", "אּ", "סּ", "דּ", "טּ", "גּ", "ץ", "חּ", "כּ", "לּ", "ךֶ", "\"", "", "", "", "", "", "", "זּ", "צּ", "שּׂ", "שּׁ", "בּ", "נּ", "מּ", "ם", ".", "ש", "", "", "", "", "", ""]
+  };
+  this.KV.BK = (function(x) {
+      var e = Array.apply(null, Array(65)).map(String.prototype.valueOf, ""), r = [], v, i, m = ['default', 'shift', 'ctrl', 'shift-ctrl', 'alt', 'shift-alt', 'ctrl-alt', 'shift-ctrl-alt'];
+      for (i = m.length - 1; i >= 0; i--)
+          if ((v = x[m[i]]) || r.length)
+              r = (v ? v : e).slice().concat(r);
+      return r
+  }
+  )(this.KV.KLS);
+  this.KH = '';
+  this.KM = 0;
+  this.KBVER = "2.2";
+  this.KMBM = 0x0010;
+  this.KRTL = 1;
+  this.KVER = "10.0.1099.0";
+  this.gs = function(t, e) {
+      return this.g0(t, e);
+  }
+  ;
+  this.g0 = function(t, e) {
+      var k = KeymanWeb
+        , r = 0
+        , m = 0;
+      if (k.KKM(e, 16384, 9) && k.KFCM(1, t, ['מ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ם");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 9) && k.KFCM(1, t, ['פ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ף");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 9) && k.KFCM(1, t, ['נ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ן");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 9) && k.KFCM(1, t, ['צ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ץ");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 13) && k.KFCM(1, t, ['מ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ם");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 13) && k.KFCM(1, t, ['פ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ף");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 13) && k.KFCM(1, t, ['נ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ן");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 13) && k.KFCM(1, t, ['צ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ץ");
+          r = this.g1(t, e);
+      } else if (k.KKM(e, 16384, 9) && k.KFCM(1, t, ['כ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ך");
+      } else if (k.KKM(e, 16384, 13) && k.KFCM(1, t, ['כ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ך");
+      } else if (k.KKM(e, 16384, 32) && k.KFCM(1, t, ['מ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ם ");
+      } else if (k.KKM(e, 16384, 32) && k.KFCM(1, t, ['פ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ף ");
+      } else if (k.KKM(e, 16384, 32) && k.KFCM(1, t, ['נ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ן ");
+      } else if (k.KKM(e, 16384, 32) && k.KFCM(1, t, ['צ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ץ ");
+      } else if (k.KKM(e, 16384, 32) && k.KFCM(1, t, ['כ'])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ך");
+      } else if (k.KKM(e, 16400, 49)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ִ");
+      } else if (k.KKM(e, 16400, 222)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "\"");
+      } else if (k.KKM(e, 16400, 51)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֶ");
+      } else if (k.KKM(e, 16400, 52)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֱ");
+      } else if (k.KKM(e, 16400, 53)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֻ");
+      } else if (k.KKM(e, 16400, 55)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֲ");
+      } else if (k.KKM(e, 16384, 222)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "'");
+      } else if (k.KKM(e, 16400, 57)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֳ");
+      } else if (k.KKM(e, 16400, 48)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֹ");
+      } else if (k.KKM(e, 16400, 56)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ָ");
+      } else if (k.KKM(e, 16400, 187)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "+");
+      } else if (k.KKM(e, 16384, 188) && k.KFCM(1, t, [{
+          t: 'd',
+          d: 0
+      }])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "֤");
+      } else if (k.KKM(e, 16384, 189)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "־");
+      } else if (k.KKM(e, 16384, 190)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "׃");
+      } else if (k.KKM(e, 16384, 191)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ן");
+      } else if (k.KKM(e, 16384, 48)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "0");
+      } else if (k.KKM(e, 16384, 49)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "1");
+      } else if (k.KKM(e, 16384, 50)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "2");
+      } else if (k.KKM(e, 16384, 51)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "3");
+      } else if (k.KKM(e, 16384, 52)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "4");
+      } else if (k.KKM(e, 16384, 53)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "5");
+      } else if (k.KKM(e, 16384, 54)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "6");
+      } else if (k.KKM(e, 16384, 55)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "7");
+      } else if (k.KKM(e, 16384, 56)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "8");
+      } else if (k.KKM(e, 16384, 57)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "9");
+      } else if (k.KKM(e, 16400, 186)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ךֶ");
+      } else if (k.KKM(e, 16384, 186)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ךָ");
+      } else if (k.KKM(e, 16400, 188) && k.KFCM(1, t, [{
+          t: 'd',
+          d: 0
+      }])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "֫");
+      } else if (k.KKM(e, 16400, 188)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ם");
+      } else if (k.KKM(e, 16384, 187) && k.KFCM(1, t, [{
+          t: 'd',
+          d: 0
+      }])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "=");
+      } else if (k.KKM(e, 16384, 187)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ְ");
+      } else if (k.KKM(e, 16400, 190)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, ".");
+      } else if (k.KKM(e, 16400, 191)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ש");
+      } else if (k.KKM(e, 16400, 50)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֵ");
+      } else if (k.KKM(e, 16400, 65)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "אּ");
+      } else if (k.KKM(e, 16400, 66)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "בּ");
+      } else if (k.KKM(e, 16400, 67)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "שּׂ");
+      } else if (k.KKM(e, 16400, 68)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "דּ");
+      } else if (k.KKM(e, 16400, 69)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ךְ");
+      } else if (k.KKM(e, 16400, 70)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "טּ");
+      } else if (k.KKM(e, 16400, 71)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "גּ");
+      } else if (k.KKM(e, 16400, 72)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ץ");
+      } else if (k.KKM(e, 16400, 73)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ךּ");
+      } else if (k.KKM(e, 16400, 74)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "חּ");
+      } else if (k.KKM(e, 16400, 75)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "כּ");
+      } else if (k.KKM(e, 16400, 76)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "לּ");
+      } else if (k.KKM(e, 16400, 77)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "מּ");
+      } else if (k.KKM(e, 16400, 78)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "נּ");
+      } else if (k.KKM(e, 16400, 79)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "וֹּ");
+      } else if (k.KKM(e, 16400, 80)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "פּ");
+      } else if (k.KKM(e, 16400, 81)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "קּ");
+      } else if (k.KKM(e, 16400, 82)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "רּ");
+      } else if (k.KKM(e, 16400, 83)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "סּ");
+      } else if (k.KKM(e, 16400, 84)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "תּ");
+      } else if (k.KKM(e, 16400, 85)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "עּ");
+      } else if (k.KKM(e, 16400, 86)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "שּׁ");
+      } else if (k.KKM(e, 16400, 87)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "וּ");
+      } else if (k.KKM(e, 16400, 88)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "צּ");
+      } else if (k.KKM(e, 16400, 89)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "יּ");
+      } else if (k.KKM(e, 16400, 90)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "זּ");
+      } else if (k.KKM(e, 16384, 219)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ף");
+      } else if (k.KKM(e, 16384, 220)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ּ");
+      } else if (k.KKM(e, 16400, 54)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ַ");
+      } else if (k.KKM(e, 16400, 189)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ֿ");
+      } else if (k.KKM(e, 16384, 192)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KDO(-1, t, 0);
+      } else if (k.KKM(e, 16384, 65)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "א");
+      } else if (k.KKM(e, 16384, 66)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ב");
+      } else if (k.KKM(e, 16384, 67)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "שׂ");
+      } else if (k.KKM(e, 16384, 68)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ד");
+      } else if (k.KKM(e, 16384, 69)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ךֵ");
+      } else if (k.KKM(e, 16384, 70)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ט");
+      } else if (k.KKM(e, 16384, 71)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ג");
+      } else if (k.KKM(e, 16384, 72)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ה");
+      } else if (k.KKM(e, 16384, 73)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ך");
+      } else if (k.KKM(e, 16384, 74)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ח");
+      } else if (k.KKM(e, 16384, 75)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "כ");
+      } else if (k.KKM(e, 16384, 76)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ל");
+      } else if (k.KKM(e, 16384, 77)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "מ");
+      } else if (k.KKM(e, 16384, 78)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "נ");
+      } else if (k.KKM(e, 16384, 79)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "וֹ");
+      } else if (k.KKM(e, 16384, 80)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "פ");
+      } else if (k.KKM(e, 16384, 81)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ק");
+      } else if (k.KKM(e, 16384, 82)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ר");
+      } else if (k.KKM(e, 16384, 83)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ס");
+      } else if (k.KKM(e, 16384, 84)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ת");
+      } else if (k.KKM(e, 16384, 85)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ע");
+      } else if (k.KKM(e, 16384, 86)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "שׁ");
+      } else if (k.KKM(e, 16384, 87)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ו");
+      } else if (k.KKM(e, 16384, 88)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "צ");
+      } else if (k.KKM(e, 16384, 89)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "י");
+      } else if (k.KKM(e, 16384, 90)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ז");
+      } else if (k.KKM(e, 16400, 219)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "ףּ");
+      } else if (k.KKM(e, 16400, 220) && k.KFCM(1, t, [{
+          t: 'd',
+          d: 0
+      }])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "ֽ");
+      } else if (k.KKM(e, 16400, 220)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "|");
+      } else if (k.KKM(e, 16400, 221)) {
+          r = m = 1;
+          k.KDC(0, t);
+          k.KO(-1, t, "שּּ");
+      } else if (k.KKM(e, 16400, 192) && k.KFCM(1, t, [{
+          t: 'd',
+          d: 0
+      }])) {
+          r = m = 1;
+          k.KDC(1, t);
+          k.KO(-1, t, "~");
+      }
+      return r;
+  }
+  ;
+  this.g1 = function(t, e) {
+      var k = KeymanWeb
+        , r = 0
+        , m = 0;
+      return r;
+  }
+  ;
+}

--- a/web/source/dom/domDefaultOutput.ts
+++ b/web/source/dom/domDefaultOutput.ts
@@ -3,19 +3,22 @@ namespace com.keyman.dom {
   let DefaultOutput = text.DefaultOutput;
   let Codes = text.Codes;
   type KeyEvent = text.KeyEvent;
+  type RuleBehavior = text.RuleBehavior;
 
   // Now for some classic JS method "extension".
   let coreIsCommand = DefaultOutput.isCommand;
   let coreApplyCommand = DefaultOutput.applyCommand;
+  let coreForBaseKeys = DefaultOutput.forBaseKeys;
 
   DefaultOutput.isCommand = function(Lkc: KeyEvent): boolean {
     let code = DefaultOutput.codeForEvent(Lkc);
+    let keyman = com.keyman.singleton;
 
     switch(code) {
       case Codes.keyCodes['K_TAB']:
       case Codes.keyCodes['K_TABBACK']:
       case Codes.keyCodes['K_TABFWD']:
-        return true;
+        return !keyman.isEmbedded;
       default:
         return coreIsCommand(Lkc);
     }
@@ -41,5 +44,23 @@ namespace com.keyman.dom {
     }
 
     coreApplyCommand(Lkc);
+  }
+
+  DefaultOutput.forBaseKeys = function(Lkc: KeyEvent, ruleBehavior?: RuleBehavior): string {
+    let n = Lkc.Lcode;
+    let keyman = com.keyman.singleton;
+
+    if(n == Codes.keyCodes['K_TAB'] || n == Codes.keyCodes['K_TABBACK'] || n == Codes.keyCodes['K_TABFWD']) {
+          // Filter out unembedded desktop scenarios; we need browser-default behavior to go through then.
+      if (Lkc.device.formFactor != utils.FormFactor.Desktop || keyman.isEmbedded) {
+        // If TAB may be treated as a 'command key', it'll have been filtered out before this point.
+        return '\t';
+      } else {
+        // For the filtered scenario, we need to explicitly NOT handle it.
+        return null;
+      }
+    } else {
+      return coreForBaseKeys(Lkc, ruleBehavior);
+    }
   }
 }

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -232,7 +232,7 @@ namespace com.keyman.dom {
         return true;
       }
 
-      var LeventMatched = (core.processKeyEvent(Levent) != null);
+      var LeventMatched = !!core.processKeyEvent(Levent);
 
       if(LeventMatched) {
         if(e  &&  e.preventDefault) {

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -89,7 +89,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      let retVal = (keyman.core.processKeyEvent(Lkc) != null);
+      let retVal = !!keyman.core.processKeyEvent(Lkc);
 
       return retVal;
     }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -247,7 +247,8 @@ namespace com.keyman.osk {
         keyText=spec['text'];
 
         // Unique layer-based transformation:  SHIFT-TAB uses a different glyph.
-        if(keyText == '*Tab*' && this.layer == 'shift') {
+        let embedded = com.keyman.singleton.isEmbedded;
+        if(keyText == '*Tab*' && this.layer == 'shift' && !embedded) {
           keyText = '*TabLeft*';
         }
       }

--- a/web/tools/recorder/recorder_KeyboardScripts.js
+++ b/web/tools/recorder/recorder_KeyboardScripts.js
@@ -14,6 +14,7 @@ function loadKeyboards() {
 
   // Existing unit_test stubs at the time of writing:
   var preloadFiles = [
+    filePrefix + "galaxie_hebrew_positional.json",
     filePrefix + "khmer_angkor.json",
     filePrefix + "lao_2008_basic.json",
     filePrefix + "options_with_save.json",

--- a/web/unit_tests/cases/engine.js
+++ b/web/unit_tests/cases/engine.js
@@ -180,3 +180,34 @@ describe('Engine - Browser Interactions', function() {
     })
   });
 });
+
+describe('Unmatched Final Groups', function() {
+  this.timeout(kmwconfig.timeouts.scriptLoad);
+
+  before(function(done) {
+    fixture.setBase('fixtures');
+    setupKMW(null, done, kmwconfig.timeouts.scriptLoad + kmwconfig.timeouts.eventDelay);
+  });
+
+  beforeEach(function(done) {
+    fixture.load("singleTextArea.html");
+    
+    window.setTimeout(function() {
+      done()
+    }, kmwconfig.timeouts.eventDelay);
+  });
+  
+  after(function() {
+    teardownKMW();
+  });
+
+  afterEach(function() {
+    fixture.cleanup();
+  });
+
+  it.only('matches rule from early group AND performs default behavior', function(done) {
+    // While a TAB-oriented version would be nice, it's much harder to write the test
+    // to detect change in last input element.
+    runKeyboardTestFromJSON('/engine_tests/ghp_enter.json', {usingOSK: true}, done, assert.equal, kmwconfig.timeouts.scriptLoad);
+  });
+});


### PR DESCRIPTION
Fixes an error reported here: https://community.software.sil.org/t/tab-key-on-touch-layout/4291

When KeymanWeb is run in embedded mode, TAB should no longer function as a DOM-oriented command.  These changes allow us to disable that logic path when embedded, enabling `'\t'` output instead.

In-app appearance after a single press of TAB:

![Screen Shot 2021-01-27 at 1 12 33 PM](https://user-images.githubusercontent.com/25213402/105950767-88706300-60a1-11eb-91da-6e4c99b23cac.png)

I don't believe it's possible for iOS to support TAB key commands - Apple's pretty strict with what it allows keyboards to do.  While the [official documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) doesn't explicitly state anything about tab commands, [this StackOverflow post](https://stackoverflow.com/a/28637083) states it to be impossible.

Compatibility of `\t` with predictive text... is probably best left to another time.  (Note:  those aren't the 'standard, default' corrections.)  Feels like an edge case...

Package used to test this:  [touch_tabbing.kmp.zip](https://github.com/keymanapp/keyman/files/5878032/touch_tabbing.kmp.zip)
- Github doesn't allow attaching .kmp files directly.