### PR TITLE
fix(android/app): Fix crash when clicking QR code

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
@@ -149,7 +149,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         HashMap<String, String> hashMap = (HashMap<String, String>) parent.getItemAtPosition(position);
         if (hashMap == null) {
-          KMLog.LogError(TAG, "map is null, position is " + position);
+          // Ignore null HashMap when clicking on QR code
+          return;
         }
         String itemTitle = MapCompat.getOrDefault(hashMap, titleKey, "");
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -11,6 +11,11 @@ import io.sentry.SentryLevel;
 public final class KMLog {
   private static final String TAG = "KMLog";
 
+  // Since we don't have access to KMManager.isTestMode()
+  private static boolean isTestMode() {
+    return Boolean.parseBoolean(System.getProperty("kmeaTestMode"));
+  }
+
   /**
    * Utility to log error and send to Sentry
    * @param tag String of the caller
@@ -20,7 +25,7 @@ public final class KMLog {
     if (msg != null && !msg.isEmpty()) {
       Log.e(tag, msg);
 
-      if (Sentry.isEnabled()) {
+      if (Sentry.isEnabled() && !isTestMode()) {
         Sentry.captureMessage(msg, SentryLevel.ERROR);
       }
     }
@@ -39,7 +44,7 @@ public final class KMLog {
       Log.e(tag, e.getMessage(), e);
     }
 
-    if (Sentry.isEnabled()) {
+    if (Sentry.isEnabled() && !isTestMode()) {
       if (msg != null && !msg.isEmpty()) {
         Sentry.addBreadcrumb(msg);
       }
@@ -57,7 +62,7 @@ public final class KMLog {
    */
   public static void LogExceptionWithData(String tag, String msg,
                                           String objName, Object obj, Throwable e) {
-    if (obj != null && Sentry.isEnabled()) {
+    if (obj != null && Sentry.isEnabled() && !isTestMode()) {
       String objStr = null;
       try {
         objStr = obj.toString();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -11,11 +11,6 @@ import io.sentry.SentryLevel;
 public final class KMLog {
   private static final String TAG = "KMLog";
 
-  // Since we don't have access to KMManager.isTestMode()
-  private static boolean isTestMode() {
-    return Boolean.parseBoolean(System.getProperty("kmeaTestMode"));
-  }
-
   /**
    * Utility to log error and send to Sentry
    * @param tag String of the caller
@@ -25,7 +20,7 @@ public final class KMLog {
     if (msg != null && !msg.isEmpty()) {
       Log.e(tag, msg);
 
-      if (Sentry.isEnabled() && !isTestMode()) {
+      if (Sentry.isEnabled()) {
         Sentry.captureMessage(msg, SentryLevel.ERROR);
       }
     }
@@ -44,7 +39,7 @@ public final class KMLog {
       Log.e(tag, e.getMessage(), e);
     }
 
-    if (Sentry.isEnabled() && !isTestMode()) {
+    if (Sentry.isEnabled()) {
       if (msg != null && !msg.isEmpty()) {
         Sentry.addBreadcrumb(msg);
       }
@@ -62,7 +57,7 @@ public final class KMLog {
    */
   public static void LogExceptionWithData(String tag, String msg,
                                           String objName, Object obj, Throwable e) {
-    if (obj != null && Sentry.isEnabled() && !isTestMode()) {
+    if (obj != null && Sentry.isEnabled()) {
       String objStr = null;
       try {
         objStr = obj.toString();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
@@ -13,6 +13,10 @@ public final class MapCompat {
   private static final String TAG = "MapCompat";
 
   public static <K, V> V getOrDefault(HashMap<K, V> map, K key, V defaultValue) {
+    if (map == null) {
+      KMLog.LogError(TAG, "HashMap is null. Returning " + defaultValue);
+      return defaultValue;
+    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       return map.getOrDefault(key, defaultValue);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
@@ -3,6 +3,7 @@ package com.tavultesoft.kmea.util;
 import android.os.Build;
 
 import java.util.HashMap;
+import java.lang.NullPointerException;
 
 /**
  * HashMap.getOrDefault is only available for Android API 24+, so this method is an alternative
@@ -12,10 +13,17 @@ import java.util.HashMap;
 public final class MapCompat {
   private static final String TAG = "MapCompat";
 
-  public static <K, V> V getOrDefault(HashMap<K, V> map, K key, V defaultValue) {
+  /**
+   *
+   * @param map HashMap<String, String>
+   * @param key String
+   * @param defaultValue String
+   * @return String
+   * @throws NullPointerException
+   */
+  public static <K, V> V getOrDefault(HashMap<K, V> map, K key, V defaultValue) throws NullPointerException {
     if (map == null) {
-      KMLog.LogError(TAG, "HashMap is null. Returning " + defaultValue);
-      return defaultValue;
+      throw new NullPointerException("MapCompat is null");
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       return map.getOrDefault(key, defaultValue);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/MapCompat.java
@@ -22,9 +22,6 @@ public final class MapCompat {
    * @throws NullPointerException
    */
   public static <K, V> V getOrDefault(HashMap<K, V> map, K key, V defaultValue) throws NullPointerException {
-    if (map == null) {
-      throw new NullPointerException("MapCompat is null");
-    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       return map.getOrDefault(key, defaultValue);
     }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
@@ -1,0 +1,68 @@
+package com.tavultesoft.kmea.util;
+
+import org.checkerframework.common.value.qual.StaticallyExecutable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+
+import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
+import com.tavultesoft.kmea.util.MapCompat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.N;
+
+@RunWith(RobolectricTestRunner.class)
+public class MapCompatTest {
+  private final HashMap<String, String> pets = new HashMap<String, String>();
+
+  // Each test sets up a HashMap
+  @Before
+  public void generatePets() {
+    pets.put("dog", "Spot");
+    pets.put("cat", "Mittens");
+  }
+
+  @Test
+  public void test_getOrDefault_nullMapReturnsDefault() {
+    Assert.assertEquals("Peanut", MapCompat.getOrDefault(null, "elephant", "Peanut"));
+
+    // Check shadow log error msg
+    List<ShadowLog.LogItem> logs = ShadowLog.getLogsForTag("MapCompat");
+    Assert.assertEquals(1, logs.size());
+    Assert.assertEquals("MapCompat", logs.get(0).tag);
+    Assert.assertEquals("HashMap is null. Returning Peanut", logs.get(0).msg);
+  }
+
+  @Config(sdk=LOLLIPOP)
+  @Test
+  public void test_getOrDefault_LollipopKeyExists() {
+    Assert.assertEquals("Spot", MapCompat.getOrDefault(pets, "dog", "none"));
+  }
+
+  @Config(sdk=N)
+  @Test
+  public void test_getOrDefault_NougatKeyExists() {
+    Assert.assertEquals("Spot", MapCompat.getOrDefault(pets, "dog", "none"));
+  }
+
+  @Config(sdk=LOLLIPOP)
+  @Test
+  public void test_getOrDefault_LollipopReturnDefault() {
+    Assert.assertEquals("Peanut", MapCompat.getOrDefault(pets, "elephant", "Peanut"));
+  }
+
+  @Config(sdk=N)
+  @Test
+  public void test_getOrDefault_NougatReturnDefault() {
+    Assert.assertEquals("Peanut", MapCompat.getOrDefault(pets, "elephant", "Peanut"));
+  }
+
+}

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
@@ -32,7 +32,6 @@ public class MapCompatTest {
   @Test
   public void test_getOrDefault_nullMapThrows() throws NullPointerException {
     exceptionRule.expect(NullPointerException.class);
-    exceptionRule.expectMessage("MapCompat is null");
 
     Assert.assertEquals("Peanut", MapCompat.getOrDefault(null, "elephant", "Peanut"));
   }

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/MapCompatTest.java
@@ -1,20 +1,16 @@
 package com.tavultesoft.kmea.util;
 
-import org.checkerframework.common.value.qual.StaticallyExecutable;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowLog;
 
-import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
-import com.tavultesoft.kmea.util.MapCompat;
 
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.N;
@@ -30,15 +26,15 @@ public class MapCompatTest {
     pets.put("cat", "Mittens");
   }
 
-  @Test
-  public void test_getOrDefault_nullMapReturnsDefault() {
-    Assert.assertEquals("Peanut", MapCompat.getOrDefault(null, "elephant", "Peanut"));
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
 
-    // Check shadow log error msg
-    List<ShadowLog.LogItem> logs = ShadowLog.getLogsForTag("MapCompat");
-    Assert.assertEquals(1, logs.size());
-    Assert.assertEquals("MapCompat", logs.get(0).tag);
-    Assert.assertEquals("HashMap is null. Returning Peanut", logs.get(0).msg);
+  @Test
+  public void test_getOrDefault_nullMapThrows() throws NullPointerException {
+    exceptionRule.expect(NullPointerException.class);
+    exceptionRule.expectMessage("MapCompat is null");
+
+    Assert.assertEquals("Peanut", MapCompat.getOrDefault(null, "elephant", "Peanut"));
   }
 
   @Config(sdk=LOLLIPOP)


### PR DESCRIPTION
Fixes #4269 

After some spelunking in the Sentry crash reports, this PR fixes the following:

* ~Disable Sentry on unit tests~
* Throw NullPointerException if null HashMap passed to MapCompat
* Ignore null HashMap when clicking on QR code (KeyboardSettingsActivity). Note, the QR code is also displayed in KeyboardInfoActivity, but that doesn't involve a null HashMap.

### User Testing
1. Load app
2. From the "Settings" menu, install "Tohono O'odham" keyboard (from the linked Sentry report)
3. After keyboard installs, go Settings --> Installed Languages --> Tohono O'odham (Latin) --> Tohono O'odham --> settings menu
4. Click on the QR code and verify nothing happens
