### PR TITLE
fix(android/app): Fix welcome.htm responsiveness

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -13,6 +13,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -162,6 +163,15 @@ public class KMPBrowserActivity extends BaseActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    // Blank the webView and destroy completely
+    if (webView != null) {
+      webView.loadUrl("about:blank");
+      ((ViewGroup) webView.getParent()).removeView(webView);
+      webView.removeAllViews();
+      webView.clearCache(true);
+      webView.destroy();
+      webView = null;
+    }
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 SIL International. All rights reserved.
+ * Copyright (C) 2020-2021 SIL International. All rights reserved.
  */
 
 package com.tavultesoft.kmapro;
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.KMPLink;
+import com.tavultesoft.kmea.util.WebViewUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -163,15 +164,7 @@ public class KMPBrowserActivity extends BaseActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    // Blank the webView and destroy completely
-    if (webView != null) {
-      webView.loadUrl("about:blank");
-      ((ViewGroup) webView.getParent()).removeView(webView);
-      webView.removeAllViews();
-      webView.clearCache(true);
-      webView.destroy();
-      webView = null;
-    }
+    WebViewUtil.cleanup(webView);
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -1,7 +1,9 @@
+/**
+ * Copyright (C) SIL International. All rights reserved.
+ */
 package com.tavultesoft.kmapro;
 
 import android.annotation.SuppressLint;
-import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
@@ -9,17 +11,8 @@ import androidx.fragment.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.view.Gravity;
 import android.view.View;
-import android.view.View.OnClickListener;
-import android.webkit.WebChromeClient;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
-import android.widget.Button;
-import android.widget.TextView;
 
 import android.widget.Toast;
 
@@ -36,9 +29,7 @@ import com.tavultesoft.kmea.util.KMLog;
 import org.json.JSONObject;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -254,9 +245,6 @@ public class PackageActivity extends AppCompatActivity implements
           languageList = new ArrayList<String>();
         }
 
-        //Dataset kmpDataset = new Dataset(context);
-        //kmpDataset.keyboards.addAll(kbdsList);
-
         List<Map<String, String>> installedPackageKeyboards =
           kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, languageList);
         // Do the notifications!
@@ -270,8 +258,6 @@ public class PackageActivity extends AppCompatActivity implements
               Toast.LENGTH_SHORT).show();
           }
           _cleanup = true;
-          notifyPackageInstallListeners(KeyboardEventHandler.EventType.PACKAGE_INSTALLED,
-            installedPackageKeyboards, 1);
           if (installedPackageKeyboards != null) {
             notifyPackageInstallListeners(KeyboardEventHandler.EventType.PACKAGE_INSTALLED,
               installedPackageKeyboards, 1);
@@ -294,8 +280,6 @@ public class PackageActivity extends AppCompatActivity implements
               Toast.LENGTH_SHORT).show();
 
             _cleanup = true;
