### PR TITLE
fix(developer): Improve stability of named code constants

### DIFF
--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -1051,12 +1051,10 @@ DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p)
     // we don't mix up named character codes which weren't supported in 5.x
     VERIFY_KEYBOARD_VERSION(fk, VERSION_60, CERR_60FeatureOnly_NamedCodes);
     // Add a single char store as a defined character constant
-    char *codename = wstrtostr(sp->szName);
     if (Uni_IsSurrogate1(*sp->dpString))
-      CodeConstants->AddCode(Uni_SurrogateToUTF32(sp->dpString[0], sp->dpString[1]), codename, fk->cxStoreArray);
+      CodeConstants->AddCode(Uni_SurrogateToUTF32(sp->dpString[0], sp->dpString[1]), sp->szName, fk->cxStoreArray);
     else
-      CodeConstants->AddCode(sp->dpString[0], codename, fk->cxStoreArray);
-    delete[] codename;
+      CodeConstants->AddCode(sp->dpString[0], sp->szName, fk->cxStoreArray);
     CodeConstants->reindex(); // has to be done after every character add due to possible use in another store.   // I4982
   }
 
@@ -1908,7 +1906,6 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
   DWORD i;
   BOOL finished = FALSE;
   WCHAR c;
-  PSTR codename;
 
   PWCHAR tstr = NULL;
   int tstrMax = 0;
@@ -2463,10 +2460,8 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
         q = p + 1;
         while (iswalnum(*q) || *q == '-' || *q == '_') q++;
         c = *q; *q = 0;
-        codename = wstrtostr(p + 1);
+        n = CodeConstants->GetCode(p + 1, &i);
         *q = c;
-        n = CodeConstants->GetCode(codename, &i);
-        delete[] codename;
         if (n == 0) return CERR_InvalidNamedCode;
         if (i < 0xFFFFFFFFL) CheckStoreUsage(fk, i, TRUE, FALSE, FALSE);   // I2993
         if (n > 0xFFFF)

--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -2458,7 +2458,7 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, PWSTR token, PWSTR output, int ma
       case 16:
         VERIFY_KEYBOARD_VERSION(fk, VERSION_60, CERR_60FeatureOnly_NamedCodes);
         q = p + 1;
-        while (iswalnum(*q) || *q == '-' || *q == '_') q++;
+        while (*q && !iswblank(*q)) q++;
         c = *q; *q = 0;
         n = CodeConstants->GetCode(p + 1, &i);
         *q = c;

--- a/windows/src/developer/kmcmpdll/NamedCodeConstants.cpp
+++ b/windows/src/developer/kmcmpdll/NamedCodeConstants.cpp
@@ -25,149 +25,154 @@
 #include <io.h>
 #include <limits.h>
 #include "NamedCodeConstants.h"
+#include "kmcmpdll.h"
 
 extern char CompileDir[];
 
-int IsHangulSyllable(const char *codename, int *code);
-int IsCJKUnifiedIdeograph(const char *codename, int *code);
+
+int IsHangulSyllable(const wchar_t *codename, int *code);
 
 BOOL FileExists(const char *filename)
 {
-	_finddata_t fi;
-	intptr_t n;
+  _finddata_t fi;
+  intptr_t n;
 
-	if((n = _findfirst(filename, &fi)) != -1)  // I3056   // I3512
-	{
-		_findclose(n);
-		return TRUE;
-	}
-	return FALSE;
+  if((n = _findfirst(filename, &fi)) != -1)  // I3056   // I3512
+  {
+    _findclose(n);
+    return TRUE;
+  }
+  return FALSE;
 }
 
 NamedCodeConstants::NamedCodeConstants()
 {
-	nEntries = 0;
-	entries = NULL;
-	nEntries_file = 0;
-	entries_file = NULL;
-	reindex();
+  nEntries = 0;
+  entries = NULL;
+  nEntries_file = 0;
+  entries_file = NULL;
+  reindex();
 }
 
 NamedCodeConstants::~NamedCodeConstants()
 {
-	if(entries) delete entries;
-	if(entries_file) delete entries_file;
+  if(entries) delete entries;
+  if(entries_file) delete entries_file;
 }
 
