### PR TITLE
fix(common/models): predictions after context reset / caret shift

### DIFF
--- a/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
+++ b/common/predictive-text/unit_tests/headless/edit-distance/distance-modeler.js
@@ -332,8 +332,8 @@ describe('Correction Distance Modeler', function() {
       let iter = searchSpace.getBestMatches(0); // disables the correction-search timeout.
       checkResults_teh(iter);
 
-      // Debugging method:  a simple loop for printing out the generated sets, in succession.
-      //
+      // // Debugging method:  a simple loop for printing out the generated sets, in succession.
+      // //
       // for(let i = 1; i <= 8; i++) {  // After 8 tiers, we run out of entries for this particular case.
       //   console.log();
       //   console.log("Batch " + i);
@@ -343,14 +343,17 @@ describe('Correction Distance Modeler', function() {
 
       //   set = set.value;
 
-      //   let entries = set[0].map(function(sequence) {
-      //     return sequence.map(value => value.key).join('');
+      //   let entries = set.map(function(result) {
+      //     return result.matchString;
       //   });
 
-      //   console.log("Entry count: " + set[0].length);
+      //   console.log("Entry count: " + set.length);
       //   entries.sort();
       //   console.log(entries);
-      //   console.log(set[1]);
+      //   console.log("Probablility:  " + set[0].totalCost);
+      //   console.log("Analysis (first entry):");
+      //   console.log(" - Edit cost:  " + set[0].knownCost);
+      //   console.log(" - Input cost: " + set[0].inputSamplingCost);
       // }
     });
 

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -352,7 +352,7 @@ namespace correction {
 
       const hasDistribution = transformDistribution && Array.isArray(transformDistribution);
       let primaryInput = hasDistribution ? transformDistribution[0].sample : null;
-      if(primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft == 0 && primaryInput.deleteRight == 0) {
+      if(primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft == 0 && !primaryInput.deleteRight) {
         primaryInput = null;
       }
       const isBackspace = primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft > 0;

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -355,7 +355,7 @@ namespace correction {
       if(primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft == 0 && !primaryInput.deleteRight) {
         primaryInput = null;
       }
-      const isBackspace = primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft > 0 && primaryInput.deleteRight == 0;
+      const isBackspace = primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft > 0 && !primaryInput.deleteRight;
       const finalToken = tokenizedContext[tokenizedContext.length-1];
 
       /* Assumption:  This is an adequate check for its two sub-branches.

--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -1,6 +1,24 @@
 /// <reference path="distance-modeler.ts" />
 
 namespace correction {
+
+  function textToCharTransforms(text: string, transformId?: number) {
+    let perCharTransforms: Transform[] = [];
+
+    for(let i=0; i < text.kmwLength(); i++) {
+      let char = text.kmwCharAt(i); // is SMP-aware
+
+      let transform: Transform = {
+        insert: char,
+        deleteLeft: 0,
+        id: transformId
+      };
+
+      perCharTransforms.push(transform);
+    }
+
+    return perCharTransforms;
+  }
   export class TrackedContextSuggestion {
     suggestion: Suggestion;
     tokenWidth: number;
@@ -145,14 +163,7 @@ namespace correction {
       // Note that we cannot just use a single, monolithic transform at this point b/c
       // of our current edit-distance optimization strategy; diagonalization is currently... 
       // not very compatible with that.
-      const backspacedTokenContext = tokenText.split('').map(function(char) {
-        let transform: Transform = {
-          insert: char,
-          deleteLeft: 0,
-          id: transformId // Not exactly optimal for every transform to have the same ID,
-                          // but is actually accurate here.
-        };
-
+      let backspacedTokenContext: Distribution<Transform>[] = textToCharTransforms(tokenText, transformId).map(function(transform) {
         return [{sample: transform, p: 1.0}];
       });
 
@@ -426,22 +437,8 @@ namespace correction {
         let token = new TrackedContextToken();
         token.raw = entry;
         if(token.raw) {
-          let chars = token.raw.split('');
-
-          /* Build single-entry prob-distribution arrays, one per char... where the single distribution is 100%
-           * for the token's actual characters.  Needed for 14.0 instead of a single token for the whole word
-           * due to current search-algorithm limitations.
-           * Basically, assume the token was the correct input, since we lack any actual probability data
-           * about the keystrokes that generated it.
-           */
-          token.transformDistributions = chars.map(function(char) {
-            return [{
-              sample: {
-                insert: char,
-                deleteLeft: 0
-              },
-              p: 1.0
-            }];
+          token.transformDistributions = textToCharTransforms(token.raw).map(function(transform) {
+            return [{sample: transform, p: 1.0}];
           });
         } else {
           // Helps model context-final wordbreaks.

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -576,7 +576,6 @@ namespace correction {
       }
 
       let batcher = new BatchingAssistant();
-      let batch: SearchResult[];
 
       // Stage 1 - if we already have extracted results, build a queue just for them and iterate over it first.
       let returnedValues = Object.values(this.returnedValues);
@@ -586,7 +585,7 @@ namespace correction {
         // Build batches of same-cost entries.
         while(preprocessedQueue.count > 0) {
           let entry = preprocessedQueue.dequeue();
-          batch = batcher.checkAndAdd(entry);
+          let batch = batcher.checkAndAdd(entry);
 
           if(batch) {
             yield batch;
@@ -595,7 +594,7 @@ namespace correction {
 
         // As we only return a batch once all entries of the same cost have been processed, we can safely
         // finalize the last preprocessed group without issue.
-        batch = batcher.tryFinalize();
+        let batch = batcher.tryFinalize();
         if(batch) {
           yield batch;
         }
@@ -618,6 +617,7 @@ namespace correction {
         } while(!timedOut && newResult.type == 'intermediate')
         
         // TODO:  check 'cost' on intermediate, running it through batcher to early-detect cost changes.
+        let batch: SearchResult[];
         if(newResult.type == 'none') {
           break;
         } else if(newResult.type == 'complete') {
@@ -630,7 +630,7 @@ namespace correction {
       } while(!timedOut && this.hasNextMatchEntry());
 
       // If we _somehow_ exhaust all search options, make sure to return the final results.
-      batch = batcher.tryFinalize();
+      let batch = batcher.tryFinalize();
       if(batch) {
         yield batch;
       }

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -128,10 +128,10 @@ class ModelCompositor {
       rawPredictions = this.predictFromCorrections(predictionRoots, context);
     } else {
       contextState = this.contextTracker.analyzeState(this.lexicalModel, 
-                                                      postContext, 
+                                                      postContext,
                                                       !this.isEmpty(inputTransform) ? 
                                                                     transformDistribution: 
-                                                                    [{sample: inputTransform, p: 1.0}]
+                                                                    null
                                                       );
 
       // TODO:  Should we filter backspaces & whitespaces out of the transform distribution?
@@ -180,7 +180,7 @@ class ModelCompositor {
             insert: correction,  // insert correction string
             // remove actual token string.  If new token, there should be nothing to delete.
             deleteLeft: newEmptyToken ? 0 : this.wordbreak(context).length, 
-            id: finalInput.id
+            id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
           }
 
           if(bestCorrectionCost === undefined) {
@@ -536,6 +536,9 @@ class ModelCompositor {
   }
 
   public resetContext(context: Context) {
+    // Force-resets the context, throwing out any previous fat-finger data, etc.
+    // Designed for use when the caret has been directly moved and/or the context sourced from a different control
+    // than before.
     if(this.contextTracker) {
       let tokenizedContext = models.tokenize(this.lexicalModel.wordbreaker || wordBreakers.default, context);
       let contextState = correction.ContextTracker.modelContextState(tokenizedContext.left, this.lexicalModel);

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -196,16 +196,26 @@ class ModelCompositor {
         // Running in bulk over all suggestions, duplicate entries may be possible.
         let predictions = this.predictFromCorrections(predictionRoots, context);
         rawPredictions = rawPredictions.concat(predictions);
-
         // TODO:  We don't currently de-duplicate predictions at this point quite yet, so
         // it's technically possible that we return too few.
 
-        if(rawPredictions.length >= ModelCompositor.MAX_SUGGESTIONS) {
-          break;
-        } else if(matches[0].totalCost >= bestCorrectionCost + 4) { // e^-4 = 0.0183156388.  Allows "80%" of an extra edit.
+        let correctionCost = matches[0].totalCost;
+        if(correctionCost >= bestCorrectionCost + 4) { // e^-4 = 0.0183156388.  Allows "80%" of an extra edit.
           // Very useful for stopping 'sooner' when words reach a sufficient length.
           break;
-        }
+        } else if(rawPredictions.length >= ModelCompositor.MAX_SUGGESTIONS) {
+          // Sort the prediction list; we need them in descending order for the next check.
+          rawPredictions.sort(function(a, b) {
+            return b.p - a.p;
+          });
+
+          // If the best suggestion from the search's current tier fails to beat the worst
+          // pending suggestion from previous tiers, assume all further corrections will 
+          // similarly fail to win; terminate the search-loop.
+          if(rawPredictions[ModelCompositor.MAX_SUGGESTIONS-1].p > Math.exp(-correctionCost)) {
+            break;
+          }
+        } 
       }
     }
 


### PR DESCRIPTION
Fixes a situation where no suggestions were presented after moving the caret via UI.

For example, having just typed the text seen below:

![Screen Shot 2021-02-03 at 10 11 52 AM](https://user-images.githubusercontent.com/25213402/106703921-cb8c8200-661d-11eb-8c97-846a4e02837a.png)

and then moving the caret to the end of the second word, "quick":

![Screen Shot 2021-02-03 at 10 12 03 AM](https://user-images.githubusercontent.com/25213402/106703934-cfb89f80-661d-11eb-8a64-cccf11b20a3c.png)

Before, no suggestions would be displayed here.  These changes make it possible.

Note that, at this time, selecting one of those suggestions will apply the suggestion at the caret's position and will not delete any excess characters to the right... kind of like what the system iOS predictive text does.  The one difference:  it will also emit a space, even if one is immediately to the right of the current caret.  I'm now working on a child PR to address these issues, along with some other related behavior.

Turns out that this change brought some underlying issues in the correction-search algorithm near enough to the surface to cause unit-test errors, so this PR also addresses those:
- Suggestion generation now less "greedy." (https://github.com/keymanapp/keyman/pull/4411/commits/29f9625d7a7eb2c635fd923bb2dd65850afb31e8)
  - Rather than checking if enough suggestions have been produced and stopping immediately, the algorithm now generates more, checking whether any new suggestions have high enough probability to replace the lowest previously-generated suggestion.
  - Results in higher-quality, more varied suggestions in some scenarios.
  - Fixes the cause of the initial unit-test failures.
- Keep suggestions may now accumulate probability if they show up multiple times from different possible input sequence sources. (https://github.com/keymanapp/keyman/pull/4411/commits/d5161e344e2c5bdd6a2a182eeac90006b0bead58)
  - Prevents the keep suggestion's probability from being overwritten with the _lowest_ value that turned up.
  - Similar measures were already in place for 'regular' suggestions; this was only missing for `'keep'`.  
    - (Handles perceived "duplication" where multiple edit patterns can yield the same resulting correction.)
  - Fixes a second error that would cause the same unit tests to fail.
- The correction-search 'batching' system is now properly reset on each loop iteration. (https://github.com/keymanapp/keyman/pull/4411/commits/2b12b0a3e87f13ae63c4fa2264ae66fb1ec1551f)
  - Prevents the same corrections from being re-sent repeatedly from the same input sequence source.
    - (Prevents _literal_, unintended duplication)
  - Wasn't necessary for passing unit tests, but still important to fix; it could _easily_ cause issues down the road.