### PR TITLE
fix(windows): remove Show Keyboard Usage hotkey

### DIFF
--- a/windows/src/desktop/kmshell/locale/de/strings.xml
+++ b/windows/src/desktop/kmshell/locale/de/strings.xml
@@ -377,10 +377,6 @@
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.1.275.0 -->
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Hotkey - show keyboard usage in OSK">Tastatur-Benutzungshilfe anzeigen</string>
-  <!-- Context: Configuration Dialog - Hotkeys tab -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.1.275.0 -->
   <string name="S_Hotkey_ShowFontHelper" comment="Hotkey - show font helper in OSK">Schriftart-Hilfe anzeigen</string>
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
@@ -713,10 +709,6 @@
   <!-- Context: Toolbar Context Help -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="Toolbar help - View Keyboard Usage pop-up text">Tastatur-Nutzung anzeigen</string>
-  <!-- Context: Toolbar Context Help -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="S_Toolbar_ViewFontHelper" comment="Toolbar help - View Font Helper pop-up text">Schriftarten anzeigen</string>
   <!-- Context: Toolbar Context Help -->
   <!-- String Type: PlainText -->
@@ -742,10 +734,6 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_OnScreenKeyboard" comment="Systray item - OSK [&amp; precedes alt + access-character]">&amp;Bildschirmtastatur</string>
-  <!-- Context: System Tray Menu Items -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Menu_KeyboardUsage" comment="Systray item - Keyboard Usage [&amp; precedes alt + access-character]">Tastatur-&amp;Verwendung</string>
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/desktop/kmshell/locale/fr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/fr/strings.xml
@@ -399,7 +399,6 @@ Maj</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
   <string name="S_Hotkey_Language_Prefix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - activation term preceding Windows language name. Note: include a space following. (introduced 7.0.241.0)"/>
   <string name="S_Hotkey_Language_Suffix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - language term following Windows language name. Note: include an initial space. (introduced 7.0.241.0)"/>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard usage in OSK (introduced 7.1.275.0)">Show Keyboard Usage Pane</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">Show Font Helper Pane</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">Show Character Map Pane</string>
   <string name="S_Hotkey_OpenTextEditor" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open text editor (introduced 7.1.275.0)">Open Text Editor</string>
@@ -469,15 +468,6 @@ Maj</string>
   <string name="SKMenu_NoKeyboardsInstalled" comment="System Tray Menu Items/PlainText: Systray - notice of no keyboard layouts installed (introduced 7.0.230.0)">No keyboard layouts are installed.
 Choose "Configuration" to install a 
 keyboard layout for your language.</string>
-  <string name="S_Usage_Welcome" comment="Usage Page/PlainText: Usage page - keyboard help button (introduced 7.0.244.0)">Keyboard Help</string>
-  <string name="S_Usage_OSK" comment="Usage Page/PlainText: Usage page - On Screen Keyboard button (introduced 7.0.244.0)">On Screen Keyboard</string>
-  <string name="S_Usage_Tutorial" comment="Usage Page/PlainText: Usage page - Getting Started button (introduced 7.0.244.0)">Get Started</string>
-  <string name="S_Usage_Help" comment="Usage Page/PlainText: Usage page - Product Help button (introduced 7.0.244.0)">Keyman Help</string>
-  <string name="S_Usage_Config" comment="Usage Page/PlainText: Usage page - Product Configuration button (introduced 7.0.244.0)">Keyman Configuration</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has no documentation (introduced 7.1.261.0)">This keyboard layout has no Getting Started or Usage documentation. Please check the Start Menu or contact the keyboard developer for more information on how to use this keyboard layout.</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has documentation (introduced 7.1.261.0)">Click the buttons below to view additional documentation and/or On Screen Keyboard.</string>
-  <string name="S_Usage_KeymanOff" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboard is active (introduced 7.1.261.0)">No keyboard layout is currently selected in Keyman.  Click on any of the keyboard icons in the toolbar above to choose a keyboard layout.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboards are installed (introduced 7.1.261.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="SKButtonDownload" comment="Formatted Messages/FormatString: Download button in Locale Selection dialog (introduced 7.0.240.0)">&amp;Download...</string>
   <string name="SKUninstallPackageFonts" comment="Formatted Messages/FormatString: Text embedded in SKUninstallPackage when fonts are ready for uninstall. [%0:s = Fonts list] (introduced 7.1.270.0)">The following fonts will also be uninstalled: %0:s.</string>
   <string name="SKCannotStartProduct" comment="Formatted Messages/FormatString: Error from Keyman Desktop failing to start keyman.exe due to an access denied or file not found [%0:s: error message] (introduced 7.0.241.0)">Keyman failed to start.  Please check your security settings to make sure that the program keyman.exe is allowed to start before continuing.  The error returned was:
@@ -506,13 +496,4 @@ Do you want to try and start Keyman again now?</string>
   <string name="S_OSK_FontHelper_NoFonts1b" comment="OSK Font Helper/HTML: OSK Font helper no fonts part 2 (introduced 8.0.294.0)">.  Please check the documentation to find fonts for this keyboard.</string>
   <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font Helper/HTML: OSK Font helper no keyboards (introduced 8.0.294.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font Helper/HTML: OSK Font helper choose keyboard (introduced 8.0.294.0)">Please choose a Keyman keyboard to find the fonts that will work with it.</string>
-  <string name="S_OSK_Hint_Title" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar title (introduced 8.0.294.0)">Hint:</string>
-  <string name="S_OSK_Hint1" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Resize the On Screen Keyboard by clicking and dragging on the window border</string>
-  <string name="S_OSK_Hint2" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Move the On Screen Keyboard by clicking and dragging on the "Keyman" title</string>
-  <string name="S_OSK_Hint3a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Insert any Unicode character into your document with the</string>
-  <string name="S_OSK_Hint3b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Character Map Tool</string>
-  <string name="S_OSK_Hint4a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Find out which fonts will work with your language with the</string>
-  <string name="S_OSK_Hint4b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Font Helper Tool</string>
-  <string name="S_OSK_Hint5a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Get more help on the keyboard by clicking the</string>
-  <string name="S_OSK_Hint5b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Keyboard Usage button</string>
 </resources>

--- a/windows/src/desktop/kmshell/locale/kan-Knda-IN/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kan-Knda-IN/strings.xml
@@ -101,7 +101,6 @@
   <string name="S_Hotkey_OpenKeyboardMenu" comment="/PlainText: ">ಕೀಲಿಮಣೆ ಆಯ್ಕೆ ಪಟ್ಟಿಯನ್ನು ತೆರೆಯಲು</string>
   <string name="S_Hotkey_ShowOnScreenKeyboard" comment="/PlainText: ">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ ಫಲಕ ತೋರಿಸಲು</string>
   <string name="S_Hotkey_OpenConfiguration" comment="/PlainText: ">ಸಂರಚನೆ(ಕಾನ್ಫಿಗರೇಷನ್) ತೆರೆಯಲು</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="/PlainText: ">ಕೀಲಿಮಣೆ ಬಳಕೆ ಫಲಕವನ್ನು ತೋರಿಸಲು</string>
   <string name="S_Hotkey_ShowFontHelper" comment="/PlainText: ">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್) ಸಹಾಯಕ ಫಲಕವನ್ನು ತೋರಿಸಲು</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="/PlainText: ">ಅಕ್ಷರ ನಕ್ಷೆ ಫಲಕವನ್ನು ತೋರಿಸಲು</string>
   <string name="S_Hotkey_OpenTextEditor" comment="/PlainText: ">ಪಠ್ಯ ಸಂಪಾದಕವನ್ನು ತೆರೆಯಲು</string>
