### PR TITLE
feat(developer): Add different Open Containing Folder buttons

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.dfm
@@ -6,7 +6,6 @@ inherited frmModelEditor: TfrmModelEditor
   ClientWidth = 712
   Font.Name = 'Tahoma'
   Position = poDesigned
-  ExplicitTop = -18
   ExplicitWidth = 712
   ExplicitHeight = 708
   PixelsPerInch = 96
@@ -60,7 +59,6 @@ inherited frmModelEditor: TfrmModelEditor
           Align = alTop
           BevelOuter = bvNone
           TabOrder = 1
-          ExplicitTop = 181
           DesignSize = (
             611
             232)
@@ -324,47 +322,15 @@ inherited frmModelEditor: TfrmModelEditor
             'The keyboard must be compiled in order to distribute or install ' +
             'it'
         end
-        object Label5: TLabel
-          Left = 10
-          Top = 79
-          Width = 82
-          Height = 13
-          Caption = 'Target filename:'
-        end
-        object cmdCompile: TButton
-          Left = 10
-          Top = 40
-          Width = 137
-          Height = 25
-          Action = modActionsModelEditor.actModelCompile
-          TabOrder = 0
-        end
-        object cmdAddToProject: TButton
-          Left = 297
-          Top = 40
-          Width = 137
-          Height = 25
-          Action = modActionsMain.actProjectAddCurrentEditorFile
-          TabOrder = 1
-        end
-        object cmdOpenContainingFolder2: TButton
-          Left = 153
-          Top = 40
-          Width = 138
-          Height = 25
-          Caption = '&Open Containing Folder'
-          TabOrder = 2
-          OnClick = cmdOpenContainingFolder2Click
-        end
         object panBuildLexicalModel: TPanel
           Left = 10
-          Top = 112
+          Top = 235
           Width = 471
           Height = 353
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 3
+          TabOrder = 2
           object lblDebugHostCaption: TLabel
             Left = 12
             Top = 158
@@ -464,15 +430,111 @@ inherited frmModelEditor: TfrmModelEditor
             OnClick = cmdBrowseTestKeyboardClick
           end
         end
-        object editOutPath: TEdit
-          Left = 98
-          Top = 76
-          Width = 383
-          Height = 21
-          TabStop = False
-          ParentColor = True
-          ReadOnly = True
-          TabOrder = 4
+        object panOpenInExplorer: TPanel
+          Left = 10
+          Top = 148
+          Width = 471
+          Height = 67
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 1
+          object lblOpenInExplorer: TLabel
+            Left = 9
+            Top = 6
+            Width = 115
+            Height = 17
+            Caption = 'Open in Explorer'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object cmdOpenSourceFolder: TButton
+            Left = 9
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = '&Open source folder'
+            TabOrder = 0
+            OnClick = cmdOpenSourceFolderClick
+          end
+          object cmdOpenBuildFolder: TButton
+            Left = 153
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open &build folder'
+            TabOrder = 1
+            OnClick = cmdOpenBuildFolderClick
+          end
+          object cmdOpenProjectFolder: TButton
+            Left = 297
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open pro&ject folder'
+            TabOrder = 2
+            OnClick = cmdOpenProjectFolderClick
+          end
+        end
+        object panFileActions: TPanel
+          Left = 10
+          Top = 32
+          Width = 471
+          Height = 97
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 0
+          object lblFileActions: TLabel
+            Left = 9
+            Top = 6
+            Width = 75
+            Height = 17
+            Caption = 'File actions'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object Label5: TLabel
+            Left = 10
+            Top = 71
+            Width = 82
+            Height = 13
+            Caption = 'Target filename:'
+          end
+          object cmdAddToProject: TButton
+            Left = 153
+            Top = 32
+            Width = 137
+            Height = 25
+            Action = modActionsMain.actProjectAddCurrentEditorFile
+            TabOrder = 1
+          end
+          object cmdCompile: TButton
+            Left = 10
+            Top = 32
+            Width = 137
+            Height = 25
+            Action = modActionsModelEditor.actModelCompile
+            TabOrder = 0
+          end
+          object editOutPath: TEdit
+            Left = 98
+            Top = 68
+            Width = 359
+            Height = 21
+            TabStop = False
+            ParentColor = True
+            ReadOnly = True
+            TabOrder = 2
+          end
         end
       end
     end

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -49,9 +49,6 @@ type
     pageCompile: TTabSheet;
     Panel1: TPanel;
     lblCongrats: TLabel;
-    cmdCompile: TButton;
-    cmdAddToProject: TButton;
-    cmdOpenContainingFolder2: TButton;
     panBuildLexicalModel: TPanel;
     cbFormat: TComboBox;
     cbWordBreaker: TComboBox;
@@ -71,8 +68,6 @@ type
     lblReadOnly: TLabel;
     dlgAddWordlist: TOpenDialog;
     dlgBrowseTestKeyboard: TOpenDialog;
