### PR TITLE
fix(mac): show local help in app

### DIFF
--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -5,6 +5,7 @@
 Keyman4MacIM/output/*
 Keyman4MacIM/Keyman4MacIM/Frameworks/**
 Keyman4MacIM/Pods/**
+Keyman4MacIM/Keyman4MacIM/Help/
 Keyman4Mac/Keyman4Mac/Frameworks/**
 Carthage/**
 **/build

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		37A245C12565DFA6000BBF92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37A245C02565DFA6000BBF92 /* Assets.xcassets */; };
 		37AE5C9D239A7B770086CC7C /* qrcode.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 37AE5C9C239A7B770086CC7C /* qrcode.min.js */; };
+		37C2B0CB25FF2C350092E16A /* Help in Resources */ = {isa = PBXBuildFile; fileRef = 37C2B0CA25FF2C340092E16A /* Help */; };
 		9800EC5A1C02940300BF0FB5 /* keyman-for-mac-os-license.html in Resources */ = {isa = PBXBuildFile; fileRef = 9800EC591C02940300BF0FB5 /* keyman-for-mac-os-license.html */; };
 		9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9803C9D71B0EFB3B0082A6F9 /* WebKit.framework */; };
 		983247281A9EA28F0010B90C /* KeymanEngine4Mac.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -139,6 +140,7 @@
 		37A00F2E239AD4D000D2C837 /* KeymanEngine4Mac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeymanEngine4Mac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		37A245C02565DFA6000BBF92 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		37AE5C9C239A7B770086CC7C /* qrcode.min.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = qrcode.min.js; sourceTree = "<group>"; };
+		37C2B0CA25FF2C340092E16A /* Help */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Help; path = Keyman4MacIM/Help; sourceTree = "<group>"; };
 		7844A655E38A234DE5D29DF9 /* Pods-Keyman.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.release.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.release.xcconfig"; sourceTree = "<group>"; };
 		8577C0C788461AFE564DDF4F /* Pods-KeymanTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KeymanTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KeymanTests/Pods-KeymanTests.debug.xcconfig"; sourceTree = "<group>"; };
 		878287E1B18ED4EE910C4BC7 /* Pods-Keyman.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.debug.xcconfig"; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 		989C9BFF1A7876DE00A20425 = {
 			isa = PBXGroup;
 			children = (
+				37C2B0CA25FF2C340092E16A /* Help */,
 				37A245C02565DFA6000BBF92 /* Assets.xcassets */,
 				37589AD422E52DA20097D39D /* Keyman.entitlements */,
 				E2C92D4720B46CEA00742A7D /* KeymanEngine4Mac.framework.dSYM */,
@@ -653,6 +656,7 @@
 				9874C3211B536847000BB543 /* info.png in Resources */,
 				98E672A01B532F5E00DBDE2F /* KMDownloadKBWindowController.xib in Resources */,
 				37AE5C9D239A7B770086CC7C /* qrcode.min.js in Resources */,
+				37C2B0CB25FF2C350092E16A /* Help in Resources */,
 				984B8F451AF1C3D900E096A8 /* OSKWindowController.xib in Resources */,
 				98FE10641B4DEE5600525F54 /* KMInfoWindowController.xib in Resources */,
 				E213601E2142D7C000A043B7 /* keyman-88.png in Resources */,

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -15,6 +15,9 @@
 @property (nonatomic, weak) IBOutlet NSButton *alwaysShowOSKCheckBox;
 @property (nonatomic, weak) IBOutlet NSButton *useVerboseLoggingCheckBox;
 @property (nonatomic, weak) IBOutlet NSTextField *verboseLoggingInfo;
+@property (nonatomic, weak) IBOutlet NSButton *supportBack;
+@property (nonatomic, weak) IBOutlet NSButton *supportForward;
+@property (nonatomic, weak) IBOutlet NSButton *supportHome;
 @property (nonatomic, strong) NSMutableArray *tableContents;
 @property (nonatomic, strong) NSTimer *reloadTimer;
 @property (nonatomic, strong) NSDate *lastReloadDate;
@@ -58,15 +61,52 @@
     [_tableView registerForDraggedTypes:@[NSFilenamesPboardType]];
     _lastReloadDate = [NSDate date];
     [self startTimer];
-
-    KeymanVersionInfo versionInfo = [[self AppDelegate] versionInfo];
-    NSString *versionUrl = [NSString stringWithFormat:@"https://%@/products/mac/%@", versionInfo.helpKeymanCom, versionInfo.versionRelease];
     
     [self.webView setFrameLoadDelegate:(id<WebFrameLoadDelegate>)self];
