### PR TITLE
fix(web): position popups correctly in landscape mode on Android and during Chrome emulation

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1789,12 +1789,8 @@ namespace com.keyman.osk {
 
       // And correct its position with respect to that element
       ss=subKeys.style;
-      var x=dom.Utils.getAbsoluteX(e)+0.5*(e.offsetWidth-subKeys.offsetWidth);
-      
-      // https://stackoverflow.com/questions/28083715/how-to-detect-if-a-mobile-device-is-emulated-by-google-chrome
-      // (Note the last reply to the accepted answer.)
-      var flipScreenDims = util.landscapeView() && util.device.OS == 'iOS' && navigator.maxTouchPoints !== 1;
-      var xMax= (flipScreenDims ? screen.height : screen.width) - subKeys.offsetWidth;
+      var x = dom.Utils.getAbsoluteX(e)+0.5*(e.offsetWidth-subKeys.offsetWidth);
+      var xMax = keyman.osk.getWidth() - subKeys.offsetWidth;
 
       if(x > xMax) {
         x=xMax;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1789,8 +1789,12 @@ namespace com.keyman.osk {
 
       // And correct its position with respect to that element
       ss=subKeys.style;
-      var x=dom.Utils.getAbsoluteX(e)+0.5*(e.offsetWidth-subKeys.offsetWidth), y,
-        xMax=(util.landscapeView()?screen.height:screen.width)-subKeys.offsetWidth;
+      var x=dom.Utils.getAbsoluteX(e)+0.5*(e.offsetWidth-subKeys.offsetWidth);
+      
+      // https://stackoverflow.com/questions/28083715/how-to-detect-if-a-mobile-device-is-emulated-by-google-chrome
+      // (Note the last reply to the accepted answer.)
+      var flipScreenDims = util.landscapeView() && util.device.OS == 'iOS' && navigator.maxTouchPoints !== 1;
+      var xMax= (flipScreenDims ? screen.height : screen.width) - subKeys.offsetWidth;
 
       if(x > xMax) {
         x=xMax;


### PR DESCRIPTION
Fixes #4930.

To ensure this doesn't break anything for Android...

## User Testing
@MakaraSok 

I'm requesting two sets of tests.  That said, I'd only expect an issue from the second (non-embedded) set if any issue occurs.

### In-app test

Just fire up the Android app (from this PR's build) and ensure subkeys work as expected in landscape mode, both in-app and in system-keyboard mode.  Behavior should be unaffected and match your default expectations.

### Non-embedded test

This one's going to be a bit more involved, but reflects the actually-changed parts of the code.

1. Ensure that KeymanWeb's test pages are accessible through `localhost` on your machine.
    - In case you don't yet have a localhost setup:  [instructions](https://github.com/sillsdev/keyman/wiki/How-to-set-up-a-local-web-server-for-the-Keyman-web-pages) 
2. In your local copy of the repo, navigate to `web/source` and run `./build.sh`.
3. Once complete, in Chrome navigate to the unminified testing page using your `localhost` setup.
    - For my setup, that's `http://localhost/testing/unminified.html`.
4. Activate device emulation and ensure that the subkeys display where you expect them to be.
    - For both Android and iOS device types, both phone and tablet form factors.
5. _Then_, use Android Studio to launch an emulated Android device.
6. Launch the Chrome app and navigate to the same testing URL, **_but_** in place of `localhost`, [type `10.0.2.2`](https://stackoverflow.com/a/6310592).
    - For my setup, that's `10.0.2.2/localhost/testing/unminified.html`.
7. Ensure that the popup keys position properly on the emulated Android device.

A similar test may be run for steps 5 through 7 for those developing on Mac in order to test iOS device setups.  (But without replacing `localhost` with `10.0.2.2`.)

Once the PR lands on `master`, this will become possible to test directly with keymanweb.com.