-void NamedCodeConstants::AddCode(int n, char *p, DWORD storeIndex)
+void NamedCodeConstants::AddCode(int n, const wchar_t *p, DWORD storeIndex)
 {
-	if((nEntries_file % ALLOC_SIZE) == 0)
-	{
-		NCCENTRY *bn = new NCCENTRY[nEntries_file + ALLOC_SIZE];
-		if(nEntries_file > 0)
-		{
-			memcpy(bn, entries_file, sizeof(NCCENTRY) * nEntries_file);
-			delete entries_file;
-		}
-		entries_file = bn;
-	}
+  if((nEntries_file % ALLOC_SIZE) == 0)
+  {
+    NCCENTRY *bn = new NCCENTRY[nEntries_file + ALLOC_SIZE];
+    if(nEntries_file > 0)
+    {
+      memcpy(bn, entries_file, sizeof(NCCENTRY) * nEntries_file);
+      delete entries_file;
+    }
+    entries_file = bn;
+  }
 
-	for(char *r = p; *r; r++)
-		if(!isalnum(*r) && *r != '-') *r = '_';
+  entries_file[nEntries_file].code = n;
+  wcsncpy_s(entries_file[nEntries_file].name, _countof(entries_file[nEntries_file].name), p, MAX_ENAME);  // I3481
+  entries_file[nEntries_file].name[MAX_ENAME] = 0;
 
-	entries_file[nEntries_file].code = n;
-	strncpy_s(entries_file[nEntries_file].name, _countof(entries_file[nEntries_file].name), p, MAX_ENAME);  // I3481
-	entries_file[nEntries_file].name[MAX_ENAME] = 0;
+  for (wchar_t *r = entries_file[nEntries_file].name; *r; r++)
+    if (!iswalnum(*r) && *r != '-') *r = '_';
+
   entries_file[nEntries_file].storeIndex = storeIndex;
-	nEntries_file++;
+  nEntries_file++;
 }
 
