### PR TITLE
fix(windows): Track modifier changes in UWP apps

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -118,6 +118,8 @@ void ProcessToggleChange(UINT key) {   // I4793
   }
 }
 
+void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);
+
 extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM lParam,   // I3589   // I3588
 	PKEYMANPROCESSOUTPUTFUNC outfunc, PKEYMANGETCONTEXTFUNC ctfunc, BOOL Updateable, BOOL Preserved) {
 
@@ -172,6 +174,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
         // in the first pass (!Updateable).
         KeyCapsLockPress(isUp);   // I4548
       }
+      ProcessModifierChange((UINT) wParam, isUp, extended);
       return FALSE;
     case VK_SHIFT:
       if (!Updateable) {
@@ -182,10 +185,12 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
       // Fall through
     case VK_MENU:
     case VK_CONTROL:
+      ProcessModifierChange((UINT) wParam, isUp, extended);
       return FALSE;
 
     case VK_NUMLOCK:
       if(!isUp) ProcessToggleChange((UINT) wParam);   // I4793
+      ProcessModifierChange((UINT) wParam, isUp, extended);
       return FALSE;
     }
     if(isUp) {

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -443,8 +443,12 @@ void GetCapsAndNumlockState() {   // I4793
 
 /*
   Update the Keyman shift state based on the key event. This has to be
-  done from the GetMessage hook because we don't consistently receive
-  modifier events in some applications (e.g. ALT in Firefox) via TSF.
+  done from both the GetMessage hook and the TSF methods, because we don't
+  consistently receive modifier events in some applications (e.g. ALT in Firefox)
+  via TSF, and we don't receive the notifications via the GetMessage hook when
+  in UWP apps (#4369).
+
+  TODO: test whether we still need the GetMessage hook for reading modifier state.       
 */
 void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended) {   // I4793
   UINT flag = 0;


### PR DESCRIPTION
Fixes #4369.

When Keyman is not handling a particular virtual key, it does not preserve the virtual key (TSF terminology, essentially reserves that virtual key + modifier for Keyman). In this situation, Keyman still receives and processes the virtual key event, but the modifier state is not passed through by kmtip to keyman32. This is normally okay, because our `GetMessage` hook is responsible for tracking modifiers.

However, in UWP apps, our `GetMessage` hook does not get run, and so we lose the modifier keys. Thus, this update ensures that the modifier keys are processed when received by the TSF TIP.

It does not hurt to process modifier events twice.