### PR TITLE
fix(windows): hotkeys offset in config list

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman_hotkeys.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_hotkeys.xsl
@@ -95,9 +95,9 @@
 
   <xsl:template name="hotkey_control">
     <div class="list_item" tabindex="1" tagType="listitem">
-      <xsl:attribute name="id">list_hotkey_<xsl:value-of select="index"/></xsl:attribute>
-      <xsl:attribute name="onkeydown">return list_keydown(event,'hotkey_<xsl:value-of select="index"/>');</xsl:attribute>
-      <xsl:attribute name="onmousedown">document.getElementById('list_hotkey_<xsl:value-of select="index"/>').focus(); return true;</xsl:attribute>
+      <xsl:attribute name="id">list_hotkey_<xsl:value-of select="Target"/></xsl:attribute>
+      <xsl:attribute name="onkeydown">return list_keydown(event,'hotkey_<xsl:value-of select="Target"/>');</xsl:attribute>
+      <xsl:attribute name="onmousedown">document.getElementById('list_hotkey_<xsl:value-of select="Target"/>').focus(); return true;</xsl:attribute>
 
       <div style="float:left; padding: 1px 0px 1px 3px;">
         <xsl:choose>
@@ -115,7 +115,7 @@
       <div style="float:right">
         <div style="float: left; padding: 1px 3px 1px 0px; color: blue;">
           <a class="hotkey" tabindex="-1">
-            <xsl:attribute name="href">keyman:hotkey_set?index=hotkey_<xsl:value-of select="index"/></xsl:attribute>
+            <xsl:attribute name="href">keyman:hotkey_set?index=hotkey_<xsl:value-of select="Target"/></xsl:attribute>
             <xsl:attribute name="onmouseover">this.style.cursor='hand';</xsl:attribute>
             <xsl:choose>
               <xsl:when test="string-length(Value) > 0"><xsl:value-of select="Value"/></xsl:when>


### PR DESCRIPTION
Fixes #4426.

After removing the hotkey for the Keyboard Usage pane, the hotkey `index` value was now offset from the hotkey `Target` value, which uncovered a bug where the two values were conflated.

Note that the parameter passed to the `keyman:hotkey_set` command is still called `index` -- this does not need to change.