### PR TITLE
fix(windows): SMP-aware deletion in TSF-aware apps

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -474,10 +474,10 @@ BOOL AITIP::QueueAction(int ItemType, DWORD dwData) {
 		  break;
 
 	  case QIT_BACK:
-		  if(dwData == BK_BACKSPACE)
+		  if(dwData & BK_BACKSPACE)
 			  while(context->CharIsDeadkey()) context->Delete();   // I4370
 		  context->Delete();   // I4370
-		  if(dwData == BK_BACKSPACE)
+		  if(dwData & BK_BACKSPACE)
 			  while(context->CharIsDeadkey()) context->Delete();   // I4370
 		  break;
 	  }
@@ -538,13 +538,21 @@ BOOL AITIP::PostKeys() {
 			MessageBeep(MB_ICONASTERISK);
 			break;
 		case QIT_BACK:
-			if(Queue[n].dwData == BK_DEADKEY) break;
+			if(Queue[n].dwData & BK_DEADKEY) break;
 			if(p > OutBuf) {
 				*(--p) = 0;
 			} else {
 			  bk++;
       }
-			break;
+      if (Queue[n].dwData & BK_SURROGATE) {
+        if (p > OutBuf) {
+          *(--p) = 0;
+        }
+        else {
+          bk++;
+        }
+      }
+      break;
 		}
 	}
 

--- a/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
+++ b/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
@@ -149,11 +149,11 @@ BOOL AIWin2000Unicode::QueueAction(int ItemType, DWORD dwData)
 		break;
 
 	case QIT_BACK:
-		if(dwData == BK_BACKSPACE)
+		if(dwData & BK_BACKSPACE)
 			while(context->CharIsDeadkey()) context->Delete();
 		//if(dwData == CODE_DEADKEY) break;
 		context->Delete();
-		if(dwData == BK_BACKSPACE)
+		if(dwData & BK_BACKSPACE)
 			while(context->CharIsDeadkey()) context->Delete();
 		break;
 	}
@@ -266,7 +266,7 @@ BOOL AIWin2000Unicode::PostKeys()
 		  MessageBeep(MB_ICONASTERISK); //(UINT) -1);
 		  break;
 	  case QIT_BACK:
-		  if(Queue[n].dwData == BK_DEADKEY) break;
+		  if(Queue[n].dwData & BK_DEADKEY) break;
 		  if(Addin_ProcessBackspace(hwnd)) break;
 
       pInputs[i].type = INPUT_KEYBOARD;

--- a/windows/src/engine/keyman32/appint/appint.cpp
+++ b/windows/src/engine/keyman32/appint/appint.cpp
@@ -61,7 +61,7 @@ WCHAR *AppContext::Buf(int n)
 	//if(n == 0) return wcschr(CurContext, 0);
 	//if(*CurContext == 0) return NULL;
 
-	for(p = wcschr(CurContext, 0); n > 0 && p > CurContext; p = decxstr(p, CurContext), n--);
+	for(p = wcschr(CurContext, 0); p != NULL && n > 0 && p > CurContext; p = decxstr(p, CurContext), n--);
 	//for(p = wcschr(CurContext, 0); n > 0 && p > CurContext; p--, n--);
 
 	if(n > 0) return NULL;
@@ -75,7 +75,7 @@ WCHAR *AppContext::BufMax(int n)  // Used only by IMX DLLs
 	if(CurContext == p || n == 0) return p; /* empty context or 0 characters requested, return pointer to end of context */  // I3091
 
   WCHAR *q = p;  // I3091
-	for(; p > CurContext && (INT_PTR)(q-p) < n; p = decxstr(p, CurContext));  // I3091
+	for(; p != NULL && p > CurContext && (INT_PTR)(q-p) < n; p = decxstr(p, CurContext));  // I3091
 
   if((INT_PTR)(q-p) > n) p = incxstr(p); /* Copes with deadkey or supplementary pair at start of returned buffer making it too long */  // I3091
 

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -451,29 +451,30 @@ BOOL ProcessGroup(LPGROUP gp)
 	*/
 
 	p = kkp->dpOutput;
