### PR TITLE
chore(ios/app): Adjust help titles for installing custom dictionaries

### DIFF
--- a/ios/help/basic/index.md
+++ b/ios/help/basic/index.md
@@ -4,7 +4,7 @@ title: Basic Help
 
 * [Switching Between Keyboards](switching-between-keyboards)
 
-* [Installing Custom Keyboards](installing-custom-keyboards)
+* [Installing Custom Keyboards/Dictionaries](installing-custom-keyboards-dictionaries)
 * [Sharing Keyboards](sharing-keyboards)
 
 * [Using the Keyman Browser](using-keyman-browser)

--- a/ios/help/basic/installing-custom-keyboards-dictionaries.md
+++ b/ios/help/basic/installing-custom-keyboards-dictionaries.md
@@ -1,10 +1,10 @@
 ---
-title: Installing Custom Keyboards - Keyman for iPhone and iPad Help
+title: Installing Custom Keyboards/Dictionaries - Keyman for iPhone and iPad Help
 ---
 
-The following steps can also be used to install a dictionary package.
+The following steps can be used to install either a keyboard package or a dictionary package.
 
-###Download the File
+### Download the File
 If downloading a custom keyboard from the internet, click the link to your custom keyboard package file.
 
 For this example, we'll install a custom keyboard from a link in Safari.  Our example keyboard is for the GFF Amharic 7 keyboard.

--- a/ios/help/basic/sharing-keyboards.md
+++ b/ios/help/basic/sharing-keyboards.md
@@ -45,4 +45,4 @@ Selecting the notification seen at the top will lead you to the following page:
 
 Select the big **Install on iPhone** (or
 **Install on iPad**) option will then download
-the file for easy installation.  (Refer to [Installing custom keyboards](installing-custom-keyboards) as necessary.)
+the file for easy installation.  (Refer to [Installing custom keyboards/dictionaries](installing-custom-keyboards-dictionaries) as necessary.)

--- a/ios/help/index.md
+++ b/ios/help/index.md
@@ -24,7 +24,7 @@ title: Keyman for iPhone and iPad 14.0 Help
 
 ### [Using Keyman for iPhone and iPad](basic/)
 * [Switching Between Keyboards](basic/switching-between-keyboards)
-* [Installing Custom Keyboards](basic/installing-custom-keyboards)
+* [Installing Custom Keyboards/Dictionaries](basic/installing-custom-keyboards-dictionaries)
 * [Sharing Keyboards](basic/sharing-keyboards)
 * [Using the Keyman Browser](basic/using-keyman-browser)
 * [Removing Keyboards](basic/uninstalling-keyboards)


### PR DESCRIPTION
Fixes keymanapp/help.keyman.com#158

* Clarifies the iOS help page title so users will know it's for installing custom keyboards/dictionaries