### PR TITLE
fix(ios): app logging messages were transient, never stored

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Log.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Log.swift
@@ -8,4 +8,19 @@
 
 import XCGLogger
 
-public let log = XCGLogger(identifier: "KeymanEngine", includeDefaultDestinations: true)
+public let log: XCGLogger = {
+  // Default:  the 'console', which is read by Xcode but doesn't reach the system logs.
+  let mainLog = XCGLogger(identifier: "KeymanEngine", includeDefaultDestinations: true)
+
+  // Ensures our log messages go out to the device's system log.
+  let systemLogDest = AppleSystemLogDestination(identifier: "")
+  systemLogDest.showLogIdentifier = true
+#if DEBUG
+  systemLogDest.outputLevel = .debug
+#else
+  systemLogDest.outputLevel = .warning
+#endif
+  mainLog.add(destination: systemLogDest)
+
+  return mainLog
+}()

--- a/ios/engine/KMEI/KeymanEngine/Classes/Log.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Log.swift
@@ -8,19 +8,27 @@
 
 import XCGLogger
 
+// From XCGLogger docs:
+// Note: This creates the log object lazily, which means it's not created until it's actually needed.
 public let log: XCGLogger = {
   // Default:  the 'console', which is read by Xcode but doesn't reach the system logs.
-  let mainLog = XCGLogger(identifier: "KeymanEngine", includeDefaultDestinations: true)
+  let mainLog = XCGLogger(identifier: "KeymanEngine", includeDefaultDestinations: false)
 
-  // Ensures our log messages go out to the device's system log.
+  // Ensures our log messages go out to the device's system log as well as the console.
   let systemLogDest = AppleSystemLogDestination(identifier: "")
   systemLogDest.showLogIdentifier = true
-#if DEBUG
-  systemLogDest.outputLevel = .debug
-#else
-  systemLogDest.outputLevel = .warning
-#endif
+
   mainLog.add(destination: systemLogDest)
+
+  // Temporary logging level to ensure that app details are reported properly.
+  mainLog.outputLevel = .info
+  mainLog.logAppDetails()
+
+#if DEBUG
+  mainLog.outputLevel = .debug
+#else
+  mainLog.outputLevel = .warning
+#endif
 
   return mainLog
 }()

--- a/ios/engine/KMEI/KeymanEngineDemo/AppDelegate.swift
+++ b/ios/engine/KMEI/KeymanEngineDemo/AppDelegate.swift
@@ -15,8 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-    KeymanEngine.log.outputLevel = .debug
-    KeymanEngine.log.logAppDetails()
     Manager.applicationGroupIdentifier = "group.KMEI"
     Manager.shared.canRemoveDefaultKeyboard = true
 

--- a/ios/engine/KMEI/SystemKeyboard/KeyboardViewController.swift
+++ b/ios/engine/KMEI/SystemKeyboard/KeyboardViewController.swift
@@ -10,6 +10,7 @@ import KeymanEngine
 
 class KeyboardViewController: InputViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    _ = log // forces init of the log, which is useful in sys-kbd contexts.
     Manager.applicationGroupIdentifier = "group.KMEI"
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }

--- a/ios/engine/KMEI/SystemKeyboard/KeyboardViewController.swift
+++ b/ios/engine/KMEI/SystemKeyboard/KeyboardViewController.swift
@@ -10,8 +10,6 @@ import KeymanEngine
 
 class KeyboardViewController: InputViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-    KeymanEngine.log.outputLevel = .debug
-    KeymanEngine.log.logAppDetails()
     Manager.applicationGroupIdentifier = "group.KMEI"
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -54,19 +54,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     SentryManager.start()
+    // Forces the logs to initialize, as their definitions result in lazy init.
+    // These references have been configured to also log app details.
+    _ = log
+    _ = KeymanEngine.log
 
     UniversalLinks.externalLinkLauncher = { url in
       UIApplication.shared.openURL(url)
     }
