### PR TITLE
fix(windows): Change TLangSwitchRefreshWatcher ownership from thread to form

### DIFF
--- a/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
+++ b/windows/src/desktop/kmshell/util/Keyman.System.KeymanStartTask.pas
@@ -12,7 +12,11 @@ type
   private
     class function GetTaskName: string;
     class procedure CleanupAlphaTasks(pTaskFolder: ITaskFolder); static;
+  {$IF FALSE}
+    //Disabled to avoid hint during build; re-enable if wanting to
+    //re-establish the task model
     class procedure DeleteTask;
+  {$ENDIF}
     class procedure CreateTask;
   public
     class procedure RecreateTask;
@@ -190,6 +194,9 @@ begin
   end;
 end;
 
+{$IF FALSE}
+// Disabled to avoid hint during build; re-enable if wanting to re-establish
+// the task model
 class procedure TKeymanStartTask.DeleteTask;
 var
   pService: ITaskService;
@@ -238,6 +245,7 @@ begin
       TKeymanSentryClient.ReportHandledException(E, 'Failed to delete task');
   end;
 end;
+{$ENDIF}
 
 class function TKeymanStartTask.GetTaskName: string;
 begin

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -550,7 +550,7 @@ begin
   if Assigned(FLangSwitchRefreshWatcher) then
   begin
     FLangSwitchRefreshWatcher.Terminate;
-    FLangSwitchRefreshWatcher := nil;
+    FreeAndNil(FLangSwitchRefreshWatcher);
   end;
 
   FreeAndNil(FInputPane);
@@ -2007,9 +2007,9 @@ begin
   if Assigned(FLangSwitchRefreshWatcher) then
   begin
     FLangSwitchRefreshWatcher.Terminate;
+    FreeAndNil(FLangSwitchRefreshWatcher);
   end;
   FLangSwitchRefreshWatcher := TLangSwitchRefreshWatcher.Create(Handle);
-  FLangSwitchRefreshWatcher.FreeOnTerminate := True;
   FLangSwitchRefreshWatcher.Start;
 end;
 


### PR DESCRIPTION
Fixes #4751.
Fixes KEYMAN-WINDOWS-76.
Fixes KEYMAN-WINDOWS-79.
Fixes KEYMAN-WINDOWS-7B.
Fixes KEYMAN-WINDOWS-7E.
Fixes KEYMAN-WINDOWS-7F.
Fixes KEYMAN-WINDOWS-7K.
Fixes KEYMAN-WINDOWS-7N.
Fixes KEYMAN-WINDOWS-80.

This resolves an issue where the `TLangSwitchRefreshWatcher` thread would
terminate early on Win7 (as it had no work to do), and free itself, but then the
main form would reference it post-free. 

This would result in various exceptions as state is corrupted at this point.

Responsibility for free has been moved to the main form.