### PR TITLE
fix(common/core/desktop): Fix warnings when compiling for armhf

### DIFF
--- a/common/core/desktop/src/kmx/kmx_file.cpp
+++ b/common/core/desktop/src/kmx/kmx_file.cpp
@@ -156,7 +156,7 @@ KMX_BOOL KMX_Processor::LoadKeyboard(km_kbp_path_name fileName, LPKEYBOARD *lpKe
 #ifdef KMX_64BIT
   kbp = CopyKeyboard(buf, filebase);
 #else
-  kbp = FixupKeyboard(buf, filebase, sz);
+  kbp = FixupKeyboard(buf, filebase);
 #endif
 
   if(!kbp) return FALSE;
@@ -261,7 +261,7 @@ LPKEYBOARD KMX_Processor::CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base)
 
 #else
 
-LPKEYBOARD KMX_Processor::FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base, KMX_DWORD dwFileSize)
+LPKEYBOARD KMX_Processor::FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base)
 {
   KMX_DWORD i, j;
   PCOMP_KEYBOARD ckbp = (PCOMP_KEYBOARD) base;
@@ -286,8 +286,8 @@ LPKEYBOARD KMX_Processor::FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base, KMX_DWOR
   {
     gp->dpName = StringOffset(base, cgp->dpName);
     gp->dpKeyArray = (LPKEY) (base + cgp->dpKeyArray);
-    if(cgp->dpMatch != NULL) gp->dpMatch = (PKMX_WCHAR) (base + cgp->dpMatch);
-    if(cgp->dpNoMatch != NULL) gp->dpNoMatch = (PKMX_WCHAR) (base + cgp->dpNoMatch);
+    if(cgp->dpMatch != 0) gp->dpMatch = (PKMX_WCHAR) (base + cgp->dpMatch);
+    if(cgp->dpNoMatch != 0) gp->dpNoMatch = (PKMX_WCHAR) (base + cgp->dpNoMatch);
 
     for(kp = gp->dpKeyArray, ckp = (PCOMP_KEY) kp, j = 0; j < gp->cxKeyArray; j++, kp++, ckp++)
     {

--- a/common/core/desktop/src/kmx/kmx_processor.h
+++ b/common/core/desktop/src/kmx/kmx_processor.h
@@ -41,13 +41,14 @@ private:
   KMX_DWORD m_modifiers = 0;
 
   /* File loading */
-  LPKEYBOARD FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base, KMX_DWORD dwFileSize);
   KMX_BOOL LoadKeyboard(km_kbp_path_name fileName, LPKEYBOARD *lpKeyboard);
   KMX_BOOL VerifyKeyboard(PKMX_BYTE filebase, size_t sz);
   KMX_BOOL VerifyChecksum(PKMX_BYTE buf,  size_t sz);
   PKMX_WCHAR StringOffset(PKMX_BYTE base, KMX_DWORD offset);
 #ifdef KMX_64BIT
   LPKEYBOARD CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);
+#else
+  LPKEYBOARD FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);
 #endif
 
   KMX_BOOL ReleaseKeyboardMemory(LPKEYBOARD kbd);


### PR DESCRIPTION
Compiling on armhf outputs two warnings:
- NULL used in arithmetic [-Wpointer-arith] (line 289 and 290)
- unused parameter ‘dwFileSize’ [-Wunused-parameter] (line 264)

(related to #5072)