-    Label5: TLabel;
-    editOutPath: TEdit;
     imgQRCode: TImage;
     lblInsertAfterWord: TLabel;
     cbInsertAfterWord: TComboBox;
@@ -82,6 +77,17 @@ type
     cbCloseQuote: TComboBox;
     lblOpenQuote: TLabel;
     lblCloseQuote: TLabel;
+    panOpenInExplorer: TPanel;
+    lblOpenInExplorer: TLabel;
+    cmdOpenSourceFolder: TButton;
+    cmdOpenBuildFolder: TButton;
+    cmdOpenProjectFolder: TButton;
+    panFileActions: TPanel;
+    lblFileActions: TLabel;
+    cmdAddToProject: TButton;
+    cmdCompile: TButton;
+    Label5: TLabel;
+    editOutPath: TEdit;
     procedure FormDestroy(Sender: TObject);
     procedure cmdAddWordlistClick(Sender: TObject);
     procedure cmdRemoveWordlistClick(Sender: TObject);
@@ -91,7 +97,6 @@ type
     procedure cbFormatClick(Sender: TObject);
     procedure cbWordBreakerClick(Sender: TObject);
     procedure memoCommentsChange(Sender: TObject);
-    procedure cmdOpenContainingFolder2Click(Sender: TObject);
     procedure cmdOpenDebugHostClick(Sender: TObject);
     procedure cmdSendURLsToEmailClick(Sender: TObject);
     procedure cmdBrowseTestKeyboardClick(Sender: TObject);
@@ -107,6 +112,9 @@ type
     procedure cbCloseQuoteKeyUp(Sender: TObject; var Key: Word;
       Shift: TShiftState);
     procedure chkIsRTLClick(Sender: TObject);
+    procedure cmdOpenSourceFolderClick(Sender: TObject);
+    procedure cmdOpenBuildFolderClick(Sender: TObject);
+    procedure cmdOpenProjectFolderClick(Sender: TObject);
   private
     type
       TWordlist = class
@@ -395,6 +403,12 @@ begin
   { Build tab }
   cmdOpenDebugHost.Enabled := lbDebugHosts.ItemIndex >= 0;
   cmdSendURLsToEmail.Enabled := lbDebugHosts.Items.Count > 0;   // I4506
+
+  // We use FProjectFile because we don't want to accidentally create a standalone
+  // project file as GetProjectFile is side-effecty. EnableControls is called early
+  // in construction before FProjectFile is assigned. It is called again later so
+  // enabled state will be correct.
+  cmdOpenProjectFolder.Enabled := Assigned(FProjectFile) and Assigned(FProjectFile.Project);
 end;
 
 procedure TfrmModelEditor.NotifyStartedWebDebug;
@@ -783,14 +797,25 @@ begin
     editTestKeyboard.Text := dlgBrowseTestKeyboard.FileName;
 end;
 
-procedure TfrmModelEditor.cmdOpenContainingFolder2Click(Sender: TObject);
+procedure TfrmModelEditor.cmdOpenDebugHostClick(Sender: TObject);
+begin
+  TUtilExecute.URL(lbDebugHosts.Items[lbDebugHosts.ItemIndex]);
+end;
+
+procedure TfrmModelEditor.cmdOpenSourceFolderClick(Sender: TObject);
 begin
   OpenContainingFolder(FileName);
 end;
 
-procedure TfrmModelEditor.cmdOpenDebugHostClick(Sender: TObject);
+procedure TfrmModelEditor.cmdOpenBuildFolderClick(Sender: TObject);
 begin
-  TUtilExecute.URL(lbDebugHosts.Items[lbDebugHosts.ItemIndex]);
+  OpenContainingFolder((ProjectFile as TmodeltsProjectFile).TargetFilename);
+end;
+
+procedure TfrmModelEditor.cmdOpenProjectFolderClick(Sender: TObject);
+begin
+  if Assigned(ProjectFile.Project) then
+    OpenContainingFolder(ProjectFile.Project.FileName);
 end;
 
 procedure TfrmModelEditor.cmdRemoveWordlistClick(Sender: TObject);

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
@@ -177,7 +177,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     Top = 0
     Width = 1043
     Height = 645
-    ActivePage = pageTouchLayout
+    ActivePage = pageDetails
     Align = alClient
     Font.Charset = ANSI_CHARSET
     Font.Color = clWindowText
@@ -698,7 +698,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
             Top = 22
             Width = 482
             Height = 13
-            Caption = 
+            Caption =
               'In Keyman 10, language metadata should now be managed in the pac' +
               'kage, not the keyboard.'
           end
@@ -721,9 +721,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     object pageLayout: TTabSheet
       Caption = 'Layout'
       ImageIndex = 5
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object pagesLayout: TPageControl
         Left = 0
         Top = 0
@@ -738,10 +735,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageLayoutDesign: TTabSheet
           Caption = 'Design'
           ImageIndex = -1