-	if(*p != UC_SENTINEL || *(p+1) != CODE_CONTEXT)
-	{
-		for(p = _td->miniContext; *p; p = incxstr(p))
-		{
-			if(*p == UC_SENTINEL)
-				switch(*(p+1))
-				{
-			    case CODE_DEADKEY: _td->app->QueueAction(QIT_BACK, BK_DEADKEY); break;
-					case CODE_NUL: break;	// 11 Aug 2003 - I25(v6) - mcdurdin - CODE_NUL context support
+	if(*p != UC_SENTINEL || *(p+1) != CODE_CONTEXT) {
+		for(PWSTR mcp = decxstr(wcschr(_td->miniContext, 0), _td->miniContext); mcp != NULL; mcp = decxstr(mcp, _td->miniContext)) {
+      if (*mcp == UC_SENTINEL) {
+        switch (*(mcp + 1)) {
+          case CODE_DEADKEY: _td->app->QueueAction(QIT_BACK, BK_DEADKEY); break;
+          case CODE_NUL: break;	// 11 Aug 2003 - I25(v6) - mcdurdin - CODE_NUL context support
         }
-      else if (Uni_IsSurrogate1(*p) && Uni_IsSurrogate2(*(p+1))) {
+      }
+      else if (Uni_IsSurrogate1(*mcp) && Uni_IsSurrogate2(*(mcp + 1))) {
 				// 2 backspaces to delete both parts of surrogate pair
 				// This only needs to be done for TSF-aware apps as legacy apps
 				// will receive a BKSP WM_KEYDOWN event which results in deleting
 				// both parts in one action
 				_td->app->QueueAction(QIT_BACK, BK_SURROGATE);
-      } else {
+      }
+      else {
 				_td->app->QueueAction(QIT_BACK, 0);
 			}
 		}
-        p = kkp->dpOutput;
 	}
-	else p+=2;				// otherwise, the "context" entry has to be jumped over
+  else {
+    // otherwise, the "context" entry has to be jumped over
+    p += 2;
+  }
 
 	/* Use PostString to post the rest of the output string. */
 

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -318,8 +318,6 @@ BOOL ProcessGroup(LPGROUP gp)
       BOOL fIsBackspace = _td->state.vkey == VK_BACK && (Globals::get_ShiftState() & (LCTRLFLAG|RCTRLFLAG|LALTFLAG|RALTFLAG)) == 0;   // I4128
 
       if(/*_td->app->DebugControlled() &&*/ fIsBackspace) {   // I4838   // I4933
-        	//if(_td->state.msg.message == wm_keymankeydown)
-				  //	_td->app->QueueAction(QIT_BACK, BK_BACKSPACE);
 				if(_td->state.msg.message == wm_keymankeydown) {   // I4933
           if(!_td->app->IsLegacy()) {   // I4933
             PWCHAR pdeletecontext = _td->app->ContextBuf(1);   // I4933
@@ -330,13 +328,18 @@ BOOL ProcessGroup(LPGROUP gp)
             }
             if (Uni_IsSurrogate1(*pdeletecontext) && Uni_IsSurrogate2(*(pdeletecontext+1))) {
               // 2 backspaces to delete both parts of surrogate pair
-              // This only needs to be done for non-legacy apps as legacy apps
+              // This only needs to be done for TSF-aware apps as legacy apps
               // will receive a BKSP WM_KEYDOWN event which results in deleting
               // both parts in one action
+              _td->app->QueueAction(QIT_BACK, BK_BACKSPACE | BK_SURROGATE);
+            }
+            else {
               _td->app->QueueAction(QIT_BACK, BK_BACKSPACE);
             }
           }
-				  _td->app->QueueAction(QIT_BACK, BK_BACKSPACE);   // I4933
+          else {
+            _td->app->QueueAction(QIT_BACK, BK_BACKSPACE);   // I4933
+          }
         }
       } else if( (!_td->app->IsLegacy() || !fIsBackspace) && !_td->TIPFPreserved) {   // I4024   // I4128   // I4287   // I4290
         SendDebugMessageFormat(_td->state.msg.hwnd, sdmKeyboard, 0, " ... IsLegacy = FALSE; IsTIP = TRUE");   // I4128
@@ -357,9 +360,6 @@ BOOL ProcessGroup(LPGROUP gp)
 				 Must have special handling for VK_BACK: delete a character from the context stack
 				 This only fires if the keyboard has no rule for backspace.
 				*/
-
-//				if(_td->state.msg.message == wm_keymankeydown)    // I4933
-	//				_td->app->QueueAction(QIT_BACK, BK_BACKSPACE);   // I4933
 			}
 			else
 			{
@@ -461,8 +461,13 @@ BOOL ProcessGroup(LPGROUP gp)
 			    case CODE_DEADKEY: _td->app->QueueAction(QIT_BACK, BK_DEADKEY); break;
 					case CODE_NUL: break;	// 11 Aug 2003 - I25(v6) - mcdurdin - CODE_NUL context support
         }
-      else
-			{
+      else if (Uni_IsSurrogate1(*p) && Uni_IsSurrogate2(*(p+1))) {
+				// 2 backspaces to delete both parts of surrogate pair
+				// This only needs to be done for TSF-aware apps as legacy apps
+				// will receive a BKSP WM_KEYDOWN event which results in deleting
+				// both parts in one action
+				_td->app->QueueAction(QIT_BACK, BK_SURROGATE);
+      } else {
 				_td->app->QueueAction(QIT_BACK, 0);
 			}
 		}

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -1,18 +1,18 @@
 /*
   Name:             Compiler
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      4 Jan 2007
 
   Modified Date:    24 Aug 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          04 Jan 2007 - mcdurdin - Add CODE_NOTANY
                     22 Mar 2010 - mcdurdin - Compiler tidyup
                     25 May 2010 - mcdurdin - I1632 - Keyboard Options
@@ -22,7 +22,7 @@
                     31 Dec 2014 - mcdurdin - I4548 - V9.0 - When Alt is down, release of Ctrl, Shift is not detectable within TIP in some languages
                     24 Aug 2015 - mcdurdin - I4865 - Add treat hints and warnings as errors into project
                     24 Aug 2015 - mcdurdin - I4866 - Add warn on deprecated features to project and compile
-                    
+
 */
 
 #ifndef	_COMPILER_H
@@ -30,7 +30,7 @@
 
 
 
-/* WM_UNICHAR */ 
+/* WM_UNICHAR */
 
 #define WM_UNICHAR		0x0109
 #define UNICODE_NOCHAR	0xFFFF
@@ -43,20 +43,20 @@
 #define KEYMANID_IGNORE		  0xFFFFFFFE
 #define KEYMANID_INVALID    0xFFFFFFFD
 
-/* Shift flags for hotkeys (version 1.0) */ 
+/* Shift flags for hotkeys (version 1.0) */
 
 #define SHIFTFLAG 0x2000
 #define CTRLFLAG 0x4000
 #define	ALTFLAG 0x8000
 
-/* Miscellaneous flags and defines */ 
+/* Miscellaneous flags and defines */
 
 #define UM_DRAWICONS	0x01
 #define NUL '\0'
 
 #define MAXGROUPS	128
 
-/* File version identifiers */ 
+/* File version identifiers */
 
 #define VERSION_30	0x00000300
 #define VERSION_31	0x00000301
@@ -107,8 +107,19 @@
 
 #define KDS_CONTROL		0x8000
 
+//
+// Backspace flags
+//
+
+// Delete a deadkey from context, do not pass on to app
 #define BK_DEADKEY		1
+
+// User pressed backspace so clear deadkeys either side of next deleted character
 #define BK_BACKSPACE	2
+
+// Next character to delete is a Unicode surrogate pair
+#define BK_SURROGATE  4
+
 /*
  A blank key (in a group without "using keys") cannot be '0' as that is
  used for error testing and blanking out unused keys and you don't really
@@ -121,7 +132,7 @@
 #define BEGIN_ANSI		0
 #define BEGIN_UNICODE	1
 
-//#define lpuch		(LPBYTE)				
+//#define lpuch		(LPBYTE)
 
 #define TSS_NONE				0
 #define TSS_BITMAP				1
@@ -192,7 +203,7 @@
 
 #define TSS__MAX				38
 
-/* wm_keyman_control_internal message control codes */ 
+/* wm_keyman_control_internal message control codes */
 
 #define KMCI_SELECTKEYBOARD     3   // I3933
 #define KMCI_SELECTKEYBOARD_TSF 4   // I3933
@@ -270,7 +281,7 @@
 #define K_CTRLFLAG		0x0020		// Either ctrl flag
 #define K_ALTFLAG		0x0040		// Either alt flag
 //#define K_METAFLAG  0x0080    // Either Meta-key flag (tentative).  Not usable in keyboard rules;
-                                // Used internally (currently, only by KMW) to ensure Meta-key 
+                                // Used internally (currently, only by KMW) to ensure Meta-key
                                 // shortcuts safely bypass rules
                                 // Meta key = Command key on macOS, Windows key on Windows
 #define CAPITALFLAG		0x0100		// Caps lock on
@@ -304,7 +315,7 @@
 
 struct COMP_STORE {
 	DWORD dwSystemID;
-	DWORD dpName;	
+	DWORD dpName;
 	DWORD dpString;
 	};
 
@@ -323,8 +334,8 @@ static_assert(sizeof(COMP_KEY) == KEYBOARDFILEKEY_SIZE, "COMP_KEY must be KEYBOA
 struct COMP_GROUP {
 	DWORD dpName;
 	DWORD dpKeyArray;		// [LPKEY] address of first item in key array
-	DWORD dpMatch;			
-	DWORD dpNoMatch;		
+	DWORD dpMatch;
+	DWORD dpNoMatch;
 	DWORD cxKeyArray;		// in array entries
 	BOOL  fUsingKeys;		// group(xx) [using keys] <-- specified or not
 	};
@@ -333,20 +344,20 @@ static_assert(sizeof(COMP_GROUP) == KEYBOARDFILEGROUP_SIZE, "COMP_GROUP must be 
 
 struct COMP_KEYBOARD {
 	DWORD dwIdentifier;		// 0000 Keyman compiled keyboard id
-	
+
 	DWORD dwFileVersion;	// 0004 Version of the file - Keyman 4.0 is 0x0400
-	
+
 	DWORD dwCheckSum;		  // 0008 As stored in keyboard
 	DWORD KeyboardID;    	// 000C as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
-	DWORD IsRegistered;		// 0010 
+	DWORD IsRegistered;		// 0010
 	DWORD version;			  // 0014 keyboard version
-	
+
 	DWORD cxStoreArray;		// 0018 in array entries
 	DWORD cxGroupArray;		// 001C in array entries
 
 	DWORD dpStoreArray;		// 0020 [LPSTORE] address of first item in store array
 	DWORD dpGroupArray;		// 0024 [LPGROUP] address of first item in group array
-	
+
 	DWORD StartGroup[2];	// 0028 index of starting groups [2 of them]
 	//DWORD StartGroupIndex;	// StartGroup current index
 

--- a/windows/src/global/vc/xstring.cpp
+++ b/windows/src/global/vc/xstring.cpp
@@ -64,7 +64,9 @@ PWSTR incxstr(PWSTR p)
 PWSTR decxstr(PWSTR p, PWSTR pStart)
 {
   if (p <= pStart) {
-    assert("Attempted to move prior to start of string");
+    // At start of string so return NULL
+		// incxstr returns pointer to NULL at end of str so
+		// be aware of this difference.
     return NULL;
   }
 
@@ -72,7 +74,7 @@ PWSTR decxstr(PWSTR p, PWSTR pStart)
 	if(*p == UC_SENTINEL_EXTENDEDEND)
 	{
 		int n = 0;
-		while(*p != UC_SENTINEL && n < 10) { p--; n++; }
+		while(p >= pStart && *p != UC_SENTINEL && n < 10) { p--; n++; }
 
     if (p < pStart) {
       // May be a malformed virtual key


### PR DESCRIPTION
Fixes #4196.

When deleting characters in a TSF-aware app, we must delete both halves of a surrogate pair. This behaviour differs from legacy apps, where a single backspace is usually sufficient to delete both characters.

Truly ancient apps that do not know about Unicode surrogate pairs are not going to delete both halves with a single backspace event. Fortunately, these are few and far between; we would handle them on a case-by-case basis if support questions for them arise.

When we come to integrating Keyman Core into Keyman for Windows, there will need to be some careful checking of surrogate pair support, as it is likely that the handling will need to change.