@@ -213,7 +212,6 @@
   <string name="S_Help_Keyboard_Prefix" comment="/PlainText: ">"</string>
   <string name="S_Help_Keyboard_Suffix" comment="/PlainText: ">" ಕೀಲಿಮಣೆಗೆ ಸಹಾಯ</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="/PlainText: ">"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ" ತೆರೆ</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="/PlainText: ">ಕೀಲಿಮಣೆ ಬಳಕೆ ಫಲಕವನ್ನು ತೆರೆ</string>
   <string name="S_Toolbar_ViewFontHelper" comment="/PlainText: ">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್) ಸಹಾಯಕ ಫಲಕವನ್ನು ತೆರೆ</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="/PlainText: ">ಅಕ್ಷರ ನಕ್ಷೆ ಫಲಕವನ್ನು ತೆರೆ</string>
   <string name="S_Menu_SwitchKeymanOff" comment="/PlainText: ">Keyman ಬೆಳಕನ್ನು ಮುಚ್ಚಿ</string>
@@ -228,15 +226,6 @@
   <string name="S_OSKContext_ShowToolbar" comment="/PlainText: ">ಉಪಕರಣ ಪಟ್ಟಿ(ಟೂಲ್‌ಬಾರ್) ತೋರಿಸು</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="/PlainText: ">ವೆಬ್ ಪುಟದಂತೆ ಉಳಿಸು...</string>
   <string name="S_OSKContext_Print" comment="/PlainText: ">ಪ್ರಿಂಟ್...</string>
-  <string name="S_Usage_Welcome" comment="/PlainText: ">ಕೀಲಿಮಣೆ ಸಹಾಯ</string>
-  <string name="S_Usage_OSK" comment="/PlainText: ">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ</string>
-  <string name="S_Usage_Tutorial" comment="/PlainText: ">ಪ್ರಾರಂಭಿಸು</string>
-  <string name="S_Usage_Help" comment="/PlainText: ">Keyman ಸಹಾಯ</string>
-  <string name="S_Usage_Config" comment="/PlainText: ">Keyman ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="/HTML: ">ಈ ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವು ಪ್ರಾರಂಭಿಸುವಿಕೆ ಅಥವಾ ಬಳಕೆ ದಸ್ತಾವೇಜನ್ನು ಹೊಂದಿಲ್ಲ. ಈ ಕೀಲಿಮಣೆ ಲೇಔಟ್ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು ಎಂಬುದರ ಕುರಿತು ಹೆಚ್ಚಿನ ಮಾಹಿತಿಗಾಗಿ ಸ್ಟಾರ್ಟ್ ಮೆನುವನ್ನು ಪರಿಶೀಲಿಸಿ ಅಥವಾ ಕೀಲಿಮಣೆ ಅಭಿವೃದ್ಧಿಪಡಿಸಿದವರನ್ನು ಸಂಪರ್ಕಿಸಿ.</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="/HTML: ">ಹೆಚ್ಚುವರಿ ದಸ್ತಾವೇಜನ್ನು ಮತ್ತು/ಅಥವಾ "ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ" ವೀಕ್ಷಿಸಲು ಕೆಳಗಿನ ಗುಂಡಿಗಳನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.</string>
-  <string name="S_Usage_KeymanOff" comment="/HTML: ">ಪ್ರಸ್ತುತ Keyman ರಲ್ಲಿ ಯಾವುದೇ ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿಲ್ಲ. ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವನ್ನು ಆಯ್ಕೆ ಮಾಡಲು ಮೇಲಿನ ಉಪಕರಣ ಪಟ್ಟಿ(ಟೂಲ್‌ಬಾರ್)ನಲ್ಲಿನ ಯಾವುದೇ ಕೀಲಿಮಣೆ ಚಿತ್ರ(ಐಕಾನ್)ಗಳನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="/HTML: ">ಯಾವುದೇ ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳನ್ನು ಪ್ರಸ್ತುತ ಸ್ಥಾಪಿಸಿಲ್ಲ ಅಥವಾ ಲೋಡ್ ಮಾಡಲಾಗಿಲ್ಲ. ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವನ್ನು ಅನುಸ್ಥಾಪಿಸಲು Keyman ಸಂರಚನೆಯನ್ನು(ಕಾನ್ಫಿಗರೇಷನ್) ಬಳಸಿ.</string>
   <string name="SKApplicationTitle" comment="/FormatString: ">Keyman</string>
   <string name="SKSplashVersion" comment="/FormatString: ">ಆವೃತ್ತಿ %0:s</string>
   <string name="SKButtonHelp" comment="/FormatString: ">ಸಹಾಯ</string>
@@ -298,7 +287,6 @@
   <string name="S_OSK_Hint4b" comment="/Plain Text: ">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್) ಸಹಾಯಕ ಉಪಕರಣ</string>
   <string name="S_OSK_Hint5a" comment="/Plain Text: ">ಕೀಲಿಮಣೆಯ ಇನ್ನಷ್ಟು ಸಹಾಯ ಪಡೆಯಲು, ಇಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಿ</string>
   <string name="S_OSK_Hint5b" comment="/Plain Text: ">ಕೀಲಿಮಣೆ ಬಳಕೆ ಗುಂಡಿ</string>
-  <string name="S_Menu_KeyboardUsage" comment="/PlainText: ">ಕೀಲಿ&amp;ಮಣೆ ಬಳಕೆ</string>
   <string name="S_Menu_FontHelper" comment="/PlainText: ">ಅಕ್ಷ&amp;ರ ಶೈಲಿ (ಫಾಂಟ್) ಸಹಾಯಕ</string>
   <string name="S_Menu_CharacterMap" comment="/PlainText: ">&amp;ಅಕ್ಷರ ನಕ್ಷೆ</string>
   <string name="S_Menu_TextEditor" comment="/PlainText: ">&amp;ಪಠ್ಯ ಸಂಪಾದಕ</string>