-          ExplicitLeft = 0
-          ExplicitTop = 0
-          ExplicitWidth = 0
-          ExplicitHeight = 0
           object panLayoutSimple: TPanel
             Left = 0
             Top = 0
@@ -965,10 +958,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageLayoutCode: TTabSheet
           Caption = 'Code'
           ImageIndex = -1
-          ExplicitLeft = 0
-          ExplicitTop = 0
-          ExplicitWidth = 0
-          ExplicitHeight = 0
         end
       end
     end
@@ -1015,9 +1004,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     object pageOnScreenKeyboard: TTabSheet
       Caption = 'On-Screen'
       ImageIndex = 7
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageTouchLayout: TTabSheet
       Caption = 'Touch Layout'
@@ -1040,47 +1026,28 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageTouchLayoutCode: TTabSheet
           Caption = 'Code'
           ImageIndex = -1
-          ExplicitLeft = 0
-          ExplicitTop = 0
-          ExplicitWidth = 0
-          ExplicitHeight = 0
         end
       end
     end
     object pageIncludeCodes: TTabSheet
       Caption = 'Char Codes'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageKMWEmbedJS: TTabSheet
       Caption = 'Embedded JS'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageKMWEmbedCSS: TTabSheet
       Caption = 'Embedded CSS'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageKMWHelp: TTabSheet
       Caption = 'Embedded Help'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageCompile: TTabSheet
       Caption = 'Build'
       ImageIndex = 1
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
       object Panel1: TPanel
         Left = 0
         Top = 0
@@ -1096,52 +1063,19 @@ inherited frmKeymanWizard: TfrmKeymanWizard
           Top = 13
           Width = 333
           Height = 13
-          Caption = 
+          Caption =
             'The keyboard must be compiled in order to distribute or install ' +
             'it'
         end
-        object cmdCompile: TButton
-          Left = 10
-          Top = 40
-          Width = 137
-          Height = 25
-          Action = modActionsKeyboardEditor.actKeyboardCompile
-          TabOrder = 0
-        end
-        object cmdStartDebugging: TButton
-          Left = 153
-          Top = 40
-          Width = 137
-          Height = 25
-          Action = modActionsKeyboardEditor.actDebugStartDebugger
-          TabOrder = 1
-        end
-        object cmdAddToProject: TButton
-          Left = 442
-          Top = 40
-          Width = 137
-          Height = 25
-          Action = modActionsMain.actProjectAddCurrentEditorFile
-          TabOrder = 2
-        end
-        object cmdOpenContainingFolder2: TButton
-          Left = 298
-          Top = 40
-          Width = 138
-          Height = 25
-          Caption = '&Open Containing Folder'
-          TabOrder = 3
-          OnClick = cmdOpenContainingFolder2Click
-        end
         object panBuildWindows: TPanel
           Left = 10
-          Top = 96
+          Top = 202
           Width = 295
           Height = 265
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 4
+          TabOrder = 2
           object lblInstallHint: TLabel
             Left = 9
             Top = 39
@@ -1189,13 +1123,13 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         end
         object panBuildKMW: TPanel
           Left = 323
-          Top = 96
+          Top = 202
           Width = 454
           Height = 265
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 5
+          TabOrder = 3
           object lblDebugHostCaption: TLabel
             Left = 12
             Top = 70
@@ -1260,6 +1194,103 @@ inherited frmKeymanWizard: TfrmKeymanWizard
             OnClick = cmdSendURLsToEmailClick
           end
         end
+        object panOpenInExplorer: TPanel
+          Left = 10
+          Top = 117
+          Width = 767
+          Height = 67
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 1
+          object lblOpenInExplorer: TLabel
+            Left = 9
+            Top = 6
+            Width = 115
+            Height = 17
+            Caption = 'Open in Explorer'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object cmdOpenSourceFolder: TButton
+            Left = 9
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = '&Open source folder'
+            TabOrder = 0
+            OnClick = cmdOpenSourceFolderClick
+          end
+          object cmdOpenBuildFolder: TButton
+            Left = 153
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open &build folder'
+            TabOrder = 1
+            OnClick = cmdOpenBuildFolderClick
+          end
+          object cmdOpenProjectFolder: TButton
+            Left = 297
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open pro&ject folder'
+            TabOrder = 2
+            OnClick = cmdOpenProjectFolderClick
+          end
+        end
+        object panFileActions: TPanel
+          Left = 10
+          Top = 32
+          Width = 767
+          Height = 67
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 0
+          object lblFileActions: TLabel
+            Left = 9
+            Top = 6
+            Width = 75
+            Height = 17
+            Caption = 'File actions'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object cmdAddToProject: TButton
+            Left = 295
+            Top = 33
+            Width = 137
+            Height = 25
+            Action = modActionsMain.actProjectAddCurrentEditorFile
+            TabOrder = 2
+          end
+          object cmdStartDebugging: TButton
+            Left = 152
+            Top = 33
+            Width = 137
+            Height = 25
+            Action = modActionsKeyboardEditor.actDebugStartDebugger
+            TabOrder = 1
+          end
+          object cmdCompile: TButton
+            Left = 9
+            Top = 33
+            Width = 137
+            Height = 25
+            Action = modActionsKeyboardEditor.actKeyboardCompile
+            TabOrder = 0
+          end
+        end
       end
     end
   end