-void NamedCodeConstants::AddCode_IncludedCodes(int n, char *p)
+void NamedCodeConstants::AddCode_IncludedCodes(int n, const wchar_t *p)
 {
-	if((nEntries % ALLOC_SIZE) == 0)
-	{
-		NCCENTRY *bn = new NCCENTRY[nEntries + ALLOC_SIZE];
-		if(nEntries > 0)
-		{
-			memcpy(bn, entries, sizeof(NCCENTRY) * nEntries);
-			delete entries;
-		}
-		entries = bn;
-	}
+  if((nEntries % ALLOC_SIZE) == 0)
+  {
+    NCCENTRY *bn = new NCCENTRY[nEntries + ALLOC_SIZE];
+    if(nEntries > 0)
+    {
+      memcpy(bn, entries, sizeof(NCCENTRY) * nEntries);
+      delete entries;
+    }
+    entries = bn;
+  }
 
-	for(char *r = p; *r; r++)
-		if(!isalnum(*r) && *r != '-') *r = '_';
+  entries[nEntries].code = n;
+  wcsncpy_s(entries[nEntries].name, _countof(entries[nEntries].name), p, MAX_ENAME);  // I3481
+  entries[nEntries].name[MAX_ENAME] = 0;
+  for (wchar_t *r = entries[nEntries].name; *r; r++)
+    if (!iswalnum(*r) && *r != '-') *r = '_';
 
-	entries[nEntries].code = n;
-	strncpy_s(entries[nEntries].name, _countof(entries[nEntries].name), p, MAX_ENAME);  // I3481
-	entries[nEntries].name[MAX_ENAME] = 0;
   entries[nEntries].storeIndex = 0xFFFFFFFFL;
-	nEntries++;
+  nEntries++;
 }
 
 int __cdecl sort_entries(const void *elem1, const void *elem2)
 {
-	return _stricmp(
-		((NCCENTRY *)elem1)->name,
-		((NCCENTRY *)elem2)->name);
+  return _wcsicmp(
+    ((NCCENTRY *)elem1)->name,
+    ((NCCENTRY *)elem2)->name);
 }
 
 BOOL NamedCodeConstants::IntLoadFile(const char *filename)
 {
-	FILE *fp = NULL;
+  FILE *fp = NULL;
   if(fopen_s(&fp, filename, "rt") != 0) return FALSE;  // I3481
 
-	char str[256], *p, *q, *context = NULL;
-	BOOL neol, first = TRUE;
+  char str[256], *p, *q, *context = NULL;
+  BOOL neol, first = TRUE;
 
-	while(fgets(str, 256, fp))
-	{
-		neol = *(strchr(str, 0) - 1) == '\n';
-		p = strtok_s(str, ";", &context);  // I3481
-		q = strtok_s(NULL, ";\n", &context);
-		if(p && q)
-		{
+  while(fgets(str, 256, fp))
+  {
+    neol = *(strchr(str, 0) - 1) == '\n';
+    p = strtok_s(str, ";", &context);  // I3481
+    q = strtok_s(NULL, ";\n", &context);
+    if(p && q)
+    {
       if(first && *p == (char)0xEF && *(p+1) == (char)0xBB && *(p+2) == (char)0xBF) p += 3;  // I3056 UTF-8   // I3512
       first = FALSE;
-			_strupr_s(q, strlen(q)+1);  // I3481   // I3641
-			int n = strtol(p, NULL, 16);
-			if(*q != '<')
-				AddCode_IncludedCodes(n, q);
-		}
-		if(!neol)
-		{
-			while(fgets(str, 256, fp)) if(*(strchr(str, 0)-1) == '\n') break;
-		}
-	}
+      _strupr_s(q, strlen(q)+1);  // I3481   // I3641
+      int n = strtol(p, NULL, 16);
+      if (*q != '<') {
+        PWSTR q0 = strtowstr(q);
+        AddCode_IncludedCodes(n, q0);
+        delete[] q0;
+      }
+    }
+    if(!neol)
+    {
+      while(fgets(str, 256, fp)) if(*(strchr(str, 0)-1) == '\n') break;
+    }
+  }
 
-	fclose(fp);
+  fclose(fp);
  
-	return TRUE;
+  return TRUE;
 }
 
 BOOL NamedCodeConstants::LoadFile(const char *filename)
 {
-	char buf[260];
-	// Look in current directory first
-	strncpy_s(buf, _countof(buf), filename, 259); buf[259] = 0;  // I3481
-	if(FileExists(buf))
-		return IntLoadFile(buf);
-	// Then look in keyboard file directory (CompileDir)
-	strncpy_s(buf, _countof(buf), CompileDir, 259); buf[259] = 0;  // I3481
-	strncat_s(buf, _countof(buf), filename, 259-strlen(CompileDir)); buf[259] = 0;
-	if(FileExists(buf))
-		return IntLoadFile(buf);
-	// Finally look in kmcmpdll.dll directory
-	GetModuleFileName(0, buf, 260);
-	char *p = strrchr(buf, '\\'); if(p) p++; else p = buf;
+  char buf[260];
+  // Look in current directory first
+  strncpy_s(buf, _countof(buf), filename, 259); buf[259] = 0;  // I3481
+  if(FileExists(buf))
+    return IntLoadFile(buf);
+  // Then look in keyboard file directory (CompileDir)
+  strncpy_s(buf, _countof(buf), CompileDir, 259); buf[259] = 0;  // I3481
+  strncat_s(buf, _countof(buf), filename, 259-strlen(CompileDir)); buf[259] = 0;
+  if(FileExists(buf))
+    return IntLoadFile(buf);
+  // Finally look in kmcmpdll.dll directory
+  GetModuleFileName(0, buf, 260);
+  char *p = strrchr(buf, '\\'); if(p) p++; else p = buf;
   *p = 0;
-	strncat_s(buf, _countof(buf), filename, 259-strlen(buf)); buf[259] = 0;  // I3481   // I3641
-	if(FileExists(buf))
-		return IntLoadFile(buf);
+  strncat_s(buf, _countof(buf), filename, 259-strlen(buf)); buf[259] = 0;  // I3481   // I3641
+  if(FileExists(buf))
+    return IntLoadFile(buf);
 
-	reindex();
+  reindex();
 
-	return FALSE;
+  return FALSE;
 }
 
 void NamedCodeConstants::reindex()
