### PR TITLE
fix(windows): setup must save install state for restarts

### DIFF
--- a/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
+++ b/windows/src/desktop/setup/Keyman.Setup.System.InstallInfo.pas
@@ -10,6 +10,7 @@ interface
 uses
   System.Classes,
   System.Generics.Collections,
+  System.JSON,
   System.SysUtils,
 
   PackageInfo,
@@ -46,6 +47,9 @@ type
     FPath: string;
     FProductCode: string;
     FVersionWithTag: string;
+  protected
+    procedure LoadFromJSON(o: TJSONObject); virtual;
+    procedure SaveToJSON(o: TJSONObject); virtual;
   public
     constructor Create(ALocationType: TInstallInfoLocationType); virtual;
     procedure UpgradeToLocalPath(const ARootPath: string);
@@ -59,6 +63,9 @@ type
   end;
 
   TInstallInfoFileLocations = class(TObjectList<TInstallInfoFileLocation>)
+  private
+    procedure LoadFromJSON(a: TJSONArray);
+    procedure SaveToJSON(a: TJSONArray);
   public
     function LatestVersion(const default: string = '0'): string;
   end;
@@ -68,6 +75,9 @@ type
     FName: string;
     FLanguages: TInstallInfoPackageLanguages;
     FLocalPackage: TPackage;
+  protected
+    procedure LoadFromJSON(o: TJSONObject); override;
+    procedure SaveToJSON(o: TJSONObject); override;
   public
     constructor Create(ALocationType: TInstallInfoLocationType); override;
     destructor Destroy; override;
@@ -79,6 +89,9 @@ type
   end;
 
   TInstallInfoPackageFileLocations = class(TObjectList<TInstallInfoPackageFileLocation>)
+  private
+    procedure LoadFromJSON(a: TJSONArray);
+    procedure SaveToJSON(a: TJSONArray);
   public
     function LatestVersion(const default: string = '0'): string;
   end;
@@ -94,6 +107,8 @@ type
   public
     constructor Create(const AID: string; const ABCP47: string = '');
     destructor Destroy; override;
+    procedure SaveToJSON(o: TJSONObject);
+    procedure LoadFromJSON(o: TJSONObject);
     property ID: string read FID;
     property BCP47: string read FBCP47 write FBCP47;
     property ShouldInstall: Boolean read FShouldInstall write FShouldInstall;
@@ -102,6 +117,10 @@ type
   end;
 
   TInstallInfoPackages = class(TObjectList<TInstallInfoPackage>)
+  private
+    procedure LoadFromJSON(a: TJSONArray);
+    procedure SaveToJSON(a: TJSONArray);
+  public
     function FindById(const id: string; createIfNotFound: Boolean): TInstallInfoPackage;
   end;
 
@@ -124,9 +143,16 @@ type
     FMsiInstallLocation: TInstallInfoFileLocation;
     function GetBestMsi: TInstallInfoFileLocation;
     function GetPackageMetadata(const KmpFilename: string; p: TPackage): Boolean;
+
   public
     constructor Create(const ATempPath: string);
     destructor Destroy; override;
+
+    procedure SaveToJSONFile(const Filename: string);
+    procedure LoadFromJSONFile(const Filename: string);
+    procedure SaveToJSON(o: TJSONObject);
+    procedure LoadFromJSON(o: TJSONObject);
+
     procedure LoadSetupInf(const SetupInfPath: string);
 
     procedure LocatePackagesAndTierFromFilename(Filename: string);
@@ -141,7 +167,7 @@ type
 
     property TempPath: string read FTempPath;
 
-    property EditionTitle: WideString read FAppName;
+    property EditionTitle: WideString read FAppName write FAppName;
 
     property MsiLocations: TInstallInfoFileLocations read FMsiLocations;
     property MsiInstallLocation: TInstallInfoFileLocation read FMsiInstallLocation write FMsiInstallLocation;
@@ -152,11 +178,13 @@ type
     property IsNewerAvailable: Boolean read FIsNewerAvailable;
 
     property Packages: TInstallInfoPackages read FPackages;
