### PR TITLE
fix(web): better check for missing MutationObserver type

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1709,7 +1709,7 @@ namespace com.keyman.dom {
         * Of course, we only want to dynamically add elements if the user hasn't enabled the manual attachment option.
         */
       
-      if(MutationObserver) {
+      if(typeof MutationObserver == 'function') {
         var observationTarget = document.querySelector('body'), observationConfig: MutationObserverInit;
         if(this.keyman.options['attachType'] != 'manual') { //I1961
           observationConfig = { childList: true, subtree: true};


### PR DESCRIPTION
So, #4242 ([Sentry error](https://sentry.keyman.com/share/issue/5e15c60b00ac41efb9af69fec920fc90/)) has continued occurring... this time, with the `MutationObserver` type.  (Fortunately, the `Worker` check has been holding well; its console message appears as a breadcrumb.)  Time to fix up the `MutationObserver` check to work better in "strict" modes.