### PR TITLE
chore(android/engine): Don't use localized string for Sentry errors 🍒 

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -598,8 +598,9 @@ final class KMKeyboard extends WebView {
   private void sendError(String packageID, String keyboardID, String languageID) {
     BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
 
-    // Don't localize msg for Sentry
-    String msg = KMString.format(context.getString(R.string.fatal_keyboard_error), packageID, keyboardID, languageID);
+    // Don't use localized string R.string.fatal_keyboard_error msg for Sentry
+    String msg = KMString.format("Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.",
+      packageID, keyboardID, languageID);
     Sentry.captureMessage(msg);
   }
 


### PR DESCRIPTION
Cherry-pick of #4978 to stable-14.0 so Sentry messages stay in English.