### PR TITLE
fix(ios): keyboard search did not alert for lack of net

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -157,6 +157,28 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     progressView?.isHidden = false
   }
 
+  private func failWithAlert(for error: Error) {
+    let errorTitle = NSLocalizedString("alert-no-connection-title", bundle: engineBundle, comment: "")
+    let alert = ResourceFileManager.shared.buildSimpleAlert(title: errorTitle, message: error.localizedDescription) {
+      // If we are in a UINavigationViewController and are not its root view...
+      if let navVC = self.navigationController, navVC.viewControllers.first != self {
+        navVC.popViewController(animated: true)
+      } else {
+        self.dismiss(animated: true)
+      }
+    }
+
+    self.present(alert, animated: true)
+  }
+
+  public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    failWithAlert(for: error)
+  }
+
+  public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    failWithAlert(for: error)
+  }
+
 
   override public func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)


### PR DESCRIPTION
While #4573 added good visual feedback for progress in the case of _slow_ internet connections, it did not incorporate anything for _inability to_ progress whenever there is no available internet.

This adds an alert for such cases, notifying the user of their lack of internet and auto-dismissing the search once "OK" is clicked.

![Screen Shot 2021-03-16 at 11 57 34 AM](https://user-images.githubusercontent.com/25213402/111258213-1b179200-864f-11eb-913f-fde5fea6e789.png)