### PR TITLE
fix(android): Localize Toast notifications

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.ResultReceiver;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.util.FileUtils;
 
 import java.io.File;
@@ -27,8 +28,7 @@ public class DownloadResultReceiver extends ResultReceiver {
   protected void onReceiveResult(int resultCode, Bundle resultData) {
     switch(resultCode) {
       case FileUtils.DOWNLOAD_ERROR :
-        Toast.makeText(context, "Download failed",
-          Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(context, R.string.download_failed, Toast.LENGTH_SHORT);
         MainActivity.cleanupPackageInstall();
         break;
       case FileUtils.DOWNLOAD_SUCCESS :

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
@@ -9,6 +9,8 @@ import android.content.ContextWrapper;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.LocaleList;
+import android.widget.Toast;
+
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
@@ -18,6 +20,20 @@ import com.tavultesoft.kmea.util.ContextUtils;
 import java.util.Locale;
 
 public class BaseActivity extends AppCompatActivity {
+  static ContextWrapper localeUpdatedContext;
+
+  /**
+   * Some classes aren't an AppCompatActivity and need this helper to localize Toast notifications
+   * in the updated locale.
+   * @param defaultContext - the context to fallback if localeUpdatedContext is null
+   * @param resID - resource ID of the string
+   * @param duration - length of the Toast notification (Toast.LENGTH_LONG or Toast.LENGTH_SHORT)
+   */
+  public static void makeToast(Context defaultContext, int resID, int duration) {
+    Context context = (localeUpdatedContext != null) ? localeUpdatedContext : defaultContext;
+    String msg = context.getString(resID);
+    Toast.makeText(context, msg, duration).show();
+  }
 
   @Override
   protected void attachBaseContext(Context newBase) {
@@ -36,7 +52,7 @@ public class BaseActivity extends AppCompatActivity {
     } else {
       localeToSwitchTo = Locale.forLanguageTag(languageTag);
     }
-    ContextWrapper localeUpdatedContext = ContextUtils.updateLocale(newBase, localeToSwitchTo);
+    this.localeUpdatedContext = ContextUtils.updateLocale(newBase, localeToSwitchTo);
     super.attachBaseContext(localeUpdatedContext);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
@@ -28,11 +28,12 @@ public class BaseActivity extends AppCompatActivity {
    * @param defaultContext - the context to fallback if localeUpdatedContext is null
    * @param resID - resource ID of the string
    * @param duration - length of the Toast notification (Toast.LENGTH_LONG or Toast.LENGTH_SHORT)
+   * @param args - optional format parameters for the string
    */
-  public static void makeToast(Context defaultContext, int resID, int duration) {
+  public static void makeToast(Context defaultContext, int resID, int duration, Object... args) {
     Context context = (localeUpdatedContext != null) ? localeUpdatedContext : defaultContext;
     String msg = context.getString(resID);
-    Toast.makeText(context, msg, duration).show();
+    Toast.makeText(context, String.format(msg, args), duration).show();
   }
 
   @Override

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -588,11 +588,13 @@ final class KMKeyboard extends WebView {
 
   }
 
-  // Display Toast notification that keyboard selection failed, so loading default keyboard.
-  // Also sends a message to Sentry
+  // Display localized Toast notification that keyboard selection failed, so loading default keyboard.
+  // Also sends a message to Sentry (not localized)
   private void sendError(String packageID, String keyboardID, String languageID) {
-    BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG);
-    String msg = String.format("Can't set %s::%s for %s language. Loading default keyboard", packageID, keyboardID, languageID);
+    BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
+
+    // Don't localize msg for Sentry
+    String msg = String.format(context.getString(R.string.fatal_keyboard_error), packageID, keyboardID, languageID);
     Sentry.captureMessage(msg);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -13,6 +13,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
@@ -154,10 +155,7 @@ final class KMKeyboard extends WebView {
         // TODO: Fix base error rather than trying to ignore it "No keyboard stubs exist"
 
         if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
-          Toast.makeText(context, "Fatal Error with " + currentKeyboard +
-            ". Loading default keyboard", Toast.LENGTH_LONG).show();
-
-          // Still send log about falling back to default keyboard (ignore language ID)
+          // Make Toast notification of error and send log about falling back to default keyboard (ignore language ID)
           sendError(packageID, keyboardID, "");
           Keyboard firstKeyboard = KeyboardController.getInstance().getKeyboardInfo(0);
           if (firstKeyboard != null) {
@@ -593,8 +591,8 @@ final class KMKeyboard extends WebView {
   // Display Toast notification that keyboard selection failed, so loading default keyboard.
   // Also sends a message to Sentry
   private void sendError(String packageID, String keyboardID, String languageID) {
+    BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG);
     String msg = String.format("Can't set %s::%s for %s language. Loading default keyboard", packageID, keyboardID, languageID);
-    Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
     Sentry.captureMessage(msg);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.util.DownloadFileUtils;
 
@@ -158,8 +159,7 @@ public class CloudApiTypes {
 
       if (filename == null || filename.isEmpty() || cachedFile == null || !cachedFile.exists()) {
         // failed to retrieve downloaded file
-        String message = context.getString(R.string.failed_to_retrieve_file);
-        Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+        BaseActivity.makeToast(context, R.string.failed_to_retrieve_file, Toast.LENGTH_LONG);
       }
 
       return cachedFile;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudCatalogDownloadCallback.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.cloud.CloudApiTypes;
@@ -110,7 +111,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
 
     private JSONArray ensureInit(Context aContext,Dataset aDataSet, JSONArray json) {
     if (json == null && aDataSet.isEmpty()) {
-      Toast.makeText(context, "Failed to access Keyman server!", Toast.LENGTH_SHORT).show();
+      BaseActivity.makeToast(context, R.string.cannot_connect, Toast.LENGTH_SHORT);
       handleDownloadError();
       return null;
     }
@@ -120,7 +121,7 @@ public class CloudCatalogDownloadCallback implements ICloudDownloadCallback<Data
 
    private JSONObject ensureInit(Context aContext,Dataset aDataSet, JSONObject json) {
     if (json == null && aDataSet.isEmpty()) {
-      Toast.makeText(context, "Failed to access Keyman server!", Toast.LENGTH_SHORT).show();
+      BaseActivity.makeToast(context, R.string.cannot_connect, Toast.LENGTH_SHORT);
       handleDownloadError();
       return null;
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.R;
@@ -107,9 +108,7 @@ public class CloudKeyboardPackageDownloadCallback implements ICloudDownloadCallb
   @Override
   public void applyCloudDownloadToModel(Context aContext, Void aModel, CloudKeyboardDownloadReturns aCloudResult)
   {
-    Toast.makeText(aContext,
-      aContext.getString(R.string.keyboard_download_finished),
-      Toast.LENGTH_SHORT).show();
+    BaseActivity.makeToast(aContext, R.string.keyboard_download_finished, Toast.LENGTH_SHORT);
 
     if(aCloudResult.installedResource != null)
     {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.cloud.CloudApiTypes;
 import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
@@ -80,8 +81,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
   @Override
   public void applyCloudDownloadToModel(Context aContext, Void aModel, List<CloudLexicalModelMetaDataDownloadCallback.MetaDataResult> aCloudResult) {
     if (aCloudResult.isEmpty()) {
-      String msg = aContext.getString(R.string.catalog_unavailable);
-      Toast.makeText(aContext, msg, Toast.LENGTH_SHORT).show();
+      BaseActivity.makeToast(aContext, R.string.catalog_unavailable, Toast.LENGTH_SHORT);
       KMLog.LogError(TAG, "Could not reach server");
       return;
     }
@@ -104,16 +104,12 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
         if(_r.returnjson.target== CloudApiTypes.ApiTarget.KeyboardLexicalModels) {
           if(  CloudDownloadMgr.getInstance().alreadyDownloadingData(_r.additionalDownloadid))
           {
-            Toast.makeText(aContext,
-              aContext.getString(R.string.dictionary_download_is_running_in_background),
-              Toast.LENGTH_SHORT).show();
+            BaseActivity.makeToast(aContext, R.string.dictionary_download_is_running_in_background, Toast.LENGTH_SHORT);
             continue;
           }
           CloudLexicalPackageDownloadCallback _callback = new CloudLexicalPackageDownloadCallback();
 
-          Toast.makeText(aContext,
-            aContext.getString(R.string.dictionary_download_start_in_background),
-            Toast.LENGTH_SHORT).show();
+          BaseActivity.makeToast(aContext, R.string.dictionary_download_start_in_background, Toast.LENGTH_SHORT);
 
           CloudDownloadMgr.getInstance().executeAsDownload(aContext,
             _r.additionalDownloadid, null, _callback,
@@ -152,8 +148,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
             KMLog.LogException(TAG, "Error parsing lexical model from api.keyman.com. ", e);
           }
         } else {
-          String msg = aContext.getString(R.string.no_associated_model);
-          Toast.makeText(aContext, msg, Toast.LENGTH_SHORT).show();
+          BaseActivity.makeToast(aContext, R.string.no_associated_model, Toast.LENGTH_SHORT);
         }
       }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalPackageDownloadCallback.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.widget.Toast;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KeyboardEventHandler;
 import com.tavultesoft.kmea.R;
@@ -98,9 +99,7 @@ public class CloudLexicalPackageDownloadCallback implements ICloudDownloadCallba
   @Override
   public void applyCloudDownloadToModel(Context aContext, Void aModel, CloudKeyboardDownloadReturns aCloudResult)
   {
-    Toast.makeText(aContext,
-      aContext.getString(R.string.dictionary_download_finished),
-      Toast.LENGTH_SHORT).show();
+    BaseActivity.makeToast(aContext, R.string.dictionary_download_finished, Toast.LENGTH_SHORT);
 
     if(aCloudResult.installedResource != null)
     {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -6,6 +6,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.BuildConfig;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
@@ -347,8 +348,7 @@ public class CloudRepository {
     preCacheDataSet(context,null,null,null);
 
     if(CloudDownloadMgr.getInstance().alreadyDownloadingData(DOWNLOAD_IDENTIFIER_CATALOGUE)) {
-      String msg = context.getString(R.string.catalog_download_is_running_in_background);
-      Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+      BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
     }
 
     return memCachedDataset;
@@ -394,12 +394,10 @@ public class CloudRepository {
       cloudQueries.toArray(params);
 
       if (CloudDownloadMgr.getInstance().alreadyDownloadingData(DOWNLOAD_IDENTIFIER_CATALOGUE)) {
-        String msg = context.getString(R.string.catalog_download_is_running_in_background);
-        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
       } else {
         updateIsRunning = true;
-        String msg = context.getString(R.string.catalog_download_start_in_background);
-        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(context, R.string.catalog_download_start_in_background, Toast.LENGTH_SHORT);
         CloudDownloadMgr.getInstance().executeAsDownload(
           context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -20,6 +20,7 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.app.NotificationManagerCompat;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.KMManager;
@@ -105,7 +106,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           return;
         }
 
-        Toast.makeText(currentContext, currentContext.getString(R.string.update_check_current), Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(currentContext, R.string.update_check_current, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
@@ -121,7 +122,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           return;
         }
 
-        Toast.makeText(currentContext, currentContext.getString(R.string.update_check_unavailable), Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(currentContext, R.string.update_check_unavailable, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         updateCheckFailed = true;
         checkingUpdates = false;
@@ -193,7 +194,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
               currentContext.startActivity(intent);
             }
           } else {
-            Toast.makeText(currentContext, "No internet connection", Toast.LENGTH_SHORT).show();
+            BaseActivity.makeToast(currentContext, R.string.cannot_connect, Toast.LENGTH_SHORT);
             checkingUpdates = false;
           }
         }
@@ -554,12 +555,12 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
 
       if (failedUpdateCount > 0) {
-        Toast.makeText(currentContext, "One or more resources failed to update!", Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(currentContext, R.string.update_failed, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         updateFailed = true;
         checkingUpdates = false;
       } else {
-        Toast.makeText(currentContext, "Resources successfully updated!", Toast.LENGTH_SHORT).show();
+        BaseActivity.makeToast(currentContext, R.string.update_success, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
@@ -49,8 +49,11 @@ public final class HelpFile {
         i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
       } catch (NullPointerException e) {
+        // Localize Toast error
         BaseActivity.makeToast(context, R.string.fileprovider_undefined, Toast.LENGTH_LONG);
-        String message = context.getString(R.string.fileprovider_undefined) + customHelp.toString();
+
+        // Don't localize message to Sentry
+        String message = String.format(context.getString(R.string.fileprovider_undefined), customHelp.toString());
         KMLog.LogException(TAG, message, e);
       }
     } else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/HelpFile.java
@@ -13,7 +13,9 @@ import android.widget.Toast;
 
 import androidx.core.content.FileProvider;
 
+import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.R;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.FileUtils;
 
@@ -47,8 +49,8 @@ public final class HelpFile {
         i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
       } catch (NullPointerException e) {
-        String message = "FileProvider undefined in app to load" + customHelp.toString();
-        Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+        BaseActivity.makeToast(context, R.string.fileprovider_undefined, Toast.LENGTH_LONG);
+        String message = context.getString(R.string.fileprovider_undefined) + customHelp.toString();
         KMLog.LogException(TAG, message, e);
       }
     } else {

--- a/android/KMEA/app/src/main/res/values-de-rDE/strings.xml
+++ b/android/KMEA/app/src/main/res/values-de-rDE/strings.xml
@@ -91,8 +91,6 @@
     <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">Das ausgewählte Wörterbuch wird bereits heruntergeladen. Bitte versuchen Sie es gleich nochmal!</string>
     <!-- Context: Background download messages-->
     <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Download des Wörterbuchs ist abgeschlossen.</string>
-    <!-- Context: Background download messages-->
-    <string name="failed_to_access_downloaded_file" comment="Failed to access downloaded file">Fehler beim Zugriff auf die heruntergeladene Datei</string>
     <!-- Context: Background download messages -->
     <string name="failed_to_retrieve_file" comment="Failed to retrieve downloaded file">Laden der heruntergeladenen Datei fehlgeschlagen</string>
     <!-- Context: General Updates -->

--- a/android/KMEA/app/src/main/res/values-fr-rFR/strings.xml
+++ b/android/KMEA/app/src/main/res/values-fr-rFR/strings.xml
@@ -91,8 +91,6 @@
     <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">Le dictionnaire sélectionné est déjà en cours de téléchargement ; veuillez réessayer dans un instant !</string>
     <!-- Context: Background download messages-->
     <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Téléchargement du dictionnaire terminé.</string>
-    <!-- Context: Background download messages-->
-    <string name="failed_to_access_downloaded_file" comment="Failed to access downloaded file">Impossible d\'accéder au fichier téléchargé</string>
     <!-- Context: Background download messages -->
     <string name="failed_to_retrieve_file" comment="Failed to retrieve downloaded file">Impossible de récupérer le fichier téléchargé</string>
     <!-- Context: General Updates -->

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
 
 
     <!-- Context: Keyboard Updates -->
-    <string name="cannot_connect" comment="Error message when network connection fails">\nCannot connect to Keyman server!\n</string>
+    <string name="cannot_connect" comment="Error message when network connection fails">Cannot connect to Keyman server!</string>
 
     <!-- Context: Keyboard Updates -->
     <string name="confirm_delete_keyboard" comment="Confirmation to delete a keyboard">Would you like to delete this keyboard?</string>
@@ -106,6 +106,12 @@
     <!-- Context: Keyboard Help welcome.htm title -->
     <string name="welcome_package" comment="Title to welcome.htm page (name and version)">Welcome to %1$s</string>
 
+    <!-- Context: Keyboard app doesn't include FileProvider library needed to view help file -->
+    <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">
+      FileProvider library needed to view help file:</string>
+
+    <!-- Context: Fatal keyboard error. Will load default keyboard -->
+    <string name="fatal_keyboard_error" comment="Fatal keyboard error. Will load default keyboard">Fatal keyboard error. Loading default keyboard.</string>
 
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Checking for associated dictionary to download</string>
@@ -160,6 +166,11 @@
     <!-- Context: General Updates -->
     <string name="update_check_current" comment="Notification that all resources are up to date">"All resources are up to date!"</string>
 
+    <!-- Context: General Updates -->
+    <string name="update_failed" comment="Notification that a resource update failed">One or more resources failed to update!</string>
+
+    <!-- Context: General Updates -->
+    <string name="update_success" comment="Notification that a resource update successfully updated">Resources successfully updated!</string>
 
     <!-- Context: Model Info -->
     <string name="model_version" comment="Title for a dictionary version">Dictionary version</string>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -108,10 +108,11 @@
 
     <!-- Context: Keyboard app doesn't include FileProvider library needed to view help file -->
     <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">
-      FileProvider library needed to view help file:</string>
+      FileProvider library needed to view help file: %1$s</string>
 
     <!-- Context: Fatal keyboard error. Will load default keyboard -->
-    <string name="fatal_keyboard_error" comment="Fatal keyboard error. Will load default keyboard">Fatal keyboard error. Loading default keyboard.</string>
+    <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">
+      Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.</string>
 
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Checking for associated dictionary to download</string>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -148,8 +148,8 @@
     <!-- Context: Background download messages-->
     <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Dictionary download is finished.</string>
 
-    <!-- Context: Background download messages-->
-    <string name="failed_to_access_downloaded_file" comment="Failed to access downloaded file">Failed to access downloaded file</string>
+    <!-- Context: Background download messages -->
+    <string name="download_failed" comment="Notification that a download failed">Download failed</string>
 
     <!-- Context: Background download messages -->
     <string name="failed_to_retrieve_file" comment="Failed to retrieve downloaded file">Failed to retrieve downloaded file</string>


### PR DESCRIPTION
Follow-on to #4261 and fixes #4475

Currently, overriding string resources to use the chosen display language only work for classes that extend `BaseActivity` (`AppCompatActivity`). For the remaining classes, Toast notifications end up using the device's default locale.

This PR adds a helper method `BaseActivity.makeToast()` so the Toast messages will be consistent with the display language. ~I had to simplify some Toast strings to avoid `makeToast` needing to `String.format` with variable parameters.~

(updated): The Toast strings optionally handle formatted strings. Note, messages to Sentry aren't localized.


### Other cleanup
* Remove unused string `failed_to_access_downloaded_file`

## User Testing
@MakaraSok , please test with the scenarios you reported in the issue
