### PR TITLE
chore(android/engine): Don't use localized string for Sentry errors

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -598,8 +598,9 @@ final class KMKeyboard extends WebView {
   private void sendError(String packageID, String keyboardID, String languageID) {
     BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
 
-    // Don't localize msg for Sentry
-    String msg = KMString.format(context.getString(R.string.fatal_keyboard_error), packageID, keyboardID, languageID);
+    // Don't use localized string R.string.fatal_keyboard_error msg for Sentry
+    String msg = KMString.format("Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.",
+      packageID, keyboardID, languageID);
     Sentry.captureMessage(msg);
   }
 


### PR DESCRIPTION
Follow-on to #4813 where the KMString wrapper ensures some string formats are kept in English locale.

Some Sentry error [messages](http://sentry.keyman.com/organizations/keyman/issues/4670/?project=7&query=is%3Aunresolved) are unintentionally getting localized. So this PR just uses the literal string instead of `getString(R.string.fatal_keyboard_error` to pass to KMString().
