### PR TITLE
fix(android/engine): Display online keyboard help

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -179,7 +179,6 @@ public final class KMManager {
   public static final String KMKey_LanguageID = "langId";
   public static final String KMKey_LanguageName = "langName";
   public static final String KMKey_KeyboardCount = "kbCount";
-  public static final String KMKey_HelpLink = "helpLink";
   public static final String KMKey_Icon = "icon";
   public static final String KMKey_Keyboard = "keyboard";
   public static final String KMKey_KeyboardID = "kbId";
@@ -193,12 +192,6 @@ public final class KMManager {
   public static final String KMKey_KeyboardModified = "lastModified";
   public static final String KMKey_KeyboardRTL = "rtl";
 
-  // DEPRECATED
-  public static final String KMKey_CustomKeyboard = "CustomKeyboard";
-
-  // DEPRECATED
-  public static final String KMKey_CustomModel = "CustomModel";
-
   public static final String KMKey_CustomHelpLink = "CustomHelpLink";
   public static final String KMKey_KMPLink = "kmp";
   public static final String KMKey_UserKeyboardIndex = "UserKeyboardIndex";
@@ -208,6 +201,11 @@ public final class KMManager {
   public static final String KMKey_LexicalModelName = "lmName";
   public static final String KMKey_LexicalModelVersion = "lmVersion";
   public static final String KMKey_LexicalModelPackageFilename = "kmpPackageFilename";
+
+  // DEPRECATED keys
+  public static final String KMKey_CustomKeyboard = "CustomKeyboard";
+  public static final String KMKey_CustomModel = "CustomModel";
+  public static final String KMKey_HelpLink = "helpLink";
 
   // Keyman internal keys
   protected static final String KMKey_ShouldShowHelpBubble = "ShouldShowHelpBubble";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -86,8 +86,10 @@ public final class KeyboardInfoActivity extends BaseActivity {
     final String customHelpLink = kbd.getHelpLink();
     // Check if app declared FileProvider
     String icon = String.valueOf(R.drawable.ic_arrow_forward);
-    // Don't show help link arrow if File Provider unavailable, or custom help doesn't exist
-    if ( (customHelpLink != null && !FileProviderUtils.exists(context) && ! KMManager.isTestMode()) ||
+    // Don't show help link arrow if it's a local help file and File Provider unavailable,
+    // or custom help doesn't exist
+    if ( (customHelpLink != null && ! KMManager.isTestMode() &&
+         ! customHelpLink.startsWith(Keyboard.HELP_URL_HOST) && !FileProviderUtils.exists(context) ) ||
          (customHelpLink == null && !packageID.equals(KMManager.KMDefault_UndefinedPackageID)) ) {
       icon = noIcon;
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -641,7 +641,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
       keyboardInfo.get(KMManager.KMKey_LanguageID),
       keyboardInfo.get(KMManager.KMKey_LanguageName),
       keyboardInfo.get(KMManager.KMKey_KeyboardVersion),
-      keyboardInfo.get(KMManager.KMKey_HelpLink),
+      keyboardInfo.get(KMManager.KMKey_CustomHelpLink),
       keyboardInfo.get(KMManager.KMKey_KMPLink),
       isNewKeyboard,
       keyboardInfo.get(KMManager.KMKey_Font),

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -198,7 +198,7 @@ public final class ModelPickerActivity extends BaseActivity {
               preInstalledModelMap.get(KMManager.KMKey_LanguageID),
               preInstalledModelMap.get(KMManager.KMKey_LanguageName),
               preInstalledModelMap.get(KMManager.KMKey_LexicalModelVersion),
-              preInstalledModelMap.get(KMManager.KMKey_HelpLink),
+              preInstalledModelMap.get(KMManager.KMKey_CustomHelpLink),
               MapCompat.getOrDefault(preInstalledModelMap, KMManager.KMKey_KMPLink, ""));
             String itemKey = preInstalled.getKey();
             int modelIndex = KeyboardPickerActivity.getLexicalModelIndex(context, itemKey);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -23,7 +23,8 @@ import java.io.Serializable;
 
 public class Keyboard extends LanguageResource implements Serializable {
   private static final String TAG = "Keyboard";
-  private static final String HELP_URL_FORMATSTR = "https://help.keyman.com/keyboard/%s/%s";
+  public static final String HELP_URL_HOST = "https://help.keyman.com/";
+  private static final String HELP_URL_FORMATSTR = "%s/keyboard/%s/%s";
 
   private boolean isNewKeyboard;
   private String font;
@@ -71,7 +72,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.version = keyboardJSON.optString(KMManager.KMKey_KeyboardVersion, null);
 
       this.helpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink,
-        String.format(HELP_URL_FORMATSTR, this.resourceID, this.version));
+        String.format(HELP_URL_FORMATSTR, HELP_URL_HOST, this.resourceID, this.version));
     } catch (JSONException e) {
       KMLog.LogException(TAG, "Keyboard exception parsing JSON: ", e);
     }
@@ -83,7 +84,7 @@ public class Keyboard extends LanguageResource implements Serializable {
                   boolean isNewKeyboard, String font, String oskFont) {
     super(packageID, keyboardID, keyboardName, languageID, languageName, version,
       (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
-        String.format(HELP_URL_FORMATSTR, keyboardID, version),
+        String.format(HELP_URL_FORMATSTR, HELP_URL_HOST, keyboardID, version),
       kmp);
 
     this.isNewKeyboard = isNewKeyboard;


### PR DESCRIPTION
This fixes a bug I found while checking out the FV Android 14.0 beta app. Those keyboards are bundled in the fv_all.kmp keyboard package, so the keyboard helps use the online links to `https://help.keyman.com/keyboard/`

* This fixes the logic in KeyboardInfoActivity so the keyboard help link is only disabled for local help where the FileProvider isn't available. (This might be addressed in #4421)
* Also deprecates a `KMManager.KMKey_HelpLink` key to avoid future confusion (All the remaining code uses KMManager.KMKey_CustomHelpLink for the key). The keys aren't documented on help.keyman.com, so nothing to update there.