### PR TITLE
fix(developer): &CasedKeys and &MnemonicLayout are not compatible together

### DIFF
--- a/windows/src/developer/kmcmpdll/CasedKeys.cpp
+++ b/windows/src/developer/kmcmpdll/CasedKeys.cpp
@@ -13,19 +13,6 @@ extern BOOL FMnemonicLayout; // TODO: these globals should be consolidated one d
 
 DWORD ExpandCapsRule(PFILE_GROUP gp, PFILE_KEY kpp, PFILE_STORE sp);
 
-PFILE_STORE FindSystemStore(PFILE_KEYBOARD fk, DWORD dwSystemID) {
-  assert(fk != NULL);
-  assert(dwSystemID != 0);
-
-  PFILE_STORE sp = fk->dpStoreArray;
-  for (DWORD i = 0; i < fk->cxStoreArray; i++, sp++) {
-    if (sp->dwSystemID == dwSystemID) {
-      return sp;
-    }
-  }
-  return NULL;
-}
-
 DWORD VerifyCasedKeys(PFILE_STORE sp) {
   assert(sp != NULL);
 

--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -1182,7 +1182,7 @@ DWORD ProcessSystemStore(PFILE_KEYBOARD fk, DWORD SystemID, PFILE_STORE sp)
   case TSS_MNEMONIC:
     VERIFY_KEYBOARD_VERSION(fk, VERSION_60, CERR_60FeatureOnly_MnemonicLayout);
     FMnemonicLayout = atoiW(sp->dpString) == 1;
-    if (FMnemonicLayout) {
+    if (FMnemonicLayout && FindSystemStore(fk, TSS_CASEDKEYS) != NULL) {
       // The &CasedKeys system store is not supported for
       // mnemonic layouts
       return CERR_CasedKeysNotSupportedWithMnemonicLayout;
@@ -3607,4 +3607,17 @@ extern "C" void __declspec(dllexport) Keyman_Diagnostic(int mode) {
   if (mode == 0) {
     RaiseException(0x0EA0BEEF, EXCEPTION_NONCONTINUABLE, 0, NULL);
   }
+}
+
+PFILE_STORE FindSystemStore(PFILE_KEYBOARD fk, DWORD dwSystemID) {
+  assert(fk != NULL);
+  assert(dwSystemID != 0);
+
+  PFILE_STORE sp = fk->dpStoreArray;
+  for (DWORD i = 0; i < fk->cxStoreArray; i++, sp++) {
+    if (sp->dwSystemID == dwSystemID) {
+      return sp;
+    }
+  }
+  return NULL;
 }

--- a/windows/src/developer/kmcmpdll/kmcmpdll.h
+++ b/windows/src/developer/kmcmpdll/kmcmpdll.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <windows.h>
+#include "compfile.h"
 
 BOOL AddCompileString(LPSTR buf);
 BOOL AddCompileMessage(DWORD msg);
@@ -12,3 +13,4 @@ extern BOOL FWarnDeprecatedCode;
 extern int currentLine;
 
 PWSTR strtowstr(PSTR in);
+PFILE_STORE FindSystemStore(PFILE_KEYBOARD fk, DWORD dwSystemID);

--- a/windows/src/test/unit-tests/kmcomp/test.bat
+++ b/windows/src/test/unit-tests/kmcomp/test.bat
@@ -52,6 +52,7 @@ call :should-pass "#2241: &CasedKeys (chars)" test_casedkeys_chars.kmn || goto :
 
 call :should-fail "#2241: &CasedKeys (mnemonic 1)" test_casedkeys_mnemonic_1.kmn || goto :eof
 call :should-fail "#2241: &CasedKeys (mnemonic 2)" test_casedkeys_mnemonic_2.kmn || goto :eof
+call :should-pass "#2241: &CasedKeys (mnemonic 3)" test_casedkeys_mnemonic_3.kmn || goto :eof
 call :should-fail "#2241: &CasedKeys (invalid chars 1)" test_casedkeys_invalid_1.kmn || goto :eof
 call :should-fail "#2241: &CasedKeys (invalid chars 2)" test_casedkeys_invalid_2.kmn || goto :eof
 

--- a/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_3.kmn
+++ b/windows/src/test/unit-tests/kmcomp/test_casedkeys_mnemonic_3.kmn
@@ -1,0 +1,9 @@
+c Tests mnemonic layout without any casedkeys
+store(&NAME) 'Test mnemonic layout but no cased keys'
+store(&mnemoniclayout) '1'
+begin Unicode > use(main)
+
+group(main) using keys
+
++ [K_A] > 'aaah'
++ [SHIFT K_A] > 'AAAH'

--- a/windows/src/test/unit-tests/kmcomp/tests.kpj
+++ b/windows/src/test/unit-tests/kmcomp/tests.kpj
@@ -217,6 +217,16 @@
       </Details>
     </File>
     <File>
+      <ID>id_9d5ea0b72f9733e0e70e04d5b3c790af</ID>
+      <Filename>test_expansion_absurd.kmn</Filename>
+      <Filepath>test_expansion_absurd.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>Test Expansions</Name>
+      </Details>
+    </File>
+    <File>
       <ID>id_5f9e583f7392151b3c3a7d4577b31a4f</ID>
       <Filename>test_valid.kmx</Filename>
       <Filepath>test_valid.kmx</Filepath>
@@ -241,13 +251,13 @@
       <ParentFileID>id_98467bd680620f99f9adeb5347541b6a</ParentFileID>
     </File>
     <File>
-      <ID>id_9d5ea0b72f9733e0e70e04d5b3c790af</ID>
-      <Filename>test_expansion_absurd.kmn</Filename>
-      <Filepath>test_expansion_absurd.kmn</Filepath>
+      <ID>id_c8f8bfc9e4fd77bdd6db910b6a18eb0b</ID>
+      <Filename>test_casedkeys_mnemonic_3.kmn</Filename>
+      <Filepath>test_casedkeys_mnemonic_3.kmn</Filepath>
       <FileVersion>1.0</FileVersion>
       <FileType>.kmn</FileType>
       <Details>
-        <Name>Test Expansions</Name>
+        <Name>Test mnemonic layout but no cased keys</Name>
       </Details>
     </File>
   </Files>


### PR DESCRIPTION
The test for `&mnemoniclayout` was incorrectly failing to check the actual state of `&casedkeys`, which broke all mnemonic layouts.