### PR TITLE
feat(developer): isRTL support for lexical model editor

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
@@ -83,7 +83,7 @@ inherited frmModelEditor: TfrmModelEditor
             Top = 200
             Width = 415
             Height = 13
-            Caption = 
+            Caption =
               'The editor was unable to parse the source file. Details shown he' +
               're are read-only.'
           end
@@ -219,7 +219,7 @@ inherited frmModelEditor: TfrmModelEditor
             Width = 26
             Height = 13
             Caption = 'close'
-            FocusControl = cbOpenQuote
+            FocusControl = cbCloseQuote
           end
           object cbFormat: TComboBox
             Left = 106
@@ -265,11 +265,6 @@ inherited frmModelEditor: TfrmModelEditor
             OnChange = cbInsertAfterWordClick
             OnClick = cbInsertAfterWordClick
             OnKeyUp = cbInsertAfterWordKeyUp
-            Items.Strings = (
-              '(space U+0020)'
-              '(no word break)'
-              '(Tibetan tsheg U+0F0B)'
-              '(Ethiopian wordspace U+1361)')
           end
           object cbOpenQuote: TComboBox
             Left = 139
@@ -280,10 +275,6 @@ inherited frmModelEditor: TfrmModelEditor
             OnChange = cbOpenQuoteClick
             OnClick = cbOpenQuoteClick
             OnKeyUp = cbOpenQuoteKeyUp
-            Items.Strings = (
-              'default'
-              'ascii'
-              'custom')
           end
           object chkIsRTL: TCheckBox
             Left = 106
@@ -303,10 +294,6 @@ inherited frmModelEditor: TfrmModelEditor
             OnChange = cbCloseQuoteClick
             OnClick = cbCloseQuoteClick
             OnKeyUp = cbCloseQuoteKeyUp
-            Items.Strings = (
-              'default'
-              'ascii'
-              'custom')
           end
         end
       end
@@ -333,7 +320,7 @@ inherited frmModelEditor: TfrmModelEditor
           Top = 13
           Width = 333
           Height = 13
-          Caption = 
+          Caption =
             'The keyboard must be compiled in order to distribute or install ' +
             'it'
         end
@@ -410,7 +397,7 @@ inherited frmModelEditor: TfrmModelEditor
             Top = 72
             Width = 389
             Height = 26
-            Caption = 
+            Caption =
               'Optionally, select a compiled keyboard with which to test this l' +
               'exical model. Any keyboards already loaded in the web debugger w' +
               'ill also be available.'

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
@@ -5,6 +5,8 @@ inherited frmModelEditor: TfrmModelEditor
   ClientHeight = 708
   ClientWidth = 712
   Font.Name = 'Tahoma'
+  Position = poDesigned
+  ExplicitTop = -18
   ExplicitWidth = 712
   ExplicitHeight = 708
   PixelsPerInch = 96
@@ -14,7 +16,7 @@ inherited frmModelEditor: TfrmModelEditor
     Top = 0
     Width = 712
     Height = 708
-    ActivePage = pageCompile
+    ActivePage = pageDetails
     Align = alClient
     Font.Charset = ANSI_CHARSET
     Font.Color = clWindowText
@@ -48,7 +50,7 @@ inherited frmModelEditor: TfrmModelEditor
         object panWordlists: TPanel
           AlignWithMargins = True
           Left = 4
-          Top = 181
+          Top = 261
           Width = 611
           Height = 232
           Margins.Left = 4
@@ -58,6 +60,7 @@ inherited frmModelEditor: TfrmModelEditor
           Align = alTop
           BevelOuter = bvNone
           TabOrder = 1
+          ExplicitTop = 181
           DesignSize = (
             611
             232)
@@ -131,7 +134,7 @@ inherited frmModelEditor: TfrmModelEditor
           Left = 4
           Top = 6
           Width = 611
-          Height = 167
+          Height = 247
           Margins.Left = 4
           Margins.Top = 6
           Margins.Right = 4
