### PR TITLE
fix(windows): avoid invalid language codes in Add Language dialog

### DIFF
--- a/windows/src/engine/kmcomapi/com/keyman_implementation.pas
+++ b/windows/src/engine/kmcomapi/com/keyman_implementation.pas
@@ -1,18 +1,18 @@
 (*
   Name:             keyman_implementation
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    22 Feb 2011
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
   Bugs:
-  Todo:             
-  Notes:            
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Add UniqueIndex, SerializeXML and ObjectByIndex
                     04 Dec 2006 - mcdurdin - Rework COM objects to be internally owned by TKeyman so that they can't be destroyed by an external process
                     19 Mar 2007 - mcdurdin - Remove forms.pas dependency
@@ -29,10 +29,23 @@ unit keyman_implementation;
 interface
 
 uses
-  Windows, ActiveX, ComObj, keymanapi_TLB, StdVcl, keymancontext,
-  keymanerrors, keymankeyboardsinstalled, keymanpackagesinstalled,
-  keymansysteminfo, keymanoptions, keymanlanguages, keymancontrol, keymanhotkeys,
-  keymanautoobject, internalinterfaces;
+  System.Win.ComObj,
+  System.Win.StdVcl,
+  Winapi.ActiveX,
+  Winapi.Windows,
+
+  internalinterfaces,
+  keymanapi_TLB,
+  keymanautoobject,
+  keymancontext,
+  keymancontrol,
+  keymanerrors,
+  keymanhotkeys,
+  keymankeyboardsinstalled,
+  keymanlanguages,
+  keymanoptions,
+  keymanpackagesinstalled,
+  keymansysteminfo;
 
 type
   TKeyman = class(TAutoObject, IKeyman, IIntKeyman, IKeymanBCP47Canonicalization)
@@ -65,6 +78,7 @@ type
 
     { IKeymanBCP47Canonicalization }
     function GetCanonicalTag(const Tag: WideString): WideString; safecall;
+    function GetFullTagList(const Tag: WideString): OleVariant; safecall;
 
     { IKeymanObject }
     // Reimplement as a special case for this interface
@@ -91,8 +105,10 @@ type
 implementation
 
 uses
-  Classes,
-  ComServ,
+  System.Classes,
+  System.Variants,
+  System.Win.ComServ,
+
   sysutils,
   klog,
   utilhandleexception,
@@ -278,6 +294,12 @@ procedure TKeyman.Set_AutoApply(Value: WordBool);
 begin
   if not FInitialized then raise Exception.Create(SErrorUninitialised);
   FControl.AutoApply := Value;
+end;
+
+function TKeyman.GetFullTagList(const Tag: WideString): OleVariant;
+begin
+  // Converts array of strings as a Variant array
+  Result := TCanonicalLanguageCodeUtils.GetFullTagList(Tag);
 end;
 
 initialization

--- a/windows/src/engine/kmcomapi/keymanapi_TLB.pas
+++ b/windows/src/engine/kmcomapi/keymanapi_TLB.pas
@@ -12,7 +12,7 @@ unit keymanapi_TLB;
 // ************************************************************************ //
 
 // $Rev: 52393 $
-// File generated on 23/09/2020 5:09:37 PM from Type Library described below.
+// File generated on 1/02/2021 8:52:41 AM from Type Library described below.
 
 // ************************************************************************  //
 // Type Lib: C:\Projects\keyman\app\windows\src\engine\kmcomapi\kmcomapi (1)
@@ -358,6 +358,7 @@ type
   IKeymanBCP47Canonicalization = interface(IKeymanObject)
     ['{CA3B3B00-EA42-4EED-9043-D1A1F1842D52}']
     function GetCanonicalTag(const Tag: WideString): WideString; safecall;
+    function GetFullTagList(const Tag: WideString): OleVariant; safecall;
   end;
 
 // *********************************************************************//
@@ -368,6 +369,7 @@ type
   IKeymanBCP47CanonicalizationDisp = dispinterface
     ['{CA3B3B00-EA42-4EED-9043-D1A1F1842D52}']
     function GetCanonicalTag(const Tag: WideString): WideString; dispid 301;
+    function GetFullTagList(const Tag: WideString): OleVariant; dispid 302;
     function SerializeXML(Flags: tagKeymanSerializeFlags; const ImagePath: WideString;
                           out References: OleVariant): WideString; dispid 401;
   end;

--- a/windows/src/engine/kmcomapi/kmcomapi.ridl
+++ b/windows/src/engine/kmcomapi/kmcomapi.ridl
@@ -6,7 +6,7 @@
 // However, when applying changes via the Editor this file will be regenerated
 // and comments or formatting changes will be lost.
 // ************************************************************************ //
-// File generated on 23/09/2020 5:25:25 PM (- $Rev: 12980 $, 651560046).
+// File generated on 1/02/2021 8:52:42 AM (- $Rev: 12980 $, 9519671).
 
 [
   uuid(F16E2A9A-DA46-4EA3-BFF3-BA46B480C961),
@@ -1015,6 +1015,8 @@ library keymanapi
   {
     [id(0x0000012D)]
     HRESULT _stdcall GetCanonicalTag([in] BSTR Tag, [out, retval] BSTR* Result);
+    [id(0x0000012E)]
+    HRESULT _stdcall GetFullTagList([in] BSTR Tag, [out, retval] VARIANT* Result);
   };
 
   [


### PR DESCRIPTION
Fixes #4343.

This patch makes all language codes from the langtags.json dataset visible through the Add Language dialog. This avoids situations where an incomplete code such as "cmo" can result in an error (a script is required for "cmo" as it is written in either Latn or Khmr).

## Searching for `cm`:

![image](https://user-images.githubusercontent.com/4498365/106401283-69921800-6477-11eb-8924-19ee1397b10c.png)

## Searching for `cmo`:

![image](https://user-images.githubusercontent.com/4498365/106401290-70208f80-6477-11eb-947e-ed65581f982f.png)
