### PR TITLE
chore(windows): remove unused keymanx64 parameter

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1966,7 +1966,7 @@ begin
     if not DuplicateHandle(GetCurrentProcess, GetCurrentProcess,
         GetCurrentProcess, @processHandle, 0, True, DUPLICATE_SAME_ACCESS) then
       RaiseLastOSError;
-    cmd := Format('%s%s %d %d %d', [ExtractFilePath(ParamStr(0)), 'keymanx64.exe', processHandle, Handle, Application.Handle]);
+    cmd := Format('%s%s %d %d', [ExtractFilePath(ParamStr(0)), 'keymanx64.exe', processHandle, Application.Handle]);
     // Duplicate the string because CreateProcess requires a mutable buffer, so
     // this guarantees it
     v := StrNew(PWideChar(cmd));

--- a/windows/src/engine/keymanx64/keymanx64.cpp
+++ b/windows/src/engine/keymanx64/keymanx64.cpp
@@ -164,21 +164,14 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 //
 //   COMMENTS:
 //
-//        Reads parent process handle, parent process main window and
-//        parent process application window handle from the command
-//        line and validates them.
+//        Reads parent process handle and master controller window
+//        handle from the command line and validates them.
 //
 BOOL ParseCmdLine(LPTSTR lpCmdLine) {
   while (iswspace(*lpCmdLine)) lpCmdLine++;
   if (!*lpCmdLine) return FALSE;
   hParentProcessHandle = (HANDLE)wcstoull(lpCmdLine, &lpCmdLine, 10);
   if (hParentProcessHandle == 0 || hParentProcessHandle == (HANDLE) ULLONG_MAX) return FALSE;
-
-  // TODO: remove this now-unused parameter as separate patch
-  while (iswspace(*lpCmdLine)) lpCmdLine++;
-  if (!*lpCmdLine) return FALSE;
-  HWND __ = (HWND) wcstoull(lpCmdLine, &lpCmdLine, 10);
-  if (__ == 0 || __ == (HWND) ULLONG_MAX) return FALSE;
 
   while (iswspace(*lpCmdLine)) lpCmdLine++;
   if (!*lpCmdLine) return FALSE;


### PR DESCRIPTION
With the recent refactor in #5060, we no longer need the main form window handle parameter in keymanx64.