### PR TITLE
fix(android/engine): Sanitize embedded KMW Sentry error

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -156,7 +156,10 @@ final class KMKeyboard extends WebView {
 
         if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
           // Make Toast notification of error and send log about falling back to default keyboard (ignore language ID)
-          sendKMWError(cm.lineNumber(), cm.sourceId(), cm.message());
+          // Sanitize sourceId info
+          String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";
+          String sourceID = cm.sourceId().replaceAll(NAVIGATION_PATTERN, "$1$2");
+          sendKMWError(cm.lineNumber(), sourceID, cm.message());
           sendError(packageID, keyboardID, "");
           Keyboard firstKeyboard = KeyboardController.getInstance().getKeyboardInfo(0);
           if (firstKeyboard != null) {


### PR DESCRIPTION
Follow-on to #4692 where we resume sending embedded KMW errors to Sentry

This re-incorporates a pattern from #4025 to sanitize the breadcrumb going to Sentry
See http://sentry.keyman.com/organizations/keyman/issues/4198

Will cherry-pick to stable-14.0
