### PR TITLE
fix(windows): show version selector for Keyman in installer

### DIFF
--- a/windows/src/desktop/setup/UfrmInstallOptions.pas
+++ b/windows/src/desktop/setup/UfrmInstallOptions.pas
@@ -286,7 +286,7 @@ begin
   chkInstallKeyman.Checked := FInstallInfo.ShouldInstallKeyman;
   chkInstallKeyman.OnClick := chkInstallKeymanClick;
   chkInstallKeyman.Enabled := FInstallInfo.IsNewerAvailable and FInstallInfo.IsInstalled;
-  cbKeymanLocation.Enabled := chkInstallKeyman.Enabled and (cbKeymanLocation.Items.Count > 1);
+  cbKeymanLocation.Enabled := chkInstallKeyman.Checked and (cbKeymanLocation.Items.Count > 1);
 
   lblTitleLocation.Left := cbKeymanLocation.Left + sbTargets.Left;
 
@@ -347,7 +347,8 @@ begin
   lblAssociatedKeyboardLanguage.Visible := FInstallInfo.Packages.Count > 0;
 
   // Special case: if there are no options to change, don't present them
-  if (FInstallInfo.Packages.Count = 0) and not chkInstallKeyman.Enabled then
+  if (FInstallInfo.Packages.Count = 0) and not chkInstallKeyman.Enabled and
+    (cbKeymanLocation.Items.Count < 2) then
   begin
     sbTargets.Visible := False;
     lblSelectModulesToInstall.Visible := False;


### PR DESCRIPTION
Fixes #4409.

If a user attempts to install an older version of Keyman, they need to be able to choose to install the older version, and not the newer one offered to them from online. However, the selector was hidden in the Install Options dialog, even when it should have been accessible.

![image](https://user-images.githubusercontent.com/4498365/110386248-29483a00-80b4-11eb-9cab-ee5ed7eecc8a.png)

This screenshot shows how the user can choose to install the bundled version (in this case 14.0.250-beta) in the Install Options dialog.

Note that the Setup version title at the bottom of the Install Options dialog (snipped off in this screenshot though) is referring to the version of setup.exe only and is informational only.