@@ -1300,7 +1331,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
   end
   object dlgBrowseBitmap: TOpenPictureDialog
     DefaultExt = 'ico'
-    Filter = 
+    Filter =
       'All supported files (*.ico, *.bmp)|*.ico;*.bmp|Icon files (*.ico' +
       ')|*.ico|Bitmap files (*.bmp)|*.bmp|All files (*.*)|*.*'
     Options = [ofHideReadOnly, ofCreatePrompt, ofEnableSizing]
@@ -1310,7 +1341,7 @@ inherited frmKeymanWizard: TfrmKeymanWizard
   end
   object dlgSaveExport: TSaveDialog
     DefaultExt = 'kmn'
-    Filter = 
+    Filter =
       'Keyman 5.0 Keyboard Wizard (*.kmn)|*.kmn|Windows NT/2000/XP keyb' +
       'oard (*.dll)|*.dll|Windows 95/98/Me keyboard (*.kbd)|*.kbd'
     Options = [ofOverwritePrompt, ofHideReadOnly, ofPathMustExist, ofEnableSizing]

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -236,10 +236,6 @@ type
     cmdISOLang_Lookup: TButton;
     Panel1: TPanel;
     lblCongrats: TLabel;
-    cmdCompile: TButton;
-    cmdStartDebugging: TButton;
-    cmdAddToProject: TButton;
-    cmdOpenContainingFolder2: TButton;
     panBuildWindows: TPanel;
     lblInstallHint: TLabel;
     lblCompileTargetHeader: TLabel;
@@ -267,6 +263,16 @@ type
     lblLanguageKeyman10Note: TLabel;
     lblLanguageKeyman10Title: TLabel;
     imgQRCode: TImage;
+    panOpenInExplorer: TPanel;
+    lblOpenInExplorer: TLabel;
+    cmdOpenSourceFolder: TButton;
+    cmdOpenBuildFolder: TButton;
+    cmdOpenProjectFolder: TButton;
+    panFileActions: TPanel;
+    lblFileActions: TLabel;
+    cmdAddToProject: TButton;
+    cmdStartDebugging: TButton;
+    cmdCompile: TButton;
     procedure FormCreate(Sender: TObject);
     procedure editNameChange(Sender: TObject);
     procedure editCopyrightChange(Sender: TObject);
@@ -294,7 +300,7 @@ type
       Shift: TShiftState);
     procedure chkLayoutDisplay102KeyClick(Sender: TObject);
     procedure cmdInsertCopyrightClick(Sender: TObject);
-    procedure cmdOpenContainingFolder2Click(Sender: TObject);
+    procedure cmdOpenSourceFolderClick(Sender: TObject);
     procedure editKeyOutputCodeClick(Sender: TObject);
     procedure editKeyOutputTextClick(Sender: TObject);
     procedure tmrUpdateCharacterMapTimer(Sender: TObject);
@@ -332,6 +338,8 @@ type
     procedure pagesTouchLayoutChanging(Sender: TObject;
       var AllowChange: Boolean);
     procedure lbDebugHostsClick(Sender: TObject);
+    procedure cmdOpenBuildFolderClick(Sender: TObject);
+    procedure cmdOpenProjectFolderClick(Sender: TObject);
   private
     frameSource: TframeTextEditor;
 
@@ -738,6 +746,8 @@ begin
   gridFeatures.Enabled := gridFeatures.RowCount > 1;   // I4587   // I4427
   cmdEditFeature.Enabled := gridFeatures.RowCount > 1;   // I4587   // I4427
   cmdRemoveFeature.Enabled := gridFeatures.RowCount > 1;   // I4587   // I4427
+
+  cmdOpenProjectFolder.Enabled := Assigned(ProjectFile.Project);
 end;
 
 procedure TfrmKeymanWizard.FocusTab;
@@ -2754,9 +2764,20 @@ begin
   editCopyright.SetFocus;
 end;
 
-procedure TfrmKeymanWizard.cmdOpenContainingFolder2Click(Sender: TObject);
+procedure TfrmKeymanWizard.cmdOpenSourceFolderClick(Sender: TObject);
 begin
   OpenContainingFolder(FileName);
+end;
+
+procedure TfrmKeymanWizard.cmdOpenBuildFolderClick(Sender: TObject);
+begin
+  OpenContainingFolder((ProjectFile as TkmnProjectFile).TargetFilename);
+end;
+
+procedure TfrmKeymanWizard.cmdOpenProjectFolderClick(Sender: TObject);
+begin
+  if Assigned(ProjectFile.Project) then
+    OpenContainingFolder(ProjectFile.Project.FileName);
 end;
 
 procedure TfrmKeymanWizard.cmdOpenDebugHostClick(Sender: TObject);

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.dfm
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.dfm
@@ -1119,9 +1119,6 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageSource: TTabSheet
       Caption = 'Source'
       ImageIndex = 9
