### PR TITLE
fix(web/ui): propagates UI module build failures

### DIFF
--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -485,6 +485,10 @@ if [ $BUILD_UI = true ]; then
     echo Compile UI Modules...
     $compilecmd -p $NODE_SOURCE/tsconfig.ui.json
 
+    if [ $? -ne 0 ]; then
+        fail "Typescript compilation of the UI modules failed."
+    fi
+
     CURRENT_PATH=`pwd`
     # Since the batch compiler for the UI modules outputs them within a subdirectory,
     # we need to copy them up to the base /intermediate/ folder.


### PR DESCRIPTION
Fixes #4303.

<img width="697" alt="Screen Shot 2021-01-27 at 1 52 13 PM" src="https://user-images.githubusercontent.com/25213402/105954323-19960880-60a7-11eb-820b-7a9440a2e76b.png">

Fortunately, for any CI builds before this, CI builds would have still failed - the bug was only for local builds.  `build.sh` has long looked for the existence of the UI modules' output files; as CI clears the output folders, those checks would have worked.  Local builds don't auto-clean, hence the bug.