-          notifyLexicalModelInstallListeners(KeyboardEventHandler.EventType.LEXICAL_MODEL_INSTALLED,
-            installedLexicalModels, 1);
           if (installedLexicalModels != null) {
             notifyLexicalModelInstallListeners(KeyboardEventHandler.EventType.LEXICAL_MODEL_INSTALLED,
               installedLexicalModels, 1);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -137,7 +137,7 @@ public class WebViewFragment extends Fragment implements BlockingStep {
         // Inject a meta viewport tag into the head of the file if it doesn't exist
         webView.loadUrl(
           "javascript:(function() {" +
-            "if(!document.querySelectorAll('meta[name=viewport]').length) {"+
+            "if(document.head && !document.querySelectorAll('meta[name=viewport]').length) {"+
             "let meta=document.createElement('meta');"+
             "meta.name='viewport';"+
             "meta.content='width=device-width, initial-scale=1';"+

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/WebViewFragment.java
@@ -14,6 +14,7 @@ import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.WebViewUtil;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -135,16 +136,7 @@ public class WebViewFragment extends Fragment implements BlockingStep {
       @Override
       public void onPageFinished(WebView view, String url) {
         // Inject a meta viewport tag into the head of the file if it doesn't exist
-        webView.loadUrl(
-          "javascript:(function() {" +
-            "if(document.head && !document.querySelectorAll('meta[name=viewport]').length) {"+
-            "let meta=document.createElement('meta');"+
-            "meta.name='viewport';"+
-            "meta.content='width=device-width, initial-scale=1';"+
-            "document.head.appendChild(meta);"+
-            "}"+
-            "})()"
-        );
+        WebViewUtil.injectViewport(view);
       }
     });
 

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -30,12 +30,6 @@
             android:theme="@style/Theme.AppCompat.Light.Dialog">
         </activity>
         <activity
-            android:name="com.tavultesoft.kmea.KMHelpFileActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
-            android:label="@string/app_name"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        </activity>
-        <activity
             android:name="com.tavultesoft.kmea.ModelPickerActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
@@ -47,6 +41,17 @@
             android:label="@string/app_name"
             android:theme="@style/Theme.AppCompat.Light.Dialog" >
         </activity>
+
+        <!-- Put other WebViewActivities in a separate process so the Keyboard WebView doesn't lag.
+        Ref https://stackoverflow.com/questions/40650643/timed-out-waiting-on-iinputcontextcallback-with-custom-keyboard-on-android -->
+        <activity
+            android:name="com.tavultesoft.kmea.KMHelpFileActivity"
+            android:process=":KMHelpFileActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        </activity>
+
     </application>
 
 </manifest>

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
 
         <activity
             android:name="com.tavultesoft.kmea.KeyboardPickerActivity"
+            android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppCompat.Light.Dialog" >
@@ -47,6 +48,7 @@
         <activity
             android:name="com.tavultesoft.kmea.KMHelpFileActivity"
             android:process=":KMHelpFileActivity"
+            android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
@@ -11,6 +11,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -79,7 +80,7 @@ public class KMHelpFileActivity extends BaseActivity {
     finishButton.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        finish();
+        finishAfterTransition();
         overridePendingTransition(0, android.R.anim.fade_out);
       }
     });
@@ -169,24 +170,21 @@ public class KMHelpFileActivity extends BaseActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    // Blank the webView and destroy completely
-    if (webView != null) {
-      webView.loadUrl("about:blank");
-      ((ViewGroup) webView.getParent()).removeView(webView);
-      webView.removeAllViews();
-      webView.clearCache(true);
-      webView.destroy();
-      webView = null;
-    }
   }
 
   @Override
-  public void onBackPressed() {
-    if (webView != null && webView.canGoBack()) {
-      webView.goBack();
-    } else {
-      super.onBackPressed();
-      finish();
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_DOWN) {
+      switch (keyCode) {
+        case KeyEvent.KEYCODE_BACK:
+          // Dismiss the help file
+          super.onBackPressed();
+          finishAndRemoveTask();
+        break;
+      }
     }
+
+    return true;
   }
