### PR TITLE
fix(web): adds null guards

### DIFF
--- a/common/predictive-text/worker/correction/context-tracker.ts
+++ b/common/predictive-text/worker/correction/context-tracker.ts
@@ -3,6 +3,11 @@
 namespace correction {
 
   function textToCharTransforms(text: string, transformId?: number) {
+    // A basic null guard.
+    if(!text) {
+      return [];
+    }
+
     let perCharTransforms: Transform[] = [];
 
     for(let i=0; i < text.kmwLength(); i++) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1836,7 +1836,9 @@ namespace com.keyman.osk {
      **/
     highlightKey(key: KeyElement, on: boolean) {
       // Do not change element class unless a key
-      if(!key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
+      if(!key || !key.className || key.className.indexOf('kmw-key-row') >= 0) {
+        return;
+      }
 
       var classes=key.className, cs = ' kmw-key-touched';
 


### PR DESCRIPTION
Fixes #4488.
Fixes KEYMAN-WEB-1F.

Because `'' != undefined`.

Also, another simple guard for a spot that turned up in a single error report.