### PR TITLE
fix(developer): UTF-8 messages in LM compiler

### DIFF
--- a/windows/src/global/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
+++ b/windows/src/global/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
@@ -28,6 +28,8 @@ begin
   cmdline := Format('"%skmlmc.cmd" "%s" -o "%s"', [ExtractFilePath(ParamStr(0)), infile, outfile]);
   Result := TUtilExecute.Console(cmdline, ExtractFileDir(infile), logtext, ec);
 
+  logtext := UTF8Decode(AnsiString(logtext));
+
   if not Result then
   begin
     ProjectFile.Project.Log(plsError, infile,


### PR DESCRIPTION
Fixes #4221.

When the Keyman Developer IDE calls out to the lexical model compiler, it receives UTF-8 compiler message strings back but they are treated as Windows-1252 strings. This fixes that.

![image](https://user-images.githubusercontent.com/4498365/109249154-41f65b80-783b-11eb-9c92-b02f4e821a68.png)
