### PR TITLE
fix(developer): schema conformance for model package compiler

### DIFF
--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -27,11 +27,12 @@ display_usage ( ) {
   echo "Usage: $0 [-test] [-publish-to-npm]"
   echo "       $0 -help"
   echo
-  echo "  -help               displays this screen and exits"
-  echo "  -test               runs unit tests after building"
-  echo "  -tdd                runs unit tests WITHOUT building"
-  echo "  -publish-to-npm     publishes the current version to the npm package index"
-  echo "  -dry-run            do build, etc, but don't actually publish"
+  echo "  -help                       displays this screen and exits"
+  echo "  -test                       runs unit tests after building"
+  echo "  -tdd                        runs unit tests WITHOUT building"
+  echo "  -skip-package-install, -S   skip package installation"
+  echo "  -publish-to-npm             publishes the current version to the npm package index"
+  echo "  -dry-run                    do build, etc, but don't actually publish"
 }
 
 ################################ Main script ################################

--- a/developer/js/source/package-compiler/kmp-json-file.ts
+++ b/developer/js/source/package-compiler/kmp-json-file.ts
@@ -15,7 +15,6 @@ interface KmpJsonFileSystem {
 }
 
 interface KmpJsonFileOptions {
-  followKeyboardVersion: boolean;
   readmeFile?: string;
   graphicFile?: string;
   executeProgram?: string;

--- a/developer/js/tests/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.json
+++ b/developer/js/tests/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.json
@@ -3,9 +3,7 @@
     "keymanDeveloperVersion": "12.0.1500.0",
     "fileVersion": "12.0"
   },
-  "options": {
-    "followKeyboardVersion": true
-  },
+  "options": {},
   "info": {
     "author": {
       "description": "Eddie Antonio Santos",
@@ -25,8 +23,7 @@
     {
       "name": "..\\build\\example.qaa.sencoten.model.js",
       "description": "Lexical model example.qaa.sencoten.model.js",
-      "copyLocation": "0",
-      "fileType": ".model.js"
+      "copyLocation": 0
     }
   ],
   "lexicalModels": [


### PR DESCRIPTION
Fixes #3199.

Ensures that the model package compiler passes schema validation for kmp.json. Three problems were corrected:

1. `followKeyboardVersion` is a source-only property; it should not be in deployable kmp.json.
2. `copyLocation` should have been a number not a string (in XML everything is a string... but JSON has more control here)
3. `fileType` is a source-only property; it also should not be in deployable kmp.json.

I have checked that the resulting files validate against the package kmp.json schema version 1.1.0 defined at https://github.com/keymanapp/api.keyman.com/blob/master/schemas/package/1.1.0/package.json.

None of these fixes should impact the use of these packages in target apps. `followKeyboardVersion` and `fileType` are used only in the source at package development time, and `copyLocation` is unused (and should be eliminated from Keyman altogether in the future).