### PR TITLE
fix(developer): Compiler check for if and nul at start of context

### DIFF
--- a/windows/src/developer/kmcmpdll/Compiler.rc
+++ b/windows/src/developer/kmcmpdll/Compiler.rc
@@ -19,23 +19,23 @@ BEGIN
     CERR_NoVersionLine      "No version line found for file"
     CERR_InvalidGroupLine   "Invalid 'group' command"
     CERR_InvalidStoreLine   "Invalid 'store' command"
-    CERR_InvalidCodeInKeyPartOfRule 
+    CERR_InvalidCodeInKeyPartOfRule
                             "Invalid command or code found in key part of rule"
     CERR_InvalidDeadkey     "Invalid 'deadkey' or 'dk' command"
     CERR_InvalidValue       "Invalid value in extended string"
     CERR_ZeroLengthString   "A string of zero characters was found"
-    CERR_TooManyIndexToKeyRefs 
+    CERR_TooManyIndexToKeyRefs
                             "Too many index commands refering to key string"
     CERR_UnterminatedString "Unterminated string in line"
-    CERR_StringInVirtualKeySection 
+    CERR_StringInVirtualKeySection
                             "extended string illegal in virtual key section"
-    CERR_AnyInVirtualKeySection 
+    CERR_AnyInVirtualKeySection
                             "'any' command is illegal in virtual key section"
     CERR_InvalidAny         "Invalid 'any' command"
     CERR_StoreDoesNotExist  "Store referenced does not exist"
-    CERR_BeepInVirtualKeySection 
+    CERR_BeepInVirtualKeySection
                             "'beep' command is illegal in virtual key section"
-    CERR_IndexInVirtualKeySection 
+    CERR_IndexInVirtualKeySection
                             "'index' command is illegal in virtual key section"
 END
 
@@ -64,24 +64,24 @@ STRINGTABLE
 BEGIN
     CERR_InvalidBitmapLine  "Invalid 'bitmaps' command"
     CERR_CannotReadBitmapFile "Cannot open the bitmap file for reading"
-    CERR_IndexDoesNotPointToAny 
+    CERR_IndexDoesNotPointToAny
                             "An index() in the output does not have a corresponding any() statement"
     CERR_ReservedCharacter  "A reserved character was found"
     CERR_InvalidCharacter   "A character was found that is outside the valid Unicode range (U+0000 - U+10FFFF)"
     CERR_InvalidCall        "The 'call' command is invalid"
-    CERR_CallInVirtualKeySection 
+    CERR_CallInVirtualKeySection
                             "'call' command is illegal in virtual key section"
-    CERR_CodeInvalidInKeyStore 
+    CERR_CodeInvalidInKeyStore
                             "The command is invalid inside a store that is used in a key part of the rule"
-    CERR_CannotLoadIncludeFile 
+    CERR_CannotLoadIncludeFile
                             "Cannot load the included file: it is either invalid or does not exist"
-    CERR_60FeatureOnly_EthnologueCode 
+    CERR_60FeatureOnly_EthnologueCode
                             "EthnologueCode system store requires VERSION 6.0"
-    CERR_60FeatureOnly_MnemonicLayout 
+    CERR_60FeatureOnly_MnemonicLayout
                             "MnemonicLayout functionality requires VERSION 6.0"
-    CERR_60FeatureOnly_OldCharPosMatching 
+    CERR_60FeatureOnly_OldCharPosMatching
                             "OldCharPosMatching system store requires VERSION 6.0"
-    CERR_60FeatureOnly_NamedCodes 
+    CERR_60FeatureOnly_NamedCodes
                             "Named character constants requires VERSION 6.0"
     CERR_60FeatureOnly_Contextn "Context(n) requires VERSION 6.0"
     CERR_501FeatureOnly_Call "Call() requires VERSION 5.01"
@@ -91,26 +91,26 @@ END
 STRINGTABLE
 BEGIN
     CERR_InvalidSystemStore "Invalid system store name found"
