### PR TITLE
fix(windows): disable autostart task

### DIFF
--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -246,7 +246,8 @@ end;
 
 class procedure TKeymanStartTask.RecreateTask;
 begin
-  if not Reg_GetDebugFlag(SRegValue_Flag_UseAutoStartTask, True) then
+  // This has proven to be too troublesome, so we will disable for 14.0.
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseAutoStartTask, False) then
   begin
     DeleteTask;
     Exit;

--- a/windows/src/engine/kmtip/kmkey.cpp
+++ b/windows/src/engine/kmtip/kmkey.cpp
@@ -290,6 +290,9 @@ void CKMTipTextService::_UninitKeyman() {
 }
 
 void CKMTipTextService::_TryAndStartKeyman() {
+#if 0
+  // This has proven to be too troublesome so we will disable for 14.0.
+
   HANDLE hEventSource = RegisterEventSource(NULL, "Keyman");
   if (!hEventSource) {
     // This is unlikely to occur, but if it does, there's probably
@@ -298,4 +301,5 @@ void CKMTipTextService::_TryAndStartKeyman() {
   }
   ReportEvent(hEventSource, EVENTLOG_INFORMATION_TYPE, SIMPLE_CATEGORY, MSG_START_KEYMAN_ON_DEMAND, NULL, 0, 0, NULL, NULL);
   DeregisterEventSource(hEventSource);
+#endif
 }


### PR DESCRIPTION
This is not yet stable enough for deployment. We'll leave it out
of version 14.0.

I still need to do a bit more work on this before it is ready for merge.