+
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
@@ -54,7 +54,7 @@ public class KMHelpFileActivity extends BaseActivity {
     // Teardown keyboards to free up webView
     KMManager.onDestroy();
 
-    // Difference processes in the same application cannot directly share WebView-related data
+    // Different processes in the same application cannot directly share WebView-related data
     // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       if (!didSetDataDirectorySuffix) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
@@ -51,6 +51,9 @@ public class KMHelpFileActivity extends BaseActivity {
     super.onCreate(savedInstanceState);
     final Context context = this;
 
+    // Teardown keyboards to free up webView
+    KMManager.onDestroy();
+
     // Difference processes in the same application cannot directly share WebView-related data
     // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
@@ -30,6 +30,7 @@ import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.HelpFile;
+import com.tavultesoft.kmea.util.WebViewUtil;
 
 import java.io.File;
 
@@ -145,16 +146,7 @@ public class KMHelpFileActivity extends BaseActivity {
       @Override
       public void onPageFinished(WebView view, String url) {
         // Inject a meta viewport tag into the head of the file if it doesn't exist
-        webView.loadUrl(
-          "javascript:(function() {" +
-            "if(document.head && !document.querySelectorAll('meta[name=viewport]').length) {"+
-            "let meta=document.createElement('meta');"+
-            "meta.name='viewport';"+
-            "meta.content='width=device-width, initial-scale=1';"+
-            "document.head.appendChild(meta);"+
-            "}"+
-            "})()"
-        );
+        WebViewUtil.injectViewport(view);
       }
     });
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMHelpFileActivity.java
@@ -53,9 +53,6 @@ public class KMHelpFileActivity extends BaseActivity {
     super.onCreate(savedInstanceState);
     final Context context = this;
 
-    // Teardown keyboards to free up webView
-    KMManager.onDestroy();
-
     // Different processes in the same application cannot directly share WebView-related data
     // https://developer.android.com/reference/android/webkit/WebView.html#setDataDirectorySuffix(java.lang.String)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -170,6 +167,7 @@ public class KMHelpFileActivity extends BaseActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    WebViewUtil.cleanup(webView);
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtil.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2021 SIL International. All rights reserved.
+ */
+package com.tavultesoft.kmea.util;
+
+import android.webkit.WebView;
+
+public final class WebViewUtil {
+  // Inject a meta viewport tag into the head of the file if it doesn't exist
+  public static void injectViewport(WebView w) {
+    if (w != null) {
+      w.loadUrl(
+        "javascript:(function() {" +
+          "if(document.head && !document.querySelectorAll('meta[name=viewport]').length) {"+
+          "let meta=document.createElement('meta');"+
+          "meta.name='viewport';"+
+          "meta.content='width=device-width, initial-scale=1';"+
+          "document.head.appendChild(meta);"+
+          "}"+
+          "})()"
+      );
+    }
+  }
+}

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtil.java
@@ -3,13 +3,14 @@
  */
 package com.tavultesoft.kmea.util;
 
+import android.view.ViewGroup;
 import android.webkit.WebView;
 
 public final class WebViewUtil {
   // Inject a meta viewport tag into the head of the file if it doesn't exist
-  public static void injectViewport(WebView w) {
-    if (w != null) {
-      w.loadUrl(
+  public static void injectViewport(WebView webView) {
+    if (webView != null) {
+      webView.loadUrl(
         "javascript:(function() {" +
           "if(document.head && !document.querySelectorAll('meta[name=viewport]').length) {"+
           "let meta=document.createElement('meta');"+
@@ -20,5 +21,21 @@ public final class WebViewUtil {
           "})()"
       );
     }
+  }
+
+  // Blank the webView and destroy completely
+  // Reference: https://stackoverflow.com/questions/17418503/destroy-webview-in-android/17458577#17458577
+  public static void cleanup(WebView webView) {
+    if (webView != null) {
+      webView.loadUrl("about:blank");
+      ViewGroup viewGroup = (ViewGroup) webView.getParent();
+      if (viewGroup != null) {
+        viewGroup.removeView(webView);
+      }
+      webView.removeAllViews();
+      webView.destroy();
+      webView = null;
+    }
+
   }
 }


### PR DESCRIPTION
Fixes #4511 where the welcome.htm page in the webView is unresponsive and can't be closed (either back button or "OK" button)

## PackageActivity
* Remove extra keyboard package install notification (this was triggering the help file to be displayed twice)

## WebView activities
* Use separate process names
* Fix `appendChild()` exception in viewport injection
* Improve the cleanup onDestroy() so that
    * webView is blanked (avoids spurious keyboard downloads
    * webView is then cleaned up

## KMHelpFileActivity
* Allow back button to finish activity

Note:
There's still lag when displaying sil_cameroon_qwerty.htm with Chrome 88 (as listed on the issue).
Since Chrome is also unresponsive with the large page, I can't address that on this PR.

## User Testing
@makarasok

### Setup
1. For each of the Android SDK devices (emulator or physical device), load a clean install of the test build
    * Android P+ ( SDK 28.0+) - these can use the Android call `WebView.setDataDirectorySuffix()` to use separate directories for multiple webviews
    * Android 5.0 (SDK 21.0) - 8.1 (SDK 27.0) - these do not have the call available. @MakaraSok - any 1 device in this range is fine for testing
 

### Run
1. Start the Keyman app
2. Download and install a keyboard package (e.g. sil_madi from the issue)
3. Go through the installation steps
4. Verify the welcome.htm file from keyboard package installation is displayed
5. Verify the welcome.htm file can be dismissed by:
    * Clicking the "OK" button or
    * Hitting the back (triangle) button
6. Exit out of Keyman menus and verify in-app keyboard appears
7. Verify the keyboard help (welcome.htm file) can also be accessed from other paths and dismissed:
    * globe button --> **ⓘ** help icon of the installed keyboard --> Help link
    * Settings --> Installed languages --> navigate to installed keyboard --> Help link
  