### PR TITLE
fix(windows): avoid error if keyman32.dll renamed

### DIFF
--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -554,9 +554,10 @@ begin
 {$IFDEF WIN64}
   Error(Cardinal(E_NOTIMPL));
 {$ELSE}
-  LoadKeyman32;
-  if not FKeyman_UnregisterControllerWindow(Value) then
-    Error(KMN_E_KeymanControl_CannotUnregisterControllerWindow);
+  if hlibKeyman32 = 0 then
+    KL.LogError('UnregisterControllerWindow: keyman32.dll is not loaded')
+  else if not FKeyman_UnregisterControllerWindow(Value) then
+    KL.LogError('UnregisterControllerWindow: Could not unregister controller window %x', [Value]);
 {$ENDIF}
 end;
 


### PR DESCRIPTION
Fixes #4939.
Fixes KEYMAN-WINDOWS-70.
Fixes KEYMAN-WINDOWS-71.
Fixes KEYMAN-WINDOWS-BR.
Fixes KEYMAN-WINDOWS-6J.

I am speculating a little here, because the root cause is not visible in the crash report, but it appears that if keyman32.dll is renamed, that the UnregisterControllerWindows function attempts to reload keyman32.dll which means that (a) it no longer has a list of registered controllers, and (b) it may fail to reload.

Instead of throwing an exception, we now only log this error in development mode. The error is not likely to cause significant trouble for end users as they are shutting down Keyman anyway at this point.

The resolution if there is any uncertainty during an upgrade is to restart Windows. This is less than ideal but avoids file locks and problems with in-memory DLLs. (Future versions of Keyman will schedule upgrades to happen automatically after a restart before Keyman has been started, in an effort to avoid this kind of trauma.)