### PR TITLE
chore(developer): upgrade bcp 47 canonicalisation to warning

### DIFF
--- a/windows/src/developer/TIKE/compile/ValidateKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/ValidateKeyboardInfo.pas
@@ -16,6 +16,7 @@ type
     function LoadJsonFile: Boolean;
     constructor Create(AJsonFile: string; ASilent: Boolean);
     function Failed(message: string): Boolean;
+    procedure Warning(message: string);
     procedure Info(message: string);
   public
     class function Execute(JsonFile, JsonSchemaPath: string; FDistribution, FSilent: Boolean; FCallback: TProjectLogObjectEvent): Boolean;
@@ -93,7 +94,7 @@ begin
           Result := Failed(msg);
 
         if not TCanonicalLanguageCodeUtils.IsCanonical(Tag, msg, False, False) then
-          Info(msg);
+          Warning(msg);
       finally
         Free;
       end;
@@ -108,7 +109,7 @@ begin
           Result := Failed(msg);
 
         if not TCanonicalLanguageCodeUtils.IsCanonical(Tag, msg, False, False) then
-          Info(msg);
+          Warning(msg);
       finally
         Free;
       end;
@@ -142,6 +143,11 @@ begin
   end;
 
   Result := Assigned(json);
+end;
+
+procedure TValidateKeyboardInfo.Warning(message: string);
+begin
+  GCallback(plsWarning, FJsonFile, Message, 0, 0);
 end;
 
 class function TValidateKeyboardInfo.Execute(JsonFile, JsonSchemaPath: string; FDistribution, FSilent: Boolean; FCallback: TProjectLogObjectEvent): Boolean;


### PR DESCRIPTION
This does not trigger a build failure; validation warnings currently always pass. Info messages are currently suppressed with -s which also suppresses the banner, which is more plumbing than we should change just now.

This is a follow-on from #4689.