### PR TITLE
chore(android/app): Always use offline help

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -1,13 +1,11 @@
 /**
- * Copyright (C) 2017-2019 SIL International. All rights reserved.
+ * Copyright (C) 2017-2021 SIL International. All rights reserved.
  */
 
 package com.tavultesoft.kmapro;
 
 import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.BuildConfig;
-import com.tavultesoft.kmea.KMManager;
-import com.tavultesoft.kmea.KMManager.FormFactor;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -19,15 +17,10 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.TextView;
 import android.annotation.SuppressLint;
-import androidx.appcompat.app.AppCompatActivity;
 
 public class InfoActivity extends BaseActivity {
   private final static String TAG = "InfoActivity";
   private WebView webView;
-  private final String HELP_PRODUCTION_HOST = "help.keyman.com";
-  private final String HELP_STAGING_HOST = "help.keyman-staging.com";
-  private final String HELP_BASE_FORMAT_STR = "https://%s/products/android/%s";
-  private String kmUrl = "";
   private final String htmlPath = "file:///android_asset/info";
   private final String htmlPage = "index.html";
   private String kmOfflineUrl = "";
@@ -48,31 +41,6 @@ public class InfoActivity extends BaseActivity {
     String versionTitle = String.format(getString(R.string.title_version), versionStr);
     version.setText(versionTitle);
 
-    // Extract the the major minor version from the full version string
-    String[] versionArray = versionStr.split("\\.", 3);
-    String majorMinorVersion = String.format("%s.%s", versionArray[0], versionArray[1]);
-
-    // Determine the appropriate form factor
-    FormFactor ff = KMManager.getFormFactor();
-    String formFactor;
-
-    if(ff == FormFactor.PHONE) {
-      formFactor = "phone";
-    } else {
-      formFactor = "tablet";
-    }
-
-    String helpHost = "";
-    switch (KMManager.getTier(BuildConfig.VERSION_NAME)) {
-      case ALPHA:
-      case BETA:
-        helpHost = HELP_STAGING_HOST;
-        break;
-      default:
-        helpHost = HELP_PRODUCTION_HOST;
-    }
-
-    kmUrl = String.format(HELP_BASE_FORMAT_STR, helpHost, majorMinorVersion);
     // The offline mirroring process (currently) adds .html to the end of the whole string.
     kmOfflineUrl = String.format("%s/%s", htmlPath, htmlPage);
     webView = (WebView) findViewById(R.id.infoWebView);
@@ -107,13 +75,8 @@ public class InfoActivity extends BaseActivity {
       }
     });
 
-    if (KMManager.hasConnection(context)) {
-      // Load app info page from server
-      webView.loadUrl(kmUrl);
-    } else {
-      // Load app info page from assets
-      webView.loadUrl(kmOfflineUrl);
-    }
+    // Always load offline info page from assets
+    webView.loadUrl(kmOfflineUrl);
   }
 
   @Override

--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -2,25 +2,6 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman for Android 14.0:
+Here are some of the new features we have added to Keyman for Android 15.0:
 
-* Improved UI for installing keyboard packages (#3498)
-* Select a language during keyboard package installation (#3481)
-
-![](../android_images/select_language.png)
-
-* Added new menu to add languages for an installed keyboard package (#3255)
-* Consolidated install menus for installing keyboards (#3245)
-* Fix slow input in the embedded browser (#3768)
-* Add system globe action to show system keyboards (#3197)
-* Improved corrections and predictions (#3555)
-* Match user input capital letters when offering suggestions (#3845)
-* Update minimum Android SDK to 21 (Android 5.0 Lollipop) (#2993)
-* Keyman now works more reliably with WeChat and Telegram (#4254)
-* Added new Settings menu to [Change Display Language](../basic/config/index#Change-Display-Language): (#4261)
-    * French
-    * Indonesian
-    * German
-    * Khmer
-    * Obolo
-    * Pulaar-fulfulde
+* 

--- a/android/help/index.md
+++ b/android/help/index.md
@@ -1,5 +1,5 @@
 ---
-title: Keyman for Android 14.0 Help
+title: Keyman for Android 15.0 Help
 ---
 
 ## [About Keyman](about/)


### PR DESCRIPTION
Fixes #5043 

This changes InfoActivity to always use offline help.
* Also updated help docs for 15.0

- [x] The Android user-acceptance test will need to be tweaked for this.
Also to 🍒 -pick to stable-14.0 (InfoActivity but not the help docs)
