### PR TITLE
fix(ios): fixes package-install/update event concurrency management

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -334,7 +334,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
 
     log.info("keyboardDownloadFailed: InstalledLanguagesViewController")
 
-    DispatchQueue.main.sync {
+    DispatchQueue.main.async {
       var msg: String
       switch(packageKey.type) {
         case .keyboard:
@@ -343,7 +343,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
           msg = NSLocalizedString("notification-download-failure-lexical-model", bundle: engineBundle, comment: "")
       }
 
-      if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
+      if let toolbar = self.navigationController?.toolbar as? ResourceDownloadStatusToolbar {
         toolbar.displayStatus(msg, withIndicator: false, duration: 3.0)
       }
 
@@ -366,8 +366,8 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
   }
 
   private func batchUpdateCompleted(results: BatchUpdateCompletedNotification) {
-    DispatchQueue.main.sync {
-      if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
+    DispatchQueue.main.async {
+      if let toolbar = self.navigationController?.toolbar as? ResourceDownloadStatusToolbar {
         if results.failures.count == 0 {
           let formatString = NSLocalizedString("notification-update-success", bundle: engineBundle, comment: "")
           toolbar.displayStatus(String.localizedStringWithFormat(formatString, results.successes.count), withIndicator: false, duration: 3.0)
@@ -379,7 +379,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
         }
       }
 
-      restoreNavigation()
+      self.restoreNavigation()
     }
   }
   


### PR DESCRIPTION
May mitigate #4387. 

From https://developer.apple.com/documentation/dispatch/dispatchqueue/1452870-sync:

> Unlike dispatch_async(_:_:), this function does not return until the block has finished. Calling this function and targeting the current queue results in deadlock.

After a bit of tracing, it turns out that `InstalledLanguageViewController`'s package-notification-event handling methods are called on `DispatchQueue.main` - and two of those events - the less-frequently called ones - are using `.sync`, not `.async`.  The affected code blocks may safely be run asynchronously.

Alas, there's no guarantee at the moment that this is the only issue behind the crash log, but this change needs to happen anyway, given Apple's documentation on the methods involved.