### PR TITLE
refactor(linux): Refactor `install_kmp.py`

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os.path
 import zipfile
-from os import listdir
 from shutil import rmtree
 from enum import Enum
 
@@ -44,8 +43,186 @@ class InstallError(Exception):
         self.message = message
 
 
-def list_files(directory, extension):
-    return (f for f in listdir(directory) if f.endswith('.' + extension))
+class InstallKmp():
+    def __init__(self):
+        self.packageID = ''
+        self.packageDir = ''
+        self.kmpdocdir = ''
+        self.kmpfontdir = ''
+
+    def _check_keyman_dir(basedir, error_message):
+        # check if keyman subdir exists
+        keyman_dir = os.path.join(basedir, "keyman")
+        if os.path.isdir(keyman_dir):
+            # Check for write access of keyman dir to be able to create subdir
+            if not os.access(keyman_dir, os.X_OK | os.W_OK):
+                raise InstallError(InstallStatus.Abort, error_message)
+        else:
+            # Check for write access of basedir and create keyman subdir if we can
+            if not os.access(basedir, os.X_OK | os.W_OK):
+                raise InstallError(InstallStatus.Abort, error_message)
+            os.mkdir(keyman_dir)
+
+    def _extract_package_id(inputfile):
+        packageID, ext = os.path.splitext(os.path.basename(inputfile))
+        return packageID.lower()
+
+    def install_kmp_shared(self, inputfile, online=False, language=None):
+        """
+        Install a kmp file to /usr/local/share/keyman
+
+        Args:
+            inputfile (str): path to kmp file
+            online (bool, default=False): whether to attempt to get online keyboard data
+        """
+        self._check_keyman_dir(
+            '/usr/local/share',
+            _("You do not have permissions to install the keyboard files to the shared area "
+              "/usr/local/share/keyman"))
+        self._check_keyman_dir(
+            '/usr/local/share/doc',
+            _("You do not have permissions to install the documentation to the shared "
+              "documentation area /usr/local/share/doc/keyman"))
+        self._check_keyman_dir(
+            '/usr/local/share/fonts',
+            _("You do not have permissions to install the font files to the shared font area "
+              "/usr/local/share/fonts"))
+
+        self._install_kmp(inputfile, online, language)
+
+    def install_kmp_user(self, inputfile, online=False, language=None):
+        self.packageID = self._extract_package_id(inputfile)
+        self.packageDir = user_keyboard_dir(self.packageID)
+        self.kmpdocdir = self.packageDir
+        self.kmpfontdir = os.path.join(user_keyman_font_dir(), self.packageID)
+
+        self._install_kmp(inputfile, online, language)
+
+    def _install_kmp(self, inputfile, online, language):
+        if not os.path.isdir(self.packageDir):
+            os.makedirs(self.packageDir)
+
+        if not os.path.isfile(inputfile):
+            message = _("File {kmpfile} doesn't exist").format(kmpfile=inputfile)
+            logging.error("install_kmp.py: %s", message)
+            raise InstallError(InstallStatus.Abort, message)
+
+        self.extract_kmp(inputfile, self.packageDir)
+        restart_ibus()
+
+        info, system, options, keyboards, files = get_metadata(self.packageDir)
+
+        if keyboards:
+            logging.info("Installing %s", info['name']['description'])
+            if online:
+                process_keyboard_data(self.packageID, self.packageDir)
+                for kb in keyboards:
+                    if kb['id'] != self.packageID:
+                        process_keyboard_data(kb['id'], self.packageDir)
+
+            for f in files:
+                fpath = os.path.join(self.packageDir, f['name'])
+                ftype = f['type']
+
+                if ftype == KMFileTypes.KM_DOC or ftype == KMFileTypes.KM_IMAGE:
+                    # Special handling of doc and images to hard link them into doc dir
+                    logging.info("Installing %s as documentation", f['name'])
+                    if not os.path.isdir(self.kmpdocdir):
+                        os.makedirs(self.kmpdocdir)
+                    kmpdocpath = os.path.join(self.kmpdocdir, f['name'])
+                    if not os.path.isfile(kmpdocpath):
+                        os.link(fpath, kmpdocpath)
+                elif ftype == KMFileTypes.KM_FONT:
+                    # Special handling of font to hard link it into font dir
+                    logging.info("Installing %s as font", f['name'])
+                    if not os.path.isdir(self.kmpfontdir):
+                        os.makedirs(self.kmpfontdir)
+                    fontpath = os.path.join(self.kmpfontdir, f['name'])
+                    if not os.path.isfile(fontpath):
+                        os.link(fpath, fontpath)
+                elif ftype == KMFileTypes.KM_OSK:
+                    # Special handling to convert kvk into LDML
+                    logging.info("Converting %s to LDML and installing both as as keyman file",
+                                 f['name'])
+                    ldml = convert_kvk_to_ldml(fpath)
+                    name, ext = os.path.splitext(f['name'])
+                    ldmlfile = os.path.join(self.packageDir, name + ".ldml")
+                    output_ldml(ldmlfile, ldml)
+                elif ftype == KMFileTypes.KM_ICON:
+                    # Special handling of icon to convert to PNG
+                    logging.info("Converting %s to PNG and installing both as keyman files",
+                                 f['name'])
+                    checkandsaveico(fpath)
+                elif ftype == KMFileTypes.KM_SOURCE:
+                    # TODO for the moment just leave it for ibus-kmfl to ignore if it doesn't load
+                    pass
+                elif ftype == KMFileTypes.KM_KMX:
+                    # Sanitize keyboard filename if not lower case
+                    kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
+                    for kb in keyboards:
+                        if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
+                            os.rename(os.path.join(self.packageDir, f['name']),
+                                      os.path.join(self.packageDir, kb['id'] + '.kmx'))
+                            fpath = os.path.join(self.packageDir, kb['id'] + '.kmx')
+                    extractico(fpath)
+
+            self.install_keyboards(keyboards, self.packageDir, language)
+        else:
+            logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
+            logging.info("Contents of %s:", inputfile)
+            for o in os.listdir(self.packageDir):
+                logging.info(o)
+            rmtree(self.packageDir)
+            message = _("No kmp.json or kmp.inf found in {packageFile}").format(
+                packageFile=inputfile)
+            raise InstallError(InstallStatus.Abort, message)
+
+    def _normalize_language(self, supportedLanguages, language):
+        if len(supportedLanguages) <= 0:
+            return ''
+
+        if not language:
+            return language
+
+        language = CanonicalLanguageCodeUtils.findBestTag(language, False, True)
+        for supportedLanguage in supportedLanguages:
+            id = CanonicalLanguageCodeUtils.findBestTag(supportedLanguage['id'], False, True)
+            if id == language:
+                return id
+        return None
+
+    def install_keyboards(self, keyboards, packageDir, language=None):
+        firstKeyboard = keyboards[0]
+        if firstKeyboard and 'languages' in firstKeyboard and len(firstKeyboard['languages']) > 0:
+                language = self._normalize_language(firstKeyboard['languages'], language)
+
+        if is_gnome_shell():
+                self._install_keyboards_to_gnome(keyboards, packageDir, language)
+        else:
+                self._install_keyboards_to_ibus(keyboards, packageDir, language)
+
+    def _install_keyboards_to_ibus(self, keyboards, packageDir, language=None):
+        bus = get_ibus_bus()
+        if bus:
+            # install all kmx for first lang not just packageID
+            for kb in keyboards:
+                ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
+                install_to_ibus(bus, ibus_keyboard_id)
+            restart_ibus(bus)
+            bus.destroy()
+        else:
+            logging.debug("could not install keyboards to IBus")
+
+    def _install_keyboards_to_gnome(self, keyboards, packageDir, language=None):
+        gnomeKeyboardsUtil = GnomeKeyboardsUtil()
+        sources = gnomeKeyboardsUtil.read_input_sources()
+
+        # install all kmx for first lang not just packageID
+        for kb in keyboards:
+            ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
+            sources.append(('ibus', ibus_keyboard_id))
+
+        gnomeKeyboardsUtil.write_input_sources(sources)
 
 
 def extract_kmp(kmpfile, directory):