-      ExplicitLeft = 0
-      ExplicitWidth = 0
-      ExplicitHeight = 0
     end
     object pageCompile: TTabSheet
       Caption = 'Compile'
@@ -1158,67 +1155,15 @@ inherited frmPackageEditor: TfrmPackageEditor
           Font.Style = [fsBold]
           ParentFont = False
         end
-        object Label5: TLabel
-          Left = 24
-          Top = 121
-          Width = 82
-          Height = 13
-          Caption = 'Target filename:'
-        end
-        object cmdBuildPackage: TButton
-          Left = 15
-          Top = 80
-          Width = 133
-          Height = 25
-          Caption = 'Compile &Package'
-          TabOrder = 0
-          OnClick = cmdBuildPackageClick
-        end
-        object editOutPath: TEdit
-          Left = 111
-          Top = 118
-          Width = 383
-          Height = 21
-          TabStop = False
-          ParentColor = True
-          ReadOnly = True
-          TabOrder = 4
-        end
-        object cmdOpenContainingFolder2: TButton
-          Left = 293
-          Top = 80
-          Width = 133
-          Height = 25
-          Caption = '&Open Containing Folder'
-          TabOrder = 2
-          OnClick = cmdOpenContainingFolder2Click
-        end
-        object cmdAddToProject: TButton
-          Left = 432
-          Top = 80
-          Width = 133
-          Height = 25
-          Action = modActionsMain.actProjectAddCurrentEditorFile
-          TabOrder = 3
-        end
-        object cmdCompileInstaller: TButton
-          Left = 154
-          Top = 80
-          Width = 133
-          Height = 25
-          Caption = 'Compile I&nstaller'
-          TabOrder = 1
-          OnClick = cmdCompileInstallerClick
-        end
         object panBuildMobile: TPanel
           Left = 328
-          Top = 162
+          Top = 274
           Width = 457
-          Height = 265
+          Height = 276
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 5
+          TabOrder = 4
           object lblDebugHostCaption: TLabel
             Left = 12
             Top = 70
@@ -1241,7 +1186,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           end
           object imgQRCode: TImage
             Left = 315
-            Top = 64
+            Top = 96
             Width = 128
             Height = 128
             Proportional = True
@@ -1258,7 +1203,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           end
           object cmdOpenDebugHost: TButton
             Left = 12
-            Top = 198
+            Top = 240
             Width = 221
             Height = 25
             Caption = 'Open packages page in local &browser'
@@ -1267,9 +1212,9 @@ inherited frmPackageEditor: TfrmPackageEditor
           end
           object lbDebugHosts: TListBox
             Left = 12
-            Top = 95
+            Top = 89
             Width = 289
-            Height = 97
+            Height = 142
             ItemHeight = 13
             TabOrder = 1
             OnClick = lbDebugHostsClick
@@ -1277,26 +1222,26 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object panBuildDesktop: TPanel
           Left = 15
-          Top = 162
+          Top = 274
           Width = 295
           Height = 124
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 6
+          TabOrder = 2
           object Label4: TLabel
             Left = 9
             Top = 35
-            Width = 254
+            Width = 236
             Height = 13
-            Caption = 'You can install the package into Keyman:'
+            Caption = 'Install the package into Keyman for Windows:'
           end
           object lblCompileTargetHeader: TLabel
             Left = 9
             Top = 6
-            Width = 202
+            Width = 247
             Height = 17
-            Caption = 'Windows and macOS Targets'
+            Caption = 'Windows, Linux and macOS Targets'
             Font.Charset = DEFAULT_CHARSET
             Font.Color = clWindowText
             Font.Height = -14
@@ -1327,13 +1272,13 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object panBuildWindowsInstaller: TPanel
           Left = 15
-          Top = 295
+          Top = 418
           Width = 295
           Height = 132
           BevelOuter = bvNone
           Color = 15921906
           ParentBackground = False
-          TabOrder = 7
+          TabOrder = 3
           object Label9: TLabel
             Left = 9
             Top = 6
@@ -1350,7 +1295,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           object lblBootstrapMSI: TLabel
             Left = 9
             Top = 69
-            Width = 110
+            Width = 64
             Height = 13
             Caption = 'Keyman MSI:'
             FocusControl = editBootstrapMSI
@@ -1391,6 +1336,122 @@ inherited frmPackageEditor: TfrmPackageEditor
             Caption = 'Find Keyman MSI...'
             TabOrder = 2
             OnClick = cmdInstallWithClick
