### PR TITLE
change(ios): minimum iOS version -> 12.1

### DIFF
--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -1704,7 +1704,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = SystemKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1750,7 +1750,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = SystemKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1893,7 +1893,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = KeymanEngine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1948,7 +1948,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = KeymanEngine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2014,7 +2014,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "KeymanEngine/resources/Keyman.bundle/Contents/Resources/KeymanEngine-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2051,7 +2051,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "KeymanEngine/resources/Keyman.bundle/Contents/Resources/KeymanEngine-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2144,7 +2144,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = KeymanEngine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2187,7 +2187,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
 				ENABLE_BITCODE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2237,7 +2237,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = SystemKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2326,7 +2326,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "KeymanEngine/resources/Keyman.bundle/Contents/Resources/KeymanEngine-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2442,7 +2442,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
 				ENABLE_BITCODE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2475,7 +2475,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
 				ENABLE_BITCODE = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors+Extension.swift
@@ -24,95 +24,50 @@ extension Colors {
   // The primary color used for selected UI elements in the settings menu.
   public static var selectionPrimary: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "SelectionPrimary")!
-      } else {
-        return UIColor(red: 204.0 / 255.0,
-                       green: 136.0 / 255.0,
-                       blue: 34.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "SelectionPrimary")!
     }
   }
 
   // The primary color used for selected UI elements in Get Started menu.
   public static var selectionSecondary: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "SelectionSecondary")!
-      } else {
-        return UIColor(red: 95.0 / 255.0,
-                       green: 196.0 / 255.0,
-                       blue: 217.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "SelectionSecondary")!
     }
   }
 
   public static var statusToolbar: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "StatusToolbar")!
-      } else {
-        return UIColor(red: 0.5,
-                       green: 0.75,
-                       blue: 0.25,
-                       alpha: 0.9)
-      }
+      return UIColor(named: "StatusToolbar")!
     }
   }
 
   public static var statusResourceUpdateButton: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "StatusResourceUpdateButton")!
-      } else {
-        return UIColor(red: 0.75,
-                       green: 1.0,
-                       blue: 0.5,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "StatusResourceUpdateButton")!
     }
   }
 
   public static var spinnerBackground: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "SpinnerBackground")!
-      } else {
-        return UIColor(white: 0.5,
-                       alpha: 0.8)
-      }
+      return UIColor(named: "SpinnerBackground")!
     }
   }
 
   public static var labelNormal: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "LabelNormal")!
-      } else {
-        return UIColor.lightGray
-      }
+      return UIColor(named: "LabelNormal")!
     }
   }
 
   public static var labelHighlighted: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "LabelHighlighted")!
-      } else {
-        return UIColor.darkGray
-      }
+      return UIColor(named: "LabelHighlighted")!
     }
   }
 
   public static var listSeparator: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "ListSeparator")!
