### PR TITLE
fix(common/models): fixes application of suggestions immediately after a backspace

### DIFF
--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -10,6 +10,71 @@ var ModelCompositor = require('../../build/intermediate').ModelCompositor;
 
 describe('ModelCompositor', function() {
   describe('Prediction with 14.0+ models', function() {
+    describe('Basic suggestion generation', function() {
+      var plainModel = new TrieModel(jsonFixture('tries/english-1000'), 
+        {wordBreaker: wordBreakers.default}
+      );
+
+      it('generates suggestions with expected properties', function() {
+        let compositor = new ModelCompositor(plainModel);
+        let context = {
+          left: 'th', startOfBuffer: true, endOfBuffer: true,
+        };
+
+        let inputTransform = {
+          insert: 'e',
+          deleteLeft: 0
+        };
+
+        let suggestions = compositor.predict(inputTransform, context);
+        suggestions.forEach(function(suggestion) {
+          // Suggstions are built based on the context state BEFORE the triggering 
+          // input, replacing the prediction's root with the complete word.
+          //
+          // This is necessary, in part, for proper display-string construction.
+          assert.equal(suggestion.transform.deleteLeft, 2);
+        });
+
+        let keep = suggestions.find(function(suggestion) {
+          return suggestion.tag == 'keep';
+        });
+
+        assert.isDefined(keep);
+        assert.equal(keep.transform.insert, 'the ');
+
+        // Expect an appended space.
+        let expectedEntries = ['they ', 'there ', 'their ', 'these ', 'themselves '];
+        expectedEntries.forEach(function(entry) {
+          assert.isDefined(suggestions.find(function(suggestion) {
+            return suggestion.transform.insert == entry;
+          }));
+        });
+      });
+
+      it('properly handles suggestions after a backspace', function() {
+        let compositor = new ModelCompositor(plainModel);
+        let context = {
+          left: 'the ', startOfBuffer: true, endOfBuffer: true,
+        };
+
+        let inputTransform = {
+          insert: '',
+          deleteLeft: 1
+        };
+
+        let suggestions = compositor.predict(inputTransform, context);
+        suggestions.forEach(function(suggestion) {
+          // Suggestions always delete the full root of the suggestion.
+          //
+          // After a backspace, that means the text 'the' - 3 chars.
+          // Char 4 is for the original backspace, as suggstions are built
+          // based on the context state BEFORE the triggering input -
+          // here, a backspace.
+          assert.equal(suggestion.transform.deleteLeft, 4);
+        });
+      });
+    });
+
     describe('applySuggestionCasing', function() {
       let plainApplyCasing = function(caseToApply, text) {
         switch(caseToApply) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -176,6 +176,7 @@ class ModelCompositor {
           }
 
           let deleteLeft = 0;
+          // remove actual token string.  If new token, there should be nothing to delete.
           if(!newEmptyToken) {
             // If this is triggered from a backspace, make sure to use its results
             // and also include its left-deletions!  It's the one post-input context case.
@@ -190,8 +191,7 @@ class ModelCompositor {
           // Replace the existing context with the correction.
           let correctionTransform: Transform = {
             insert: correction,  // insert correction string
-            // remove actual token string.  If new token, there should be nothing to delete.
-            deleteLeft: newEmptyToken ? 0 : deleteLeft, 
+            deleteLeft: deleteLeft, 
             id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
           }
 

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -175,11 +175,23 @@ class ModelCompositor {
             finalInput = inputTransform;  // A fallback measure.  Greatly matters for empty contexts.
           }
 
+          let deleteLeft = 0;
+          if(!newEmptyToken) {
+            // If this is triggered from a backspace, make sure to use its results
+            // and also include its left-deletions!  It's the one post-input context case.
+            if(allowBksp) {
+              deleteLeft = this.wordbreak(postContext).kmwLength() + inputTransform.deleteLeft;
+            } else {
+              // Normal case - use the pre-input context.
+              deleteLeft = this.wordbreak(context).kmwLength();
+            }
+          }
+
           // Replace the existing context with the correction.
           let correctionTransform: Transform = {
             insert: correction,  // insert correction string
             // remove actual token string.  If new token, there should be nothing to delete.
-            deleteLeft: newEmptyToken ? 0 : this.wordbreak(context).kmwLength(), 
+            deleteLeft: newEmptyToken ? 0 : deleteLeft, 
             id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
           }
 


### PR DESCRIPTION
Fixes #3616.

In particular, its final issue as mentioned in https://github.com/keymanapp/keyman/issues/3616#issuecomment-777987194:
> The issue is, unless we delete a character from the existing word [after a backspace], keyman will not replace the word, instead add the [full] suggestion to the context. This is wrong.

Also adds some unit tests for this case, along with a more normal-case test that's useful as a comparison.