### PR TITLE
fix(developer): avoid crash if .kpj.user file is malformed 🍒

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLoader.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.ProjectLoader.pas
@@ -177,7 +177,13 @@ var
 begin
   if not FileExists(ChangeFileExt(FFileName, Ext_ProjectSourceUser)) then Exit;
 
-  doc := LoadXMLDocument(ChangeFileExt(FFileName, Ext_ProjectSourceUser)); //TXMLDocument.Create(nil);
+  try
+    doc := LoadXMLDocument(ChangeFileExt(FFileName, Ext_ProjectSourceUser));
+  except
+    on E:Exception do
+      raise EProjectLoader.Create('Error loading project user settings file: '+E.Message);
+  end;
+
 
   root := doc.DocumentElement;
   if root.NodeName <> 'KeymanDeveloperProjectUser' then


### PR DESCRIPTION
Cherry-pick of #4918.

Fixes #4917.

This updates `TProjectLoader` to use the same exception handling pattern for loading the .kpj.user file as we use for the .kpj file.