### PR TITLE
fix(web): use language code correctly in toolbar

### DIFF
--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -531,7 +531,7 @@ if(!window['keyman']['ui']['name']) {
             var itemNode = ui.createNode('li');
             kbdText = lang.keyboards[n]['Name'].replace(/\s?keyboard/i,'');
             // We append the full BCP-47 code here for disambiguation when regional and/or script variants exist.
-            kbdText = kbdText + " [" + lang.keyboards[n].LanguageCode + "]";
+            kbdText = kbdText + " [" + lang.keyboards[n]['LanguageCode'] + "]";
             aNode = ui.createNode('a', null, null, kbdText);
             aNode.href = '#';
             aNode.title = '';


### PR DESCRIPTION
Fixes #4566.

When the toolbar shows a differentiation for the language code, it was not using the correct minification-safe property name, which resulted in `[undefined]` being displayed instead.