-      } else {
-        return UIColor.lightGray
-      }
+      return UIColor(named: "ListSeparator")!
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Colors.swift
@@ -32,103 +32,50 @@ public class Colors {
 
   public static var popupKey: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "KeyPrimary", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 244.0 / 255.0,
-                       green: 244.0 / 255.0,
-                       blue: 244.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "KeyPrimary", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var keyText: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "KeyText", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor.black
-      }
+      return UIColor(named: "KeyText", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var popupKeyHighlighted: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 136.0 / 255.0,
-                       green: 136.0 / 255.0,
-                       blue: 1.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   // I'm not 100% on the distinction, but this should be fine for now.
   public static var popupKeyTint: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 181.0 / 255.0,
-                       green: 181.0 / 255.0,
-                       blue: 181.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "SelectedKey", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var keyboardBackground: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "KeyboardBackground", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 210.0 / 255.0,
-                       green: 214.0 / 255.0,
-                       blue: 220.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "KeyboardBackground", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var keyboardSelectionPrimary: UIColor {
     get {
-      if #available(iOS 11.0, *) {
-        return UIColor(named: "KeyboardSelectionPrimary", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 204.0 / 255.0,
-                       green: 136.0 / 255.0,
-                       blue: 34.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "KeyboardSelectionPrimary", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var helpBubbleGradient1: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient1", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 253.0 / 255.0,
-                       green: 244.0 / 255.0,
-                       blue: 196.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "HelpBubbleGradient1", in: engineBundle, compatibleWith: nil)!
     }
   }
 
   public static var helpBubbleGradient2: UIColor {
     get {
-      if #available(iOSApplicationExtension 11.0, *) {
-        return UIColor(named: "HelpBubbleGradient2", in: engineBundle, compatibleWith: nil)!
-      } else {
-        return UIColor(red: 233.0 / 255.0,
-                       green: 224.0 / 255.0,
-                       blue: 176.0 / 255.0,
-                       alpha: 1.0)
-      }
+      return UIColor(named: "HelpBubbleGradient2", in: engineBundle, compatibleWith: nil)!
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/JSONDecoder.DateDecodingStrategy+ISO8601Fallback.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/JSONDecoder.DateDecodingStrategy+ISO8601Fallback.swift
@@ -16,13 +16,7 @@ extension JSONDecoder.DateDecodingStrategy {
     return .formatted(formatter)
   }
   static var ios8601WithFallback: JSONDecoder.DateDecodingStrategy {
-    if #available(iOS 10.0, *) {
-      return .iso8601
-    }
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-    return .formatted(formatter)
+    return .iso8601
   }
   
   static var ios8601WithMilliseconds: JSONDecoder.DateDecodingStrategy {

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -73,34 +73,18 @@ private class CustomInputView: UIInputView, UIInputViewAudioFeedback {
   func setConstraints() {
     let innerView = keymanWeb.view!
 
-    var guide: UILayoutGuide
-    var conditionalGuide: Bool = false
-
-    if #available(iOSApplicationExtension 11.0, *) {
-      guide = self.safeAreaLayoutGuide
-      conditionalGuide = true
-    } else {
-      guide = self.layoutMarginsGuide
-    }
+    let guide = self.safeAreaLayoutGuide
 
     // Fallback on earlier versions
     innerView.topAnchor.constraint(equalTo:    guide.topAnchor).isActive = true
     innerView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
-    if conditionalGuide {
-      innerView.leftAnchor.constraint(equalTo:   guide.leftAnchor).isActive = true
-      innerView.rightAnchor.constraint(equalTo:  guide.rightAnchor).isActive = true
-    } else {
-      innerView.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
-      innerView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
-    }
+
+    innerView.leftAnchor.constraint(equalTo:   guide.leftAnchor).isActive = true
+    innerView.rightAnchor.constraint(equalTo:  guide.rightAnchor).isActive = true
 
     // Allow these to be broken if/as necessary to resolve layout issues.
-    var kbdWidthConstraint: NSLayoutConstraint
-    if conditionalGuide {
-      kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: guide.widthAnchor)
-    } else {
-      kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: self.widthAnchor)
-    }
+    let kbdWidthConstraint = innerView.widthAnchor.constraint(equalTo: guide.widthAnchor)
+
     kbdWidthConstraint.priority = .defaultHigh
     kbdWidthConstraint.isActive = true
 
@@ -176,14 +160,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     let scaling = KeyboardScaleMap.getDeviceDefaultKeyboardScale(forPortrait: self.isPortrait)
 
     return scaling?.bannerHeight ?? 38 // default for iPhone SE, older/smaller devices
-  }
-
-  open override var hasFullAccess: Bool {
-    if #available(iOS 11.0, *) {
-      // Nice and straight-forward here!
-      return super.hasFullAccess
-    }
-    return Storage.shared != nil
   }
 
   private var keyboardListCount: Int {
@@ -352,11 +328,9 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
       // A full-context deletion will report numCharsToDelete == 0 and won't
       // otherwise delete selected text.
-      if #available(iOSApplicationExtension 11.0, *) {
-        if let selected = textDocumentProxy.selectedText {
-          if selected.count > 0 {
-            textDocumentProxy.deleteBackward()
-          }
+      if let selected = textDocumentProxy.selectedText {
+        if selected.count > 0 {
+          textDocumentProxy.deleteBackward()
         }
       }
       return
@@ -451,12 +425,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   // These require the view to appear - parent and our relationship with it must exist!
   private func setOuterConstraints() {
     var baseWidthConstraint: NSLayoutConstraint
-    if #available(iOSApplicationExtension 11.0, *) {
-      baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.safeAreaLayoutGuide.widthAnchor)
-    } else {
-      //baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.layoutMarginsGuide.widthAnchor)
-      baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.widthAnchor)
-    }
+    baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.safeAreaLayoutGuide.widthAnchor)
     baseWidthConstraint.priority = UILayoutPriority(rawValue: 999)
     baseWidthConstraint.isActive = true
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -540,17 +540,12 @@ extension KeymanWebViewController: WKScriptMessageHandler {
       // Not usable by older iPhone models.
       AudioServicesPlaySystemSound(kSystemSoundID_MediumVibrate)
     } else { // if vibrationSupport == .taptic
-      if #available(iOSApplicationExtension 10.0, *) {
-        // Available with iPhone 7 and beyond, we can now produce nicely customized haptic feedback.
-        // We use this style b/c it's short, and in essence it is a minor UI element collision -
-        // a single key with blocked (erroneous) output.
-        // Oddly, is a closer match to SystemSoundID 1520 than 1521.
-        let vibrator = UIImpactFeedbackGenerator(style: UIImpactFeedbackGenerator.FeedbackStyle.heavy)
-        vibrator.impactOccurred()
-      } else {
-        // Fallback on earlier feedback style
-        AudioServicesPlaySystemSound(kSystemSoundID_MediumVibrate)
-      }
+      // Available with iPhone 7 and beyond, we can now produce nicely customized haptic feedback.
+      // We use this style b/c it's short, and in essence it is a minor UI element collision -
+      // a single key with blocked (erroneous) output.
+      // Oddly, is a closer match to SystemSoundID 1520 than 1521.
+      let vibrator = UIImpactFeedbackGenerator(style: UIImpactFeedbackGenerator.FeedbackStyle.heavy)
+      vibrator.impactOccurred()
     }
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/PackageInstallViewController.swift
@@ -356,7 +356,7 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     self.pickingCompletionHandler(selectedResources.map { $0.typedFullID })
 
     // Prevent swipe dismissal.