@@ -143,13 +146,14 @@ inherited frmModelEditor: TfrmModelEditor
           TabOrder = 0
           DesignSize = (
             611
-            167)
+            247)
           object lblFormat: TLabel
             Left = 12
             Top = 30
             Width = 36
             Height = 13
             Caption = '&Format'
+            FocusControl = cbFormat
           end
           object lblBasicInformation: TLabel
             AlignWithMargins = True
@@ -174,7 +178,7 @@ inherited frmModelEditor: TfrmModelEditor
           end
           object lblComments: TLabel
             Left = 12
-            Top = 83
+            Top = 163
             Width = 50
             Height = 13
             Caption = 'Comme&nts'
@@ -185,8 +189,40 @@ inherited frmModelEditor: TfrmModelEditor
             Font.Style = []
             ParentFont = False
           end
+          object lblInsertAfterWord: TLabel
+            Left = 12
+            Top = 83
+            Width = 86
+            Height = 13
+            Caption = '&Insert after word'
+            FocusControl = cbInsertAfterWord
+          end
+          object lblQuotationMarks: TLabel
+            Left = 12
+            Top = 110
+            Width = 86
+            Height = 13
+            Caption = '&Quotation marks'
+            FocusControl = cbOpenQuote
+          end
+          object lblOpenQuote: TLabel
+            Left = 106
+            Top = 110
+            Width = 27
+            Height = 13
+            Caption = 'open'
+            FocusControl = cbOpenQuote
+          end
+          object lblCloseQuote: TLabel
+            Left = 220
+            Top = 110
+            Width = 26
+            Height = 13
+            Caption = 'close'
+            FocusControl = cbOpenQuote
+          end
           object cbFormat: TComboBox
-            Left = 98
+            Left = 106
             Top = 26
             Width = 145
             Height = 21
@@ -198,7 +234,7 @@ inherited frmModelEditor: TfrmModelEditor
               'Custom (custom-1.0)')
           end
           object cbWordBreaker: TComboBox
-            Left = 98
+            Left = 106
             Top = 53
             Width = 145
             Height = 21
@@ -211,14 +247,66 @@ inherited frmModelEditor: TfrmModelEditor
               'custom')
           end
           object memoComments: TMemo
-            Left = 98
-            Top = 80
-            Width = 506
+            Left = 106
+            Top = 160
+            Width = 498
             Height = 87
             Anchors = [akLeft, akTop, akRight]
             BevelOuter = bvNone
-            TabOrder = 2
+            TabOrder = 6
             OnChange = memoCommentsChange
+          end
+          object cbInsertAfterWord: TComboBox
+            Left = 106
+            Top = 80
+            Width = 145
+            Height = 21
+            TabOrder = 2
+            OnChange = cbInsertAfterWordClick
+            OnClick = cbInsertAfterWordClick
+            OnKeyUp = cbInsertAfterWordKeyUp
+            Items.Strings = (
+              '(space U+0020)'
+              '(no word break)'
+              '(Tibetan tsheg U+0F0B)'
+              '(Ethiopian wordspace U+1361)')
+          end
+          object cbOpenQuote: TComboBox
+            Left = 139
+            Top = 107
+            Width = 63
+            Height = 21
+            TabOrder = 3
+            OnChange = cbOpenQuoteClick
+            OnClick = cbOpenQuoteClick
+            OnKeyUp = cbOpenQuoteKeyUp
+            Items.Strings = (
+              'default'
+              'ascii'
+              'custom')
+          end
+          object chkIsRTL: TCheckBox
+            Left = 106
+            Top = 134
+            Width = 111
+            Height = 17
+            Caption = 'Right-to-left script'
+            TabOrder = 5
+            OnClick = chkIsRTLClick
+          end
+          object cbCloseQuote: TComboBox
+            Left = 252
+            Top = 107
+            Width = 63
+            Height = 21
+            TabOrder = 4
+            OnChange = cbCloseQuoteClick
+            OnClick = cbCloseQuoteClick
+            OnKeyUp = cbCloseQuoteKeyUp
+            Items.Strings = (
+              'default'
+              'ascii'
+              'custom')
           end
         end
       end

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -206,9 +206,10 @@ type
   end;
 
 const