@@ -68,249 +245,6 @@ def process_keyboard_data(keyboardID, packageDir):
     # 	raise InstallError(InstallStatus.Abort, message)
 
 
-def check_keyman_dir(basedir, error_message):
-    # check if keyman subdir exists
-    keyman_dir = os.path.join(basedir, "keyman")
-    if os.path.isdir(keyman_dir):
-        # Check for write access of keyman dir to be able to create subdir
-        if not os.access(keyman_dir, os.X_OK | os.W_OK):
-            raise InstallError(InstallStatus.Abort, error_message)
-    else:
-        # Check for write access of basedir and create keyman subdir if we can
-        if not os.access(basedir, os.X_OK | os.W_OK):
-            raise InstallError(InstallStatus.Abort, error_message)
-        os.mkdir(keyman_dir)
-
-
-def extract_package_id(inputfile):
-    packageID, ext = os.path.splitext(os.path.basename(inputfile))
-    return packageID.lower()
-
-
-def install_kmp_shared(inputfile, online=False, language=None):
-    """
-    Install a kmp file to /usr/local/share/keyman
-
-    Args:
-        inputfile (str): path to kmp file
-        online (bool, default=False): whether to attempt to get online keyboard data
-    """
-    check_keyman_dir(
-        '/usr/local/share',
-        _("You do not have permissions to install the keyboard files to the shared area "
-          "/usr/local/share/keyman"))
-    check_keyman_dir(
-        '/usr/local/share/doc',
-        _("You do not have permissions to install the documentation to the shared "
-          "documentation area /usr/local/share/doc/keyman"))
-    check_keyman_dir(
-        '/usr/local/share/fonts',
-        _("You do not have permissions to install the font files to the shared font area "
-          "/usr/local/share/fonts"))
-
-    packageID = extract_package_id(inputfile)
-    packageDir = os.path.join('/usr/local/share/keyman', packageID)
-    kmpdocdir = os.path.join('/usr/local/share/doc/keyman', packageID)
-    kmpfontdir = os.path.join('/usr/local/share/fonts/keyman', packageID)
-    if not os.path.isdir(packageDir):
-        os.makedirs(packageDir)
-    extract_kmp(inputfile, packageDir)
-    # restart IBus so it knows about the keyboards being installed
-    logging.debug("restarting IBus")
-    restart_ibus()
-    info, system, options, keyboards, files = get_metadata(packageDir)
-
-    if keyboards:
-        logging.info("Installing %s", info['name']['description'])
-        if online:
-            process_keyboard_data(packageID, packageDir)
-            if len(keyboards) > 1:
-                for kb in keyboards:
-                    if kb['id'] != packageID:
-                        process_keyboard_data(kb['id'], packageDir)
-
-        for f in files:
-            fpath = os.path.join(packageDir, f['name'])
-            ftype = f['type']
-            if ftype == KMFileTypes.KM_DOC or ftype == KMFileTypes.KM_IMAGE:
-                # Special handling of doc and images to hard link them into doc dir
-                logging.info("Installing %s as documentation", f['name'])
-                if not os.path.isdir(kmpdocdir):
-                    os.makedirs(kmpdocdir)
-                kmpdocpath = os.path.join(kmpdocdir, f['name'])
-                if not os.path.isfile(kmpdocpath):
-                    os.link(fpath, kmpdocpath)
-            elif ftype == KMFileTypes.KM_FONT:
-                # Special handling of font to hard link it into font dir
-                logging.info("Installing %s as font", f['name'])
-                if not os.path.isdir(kmpfontdir):
-                    os.makedirs(kmpfontdir)
-                kmpfontpath = os.path.join(kmpfontdir, f['name'])
-                if not os.path.isfile(kmpfontpath):
-                    os.link(fpath, kmpfontpath)
-            elif ftype == KMFileTypes.KM_SOURCE:
-                # TODO for the moment just leave it for ibus-kmfl to ignore if it doesn't load
-                logging.info("Installing %s as keyman file", f['name'])
-            elif ftype == KMFileTypes.KM_OSK:
-                # Special handling to convert kvk into LDML
-                logging.info("Converting %s to LDML and installing both as as keyman file",
-                             f['name'])
-                ldml = convert_kvk_to_ldml(fpath)
-                name, ext = os.path.splitext(f['name'])
-                ldmlfile = os.path.join(packageDir, name + ".ldml")
-                output_ldml(ldmlfile, ldml)
-            elif ftype == KMFileTypes.KM_ICON:
-                # Special handling of icon to convert to PNG
-                logging.info("Converting %s to PNG and installing both as keyman files",
-                             f['name'])
-                checkandsaveico(fpath)
-            elif ftype == KMFileTypes.KM_KMX:
-                # Sanitize keyboard filename if not lower case
-                kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
-                for kb in keyboards:
-                    if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
-                        os.rename(os.path.join(packageDir, f['name']),
-                                  os.path.join(packageDir, kb['id'] + '.kmx'))
-                        fpath = os.path.join(packageDir, kb['id'] + '.kmx')
-                extractico(fpath)
-
-        install_keyboards_to_ibus(keyboards, packageDir, language)
-    else:
-        logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
-        logging.info("Contents of %s:", inputfile)
-        for o in os.listdir(packageDir):
-            logging.info(o)
-        rmtree(packageDir)
-        message = _("install_kmp.py: error: No kmp.json or kmp.inf found in {package}").format(package=inputfile)
-        raise InstallError(InstallStatus.Abort, message)
-
-
-def install_kmp_user(inputfile, online=False, language=None):
-    packageID = extract_package_id(inputfile)
-    packageDir = user_keyboard_dir(packageID)
-    if not os.path.isdir(packageDir):
-        os.makedirs(packageDir)
-
-    if not os.path.isfile(inputfile):
-        message = _("File {kmpfile} doesn't exist").format(kmpfile=inputfile)
-        logging.error("install_kmp.py: %s", message)
-        raise InstallError(InstallStatus.Abort, message)
-
-    extract_kmp(inputfile, packageDir)
-    restart_ibus()
-
-    info, system, options, keyboards, files = get_metadata(packageDir)
-
-    if keyboards:
-        logging.info("Installing %s", info['name']['description'])
-        if online:
-            process_keyboard_data(packageID, packageDir)
-            if len(keyboards) > 1:
-                for kb in keyboards:
-                    if kb['id'] != packageID:
-                        process_keyboard_data(kb['id'], packageDir)
-
-        for f in files:
-            fpath = os.path.join(packageDir, f['name'])
-            ftype = f['type']
-            if ftype == KMFileTypes.KM_FONT:
-                # Special handling of font to hard link it into font dir
-                fontsdir = os.path.join(user_keyman_font_dir(), packageID)
-                if not os.path.isdir(fontsdir):
-                    os.makedirs(fontsdir)
-                fontpath = os.path.join(fontsdir, f['name'])
-                if not os.path.isfile(fontpath):
-                    os.link(fpath, fontpath)
-                logging.info("Installing %s as font", f['name'])
-            elif ftype == KMFileTypes.KM_OSK:
-                # Special handling to convert kvk into LDML
-                logging.info("Converting %s to LDML and installing both as as keyman file",
-                             f['name'])
-                ldml = convert_kvk_to_ldml(fpath)
-                name, ext = os.path.splitext(f['name'])
-                ldmlfile = os.path.join(packageDir, name + ".ldml")
-                output_ldml(ldmlfile, ldml)
-            elif ftype == KMFileTypes.KM_ICON:
-                # Special handling of icon to convert to PNG
-                logging.info("Converting %s to PNG and installing both as keyman files",
-                             f['name'])
-                checkandsaveico(fpath)
-            elif ftype == KMFileTypes.KM_SOURCE:
-                # TODO for the moment just leave it for ibus-kmfl to ignore if it doesn't load
-                pass
-            elif ftype == KMFileTypes.KM_KMX:
-                # Sanitize keyboard filename if not lower case
-                kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
-                for kb in keyboards:
-                    if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
-                        os.rename(os.path.join(packageDir, f['name']),
-                                  os.path.join(packageDir, kb['id'] + '.kmx'))
-                        fpath = os.path.join(packageDir, kb['id'] + '.kmx')
-                extractico(fpath)
-
-        install_keyboards(keyboards, packageDir, language)
-    else:
-        logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
-        logging.info("Contents of %s:", inputfile)
-        for o in os.listdir(packageDir):
-            logging.info(o)
-        rmtree(packageDir)
-        message = _("No kmp.json or kmp.inf found in {packageFile}").format(
-            packageFile=inputfile)
-        raise InstallError(InstallStatus.Abort, message)
-
-
-def _normalize_language(supportedLanguages, language):
-    if len(supportedLanguages) <= 0:
-        return ''
-
-    if not language:
-        return language
-
-    language = CanonicalLanguageCodeUtils.findBestTag(language, False, True)
-    for supportedLanguage in supportedLanguages:
-        id = CanonicalLanguageCodeUtils.findBestTag(supportedLanguage['id'], False, True)
-        if id == language:
-            return id
-    return None
-
-
-def install_keyboards(keyboards, packageDir, language=None):
-    firstKeyboard = keyboards[0]
-    if firstKeyboard and 'languages' in firstKeyboard and len(firstKeyboard['languages']) > 0:
-        language = _normalize_language(firstKeyboard['languages'], language)
-
-    if is_gnome_shell():
-        install_keyboards_to_gnome(keyboards, packageDir, language)
-    else:
-        install_keyboards_to_ibus(keyboards, packageDir, language)
-
-
-def install_keyboards_to_ibus(keyboards, packageDir, language=None):
-    bus = get_ibus_bus()
-    if bus:
-        # install all kmx for first lang not just packageID
-        for kb in keyboards:
-            ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
-            install_to_ibus(bus, ibus_keyboard_id)
-        restart_ibus(bus)
-        bus.destroy()
-    else:
-        logging.debug("could not install keyboards to IBus")
-
-
-def install_keyboards_to_gnome(keyboards, packageDir, language=None):
-    gnomeKeyboardsUtil = GnomeKeyboardsUtil()
-    sources = gnomeKeyboardsUtil.read_input_sources()
-
-    # install all kmx for first lang not just packageID
-    for kb in keyboards:
-        ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
-        sources.append(('ibus', ibus_keyboard_id))
-
-    gnomeKeyboardsUtil.write_input_sources(sources)
-
-
 def install_kmp(inputfile, online=False, sharedarea=False, language=None):
     """
     Install a kmp file
@@ -321,6 +255,6 @@ def install_kmp(inputfile, online=False, sharedarea=False, language=None):
         sharedarea(bool, default=False): whether install kmp to shared area or user directory
     """
     if sharedarea:
