### PR TITLE
fix(android/engine): Change getList() to return an empty list instead of null

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -469,7 +469,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
   // Gets a raw list of installed lexical models.
   @SuppressWarnings("unchecked")
   private static ArrayList<HashMap<String, String>> getList(Context context, String filename) {
-    ArrayList<HashMap<String, String>> list = null;
+    ArrayList<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
     File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), filename);
     if (file.exists()) {
       try {


### PR DESCRIPTION
Fixes #4925 

This prevents the `NullPointerException` in CloudRepository.prepareResourcesUpdateQuery() when the list of installed lexical models doesn't exist.

With this change, when the package update query is generated, the empty lexical model list just becomes an empty string for the lexical model portion of the query

### CloudRepository.prepareResourcesUpdateQuery()
```java
    String lexicalModelQuery = "";
    for(HashMap<String, String> hashMap : KMManager.getLexicalModelsList(aContext)) {  // <-- this is the affected line
      if (hashMap != null && hashMap.containsKey(KMManager.KMKey_LexicalModelID)) {
         ...
      }
    }

    String queryURL = String.format(API_PACKAGE_VERSION_FORMATSTR, getHost(), keyboardQuery, lexicalModelQuery);

```