### PR TITLE
fix(windows): refactor controller windows

### DIFF
--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -176,7 +176,6 @@ type
     FToolbarHintWindow: THintWindow;
     FUpdatingToolbar: Boolean;
     FActivePageSet: Boolean;
-    FRegistered: Boolean;
     FLastTotalKeyboards: Integer;   // I4606
 
     FKeyboardButtons: TArray<TKeymanToolButton>;
@@ -232,9 +231,6 @@ type
     procedure PreRefreshKeyman;
     procedure UpdateToolbar;
     procedure RefreshSelectedKeyboard;  // I2398
-
-    procedure Unregister;
-    procedure Register;
 
     function GetToolbarPositionXML: WideString;
 
@@ -325,7 +321,6 @@ begin
   SnapBuffer := 8;
 
   cmi := TKeymanCustomisationMenuItem_Clone.Create;
-  Register;  // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
 
   FUnicode := True;
 
@@ -623,8 +618,6 @@ end;
 
 procedure TfrmVisualKeyboard.FormDestroy(Sender: TObject);
 begin
-  Unregister; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-
   SaveSettings;
 
   FreeAndNil(FOnScreenKeyboard);
@@ -635,20 +628,6 @@ begin
   cmi := nil;
 
   Application.OnMessage := nil;
-end;
-
-procedure TfrmVisualKeyboard.Register; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-begin
-  if not FRegistered then // I2692
-    kmint.KeymanEngineControl.RegisterControllerWindow(Handle);
-  FRegistered := True;
-end;
-
-procedure TfrmVisualKeyboard.Unregister; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-begin
-  if FRegistered then // I2692
-    kmint.KeymanEngineControl.UnregisterControllerWindow(Handle);
-  FRegistered := False;
 end;
 
 function TfrmVisualKeyboard.FormHelp(Command: Word; Data: NativeInt; var CallHelp: Boolean): Boolean;

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -15,7 +15,7 @@ EXPORTS
 			KMHideIM
 			KMGetActiveKeyboard
 			KMGetKeyboardPath
-			
+
       TIPActivateEx
       TIPActivateKeyboard
 			TIPProcessKey
@@ -23,17 +23,18 @@ EXPORTS
       GetKeyboardPreservedKeys
 
 			GetActiveKeymanID
-			Keyman_RegisterControllerWindow
-			Keyman_UnregisterControllerWindow
+			Keyman_RegisterControllerThread
+			Keyman_UnregisterControllerThread
+      Keyman_RegisterMasterController
+      Keyman_UnregisterMasterController
 			Keyman_RestartEngine
-			
+
       Keyman_SendMasterController
-      Keyman_PostControllers
       Keyman_PostMasterController
-      
+
       Keyman_StartExit
       Keyman_ResetInitialisation
-      
+
   	  Keyman_WriteDebugEvent
 
       Keyman_UpdateTouchPanelVisibility

--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -699,8 +699,9 @@ void HandleRefresh(int code, LONG tag)
     // of keyman32/keyman64 that a refresh is coming through
     Globals::PostMasterController(wm_keyman_refresh, KR_PRE_REFRESH, 0);
 
-    // We need to tell the controller windows to refresh themselves also
-    Globals::PostControllers(wm_keyman_control, KMC_REFRESH, 0);
+    // We need to tell the controller window to refresh itself also
+    // TODO: eliminate this message (we can hop onto the above message)
+    Globals::PostMasterController(wm_keyman_control, KMC_REFRESH, 0);
     break;
 
   case KR_PRE_REFRESH:

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -137,9 +137,7 @@ public:
 
   static BOOL ResetControllers();
 
-	static void PostControllers(UINT msg, WPARAM wParam, LPARAM lParam);
-  static void PostProcessControllers(UINT msg, WPARAM wParam, LPARAM lParam);
-  static BOOL IsControllerProcess();
+  static BOOL IsControllerThread(DWORD tid);
 
   static BOOL InitHandles();
   static BOOL InitSettings();

