### PR TITLE
fix(ios): now handles security-scoped files

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -32,7 +32,12 @@ public class ResourceFileManager {
 
     // Throws an error if the destination file already exists, and there's no
     // built-in override parameter.  Hence, the previous if-block.
-    try fileManager.copyItem(at: source, to: destination)
+    if source.startAccessingSecurityScopedResource() {
+      defer { source.stopAccessingSecurityScopedResource() }
+      try fileManager.copyItem(at: source, to: destination)
+    } else {
+      try fileManager.copyItem(at: source, to: destination)
+    }
   }
 
   /**

--- a/ios/history.md
+++ b/ios/history.md
@@ -1,6 +1,9 @@
 
 # Keyman for iPhone and iPad Version History
 
+## 2021-02-25 13.0.117 stable
+* Fixes an issue that sometimes prevented keyboard and dictionary installation (#4524)
+
 ## 2020-07-16 13.0.109 stable
 * Improve performance when typing long documents with predictive text (#3302)
 


### PR DESCRIPTION
🍒-pick of #4095 and #4327.  (The latter is the 'final' version of the fix, as it wasn't handled perfectly the first time.)