### PR TITLE
fix(developer): buffer size for range expansions

### DIFF
--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -2636,7 +2636,7 @@ DWORD process_expansion(PFILE_KEYBOARD fk, LPWSTR q, LPWSTR tstr, int *mx, int m
   }
 
   // Look ahead at next element
-  WCHAR temp[64];
+  WCHAR temp[GLOBAL_BUFSIZE];
   PWCHAR r = NULL;
 
   DWORD msg;


### PR DESCRIPTION
Fixes #4830.

There remain some additional buffer size checks we should be doing in `GetXString` but this will address the current issue by using the standard maximum buffer size.