### PR TITLE
fix(developer): don't check both setup.exe and setup-redist.exe

### DIFF
--- a/windows/src/global/delphi/general/CompilePackageInstaller.pas
+++ b/windows/src/global/delphi/general/CompilePackageInstaller.pas
@@ -294,10 +294,10 @@ begin
         WriteMessage('Redist path not specified, loading default ('+FRedistSetupPath+')');
       end;
 
-      if not FileExists(FRedistSetupPath + 'setup.exe') or
+      if not FileExists(FRedistSetupPath + 'setup.exe') and
          not FileExists(FRedistSetupPath + 'setup-redist.exe') then
       begin
-        FatalMessage('setup.exe or setup-redist.exe are missing from redist ('+FRedistSetupPath+').');
+        FatalMessage('Neither setup.exe nor setup-redist.exe are present in redist ('+FRedistSetupPath+').');
         Exit;
       end;
 


### PR DESCRIPTION
Fixes #4354.

The redistributable build should be checking for the existence of either setup.exe or setup-redist.exe. Note that the only difference between the two is whether or not the file has a digital signature (as we should not put a digital signature on an executable that will later have a .zip appended, rather the final file should be signed).