### PR TITLE
chore(ios): better visual feedback for keyboard search during poor internet connectivity

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/AssociatingPackageInstaller.swift
@@ -121,7 +121,9 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     var associationQueryProgress: [Int: LanguagePickAssociator.Progress] = [:]
     var installProgressMap: [KeymanPackage.Key: PackageInstallResult?] = [:]
 
-    let progressCallback: ProgressReceiver
+    let externalProgressCallback: ProgressReceiver
+    var promptProgressCallback: ProgressReceiver?
+
     let downloadManager: ResourceDownloadManager
 
     var isCancelled = false
@@ -129,7 +131,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     init(with associationSpecs: [Associator], downloadManager: ResourceDownloadManager, receiver: @escaping ProgressReceiver) {
       self.associationSpecs = associationSpecs
       self.downloadManager = downloadManager
-      self.progressCallback = receiver
+      self.externalProgressCallback = receiver
     }
 
     // Since progress info is stored here, it makes the most sense to track progress-related
@@ -139,12 +141,19 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
       return !isCancelled && pickingCompleted
     }
 
+    internal func notifyProgress(_ status: Progress) {
+      // Prompt gets first dibs - that way, if a prompt exists, its UI code
+      // executes before control transfers back to other modules.
+      self.promptProgressCallback?(status)
+      self.externalProgressCallback(status)
+    }
+
     /**
      * Computes the initial level of progress made toward the overall installation at the time that language selections were
      * finalized.
      */
     internal func initializeProgress() {
-      self.progressCallback(.starting)
+      notifyProgress(.starting)
     }
 
     /**
@@ -153,7 +162,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     internal func reportProgress(complete: Bool = false) {
       if reportsProgress {
         if complete {
-          progressCallback(.complete)
+          notifyProgress(.complete)
         } else {
           //progressCallback(.inProgress)
         }
@@ -161,7 +170,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     }
 
     internal func reportCancelled() {
-      progressCallback(.cancelled)
+      notifyProgress(.cancelled)
     }
   }
 
@@ -388,8 +397,7 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
    * May only be called once during the lifetime of its instance and is mutually exclusive with `pickLanguages`,
    * the programmatic alternative.
    */
-  public func promptForLanguages(inNavigationVC navVC: UINavigationController,
-                                 uiCompletionHandler: @escaping (() -> Void)) {
+  public func promptForLanguages(inNavigationVC navVC: UINavigationController) {
     guard self.associationQueriers == nil, !closureShared.pickingCompleted else {
       fatalError("Invalid state - language picking has already been triggered.")
     }
@@ -400,7 +408,6 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
     closureShared.installGroup.enter()
 
     let wrappedCompletionHandler = {
-      uiCompletionHandler()
       self.closureShared.installGroup.leave()
     }
 
@@ -410,6 +417,9 @@ public class AssociatingPackageInstaller<Resource: LanguageResource, Package: Ty
                                                               pickingCompletionHandler: coreInstallationClosure(),
                                                               uiCompletionHandler: wrappedCompletionHandler)
 
+    closureShared.promptProgressCallback = { progress in
+      pickerPrompt.progressUpdate(progress)
+    }
     navVC.pushViewController(pickerPrompt, animated: true)
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -69,6 +69,9 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
   private let languageCode: String?
   private let session: URLSession
 
+  private var progressView: UIProgressView?
+  private var observation: NSKeyValueObservation? = nil
+
   private static var ENDPOINT_ROOT: URL {
     var baseURL = KeymanHosts.KEYMAN_COM
     baseURL.appendPathComponent("go")
@@ -93,6 +96,10 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     fatalError("init(coder:) has not been implemented")
   }
 
+  deinit {
+    observation = nil
+  }
+
   public override func loadView() {
     let webView = WKWebView()
     webView.navigationDelegate = self
@@ -104,6 +111,18 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
       webView.load(URLRequest(url: KeyboardSearchViewController.ENDPOINT_ROOT))
     }
 
+    progressView = UIProgressView(progressViewStyle: .bar)
+    progressView!.translatesAutoresizingMaskIntoConstraints = false
+    observation = webView.observe(\.estimatedProgress) { _, _ in
+      if let progressView = self.progressView {
+        progressView.setProgress(Float(webView.estimatedProgress), animated: true)
+        progressView.isHidden = progressView.progress > 0.99
+      }
+    }
+    progressView!.setProgress(1, animated: false)
+    progressView!.isHidden = true
+
+    webView.addSubview(progressView!)
     view = webView
   }
 
