### PR TITLE
feat(android/app): Auto-generate Play Store release notes

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -47,6 +47,9 @@ KMAPro/**/assets/info/
 # KMAPRo default packages
 KMAPro/**/assets/*.kmp
 
+# Play Store release notes (copied from whatsnew.md)
+KMAPro/kMAPro/src/main/play/release-notes/**/*.txt
+
 # Eclipse files
 .project
 .settings/

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -106,3 +106,14 @@ if $DO_HTM; then
   cp android_images/* "$DESTHTM/android_images/"
 
 fi
+
+#
+# Copy release notes for Gradle Play Publisher to upload
+# Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
+#
+PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
+if [ $TIER = "stable" ]; then
+  PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
+fi
+echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
+cp $KEYMAN_ROOT/android/help/about/whatsnew.md $PLAY_RELEASE_NOTES

--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -1,7 +1,6 @@
 ---
 title: What's New
 ---
+Here are some of the new features we have added to Keyman 15.0 for Android:
 
-Here are some of the new features we have added to Keyman for Android 15.0:
-
-* 
+* Meet Google Play's target API level requirement of 30 (Android 11)


### PR DESCRIPTION
Addresses #4686

From the Gradle Play Publisher [Reference](https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes), this PR updates build-help.sh to copy the release note info from `whatsnew.md` to the txt file the Gradle Play Publisher expects (`tier`.txt or default.txt if unspecified).

For now, our markdown preamble gets included 
```
---
title: What's New
---
```

Will verify the release notes on the alpha build get published before closing the issue.

