### PR TITLE
fix(android): fixes errors within lists used for UI

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/adapters/NestedAdapter.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/adapters/NestedAdapter.java
@@ -94,10 +94,19 @@ public class NestedAdapter<Element, A extends ArrayAdapter<Element> & ListBacked
   }
 
   public NestedAdapter(@NonNull Context context, int resource, @NonNull A adapter, AdapterFilter<Element, A, FilterArg> filter, FilterArg filterArg) {
-    this(context, resource, adapter, filter, filterArg, filter.selectFrom(adapter, filterArg));
+    // Ensure that the list we pass through is writeable.  Errors may result otherwise.
+    this(context, resource, adapter, filter, filterArg, new ArrayList<>(filter.selectFrom(adapter, filterArg)));
   }
 
-  public NestedAdapter(@NonNull Context context, int resource, @NonNull A adapter, AdapterFilter<Element, A, FilterArg> filter, FilterArg filterArg, List<Element> filteredList) {
+  // In order for the instance to be properly constructed, the `filteredList`
+  // parameter must be mutable.  Unfortunately, there's no way to robustly
+  // check for that, and it illegal to construct a modifiable version
+  // before the super's constructor call b/c Java limitations.
+  // So... we'll keep it locked behind 'protected' for now.
+  //
+  // Could probably throw an extra parameter on for an 'internal' version
+  // and use the current signature as a 'helper' like with the constructor above?
+  protected NestedAdapter(@NonNull Context context, int resource, @NonNull A adapter, AdapterFilter<Element, A, FilterArg> filter, FilterArg filterArg, List<Element> filteredList) {
     super(context, resource, filteredList);
 
     this.wrappedAdapter = adapter;

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -72,7 +72,11 @@ displayInfo "" \
 cd $KEYMAN_ROOT/android/help
 
 MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
-MD=`find -name "*.md"`
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  MD=`find . -name "*.md"`
+else
+  MD=`find -name "*.md"`
+fi
 DESTHTM="$THIS_DIR/KMAPro/kMAPro/src/main/assets/info"
 
 if $DO_HTM; then

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -72,11 +72,7 @@ displayInfo "" \
 cd $KEYMAN_ROOT/android/help
 
 MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-  MD=`find . -name "*.md"`
-else
-  MD=`find -name "*.md"`
-fi
+MD=`find . -name "*.md"`
 DESTHTM="$THIS_DIR/KMAPro/kMAPro/src/main/assets/info"
 
 if $DO_HTM; then


### PR DESCRIPTION
Fixes #3200.

Yep.  Turns out that some of NestedAdapter's constructor calls were receiving unmodifiable lists... which, honestly, is a reasonable expectation.  So, the "proper" way forward is to shift to a perspective where the class _expects_ unmodifiable lists and creates its own editable copy.

Also throws in a minor couple of fixes for `build-help.sh`.  A tweak not easily seen by reviewing the code: it lacked the executable bit needed to run on *nix systems.