### PR TITLE
chore(linux): Ignore buildtools in keyman-config tarball

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -76,7 +76,7 @@ for proj in ${extra_projects}; do
         dch keyman-config --newversion ${VERSION} --force-bad-version --nomultimaint
         dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
             --tar-ignore=.gitignore --tar-ignore=experiments --tar-ignore=debian \
-            --tar-ignore=__pycache__ -Zgzip -b .
+            --tar-ignore=buildtools --tar-ignore=__pycache__ -Zgzip -b .
         mv ../keyman-config_*.tar.gz ../dist/keyman-config-${VERSION}.tar.gz
         echo "3.0 (quilt)" > debian/source/format
     elif [ "${proj}" == "keyboardprocessor" ]; then


### PR DESCRIPTION
`buildtools/build-langtags.py` gets executed before creating the source tarball, so we don't need it in the source package. Excluding it reduces confusion because the files it requires are not found in the source package.