### PR TITLE
feat(common): offline help css

### DIFF
--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -72,6 +72,7 @@ displayInfo "" \
 cd $KEYMAN_ROOT/android/help
 
 MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
+CSS="../../resources/build/offline-help-style-spec.txt"
 MD=`find . -name "*.md"`
 DESTHTM="$THIS_DIR/KMAPro/kMAPro/src/main/assets/info"
 
@@ -94,7 +95,7 @@ if $DO_HTM; then
       OUTFILE="$DESTHTM/${INFILE%.md}.html"
       echo "Processing $INFILE to $(basename "$OUTFILE")"
       mkdir -p "$(dirname "$OUTFILE")"
-      pandoc -s --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
+      pandoc -s -H "$CSS" --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
     done
   fi
 

--- a/ios/build-help.sh
+++ b/ios/build-help.sh
@@ -72,6 +72,7 @@ displayInfo "" \
 cd $KEYMAN_ROOT/ios/help
 
 MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
+CSS="../../resources/build/offline-help-style-spec.txt"
 MD=`find . -name "*.md"`
 DESTHTM="$THIS_DIR/keyman/Keyman/resources/OfflineHelp.bundle/Contents/Resources"
 
@@ -94,7 +95,7 @@ if $DO_HTM; then
       OUTFILE="$DESTHTM/${INFILE%.md}.html"
       echo "Processing $INFILE to $(basename "$OUTFILE")"
       mkdir -p "$(dirname "$OUTFILE")"
-      pandoc -s --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
+      pandoc -s -H "$CSS" --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
     done
   fi
 

--- a/mac/build-help.sh
+++ b/mac/build-help.sh
@@ -72,6 +72,7 @@ displayInfo "" \
 cd $KEYMAN_ROOT/mac/help
 
 MDLUA="$KEYMAN_ROOT/resources/build/html-link.lua"
+CSS="../../resources/build/offline-help-style-spec.txt"
 MD=`find . -name "*.md"`
 DESTHTM="$THIS_DIR/Keyman4MacIM/Keyman4MacIM/Help"
 
@@ -94,7 +95,7 @@ if $DO_HTM; then
       OUTFILE="$DESTHTM/${INFILE%.md}.html"
       echo "Processing $INFILE to $(basename "$OUTFILE")"
       mkdir -p "$(dirname "$OUTFILE")"
-      pandoc -s --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
+      pandoc -s -H "$CSS" --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
     done
   fi
 

--- a/resources/build/offline-help-style-spec.txt
+++ b/resources/build/offline-help-style-spec.txt
@@ -255,4 +255,34 @@ article dl dd span.optional {
 	padding: 1px 6px 3px;
 	border-radius: 6px;
 }
+
+/* Font styling limited to Ascii characters */
+kbd {
+    background: none repeat scroll 0 0 #CCCCD0;
+		border: 1px solid #808080;
+		border-right: 2px solid #606060;
+    border-bottom: 2px solid #606060;
+    border-radius: 4px;
+    color: #000000;
+    font-family: "NotoSans-Regular-Ascii";
+    font-size: 13px;
+    font-weight: bold;
+    margin: 0;
+    padding: 1px 4px;
+    min-width: 1.5em;
+    text-align: center;
+    display: inline-block;
+}
+
+/* Make the <kbd> element look like an iOS key. */
+kbd.ios {
+    background-color: #fafafa; /* faaa fa fa fa fa faaaa far better... */
+    border: 0;
+    box-shadow: /* Hard shadow */     0 1px rgba(0,0,0,0.4),
+                /* Diffuse shadow */  0 1px 4px rgba(0,0,0,0.2),
+                /* Highlight */ inset 0 1px white;
+    border-radius: 4px;
+    font-weight: 500;
+}
+
 </style>

