### PR TITLE
feat(developer): Add 'full copyright' field to templates

### DIFF
--- a/windows/src/developer/TIKE/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
@@ -66,6 +66,7 @@ begin
       iwk.KeyboardIDTemplate := f.KeyboardID;
       iwk.NameTemplate := f.KeyboardName;
       iwk.Copyright := f.Copyright;
+      iwk.FullCopyright := f.FullCopyright;
       iwk.Version := f.Version;
       iwk.BCP47Tags := f.BCP47Tags;
       iwk.Author := f.Author;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.dfm
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.dfm
@@ -2,18 +2,19 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'New Wordlist Lexical Model Project'
-  ClientHeight = 484
+  ClientHeight = 510
   ClientWidth = 412
   OldCreateOrder = True
   Position = poScreenCenter
   OnDestroy = FormDestroy
+  ExplicitTop = -8
   ExplicitWidth = 418
-  ExplicitHeight = 513
+  ExplicitHeight = 539
   PixelsPerInch = 96
   TextHeight = 13
   object lblFileName: TLabel
     Left = 8
-    Top = 395
+    Top = 423
     Width = 46
     Height = 13
     Caption = 'Model &ID:'
@@ -21,7 +22,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblPath: TLabel
     Left = 8
-    Top = 259
+    Top = 287
     Width = 26
     Height = 13
     Caption = '&Path:'
@@ -29,7 +30,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblAuthorID: TLabel
     Left = 8
-    Top = 314
+    Top = 342
     Width = 51
     Height = 13
     Caption = 'Aut&hor ID:'
@@ -45,7 +46,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblVersion: TLabel
     Left = 8
-    Top = 92
+    Top = 120
     Width = 39
     Height = 13
     Caption = '&Version:'
@@ -61,7 +62,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblLanguages: TLabel
     Left = 9
-    Top = 118
+    Top = 146
     Width = 52
     Height = 13
     Caption = '&Languages'
@@ -69,14 +70,14 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblBCP47: TLabel
     Left = 8
-    Top = 341
+    Top = 369
     Width = 90
     Height = 13
     Caption = '&Primary Language:'
   end
   object lblUniq: TLabel
     Left = 8
-    Top = 368
+    Top = 396
     Width = 67
     Height = 13
     Caption = 'Uni&que Name:'
@@ -92,52 +93,60 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object Bevel1: TBevel
     Left = 8
-    Top = 289
+    Top = 317
     Width = 397
     Height = 2
   end
   object lblProjectFilename: TLabel
     Left = 8
-    Top = 422
+    Top = 450
     Width = 77
     Height = 13
     Caption = 'Project &filename'
     FocusControl = editProjectFilename
   end
+  object Label1: TLabel
+    Left = 8
+    Top = 92
+    Width = 68
+    Height = 13
+    Caption = 'Fu&ll copyright:'
+    FocusControl = editFullCopyright
+  end
   object editModelID: TEdit
     Left = 120
-    Top = 392
+    Top = 420
     Width = 205
     Height = 21
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 13
+    TabOrder = 14
     OnChange = editModelIDChange
   end
   object cmdBrowse: TButton
     Left = 332
-    Top = 256
+    Top = 284
     Width = 73
     Height = 21
     Caption = '&Browse...'
-    TabOrder = 9
+    TabOrder = 10
     OnClick = cmdBrowseClick
   end
   object editPath: TEdit
     Left = 120
-    Top = 256
+    Top = 284
     Width = 205
     Height = 21
-    TabOrder = 8
+    TabOrder = 9
     OnChange = editPathChange
   end
   object editAuthorID: TEdit
     Left = 120
-    Top = 311
+    Top = 339
     Width = 205
     Height = 21
-    TabOrder = 10
+    TabOrder = 11
     OnChange = editModelIDComponentChange
   end
   object editCopyright: TEdit
@@ -150,10 +159,10 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object editVersion: TEdit
     Left = 120
