### PR TITLE
fix(windows): help contents broken from tray menu 🍒

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1648,7 +1648,7 @@ begin
   if FEnableCrashTest and (GetKeyState(VK_CONTROL) < 0) and (GetKeyState(VK_SHIFT) < 0) then
     TKeymanSentryClient.Validate(True);
 
-  TKeymanDesktopShell.OpenHelpJump('context_traymenu', Self.ActiveKeyboard);
+  TKeymanDesktopShell.OpenHelpJump('index', Self.ActiveKeyboard);
 end;
 
 procedure TfrmKeyman7Main.MnuRunProgram(Sender: TObject);   // I4606


### PR DESCRIPTION
Cherry-pick of #4922.

Fixes #4874.

Opening product help from the tray menu would end up at a broken page.

Given the title of the link is "Help Contents", I have opted to open at the help contents... (rather than the alternative of context/tray-menu).