### PR TITLE
feat(linux): Improve Sentry crash reporting 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -1,5 +1,7 @@
+import getpass
 import gettext
 import importlib
+import logging
 import os.path
 import platform
 import sys
@@ -44,15 +46,22 @@ else:
     try:
         # Try new sentry-sdk first
         sentry_sdk = importlib.import_module('sentry_sdk')
-        from sentry_sdk import configure_scope
+        from sentry_sdk import configure_scope, set_user
+        from sentry_sdk.integrations.logging import LoggingIntegration
         HaveSentryNewSdk = True
 
+        sentry_logging = LoggingIntegration(
+            level=logging.INFO,          # Capture info and above as breadcrumbs
+            event_level=logging.CRITICAL # Send critical errors as events
+        )
         SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357@sentry.keyman.com/12"
         sentry_sdk.init(
             dsn=SentryUrl,
             environment=__environment__,
             release=__version__,
+            integrations=[sentry_logging],
         )
+        set_user({'id': hash(getpass.getuser())})
         with configure_scope() as scope:
             scope.set_tag("app", os.path.basename(sys.argv[0]))
             scope.set_tag("pkgversion", __pkgversion__)
@@ -68,6 +77,7 @@ else:
 
             SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@sentry.keyman.com/12"
             client = Client(SentryUrl, environment=__environment__, release=__version__)
+            client.user_context({'id': hash(getpass.getuser())})
             client.tags_context({
                 'app': os.path.basename(sys.argv[0]),
                 'pkgversion': __pkgversion__,

--- a/linux/keyman-config/keyman_config/convertico.py
+++ b/linux/keyman-config/keyman_config/convertico.py
@@ -50,7 +50,7 @@ def checkandsaveico(icofile):
         # Using .bmp.png file extension so it won't conflict if the package already contains .png
         im4.save(bmpfile + '.png', 'png')
     except (IOError, OSError):
-        logging.error("Cannot convert %s to png", icofile)
+        logging.critical("Cannot convert %s to png", icofile)
         pass
     finally:
         # Clean up intermediary .bmp file if it was generated

--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -23,12 +23,12 @@ def download_and_install_package(url):
     if parsedUrl.scheme == 'keyman':
         logging.info("downloading " + url)
         if not url.startswith('keyman://download/keyboard/'):
-            logging.error("Don't know what to do with URL " + url)
+            logging.critical("Don't know what to do with URL " + url)
             return
 
         packageId = parsedUrl.path[len('/keyboard/'):]
         if not packageId:
-            logging.error("Missing package id")
+            logging.critical("Missing package id")
             return
 
         downloadFile = os.path.join(get_download_folder(), packageId)
@@ -37,11 +37,11 @@ def download_and_install_package(url):
     elif parsedUrl.scheme == '' or parsedUrl.scheme == 'file':
         packageFile = parsedUrl.path
     else:
-        logging.error("Invalid URL: " + url)
+        logging.critical("Invalid URL: " + url)
         return
 
     if packageFile and not _install_package(packageFile, bcp47):
-        logging.error("Can't find file " + url)
+        logging.critical("Can't find file " + url)
 
 
 def _extract_bcp47(query):

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -445,7 +445,7 @@ def parsemetadata(jsonfile, verbose=False):
             try:
                 data = json.load(read_file)
             except JSONDecodeError as e:
-                logging.error("parsemetadata: " + jsonfile + " invalid")
+                logging.critical("parsemetadata: " + jsonfile + " invalid")
                 # Use empty details
                 data = {"nonexistent": "none"}
                 keyboards = []

--- a/linux/keyman-config/keyman_config/kvk2ldml.py
+++ b/linux/keyman-config/keyman_config/kvk2ldml.py
@@ -213,7 +213,7 @@ def get_nstring(file, fileContent, offset):
     stringlength = struct.unpack_from("<H", fileContent, offset)
     file.seek(offset + 2)
     if stringlength[0] > 256:
-        logging.error("error: suspiciously long string. ABORT.")
+        logging.critical("error: suspiciously long string. ABORT.")
         sys.exit(5)
     if stringlength[0]:
         # don't read the null string terminator


### PR DESCRIPTION
- don't log regular errors - those are handled and we report them
  to the user, but don't want to create a Sentry error
- report some errors, which we want to see on Sentry, as critical
- log hash of username in crash report

(🍒 of PR #4914)