### PR TITLE
fix(windows): make keymanx64 responsible for its own lifecycle

### DIFF
--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -361,11 +361,10 @@ BOOL Globals::get_debug_ToConsole() { return f_debug_ToConsole; }
 void Globals::SetBaseKeyboardName(wchar_t *baseKeyboardName, wchar_t *baseKeyboardNameAlt) {   // I4583
   wcscpy_s(f_BaseKeyboardName, baseKeyboardName);
   wcscpy_s(f_BaseKeyboardNameAlt, baseKeyboardNameAlt);
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardName(name='%ws', nameAlt='%ws')", baseKeyboardName, baseKeyboardNameAlt);
 }
 
 void Globals::SetBaseKeyboardFlags(char *baseKeyboard, BOOL simulateAltGr, BOOL mnemonicDeadkeyConversionMode) {   // I4583   // I4552
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d)",
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d",
     baseKeyboard, simulateAltGr, mnemonicDeadkeyConversionMode);
   strcpy_s(f_BaseKeyboard, baseKeyboard);
   f_SimulateAltGr = simulateAltGr;

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -361,10 +361,11 @@ BOOL Globals::get_debug_ToConsole() { return f_debug_ToConsole; }
 void Globals::SetBaseKeyboardName(wchar_t *baseKeyboardName, wchar_t *baseKeyboardNameAlt) {   // I4583
   wcscpy_s(f_BaseKeyboardName, baseKeyboardName);
   wcscpy_s(f_BaseKeyboardNameAlt, baseKeyboardNameAlt);
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardName(name='%ws', nameAlt='%ws')", baseKeyboardName, baseKeyboardNameAlt);
 }
 
 void Globals::SetBaseKeyboardFlags(char *baseKeyboard, BOOL simulateAltGr, BOOL mnemonicDeadkeyConversionMode) {   // I4583   // I4552
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d",
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d)",
     baseKeyboard, simulateAltGr, mnemonicDeadkeyConversionMode);
   strcpy_s(f_BaseKeyboard, baseKeyboard);
   f_SimulateAltGr = simulateAltGr;

--- a/windows/src/global/delphi/general/UserMessages.pas
+++ b/windows/src/global/delphi/general/UserMessages.pas
@@ -31,7 +31,6 @@ const
   WM_USER_Start = WM_USER+101;
   WM_USER_ParameterPass = WM_USER+100;
   WM_USER_SendFontChange = WM_USER+102;
-  WM_USER_PlatformComms = WM_USER+103;
   WM_USER_VisualKeyboardClosed = WM_USER+105;   // I4242
 
 const


### PR DESCRIPTION
Fixes #4976.
Fixes KEYMAN-WINDOWS-2K.
Fixes KEYMAN-WINDOWS-3F.
Fixes KEYMAN-WINDOWS-5A.
Fixes KEYMAN-WINDOWS-3E.

This fix reworks keymanx64's lifecycle, moving responsibility for process shutdown from keyman.exe to keymanx64.exe.

This eliminates the need for interprocess communication, and simplifies the startup and shutdown of keymanx64.exe. Removing this means that we can more safely handle situations where two instances of keymanx64 may be started, as one of them will rapidly terminate when it discovers that its parent process has disappeared.

I will cherry-pick this to stable-14.0 once we have run this on alpha 15 for a short while. It is a bit of a change in design and while I believe the changes are robust, better safe than sorry.