### PR TITLE
fix(web): active element selection in multi-touch scenarios

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -525,12 +525,19 @@ namespace com.keyman.dom {
     }
 
     private static selectTouch(e: TouchEvent): Touch {
+      /**
+       * During multi-touch event's, it's possible for one or more touches of said multi-touch
+       * to be against irrelevant parts of the page.  We only want to consider touches against
+       * valid OutputTargets - against elements of the page that KMW can attach to.
+       * With touch active... that's a TouchAliasElement.
+       */
       let isValidTouch = function(touch: Touch, target: EventTarget): boolean {
         return e.target == target && !!(findTouchAliasTarget(touch.target as HTMLElement));
       }
 
       // The event at least tells us the event's target, which can be used to help check
-      // whether or not individual `Touch`es may be related to this event.
+      // whether or not individual `Touch`es may be related to this specific event for
+      // an ongoing multitouch scenario.
       let target = e.target;
       
       // Find the first touch affected by this event that matches the current target.

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -524,6 +524,27 @@ namespace com.keyman.dom {
       super(keyman);
     }
 
+    private static selectTouch(e: TouchEvent): Touch {
+      let isValidTouch = function(touch: Touch, target: EventTarget): boolean {
+        return e.target == target && !!(findTouchAliasTarget(touch.target as HTMLElement));
+      }
+
+      // The event at least tells us the event's target, which can be used to help check
+      // whether or not individual `Touch`es may be related to this event.
+      let target = e.target;
+      
+      // Find the first touch affected by this event that matches the current target.
+      for(let i=0; i < e.changedTouches.length; i++) {
+        if(isValidTouch(e.changedTouches[i], target)) {
+          return e.changedTouches[i];
+        }
+      }
+
+      // Shouldn't be possible.  Just in case, we'd prefer a silent failure that allows
+      // callers to silently abort.
+      throw new Error("Could not select valid Touch for event.");
+    }
+
     /**
      * Handle receiving focus by simulated input field 
      *      
@@ -538,7 +559,12 @@ namespace com.keyman.dom {
       };
 
       if(e && dom.Utils.instanceof(e, "TouchEvent")) {
-        tEvent=(e as TouchEvent).touches[0];
+        try {
+          tEvent=DOMTouchHandlers.selectTouch(e as TouchEvent);
+        } catch(err) {
+          console.warn(err);
+          return;
+        }
       } else { // Allow external code to set focus and thus display the OSK on touch devices if required (KMEW-123)
         tEvent={clientX:0, clientY:0}
 
@@ -796,9 +822,16 @@ namespace com.keyman.dom {
 
       // Identify the target from the touch list or the event argument (IE 10 only)
       var target: HTMLElement;
+      let touch: Touch;
       
       if(dom.Utils.instanceof(e, "TouchEvent")) {
-        target = (e as TouchEvent).targetTouches[0].target as HTMLElement;
+        try {
+          touch=DOMTouchHandlers.selectTouch(e as TouchEvent);
+        } catch(err) {
+          console.warn(err);
+          return;
+        }
+        target = touch.target as HTMLElement;
       } else {
         target = e.target as HTMLElement;
       }
@@ -816,8 +849,8 @@ namespace com.keyman.dom {
       var x, y;
 
       if(dom.Utils.instanceof(e, "TouchEvent")) {
-        x = (e as TouchEvent).touches[0].screenX;
-        y = (e as TouchEvent).touches[0].screenY;
+        x = touch.screenX;
+        y = touch.screenY;
       } else {
         x = (e as MouseEvent).screenX;
         y = (e as MouseEvent).screenY;

--- a/web/source/dom/touchAliasElement.ts
+++ b/web/source/dom/touchAliasElement.ts
@@ -34,52 +34,6 @@ namespace com.keyman.dom {
     // Not to be confused with the simulated scrollbar.
     let scroller: HTMLElement;
 
-    // Designed to 'breadcrumb' elements to assist in diagnosis of an evasive known issue.
-    let elementLogger = function() {
-      let elementDescriber = function(element: HTMLElement) {
-        if(element) {
-          let childIndex = undefined;
-          let parent = element.parentElement;
-          if(parent) {
-            for(let child = parent.firstChild, i = 0; child; child = child.nextSibling, i++) {
-              if(child == element) {
-                childIndex = i;
-                break;
-              }
-            }
-          }
-
-          // ID:  should never be specified for TouchAliasElement components
-          // Class:  specified for the root TouchAliasElement and for its text spans
-          // index:  useful for identifying elements with no class info
-          return `tag type ${element.tagName}, class '${element.classList}', index under parent: '${childIndex}', id '${element.id}'`;
-        } else {
-          return `null`;
-        }
-      };
-
-      // Very rough breadcrumbs for use with any Sentry logs.
-
-      // We'd expect to see the telltale 'keymanweb-input' appear as the class for one of the
-      // three elements logged here... at least, normally.
-      console.info(`(For diagnosing https://github.com/keymanapp/keyman/issues/4797)`);
-      // We don't use .innerHTML because that would tell us what the user's been typing.
-      // No keylogging!
-      console.info(`Original target: ${elementDescriber(target)}`);
-      if(target.previousSibling && target.previousSibling instanceof HTMLElement) {
-        console.info(`Previous sibling: ${elementDescriber(target.previousSibling)}`);
-      }
-      if(target.nextSibling && target.nextSibling instanceof HTMLElement) {
-        console.info(`Next sibling: ${elementDescriber(target.nextSibling)}`);
-      }
-      console.info(`Target's parent: ${elementDescriber(target.parentElement)}`);
-      if(target.parentElement instanceof HTMLElement) {
-        console.info(`Target's grandparent: ${elementDescriber(target.parentElement.parentElement)}`);
-      }
-      // Triggers the actual Sentry log (on pages that include Sentry logging)
-      //throw new Error(`Unexpected touch-start event target.`);
-    };
-
     // Identify the scroller element
     if(target && dom.Utils.instanceof(target, "HTMLSpanElement")) {
       scroller=target.parentNode as HTMLElement;
@@ -101,12 +55,6 @@ namespace com.keyman.dom {
       return target['kmw_ip'] as TouchAliasElement;
     } else {
       // If it's not in any way related to a TouchAliasElement, simply return null.
-      // NOTE:  At present, this method should only be called in places that actually EXPECT a TouchAliasElement...
-      // So if we fail to find one, something's gone wrong, and we'd like more details.
-
-      // There's an evasive error related to this at present so we'll temporarily console-log info
-      // that may help us determine why we couldn't find the expected element.
-      elementLogger();
       return null;
     }
 
@@ -115,7 +63,6 @@ namespace com.keyman.dom {
     if(root['base'] !== undefined) {
       return root as TouchAliasElement;
     } else {
-      elementLogger();
       return null;
     }
   }


### PR DESCRIPTION
Fixes #4797.

According to MDN's notes on browser compatibility, there should be no loss of compatibility with these changes.
- `touches`: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches#browser_compatibility
- `changedTouches`: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches#browser_compatibility

### User Testing

Note:  this will require testing on a live touch device; Chrome emulation does not support multiple touches.  As such, you'll likely need a test setup using a service similar to `ngrok` to properly 'serve' the testing page for your device.

As for the actual test... it's best to refer to the repro notes in #4797.  Note that you'll need to use developer mode and open the console view to verify that no errors occur; the user-visible effect (broken longpress key menu) still remains, as that's a separate (OSK) issue.

Some 'fun' things you can do now:  touch the top-most input element on the "unminified source" testing page, and without letting go, touch the second.  Without releasing either finger, try to scroll the top element - it'll scroll properly.  If you don't mind playing Twister with your fingers, use yet another to type with the OSK, and the second input element should receive the keystroke, even if actively scrolling the first, so long as both of the first two touches are held.
