### PR TITLE
fix(web): fixes lack of respect for underlying-key display settings

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -37,15 +37,15 @@ namespace com.keyman.keyboards {
     shiftKey?: LayoutKey,
     capsKey?: LayoutKey,
     numKey?: LayoutKey,
-    scrollKey?: LayoutKey
+    scrollKey?: LayoutKey,
     aligned?: boolean
   }
 
   export type LayoutFormFactor = {
+    "displayUnderlying"?: boolean,
     "font": string,
     "layer": LayoutLayer[],
-    keyLabels?: boolean,
-    isDefault?: boolean;
+    isDefault?: boolean
   }
 
   export type LayoutSpec = {
@@ -175,6 +175,11 @@ namespace com.keyman.keyboards {
       // For desktop devices, we must create all layers, even if invalid.
       if(formFactor == 'desktop') {
         invalidIdList = Layouts.generateLayerIds(chiral);
+
+        // Only display these by default for the desktop layout.
+        // Mobile form-factors must have a pre-defined layout in order 
+        // to display underlying keys.
+        layout["displayUnderlying"] = !!keyboard.scriptObject['KDU'];
 
         // Filter out all ids considered valid.  (We also don't want duplicates in the following list...)
         for(n=0; n<invalidIdList.length; n++) {

--- a/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -172,14 +172,14 @@ namespace com.keyman.keyboards {
         }
       }
 
+      // If there is no predefined layout, even touch layouts will follow the desktop's
+      // setting for the displayUnderlying flag.  As the desktop layout uses a different
+      // format for its layout spec, that's found at the field referenced below.
+      layout["displayUnderlying"] = !!keyboard.scriptObject['KDU'];
+
       // For desktop devices, we must create all layers, even if invalid.
       if(formFactor == 'desktop') {
         invalidIdList = Layouts.generateLayerIds(chiral);
-
-        // Only display these by default for the desktop layout.
-        // Mobile form-factors must have a pre-defined layout in order 
-        // to display underlying keys.
-        layout["displayUnderlying"] = !!keyboard.scriptObject['KDU'];
 
         // Filter out all ids considered valid.  (We also don't want duplicates in the following list...)
         for(n=0; n<invalidIdList.length; n++) {

--- a/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -71,11 +71,6 @@ namespace com.keyman.keyboards {
       return this.scriptObject['KN'];
     }
 
-    get displaysUnderlyingKeys(): boolean {
-      // Returns false if undefined or false-like (including 0), true otherwise.
-      return !!this.scriptObject['KDU'];
-    }
-
     // TODO:  Better typing.
     private get _legacyLayoutSpec(): any {
       return this.scriptObject['KV'];  // used with buildDefaultLayout; layout must be constructed at runtime.

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -419,8 +419,8 @@ namespace com.keyman.osk {
 
       totalPercent=totalPercent+spec['padpc']+spec['widthpc'];
 
-      // Add the (US English) keycap label for desktop OSK or if KDU flag is non-zero
-      if(layout.keyLabels || isDesktop) {
+      // Add the (US English) keycap label for layouts requesting display of underlying keys
+      if(layout["displayUnderlying"]) {
         let keyCap = this.generateKeyCapLabel();
 
         if(keyCap) {
@@ -688,9 +688,6 @@ namespace com.keyman.osk {
       } else {
         this.fontFamily='';
       }
-
-      // Set flag to add default (US English) key label if specified by keyboard
-      layout.keyLabels = keyboard && keyboard.displaysUnderlyingKeys;
 
       let divLayerContainer = this.deviceDependentLayout(keyboard, device.formFactor as utils.FormFactor);
 


### PR DESCRIPTION
Fixes #3950.

Yeah, I missed the mark on my understanding of `KDU` and `displayUnderlying` while doing the Web-core refactor.  This should patch it all up.

Not noted on #3950 - `KDU` was completely ignored when displaying desktop layouts; it was being overridden to `true` for them.