### PR TITLE
chore(windows/resources): Fix typo about Community Forum link

### DIFF
--- a/windows/src/desktop/help/index.md
+++ b/windows/src/desktop/help/index.md
@@ -14,7 +14,7 @@ frequently asked questions, tutorials, and videos.
 * [Does Keyman for Windows run on Mac?](common/mac)
 
 ## Ask for Help
-[Ask other users in the SIL Keyman Keyman Community](https://community.software.sil.org/c/keyman)
+[Ask other users in the SIL Keyman Community](https://community.software.sil.org/c/keyman)
 
 ## Help Topics
 


### PR DESCRIPTION
I noticed an extra "Keyman" when incorporating the line towards Android and Linux help