### PR TITLE
fix(developer): kmconvert commandline and deploy

### DIFF
--- a/windows/src/Target.mak
+++ b/windows/src/Target.mak
@@ -40,6 +40,8 @@ dirs:
 
     @-mkdir $(ROOT)\bin\developer\samples 2>nul
     @-mkdir $(ROOT)\bin\developer\xml 2>nul
+    @-mkdir $(ROOT)\bin\developer\projects 2>nul
+    @-mkdir $(ROOT)\bin\developer\projects\templates 2>nul
     @-mkdir $(ROOT)\bin\buildtools 2>nul
     @-mkdir $(ROOT)\bin\engine 2>nul
     @-mkdir $(ROOT)\bin\desktop 2>nul

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -145,7 +145,11 @@ begin
       Run;
     except
       on E: Exception do
-        SentryHandleException(E);
+        if not SentryHandleException(E) then
+        begin
+          writeln(E.Message);
+          ExitCode := 99;
+        end;
     end;
   finally
     TKeymanSentryClient.Stop;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
@@ -42,6 +42,7 @@ begin
   Destination := '.';
   Copyright := 'Copyright (C)';
   Version := '1.0';
+  Targets := [ktAny];
 
   if ParamCount < 2 then
     Exit(False);
@@ -120,7 +121,7 @@ begin
   else if name = '-version' then Version := value
   else if name = '-languages' then BCP47Tags := value
   else if name = '-author' then Author := value
-
+  else if name = '-targets' then Targets := StringToKeymanTargets(value)
   else if name = '-id-author' then ModelIdAuthor := value
   else if name = '-id-language' then ModelIdLanguage := value
   else if name = '-id-uniq' then ModelIdUniq := value

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -75,7 +75,9 @@ var
 begin
   kpt := TKeyboardProjectTemplate.Create(FParameters.Destination, FParameters.KeyboardID, FParameters.Targets);
   try
-    kpt.Name := FParameters.Name;
+    if FParameters.Name = ''
+      then kpt.Name := FParameters.KeyboardID
+      else kpt.Name := FParameters.Name;
     kpt.Copyright := FParameters.Copyright;
     kpt.Version := FParameters.Version;
     kpt.BCP47Tags := FParameters.BCP47Tags;

--- a/windows/src/developer/kmconvert/Makefile
+++ b/windows/src/developer/kmconvert/Makefile
@@ -12,6 +12,11 @@ build: version.res manifest.res dirs icons
     $(COPY) $(WIN32_TARGET_PATH)\kmconvert.exe $(PROGRAM)\developer
     if exist $(WIN32_TARGET_PATH)\kmconvert.dbg $(COPY) $(WIN32_TARGET_PATH)\kmconvert.dbg $(DEBUGPATH)\developer
 
+    # Copy template files to project
+    -rd /s/q $(ROOT)\bin\developer\projects\templates
+    -mkdir $(ROOT)\bin\developer\projects\templates
+    xcopy /s /y data\* $(ROOT)\bin\developer\projects\templates
+
 icons:
     rc icons.rc
 

--- a/windows/src/developer/kmconvert/kmconvert.dpr
+++ b/windows/src/developer/kmconvert/kmconvert.dpr
@@ -105,7 +105,11 @@ begin
       Run;
     except
       on E: Exception do
-        if not SentryHandleException(E) then raise;
+        if not SentryHandleException(E) then
+        begin
+          writeln(E.Message);
+          ExitCode := 99;
+        end;
     end;
   finally
     TKeymanSentryClient.Stop;


### PR DESCRIPTION
A few fixes and improvements:
* kmconvert was missing a command line parameter for `-target` to specify the platform targets for a project
* kmconvert should avoid throwing unhandled exceptions, rather if sentry is not present then just write to console.
* Include kmconvert and its data files in the deployment of kmcomp.zip, which is done on the build agent (just need to make sure files are in the right place here.)
* Side fix: also made sure kmcomp would emit the exception message to console if sentry is not present.