-    if #available(iOSApplicationExtension 13.0, *) {
+    if #available(iOS 13.0, *) {
       self.isModalInPresentation = true
     }
 
@@ -375,7 +375,7 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     // First, show the package's welcome - if it exists.
     if let welcomeVC = PackageWebViewController(for: package, page: .welcome) {
       // Prevent swipe dismissal.
-      if #available(iOSApplicationExtension 13.0, *) {
+      if #available(iOS 13.0, *) {
         welcomeVC.isModalInPresentation = true
       }
 
@@ -467,11 +467,7 @@ public class PackageInstallViewController<Resource: LanguageResource>: UIViewCon
     } else {
       let selectionColor = UIView()
 
-      if #available(iOSApplicationExtension 11.0, *) {
-        selectionColor.backgroundColor = UIColor(named: "SelectionPrimary")
-      } else {
-        selectionColor.backgroundColor = Colors.selectionPrimary
-      }
+      selectionColor.backgroundColor = Colors.selectionPrimary
 
       cell = UITableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)
       cell.selectedBackgroundView = selectionColor

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -195,11 +195,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     } else {
       let selectionColor = UIView()
 
-      if #available(iOSApplicationExtension 11.0, *) {
-        selectionColor.backgroundColor = UIColor(named: "SelectionPrimary")
-      } else {
-        selectionColor.backgroundColor = Colors.selectionPrimary
-      }
+      selectionColor.backgroundColor = Colors.selectionPrimary
 
       if keyboards.count < 2 {
         cell = KeyboardNameTableViewCell(style: .subtitle, reuseIdentifier: cellIdentifier)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/LanguageSettingsViewController.swift
@@ -150,10 +150,9 @@ class LanguageSettingsViewController: UITableViewController {
           doPredictionsSwitch!.isOn = userDefaults.predictSettingForLanguage(languageID: self.language.id)
           doPredictionsSwitch!.addTarget(self, action: #selector(self.predictionSwitchValueChanged), for: .valueChanged)
           cell.addSubview(doPredictionsSwitch!)
-          if #available(iOSApplicationExtension 9.0, *) {
-            doPredictionsSwitch!.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-            doPredictionsSwitch!.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
-          }
+
+          doPredictionsSwitch!.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+          doPredictionsSwitch!.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
         } else if 1 == indexPath.row {
           correctionsCell = cell
           cell.accessoryType = .none
@@ -166,10 +165,9 @@ class LanguageSettingsViewController: UITableViewController {
           doCorrectionsSwitch!.isOn = userDefaults.correctSettingForLanguage(languageID: self.language.id)
           doCorrectionsSwitch!.addTarget(self, action: #selector(self.correctionSwitchValueChanged), for: .valueChanged)
           cell.addSubview(doCorrectionsSwitch!)
-          if #available(iOSApplicationExtension 9.0, *) {
-            doCorrectionsSwitch!.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-            doCorrectionsSwitch!.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
-          }
+
+          doCorrectionsSwitch!.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+          doCorrectionsSwitch!.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
 
           // Disable interactivity if the prediction toggle is set to 'off'.
           doCorrectionsSwitch!.isHidden = !userDefaults.predictSettingForLanguage(languageID: self.language.id)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/SettingsViewController.swift
@@ -78,30 +78,27 @@ open class SettingsViewController: UITableViewController {
       "reuseid": "enablecrashreporting"
       ])
 
-    // The iOS Files app is only available with 11.0+.
-    if #available(iOS 11.0, *) {
-      if let _ = URL(string: UIApplication.openSettingsURLString) {
-        itemsArray.append([
-          "title": NSLocalizedString("menu-settings-system-keyboard-menu", bundle: engineBundle, comment: ""),
-          "subtitle": "",
-          "reuseid": "systemkeyboardsettings"
-          ])
-      }
-
+    if let _ = URL(string: UIApplication.openSettingsURLString) {
       itemsArray.append([
-        "title": NSLocalizedString("menu-settings-install-from-file", bundle: engineBundle, comment: ""),
-        "subtitle": NSLocalizedString("menu-settings-install-from-file-description", bundle: engineBundle, comment: ""),
-        "reuseid" : "installfile"
+        "title": NSLocalizedString("menu-settings-system-keyboard-menu", bundle: engineBundle, comment: ""),
+        "subtitle": "",
+        "reuseid": "systemkeyboardsettings"
         ])
-
-      #if DEBUG && !NO_SENTRY
-              itemsArray.append([
-        "title": "Force a crash",
-        "subtitle": "Test Sentry error-reporting integration",
-        "reuseid" : "forcederror"
-        ])
-      #endif
     }
+
+    itemsArray.append([
+      "title": NSLocalizedString("menu-settings-install-from-file", bundle: engineBundle, comment: ""),
+      "subtitle": NSLocalizedString("menu-settings-install-from-file-description", bundle: engineBundle, comment: ""),
+      "reuseid" : "installfile"
+      ])
+
+    #if DEBUG && !NO_SENTRY
+            itemsArray.append([
+      "title": "Force a crash",
+      "subtitle": "Test Sentry error-reporting integration",
+      "reuseid" : "forcederror"
+      ])
+    #endif
 
     _ = view
   }
@@ -158,11 +155,9 @@ open class SettingsViewController: UITableViewController {
         showBannerSwitch.addTarget(self, action: #selector(self.bannerSwitchValueChanged),
                                       for: .valueChanged)
         cell.addSubview(showBannerSwitch)
-        
-        if #available(iOSApplicationExtension 9.0, *) {
-          showBannerSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-          showBannerSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
-        }
+
+        showBannerSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+        showBannerSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
       case "showgetstarted":
         let showAgainSwitch = UISwitch()
         showAgainSwitch.translatesAutoresizingMaskIntoConstraints = false
@@ -174,11 +169,9 @@ open class SettingsViewController: UITableViewController {
         showAgainSwitch.addTarget(self, action: #selector(self.showGetStartedSwitchValueChanged),
                                       for: .valueChanged)
         cell.addSubview(showAgainSwitch)
-        
-        if #available(iOSApplicationExtension 9.0, *) {
-          showAgainSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-          showAgainSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
-        }
+
+        showAgainSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+        showAgainSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
       case "enablecrashreporting":
         let enableReportingSwitch = UISwitch()
         enableReportingSwitch.translatesAutoresizingMaskIntoConstraints = false
@@ -191,10 +184,9 @@ open class SettingsViewController: UITableViewController {
                                       for: .valueChanged)
         cell.addSubview(enableReportingSwitch)
 
-        if #available(iOSApplicationExtension 9.0, *) {
-          enableReportingSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-          enableReportingSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
-        }
+        enableReportingSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
+        enableReportingSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
+        
       case "systemkeyboardsettings", "installfile", "forcederror":
         break
       default:

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
@@ -46,10 +46,8 @@ public class TextField: UITextField, KeymanResponder {
     delegateProxy = TextFieldDelegateProxy(self)
     delegate = delegateProxy
 
-    if #available(iOS 9.0, *) {
-      inputAssistantItem.leadingBarButtonGroups = []
-      inputAssistantItem.trailingBarButtonGroups = []
-    }
+    inputAssistantItem.leadingBarButtonGroups = []
+    inputAssistantItem.trailingBarButtonGroups = []
 
     self.inputView = Manager.shared.inputViewController.view
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
@@ -45,10 +45,8 @@ public class TextView: UITextView, KeymanResponder {
     delegateProxy = TextViewDelegateProxy(self)
     delegate = delegateProxy
 
-    if #available(iOS 9.0, *) {
-      inputAssistantItem.leadingBarButtonGroups = []
-      inputAssistantItem.trailingBarButtonGroups = []
-    }
+    inputAssistantItem.leadingBarButtonGroups = []
+    inputAssistantItem.trailingBarButtonGroups = []
     
     self.inputView = Manager.shared.inputViewController.view
 

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -1105,7 +1105,7 @@
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "Keyman-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1140,7 +1140,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				INFOPLIST_FILE = "Keyman-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1297,7 +1297,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1341,7 +1341,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1436,7 +1436,7 @@
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "Keyman-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1481,7 +1481,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -64,7 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ = KeymanEngine.log
 
     UniversalLinks.externalLinkLauncher = { url in
-      UIApplication.shared.openURL(url)
+      UIApplication.shared.open(url)
     }
 
     Manager.applicationGroupIdentifier = "group.KM4I"