-    Top = 89
+    Top = 117
     Width = 205
     Height = 21
-    TabOrder = 3
+    TabOrder = 4
     Text = '1.0'
     OnChange = editVersionChange
   end
@@ -167,27 +176,27 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object cmdOK: TButton
     Left = 252
-    Top = 451
+    Top = 479
     Width = 73
     Height = 25
     Caption = 'OK'
     Default = True
-    TabOrder = 15
+    TabOrder = 16
     OnClick = cmdOKClick
   end
   object cmdCancel: TButton
     Left = 331
-    Top = 451
+    Top = 479
     Width = 73
     Height = 25
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 16
+    TabOrder = 17
   end
   object gridLanguages: TStringGrid
     Left = 8
-    Top = 139
+    Top = 167
     Width = 317
     Height = 102
     ColCount = 2
@@ -195,7 +204,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     FixedCols = 0
     RowCount = 9
     Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-    TabOrder = 4
+    TabOrder = 5
     OnClick = gridLanguagesClick
     OnDblClick = gridLanguagesDblClick
     ColWidths = (
@@ -204,46 +213,46 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object cmdAddLanguage: TButton
     Left = 332
-    Top = 139
+    Top = 167
     Width = 73
     Height = 25
     Caption = '&Add...'
-    TabOrder = 5
+    TabOrder = 6
     OnClick = cmdAddLanguageClick
   end
   object cmdEditLanguage: TButton
     Left = 332
-    Top = 170
+    Top = 198
     Width = 73
     Height = 25
     Caption = '&Edit...'
-    TabOrder = 6
+    TabOrder = 7
     OnClick = cmdEditLanguageClick
   end
   object cmdRemoveLanguage: TButton
     Left = 332
-    Top = 201
+    Top = 229
     Width = 73
     Height = 25
     Caption = '&Remove'
-    TabOrder = 7
+    TabOrder = 8
     OnClick = cmdRemoveLanguageClick
   end
   object editUniq: TEdit
     Left = 120
-    Top = 365
+    Top = 393
     Width = 205
     Height = 21
-    TabOrder = 12
+    TabOrder = 13
     OnChange = editModelIDComponentChange
   end
   object cbBCP47: TComboBox
     Left = 120
-    Top = 338
+    Top = 366
     Width = 205
     Height = 21
     Style = csDropDownList
-    TabOrder = 11
+    TabOrder = 12
     OnClick = editModelIDComponentChange
   end
   object editModelName: TEdit
@@ -256,12 +265,20 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object editProjectFilename: TEdit
     Left = 120
-    Top = 419
+    Top = 447
     Width = 284
     Height = 21
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 14
+    TabOrder = 15
+  end
+  object editFullCopyright: TEdit
+    Left = 120
+    Top = 89
+    Width = 205
+    Height = 21
+    TabOrder = 3
+    OnChange = editFullCopyrightChange
   end
 end

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
@@ -56,6 +56,8 @@ type
     Bevel1: TBevel;
     lblProjectFilename: TLabel;
     editProjectFilename: TEdit;
+    Label1: TLabel;
+    editFullCopyright: TEdit;
     procedure cmdOKClick(Sender: TObject);
     procedure editModelIDComponentChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -72,6 +74,7 @@ type
     procedure editModelIDChange(Sender: TObject);
     procedure cmdBrowseClick(Sender: TObject);
     procedure editModelNameChange(Sender: TObject);
+    procedure editFullCopyrightChange(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -96,6 +99,7 @@ type
     function GetUniq: string;
     procedure UpdateModelIDFromComponents;
     procedure UpdateProjectFilename;
+    function GetFullCopyright: string;
   protected
     function GetHelpTopic: string; override;
     property AuthorID: string read GetAuthorID;
@@ -103,6 +107,7 @@ type
     property Uniq: string read GetUniq;
   public
     property Copyright: string read GetCopyright;
+    property FullCopyright: string read GetFullCopyright;
     property Version: string read GetVersion;
     property Author: string read GetAuthor;
     property ModelName: string read GetModelName;
@@ -147,6 +152,7 @@ begin
     try
       pt.Name := f.ModelName;
       pt.Copyright := f.Copyright;
+      pt.FullCopyright := f.FullCopyright;
       pt.Author := f.Author;
       pt.Version := f.Version;
       pt.BCP47Tags := f.BCP47Tags;
@@ -311,6 +317,12 @@ begin
   EnableControls;
 end;
 
+procedure TfrmNewModelProjectParameters.editFullCopyrightChange(
+  Sender: TObject);
+begin
+  EnableControls;
+end;
+
 procedure TfrmNewModelProjectParameters.editModelIDChange(Sender: TObject);
 begin
   UpdateProjectFilename;
@@ -376,6 +388,11 @@ end;
 function TfrmNewModelProjectParameters.GetCopyright: string;
 begin
   Result := Trim(editCopyright.Text);
+end;
+
+function TfrmNewModelProjectParameters.GetFullCopyright: string;
+begin
+  Result := editFullCopyright.Text;
 end;
 
 function TfrmNewModelProjectParameters.GetModelID: string;
@@ -457,7 +474,8 @@ end;
 procedure TfrmNewModelProjectParameters.UpdateAuthorIDFromAuthor;
 begin
   editAuthorID.Text := TLexicalModelUtils.CleanLexicalModelIDComponent(Author);
-  editCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
+  editCopyright.Text := Char($00A9 {copyright})+' '+Author;
+  editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
 end;
 
 procedure TfrmNewModelProjectParameters.UpdateUniqFromModelName;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
@@ -36,7 +36,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblCoypright: TLabel
     Left = 12
-    Top = 38
+    Top = 65
     Width = 51
     Height = 13
     Caption = '&Copyright:'
@@ -44,7 +44,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblVersion: TLabel
     Left = 12
-    Top = 65
+    Top = 118
     Width = 39
     Height = 13
     Caption = '&Version:'
@@ -52,7 +52,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblAuthor: TLabel
     Left = 12
-    Top = 92
+    Top = 38
     Width = 37
     Height = 13
     Caption = 'A&uthor:'
@@ -60,7 +60,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblTargets: TLabel
     Left = 12
-    Top = 119
+    Top = 145
     Width = 41
     Height = 13
     Caption = '&Targets:'
@@ -82,12 +82,20 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Caption = 'Project &filename'
     FocusControl = editProjectFilename
   end
+  object Label1: TLabel
+    Left = 12
+    Top = 91
+    Width = 68
+    Height = 13
+    Caption = 'Fu&ll copyright:'
+    FocusControl = editFullCopyright
+  end
   object editKeyboardID: TEdit
     Left = 120
     Top = 272
     Width = 205
     Height = 21
-    TabOrder = 11
+    TabOrder = 12
     OnChange = editKeyboardIDChange
   end
   object cmdBrowse: TButton
@@ -96,7 +104,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Width = 73
     Height = 21
     Caption = '&Browse...'
-    TabOrder = 10
+    TabOrder = 11
     OnClick = cmdBrowseClick
   end
   object editPath: TEdit
@@ -104,7 +112,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Top = 245
     Width = 205
     Height = 21
-    TabOrder = 9
+    TabOrder = 10
     OnChange = editPathChange
   end
   object editKeyboardName: TEdit
@@ -117,28 +125,28 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object editCopyright: TEdit
     Left = 120
-    Top = 35
+    Top = 62
     Width = 205
     Height = 21
-    TabOrder = 1
+    TabOrder = 2
     Text = #169
     OnChange = editCopyrightChange
   end
   object editVersion: TEdit
     Left = 120
-    Top = 62
+    Top = 115
     Width = 205
     Height = 21
-    TabOrder = 2
+    TabOrder = 4
     Text = '1.0'
     OnChange = editVersionChange
   end
   object editAuthor: TEdit
     Left = 120
-    Top = 89
+    Top = 35
     Width = 205
     Height = 21
-    TabOrder = 3
+    TabOrder = 1
     OnChange = editAuthorChange
   end
   object cmdOK: TButton
@@ -148,7 +156,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Height = 25
     Caption = 'OK'
     Default = True
-    TabOrder = 13
+    TabOrder = 14
     OnClick = cmdOKClick
   end
   object cmdCancel: TButton
@@ -159,16 +167,16 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 14
+    TabOrder = 15
   end
   object clbTargets: TCheckListBox
     Left = 120
-    Top = 116
+    Top = 142
     Width = 205
     Height = 97
     OnClickCheck = clbTargetsClickCheck
     ItemHeight = 13
-    TabOrder = 4
+    TabOrder = 5
   end
   object gridKeyboardLanguages: TStringGrid
     Left = 339
@@ -180,7 +188,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     FixedCols = 0
     RowCount = 9
     Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-    TabOrder = 5
+    TabOrder = 6
     OnClick = gridKeyboardLanguagesClick
     OnDblClick = gridKeyboardLanguagesDblClick
     ColWidths = (
@@ -193,7 +201,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Width = 73
     Height = 25
     Caption = '&Add...'
-    TabOrder = 6
+    TabOrder = 7
     OnClick = cmdKeyboardAddLanguageClick
   end
   object cmdKeyboardEditLanguage: TButton
@@ -202,7 +210,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Width = 73
     Height = 25
     Caption = 'Ed&it...'
-    TabOrder = 7
+    TabOrder = 8
     OnClick = cmdKeyboardEditLanguageClick
   end
   object cmdKeyboardRemoveLanguage: TButton
@@ -211,7 +219,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     Width = 72
     Height = 25
     Caption = '&Remove'
-    TabOrder = 8
+    TabOrder = 9
     OnClick = cmdKeyboardRemoveLanguageClick
   end
   object editProjectFilename: TEdit
@@ -222,7 +230,16 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 12
+    TabOrder = 13
     OnChange = editKeyboardIDChange
+  end
+  object editFullCopyright: TEdit
+    Left = 120
+    Top = 88
+    Width = 205
+    Height = 21
+    TabOrder = 3
+    Text = #169' YYYY'
+    OnChange = editFullCopyrightChange
   end
 end

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -49,6 +49,8 @@ type
     lblKeyboardLanguages: TLabel;
     lblProjectFilename: TLabel;
     editProjectFilename: TEdit;
+    Label1: TLabel;
+    editFullCopyright: TEdit;
     procedure cmdOKClick(Sender: TObject);
     procedure editKeyboardNameChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -65,6 +67,7 @@ type
     procedure editPathChange(Sender: TObject);
     procedure editKeyboardIDChange(Sender: TObject);
     procedure cmdBrowseClick(Sender: TObject);
+    procedure editFullCopyrightChange(Sender: TObject);
   private
     dlgBrowse: TBrowse4Folder;
     pack: TKPSFile; // Used temporarily for storing language list
@@ -86,10 +89,12 @@ type
     procedure SetKeyboardID(const Value: string);
     procedure SetKeyboardName(const Value: string);
     procedure UpdateProjectFilename;
+    function GetFullCopyright: string;
   protected
     function GetHelpTopic: string; override;
   public
     property Copyright: string read GetCopyright;
+    property FullCopyright: string read GetFullCopyright;
     property Version: string read GetVersion;
     property Author: string read GetAuthor;
     property Targets: TKeymanTargets read GetTargets;
@@ -145,6 +150,7 @@ begin
     try
       pt.Name := f.KeyboardName;
       pt.Copyright := f.Copyright;
+      pt.FullCopyright := f.FullCopyright;
       pt.Author := f.Author;
       pt.Version := f.Version;
       pt.BCP47Tags := f.BCP47Tags;
@@ -178,6 +184,7 @@ var
 begin
   inherited;
   editPath.Text := FKeymanDeveloperOptions.DefaultProjectPath;
+  editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' ';
 
   dlgBrowse := TBrowse4Folder.Create(Self);
   dlgBrowse.InitialDir := editPath.Text;
@@ -298,9 +305,18 @@ end;
 procedure TfrmNewProjectParameters.editAuthorChange(Sender: TObject);
 begin
   EnableControls;
+  if not editCopyright.Modified then
+    editCopyright.Text := Char($00A9 {copyright})+' '+Author;
+  if not editFullCopyright.Modified then
+    editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
 end;
 
 procedure TfrmNewProjectParameters.editCopyrightChange(Sender: TObject);
+begin
+  EnableControls;
+end;
+
+procedure TfrmNewProjectParameters.editFullCopyrightChange(Sender: TObject);
 begin
   EnableControls;
 end;
@@ -361,6 +377,11 @@ end;
 function TfrmNewProjectParameters.GetCopyright: string;
 begin
   Result := Trim(editCopyright.Text);
+end;
+
+function TfrmNewProjectParameters.GetFullCopyright: string;
+begin
+  Result := Trim(editFullCopyright.Text);
 end;
 
 function TfrmNewProjectParameters.GetHelpTopic: string;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -27,6 +27,7 @@ type
     FBCP47Tags: string;
     FCopyright: string;
     FTargets: TKeymanTargets;
+    FFullCopyright: string;
     function LoadKLIDDetails: Boolean;
     function ImportKeyboard(const DestinationFilename, DestinationKVKSFilename: string): Boolean;
     function GenerateIcon(const IconFilename: string): Boolean;
@@ -44,6 +45,7 @@ type
     function FindBCP47TagForKLID: string; overload;
     function GetProjectFilename: string;
     procedure SetTargets(const Value: TKeymanTargets);
+    procedure SetFullCopyright(const Value: string);
  public
     function Execute: Boolean; overload;
 
@@ -56,6 +58,7 @@ type
     property KeyboardIDTemplate: string read FKeyboardIDTemplate write SetKeyboardIDTemplate;
     property NameTemplate: string read FNameTemplate write SetNameTemplate;
     property Copyright: string read FCopyright write SetCopyright;
+    property FullCopyright: string read FFullCopyright write SetFullCopyright;
     property Version: string read FVersion write SetVersion;
     property BCP47Tags: string read FBCP47Tags write SetBCP47Tags;
     property Author: string read FAuthor write SetAuthor;
@@ -155,6 +158,11 @@ begin
   FDestinationPath := IncludeTrailingPathDelimiter(Value);
 end;
 
+procedure TImportWindowsKeyboard.SetFullCopyright(const Value: string);
+begin
+  FFullCopyright := Value;
+end;
+
 procedure TImportWindowsKeyboard.SetKeyboardIDTemplate(const Value: string);
 begin
   if Value = ''
@@ -211,6 +219,7 @@ begin
 
     FTemplate.Name := Format(FNameTemplate, [FBaseName]);
     FTemplate.Copyright := FCopyright;
+    FTemplate.FullCopyright := FFullCopyright;
     FTemplate.Author := FAuthor;
     FTemplate.Version := FVersion;
     FTemplate.IncludeIcon := True;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
@@ -14,6 +14,7 @@ type
     KeyboardID: string;
     Name: string;
     Copyright: string;
+    FullCopyright: string;
     Version: string;
     BCP47Tags: string;
     Author: string;
@@ -41,6 +42,7 @@ var
 begin
   Destination := '.';
   Copyright := 'Copyright (C)';
+  FullCopyright := 'Copyright (C) '+FormatDateTime('yyyy', Now);
   Version := '1.0';
   Targets := [ktAny];
 
@@ -91,22 +93,23 @@ begin
   writeln('  Creates a wordlist lexical model project in the repository template format');
   writeln;
   writeln('Parameters:');
-  writeln('  -nologo              Don''t show the program description and copyright banner');
-  writeln('  -klid <source-klid>  The KLID of the keyboard to import, per LoadKeyboardLayout');
-  writeln('  -id <keyboard_id>    The id of the keyboard to create');
-  writeln('                       (in `import-windows` mode, can be a format string)');
-  writeln('  -o <destination>     The target folder to write the project into, defaults to "."');
-  writeln('  -author <data>       Name of author of the keyboard/model, no default');
-  writeln('  -name <data>         Name of the keyboard/model, e.g. "My First Keyboard", "%s Basic" ');
-  writeln('                       (format strings are only valid in `import-windows` mode)');
-  writeln('  -copyright <data>    Copyright string for the keyboard/model, defaults to "Copyright (C)"');
-  writeln('  -version <data>      Version number of the keyboard/model, defaults to "1.0"');
-  writeln('  -languages <data>    space-separated list of BCP 47 tags, e.g. "en-US tpi-PG"');
+  writeln('  -nologo               Don''t show the program description and copyright banner');
+  writeln('  -klid <source-klid>   The KLID of the keyboard to import, per LoadKeyboardLayout');
+  writeln('  -id <keyboard_id>     The id of the keyboard to create');
+  writeln('                        (in `import-windows` mode, can be a format string)');
+  writeln('  -o <destination>      The target folder to write the project into, defaults to "."');
+  writeln('  -author <data>        Name of author of the keyboard/model, no default');
+  writeln('  -name <data>          Name of the keyboard/model, e.g. "My First Keyboard", "%s Basic" ');
+  writeln('                        (format strings are only valid in `import-windows` mode)');
+  writeln('  -copyright <data>     Copyright string for the keyboard/model, defaults to "Copyright (C)"');
+  writeln('  -fullcopyright <data> Longer copyright string for the keyboard/model, defaults to "Copyright (C) yyyy"');
+  writeln('  -version <data>       Version number of the keyboard/model, defaults to "1.0"');
+  writeln('  -languages <data>     Space-separated list of BCP 47 tags, e.g. "en-US tpi-PG"');
   // Model parameters
   writeln('Note: model identifiers are constructed from params: <id-author>.<id-language>.<id-uniq>');
-  writeln('  -id-author <data>    Identifier for author of model');
-  writeln('  -id-language <data>  Single BCP 47 tag identifying primary language of model');
-  writeln('  -id-uniq <data>      Unique name for the model');
+  writeln('  -id-author <data>     Identifier for author of model');
+  writeln('  -id-language <data>   Single BCP 47 tag identifying primary language of model');
+  writeln('  -id-uniq <data>       Unique name for the model');
 end;
 
 { TKMConvertParameters }
@@ -118,6 +121,7 @@ begin
   else if name = '-id' then KeyboardID := value
   else if name = '-name' then Self.Name := value
   else if name = '-copyright' then Copyright := value
+  else if name = '-full-copyright' then FullCopyright := value
   else if name = '-version' then Version := value
   else if name = '-languages' then BCP47Tags := value
   else if name = '-author' then Author := value

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -51,6 +51,7 @@ begin
     iwk.KeyboardIDTemplate := FParameters.KeyboardID;
     iwk.NameTemplate := FParameters.Name;
     iwk.Copyright := FParameters.Copyright;
+    iwk.FullCopyright := FParameters.FullCopyright;
     iwk.Version := FParameters.Version;
     iwk.BCP47Tags := FParameters.BCP47Tags;
     iwk.Author := FParameters.Author;
@@ -79,6 +80,7 @@ begin
       then kpt.Name := FParameters.KeyboardID
       else kpt.Name := FParameters.Name;
     kpt.Copyright := FParameters.Copyright;
+    kpt.FullCopyright := FParameters.FullCopyright;
     kpt.Version := FParameters.Version;
     kpt.BCP47Tags := FParameters.BCP47Tags;
     kpt.Author := FParameters.Author;
@@ -116,6 +118,7 @@ begin
   try
     mpt.Name := FParameters.Name;
     mpt.Copyright := FParameters.Copyright;
+    mpt.FullCopyright := FParameters.FullCopyright;
     mpt.Version := FParameters.Version;
     mpt.BCP47Tags := FParameters.BCP47Tags;
     mpt.Author := FParameters.Author;

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
@@ -24,6 +24,7 @@ type
     FBCP47Tags: string;
     FProjectType: TKeymanProjectType;
     FTargets: TKeymanTargets;
+    FFullCopyright: string;
 
   protected
     const
@@ -61,6 +62,7 @@ type
 
     property Name: string read FName write FName;
     property Copyright: string read FCopyright write FCopyright;
+    property FullCopyright: string read FFullCopyright write FFullCopyright;
     property Author: string read FAuthor write FAuthor;
     property Version: string read FVersion write FVersion;
     property BCP47Tags: string read FBCP47Tags write FBCP47Tags;
@@ -235,6 +237,7 @@ begin
   s := ReplaceStr(s, '$NAME', FName);
   s := ReplaceStr(s, '$VERSION', FVersion);
   s := ReplaceStr(s, '$COPYRIGHT', FCopyright);
+  s := ReplaceStr(s, '$FULLCOPYRIGHT', FFullCopyright);
   s := ReplaceStr(s, '$AUTHOR', FAuthor);
   s := ReplaceStr(s, '$DATE', FormatDateTime('yyyy-mm-dd', Now));
   if Pos('$LANGUAGES_KEYBOARD_INFO', s) > 0 then

--- a/windows/src/developer/kmconvert/data/basic-keyboard/LICENSE.md
+++ b/windows/src/developer/kmconvert/data/basic-keyboard/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-$COPYRIGHT
+$FULLCOPYRIGHT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/windows/src/developer/kmconvert/data/basic-keyboard/README.md
+++ b/windows/src/developer/kmconvert/data/basic-keyboard/README.md
@@ -1,17 +1,18 @@
 $NAME keyboard
 ==============
 
-$COPYRIGHT
-
 Version $VERSION
 
 Description
 -----------
-
 $NAME generated from template
 
 Links
 -----
+
+Copyright
+---------
+See [LICENSE.md](LICENSE.md)
 
 Supported Platforms
 -------------------

--- a/windows/src/developer/kmconvert/data/basic-keyboard/source/welcome.htm
+++ b/windows/src/developer/kmconvert/data/basic-keyboard/source/welcome.htm
@@ -22,7 +22,5 @@
 
 <!-- Insert Keyboard Layout Images or HTML here -->
 
-<p>$COPYRIGHT</p>
-
 </body>
 </html>

--- a/windows/src/developer/kmconvert/data/wordlist-lexical-model/LICENSE.md
+++ b/windows/src/developer/kmconvert/data/wordlist-lexical-model/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-$COPYRIGHT
+$FULLCOPYRIGHT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/windows/src/developer/kmconvert/data/wordlist-lexical-model/README.md
+++ b/windows/src/developer/kmconvert/data/wordlist-lexical-model/README.md
@@ -1,17 +1,18 @@
 $NAME lexical model
 ===================
 
-$COPYRIGHT
-
 Version $VERSION
 
 Description
 -----------
-
 $NAME generated from template
 
 Links
 -----
+
+Copyright
+---------
+See [LICENSE.md](LICENSE.md)
 
 Supported Platforms
 -------------------


### PR DESCRIPTION
Fixes #4807.

We want to differentiate between a short copyright message and a longer one that also contains a date. The long one is only needed in one place in a typical keyboard project. This reduces maintenance when making keyboard updates.

As a little side tweak, the New Keyboard Project Parameters dialog now prefills the copyright fields with the author's name as they type it, to reduce the amount of data
entry required.