### PR TITLE
fix(windows): incxstr could run over buffer with malformed data

### DIFF
--- a/common/core/desktop/src/kmx/kmx_xstring.cpp
+++ b/common/core/desktop/src/kmx/kmx_xstring.cpp
@@ -121,7 +121,7 @@ PKMX_WCHAR km::kbp::kmx::incxstr(PKMX_WCHAR p)
     case CODE_INDEX:    return p+2;
     case CODE_USE:      return p+1;
     case CODE_DEADKEY:    return p+1;
-    case CODE_EXTENDED:   p += 2; while(*p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
+    case CODE_EXTENDED:   p += 2; while(*p && *p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
     case CODE_CLEARCONTEXT: return p+1;
     case CODE_CALL:     return p+1;
     case CODE_CONTEXTEX:  return p+1;

--- a/windows/src/engine/mcompile/mc_crc32.cpp
+++ b/windows/src/engine/mcompile/mc_crc32.cpp
@@ -1,5 +1,5 @@
 
-#include "stdafx.h"
+#include "pch.h"
 
 #define CRC32_POLYNOMIAL 0xEDB88320
 

--- a/windows/src/engine/mcompile/mc_import_rules.cpp
+++ b/windows/src/engine/mcompile/mc_import_rules.cpp
@@ -19,7 +19,7 @@
                     06 Feb 2015 - mcdurdin - I4552 - V9.0 - Add mnemonic recompile option to ignore deadkeys
 */
 
-#include "stdafx.h"
+#include "pch.h"
 #include <vector>
 
 enum ShiftState {

--- a/windows/src/engine/mcompile/mc_kmxfile.cpp
+++ b/windows/src/engine/mcompile/mc_kmxfile.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+#include "pch.h"
 
 
 static BOOL LoadKeyboardFile(LPSTR fileName, LPKEYBOARD *lpKeyboard);

--- a/windows/src/engine/mcompile/mc_savekeyboard.cpp
+++ b/windows/src/engine/mcompile/mc_savekeyboard.cpp
@@ -1,5 +1,5 @@
 
-#include "stdafx.h"
+#include "pch.h"
 
 DWORD WriteCompiledKeyboard(LPKEYBOARD fk, HANDLE hOutfile, BOOL FSaveDebug);
 

--- a/windows/src/engine/mcompile/mc_syskbd.cpp
+++ b/windows/src/engine/mcompile/mc_syskbd.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+#include "pch.h"
 
 BOOL IsWow64();
 

--- a/windows/src/engine/mcompile/mc_syskbdnt32.cpp
+++ b/windows/src/engine/mcompile/mc_syskbdnt32.cpp
@@ -27,7 +27,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "stdafx.h"
+#include "pch.h"
 #include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
 
 

--- a/windows/src/engine/mcompile/mc_syskbdnt64.cpp
+++ b/windows/src/engine/mcompile/mc_syskbdnt64.cpp
@@ -27,7 +27,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "stdafx.h"
+#include "pch.h"
 #include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
 
 typedef struct {

--- a/windows/src/engine/mcompile/mc_unicode.cpp
+++ b/windows/src/engine/mcompile/mc_unicode.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+#include "pch.h"
 
 const WCHAR cp1252[256] = {
   /*0x00*/  0x0000,  //Null

--- a/windows/src/engine/mcompile/mcompile.cpp
+++ b/windows/src/engine/mcompile/mcompile.cpp
@@ -29,7 +29,7 @@
 // for the subcomponents of the compiled keyboard is an unnecessary optimisation. Just so you know.
 //
 
-#include "stdafx.h"
+#include "pch.h"
 #include <vector>
 
 #include <stdio.h>
@@ -464,38 +464,6 @@ BOOL DoConvert(LPKEYBOARD kbd, LPWSTR kbid, BOOL bDeadkeyConversion) {   // I455
 
   return TRUE;
 }
-
-PWSTR incxstr(PWSTR p)
-{
-	if(*p == 0) return p;
-	if(*p != UC_SENTINEL)
-	{
-		if(*p >= 0xD800 && *p <= 0xDBFF && *(p+1) >= 0xDC00 && *(p+1) <= 0xDFFF) return p+2;
-		return p+1;
-	}
-
-	p+=2;
-	switch(*(p-1))
-	{
-		case CODE_ANY:			return p+1;
-		case CODE_NOTANY:   return p+1;
-		case CODE_INDEX:		return p+2;
-		case CODE_USE:			return p+1;
-		case CODE_DEADKEY:		return p+1;
-		case CODE_EXTENDED:		p += 2; while(*p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
-		case CODE_CLEARCONTEXT: return p+1;
-		case CODE_CALL:			return p+1;
-		case CODE_CONTEXTEX:	return p+1;
-    case CODE_IFOPT:    return p+3;
-    case CODE_IFSYSTEMSTORE: return p+3;
-    case CODE_SETOPT:   return p+2;
-    case CODE_SETSYSTEMSTORE: return p+2;
-    case CODE_RESETOPT: return p+1;
-    case CODE_SAVEOPT:  return p+1;
-		default:				return p;
-	}
-}
-
 
 void LogError(PWSTR fmt, ...) {
 	WCHAR fmtbuf[256];

--- a/windows/src/engine/mcompile/mcompile.vcxproj
+++ b/windows/src/engine/mcompile/mcompile.vcxproj
@@ -60,6 +60,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\..\ext\sentry;..\..\global\inc</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -77,6 +78,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\..\ext\sentry;..\..\global\inc</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -93,7 +95,7 @@
     <ClInclude Include="..\..\..\..\engine\keyman32\KBD.H" />
     <ClInclude Include="mc_kmxfile.h" />
     <ClInclude Include="mcompile.h" />
-    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="pch.h" />
     <ClInclude Include="mc_syskbd.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
@@ -103,15 +105,18 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\global\vc\VKScanCodes.cpp" />
+    <ClCompile Include="..\..\global\vc\xstring.cpp" />
     <ClCompile Include="mc_crc32.cpp" />
     <ClCompile Include="mc_import_rules.cpp" />
     <ClCompile Include="mc_kmxfile.cpp" />
     <ClCompile Include="mcompile.cpp" />
     <ClCompile Include="mc_savekeyboard.cpp" />
     <ClCompile Include="mc_unicode.cpp" />
-    <ClCompile Include="stdafx.cpp">
+    <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="mc_syskbd.cpp" />
     <ClCompile Include="mc_syskbdnt32.cpp" />

--- a/windows/src/engine/mcompile/mcompile.vcxproj.filters
+++ b/windows/src/engine/mcompile/mcompile.vcxproj.filters
@@ -21,9 +21,6 @@
     <None Include="ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="stdafx.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="targetver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -39,11 +36,11 @@
     <ClInclude Include="mc_syskbd.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="stdafx.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\global\vc\VKScanCodes.cpp">
       <Filter>Library Source Files</Filter>
     </ClCompile>
@@ -75,6 +72,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\global\vc\keymansentry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\global\vc\xstring.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/windows/src/engine/mcompile/pch.cpp
+++ b/windows/src/engine/mcompile/pch.cpp
@@ -1,0 +1,8 @@
+// pch.cpp : source file that includes just the standard includes
+// m-to-p.pch will be the pre-compiled header
+// pch.obj will contain the pre-compiled type information
+
+#include "pch.h"
+
+// TODO: reference any additional headers you need in PC.H
+// and not in this file

--- a/windows/src/engine/mcompile/pch.h
+++ b/windows/src/engine/mcompile/pch.h
@@ -1,4 +1,4 @@
-// stdafx.h : include file for standard system include files,
+// pch.h : include file for standard system include files,
 // or project specific include files that are used frequently, but
 // are changed infrequently
 //

--- a/windows/src/engine/mcompile/stdafx.cpp
+++ b/windows/src/engine/mcompile/stdafx.cpp
@@ -1,8 +1,0 @@
-// stdafx.cpp : source file that includes just the standard includes
-// m-to-p.pch will be the pre-compiled header
-// stdafx.obj will contain the pre-compiled type information
-
-#include "stdafx.h"
-
-// TODO: reference any additional headers you need in STDAFX.H
-// and not in this file

--- a/windows/src/global/vc/VKScanCodes.cpp
+++ b/windows/src/global/vc/VKScanCodes.cpp
@@ -17,7 +17,7 @@
                     17 Dec 2013 - mcdurdin - I4006 - V9.0 - Remove old aiDefault code
 */
 
-#include "stdafx.h"   // I4006
+#include "pch.h"   // I4006
 
 const UINT USVirtualKeyToScanCode[256] = 
 {

--- a/windows/src/test/mnemonic-to-positional/importkeyboard/importkeyboard/importkeyboard.cpp
+++ b/windows/src/test/mnemonic-to-positional/importkeyboard/importkeyboard/importkeyboard.cpp
@@ -28,7 +28,7 @@ const int ShiftStateMap[] = {
   ISVIRTUALKEY | RALTFLAG | K_SHIFTFLAG,
   0,
   0};
-    
+
 class DeadKey {
 private:
   WCHAR m_deadchar;
@@ -100,11 +100,11 @@ public:
   UINT SC() {
     return this->m_sc;
   }
-  
+
   std::wstring GetShiftState(ShiftState shiftState, bool capsLock) {
     return this->m_rgss[(UINT)shiftState][(capsLock ? 1 : 0)];
   }
-  
+
   void SetShiftState(ShiftState shiftState, std::wstring value, bool isDeadKey, bool capsLock) {
     this->m_rgfDeadKey[(UINT)shiftState][(capsLock ? 1 : 0)] = isDeadKey;
     this->m_rgss[(UINT)shiftState][(capsLock ? 1 : 0)] = value;
@@ -167,13 +167,13 @@ public:
     }
     return true;
   }
-    
+
   bool IsKeymanUsedKey() {
     return (this->m_vk >= 0x20 && this->m_vk <= 0x5F) || (this->m_vk >= 0x88);
   }
 
   UINT GetShiftStateValue(int capslock, int caps, ShiftState ss) {
-    return 
+    return
       ShiftStateMap[(int)ss] |
       (capslock ? (caps ? CAPITALFLAG : NOTCAPITALFLAG) : 0);
   }
@@ -217,7 +217,7 @@ public:
           //TODO: Do we need to put this rule out?
         } else if (this->m_rgfDeadKey[(int)ss, caps]) {
           // It's a dead key, append an @ sign.
-          key->dpContext = new WCHAR[1]; 
+          key->dpContext = new WCHAR[1];
           *key->dpContext = 0;
           key->ShiftFlags = this->GetShiftStateValue(capslock, caps, (ShiftState) ss);
           key->Key = this->VK();
@@ -228,7 +228,7 @@ public:
           *p++ = CODE_DEADKEY;
           *p++ = DeadKeyMap(st[0], deadkeys, deadkeyBase);
           *p = 0;
-          //sbRow.Append(string.Format("+ [{0}{1}] > dk({2:x4})\r\n", this.GetShiftStateName(capslock, caps, ss, IsKMW), 
+          //sbRow.Append(string.Format("+ [{0}{1}] > dk({2:x4})\r\n", this.GetShiftStateName(capslock, caps, ss, IsKMW),
           //    this.GetVKeyName((int)this.VK), (ushort)st[0]));
           //sbRow.Append(string.Format("\t{0:x4}@", ((ushort)st[0])));
           return true;
@@ -237,7 +237,7 @@ public:
           for (size_t ich = 0; ich < st.size(); ich++) {
             if(st[ich] < 0x20 || st[ich] == 0x7F) { isvalid=false; break; }
           }
-            
+
           if(isvalid) {
             key->Key = this->VK();
             key->ShiftFlags = this->GetShiftStateValue(capslock, caps, (ShiftState) ss);
@@ -322,7 +322,7 @@ public:
             while (rc >= 0) {
               // We know that this is a dead key coming up, otherwise
               // this function would never have been called. If we do
-              // *not* get a dead key then that means the state is 
+              // *not* get a dead key then that means the state is
               // messed up so we run again and again to clear it up.
               // Risk is technically an infinite loop but per Hiroyama
               // that should be impossible here.
@@ -336,7 +336,7 @@ public:
             if (rc == 1) {
               // That was indeed a base character for our dead key.
               // And we now have a composite character. Let's run
-              // through one more time to get the actual base 
+              // through one more time to get the actual base
               // character that made it all possible?
               WCHAR combchar = sbBuffer[0];
               rc = ToUnicodeEx(rgKey[iKey]->VK(), rgKey[iKey]->SC(), lpKeyState, sbBuffer, _countof(sbBuffer), 0, hkl);
@@ -352,9 +352,9 @@ public:
               if ((((ss == Ctrl) || (ss == ShftCtrl)) &&
                   (IsControlChar(basechar))) ||
                   (basechar == combchar)) {
-                // ToUnicodeEx has an internal knowledge about those 
-                // VK_A ~ VK_Z keys to produce the control characters, 
-                // when the conversion rule is not provided in keyboard 
+                // ToUnicodeEx has an internal knowledge about those
+                // VK_A ~ VK_Z keys to produce the control characters,
+                // when the conversion rule is not provided in keyboard
                 // layout files
 
                 // Additionally, dead key state is lost for some of these
@@ -433,13 +433,13 @@ int wmain(int argc, WCHAR* argv[]) {
 
   int cKeyboards = GetKeyboardLayoutList(0, NULL);
   HKL *rghkl = new HKL[cKeyboards];
-  GetKeyboardLayoutList(cKeyboards, rghkl);            
+  GetKeyboardLayoutList(cKeyboards, rghkl);
   HKL hkl = LoadKeyboardLayout(inputHKL, KLF_NOTELLSHELL);
   if(hkl == NULL) {
       puts("Sorry, that keyboard does not seem to be valid.");
       return 1;
   }
-            
+
   BYTE lpKeyState[256];// = new KeysEx[256];
   std::vector<VirtualKey*> rgKey; //= new VirtualKey[256];
   std::vector<DeadKey*> alDead;
@@ -447,7 +447,7 @@ int wmain(int argc, WCHAR* argv[]) {
   rgKey.resize(256);
 
   // Scroll through the Scan Code (SC) values and get the valid Virtual Key (VK)
-  // values in it. Then, store the SC in each valid VK so it can act as both a 
+  // values in it. Then, store the SC in each valid VK so it can act as both a
   // flag that the VK is valid, and it can store the SC value.
   for(UINT sc = 0x01; sc <= 0x7f; sc++) {
     VirtualKey *key = new VirtualKey(sc, hkl);
@@ -471,7 +471,7 @@ int wmain(int argc, WCHAR* argv[]) {
       UINT sc = MapVirtualKeyEx(vk, 0, hkl);
       UINT vkL = MapVirtualKeyEx(sc, 1, hkl);
       UINT vkR = MapVirtualKeyEx(sc, 3, hkl);
-      if((vkL != vkR) && 
+      if((vkL != vkR) &&
           (vk != vkL)) {
           switch(vk) {
               case VK_LCONTROL:
@@ -515,9 +515,9 @@ int wmain(int argc, WCHAR* argv[]) {
                           if((rc == 1) &&
                               (ss == Ctrl || ss == ShftCtrl) &&
                               (rgKey[iKey]->VK() == ((UINT)sbBuffer[0] + 0x40))) {
-                              // ToUnicodeEx has an internal knowledge about those 
-                              // VK_A ~ VK_Z keys to produce the control characters, 
-                              // when the conversion rule is not provided in keyboard 
+                              // ToUnicodeEx has an internal knowledge about those
+                              // VK_A ~ VK_Z keys to produce the control characters,
+                              // when the conversion rule is not provided in keyboard
                               // layout files
                               continue;
                           }
@@ -586,7 +586,7 @@ int wmain(int argc, WCHAR* argv[]) {
   }
 
 
-    
+
   LPKEYBOARD kp = new KEYBOARD;
   memset(kp, 0, sizeof(KEYBOARD));
   int nDeadkey = 0;
@@ -631,7 +631,7 @@ int wmain(int argc, WCHAR* argv[]) {
 
   for (UINT iKey = 0; iKey < rgKey.size(); iKey++) {
     if ((rgKey[iKey] != NULL) && rgKey[iKey]->IsKeymanUsedKey() && (!rgKey[iKey]->IsEmpty())) {
-      // for each item, 
+      // for each item,
       if(rgKey[iKey]->LayoutRow(loader.MaxShiftState(), &gp->dpKeyArray[nKeys], &alDead, nDeadkey)) {
         nKeys++;
       }
@@ -671,14 +671,14 @@ int wmain(int argc, WCHAR* argv[]) {
       sp->dpName = NULL;
       sp->dwSystemID = 0;
       sp->dpString = new WCHAR[dk->Count() + 1];
-      for(int j = 0; j < dk->Count(); j++) 
+      for(int j = 0; j < dk->Count(); j++)
         sp->dpString[j] = dk->GetBaseCharacter(j);
       sp++;
 
       sp->dpName = NULL;
       sp->dwSystemID = 0;
       sp->dpString = new WCHAR[dk->Count() + 1];
-      for(int j = 0; j < dk->Count(); j++) 
+      for(int j = 0; j < dk->Count(); j++)
         sp->dpString[j] = dk->GetCombinedCharacter(j);
       sp++;
 
@@ -704,7 +704,7 @@ int wmain(int argc, WCHAR* argv[]) {
       kkp++;
     }
   }
-  
+
 }
 
 PWSTR incxstr(PWSTR p)
@@ -724,7 +724,7 @@ PWSTR incxstr(PWSTR p)
 		case CODE_INDEX:		return p+2;
 		case CODE_USE:			return p+1;
 		case CODE_DEADKEY:		return p+1;
-		case CODE_EXTENDED:		p += 2; while(*p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
+		case CODE_EXTENDED:		p += 2; while(*p && *p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
 		case CODE_CLEARCONTEXT: return p+1;
 		case CODE_CALL:			return p+1;
 		case CODE_CONTEXTEX:	return p+1;

--- a/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/m-to-p.cpp
+++ b/windows/src/test/mnemonic-to-positional/m-to-p/m-to-p/m-to-p.cpp
@@ -17,7 +17,7 @@ int wmain(int argc, wchar_t * argv[])
          "  layout file given by kbdfile.dll\n\n"
 
          "  kbid should be a hexadecimal number e.g. 409 for US English\n");
-    */  
+    */
     return 1;
   }
 
@@ -25,7 +25,7 @@ int wmain(int argc, wchar_t * argv[])
 
   // 1. Load the keyman keyboard file
 
-  // 2. For each key on the system layout, determine its output character and perform a 
+  // 2. For each key on the system layout, determine its output character and perform a
   //    1-1 replacement on the keyman keyboard of that character with the base VK + shift
   //    state.  This fixup will transform the char to a vk, which will avoid any issues
   //    with the key.
@@ -36,8 +36,8 @@ int wmain(int argc, wchar_t * argv[])
   //  rule for that deadkey, e.g. [K_LBRKT] > dk(c101)
   //
   //  Next, update each rule that references the output from that deadkey to add an extra
-  //  context deadkey at the end of the context match, e.g. 'a' dk(c101) + [K_SPACE] > 'b'.  
-  //  This will require a memory layout change for the .kmx file, plus fixups on the 
+  //  context deadkey at the end of the context match, e.g. 'a' dk(c101) + [K_SPACE] > 'b'.
+  //  This will require a memory layout change for the .kmx file, plus fixups on the
   //  context+output index offsets
   //
   //  --> virtual character keys
@@ -46,7 +46,7 @@ int wmain(int argc, wchar_t * argv[])
   //  switch the shift state from the VIRTUALCHARKEY to VIRTUALKEY, without changing any
   //  other properties of the key.
   //
-  
+
   // 3. Write the new keyman keyboard file
 
   if(!LoadNewLibrary(indll)) {
@@ -283,7 +283,7 @@ void ConvertDeadkey(LPKEYBOARD kbd, WORD vk, UINT shift, WCHAR deadkey) {
 
   GetDeadkeys(deadkey, pdk = deadkeys);  // returns array of [usvk, ch_out] pairs
   while(*pdk) {
-    // Look up the ch 
+    // Look up the ch
     UINT vkUnderlying = VKUnderlyingLayoutToVKUS(*pdk);
     TranslateDeadkeyKeyboard(kbd, dkid, vkUnderlying, *(pdk+1), *(pdk+2));
     pdk+=3;
@@ -321,7 +321,7 @@ BOOL DoConvert(LPKEYBOARD kbd, LPWSTR kbid) {
     UINT vkUnderlying = VKUSToVKUnderlyingLayout(VKMap[i]);
     // Go through each of the shift states - base, shift, ctrl+alt, ctrl+alt+shift, [caps vs ncaps?]
     for(int j = 0; VKShiftState[j] != 0xFFFF; j++) {
-      
+
       WCHAR ch = CharFromVK(vkUnderlying, VKShiftState[j], &DeadKey);
 
       //LogError("--- VK_%d -> VK_%d [%c] dk=%d", VKMap[i], vkUnderlying, ch == 0 ? 32 : ch, DeadKey);
@@ -362,7 +362,7 @@ PWSTR incxstr(PWSTR p)
 		case CODE_INDEX:		return p+2;
 		case CODE_USE:			return p+1;
 		case CODE_DEADKEY:		return p+1;
-		case CODE_EXTENDED:		p += 2; while(*p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
+		case CODE_EXTENDED:		p += 2; while(*p && *p != UC_SENTINEL_EXTENDEDEND) p++; return p+1;
 		case CODE_CLEARCONTEXT: return p+1;
 		case CODE_CALL:			return p+1;
 		case CODE_CONTEXTEX:	return p+1;


### PR DESCRIPTION
Fixes #4591.

I fixed incxstr in 4 places:

1. Common/Core: kmx_xstring.cpp
2. Engine: xstring.cpp
3. Test project importkeyboard importkeyboard.cpp
4. Test project m-to-p m-to-p.cpp

I updated mcompile to remove its own copy of incxstr (identical to that in xstring.cpp) to reduce WETness but opted not to do so for the test apps, which are pretty much throwaway anyway.

I note that there is more work we could do here; we need to check every character as we increment so we don't miss a `U+0000` end of string with malformed data. But I would like to tackle that as a separate job at some point in the future after Core integration.