--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -170,11 +170,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // Workaround to display overlay window above keyboard
-    if #available(iOS 9.0, *) {
-      let windows = UIApplication.shared.windows
-      if let lastWindow = windows.last {
-        _overlayWindow!.windowLevel = lastWindow.windowLevel + 1
-      }
+    let windows = UIApplication.shared.windows
+    if let lastWindow = windows.last {
+      _overlayWindow!.windowLevel = lastWindow.windowLevel + 1
     }
     return _overlayWindow!
   }

--- a/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/GetStartedViewController/GetStartedViewController.swift
@@ -114,17 +114,14 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       }
     case 1:
       cell.textLabel?.text = NSLocalizedString("tutorial-system-keyboard", comment: "")
-      if #available(iOS 11.0, *) {
-        // We can expedite this via near-direct settings link.
-        // So, let's add the one extra needed detail to our detail text.
-        let keyboardsMenuText = NSLocalizedString("ios-settings-keyboards", comment: "")
-        let enableText = String.init(format: NSLocalizedString("toggle-to-enable", comment: ""), "Keyman")
-        // Probably needs to be i18n-adjusted too.
-        let menuBreadcrumbing = NSLocalizedString("menu-breadcrumbing", comment: "")
-        cell.detailTextLabel?.text = String.init(format: menuBreadcrumbing, keyboardsMenuText, enableText)
-      } else {
-        cell.detailTextLabel?.text = ""
-      }
+      // We can expedite this via near-direct settings link.
+      // So, let's add the one extra needed detail to our detail text.
+      let keyboardsMenuText = NSLocalizedString("ios-settings-keyboards", comment: "")
+      let enableText = String.init(format: NSLocalizedString("toggle-to-enable", comment: ""), "Keyman")
+      // Probably needs to be i18n-adjusted too.
+      let menuBreadcrumbing = NSLocalizedString("menu-breadcrumbing", comment: "")
+      cell.detailTextLabel?.text = String.init(format: menuBreadcrumbing, keyboardsMenuText, enableText)
+
       if !AppDelegate.isKeymanEnabledSystemWide() {
         cell.accessoryType = .none
       } else {
@@ -155,8 +152,7 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
       mainViewController.dismissGetStartedView(nil)
       mainViewController.showInstalledLanguages()
     case 1:
-      if #available(iOS 11.0, *),  // if "Keyboards" is an option in our app's settings menu
-         let appSettings = URL(string: UIApplication.openSettingsURLString) {
+      if let appSettings = URL(string: UIApplication.openSettingsURLString) {
         UniversalLinks.externalLinkLauncher?(appSettings)
       } else {
         let setUpVC = SetUpViewController()

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -109,16 +109,14 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // Unfortunately, it's the main app with the file definitions.
     // We have to gerry-rig this so that the framework-based SettingsViewController
     // can launch the app-based DocumentViewController.
-    if #available(iOS 11.0, *) {
-      Manager.shared.fileBrowserLauncher = { navVC in
-        let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"],
-                                              in: .import,
-                                              navVC: navVC)
+    Manager.shared.fileBrowserLauncher = { navVC in
+      let vc = PackageBrowserViewController(documentTypes: ["com.keyman.kmp"],
+                                            in: .import,
+                                            navVC: navVC)
 
-        // Present the "install from file" browser within the specified navigation view controller.
-        // (Allows displaying from within the Settings menu)
-        navVC.present(vc, animated: true)
-      }
+      // Present the "install from file" browser within the specified navigation view controller.
+      // (Allows displaying from within the Settings menu)
+      navVC.present(vc, animated: true)
     }
   }
 
@@ -144,13 +142,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       ResourceDownloadManager.shared.queryKeysForUpdatablePackages { _, _ in }
     }
 
