### PR TITLE
chore(android): Add -clean flag to build script

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -41,7 +41,7 @@ android {
     String env_release_store_password = System.getenv("release_store_password")
     String env_release_key_alias = System.getenv("release_key_alias")
     String env_release_key_password = System.getenv("release_key_password")
-    if (env_release_store_file != null) {
+    if (env_release_store_file != null && file(env_release_store_file).exists()) {
         signingConfigs {
             release {
                 println "Using signing from environment"
@@ -86,7 +86,7 @@ sentry {
 }
 
 String env_keys_json_file = System.getenv("keys_json_file")
-if (env_keys_json_file != null) {
+if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
     apply plugin: 'com.github.triplet.play'
 
     play {

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -62,7 +62,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            if (env_release_store_file != null) {
+            if (env_release_store_file != null && file(env_release_store_file).exists()) {
                 signingConfig signingConfigs.release
             }
         }

--- a/android/build.sh
+++ b/android/build.sh
@@ -37,17 +37,11 @@ clean ( ) {
 
 echo Build KMEA and KMAPro:
 
-# Parse args
-while [[ $# -gt 0 ]] ; do
-    key="$1"
-    case $key in
-        -clean)
-            clean
-            ;;
-    esac
-    shift # past argument
-done
-
+# Check about cleaning artifact paths
+if [[ "$1" == "-clean" ]] ; then
+  clean
+  shift
+fi
 
 # Building Keyman Engine for Android
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build Keyman Engine for Android, Keyman for Android, and FirstVoices Android app
-# Use '-clean' flag to clean build artifacts
+# Use '-clean' flag to clean build artifacts (won't do other build steps)
 
 # Set sensible script defaults:
 # set -e: Terminate script if a command returns an error
@@ -43,8 +43,6 @@ clean ( ) {
     echo "Cleaning upload directory"
     rm -rf "$KEYMAN_ROOT/android/upload"
   fi
-
-  exit
 }
 
 echo Build KMEA and KMAPro:
@@ -52,7 +50,7 @@ echo Build KMEA and KMAPro:
 # Check about cleaning artifact paths
 if [[ "$1" == "-clean" ]] ; then
   clean
-  shift
+  exit
 fi
 
 # Building Keyman Engine for Android

--- a/android/build.sh
+++ b/android/build.sh
@@ -32,6 +32,7 @@ clean ( ) {
   if [ -d "$KEYMAN_ROOT/android/upload" ]; then
     echo "Cleaning upload directory"
     rm -rf "$KEYMAN_ROOT/android/upload"
+  fi
 }
 
 echo Build KMEA and KMAPro:

--- a/android/build.sh
+++ b/android/build.sh
@@ -20,15 +20,20 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 #
 SHLVL=0
 
+# Clean build artifacts: keyman-engine.aar libaries, output and upload directories
 clean ( ) {
-  if [ -f "$KEYMAN_ROOT/android/KMAPro/kMAPro/libs/keyman-engine.aar" ]; then
-    echo "Cleaning keyman-engine.aar"
-    rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/libs/keyman-engine.aar"
-  fi
+  cd "$KEYMAN_ROOT/android"
+
+  find . -name "keyman-engine.aar" | while read fname; do
+    echo "Cleaning $fname"
+    rm $fname
+  done
+
   if [ -d "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs" ]; then
-    echo "Cleaning KMAPro build outputs"
+    echo "Cleaning KMAPro build outputs directory"
     rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs"
   fi
+
   if [ -d "$KEYMAN_ROOT/android/upload" ]; then
     echo "Cleaning upload directory"
     rm -rf "$KEYMAN_ROOT/android/upload"

--- a/android/build.sh
+++ b/android/build.sh
@@ -20,7 +20,33 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 #
 SHLVL=0
 
+clean ( ) {
+  if [ -f "$KEYMAN_ROOT/android/KMAPro/kMAPro/libs/keyman-engine.aar" ]; then
+    echo "Cleaning keyman-engine.aar"
+    rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/libs/keyman-engine.aar"
+  fi
+  if [ -d "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs" ]; then
+    echo "Cleaning KMAPro build outputs"
+    rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs"
+  fi
+  if [ -d "$KEYMAN_ROOT/android/upload" ]; then
+    echo "Cleaning upload directory"
+    rm -rf "$KEYMAN_ROOT/android/upload"
+}
+
 echo Build KMEA and KMAPro:
+
+# Parse args
+while [[ $# -gt 0 ]] ; do
+    key="$1"
+    case $key in
+        -clean)
+            clean
+            ;;
+    esac
+    shift # past argument
+done
+
 
 # Building Keyman Engine for Android
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Build Keyman Engine Android and KMAPro
+# Build Keyman Engine for Android, Keyman for Android, and FirstVoices Android app
+# Use '-clean' flag to clean build artifacts
 
 # Set sensible script defaults:
 # set -e: Terminate script if a command returns an error
@@ -28,6 +29,10 @@ clean ( ) {
     echo "Cleaning $fname"
     rm $fname
   done
+  if [ -f "$KEYMAN_ROOT/oem/firstvoices/android/app/libs/keyman-engine.aar" ]; then
+    echo "Cleaning OEM FirstVoices keyman-engine.aar"
+    rm "$KEYMAN_ROOT/oem/firstvoices/android/app/libs/keyman-engine.aar"
+  fi
 
   if [ -d "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs" ]; then
     echo "Cleaning KMAPro build outputs directory"
@@ -38,6 +43,8 @@ clean ( ) {
     echo "Cleaning upload directory"
     rm -rf "$KEYMAN_ROOT/android/upload"
   fi
+
+  exit
 }
 
 echo Build KMEA and KMAPro:

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     String env_release_store_password = System.getenv("oem_firstvoices_release_store_password")
     String env_release_key_alias = System.getenv("oem_firstvoices_release_key_alias")
     String env_release_key_password = System.getenv("oem_firstvoices_release_key_password")
-    if (env_release_store_file != null) {
+    if (env_release_store_file != null && file(env_release_store_file).exists()) {
         signingConfigs {
             release {
                 println "Using signing from environment"
@@ -49,7 +49,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (env_release_store_file != null) {
+            if (env_release_store_file != null && file(env_release_store_file).exists()) {
                 signingConfig signingConfigs.release
             }
         }
@@ -73,7 +73,7 @@ sentry {
 }
 
 String env_keys_json_file = System.getenv("oem_firstvoices_keys_json_file")
-if (env_keys_json_file != null) {
+if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
     apply plugin: 'com.github.triplet.play'
 
     play {


### PR DESCRIPTION
Infrastructure update to add `-clean` flag to build script

Also update app Gradle files to check if key store files exists (in support of running Test-14.0 builds on the Linux build agent)

TODO:
- [ ] Cherry-pick to stable-14.0
- [ ] Enable Linux build agent for Android "Test-14.0" and Test-14.0: Samples and Test projects" configs after this PR is on 14.0 and 15.0
- [ ] Adjust build steps to use gosh and `build.sh -clean`