### PR TITLE
chore(windows): fully disable auto start task

### DIFF
--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -12,10 +12,10 @@ type
   private
     class function GetTaskName: string;
     class procedure CleanupAlphaTasks(pTaskFolder: ITaskFolder); static;
-  public
-    class procedure RecreateTask;
     class procedure DeleteTask;
     class procedure CreateTask;
+  public
+    class procedure RecreateTask;
   end;
 
 implementation
@@ -247,10 +247,7 @@ end;
 class procedure TKeymanStartTask.RecreateTask;
 begin
   if not Reg_GetDebugFlag(SRegValue_Flag_UseAutoStartTask, True) then
-  begin
-    DeleteTask;
     Exit;
-  end;
 
   CreateTask;
 end;

--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -246,7 +246,7 @@ end;
 
 class procedure TKeymanStartTask.RecreateTask;
 begin
-  if not Reg_GetDebugFlag(SRegValue_Flag_UseAutoStartTask, True) then
+  if not Reg_GetDebugFlag(SRegValue_Flag_UseAutoStartTask, False) then
     Exit;
 
   CreateTask;

--- a/windows/src/engine/kmtip/kmkey.cpp
+++ b/windows/src/engine/kmtip/kmkey.cpp
@@ -290,6 +290,9 @@ void CKMTipTextService::_UninitKeyman() {
 }
 
 void CKMTipTextService::_TryAndStartKeyman() {
+  if (!_tryAndStartKeyman)
+      return;
+
   HANDLE hEventSource = RegisterEventSource(NULL, "Keyman");
   if (!hEventSource) {
     // This is unlikely to occur, but if it does, there's probably

--- a/windows/src/engine/kmtip/kmtip.cpp
+++ b/windows/src/engine/kmtip/kmtip.cpp
@@ -31,6 +31,7 @@
 
 #include "pch.h"
 #include "kmtip.h"
+#include "registryw.h"
 
 //+---------------------------------------------------------------------------
 //
@@ -85,6 +86,9 @@ CKMTipTextService::CKMTipTextService()
     _PreservedKeys = NULL;
     _cPreservedKeyCount = 0;
     _dwDeepIntegration = 0;
+
+    RegistryReadOnlyW reg(HKEY_CURRENT_USER);
+    _tryAndStartKeyman = reg.OpenKeyReadOnly(REGSZ_KeymanEngineDebug_CU) && reg.ValueExists(REGSZ_Flag_UseAutoStartTask) && reg.ReadInteger(REGSZ_Flag_UseAutoStartTask) != 0;
 
     _cRef = 1;
     ThreadThis = this;

--- a/windows/src/engine/kmtip/kmtip.h
+++ b/windows/src/engine/kmtip/kmtip.h
@@ -133,6 +133,8 @@ private:
 
     DWORD _dwDeepIntegration;   // I4375
 
+    BOOL _tryAndStartKeyman;
+
     LONG _cRef;     // COM ref count
 };
 

--- a/windows/src/engine/kmtip/registryw.h
+++ b/windows/src/engine/kmtip/registryw.h
@@ -58,14 +58,6 @@
 #define REGSZ_KeymanActiveLanguagesW REGSZ_KeymanCUW L"\\active languages"
 #define REGSZ_KeymanLanguageHotkeysW REGSZ_KeymanCUW L"\\language hotkeys"
 
-#ifdef _WIN64
-#define REGSZ_KeymanAddinsCUW         		REGSZ_KeymanCUW L"\\add-ins (x64)"
-#define REGSZ_KeymanAddinsLMW         		REGSZ_KeymanLMW L"\\add-ins (x64)"
-#else
-#define REGSZ_KeymanAddinsCUW         		REGSZ_KeymanCUW L"\\add-ins"
-#define REGSZ_KeymanAddinsLMW         		REGSZ_KeymanLMW L"\\add-ins"
-#endif
-
 #define REGSZ_KeymanHotkeysW				REGSZ_KeymanCUW L"\\hotkeys"
 
 #define REGSZ_EvaluationW		L"evaluation"
@@ -112,11 +104,8 @@
 #define REGSZ_ShouldShowStartupW		L"show keyman startup"
 #define REGSZ_ShouldStartInternatW	L"should start internat"
 
-/* Addins */ 
-
-#define REGSZ_AddinNameW			 L"addin name"
-#define REGSZ_AddinFileNameW	 L"addin file name"
-#define REGSZ_AddinEnabledW    L"addin enabled"
+#define REGSZ_KeymanEngineDebug_CU  L"software\\keyman\\keyman engine\\Debug"
+#define REGSZ_Flag_UseAutoStartTask L"Flag_UseAutoStartTask"
 
 /* Registry keys for upgrade purposes only */ 
 

--- a/windows/src/global/delphi/general/Keyman.System.Settings.pas
+++ b/windows/src/global/delphi/general/Keyman.System.Settings.pas
@@ -415,11 +415,11 @@ const
       Name: SRegValue_Flag_UseAutoStartTask;
       RootKey: HKCU;
       Key: SRegKey_KeymanEngineDebug_CU;
-      Description: 'Set to 0 to disable the autostart task that starts '+
+      Description: 'Set to 1 to enable the autostart task that starts '+
                    'Keyman when a Keyman TIP is selected. After making this '+
                    'change, you will need to open Keyman Configuration once '+
                    'for it to take effect.';
-      DefaultInt: 1;
+      DefaultInt: 0;
       ValueType: kstInteger
     ),
 


### PR DESCRIPTION
If the registry setting `HKCU\Software\Keyman Engine\Debug:Flag_UseAutoStartTask[REG_WORD]` is not `0`, then the this will enable the restart task. Otherwise, all aspects of it are disabled.

For Keyman 14.0 initial release, we will have this flag disabled. If we can improve stability of it, we'll consider turning it on.