### PR TITLE
fix(ios): kbd search now caches publishing data for result

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -190,6 +190,16 @@ public class KeymanPackage {
       distributionMethod = downloadURL != nil ? .cloud : .unknown
       self.downloadURL = downloadURL
     }
+
+    // Used to store metadata for newly-downloaded results from the keyboard search.
+    // To save a version, we require also having a known URL.
+    internal init(downloadURL: URL, version: Version) {
+      self.timestampForLastQuery = NSDate().timeIntervalSince1970
+      self.latestVersion = version.fullString
+      self.downloadURL = downloadURL
+
+      distributionMethod = .cloud
+    }
   }
 
   static private let kmpFile = "kmp.json"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -254,6 +254,15 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
             // Illegal state - we already checked this.
             fatalError()
         }
+
+        // We've likely installed the package, and we already know
+        // the package's current publishing state - we literally just
+        // downloaded it from the cloud as part of the keyboard search.
+        //
+        // Why query later when we know the query's answer NOW?
+        let publishState = KeymanPackage.DistributionStateMetadata(downloadURL: packageURL, version: package.version)
+
+        Storage.active.userDefaults.cachedPackageQueryMetadata[package.key] = publishState
       }
 
       downloadManager.downloadPackage(withKey: packageKey, from: packageURL, withNotifications: true, completionBlock: downloadClosure)


### PR DESCRIPTION
Addresses an issue noted during iOS user acceptance testing (see #4694).

In its current state, the iOS engine caches the result of update queries and notes whether or not each installed package is one that we've published.  Before the first search _update_ query may occur, the QR code for a newly-installed package wasn't showing.  Of course, if we installed the package from keyboard search... we should already know exactly how the package was published - we got it from the official source!