### PR TITLE
chore(linux): Don't report to Sentry in dev environment

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -36,6 +36,8 @@ KeymanDownloadsUrl = 'https://downloads.keyman.com'
 
 if 'unittest' in sys.modules.keys():
     print('Not reporting to Sentry')
+elif os.environ.get('KEYMAN_NOSENTRY'):
+    print('Not reporting to Sentry because KEYMAN_NOSENTRY environment variable set')
 else:
     try:
         # Try new sentry-sdk first


### PR DESCRIPTION
When the environment variable KEYMAN_NOSENTRY is set we'll skip reporting to Sentry. This is helpful on development machines.