--- a/windows/src/desktop/kmshell/locale/km-KH/strings.xml
+++ b/windows/src/desktop/kmshell/locale/km-KH/strings.xml
@@ -377,10 +377,6 @@
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.1.275.0 -->
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Hotkey - show keyboard usage in OSK">បង្ហាញផ្ទាំង \"ការប្រើប្រាស់​ក្ដារចុច\"</string>
-  <!-- Context: Configuration Dialog - Hotkeys tab -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.1.275.0 -->
   <string name="S_Hotkey_ShowFontHelper" comment="Hotkey - show font helper in OSK">បង្ហាញ​ផ្ទាំង \"អង្គ​ជំនួយ​ពុម្ព​អក្សរ\"</string>
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
@@ -713,10 +709,6 @@
   <!-- Context: Toolbar Context Help -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="Toolbar help - View Keyboard Usage pop-up text">មើល \"ការប្រើប្រាស់​ក្ដារចុច\"</string>
-  <!-- Context: Toolbar Context Help -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="S_Toolbar_ViewFontHelper" comment="Toolbar help - View Font Helper pop-up text">មើល​ \"អង្គ​ជំនួយ​ពុម្ព​អក្សរ\"</string>
   <!-- Context: Toolbar Context Help -->
   <!-- String Type: PlainText -->
@@ -742,10 +734,6 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_OnScreenKeyboard" comment="Systray item - OSK [&amp; precedes alt + access-character]">ក្ដារចុច​លើ​អេក្រង់</string>
-  <!-- Context: System Tray Menu Items -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Menu_KeyboardUsage" comment="Systray item - Keyboard Usage [&amp; precedes alt + access-character]">ការប្រើបាស់​ក្ដារចុច</string>
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/desktop/kmshell/locale/my/strings.xml
+++ b/windows/src/desktop/kmshell/locale/my/strings.xml
@@ -97,7 +97,6 @@
   <string name="S_Hotkey_OpenTextEditor" comment="/PlainText: ">စာသားအယ်ဒီတာကိုဖွင့်ပါ</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="/PlainText: ">စာသားမြေပုံကိုပြပါ</string>
   <string name="S_Hotkey_ShowFontHelper" comment="/PlainText: ">ဖောင့်အကူအညီကိုပြပါ</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="/PlainText: ">ကီးဘုတ်အသုံးပြုမှုကိုပြပါ</string>
   <string name="S_Hotkey_ShowOnScreenKeyboard" comment="/PlainText: ">Screenမှာပေါ်တဲ့ကီးဘုတ်ကိုပြပါ</string>
   <string name="S_Hotkey_SwitchLanguage" comment="/PlainText: ">ဘာသာစကားပြောင်းလဲမှုကိုဖွင့်ပါ</string>
   <string name="S_Hotkey_TurnKeymanOff" comment="/PlainText: ">ဖွင့်ပါ၊ အမည်ကို၊ ပိတ်</string>
@@ -204,15 +203,6 @@
   <string name="S_Update_OldVersionHead" comment="/PlainText: ">ဗားရှင်းအဟောင်း</string>
   <string name="S_Update_SizeHead" comment="/PlainText: ">အရွယ်</string>
   <string name="S_Update_Title" comment="/PlainText: ">မွမ်းမံထားသော Keyman အစိတ်အပိုင်းများကို ရရှိနိုင်ပါသည်</string>
-  <string name="S_Usage_Config" comment="/PlainText: ">Keyman စနစ်ပိုင်းဆိုင်ရာ</string>
-  <string name="S_Usage_Help" comment="/PlainText: ">Keyman အကူအညီ</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="/HTML: ">မျက်နှာပြင်ပေါ်သုံးကီးဘုတ်အတွက် အပို မှတ်တမ်းမှတ်ရာများကို ကြည့်ရန် အောက်ပါ ခလုတ်ကိုနှိပ်ပါ</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="/HTML: ">ဒီကီးဘုတ် လက်ကွက်မှာ စတင်သုံးစွဲခြင်းနဲ့ မှတ်တမ်းမှတ်ရာများဖတ်ရှုရန်များမပါဝင်ပါ။ Start Menu သို့မဟုတ် ကီးဘုတ် ဖန်တီးသူကိုဆက်သွယ်ပြီး ဒီကီးဘုတ်ကို ဘယ်လိုသုံးရမလဲ မေးမြန်းပါ</string>
-  <string name="S_Usage_KeymanOff" comment="/HTML: "> &amp;Name;မှာမည်သည့်ကီးဘုတ်လက်ကွက်မှမရွေးချယ်ထားပါ။ အပေါ်မှာရှိတဲ့ toolbarထဲက ကီးဘုတ်ပုံတစ်ခုခုကိုရွေးပြီး ကီးဘုတ်လက်ကွက် သတ်မှတ်ပါ</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="/HTML: ">မည်သည့်ကီးဘုတ်ကိုမျှမတပ်ဆင်ထားပါ။ &amp;Name;စနစ်ဆိုင်ရာကို သုံးပြီး ကီ:ဘုတ်လက်ကွက်တစ်ခုခုထည့်သွင်းပါ</string>
-  <string name="S_Usage_OSK" comment="/PlainText: "> Screen မှာပေါ်ကီးဘုတ်</string>
-  <string name="S_Usage_Tutorial" comment="/PlainText: ">စတင်အသုံးပြုပါ</string>
-  <string name="S_Usage_Welcome" comment="/PlainText: ">ကီးဘုတ်အကူအညီ</string>
   <string name="S_Yes" comment="/PlainText: ">လုပ်မည်</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="/PlainText: ">ဝက်ဘ်စာမျက်နှာအဖြစ်သိမ်းပါ</string>
   <string name="S_OSKContext_ShowToolbar" comment="/PlainText: ">Toolbar ကိုပြပါ</string>
@@ -299,7 +289,6 @@
   <string name="S_Menu_SwitchKeymanOff" comment="/PlainText: ">Keyman ကိုပိတ်</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="/PlainText: ">အက္ခရာမြေပုံကိုကြည့်ပါ</string>
   <string name="S_Toolbar_ViewFontHelper" comment="/PlainText: ">ဖောင့်အကူအညီကိုကြည့်ပါ</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="/PlainText: ">ကီးဘုတ်အသုံးပြုမှုကိုကြည့်ပါ</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="/PlainText: ">Screenပေါ်သုံးကီ:ဘုတ်ကိုကြည့်ပါ</string>
   <string name="S_KeepInTouch" comment="Configuration Dialog - Tab names/PlainText: Keep in touch tab name (introduced 9.0.493.0)">Keep in Touch</string>
   <string name="S_KeepInTouch_AccessChar" comment="Configuration Dialog - Tab names/PlainText: Direct access to the Keep in Touch tab using alt+ (introduced 9.0.492.0)">T</string>

--- a/windows/src/desktop/kmshell/locale/pt-BR/strings.xml
+++ b/windows/src/desktop/kmshell/locale/pt-BR/strings.xml
@@ -143,15 +143,6 @@
   <string name="S_Update_OldVersionHead" comment="/PlainText: ">Versão Antiga</string>
   <string name="S_Update_SizeHead" comment="/PlainText: ">Tamanho</string>
   <string name="S_Update_Title" comment="/PlainText: ">Versão Atualizada Disponível</string>
