### PR TITLE
fix(common/resources): Just use master branch for help.keyman.com

### DIFF
--- a/resources/build/help-keyman-com.sh
+++ b/resources/build/help-keyman-com.sh
@@ -140,11 +140,7 @@ function commit_and_push {
   local branchname="auto/$platform-help-$VERSION_WITH_TAG"
   local modifiedfiles="$HELP_KEYMAN_COM/products/$platform/$VERSION_RELEASE"
 
-  # Base branch depends on the tier
   local basebranch="master"
-  if [ "$TIER" == "alpha" ] || [ "$TIER" == "beta" ]; then
-      basebranch="staging"
-  fi
 
   git checkout -b $branchname $basebranch
   git add $modifiedfiles || return 1


### PR DESCRIPTION
Follow-on to #4433 and fixes failing CI builds

CI fails to checkout new help.keyman.com branches off of `staging`.

```
 fatal: 'staging' is not a commit and a branch 'auto/windows-help-14.0.240-beta' cannot be created from it
```

We'll simplify just having help docs update the master branch on help.keyman.com