### PR TITLE
fix(developer): Reduce non-canonical BCP 47 tag warning in PackageInfo to "Info"

### DIFF
--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshLexicalModels.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshLexicalModels.pas
@@ -120,7 +120,7 @@ begin
         else if not TCanonicalLanguageCodeUtils.IsCanonical(tag, msg, False, False) then
         begin
 
-          DoError(Format(SWarning_LanguageTagIsNotCanonical, [lm.ID, lang.ID, msg]), plsWarning);
+          DoError(Format(SWarning_LanguageTagIsNotCanonical, [lm.ID, lang.ID, msg]), plsInfo);
         end;
       finally
         Free;


### PR DESCRIPTION
Fixes #4862

In `PackageInfoRefreshLexicalModels.pas`. reduce non-canonical BCP 47 tag warning to "info" so they do not block the build.

Mirrors change in `PackageInfoRefreshKeyboards.pas` from 1f87c7608c7c8246c59260326c4e076dd5d82760

Tested that the modified Tike.exe could compile the package from keymanapp/lexical-models#122

TODO
- [ ] 🍒 pick to stable-14.0

