### PR TITLE
fix(ios): artifact upload preparation

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -19,6 +19,9 @@ engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyman-sentr
 Keyman 2*
 Carthage
 
+# Path for build artifact upload preparation
+upload
+
 # Default resource packages (which may be downloaded automatically via build-script
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/*.kmp
 

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -283,7 +283,7 @@ if [ $DO_KEYMANAPP = true ]; then
     # Time to prepare the deployment archive data.
     echo ""
     echo "Preparing .xcarchive."
-    xcodebuild $XCODEFLAGS_EXT -scheme Keyman \
+    xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
                 -archivePath $ARCHIVE_PATH \
                 archive -allowProvisioningUpdates \
                 VERSION=$VERSION \

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -9,13 +9,22 @@ set -e
 # Exit if unset variable used
 ## set -u (causes history-utils.sh to fail)
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# This script runs from its parent's folder
+cd "$(dirname "$THIS_SCRIPT")/.."
+
 # Only allow one upload artifact set to exist.
 if [ -d "upload" ]; then
   rm -rf upload
 fi
 
 #Include script dependency
-. ../resources/build/history/history-utils.sh         #includes the following
+. $KEYMAN_ROOT/resources/build/history/history-utils.sh         #includes the following
 #. ../resources/shellHelperFunctions.sh
 
 BUILD_NUMBER=`cat ../VERSION.md`
@@ -37,7 +46,7 @@ mkdir -p "${UPLOAD_DIR}"
 # First, we prep the files for publication: write changelog
 
 echo "Writing changelog to $CHANGELOG_PATH"
-get_version_notes "ios" "%build.number%" "$TIER" > $CHANGELOG_PATH
+get_version_notes "ios" "${BUILD_NUMBER}" "$TIER" > $CHANGELOG_PATH
 echo "* Minor fixes and performance improvements" >> $CHANGELOG_PATH
 assertFileExists "${CHANGELOG_PATH}"
 


### PR DESCRIPTION
I made one mistake when importing the artifact-prep script in #5140 - TeamCity's build variables are managed by TC itself and replaced _before_ the script is sent to a build agent to run.  So, `%build_number%` is not available for the in-repo version of the script.

Fortunately... we already have access to `$BUILD_NUMBER`.  It's a simple replacement.  I then added a few tweaks to use our standard shell-script headers and such.

Finally, I added one tweak to the iOS build script, just to be sure Xcode doesn't fail an .xcarchive build for code-signing weirdness, as it's not required for that file type.  This is a small tweak to something from #5155 from yesterday; this part will be 15.0-only.