### PR TITLE
fix(android): Fix NullPointerException in package installation

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -517,7 +517,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           if (progressDialog == null) {
             progressDialog = new ProgressDialog(MainActivity.this);
             progressDialog.setMessage(String.format(getString(R.string.downloading_keyboard_package), filename));
-            progressDialog.setCancelable(false);
+            progressDialog.setCancelable(true); // Cancelable in case there's exceptions
             progressDialog.show();
 
             // Download the KMP to app cache

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -265,7 +265,8 @@ public class PackageActivity extends AppCompatActivity implements
           if(_cleanup)
             cleanup();
         } else {
-          showErrorDialog(context, pkgId, getString(R.string.no_new_touch_keyboards_to_install));
+          // Use Toast so it will linger when PackageActivity finishes
+          showErrorToast(context, getString(R.string.no_new_touch_keyboards_to_install));
         }
       } else if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
         List<Map<String, String>> installedLexicalModels =
@@ -287,12 +288,14 @@ public class PackageActivity extends AppCompatActivity implements
           if(_cleanup)
             cleanup();
         } else {
-          showErrorDialog(context, pkgId, getString(R.string.no_new_predictive_text_to_install));
+          // Use Toast so it will linger when PackageActivity finishes
+          showErrorToast(context, getString(R.string.no_new_predictive_text_to_install));
         }
       }
     } catch (Exception e) {
       KMLog.LogException(TAG, "", e);
-      showErrorDialog(context, pkgId, getString(R.string.no_targets_to_install));
+      // Use Toast so it will linger when PackageActivity finishes
+      showErrorToast(context, getString(R.string.no_targets_to_install));
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -734,7 +734,7 @@ public class PackageProcessor {
    *                   only used for the first keyboard in a package.
    * @return A list of data maps of the newly installed and/or newly upgraded entries found in the package.
    * May be empty if the package file is actually an old version.
-   * <br/><br/>
+   *
    * The format for each map matches those of the current `download` method output of KMKeyboardDownloader
    * as closely as practical.
    * @throws IOException
@@ -745,6 +745,9 @@ public class PackageProcessor {
     // TODO:  Consider throwing an exception instead?
     ArrayList<Map<String, String>> specs = new ArrayList<>();
     if (KMManager.isReservedNamespace(getPackageID(path))) {
+      return specs;
+    }
+    if (path == null || tempPath == null) {
       return specs;
     }
     JSONObject newInfoJSON = loadPackageInfo(tempPath);


### PR DESCRIPTION
Fixes #4789 from the Sentry logs where some users were experiencing NullPointerException during package installation.

This also improves the UX on errors:
* the download dialog can be dismissed (when errors occur)
* change from Error dialog to Toast notifications so they'll be displayed when the package activity finishes.

Will cherry-pick to stable-14.0