@@ -131,6 +150,25 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     }
 
     decisionHandler(.allow)
+    // Makes it clear that there IS a progress bar, in case of super-slow response.
+    progressView?.setProgress(0, animated: false)
+    // This way, if the load is instant, the 0.01 doesn't really stand out.
+    progressView?.setProgress(0.01, animated: true)
+    progressView?.isHidden = false
+  }
+
+
+  override public func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    if let navVC = self.navigationController {
+      progressView?.topAnchor.constraint(equalTo: navVC.navigationBar.bottomAnchor).isActive = true
+    } else {
+      progressView?.topAnchor.constraint(equalTo: self.view.topAnchor).isActive = true
+    }
+
+    progressView?.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
+    progressView?.leftAnchor.constraint(equalTo: self.view.leftAnchor).isActive = true
   }
 
   override public func viewWillDisappear(_ animated: Bool) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -60,6 +60,7 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
 
   private var dismissalBlock: (() -> Void)? = nil
   private weak var welcomeView: UIView?
+  private var mayPick: Bool = true
 
   public init(for package: Resource.Package,
               defaultLanguageCode: String? = nil,
@@ -268,9 +269,11 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     }
 
     set(mode) {
-      leftNavMode = mode
+      if mayPick {
+        leftNavMode = mode
 
-      navigationItem.leftBarButtonItem = navMapping[mode]
+        navigationItem.leftBarButtonItem = navMapping[mode]
+      }
     }
   }
 
@@ -280,9 +283,11 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     }
 
     set(mode) {
-      rightNavMode = mode
+      if mayPick {
+        rightNavMode = mode
 
-      navigationItem.rightBarButtonItem = navMapping[mode]
+        navigationItem.rightBarButtonItem = navMapping[mode]
+      }
     }
   }
 
@@ -358,8 +363,10 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     // No more selection-manipulation allowed.
     // This matters when there's no welcome page available.
     languageTable.isUserInteractionEnabled = false
-    // Prevent extra 'install' commands.
+    // Prevent extra 'install' commands and nav-bar related manipulation.
+    self.navigationItem.leftBarButtonItem?.isEnabled = false
     self.rightNavigationMode = .none
+    self.mayPick = false
 
     let dismissalBlock = {
       self.associators.forEach { $0.pickerFinalized() }
@@ -399,7 +406,8 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
         dismissalBlock()
       }
     } else {
-      dismissalBlock()
+      self.dismissalBlock = dismissalBlock
+      onWelcomeDismissed()
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -228,27 +228,23 @@ public class ResourceFileManager {
         activitySpinner.centerXAnchor.constraint(equalTo: rootVC.view.centerXAnchor).isActive = true
         activitySpinner.centerYAnchor.constraint(equalTo: rootVC.view.centerYAnchor).isActive = true
         rootVC.view.isUserInteractionEnabled = false
-      } else if status == .complete {
+      } else if status == .complete || status == .cancelled {
         // Report completion!
         activitySpinner.stopAnimating()
         activitySpinner.removeFromSuperview()
         rootVC.view.isUserInteractionEnabled = true
-        rootVC.dismiss(animated: true, completion: nil)
+        rootVC.dismiss(animated: true) {
+          Manager.shared.showKeyboard()
+        }
         successHandler?(package)
       }
     }
 
     if let navVC = rootVC as? UINavigationController {
-      packageInstaller.promptForLanguages(inNavigationVC: navVC) {
-        // The user will be on the main screen after this, so we should resummon the keyboard.
-        Manager.shared.showKeyboard()
-      }
+      packageInstaller.promptForLanguages(inNavigationVC: navVC)
     } else {
       let nvc = UINavigationController.init()
-      packageInstaller.promptForLanguages(inNavigationVC: nvc) {
-        // The user will be on the main screen after this, so we should resummon the keyboard.
-        Manager.shared.showKeyboard()
-      }
+      packageInstaller.promptForLanguages(inNavigationVC: nvc)
       rootVC.present(nvc, animated: true, completion: nil)
     }
   }

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -116,9 +116,7 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
     }
 
     if let navVC = self.navVC {
-      packageInstaller.promptForLanguages(inNavigationVC: navVC) {
-        // do nothing; the Settings menu dismissal will take care of displaying the keyboard
-      }
+      packageInstaller.promptForLanguages(inNavigationVC: navVC)
     }
   }
 }


