### PR TITLE
fix(web): hides touch-alias caret when keystroke causes focus change

### DIFF
--- a/web/source/dom/domDefaultOutput.ts
+++ b/web/source/dom/domDefaultOutput.ts
@@ -28,14 +28,27 @@ namespace com.keyman.dom {
     let code = DefaultOutput.codeForEvent(Lkc);
     let domManager = com.keyman.singleton.domManager;
 
+    let hideCaret: () => void;
+    if(Lkc.Ltarg instanceof com.keyman.dom.targets.TouchAlias) {
+      hideCaret = function() {
+        let target = Lkc.Ltarg as com.keyman.dom.targets.TouchAlias;
+        target.root.hideCaret();
+      }
+    } else {
+      hideCaret = function() {};
+    }
+
     switch(code) {
       case Codes.keyCodes['K_TAB']:
+        hideCaret();
         domManager.moveToNext((Lkc.Lmodifiers & text.Codes.modifierCodes['SHIFT']) != 0);
         break;
       case Codes.keyCodes['K_TABBACK']:
+        hideCaret();
         domManager.moveToNext(true);
         break;
       case Codes.keyCodes['K_TABFWD']:
+        hideCaret();
         domManager.moveToNext(false);
         break;
     }

--- a/web/source/dom/targets/touchAlias.ts
+++ b/web/source/dom/targets/touchAlias.ts
@@ -69,6 +69,7 @@ namespace com.keyman.dom.targets {
         this.insertTextBeforeCaret('\n');
       } else if(dom.Utils.instanceof(this.root.base, "HTMLInputElement")) {
         // HTMLInputElements do not permit newlines; they instead have DOM-specific behaviors.
+        this.root.hideCaret();
         Input.newlineHandler(this.root.base as HTMLInputElement);
       } else {
         console.warn("TouchAlias OutputTarget cannot output newlines for unexpected base element types!");


### PR DESCRIPTION
Fixes #3954.