### PR TITLE
fix(ios): fixes sys-kbd setup help link for iOS 9 and 10

### DIFF
--- a/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
@@ -71,7 +71,7 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
 
   private func loadFromServer() {
     let appVersion = Version.current.majorMinor
-    let url = "https://help.keyman.com/products/iphone-and-ipad/\(appVersion.plainString)"
+    let url = "\(KeymanHosts.HELP_KEYMAN_COM)/products/iphone-and-ipad/\(appVersion.plainString)"
       + "/start/installing-system-keyboard?embed=ios"
     webView.loadRequest(URLRequest(url: URL(string: url)!))
     log.debug("Set up page URL: \(url)")

--- a/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
@@ -44,12 +44,15 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
   }
 
   func reloadKeymanHelp() {
-    let networkStatus = networkReachable?.connection
-    switch networkStatus {
-    case Reachability.Connection.none?:
+    if let networkStatus = networkReachable?.connection {
+      switch networkStatus {
+      case Reachability.Connection.none, Reachability.Connection.unavailable:
+        loadFromLocal()
+      default:
+        loadFromServer()
+      }
+    } else {
       loadFromLocal()
-    default:
-      loadFromServer()
     }
   }
 
@@ -62,16 +65,16 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
 
     // Yes, .php.html.  That's how `wget` is set to retrieve it, since Safari won't recognize the contents
     // without the .html ending, it seems.
-    let filePath = offlineHelpBundle.path(forResource: "installing-system-keyboard.php",
+    let filePath = offlineHelpBundle.path(forResource: "installing-system-keyboard",
                                           ofType: "html",
-                                          inDirectory: nil)
+                                          inDirectory: "start")
     webView.loadRequest(URLRequest(url: URL.init(fileURLWithPath: filePath!)))
   }
 
   private func loadFromServer() {
     let appVersion = Version.current.majorMinor
     let url = "https://help.keyman.com/products/iphone-and-ipad/\(appVersion.plainString)"
-      + "/installing-system-keyboard.php?embed=ios"
+      + "/start/installing-system-keyboard"
     webView.loadRequest(URLRequest(url: URL(string: url)!))
     log.debug("Set up page URL: \(url)")
   }

--- a/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/SetUpViewController/SetUpViewController.swift
@@ -63,8 +63,6 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
   private func loadFromLocal() {
     let offlineHelpBundle = Bundle(path: Bundle.main.path(forResource: "OfflineHelp", ofType: "bundle")!)!
 
-    // Yes, .php.html.  That's how `wget` is set to retrieve it, since Safari won't recognize the contents
-    // without the .html ending, it seems.
     let filePath = offlineHelpBundle.path(forResource: "installing-system-keyboard",
                                           ofType: "html",
                                           inDirectory: "start")
@@ -74,7 +72,7 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
   private func loadFromServer() {
     let appVersion = Version.current.majorMinor
     let url = "https://help.keyman.com/products/iphone-and-ipad/\(appVersion.plainString)"
-      + "/start/installing-system-keyboard"
+      + "/start/installing-system-keyboard?embed=ios"
     webView.loadRequest(URLRequest(url: URL(string: url)!))
     log.debug("Set up page URL: \(url)")
   }


### PR DESCRIPTION
While we did think to fix the `InfoViewController` class, we'd simply forgotten to make the same changes for the `SetUpViewController`.

Fixes #4770.