### PR TITLE
fix(android/app): Load system keyboard before checking overrides

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -136,7 +136,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     KMManager.setMayPredictOverride(inputType);
     if (KMManager.getMayPredictOverride()) {
       KMManager.setBannerOptions(false);
-    } else {
+    } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
       // Check if predictions needs to be re-enabled per Settings preference
       Context appContext = getApplicationContext();
       Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(appContext);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -467,6 +467,18 @@ public final class KMManager {
     }
   }
 
+  public static boolean isKeyboardLoaded(KeyboardType type) {
+    if (type == KeyboardType.KEYBOARD_TYPE_INAPP) {
+      return InAppKeyboardLoaded;
+    } else if (type == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
+      return SystemKeyboardLoaded;
+    } else {
+      String msg = "Keyboard type undefined";
+      KMLog.LogError(TAG, msg);
+      return false;
+    }
+  }
+
   @SuppressLint("InflateParams")
   public static View createInputView(InputMethodService inputMethodService) {
     //final Context context = appContext;


### PR DESCRIPTION
Fixes #4695 

This fixes the race condition when the System Keyboard is created (outside of the Keyman app).
`Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(appContext);` would check for the current keyboard info (and index)
before the system keyboard had loaded.