### PR TITLE
chore(android/engine): Rename "Fula" to "Pulaar"

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
@@ -37,10 +37,10 @@ public class DisplayLanguages {
       new DisplayLanguageType(unspecifiedLocale, context.getString(R.string.default_locale)),
       new DisplayLanguageType("en", "English"),
       new DisplayLanguageType("fr-FR", "French"),
-      new DisplayLanguageType("ff-ZA", "Fula"),
       new DisplayLanguageType("de-DE", "German"),
       new DisplayLanguageType("km-KH", "Khmer"),
-      new DisplayLanguageType("ann", "Obolo")
+      new DisplayLanguageType("ann", "Obolo"),
+      new DisplayLanguageType("ff-ZA", "Pulaar") // or Fulah
     };
     return languages;
   }


### PR DESCRIPTION
Fixes #4858 to rename the Display Language from "Fula" to "Pulaar".