--- a/windows/src/engine/keyman32/kmhook_callwndproc.cpp
+++ b/windows/src/engine/keyman32/kmhook_callwndproc.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmhook_callwndproc
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    22 Apr 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Visual keyboard updating
                     30 May 2007 - mcdurdin - I864 - Log exceptions in hook procedures
                     11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
@@ -111,11 +111,11 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
     {
       //DebugLastError("get_Keyman_Initialised");
     }
-	  else 
+	  else
 	  {
   /*
 		  SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "kmnCallWndProc %s %x %x "
-		  "{hwnd:%d msg:%d wp:%d lp:%d} ctrl: %x/%x alt: %x/%x shift: %x/%x", 
+		  "{hwnd:%d msg:%d wp:%d lp:%d} ctrl: %x/%x alt: %x/%x shift: %x/%x",
 		  MessageName(cp->message), cp->wParam, cp->lParam,
 		  cp->hwnd, cp->message, cp->wParam, cp->lParam,
 		  GetKeyState(VK_CONTROL), GetAsyncKeyState(VK_CONTROL),
@@ -125,7 +125,7 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
       PKEYMAN64THREADDATA _td = ThreadGlobals();
       if(!_td)
       {
-        if(!Globals::CheckControllers()) 
+        if(!Globals::CheckControllers())
         {
           DebugLastError("CheckControllers");
           return CallNextHookEx(Globals::get_hhookCallWndProc(), nCode, wParam, lParam);
@@ -165,10 +165,10 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         {
           CheckScheduledRefresh();
           HWND hwnd = IsLanguageSwitchWindowVisible();   // I4326
-          if(hwnd != NULL && !Globals::IsControllerProcess()) SendToLanguageSwitchWindow(hwnd, VK_ESCAPE, 0); // I3025
+          if(hwnd != NULL && !Globals::IsControllerThread(GetCurrentThreadId())) SendToLanguageSwitchWindow(hwnd, VK_ESCAPE, 0); // I3025
 
           SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_KILLFOCUS %x -> %x", cp->hwnd, cp->wParam);  // I3226   // I3531
-          if(!IsSysTrayWindow(cp->hwnd) && !Globals::IsControllerWindow(cp->hwnd) && !Globals::IsControllerProcess())   // I2443 - always do the focus change now? really unsure about this one
+          if(!IsSysTrayWindow(cp->hwnd) && !Globals::IsControllerThread(GetCurrentThreadId()))   // I2443 - always do the focus change now? really unsure about this one
           {
   			    PostMessage(cp->hwnd, wm_keyman, KM_FOCUSCHANGED, 0);
 	  		    SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_KILLFOCUS -- Telling Keyman focus has changed");
@@ -181,10 +181,8 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         CheckScheduledRefresh();
         if (IsSysTrayWindow(cp->hwnd))      // I2443 - always do the focus change now? really unsure about this one
           SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsSysTrayWindow");
-        else if (Globals::IsControllerWindow(cp->hwnd))
-          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerWindow");
-        else if (Globals::IsControllerProcess())
-          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerProcess");
+        else if (Globals::IsControllerThread(GetCurrentThreadId()))
+          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerThread");
         else
         {
           PostMessage(cp->hwnd, wm_keyman, KM_FOCUSCHANGED, KMF_WINDOWCHANGED);

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -403,7 +403,8 @@ void ProcessWMKeymanControlInternal(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
 void UpdateKeymanUI()
 {
-	Globals::PostControllers(wm_keyman_control, KMC_CHANGEUISTATE, 2);  // TODO: Fixup constant
+  //TODO: this does not appear to be used; remove as separate patch
+	Globals::PostMasterController(wm_keyman_control, KMC_CHANGEUISTATE, 2);
 }
 
 /*

--- a/windows/src/engine/keyman32/kmhook_keyboard.cpp
+++ b/windows/src/engine/keyman32/kmhook_keyboard.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmhook_keyboard
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    25 Oct 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Hotkeys testing
                     14 Sep 2006 - mcdurdin - Initialise process when no messages have been passed
                     30 May 2007 - mcdurdin - I864 - Log exceptions in hook procedures
@@ -72,7 +72,7 @@ BOOL ForegroundWindowIsRDP();   // I4197
 
 BOOL InLanguageSwitchKeySequence = FALSE;
 HWND hwndLanguageSwitch = 0;
-		
+
 BOOL ForegroundWindowIsRDP() {   // I4197
   //TODO: Cache result
   DWORD dwProcessId;
@@ -139,12 +139,12 @@ BOOL KeyLanguageSwitchPress(WPARAM wParam, BOOL extended, BOOL isUp, DWORD Shift
       {
         InLanguageSwitchKeySequence = FALSE;
         //ReportActiveKeyboard(_td, PC_UPDATE);
-        Globals::PostControllers(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
+        Globals::PostMasterController(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
         PostDummyKeyEvent();   // I4124   // I4844
         keybd_event(VK_SHIFT, SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0);    // I4203
         return TRUE;
       }
-      
+
       return FALSE;
     }
     else
@@ -176,15 +176,15 @@ int ProcessLanguageSwitchShiftKey(WPARAM wParam, BOOL isUp)
   {
     case VK_LSHIFT:
     case VK_RSHIFT:
-    case VK_SHIFT:   
-    case VK_CONTROL: 
+    case VK_SHIFT:
+    case VK_CONTROL:
     case VK_LCONTROL:   // I4124
     case VK_RCONTROL:   // I4124
-    case VK_MENU:    
+    case VK_MENU:
     case VK_LMENU:   // I4124
     case VK_RMENU:   // I4124
       break;
-    default:         
+    default:
       return 1;
   }
 

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -27,8 +27,10 @@ type
     procedure StartKeyman32Engine; safecall;   // I5133
     procedure StopKeyman32Engine; safecall;   // I5133
     procedure ResetKeyman32Engine; safecall;   // I5133
-    procedure RegisterControllerWindow(Value: LongWord); safecall;
-    procedure UnregisterControllerWindow(Value: LongWord); safecall;
+    procedure RegisterMasterController(Value: LongWord); safecall;
+    procedure UnregisterMasterController(Value: LongWord); safecall;
+    procedure RegisterControllerThread(Value: LongWord); safecall;
+    procedure UnregisterControllerThread(Value: LongWord); safecall;
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;


### PR DESCRIPTION
Fixes #5004.

This cleans up the use of controller windows. A single window is now given the responsibility of being the master controller, which receives messages from Keyman32 and other components around UI activation, active keyboard, etc.

The master controller is keyman.exe's `TApplication` window, which does not get destroyed and recreated, unlike the main form window.

Any thread which has responsibility for Keyman UI (keyman.exe main thread, keymanx64.exe main thread) is also registered as a controller thread. A controller thread has special handling for interactions with keyman32 around focus tracking.

Caveats:

* While keymanx64 does not have a visible window and thus probably does not need to be registered as a controller thread, it doesn't really hurt.
* Note that keymanx64 registers the 32-bit controller thread as well, which again is probably unnecessary as the 64-bit process cannot interact with the 32-bit thread.
* Keyman's main form still handles wm_keyman_control messages, as there are a number of other components which post to that window (e.g. text editor, com library visual keyboard interactions). Unlike the original problem trigger, the reference handle is not stored long-term and so there is unlikely to be a problem with main form window re-creation causing an issue in these contexts.

There are several TODO items in this which I will address in follow-ups, to reduce the scope of these changes.

I hope to cherry-pick this to stable-14.0, but will run for a while in 15.0 before doing so.

Note that this should resolve some long-standing issues with controller windows causing errors on exit of Keyman (see #2147).