### PR TITLE
fix(developer/compilers): fixes error when "constructor" is in wordlist

### DIFF
--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -138,7 +138,7 @@ function _parseWordList(wordlist: WordList, source:  WordListSource): void {
     }
     wordsSeenInThisFile.add(wordform);
 
-    wordlist[wordform] = (wordlist[wordform] || 0) + count;
+    wordlist[wordform] = (isNaN(wordlist[wordform]) ? 0 : wordlist[wordform] || 0) + count;
   }
 }
 
@@ -459,15 +459,22 @@ namespace Trie {
    * @param node The node to start summing weights.
    */
   function sumWeights(node: Node): number {
+    let val: number;
     if (node.type === 'leaf') {
-      return node.entries
+      val = node.entries
         .map(entry => entry.weight)
+        //.map(entry => isNaN(entry.weight) ? 1 : entry.weight)
         .reduce((acc, count) => acc + count, 0);
     } else {
-      return Object.keys(node.children)
+      val = Object.keys(node.children)
         .map((key) => sumWeights(node.children[key]))
         .reduce((acc, count) => acc + count, 0);
     }
+
+    if(isNaN(val)) {
+      console.error("Unexpected NaN has appeared!");
+    }
+    return val;
   }
 }
 


### PR DESCRIPTION
... JS, I love you, but sometimes...

Fixes a 'fun' error that destroyed all wordlist weighting during some of my predictive text testing.  Its probable underlying cause is a `node` version update, which results in the following spot of fun:

<img width="1634" alt="Screen Shot 2021-02-22 at 4 19 45 PM" src="https://user-images.githubusercontent.com/25213402/108688777-e1110f80-752a-11eb-9543-e06d21046373.png">

So, for an English wordlist including the word "constructor", there's actually a pre-existing entry in the wordlist map-object.  Said entry is (obviously) "not a number," and in JS, NaN + any number = NaN.  This, in turn, causes a cascading failure that effectively destroys all wordlist weighting for the model.  For funsies, take a look at the result of said failure cascade:

<img width="453" alt="Screen Shot 2021-02-22 at 4 21 29 PM" src="https://user-images.githubusercontent.com/25213402/108689035-2e8d7c80-752b-11eb-9e4f-4748fa346188.png">

This has near-certainly affected our recently-distributed versions of the MTNT model, unfortunately - we've got a [checked-in copy](https://raw.githubusercontent.com/keymanapp/keyman/beta/web/testing/prediction-mtnt/nrc.en.mtnt.model.js) with that nasty "totalWeight" value within the repo.  The difference would likely be a bit subtle, since keystroke input still provides decent weighting for predictions, but this would have some impact.
