### PR TITLE
feat(developer): &CasedKeys system store

### DIFF
--- a/windows/src/developer/TIKE/help/kwhelp.pas
+++ b/windows/src/developer/TIKE/help/kwhelp.pas
@@ -41,7 +41,7 @@ type
   end;
 
 const
-  HelpArray: array[0..73] of THelpArray = (   // I4840
+  HelpArray: array[0..74] of THelpArray = (   // I4840
     (Word: 'BITMAP' ),
     (Word: 'begin' ),
     (Word: 'COPYRIGHT' ),
@@ -53,6 +53,7 @@ const
 {9} (Word: 'VERSION' ),
 
     (Word: '&BITMAP'; Topic: 'bitmap' ),
+    (Word: '&CasedKeys'; Topic: 'casedkeys' ),
     (Word: '&COPYRIGHT'; Topic: 'copyright' ),
     (Word: '&EthnologueCode'; Topic: 'ethnologuecode' ),   // I4840
     (Word: '&HOTKEY'; Topic: 'hotkey' ),

--- a/windows/src/developer/kmcmpdll/CasedKeys.cpp
+++ b/windows/src/developer/kmcmpdll/CasedKeys.cpp
@@ -1,0 +1,163 @@
+
+#include "pch.h"
+
+#include <compfile.h>
+#include <compiler.h>
+#include <comperr.h>
+#include <vkeys.h>
+#include <kmcmpdll.h>
+
+#include "CharToKeyConversion.h"
+
+extern BOOL FMnemonicLayout; // TODO: these globals should be consolidated one day
+
+DWORD ExpandCapsRule(PFILE_GROUP gp, PFILE_KEY kpp, PFILE_STORE sp);
+
+PFILE_STORE FindSystemStore(PFILE_KEYBOARD fk, DWORD dwSystemID) {
+  assert(fk != NULL);
+  assert(dwSystemID != 0);
+
+  PFILE_STORE sp = fk->dpStoreArray;
+  for (DWORD i = 0; i < fk->cxStoreArray; i++, sp++) {
+    if (sp->dwSystemID == dwSystemID) {
+      return sp;
+    }
+  }
+  return NULL;
+}
+
+DWORD VerifyCasedKeys(PFILE_STORE sp) {
+  assert(sp != NULL);
+
+  if (FMnemonicLayout) {
+    // The &CasedKeys system store is not supported for
+    // mnemonic layouts in 14.0
+    return CERR_CasedKeysNotSupportedWithMnemonicLayout;
+  }
+
+  // We will rewrite this store with virtual keys
+
+  PWSTR p = sp->dpString;
+  PWSTR buf = new WCHAR[wcslen(p) * 5 + 1];  // extended keys are 5 units long, so this is the max length
+  PWSTR q = buf;
+
+  while (*p) {
+    UINT key = 0, shift = 0;
+    if (*p != UC_SENTINEL) {
+      if (!MapUSCharToVK(*p, &key, &shift)) {
+        return CERR_CasedKeysMustContainOnlyVirtualKeys;
+      }
+      if (shift & K_SHIFTFLAG) {
+        return CERR_CasedKeysMustNotIncludeShiftStates;
+      }
+    }
+    else {
+      if (*(p + 1) != CODE_EXTENDED) {
+        return CERR_CasedKeysMustContainOnlyVirtualKeys;
+      }
+      shift = *(p + 2);
+      key = *(p + 3);
+      if (shift != ISVIRTUALKEY) {
+        return CERR_CasedKeysMustNotIncludeShiftStates;
+      }
+    }
+    *q++ = UC_SENTINEL;
+    *q++ = CODE_EXTENDED;
+    *q++ = shift;
+    *q++ = key;
+    *q++ = UC_SENTINEL_EXTENDEDEND;
+    *q = 0;
+
+    p = incxstr(p);
+  }
+
+  delete[] sp->dpString;
+  sp->dpString = buf;
+
+  return CERR_None;
+}
+
+DWORD ExpandCapsRulesForGroup(PFILE_KEYBOARD fk, PFILE_GROUP gp) {
+  assert(fk != NULL);
+  assert(gp != NULL);
+
+  if (FMnemonicLayout) {
+    // The &CasedKeys system store is not supported for
+    // mnemonic layouts in 14.0
+    return CERR_None;
+  }
+
+  PFILE_STORE sp = FindSystemStore(fk, TSS_CASEDKEYS);
+  if (!sp) {
+    // If there is no &CasedKeys system store, then we do not
+    // process the key
+    return CERR_None;
+  }
+
+  DWORD msg;
+  // ExpandCapsRule may add extra rules at the end of gp->dpKeyArray,
+  // reallocating it, so we (a) cache the original length, and (b)
+  // dereference the array every call
+  int cxKeyArray = gp->cxKeyArray;
+  for (int i = 0; i < cxKeyArray; i++) {
+    if ((msg = ExpandCapsRule(gp, &gp->dpKeyArray[i], sp)) != CERR_None) {
+      return msg;
+    }
+  }
+  return CERR_None;
+}
+
+DWORD ExpandCapsRule(PFILE_GROUP gp, PFILE_KEY kpp, PFILE_STORE sp) {
+  UINT key = kpp->Key;
+  UINT shift = kpp->ShiftFlags;
+
+  if (shift == 0) {
+    // Convert US key cap to a virtual key
+    if (!MapUSCharToVK(kpp->Key, &key, &shift)) {
+      return CERR_None;
+    }
+  }
+
+  if (shift & (CAPITALFLAG | NOTCAPITALFLAG)) {
+    // Don't attempt expansion if either Caps Lock flag is specified in the key rule
+    return CERR_None;
+  }
+
+  PWSTR p = sp->dpString;
+  for (; *p; p = incxstr(p)) {
+    // We've already verified that the store contains only virtual keys in VerifyCasedKeys
+    if (*(p + 3) == key) {
+      break;
+    }
+  }
+
+  if (!*p) {
+    // This key is not modified by Caps Lock
+    return CERR_None;
+  }
+
+  // This key is modified by Caps Lock, so we need to duplicate this rule
+  PFILE_KEY k = new FILE_KEY[gp->cxKeyArray + 1];
+  if (!k) return CERR_CannotAllocateMemory;
+  memcpy(k, gp->dpKeyArray, gp->cxKeyArray * sizeof(FILE_KEY));
+
+  kpp = &k[(INT_PTR)(kpp - gp->dpKeyArray)];
+
+  delete gp->dpKeyArray;
+  gp->dpKeyArray = k;
+  gp->cxKeyArray++;
+
+  k = &k[gp->cxKeyArray - 1];
+  k->dpContext = new WCHAR[wcslen(kpp->dpContext) + 1];
+  k->dpOutput = new WCHAR[wcslen(kpp->dpOutput) + 1];
+  wcscpy_s(k->dpContext, wcslen(kpp->dpContext) + 1, kpp->dpContext);	// copy the context.
+  wcscpy_s(k->dpOutput, wcslen(kpp->dpOutput) + 1, kpp->dpOutput);		// copy the output.
+  k->Key = key;
+  k->Line = kpp->Line;
+  // Add the CAPITAL FLAG, invert shift flag for the rule
+  k->ShiftFlags = shift ^ K_SHIFTFLAG | CAPITALFLAG;
+  kpp->Key = key;
+  kpp->ShiftFlags = shift | NOTCAPITALFLAG;
+
+  return CERR_None;
+}

--- a/windows/src/developer/kmcmpdll/CasedKeys.h
+++ b/windows/src/developer/kmcmpdll/CasedKeys.h
@@ -1,0 +1,4 @@
+#pragma once
+
+DWORD VerifyCasedKeys(PFILE_STORE sp);
+DWORD ExpandCapsRulesForGroup(PFILE_KEYBOARD fk, PFILE_GROUP gp);

--- a/windows/src/developer/kmcmpdll/CharToKeyConversion.cpp
+++ b/windows/src/developer/kmcmpdll/CharToKeyConversion.cpp
@@ -1,0 +1,187 @@
+
+#include "pch.h"
+#include <CharToKeyConversion.h>
+
+/* Following code lifted from syskbd.cpp and tweaked for compiler use. Todo: consolidate */
+
+WCHAR VKToChar(WORD keyCode, UINT shiftFlags)
+{
+  char shiftedDigit[] = ")!@#$%^&*(";
+  int n, Shift;
+
+  if (!(shiftFlags & ISVIRTUALKEY)) return keyCode;
+
+  if (shiftFlags & (LCTRLFLAG | RCTRLFLAG | LALTFLAG | RALTFLAG)) return 0;
+
+  if (keyCode >= '0' && keyCode <= '9')
+  {
+    n = keyCode - '0';
+    return ((shiftFlags & K_SHIFTFLAG) ? shiftedDigit[n] : keyCode);
+  }
+
+  if (keyCode >= 'A' && keyCode <= 'Z')
+  {
+    Shift = (shiftFlags & K_SHIFTFLAG);
+    if (shiftFlags & (CAPITALFLAG)) Shift = !Shift;
+    return (Shift ? keyCode : keyCode + 32);
+  }
+
+  if (keyCode >= VK_NUMPAD0 && keyCode <= VK_NUMPAD9)
+  {
+    if (!(shiftFlags & NUMLOCKFLAG)) return 0;
+    return keyCode - (VK_NUMPAD0 - '0');
+  }
+
+  Shift = (shiftFlags & K_SHIFTFLAG);
+
+  switch (keyCode)
+  {
+  case VK_ACCENT:
+    return Shift ? '~' : '`';
+  case VK_HYPHEN:
+    return Shift ? '_' : '-';
+  case VK_EQUAL:
+    return Shift ? '+' : '=';
+  case VK_BKSLASH:
+    return Shift ? '|' : 92;
+  case VK_LBRKT:
+    return Shift ? '{' : '[';
+  case VK_RBRKT:
+    return Shift ? '}' : ']';
+  case VK_COLON:
+    return Shift ? ':' : ';';
+  case VK_QUOTE:
+    return Shift ? '"' : 39;
+  case VK_COMMA:
+    return Shift ? '<' : ',';
+  case VK_PERIOD:
+    return Shift ? '>' : '.';
+  case VK_SLASH:
+    return Shift ? '?' : '/';
+  case VK_SPACE:
+    return ' ';
+  }
+  return 0;
+  //keyCode;
+}
+
+
+/* This array is lifted from preservedkeymap.cpp */
+// TODO: share this
+const struct
+{
+  UINT key;
+  BOOL shift;
+} USCharMap[] = {
+  { VK_SPACE, FALSE }, // 20 ' '
+  { '1', TRUE }, // 21 '!'
+  { VK_QUOTE, TRUE }, // 22 '"'
+  { '3', TRUE }, // 23 '#'
+  { '4', TRUE }, // 24 '$'
+  { '5', TRUE }, // 25 '%'
+  { '7', TRUE }, // 26 '&'
+  { VK_QUOTE, FALSE }, // 27 '''
+  { '9', TRUE }, // 28 '('
+  { '0', TRUE }, // 29 ')'
+  { '8', TRUE }, // 2A '*'
+  { VK_EQUAL, TRUE }, // 2B '+'
+  { VK_COMMA, FALSE }, // 2C ','
+  { VK_HYPHEN, FALSE }, // 2D '-'
+  { VK_PERIOD, FALSE }, // 2E '.'
+  { VK_SLASH, FALSE }, // 2F '/'
+
+  { '0', FALSE }, // 30 '0'
+  { '1', FALSE }, // 31 '1'
+  { '2', FALSE }, // 32 '2'
+  { '3', FALSE }, // 33 '3'
+  { '4', FALSE }, // 34 '4'
+  { '5', FALSE }, // 35 '5'
+  { '6', FALSE }, // 36 '6'
+  { '7', FALSE }, // 37 '7'
+  { '8', FALSE }, // 38 '8'
+  { '9', FALSE }, // 39 '9'
+  { VK_COLON, TRUE }, // 3A ':'
+  { VK_COLON, FALSE }, // 3B ';'
+  { VK_COMMA, TRUE }, // 3C '<'
+  { VK_EQUAL, FALSE }, // 3D '='
+  { VK_PERIOD, TRUE }, // 3E '>'
+  { VK_SLASH, TRUE }, // 3F '?'
+
+  { '2', TRUE }, // 40 '@'
+  { 'A', TRUE }, // 41 'A'
+  { 'B', TRUE }, // 42 'B'
+  { 'C', TRUE }, // 43 'C'
+  { 'D', TRUE }, // 44 'D'
+  { 'E', TRUE }, // 45 'E'
+  { 'F', TRUE }, // 46 'F'
+  { 'G', TRUE }, // 47 'G'
+  { 'H', TRUE }, // 48 'H'
+  { 'I', TRUE }, // 49 'I'
+  { 'J', TRUE }, // 4A 'J'
+  { 'K', TRUE }, // 4B 'K'
+  { 'L', TRUE }, // 4C 'L'
+  { 'M', TRUE }, // 4D 'M'
+  { 'N', TRUE }, // 4E 'N'
+  { 'O', TRUE }, // 4F 'O'
+
+  { 'P', TRUE }, // 50 'P'
+  { 'Q', TRUE }, // 51 'Q'
+  { 'R', TRUE }, // 52 'R'
+  { 'S', TRUE }, // 53 'S'
+  { 'T', TRUE }, // 54 'T'
+  { 'U', TRUE }, // 55 'U'
+  { 'V', TRUE }, // 56 'V'
+  { 'W', TRUE }, // 57 'W'
+  { 'X', TRUE }, // 58 'X'
+  { 'Y', TRUE }, // 59 'Y'
+  { 'Z', TRUE }, // 5A 'Z'
+  { VK_LBRKT, FALSE }, // 5B '['
+  { VK_BKSLASH, FALSE }, // 5C '\'
+  { VK_RBRKT, FALSE }, // 5D ']'
+  { '6', TRUE }, // 5E '^'
+  { VK_HYPHEN, TRUE }, // 5F '_'
+
+  { VK_ACCENT, FALSE }, // 60 '`'
+  { 'A', FALSE }, // 61 'a'
+  { 'B', FALSE }, // 62 'b'
+  { 'C', FALSE }, // 63 'c'
+  { 'D', FALSE }, // 64 'd'
+  { 'E', FALSE }, // 65 'e'
+  { 'F', FALSE }, // 66 'f'
+  { 'G', FALSE }, // 67 'g'
+  { 'H', FALSE }, // 68 'h'
+  { 'I', FALSE }, // 69 'i'
+  { 'J', FALSE }, // 6A 'j'
+  { 'K', FALSE }, // 6B 'k'
+  { 'L', FALSE }, // 6C 'l'
+  { 'M', FALSE }, // 6D 'm'
+  { 'N', FALSE }, // 6E 'n'
+  { 'O', FALSE }, // 6F 'o'
+
+  { 'P', FALSE }, // 70 'p'
+  { 'Q', FALSE }, // 71 'q'
+  { 'R', FALSE }, // 72 'r'
+  { 'S', FALSE }, // 73 's'
+  { 'T', FALSE }, // 74 't'
+  { 'U', FALSE }, // 75 'u'
+  { 'V', FALSE }, // 76 'v'
+  { 'W', FALSE }, // 77 'w'
+  { 'X', FALSE }, // 78 'x'
+  { 'Y', FALSE }, // 79 'y'
+  { 'Z', FALSE }, // 7A 'z'
+  { VK_LBRKT, TRUE }, // 7B '{'
+  { VK_BKSLASH, TRUE }, // 7C '|'
+  { VK_RBRKT, TRUE }, // 7D '}'
+  { VK_ACCENT, TRUE }  // 7E '~'
+};
+
+BOOL MapUSCharToVK(UINT ch, UINT *puKey, UINT *puShiftFlags) {
+  assert(puKey != NULL);
+  assert(puShiftFlags != NULL);
+  if (ch >= 0x20 && ch < 0x7F) {
+    *puKey = USCharMap[ch - 0x20].key;
+    *puShiftFlags = ISVIRTUALKEY | (USCharMap[ch - 0x20].shift ? K_SHIFTFLAG : 0);
+    return TRUE;
+  }
+  return FALSE;
+}

--- a/windows/src/developer/kmcmpdll/CharToKeyConversion.h
+++ b/windows/src/developer/kmcmpdll/CharToKeyConversion.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <windows.h>
+
+#define VK_COLON	0xBA
+#define VK_EQUAL	0xBB
+#define VK_COMMA	0xBC
+#define VK_HYPHEN	0xBD
+#define VK_PERIOD	0xBE
+#define	VK_SLASH	0xBF
+#define VK_ACCENT	0xC0
+#define VK_LBRKT	0xDB
+#define VK_BKSLASH	0xDC
+#define VK_RBRKT	0xDD
+#define VK_QUOTE	0xDE
+#define VK_xDF		0xDF
+
+BOOL MapUSCharToVK(UINT ch, UINT *puKey, UINT *puShiftFlags);
+WCHAR VKToChar(WORD keyCode, UINT shiftFlags);
+

--- a/windows/src/developer/kmcmpdll/Compiler.rc
+++ b/windows/src/developer/kmcmpdll/Compiler.rc
@@ -237,3 +237,10 @@ BEGIN
     CERR_VKeyExpansionMustUseConsistentShift           "A virtual key expansion must use the same shift state for both terminators"
     CERR_ExpansionMustBePositive                       "An expansion must have positive difference (i.e. A-Z, not Z-A)"
 END
+
+STRINGTABLE
+BEGIN
+    CERR_CasedKeysMustContainOnlyVirtualKeys           "The &CasedKeys system store must contain only virtual keys or characters found on a US English keyboard"
+    CERR_CasedKeysMustNotIncludeShiftStates            "The &CasedKeys system store must not include shift states"
+    CERR_CasedKeysNotSupportedWithMnemonicLayout       "The &CasedKeys system store is not supported with mnemonic layouts"
+END

--- a/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj
@@ -294,6 +294,8 @@
     <ClInclude Include="..\..\global\inc\Comperr.h" />
     <ClInclude Include="..\..\global\inc\Compfile.h" />
     <ClInclude Include="..\..\global\inc\Compiler.h" />
+    <ClInclude Include="CasedKeys.h" />
+    <ClInclude Include="CharToKeyConversion.h" />
     <ClInclude Include="comprc.h" />
     <ClInclude Include="..\..\global\inc\ConvertUTF.h" />
     <ClInclude Include="..\..\global\inc\crc32.h" />
@@ -330,6 +332,8 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\global\vc\xstring.cpp" />
+    <ClCompile Include="CasedKeys.cpp" />
+    <ClCompile Include="CharToKeyConversion.cpp" />
     <ClCompile Include="Compiler.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj.filters
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.vcxproj.filters
@@ -70,6 +70,12 @@
     <ClInclude Include="pch.h">
       <Filter>Header files</Filter>
     </ClInclude>
+    <ClInclude Include="CharToKeyConversion.h">
+      <Filter>Header files</Filter>
+    </ClInclude>
+    <ClInclude Include="CasedKeys.h">
+      <Filter>Header files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Compiler.cpp" />
@@ -89,6 +95,8 @@
     <ClCompile Include="versioning.cpp" />
     <ClCompile Include="DeprecationChecks.cpp" />
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="CasedKeys.cpp" />
+    <ClCompile Include="CharToKeyConversion.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Compiler.rc" />

--- a/windows/src/developer/kmdecomp/kmdecomp.cpp
+++ b/windows/src/developer/kmdecomp/kmdecomp.cpp
@@ -59,14 +59,20 @@ int run(int argc, char *argv[])
 	{
 		puts("KMDECOMP: Decompile Keyman .kmx keyboard");
 		puts("(C) SIL International");
-		puts("Usage: KMDECOMP <filename>\n");
+		puts("Usage: KMDECOMP <filename> [output]\n");
 		puts("Will create a .kmn and optionally a .bmp/.ico with the same filename and in the same location as the input");
 		return 1;
 	}
 
 	if(!LoadKeyboard(argv[1], &kbd, &lpBitmap, &cbBitmap)) return 2;
 
-	_splitpath_s(argv[1], drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, NULL, 0);
+  if (argc < 3) {
+    _splitpath_s(argv[1], drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, NULL, 0);
+  }
+  else {
+    _splitpath_s(argv[2], drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, NULL, 0);
+  }
+
 	_makepath_s(buf, _MAX_PATH, drive, dir, filename, ".kmn");
 	_makepath_s(buf2, _MAX_PATH, drive, dir, filename, ".bmp");
 

--- a/windows/src/developer/kmdecomp/savekeyboard.cpp
+++ b/windows/src/developer/kmdecomp/savekeyboard.cpp
@@ -90,6 +90,7 @@ const PWCHAR StoreTokens[MAX_SYSTEM_STORE] = {   // I4652
   SSN__PREFIX L"KEYBOARDVERSION",   // I4140
 	SSN__PREFIX L"KMW_EMBEDCSS",
   SSN__PREFIX L"TARGETS",   // I4504
+  SSN__PREFIX L"CASEDKEYS",
 	NULL
 };
 
@@ -254,7 +255,7 @@ PWCHAR ExtString(PWCHAR str)
           else
 					  wsprintfW(p, L"[%s%s] ", flagstr(*str), VKeyNames[*(str+1)]);
         }
-				str++;
+				str+=2; // skip UC_SENTINEL_EXTENDEDEND
 				p = wcschr(p, 0);
 				break;
 			case CODE_SWITCH:

--- a/windows/src/global/delphi/general/CompileErrorCodes.pas
+++ b/windows/src/global/delphi/general/CompileErrorCodes.pas
@@ -153,6 +153,10 @@ const
   CERR_VKeyExpansionMustUseConsistentShift         = $4067;
   CERR_ExpansionMustBePositive                     = $4068;
 
+  CERR_CasedKeysMustContainOnlyVirtualKeys         = $4069;
+  CERR_CasedKeysMustNotIncludeShiftStates          = $406A;
+  CERR_CasedKeysNotSupportedWithMnemonicLayout     = $406B;
+
   CWARN_TooManyWarnings                            = $2080;
   CWARN_OldVersion                                 = $2081;
   CWARN_BitmapNotUsed                              = $2082;

--- a/windows/src/global/inc/Comperr.h
+++ b/windows/src/global/inc/Comperr.h
@@ -149,6 +149,10 @@
 #define CERR_VKeyExpansionMustUseConsistentShift           0x00004067
 #define CERR_ExpansionMustBePositive                       0x00004068
 
+#define CERR_CasedKeysMustContainOnlyVirtualKeys           0x00004069
+#define CERR_CasedKeysMustNotIncludeShiftStates            0x0000406A
+#define CERR_CasedKeysNotSupportedWithMnemonicLayout       0x0000406B
+
 #define CWARN_TooManyWarnings                              0x00002080
 #define CWARN_OldVersion                                   0x00002081
 #define CWARN_BitmapNotUsed                                0x00002082

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -199,9 +199,11 @@
 #define TSS_KEYBOARDVERSION  36      // &keyboardversion system store   // I4140
 #define TSS_KMW_EMBEDCSS     37
 
-#define TSS_TARGETS         38
+#define TSS_TARGETS          38
 
-#define TSS__MAX				38
+#define TSS_CASEDKEYS        39
+
+#define TSS__MAX				     39
 
 /* wm_keyman_control_internal message control codes */
 

--- a/windows/src/test/unit-tests/kmcomp/test.bat
+++ b/windows/src/test/unit-tests/kmcomp/test.bat
@@ -46,6 +46,14 @@ fc /b test_expansion.kmx test_expansion_1.kmx || goto :eof
 
 call :should-fail "#2241: invalid expansions" test_expansion_invalid.kmn || goto :eof
 
+call :should-pass "#2241: &CasedKeys" test_casedkeys.kmn || goto :eof
+call :should-pass "#2241: &CasedKeys (chars)" test_casedkeys_chars.kmn || goto :eof
+
+call :should-fail "#2241: &CasedKeys (mnemonic 1)" test_casedkeys_mnemonic_1.kmn || goto :eof
+call :should-fail "#2241: &CasedKeys (mnemonic 2)" test_casedkeys_mnemonic_2.kmn || goto :eof
+call :should-fail "#2241: &CasedKeys (invalid chars 1)" test_casedkeys_invalid_1.kmn || goto :eof
+call :should-fail "#2241: &CasedKeys (invalid chars 2)" test_casedkeys_invalid_2.kmn || goto :eof
+
 goto :eof
 
 :should-pass

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys.kmn
@@ -1,0 +1,39 @@
+c Tests cased keys rule expansions
+store(&NAME) 'Test &CasedKeys'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) [K_A] [K_E] [K_I] [K_O] [K_U] [K_1] .. [K_4]
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'
+
++ [K_E] > 'eh'
++ [SHIFT K_E] > 'EH'
+
++ [K_O] > 'oh'
++ [SHIFT K_O] > 'OH'
+
++ [K_1] > 'small one'
++ [SHIFT K_1] > 'big one'
+
+c These ones should not be expanded, because they are unreferenced
+
++ [K_5] > 'small five'
++ [SHIFT K_5] > 'big five'
+
++ [K_C] > 'small c'
++ [SHIFT K_C] > 'big c'
+
+c These should not be expanded either, because they are capsified already
+
++ [CAPS K_B] > 'Caps B'
++ [NCAPS K_B] > 'NCaps B'
++ [CAPS SHIFT K_B] > 'Caps Shift B'
++ [NCAPS SHIFT K_B] > 'NCaps Shift B'
+
++ [CAPS K_I] > 'Caps I'
++ [NCAPS K_I] > 'NCaps I'
++ [CAPS SHIFT K_I] > 'Caps Shift I'
++ [NCAPS SHIFT K_I] > 'NCaps Shift I'

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_chars.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_chars.kmn
@@ -1,0 +1,41 @@
+c Tests cased keys rule expansions - character-based rules
+store(&NAME) 'Test &CasedKeys'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) 'a'..'z1/'
+
++ 'a' > 'aaah'
++ 'A' > 'AAAH'
+
++ 'e' > 'eh'
++ 'E' > 'EH'
+
++ 'o' > 'oh'
++ 'O' > 'OH'
+
++ '1' > 'small one'
++ '!' > 'big one'
+
++ '/' > 'little slash'
++ '?' > 'big slash'
+
+c These ones should not be expanded, because they are unreferenced
+
++ '5' > 'small five'
++ '%' > 'big five'
+
+
+
+c These should not be expanded either, because they are capsified already
+
++ [CAPS K_B] > 'Caps B'
++ [NCAPS K_B] > 'NCaps B'
++ [CAPS SHIFT K_B] > 'Caps Shift B'
++ [NCAPS SHIFT K_B] > 'NCaps Shift B'
+
++ [CAPS K_I] > 'Caps I'
++ [NCAPS K_I] > 'NCaps I'
++ [CAPS SHIFT K_I] > 'Caps Shift I'
++ [NCAPS SHIFT K_I] > 'NCaps Shift I'

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_invalid_1.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_invalid_1.kmn
@@ -1,0 +1,10 @@
+c Tests cased keys - invalid codes
+store(&NAME) 'Test &CasedKeys'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) U+1000
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_invalid_2.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_invalid_2.kmn
@@ -1,0 +1,10 @@
+c Tests cased keys - invalid codes
+store(&NAME) 'Test &CasedKeys'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) [SHIFT K_1]
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_1.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_1.kmn
@@ -1,0 +1,11 @@
+c Tests cased keys - invalid with mnemonic layout
+store(&NAME) 'Test &CasedKeys'
+store(&mnemoniclayout) '1'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) [K_A] [K_E] [K_I] [K_O] [K_U] [K_1] .. [K_4]
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_2.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_2.kmn
@@ -1,0 +1,11 @@
+c Tests cased keys - invalid with mnemonic layout
+store(&NAME) 'Test &CasedKeys'
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(&CasedKeys) [K_A] [K_E] [K_I] [K_O] [K_U] [K_1] .. [K_4]
+store(&mnemoniclayout) '1'
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'

