### PR TITLE
fix(linux): Fix Makefile and instructions for building

### DIFF
--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -1,7 +1,10 @@
 #!/usr/bin/make
 
-default: clean version man
+default: clean version man langtags
 	python3 setup.py build
+
+langtags:
+	cd buildtools && python3 ./build-langtags.py
 
 install: # run as sudo
 	pip3 install qrcode sentry-sdk

--- a/linux/keyman-config/README.md
+++ b/linux/keyman-config/README.md
@@ -35,6 +35,12 @@ sudo cp com.keyman.gschema.xml /usr/share/glib-2.0/schemas
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas
 ```
 
+### Standards data file
+
+Running `km-config` requires a language tag mapping file
+`keyman_config/standards/lang_tags_map.py`. This file gets generated during a package
+build, and also when running `make`.
+
 ### Installing manually from the repo
 
 `make && sudo make install` will install locally to `/usr/local`


### PR DESCRIPTION
Building km-config now requires an additional step so that
generates `lang_tags_map.py`. During a package build this happens in
`reconf.sh`. This change updates the documentation, and also adds
this build step to the Makefile, so that the file gets generated
when building from the command line.

Closes #5074.