@@ -176,50 +181,50 @@ void NamedCodeConstants::reindex()
     qsort(entries, nEntries, sizeof(NCCENTRY), sort_entries);
   }
 
-	char c = '.', d;
-	int i;
+  wchar_t c = L'.', d;
+  int i;
 
-	for(i = 0; i < 128; i++) chrindexes[i] = -1;
+  for(i = 0; i < 128; i++) chrindexes[i] = -1;
 
   if (entries != NULL) {
     for (i = 0; i < nEntries; i++)
     {
-      d = toupper(entries[i].name[0]);
+      d = towupper(entries[i].name[0]);
       if (d != c && d >= 32 && d <= 127)
         chrindexes[c = d] = i;
     }
   }
 }
 
-int NamedCodeConstants::GetCode(const char *codename, DWORD *storeIndex)
+int NamedCodeConstants::GetCode(const wchar_t *codename, DWORD *storeIndex)
 {
   *storeIndex = 0xFFFFFFFFL;    // I2993
-	int code = GetCode_IncludedCodes(codename);
-	if(code) return code;
-	for(int i = 0; i < nEntries_file; i++)
-		if(!_stricmp(entries_file[i].name, codename))
+  int code = GetCode_IncludedCodes(codename);
+  if(code) return code;
+  for(int i = 0; i < nEntries_file; i++)
+    if(!_wcsicmp(entries_file[i].name, codename))
     {
       *storeIndex = entries_file[i].storeIndex;
       return entries_file[i].code;
     }
-	return 0;
+  return 0;
 }
 
