### PR TITLE
feat(android/app): Add telemetry for launching WebBrowserActivity

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -583,6 +583,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   }
 
   private void showWebBrowser() {
+    // Telemetry for in-app browser usage.
+    // Logging here because WebBrowserActivity is launched in a separate process.
+    KMLog.LogInfo(TAG, "WebBrowserActivity launched");
+
     Intent i = new Intent(this, WebBrowserActivity.class);
     i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
     startActivity(i);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -12,6 +12,21 @@ public final class KMLog {
   private static final String TAG = "KMLog";
 
   /**
+   * Utility to log info and send to Sentry
+   * @param tag String of the caller
+   * @param msg String of the info message
+   */
+  public static void LogInfo(String tag, String msg) {
+    if (msg != null && !msg.isEmpty()) {
+      Log.i(tag, msg);
+
+      if (Sentry.isEnabled()) {
+        Sentry.captureMessage(msg, SentryLevel.INFO);
+      }
+    }
+  }
+
+  /**
    * Utility to log error and send to Sentry
    * @param tag String of the caller
    * @param msg String of the error message


### PR DESCRIPTION
Fixes #5019 adding telemetry when WebBrowserActivity is launched.

Handled with new utility `KMLog.LogInfo()`.

Will 🍒-pick to stable-14.0