### PR TITLE
fix(windows): prevent re-registration of TIPs on 14.0 upgrade

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.System.UImportOlderVersionKeyboards11To13.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.System.UImportOlderVersionKeyboards11To13.pas
@@ -4,10 +4,12 @@ interface
 
 type
   TImportOlderVersionKeyboards11To13 = class
+  private
+    class function ShouldRun: Boolean;
+    class procedure ReRegisterTips;
   public
     class procedure Execute;
     class procedure BackupCurrentUser;
-    class procedure ReRegisterTips;
     class procedure ImportCurrentUser;
   end;
 
@@ -37,6 +39,9 @@ uses
 
 class procedure TImportOlderVersionKeyboards11To13.Execute;  // I2361
 begin
+  if not ShouldRun then
+    Exit;
+
   // execute KMshell as login user to backup list of installed Keyman TIPs
   TUtilExecute.CreateProcessAsShellUser(ParamStr(0), '"'+ParamStr(0)+'" -upgradekeyboards=13,backup', True);
 
@@ -101,6 +106,9 @@ var
   uks: TUpgradeKeyboardList;
   uk: TUpgradeKeyboard;
 begin
+  if not ShouldRun then
+    Exit;
+
   uks := LoadUpgradeKeyboards;
   r := TRegistry.Create;
   try
@@ -177,6 +185,36 @@ begin
   (kmcom.Keyboards as IKeymanKeyboardsInstalled2).RefreshInstalledKeyboards;
 end;
 
+class function TImportOlderVersionKeyboards11To13.ShouldRun: Boolean;
+var
+  r: TRegistry;
+  keys: TStringList;
+  i: Integer;
+begin
+  r := TRegistry.Create(KEY_READ);
+  keys := TStringList.Create;
+  try
+    r.RootKey := HKEY_LOCAL_MACHINE;
+    if not r.OpenKeyReadOnly(SRegKey_InstalledKeyboards_LM) then
+      // No keyboards exist, no upgrade necessary
+      Exit(False);
+
+    r.GetKeyNames(keys);
+    if keys.Count = 0 then
+      // No keyboards exist, no upgrade necessary
+      Exit(False);
+
+    for i := 0 to keys.Count - 1 do
+      if r.KeyExists('\' + SRegKey_InstalledKeyboards_LM + '\' + keys[i] + '\' + SRegSubKey_TransientLanguageProfiles) then
+        // The keyboard has already been upgraded to 14.0, we mustn't upgrade again
+        Exit(False);
+
+    Result := True;
+  finally
+    r.Free;
+  end;
+end;
+
 class procedure TImportOlderVersionKeyboards11To13.ImportCurrentUser;
 var
   r: TRegistry;
@@ -191,6 +229,9 @@ var
   RegistrationRequired: WordBool;
   i: Integer;
 begin
+  if not ShouldRun then
+    Exit;
+
   r := TRegistry.Create;
   strings := TStringList.Create;
   try


### PR DESCRIPTION
Fixes #4445.

When upgrading from 11.0, 12.0 or 13.0, Keyman needs to re-register the TIPs so that we use the new registration model for 14.0. However, if we do this on a 14.0 version install, we end up registering TIPs for every single suggested language for a keyboard, which is definitely not what we want.

This fix simply looks to see if we have a 14.0-style installation already, as evidenced by the presence of a `Transient Language Profiles` key, and if found, does not continue the 11to13 upgrade process.