### PR TITLE
fix(oem/fv/android): Migrate keyboard list from 12.0 to 14.0 🍒 

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -37,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
         new FVShared(this);
 
         FVShared.getInstance().upgradeTo12();
+        FVShared.getInstance().upgradeTo14();
         FVShared.getInstance().preloadPackages();
 
         if (BuildConfig.DEBUG) {


### PR DESCRIPTION
Cherry-pick #4951 to stable-14.0 for the FV Android app

This migrates the packageID to "fv_all" and OSK font of the installed keyboards list.
