### PR TITLE
fix(android/engine): Add KMString wrapper for formatting Strings

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.KMPLink;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.WebViewUtil;
 
 import java.util.regex.Matcher;
@@ -41,7 +42,7 @@ public class KMPBrowserActivity extends BaseActivity {
   // 1. Host isn't keyman.com (production/staging)
   // 2. Host is keyman.com but not /keyboards/
   private static final String INTERNAL_KEYBOARDS_LINK_FORMATSTR = "^http(s)?://(%s|%s)/keyboards([/?].*)?$";
-  private static final String keyboardPatternFormatStr = String.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
+  private static final String keyboardPatternFormatStr = KMString.format(INTERNAL_KEYBOARDS_LINK_FORMATSTR,
     KMPLink.KMP_PRODUCTION_HOST,
     KMPLink.KMP_STAGING_HOST);
   private static final Pattern keyboardPattern = Pattern.compile(keyboardPatternFormatStr);
@@ -141,9 +142,9 @@ public class KMPBrowserActivity extends BaseActivity {
     String host = KMPLink.getHost();
     // If language ID is provided, include it in the keyboard search
     String languageID = getIntent().getStringExtra("languageCode");
-    String languageStr = (languageID != null) ? String.format(KMP_SEARCH_KEYBOARDS_LANGUAGES, languageID) : "";
+    String languageStr = (languageID != null) ? KMString.format(KMP_SEARCH_KEYBOARDS_LANGUAGES, languageID) : "";
     String appMajorVersion = KMManager.getMajorVersion();
-    String kmpSearchUrl = String.format(KMP_SEARCH_KEYBOARDS_FORMATSTR, host, appMajorVersion, languageStr);
+    String kmpSearchUrl = KMString.format(KMP_SEARCH_KEYBOARDS_FORMATSTR, host, appMajorVersion, languageStr);
     webView.loadUrl(kmpSearchUrl);
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
@@ -35,6 +35,7 @@ import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 import com.tavultesoft.kmea.util.QRCodeUtil;
 
@@ -181,7 +182,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
         } else if (itemTitle.equals(getString(R.string.uninstall_keyboard))) {
           // Uninstall selected keyboard
           String title = String.format("%s: %s", languageName, kbName);
-          String keyboardKey = String.format("%s_%s", languageID, kbID);
+          String keyboardKey = KMString.format("%s_%s", languageID, kbID);
           DialogFragment dialog = ConfirmDialogFragment.newInstanceForItemKeyBasedAction(
             DIALOG_TYPE_DELETE_KEYBOARD, title, getString(R.string.confirm_delete_keyboard), keyboardKey);
           dialog.show(getFragmentManager(), "dialog");
@@ -196,7 +197,7 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
+      String url = KMString.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -38,6 +38,7 @@ import com.tavultesoft.kmea.util.DownloadFileUtils;
 import com.tavultesoft.kmea.util.DownloadIntentService;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMPLink;
+import com.tavultesoft.kmea.util.KMString;
 
 import android.Manifest;
 import android.app.ProgressDialog;
@@ -622,7 +623,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           text = text.replace(" ", "&nbsp;");
           text = text.replace('\n', ' ');
           text = text.replace(" ", "<br>");
-          shareIntent.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(String.format(htmlMailFormat, text, extraMailText)));
+          shareIntent.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(KMString.format(htmlMailFormat, text, extraMailText)));
         } else {
           // Text for all others
           shareIntent.putExtra(Intent.EXTRA_TEXT, text);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -21,6 +21,7 @@ import com.tavultesoft.kmea.KeyboardEventHandler.EventType;
 import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardEventListener;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -142,7 +143,7 @@ final class KMKeyboard extends WebView {
 
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {
-        String msg = String.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());
+        String msg = KMString.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());
         if (KMManager.isDebugMode()) {
           if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
             Log.d(TAG, msg);
@@ -256,7 +257,7 @@ final class KMKeyboard extends WebView {
 
   public void executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
     String jsFormat = "executeHardwareKeystroke(%d,%d, %d, %d)";
-    String jsString = String.format(jsFormat, code, shift, lstates, eventModifiers);
+    String jsString = KMString.format(jsFormat, code, shift, lstates, eventModifiers);
     loadJavascript(jsString);
   }
 
@@ -287,7 +288,7 @@ final class KMKeyboard extends WebView {
     DisplayMetrics dms = context.getResources().getDisplayMetrics();
     int kbWidth = (int) (dms.widthPixels / dms.density);
     // Ensure window is loaded for javascript functions
-    loadJavascript(String.format(
+    loadJavascript(KMString.format(
       "window.onload = function(){ setOskWidth(\"%d\");"+
       "setOskHeight(\"0\"); };", kbWidth));
     if (ShouldShowHelpBubble) {
@@ -319,8 +320,8 @@ final class KMKeyboard extends WebView {
     dismissKeyPreview(0);
     dismissSubKeysWindow();
     int bannerHeight = KMManager.getBannerHeight(context);
-    loadJavascript(String.format("setBannerHeight(%d)", bannerHeight));
-    loadJavascript(String.format("setOskWidth(%d)", newConfig.screenWidthDp));
+    loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));
+    loadJavascript(KMString.format("setOskWidth(%d)", newConfig.screenWidthDp));
     loadJavascript("setOskHeight(0)");
     if (dismissHelpBubble()) {
       Handler handler = new Handler();
@@ -458,7 +459,7 @@ final class KMKeyboard extends WebView {
         KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
 
     }
-    String kbKey = String.format("%s_%s", languageID, keyboardID);
+    String kbKey = KMString.format("%s_%s", languageID, keyboardID);
 
     setKeyboardRoot(packageID);
 
@@ -504,7 +505,7 @@ final class KMKeyboard extends WebView {
         KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
     }
 
-    String kbKey = String.format("%s_%s", languageID, keyboardID);
+    String kbKey = KMString.format("%s_%s", languageID, keyboardID);
 
     setKeyboardRoot(packageID);
     String keyboardPath = makeKeyboardPath(packageID, keyboardID, keyboardVersion);
@@ -516,7 +517,7 @@ final class KMKeyboard extends WebView {
     } else {
       if (FileUtils.hasFontExtension(kFont)) {
         txtFont = kFont;
-        tFont = String.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kFont.substring(0, kFont.length() - 4), keyboardRoot, kFont);
+        tFont = KMString.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kFont.substring(0, kFont.length() - 4), keyboardRoot, kFont);
       } else {
         txtFont = getFontFilename(kFont);
         if (!txtFont.isEmpty()) {
@@ -530,7 +531,7 @@ final class KMKeyboard extends WebView {
     } else {
       if (FileUtils.hasFontExtension(kOskFont)) {
         oskFont = kOskFont;
-        oFont = String.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kOskFont.substring(0, kOskFont.length() - 4), keyboardRoot, kOskFont);
+        oFont = KMString.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kOskFont.substring(0, kOskFont.length() - 4), keyboardRoot, kOskFont);
       } else {
         oskFont = getFontFilename(kOskFont);
         if (!oskFont.isEmpty()) {
@@ -557,7 +558,7 @@ final class KMKeyboard extends WebView {
     languageName = languageName.replaceAll("\'", "\\\\'");
 
     String jsFormat = "setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
-    String jsString = String.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
+    String jsString = KMString.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
     loadJavascript(jsString);
 
     this.packageID = packageID;
@@ -598,7 +599,7 @@ final class KMKeyboard extends WebView {
     BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
 
     // Don't localize msg for Sentry
-    String msg = String.format(context.getString(R.string.fatal_keyboard_error), packageID, keyboardID, languageID);
+    String msg = KMString.format(context.getString(R.string.fatal_keyboard_error), packageID, keyboardID, languageID);
     Sentry.captureMessage(msg);
   }
 
@@ -921,7 +922,7 @@ final class KMKeyboard extends WebView {
           String keyId = subkeyList.get(index).get("keyId");
           String keyText = getSubkeyText(keyId, subkeyList.get(index).get("keyText"));
           String jsFormat = "executePopupKey('%s','%s')";
-          String jsString = String.format(jsFormat, keyId, keyText);
+          String jsString = KMString.format(jsFormat, keyId, keyText);
           loadJavascript(jsString);
         }
       });

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -73,6 +73,7 @@ import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.CharSequenceUtil;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 
 import org.json.JSONArray;
@@ -948,7 +949,7 @@ public final class KMManager {
       public boolean accept(File pathname) {
         String name = pathname.getName();
 
-        String patternStr = String.format("^([A-Za-z0-9-_]+)-([0-9.]+)(\\.js)$");
+        String patternStr = KMString.format("^([A-Za-z0-9-_]+)-([0-9.]+)(\\.js)$");
         Pattern pattern = Pattern.compile(patternStr);
         Matcher matcher = pattern.matcher(name);
         if (matcher.matches() && (matcher.groupCount() == 3) &&
@@ -1071,12 +1072,12 @@ public final class KMManager {
     if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
       params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
-      InAppKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
       params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
-      SystemKeyboard.loadJavascript(String.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
     return true;
   }
@@ -1087,7 +1088,7 @@ public final class KMManager {
       currentLexicalModel = null;
     }
 
-    String url = String.format("deregisterModel('%s')", modelID);
+    String url = KMString.format("deregisterModel('%s')", modelID);
     if (InAppKeyboard != null) { // && InAppKeyboardLoaded) {
       InAppKeyboard.loadJavascript(url);
     }
@@ -1099,7 +1100,7 @@ public final class KMManager {
   }
 
   public static boolean setBannerOptions(boolean mayPredict) {
-    String url = String.format("setBannerOptions(%s)", mayPredict);
+    String url = KMString.format("setBannerOptions(%s)", mayPredict);
     if (InAppKeyboard != null) {
       InAppKeyboard.loadJavascript(url);
     }
@@ -1468,7 +1469,7 @@ public final class KMManager {
 
       for (File file : files) {
         String filename = file.getName();
-        String base = String.format("%s-", keyboardID);
+        String base = KMString.format("%s-", keyboardID);
         int index = filename.indexOf(base);
         if (index == 0) {
           int firstIndex = base.length();
@@ -1631,14 +1632,14 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
-        InAppKeyboard.loadJavascript(String.format("updateKMText('%s')", kmText));
+        InAppKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
         result = true;
       }
 
       InAppKeyboardShouldIgnoreTextChange = false;
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
-        SystemKeyboard.loadJavascript(String.format("updateKMText('%s')", kmText));
+        SystemKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
         result = true;
       }
 
@@ -1652,7 +1653,7 @@ public final class KMManager {
     boolean result = false;
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreSelectionChange) {
-        InAppKeyboard.loadJavascript(String.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
 
@@ -1667,7 +1668,7 @@ public final class KMManager {
           }
         }
 
-        SystemKeyboard.loadJavascript(String.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        SystemKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
 
@@ -1703,7 +1704,7 @@ public final class KMManager {
     int index = KeyboardController.INDEX_NOT_FOUND;
 
     if (keyboardID != null & languageID != null) {
-      String kbKey = String.format("%s_%s", languageID, keyboardID);
+      String kbKey = KMString.format("%s_%s", languageID, keyboardID);
       index = KeyboardController.getInstance().getKeyboardIndex(kbKey);
     }
 
@@ -1722,7 +1723,7 @@ public final class KMManager {
     boolean result = false;
 
     if (packageID != null && keyboardID != null && languageID != null) {
-      File keyboardFile = new File(getPackagesDir(), packageID + File.separator + String.format("%s.js", keyboardID));
+      File keyboardFile = new File(getPackagesDir(), packageID + File.separator + KMString.format("%s.js", keyboardID));
       result = KeyboardController.getInstance().keyboardExists(packageID, keyboardID, languageID) &&
         keyboardFile.exists();
     }
@@ -1734,7 +1735,7 @@ public final class KMManager {
     boolean result = false;
 
     if (packageID != null && languageID != null &&  modelID != null) {
-      String lmKey = String.format("%s_%s_%s", packageID, languageID, modelID);
+      String lmKey = KMString.format("%s_%s_%s", packageID, languageID, modelID);
       result = KeyboardPickerActivity.containsLexicalModel(context, lmKey);
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardInfoActivity.java
@@ -31,6 +31,7 @@ import android.widget.Toast;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 import com.tavultesoft.kmea.util.QRCodeUtil;
 import com.tavultesoft.kmea.KMHelpFileActivity;
@@ -148,7 +149,7 @@ public final class KeyboardInfoActivity extends BaseActivity {
       LinearLayout qrLayout = (LinearLayout) view.findViewById(R.id.qrLayout);
       listView.addFooterView(qrLayout);
 
-      String url = String.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
+      String url = KMString.format(QRCodeUtil.QR_CODE_URL_FORMATSTR, kbID);
       Bitmap myBitmap = QRCodeUtil.toBitmap(url);
       ImageView imageView = (ImageView) findViewById(R.id.qrCode);
       imageView.setImageBitmap(myBitmap);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -21,6 +21,7 @@ import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -341,7 +342,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
       String langID = lexicalModelInfo.get(KMManager.KMKey_LanguageID);
 
       if (pkgID != null && modelID != null && langID != null) {
-        String lmKey = String.format("%s_%s_%s", pkgID, langID, modelID);
+        String lmKey = KMString.format("%s_%s_%s", pkgID, langID, modelID);
         if (lmKey.length() >= 5) {
           int x = getLexicalModelIndex(context, lmKey);
           if (x >= 0) {
@@ -569,7 +570,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     }
 
     for(HashMap<String, String> lmInfo : lexicalModelsList) {
-      String key = String.format("%s_%s_%s", lmInfo.get(KMManager.KMKey_PackageID),
+      String key = KMString.format("%s_%s_%s", lmInfo.get(KMManager.KMKey_PackageID),
         lmInfo.get(KMManager.KMKey_LanguageID), lmInfo.get(KMManager.KMKey_LexicalModelID));
       if (lexicalModelKey.equalsIgnoreCase(key)) {
         return true;
@@ -599,7 +600,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
         String pkgId = lmInfo.get(KMManager.KMKey_PackageID);
         String langId = lmInfo.get(KMManager.KMKey_LanguageID);
         String lmId = lmInfo.get(KMManager.KMKey_LexicalModelID);
-        String lmKey = String.format("%s_%s_%s", pkgId, langId, lmId);
+        String lmKey = KMString.format("%s_%s_%s", pkgId, langId, lmId);
         if (lmKey.equals(lexicalModelKey)) {
           index = i;
           break;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelInfoActivity.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.util.FileProviderUtils;
+import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 import com.tavultesoft.kmea.KMHelpFileActivity;
 
@@ -151,7 +152,7 @@ public final class ModelInfoActivity extends BaseActivity {
         // "Uninstall Model" clicked
         } else if (itemTitle.equals(getString(R.string.uninstall_model))) {
           // Uninstall selected model
-          String lexicalModelKey = String.format("%s_%s_%s", packageID, languageID, modelID);
+          String lexicalModelKey = KMString.format("%s_%s_%s", packageID, languageID, modelID);
           DialogFragment dialog = ConfirmDialogFragment.newInstanceForItemKeyBasedAction(
             DIALOG_TYPE_DELETE_MODEL, modelName, getString(R.string.confirm_delete_model), lexicalModelKey);
           dialog.show(getFragmentManager(), "dialog");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -14,6 +14,7 @@ import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -72,7 +73,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.version = keyboardJSON.optString(KMManager.KMKey_KeyboardVersion, null);
 
       this.helpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink,
-        String.format(HELP_URL_FORMATSTR, HELP_URL_HOST, this.resourceID, this.version));
+        KMString.format(HELP_URL_FORMATSTR, HELP_URL_HOST, this.resourceID, this.version));
     } catch (JSONException e) {
       KMLog.LogException(TAG, "Keyboard exception parsing JSON: ", e);
     }
@@ -84,7 +85,7 @@ public class Keyboard extends LanguageResource implements Serializable {
                   boolean isNewKeyboard, String font, String oskFont) {
     super(packageID, keyboardID, keyboardName, languageID, languageName, version,
       (FileUtils.isWelcomeFile(helpLink)) ? helpLink :
-        String.format(HELP_URL_FORMATSTR, HELP_URL_HOST, keyboardID, version),
+        KMString.format(HELP_URL_FORMATSTR, HELP_URL_HOST, keyboardID, version),
       kmp);
 
     this.isNewKeyboard = isNewKeyboard;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -88,7 +89,7 @@ public abstract class LanguageResource implements Serializable {
   }
 
   public String getKey() {
-    return String.format("%s_%s", languageID, resourceID);
+    return KMString.format("%s_%s", languageID, resourceID);
   }
 
   public abstract Bundle buildDownloadBundle();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -12,6 +12,7 @@ import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -101,7 +102,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
 
   @Override
   public String getKey() {
-    return String.format("%s_%s_%s", packageID, languageID, resourceID);
+    return KMString.format("%s_%s_%s", packageID, languageID, resourceID);
   }
 
   public String getLexicalModelID() { return getResourceID(); }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
@@ -10,6 +10,7 @@ import com.tavultesoft.kmea.BuildConfig;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.Tier;
+import com.tavultesoft.kmea.util.KMString;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,14 +24,14 @@ public final class KMPLink {
   public static final String KMP_STAGING_HOST = "keyman-staging.com";
 
   private static final String KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR = "^http(s)?://(%s|%s)/keyboards/install/([^\\?/]+)(\\?(.+))?$";
-  private static final String installPatternFormatStr = String.format(KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR,
+  private static final String installPatternFormatStr = KMString.format(KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR,
     KMP_PRODUCTION_HOST,
     KMP_STAGING_HOST);
   private static final Pattern installPattern = Pattern.compile(installPatternFormatStr);
 
   // Keyman 14.0+ keyboard download links from Keyman server
   private static final String KMP_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR = "^https://(%s|%s)(/go/package/download/)(\\w+)(\\?platform=android&tier=(alpha|beta|stable))(&bcp47=)?(.+)?";
-  private static final String downloadPatternFormatStr = String.format(KMP_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR,
+  private static final String downloadPatternFormatStr = KMString.format(KMP_DOWNLOAD_KEYBOARDS_PATTERN_FORMATSTR,
     KMP_PRODUCTION_HOST,
     KMP_STAGING_HOST);
   private static final Pattern downloadPattern = Pattern.compile(downloadPatternFormatStr);
@@ -139,7 +140,7 @@ public final class KMPLink {
       Uri installUri = Uri.parse(url);
       String languageID = installUri.getQueryParameter(KMKeyboardDownloaderActivity.KMKey_BCP47);
 
-      String downloadURL = String.format(KMP_DOWNLOAD_KEYBOARDS_FORMATSTR,
+      String downloadURL = KMString.format(KMP_DOWNLOAD_KEYBOARDS_FORMATSTR,
         host,
         packageID);
       uri = Uri.parse(downloadURL)
@@ -180,7 +181,7 @@ public final class KMPLink {
       String keyboardID = installUri.getQueryParameter("keyboard");
       String languageID = installUri.getQueryParameter("language");
 
-      String downloadURL = String.format(KMP_DOWNLOAD_KEYBOARDS_FORMATSTR,
+      String downloadURL = KMString.format(KMP_DOWNLOAD_KEYBOARDS_FORMATSTR,
         host,
         keyboardID); // Using keyboardID instead of packageID
       uri = Uri.parse(downloadURL)

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMString.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMString.java
@@ -1,0 +1,18 @@
+package com.tavultesoft.kmea.util;
+
+import java.util.Locale;
+
+/**
+ * Utility to do String.format with Locale.ENGLISH.
+ * This is needed for formatting strings used in Javascript calls
+ */
+public final class KMString {
+  private static final String TAG = "KMString";
+  private static Locale ENGLISH_LOCALE = Locale.ENGLISH;
+
+  public static String format(String format, Object... args) {
+    String value = String.format(ENGLISH_LOCALE, format, args);
+    return value;
+  }
+
+}


### PR DESCRIPTION
🍒 pick of #4813 for stable-14.0

This adds KMString - a wrapper for String.format calls that need to be kept in `Locale.ENGLISH` (needed for JS calls, URLs, and generating lookup keys)

### User Testing
@MakaraSok

1. On the device, set the system locale to non-English (like Khmer or Arabic)
2. Load the test build
3. Verify you can install farsiman keyboard from keyman.com
4. Verify the globe keyboard picker successfully can switch keyboards between sil_euro_latin and farsiman
5. Type some random text in the Keyman app, and then select a portion of the text
6. In the currently selected keyboard, type a key and verify the substring gets replaced.
7. Click the globe keyboard picker and display a keyboard info page for sil_euro_latin
8. Verify QR code is generated
9. Exit back to the main screen
10. From the Keyman app, click the "Share" menu icon
11. Select the option to share text via email (gmail)
12. Verify the mail app correctly shows the shared text

