### PR TITLE
fix(android/engine): Reset in-app context when selection changes

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2386,22 +2386,24 @@ public final class KMManager {
 
           if (dn <= 0) {
             if (start == end) {
-              if (!s.isEmpty() && s.charAt(0) == '\n') {
+              if (s.length() > 0 && s.charAt(0) == '\n') {
                 textView.keyDownUp(KeyEvent.KEYCODE_ENTER);
               } else {
                 // *** TO DO: Try to find a solution to the bug on API < 17, insert overwrites on next line
-                InAppKeyboardShouldIgnoreTextChange = true;
-                InAppKeyboardShouldIgnoreSelectionChange = true;
-                textView.getText().insert(start, s);
+                if (s.length() > 0) {
+                  InAppKeyboardShouldIgnoreTextChange = true;
+                  InAppKeyboardShouldIgnoreSelectionChange = true;
+                  textView.getText().insert(start, s);
+                }
               }
             } else {
-              if (!s.isEmpty() && s.charAt(0) == '\n') {
+              if (s.length() > 0 && s.charAt(0) == '\n') {
                 InAppKeyboardShouldIgnoreTextChange = true;
                 InAppKeyboardShouldIgnoreSelectionChange = true;
                 textView.getText().replace(start, end, "");
                 textView.keyDownUp(KeyEvent.KEYCODE_ENTER);
               } else {
-                if (s.isEmpty()) {
+                if (s.length() == 0) {
                   textView.getText().delete(start, end);
                 } else {
                   InAppKeyboardShouldIgnoreTextChange = true;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
@@ -65,7 +65,9 @@ public final class KMTextView extends AppCompatEditText {
     int selStart = textView.getSelectionStart();
     int selEnd = textView.getSelectionEnd();
     KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
-    KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
+    if (KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
+      KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
+    }
   }
 
   private void init(final Context context) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMTextView.java
@@ -66,7 +66,6 @@ public final class KMTextView extends AppCompatEditText {
     int selEnd = textView.getSelectionEnd();
     KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
     KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
-    KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
   }
 
   private void init(final Context context) {
@@ -165,7 +164,9 @@ public final class KMTextView extends AppCompatEditText {
   protected void onSelectionChanged(int selStart, int selEnd) {
     super.onSelectionChanged(selStart, selEnd);
     if (activeView != null && activeView.equals(this)) {
-      KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd);
+      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
+        KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4575 and follow-on to #3867

## KMManager changes
* Reset in-app context when selection changes.
* chore using `s.length()` instead of `!s.isempty()` for consistency between in-app and system keyboard `insertText()`
* When nothing to delete (`dn <= 0`), only insert text if `s.length() > 0` 

## User Testing
@MakaraSok , reproduce the steps you reported in the issue
