### PR TITLE
fix(linux): Fix crash if `<kbd>.json` doesn't contain description 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -110,7 +110,7 @@ class KeyboardDetailsView(Gtk.Dialog):
             grid.attach_next_to(lbl_pkg_desc, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
             prevlabel = lbl_pkg_desc
             label = Gtk.Label()
-            label.set_text(kbdata['description'])
+            label.set_text(kbdata.get('description'))
             label.set_halign(Gtk.Align.START)
             label.set_selectable(True)
             label.set_line_wrap(80)


### PR DESCRIPTION
This fixes #4823. 🍒 of PR #4835.

(cherry picked from commit ebe49cfc6f4b571c641e92adfe61af4bf67a626b)
