### PR TITLE
fix(linux): Fix crash if query doesn't contain bcp47 tag 🍒 (#4800)

### DIFF
--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -47,9 +47,10 @@ def download_and_install_package(url):
 def _extract_bcp47(query):
     if query:
         queryStrings = parse_qs(query)
-        values = queryStrings['bcp47']
-        if len(values) > 0:
-            return values[0]
+        if 'bcp47' in queryStrings:
+            values = queryStrings['bcp47']
+            if len(values) > 0:
+                return values[0]
     return ''
 
 


### PR DESCRIPTION
cherry pick of #4801 