### PR TITLE
fix(android, ios): eliminates OSK layout flashing from predictive text banner display

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -113,7 +113,9 @@
       kmw['correctOSKTextSize']();
 
       fragmentToggle = (fragmentToggle + 1) % 100;
-      window.location.hash = 'refreshBannerHeight-'+fragmentToggle+'+change='+change;
+      if(change != 'configured') { // doesn't change the display; only initiates suggestions.
+        window.location.hash = 'refreshBannerHeight-'+fragmentToggle+'+change='+change;
+      }
     }
 
     // Query KMW if a given keyboard uses chiral modifiers.

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -136,14 +136,13 @@ namespace com.keyman.text.prediction {
       let specType: 'file'|'raw' = model.path ? 'file' : 'raw';
       let source = specType == 'file' ? model.path : model.code;
       let lp = this;
-      lp.currentModel = model;
-      
+
       // We pre-emptively emit so that the banner's DOM elements may update synchronously.
       // Prevents an ugly "flash of unstyled content" layout issue during keyboard load
       // on our mobile platforms when embedded.
+      lp.currentModel = model;
       lp.emit('statechange', 'active');
 
-      // We should wait until the model is successfully loaded before setting our state values.
       return this.lmEngine.loadModel(source, specType).then(function(config: Configuration) { 
         lp.configuration = config;
         lp.emit('statechange', 'configured');

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -398,7 +398,10 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.addListener('suggestionsready', manager.updateSuggestions);
       keyman.core.languageProcessor.addListener('tryaccept', manager.tryAccept);
       keyman.core.languageProcessor.addListener('tryrevert', manager.tryRevert);
+    }
 
+    postConfigure() {
+      let keyman = com.keyman.singleton;
       // Trigger a null-based initial prediction to kick things off.
       keyman.core.languageProcessor.predictFromTarget(dom.Utils.getOutputTarget());
     }

--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -212,13 +212,21 @@ namespace com.keyman.osk {
       let keyman = com.keyman.singleton;
 
       // Only display a SuggestionBanner when LanguageProcessor states it is active.s
-      if(keyman.core.languageProcessor.isActive) {
+      if(state == 'active') {
         this.setBanner('suggestion');
-      } else if(this.alwaysShow) {
-        this.setBanner('image');
-      } else {
-        this.setBanner('blank');
-      }
+      } else if(state == 'inactive') {
+        if(this.alwaysShow) {
+          this.setBanner('image');
+        } else {
+          this.setBanner('blank');
+        }
+      } else if(state == 'configured') {
+        let suggestionBanner = this.activeBanner as SuggestionBanner;
+        if(suggestionBanner.postConfigure) {
+          // Triggers the initially-displayed suggestions.s
+          suggestionBanner.postConfigure();
+        }
+      } 
     }
 
     /**


### PR DESCRIPTION
Fixes #3294.

- Keyboards with associated dictionaries will now load more smoothly.

There will still be a small amount of layout calibration / FOUC-ish behavior on the initial load of each keyboard during the app / app extension's lifetime.  The egregious shift caused by the banner appearing late has been fixed.  (The banner's suggestions, on the other hand, will arrive at the original, 'late', time.)

Further keyboard swapping will be 100% smooth for as long as the system keeps the app/keyboard/extension alive.

### User Testing
@MakaraSok (or others, if so inclined)

Could use a user test on Android; I've already tested with iOS.
- While I _doubt_ it'll matter, a bit of testing with the keyboard-based keyboard-swapping shortcuts may not be a bad idea, just in case.
- Be sure to test that keyboard swapping works correctly both in-app and when used as the system keyboard.
- Does the banner display properly every time you expect it?
    - Note:  initial suggestions will likely appear 'late' after a swap.  _That_ can't be helped.
- Does the banner display at the same time as the main keyboard, or sometime later?  (Should be simultaneous) 