+          end
+        end
+        object panOpenInExplorer: TPanel
+          Left = 15
+          Top = 187
+          Width = 767
+          Height = 67
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 1
+          object lblOpenInExplorer: TLabel
+            Left = 9
+            Top = 6
+            Width = 115
+            Height = 17
+            Caption = 'Open in Explorer'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object cmdOpenSourceFolder: TButton
+            Left = 9
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = '&Open source folder'
+            TabOrder = 0
+            OnClick = cmdOpenSourceFolderClick
+          end
+          object cmdOpenBuildFolder: TButton
+            Left = 153
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open &build folder'
+            TabOrder = 1
+            OnClick = cmdOpenBuildFolderClick
+          end
+          object cmdOpenProjectFolder: TButton
+            Left = 297
+            Top = 33
+            Width = 138
+            Height = 25
+            Caption = 'Open pro&ject folder'
+            TabOrder = 2
+            OnClick = cmdOpenProjectFolderClick
+          end
+        end
+        object panFileActions: TPanel
+          Left = 15
+          Top = 67
+          Width = 767
+          Height = 102
+          BevelOuter = bvNone
+          Color = 15921906
+          ParentBackground = False
+          TabOrder = 0
+          object lblFileActions: TLabel
+            Left = 9
+            Top = 6
+            Width = 75
+            Height = 17
+            Caption = 'File actions'
+            Font.Charset = DEFAULT_CHARSET
+            Font.Color = clWindowText
+            Font.Height = -14
+            Font.Name = 'Tahoma'
+            Font.Style = [fsBold]
+            ParentFont = False
+          end
+          object Label5: TLabel
+            Left = 9
+            Top = 73
+            Width = 82
+            Height = 13
+            Caption = 'Target filename:'
+          end
+          object editOutPath: TEdit
+            Left = 96
+            Top = 70
+            Width = 383
+            Height = 21
+            TabStop = False
+            ParentColor = True
+            ReadOnly = True
+            TabOrder = 0
+          end
+          object cmdCompileInstaller: TButton
+            Left = 148
+            Top = 32
+            Width = 133
+            Height = 25
+            Caption = 'Compile I&nstaller'
+            TabOrder = 1
+            OnClick = cmdCompileInstallerClick
+          end
+          object cmdAddToProject: TButton
+            Left = 287
+            Top = 32
+            Width = 133
+            Height = 25
+            Action = modActionsMain.actProjectAddCurrentEditorFile
+            TabOrder = 2
+          end
+          object cmdBuildPackage: TButton
+            Left = 9
+            Top = 32
+            Width = 133
+            Height = 25
+            Caption = 'Compile &Package'
+            TabOrder = 3
+            OnClick = cmdBuildPackageClick
           end
         end
       end

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -135,11 +135,6 @@ type
     Panel4: TPanel;
     Label13: TLabel;
     lblCompilePackage: TLabel;
-    cmdBuildPackage: TButton;
-    editOutPath: TEdit;
-    cmdOpenContainingFolder2: TButton;
-    cmdAddToProject: TButton;
-    cmdCompileInstaller: TButton;
     pageKeyboards: TTabSheet;
     Panel5: TPanel;
     Label2: TLabel;
@@ -174,7 +169,6 @@ type
     lblCompileTargetHeader: TLabel;
     cmdInstall: TButton;
     cmdUninstall: TButton;
-    Label5: TLabel;
     panBuildWindowsInstaller: TPanel;
     Label9: TLabel;
     lblBootstrapMSI: TLabel;
@@ -198,6 +192,18 @@ type
     chkLexicalModelRTL: TCheckBox;
     editLexicalModelFilename: TEdit;
     imgQRCode: TImage;
+    panOpenInExplorer: TPanel;
+    lblOpenInExplorer: TLabel;
+    cmdOpenSourceFolder: TButton;
+    cmdOpenBuildFolder: TButton;
+    cmdOpenProjectFolder: TButton;
+    panFileActions: TPanel;
+    lblFileActions: TLabel;
+    editOutPath: TEdit;
+    cmdCompileInstaller: TButton;
+    cmdAddToProject: TButton;
+    cmdBuildPackage: TButton;
+    Label5: TLabel;
     procedure cmdCloseClick(Sender: TObject);
     procedure cmdAddFileClick(Sender: TObject);
     procedure cmdRemoveFileClick(Sender: TObject);
@@ -226,7 +232,6 @@ type
     procedure editStartMenuPathChange(Sender: TObject);
     procedure cbKMPImageFileClick(Sender: TObject);
     procedure cmdUninstallClick(Sender: TObject);
-    procedure cmdOpenContainingFolder2Click(Sender: TObject);
     procedure cmdOpenContainingFolderClick(Sender: TObject);
     procedure cmdOpenFileClick(Sender: TObject);
     procedure cmdCompileInstallerClick(Sender: TObject);
@@ -256,6 +261,9 @@ type
     procedure chkLexicalModelRTLClick(Sender: TObject);
     procedure editLexicalModelDescriptionChange(Sender: TObject);
     procedure lbDebugHostsClick(Sender: TObject);
