### PR TITLE
fix(windows): avoid disabling Keyman when speech recognition starts 🍒

### DIFF
--- a/windows/src/engine/kmtip/debug.cpp
+++ b/windows/src/engine/kmtip/debug.cpp
@@ -120,3 +120,11 @@ void WINAPI Keyman_Diagnostic(int mode) {
     RaiseException(0xDEADBEEF, EXCEPTION_NONCONTINUABLE, 0, NULL);
   }
 }
+
+BOOL _LogSUCCEEDED(char *file, int line, PWSTR caller, PSTR callee, HRESULT hr) {
+  BOOL result = SUCCEEDED(hr);
+  if (!result) {
+    SendDebugMessageFormat_1(file, line, L"CKMTipTextService::Log: call in %s to %hs failed with %x", caller, callee, hr);
+  }
+  return result;
+}

--- a/windows/src/engine/kmtip/globals.h
+++ b/windows/src/engine/kmtip/globals.h
@@ -64,6 +64,9 @@ void DebugLastError_1(char *file, int line, char *func, PWCHAR msg, DWORD err);
 #define DebugLastError(msg) (DebugLastError_1(__FILE__,__LINE__,__FUNCTION__,(msg),GetLastError()))
 #define DebugLastError0(msg,err) (DebugLastError_1(__FILE__,__LINE__,__FUNCTION__,(msg),(err)))
 
+#define LogSUCCEEDED(hr) _LogSUCCEEDED(__FILE__, __LINE__, __FUNCTIONW__, (#hr), (hr))
+BOOL _LogSUCCEEDED(char *file, int line, PWSTR caller, PSTR callee, HRESULT hr);
+
 //#define LogEnter() (SendDebugMessageFormat_1(__FILE__, __LINE__, L"%hs ENTER", __FUNCTION__))
 //#define LogExit() (SendDebugMessageFormat_1(__FILE__, __LINE__, L"%hs EXIT", __FUNCTION__))
 #define LogEnter()

--- a/windows/src/engine/kmtip/kmtip.cpp
+++ b/windows/src/engine/kmtip/kmtip.cpp
@@ -80,7 +80,6 @@ CKMTipTextService::CKMTipTextService()
    // I3582
     _dwThreadMgrEventSinkCookie = TF_INVALID_COOKIE;
 
-    memset(&guidActiveProfile, 0, sizeof(GUID));
     _keystrokeSinkInitialized = FALSE;
     _dwActiveLanguageProfileNotifySinkCookie = 0;
     _PreservedKeys = NULL;

--- a/windows/src/engine/kmtip/kmtip.h
+++ b/windows/src/engine/kmtip/kmtip.h
@@ -117,8 +117,6 @@ private:
     // state
     //
 
-    GUID guidActiveProfile;   // I4274
-
     BOOL _keystrokeSinkInitialized;
     BOOL fEatenBuf[256];
 


### PR DESCRIPTION
Cherry-pick of #5000.

Fixes #4965.

When speech recognition is enabled, it sometimes activates after a Keyman keyboard is selected. This would cause Keyman to think it is being deactivated. We needed to check in `CKMTipTextService::OnActivated` that it was a keyboard-type TIP that was being activated, and only deactivate the Keyman hooks in that situation.

This commit also adds a little logging helper function, and removes an unused variable `guidActiveProfile`.