### PR TITLE
fix(developer): two small issues in kmdecomp

### DIFF
--- a/windows/src/developer/kmdecomp/kmdecomp.vcxproj
+++ b/windows/src/developer/kmdecomp/kmdecomp.vcxproj
@@ -52,11 +52,11 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Midl>

--- a/windows/src/developer/kmdecomp/savekeyboard.cpp
+++ b/windows/src/developer/kmdecomp/savekeyboard.cpp
@@ -184,7 +184,7 @@ PWCHAR KeyString(LPKEY key)
 
 PWCHAR ifvalue(WCHAR ch)
 {
-  if(ch == L'1') return L"!=";
+  if(ch == 1) return L"!=";
   return L"=";
 }
 


### PR DESCRIPTION
1. build paths when loaded as part of solution were incorrect
2. decompiling `if` statements did not work for `!=`