### PR TITLE
fix(web): publish restorePosition() function

### DIFF
--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -474,7 +474,7 @@ namespace com.keyman.osk {
      * Scope        Public
      * Description  Move OSK back to default position, floating under active input element
      */
-    restorePosition: () => void = function(this: OSKManager) {
+    ['restorePosition']: () => void = function(this: OSKManager) {
       let isVisible = this._Visible;
       if(isVisible) {
         com.keyman.singleton.domManager.focusLastActiveElement();  // I2036 - OSK does not unpin to correct location

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -414,7 +414,7 @@ namespace com.keyman.osk {
       Limg.id='kmw-pin-image';
       Limg.className='kmw-title-bar-image';
       Limg.title='Pin the On Screen Keyboard to its default location on the active text box';
-      Limg.onclick=this.restorePosition;
+      Limg.onclick=this.handlePinClick;
       Limg.onmousedown=util._CancelMouse;
       bar.appendChild(Limg);
 
@@ -469,12 +469,21 @@ namespace com.keyman.osk {
         +'<span style="font-size:0.8em">Copyright &copy; 2017 SIL International</span>');
     }
 
+    private handlePinClick: (event: Event) => void = function(this: OSKManager, event: Event) {
+      this.restorePosition(true);
+      if(event) {
+        event.returnValue = false;
+      }
+    }.bind(this);
+
     /**
      * Function     restorePosition
      * Scope        Public
+     * @param       {boolean?}      keepDefaultPosition  If true, does not reset the default x,y set by `setRect`.
+     *                                                   If false or omitted, resets the default x,y as well.
      * Description  Move OSK back to default position, floating under active input element
      */
-    ['restorePosition']: () => void = function(this: OSKManager) {
+    ['restorePosition']: (keepDefaultPosition?: boolean) => void = function(this: OSKManager, keepDefaultPosition?: boolean) {
       let isVisible = this._Visible;
       if(isVisible) {
         com.keyman.singleton.domManager.focusLastActiveElement();  // I2036 - OSK does not unpin to correct location
@@ -482,6 +491,10 @@ namespace com.keyman.osk {
 
       this.loadCookie();
       this.userPositioned=false;
+      if(!keepDefaultPosition) {
+        delete this.dfltX;
+        delete this.dfltY;
+      }
       this.saveCookie();
 
       if(isVisible) {
@@ -491,9 +504,6 @@ namespace com.keyman.osk {
       this.doResizeMove(); //allow the UI to respond to OSK movements
       if(this.pinImg) {
         this.pinImg.style.display='none';
-      }
-      if(window.event) {
-        window.event.returnValue=false;
       }
     }.bind(this);
 
@@ -532,7 +542,7 @@ namespace com.keyman.osk {
       Limg = this.pinImg = util._CreateElement('div');  //I2186
       Limg.className='kmw-pin-image';
       Limg.title='Pin the On Screen Keyboard to its default location on the active text box';
-      Limg.onclick=this.restorePosition;
+      Limg.onclick=this.handlePinClick;
       Limg.onmousedown=util._CancelMouse;
       Limg.style.display='none';
 

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -469,13 +469,6 @@ namespace com.keyman.osk {
         +'<span style="font-size:0.8em">Copyright &copy; 2017 SIL International</span>');
     }
 
-    private handlePinClick: (event: Event) => void = function(this: OSKManager, event: Event) {
-      this.restorePosition(true);
-      if(event) {
-        event.returnValue = false;
-      }
-    }.bind(this);
-
     /**
      * Function     restorePosition
      * Scope        Public
@@ -504,6 +497,13 @@ namespace com.keyman.osk {
       this.doResizeMove(); //allow the UI to respond to OSK movements
       if(this.pinImg) {
         this.pinImg.style.display='none';
+      }
+    }.bind(this);
+
+    private handlePinClick: (event: Event) => void = function(this: OSKManager, event: Event) {
+      this.restorePosition(true);
+      if(event) {
+        event.returnValue = false;
       }
     }.bind(this);
 

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -354,6 +354,7 @@ namespace com.keyman.osk {
      * Create a control bar with title and buttons for the desktop OSK
      */
     controlBar(): HTMLDivElement {
+      // TODO: merge with _TitleBarInterior?
       let keymanweb = com.keyman.singleton;
       let util = keymanweb.util;
 
@@ -413,20 +414,7 @@ namespace com.keyman.osk {
       Limg.id='kmw-pin-image';
       Limg.className='kmw-title-bar-image';
       Limg.title='Pin the On Screen Keyboard to its default location on the active text box';
-      Limg.onclick=function(this: OSKManager) {
-        this.loadCookie();
-        this.userPositioned=false;
-        this.saveCookie();
-        this._Show();
-        this.doResizeMove(); //allow the UI to respond to OSK movements
-        if(this.pinImg) {
-          this.pinImg.style.display='none';
-        }
-        if(window.event) {
-          window.event.returnValue=false;
-        }
-        return false;
-      }.bind(this);
+      Limg.onclick=this.restorePosition;
       Limg.onmousedown=util._CancelMouse;
       bar.appendChild(Limg);
 
@@ -482,17 +470,25 @@ namespace com.keyman.osk {
     }
 
     /**
-     * Move OSK back to default position
+     * Function     restorePosition
+     * Scope        Public
+     * Description  Move OSK back to default position, floating under active input element
      */
     restorePosition: () => void = function(this: OSKManager) {
-      if(this._Visible) {
+      let isVisible = this._Visible;
+      if(isVisible) {
         com.keyman.singleton.domManager.focusLastActiveElement();  // I2036 - OSK does not unpin to correct location
-        this.loadCookie();
-        this.userPositioned=false;
-        this.saveCookie();
-        this._Show();
-        this.doResizeMove(); //allow the UI to respond to OSK movements
       }
+
+      this.loadCookie();
+      this.userPositioned=false;
+      this.saveCookie();
+
+      if(isVisible) {
+        this._Show();
+      }
+
+      this.doResizeMove(); //allow the UI to respond to OSK movements
       if(this.pinImg) {
         this.pinImg.style.display='none';
       }

--- a/web/testing/index.html
+++ b/web/testing/index.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match iOS device widths -->                         
+
+    <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Testing</title>
-    <style type='text/css'>   
+    <style type='text/css'>
       body {padding-left:20px;margin-left:12px; font-family:Tahoma,Helvetica}
       h1 {color: #800;margin-left:10px;}
       h2 {color: #008;margin-left:20px;}
@@ -32,6 +32,7 @@
   <h2><a href="./toolbar/">Toolbar UI testing</a></h2>
   <h2><a href="./build-visual-keyboard/">Tests keyboard documentation rendering.</a></h2>
   <h2><a href="./sentry-integration/">Tests Sentry error-reporting functionality</a></h2>
+  <h2><a href="./osk-movement/">Test page for osk setRect() and restorePosition() interaction</a></h2>
   <h1>Auto-attachment mode tests</h1>
   <h2><a href="./issue29">Test desktop MutationObserver functionality</a></h2>
   <h2><a href="./issue62">Light test for touch-based MutationObserver functionality</a></h2>

--- a/web/testing/osk-movement/index.html
+++ b/web/testing/osk-movement/index.html
@@ -2,102 +2,108 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match phone and tablet device widths -->                         
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
 
     <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
-    <!-- Your page CSS --> 
-    <style type='text/css'>   
+    <!-- Your page CSS -->
+    <style type='text/css'>
       body {font-family: Tahoma,helvetica;}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
-      #KeymanWebControl {width:50%;min-width:600px;}       
-    </style> 
- 
-    <!-- Insert uncompiled KeymanWeb source scripts -->              
-    <script src="../release/unminified/web/keymanweb.js" type="application/javascript"></script>
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
 
-    <!-- 
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../release/unminified/web/keymanweb.js" type="application/javascript"></script>
+
+    <!--
       For desktop browsers, a script for the user interface must be inserted here.
-       
-      Standard UIs are toggle, button, float and toolbar.  
-      The toolbar UI is best for any page designed to support keyboards for 
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
       a large number of languages.
     -->
-    <script src="../release/unminified/web/kmwuitoggle.js"></script>
- 
+    <script src="../../release/unminified/web/kmwuitoggle.js"></script>
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       var kmw=window.keyman;
       kmw.init({
 		    attachType:'auto'
       }).then(function() {
-        loadKeyboards();
+        loadKeyboards(1);
       });
-    </script> 
-    
+    </script>
+
     <!-- Add keyboard management script for local selection of keyboards to use -->
-    <script src="commonHeader.js"></script>
-  
+    <script src="../commonHeader.js"></script>
+
   </head>
 
-<!-- Sample page HTML -->  
-  <body> 
+<!-- Sample page HTML -->
+  <body>
     <h2>KeymanWeb Sample Page - Unminified Source</h2>
 
     <div>
-    <!-- 
+    <!--
       The following DIV is used to position the Button or Toolbar User Interfaces on the page.
       If omitted, those User Interfaces will appear at the top of the document body.
       (It is ignored by other User Interfaces.)
     -->
-    <div id='KeymanWebControl'></div>                                                                                   
+    <div id='KeymanWebControl'></div>
 
     <h3>Type in your language in this text area:</h3>
     <textarea id='ta1' class='test' placeholder='Type here'></textarea>
-  
+
     <h3>or in this input field:</h3>
     <input class='test' value='' placeholder='or here'/>
-    
+
     <!--  The following elements show how the language menu can be dynamically extended at any time -->
     <h3>Add a keyboard by keyboard name:</h3>
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
- 
+
     <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 
     <h3>Add a keyboard by language name:</h3>
     <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
-    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />
 
     <h3><a href="./">Return to testing home page</a></h3>
+
+    <h3>Control keyboard position</h3>
+    <input type='button' onclick='keyman.osk.restorePosition(true);document.getElementById("ta1").focus();' value='restorePosition(true)' />
+    <input type='button' onclick='keyman.osk.restorePosition(false);document.getElementById("ta1").focus();' value='restorePosition(false)' />
+    <input type='button' onclick='keyman.osk.restorePosition();document.getElementById("ta1").focus();' value='restorePosition()' />
+    <input type='button' onclick='keyman.osk.setRect({left:16, top:16});document.getElementById("ta1").focus();' value='setRect(16,16)' />
   </div>
 
   </body>
-  
-  <!-- 
+
+  <!--
     *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
     *
     * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
-    * to display the special characters used in the On-Screen Keyboard. 
-    * 
-    * To work around this Firefox bug, navigate to <b>about:config</b> 
-    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b> 
-    * while testing. 
-    * 
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
     * Firefox resolves website-based CSS URI references correctly without needing
     * any configuration change, so this change should only be made for file-based testing.
-    *   
-    ***   
-  -->     
+    *
+    ***
+  -->
 </html>

--- a/web/testing/unminified.html
+++ b/web/testing/unminified.html
@@ -2,38 +2,38 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match phone and tablet device widths -->                         
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
 
     <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
-    <!-- Your page CSS --> 
-    <style type='text/css'>   
+    <!-- Your page CSS -->
+    <style type='text/css'>
       body {font-family: Tahoma,helvetica;}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
-      #KeymanWebControl {width:50%;min-width:600px;}       
-    </style> 
- 
-    <!-- Insert uncompiled KeymanWeb source scripts -->              
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
     <script src="../release/unminified/web/keymanweb.js" type="application/javascript"></script>
 
-    <!-- 
+    <!--
       For desktop browsers, a script for the user interface must be inserted here.
-       
-      Standard UIs are toggle, button, float and toolbar.  
-      The toolbar UI is best for any page designed to support keyboards for 
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
       a large number of languages.
     -->
     <script src="../release/unminified/web/kmwuitoggle.js"></script>
- 
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       var kmw=window.keyman;
@@ -42,62 +42,68 @@
       }).then(function() {
         loadKeyboards();
       });
-    </script> 
-    
+    </script>
+
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <script src="commonHeader.js"></script>
-  
+
   </head>
 
-<!-- Sample page HTML -->  
-  <body> 
+<!-- Sample page HTML -->
+  <body>
     <h2>KeymanWeb Sample Page - Unminified Source</h2>
 
     <div>
-    <!-- 
+    <!--
       The following DIV is used to position the Button or Toolbar User Interfaces on the page.
       If omitted, those User Interfaces will appear at the top of the document body.
       (It is ignored by other User Interfaces.)
     -->
-    <div id='KeymanWebControl'></div>                                                                                   
+    <div id='KeymanWebControl'></div>
 
     <h3>Type in your language in this text area:</h3>
     <textarea id='ta1' class='test' placeholder='Type here'></textarea>
-  
+
     <h3>or in this input field:</h3>
     <input class='test' value='' placeholder='or here'/>
-    
+
     <!--  The following elements show how the language menu can be dynamically extended at any time -->
     <h3>Add a keyboard by keyboard name:</h3>
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
     <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
- 
+
     <h3>Add a keyboard by BCP-47 language code:</h3>
     <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
     <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
 
     <h3>Add a keyboard by language name:</h3>
     <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
-    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />   
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />
 
     <h3><a href="./">Return to testing home page</a></h3>
+
+    <h3>Control keyboard position</h3>
+    <input type='button' onclick='keyman.osk.restorePosition(true);document.getElementById("ta1").focus();' value='restorePosition(true)' />
+    <input type='button' onclick='keyman.osk.restorePosition(false);document.getElementById("ta1").focus();' value='restorePosition(false)' />
+    <input type='button' onclick='keyman.osk.restorePosition();document.getElementById("ta1").focus();' value='restorePosition()' />
+    <input type='button' onclick='keyman.osk.setRect({left:16, top:16});document.getElementById("ta1").focus();' value='setRect(16,16)' />
   </div>
 
   </body>
-  
-  <!-- 
+
+  <!--
     *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
     *
     * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
-    * to display the special characters used in the On-Screen Keyboard. 
-    * 
-    * To work around this Firefox bug, navigate to <b>about:config</b> 
-    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b> 
-    * while testing. 
-    * 
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
     * Firefox resolves website-based CSS URI references correctly without needing
     * any configuration change, so this change should only be made for file-based testing.
-    *   
-    ***   
-  -->     
+    *
+    ***
+  -->
 </html>


### PR DESCRIPTION
This makes the `osk.restorePosition()` function public and makes it work even if the OSK is not presently visible. Also DRY out the repeated implementation.

Also fixes #4948.

Inspired by https://community.software.sil.org/t/keyboard-location/4655/10 and will cherry-pick to stable-14.0 upon approval. Will also update help.keyman.com shortly and reference this PR there.

Note, I have not tried to DRY out the rest of the `_TitleBarInterior()`/`controlBar()` chaos but certainly worth doing.