### PR TITLE
fix(android/engine): Fix crash when download file fails to copy to cache

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudApiTypes.java
@@ -151,13 +151,17 @@ public class CloudApiTypes {
      * @return File - handle to the downloaded file in cache
      */
     public File cacheAndOpenDestinationFile(Context context) {
+      File cachedFile = null;
       DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
       Uri data = downloadManager.getUriForDownloadedFile(downloadId);
-      DownloadFileUtils.Info info = DownloadFileUtils.cacheDownloadFile(context, data);
-      String filename = info.getFilename();
-      File cachedFile = info.getFile();
 
-      if (filename == null || filename.isEmpty() || cachedFile == null || !cachedFile.exists()) {
+      if (data != null) {
+        DownloadFileUtils.Info info = DownloadFileUtils.cacheDownloadFile(context, data);
+        String filename = info.getFilename();
+        cachedFile = info.getFile();
+      }
+
+      if (cachedFile == null) {
         // failed to retrieve downloaded file
         BaseActivity.makeToast(context, R.string.failed_to_retrieve_file, Toast.LENGTH_LONG);
       }


### PR DESCRIPTION
This fixes a Sentry [crash ](http://sentry.keyman.com/organizations/keyman/issues/2699/?project=7&query=is%3Aunresolved)
> Attempt to invoke virtual method 'java.lang.String android.net.Uri.getScheme()' on a null object reference




when a cloud downloaded file fails to copy to cache. This would cause an exception in 
```
DownloadFileUtils.Info info = DownloadFileUtils.cacheDownloadFile(context, data);
```
