### PR TITLE
fix(windows): When uninstalling, exit Keyman

### DIFF
--- a/windows/src/desktop/insthelp/insthelp.dpr
+++ b/windows/src/desktop/insthelp/insthelp.dpr
@@ -3,12 +3,12 @@ program insthelp;
 uses
   main in 'main.pas',
   Winapi.ActiveX,
-//  System.Win.ComObj,
   klog in '..\..\global\delphi\general\klog.pas',
   RegistryKeys in '..\..\global\delphi\general\RegistryKeys.pas',
   KeymanVersion in '..\..\global\delphi\general\KeymanVersion.pas',
   Keyman.System.InstHelp.KeymanStartTaskUninstall in 'Keyman.System.InstHelp.KeymanStartTaskUninstall.pas',
-  TaskScheduler_TLB in '..\..\global\delphi\winapi\TaskScheduler_TLB.pas';
+  TaskScheduler_TLB in '..\..\global\delphi\winapi\TaskScheduler_TLB.pas',
+  UserMessages in '..\..\global\delphi\general\UserMessages.pas';
 
 {$R version.res}
 {-R manifest.res}

--- a/windows/src/desktop/insthelp/insthelp.dproj
+++ b/windows/src/desktop/insthelp/insthelp.dproj
@@ -92,6 +92,7 @@
         <DCCReference Include="..\..\global\delphi\general\KeymanVersion.pas"/>
         <DCCReference Include="Keyman.System.InstHelp.KeymanStartTaskUninstall.pas"/>
         <DCCReference Include="..\..\global\delphi\winapi\TaskScheduler_TLB.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\UserMessages.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/windows/src/desktop/insthelp/main.pas
+++ b/windows/src/desktop/insthelp/main.pas
@@ -46,7 +46,22 @@ uses
   Winapi.Windows,
   Keyman.System.InstHelp.KeymanStartTaskUninstall,
   klog,
-  RegistryKeys;
+  RegistryKeys,
+  UserMessages;
+
+procedure ShutdownKeyman;
+var
+  hwnd: THandle;
+const
+  KMC_StopProduct = 1;  // from UfrmKeyman7Main.pas
+begin
+  hwnd := FindWindow('TfrmKeyman7Main', nil);
+  if hwnd <> 0 then
+  begin
+    PostMessage(hwnd, WM_USER_ParameterPass, KMC_StopProduct, 0);
+    Sleep(1000); // We'll wait 1 second to give Keyman Engine time to shut down
+  end;
+end;
 
 procedure UninstallUser;
 var
@@ -59,6 +74,8 @@ var
 begin
   KL.MethodEnter(nil, 'Uninstall', []);
   try
+    ShutdownKeyman;
+
     { I985: desktop_xxx.pxx not removed from registry at uninstall }
     if RegOpenKeyEx(HKEY_CURRENT_USER, PChar(SRegKey_WindowsRun_CU), 0, KEY_ALL_ACCESS, hk) = ERROR_SUCCESS then
     begin

--- a/windows/src/desktop/insthelp/main.pas
+++ b/windows/src/desktop/insthelp/main.pas
@@ -52,6 +52,7 @@ uses
 procedure ShutdownKeyman;
 var
   hwnd: THandle;
+  Counter: Integer;
 const
   KMC_StopProduct = 1;  // from UfrmKeyman7Main.pas
 begin
@@ -59,7 +60,12 @@ begin
   if hwnd <> 0 then
   begin
     PostMessage(hwnd, WM_USER_ParameterPass, KMC_StopProduct, 0);
-    Sleep(1000); // We'll wait 1 second to give Keyman Engine time to shut down
+    Counter := 0;
+    while (FindWindow('TfrmKeyman7Main', nil) <> 0) and (Counter < 10) do
+    begin
+      Sleep(1000); // We'll wait up to 10 seconds to give Keyman Engine time to shut down
+      Inc(Counter);
+    end;
   end;
 end;
 

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -110,7 +110,7 @@
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
-        <Debugger_RunParams>-sentry-client-test-exception</Debugger_RunParams>
+        <Debugger_RunParams>-validate-repo-changes C:\Projects\keyman\keyboards compare-bcp47-scripts</Debugger_RunParams>
         <DCC_AssertionsAtRuntime>true</DCC_AssertionsAtRuntime>
         <DCC_DebugInformation>2</DCC_DebugInformation>
         <VerInfo_Locale>1033</VerInfo_Locale>
@@ -266,9 +266,7 @@
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.modelTsProjectFileAction.pas"/>
         <DCCReference Include="..\..\global\delphi\lexicalmodels\Keyman.Developer.System.LexicalModelCompile.pas"/>
         <DCCReference Include="..\..\global\delphi\lexicalmodels\Keyman.System.LexicalModelUtils.pas"/>
-        <DCCReference Include="Keyman.Developer.System.Project.ProjectLogConsole.pas">
-            <Form>$R icons.RES</Form>
-        </DCCReference>
+        <DCCReference Include="Keyman.Developer.System.Project.ProjectLogConsole.pas" />
         <DCCReference Include="..\..\ext\sentry\Sentry.Client.pas"/>
         <DCCReference Include="..\..\ext\sentry\Sentry.Client.Console.pas"/>
         <DCCReference Include="..\..\ext\sentry\sentry.pas"/>
@@ -277,6 +275,7 @@
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas"/>
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
+        <DCCReference Include="Keyman.Developer.System.ValidateRepoChanges.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
Fixes #4185.

Make sure Keyman is shut down during the uninstall so that it isn't left in a weird state with missing files. This also reduces the need for a reboot after uninstall.