+    procedure cmdOpenSourceFolderClick(Sender: TObject);
+    procedure cmdOpenBuildFolderClick(Sender: TObject);
+    procedure cmdOpenProjectFolderClick(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -1043,16 +1051,6 @@ begin
   lbStartMenuEntriesClick(lbStartMenuEntries);
 end;
 
-procedure TfrmPackageEditor.cmdOpenContainingFolder2Click(Sender: TObject);
-begin
-  OpenContainingFolder(FileName);
-end;
-
-procedure TfrmPackageEditor.cmdOpenContainingFolderClick(Sender: TObject);
-begin
-  OpenContainingFolder((lbFiles.Items.Objects[lbFiles.ItemIndex] as TPackageContentFile).FileName);
-end;
-
 procedure TfrmPackageEditor.cmdOpenDebugHostClick(Sender: TObject);
 begin
   TUtilExecute.URL(lbDebugHosts.Items[lbDebugHosts.ItemIndex] + '/packages.html');
@@ -1081,6 +1079,27 @@ begin
       f.Free;
     end;
   end;
+end;
+
+procedure TfrmPackageEditor.cmdOpenSourceFolderClick(Sender: TObject);
+begin
+  OpenContainingFolder(FileName);
+end;
+
+procedure TfrmPackageEditor.cmdOpenBuildFolderClick(Sender: TObject);
+begin
+  OpenContainingFolder((ProjectFile as TkpsProjectFile).TargetFilename);
+end;
+
+procedure TfrmPackageEditor.cmdOpenProjectFolderClick(Sender: TObject);
+begin
+  if Assigned(ProjectFile.Project) then
+    OpenContainingFolder(ProjectFile.Project.FileName);
+end;
+
+procedure TfrmPackageEditor.cmdOpenContainingFolderClick(Sender: TObject);
+begin
+  OpenContainingFolder((lbFiles.Items.Objects[lbFiles.ItemIndex] as TPackageContentFile).FileName);
 end;
 
 procedure TfrmPackageEditor.cmdDeleteStartMenuEntryClick(Sender: TObject);
@@ -1195,17 +1214,15 @@ begin
     for i := 0 to pack.Info.Count - 1 do
       UpdateInfo(pack.Info[i].Name, pack.Info[i].Description, pack.Info[i].URL);
     chkFollowKeyboardVersion.Checked := pack.KPSOptions.FollowKeyboardVersion;
-    EnableDetailsTabControls;
 
     lbStartMenuEntries.Clear;
-    
+
     for i := 0 to pack.StartMenu.Entries.Count - 1 do
       lbStartMenuEntries.Items.AddObject(pack.StartMenu.Entries[i].Name, pack.StartMenu.Entries[i]);
 
     chkCreateStartMenu.Checked := pack.StartMenu.DoCreate;
     chkStartMenuUninstall.Checked := pack.StartMenu.AddUninstallEntry;
     editStartMenuPath.Text := pack.StartMenu.Path;
-    EnableStartMenuControls;
 
     editOutPath.Text := (ProjectFile as TkpsProjectFile).TargetFilename;   // I4688
     editBootstrapMSI.Text := pack.KPSOptions.MSIFileName;
@@ -1220,6 +1237,8 @@ begin
 
     RefreshKeyboardList;
     RefreshLexicalModelList;
+
+    EnableControls;
   finally
     Dec(FSetup);
   end;
@@ -1547,6 +1566,12 @@ end;
 procedure TfrmPackageEditor.EnableCompileTabControls;
 begin
   cmdOpenDebugHost.Enabled := lbDebugHosts.ItemIndex >= 0;
+
+  // We use FProjectFile because we don't want to accidentally create a standalone
+  // project file as GetProjectFile is side-effecty. EnableControls is called early
+  // in construction before FProjectFile is assigned. It is called again later so
+  // enabled state will be correct.
+  cmdOpenProjectFolder.Enabled := Assigned(FProjectFile) and Assigned(FProjectFile.Project);
 end;
 
 procedure TfrmPackageEditor.EnableDetailsTabControls;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -460,6 +460,20 @@ begin
     else if SelectedMRUFileName <> '' then
       OpenContainingFolder(SelectedMRUFileName);
   end
+  else if Command = 'openbuildfolder' then
+  begin
+    pf := SelectedProjectFile;
+    if Assigned(pf) and (pf is TkmnProjectFile) then
+      OpenContainingFolder((pf as TkmnProjectFile).TargetFileName)
+    else if Assigned(pf) and (pf is TkpsProjectFile) then
+      OpenContainingFolder((pf as TkpsProjectFile).TargetFileName)
+    else if Assigned(pf) and (pf is TmodelTsProjectFile) then
+      OpenContainingFolder((pf as TmodelTsProjectFile).TargetFileName);
+  end
+  else if Command = 'openprojectfolder' then
+  begin
+    OpenContainingFolder(FGlobalProject.FileName);
+  end
   else if Command = 'removefile' then
   begin
     pf := SelectedProjectFile;

--- a/windows/src/developer/TIKE/xml/project/keyboards.xsl
+++ b/windows/src/developer/TIKE/xml/project/keyboards.xsl
@@ -163,8 +163,13 @@
         </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">
-        <xsl:with-param name="caption">Open Containing Folder</xsl:with-param>
+        <xsl:with-param name="caption">Open Source Folder</xsl:with-param>
         <xsl:with-param name="command">keyman:opencontainingfolder?id=<xsl:value-of select="ID" />
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open Build Folder</xsl:with-param>
+        <xsl:with-param name="command">keyman:openbuildfolder?id=<xsl:value-of select="ID" />
         </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">

--- a/windows/src/developer/TIKE/xml/project/models.xsl
+++ b/windows/src/developer/TIKE/xml/project/models.xsl
@@ -149,8 +149,13 @@
         </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">
-        <xsl:with-param name="caption">Open Containing Folder</xsl:with-param>
+        <xsl:with-param name="caption">Open Source Folder</xsl:with-param>
         <xsl:with-param name="command">keyman:opencontainingfolder?id=<xsl:value-of select="ID" />
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open Build Folder</xsl:with-param>
+        <xsl:with-param name="command">keyman:openbuildfolder?id=<xsl:value-of select="ID" />
         </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">

--- a/windows/src/developer/TIKE/xml/project/packages.xsl
+++ b/windows/src/developer/TIKE/xml/project/packages.xsl
@@ -140,8 +140,13 @@
         <xsl:with-param name="command">keyman:editfileexternal?id=<xsl:value-of select="ID" /></xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">
-        <xsl:with-param name="caption">Open Containing Folder</xsl:with-param>
+        <xsl:with-param name="caption">Open Source Folder</xsl:with-param>
         <xsl:with-param name="command">keyman:opencontainingfolder?id=<xsl:value-of select="ID" /></xsl:with-param>
+      </xsl:call-template>
+      <xsl:call-template name="menuitem">
+        <xsl:with-param name="caption">Open Build Folder</xsl:with-param>
+        <xsl:with-param name="command">keyman:openbuildfolder?id=<xsl:value-of select="ID" />
+        </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="menuitem">
         <xsl:with-param name="caption">Remove from Project</xsl:with-param>

--- a/windows/src/developer/TIKE/xml/project/welcome.xsl
+++ b/windows/src/developer/TIKE/xml/project/welcome.xsl
@@ -47,6 +47,11 @@
       </div>
 
       <div style="padding: 0 10px 10px 10px;">
+        <xsl:call-template name="button">
+          <xsl:with-param name="caption">Open project folder</xsl:with-param>
+          <xsl:with-param name="command">keyman:openprojectfolder</xsl:with-param>
+        </xsl:call-template>
+
         <div style="clear:both">
           <h2>Recent Files</h2>
         </div>

--- a/windows/src/global/delphi/general/utilsystem.pas
+++ b/windows/src/global/delphi/general/utilsystem.pas
@@ -329,11 +329,13 @@ var
   sei: TShellExecuteInfo;
   s: string;
 begin
-  s := '/select,'+FileName;
+  if not FileExists(FileName)
+    then s := '"'+ExtractFilePath(FileName)+'"'
+    else s := '"/select,'+FileName+'"';
   FillChar(sei, SizeOf(sei), 0);
   sei.cbSize := SizeOf(TShellExecuteInfo);
   sei.lpVerb := 'open';
-  sei.lpFile := 'explorer'; //PChar(s);
+  sei.lpFile := 'explorer';
   sei.lpParameters := PChar(s);
   sei.nShow := SW_SHOWNORMAL;
   ShellExecuteEx(@sei);


### PR DESCRIPTION
Fixes #4314.

Adds 'Open Source Folder', 'Open Build Folder', and 'Open Project Folder' actions to various parts of Keyman Developer.

# Project - Information - open project folder button

![image](https://user-images.githubusercontent.com/4498365/109768586-334de100-7c4d-11eb-9c0a-bac640b7bdae.png)

# Project - Open Containing Folder commands (right click or Options menu)

![image](https://user-images.githubusercontent.com/4498365/109768680-52e50980-7c4d-11eb-8485-23f86d438c6d.png)

# Keyboard Editor - Build tab

Note that the File actions box is also new in all three editors -- a rearrangement of existing controls, however.

![image](https://user-images.githubusercontent.com/4498365/109768980-b2dbb000-7c4d-11eb-84bc-4148f850435a.png)

# Package Editor - Compile tab

![image](https://user-images.githubusercontent.com/4498365/109768923-a2c3d080-7c4d-11eb-8898-b5b47eae59c3.png)

# Model Editor - Build tab

![image](https://user-images.githubusercontent.com/4498365/109768754-6c865100-7c4d-11eb-9dd5-d783dd7eb7f1.png)