-int NamedCodeConstants::GetCode_IncludedCodes(const char *codename)
+int NamedCodeConstants::GetCode_IncludedCodes(const wchar_t *codename)
 {
-	char c = toupper(*codename);
-	int code;
+  wchar_t c = towupper(*codename);
+  int code;
 
-	if(IsHangulSyllable(codename, &code)) return code;
+  if(IsHangulSyllable(codename, &code)) return code;
 
-	if(c < 32 || c > 127 || chrindexes[c] < 0) return 0;
-	for(int n = chrindexes[c]; n < nEntries && toupper(entries[n].name[0]) == c; n++)
-	{
-		int cmp = _stricmp(codename, entries[n].name);
-		if(cmp == 0) return entries[n].code;
-		if(cmp < 0) break;
-	}
-	return 0;
+  if(c < 32 || c > 127 || chrindexes[c] < 0) return 0;
+  for(int n = chrindexes[c]; n < nEntries && towupper(entries[n].name[0]) == c; n++)
+  {
+    int cmp = _wcsicmp(codename, entries[n].name);
+    if(cmp == 0) return entries[n].code;
+    if(cmp < 0) break;
+  }
+  return 0;
 }
 
 /*
@@ -239,92 +244,80 @@ const int
  HangulNCount = HangulVCount * HangulTCount,   // 588
  HangulSCount = HangulLCount * HangulNCount;   // 11172
 
-const char *
-	Hangul_JAMO_L_TABLE[] = {
-        "G", "GG", "N", "D", "DD", "R", "M", "B", "BB",
-		"S", "SS", "", "J", "JJ", "C", "K", "T", "P", "H" };
+const wchar_t *
+  Hangul_JAMO_L_TABLE[] = {
+        L"G", L"GG", L"N", L"D", L"DD", L"R", L"M", L"B", L"BB",
+    L"S", L"SS", L"", L"J", L"JJ", L"C", L"K", L"T", L"P", L"H" };
 
-const char *
-	Hangul_JAMO_V_TABLE[] = {
-        "A", "AE", "YA", "YAE", "EO", "E", "YEO", "YE", "O",
-        "WA", "WAE", "OE", "YO", "U", "WEO", "WE", "WI",
-        "YU", "EU", "YI", "I" };
+const wchar_t *
+  Hangul_JAMO_V_TABLE[] = {
+        L"A", L"AE", L"YA", L"YAE", L"EO", L"E", L"YEO", L"YE", L"O",
+        L"WA", L"WAE", L"OE", L"YO", L"U", L"WEO", L"WE", L"WI",
+        L"YU", L"EU", L"YI", L"I" };
 
-const char *
-	Hangul_JAMO_T_TABLE[] = {
-        "", "G", "GG", "GS", "N", "NJ", "NH", "D", "L", "LG", "LM",
-        "LB", "LS", "LT", "LP", "LH", "M", "B", "BS",
-        "S", "SS", "NG", "J", "C", "K", "T", "P", "H" };
+const wchar_t *
+  Hangul_JAMO_T_TABLE[] = {
+        L"", L"G", L"GG", L"GS", L"N", L"NJ", L"NH", L"D", L"L", L"LG", L"LM",
+        L"LB", L"LS", L"LT", L"LP", L"LH", L"M", L"B", L"BS",
+        L"S", L"SS", L"NG", L"J", L"C", L"K", L"T", L"P", L"H" };
 
-int IsHangulSyllable(const char *codename, int *code)
+int IsHangulSyllable(const wchar_t *codename, int *code)
 {
-	if(_strnicmp(codename, "HANGUL_SYLLABLE_", 16)) return 0;
-	codename += 16;
-	if(!*codename) return 0;
+  if(_wcsnicmp(codename, L"HANGUL_SYLLABLE_", 16)) return 0;
+  codename += 16;
+  if(!*codename) return 0;
 
-	int i, LIndex, VIndex, TIndex;
+  int i, LIndex, VIndex, TIndex;
 
     /* Find initial */ 
 
-	int ch = toupper(*codename); 
-	if(strchr("GNDRMBSJCKTPH", ch))
-	{
-		/* Has an initial syllable */ 
-		int fdouble = toupper(*(codename+1)) == ch;
+  int ch = towupper(*codename); 
+  if(strchr("GNDRMBSJCKTPH", ch))
+  {
+    /* Has an initial syllable */ 
+    int fdouble = towupper(*(codename+1)) == ch;
 
-		LIndex = -1;
-		for(i = 0; i < HangulLCount; i++)
-			if(Hangul_JAMO_L_TABLE[i][0] == ch && 
-				(!fdouble || (Hangul_JAMO_L_TABLE[i][1] == ch && fdouble)))
-			{
-				LIndex = i;
-				break;
-			}
-		if(LIndex == -1) return 0;
-		codename++;
-		if(fdouble) codename++;
-	}
-	else LIndex = 11; /* no initial */ 
+    LIndex = -1;
+    for(i = 0; i < HangulLCount; i++)
+      if(Hangul_JAMO_L_TABLE[i][0] == ch && 
+        (!fdouble || (Hangul_JAMO_L_TABLE[i][1] == ch && fdouble)))
+      {
+        LIndex = i;
+        break;
+      }
+    if(LIndex == -1) return 0;
+    codename++;
+    if(fdouble) codename++;
+  }
+  else LIndex = 11; /* no initial */ 
 
     /* Find vowel */ 
 