-    CERR_CallIsProfessionalFeature 
+    CERR_CallIsProfessionalFeature
                             "Call() is only available in Keyman Developer Professional"
-    CERR_IncludeCodesIsProfessionalFeature 
+    CERR_IncludeCodesIsProfessionalFeature
                             "&IncludeCodes is only available in Keyman Developer Professional"
-    CERR_MnemonicLayoutIsProfessionalFeature 
+    CERR_MnemonicLayoutIsProfessionalFeature
                             "&MnemonicLayout is only available in Keyman Developer Professional"
-    CERR_60FeatureOnly_VirtualCharKey 
+    CERR_60FeatureOnly_VirtualCharKey
                             "Virtual character keys require VERSION 6.0"
-    CERR_VersionAlreadyIncluded 
+    CERR_VersionAlreadyIncluded
                             "Only one VERSION or store(&version) line allowed in a source file."
     CERR_70FeatureOnly      "This feature requires store(&version) '7.0'"
     CERR_80FeatureOnly      "This feature requires store(&version) '8.0'"
-    CERR_InvalidInVirtualKeySection 
+    CERR_InvalidInVirtualKeySection
                             "This statement is not valid in a virtual key section"
     CERR_InvalidIf          "The if() statement is not valid"
     CERR_InvalidReset       "The reset() statement is not valid"
     CERR_InvalidSet         "The set() statement is not valid"
     CERR_InvalidSave        "The save() statement is not valid"
     CERR_InvalidEthnologueCode "Invalid &ethnologuecode format"
-    CERR_90FeatureOnly_IfSystemStores 
+    CERR_90FeatureOnly_IfSystemStores
                             "if(&store) requires store(&version) '9.0'"
     CERR_IfSystemStore_NotFound "System store in if() not found"
     CERR_90FeatureOnly_SetSystemStores "set(&store) requires store(&version) '9.0'"
@@ -121,10 +121,10 @@ END
 STRINGTABLE
 BEGIN
     CERR_InvalidIndex       "Invalid 'index' command"
-    CERR_OutsInVirtualKeySection 
+    CERR_OutsInVirtualKeySection
                             "'outs' command is illegal in virtual key section"
     CERR_InvalidOuts        "Invalid 'outs' command"
-    CERR_ContextInVirtualKeySection 
+    CERR_ContextInVirtualKeySection
                             "'context' command is illegal in virtual key section"
     CERR_InvalidUse         "Invalid 'use' command"
     CERR_GroupDoesNotExist  "Group does not exist"
@@ -134,7 +134,7 @@ BEGIN
     CERR_InvalidLineContinuation "Invalid line continuation"
     CERR_LineTooLong        "Line too long"
     CERR_InvalidCopyright   "Invalid 'copyright' command"
-    CERR_CodeInvalidInThisSection 
+    CERR_CodeInvalidInThisSection
                             "This line is invalid in this section of the file"
     CERR_InvalidMessage     "Invalid 'message' command"
     CERR_InvalidLanguageName "Invalid 'languagename' command"
@@ -145,25 +145,25 @@ BEGIN
     CWARN_TooManyWarnings   "Too many warnings or errors"
     CWARN_OldVersion        "The keyboard file is an old version"
     CWARN_BitmapNotUsed     "The 'bitmaps' statement is obsolete and only the first bitmap referred to will be used, you should use 'bitmap'."
-    CWARN_CustomLanguagesNotSupported 
+    CWARN_CustomLanguagesNotSupported
                             "Languages over 0x1FF, 0x1F are not supported correctly by Windows.  You should use no LANGUAGE line instead."
     CWARN_KeyBadLength      "There are too many characters in the keystroke part of the rule."
     CWARN_IndexStoreShort   "The store referenced in index() is shorter than the store referenced in any()"
     CWARN_UnicodeInANSIGroup "A Unicode character was found in an ANSI group"
     CWARN_ANSIInUnicodeGroup "An ANSI character was found in a Unicode group"
