### PR TITLE
fix(web): mnemonic keystrokes w FF keymapping

### DIFF
--- a/common/core/web/keyboard-processor/src/text/keyMapping.ts
+++ b/common/core/web/keyboard-processor/src/text/keyMapping.ts
@@ -14,8 +14,9 @@ namespace com.keyman {
     Opera:  KeyMap = new KeyMap();
 
     constructor() {
-      //ffie['k109'] = 189; // -    // These two number-pad VK rules are *not* correct for more recent FF! JMD 8/11/12
-      //ffie['k107'] = 187; // =    // FF 3.0 // I2062
+      // All three have been around since at least May 2014 / FF 29.
+      // It'd hard to find precise history, but at least that much has been confirmed.
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode, on Feb 26 2021.
       this.FF['k61'] = 187;  // =   // FF 2.0
       this.FF['k59'] = 186;  // ;
       this.FF['k173'] = 189; // -/_

--- a/common/core/web/keyboard-processor/src/text/keyMapping.ts
+++ b/common/core/web/keyboard-processor/src/text/keyMapping.ts
@@ -18,6 +18,7 @@ namespace com.keyman {
       //ffie['k107'] = 187; // =    // FF 3.0 // I2062
       this.FF['k61'] = 187;  // =   // FF 2.0
       this.FF['k59'] = 186;  // ;
+      this.FF['k173'] = 189; // -/_
     }
   }
 

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -160,11 +160,11 @@ namespace com.keyman.dom {
       // Physically-typed keys require use of a 'desktop' form factor and thus are based on a virtual "physical" Device.
       s.device = keyman.util.physicalDevice.coreSpec;
 
-      // Check for any browser-based keymapping before proceeding further.
-      // This is needed _now_ for mnenomic keyboards.  (See https://github.com/keymanapp/keyman/issues/1125.)
+      // Perform any browser-specific key remapping before other remaps and mnemonic transforms. 
+      // (See https://github.com/keymanapp/keyman/issues/1125.)
       if(!keyman.isEmbedded && s.device.browser == utils.Browser.Firefox) {
-        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
-        // FireFox, Mozilla Suite
+      // Browser key identifiers are not completely consistent; Firefox has a few (for US punctuation)
+      // that differ from the norm.  Refer to https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode.
         if(KeyMapping.browserMap.FF['k'+s.Lcode]) {
           s.Lcode = KeyMapping.browserMap.FF['k'+s.Lcode];
         }

--- a/web/source/dom/preProcessor.ts
+++ b/web/source/dom/preProcessor.ts
@@ -157,6 +157,19 @@ namespace com.keyman.dom {
        */
       s.Lmodifiers |= (e.metaKey ? modifierCodes['META']: 0);
 
+      // Physically-typed keys require use of a 'desktop' form factor and thus are based on a virtual "physical" Device.
+      s.device = keyman.util.physicalDevice.coreSpec;
+
+      // Check for any browser-based keymapping before proceeding further.
+      // This is needed _now_ for mnenomic keyboards.  (See https://github.com/keymanapp/keyman/issues/1125.)
+      if(!keyman.isEmbedded && s.device.browser == utils.Browser.Firefox) {
+        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
+        // FireFox, Mozilla Suite
+        if(KeyMapping.browserMap.FF['k'+s.Lcode]) {
+          s.Lcode = KeyMapping.browserMap.FF['k'+s.Lcode];
+        }
+      }
+
       // Mnemonic handling.
       if(activeKeyboard && activeKeyboard.isMnemonic) {
         // The following will never set a code corresponding to a modifier key, so it's fine to do this,
@@ -167,9 +180,6 @@ namespace com.keyman.dom {
       // The 0x6F used to be 0x60 - this adjustment now includes the chiral alt and ctrl modifiers in that check.
       var LisVirtualKeyCode = (typeof e.charCode != 'undefined' && e.charCode != null  &&  (e.charCode == 0 || (s.Lmodifiers & 0x6F) != 0));
       s.LisVirtualKey = LisVirtualKeyCode || e.type != 'keypress';
-
-      // Physically-typed keys require use of a 'desktop' form factor and thus are based on a virtual "physical" Device.
-      s.device = keyman.util.physicalDevice.coreSpec;
 
       // This is based on a KeyboardEvent, so it's not considered 'synthetic' within web-core.
       s.isSynthetic = false;
@@ -198,15 +208,6 @@ namespace com.keyman.dom {
             device: keyman.util.physicalDevice.coreSpec,
             isSynthetic: false
           };
-        }
-      }
-
-      // Check for any browser-based keymapping before returning the object.
-      if(!keyman.isEmbedded && s.device.browser == utils.Browser.Firefox) {
-        // I1466 - Convert the - keycode on mnemonic as well as positional layouts
-        // FireFox, Mozilla Suite
-        if(KeyMapping.browserMap.FF['k'+s.Lcode]) {
-          s.Lcode = KeyMapping.browserMap.FF['k'+s.Lcode];
         }
       }
       


### PR DESCRIPTION
Fixes #1125.

Looks like the browser-based keymapping was done too late during keystroke analysis.

Note that moving said keymapping to earlier within the same function may slightly affect a few `.vkCode` values in the legacy path.  That said... the only use I see for `.vkCode` in further processing is a `> 255` check, which would _not_ be affected.  It's also quite possible that if there are side-effects, they're good ones - given how niche the scenario is, I wouldn't be surprised if this actually fixed a similar bug on that legacy path that simply hasn't yet been discovered.