-    property TitleImageFilename: string read FTitleImageFilename;
-    property StartDisabled: Boolean read FStartDisabled;
-    property StartWithConfiguration: Boolean read FStartWithConfiguration;
+    property TitleImageFilename: string read FTitleImageFilename write FTitleImageFilename; // write used only for tests
+    property StartDisabled: Boolean read FStartDisabled write FStartDisabled; // write used only for tests
+    property StartWithConfiguration: Boolean read FStartWithConfiguration write FStartWithConfiguration; // write used only for tests
 
     property Tier: string read FTier write FTier;
+
+    property Strings: TStrings read FStrings; // Note: use .Text(), not .Strings to read localized strings
 
     property ShouldInstallKeyman: Boolean read FShouldInstallKeyman write FShouldInstallKeyman;
   end;
@@ -170,6 +198,7 @@ uses
   System.Zip,
   Winapi.Windows,
 
+  JsonUtil,
   Keyman.Setup.System.MsiUtils,
   Keyman.Setup.System.SetupUILanguageManager,
   KeymanVersion,
@@ -373,6 +402,128 @@ begin
   end;
 end;
 
+procedure TInstallInfo.LoadFromJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+  item: TJSONValue;
+  n: Integer;
+begin
+  FTempPath := o.GetValue<string>('TempPath', '');
+  FAppName := o.GetValue<string>('AppName', '');
+  FStartDisabled := o.GetValue<Boolean>('StartDisabled', False);
+  FStartWithConfiguration := o.GetValue<Boolean>('StartWithConfiguration', False);
+  FShouldInstallKeyman := o.GetValue<Boolean>('ShouldInstallKeyman', True);
+  FTier := o.GetValue<string>('Tier', KeymanVersion.CKeymanVersionInfo.Tier);
+
+  FPackages.Clear;
+  a := o.GetValue<TJSONArray>('Packages', nil);
+  if Assigned(a) then
+    FPackages.LoadFromJSON(a);
+
+  FStrings.Clear;
+  a := o.GetValue<TJSONArray>('Strings', nil);
+  if Assigned(a) then
+    for item in a do
+      FStrings.Add(item.AsType<string>);
+
+  FMsiLocations.Clear;
+  a := o.GetValue<TJSONArray>('MsiLocations', nil);
+  if Assigned(a) then
+    FMsiLocations.LoadFromJSON(a);
+
+  n := o.GetValue<Integer>('BestMsi', -1);
+  if (n >= 0) and (n < FMsiLocations.Count)
+    then FBestMsi := FMsiLocations[n]
+    else FBestMsi := nil;
+
+  n := o.GetValue<Integer>('MsiInstallLocation', -1);
+  if (n >= 0) and (n < FMsiLocations.Count)
+    then FMsiInstallLocation := FMsiLocations[n]
+    else FMsiInstallLocation := nil;
+
+  FTitleImageFilename := o.GetValue<string>('TitleImageFilename', '');
+  if (FTitleImageFilename <> '') and not FileExists(FTitleImageFilename) then
+    FTitleImageFilename := '';
+
+//>> always calculate this  FInstalledVersion.Version := : TMSIInfo;
+//>> always calculate this  FIsInstalled: Boolean;
+//>> always calculate this  FIsNewerAvailable: Boolean;
+end;
+
+procedure TInstallInfo.SaveToJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+  s: string;
+begin
+  o.AddPair('TempPath', FTempPath);
+  o.AddPair('AppName', FAppName);
+  o.AddPair('StartDisabled', TJSONBool.Create(FStartDisabled));
+  o.AddPair('StartWithConfiguration', TJSONBool.Create(FStartWithConfiguration));
+  o.AddPair('ShouldInstallKeyman', TJSONBool.Create(FShouldInstallKeyman));
+  o.AddPair('Tier', FTier);
+
+  a := TJSONArray.Create;
+  o.AddPair('Packages', a);
+  FPackages.SaveToJSON(a);
+
+  a := TJSONArray.Create;
+  o.AddPair('Strings', a);
+  for s in FStrings do
+    a.Add(s);
+
+  a := TJSONArray.Create;
+  o.AddPair('MsiLocations', a);
+  FMsiLocations.SaveToJSON(a);
+
+  o.AddPair('BestMsi', TJSONNumber.Create(FMsiLocations.IndexOf(FBestMsi)));
+  o.AddPair('MsiInstallLocation', TJSONNumber.Create(FMsiLocations.IndexOf(FMsiInstallLocation)));
+  o.AddPair('TitleImageFilename', FTitleImageFilename);
+end;
+
+procedure TInstallInfo.LoadFromJSONFile(const Filename: string);
+var
+  o: TJSONObject;
+  s: TStringStream;
+begin
+  s := TStringStream.Create('', TEncoding.UTF8);
+  try
+    s.LoadFromFile(Filename);
+    o := TJSONObject.ParseJSONValue(s.DataString) as TJSONObject;
+    if Assigned(o) then
+    try
+      LoadFromJSON(o);
+    finally
+      o.Free;
+    end;
+  finally
+    s.Free;
+  end;
+end;
+
+procedure TInstallInfo.SaveToJSONFile(const Filename: string);
+var
+  o: TJSONObject;
+  ss: TStringStream;
+  s: TStringList;
+begin
+  o := TJSONObject.Create;
+  SaveToJSON(o);
+  s := TStringList.Create;
+  try
+    // We use this instead of o.Format because o.Format inserts
+    // \ in front of / which is ugly and unnecessary
+    PrettyPrintJSON(o, s);
+    ss := TStringStream.Create(s.Text, TEncoding.UTF8);
+    try
+      ss.SaveToFile(Filename);
+    finally
+      ss.Free;
+    end;
+  finally
+    s.Free;
+  end;
+end;
+
 procedure TInstallInfo.LoadLocalPackagesMetadata;
 var
   pack: TInstallInfoPackage;