-	char V[4] = "";
-	V[0] = *codename;
-	if(V[0] && strchr("AEIOUWY", toupper(*(codename+1)))) V[1] = *(codename+1);
-	if(V[1] && strchr("AEIOUWY", toupper(*(codename+2)))) V[2] = *(codename+2);
+  wchar_t V[4] = L"";
+  V[0] = *codename;
+  if(V[0] && strchr("AEIOUWY", towupper(*(codename+1)))) V[1] = *(codename+1);
+  if(V[1] && strchr("AEIOUWY", towupper(*(codename+2)))) V[2] = *(codename+2);
 
-    VIndex = -1;
-    for(i = 0; i < HangulVCount; i++)
-		if(!_stricmp(Hangul_JAMO_V_TABLE[i], V)) { VIndex = i; break; }
+  VIndex = -1;
+  for(i = 0; i < HangulVCount; i++)
+  if(!_wcsicmp(Hangul_JAMO_V_TABLE[i], V)) { VIndex = i; break; }
 
-    if(VIndex == -1) return 0;
+  if(VIndex == -1) return 0;
 
-	codename += strlen(V);
+  codename += wcslen(V);
 
-    /* Find final */ 
+  /* Find final */ 
 
-    TIndex = -1;
+  TIndex = -1;
     
-    for(i = 0; i < HangulTCount; i++)
-		if(!_stricmp(Hangul_JAMO_T_TABLE[i], codename)) { TIndex = i; break; }
+  for(i = 0; i < HangulTCount; i++)
+  if(!_wcsicmp(Hangul_JAMO_T_TABLE[i], codename)) { TIndex = i; break; }
 
-    if(TIndex == -1) return 0;
+  if(TIndex == -1) return 0;
 
-    /* Composition */ 
+  /* Composition */ 
 
-    *code = (HangulSBase + (LIndex * HangulVCount + VIndex) * HangulTCount) + TIndex;
+  *code = (HangulSBase + (LIndex * HangulVCount + VIndex) * HangulTCount) + TIndex;
 
-    return 1;
-}
-
-int IsCJKUnifiedIdeograph(const char *codename, int *code)
-{
-	if(_strnicmp(codename, "CJK_UNIFIED_IDEOGRAPH", 21)) return 0;
-	codename += 21;
-
-	if(strlen(codename) != 4) return 0;
-
-	*code = strtol(codename, NULL, 16);
-	if(*code == 0 || *code == LONG_MAX || *code == LONG_MIN) return 0;
-	return 1;
+  return 1;
 }

--- a/windows/src/developer/kmcmpdll/NamedCodeConstants.cpp
+++ b/windows/src/developer/kmcmpdll/NamedCodeConstants.cpp
@@ -78,7 +78,7 @@ void NamedCodeConstants::AddCode(int n, const wchar_t *p, DWORD storeIndex)
   entries_file[nEntries_file].name[MAX_ENAME] = 0;
 
   for (wchar_t *r = entries_file[nEntries_file].name; *r; r++)
-    if (!iswalnum(*r) && *r != '-') *r = '_';
+    if (iswblank(*r) && *r != '-') *r = '_';
 
   entries_file[nEntries_file].storeIndex = storeIndex;
   nEntries_file++;
@@ -101,7 +101,7 @@ void NamedCodeConstants::AddCode_IncludedCodes(int n, const wchar_t *p)
   wcsncpy_s(entries[nEntries].name, _countof(entries[nEntries].name), p, MAX_ENAME);  // I3481
   entries[nEntries].name[MAX_ENAME] = 0;
   for (wchar_t *r = entries[nEntries].name; *r; r++)
