### PR TITLE
fix(android/engine): Don't set lexical model list to null

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -478,7 +478,6 @@ public final class KeyboardPickerActivity extends BaseActivity {
         inputStream.close();
       } catch (Exception e) {
         KMLog.LogException(TAG, "Failed to read " + filename + ". Error: ", e);
-        list = null;
       }
     }
 


### PR DESCRIPTION
Follow-on to #4926

My bad 🤦 

When I was removing test code, I forgot to include this removed line on the original PR.
This way, the initialized empty list of lexical models gets returned instead of null.