@@ -540,6 +691,41 @@ begin
     end;
 end;
 
+procedure TInstallInfoPackage.LoadFromJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+  n: Integer;
+begin
+//    FID: string;
+  FBCP47 := o.GetValue<string>('bcp47', '');
+
+  FLocations.Clear;
+  a := o.GetValue<TJSONArray>('locations', nil);
+  if Assigned(a) then
+    FLocations.LoadFromJSON(a);
+
+  FShouldInstall := o.GetValue<Boolean>('shouldInstall', True);
+  n := o.GetValue<Integer>('installLocation', -1);
+  if (n >= 0) and (n < FLocations.Count)
+    then FInstallLocation := FLocations[n]
+    else FInstallLocation := nil;
+end;
+
+procedure TInstallInfoPackage.SaveToJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+begin
+  o.AddPair('id', FID);
+  o.AddPair('bcp47', FBCP47);
+
+  a := TJSONArray.Create;
+  o.AddPair('locations', a);
+  FLocations.SaveToJSON(a);
+
+  o.AddPair('shouldInstall', TJSONBool.Create(FShouldInstall));
+  o.AddPair('installLocation', TJSONNumber.Create(FLocations.IndexOf(FInstallLocation)));
+end;
+
 { TInstallInfoPackageLanguage }
 
 constructor TInstallInfoPackageLanguage.Create(const ABCP47, AName: string);
@@ -562,6 +748,37 @@ begin
       Result := location.Version;
 end;
 
+procedure TInstallInfoPackageFileLocations.LoadFromJSON(a: TJSONArray);
+var
+  item: TJSONValue;
+  fileLocationItem: TJSONObject;
+  fileLocation: TInstallInfoPackageFileLocation;
+begin
+  for item in a do
+  begin
+    if item is TJSONObject then
+    begin
+      fileLocationItem := item as TJSONObject;
+      fileLocation := TInstallInfoPackageFileLocation.Create(fileLocationItem.GetValue<TInstallInfoLocationType>('locationType', iilLocal));
+      fileLocation.LoadFromJSON(fileLocationItem);
+      Self.Add(fileLocation);
+    end;
+  end;
+end;
+
+procedure TInstallInfoPackageFileLocations.SaveToJSON(a: TJSONArray);
+var
+  item: TInstallInfoPackageFileLocation;
+  o: TJSONObject;
+begin
+  for item in Self do
+  begin
+    o := TJSONObject.Create;
+    item.SaveToJSON(o);
+    a.Add(o);
+  end;
+end;
+
 { TInstallInfoFileLocations }
 
 function TInstallInfoFileLocations.LatestVersion(const default: string): string;