-
-    #if DEBUG
-      KeymanEngine.log.outputLevel = .debug
-      log.outputLevel = .debug
-      KeymanEngine.log.logAppDetails()
-    #else
-      KeymanEngine.log.outputLevel = .warning
-      log.outputLevel = .warning
-    #endif
 
     Manager.applicationGroupIdentifier = "group.KM4I"
 

--- a/ios/keyman/Keyman/Keyman/Log.swift
+++ b/ios/keyman/Keyman/Keyman/Log.swift
@@ -8,19 +8,27 @@
 
 import XCGLogger
 
+// From XCGLogger docs:
+// Note: This creates the log object lazily, which means it's not created until it's actually needed.
 public let log: XCGLogger = {
   // Default:  the 'console', which is read by Xcode but doesn't reach the system logs.
-  let mainLog = XCGLogger(identifier: "Keyman", includeDefaultDestinations: true)
+  let mainLog = XCGLogger(identifier: "Keyman", includeDefaultDestinations: false)
 
-  // Ensures our log messages go out to the device's system log.
+  // Ensures our log messages go out to the device's system log as well as the console.
   let systemLogDest = AppleSystemLogDestination(identifier: "")
   systemLogDest.showLogIdentifier = true
-#if DEBUG
-  systemLogDest.outputLevel = .debug
-#else
-  systemLogDest.outputLevel = .warning
-#endif
+
   mainLog.add(destination: systemLogDest)
+
+  // Temporary logging level to ensure that app details are reported properly.
+  mainLog.outputLevel = .info
+  mainLog.logAppDetails()
+
+#if DEBUG
+  mainLog.outputLevel = .debug
+#else
+  mainLog.outputLevel = .warning
+#endif
 
   return mainLog
 }()

--- a/ios/keyman/Keyman/Keyman/Log.swift
+++ b/ios/keyman/Keyman/Keyman/Log.swift
@@ -8,4 +8,19 @@
 
 import XCGLogger
 
-let log = XCGLogger(identifier: "Keyman", includeDefaultDestinations: true)
+public let log: XCGLogger = {
+  // Default:  the 'console', which is read by Xcode but doesn't reach the system logs.
+  let mainLog = XCGLogger(identifier: "Keyman", includeDefaultDestinations: true)
+
+  // Ensures our log messages go out to the device's system log.
+  let systemLogDest = AppleSystemLogDestination(identifier: "")
+  systemLogDest.showLogIdentifier = true
+#if DEBUG
+  systemLogDest.outputLevel = .debug
+#else
+  systemLogDest.outputLevel = .warning
+#endif
+  mainLog.add(destination: systemLogDest)
+
+  return mainLog
+}()

--- a/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
+++ b/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
@@ -21,6 +21,8 @@ class KeyboardViewController: InputViewController {
       // is enabled.  They seem to get blocked otherwise, except in the Simulator.
       SentryManager.start(sendingEnabled: true)
     }
+    _ = log
+    _ = KeymanEngine.log
 
     Manager.applicationGroupIdentifier = "group.KM4I"
 

--- a/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
+++ b/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
@@ -22,12 +22,6 @@ class KeyboardViewController: InputViewController {
       SentryManager.start(sendingEnabled: true)
     }
 
-    #if DEBUG
-      KeymanEngine.log.outputLevel = .debug
-      KeymanEngine.log.logAppDetails()
-    #else
-      KeymanEngine.log.outputLevel = .warning
-    #endif
     Manager.applicationGroupIdentifier = "group.KM4I"
 
     let bundle = Bundle(for: KeyboardViewController.self)


### PR DESCRIPTION
This fixes an issue that had been interfering with my ability to properly assess #4126.

In short, up until now, our error logging never actually output log messages to a device's system logs.  That's 'fine' when debugging through Xcode, but there are some situations where that's not an available option.