--- a/windows/src/test/unit-tests/kmcomp/tests.kpj
+++ b/windows/src/test/unit-tests/kmcomp/tests.kpj
@@ -157,6 +157,66 @@
       </Details>
     </File>
     <File>
+      <ID>id_c35b5f806c85252da940a60449e089e0</ID>
+      <Filename>test_casedkeys.kmn</Filename>
+      <Filepath>test_casedkeys.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
+      <ID>id_3a9d89cd15f05037ef2d5a71fd78ed35</ID>
+      <Filename>test_casedkeys_chars.kmn</Filename>
+      <Filepath>test_casedkeys_chars.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
+      <ID>id_70997591a064ca387dac08622a04c392</ID>
+      <Filename>test_casedkeys_invalid_1.kmn</Filename>
+      <Filepath>test_casedkeys_invalid_1.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
+      <ID>id_8551121eb12d38673567587b753908f7</ID>
+      <Filename>test_casedkeys_invalid_2.kmn</Filename>
+      <Filepath>test_casedkeys_invalid_2.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
+      <ID>id_2e7200332135cd7d8ce6109a31be82fe</ID>
+      <Filename>test_casedkeys_mnemonic_1.kmn</Filename>
+      <Filepath>test_casedkeys_mnemonic_1.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
+      <ID>id_7d86f03f3e1c308ab03429ac05556e5a</ID>
+      <Filename>test_casedkeys_mnemonic_2.kmn</Filename>
+      <Filepath>test_casedkeys_mnemonic_2.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test &amp;CasedKeys</Name>
+      </Details>
+    </File>
+    <File>
       <ID>id_5f9e583f7392151b3c3a7d4577b31a4f</ID>
       <Filename>test_valid.kmx</Filename>
       <Filepath>test_valid.kmx</Filepath>


