### PR TITLE
fix(ios): package installer completion requires welcome dismissal

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -397,11 +397,18 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     initializeSynchronizationGroups()
     constructAssociationPickers()
 
+    closureShared.installGroup.enter()
+
+    let wrappedCompletionHandler = {
+      uiCompletionHandler()
+      self.closureShared.installGroup.leave()
+    }
+
     let pickerPrompt = PackageInstallViewController<Resource>(for: self.package,
                                                               defaultLanguageCode: defaultLgCode,
                                                               languageAssociators: associationQueriers!,
                                                               pickingCompletionHandler: coreInstallationClosure(),
-                                                              uiCompletionHandler: uiCompletionHandler)
+                                                              uiCompletionHandler: wrappedCompletionHandler)
 
     navVC.pushViewController(pickerPrompt, animated: true)
   }


### PR DESCRIPTION
Fixes #4493.

When asked to use an interactive language picker, the package installation system will now require the user to finish all installer-UI interaction before the installation system will signal completion of package installation to other components of KeymanEngine.  (There was a critical piece of concurrency code missing.)

There's one piece of post-install code that has UI effects, which is what was triggering the early welcome-dismissal.