-    if (!iswalnum(*r) && *r != '-') *r = '_';
+    if (iswblank(*r)) *r = '_';
 
   entries[nEntries].storeIndex = 0xFFFFFFFFL;
   nEntries++;

--- a/windows/src/developer/kmcmpdll/NamedCodeConstants.h
+++ b/windows/src/developer/kmcmpdll/NamedCodeConstants.h
@@ -7,7 +7,7 @@
 
 struct NCCENTRY
 {
-	char name[MAX_ENAME+1];
+	wchar_t name[MAX_ENAME+1];
 	int code;
   DWORD storeIndex;
 };
@@ -20,17 +20,17 @@ private:
 	int nEntries, nEntries_file;
 	int chrindexes[128];		// A-Z, 0-9, -, _; simple index
 
-	int GetCode_IncludedCodes(const char *codename);
-	void AddCode_IncludedCodes(int n, char *p);
+	int GetCode_IncludedCodes(const wchar_t *codename);
+	void AddCode_IncludedCodes(int n, const wchar_t *p);
 	BOOL IntLoadFile(const char *filename);
 public:
 	NamedCodeConstants();
 	~NamedCodeConstants();
 
 	void reindex();
-	void AddCode(int n, char *p, DWORD storeIndex);
+	void AddCode(int n, const wchar_t *p, DWORD storeIndex);
 	BOOL LoadFile(const char *filename);
-	int GetCode(const char *codename, DWORD *storeIndex);
+	int GetCode(const wchar_t *codename, DWORD *storeIndex);
 };
 
 #endif //_NAMEDCODECONSTANTS_H

--- a/windows/src/developer/kmcmpdll/kmcmpdll.h
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.h
@@ -10,3 +10,5 @@ BOOL AddCompileMessage(DWORD msg);
 
 extern BOOL FWarnDeprecatedCode;
 extern int currentLine;
+
+PWSTR strtowstr(PSTR in);

--- a/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
@@ -66,11 +66,10 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Platform)\$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">obj\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">obj\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
@@ -89,11 +88,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\ext\json;..\..\ext\json-schema-validator</IncludePath>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\ext\json;..\..\ext\json-schema-validator</IncludePath>
     <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>$(ProjectName).x64</TargetName>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\ext\json;..\..\ext\json-schema-validator</IncludePath>
@@ -102,6 +103,7 @@
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\ext\json;..\..\ext\json-schema-validator</IncludePath>
     <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>$(ProjectName).x64</TargetName>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>

--- a/windows/src/test/unit-tests/kmcomp/test.bat
+++ b/windows/src/test/unit-tests/kmcomp/test.bat
@@ -37,6 +37,8 @@ call :should-fail "#4280: if should be at start of context 2" test_4280_if_start
 call :should-fail "#4280: nul should be at start of context 1" test_4280_nul_start_1.kmn || goto :eof
 call :should-fail "#4280: nul should be at start of context 2" test_4280_nul_start_2.kmn || goto :eof
 
+call :should-pass "#4423: named code constants, various tests" test_namedcodeconstants.kmn || goto :eof
+
 goto :eof
 
 :should-pass

--- a/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.kmn
@@ -1,0 +1,23 @@
+c This tests #4423 -- single character stores that trigger the named character constants
+c code and resulted in a codepage conversion error.
+
+store(&VERSION) '10.0'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&includecodes) 'test_namedcodeconstants.txt'
+
+store(főő) '0'
+store(bar) '1'
+store(smp) U+12345
+
+$főő + 'a' > 'b'
+$bar + 'a' > 'c'
+
+$hangul_syllable_go + 'a' > 'd'
+
+$mycode + 'a' > 'e'
+
+$smp + 'a' > 'f'

--- a/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.kmn
@@ -12,6 +12,7 @@ store(&includecodes) 'test_namedcodeconstants.txt'
 store(főő) '0'
 store(bar) '1'
 store(smp) U+12345
