### PR TITLE
fix(developer): Avoid blank keys when importing KMX to KVKS

### DIFF
--- a/windows/src/developer/TIKE/dialogs/UfrmVisualKeyboardImportKMX.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmVisualKeyboardImportKMX.pas
@@ -355,19 +355,14 @@ var
   vk: TVKKey;
   n: Integer;
 begin
-//  lb.items.Add('AddKey: ENTER');
-
   if nkey >= keys.count then
   begin
-//    lb.items.Add('AddKey: EXIT: bug!');
-    exit;
+    Exit;
   end;
 
-//  lb.items.Add(Format('AddKey: nkey: %d data: "%s" vk: %s ', [nkey, data, VKeyNames[TVKKey(keys[nkey]).vkey]]));
-  if (data <> '') then //and (nkey < keys.Count) then
+  if Trim(data) <> '' then
   begin
     vk := TVKKey(keys[nkey]);
-//    ShowMessage(Format('key: %d shift: %d text: "%s"', [vk.vkey, vk.shift, data]));
     n := FVK.Keys.IndexOf(vk.vkey, vk.shift);
     if n < 0
       then k := TVisualKeyboardKey.Create
@@ -379,11 +374,9 @@ begin
     if n < 0 then FVK.Keys.Add(k);
   end;
 
-//  data := '';
   Inc(nkey);
 
   PostMessage(Handle, WM_User_SendNextKey, 0, 0);   // I4156
-//  lb.items.Add('AddKey: Exit (nkey now='+IntToStr(nkey));
 end;
 
 {-------------------------------------------------------------------------------

--- a/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeOnScreenKeyboardEditor.pas
@@ -674,7 +674,7 @@ procedure TframeOnScreenKeyboardEditor.cmdVKImportKMXClick(Sender: TObject);
           if ValidExtShiftStates[j] = [essAlt] then Continue;
           if ValidExtShiftStates[j] = [essShift, essAlt] then Continue;  // I1471:9011
 
-          if (kbdOnScreen.Keys[i].KeyCaps[j] <> '') and
+          if (Trim(kbdOnScreen.Keys[i].KeyCaps[j]) <> '') and
             (kbdOnScreen.Keys[i].KeyCaps[j][1] >= #32) then
           begin
             k := TVisualKeyboardKey.Create;


### PR DESCRIPTION
Fixes #3011.

Keys that have only whitespace will no longer generate separate key data for the on screen keyboard, as they have no visual presentation anyway.