### PR TITLE
fix(common/core/desktop): Don't segfault on invalid .kmx file 🍒

### DIFF
--- a/common/core/desktop/src/kmx/kmx_processevent.cpp
+++ b/common/core/desktop/src/kmx/kmx_processevent.cpp
@@ -15,9 +15,11 @@ namespace km {
       p.replace_extension(".kmx");
       _valid = bool(_kmx.Load(p.c_str()));
 
+      if (!_valid)
+        return;
+
       keyboard_attributes::options_store defaults;
-      if (_valid)
-        _kmx.GetOptions()->Init(defaults);
+      _kmx.GetOptions()->Init(defaults);
 
       for (auto const & opt: defaults)
       {


### PR DESCRIPTION
(Fixes #5100)

🍒 of #5101 