### PR TITLE
fix(linux): Fix switching to keyboard in middle of line (#4678)

### DIFF
--- a/common/core/desktop/tests/unit/kmx/kmx.cpp
+++ b/common/core/desktop/tests/unit/kmx/kmx.cpp
@@ -364,8 +364,6 @@ int run_test(const km::kbp::path & source, const km::kbp::path & compiled) {
 }
 
 std::string string_to_hex(const std::u16string& input) {
-    static const char hex_digits[] = "0123456789ABCDEF";
-
     std::ostringstream result;
     result << std::setfill('0') << std::hex << std::uppercase;
 

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -220,7 +220,7 @@ static void reset_context(IBusEngine *engine)
         g_message("new context is:%u:%s: cursor:%d anchor:%d", context_pos - context_start, surrounding_text, cursor_pos, anchor_pos);
 
         g_message(":%s:%s:", surrounding_text, current_context_utf8);
-        if (g_strcmp0(surrounding_text, current_context_utf8) != 0)
+        if (!g_str_has_suffix(surrounding_text, current_context_utf8))
         {
             g_message("setting context because it has changed from expected");
             if (km_kbp_context_items_from_utf8(surrounding_text, &context_items) == KM_KBP_STATUS_OK) {


### PR DESCRIPTION
Don't re-set context if it changed because the cursor location was wrong. When the user switches to the EuroLatin keyboard in the middle of the line, we're getting a wrong cursor location. This will be fixed with the next keypress, but it leads to the context string suddenly having more characters added to the front. If we re-set the context because it's different now we will loose the information we previously added to the context.

We now compare the end of the string. If the new context string ends with the old context string we assume that the cursor position got updated and don't re-set the context.

This fixes #4678.