### PR TITLE
fix(developer): TframeTextEditor.SetText was not synchronous 🍒

### DIFF
--- a/windows/src/developer/TIKE/main/UframeTextEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeTextEditor.pas
@@ -705,6 +705,11 @@ begin
 
   if FHasBeenLoaded then
   begin
+    // #5095 Update the backing store so we have the data available immediately
+    if modWebHttpServer.AppSource.IsSourceRegistered(FFileName) then
+      modWebHttpServer.AppSource.SetSource(FFilename, Value);
+
+    // Then update the text editor as well
     v := TJSONString.Create(Value);
     try
       ExecuteCommand('setText', v);


### PR DESCRIPTION
Fixes #5095.

Cherry-pick of #5096.

If the text editor was loaded, `SetText` would not be synchronous because it executed some Javascript to make the text change, so setting the text and immediately reading it again would give the old text. This is what the On Screen Keyboard editor was doing (it would synchronize the visual editor and text editor at save). This fix updates `SetText` to update the backing store as well as the front end editor.