-    CWARN_UnicodeSurrogateUsed 
+    CWARN_UnicodeSurrogateUsed
                             "A Unicode surrogate character was found.  You should use Unicode scalar values to represent values > U+FFFF"
     CWARN_ReservedCharacter "A Unicode character was found that should not be used"
     CWARN_Info              "Information"
-    CWARN_VirtualKeyWithMnemonicLayout 
+    CWARN_VirtualKeyWithMnemonicLayout
                             "Virtual key used instead of virtual character key with a mnemonic layout"
-    CWARN_VirtualCharKeyWithPositionalLayout 
+    CWARN_VirtualCharKeyWithPositionalLayout
                             "Virtual character key used with a positional layout instead of mnemonic layout"
-    CWARN_StoreAlreadyUsedAsOptionOrCall 
+    CWARN_StoreAlreadyUsedAsOptionOrCall
                             "Store already used as an option or in a call statement and should not be used as a normal store"
-    CWARN_StoreAlreadyUsedAsStoreOrCall 
+    CWARN_StoreAlreadyUsedAsStoreOrCall
                             "Store already used as a normal store or in a call statement and should not be used as an option"
-    CWARN_StoreAlreadyUsedAsStoreOrOption 
+    CWARN_StoreAlreadyUsedAsStoreOrOption
                             "Store already used as a normal store or as an option and should not be used in a call statement"
 END
 
@@ -185,11 +185,11 @@ END
 
 STRINGTABLE
 BEGIN
-    CWARN_PunctuationInEthnologueCode 
+    CWARN_PunctuationInEthnologueCode
                             "Punctuation should not be used to separate Ethnologue codes; instead use spaces"
 END
 
-STRINGTABLE 
+STRINGTABLE
 BEGIN
     CERR_CannotCreateTempfile "Cannot create temp file"
 END
@@ -225,4 +225,6 @@ BEGIN
     CWARN_LanguageHeadersDeprecatedInKeyman10 "This language header has been deprecated in Keyman 10. Instead, add language metadata in the package file"
     CWARN_HotkeyHasInvalidModifier            "Hotkey has modifiers that are not supported. Use only SHIFT, CTRL and ALT"
     CINFO_NonUnicodeFile                      "Keyman Developer has detected that the file has ANSI encoding. Consider converting this file to UTF-8"
+    CWARN_NulNotFirstStatementInContext       "nul must be the first statement in the context"
+    CWARN_IfShouldBeAtStartOfContext          "if, platform and baselayout should be at start of context (after nul, if present])"
 END

--- a/windows/src/global/delphi/general/CompileErrorCodes.pas
+++ b/windows/src/global/delphi/general/CompileErrorCodes.pas
@@ -202,6 +202,9 @@ const
 
   CWARN_OptionStoreNameInvalid                      = $20AA;
 
+  CWARN_NulNotFirstStatementInContext               = $20AB;
+  CWARN_IfShouldBeAtStartOfContext                  = $20AC;
+
 implementation
 
 end.

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -199,6 +199,9 @@
 
 #define CWARN_OptionStoreNameInvalid                       0x000020AA
 
+#define CWARN_NulNotFirstStatementInContext                0x000020AB
+#define CWARN_IfShouldBeAtStartOfContext                   0x000020AC
+
 #define CERR_BufferOverflow                                0x000080C0
 #define CERR_Break                                         0x000080C1
 

--- a/windows/src/test/unit-tests/kmcomp/test.bat
+++ b/windows/src/test/unit-tests/kmcomp/test.bat
@@ -32,6 +32,11 @@ call :should-fail "10.0 .kmn with 14.0-only touch layout codes" test_touchlayout
 call :should-pass "14.0 .kmn with 14.0 touch layout codes" test_touchlayout_14_2.kmn || goto :eof
 call :should-pass "9.0 .kmn with accepted 14.0 touch layout codes" test_touchlayout_14_2.kmn || goto :eof
 
