### PR TITLE
fix(web, ios): better SMP, emoji handling with frequent keyboard swaps

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -246,6 +246,12 @@ namespace com.keyman.keyboards {
       return true;
     }
 
+    get usesSupplementaryPlaneChars(): boolean {
+      let kbd = this.scriptObject;
+      // I3319 - SMP extension, I3363 (Build 301)
+      return kbd && ((kbd['KS'] && kbd['KS'] == 1) || kbd['KN'] == 'Hieroglyphic');
+    }
+
     usesDesktopLayoutOnDevice(device: utils.DeviceSpec) {
       if(this.scriptObject['KVKL']) {
         // A custom mobile layout is defined... but are we using it?

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -588,9 +588,6 @@ namespace com.keyman.keyboards {
         this.keymanweb.domManager._SetTargDir(this.keymanweb.domManager.getLastActiveElement());  // I2077 - LTR/RTL timing
       }
 
-      var Pk=keyman.core.activeKeyboard;  // I3319
-      String.kmwEnableSupplementaryPlane(true);
-
       // Initialize the OSK (provided that the base code has been loaded)
       osk._Load();
       return Promise.resolve();
@@ -661,8 +658,6 @@ namespace com.keyman.keyboards {
               manager.keymanweb.uiManager.justActivated = true; // TODO:  Resolve without need for the cast.
               manager.keymanweb.domManager._SetTargDir(manager.keymanweb.domManager.getLastActiveElement());
             }
-
-            String.kmwEnableSupplementaryPlane(true);
             
             manager.saveCurrentKeyboard(kbd['KI'], kbdStub['KLC']);
 

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -589,9 +589,11 @@ namespace com.keyman.keyboards {
       }
 
       var Pk=keyman.core.activeKeyboard;  // I3319
-      if(Pk !== null)  // I3363 (Build 301)
-        Pk = Pk.scriptObject;
-        String.kmwEnableSupplementaryPlane(Pk && ((Pk['KS'] && (Pk['KS'] == 1)) || (Pk['KN'] == 'Hieroglyphic'))); // I3319
+      if(Pk !== null) { // I3363 (Build 301)
+        // For embedded devices, we should consider that the user may keyboard-swap.
+        // See https://github.com/keymanapp/keyman/issues/4868 for one example issue.
+        String.kmwEnableSupplementaryPlane(keyman.isEmbedded || Pk.usesSupplementaryPlaneChars); // I3319
+      }
 
       // Initialize the OSK (provided that the base code has been loaded)
       osk._Load();
@@ -664,7 +666,11 @@ namespace com.keyman.keyboards {
               manager.keymanweb.domManager._SetTargDir(manager.keymanweb.domManager.getLastActiveElement());
             }
 
-            String.kmwEnableSupplementaryPlane(kbd && ((kbd['KS'] && kbd['KS'] == 1) || kbd['KN'] == 'Hieroglyphic')); // I3319 - SMP extension, I3363 (Build 301)
+            // For embedded devices, we should consider that the user may keyboard-swap.
+            // See https://github.com/keymanapp/keyman/issues/4868 for one example issue.
+            let keyman = com.keyman.singleton;
+            String.kmwEnableSupplementaryPlane(keyman.isEmbedded || core.activeKeyboard.usesSupplementaryPlaneChars);
+            
             manager.saveCurrentKeyboard(kbd['KI'], kbdStub['KLC']);
 
             // Prepare and show the OSK for this keyboard

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -589,11 +589,7 @@ namespace com.keyman.keyboards {
       }
 
       var Pk=keyman.core.activeKeyboard;  // I3319
-      if(Pk !== null) { // I3363 (Build 301)
-        // For embedded devices, we should consider that the user may keyboard-swap.
-        // See https://github.com/keymanapp/keyman/issues/4868 for one example issue.
-        String.kmwEnableSupplementaryPlane(keyman.isEmbedded || Pk.usesSupplementaryPlaneChars); // I3319
-      }
+      String.kmwEnableSupplementaryPlane(true);
 
       // Initialize the OSK (provided that the base code has been loaded)
       osk._Load();
@@ -666,10 +662,7 @@ namespace com.keyman.keyboards {
               manager.keymanweb.domManager._SetTargDir(manager.keymanweb.domManager.getLastActiveElement());
             }
 
-            // For embedded devices, we should consider that the user may keyboard-swap.
-            // See https://github.com/keymanapp/keyman/issues/4868 for one example issue.
-            let keyman = com.keyman.singleton;
-            String.kmwEnableSupplementaryPlane(keyman.isEmbedded || core.activeKeyboard.usesSupplementaryPlaneChars);
+            String.kmwEnableSupplementaryPlane(true);
             
             manager.saveCurrentKeyboard(kbd['KI'], kbdStub['KLC']);
 

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -133,7 +133,7 @@ if(!window['keyman']['initialized']) {
     util.attachDOMEvent(window, 'blur', keymanweb['pageFocusHandler'], false);   // I775
     
     // Initialize supplementary plane string extensions
-    String.kmwEnableSupplementaryPlane(false);    
+    String.kmwEnableSupplementaryPlane(true);    
 
   })();
 }


### PR DESCRIPTION
Fixes #4868.  No Android-specific changes appear to be needed, though extra testing in that regard would be wise.

------

When in scenarios where users may frequently swap keyboards - especially between keyboards where some use SMP characters but some don't - attempting to backspace into context typed by previous keyboards can prove tricky if trying to optimize out SMP logic.  This was done far in the past for performance reasons, but the additional complexity it brings (and the resulting bugs, like #4868) is no longer worth it.  For comparison, while testing the iOS changes, I noted that Apple's default backspace handling function near-certainly always makes SMP checks.

Permanently enabling KMW's SMP processing logic is the first step.  However, within our iOS engine, it turns out additional work was needed to properly delete some emojis, such as skintoned variants, which are represented as multiple combining code points - many of which are themselves comprised of two code units.  Apple's default backspace auto-removes the entire combining set, rather than a single code point of the multi-point emoji... something that KMW is simply not equipped to do right now.  So, to ensure proper context synchronization, we ensure that only the part KMW knows to delete is deleted.

------

## User Testing
@MakaraSok 

Test out how well Keyman + predictive text work with pre-existing context.

1.  Before activating Keyman, type "hello the ", then add the emoji "👍🏻".  So, `hello the 👍🏻`.
2. Activate Keyman and set `sil_euro_latin` as the active keyboard.
3. Hit backspace.  `hello the 👍` should result.  (Note the different skintone.)
4. Hit backspace twice more.  `hello the` should result, along with suggestions prefixed with "the".
5. Apply a suggestion.  As `there` is usually available, pick that one if possible - `hello there ` should result.

Test some similar pre-existing strings, possibly with multiple emoji in sequence after some typed text.  Ensure that when the caret does reach the end of a word, appropriate suggestions result (if any appear).  Applying suggestions should give the expected result.