-        install_kmp_shared(inputfile, online, language)
+        InstallKmp().install_kmp_shared(inputfile, online, language)
     else:
-        install_kmp_user(inputfile, online, language)
+        InstallKmp().install_kmp_user(inputfile, online, language)

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -2,8 +2,7 @@
 import unittest
 from unittest.mock import patch, ANY
 
-from keyman_config.install_kmp import install_keyboards_to_ibus, install_keyboards_to_gnome, \
-    _normalize_language
+from keyman_config.install_kmp import InstallKmp
 
 
 class InstallKmpTests(unittest.TestCase):
@@ -26,7 +25,7 @@ class InstallKmpTests(unittest.TestCase):
         # Setup
         self.mockGetIbusBus.return_value = None
         # Execute
-        install_keyboards_to_ibus([], None)
+        InstallKmp()._install_keyboards_to_ibus([], None)
         # Verify
         self.mockRestartIbus.assert_not_called()
 
@@ -35,7 +34,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1'}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir')
         # Verify
         self.mockInstallToIbus.assert_called_once_with(ANY, 'fooDir/foo1.kmx')
         self.mockRestartIbus.assert_called_once()
@@ -46,7 +45,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1'}, {'id': 'foo2'}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir')
         # Verify
         self.mockInstallToIbus.assert_any_call(ANY, 'fooDir/foo1.kmx')
         self.mockInstallToIbus.assert_any_call(ANY, 'fooDir/foo2.kmx')
