### PR TITLE
fix(android/engine): Check lexical-model file exists before using

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1049,7 +1049,14 @@ public final class KMManager {
     String pkgID = lexicalModelInfo.get(KMKey_PackageID);
     String modelID = lexicalModelInfo.get(KMKey_LexicalModelID);
     String languageID = lexicalModelInfo.get(KMKey_LanguageID);
-    String path = "file://" + getLexicalModelsDir() + pkgID + File.separator + modelID + ".model.js";
+    boolean modelFileExists = true;
+    File modelFile = new File(getLexicalModelsDir(), pkgID + File.separator + modelID + ".model.js");
+    String path = "file://" + modelFile.getAbsolutePath();
+
+    if (!modelFile.exists()) {
+      modelFileExists = false;
+      KMLog.LogError(TAG, modelFile.getAbsolutePath() + " does not exist");
+    }
 
     JSONObject modelObj = new JSONObject();
     JSONArray languageJSONArray = new JSONArray();
@@ -1076,12 +1083,12 @@ public final class KMManager {
     boolean mayCorrect = prefs.getBoolean(getLanguageCorrectionPreferenceKey(languageID), true);
 
     RelativeLayout.LayoutParams params;
-    if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange) {
+    if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreTextChange && modelFileExists) {
       params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
-    if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange) {
+    if (SystemKeyboard != null && SystemKeyboardLoaded && !SystemKeyboardShouldIgnoreTextChange && modelFileExists) {
       params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1053,8 +1053,10 @@ public final class KMManager {
     File modelFile = new File(getLexicalModelsDir(), pkgID + File.separator + modelID + ".model.js");
     String path = "file://" + modelFile.getAbsolutePath();
 
+    // Disable sugestions if lexical-model file doesn't exist
     if (!modelFile.exists()) {
       modelFileExists = false;
+      setBannerOptions(false);
       KMLog.LogError(TAG, modelFile.getAbsolutePath() + " does not exist");
     }
 


### PR DESCRIPTION
Fixes #4944 

This update checks that a lexical-model file exists before attempting to use it. We'll also get a Sentry log that the file is missing.

### Test Scenario (Updated) 
Setup:
1. Install the debug app
2. From the Settings menu, install gff_amharic keyboard (dictionary also installs in the background)
3. From Android Studio, delete the `nrc.en.mtnt.model.js` file from the device.

Steps:
1. Restart the app and switch to sil_euro_latin keyboard
2. Verify keyboard functions and suggestion banner is disabled
3. Switch to gff_amharic
4. Verify keyboard functions and suggestion banner is on (context may need to be cleared for new suggestions to appear. e.g. non-Latin characters)
5. Switch back to sil_euro_latin keyboard
6. Verify keyboard functions and suggestion banner is disabled

Question: Should we give a Toast notification alerting the user that suggestions are disabled because the file doesn't exist? I'm concerned about the user getting spammed by the msg.