-    // Implement a default color...
-    var bgColor = UIColor(red: 1.0, green: 1.0, blue: 207.0 / 255.0, alpha: 1.0)
-    // And if the iOS version is current enough, override it from the palette.
-    if #available(iOS 11.0, *) {
-      bgColor = UIColor(named: "InputBackground")!
-    }
-    view?.backgroundColor = bgColor
+    view?.backgroundColor = UIColor(named: "InputBackground")!
 
     // Check for configuration profiles/fonts to install
     FontManager.shared.registerCustomFonts()
@@ -192,7 +184,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     textView = TextView(frame: view.frame)
     textView.setKeymanDelegate(self)
     textView.viewController = self
-    textView.backgroundColor = bgColor
+    textView.backgroundColor = UIColor(named: "InputBackground")!
     textView.isScrollEnabled = true
     textView.isUserInteractionEnabled = true
     textView.font = textView.font?.withSize(textSize)
@@ -206,7 +198,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     }
 
     infoView.view?.isHidden = true
-    infoView.view?.backgroundColor = bgColor
+    infoView.view?.backgroundColor = UIColor(named: "InputBackground")!
     view?.addSubview(infoView!.view)
 
     resizeViews(withKeyboardVisible: textView.isFirstResponder)
@@ -403,11 +395,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
 
   @objc func keyboardDidShow(_ notification: Notification) {
     // Workaround to display overlay window above keyboard
-    if #available(iOS 9.0, *) {
-      let windows = UIApplication.shared.windows
-      let lastWindow = windows.last
-      overlayWindow.windowLevel = lastWindow!.windowLevel + 1
-    }
+    let windows = UIApplication.shared.windows
+    let lastWindow = windows.last
+    overlayWindow.windowLevel = lastWindow!.windowLevel + 1
   }
 
   @objc func keyboardWillHide(_ notification: Notification) {

--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -128,7 +128,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     super.viewDidLoad()
 
     extendedLayoutIncludesOpaqueBars = true
-    automaticallyAdjustsScrollViewInsets = false
 
     let systemFonts = Set<String>(UIFont.familyNames)
 
@@ -846,7 +845,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       userData.synchronize()
 
       if action.style == .default {
-        UIApplication.shared.openURL(URL(string: "\(baseUri)\(profileName)")!)
+        UIApplication.shared.open(URL(string: "\(baseUri)\(profileName)")!)
       }
       self.profileName = nil
     }

