### PR TITLE
chore(ios): renames problematic app selectors

### DIFF
--- a/ios/keyman/Keyman/Keyman/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/MainViewController.swift
@@ -83,11 +83,13 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
     // Setup Notifications
-    NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow),
+    NotificationCenter.default.addObserver(self, selector: #selector(self.onKeyboardWillShow),
         name: UIResponder.keyboardWillShowNotification, object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardDidShow),
+    // `keyboardDidShow` apparently matches an internal Apple API and will fail an app submission.
+    // So, cheap workaround:  just prefix the thing.
+    NotificationCenter.default.addObserver(self, selector: #selector(self.onKeyboardDidShow),
         name: UIResponder.keyboardDidShowNotification, object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide),
+    NotificationCenter.default.addObserver(self, selector: #selector(self.onKeyboardWillHide),
         name: UIResponder.keyboardWillHideNotification, object: nil)
     keyboardLoadedObserver = NotificationCenter.default.addObserver(
       forName: Notifications.keyboardLoaded,
@@ -396,12 +398,12 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     return navigationController!.navigationBar.frame.height
   }
 
-  @objc func keyboardWillShow(_ notification: Notification) {
+  @objc func onKeyboardWillShow(_ notification: Notification) {
     _ = dismissDropDownMenu()
     resizeViews(withKeyboardVisible: true)
   }
 
-  @objc func keyboardDidShow(_ notification: Notification) {
+  @objc func onKeyboardDidShow(_ notification: Notification) {
     // Workaround to display overlay window above keyboard
     if #available(iOS 9.0, *) {
       let windows = UIApplication.shared.windows
@@ -410,7 +412,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     }
   }
 
-  @objc func keyboardWillHide(_ notification: Notification) {
+  @objc func onKeyboardWillHide(_ notification: Notification) {
     resizeViews(withKeyboardVisible: false)
   }
 
@@ -474,7 +476,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       navigationItem.rightBarButtonItem = nil
       setNavBarButtons()
       if wasKeyboardVisible {
-        perform(#selector(self.showKeyboard), with: nil, afterDelay: 0.75)
+        perform(#selector(self.displayKeyboard), with: nil, afterDelay: 0.75)
       }
       if shouldShowGetStarted {
         perform(#selector(self.showGetStartedView), with: nil, afterDelay: 0.75)
@@ -827,7 +829,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     }
   }
 
-  @objc func showKeyboard() {
+  // showKeyboard matches an internal Apple API, so it's not available for use as a selector.
+  @objc func displayKeyboard() {
     textView.becomeFirstResponder()
   }
 


### PR DESCRIPTION
Because 🍎:

![Screen Shot 2021-05-28 at 6 30 34 AM](https://user-images.githubusercontent.com/25213402/119909092-40454c80-bf7e-11eb-8f9e-ae4179282e13.png)

Note the mention of "selectors" - this implies that our KeymanEngine method on Manager isn't at fault - it's the `@objc` app-only selector methods changed here.