-    [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString: versionUrl]]];
+    [self.webView setPolicyDelegate:(id<WebPolicyDelegate>)self];
+
+    NSURL *homeUrl = [[NSBundle mainBundle] URLForResource:@"index" withExtension:@"html" subdirectory:@"Help"];
+    [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:homeUrl]];
 
     [self.alwaysShowOSKCheckBox setState:(self.AppDelegate.alwaysShowOSK ? NSOnState : NSOffState)];
     [self.useVerboseLoggingCheckBox setState:(self.AppDelegate.useVerboseLogging ? NSOnState : NSOffState)];
+}
+
+- (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request newFrameName:(NSString *)frameName decisionListener:(id<WebPolicyDecisionListener>)listener {
+    [[NSWorkspace sharedWorkspace] openURL:[actionInformation objectForKey:WebActionOriginalURLKey]];
+    [listener ignore];
+}
+
+- (void)webView:(WebView *)webView decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener {
+    NSString* url = [[request URL] absoluteString];
+    if (self.AppDelegate.debugMode)
+        NSLog(@"decidePolicyForNavigationAction, navigating to %@", url);
+
+    if([url hasPrefix: @"file:"]) {
+        [listener use];
+    } else {
+        [listener ignore];
+        [[NSWorkspace sharedWorkspace] openURL: [request URL]];
+    }
+}
+
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame; {
+    self.supportBack.enabled = [self.webView canGoBack];
+    self.supportForward.enabled = [self.webView canGoForward];
+}
+
+- (IBAction)supportBackAction:(id)sender {
+    [self.webView goBack];
+}
+
+- (IBAction)supportForwardAction:(id)sender {
+    [self.webView goForward];
+}
+
+- (IBAction)supportHomeAction:(id)sender {
+    NSURL *homeUrl = [[NSBundle mainBundle] URLForResource:@"index" withExtension:@"html" subdirectory:@"Help"];
+    [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:homeUrl]];
+
 }
 
 - (void)setTableView:(NSTableView *)tableView {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/preferences.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/preferences.xib
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.3"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="16097.3"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="KMConfigurationWindowController">
             <connections>
                 <outlet property="alwaysShowOSKCheckBox" destination="k5c-KF-717" id="EYm-1F-c71"/>
+                <outlet property="supportBack" destination="LX7-yF-rV2" id="ciN-Ia-7ei"/>
+                <outlet property="supportForward" destination="OSG-wW-VHs" id="8dG-cd-ByI"/>
+                <outlet property="supportHome" destination="RUX-eW-d6h" id="i5g-Lo-6zG"/>
                 <outlet property="tableView" destination="epz-Md-JOY" id="fHy-6f-hXN"/>
                 <outlet property="useVerboseLoggingCheckBox" destination="uWx-3J-U0D" id="deO-CV-6KJ"/>
                 <outlet property="verboseLoggingInfo" destination="PiJ-pY-UY7" id="o0X-ZY-NKX"/>
@@ -19,16 +22,16 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Keyman Configuration" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
+        <window title="Keyman Configuration" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="800" height="600"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <tabView id="Kgr-ki-UM3">
+                    <tabView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kgr-ki-UM3">
                         <rect key="frame" x="13" y="10" width="774" height="584"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <font key="font" metaFont="system"/>
@@ -38,18 +41,18 @@
                                     <rect key="frame" x="10" y="33" width="754" height="538"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button verticalHuggingPriority="750" id="9T1-dw-Njs">
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9T1-dw-Njs">
                                             <rect key="frame" x="17" y="4" width="150" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="roundRect" title="Download keyboard..." bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="CTw-kf-WNS">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="cellTitle"/>
+                                                <font key="font" metaFont="label" size="12"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="downloadAction:" target="-2" id="7Xp-r0-nca"/>
                                             </connections>
                                         </button>
-                                        <scrollView autohidesScrollers="YES" horizontalLineScroll="27" horizontalPageScroll="10" verticalLineScroll="27" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="8YI-W2-94d">
+                                        <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="27" horizontalPageScroll="10" verticalLineScroll="27" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8YI-W2-94d">
                                             <rect key="frame" x="17" y="31" width="720" height="504"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <clipView key="contentView" id="exW-ga-u8o">
@@ -58,7 +61,7 @@
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="25" rowSizeStyle="automatic" headerView="iHl-b4-479" viewBased="YES" id="epz-Md-JOY">
                                                         <rect key="frame" x="0.0" y="0.0" width="718" height="486"/>
-                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         <tableViewGridLines key="gridStyleMask" dashed="YES"/>
@@ -66,7 +69,6 @@
                                                         <tableColumns>
                                                             <tableColumn identifier="Column1" editable="NO" width="57" minWidth="40" maxWidth="1000" id="mbF-S8-0mm">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center">
-                                                                    <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                 </tableHeaderCell>
@@ -80,7 +82,7 @@
                                                                         <rect key="frame" x="1" y="1" width="57" height="25"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <button id="mcD-zc-0eI">
+                                                                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mcD-zc-0eI">
                                                                                 <rect key="frame" x="7" y="3" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uMz-th-dqQ">
@@ -88,7 +90,7 @@
                                                                                     <font key="font" metaFont="system"/>
                                                                                 </buttonCell>
                                                                             </button>
-                                                                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="Nbh-TH-u9d">
+                                                                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nbh-TH-u9d">
                                                                                 <rect key="frame" x="32" y="3" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="485-iw-eDf"/>
@@ -103,7 +105,6 @@
                                                             </tableColumn>
                                                             <tableColumn identifier="Column2" editable="NO" width="550" minWidth="40" maxWidth="1000" id="jex-Nd-Qzg">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Installed Keyboard">
-                                                                    <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                 </tableHeaderCell>
@@ -117,7 +118,7 @@
                                                                         <rect key="frame" x="61" y="1" width="550" height="25"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="YfS-ug-Llz">
+                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YfS-ug-Llz">
                                                                                 <rect key="frame" x="7" y="3" width="536" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Table View Cell" id="J2x-OZ-TSX">
@@ -135,7 +136,6 @@
                                                             </tableColumn>
                                                             <tableColumn identifier="Column3" editable="NO" width="84" minWidth="10" maxWidth="3.4028234663852886e+38" id="Eec-YW-6x8">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                    <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                 </tableHeaderCell>
@@ -149,28 +149,28 @@
                                                                         <rect key="frame" x="614" y="1" width="84" height="25"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <button id="mJA-up-QcJ">
+                                                                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mJA-up-QcJ">
                                                                                 <rect key="frame" x="7" y="4" width="20" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSInfo" imagePosition="only" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="MGW-Cn-mJi">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="cellTitle"/>
+                                                                                    <font key="font" metaFont="label" size="12"/>
                                                                                 </buttonCell>
                                                                             </button>
-                                                                            <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="hIP-50-6WN">
+                                                                            <button horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hIP-50-6WN">
                                                                                 <rect key="frame" x="32" y="3" width="19" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="help" bezelStyle="helpButton" image="buttonCell:clx-vL-wIY:image" imagePosition="only" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="clx-vL-wIY">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                                    <font key="font" metaFont="controlContent" size="11"/>
                                                                                 </buttonCell>
                                                                             </button>
-                                                                            <button verticalHuggingPriority="750" id="L8z-uW-bYk">
+                                                                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L8z-uW-bYk">
                                                                                 <rect key="frame" x="56" y="3" width="19" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                                 <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="NSRemoveTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kkR-ba-cFc">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="cellTitle"/>
+                                                                                    <font key="font" metaFont="label" size="12"/>
                                                                                 </buttonCell>
                                                                             </button>
                                                                         </subviews>
@@ -211,7 +211,7 @@
                                     <rect key="frame" x="10" y="33" width="754" height="538"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button id="k5c-KF-717">
+                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="k5c-KF-717">
                                             <rect key="frame" x="15" y="509" width="234" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Always show on-screen keyboard" bezelStyle="regularSquare" imagePosition="left" inset="2" id="4UX-80-0Vo">
@@ -222,7 +222,7 @@
                                                 <action selector="alwaysShowOSKCheckBoxAction:" target="-2" id="TbQ-5n-ODK"/>
                                             </connections>
                                         </button>
-                                        <button toolTip="Turn this on if you are having problems with a specific keyboard or with Keyman in general." verticalHuggingPriority="750" misplaced="YES" id="uWx-3J-U0D">
+                                        <button toolTip="Turn this on if you are having problems with a specific keyboard or with Keyman in general." verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWx-3J-U0D">
                                             <rect key="frame" x="15" y="483" width="200" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="check" title="Use verbose Console logging" bezelStyle="regularSquare" imagePosition="left" inset="2" id="7J6-zy-R20">
@@ -233,7 +233,7 @@
                                                 <action selector="useVerboseLoggingCheckBoxAction:" target="-2" id="DGX-fy-5qP"/>
                                             </connections>
                                         </button>
-                                        <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" id="PiJ-pY-UY7">
+                                        <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PiJ-pY-UY7">
                                             <rect key="frame" x="34" y="414" width="705" height="63"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="MrI-GM-7d6">
@@ -251,13 +251,46 @@
                                     <rect key="frame" x="10" y="33" width="754" height="538"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <webView id="gTQ-rF-m9S">
+                                        <webView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTQ-rF-m9S">
                                             <rect key="frame" x="17" y="43" width="720" height="492"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
                                                 <nil key="identifier"/>
                                             </webPreferences>
                                         </webView>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LX7-yF-rV2">
+                                            <rect key="frame" x="17" y="9" width="82" height="19"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="roundRect" title="&lt; Back" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JOK-JV-n8w">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="label" size="12"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="supportBackAction:" target="-2" id="Ji4-Fz-xim"/>
+                                            </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OSG-wW-VHs">
+                                            <rect key="frame" x="107" y="9" width="93" height="19"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="roundRect" title="Forward &gt;" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="eXr-8V-h1g">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="label" size="12"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="supportForwardAction:" target="-2" id="W8M-lj-U9k"/>
+                                            </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RUX-eW-d6h">
+                                            <rect key="frame" x="208" y="9" width="93" height="19"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="roundRect" title="Home" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fXS-aC-CMH">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="label" size="12"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="supportHomeAction:" target="-2" id="cZr-Mg-CNl"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </view>
                             </tabViewItem>
@@ -277,53 +310,53 @@
         <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="buttonCell:clx-vL-wIY:image" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
-YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
-GR4fIyQrLjE3OlUkbnVsbNUJCgsMDQ4PEBESVk5TU2l6ZVYkY2xhc3NcTlNJbWFnZUZsYWdzVk5TUmVw
-c1dOU0NvbG9ygAKADRIgwwAAgAOAC1Z7MSwgMX3SFQoWGFpOUy5vYmplY3RzoReABIAK0hUKGh2iGxyA
-BYAGgAkQANIgCiEiXxAUTlNUSUZGUmVwcmVzZW50YXRpb26AB4AITxEIjE1NACoAAAAKAAAAEAEAAAMA
-AAABAAEAAAEBAAMAAAABAAEAAAECAAMAAAACAAgACAEDAAMAAAABAAEAAAEGAAMAAAABAAEAAAEKAAMA
-AAABAAEAAAERAAQAAAABAAAACAESAAMAAAABAAEAAAEVAAMAAAABAAIAAAEWAAMAAAABAAEAAAEXAAQA
-AAABAAAAAgEcAAMAAAABAAEAAAEoAAMAAAABAAIAAAFSAAMAAAABAAEAAAFTAAMAAAACAAEAAYdzAAcA
-AAe8AAAA0AAAAAAAAAe8YXBwbAIgAABtbnRyR1JBWVhZWiAH0AACAA4ADAAAAABhY3NwQVBQTAAAAABu
-b25lAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWFwcGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVkZXNjAAAAwAAAAG9kc2NtAAABMAAABi5jcHJ0AAAHYAAAADh3
-dHB0AAAHmAAAABRrVFJDAAAHrAAAAA5kZXNjAAAAAAAAABVHZW5lcmljIEdyYXkgUHJvZmlsZQAAAAAA
-AAAAAAAAFUdlbmVyaWMgR3JheSBQcm9maWxlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAbWx1YwAAAAAAAAAeAAAADHNrU0sAAAAqAAABeGRhREsAAAA0AAABomNhRVMA
-AAAsAAAB1nB0QlIAAAAqAAACAnVrVUEAAAAsAAACLGZyRlUAAAAqAAACWGh1SFUAAAAuAAACgnpoVFcA
-AAAQAAACsG5iTk8AAAAsAAACwGNzQ1oAAAAkAAAC7GhlSUwAAAAgAAADEGl0SVQAAAAuAAADMHJvUk8A
-AAAkAAADXmRlREUAAAA6AAADgmtvS1IAAAAYAAADvHN2U0UAAAAuAAAD1HpoQ04AAAAQAAAEAmphSlAA
-AAAWAAAEEmVsR1IAAAAkAAAEKHB0UE8AAAA4AAAETG5sTkwAAAAqAAAEhGVzRVMAAAAoAAAErnRoVEgA
-AAAkAAAE1nRyVFIAAAAiAAAE+mZpRkkAAAAsAAAFHGhySFIAAAA6AAAFSHBsUEwAAAA2AAAFgnJ1UlUA
-AAAmAAAFuGFyRUcAAAAoAAAF3mVuVVMAAAAoAAAGBgBWAWEAZQBvAGIAZQBjAG4A/QAgAHMAaQB2AP0A
-IABwAHIAbwBmAGkAbABHAGUAbgBlAHIAZQBsACAAZwByAOUAdABvAG4AZQBiAGUAcwBrAHIAaQB2AGUA
-bABzAGUAUABlAHIAZgBpAGwAIABkAGUAIABnAHIAaQBzACAAZwBlAG4A6AByAGkAYwBQAGUAcgBmAGkA
-bAAgAEMAaQBuAHoAYQAgAEcAZQBuAOkAcgBpAGMAbwQXBDAEMwQwBDsETAQ9BDgEOQAgBD8EQAQ+BEQE
-MAQ5BDsAIABHAHIAYQB5AFAAcgBvAGYAaQBsACAAZwDpAG4A6QByAGkAcQB1AGUAIABnAHIAaQBzAMEA
-bAB0AGEAbADhAG4AbwBzACAAcwB6APwAcgBrAGUAIABwAHIAbwBmAGkAbJAadShwcJaOgnJfaWPPj/AA
-RwBlAG4AZQByAGkAcwBrACAAZwByAOUAdABvAG4AZQBwAHIAbwBmAGkAbABPAGIAZQBjAG4A/QAgAWEA
-ZQBkAP0AIABwAHIAbwBmAGkAbAXkBegF1QXkBdkF3AAgAEcAcgBhAHkAIAXbBdwF3AXZAFAAcgBvAGYA
-aQBsAG8AIABnAHIAaQBnAGkAbwAgAGcAZQBuAGUAcgBpAGMAbwBQAHIAbwBmAGkAbAAgAGcAcgBpACAA
-ZwBlAG4AZQByAGkAYwBBAGwAbABnAGUAbQBlAGkAbgBlAHMAIABHAHIAYQB1AHMAdAB1AGYAZQBuAC0A
-UAByAG8AZgBpAGzHfLwYACAARwByAGEAeQAg1QS4XNMMx3wARwBlAG4AZQByAGkAcwBrACAAZwByAOUA
-cwBrAGEAbABlAHAAcgBvAGYAaQBsZm6QGnBwXqZjz4/wZYdO9k4AgiwwsDDsMKQw1zDtMNUwoTCkMOsD
-kwO1A70DuQO6A8wAIAPAA8EDvwPGA68DuwAgA7MDugPBA7kAUABlAHIAZgBpAGwAIABnAGUAbgDpAHIA
-aQBjAG8AIABkAGUAIABjAGkAbgB6AGUAbgB0AG8AcwBBAGwAZwBlAG0AZQBlAG4AIABnAHIAaQBqAHMA
-cAByAG8AZgBpAGUAbABQAGUAcgBmAGkAbAAgAGcAcgBpAHMAIABnAGUAbgDpAHIAaQBjAG8OQg4bDiMO
-RA4fDiUOTA4qDjUOQA4XDjIOFw4xDkgOJw5EDhsARwBlAG4AZQBsACAARwByAGkAIABQAHIAbwBmAGkA
-bABpAFkAbABlAGkAbgBlAG4AIABoAGEAcgBtAGEAYQBwAHIAbwBmAGkAaQBsAGkARwBlAG4AZQByAGkB
-DQBrAGkAIABwAHIAbwBmAGkAbAAgAHMAaQB2AGkAaAAgAHQAbwBuAG8AdgBhAFUAbgBpAHcAZQByAHMA
-YQBsAG4AeQAgAHAAcgBvAGYAaQBsACAAcwB6AGEAcgBvAVsAYwBpBB4EMQRJBDgEOQAgBEEENQRABEsE
-OQAgBD8EQAQ+BEQEOAQ7BEwGRQZEBkEAIAYqBjkGMQZKBkEAIABHAHIAYQB5ACAGJwZEBjkGJwZFAEcA
-ZQBuAGUAcgBpAGMAIABHAHIAYQB5ACAAUAByAG8AZgBpAGwAZQAAdGV4dAAAAABDb3B5cmlnaHQgMjAw
-NyBBcHBsZSBJbmMuLCBhbGwgcmlnaHRzIHJlc2VydmVkLgBYWVogAAAAAAAA81EAAQAAAAEWzGN1cnYA
-AAAAAAAAAQHNAADSJSYnKFokY2xhc3NuYW1lWCRjbGFzc2VzXxAQTlNCaXRtYXBJbWFnZVJlcKMnKSpa
-TlNJbWFnZVJlcFhOU09iamVjdNIlJiwtV05TQXJyYXmiLCrSJSYvMF5OU011dGFibGVBcnJheaMvLCrT
-MjMKNDU2V05TV2hpdGVcTlNDb2xvclNwYWNlRDAgMAAQA4AM0iUmODlXTlNDb2xvcqI4KtIlJjs8V05T
-SW1hZ2WiOypfEA9OU0tleWVkQXJjaGl2ZXLRP0BUcm9vdIABAAgAEQAaACMALQAyADcARgBMAFcAXgBl
-AHIAeQCBAIMAhQCKAIwAjgCVAJoApQCnAKkAqwCwALMAtQC3ALkAuwDAANcA2QDbCWsJcAl7CYQJlwmb
-CaYJrwm0CbwJvwnECdMJ1wneCeYJ8wn4CfoJ/AoBCgkKDAoRChkKHAouCjEKNgAAAAAAAAIBAAAAAAAA
-AEEAAAAAAAAAAAAAAAAAAAo4A
+YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T
+S2V5ZWRBcmNoaXZlctEICVRyb290gAGuCwwZGh8UJCgpMDM2PD9VJG51bGzWDQ4PEBESExQVFhcYVk5T
+U2l6ZV5OU1Jlc2l6aW5nTW9kZVYkY2xhc3NcTlNJbWFnZUZsYWdzVk5TUmVwc1dOU0NvbG9ygAIQAIAN
+EiDDAACAA4ALVnsxLCAxfdIbDxweWk5TLm9iamVjdHOhHYAEgArSGw8gI6IhIoAFgAaACdIlDyYnXxAU
+TlNUSUZGUmVwcmVzZW50YXRpb26AB4AITxEIjE1NACoAAAAKAAAAEAEAAAMAAAABAAEAAAEBAAMAAAAB
+AAEAAAECAAMAAAACAAgACAEDAAMAAAABAAEAAAEGAAMAAAABAAEAAAEKAAMAAAABAAEAAAERAAQAAAAB
+AAAACAESAAMAAAABAAEAAAEVAAMAAAABAAIAAAEWAAMAAAABAAEAAAEXAAQAAAABAAAAAgEcAAMAAAAB
+AAEAAAEoAAMAAAABAAIAAAFSAAMAAAABAAEAAAFTAAMAAAACAAEAAYdzAAcAAAe8AAAA0AAAAAAAAAe8
+YXBwbAIgAABtbnRyR1JBWVhZWiAH0AACAA4ADAAAAABhY3NwQVBQTAAAAABub25lAAAAAAAAAAAAAAAA
+AAAAAAAA9tYAAQAAAADTLWFwcGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAVkZXNjAAAAwAAAAG9kc2NtAAABMAAABi5jcHJ0AAAHYAAAADh3dHB0AAAHmAAAABRrVFJD
+AAAHrAAAAA5kZXNjAAAAAAAAABVHZW5lcmljIEdyYXkgUHJvZmlsZQAAAAAAAAAAAAAAFUdlbmVyaWMg
+R3JheSBQcm9maWxlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+bWx1YwAAAAAAAAAeAAAADHNrU0sAAAAqAAABeGRhREsAAAA0AAABomNhRVMAAAAsAAAB1nB0QlIAAAAq
+AAACAnVrVUEAAAAsAAACLGZyRlUAAAAqAAACWGh1SFUAAAAuAAACgnpoVFcAAAAQAAACsG5iTk8AAAAs
+AAACwGNzQ1oAAAAkAAAC7GhlSUwAAAAgAAADEGl0SVQAAAAuAAADMHJvUk8AAAAkAAADXmRlREUAAAA6
+AAADgmtvS1IAAAAYAAADvHN2U0UAAAAuAAAD1HpoQ04AAAAQAAAEAmphSlAAAAAWAAAEEmVsR1IAAAAk
+AAAEKHB0UE8AAAA4AAAETG5sTkwAAAAqAAAEhGVzRVMAAAAoAAAErnRoVEgAAAAkAAAE1nRyVFIAAAAi
+AAAE+mZpRkkAAAAsAAAFHGhySFIAAAA6AAAFSHBsUEwAAAA2AAAFgnJ1UlUAAAAmAAAFuGFyRUcAAAAo
+AAAF3mVuVVMAAAAoAAAGBgBWAWEAZQBvAGIAZQBjAG4A/QAgAHMAaQB2AP0AIABwAHIAbwBmAGkAbABH
+AGUAbgBlAHIAZQBsACAAZwByAOUAdABvAG4AZQBiAGUAcwBrAHIAaQB2AGUAbABzAGUAUABlAHIAZgBp
+AGwAIABkAGUAIABnAHIAaQBzACAAZwBlAG4A6AByAGkAYwBQAGUAcgBmAGkAbAAgAEMAaQBuAHoAYQAg
+AEcAZQBuAOkAcgBpAGMAbwQXBDAEMwQwBDsETAQ9BDgEOQAgBD8EQAQ+BEQEMAQ5BDsAIABHAHIAYQB5
+AFAAcgBvAGYAaQBsACAAZwDpAG4A6QByAGkAcQB1AGUAIABnAHIAaQBzAMEAbAB0AGEAbADhAG4AbwBz
+ACAAcwB6APwAcgBrAGUAIABwAHIAbwBmAGkAbJAadShwcJaOgnJfaWPPj/AARwBlAG4AZQByAGkAcwBr
+ACAAZwByAOUAdABvAG4AZQBwAHIAbwBmAGkAbABPAGIAZQBjAG4A/QAgAWEAZQBkAP0AIABwAHIAbwBm
+AGkAbAXkBegF1QXkBdkF3AAgAEcAcgBhAHkAIAXbBdwF3AXZAFAAcgBvAGYAaQBsAG8AIABnAHIAaQBn
+AGkAbwAgAGcAZQBuAGUAcgBpAGMAbwBQAHIAbwBmAGkAbAAgAGcAcgBpACAAZwBlAG4AZQByAGkAYwBB
+AGwAbABnAGUAbQBlAGkAbgBlAHMAIABHAHIAYQB1AHMAdAB1AGYAZQBuAC0AUAByAG8AZgBpAGzHfLwY
+ACAARwByAGEAeQAg1QS4XNMMx3wARwBlAG4AZQByAGkAcwBrACAAZwByAOUAcwBrAGEAbABlAHAAcgBv
+AGYAaQBsZm6QGnBwXqZjz4/wZYdO9k4AgiwwsDDsMKQw1zDtMNUwoTCkMOsDkwO1A70DuQO6A8wAIAPA
+A8EDvwPGA68DuwAgA7MDugPBA7kAUABlAHIAZgBpAGwAIABnAGUAbgDpAHIAaQBjAG8AIABkAGUAIABj
+AGkAbgB6AGUAbgB0AG8AcwBBAGwAZwBlAG0AZQBlAG4AIABnAHIAaQBqAHMAcAByAG8AZgBpAGUAbABQ
+AGUAcgBmAGkAbAAgAGcAcgBpAHMAIABnAGUAbgDpAHIAaQBjAG8OQg4bDiMORA4fDiUOTA4qDjUOQA4X
+DjIOFw4xDkgOJw5EDhsARwBlAG4AZQBsACAARwByAGkAIABQAHIAbwBmAGkAbABpAFkAbABlAGkAbgBl
+AG4AIABoAGEAcgBtAGEAYQBwAHIAbwBmAGkAaQBsAGkARwBlAG4AZQByAGkBDQBrAGkAIABwAHIAbwBm
+AGkAbAAgAHMAaQB2AGkAaAAgAHQAbwBuAG8AdgBhAFUAbgBpAHcAZQByAHMAYQBsAG4AeQAgAHAAcgBv
+AGYAaQBsACAAcwB6AGEAcgBvAVsAYwBpBB4EMQRJBDgEOQAgBEEENQRABEsEOQAgBD8EQAQ+BEQEOAQ7
+BEwGRQZEBkEAIAYqBjkGMQZKBkEAIABHAHIAYQB5ACAGJwZEBjkGJwZFAEcAZQBuAGUAcgBpAGMAIABH
+AHIAYQB5ACAAUAByAG8AZgBpAGwAZQAAdGV4dAAAAABDb3B5cmlnaHQgMjAwNyBBcHBsZSBJbmMuLCBh
+bGwgcmlnaHRzIHJlc2VydmVkLgBYWVogAAAAAAAA81EAAQAAAAEWzGN1cnYAAAAAAAAAAQHNAADSKiss
+LVokY2xhc3NuYW1lWCRjbGFzc2VzXxAQTlNCaXRtYXBJbWFnZVJlcKMsLi9aTlNJbWFnZVJlcFhOU09i
+amVjdNIqKzEyV05TQXJyYXmiMS/SKis0NV5OU011dGFibGVBcnJheaM0MS/TNzgPOTo7V05TV2hpdGVc
+TlNDb2xvclNwYWNlRDAgMAAQA4AM0iorPT5XTlNDb2xvcqI9L9IqK0BBV05TSW1hZ2WiQC8ACAARABoA
+JAApADIANwBJAEwAUQBTAGIAaAB1AHwAiwCSAJ8ApgCuALAAsgC0ALkAuwC9AMQAyQDUANYA2ADaAN8A
+4gDkAOYA6ADtAQQBBgEICZgJnQmoCbEJxAnICdMJ3AnhCekJ7AnxCgAKBAoLChMKIAolCicKKQouCjYK
+OQo+CkYAAAAAAAACAQAAAAAAAABCAAAAAAAAAAAAAAAAAAAKSQ
 </mutableData>
         </image>
     </resources>

--- a/mac/build-help.sh
+++ b/mac/build-help.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Set sensible script defaults:
+# set -e: Terminate script if a command returns an error
+set -e
+# set -u: Terminate script if an unset variable is used
+set -u
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+QUIET=0
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+THIS_DIR="$(dirname "$THIS_SCRIPT")"
+
+display_usage() {
+  echo "build.sh [--no-clean] target [...target]"
+  echo "Builds help documentation for Keyman for macOS"
+  echo "Targets:"
+  echo "  * htm or html: convert documentation to html using pandoc"
+  echo
+  echo " --no-clean: don't clean target folder before building"
+}
+
+DO_HTM=false
+DO_CLEAN=true
+
+# Debug flags
+DO_HTM_CONVERSION=true
+
+#
+# Parse args
+#
+
+shopt -s nocasematch
+
+while [[ $# -gt 0 ]] ; do
+  key="$1"
+  case $key in
+    htm | html)
+      DO_HTM=true
+      ;;
+    --no-clean)
+      DO_CLEAN=false
+      ;;
+    *)
+      display_usage
+      exit 1
+  esac
+  shift # past argument
+done
+
+if ! $DO_HTM ; then
+  display_usage
+  exit 1
+fi
+
+displayInfo "" \
+  "DO_HTM: $DO_HTM" \
+  "DO_CLEAN: $DO_CLEAN" \
+  ""
+
+#
+# Compile all .md to .html
+#
+
+cd $KEYMAN_ROOT/mac/help
+
+MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
+MD=`find . -name "*.md"`
+DESTHTM="$THIS_DIR/Keyman4MacIM/Keyman4MacIM/Help"
+
+if $DO_HTM; then
+  #
+  # Clean existing folder
+  #
+
+  if $DO_CLEAN; then
+    rm -rf "$DESTHTM" || true # We don't want to die when we clean an empty folder
+  fi
+  mkdir -p "$DESTHTM"
+
+  #
+  # Generate HTML files from Markdown
+  #
+
+  if $DO_HTM_CONVERSION; then
+    for INFILE in $MD; do
+      OUTFILE="$DESTHTM/${INFILE%.md}.html"
+      echo "Processing $INFILE to $(basename "$OUTFILE")"
+      mkdir -p "$(dirname "$OUTFILE")"
+      pandoc -s --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
+    done
+  fi
+
+  #
+  # Copy Images
+  #
+  cd $KEYMAN_ROOT/mac/help/
+  mkdir -p "$DESTHTM/mac_images"
+  cp mac_images/* "$DESTHTM/mac_images/"
+
+fi

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -124,6 +124,7 @@ DO_KEYMANIM=true
 DO_KEYMANTESTAPP=false
 DO_CODESIGN=true
 DO_PODS=true
+DO_HELP=true
 CODESIGNING_SUPPRESSION="CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 BUILD_OPTIONS=""
 BUILD_ACTIONS="build"
@@ -199,6 +200,9 @@ while [[ $# -gt 0 ]] ; do
         -no-codesign)
             DO_CODESIGN=false
             ;;
+        -no-help)
+            DO_HELP=false
+            ;;
         -quiet)
             QUIET_FLAG=$1
             BUILD_OPTIONS="$BUILD_OPTIONS $QUIET_FLAG"
@@ -233,6 +237,7 @@ if $SKIP_BUILD ; then
     DO_KEYMANENGINE=false
     DO_KEYMANIM=false
     DO_KEYMANTESTAPP=false
+    DO_HELP=false
     BUILD_ACTIONS=""
     TEST_ACTION=""
     BUILD_OPTIONS=""
@@ -251,6 +256,7 @@ displayInfo "" \
     "DO_KEYMANTESTAPP: $DO_KEYMANTESTAPP" \
     "DO_CODESIGN: $DO_CODESIGN" \
     "DO_PODS: $DO_PODS" \
+    "DO_HELP: $DO_HELP" \
     "BUILD_OPTIONS: $BUILD_OPTIONS" \
     "BUILD_ACTIONS: $BUILD_ACTIONS" \
     "TEST_ACTION: $TEST_ACTION" \
@@ -354,12 +360,18 @@ fi
 ### Build Keyman.app (Input Method and Configuration app) ###
 
 if $DO_KEYMANIM ; then
+    if $DO_HELP ; then
+        echo "Building help"
+        $(dirname "$THIS_SCRIPT")/build-help.sh html
+    fi
+    
     echo_heading "Building Keyman.app"
     cd "$KM4MIM_BASE_PATH"
     if $DO_PODS ; then
         pod update
         pod install
     fi
+
     cd "$KEYMAN_MAC_BASE_PATH"
     execBuildCommand $IM_NAME "xcodebuild -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS $BUILD_ACTIONS -scheme Keyman SYMROOT=\"$KM4MIM_BASE_PATH/build\""
     if [ "$TEST_ACTION" == "test" ]; then


### PR DESCRIPTION
Fixes #3979.

Instead of loading help.keyman.com in the support frame, we now load a local copy of the help. External links within the help will open in the user's browser. This avoids issues of navigation to keyboard download and other sites which won't work well.

Also, adds Back, Forward and Home buttons to the window so the user can navigate more easily with mouse.

Finally, this means that the local help will always be synchronised with the app version and brings the macOS help in line with the other platforms.

While the help could be formatted more beautifully and we may be able to improve search, index, etc, we should do this as a separate PR.

![Screen Shot 2021-03-15 at 5 24 37 pm](https://user-images.githubusercontent.com/4498365/111111942-5c5a6400-85b3-11eb-9f33-1d0c9d12702a.png)
