### PR TITLE
chore(windows): tests should be case-sensitive

### DIFF
--- a/windows/src/global/delphi/general/Keyman.System.UILanguageManager.pas
+++ b/windows/src/global/delphi/general/Keyman.System.UILanguageManager.pas
@@ -58,15 +58,17 @@ end;
 class function TUILanguageManager.Find(KeymanLanguages, UserLanguages: TStrings): string;
 var
   ktag, ktag2, utag, utag2: string;
+  n: Integer;
 begin
 
   for utag in UserLanguages do
   begin
     utag2 := utag;
 
-    // Try and look for an exact match first
-    if KeymanLanguages.IndexOf(utag2) >= 0 then
-      Exit(utag2);
+    // Try and look for an exact (case-insensitive) match first
+    n := KeymanLanguages.IndexOf(utag2);
+    if n >= 0 then
+      Exit(KeymanLanguages[n]);
 
     // Then try and set the region-neutral language
     if Pos('-', utag2) > 0 then

--- a/windows/src/test/unit-tests/androidstringtokeymanlocalestring/Keyman.Test.AndroidStringToKeymanLocaleStringTest.pas
+++ b/windows/src/test/unit-tests/androidstringtokeymanlocalestring/Keyman.Test.AndroidStringToKeymanLocaleStringTest.pas
@@ -10,6 +10,9 @@ type
   [TestFixture]
   TAndroidStringToKeymanLocaleStringTest = class(TObject)
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestTransform;
   end;
@@ -17,6 +20,11 @@ type
 implementation
 
 { TAndroidStringToKeymanLocaleStringTest }
+
+procedure TAndroidStringToKeymanLocaleStringTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TAndroidStringToKeymanLocaleStringTest.TestTransform;
 begin

--- a/windows/src/test/unit-tests/group-helper-rsp19902/Keyman.Test.RegExGroupHelperRSP19902Test.pas
+++ b/windows/src/test/unit-tests/group-helper-rsp19902/Keyman.Test.RegExGroupHelperRSP19902Test.pas
@@ -26,6 +26,9 @@ type
   private
     procedure RunBasicRegEx(s,r,x: string; ShouldPassBuiltinTest: Boolean = False);
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestNoSMP;
 
@@ -109,6 +112,11 @@ end;
 procedure TGroupHelperRSP19902Test.TestSinglePrefixSMPAndSingleMatchedSMP;
 begin
   RunBasicRegEx(Chakma1+'bc'+Chakma2+'efg', '(c.e)', 'c'+Chakma2+'e');
+end;
+
+procedure TGroupHelperRSP19902Test.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
 end;
 
 procedure TGroupHelperRSP19902Test.TestDoublePrefixSMPAndSingleMatchedSMP;

--- a/windows/src/test/unit-tests/model-ts-parser/Keyman.System.Test.LexicalModelParserTest.pas
+++ b/windows/src/test/unit-tests/model-ts-parser/Keyman.System.Test.LexicalModelParserTest.pas
@@ -42,6 +42,8 @@ uses
 
 procedure TLexicalModelParserTest.Setup;
 begin
+  Assert.IgnoreCaseDefault := False;
+
   // Running from platform/configuration/ folder has
   // assets two levels up.
   if FileExists('..\..\assets\nrc.en.mtnt.model.ts')

--- a/windows/src/unit-tests/jsonutil/Keyman.System.Test.JsonUtilTest.pas
+++ b/windows/src/unit-tests/jsonutil/Keyman.System.Test.JsonUtilTest.pas
@@ -13,6 +13,9 @@ type
   private
     function DateTimeString(d: TDateTime): string;
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestJsonDateToDateTime;
 
@@ -59,6 +62,11 @@ begin
   except
     Result := '';
   end;
+end;
+
+procedure TJsonUtilTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
 end;
 
 procedure TJsonUtilTest.TestDateTimeToJsonDate;

--- a/windows/src/unit-tests/keyboard-js-info/Keyman.Test.System.KeyboardJSInfoTest.pas
+++ b/windows/src/unit-tests/keyboard-js-info/Keyman.Test.System.KeyboardJSInfoTest.pas
@@ -30,6 +30,7 @@ uses
 
 procedure TKeyboardJSInfoTest.Setup;
 begin
+  Assert.IgnoreCaseDefault := False;
 end;
 
 procedure TKeyboardJSInfoTest.TearDown;

--- a/windows/src/unit-tests/keyboard-package-versions/Keyman.Test.System.CompilePackageVersioningTest.pas
+++ b/windows/src/unit-tests/keyboard-package-versions/Keyman.Test.System.CompilePackageVersioningTest.pas
@@ -60,6 +60,8 @@ var
   p: TProjectConsole;
   i: Integer;
 begin
+  Assert.IgnoreCaseDefault := False;
+
   FRoot := ExtractFileDir(ExtractFileDir(ExtractFileDir(ParamStr(0))));
 
   //

--- a/windows/src/unit-tests/kmx-file-languages/Keyman.Test.System.KMXFileLanguagesTest.pas
+++ b/windows/src/unit-tests/kmx-file-languages/Keyman.Test.System.KMXFileLanguagesTest.pas
@@ -13,6 +13,9 @@ type
   TKMXFileLanguagesTest = class(TObject)
   private
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     [TestCase('TestEnglish','eng,en')]
     [TestCase('TestAmharic','amh,am')]