+call :should-fail "#4280: if should be at start of context 1" test_4280_if_start_1.kmn || goto :eof
+call :should-fail "#4280: if should be at start of context 2" test_4280_if_start_2.kmn || goto :eof
+call :should-fail "#4280: nul should be at start of context 1" test_4280_nul_start_1.kmn || goto :eof
+call :should-fail "#4280: nul should be at start of context 2" test_4280_nul_start_2.kmn || goto :eof
+
 goto :eof
 
 :should-pass

--- a/windows/src/test/unit-tests/kmcomp/test_4280_if_start_1.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_4280_if_start_1.kmn
@@ -1,0 +1,12 @@
+c test_4280_if_start_1
+
+store(&VERSION) '10.0'
+store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c if() should be before 'a'
+'a' if(&platform = 'windows') + 'b' > '...windows!'
+

--- a/windows/src/test/unit-tests/kmcomp/test_4280_if_start_2.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_4280_if_start_2.kmn
@@ -1,0 +1,12 @@
+c test_4280_if_start_2
+
+store(&VERSION) '10.0'
+store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c if() should be before 'a' but after nul
+nul 'a' if(&platform = 'windows') + 'b' > 'windows!'
+

--- a/windows/src/test/unit-tests/kmcomp/test_4280_nul_start_1.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_4280_nul_start_1.kmn
@@ -1,0 +1,13 @@
+c test_4280_nul_start_1
+
+store(&VERSION) '10.0'
+store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c nul should be first statement in context
+if(&platform = 'windows') nul + 'e' > '<windows!'
+
+

--- a/windows/src/test/unit-tests/kmcomp/test_4280_nul_start_2.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_4280_nul_start_2.kmn
@@ -1,0 +1,11 @@
+c test_4280_nul_start_2
+
+store(&VERSION) '10.0'
+store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c nul should be first statement in context
+'a' nul + 'x' > 'zeep'

--- a/windows/src/test/unit-tests/kmcomp/tests.kpj
+++ b/windows/src/test/unit-tests/kmcomp/tests.kpj
@@ -110,5 +110,37 @@
       <FileType>.doc</FileType>
       <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
     </File>
+    <File>
+      <ID>id_4c59db88c3869d699c9df7f46731a97a</ID>
+      <Filename>test_4280_if_start_1.kmn</Filename>
+      <Filepath>test_4280_if_start_1.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details/>
+    </File>
+    <File>
+      <ID>id_279f3bc5af5315ab75f67c6a194dbc25</ID>
+      <Filename>test_4280_if_start_2.kmn</Filename>
+      <Filepath>test_4280_if_start_2.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details/>
+    </File>
+    <File>
+      <ID>id_f27b4ef329275996bec15a9638f6d440</ID>
+      <Filename>test_4280_nul_start_1.kmn</Filename>
+      <Filepath>test_4280_nul_start_1.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details/>
+    </File>
+    <File>
+      <ID>id_c0515825c0484a590391c8d99430303f</ID>
+      <Filename>test_4280_nul_start_2.kmn</Filename>
+      <Filepath>test_4280_nul_start_2.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details/>
+    </File>
   </Files>
 </KeymanDeveloperProject>


### PR DESCRIPTION
Fixes #4280.

Adds checks to verify that `if()`, `platform()`, `baselayout()` and `nul` are at the start of the context in the appropriate order.

Adds unit tests to validate these checks.

These are conditions that have been present in earlier versions of Keyman but not enforced until now. Keyboards that do not meet these conditions would not work correctly in all circumstances and should be updated to meet the requirements.

An alternative would have been to reorder the context string but that is much more complex as manipulation would also have been required for the output string. The enforced order is logical and reduces confusion in any case.

Updated documentation coming along shortly.