@@ -58,7 +57,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}]}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir')
         # Verify
         self.mockInstallToIbus.assert_called_once_with(ANY, 'en:fooDir/foo1.kmx')
         self.mockRestartIbus.assert_called_once()
@@ -69,7 +68,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir')
         # Verify
         self.mockInstallToIbus.assert_called_once()
         self.mockInstallToIbus.assert_called_with(ANY, 'en:fooDir/foo1.kmx')
@@ -82,7 +81,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir', 'fr')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir', 'fr')
         # Verify
         self.mockInstallToIbus.assert_called_once()
         self.mockInstallToIbus.assert_called_with(ANY, 'fr:fooDir/foo1.kmx')
@@ -95,7 +94,7 @@ class InstallKmpTests(unittest.TestCase):
         bus = self.mockGetIbusBus.return_value
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_ibus(keyboards, 'fooDir', 'de')
+        InstallKmp()._install_keyboards_to_ibus(keyboards, 'fooDir', 'de')
         # Verify
         self.mockInstallToIbus.assert_called_once()
         self.mockInstallToIbus.assert_called_with(ANY, 'de:fooDir/foo1.kmx')
@@ -109,7 +108,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1'}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx')])
@@ -121,7 +120,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1'}, {'id': 'foo2'}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')])
@@ -133,7 +132,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}]}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')])
@@ -145,7 +144,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')])
@@ -157,7 +156,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir', 'fr')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir', 'fr')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')])
@@ -169,7 +168,7 @@ class InstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [('xkb', 'en')]
         keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
         # Execute
-        install_keyboards_to_gnome(keyboards, 'fooDir', 'de')
+        InstallKmp()._install_keyboards_to_gnome(keyboards, 'fooDir', 'de')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
             [('xkb', 'en'), ('ibus', 'de:fooDir/foo1.kmx')])
@@ -196,7 +195,7 @@ class InstallKmpTests(unittest.TestCase):
         ]:
             with self.subTest(data = data):
                 # Execute
-                result = _normalize_language(languages, data['given'])
+                result = InstallKmp()._normalize_language(languages, data['given'])
 
                 # Verify
                 self.assertEqual(result, data['expected'])
@@ -206,7 +205,7 @@ class InstallKmpTests(unittest.TestCase):
         languages = []
 
         # Execute
-        result = _normalize_language(languages, 'en')
+        result = InstallKmp()._normalize_language(languages, 'en')
 
         # Verify
         self.assertEqual(result, '')


### PR DESCRIPTION
- Introduce `InstallKmp` class
- Remove unused `list_files` method
- Extract common method that `install_kmp_shared` and `install_kmp_user` use
- Make internal methods protected