@@ -35,8 +38,8 @@ type
     procedure TestEthnologueCodeListToArray2(code1, code2: string);
 
     [Test]
-    [TestCase('TestLCIDToBCP47-1', '0409,en-us')]
-    [TestCase('TestLCIDToBCP47-2', '0c09,en-au')]
+    [TestCase('TestLCIDToBCP47-1', '0409,en-US')]
+    [TestCase('TestLCIDToBCP47-2', '0c09,en-AU')]
     [TestCase('TestLCIDToBCP47-3', '0454,lo-LA')]
     procedure TestLCIDToBCP47(code1, code2: string);
   end;
@@ -45,6 +48,11 @@ implementation
 
 uses
   System.SysUtils;
+
+procedure TKMXFileLanguagesTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TKMXFileLanguagesTest.TestEthnologueCodeListToArray;
 var

--- a/windows/src/unit-tests/package-info/PackageInfoTest.pas
+++ b/windows/src/unit-tests/package-info/PackageInfoTest.pas
@@ -55,6 +55,7 @@ uses
 
 procedure TPackageInfoTest.Setup;
 begin
+  Assert.IgnoreCaseDefault := False;
   CoInitializeEx(nil, COINIT_APARTMENTTHREADED);
   DataPath := ExtractFilePath(ParamStr(0)) + '..\..\test\';
 end;

--- a/windows/src/unit-tests/standards-data/Keyman.Test.System.CanonicalLanguageCodeUtilsTest.pas
+++ b/windows/src/unit-tests/standards-data/Keyman.Test.System.CanonicalLanguageCodeUtilsTest.pas
@@ -9,6 +9,9 @@ type
   [TestFixture]
   TCanonicalLanguageCodeUtilsTest = class(TObject)
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestSomeTags;
   end;
@@ -19,6 +22,11 @@ uses
   Keyman.System.CanonicalLanguageCodeUtils;
 
 { TCanonicalLanguageCodeUtilsTest }
+
+procedure TCanonicalLanguageCodeUtilsTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TCanonicalLanguageCodeUtilsTest.TestSomeTags;
 begin
@@ -54,10 +62,8 @@ begin
   Assert.AreEqual('th-TH', TCanonicalLanguageCodeUtils.FindBestTag('th-th', True));
   Assert.AreEqual('th-TH', TCanonicalLanguageCodeUtils.FindBestTag('th-thai-th', True));
 
-  // note casing shows that the following lang tag was returned unmodified because
-  // it was not found in our canonicalization tables. This is expected behaviour.
-  // (Remember that BCP 47 tags are not case sensitive)
-  Assert.AreEqual('th-latn-de', TCanonicalLanguageCodeUtils.FindBestTag('th-latn-de', True));
+  // A BCP 47 tag that is not in our canonicalization tables
+  Assert.AreEqual('th-Latn-DE', TCanonicalLanguageCodeUtils.FindBestTag('th-latn-de', True));
 
   Assert.AreEqual('fr-FR', TCanonicalLanguageCodeUtils.FindBestTag('fr', True));
   Assert.AreEqual('fr-FR', TCanonicalLanguageCodeUtils.FindBestTag('fr-FR', True));

--- a/windows/src/unit-tests/standards-data/Keyman.Test.System.Standards.LangTagsRegistryTest.pas
+++ b/windows/src/unit-tests/standards-data/Keyman.Test.System.Standards.LangTagsRegistryTest.pas
@@ -9,6 +9,9 @@ type
   [TestFixture]
   TLangTagsTest = class(TObject)
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestSomeTags;
   end;
@@ -19,6 +22,11 @@ uses
   Keyman.System.Standards.LangTagsRegistry;
 
 { TLangTagsTest }
+
+procedure TLangTagsTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TLangTagsTest.TestSomeTags;
 begin

--- a/windows/src/unit-tests/ui-language-manager/Keyman.System.Test.UILanguageManagerTest.pas
+++ b/windows/src/unit-tests/ui-language-manager/Keyman.System.Test.UILanguageManagerTest.pas
@@ -11,6 +11,9 @@ type
   [TestFixture]
   TUILanguageManagerTest = class(TObject)
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestFind;
   end;
@@ -21,6 +24,11 @@ uses
   Keyman.System.UILanguageManager;
 
 { TUILanguageManagerTest }
+
+procedure TUILanguageManagerTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TUILanguageManagerTest.TestFind;
 var

--- a/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
+++ b/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
@@ -11,6 +11,9 @@ type
   [TestFixture]
   TInstallInfoTest = class(TObject)
   public
+    [Setup]
+    procedure Setup;
+
     [Test]
     procedure TestLocatePackagesAndTierFromFilename;
 
@@ -25,6 +28,11 @@ uses
   Keyman.Setup.System.InstallInfo;
 
 { TInstallInfoTest }
+
+procedure TInstallInfoTest.Setup;
+begin
+  Assert.IgnoreCaseDefault := False;
+end;
 
 procedure TInstallInfoTest.TestLocatePackagesAndTierFromFilename;
 var


### PR DESCRIPTION
DUnitX by default does case-insensitive string equality assertions, and we don't really want to make that assumption.

There was one minor fail uncovered in Keyman.System.UILanguageManager as a result of this -- it now returns a matching entry as found in the list of UI languages, rather than the input, to get same case as the UI language list entry.

Thank you @ermshiperete.