### PR TITLE
chore(common): Enhance PR labeling based on PR title

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,12 @@
 #
-# This file adds labels based on the scopes in resources/scopes/scopes.json.
+# This file adds labels based on the scopes in resources/scopes/scopes.json and
+# resources/scopes/commit-types.json
 # Currently it must be manually kept up to date. Not all labels are added, only
 # common ones. The others are commented out. There is still some variance between
 # folder names and labels; consider this documentation of that ;-)
+
+#
+# Add labels based on changed files using actions/labeler
 #
 
 android/: android/**

--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -1,0 +1,63 @@
+version: v1
+
+# This file adds labels based on the scopes in resources/scopes/scopes.json and
+# resources/scopes/commit-types.json
+# Currently it must be manually kept up to date. Not all labels are added, only
+# common ones. The others are commented out. There is still some variance between
+# folder names and labels; consider this documentation of that ;-)
+
+#
+# Add labels based on the PR title using fuxingloh/multi-labeler
+#
+
+labels:
+  - label: 'feat'
+    matcher:
+      title: '^feat(\(|:)'
+  - label: 'fix'
+    matcher:
+      title: '^fix(\(|:)'
+  - label: 'chore'
+    matcher:
+      title: '^chore(\(|:)'
+  # "change",
+  - label: 'docs'
+    matcher:
+      title: '^docs(\(|:)'
+  # "style",
+  - label: 'refactor'
+    matcher:
+      title: '^refactor(\(|:)'
+  # "test",
+  - label: 'auto'
+    matcher:
+      title: '^auto(\(|:)'
+
+  # Below are the scopes that we look for in the PR title
+  - label: 'android/'
+    matcher:
+      title: '\(.*android.*\):'
+  - label: 'common/'
+    matcher:
+      title: '\(.*common.*\):'
+  - label: 'developer/'
+    matcher:
+      title: '\(.*developer.*\):'
+  - label: 'ios/'
+    matcher:
+      title: '\(.*ios.*\):'
+  - label: 'linux/'
+    matcher:
+      title: '\(.*linux.*\):'
+  - label: 'mac/'
+    matcher:
+      title: '\(.*mac.*\):'
+  - label: 'oem/'
+    matcher:
+      title: '\(.*oem.*\):'
+  - label: 'web/'
+    matcher:
+      title: '\(.*web.*\):'
+  - label: 'windows/'
+    matcher:
+      title: '\(.*windows.*\):'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,13 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@4b52aec09ba832eb9aecccddbccce644ba9ba69d
+    - name: Update labels based on changed files
+      uses: actions/labeler@4b52aec09ba832eb9aecccddbccce644ba9ba69d
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Update labels based on PR title
+      id: labeler
+      uses: fuxingloh/multi-labeler@8afa186ed03230c98fe24ebf9fe35093072ad46e
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        config-path: .github/multi-labeler.yml


### PR DESCRIPTION
This PR adds the labeler-action GH action that applies labels based on the PR title. This allows to automatically assign labels based on our conventional commit message.

Cherry-pick from the master branch (PR #4226).