### PR TITLE
fix(android/engine): Change getList() to return an empty list instead of null 🍒 

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -469,7 +469,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
   // Gets a raw list of installed lexical models.
   @SuppressWarnings("unchecked")
   private static ArrayList<HashMap<String, String>> getList(Context context, String filename) {
-    ArrayList<HashMap<String, String>> list = null;
+    ArrayList<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
     File file = new File(context.getDir("userdata", Context.MODE_PRIVATE), filename);
     if (file.exists()) {
       try {
@@ -478,7 +478,6 @@ public final class KeyboardPickerActivity extends BaseActivity {
         inputStream.close();
       } catch (Exception e) {
         KMLog.LogException(TAG, "Failed to read " + filename + ". Error: ", e);
-        list = null;
       }
     }
 


### PR DESCRIPTION
Cherry-pick of #4926 and #4927 to stable-14.0

This prevents the NullPointerException when an empty lexical model list is then used to query for package updates.