### PR TITLE
fix(ios): fixes unit test mocking, test init

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -275,13 +275,6 @@
 			remoteGlobalIDString = C06D372A1F81F4E100F61AE0;
 			remoteInfo = KeymanEngine;
 		};
-		CE4459CB23FBB8DA003151FD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F243887514BBD43000A3E055 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F243887D14BBD43000A3E055;
-			remoteInfo = KeymanEngineDemo;
-		};
 		CE4459EA23FBBB79003151FD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F243887514BBD43000A3E055 /* Project object */;
@@ -1173,7 +1166,6 @@
 			);
 			dependencies = (
 				9A079DD6223194B100581263 /* PBXTargetDependency */,
-				CE4459CC23FBB8DA003151FD /* PBXTargetDependency */,
 				CE4459F923FBBCB3003151FD /* PBXTargetDependency */,
 			);
 			name = KeymanEngineTests;
@@ -1662,11 +1654,6 @@
 			isa = PBXTargetDependency;
 			target = C06D372A1F81F4E100F61AE0 /* KeymanEngine */;
 			targetProxy = C06D37CA1F83204200F61AE0 /* PBXContainerItemProxy */;
-		};
-		CE4459CC23FBB8DA003151FD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = F243887D14BBD43000A3E055 /* KeymanEngineDemo */;
-			targetProxy = CE4459CB23FBB8DA003151FD /* PBXContainerItemProxy */;
 		};
 		CE4459EB23FBBB79003151FD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/AssociatingPackageInstallerTests.swift
@@ -34,6 +34,10 @@ class AssociatingPackageInstallerTests: XCTestCase {
   }
 
   override func setUp() {
+    // Ensure Manager's standard init() occurs before our tests.
+    // Otherwise, if our first Manager reference is DURING a test, we'll see unwanted behavior from it.
+    _ = Manager.shared
+    
     // Resets resource directories for a clean slate.
     // We'll be testing against actually-installed packages.
     TestUtils.standardTearDown()

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDataTaskMock.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDataTaskMock.swift
@@ -26,5 +26,10 @@ extension TestUtils.Downloading {
     override func resume() {
       closure()
     }
+
+    override func cancel() {
+      // We must prevent the original cancel() from occurring, as it'll
+      // cause asynchronous errors otherwise.
+    }
   }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDownloadTaskMock.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/Downloading/URLSessionDownloadTaskMock.swift
@@ -32,5 +32,10 @@ extension TestUtils.Downloading {
     override func resume() {
       closure()
     }
+
+    override func cancel() {
+      // We must prevent the original cancel() from occurring, as it'll
+      // cause asynchronous errors otherwise.
+    }
   }
 }

--- a/ios/keymanios.xcworkspace/xcshareddata/xcschemes/Keyman.xcscheme
+++ b/ios/keymanios.xcworkspace/xcshareddata/xcschemes/Keyman.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:keyman/Keyman/Keyman.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9A079DCE223194B100581263"
+               BuildableName = "KeymanEngineTests.xctest"
+               BlueprintName = "KeymanEngineTests"
+               ReferencedContainer = "container:engine/KMEI/KeymanEngine.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
Updates our unit tests for compatibility with Xcode 12.2 & fixes a test bug.

The trickiest part was realizing that while the original `URLSessionTask`-related mocks were previously sufficient, later Xcode / Swift versions (not sure which) require a bit more mocking.  The original superclass `cancel` method was causing asynchronous errors on an unexpected thread.  (This is likely because the `resume` method would normally start a separate thread when not mocked, which `cancel` was unable to find as a result.)

Sadly, that means the test bug wasn't related to #4382 after all, _but_ this will facilitate diagnosing and fixing said bug substantially.