### PR TITLE
fix(windows): handle invalid package names during install 🍒

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -68,6 +68,7 @@ end;
 class function TTIPMaintenance.InstallTipForPackage(const PackageFilename, BCP47Tag: string): Boolean;
 var
   PackageID: string;
+  n: Integer;
   pack: IKeymanPackageInstalled;
 begin
   // This function has a known limitation: if a package contains more than one keyboard,
@@ -75,9 +76,11 @@ begin
   // considered an acceptable limitation at this time
 
   PackageID := ChangeFileExt(ExtractFileName(PackageFilename), '');
-  pack := kmcom.Packages[PackageID];
-  if not Assigned(pack) then
+  n := kmcom.Packages.IndexOf(PackageID);
+  if n < 0 then
     Exit(False);
+
+  pack := kmcom.Packages[n];
 
   if pack.Keyboards.Count = 0 then
     Exit(False);

--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -545,7 +545,12 @@ begin
       for i := 0 to kmcom.Packages.Count - 1 do
       begin
         pkg := kmcom.Packages[i];
-        Fields.Add(ansistring('package_'+pkg.ID), ansistring(pkg.Version));
+
+        // Due to limitations in PHP parsing of query string parameters names with
+        // space or period, we need to split the parameters up. The legacy pattern
+        // is still supported on the server side. Relates to #4886.
+        Fields.Add(AnsiString('packageid_'+IntToStr(i)), AnsiString(pkg.ID));
+        Fields.Add(AnsiString('packageversion_'+IntToStr(i)), AnsiString(pkg.Version));
         pkg := nil;
       end;
         

--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -642,7 +642,7 @@ var
       s := '-s -install-tips-for-packages ';
       for pack in FInstallInfo.Packages do
       begin
-        if pack.ShouldInstall then
+        if pack.ShouldInstall and Assigned(pack.InstallLocation) then
           s := s + '"'+pack.ID+'='+pack.BCP47+'" ';
       end;
 


### PR DESCRIPTION
Fixes #4886.

Cherry-pick of #4887.

This patch includes 5 separate fixes for the various scenarios we encountered during package installation.

1. RunTools.pas: don't attempt to install TIPs if package is not also being installed.

2. Keyman.Setup.System.OnlineResourceCheck.pas, OnlineUpdateCheck.pas: handle online update check for packages with spaces or periods in the id (legacy packages only). See also keymanapp/api.keyman.com#150

3. Keyman.Setup.System.InstallInfo.pas: Handle browsers renaming downloaded files with `(n)` and `[n]` patterns as well as the current ` (n)` pattern.

4. Keyman.Setup.System.InstallInfo.pas: Handle browsers renaming downloaded files with `_n` pattern. See code comments for details.

5. Keyman.Configuration.System.TIPMaintenance.pas: Avoid crashing if `kmshell -install-tips-for-packages` is passed an invalid package name.

The crash is actually fixed in point 5 above, but the root causes are addressed in the other points.