### PR TITLE
fix(common/core/web): disambiguation of keys sharing same base key ID

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -38,7 +38,18 @@ namespace com.keyman.keyboards {
     // - isUnicode
     // - isHardwareKey
     // - etc.
-    public get baseKeyIdentifier(): string {
+
+    // Reference for the terminology in the comments below:
+    // https://help.keyman.com/developer/current-version/guides/develop/creating-a-touch-keyboard-layout-for-amharic-the-nitty-gritty
+
+    /**
+     * Matches the key code as set within Keyman Developer for the layout.
+     * For example, K_R or U_0020.  Denotes either physical keys or virtual keys with custom output,
+     * with no additional metadata like layer or active modifiers.
+     * 
+     * Is used to determine the keycode for input events, rule-matching, and keystroke processing.
+     */
+    public get baseKeyID(): string {
       if(typeof this.id === 'undefined') {
         return undefined;
       }
@@ -46,6 +57,14 @@ namespace com.keyman.keyboards {
       return this.id;
     }
 
+    /**
+     * A unique identifier based on both the key ID & the 'desktop layer' to be used for the key.
+     * 
+     * Allows diambiguation of scenarios where the same key ID is used twice within a layer, but
+     * with different innate modifiers.  (Refer to https://github.com/keymanapp/keyman/issues/4617)
+     * 
+     * Useful when the active layer of an input-event is already known.
+     */
     public get coreID(): string {
       if(typeof this.id === 'undefined') {
         return undefined;
@@ -60,6 +79,15 @@ namespace com.keyman.keyboards {
       return baseID;
     }
 
+    /**
+     * A keyboard-unique identifier to be used for any display elements representing this key
+     * in user interfaces and/or on-screen keyboards.
+     * 
+     * Distinguishes between otherwise-identical keys on different layers of an OSK.
+     * Includes identifying information about the key's display layer.
+     * 
+     * Useful when only the active keyboard is known about an input event.
+     */
     public get elementID(): string {
       if(typeof this.id === 'undefined') {
         return undefined;
@@ -448,12 +476,12 @@ namespace com.keyman.keyboards {
       this.row.forEach(function(row: ActiveRow): void {
         row.key.forEach(function(key: ActiveKey): void {
           // If the key lacks an ID, just skip it.  Sometimes used for padding.
-          if(!key.baseKeyIdentifier) {
+          if(!key.baseKeyID) {
             return;
           } else {
             // Attempt to filter out known non-output keys.
             // Results in a more optimized distribution.
-            switch(key.baseKeyIdentifier) {
+            switch(key.baseKeyID) {
               case 'K_SHIFT':
               case 'K_LOPT':
               case 'K_ROPT':
@@ -465,7 +493,7 @@ namespace com.keyman.keyboards {
                 // Refer to text/codes.ts - these are Keyman-custom "keycodes" used for
                 // layer shifting keys.  To be safe, we currently let K_TABBACK and 
                 // K_TABFWD through, though we might be able to drop them too.
-                let code = com.keyman.text.Codes[key.baseKeyIdentifier];
+                let code = com.keyman.text.Codes[key.baseKeyID];
                 if(code > 50000 && code < 50011) {
                   return;
                 }

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -62,6 +62,16 @@ namespace com.keyman.keyboards {
      * 
      * Allows diambiguation of scenarios where the same key ID is used twice within a layer, but
      * with different innate modifiers.  (Refer to https://github.com/keymanapp/keyman/issues/4617)
+     * The 'desktop layer' may be omitted if it matches the key's display layer.
+     * 
+     * Examples, given a 'default' display layer, matching keys to Keyman keyboard language:
+     * 
+     * ```
+     * "K_Q" 
+     * + [K_Q]
+     * "K_Q+shift"
+     * + [K_Q SHIFT]
+     * ```
      * 
      * Useful when the active layer of an input-event is already known.
      */
@@ -85,6 +95,15 @@ namespace com.keyman.keyboards {
      * 
      * Distinguishes between otherwise-identical keys on different layers of an OSK.
      * Includes identifying information about the key's display layer.
+     * 
+     * Examples, given a 'default' display layer, matching keys to Keyman keyboard language:
+     * 
+     * ```
+     * "default-K_Q" 
+     * + [K_Q]
+     * "default-K_Q+shift"
+     * + [K_Q SHIFT]
+     * ```
      * 
      * Useful when only the active keyboard is known about an input event.
      */

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -402,14 +402,14 @@ namespace com.keyman.text {
         var baseKey: com.keyman.osk.OSKKeySpec = osk.vkbd.popupBaseKey['key'].spec;
         var found = false;
 
-        if(baseKey.id == keyName) {
+        if(baseKey.coreID == keyName) {
           nextLayer = baseKey.nextlayer;
           found = true;
         } else {
           // Search for the specified subkey so we can retrieve its useful properties.
           // It should be within the popupBaseKey's subkey list.
           for(let subKey of baseKey.sk) {
-            if(subKey.id == keyName) {
+            if(subKey.coreID == keyName) {
               // ... to consider:  why are we not just taking the keyspec wholesale right here?
               nextLayer = subKey.nextlayer;
               found = true;
@@ -419,7 +419,7 @@ namespace com.keyman.text {
         }
 
         if(!found) {
-          console.warn("Could not find subkey '" + origArg + "' under the current base key '" + baseKey.id + "'!");
+          console.warn("Could not find subkey '" + origArg + "' under the current base key '" + baseKey.coreID + "'!");
         }
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -48,7 +48,13 @@ namespace com.keyman.osk {
         // Deleting matched deadkeys here seems to correct some of the issues.   (JD 6/6/14)
         outputTarget.deadkeys().deleteMatched();      // Delete any matched deadkeys before continuing
 
-        let keySpec = (e['key'] ? e['key'].spec : null) as keyboards.ActiveKey;
+        // Future note:  we need to refactor osk.OSKKeySpec to instead be a 'tag field' for
+        // keyboards.ActiveKey.  (Prob with generics, allowing the Web-only parts to
+        // be fully specified within the tag.)  
+        //
+        // Would avoid the type shenanigans needed here because of our current type-abuse setup 
+        // for key spec tracking.
+        let keySpec = (e['key'] ? e['key'].spec : null) as unknown as keyboards.ActiveKey;
         if(!keySpec) {
           console.error("OSK key with ID '" + e.id + "', keyID '" + e.keyId + "' missing needed specification");
           return true;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -46,6 +46,12 @@ namespace com.keyman.osk {
   //#region OSK key objects and construction
   export class OSKKeySpec implements keyboards.LayoutKey {
     id: string;
+
+    // Only set (within @keymanapp/keyboard-processor) for keys actually specified in a loaded layout
+    baseKeyIdentifier?: string;
+    coreID?: string;
+    elementID?: string;
+
     text?: string;
     sp?: number | keyboards.ButtonClass;
     width: string;
@@ -317,13 +323,13 @@ namespace com.keyman.osk {
 
     getId(osk: VisualKeyboard): string {
       // Define each key element id by layer id and key id (duplicate possible for SHIFT - does it matter?)
-      return this.layer+'-'+this.spec.id;
+      return this.spec.elementID;
     }
 
     // Produces a small reference label for the corresponding physical key on a US keyboard.
     private generateKeyCapLabel(): HTMLDivElement {
       // Create the default key cap labels (letter keys, etc.)
-      var x = Codes.keyCodes[this.spec.id];
+      var x = Codes.keyCodes[this.spec.baseKeyIdentifier];
       switch(x) {
         // Converts the keyman key id code for common symbol keys into its representative ASCII code.
         // K_COLON -> K_BKQUOTE
@@ -1766,7 +1772,11 @@ namespace com.keyman.osk {
         //  bk = skElement;
         //  break;
         //} else
-        if(skSpec.id == baseKey.keyId && skSpec.layer == baseKey.key.layer) {
+        if(!baseKey.key || !baseKey.key.spec) {
+          continue;
+        }
+
+        if(skSpec.elementID == baseKey.key.spec.elementID) {
           bk = skElement;
           break; // Best possible match has been found.  (Disable 'break' once above block is implemented.)
         }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -48,7 +48,7 @@ namespace com.keyman.osk {
     id: string;
 
     // Only set (within @keymanapp/keyboard-processor) for keys actually specified in a loaded layout
-    baseKeyIdentifier?: string;
+    baseKeyID?: string;
     coreID?: string;
     elementID?: string;
 
@@ -329,7 +329,7 @@ namespace com.keyman.osk {
     // Produces a small reference label for the corresponding physical key on a US keyboard.
     private generateKeyCapLabel(): HTMLDivElement {
       // Create the default key cap labels (letter keys, etc.)
-      var x = Codes.keyCodes[this.spec.baseKeyIdentifier];
+      var x = Codes.keyCodes[this.spec.baseKeyID];
       switch(x) {
         // Converts the keyman key id code for common symbol keys into its representative ASCII code.
         // K_COLON -> K_BKQUOTE

--- a/web/testing/prediction-mtnt/index.html
+++ b/web/testing/prediction-mtnt/index.html
@@ -42,6 +42,7 @@
       }).then(function() {
         kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
         kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
+        kmw.addKeyboards('sil_euro_latin@en');
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)


### PR DESCRIPTION
Fixes #4617.

Implements the spec suggested within https://github.com/keymanapp/keyman/issues/4617#issuecomment-799907262, additionally noting a few different _kinds_ of ID needed at various levels of keyboard processing:

- `baseKeyIdentifier`:  this is the key ID as known to the Keyman keyboard language.  No modifiers, no layer information, etc.  _**Just**_ the base key.
- `coreID`: `baseKeyIdentifier` + the _modifier_ layer, if different from the key's _display_ layer.
    - "Modifier layer":  the layer representing a modifier set that would be accessible to the Keyman keyboard language, as set by keyboard developers within the touch-layout designer on a per-key basis as an override.
    - Check against https://github.com/keymanapp/keyman/issues/4617#issuecomment-799907262 for further clarification, explanation, and examples as needed.
- `elementID`: the key's _display_ layer + `coreID`.  This is the identifier used as a web element ID and will be unique among all keys of the loaded keyboard (unless there is an intended, _literal_ duplicate key definition).
    - Caveat:  if two separate keyboards are simultaneously loaded somehow, two keys with the same `elementID` may coexist - one from each keyboard.

Note that this does introduce a breaking change for any developer who may have had code relying on key IDs.  That said, this spec does its best to minimize breaks, preserving the original ID structure for the most common cases.

To wit:  I made no changes whatsoever to the unit tests, many of which use pre-recorded sequences that rely, _directly_, on key IDs.  None of them broke.

## User Testing
@MakaraSok 

Please test with the same resources you were using to report the original issue.  The symptoms should be resolved.

From a quick load/test within iOS:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-03-17 at 11 09 37](https://user-images.githubusercontent.com/25213402/111413692-51b5e100-8711-11eb-9a9c-4ea17c8918e2.png)

Additionally, please test a keyboard or two with subkeys - even `sil_euro_latin` should suffice here.  There were a few tweaks needed to maintain popup key behavior as a result, so we need to be sure that nothing was broken there.

Some tests with `khmer_angkor` would also be good - it has some subkeys with modifiers that don't match the display layer.  For example, ឆ (base key) has ឈ (subkey, '+shift') and ក (base key) គ (subkey, '+shift').  Everything should "feel normal" with no unexpected changes.

Finally, some tests with `sil_cameroon_qwerty` may be nice.  I've already tested them within Web, but Android-based tests may be wise as well.  The top row of its SHIFT layer has some diacritic keys with modifier sets that don't match the SHIFT layer, thus have new IDs internally.  (There may be more keys, but those were the easiest to find.)   Everything should "feel normal" with no unexpected changes.

I've run most of these tests myself on Web, with some also on emulated Android... but it'd be good to have a second pair of eyes on this.