### PR TITLE
fix(windows): tsysinfox64 not signed

### DIFF
--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -231,11 +231,12 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
       .then(() => {
         console.log(`Creating comment on Pull Request #${pull}`);
         return octokit.issues.createComment({
-        owner: 'keymanapp',
-        repo: 'keyman',
-        issue_number: pull,
-        body: messagePull,
-      })});
+          owner: 'keymanapp',
+          repo: 'keyman',
+          issue_number: pull,
+          body: messagePull,
+        })
+      });
   });
 
   return result;

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -223,17 +223,19 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
   // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits
   let result: Promise<any> = Promise.resolve();
   pulls.forEach(pull => {
-    console.log(`Creating comment on Pull Request #{pull}`);
+
     result = result
       // At least 1 second delay between requests; we'll do 10 seconds
       .then(() => new Promise(resolve => setTimeout(resolve, 10000)))
       // Always serially rather than in parallel
-      .then(() => octokit.issues.createComment({
+      .then(() => {
+        console.log(`Creating comment on Pull Request #${pull}`);
+        return octokit.issues.createComment({
         owner: 'keymanapp',
         repo: 'keyman',
         issue_number: pull,
         body: messagePull,
-      }));
+      })});
   });
 
   return result;

--- a/windows/src/Makefile
+++ b/windows/src/Makefile
@@ -232,12 +232,12 @@ build-release-wrapper: clean-output global-versions
     $(MAKE) dirs
     $(MAKE) build-tools
 !ifdef QUICK_BUILD_KEYMAN
-    $(MAKE) build
-    $(MAKE) build-release
+    $(MAKE) -DSIGNCODE_BUILD build
+    $(MAKE) -DSIGNCODE_BUILD build-release
     $(MAKE) signcode
 !else
-    $(MAKE) build unit-tests
-    $(MAKE) build-release
+    $(MAKE) -DSIGNCODE_BUILD build unit-tests
+    $(MAKE) -DSIGNCODE_BUILD build-release
     $(MAKE) signcode
     $(MAKE) -DTARGET=test test
     $(MAKE) backup


### PR DESCRIPTION
Fixes #4484.

tsysinfox64 was being signed, but too late in the build process as it is embedded into tsysinfo.exe. There was code to sign it earlier, but that was being skipped due to a missing build flag. This has been a problem for some time.

It is possible to test this by doing a full release build locally, but I will test on the next beta anyway once it merges, which might be a more efficient approach.