### PR TITLE
fix(developer): debug information with unicode identifiers

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -223,7 +223,7 @@ type
     procedure ReportError(line: Integer; msgcode: LongWord; const text: string);  // I1971
     function ExpandSentinel(pwsz: PWideChar): TSentinelRecord;
     function CallFunctionName(s: WideString): WideString;
-    function JavaScript_Name(i: Integer; pwszName: PWideChar; UseNameForRelease: Boolean = False): string;   // I3659
+    function JavaScript_Name(i: Integer; pwszName: PWideChar; KeepNameForPersistentStorage: Boolean = False): string;   // I3659
     function JavaScript_Store(line: Integer; pwsz: PWideChar): string;
     function JavaScript_Shift(fkp: PFILE_KEY; FMnemonic: Boolean): Integer;
     function JavaScript_ShiftAsString(fkp: PFILE_KEY; FMnemonic: Boolean): string;   // I4872
@@ -874,18 +874,18 @@ begin
     else Result := IntToStr(JavaScript_Key(fkp, FMnemonic));
 end;
 
-function TCompileKeymanWeb.JavaScript_Name(i: Integer; pwszName: PWideChar; UseNameForRelease: Boolean): string;   // I3659
+function TCompileKeymanWeb.JavaScript_Name(i: Integer; pwszName: PWideChar; KeepNameForPersistentStorage: Boolean): string;   // I3659
 var
   FChanged: Boolean;
   p: PWideChar;
 begin
   FChanged := False;
   p := pwszName;
-  if not Assigned(pwszName) or (pwszName^ = #0) or (not Self.FDebug and not UseNameForRelease) then   // I3659   // I3681
+  if not Assigned(pwszName) or (pwszName^ = #0) or (not Self.FDebug and not KeepNameForPersistentStorage) then   // I3659   // I3681
     Result := IntToStr(i) // for uniqueness
   else
   begin
-    if UseNameForRelease   // I3659
+    if KeepNameForPersistentStorage // I3659
       then Result := '' // Potential for overlap in theory but in practice we only use this for named option stores so can never overlap
       else Result := '_'; // Ensures we cannot overlap numbered instances
     while pwszName^ <> #0 do
@@ -901,7 +901,7 @@ begin
       end;
       Inc(pwszName);
     end;
-    if not UseNameForRelease then
+    if not KeepNameForPersistentStorage then
     begin
       // Ensure each transformed name is still unique
       Result := Result + '_' + IntToStr(i);

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -312,6 +312,7 @@ const
 
 function GlobalProjectStateWndHandle: THandle;
 function ProjectCompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;  // I3310   // I4694
+function ProjectCompilerMessageW(line: Integer; msgcode: LongWord; const text: string): Integer;
 procedure ProjectCompilerMessageClear;
 
 function ProjectTypeFromString(s: string): TProjectType;
@@ -1174,6 +1175,11 @@ begin
 end;
 
 function ProjectCompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;  // I3310   // I4694
+begin
+  Result := ProjectCompilerMessageW(line, msgcode, String_AtoU(text));
+end;
+
+function ProjectCompilerMessageW(line: Integer; msgcode: LongWord; const text: string): Integer;  // I3310   // I4694
 const // from compile.pas
   CERR_FATAL   = $00008000;
   CERR_ERROR   = $00004000;
@@ -1203,7 +1209,7 @@ begin
       Exit(1);
   end;
 
-  TProject.CompilerMessageFile.Log(FLogState, String_AtoU(text), msgcode, line);   // I4706
+  TProject.CompilerMessageFile.Log(FLogState, text, msgcode, line);   // I4706
 
   if (FLogState <> plsInfo) and (MessageCount = MAX_MESSAGES) then
     TProject.CompilerMessageFile.Log(

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
@@ -167,7 +167,7 @@ begin
           Result := CompileVisualKeyboard(FKVKSourceFile, FKVKTargetFile);
 
         if Result then
-          Result := ckw.Compile(OwnerProject, FileName, FOutFileName, Debug, ProjectCompilerMessage);   // I3681   // I4140   // I4865   // I4866
+          Result := ckw.Compile(OwnerProject, FileName, FOutFileName, Debug, ProjectCompilerMessageW);   // I3681   // I4140   // I4865   // I4866
 
         if HasCompileWarning and (WarnAsError or OwnerProject.Options.CompilerWarningsAsErrors) then Result := False;   // I4706
 

--- a/windows/src/global/delphi/general/CompileErrorCodes.pas
+++ b/windows/src/global/delphi/general/CompileErrorCodes.pas
@@ -200,6 +200,8 @@ const
 
   CWARN_TouchLayoutSpecialLabelOnNormalKey          = $20A9;
 
+  CWARN_OptionStoreNameInvalid                      = $20AA;
+
 implementation
 
 end.

--- a/windows/src/global/delphi/general/compile.pas
+++ b/windows/src/global/delphi/general/compile.pas
@@ -133,6 +133,7 @@ type
 
 type
   TCompilerCallback = function( line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;  // I3310
+  TCompilerCallbackW = function( line: Integer; msgcode: LongWord; const text: string): Integer; // not available to C++ in this form
 
 const
   CKF_KEYMAN = 0;

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -197,6 +197,8 @@
 
 #define CWARN_TouchLayoutSpecialLabelOnNormalKey           0x000020A9
 
+#define CWARN_OptionStoreNameInvalid                       0x000020AA
+
 #define CERR_BufferOverflow                                0x000080C0
 #define CERR_Break                                         0x000080C1
 


### PR DESCRIPTION
Fixes #4250.

This implements @jahorton's suggestion of including the original name in a comment alongside the munged name, as well as appending the unique integer identifier of each symbol.

Note: the error reporting code needed a massage to support Unicode error strings; in the future we should update the C++ compiler to emit Unicode error strings also.