### PR TITLE
fix(linux): Don't crash on network problem (fixes #4911) 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -159,7 +159,11 @@ def download_kmp_file(url, kmpfile, cache=False):
         requests_cache.install_cache(cache_name='keyman_kmp_cache', backend='sqlite', expire_after=expire_after)
         now = time.ctime(int(time.time()))
 
-    response = requests.get(url)  # , stream=True)
+    try:
+        response = requests.get(url)  # , stream=True)
+    except requests.exceptions.ConnectionError:
+        logging.error("Connection error downloading %s", url)
+        return downloadfile
 
     if cache:
         logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))

--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -40,7 +40,7 @@ def download_and_install_package(url):
         logging.error("Invalid URL: " + url)
         return
 
-    if not _install_package(packageFile, bcp47):
+    if packageFile and not _install_package(packageFile, bcp47):
         logging.error("Can't find file " + url)
 
 


### PR DESCRIPTION
If the network is down or the server name can't be resolved we shouldn't crash. This change logs an error instead.

🍒-pick of #4912 