### PR TITLE
fix(mac): register configuration window on load

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -52,6 +52,7 @@
 }
 
 - (void)windowDidLoad {
+    [self.AppDelegate registerConfigurationWindow:self];
     [super windowDidLoad];
     [self.window center];
     [_tableView registerForDraggedTypes:@[NSFilenamesPboardType]];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -127,6 +127,7 @@ typedef struct {
 - (KeymanVersionInfo)versionInfo;
 - (NSString *)keymanDataPath;
 - (NSArray *)legacyAppsUserDefaults;
+- (void)registerConfigurationWindow:(NSWindowController *)window;
 @end
 
 #endif /* KMInputMethodAppDelegate_h */

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -1009,6 +1009,10 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     [self.configWindow.window setLevel:NSFloatingWindowLevel];
 }
 
+- (void)registerConfigurationWindow:(NSWindowController *)window {
+    _configWindow = window;
+}
+
 - (void)showOSK {
     [[self.oskWindow window] makeKeyAndOrderFront:nil];
     [[self.oskWindow window] setLevel:NSStatusWindowLevel];


### PR DESCRIPTION
Fixes #3945.

When the configuration window is opened via `showPreferences`, we were not aware that the configuration window had been opened, so subsequent references to it would recreate it.