@@ -572,6 +789,37 @@ begin
   for location in Self do
     if CompareVersions(Result, location.Version) > 0 then
       Result := location.Version;
+end;
+
+procedure TInstallInfoFileLocations.LoadFromJSON(a: TJSONArray);
+var
+  item: TJSONValue;
+  fileLocationItem: TJSONObject;
+  fileLocation: TInstallInfoFileLocation;
+begin
+  for item in a do
+  begin
+    if item is TJSONObject then
+    begin
+      fileLocationItem := item as TJSONObject;
+      fileLocation := TInstallInfoFileLocation.Create(fileLocationItem.GetValue<TInstallInfoLocationType>('locationType', iilLocal));
+      fileLocation.LoadFromJSON(fileLocationItem);
+      Self.Add(fileLocation);
+    end;
+  end;
+end;
+
+procedure TInstallInfoFileLocations.SaveToJSON(a: TJSONArray);
+var
+  item: TInstallInfoFileLocation;
+  o: TJSONObject;
+begin
+  for item in Self do
+  begin
+    o := TJSONObject.Create;
+    item.SaveToJSON(o);
+    a.Add(o);
+  end;
 end;
 
 { TInstallInfoPackages }
@@ -588,6 +836,37 @@ begin
   end
   else
     Result := nil;
+end;
+
+procedure TInstallInfoPackages.LoadFromJSON(a: TJSONArray);
+var
+  item: TJSONValue;
+  packageItem: TJSONObject;
+  package: TInstallInfoPackage;
+begin
+  for item in a do
+  begin
+    if item is TJSONObject then
+    begin
+      packageItem := item as TJSONObject;
+      package := TInstallInfoPackage.Create(packageItem.GetValue<string>('id', ''));
+      package.LoadFromJSON(packageItem);
+      Self.Add(package);
+    end;
+  end;
+end;
+
+procedure TInstallInfoPackages.SaveToJSON(a: TJSONArray);
+var
+  item: TInstallInfoPackage;
+  o: TJSONObject;
+begin
+  for item in Self do
+  begin
+    o := TJSONObject.Create;
+    item.SaveToJSON(o);
+    a.Add(o);
+  end;
 end;
 
 { TInstallInfoPackageFileLocation }
@@ -625,6 +904,53 @@ begin
     Result := FName;
 end;
 
