### PR TITLE
chore(web): Add CI script to kill BrowserStack tunnel 🍒 

### DIFF
--- a/web/source/build_kill_browserstack.sh
+++ b/web/source/build_kill_browserstack.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+# 
+# CI script to kill BrowserStack testing tunnel (Windows only)
+#
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+get_builder_OS
+
+if [ ${os_id} == 'win' ]; then
+  taskkill //f //im BrowserStackLocal.exe
+fi


### PR DESCRIPTION
🍒 -pick of #5136 to stable-14.0

This way, the KeymanWeb Test-14.0 CI configuration can call `npx ../../resources/gosh/gosh.js ./build_kill_browserstack.sh` on either 14.0 or 15.0 builds (and use the Linux build agent)

TODO
- [ ] Update the config step after this PR merges