--- a/resources/build/offline-help-style-spec.txt
+++ b/resources/build/offline-help-style-spec.txt
@@ -1,0 +1,258 @@
+<style>
+/**************************************
+ * CSS RESET
+ * ***********************************/
+
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+  padding-left: 10px;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+}
+
+tbody {
+    display: table-row-group;
+    vertical-align: middle;
+}
+
+table td{
+	padding: 4px;
+}
+
+html{
+		font-family: 'Cabin', sans-serif;
+		color: #333;
+}
+
+html p,
+html dd,
+html li {
+  font-family: 'Calibri', sans-serif;
+  font-size: 14pt;
+}
+
+body {
+	line-height: inherit;
+}
+
+/**************************************
+ * Page Layout CSS
+ * ***********************************/
+
+html{
+    cursor: default;
+    background: #fff;
+}
+
+:not(div.interface-hierarchy) blockquote {
+  margin-left: 32px;
+  margin-bottom: 16px;
+  background: rgba(242,242,242,0.9);
+  padding: 4px;
+  border-radius: 4px;
+}
+
+h1{
+	text-align: left;
+	font-size: 28pt;
+	padding: 40px 10px 10px 10px;
+}
+
+h2{
+	font-size: 20pt;
+	line-height: 1.4;
+	padding: 32px 10px 10px 10px;
+}
+
+h3{
+	font-size: 16pt;
+	font-weight: 600;
+	padding: 16px 10px 10px 10px;
+}
+
+h3, h2, h1 {
+  color: #B92034;
+  margin-top: 10px;
+}
+
+h1 a, h2 a, h3 a {
+  color: #B92034;
+}
+
+h1 a:visited, h2 a:visited, h3 a:visited {
+  color: #B92034;
+}
+
+h4{
+  font-size: 14pt;
+  font-weight: 600;
+  padding: 4px 10px 4px 10px;
+}
+
+p, dl, .itemizedlist {
+	padding: 0px 10px 10px 10px;
+	line-height: 1.4;
+	font-size: 14pt;
+}
+
+p a{
+	color: #B92034;
+	text-decoration: underline;
+	cursor: pointer;
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+li{
+	margin-left: 30px;
+	list-style: disc;
+	list-style-position: outside;
+	line-height: 1.4;
+  font-size: 14pt;
+}
+
+img.center{
+	margin-left: auto;
+	margin-right: auto;
+	display: block;
+}
+
+img.inline {
+  margin: 0;
+}
+
+.itemizedlist li{
+	list-style-position: outside;
+}
+
+li {
+  margin-bottom: 12px;
+}
+
+/* TODO: deprecate this since prismjs handles it. This also conflicts with the line-numbers plugin */
+pre {
+  margin-left: 9px;
+  margin-right: 9px;
+  padding: 9px;
+  line-height: 1.4;
+}
+
+pre code {
+  line-height: 1.4;
+}
+
+ol li a{
+	color: #B92034;
+}
+
+code {
+  font-family: Consolas, Courier, "Courier New", mono;
+  font-size: 10.5pt;
+}
+
+strong, b {
+  font-weight: bold;
+}
+
+i, cite, em, var, address, dfn {
+font-style: italic;
+}
+
+dt {
+  margin-top: 16px;
+}
+
+dt:first-child {
+  margin-top: 0;
+}
+
+dd {
+  margin-left: 32pt;
+}
+
+table.standard-table td,
+table.standard-table th {
+  border: solid #e0e0dc;
+  border-width: 0 1px 1px 0;
+  padding: 6px;
+  text-align: left;
+}
+table.standard-table th {
+  border: 2px solid #fff;
+  border-bottom: 2px solid #d4dde4;
+  background: #eaeff2;
+  background: rgba(212,221,228,.5);
+  font-family: 'Open Sans Light',sans-serif;
+  font-size: 14px;
+  padding: 2px 8px 4px;
+  font-weight: 700;
+}
+
+table.standard-table td {
+  background-color: #f9fafb;
+  background-color: rgba(212,221,228,.15);
+  border: 2px solid #fff;
+  box-shadow: inset 0 -1px 0 0 #eaeff2;
+  box-shadow: inset 0 -1px 0 0 rgba(212,221,228,.5);
+}
+
+article dl dt span.readonly {
+  background-color: #666769;
+  font-size: 13px;
+  color: white;
+  padding: 1px 6px 3px;
+  border-radius: 6px;
+}
+
+article dl dd span.optional {
+	background-color: #9c9c9c;
+	font-size: 13px;
+	font-style: italic;
+	font-weight: lighter;
+	color: white;
+	padding: 1px 6px 3px;
+	border-radius: 6px;
+}
+</style>

--- a/windows/src/desktop/help/build.sh
+++ b/windows/src/desktop/help/build.sh
@@ -137,6 +137,7 @@ build_hhc() {
 #
 
 MDLUA="$KEYMAN_ROOT/resources/build/htm-link.lua"
+CSS="../../../../resources/build/offline-help-style-spec.txt"
 MD=`find -name "*.md"`
 DESTCHM="$THIS_DIR/../../../bin/help/desktop"
 
@@ -159,7 +160,7 @@ if $DO_CHM; then
       OUTFILE="$DESTCHM/${INFILE%.md}.htm"
       echo "Processing $INFILE to $(basename "$OUTFILE")"
       mkdir -p "$(dirname "$OUTFILE")"
-      pandoc -s --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
+      pandoc -s -H "$CSS" --lua-filter="$MDLUA" -t html -o "$OUTFILE" $INFILE
     done
   fi
 


### PR DESCRIPTION
This PR adds a new common resource file:  `resources/build/offline-help-style-spec.txt`.  This defines custom CSS wrapped in a <style> tag as needed for compatibility with `pandoc -H`:

        -H FILE, --include-in-header=FILE|URL
              Include  contents  of  FILE, verbatim, at the end of the header.
              This can be  used,  for  example,  to  include  special  CSS  or
              JavaScript in HTML documents.  This option can be used repeated-
              ly to include multiple files in the header.  They  will  be  in-
              cluded in the order specified.  Implies --standalone.

This can then be directly imported into all pages converted from markdown.

Also, a fun detail:  if we need project-specific CSS, this approach will support that as well:

> This option can be used repeatedly to include multiple files in the header.  They will be included in the order specified.

Due to the wonderful similarity among our offline-help scripts, I was able to integrate this and verify the results (in an independent browser) for the following:
* android
* iOS
* mac
* windows

Here's how the main iOS offline help page looks when doing so.  I figured I'd use Chrome emulation to get the feel right.

<img width="285" alt="Screen Shot 2021-05-26 at 4 08 47 PM" src="https://user-images.githubusercontent.com/25213402/119634360-e12bee80-be3c-11eb-8a63-397ae58f8fb5.png">

So much better than:

<img width="289" alt="Screen Shot 2021-05-26 at 4 10 58 PM" src="https://user-images.githubusercontent.com/25213402/119634469-fb65cc80-be3c-11eb-813a-40b753d80b05.png">

I built the custom CSS file starting from https://github.com/keymanapp/help.keyman.com/blob/master/cdn/dev/css/template.css, pruning out everything dependent upon that site's structure, leaving only what was relevant (typically, whatever fell within the #section2 element, which holds each page's main content).  This way, the help site and the offline help pages should have a similar feel.

--------

It's worth noting that this should be very easy to 🍒-pick back to stable, adding a late "feature" to 14.0 if we want.  It's not a code change, after all - just a nice tweak to the help docs.