### PR TITLE
change(web): adds error + console logs usable for Sentry reporting targeting #4797

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -565,8 +565,6 @@ namespace com.keyman.dom {
       let tTarg=tEvent.target as HTMLElement;
 
       // Determines the actual TouchAliasElement - the part tied to an OutputTarget.
-      // Ideally, we shouldn't need the second part as a fallback; it's there to preserve existing
-      // behavior from 13.0, as this was refactored LATE in the 14.0 beta process.
       let target = findTouchAliasTarget(tTarg);
 
       // Some parts rely upon the scroller element.

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -206,7 +206,9 @@ namespace com.keyman.dom {
 
       // Makes sure we properly detect the TouchAliasElement root, 
       // rather than one of its constituent children.
-      Ltarg = findTouchAliasTarget(Ltarg);
+      if(this.keyman.util.device.touchable) {
+        Ltarg = findTouchAliasTarget(Ltarg);
+      }
 
       if(DOMEventHandlers.states._IgnoreBlurFocus) {
         // Prevent triggering other blur-handling events (as possible)

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -208,6 +208,10 @@ namespace com.keyman.dom {
       // rather than one of its constituent children.
       if(this.keyman.util.device.touchable) {
         Ltarg = findTouchAliasTarget(Ltarg);
+
+        if(!Ltarg) {
+          return true;
+        }
       }
 
       if(DOMEventHandlers.states._IgnoreBlurFocus) {
@@ -567,6 +571,10 @@ namespace com.keyman.dom {
       // Determines the actual TouchAliasElement - the part tied to an OutputTarget.
       let target = findTouchAliasTarget(tTarg);
 
+      if(!target) {
+        return;
+      }
+
       // Some parts rely upon the scroller element.
       let scroller = target.firstChild as HTMLElement;
 
@@ -800,6 +808,10 @@ namespace com.keyman.dom {
       
       // Identify the input element from the touch event target (touched element may be contained by input)
       target = findTouchAliasTarget(target);
+
+      if(!target) {
+        return;
+      }
 
       var x, y;
 

--- a/web/source/dom/touchAliasElement.ts
+++ b/web/source/dom/touchAliasElement.ts
@@ -30,6 +30,8 @@ namespace com.keyman.dom {
   // If the specified HTMLElement is either a TouchAliasElement or one of its children elements,
   // this method will return the root TouchAliasElement.
   export function findTouchAliasTarget(target: HTMLElement): TouchAliasElement {
+    // The scrollable container element for the before & after text spans & the caret.
+    // Not to be confused with the simulated scrollbar.
     let scroller: HTMLElement;
 
     // Identify the scroller element
@@ -38,7 +40,7 @@ namespace com.keyman.dom {
     } else if(target && (target.className != null && target.className.indexOf('keymanweb-input') >= 0)) {
       scroller=target.firstChild as HTMLElement;
     } else if(target && dom.Utils.instanceof(target, "HTMLDivElement")) {
-      // Two possibilities:  the scroller & the blinking DIV of the caret.
+      // Three possibilities:  the scroller, the scrollbar, & the blinking DIV of the caret.
       // A direct click CAN trigger events on the blinking element itself if well-timed.
       scroller=target;
 
@@ -46,6 +48,9 @@ namespace com.keyman.dom {
       if(scroller.parentElement && scroller.parentElement.className.indexOf('keymanweb-input') < 0) {
         scroller = scroller.parentElement;
       }
+
+      // scroller is now either the actual scroller or the scrollbar element.
+      // We don't return either of these, and they both have the same parent element.
     } else if(target['kmw_ip']) { // In case it's called on a TouchAliasElement's base (aliased) element.
       return target['kmw_ip'] as TouchAliasElement;
     } else {
@@ -661,7 +666,7 @@ namespace com.keyman.dom {
     setScrollBar() {
       let e = <TouchAliasElement> (<any> this);
 
-      // Display the scrollbar if necessary.  Added TEXTAREA condition to correct rotation issue KMW-5.  Fixed for 310 beta.
+      // Display the scrollbar if necessary.  Added isMultiline condition to correct rotation issue KMW-5.  Fixed for 310 beta.
       var scroller=this.__scrollDiv, sbs=this.__scrollBar.style;
       if((scroller.offsetWidth > e.offsetWidth || scroller.offsetLeft < 0) && !e.isMultiline()) {
         sbs.height='4px';


### PR DESCRIPTION
Sadly, I'm currently unable to reproduce #4797, despite the fact that we're usually seeing at least a couple counts of it per day from keymanweb.com's Sentry logs.  So, to better assist diagnosis of the cause, this PR adds 'breadcrumbs' that will provide extra information about the error's context.

While `target.innerHTML` (or `target.parent.innerHTML`, or the like) might seem to be a more simple, straightforward solution... that would also include the user's typed input, which is obviously a privacy concern.  Rather than attempt complicated regex to scrub it out at all levels... I instead opted to manually collate relevant info using the current approach.

Will need to be 🍒-picked to stable in order for keymanweb.com to provide us anything useful, of course.

Example resulting log:  https://sentry.keyman.com/organizations/keyman/issues/4658/?project=10&query=is%3Aunresolved