### PR TITLE
fix(android/engine): Remove WRITE_EXTERNAL_STORAGE from manifest

### DIFF
--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application


### PR DESCRIPTION
Follow-on to #4170 which removed usage of WRITE_EXTERNAL_STORAGE permission

The permission was removed from the main app's manifest, but also needs to be removed from KMEA.

I also checked the sample and test apps, and FV manifest; they're not affected.