### PR TITLE
fix(common/core/web): predictive banner activation logic

### DIFF
--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -173,7 +173,11 @@ namespace com.keyman.text.prediction {
         return;
       }
 
-      if(outputTarget) {
+      // Don't attempt predictions when disabled!
+      // invalidateContext otherwise bypasses .predict()'s check against this.
+      if(!this.isActive) {
+        return;
+      } else if(outputTarget) {
         let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null);
         this.predict_internal(transcription, true);
       } else {

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -141,7 +141,9 @@ namespace com.keyman.text.prediction {
       // Prevents an ugly "flash of unstyled content" layout issue during keyboard load
       // on our mobile platforms when embedded.
       lp.currentModel = model;
-      lp.emit('statechange', 'active');
+      if(this.mayPredict) {
+        lp.emit('statechange', 'active');
+      }
 
       return this.lmEngine.loadModel(source, specType).then(function(config: Configuration) { 
         lp.configuration = config;
@@ -411,7 +413,13 @@ namespace com.keyman.text.prediction {
       this._mayPredict = flag;
 
       if(oldVal != flag) {
-        this.emit('statechange', flag ? 'active' : 'inactive');
+        // If there's no model to be activated and we've reached this point,
+        // the banner should remain inactive, as it already was.
+        // If it there was one and we've reached this point, we're globally
+        // deactivating, so we're fine.
+        if(this.activeModel) {
+          this.emit('statechange', flag ? 'active' : 'inactive');
+        }
       }
     }
 


### PR DESCRIPTION
Resolves an issue noted on #4694 where toggling predictions off... failed to hide the banner and still allowed predictions in specific scenarios, at least within the iOS app.  It's actually a core-web bug.

I'm near-positive the break occurred in #4370; at minimum, a _part_ of the break did.  The signal used to display the banner was being called whether or not predictions were supposed to be active.

The bit about context invalidation was likely from a different 14.0 PR, as I do remember some work in that area being necessary after the newer correction algorithm was implemented.

----

There _is_ a remaining behavior that's not 100% intended.  I... might have forgotten to add a kill-switch to the correction algorithm's, uh... tendency to correct.  That setting was never passed into the lm-layer before, as before version 14, it was wholly reliant on being fed an input distribution.  The new correction algorithm's powerful enough to overcome that... _somewhat_.  The net result:  the "may correct" toggle currently provides a _very strong bias_ in favor of the exact input text, but it _will_ correct for one (or maybe two typos) if there simply are no matches for the exact input.  (Though, with less touch-context awareness.)

![Screen Shot 2021-03-18 at 8 42 58 AM](https://user-images.githubusercontent.com/25213402/111560843-fb56aa00-87c5-11eb-8312-d0790f655399.png)

When there _are_ matches for exact input:

![Screen Shot 2021-03-18 at 8 45 36 AM](https://user-images.githubusercontent.com/25213402/111561089-7ae47900-87c6-11eb-9067-51370456b9c9.png)

Input sequence:  the 'i' was pressed on the middle of the right edge, while the 'd' was pressed at the center of its top edge.  With corrections _enabled_, we get this instead from the same touch patterns:

![Screen Shot 2021-03-18 at 8 47 26 AM](https://user-images.githubusercontent.com/25213402/111561192-a10a1900-87c6-11eb-8df8-09b9f51a2914.png)

Here, the chance of the input being an 'o' instead of 'i', when combined with a higher base probability for "love" over "live", makes "love" the top suggestion overall.  Quite the contrast to it not even _appearing_ with corrections disabled.