### PR TITLE
chore(ios): works around wrong-workspace Carthage 0.38 lookup issue

### DIFF
--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -212,9 +212,18 @@ update_bundle
 if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
-    # TODO: Replace the workaround-script with the base `carthage` command once
-    # we've properly updated to 0.37's better approach.
-    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap --platform iOS || fail "carthage boostrap failed"
+
+    carthage checkout || fail "Carthage dependency loading failed"
+
+    # Carthage sometimes picks the wrong .xcworkspace if two are available in a dependency's repo.
+    # Easiest way to override it - delete the wrong one (or just its scheme)
+
+    # Deleted workspace - a test for proper deployment to CocoaPods.  Doesn't matter here.
+    rm -r ./Carthage/Checkouts/DeviceKit/CocoaPodsVerification/ || fail "Carthage dependency loading failed"
+
+    # stable-14.0 will continue to use the old fat-framework approach.
+    # In 15.0, this will be replaced with an XCFramework approach instead.
+    carthage build --platform iOS || fail "Carthage dependency loading failed"
 fi
 
 echo

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -213,7 +213,7 @@ if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
 
-    carthage checkout || fail "Carthage dependency loading failed"
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh checkout || fail "Carthage dependency loading failed"
 
     # Carthage sometimes picks the wrong .xcworkspace if two are available in a dependency's repo.
     # Easiest way to override it - delete the wrong one (or just its scheme)
@@ -223,7 +223,7 @@ if [ $DO_CARTHAGE = true ]; then
 
     # stable-14.0 will continue to use the old fat-framework approach.
     # In 15.0, this will be replaced with an XCFramework approach instead.
-    carthage build --platform iOS || fail "Carthage dependency loading failed"
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh build --platform iOS || fail "Carthage dependency loading failed"
 fi
 
 echo

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -155,9 +155,18 @@ fi
 if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
-    # TODO: Replace the workaround-script with the base `carthage` command once
-    # we've properly updated to 0.37's better approach.
-    $KEYMAN_ROOT/resources/build/carthage-workaround.sh bootstrap --platform iOS || fail "carthage bootstrap failed"
+
+    carthage checkout || fail "Carthage dependency loading failed"
+
+    # Carthage sometimes picks the wrong .xcworkspace if two are available in a dependency's repo.
+    # Easiest way to override it - delete the wrong one (or just its scheme)
+
+    # Deleted workspace - a test for proper deployment to CocoaPods.  Doesn't matter here.
+    rm -r ./Carthage/Checkouts/DeviceKit/CocoaPodsVerification/ || fail "Carthage dependency loading failed"
+
+    # stable-14.0 will continue to use the old fat-framework approach.
+    # In 15.0, this will be replaced with an XCFramework approach instead.
+    carthage build --platform iOS || fail "Carthage dependency loading failed"
 fi
 
 #

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -156,7 +156,7 @@ if [ $DO_CARTHAGE = true ]; then
     echo
     echo "Load dependencies with Carthage"
 
-    carthage checkout || fail "Carthage dependency loading failed"
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh checkout || fail "Carthage dependency loading failed"
 
     # Carthage sometimes picks the wrong .xcworkspace if two are available in a dependency's repo.
     # Easiest way to override it - delete the wrong one (or just its scheme)
@@ -166,7 +166,7 @@ if [ $DO_CARTHAGE = true ]; then
 
     # stable-14.0 will continue to use the old fat-framework approach.
     # In 15.0, this will be replaced with an XCFramework approach instead.
-    carthage build --platform iOS || fail "Carthage dependency loading failed"
+    $KEYMAN_ROOT/resources/build/carthage-workaround.sh build --platform iOS || fail "Carthage dependency loading failed"
 fi
 
 #


### PR DESCRIPTION
As noted during development of #5107, moving to Carthage 0.38 had one minor hiccup that will affect stable builds - it chooses the wrong workspace within the DeviceKit repo when building the framework.  Fortunately, we can simply delete that workspace after it's fetched, after which things will work fine like before.