-  <string name="S_Usage_Config" comment="/PlainText: ">Configuração do Keyman Desktop</string>
-  <string name="S_Usage_Help" comment="/PlainText: ">Ajuda para Keyman Desktop</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="/HTML: ">Clique nos botões em baixo para ver documentações adicionais e/ou Teclado Virtual.</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="/HTML: ">Este layout de teclado não possui documentação para Iniciar ou Usar. Favor verificar no Menu Iniciar ou contatar o desenvolvedor do teclado para mais informações sobre como usar este layout de teclado.</string>
-  <string name="S_Usage_KeymanOff" comment="/HTML: ">Nenhum layout de teclado está selecionado agora no Keyman Desktop. Clique em qualquer dos ícones na barra de ferramentas em cima para selecionar um layout de teclado.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="/HTML: ">Nenhum layout de teclado está instalado ou carregado agora. Use a Configuração do Keyman Desktop para instalar um layout de teclado.</string>
-  <string name="S_Usage_OSK" comment="/PlainText: ">Teclado Virtual</string>
-  <string name="S_Usage_Tutorial" comment="/PlainText: ">Começar</string>
-  <string name="S_Usage_Welcome" comment="/PlainText: ">Ajuda para Teclado</string>
   <string name="S_Yes" comment="/PlainText: ">Sim</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="/PlainText: ">&amp;Salvar como Página da Web</string>
   <string name="S_OSKContext_ShowToolbar" comment="/PlainText: ">Mostrar Barra de &amp;Ferramentas</string>
@@ -231,7 +222,6 @@ AVISO DE PRIVACIDADE: Este arquivo vai gravar todos os caracteres que você digi
   <string name="S_Menu_SwitchKeymanOff" comment="/PlainText: ">Desativar Keyman</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="/PlainText: ">Ver Mapeamento dos Caracteres</string>
   <string name="S_Toolbar_ViewFontHelper" comment="/PlainText: ">Ver o Assistente de Fonte</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="/PlainText: ">Ver a Usagem de Teclados.</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="/PlainText: ">Ver o Teclado Virtual</string>
   <string name="S_LocaleAuthors" comment="System/PlainText: Name(s) of people who created this translation - i.e. your name (introduced 7.1.266.0)">Keyman</string>
   <string name="S_Button_Apply" comment="General Strings/PlainText: Apply button term (introduced 8.0.314.0)">Apply</string>
@@ -252,7 +242,6 @@ AVISO DE PRIVACIDADE: Este arquivo vai gravar todos os caracteres que você digi
   <string name="koDeadkeyConversion" comment="Configuration Dialog - Options tab/FormatString: Advanced options - Base keyboard deadkeys are treated as normal keys (introduced 9.0.480.0)">Treat hardware deadkeys as plain keys</string>
   <string name="koSwitchLanguageForAllApplications" comment="Configuration Dialog - Options tab/FormatString: Advanced options - selected language applies to all applications (introduced 7.1.274.0)">Select keyboard layout for all applications</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard usage in OSK (introduced 7.1.275.0)">Show Keyboard Usage Pane</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">Show Font Helper Pane</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">Show Character Map Pane</string>
   <string name="S_Hotkey_OpenTextEditor" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open text editor (introduced 7.1.275.0)">Open Text Editor</string>