### PR DESCRIPTION
Fixes #2241.

The `&CasedKeys` system store is a compiler feature that reduces the repetitive nature of keyboard rules for `CAPS` and `NCAPS`. The `&CasedKeys` system store defines a list of virtual keys for which 'normal' Caps Lock rules apply. This store has no default value, for backward compatibility.

Once this store is defined, then you can define just the unshifted and shifted versions of a rule, and Keyman Developer will synthesize the `CAPS` and `NCAPS` versions of the rule. For example, you may have the following rules:

```
store(&CasedKeys) [K_A]
+ [K_A] > 'α'
+ [SHIFT K_A] > 'Α'
```

These would be replaced by the compiler with:

```
store(&CasedKeys) [K_A]
+ [NCAPS K_A] > 'α'
+ [SHIFT CAPS K_A] > 'α'
+ [CAPS K_A] > 'Α'
+ [SHIFT NCAPS K_A] > 'Α'
```

You can also use this functionality with characters in the key part of the rule:

```
store(&CasedKeys) 'a'..'c'
+ 'a' > 'α'
+ 'A' > 'Α'
```

and the compiled expansion would be similar:

```
store(&CasedKeys) [K_A] [K_B] [K_C]
+ [NCAPS K_A] > 'α'
+ [SHIFT CAPS K_A] > 'α'
+ [CAPS K_A] > 'Α'
+ [SHIFT NCAPS K_A] > 'Α'
```

This feature is backwardly compatible with Keyman 6.0, as it is entirely implemented in the compiler.

This feature is not compatible with mnemonic layouts, and the keys defined in the `&CasedKeys` store must be the unshifted base keys as found on a US English keyboard, or you can use ISO9995 identifiers if you prefer.

If you define a rule where you specify either `NCAPS` or `CAPS`, for a key found in the store, then no change will be made to that rule. You can also continue to define rules which use `NCAPS` or `CAPS` for keys not found in the store.

As a side-benefit, this allows the visual designer to be used and support Caps Lock, although at this stage, the `&CasedKeys` store is not surfaced in the visual designer.