### PR TITLE
chore(windows): add telemetry to trace crash on exit 🍒

### DIFF
--- a/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
+++ b/windows/src/global/delphi/chromium/Keyman.System.CEFManager.pas
@@ -20,6 +20,7 @@ type
   IKeymanCEFHost = interface
     ['{DFABC8BF-803E-45E6-B7DC-522C7FEB08EB}']
     procedure StartShutdown(CompletionHandler: TShutdownCompletionHandlerEvent);
+    function GetDebugInfo: string;
   end;
 
   TCEFManager = class
@@ -53,6 +54,7 @@ uses
   Winapi.Tlhelp32,
   Winapi.Windows,
 
+  Keyman.System.KeymanSentryClient,
   KeymanPaths,
   KeymanVersion,
   RegistryKeys,
@@ -128,7 +130,14 @@ begin
 end;
 
 destructor TCEFManager.Destroy;
+var
+  i: Integer;
 begin
+  if FWindows.Count > 0 then
+  begin
+    for i := 0 to FWindows.Count - 1 do
+      TKeymanSentryClient.Breadcrumb('trace', 'TCEFManager.Destroy:Window['+IntToStr(i)+']='+FWindows[i].GetDebugInfo);
+  end;
   Assert(FWindows.Count = 0);
   Cleanup(nil);
   inherited Destroy;

--- a/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.pas
+++ b/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.pas
@@ -161,6 +161,7 @@ type
 
     // IKeymanCEFHost
     procedure StartShutdown(CompletionHandler: TShutdownCompletionHandlerEvent);
+    function GetDebugInfo: string;
 
     procedure Handle_CEF_DESTROY(var Message: TMessage);
     procedure Handle_CEF_AFTERDESTROY(var Message: TMessage);
@@ -296,6 +297,12 @@ begin
   AssertVclThread;
   inherited;
   PostMessage(FCallbackWnd, CEF_SHOW, 0, 0);
+end;
+
+function TframeCEFHost.GetDebugInfo: string;
+begin
+  Result := FNextURL;
+  if Assigned(Owner) then Result := Owner.ClassName+':'+Result;
 end;
 
 function TframeCEFHost.HasFocus: Boolean;


### PR DESCRIPTION
Cherry-pick of #5007.

Relates to #4700.

This simply adds some debug logging so that when the current crash occurs, we can discover which windows have failed to automatically close, which should give us enough detail to be able to reproduce the problem, hopefully, and fix it.