### PR TITLE
change(android/app): Separate displaying welcome.htm from keyboard installation

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -31,9 +31,11 @@ import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.LexicalModel;
+import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.DownloadFileUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
+import com.tavultesoft.kmea.util.HelpFile;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMPLink;
 
@@ -903,7 +905,9 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   public void onPackageInstalled(List<Map<String, String>> keyboardsInstalled) {
     cleanupPackageInstall();
 
-    for(int i=0; i < keyboardsInstalled.size(); i++) {
+    String packageID = null;
+    String customHelpLink = null;
+    for (int i = 0; i < keyboardsInstalled.size(); i++) {
       HashMap<String, String> hashMap = new HashMap<>(keyboardsInstalled.get(i));
       String languageID = hashMap.get(KMManager.KMKey_LanguageID);
       Keyboard keyboardInfo = new Keyboard(
@@ -920,6 +924,8 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         hashMap.get(KMManager.KMKey_OskFont));
 
       if (i == 0) {
+        packageID = keyboardInfo.getPackageID();
+        customHelpLink = keyboardInfo.getHelpLink();
         if (KMManager.addKeyboard(this, keyboardInfo)) {
           KMManager.setKeyboard(keyboardInfo);
         }
@@ -954,6 +960,17 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             context, _downloadid, null, _callback,
             aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
         }
+      }
+    }
+
+    // Display welcome.htm help file
+    if (customHelpLink != null && !customHelpLink.isEmpty() &&
+        packageID != null && !packageID.isEmpty() && FileUtils.isWelcomeFile(customHelpLink)) {
+      // Display local welcome.htm help file, including associated assets
+      Intent i = HelpFile.toActionView(context, customHelpLink, packageID);
+
+      if (FileProviderUtils.exists(context)) {
+        startActivity(i);
       }
     }
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -52,7 +52,6 @@ public class PackageActivity extends AppCompatActivity implements
   private static ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener> kbDownloadEventListeners = null;
   private PackageProcessor kmpProcessor;
   private String pkgName;
-  private boolean hasWelcome;
   private StepperLayout mStepperLayout;
   private StepperAdapter mStepperAdapter;
 
@@ -104,7 +103,6 @@ public class PackageActivity extends AppCompatActivity implements
     }
 
     pkgName = kmpProcessor.getPackageName(pkgInfo);
-    hasWelcome = kmpProcessor.hasWelcome(pkgInfo);
     final int keyboardCount = kmpProcessor.getKeyboardCount(pkgInfo);
 
     // Number of languages associated with the first keyboard in a keyboard package.
@@ -129,7 +127,7 @@ public class PackageActivity extends AppCompatActivity implements
     boolean isInstallingPackage = true;
     mStepperLayout = (StepperLayout) findViewById(R.id.stepperLayout);
     mStepperAdapter = new StepperAdapter(getSupportFragmentManager(), this,
-      isInstallingPackage, tempPackagePath, pkgTarget, pkgId, pkgName, null, hasWelcome, languageID, languageCount);
+      isInstallingPackage, tempPackagePath, pkgTarget, pkgId, pkgName, null, languageID, languageCount);
     mStepperLayout.setAdapter(mStepperAdapter);
     mStepperLayout.setListener(this);
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
@@ -56,8 +56,6 @@ public class SelectLanguageActivity extends AppCompatActivity implements
     JSONObject pkgInfo = kmpProcessor.loadPackageInfo(packagePath);
 
     String pkgName = kmpProcessor.getPackageName(pkgInfo);
-    boolean hasWelcome = kmpProcessor.hasWelcome(pkgInfo);
-
 
     if (keyboard == null) {
       KMLog.LogError(TAG, "Package " + packageID + " has 0 keyboards");
@@ -66,7 +64,7 @@ public class SelectLanguageActivity extends AppCompatActivity implements
 
     mStepperLayout = (StepperLayout) findViewById(R.id.stepperLayout);
     mStepperAdapter = new StepperAdapter(getSupportFragmentManager(), this,
-      isInstallingPackage, packagePath, pkgTarget, packageID, pkgName, keyboard, hasWelcome);
+      isInstallingPackage, packagePath, pkgTarget, packageID, pkgName, keyboard);
     mStepperLayout.setAdapter(mStepperAdapter);
     mStepperLayout.setListener(this);
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageFragment.java
@@ -254,28 +254,21 @@ public final class SelectLanguageFragment extends Fragment implements BlockingSt
 
   @Override
   public void onNextClicked(final StepperLayout.OnNextClickedCallback callback) {
-    // Send data to calling Activity
+    // Do nothing
+  }
+
+  @Override
+  public void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback) {
     if (!isInstallingPackage) {
       this.callback.onLanguagesSelected(addKeyboardsList);
     } else {
       this.callback.onLanguagesSelected(PackageProcessor.PP_TARGET_KEYBOARDS, packageID, languageList);
     }
 
-    new Handler().postDelayed(new Runnable() {
-      @Override
-      public void run() {
-        //you can do anythings you want
-        callback.goToNextStep();
-      }
-    }, 1000L);// delay open another fragment,
-  }
-  @Override
-  public void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback) {
-    if (!isInstallingPackage) {
-      this.callback.onLanguagesSelected(addKeyboardsList);
-    }
+    // Cleanup
     getActivity().finish();
   }
