### PR TITLE
chore(common): allow forced version increment

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -29,9 +29,11 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 gitbranch=`git branch --show-current`
 
 FORCE=0
+HISTORY_FORCE=
 
 if [[ "$1" == "-f" ]]; then
   FORCE=1
+  HISTORY_FORCE=--force
   shift
 fi
 
@@ -86,7 +88,7 @@ popd > /dev/null
 
 pushd "$KEYMAN_ROOT" > /dev/null
 ABORT=0
-node resources/build/version/lib/index.js history version -t "$GITHUB_TOKEN" -b "$base" || ABORT=$?
+node resources/build/version/lib/index.js history version -t "$GITHUB_TOKEN" -b "$base" $HISTORY_FORCE || ABORT=$?
 
 if [[ $ABORT = 1 ]]; then
   if [[ $FORCE = 0 ]]; then

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 
 const argv = yargs
   .command(['history'], 'Fixes up HISTORY.md with pull request data')
-  .command(['version'], 'Increments the current ptach version in VERSION.md')
+  .command(['version'], 'Increments the current patch version in VERSION.md')
   .demandCommand(1, 2)
   .options({
     'base': {
@@ -22,6 +22,11 @@ const argv = yargs
       demandOption: true,
       alias: 't',
       type: 'string'
+    },
+
+    'force': {
+      description: 'Force a version increment even if no changes found',
+      type: 'boolean'
     }
   })
   .help()
@@ -53,7 +58,7 @@ const main = async (): Promise<void> => {
 
   if(argv._.includes('history')) {
     logInfo(`# Validating history for ${version}`);
-    changeCount = await fixupHistory(octokit, argv.base);
+    changeCount = await fixupHistory(octokit, argv.base, argv.force);
     logInfo(`# ${changeCount} change(s) found for ${version}\n`);
   }
 


### PR DESCRIPTION
Allows us to manually run a version increment, for example if there is a problem with a release build such as running out of space on the download server.

When triggering from TeamCity, we need to manually set the force parameter to `-f`. This is a little bit of a failsafe.