### PR TITLE
fix(common/resources): Fix help.keyman.com path for commit

### DIFF
--- a/resources/build/help-keyman-com.sh
+++ b/resources/build/help-keyman-com.sh
@@ -138,7 +138,7 @@ function commit_and_push {
   fi
 
   local branchname="auto/$platform-help-$VERSION_WITH_TAG"
-  local modifiedfiles="$HELP_KEYMAN_COM/products/$platform/$VERSION_RELEASE"
+  local modifiedfiles="products/$platform/$VERSION_RELEASE"
 
   local basebranch="master"
 


### PR DESCRIPTION
Act 3 of the help-keyman-com.sh refactor, follows #4433 #4459

My local testing had full paths for the environment var `$HELP_KEYMAN_COM` so that's why it worked for me, but not CI (uses relative paths)

l. 133 already did `pushd HELP_KEYMAN_COM`