### PR TITLE
fix(web): removes package namespacing from kbd's CSS class

### DIFF
--- a/android/history.md
+++ b/android/history.md
@@ -1,5 +1,9 @@
 # Keyman for Android Version History
 
+## 2021-02-25 13.0.6221 stable
+* Bug fix:
+  * Fixes an issue with the CSS classname name used by keyboards (#4516)
+
 ## 2020-10-07 13.0.6219 stable
 * Bug fix:
   * Fix how layer is separated from key name (updated Keyman Web Engine #3674)

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -298,8 +298,14 @@ namespace com.keyman.osk {
       }
 
       // Correct the classname for the (inner) OSK frame (Build 360)
+      var kbdID: string = (activeKeyboard ? activeKeyboard['KI'].replace('Keyboard_','') : '');
+      if(keymanweb.isEmbedded && kbdID.indexOf('::') != -1) {
+        // De-namespaces the ID for use with CSS classes.
+        // Keyboard IDs may not contain the ':' symbol, so this is safe.
+        kbdID = kbdID.substring(kbdID.indexOf('::') + 2);
+      }
       var innerFrame=<HTMLDivElement> this._Box.firstChild,
-        kbdClass = ' kmw-keyboard-' + (activeKeyboard ? activeKeyboard['KI'].replace('Keyboard_','') : '');
+        kbdClass = ' kmw-keyboard-' + kbdID;
       if(innerFrame.id == 'keymanweb_title_bar') {
         // Desktop order is title_bar, banner_container, inner-frame
         innerFrame=<HTMLDivElement> innerFrame.nextSibling.nextSibling;


### PR DESCRIPTION
A 🍒-pick of #4516.

While not _strictly_ necessary and not targeted at a major :fire: of any sort, I figure we may as well slip it in while a few other bugfixes are cherry-picked.  Having the fix land in 13.0 stable instead of 14.0 stable should allow any workarounds for the underlying bug to be removed earlier by any affected keyboard designers.

If we'd rather just leave it to 14.0, I understand.