+
   @Override
   public void onBackClicked(StepperLayout.OnBackClickedCallback callback) {
     callback.goToPrevStep();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -38,6 +38,7 @@ public final class FileUtils {
   // File extensions and file types
   public static final String JAVASCRIPT = ".js";
   public static final String LEXICALMODEL = ".model.js";
+  public static final String PDF = ".pdf";
   public static final String TRUETYPEFONT = ".ttf";
   public static final String OPENTYPEFONT = ".otf";
 
@@ -437,6 +438,11 @@ public final class FileUtils {
   public static boolean hasKeymanPackageExtension(String filename) {
     String f = filename.toLowerCase();
     return f.endsWith(KEYMANPACKAGE);
+  }
+
+  public static boolean hasPDFExtension(String filename) {
+    String f = filename.toLowerCase();
+    return f.endsWith(PDF);
   }
 
   public static boolean isTTFFont(String filename) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
@@ -20,6 +20,7 @@ public final class HelpFile {
   private static final String TAG = "HelpFile";
   private static final String[] ASSET_MIME_TYPES =  {
     ClipDescription.MIMETYPE_TEXT_HTML,
+    "application/pdf",
     "text/css",
     "image/gif",
     "image/jpeg",
@@ -68,11 +69,19 @@ public final class HelpFile {
         for(File assetFile : files) {
           Uri assetUri = FileProvider.getUriForFile(
             context, authority, assetFile);
-          clipData.addItem(new ClipData.Item(assetUri));
+          // Special handling for PDF
+          if (FileUtils.hasPDFExtension(assetUri.toString())) {
+            clipData.addItem(new ClipData.Item(assetUri));
+          } else {
+            clipData.addItem(new ClipData.Item(assetUri));
+          }
         }
 
         // Associate assets in clipData to the intent
         i.setClipData(clipData);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
       } catch (NullPointerException e) {
         String message = "FileProvider undefined in app to load" + customHelp.toString();
         Toast.makeText(context, message, Toast.LENGTH_LONG).show();


### PR DESCRIPTION
Fixes #4021

Currently, linked assets in welcome.htm aren't viewable during package installation because the content is instantiated while the package resides in a temporary location (The package folder gets moved to the final path after the "INSTALL" button is clicked).

This PR separates displaying welcome.htm from the package installation process. This way, when the welcome.htm is viewed in the MainActivity handler: 
* Can reuse the HelpFile intent (already handles File Provider permissions and is used for displaying keyboard help)
* The package is in the final destination

We do lose out on the niceity of having an "OK" button to exit out of the welcome.htm page.
User will just have to hit the back button (same for closing keyboard help)

Some sample screens

khmer_angkor welcome.htm
![khmer](https://user-images.githubusercontent.com/7358010/106718762-0f8a8180-6634-11eb-99c0-7ce218a864ca.png)

sil_cameroon_qwerty select language during install ("INSTALL" instead of "NEXT" button)
![select language](https://user-images.githubusercontent.com/7358010/106718886-3a74d580-6634-11eb-93d2-a44d5fb9aadc.png)

sil_cameroon_qwerty welcome.htm
![welcome](https://user-images.githubusercontent.com/7358010/106718918-4365a700-6634-11eb-8871-4eee8d71f1ef.png)

sil_cameroon_qwerty - Add language to existing keyboard
![add language](https://user-images.githubusercontent.com/7358010/106718800-1ca77080-6634-11eb-87f3-b369beb248ed.png)

@MakaraSok - you can test with the PR build
Just install khmer_angkor and verify  you can access the pdf files.

Note: the `Intent.VIEW` has a quirk where it will copy the pdf file to Downloads before viewing it. 
The device will handle PDF files however it does.