### PR TITLE
chore(linux): Pass second tag parameter to Jenkins build

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -69,7 +69,7 @@ function triggerJenkinsBuild() {
   local TAG=""
   # This will only be true if we created and pushed a tag
   if [ "${action:-""}" == "commit" ]; then
-    TAG=", \"tag\": \"$GIT_TAG\""
+    TAG=", \"tag\": \"$GIT_TAG\", \"tag2\": \"$GIT_TAG\""
   fi
 
   if [[ $JENKINS_BRANCH =~ [0-9]+ ]]; then


### PR DESCRIPTION
This is necessary to be able to distinguish between a newly triggered tagged build and a retriggered tagged build. The first tag param gets saved between builds, but then we need a second parameter that doesn't get saved that tells us if this build is a retriggered one.

Cherry-pick of #4376 