### PR DESCRIPTION
Fixes #4339.

Nobody likes a lack of feedback or when something instinctively feels broken.  It's better to let a user know that progress is happening... even if so.  So, toward that end... a batch of mini-features and fixes designed to better inform users of the app's progress during a keyboard search.

Something that may be worth keeping in mind:  the package installer uses asynchronous code that makes it quite possible for associated lexical model queries to still be ongoing when the user reaches a package's welcome page.  Commits 2 and 3 are about improving the UX in such conditions.

------

First commit:  the keyboard search now displays a progress bar while loading relevant pages.

![Blank page progress](https://user-images.githubusercontent.com/25213402/109747679-2cea4580-7c0a-11eb-8e79-f08dcc660597.png)

That little bit of blue makes a _world_ of difference.  Without it... the search feels outright broken, with no indication that the issue is a poor 'net connection.  Might not be a bad idea to have _some_ sort of default text / a 'filler' page to display during the load as well, though.  But... that's design work best left to another time.

It works for more than just the initial page load, too:

![drill-down progress](https://user-images.githubusercontent.com/25213402/109747752-4e4b3180-7c0a-11eb-8fdf-71aaba7bec57.png)

It took a little while to work out just how to achieve that visual metaphor iOS users know and love, but it's there now.  Of course, its actual responsiveness is also on par with the system's usual responsiveness.  So... not that great, but at least it's there.

------

Second + third commits:  the finalization process for package installation is now more polished - both in the frontend and the backend.  The two "completion handler" pathways, which were confusing to manage, have now been successfully united into a single, consistent, and clearer-to-understand pathway.  (Yay!)

In terms of user benefit, the keyboard will now never display until `AssociatingPackageInstaller` fully relinquishes control.  (Well, once the fix within #4568 also lands.)  Furthermore, if installations are delayed because of internet issues when attempting to look up associated lexical models, the welcome page (should it be available) will _remain_ interactive, just with a wait-spinner on top of it.

![Screen Shot 2021-03-03 at 12 59 32 PM](https://user-images.githubusercontent.com/25213402/109760462-4945ac80-7c21-11eb-8b6f-4adbec6dc3b0.png)

In such cases, lexical-model association queries are pending in the background.  The view will auto-dismiss once those queries complete.

No welcome page?  No problem!  You'll be able to check out the readme page, but you won't be able to select anything or scroll the language list.  Also has a spinner.  A good test is with the following legacy package, though it does lack multiple language codes: https://downloads.keyman.com/keyboards/gff_bcq_7/1.0/gff_bcq_7.kmp

![Screen Shot 2021-03-03 at 1 47 01 PM](https://user-images.githubusercontent.com/25213402/109765092-f4a53000-7c26-11eb-97b9-d102d911faf5.png)

Ideally,  we'd use progress bars (like with the first commit) instead of spinners... but the code we'd need to actually _track_ progress to give meaningful 'bar' information was triaged beyond 14.0.

(Refer to the final few lines of the following.)

https://github.com/keymanapp/keyman/blob/6180b01a31e7ce47be119b1293dc661b007e15fe/ios/engine/KMEI/KeymanEngine/Classes/Resource%20Management/AssociatingPackageInstaller.swift#L174-L193

So, spinners.