### PR TITLE
fix(developer): Support all fonts in Keyboard Fonts dialog

### DIFF
--- a/windows/src/developer/TIKE/dialogs/UfrmKeyboardFonts.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmKeyboardFonts.dfm
@@ -166,6 +166,9 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
   object editCodeSize: TEdit
     Left = 391
@@ -193,6 +196,9 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
   object editCharSize: TEdit
     Left = 391
@@ -220,6 +226,9 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
   object editOSKSize: TEdit
     Left = 391
@@ -288,6 +297,9 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
   object fcbTouchLayoutTablet: TscFontComboBox
     Left = 176
@@ -308,6 +320,9 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
   object fcbTouchLayoutDesktop: TscFontComboBox
     Left = 176
@@ -328,5 +343,8 @@ inherited frmKeyboardFonts: TfrmKeyboardFonts
     PreviewWidth = 240
     PreviewHeight = 60
     FontTypes = [ftTrueTypeAnsi, ftTrueTypeSymbol]
+    ShowPreview = False
+    ShowPreviewFontName = False
+    ShowPreviewInList = False
   end
 end


### PR DESCRIPTION
Fixes #2789.

The Keyboard Fonts dialog skipped some fonts which it did not recognise as valid TrueType fonts. As a bonus, I've rewritten a few parts of it to make it significantly faster to load.

I also turned off the font formatting for the list, as it was not very helpful and hurt performance considerably.