### PR TITLE
fix(linux): Swap order of dependencies for Debian package

### DIFF
--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -20,7 +20,7 @@ Build-Depends:
  python3-pil,
  python3-pip,
  python3-qrcode,
- python3-raven | python3-sentry-sdk,
+ python3-sentry-sdk | python3-raven,
  python3-requests,
  python3-requests-cache,
  python3-setuptools,


### PR DESCRIPTION
It turns out that the Debian package build system only considers the first alternative; `python3-raven` isn't available on the current
Debian version, however we still need it on Ubuntu 18.04 Bionic where `python3-sentry-sdk` is not available. This change swaps the alternatives and so should work both on Debian as well as for Bionic.