### PR TITLE
fix(developer): touch layout osk import handling of multiple modifiers

### DIFF
--- a/windows/src/developer/TIKE/oskbuilder/TouchLayoutDefinitions.pas
+++ b/windows/src/developer/TIKE/oskbuilder/TouchLayoutDefinitions.pas
@@ -123,12 +123,12 @@ const
     'rightalt',
     'rightctrl-rightalt',
     //'shift',
-    'shift-lctrl',
-    'shift-rctrl',
-    'shift-lalt',
-    'shift-ralt',
-    'shift-lctrl-lalt',
-    'shift-rctrl-ralt'
+    'leftctrl-shift',
+    'rightctrl-shift',
+    'leftalt-shift',
+    'rightalt-shift',
+    'leftctrl-leftalt-shift',
+    'rightctrl-rightalt-shift'
   );
 
 implementation


### PR DESCRIPTION
Fixes #2740.

The definitions for several of the combined modifiers was incorrect, which led to a mismatch when attempting to import those layers from a visual keyboard into the touch layout editor.