@@ -300,13 +289,4 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <string name="S_OSK_FontHelper_NoFonts1b" comment="OSK Font Helper/HTML: OSK Font helper no fonts part 2 (introduced 8.0.294.0)">.  Please check the documentation to find fonts for this keyboard.</string>
   <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font Helper/HTML: OSK Font helper no keyboards (introduced 8.0.294.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font Helper/HTML: OSK Font helper choose keyboard (introduced 8.0.294.0)">Please choose a Keyman keyboard to find the fonts that will work with it.</string>
-  <string name="S_OSK_Hint_Title" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar title (introduced 8.0.294.0)">Hint:</string>
-  <string name="S_OSK_Hint1" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Resize the On Screen Keyboard by clicking and dragging on the window border</string>
-  <string name="S_OSK_Hint2" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Move the On Screen Keyboard by clicking and dragging on the "Keyman" title</string>
-  <string name="S_OSK_Hint3a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Insert any Unicode character into your document with the</string>
-  <string name="S_OSK_Hint3b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Character Map Tool</string>
-  <string name="S_OSK_Hint4a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Find out which fonts will work with your language with the</string>
-  <string name="S_OSK_Hint4b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Font Helper Tool</string>
-  <string name="S_OSK_Hint5a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Get more help on the keyboard by clicking the</string>
-  <string name="S_OSK_Hint5b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Keyboard Usage button</string>
 </resources>

--- a/windows/src/desktop/kmshell/locale/qqq/strings.xml
+++ b/windows/src/desktop/kmshell/locale/qqq/strings.xml
@@ -126,7 +126,6 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="S_Hotkey_OpenKeyboardMenu" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - Open Keyman systemtray menu (introduced 7.0.230.0)">[!!Ōƥȇń Ķęƴɓőäŗď Měƞų!!]</string>
   <string name="S_Hotkey_ShowOnScreenKeyboard" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard in OSK (introduced 7.0.230.0)">[!!Śħōŵ Ŏƞ Ŝĉřęęƞ ĶėƴƂőäŗď Ƥâņȇ!!]</string>
   <string name="S_Hotkey_OpenConfiguration" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open Keyman Configuration (introduced 7.0.230.0)">[!!Őƥȅņ Čŏƞƒıġŭřãŧĭőń!!]</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard usage in OSK (introduced 7.1.275.0)">[!!Šĥōŵ Ƙȅɏƀŏâŗď Ũşāġė Ƥȁņě!!]</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">[!!Šħŏŵ Ƒơņŧ Ĥēľƿėř Ƥăňě!!]</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">[!!Šĥőŵ Ćħąŗâćţěŗ Mȁƥ Ƥȃņě!!]</string>
   <string name="S_Hotkey_OpenTextEditor" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open text editor (introduced 7.1.275.0)">[!!Ơƥĕŉ Ţěxţ Ęđĩţŏŕ!!]</string>
@@ -278,7 +277,6 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="S_Help_Keyboard_Prefix" comment="Help Dialog/PlainText: Help - text preceding keyboard name (introduced 7.0.230.0)">[!!Ħėŀƥ ōņ "!!]</string>
   <string name="S_Help_Keyboard_Suffix" comment="Help Dialog/PlainText: Help - text following keyboard name (introduced 7.0.230.0)">[!!" ƙęŷƃőáŕď!!]</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="Toolbar Context Help/PlainText: Toolbar help - View OSK pop-up text (introduced 7.0.230.0)">[!!Vīěŵ Őŋ Şčŗęȇņ Ƙȅƴƅŏȃřď!!]</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="Toolbar Context Help/PlainText: Toolbar help - View Keyboard Usage pop-up text (introduced 7.0.230.0)">[!!Vįĕŵ Ƙȇɏƅơãŗď Ŭśȁĝě!!]</string>
   <string name="S_Toolbar_ViewFontHelper" comment="Toolbar Context Help/PlainText: Toolbar help - View Font Helper pop-up text (introduced 7.0.230.0)">[!!Vĩėŵ Ƒōňţ Ħēĺƥěŗ!!]</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="Toolbar Context Help/PlainText: Toolbar help - View Character Map pop-up text (introduced 7.0.230.0)">[!!Vīěŵ Ċħåřāčŧĕř Máƿ!!]</string>
   <string name="S_Menu_SwitchKeymanOff" comment="Toolbar Context Help/PlainText: Toolbar help - Switch Keyman Desktop Off pop-up text (introduced 7.0.230.0)">[!!Ŝŵĭŧčħ !!]Keyman[!! Ōƒƒ!!]</string>
@@ -290,7 +288,6 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <!-- - - - - - - - - - - - - - - - - - -->
   <string name="S_Menu_SwitchKeymanOff" comment="System Tray Menu Items/PlainText: Systray item - Switch Keyman Desktop Off [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!Şŵıţčħ !!]Keyman[!! &amp;Ōƒƒ!!]</string>
   <string name="S_Menu_OnScreenKeyboard" comment="System Tray Menu Items/PlainText: Systray item - OSK [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!Ōń Ŝćŗĕėň &amp;ĶȇȳƂőářď!!]</string>
-  <string name="S_Menu_KeyboardUsage" comment="System Tray Menu Items/PlainText: Systray item - Keyboard Usage [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!Ķȇƴƃơăřď &amp;Ůšăĝė!!]</string>
   <string name="S_Menu_FontHelper" comment="System Tray Menu Items/PlainText: Systray item - Font Helper [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!&amp;Ƒōńť Ħȇŀƥěŕ!!]</string>
   <string name="S_Menu_CharacterMap" comment="System Tray Menu Items/PlainText: Systray item - Character Map [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!Ĉĥãřāĉťęř &amp;Mâƥ!!]</string>
   <string name="S_Menu_TextEditor" comment="System Tray Menu Items/PlainText: Systray item - Text Editor [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!&amp;Ťēxť Ȇďĩťŏř...!!]</string>
@@ -304,18 +301,6 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="S_OSKContext_ShowToolbar" comment="On Screen Keyboard Menu Items/PlainText: OSK right-click menu - show/hide OSK toolbar (introduced 7.0.230.0)">[!!Ŝĥŏŵ Ťōōĺƀåř!!]</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="On Screen Keyboard Menu Items/PlainText: OSK right-click menu - save diagram of active keyboard layout as a web page (introduced 7.0.230.0)">[!!Śǻvĕ äš ŴěƄ Ƥąģę...!!]</string>
   <string name="S_OSKContext_Print" comment="On Screen Keyboard Menu Items/PlainText: OSK right-click menu - print diagram of active keyboard layout (introduced 7.0.230.0)">[!!Ƥŕıňŧ...!!]</string>
-  <!-- - - - - - - - - - - - - - - - - - -->
-  <!-- Usage Page                        -->
-  <!-- - - - - - - - - - - - - - - - - - -->
-  <string name="S_Usage_Welcome" comment="Usage Page/PlainText: Usage page - keyboard help button (introduced 7.0.244.0)">[!!Ƙȅŷƅőǻřď Ħēłƥ!!]</string>
-  <string name="S_Usage_OSK" comment="Usage Page/PlainText: Usage page - On Screen Keyboard button (introduced 7.0.244.0)">[!!Őņ Ŝćŗėėń ĶȇɏƄōâŕď!!]</string>
-  <string name="S_Usage_Tutorial" comment="Usage Page/PlainText: Usage page - Getting Started button (introduced 7.0.244.0)">[!!Ģȅŧ Šťàŗťĕď!!]</string>
-  <string name="S_Usage_Help" comment="Usage Page/PlainText: Usage page - Product Help button (introduced 7.0.244.0)">Keyman[!! Ĥėŀƥ!!]</string>
-  <string name="S_Usage_Config" comment="Usage Page/PlainText: Usage page - Product Configuration button (introduced 7.0.244.0)">Keyman[!! Ċơŋƒĩġũřăţıơņ!!]</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has no documentation (introduced 7.1.261.0)">[!!Ťħĩŝ ƙȅŷƄőäŗđ ĺàŷŏũţ ĥáś ŉō Ĝěťťīņģ Śťăŗţęď ơř Ũŝȁģē ďơċũměņťȁţĩŏƞ. Ƥľȅǻšě ĉħėċĸ ŧħē Šťàřţ Měńů őŗ ĉőŋţáĉť ŧħę ƙȇȳƂŏåŗď ďȇvēľőƥȅŗ ƒōŗ mőŗē ıňƒŏŗmȃŧĩőň ōƞ ĥơŵ ťō ųŝę ŧĥĭş ķěȳƅőářđ ŀâŷōųţ.!!]</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has documentation (introduced 7.1.261.0)">[!!Čļīćƙ ťĥȅ ƅŭťŧŏňś ƃȅłơŵ ťơ vıęŵ åďďįŧĩōņāľ ďŏĉųmȅņŧāŧīơƞ ąŉđ/őř Őń Şčřȇęŉ Ƙȇƴƃŏȁŗď.!!]</string>
-  <string name="S_Usage_KeymanOff" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboard is active (introduced 7.1.261.0)">[!!Ňơ ƙęƴƃŏàŕđ ĺȁƴơųŧ ĭś ćũřŗęńţľȳ ŝȇľěćŧĕđ ĩņ !!]Keyman[!!.  Ĉŀĩĉƙ őƞ àŋɏ őƒ ŧĥē ƙěŷƀőăřď ıćőņš ıƞ ŧħĕ ŧŏơŀƀąŗ åƄơvȇ ťơ ćħőŏşȅ ã ĸȅɏƀơáŕď ĺãŷōūţ.!!]</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboards are installed (introduced 7.1.261.0)">[!!Ŋō ķĕŷƄőàřđ ľãƴŏųŧŝ ąřė ċůŕŕěŋťĺŷ įƞšťàļľĕď ơŗ ŀơȃđȅđ.  Ŭşē !!]Keyman[!! Čōŉƒīĝűŗāťĩőň ŧơ ıƞšŧȃľļ à ķȅɏƂơâřď ĺãɏōũť.!!]</string>
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <!-- Formatted messages, assorted                                              -->
   <!-- These messages cannot contain HTML tags and are plain text                -->
@@ -391,16 +376,6 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="S_OSK_FontHelper_NoFonts1b" comment="OSK Font Helper/HTML: OSK Font helper no fonts part 2 (introduced 8.0.294.0)">[!!.  Ƥľȇāšē !!][!!čħēċƙ ťħė ďŏĉūmęņţǻţīŏņ!!][!! ţơ ƒıńď ƒơňţś ƒōŕ ťĥış ķȇɏƀōãřď.!!]</string>
   <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font Helper/HTML: OSK Font helper no keyboards (introduced 8.0.294.0)">[!!Ńŏ ĸęƴƅơāŗđ ŀåƴōůŧś äŕȅ ćųŗŕęņťĺȳ īņśťâłłēđ ōŕ łőäđĕď.  Ŭŝě !!]Keyman[!! Ĉőŋƒįğűřąŧīŏņ ŧơ ıŉŝťȃĺľ ä ƙĕɏƃōąŗđ łâƴơŭŧ.!!]</string>
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font Helper/HTML: OSK Font helper choose keyboard (introduced 8.0.294.0)">[!!Ƥľęǻśĕ ćħōŏšě å !!]Keyman[!! ķēƴƄŏȃřđ ţő ƒīƞď ţħė ƒőƞŧş ŧĥáŧ ŵįĺĺ ŵőŗĸ ŵıŧħ īŧ.!!]</string>
-  <!-- OSK Hints -->
-  <string name="S_OSK_Hint_Title" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar title (introduced 8.0.294.0)">[!!Ħīŉť:!!]</string>
-  <string name="S_OSK_Hint1" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Řěšıżȇ ŧħȅ Őň Şċŕĕĕň Ƙěŷƅơǻřđ ƃŷ ćŀĭćĸīňģ äńď đŕäĝġıńĝ ŏŉ ŧĥę ŵįŉďơŵ ƅơŗďėŕ!!]</string>
-  <string name="S_OSK_Hint2" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Mővȅ ţĥȅ Ơň Şčřėěŋ ƘėŷƄơäřď Ƃɏ čŀīċĸĩŉĝ ąŉđ ďřâģğıŋĝ ōń ťĥȅ "!!]Keyman[!!" ŧīťłē!!]</string>
-  <string name="S_OSK_Hint3a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Ĩņśȅřť ąŋƴ Ůńĩćōđē ćħăŗǻċŧěř ĩņťō ƴơũŕ đōčŭměňŧ ŵıŧĥ ŧħȅ!!]</string>
-  <string name="S_OSK_Hint3b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Čĥǻŗąĉŧėř Mäƥ Ťŏŏŀ!!]</string>
-  <string name="S_OSK_Hint4a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Ƒĩńď őűť ŵĥıćĥ ƒơņţş ŵĭŀł ŵōřƙ ŵıţħ ŷōŭŕ ŀåņğūȃĝė ŵĭťĥ ťĥȇ!!]</string>
-  <string name="S_OSK_Hint4b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Ƒơŉţ Ħęŀƥȅŕ Ťōōļ!!]</string>
-  <string name="S_OSK_Hint5a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Ğēţ mơŕē ħěŀƥ ōŋ ţħė ĸȅȳƄơäřđ Ƃȳ ċļįčķįŋğ ţħě!!]</string>
-  <string name="S_OSK_Hint5b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">[!!Ƙěɏƀơåřď Ůśâģȇ Ƅűŧţơņ!!]</string>
   <!-- - - - - - - - - - - - - - - - - - -->
   <!-- Text Editor                       -->
   <!-- - - - - - - - - - - - - - - - - - -->

--- a/windows/src/desktop/kmshell/locale/ta/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ta/strings.xml
@@ -332,7 +332,6 @@ Entries not in this file will be sourced from the default locale.xml file in the
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
   <string name="S_Hotkey_Language_Prefix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - activation term preceding Windows language name. Note: include a space following. (introduced 7.0.241.0)"/>
   <string name="S_Hotkey_Language_Suffix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - language term following Windows language name. Note: include an initial space. (introduced 7.0.241.0)"/>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard usage in OSK (introduced 7.1.275.0)">Show Keyboard Usage Pane</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">Show Font Helper Pane</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">Show Character Map Pane</string>
   <string name="S_Hotkey_OpenTextEditor" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open text editor (introduced 7.1.275.0)">Open Text Editor</string>
@@ -405,15 +404,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <string name="SKMenu_NoKeyboardsInstalled" comment="System Tray Menu Items/PlainText: Systray - notice of no keyboard layouts installed (introduced 7.0.230.0)">No keyboard layouts are installed.
 Choose "Configuration" to install a 
 keyboard layout for your language.</string>
-  <string name="S_Usage_Welcome" comment="Usage Page/PlainText: Usage page - keyboard help button (introduced 7.0.244.0)">Keyboard Help</string>
-  <string name="S_Usage_OSK" comment="Usage Page/PlainText: Usage page - On Screen Keyboard button (introduced 7.0.244.0)">On Screen Keyboard</string>
-  <string name="S_Usage_Tutorial" comment="Usage Page/PlainText: Usage page - Getting Started button (introduced 7.0.244.0)">Get Started</string>
-  <string name="S_Usage_Help" comment="Usage Page/PlainText: Usage page - Product Help button (introduced 7.0.244.0)">Keyman Help</string>
-  <string name="S_Usage_Config" comment="Usage Page/PlainText: Usage page - Product Configuration button (introduced 7.0.244.0)">Keyman Configuration</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has no documentation (introduced 7.1.261.0)">This keyboard layout has no Getting Started or Usage documentation. Please check the Start Menu or contact the keyboard developer for more information on how to use this keyboard layout.</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="Usage Page/HTML: Usage page - Text shown when keyboard has documentation (introduced 7.1.261.0)">Click the buttons below to view additional documentation and/or On Screen Keyboard.</string>
-  <string name="S_Usage_KeymanOff" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboard is active (introduced 7.1.261.0)">No keyboard layout is currently selected in Keyman.  Click on any of the keyboard icons in the toolbar above to choose a keyboard layout.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="Usage Page/HTML: Usage page - Text shown when no Keyman keyboards are installed (introduced 7.1.261.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="SKButtonPrint" comment="Formatted Messages/FormatString: Print button in Welcome dialog for keyboards (introduced 7.0.239.0)">&amp;Print...</string>
   <string name="SKButtonDownload" comment="Formatted Messages/FormatString: Download button in Locale Selection dialog (introduced 7.0.240.0)">&amp;Download...</string>
   <string name="SKUninstallKeyboard" comment="Formatted Messages/FormatString: Request for confirmation to uninstall keyboard layout [%0:s = Keyboard name] (introduced 7.0.239.0)">Are you sure you want to uninstall keyboard %0:s?</string>
@@ -447,13 +437,4 @@ Do you want to try and start Keyman again now?</string>
   <string name="S_OSK_FontHelper_NoFonts1b" comment="OSK Font Helper/HTML: OSK Font helper no fonts part 2 (introduced 8.0.294.0)">.  Please check the documentation to find fonts for this keyboard.</string>
   <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font Helper/HTML: OSK Font helper no keyboards (introduced 8.0.294.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font Helper/HTML: OSK Font helper choose keyboard (introduced 8.0.294.0)">Please choose a Keyman keyboard to find the fonts that will work with it.</string>
-  <string name="S_OSK_Hint_Title" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar title (introduced 8.0.294.0)">Hint:</string>
-  <string name="S_OSK_Hint1" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Resize the On Screen Keyboard by clicking and dragging on the window border</string>
-  <string name="S_OSK_Hint2" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Move the On Screen Keyboard by clicking and dragging on the "Keyman" title</string>
-  <string name="S_OSK_Hint3a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Insert any Unicode character into your document with the</string>
-  <string name="S_OSK_Hint3b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Character Map Tool</string>
-  <string name="S_OSK_Hint4a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Find out which fonts will work with your language with the</string>
-  <string name="S_OSK_Hint4b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Font Helper Tool</string>
-  <string name="S_OSK_Hint5a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Get more help on the keyboard by clicking the</string>
-  <string name="S_OSK_Hint5b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Keyboard Usage button</string>
 </resources>

--- a/windows/src/desktop/kmshell/locale/tr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/tr/strings.xml
@@ -98,7 +98,6 @@
   <string name="S_Hotkey_OpenTextEditor" comment="/PlainText: ">Metin Düzenleyici Aç</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="/PlainText: ">Karakter Haritası Bölmesini Göster</string>
   <string name="S_Hotkey_ShowFontHelper" comment="/PlainText: ">Yazı Tipi Yardımcısı Bölmesini Göster</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="/PlainText: ">Klavye Kullanım Bölmesini Göster</string>
   <string name="S_Hotkey_ShowOnScreenKeyboard" comment="/PlainText: ">Ekran Klavye Bölmesi Göster</string>
   <string name="S_Hotkey_SwitchLanguage" comment="/PlainText: ">Dil Değiştiricisini Açın</string>
   <string name="S_Hotkey_TurnKeymanOff" comment="/PlainText: ">Keyman'u Kapat</string>
@@ -208,15 +207,6 @@
   <string name="S_Update_OldVersionHead" comment="/PlainText: ">Eski Versiyon</string>
   <string name="S_Update_SizeHead" comment="/PlainText: ">Boyut</string>
   <string name="S_Update_Title" comment="/PlainText: ">Güncellenmiş Keyman Bileşenler Mevcut</string>
-  <string name="S_Usage_Config" comment="/PlainText: ">Keyman Yapılandırma</string>
-  <string name="S_Usage_Help" comment="/PlainText: ">Keyman Yardım</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="/HTML: ">Ek belgeleri ve/veya Ekran Klavyesini görüntülemek için aşağıdaki düğmeleri tıklayın.</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="/HTML: ">Bu klavye düzeni bir Hemen Başlayın veya Kullanım kılavuzu içermez. Lütfen bu klavye düzenini kullanma hakkında daha fazla bilgi için Başlat Menüsünü kontrol edin veya klavye geliştiricisine başvurun.</string>
-  <string name="S_Usage_KeymanOff" comment="/HTML: ">Keyman içinde herhangi bir klavye düzeni seçili değil.  Klavye düzenini seçmek için yukarıdaki araç çubuğundaki klavye simgelerinden herhangi birine tıklayın.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="/HTML: ">Herhangi bir klavye düzeni kurulu veya yüklü değildir.  Bir klavye düzeni kopyası yüklemek için Keyman Konfigürasyon kısmına tıklayın.</string>
-  <string name="S_Usage_OSK" comment="/PlainText: ">Ekran Klavyesi</string>
-  <string name="S_Usage_Tutorial" comment="/PlainText: ">Hemen Başlayın</string>
-  <string name="S_Usage_Welcome" comment="/PlainText: ">Klavye Yardımı</string>
   <string name="S_Yes" comment="/PlainText: ">Evet</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="/PlainText: ">Web sayfası olarak kaydet...</string>
   <string name="S_OSKContext_ShowToolbar" comment="/PlainText: ">Araç Çubuğu Göster</string>
@@ -301,9 +291,7 @@
   <string name="S_Menu_SwitchKeymanOff" comment="/PlainText: ">Keyman'u &amp;Kapat</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="/PlainText: ">Karakter Haritasını İncele</string>
   <string name="S_Toolbar_ViewFontHelper" comment="/PlainText: ">Yazı Tipi Yardımcısını Görüntüle</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="/PlainText: ">Klavye Kullanımını Görüntüle</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="/PlainText: ">Ekran Klavyesi Göster</string>
-  <string name="S_Menu_KeyboardUsage" comment="/PlainText: ">&amp;Klavye Kullanımı</string>
   <string name="S_Menu_FontHelper" comment="/PlainText: ">&amp;Font Yardımcısı</string>
   <string name="S_Menu_CharacterMap" comment="/PlainText: ">Karakter &amp;Haritası</string>
   <string name="S_Menu_TextEditor" comment="/PlainText: ">&amp;Metin Düzenleyici...</string>

--- a/windows/src/desktop/kmshell/locale/vec/strings.xml
+++ b/windows/src/desktop/kmshell/locale/vec/strings.xml
@@ -141,15 +141,6 @@
   <string name="S_Update_OldVersionHead" comment="/PlainText: ">Version vècia</string>
   <string name="S_Update_SizeHead" comment="/PlainText: ">Dimension</string>
   <string name="S_Update_Title" comment="/PlainText: ">Xé disponìbiƚe conponenti Keyman axornài</string>
-  <string name="S_Usage_Config" comment="/PlainText: ">Confegurasion de Keyman Desktop</string>
-  <string name="S_Usage_Help" comment="/PlainText: ">Àida de Keyman Desktop</string>
-  <string name="S_Usage_KeyboardDocumentation" comment="/HTML: ">Clica i botoni soto par védar documentasion de xonta e/o ƚa tastièra so schèrmo.</string>
-  <string name="S_Usage_KeyboardNoDocumentation" comment="/HTML: ">Sto layout de tastièra no 'l gà documentasion de introdusion o de uxo. Vedi el menu de invìo o contata el sviƚupador de ƚa tastièra par altre informasion so come doparar sto layout.</string>
-  <string name="S_Usage_KeymanOff" comment="/HTML: ">No te gà desernìo nisun layout in Keyman Desktop. Clica so na icona cualsesipia inte ƚa strica de ƚe inpreste de sora par desernir un layout de tastièra.</string>
-  <string name="S_Usage_NoKeyboardsInstalled" comment="/HTML: ">No ghe xé layouts de tastièra istaƚài o cargài. Dòpara ƚa confegurasion Keyman Desktop par istaƚar un layout de tastièra.</string>
-  <string name="S_Usage_OSK" comment="/PlainText: ">Tastièra so schèrmo</string>
-  <string name="S_Usage_Tutorial" comment="/PlainText: ">Introdusion</string>
-  <string name="S_Usage_Welcome" comment="/PlainText: ">Àida tastièra</string>
   <string name="S_Yes" comment="/PlainText: ">Sì</string>
   <string name="S_OSKContext_SaveAsWebPage" comment="/PlainText: ">Salva fà pàxena web...</string>
   <string name="S_OSKContext_ShowToolbar" comment="/PlainText: ">Mostra strica de ƚe inpreste</string>
@@ -225,7 +216,6 @@
   <string name="S_Menu_SwitchKeymanOff" comment="/PlainText: ">Destùa Keyman Desktop</string>
   <string name="S_Toolbar_ViewCharacterMap" comment="/PlainText: ">Vedi mapa caràteri</string>
   <string name="S_Toolbar_ViewFontHelper" comment="/PlainText: ">Vedi guida font</string>
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="/PlainText: ">Vedi àida funsionamento tastièra</string>
   <string name="S_Toolbar_ViewOnScreenKeyboard" comment="/PlainText: ">Vedi àida tastièra so schèrmo</string>
   <string name="S_LocaleAuthors" comment="System/PlainText: Name(s) of people who created this translation - i.e. your name (introduced 7.1.266.0)">Keyman</string>
   <string name="S_BETA" comment="System/PlainText: Set this text to 'BETA' for beta versions of Keyman, and empty otherwise (introduced 7.0.230.0)"/>
@@ -247,7 +237,6 @@
   <string name="koDeadkeyConversion" comment="Configuration Dialog - Options tab/FormatString: Advanced options - Base keyboard deadkeys are treated as normal keys (introduced 9.0.480.0)">Treat hardware deadkeys as plain keys</string>
   <string name="koSwitchLanguageForAllApplications" comment="Configuration Dialog - Options tab/FormatString: Advanced options - selected language applies to all applications (introduced 7.1.274.0)">Select keyboard layout for all applications</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show keyboard usage in OSK (introduced 7.1.275.0)">Show Keyboard Usage Pane</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">Show Font Helper Pane</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">Show Character Map Pane</string>
   <string name="S_Hotkey_OpenTextEditor" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - open text editor (introduced 7.1.275.0)">Open Text Editor</string>
@@ -296,13 +285,4 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <string name="S_OSK_FontHelper_NoFonts1b" comment="OSK Font Helper/HTML: OSK Font helper no fonts part 2 (introduced 8.0.294.0)">.  Please check the documentation to find fonts for this keyboard.</string>
   <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font Helper/HTML: OSK Font helper no keyboards (introduced 8.0.294.0)">No keyboard layouts are currently installed or loaded.  Use Keyman Configuration to install a keyboard layout.</string>
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font Helper/HTML: OSK Font helper choose keyboard (introduced 8.0.294.0)">Please choose a Keyman keyboard to find the fonts that will work with it.</string>
-  <string name="S_OSK_Hint_Title" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar title (introduced 8.0.294.0)">Hint:</string>
-  <string name="S_OSK_Hint1" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Resize the On Screen Keyboard by clicking and dragging on the window border</string>
-  <string name="S_OSK_Hint2" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Move the On Screen Keyboard by clicking and dragging on the "Keyman" title</string>
-  <string name="S_OSK_Hint3a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Insert any Unicode character into your document with the</string>
-  <string name="S_OSK_Hint3b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Character Map Tool</string>
-  <string name="S_OSK_Hint4a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Find out which fonts will work with your language with the</string>
-  <string name="S_OSK_Hint4b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Font Helper Tool</string>
-  <string name="S_OSK_Hint5a" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Get more help on the keyboard by clicking the</string>
-  <string name="S_OSK_Hint5b" comment="OSK Hints/Plain Text: On Screen Keyboard Hintbar hint (introduced 8.0.294.0)">Keyboard Usage button</string>
 </resources>

--- a/windows/src/desktop/kmshell/xml/keyman_hotkeys.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_hotkeys.xsl
@@ -105,7 +105,7 @@
           <xsl:when test="Target='1'"><xsl:value-of select="$locale/string[@name='S_Hotkey_OpenKeyboardMenu']"/></xsl:when>
           <xsl:when test="Target='2'"><xsl:value-of select="$locale/string[@name='S_Hotkey_ShowOnScreenKeyboard']"/></xsl:when>
           <xsl:when test="Target='3'"><xsl:value-of select="$locale/string[@name='S_Hotkey_OpenConfiguration']"/></xsl:when>
-          <xsl:when test="Target='4'"><xsl:value-of select="$locale/string[@name='S_Hotkey_ShowKeyboardUsage']"/></xsl:when>
+          
           <xsl:when test="Target='5'"><xsl:value-of select="$locale/string[@name='S_Hotkey_ShowFontHelper']"/></xsl:when>
           <xsl:when test="Target='6'"><xsl:value-of select="$locale/string[@name='S_Hotkey_ShowCharacterMap']"/></xsl:when>
           <xsl:when test="Target='7'"><xsl:value-of select="$locale/string[@name='S_Hotkey_OpenTextEditor']"/></xsl:when>

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -486,11 +486,6 @@
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.1.275.0 -->
-  <string name="S_Hotkey_ShowKeyboardUsage" comment="Hotkey - show keyboard usage in OSK">Show Keyboard Usage Pane</string>
-
-  <!-- Context: Configuration Dialog - Hotkeys tab -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.1.275.0 -->
   <string name="S_Hotkey_ShowFontHelper" comment="Hotkey - show font helper in OSK">Show Font Helper Pane</string>
 
   <!-- Context: Configuration Dialog - Hotkeys tab -->
@@ -934,11 +929,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Context: Toolbar Context Help -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Toolbar_ViewKeyboardUsage" comment="Toolbar help - View Keyboard Usage pop-up text">View Keyboard Usage</string>
-
-  <!-- Context: Toolbar Context Help -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="S_Toolbar_ViewFontHelper" comment="Toolbar help - View Font Helper pop-up text">View Font Helper</string>
 
   <!-- Context: Toolbar Context Help -->
@@ -973,11 +963,6 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_OnScreenKeyboard" comment="Systray item - OSK [&amp; precedes alt + access-character]">On Screen &amp;Keyboard</string>
-
-  <!-- Context: System Tray Menu Items -->
-  <!-- String Type: PlainText -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Menu_KeyboardUsage" comment="Systray item - Keyboard Usage [&amp; precedes alt + access-character]">Keyboard &amp;Usage</string>
 
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->

--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -661,6 +661,7 @@ begin
     case ActivePage of
       apKeyboard: TKeymanDesktopShell.OpenHelp('context_onscreenkeyboard');
       apCharacterMap: TKeymanDesktopShell.OpenHelp('context_charactermap');
+      apFontHelper: TKeymanDesktopShell.OpenHelp('context_fonthelper');
       apEntryHelper: TKeymanDesktopShell.OpenHelp('context_entryhelper');
     end;
   end;

--- a/windows/src/global/delphi/general/InterfaceHotkeys.pas
+++ b/windows/src/global/delphi/general/InterfaceHotkeys.pas
@@ -24,12 +24,11 @@ uses
   keymanapi_TLB;
 
 const
-  CInterfaceHotkeys: array[0..8] of KeymanHotkeyTarget = (
+  CInterfaceHotkeys: array[0..7] of KeymanHotkeyTarget = (
     khKeymanOff,
     khKeyboardMenu,
     khVisualKeyboard,
     khKeymanConfiguration,
-    khKeyboardUsage,
     khFontHelper,
     khCharacterMap,
     khTextEditor,


### PR DESCRIPTION
Fixes #4336.

Removes the "Show Keyboard Usage Page" hotkey entry as it has no effect, and cleans up Keyboard Usage and OSK Hint strings from all the current locales.