### PR TITLE
fix(common): create GitHub comments serially

### DIFF
--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -219,12 +219,18 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
 
   const messagePull = `Changes in this pull request will be available for download in [Keyman version ${versionTier}](https://keyman.com/downloads/releases/${tier}/${version})`;
 
-  return Promise.all(pulls.map( pull => octokit.issues.createComment({
-    owner: 'keymanapp',
-    repo: 'keyman',
-    issue_number: pull,
-    body: messagePull,
-  })));
+  // Create comments serially rather than in parallel
+  let result: Promise<any> = Promise.resolve();
+  pulls.forEach(pull => {
+    result = result.then(() => octokit.issues.createComment({
+      owner: 'keymanapp',
+      repo: 'keyman',
+      issue_number: pull,
+      body: messagePull,
+    }));
+  });
+
+  return result;
 }
 
 /**

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -223,6 +223,7 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
   // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits
   let result: Promise<any> = Promise.resolve();
   pulls.forEach(pull => {
+    console.log(`Creating comment on Pull Request #{pull}`);
     result = result
       // At least 1 second delay between requests; we'll do 10 seconds
       .then(() => new Promise(resolve => setTimeout(resolve, 10000)))

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -219,15 +219,20 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
 
   const messagePull = `Changes in this pull request will be available for download in [Keyman version ${versionTier}](https://keyman.com/downloads/releases/${tier}/${version})`;
 
-  // Create comments serially rather than in parallel
+  // Potentially creating many comments, we need to respect GitHub rate limits
+  // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits
   let result: Promise<any> = Promise.resolve();
   pulls.forEach(pull => {
-    result = result.then(() => octokit.issues.createComment({
-      owner: 'keymanapp',
-      repo: 'keyman',
-      issue_number: pull,
-      body: messagePull,
-    }));
+    result = result
+      // At least 1 second delay between requests; we'll do 10 seconds
+      .then(() => new Promise(resolve => setTimeout(resolve, 10000)))
+      // Always serially rather than in parallel
+      .then(() => octokit.issues.createComment({
+        owner: 'keymanapp',
+        repo: 'keyman',
+        issue_number: pull,
+        body: messagePull,
+      }));
   });
 
   return result;


### PR DESCRIPTION
This is a suggested approach for addressing the rate limit issues we were experiencing. We'll try it and see.

Have I got the `promise` mechanism correct here? It looks right to me but hard to test...