-  CInsertAfterWordOptions: array[0..3] of TComboStringOption = (
+  CInsertAfterWordOptions: array[0..4] of TComboStringOption = (
     (value: ' '; name: '(space U+0020)'),
     (value: ''; name: '(no word break)'),
+    (value: Char($200B); name: '(Zero Width Space U+200B)'),
     (value: Char($0F0B); name: '(Tibetan tsheg U+0F0B)'),
     (value: Char($1361); name: '(Ethiopian wordspace U+1361)')
   );

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -207,9 +207,9 @@ type
 
 const
   CInsertAfterWordOptions: array[0..4] of TComboStringOption = (
-    (value: ' '; name: '(space U+0020)'),
-    (value: ''; name: '(no word break)'),
-    (value: Char($200B); name: '(Zero Width Space U+200B)'),
+    (value: ' '; name: '(Space U+0020)'),
+    (value: ''; name: '(No word break)'),
+    (value: Char($200B); name: '(Zero width space U+200B)'),
     (value: Char($0F0B); name: '(Tibetan tsheg U+0F0B)'),
     (value: Char($1361); name: '(Ethiopian wordspace U+1361)')
   );

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -1,4 +1,4 @@
-unit Keyman.Developer.UI.UfrmModelEditor;
+﻿unit Keyman.Developer.UI.UfrmModelEditor;
 
 interface
 
@@ -74,6 +74,14 @@ type
     Label5: TLabel;
     editOutPath: TEdit;
     imgQRCode: TImage;
+    lblInsertAfterWord: TLabel;
+    cbInsertAfterWord: TComboBox;
+    lblQuotationMarks: TLabel;
+    cbOpenQuote: TComboBox;
+    chkIsRTL: TCheckBox;
+    cbCloseQuote: TComboBox;
+    lblOpenQuote: TLabel;
+    lblCloseQuote: TLabel;
     procedure FormDestroy(Sender: TObject);
     procedure cmdAddWordlistClick(Sender: TObject);
     procedure cmdRemoveWordlistClick(Sender: TObject);
@@ -89,6 +97,16 @@ type
     procedure cmdBrowseTestKeyboardClick(Sender: TObject);
     procedure editTestKeyboardChange(Sender: TObject);
     procedure lbDebugHostsClick(Sender: TObject);
+    procedure cbInsertAfterWordClick(Sender: TObject);
+    procedure cbInsertAfterWordKeyUp(Sender: TObject; var Key: Word;
+      Shift: TShiftState);
+    procedure cbOpenQuoteClick(Sender: TObject);
+    procedure cbOpenQuoteKeyUp(Sender: TObject; var Key: Word;
+      Shift: TShiftState);
+    procedure cbCloseQuoteClick(Sender: TObject);
+    procedure cbCloseQuoteKeyUp(Sender: TObject; var Key: Word;
+      Shift: TShiftState);
+    procedure chkIsRTLClick(Sender: TObject);
   private
     type
       TWordlist = class
@@ -161,19 +179,107 @@ begin
   Result := Ord(format) - 1;  // unknown = -1
 end;
 
+function FormatFromIndex(index: Integer): TLexicalModelFormat;
+begin
+  Result := TLexicalModelFormat(index+1);  // unknown = -1
+end;
+
 function WordBreakerToIndex(wordBreaker: TLexicalModelWordBreaker): Integer;
 begin
   Result := Ord(wordBreaker) - 1;  // unknown = -1
 end;
 
-function FormatFromIndex(format: Integer): TLexicalModelFormat;
+function WordBreakerFromIndex(index: Integer): TLexicalModelWordBreaker;
 begin
-  Result := TLexicalModelFormat(format+1);  // unknown = -1
+  Result := TLexicalModelWordBreaker(index+1);  // unknown = -1
 end;
 
-function WordBreakerFromIndex(wordBreaker: Integer): TLexicalModelWordBreaker;
+type
+  TComboStringOption = record
+    value, name: string;
+    class procedure FillCombo(const opts: array of TComboStringOption;
+      combo: TComboBox); static;
+    class function GetValue(const opts: array of TComboStringOption;
+      combo: TComboBox): string; static;
+    class procedure SetValue(const opts: array of TComboStringOption;
+      const text: string; combo: TComboBox); static;
+  end;
+
+const
+  CInsertAfterWordOptions: array[0..3] of TComboStringOption = (
+    (value: ' '; name: '(space U+0020)'),
+    (value: ''; name: '(no word break)'),
+    (value: Char($0F0B); name: '(Tibetan tsheg U+0F0B)'),
+    (value: Char($1361); name: '(Ethiopian wordspace U+1361)')
+  );
+
+  COpenQuoteOptions: array[0..11] of TComboStringOption = (
+    (value: TLexicalModelParser.CDefaultOpenQuote),
+    (value: '«'),
+    (value: '„'),
+    (value: '»'),
+    (value: '"'),
+    (value: ''''),
+    (value: '‹'),
+    (value: '‘'),
+    (value: '‚'),
+    (value: '›'),
+    (value: '「'),
+    (value: '『')
+  );
+
+  CCloseQuoteOptions: array[0..10] of TComboStringOption = (
+    (value: TLexicalModelParser.CDefaultCloseQuote),
+    (value: '»'),
+    (value: '“'),
+    (value: '«'),
+    (value: '"'),
+    (value: ''''),
+    (value: '›'),
+    (value: '’'),
+    (value: '‹'),
+    (value: '」'),
+    (value: '』')
+  );
+
+class procedure TComboStringOption.SetValue(const opts: array of TComboStringOption; const text: string;
+  combo: TComboBox);
+var
+  index: Integer;
 begin
-  Result := TLexicalModelWordBreaker(wordBreaker+1);  // unknown = -1
+  for index := 0 to High(opts) do
+    if opts[index].value = text then
+    begin
+      combo.ItemIndex := index;
+      Exit;
+    end;
+  combo.Text := text;
+end;
+
+class function TComboStringOption.GetValue(const opts: array of TComboStringOption;
+  combo: TComboBox): string;
+begin
+  if (combo.ItemIndex >= 0) and (combo.ItemIndex <= High(opts))
+    then Result := opts[combo.ItemIndex].value
+    else Result := combo.Text;
+end;
+
+class procedure TComboStringOption.FillCombo(const opts: array of TComboStringOption; combo: TComboBox);
+var
+  opt: TComboStringOption;
+begin
+  combo.Items.BeginUpdate;
+  try
+    combo.Items.Clear;
+    for opt in opts do
+    begin
+      if opt.name = ''
+        then combo.Items.Add(opt.value)
+        else combo.Items.Add(opt.name);
+    end;
+  finally
+    combo.Items.EndUpdate;
+  end;
 end;
 
 { TfrmModelEditor }
@@ -269,6 +375,16 @@ begin
   lblWordBreaker.Enabled := e;
   cbWordBreaker.Enabled := e;
   lblComments.Enabled := e;
+
+  lblInsertAfterWord.Enabled := e;
+  cbInsertAfterWord.Enabled := e;
+  lblQuotationMarks.Enabled := e;
+  lblOpenQuote.Enabled := e;
+  cbOpenQuote.Enabled := e;
+  lblCloseQuote.Enabled := e;
+  cbCloseQuote.Enabled := e;
+  chkIsRTL.Enabled := e;
+
   memoComments.Enabled := e;
   cmdAddWordlist.Enabled := e;
   gridWordlists.Enabled := e and (parser.Wordlists.Count > 0);
@@ -310,6 +426,10 @@ begin
     frameSource.Visible := True;
     frameSource.OnChanged := SourceChanged;
     frameSource.TextFileFormat := tffUTF8;
+
+    TComboStringOption.FillCombo(CInsertAfterWordOptions, cbInsertAfterWord);
+    TComboStringOption.FillCombo(COpenQuoteOptions, cbOpenQuote);
+    TComboStringOption.FillCombo(CCloseQuoteOptions, cbCloseQuote);
 
     pages.ActivePage := pageDetails;
   finally
@@ -459,6 +579,11 @@ var
 begin
   cbFormat.ItemIndex := FormatToIndex(parser.Format);
   cbWordBreaker.ItemIndex := WordBreakerToIndex(parser.WordBreaker);
+  TComboStringOption.SetValue(CInsertAfterWordOptions, parser.InsertAfterWord, cbInsertAfterWord);
+  TComboStringOption.SetValue(COpenQuoteOptions, parser.OpenQuote, cbOpenQuote);
+  TComboStringOption.SetValue(CCloseQuoteOptions, parser.CloseQuote, cbCloseQuote);
+  chkIsRTL.Checked := parser.IsRTL;
+
   memoComments.Text := parser.Comment;
 
   if parser.Wordlists.Count = 0 then
@@ -570,6 +695,20 @@ begin
   Result := WordlistFromTab(pages.ActivePage) <> nil;
 end;
 
+procedure TfrmModelEditor.cbCloseQuoteClick(Sender: TObject);
+begin
+  if FSetup > 0 then
+    Exit;
+  parser.CloseQuote := TComboStringOption.GetValue(CCloseQuoteOptions, cbCloseQuote);
+  Modified := True;
+end;
+
+procedure TfrmModelEditor.cbCloseQuoteKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  cbCloseQuoteClick(Sender);
+end;
+
 procedure TfrmModelEditor.cbFormatClick(Sender: TObject);
 begin
   if FSetup > 0 then
@@ -578,11 +717,47 @@ begin
   Modified := True;
 end;
 
+procedure TfrmModelEditor.cbInsertAfterWordClick(Sender: TObject);
+begin
+  if FSetup > 0 then
+    Exit;
+  parser.InsertAfterWord := TComboStringOption.GetValue(CInsertAfterWordOptions, cbInsertAfterWord);
+  Modified := True;
+end;
+
+procedure TfrmModelEditor.cbInsertAfterWordKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  cbInsertAfterWordClick(Sender);
+end;
+
+procedure TfrmModelEditor.cbOpenQuoteClick(Sender: TObject);
+begin
+  if FSetup > 0 then
+    Exit;
+  parser.OpenQuote := TComboStringOption.GetValue(COpenQuoteOptions, cbOpenQuote);
+  Modified := True;
+end;
+
+procedure TfrmModelEditor.cbOpenQuoteKeyUp(Sender: TObject; var Key: Word;
+  Shift: TShiftState);
+begin
+  cbOpenQuoteClick(cbOpenQuote);
+end;
+
 procedure TfrmModelEditor.cbWordBreakerClick(Sender: TObject);
 begin
   if FSetup > 0 then
     Exit;
   parser.WordBreaker := WordBreakerFromIndex(cbWordBreaker.ItemIndex);
+  Modified := True;
+end;
+
+procedure TfrmModelEditor.chkIsRTLClick(Sender: TObject);
+begin
+  if FSetup > 0 then
+    Exit;
+  parser.IsRTL := chkIsRTL.Checked;
   Modified := True;
 end;
 

--- a/windows/src/developer/TIKE/main/Keyman.Developer.System.LexicalModelParser.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.System.LexicalModelParser.pas
@@ -18,6 +18,10 @@ type
     FWordlists: TStrings;
     FWordBreaker: TLexicalModelWordBreaker;
     FIsEditable: Boolean;
+    FInsertAfterWord: string;
+    FIsRTL: Boolean;
+    FOpenQuote: string;
+    FCloseQuote: string;
     function GetText: string;
     procedure PrepareText;
     procedure SetComment(const Value: string);
@@ -30,6 +34,16 @@ type
     function ReplaceSources(const m: TMatch): string;
     function ReplaceComment(const m: TMatch): string;
     procedure WordlistsChange(Sender: TObject);
+    function ReplaceInsertAfterWord(const punctuation: string): string;
+    function ReplaceIsRTL(const punctuation: string): string;
+    function ReplaceQuotesForKeepSuggestion(const punctuation: string): string;
+    procedure SetCloseQuote(const Value: string);
+    procedure SetInsertAfterWord(const Value: string);
+    procedure SetIsRTL(const Value: Boolean);
+    procedure SetOpenQuote(const Value: string);
+
+    function JSONEncodeString(const s: string): string;
+    function JSONDecodeString(s: string): string;
   public
     constructor Create(Source: string);
     destructor Destroy; override;
@@ -39,11 +53,23 @@ type
     property Wordlists: TStrings read FWordlists;
     property Comment: string read FComment write SetComment;
     property IsEditable: Boolean read FIsEditable;
+    property IsRTL: Boolean read FIsRTL write SetIsRTL;
+    property OpenQuote: string read FOpenQuote write SetOpenQuote;
+    property CloseQuote: string read FCloseQuote write SetCloseQuote;
+    property InsertAfterWord: string read FInsertAfterWord write SetInsertAfterWord;
+  public
+    // These defaults are defined in common/lexical-model-types/index.d.ts
+    const
+      CDefaultInsertAfterWord = ' ';
+      CDefaultIsRTL = False;
+      CDefaultOpenQuote = Char($201c);
+      CDefaultCloseQuote = Char($201d);
   end;
 
 implementation
 
 uses
+  System.JSON,
   System.SysUtils;
 
 { TLexicalModelParser }
@@ -54,6 +80,31 @@ const
   SWordBreaker = 'wordBreaker\s*:\s*([''"])(.+?)(\1)';
   SSources = 'sources\s*:\s*\[(.+?)\]';
   SSource = '\s*([''"])(.+?)(\1)\s*(,?)';
+
+  SEndOfObject = '\s*};';
+  SPunctuationID = 'punctuation';
+  SPunctuation =
+    ',?\s*'+SPunctuationID+'\s*:\s*{\s*(('+
+      '(insertAfterWord\s*:\s*(([''"]).*?(\5)))|'+
+      '(isRTL\s*:\s*(true|false))|'+
+      '(quotesForKeepSuggestion\s*:\s*{\s*'+
+        'open\s*:\s*(([''"]).*?(\11))\s*,\s*'+
+        'close\s*:\s*(([''"]).*?(\14))\s*})'+
+      '),?\s*)*}';
+
+  // These may delete the entry so we need to take the `,` into account
+  SInsertAfterWordID = 'insertAfterWord';
+  SInsertAfterWord = ',?\s*'+SInsertAfterWordID+'\s*:\s*(([''"]).*?(\2))';
+
+  SIsRTLID = 'isRTL';
+  SIsRTL = ',?\s*'+SIsRTLID+'\s*:\s*(true|false)';
+
+  SQuotesForKeepSuggestionID = 'quotesForKeepSuggestion';
+  SQuotesForKeepSuggestion =
+    ',?\s*'+SQuotesForKeepSuggestionID+'\s*:\s*{\s*'+
+      'open\s*:\s*(([''"]).*?(\2))\s*,\s*'+
+      'close\s*:\s*(([''"]).*?(\5))\s*'+
+    '}';
 
 constructor TLexicalModelParser.Create(Source: string);
 begin
@@ -79,6 +130,37 @@ begin
   Result := FText.Text;
 end;
 
+function TLexicalModelParser.JSONDecodeString(s: string): string;
+var
+  v: TJSONValue;
+begin
+  if s[1] = '''' then
+  begin
+    // Javascript can have ' but JSON only "
+    s[1] := '"';
+    s[Length(s)] := '"';
+  end;
+  v := TJSONObject.ParseJSONValue(s);
+  try
+    if not v.TryGetValue<string>(Result) then
+      Result := '';
+  finally
+    v.Free;
+  end;
+end;
+
+function TLexicalModelParser.JSONEncodeString(const s: string): string;
+var
+  j: TJSONString;
+begin
+  j := TJSONString.Create(s);
+  try
+    Result := j.ToJSON;
+  finally
+    j.Free;
+  end;
+end;
+
 procedure TLexicalModelParser.Modify;
 begin
   FModified := True;
@@ -97,6 +179,11 @@ begin
   FFormat := lmfUnknown;
   FWordBreaker := lmwbUnknown;
   FComment := '';
+
+  FInsertAfterWord := CDefaultInsertAfterWord;
+  FIsRTL := CDefaultIsRTL;
+  FOpenQuote := CDefaultOpenQuote;
+  FCloseQuote := CDefaultCloseQuote;
 
   s := FText.Text;
 
@@ -131,7 +218,40 @@ begin
   else
     FIsEditable := False;
 
-  FIsEditable := FIsEditable and (FFormat <> lmfUnknown) and (FWordBreaker <> lmwbUnknown);
+  // insertAfterWord:
+  m := TRegEx.Match(s, SInsertAfterWord, [roMultiLine]);
+  if m.Success then
+    FInsertAfterWord := JSONDecodeString(m.Groups[1].Value)
+  else if TRegEx.Match(s, SInsertAfterWordID, [roMultiLine]).Success then
+    FIsEditable := False;
+
+
+  // isRTL: true
+  m := TRegEx.Match(s, SIsRTL, [roMultiLine]);
+  if m.Success then
+    FIsRTL := m.Groups[1].Value = 'true'
+  else if TRegEx.Match(s, SIsRTLID, [roMultiLine]).Success then
+    FIsEditable := False;
+
+  // quotesForKeepSuggestion: We assume that both open and close are defined,
+  // in that order.
+  m := TRegEx.Match(s, SQuotesForKeepSuggestion, [roMultiLine]);
+  if m.Success then
+  begin
+    FOpenQuote := JSONDecodeString(m.Groups[1].Value);
+    FCloseQuote := JSONDecodeString(m.Groups[4].Value);
+  end
+  else if TRegEx.Match(s, SQuotesForKeepSuggestionID, [roMultiLine]).Success then
+    FIsEditable := False;
+
+  if TRegEx.IsMatch(s, SPunctuationID) and not TRegEx.IsMatch(s, SPunctuation) then
+    FIsEditable := False;
+
+
+  FIsEditable := FIsEditable and
+    TRegEx.IsMatch(s, SEndOfObject) and
+    (FFormat <> lmfUnknown) and
+    (FWordBreaker <> lmwbUnknown);
 end;
 
 function TLexicalModelParser.ReplaceComment(const m: TMatch): string;
@@ -173,9 +293,43 @@ begin
     m.Value.Substring(m.Groups[1].Index - m.Index + m.Groups[1].Length);
 end;
 
+function TLexicalModelParser.ReplaceInsertAfterWord(const punctuation: string): string;
+begin
+  if punctuation = ''
+    then Result := ''
+    else Result := punctuation + ','#13#10;
+
+  Result := Result +
+    '    insertAfterWord: '+JSONEncodeString(FInsertAfterWord);
+end;
+
+function TLexicalModelParser.ReplaceIsRTL(const punctuation: string): string;
+begin
+  if punctuation = ''
+    then Result := ''
+    else Result := punctuation + ','#13#10;
+
+  Result := Result +
+    '    isRTL: true';
+end;
+
+function TLexicalModelParser.ReplaceQuotesForKeepSuggestion(const punctuation: string): string;
+begin
+  if punctuation = ''
+    then Result := ''
+    else Result := punctuation + ','#13#10;
+
+  Result := Result +
+    '    quotesForKeepSuggestion: {'#13#10+
+    '      open: '+JSONEncodeString(FOpenQuote)+','#13#10+
+    '      close: '+JSONEncodeString(FCloseQuote)+#13#10+
+    '    }';
+end;
+
 procedure TLexicalModelParser.PrepareText;
 var
-  s: string;
+  punctuation, s: string;
+  m: TMatch;
 begin
   if not FModified then Exit;
 
@@ -186,6 +340,31 @@ begin
   s := TRegEx.Replace(s, SWordBreaker, ReplaceWordBreaker, [roMultiLine]);
   s := TRegEx.Replace(s, SSources, ReplaceSources, [roMultiLine]);
 
+  s := TRegEx.Replace(s, SPunctuation, '', [roMultiLine]);
+
+  punctuation := '';
+
+  if FInsertAfterWord <> CDefaultInsertAfterWord then
+    punctuation := ReplaceInsertAfterWord(punctuation);
+
+  if FIsRTL <> CDefaultIsRTL then
+    punctuation := ReplaceIsRTL(punctuation);
+
+  if (FOpenQuote <> CDefaultOpenQuote) or (FCloseQuote <> CDefaultCloseQuote) then
+    punctuation := ReplaceQuotesForKeepSuggestion(punctuation);
+
+  if punctuation <> '' then
+  begin
+    punctuation :=
+      ','#13#10+
+      '  punctuation: {'+#13#10+
+           punctuation + #13#10+
+      '  }';
+    m := TRegEx.Match(s, SEndOfObject, [roMultiLine]);
+    if m.Success then
+      s := s.Substring(0, m.Index - 1) + punctuation + s.Substring(m.Index);
+  end;
+
   // Replace, remove or add comment
   if TRegEx.IsMatch(s, SComment, [roSingleLine]) then
     s := TRegEx.Replace(s, SComment, ReplaceComment, [roSingleLine])
@@ -194,6 +373,16 @@ begin
 
 
   FText.Text := s;
+end;
+
+procedure TLexicalModelParser.SetCloseQuote(const Value: string);
+begin
+  Assert(FIsEditable);
+  if FCloseQuote <> Value then
+  begin
+    FCloseQuote := Value;
+    Modify;
+  end;
 end;
 
 procedure TLexicalModelParser.SetComment(const Value: string);
@@ -212,6 +401,36 @@ begin
   if FFormat <> Value then
   begin
     FFormat := Value;
+    Modify;
+  end;
+end;
+
+procedure TLexicalModelParser.SetInsertAfterWord(const Value: string);
+begin
+  Assert(FIsEditable);
+  if FInsertAfterWord <> Value then
+  begin
+    FInsertAfterWord := Value;
+    Modify;
+  end;
+end;
+
+procedure TLexicalModelParser.SetIsRTL(const Value: Boolean);
+begin
+  Assert(FIsEditable);
+  if FIsRTL <> Value then
+  begin
+    FIsRTL := Value;
+    Modify;
+  end;
+end;
+
+procedure TLexicalModelParser.SetOpenQuote(const Value: string);
+begin
+  Assert(FIsEditable);
+  if FOpenQuote <> Value then
+  begin
+    FOpenQuote := Value;
     Modify;
   end;
 end;


### PR DESCRIPTION
Fixes #2556.

This adds support for `isRTL`, `insertAfterWord`, and `quotesForKeepSuggestions` punctuation options for lexical models, both in the parsing and in the user interface. A number of options are presented to the user for the quotes and word breaking characters.

The parser continues to be a regex-based typescriptish parser. Expect it to be gross. It's too big a job to do properly right now, so it is somewhat limited and will bail if it finds structures it can't understand.

I would hope to use something a bit smarter in the future to interface with the editor. Probably when we are actually fully web-based and can depend on a Typescript compiler directly.

Please don't get mad at me! 😟😟😟