### PR TITLE
fix(developer): Generate platforms correctly from template

### DIFF
--- a/windows/src/developer/TIKE/main/KeyboardParser.pas
+++ b/windows/src/developer/TIKE/main/KeyboardParser.pas
@@ -7,12 +7,12 @@
 
   Modified Date:    23 Feb 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          23 Aug 2006 - mcdurdin - Initial version
                     30 Aug 2006 - mcdurdin - Fix bug with parsing shift/ctrl/alt rules
                     28 Sep 2006 - mcdurdin - Move version line to start of file
@@ -332,7 +332,7 @@ const
     // use the defined constants.
     [ktWindows, ktMacosx, ktLinux, ktDesktop], //KMXKeymanTargets
     [ktAny, ktWindows, ktMacosx, ktLinux, ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktDesktop, ktTablet], //AllKeymanTargets
-    [ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktTablet], //TouchKeymanTargets
+    [ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktTablet], //KMWKeymanTargets
     [ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktTablet], //KMWKeymanTargets
     [ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktTablet], //KMWKeymanTargets
     [ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet, ktMobile, ktTablet], //KMWKeymanTargets
@@ -876,7 +876,7 @@ constructor TKeyboardParser_SystemStore.CreateNew(
 begin
   inherited CreateNew;
   FSystemStoreType := ASystemStoreType;
-  Value := AValue; // Also sets Line  
+  Value := AValue; // Also sets Line
 end;
 
 function TKeyboardParser_SystemStore.IsComplexLine: Boolean;
@@ -1530,7 +1530,7 @@ constructor TKeyboardParser_Group.CreateNew(AGroupName: WideString;
 begin
   inherited CreateNew;
   FGroupName := AGroupName;
-  FUsingKeys := AUsingKeys; 
+  FUsingKeys := AUsingKeys;
   UpdateLine;
 end;
 

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -15,7 +15,6 @@ type
 
   TKeyboardProjectTemplate = class(TProjectTemplate)
   private
-    FTargets: TKeymanTargets;
     FIconFilename: string;
     FOSKFilename: string;
     FTouchLayoutFilename: string;
@@ -81,8 +80,7 @@ uses
 
 constructor TKeyboardProjectTemplate.Create(const BasePath, KeyboardID: string; Targets: TKeymanTargets);
 begin
-  inherited Create(BasePath, KeyboardID);
-  FTargets := Targets;
+  inherited Create(BasePath, KeyboardID, Targets);
 end;
 
 procedure TKeyboardProjectTemplate.Generate;
@@ -130,22 +128,22 @@ end;
 
 function TKeyboardProjectTemplate.HasIcon: Boolean;
 begin
-  Result := FIncludeIcon and ((KMXKeymanTargets+[ktAny]) * FTargets <> []);
+  Result := FIncludeIcon and ((KMXKeymanTargets+[ktAny]) * Targets <> []);
 end;
 
 function TKeyboardProjectTemplate.HasKMX: Boolean;
 begin
-  Result := (KMXKeymanTargets+[ktAny]) * FTargets <> [];
+  Result := (KMXKeymanTargets+[ktAny]) * Targets <> [];
 end;
 
 function TKeyboardProjectTemplate.HasKVKS: Boolean;
 begin
-  Result := (KeymanTargetsUsingKVK+[ktAny]) * FTargets <> [];
+  Result := (KeymanTargetsUsingKVK+[ktAny]) * Targets <> [];
 end;
 
 function TKeyboardProjectTemplate.HasTouchLayout: Boolean;
 begin
-  Result := (TouchKeymanTargets+[ktAny]) * FTargets <> [];
+  Result := (TouchKeymanTargets+[ktAny]) * Targets <> [];
 end;
 
 procedure TKeyboardProjectTemplate.WriteKeyboardInfo;
@@ -175,7 +173,7 @@ begin
       kp.SetSystemStoreValue(ssCopyright, Copyright);
     kp.SetSystemStoreValue(ssVersion, SKeymanKeyboardVersion);
     kp.SetSystemStoreValue(ssKeyboardVersion, Version);
-    kp.SetSystemStoreValue(ssTargets, KeymanTargetsToString(FTargets));
+    kp.SetSystemStoreValue(ssTargets, KeymanTargetsToString(Targets));
 
     if HasIcon then
       kp.Features.Add(kfIcon);

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
@@ -66,7 +66,7 @@ uses
 
 constructor TModelProjectTemplate.Create(const BasePath, ModelID: string);
 begin
-  inherited Create(BasePath, ModelID);
+  inherited Create(BasePath, ModelID, TouchKeymanTargets);
 end;
 
 procedure TModelProjectTemplate.Generate;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
@@ -23,6 +23,7 @@ type
     FVersion: string;
     FBCP47Tags: string;
     FProjectType: TKeymanProjectType;
+    FTargets: TKeymanTargets;
 
   protected
     const
@@ -50,11 +51,13 @@ type
     property BasePath: string read FBasePath;
     property ID: string read FID;
   public
-    constructor Create(const BasePath, ID: string);
+    constructor Create(const BasePath, ID: string; ATargets: TKeymanTargets);
 
     procedure Generate; virtual; abstract;
 
     property ProjectType: TKeymanProjectType read FProjectType;
+
+    property Targets: TKeymanTargets read FTargets;
 
     property Name: string read FName write FName;
     property Copyright: string read FCopyright write FCopyright;
@@ -87,12 +90,13 @@ uses
 
 { TProjectTemplate }
 
-constructor TProjectTemplate.Create(const BasePath, ID: string);
+constructor TProjectTemplate.Create(const BasePath, ID: string; ATargets: TKeymanTargets);
 begin
   inherited Create;
   FBasePath := IncludeTrailingPathDelimiter(ExpandFileName(BasePath));
   FID := ID;
   FVersion := '1.0';
+  FTargets := ATargets;
 end;
 
 function TProjectTemplate.GetFilename(Base: string): string;
@@ -211,7 +215,8 @@ var
     begin
       if kt = ktAny then
         Continue;
-      Result := Result + ' * ' + SKeymanTargetNames[kt] + #13#10;
+      if (kt in FTargets) or (ktAny in FTargets) then
+        Result := Result + ' * ' + SKeymanTargetNames[kt] + #13#10;
     end;
   end;
 

--- a/windows/src/global/delphi/general/UKeymanTargets.pas
+++ b/windows/src/global/delphi/general/UKeymanTargets.pas
@@ -22,7 +22,7 @@ const
   ];
 
   TouchKeymanTargets: TKeymanTargets = [
-    ktWeb, ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet,
+    ktIphone, ktIpad, ktAndroidphone, ktAndroidtablet,
     ktMobile, ktTablet
   ];
 


### PR DESCRIPTION
Fixes #2679.

If web is specified but not a touch platform, exclude touch layout from a generated project. Also, fixup list of supported platforms in the generated README.md.