### PR TITLE
chore(windows): remove KMC_CHANGEUISTATE

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -91,7 +91,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateEx(BOOL FActivate) {  //
   if(!FActivate)
     SelectKeyboard(KEYMANID_NONKEYMAN);   // I3594
   Globals::PostMasterController(wm_keyman_control, KMC_SETFOCUSINFO, 0);   // I3961
-	UpdateKeymanUI();
 	return TRUE;
 }
 

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -279,9 +279,6 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 		return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
 	}
 
-	if(mp->message == WM_ACTIVATEAPP && mp->wParam)
-		UpdateKeymanUI();
-
 	if(*Globals::hwndIM() != 0)
 	{
 		if(mp->message == wm_keymanim_close)
@@ -342,11 +339,9 @@ void ProcessWMKeyman(HWND hwnd, WPARAM wParam, LPARAM lParam)
 	{
 	case KM_DISABLEUI:
 		_td->KeymanUIDisabled = TRUE;
-		UpdateKeymanUI();
 		break;
 	case KM_ENABLEUI:
 		_td->KeymanUIDisabled = FALSE;
-		UpdateKeymanUI();
 		break;
 	case KM_FOCUSCHANGED:
     if(lParam & KMF_WINDOWCHANGED)
@@ -399,12 +394,6 @@ void ProcessWMKeymanControlInternal(HWND hwnd, WPARAM wParam, LPARAM lParam)
     SetForegroundWindow(hwnd);
     break;
 	}
-}
-
-void UpdateKeymanUI()
-{
-  //TODO: this does not appear to be used; remove as separate patch
-	Globals::PostMasterController(wm_keyman_control, KMC_CHANGEUISTATE, 2);
 }
 
 /*

--- a/windows/src/global/delphi/general/KeymanControlMessages.pas
+++ b/windows/src/global/delphi/general/KeymanControlMessages.pas
@@ -1,18 +1,18 @@
 (*
   Name:             KeymanControlMessages
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      27 Mar 2008
 
   Modified Date:    13 Oct 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          27 Mar 2008 - mcdurdin - Initial version
                     20 Jul 2008 - mcdurdin - I1412 - Improve performance of tutorial
                     11 Dec 2009 - mcdurdin - I934 - x64 - platform comms - focus info
@@ -28,7 +28,7 @@ interface
 
 const
   //KMC_KEYBOARDCHANGED = 1;   // I3949
-  KMC_CHANGEUISTATE = 2;
+  //KMC_CHANGEUISTATE = 2;
   KMC_GETLOADED = 3;
   KMC_REFRESH = 4;
   KMC_INTERFACEHOTKEY = 5;

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -286,10 +286,7 @@ BOOL ProcessMessage( LPMSG mp );
 BOOL ProcessGroup(LPGROUP gp);
 BOOL ContextMatch(LPKEY kkp);
 int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr);
-//void PostKey( int keystroke, int msgflags, LPMSG msg );
-//void GetINIAdvanced( void );
 BOOL LoadAllKeymanKeyboards(DWORD layout);
-void UpdateKeymanUI();
 
 BOOL IsSysTrayWindow(HWND hwnd);
 

--- a/windows/src/global/inc/keymancontrol.h
+++ b/windows/src/global/inc/keymancontrol.h
@@ -1,18 +1,18 @@
 /*
   Name:             keymancontrol
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    13 Oct 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Add KMC_REFRESH and KMC_INTERFACEHOTKEY wm_keyman_control messages
                     11 Dec 2009 - mcdurdin - I934 - x64 platfrom comms add KMC_SETFOCUSINFO
                     06 Apr 2010 - mcdurdin - I2271 - Select Keyboard tidy up
@@ -23,7 +23,7 @@
 */
 
 //#define KMC_KEYBOARDCHANGED	1   // I3949
-#define KMC_CHANGEUISTATE  	2
+//#define KMC_CHANGEUISTATE  	2
 //#define KMC_GETLOADED	    	3
 #define KMC_REFRESH			    4
 #define KMC_INTERFACEHOTKEY	5


### PR DESCRIPTION
The `KMC_CHANGEUISTATE` flag for `wm_keyman_control` is no longer processed anywhere. Removes it and the `UpdateKeymanUI` function which called it.

The `#define` for the flag has been left, commented out, to clarify what would otherwise be a gap in identifiers (use `git blame` to learn more).