### PR TITLE
fix(ios): tutorial's link to "Add a Keyboard" links directly to keyboard search

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -439,8 +439,8 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
 }
 
 extension InstalledLanguagesViewController {
-  
-  @objc func addClicked(_ sender: Any) {
+
+  public func launchKeyboardSearch() {
     let keyboardSearchVC = KeyboardSearchViewController(keyboardSelectionBlock: KeyboardSearchViewController.defaultDownloadClosure() { result in
       switch result {
         case .cancelled:
@@ -458,6 +458,10 @@ extension InstalledLanguagesViewController {
     })
 
     navigationController!.pushViewController(keyboardSearchVC, animated: true)
+  }
+
+  @objc func addClicked(_ sender: Any) {
+    launchKeyboardSearch()
   }
 }
 

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -536,7 +536,10 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     let installedLanguagesVC = InstalledLanguagesViewController()
     nc.pushViewController(installedLanguagesVC, animated: true)
 
-    self.present(nc, animated: true)
+    self.present(nc, animated: true) {
+      // Requires a host NavigationViewController, hence calling it afterward.
+      installedLanguagesVC.launchKeyboardSearch()
+    }
   }
 
   @objc func actionButtonClick(_ sender: Any) {


### PR DESCRIPTION
Fixes #3980.

While technically not 100% direct - it does present the Installed Languages view first - that's only with a short delay.  The keyboard search will automatically present immediately afterward.  This isn't exactly a bad thing either; this clearly demonstrates where a user can find the keyboard search if not using the "Getting Started" tutorial.