+store(😉) '🤪'
 
 $főő + 'a' > 'b'
 $bar + 'a' > 'c'
@@ -21,3 +22,4 @@ $hangul_syllable_go + 'a' > 'd'
 $mycode + 'a' > 'e'
 
 $smp + 'a' > 'f'
+$😉 + 'a' > '😡'

--- a/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.txt
+++ b/windows/src/test/unit-tests/kmcomp/test_namedcodeconstants.txt
@@ -1,0 +1,1 @@
+0041;MYCODE;test code for 'A'

--- a/windows/src/test/unit-tests/kmcomp/tests.kpj
+++ b/windows/src/test/unit-tests/kmcomp/tests.kpj
@@ -87,30 +87,6 @@
       <Details/>
     </File>
     <File>
-      <ID>id_5f9e583f7392151b3c3a7d4577b31a4f</ID>
-      <Filename>test_valid.kmx</Filename>
-      <Filepath>test_valid.kmx</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.kmx</FileType>
-      <ParentFileID>id_03dbd77eff6b6b923de6983fab2bd9d0</ParentFileID>
-    </File>
-    <File>
-      <ID>id_416e28ba6ecd3550e599b16a2c37e864</ID>
-      <Filename>test_invalid_kmx.kmx</Filename>
-      <Filepath>test_invalid_kmx.kmx</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.kmx</FileType>
-      <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
-    </File>
-    <File>
-      <ID>id_ee200303f52275647138898037a80e0e</ID>
-      <Filename>test.doc</Filename>
-      <Filepath>test.doc</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.doc</FileType>
-      <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
-    </File>
-    <File>
       <ID>id_4c59db88c3869d699c9df7f46731a97a</ID>
       <Filename>test_4280_if_start_1.kmn</Filename>
       <Filepath>test_4280_if_start_1.kmn</Filepath>
@@ -138,6 +114,38 @@
       <ID>id_c0515825c0484a590391c8d99430303f</ID>
       <Filename>test_4280_nul_start_2.kmn</Filename>
       <Filepath>test_4280_nul_start_2.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details/>
+    </File>
+    <File>
+      <ID>id_5f9e583f7392151b3c3a7d4577b31a4f</ID>
+      <Filename>test_valid.kmx</Filename>
+      <Filepath>test_valid.kmx</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.kmx</FileType>
+      <ParentFileID>id_03dbd77eff6b6b923de6983fab2bd9d0</ParentFileID>
+    </File>
+    <File>
+      <ID>id_416e28ba6ecd3550e599b16a2c37e864</ID>
+      <Filename>test_invalid_kmx.kmx</Filename>
+      <Filepath>test_invalid_kmx.kmx</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.kmx</FileType>
+      <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
+    </File>
+    <File>
+      <ID>id_ee200303f52275647138898037a80e0e</ID>
+      <Filename>test.doc</Filename>
+      <Filepath>test.doc</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.doc</FileType>
+      <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
+    </File>
+    <File>
+      <ID>id_068020cc7b6376ed155d5b9fc0215cc6</ID>
+      <Filename>test_namedcodeconstants.kmn</Filename>
+      <Filepath>test_namedcodeconstants.kmn</Filepath>
       <FileVersion>1.0</FileVersion>
       <FileType>.kmn</FileType>
       <Details/>


### PR DESCRIPTION
Fixes #4423.

Using a named character constant with a store name that included characters outside ascii could cause kmcmpdll to crash with an assertion failure.

This fix allows store names defined in the .kmn file to use characters outside ascii.

Note that more work needs to be done on which characters are acceptable to use, as this is somewhat implementation-specific according to the C++ specification for `iswalpha`.

Added a test case to verify various named code constant examples.

Also removes dead code for `IsCJKUnifiedIdeograph` as this was never used and somewhat pointless in any case.

NamedCodeConstants.cpp could stand to be rewritten using `std::map` or equivalent. Current implementation is pretty icky.