### PR TITLE
chore(ios): prep for CI transition to Xcode 12, build script tweak

### DIFF
--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -186,6 +186,14 @@ update_bundle ( ) {
     fi
 
     # Our default resources are part of the bundle, so let's check on them.
+    if [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_KBD_ID.kmp" ]; then
+      DO_KMP_DOWNLOADS=true
+      warn "OVERRIDE:  Performing -download-resources run, as the keyboard package is missing!"
+    elif [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_LM_ID.model.kmp" ]; then
+      DO_KMP_DOWNLOADS=true
+      warn "OVERRIDE:  Performing -download-resources run, as the lexical model package is missing!"
+    fi
+
     if [ $DO_KMP_DOWNLOADS = true ]; then
       echo_heading "Downloading up-to-date packages for default resources"
 
@@ -195,12 +203,6 @@ update_bundle ( ) {
       echo "${SUCCESS_GREEN}Packages successfully updated${NORMAL}"
 
       # If we aren't downloading resources, make sure copies of them already exist!
-    elif [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_KBD_ID.kmp" ]; then
-      fail "No run with -download-resources has been performed yet; the keyboard package is missing!"
-    elif [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_LM_ID.model.kmp" ]; then
-      fail "No run with -download-resources has been performed yet; the lexical model package is missing!"
-    else
-      warn "Reusing previously-downloaded packages for default resources"
     fi
 }
 

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -210,7 +210,9 @@ update_bundle
 if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
-    carthage bootstrap --platform iOS || fail "carthage boostrap failed"
+    # TODO: Replace the workaround-script with the base `carthage` command once
+    # we've properly updated to 0.37's better approach.
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap --platform iOS || fail "carthage boostrap failed"
 fi
 
 echo

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -291,7 +291,9 @@ if $CLEAN ; then
 fi
 
 if [ "$TEST_ACTION" == "test" ]; then
-    carthage bootstrap
+    # TODO: Replace the workaround-script with the base `carthage` command once
+    # we've properly updated to 0.37's better approach.
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap
 fi
 
 execBuildCommand() {

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -291,9 +291,7 @@ if $CLEAN ; then
 fi
 
 if [ "$TEST_ACTION" == "test" ]; then
-    # TODO: Replace the workaround-script with the base `carthage` command once
-    # we've properly updated to 0.37's better approach.
-    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap
+    carthage bootstrap
 fi
 
 execBuildCommand() {

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -157,7 +157,7 @@ if [ $DO_CARTHAGE = true ]; then
     echo "Load dependencies with Carthage"
     # TODO: Replace the workaround-script with the base `carthage` command once
     # we've properly updated to 0.37's better approach.
-    $KEYMAN_ROOT/resources/build/carthage-workaround.sh --platform iOS || fail "carthage boostrap failed"
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap --platform iOS || fail "carthage bootstrap failed"
 fi
 
 #

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -155,7 +155,9 @@ fi
 if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
-    carthage bootstrap --platform iOS || fail "carthage boostrap failed"
+    # TODO: Replace the workaround-script with the base `carthage` command once
+    # we've properly updated to 0.37's better approach.
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh --platform iOS || fail "carthage boostrap failed"
 fi
 
 #

--- a/resources/build/carthage-workaround.sh
+++ b/resources/build/carthage-workaround.sh
@@ -1,0 +1,23 @@
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+# From https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md
+
+# Needed for initial Xcode 12 compatibility when using versions of Carthage before 0.37.
+# TODO:  Remove once we've updated to Carthage 0.37's better approach.
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
Formally adds https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md as a resource script to assist with our CI transition to Xcode 12.

Also makes a tweak to iOS's build script:  packages are auto-downloaded if no local copy exists, rather than failing the build and forcing a re-run with `-download-resources`.

----

Note that the macOS build script does make a Carthage call here: https://github.com/keymanapp/keyman/blob/03c230c4e7c6e53320921ed91e15e11d8abe8fcc/mac/build.sh#L293-L295

I'm not sure if that one needs to be adjusted, so I've left that decision to a Mac-oriented PR.  There's a good chance it's not needed, since the macOS app shouldn't need to run within the Simulator.