### PR TITLE
chore(android/engine): Rename "Pulaar" to "Pulaar-Fulfulde"

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
@@ -40,7 +40,7 @@ public class DisplayLanguages {
       new DisplayLanguageType("de-DE", "German"),
       new DisplayLanguageType("km-KH", "Khmer"),
       new DisplayLanguageType("ann", "Obolo"),
-      new DisplayLanguageType("ff-ZA", "Pulaar") // or Fulah
+      new DisplayLanguageType("ff-ZA", "Pulaar-Fulfulde") // or Fulah
     };
     return languages;
   }


### PR DESCRIPTION
Follow-on to #4859 

From the community site [discussion](https://community.software.sil.org/t/language-settings-translation/4611/8), it turns out

> Since the language has two names in Fulah, Pulaar in the West, Fulfulde in the East, in software localizations, we mostly adopt Pulaar-Fulfulde for simplicity, but more importantly, for **unity**!

At this moment, I'm not sure how the Android app could re-use the Windows string name `ssLanguageName`
* That string identifier is already used by Keyman for Windows
* If all the language names on the "Change Display Language" menu used `ssLanguageName`, wouldn't they all list the same language in the chosen locale?