--- a/ios/samples/KMSample1/KMSample1.xcodeproj/project.pbxproj
+++ b/ios/samples/KMSample1/KMSample1.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 					"$(SRCROOT)/../../Carthage/Build/",
 				);
 				INFOPLIST_FILE = KMSample1/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -402,7 +402,7 @@
 					"$(SRCROOT)/../../Carthage/Build/",
 				);
 				INFOPLIST_FILE = KMSample1/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/samples/KMSample2/KMSample2.xcodeproj/project.pbxproj
+++ b/ios/samples/KMSample2/KMSample2.xcodeproj/project.pbxproj
@@ -553,7 +553,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = KMSample2/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -578,7 +578,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = KMSample2/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -604,7 +604,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -629,7 +629,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -650,7 +650,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				INFOPLIST_FILE = FirstVoices/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -679,7 +679,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = D7TR486TEH;
 				INFOPLIST_FILE = FirstVoices/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -710,7 +710,7 @@
 				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -745,7 +745,7 @@
 				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SWKeyboard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Fixes #5018.

<img width="266" alt="Screen Shot 2021-05-27 at 2 35 39 PM" src="https://user-images.githubusercontent.com/25213402/119784930-e3ec1980-bef8-11eb-8671-89b1fd7da451.png">

Also removes conditional check branches that addresses version of iOS that will no longer be supported, along with some of the deprecations.

------

There is one major work item left undone by this PR:

<img width="262" alt="Screen Shot 2021-05-27 at 2 30 04 PM" src="https://user-images.githubusercontent.com/25213402/119785041-09792300-bef9-11eb-95bc-a02a5a7b9857.png">

Of course, we _could_ just use iOS 11 instead of 12 and avoid the deprecation for now, but... we should probably still address this.  Also, if memory serves, iOS 11 is the point where XIBs against WKWebView become properly supported, so this PR will facilitate converting our old XIBs against UIWebView, making this remaining work item far less of a pain point than it used to be.