### PR TITLE
fix(linux): Don't crash if uninstalling last keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -38,7 +38,7 @@ class GnomeKeyboardsUtil():
 
     def _convert_array_to_variant(self, array):
         if len(array) == 0:
-            return None
+            return Variant('a(ss)', None)
 
         children = []
         for (type, id) in array:


### PR DESCRIPTION
If a Keyman keyboard is the only installed/selected keyboard in Gnome and the user uninstalls this in km-config, we have to set the value for `sources` to an empty array variant. Previously this crashed.

Fixes #4375.