### PR TITLE
fix(windows): crash deleting wordlist

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -212,6 +212,7 @@ begin
   try
     FillDetails;
     UpdateWordlistTabs;
+    MoveDesignToSource;
   finally
     Dec(FSetup);
   end;
@@ -659,9 +660,16 @@ end;
 { TfrmModelEditor.TWordlist }
 
 destructor TfrmModelEditor.TWordlist.Destroy;
+var
+  pages: TPageControl;
+  NewTab: TTabSheet;
 begin
   Frame.Free;
+  // Workaround for https://quality.embarcadero.com/browse/RSP-32327
+  pages := Tab.PageControl;
+  NewTab := pages.ActivePage;
   Tab.Free;
+  pages.ActivePage := NewTab;
   inherited Destroy;
 end;
 

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.modelTsProjectFile.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.modelTsProjectFile.pas
@@ -96,8 +96,10 @@ procedure TmodelTsProjectFile.LoadState(node: IXMLNode);   // I4698
 begin
   inherited LoadState(node);
   try
-    if node.ChildNodes.IndexOf('Debug') >= 0 then FDebug := node.ChildValues['Debug'];
-    if node.ChildNodes.IndexOf('TestKeyboard') >= 0
+    if (node.ChildNodes.IndexOf('Debug') >= 0) and not VarIsNull(node.ChildValues['Debug'])
+      then FDebug := node.ChildValues['Debug']
+      else FDebug := False;
+    if (node.ChildNodes.IndexOf('TestKeyboard') >= 0) and not VarIsNull(node.ChildValues['TestKeyboard'])
       then FTestKeyboard := node.ChildValues['TestKeyboard']
       else FTestKeyboard := '';
   except


### PR DESCRIPTION
Fixes #4393.
Fixes [KEYMAN-DEVELOPER-46](https://sentry.keyman.com/organizations/keyman/?query=KEYMAN-DEVELOPER-46).
Fixes [KEYMAN-DEVELOPER-45](https://sentry.keyman.com/organizations/keyman/?query=KEYMAN-DEVELOPER-45).

This arose because deleting a tab caused Delphi VCL to switch to another tab in the page control, which is IMHO a bug in the `TPageControl` VCL component. Furthermore, when the active page is changed under these circumstances, the normal `OnChange` and `OnChanging` events are not fired, which means that the Source tab (which is the lucky tab to be activated) never gets initialised. This cascades eventually to a crash due to the Source tab's text editor not being properly loaded.

Two parts to this fix:

1. Restore the active page when we delete a wordlist tab ([RSP-32327](https://quality.embarcadero.com/browse/RSP-32327)); this does not resolve the crash but does avoid weird side-effect of the active tab changing.
2. Initialise the source tab when we load the form so that the initialisation issue described above is avoided.

A separate fix in modelTsProjectFile avoids a (handled) null variant conversion exception.