### PR TITLE
fix(windows): hotkeys correctly ignore right modifier keys

### DIFF
--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -146,6 +146,7 @@ LRESULT _kmnLowLevelKeyboardProc(
 
   DWORD Flag = 0;
   if (UseRegisterHotkey()) {
+    // The old RegisterHotkey pattern does not support chiral modifier keys
     switch (hs->vkCode) {
       case VK_LCONTROL:
       case VK_RCONTROL:
@@ -159,16 +160,20 @@ LRESULT _kmnLowLevelKeyboardProc(
     }
   }
   else {
+    // #4619: We differentiate between Left and Right Ctrl/Shift/Alt. The right modifiers are
+    // not used for hotkeys, leaving them available for use as keystroke modifiers within a
+    // Keyman keyboard. But we need to track them anyway, so that a user doesn't press them
+    // and receive a hotkey event when they shouldn't (e.g. RALT+F4 if the hotkey is F4).
     switch (hs->vkCode) {
       case VK_LCONTROL: Flag = HK_CTRL; break;
-      case VK_RCONTROL: Flag = 0; break;
-      case VK_CONTROL:  Flag = extended ? HK_CTRL : 0; break;
+      case VK_RCONTROL: Flag = HK_RCTRL_INVALID; break;
+      case VK_CONTROL:  Flag = extended ? HK_RCTRL_INVALID : HK_CTRL; break;
       case VK_LMENU:    Flag = HK_ALT; break;
-      case VK_RMENU:    Flag = 0; break;
-      case VK_MENU:     Flag = extended ? HK_ALT : 0; break;
+      case VK_RMENU:    Flag = HK_RALT_INVALID; break;
+      case VK_MENU:     Flag = extended ? HK_RALT_INVALID : HK_ALT; break;
       case VK_LSHIFT:   Flag = HK_SHIFT; break;
-      case VK_RSHIFT:   Flag = 0; break;
-      case VK_SHIFT:    Flag = hs->scanCode == SCANCODE_RSHIFT ? 0 : HK_SHIFT; break;
+      case VK_RSHIFT:   Flag = HK_RSHIFT_INVALID; break;
+      case VK_SHIFT:    Flag = hs->scanCode == SCANCODE_RSHIFT ? HK_RSHIFT_INVALID : HK_SHIFT; break;
     }
   }
 

--- a/windows/src/engine/keyman32/kmhook_keyboard.cpp
+++ b/windows/src/engine/keyman32/kmhook_keyboard.cpp
@@ -121,12 +121,12 @@ BOOL KeyLanguageSwitchPress(WPARAM wParam, BOOL extended, BOOL isUp, DWORD Shift
     if(!hotkey) return FALSE;
   }
 
-  if((hotkey->HotkeyValue & HK_CTRL) && (wParam == VK_CONTROL || wParam == VK_LCONTROL || wParam == VK_RCONTROL) && !isUp && (ShiftState & K_MODIFIERFLAG & ~(LCTRLFLAG|RCTRLFLAG)) == 0)   // I4124
+  if((hotkey->HotkeyValue & HK_CTRL) && (wParam == VK_CONTROL || wParam == VK_LCONTROL || wParam == VK_RCONTROL) && !isUp && (ShiftState & ~(HK_CTRL|HK_RCTRL_INVALID)) == 0)   // I4124
   {
     InLanguageSwitchKeySequence = TRUE;
     return FALSE;
   }
-  else if((hotkey->HotkeyValue & HK_ALT) && (wParam == VK_MENU || wParam == VK_LMENU || wParam == VK_RMENU) && !extended && !isUp && (ShiftState & K_MODIFIERFLAG & ~LALTFLAG) == 0)   // I4124
+  else if((hotkey->HotkeyValue & HK_ALT) && (wParam == VK_MENU || wParam == VK_LMENU || wParam == VK_RMENU) && !extended && !isUp && (ShiftState & ~HK_ALT) == 0)   // I4124
   {
     InLanguageSwitchKeySequence = TRUE;
     return FALSE;

--- a/windows/src/global/inc/Compiler.h
+++ b/windows/src/global/inc/Compiler.h
@@ -275,6 +275,10 @@
 #define HK_CTRL			0x00020000
 #define HK_SHIFT		0x00040000
 
+#define HK_RALT_INVALID			0x00100000
+#define HK_RCTRL_INVALID		0x00200000
+#define HK_RSHIFT_INVALID		0x00400000
+
 #define LCTRLFLAG		0x0001		// Left Control flag
 #define RCTRLFLAG		0x0002		// Right Control flag
 #define LALTFLAG		0x0004		// Left Alt flag


### PR DESCRIPTION
Fixes #4619.

The hotkey check in keyman32 would ignore right modifier keys, but the behaviour was not quite right: it actually needs to take the modifier into account, but just not treat it as a valid modifier.

While fixing this, I noticed that some of the tests in the `KeyLanguageSwitchPress` function were using the wrong modifier flags. I wish I had fewer different modifier flag sets but that ship has probably sailed.

Oh yes, and the hotkey test for the undifferentiated modifier key actually flipped the result of the `extended` bit test previously. Didn't really matter as Windows sends the differentiated modifier key in most cases but yeuuch.