### PR TITLE
fix(web): fixes subkey lookup for fat-finger processing

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -32,6 +32,8 @@ namespace com.keyman.keyboards {
     proportionalX: number;
     proportionalWidth: number;
 
+    sk?: ActiveKey[];
+
     // Keeping things simple here, as this was added LATE in 14.0 beta.
     // Could definitely extend in the future to instead return an object
     // that denotes the 'nature' of the key.
@@ -218,6 +220,18 @@ namespace com.keyman.keyboards {
       }
 
       return Lkc;
+    }
+
+    public getSubkey(id: string): ActiveKey {
+      if(this.sk) {
+        for(let key of this.sk) {
+          if(key.id == id) {
+            return key;
+          }
+        }
+      }
+
+      return null;
     }
   }
 
@@ -570,7 +584,13 @@ namespace com.keyman.keyboards {
         keyId = keyId.replace(this.id + '-', '');
       }
 
-      return this.keyMap[keyId];
+      let idComponents = keyId.split('::');
+      if(idComponents.length > 1) {
+        let baseKey = this.keyMap[idComponents[0]];
+        return baseKey.getSubkey(idComponents[1]);
+      } else {
+        return this.keyMap[keyId];
+      }
     }
   }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1090,6 +1090,9 @@ namespace com.keyman.osk {
         if(popupKeyID == baseKeyID) {
           baseKeyMass += popupKeyMass;
           popupKeyMass = 0;
+        } else {
+          // We namespace it so that lookup operations know to find it via its base key.
+          popupKeyID = `${baseKeyID}::${popupKeyID}`;
         }
 
         // Compute the normalization factor


### PR DESCRIPTION
Fixes one part of #4953 - from the third screenshot onward.

Turns out that subkeys couldn't be "looked up" during fat-finger alternate computation, so their entries were never available as prediction roots.  This is easily fixed by 'namespacing' popup key IDs in order to forward the lookup operation appropriately.