### PR TITLE
fix(common/core/web): mock construction with caret at index 0

### DIFF
--- a/common/core/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/core/web/keyboard-processor/src/text/outputTarget.ts
@@ -288,7 +288,8 @@ namespace com.keyman.text {
 
       this.text = text ? text : "";
       var defaultLength = this.text._kmwLength();
-      this.caretIndex = caretPos ? caretPos : defaultLength;
+      // An index of 0 should still be considered 'defined', while null and undefined... not so much.
+      this.caretIndex = (caretPos || caretPos === 0) ? caretPos : defaultLength;
     }
 
     // Clones the state of an existing EditableElement, creating a Mock version of its state.

--- a/common/core/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/core/web/keyboard-processor/src/text/outputTarget.ts
@@ -288,8 +288,8 @@ namespace com.keyman.text {
 
       this.text = text ? text : "";
       var defaultLength = this.text._kmwLength();
-      // An index of 0 should still be considered 'defined', while null and undefined... not so much.
-      this.caretIndex = (caretPos || caretPos === 0) ? caretPos : defaultLength;
+      // Ensures that `caretPos == 0` is handled correctly.
+      this.caretIndex = typeof caretPos == "number" ? caretPos : defaultLength;
     }
 
     // Clones the state of an existing EditableElement, creating a Mock version of its state.

--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -9,11 +9,11 @@ available_platforms=(android ios linux mac web windows)
 # e.g. android='common/models|common/predictive-text'
 # will expand into android='^(android|(oem/[^/]+/android)|common/models|common/predictive-text)'
 
-watch_android='web|common/models|common/predictive-text|common/lexical-model-types'
-watch_ios='web|common/models|common/predictive-text|common/lexical-model-types'
+watch_android='web|common/models|common/predictive-text|common/lexical-model-types|common/core/web'
+watch_ios='web|common/models|common/predictive-text|common/lexical-model-types|common/core/web'
 watch_linux='common/engine'
 watch_mac='common/engine'
-watch_web='common/models|common/predictive-text|common/lexical-model-types'
+watch_web='common/models|common/predictive-text|common/lexical-model-types|common/core/web'
 
 # Windows currently builds Developer and Desktop, so we need everything from common,developer,web
 watch_windows='common|developer|web'


### PR DESCRIPTION
Fixes #4463.

The bug directly fixed by these changes triggered a context desync when embedded in the Android and iOS apps, which is what caused #4463.