### PR TITLE
fix(web): removes stylesheets from unloaded keyboards

### DIFF
--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -197,8 +197,10 @@ namespace com.keyman.osk {
         s.fontSize = fontScale + 'em';
       }
 
+      if(this.vkbd) {
+        this.vkbd.shutdown();
+      }
       this.vkbd = null;
-      // TODO:  Consider a 'vkbd.release()' method?
 
       // Instantly resets the OSK container, erasing / delinking the previously-loaded keyboard.
       this._Box.innerHTML = '';
@@ -311,6 +313,9 @@ namespace com.keyman.osk {
      * Description  Generates the visual keyboard element and attaches it to KMW
      */
     private _GenerateVisualKeyboard(keyboard: keyboards.Keyboard) {
+      if(this.vkbd) {
+        this.vkbd.shutdown();
+      }
       this.vkbd = new com.keyman.osk.VisualKeyboard(keyboard);
       let util = com.keyman.singleton.util;
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2763,5 +2763,14 @@ namespace com.keyman.osk {
       }, 5000);
       return false;
     };
+
+    shutdown() {
+      let keyman = com.keyman.singleton;
+
+      // Prevents style-sheet pollution from multiple keyboard swaps.
+      if(this.styleSheet) {
+        keyman.util.removeStyleSheet(this.styleSheet);
+      }
+    }
   }
 }


### PR DESCRIPTION
Intended to replace #4317.

Proactively removes stylesheets whenever throwing out old OSK (`VisualKeyboard`) instances, rather than relying on a static variable referenced whenever a new one is loaded.