+procedure TInstallInfoPackageFileLocation.LoadFromJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+  item: TJSONValue;
+begin
+  inherited LoadFromJSON(o);
+  FName := o.GetValue<string>('name', '');
+
+  FLanguages.Clear;
+  a := o.GetValue<TJSONArray>('languages', nil);
+  if Assigned(a) then
+    for item in a do
+    begin
+      if item is TJSONObject then
+      begin
+        FLanguages.Add(TInstallInfoPackageLanguage.Create(
+          item.GetValue<string>('bcp47', ''),
+          item.GetValue<string>('name', '')
+        ));
+      end;
+    end;
+
+//  TODO: FLocalPackage: TPackage;
+end;
+
+procedure TInstallInfoPackageFileLocation.SaveToJSON(o: TJSONObject);
+var
+  a: TJSONArray;
+  ol: TJSONObject;
+  item: TInstallInfoPackageLanguage;
+begin
+  inherited SaveToJSON(o);
+  o.AddPair('name', FName);
+
+  a := TJSONArray.Create;
+  o.AddPair('languages', a);
+  for item in FLanguages do
+  begin
+    ol := TJSONObject.Create;
+    ol.AddPair('bcp47', item.BCP47);
+    ol.AddPair('name', item.Name);
+    a.Add(ol);
+  end;
+
+// TODO: FLocalPackage: TPackage;
+end;
+
 { TInstallInfoFileLocation }
 
 constructor TInstallInfoFileLocation.Create(
@@ -632,6 +958,27 @@ constructor TInstallInfoFileLocation.Create(
 begin
   inherited Create;
   FLocationType := ALocationType;
+end;
+
+procedure TInstallInfoFileLocation.LoadFromJSON(o: TJSONObject);
+begin
+  FUrl := o.GetValue<string>('url', '');
+  FSize := o.GetValue<Integer>('size', 0);
+  FVersion := o.GetValue<string>('version', '');
+  FPath := o.GetValue<string>('path', '');
+  FProductCode := o.GetValue<string>('productCode', '');
+  FVersionWithTag := o.GetValue<string>('versionWithTag', '');
+end;
+
+procedure TInstallInfoFileLocation.SaveToJSON(o: TJSONObject);
+begin
+  o.AddPair('locationType', TJSONNumber.Create(Ord(FLocationType)));
+  o.AddPair('url', FUrl);
+  o.AddPair('size', TJSONNumber.Create(FSize));
+  o.AddPair('version', FVersion);
+  o.AddPair('path', FPath);
+  o.AddPair('productCode', FProductCode);
+  o.AddPair('versionWithTag', FVersionWithTag);
 end;
 
 procedure TInstallInfoFileLocation.UpgradeToLocalPath(const ARootPath: string);

--- a/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
+++ b/windows/src/unit-tests/windows-setup/Keyman.System.Test.InstallInfoTest.pas
@@ -19,13 +19,19 @@ type
 
     [Test]
     procedure TestLocatePackagesFromParameter;
+
+    [Test]
+    procedure TestSerialization;
   end;
 
 implementation
 
 uses
+  System.JSON,
+
   KeymanVersion,
-  Keyman.Setup.System.InstallInfo;
+  Keyman.Setup.System.InstallInfo,
+  utildir;
 
 { TInstallInfoTest }
 
@@ -190,6 +196,191 @@ begin
     Assert.IsEmpty(ii.Packages[0].BCP47);
   finally
     ii.Free;
+  end;
+end;
+
+procedure TInstallInfoTest.TestSerialization;
+var
+  ii: TInstallInfo;
+//  o: TJSONObject;
+  iifl: TInstallInfoFileLocation;
+  iipflo: TInstallInfoPackageFileLocation;
+  lang: TInstallInfoPackageLanguage;
+  iip: TInstallInfoPackage;
+  FTempFilename: string;
+const
+  ii_EditionTitle = 'Test App';
+  ii_StartDisabled = True; // use non-default value
+  ii_StartWithConfiguration = True; // use non-default value
+  ii_ShouldInstallKeyman = False;  // use non-default value
+  ii_Tier = 'stable';  // may not be the default tier
+  ii_String = 'ssApplicationTitle=Test App';
+
+  iifll_LocationType: TInstallInfoLocationType = iilLocal;
+  iifll_Size = 1234;
+  iifll_Path = 'c:\foo\keyman.msi';
+  iifll_Url = '';
+  iifll_ProductCode = 'D992D213-3F78-42D8-AC97-289059E6DC15';
+  iifll_VersionWithTag = '14.0.111-beta-test';
+  iifll_Version = '14.0.111';
+
+  iiflo_LocationType: TInstallInfoLocationType = iilOnline;
+  iiflo_Size = 2468;
+  iiflo_Path = '';
+  iiflo_Url = 'https://downloads.keyman.example/keyman.msi';
+  iiflo_ProductCode = 'D992D213-3F78-42D8-AC97-289059E6DC15';
+  iiflo_VersionWithTag = '14.0.112-beta-test';
+  iiflo_Version = '14.0.112';
+
+  iipflo_LocationType: TInstallInfoLocationType = iilOnline;
+  iipflo_name = 'Khmer Angkor';
+  iipflo_Size = 1111;
+  iipflo_Path = '';
+  iipflo_Url = 'https://downloads.keyman.example/khmer_angkor.kmp';
+  iipflo_ProductCode = '';
+  iipflo_VersionWithTag = '1.2.3';
+  iipflo_Version = '1.2.3';
+
+  lang_0_bcp47 = 'km';
+  lang_0_name = 'Khmer';
+  lang_1_bcp47 = 'cmo';
+  lang_1_name = 'Mnong, Central';
+
+  iip_ShouldInstall = False; // non-default
+  iip_ID = 'khmer_angkor';
+  iip_BCP47 = 'km';
+begin
+  FTempFilename := KGetTempFileName;
+//  o := TJSONObject.Create;
+  try
+    ii := TInstallInfo.Create('');
+    try
+      // Add a common set of data.
+      iip := TInstallInfoPackage.Create(iip_ID, iip_BCP47);
+      iip.ShouldInstall := iip_ShouldInstall;
+
+      iipflo := TInstallInfoPackageFileLocation.Create(iipflo_LocationType);
+      iipflo.Name := iipflo_Name;
+
+      lang := TInstallInfoPackageLanguage.Create(lang_0_bcp47, lang_0_name);
+      iipflo.Languages.Add(lang);
+      lang := TInstallInfoPackageLanguage.Create(lang_1_bcp47, lang_1_name);
+      iipflo.Languages.Add(lang);
+      iipflo.Size := iipflo_Size;
+      iipflo.Path := iipflo_Path;
+      iipflo.Url := iipflo_Url;
+      iipflo.ProductCode := iipflo_ProductCode;
+      iipflo.VersionWithTag := iipflo_VersionWithTag;
+      iipflo.Version := iipflo_Version;
+      iip.Locations.Add(iipflo);
+
+      iip.InstallLocation := iipflo;
+      ii.Packages.Add(iip);
+
+      ii.EditionTitle := ii_EditionTitle;
+      ii.StartDisabled := ii_StartDisabled;
+      ii.StartWithConfiguration := ii_StartWithConfiguration;
+      ii.ShouldInstallKeyman := ii_ShouldInstallKeyman;
+      ii.Tier := ii_Tier;
+      ii.Strings.Add(ii_String);
+
+      iifl := TInstallInfoFileLocation.Create(iifll_LocationType);
+      iifl.Size := iifll_Size;
+      iifl.Path := iifll_Path;
+      iifl.Url := iifll_Url;
+      iifl.ProductCode := iifll_ProductCode;
+      iifl.VersionWithTag := iifll_VersionWithTag;
+      iifl.Version := iifll_Version;
+      ii.MsiLocations.Add(iifl);
+
+      iifl := TInstallInfoFileLocation.Create(iiflo_LocationType);
+      iifl.Size := iiflo_Size;
+      iifl.Path := iiflo_Path;
+      iifl.Url := iiflo_Url;
+      iifl.ProductCode := iiflo_ProductCode;
+      iifl.VersionWithTag := iiflo_VersionWithTag;
+      iifl.Version := iiflo_Version;
+      ii.MsiLocations.Add(iifl);
+
+      ii.CheckMsiUpgradeScenarios;
+      ii.MsiInstallLocation := ii.MsiLocations[0];
+
+      // We test with the temp filename because we'll know it exists when we
+      // want to assert the result later -- it's not used to actually draw the
+      // title as part of this test, so this is safe and avoids creating another
+      // dummy file for the test.
+      ii.TitleImageFilename := FTempFilename;
+
+      ii.SaveToJSONFile(FTempFilename);
+    finally
+      ii.Free;
+    end;
+
+    ii := TInstallInfo.Create('');
+    try
+      // Validate the data
+      ii.LoadFromJSONFile(FTempFilename);
+
+      Assert.AreEqual(1, ii.Packages.Count);
+      iip := ii.Packages[0];
+      Assert.AreEqual(iip_ID, iip.ID);
+      Assert.AreEqual(iip_BCP47, iip.BCP47);
+      Assert.AreEqual(iip_ShouldInstall, iip.ShouldInstall);
+
+      Assert.AreEqual(1, iip.Locations.Count);
+      iipflo := iip.Locations[0];
+      Assert.AreEqual(iilOnline, iipflo.LocationType);
+      Assert.AreEqual(iipflo_Name, iipflo.Name);
+
+      Assert.AreEqual(2, iipflo.Languages.Count);
+      Assert.AreEqual(lang_0_bcp47, iipflo.Languages[0].BCP47);
+      Assert.AreEqual(lang_0_name, iipflo.Languages[0].Name);
+      Assert.AreEqual(lang_1_bcp47, iipflo.Languages[1].BCP47);
+      Assert.AreEqual(lang_1_name, iipflo.Languages[1].Name);
+
+      Assert.AreEqual(iipflo_Size, iipflo.Size);
+      Assert.AreEqual(iipflo_Path, iipflo.Path);
+      Assert.AreEqual(iipflo_Url, iipflo.Url);
+      Assert.AreEqual(iipflo_ProductCode, iipflo.ProductCode);
+      Assert.AreEqual(iipflo_VersionWithTag, iipflo.VersionWithTag);
+      Assert.AreEqual(iipflo_Version, iipflo.Version);
+
+      Assert.IsTrue(iip.InstallLocation = iip.Locations[0]);
+
+
+      Assert.AreEqual(ii_EditionTitle, ii.EditionTitle);
+      Assert.AreEqual(ii_StartDisabled, ii.StartDisabled);
+      Assert.AreEqual(ii_StartWithConfiguration, ii.StartWithConfiguration);
+      Assert.AreEqual(ii_ShouldInstallKeyman, ii.ShouldInstallKeyman);
+      Assert.AreEqual(ii_Tier, ii.Tier);
+      Assert.AreEqual(ii_String, ii.Strings[0]);
+
+      Assert.AreEqual(2, ii.MsiLocations.Count);
+      iifl := ii.MsiLocations[0];
+
+      Assert.AreEqual(iifll_Size, iifl.Size);
+      Assert.AreEqual(iifll_Path, iifl.Path);
+      Assert.AreEqual(iifll_Url, iifl.Url);
+      Assert.AreEqual(iifll_ProductCode, iifl.ProductCode);
+      Assert.AreEqual(iifll_VersionWithTag, iifl.VersionWithTag);
+      Assert.AreEqual(iifll_Version, iifl.Version);
+
+      iifl := ii.MsiLocations[1];
+      Assert.AreEqual(iiflo_Size, iifl.Size);
+      Assert.AreEqual(iiflo_Path, iifl.Path);
+      Assert.AreEqual(iiflo_Url, iifl.Url);
+      Assert.AreEqual(iiflo_ProductCode, iifl.ProductCode);
+      Assert.AreEqual(iiflo_VersionWithTag, iifl.VersionWithTag);
+      Assert.AreEqual(iiflo_Version, iifl.Version);
+
+      Assert.IsTrue(ii.MsiInstallLocation = ii.MsiLocations[0]);
+
+      Assert.AreEqual(FTempFilename, ii.TitleImageFilename);
+    finally
+      ii.Free;
+    end;
+  finally
+    DeleteFile(FTempFilename);
   end;
 end;
 


### PR DESCRIPTION
Fixes #4467.

# Background

In some scenarios, e.g. files in use, Setup must restart before it completes. This is particularly the case if kmcomapi.dll is locked and Windows will move the new version into place after a restart. In this scenario, we would end up calling the old version of kmcomapi.dll to install keyboards, etc, which is definitely not desirable.

# Problem

Setup was not saving complete state before the restart, so when it resumed post-restart, would get a blank slate to work from, losing command-line options passed in and any choices that the end user may have made during the installation.

# Fix

This PR adds serialization of the `TInstallInfo` state data, so that the install state can be saved to disk before restart, and reloaded after the restart. This also means that the `-c` parameter now takes a filename, being the temporary state JSON file, and when in "ContinueSetup" mode, no longer needs to perform all the checks it did previously, making the second half of Setup somewhat faster.

# Testing

Added a unit test for the serialization of `TInstallInfo`, and have tested on a VM in various scenarios without problems.

This fix is somewhat broader than I really like to make while in Beta, but I don't think there was a viable alternative.