### PR TITLE
chore(linux): Debug triggering Jenkins build

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -80,6 +80,8 @@ function triggerJenkinsBuild() {
     JENKINS_BRANCH="PR-${JENKINS_BRANCH}"
   fi
 
+  echo "DEBUG: Triggering with data: { \"project\": \"$JENKINS_JOB/$JENKINS_BRANCH\", \"branch\": \"$JENKINS_BRANCH\" $TAG $FORCE }"
+
   local OUTPUT=$(curl --silent --write-out '\n' \
     -X POST \
     --header "token: $JENKINS_TOKEN" \
@@ -104,4 +106,5 @@ function triggerJenkinsBuild() {
       echo "$line"
     fi
   done
+  echo ""
 }


### PR DESCRIPTION
Triggering the Jenkins build from the Stable release trigger on TC
fails. This change outputs the data we're actually sending.
