### PR TITLE
fix(windows): Handle Caps Lock event correctly from TIP

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -118,8 +118,6 @@ void ProcessToggleChange(UINT key) {   // I4793
   }
 }
 
-void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);
-
 extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM lParam,   // I3589   // I3588
 	PKEYMANPROCESSOUTPUTFUNC outfunc, PKEYMANGETCONTEXTFUNC ctfunc, BOOL Updateable, BOOL Preserved) {
 
@@ -174,7 +172,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
         // in the first pass (!Updateable).
         KeyCapsLockPress(isUp);   // I4548
       }
-      ProcessModifierChange((UINT) wParam, isUp, extended);
       return FALSE;
     case VK_SHIFT:
       if (!Updateable) {
@@ -190,7 +187,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
 
     case VK_NUMLOCK:
       if(!isUp) ProcessToggleChange((UINT) wParam);   // I4793
-      ProcessModifierChange((UINT) wParam, isUp, extended);
       return FALSE;
     }
     if(isUp) {

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -109,8 +109,6 @@ LRESULT CALLBACK kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 	return res;
 }
 
-void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
-
 LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 {
 	LPMSG mp;
@@ -448,7 +446,7 @@ void GetCapsAndNumlockState() {   // I4793
   via TSF, and we don't receive the notifications via the GetMessage hook when
   in UWP apps (#4369).
 
-  TODO: test whether we still need the GetMessage hook for reading modifier state.       
+  TODO: test whether we still need the GetMessage hook for reading modifier state.
 */
 void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended) {   // I4793
   UINT flag = 0;
@@ -457,8 +455,6 @@ void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended) {   // I4793
     case VK_SHIFT:   flag = K_SHIFTFLAG; break;
     case VK_MENU:    flag = isExtended ? RALTFLAG : LALTFLAG; break;
     case VK_CONTROL: flag = isExtended ? RCTRLFLAG : LCTRLFLAG; break;
-    case VK_CAPITAL: flag = CAPITALFLAG; break;
-    case VK_NUMLOCK: flag = NUMLOCKFLAG; break;
   }
 
   UINT oldShiftState = Globals::get_ShiftState();

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -428,6 +428,7 @@ void ReportActiveKeyboard(WORD wCommand);   // I3933   // I3949
 void SelectKeyboardHKL(DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4271
 BOOL SelectKeyboardTSF(DWORD KeymanID, BOOL foreground);   // I3933   // I3949   // I4271
 BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL hkl, GUID clsid, GUID guidProfile);
+void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
 
 #endif
 


### PR DESCRIPTION
Fixes #4525.

This is a regression from #4468, which inadvertently added modifier checks for `VK_CAPITAL` and `VK_NUMLOCK`, when it should not have done so, as the flag was then being reset when the key was released rather than toggled.

`ProcessModifierChange` pretended that it could handle `VK_CAPITAL` and `VK_NUMLOCK` but it would never have worked, and the other caller (the GetMessage hook) never passed those key events through, only Shift, Ctrl and Alt, so that's now what the TIP handler does as well.

This leaves the rest of the fix from #4468 in place as that appears correct.

I took the opportunity to move a repeated function declaration into keyman64.h.