### PR TITLE
chore(linux): Fix triggering of Jenkins builds for stable branch

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -76,7 +76,7 @@ function triggerJenkinsBuild() {
     TAG=", \"tag\": \"$GIT_TAG\", \"tag2\": \"$GIT_TAG\""
   fi
 
-  if [[ $JENKINS_BRANCH =~ [0-9]+ ]]; then
+  if [[ $JENKINS_BRANCH != stable-* ]] && [[ $JENKINS_BRANCH =~ [0-9]+ ]]; then
     JENKINS_BRANCH="PR-${JENKINS_BRANCH}"
   fi
 


### PR DESCRIPTION
Previously we tried to trigger on the wrong, non-existing branch `PR-stable-14.0`.