### PR TITLE
chore(windows): disable profile repair 🍒

### DIFF
--- a/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
+++ b/windows/src/desktop/kmshell/main/KeyboardTIPCheck.pas
@@ -1,20 +1,20 @@
 (*
   Name:             KeyboardTIPCheck
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      23 Jun 2015
 
   Modified Date:    23 Jun 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          23 Jun 2015 - mcdurdin - I4773 - Keyman needs to rebuild its language profiles if they are inadvertently deleted
-                    
+
 *)
 unit KeyboardTIPCheck;   // I4773
 
@@ -82,6 +82,7 @@ begin
       begin
         if kmcom.SystemInfo.IsAdministrator then
         begin
+          //TTIPMaintenance.DoRegister(k.ID, k.Languages[j].BCP47Code);
           (k.Languages[j] as IKeymanKeyboardLanguageInstalled2).RegisterTip(k.Languages[j].LangID);
         end
         else

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -358,7 +358,7 @@ begin
     if MessageDlg('Some keyboard profiles have been damaged. Correct these now?', mtConfirmation, mbOkCancel, 0) = mrOk then
     begin
       WaitForElevatedConfiguration(0, '-repair', True);
-      TKeyboardTIPCheck.ReEnablePostRepair;
+      // TKeyboardTIPCheck.ReEnablePostRepair; //possible future mitigation idea, see #4893.
     end;
   end;
 *)


### PR DESCRIPTION
Cherry-pick of #4899.

Fixes #4893.
Fixes KEYMAN-WINDOWS-50.
Fixes KEYMAN-WINDOWS-4Z.

Profile repair was using legacy code for re-establishing Keyman TIP profiles after they had been modified by a third party app or Windows. However, with Keyman 14's new profile registration pattern, this is both less likely to occur and also easier to resolve (just disabling and re-enabling the keyboard should do it).

Thus, I have opted to disable the profile repair code as, with the way it stands at present, it may well make things worse, even aside from the crash, because of disparities between user and admin TSF settings.