### PR TITLE
chore(linux): Swap order of dependency

### DIFF
--- a/linux/keyman-config/debian/control
+++ b/linux/keyman-config/debian/control
@@ -70,7 +70,7 @@ Depends:
  kmflcomp (>=10.99.33),
  python3-bs4,
  python3-gi,
- python3-raven | python3-sentry-sdk,
+ python3-sentry-sdk | python3-raven,
  ${misc:Depends},
  ${python3:Depends},
 Description: Keyman for Linux configuration


### PR DESCRIPTION
This was already partially done in 4dd0a48b2 (PR #5064), but we missed this line.