### PR TITLE
chore(linux): Don't report on Sentry when running unit tests

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -34,36 +34,39 @@ else:
 # There's no staging site for downloads
 KeymanDownloadsUrl = 'https://downloads.keyman.com'
 
-try:
-    # Try new sentry-sdk first
-    sentry_sdk = importlib.import_module('sentry_sdk')
-    from sentry_sdk import configure_scope
-    HaveSentryNewSdk = True
-
-    SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357@sentry.keyman.com/12"
-    sentry_sdk.init(
-        dsn=SentryUrl,
-        environment=__tier__,
-        release=__version__,
-    )
-    with configure_scope() as scope:
-        scope.set_tag("app", os.path.basename(sys.argv[0]))
-        scope.set_tag("platform", platform.platform())
-        scope.set_tag("system", platform.system())
-except ImportError:
+if 'unittest' in sys.modules.keys():
+    print('Not reporting to Sentry')
+else:
     try:
-        # sentry-sdk is not available, so use older raven
-        raven = importlib.import_module('raven')
-        from raven import Client
-        HaveSentryNewSdk = False
+        # Try new sentry-sdk first
+        sentry_sdk = importlib.import_module('sentry_sdk')
+        from sentry_sdk import configure_scope
+        HaveSentryNewSdk = True
 
-        SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@sentry.keyman.com/12"
-        client = Client(SentryUrl, environment=__tier__, release=__version__)
-        client.tags_context({
-            'app': os.path.basename(sys.argv[0]),
-            'platform': platform.platform(),
-            'system': platform.system(),
-        })
+        SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357@sentry.keyman.com/12"
+        sentry_sdk.init(
+            dsn=SentryUrl,
+            environment=__tier__,
+            release=__version__,
+        )
+        with configure_scope() as scope:
+            scope.set_tag("app", os.path.basename(sys.argv[0]))
+            scope.set_tag("platform", platform.platform())
+            scope.set_tag("system", platform.system())
     except ImportError:
-        # even raven is not available. This is the case on Ubuntu 16.04. Just ignore.
-        print(_('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.'))
+        try:
+            # sentry-sdk is not available, so use older raven
+            raven = importlib.import_module('raven')
+            from raven import Client
+            HaveSentryNewSdk = False
+
+            SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@sentry.keyman.com/12"
+            client = Client(SentryUrl, environment=__tier__, release=__version__)
+            client.tags_context({
+                'app': os.path.basename(sys.argv[0]),
+                'platform': platform.platform(),
+                'system': platform.system(),
+            })
+        except ImportError:
+            # even raven is not available. This is the case on Ubuntu 16.04. Just ignore.
+            print(_('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.'))


### PR DESCRIPTION
When running unit tests we try to install some keyboards with invalid URLs which normally results in an issue being reported on
Sentry. This change detects when we're running unit tests and in that case doesn't initialize Sentry reporting.

Cherry-pick from #4356.