### PR TITLE
fix(windows): access violation closing text editor

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -480,7 +480,7 @@ begin
     fmTextEditor:
       begin  // I2720
         FMutex := TKeymanMutex.Create('KeymanTextEditor');
-        if FMutex.MutexOwned then OpenTextEditor(nil) else FocusTextEditor;
+        if FMutex.MutexOwned then OpenTextEditor else FocusTextEditor;
       end;
 
     fmBaseKeyboard:   // I4169

--- a/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
+++ b/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
@@ -181,7 +181,7 @@ type
   public
   end;
 
-procedure OpenTextEditor(Owner: TComponent = nil);  // I2260
+procedure OpenTextEditor;  // I2260
 
 implementation
 
@@ -223,20 +223,16 @@ resourcestring
 const
   GutterWid = 6;
 
-procedure OpenTextEditor(Owner: TComponent = nil);  // I2260
+procedure OpenTextEditor;  // I2260
 var
   frmTextEditor: TfrmTextEditor;
 begin
-  if ApplicationRunning then
-  begin
-    frmTextEditor := TfrmTextEditor.Create(nil);
-    frmTextEditor.Show;
-  end
-  else
-  begin
-    UfrmWebContainer.CreateForm(TfrmTextEditor, frmTextEditor);
-    frmTextEditor.Visible := True;
-  end;
+  UfrmWebContainer.CreateForm(TfrmTextEditor, frmTextEditor);
+  frmTextEditor.Visible := True;
+  ApplicationRunning := True;
+  Application.Run;
+  ApplicationRunning := False;
+  FreeAndNil(frmTextEditor);
 end;
 
 { TfrmTextEditor }


### PR DESCRIPTION
Fixes #4848.

This error arose because the form was destroyed after kmshell.dpr completes, which meant that sentry had already been destroyed. The sentry call was simply to record a breadcrumb of the form being closed.

The fix is to move the lifecycle of the form into the `OpenTextEditor` function. `OpenTextEditor` is used only by `initprog.RunKMCOM` and so it is safe to remove the ApplicationRunning path of the code, which simplifies the lifecycle of the form.