### PR TITLE
fix(common): build script help param

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]] ; do
             DO_KEYBOARDS_DOWNLOAD=true
             DO_MODELS_DOWNLOAD=true
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
     esac

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -92,7 +92,7 @@ while [[ $# -gt 0 ]] ; do
             KMWFLAGS=-debug_embedded
             KMW_PATH=unminified
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
         -no-test)

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]] ; do
         -debug)
             ONLY_DEBUG=true
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
     esac

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]] ; do
         -debug)
             ONLY_DEBUG=true
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
     esac

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -50,7 +50,7 @@ while [[ $# -gt 0 ]] ; do
     -fv)
         DO_FV=true
         ;;
-    -h|-?)
+    -h|-\?)
         display_usage
         ;;
   esac

--- a/common/core/web/keyboard-processor/test.sh
+++ b/common/core/web/keyboard-processor/test.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]] ; do
     -skip-package-install|-S)
       FETCH_DEPS=false
       ;;
-    -h|-help|-?)
+    -h|-help|-\?)
       display_usage
       exit
       ;;

--- a/common/predictive-text/unit_tests/in_browser/browser-test.sh
+++ b/common/predictive-text/unit_tests/in_browser/browser-test.sh
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]] ; do
         -help)
             display_usage
             ;;
-        -?)
+        -\?)
             display_usage
             ;;
     esac

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]] ; do
         -no-kmw)
             DO_KMW_BUILD=false
             ;;
-        -h|-?|-help)
+        -h|-\?|-help)
             display_usage
             exit 0
             ;;

--- a/ios/samples/build_common.sh
+++ b/ios/samples/build_common.sh
@@ -78,7 +78,7 @@ while [[ $# -gt 0 ]] ; do
             CODE_SIGN=false
             KMEI_FLAGS="$KMEI_FLAGS -no-codesign"
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
         -clean)

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]] ; do
         -debug)
             VERBOSITY="-debug"
             ;;
-        -h|-?|-help|--help)
+        -h|-\?|-help|--help)
             display_usage
             ;;
         -*)
@@ -171,7 +171,7 @@ echo "---- End Listing ----"
 
 # Step 3 - Replace existing application files with new version
 displayInfo "Copying files from \"$SOURCE_KM_APP\"..."
-find "$DEST_KM_APP" -mindepth 1 -maxdepth 1 
+find "$DEST_KM_APP" -mindepth 1 -maxdepth 1
 echo "---------"
 find "$DEST_KM_APP" -mindepth 1 -maxdepth 1 -print0 | xargs -0 rm -rf
 cp -fR "$SOURCE_KM_APP/" "$DEST_KM_APP"

--- a/mac/Keyman4MacIM/write-download_info.sh
+++ b/mac/Keyman4MacIM/write-download_info.sh
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]] ; do
                 shift # past argument
             fi
             ;;
-        -h|-?|-help|--help)
+        -h|-\?|-help|--help)
             display_usage
             ;;
         -*)

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -211,7 +211,7 @@ while [[ $# -gt 0 ]] ; do
         -upload-sentry)
             UPLOAD_SENTRY=true
             ;;
-        -h|-?|-help|--help)
+        -h|-\?|-help|--help)
             display_usage
             ;;
         engine)
@@ -364,7 +364,7 @@ if $DO_KEYMANIM ; then
         echo "Building help"
         $(dirname "$THIS_SCRIPT")/build-help.sh html
     fi
-    
+
     echo_heading "Building Keyman.app"
     cd "$KM4MIM_BASE_PATH"
     if $DO_PODS ; then
@@ -387,7 +387,7 @@ if $DO_KEYMANIM ; then
         ENTITLEMENTS_FILE=Keyman.entitlements
     fi
 
-    if [ -z "$DEVELOPMENT_TEAM" ]; then 
+    if [ -z "$DEVELOPMENT_TEAM" ]; then
         DEVELOPMENT_TEAM=3YE4W86L3G
     fi
 

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]] ; do
       DO_KEYBOARDS_DOWNLOAD=true
       DO_MODELS_DOWNLOAD=true
       ;;
-    -h|-?)
+    -h|-\?)
       display_usage
       ;;
     -debug)

--- a/oem/firstvoices/android/build_common.sh
+++ b/oem/firstvoices/android/build_common.sh
@@ -62,7 +62,7 @@ while [[ $# -gt 0 ]] ; do
         -lib-nobuild|-no-lib-build)
             ALLOW_KMEA_BUILD=false
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
     esac
@@ -109,7 +109,7 @@ if [ $DO_UPDATE = true ]; then
       exit 1
     fi
 
-    # Copy Keyman Engine aar to 
+    # Copy Keyman Engine aar to
     cp "$KEYMAN_ENGINE_SRC" "$KEYMAN_ENGINE_DST"
 fi
 

--- a/oem/firstvoices/common/build_keyboards.sh
+++ b/oem/firstvoices/common/build_keyboards.sh
@@ -61,7 +61,7 @@ while [[ $# -gt 0 ]] ; do
     -copy-keyboards)
       DO_BUILD=false
       ;;
-    -h|-?)
+    -h|-\?)
       display_usage
       ;;
     -clean-keyboards)
@@ -118,7 +118,7 @@ if [ $DO_BUILD = true ] || [ $DO_COPY = true ]; then
       if [ $DO_COPY = true ]; then
         echo "Copying $id ($name) to $KEYBOARDS_TARGET"
         mkdir -p "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id"
-        unzip -o release/$shortname/$id/build/$id.kmp $id.js kmp.json -d "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id/" 
+        unzip -o release/$shortname/$id/build/$id.kmp $id.js kmp.json -d "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id/"
         cp release/$shortname/$id/build/$id.keyboard_info "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id.keyboard_info"
       fi
 #        die "done"

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -89,7 +89,7 @@ while [[ $# -gt 0 ]] ; do
         -no-archive)
             DO_ARCHIVE=false
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
         -clean)
@@ -198,7 +198,7 @@ if [ $CODE_SIGN = true ]; then
   else
     xcodebuild $XCODEFLAGS -scheme "$TARGET" \
                VERSION=$VERSION \
-               VERSION_WITH_TAG=$VERSION_WITH_TAG    
+               VERSION_WITH_TAG=$VERSION_WITH_TAG
   fi
 else
   xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# 
+#
 # Compile keymanweb and copy compiled javascript and resources to output/embedded folder
 #
 
@@ -21,13 +21,13 @@ display_usage ( ) {
     echo "build.sh [-ui | -test | -embed | -web | -debug_embedded] [-no_minify] [-clean] [-upload-sentry]"
     echo
     echo "  -ui               to compile only desktop user interface modules"
-    echo "  -test             to compile for testing without copying resources or" 
+    echo "  -test             to compile for testing without copying resources or"
     echo "                    updating the saved version number.  Assumes dependencies
                               are unaltered."
     echo "  -embed            to compile only the KMEA/KMEI embedded engine."
     echo "  -web              to compile only the KeymanWeb engine."
     echo "  -debug_embedded   to compile a readable version of the embedded KMEA/KMEI code"
-    echo "  -no_minify        to disable the minification '/release/' build sections -"  
+    echo "  -no_minify        to disable the minification '/release/' build sections -"
     echo "                      the '/release/unminified' subfolders will still be built."
     echo "  -clean            to erase pre-existing build products before the build."
     echo "  -upload-sentry    to upload debug symbols to our Sentry server"
@@ -64,14 +64,14 @@ minifier="$CLOSURECOMPILERPATH/compiler.jar"
 # with TypeScript's `extend` implementation (it doesn't recognize a constructor without manual edits).
 # We also get a global `this` warning from the same.
 #
-# `checkVars` is blocked b/c Closure will otherwise fail on TypeScript namespacing, as each original TS 
+# `checkVars` is blocked b/c Closure will otherwise fail on TypeScript namespacing, as each original TS
 # source file will redeclare the namespace variable, despite being merged into a single file post-compilation.
 #
 # `jsDocMissingType` prevents errors on type documentation Closure thinks is missing.  TypeScript may not
 # have the same requirements, and we trust TypeScript over Closure.
 minifier_warnings="--jscomp_error=* --jscomp_off=lintChecks --jscomp_off=unusedLocalVariables --jscomp_off=globalThis --jscomp_off=checkTypes --jscomp_off=checkVars --jscomp_off=jsdocMissingType --jscomp_off=uselessCode --jscomp_off=missingRequire --jscomp_off=strictMissingRequire"
 
-# We use these to prevent Closure from auto-inserting its own polyfills.  Turns out, they can break in the 
+# We use these to prevent Closure from auto-inserting its own polyfills.  Turns out, they can break in the
 # WebView used by Android API 19, which our app still supports.
 #
 # Also, we currently apply all needed polyfills either manually or during TS compilation; we don't need the extra,
@@ -153,21 +153,21 @@ finish_nominify ( ) {
 }
 
 copy_resources ( ) {
-    echo 
+    echo
     echo Copy resources to $1/ui, .../osk
 
     # Create our entire compilation results path.  Can't one-line them due to shell-script parsing errors.
-    if ! [ -d $1/ui ];      then 
-        mkdir -p "$1/ui"      
+    if ! [ -d $1/ui ];      then
+        mkdir -p "$1/ui"
     fi
-    if ! [ -d $1/osk ];     then 
-        mkdir -p "$1/osk"     
+    if ! [ -d $1/osk ];     then
+        mkdir -p "$1/osk"
     fi
-    if ! [ -d $1/src/ui ];  then 
-        mkdir -p "$1/src/ui"  
+    if ! [ -d $1/src/ui ];  then
+        mkdir -p "$1/src/ui"
     fi
-    if ! [ -d $1/src/osk ]; then 
-        mkdir -p "$1/src/osk" 
+    if ! [ -d $1/src/osk ]; then
+        mkdir -p "$1/src/osk"
     fi
 
     cp -Rf $SOURCE/resources/ui  $1/  >/dev/null
@@ -287,7 +287,7 @@ while [[ $# -gt 0 ]] ; do
             BUILD_FULLWEB=false
             BUILD_DEBUG_EMBED=true
             ;;
-        -h|-?)
+        -h|-\?)
             display_usage
             ;;
         -no_minify)
@@ -509,7 +509,7 @@ if [ $BUILD_UI = true ]; then
 
     finish_nominify $UI "${UI_TARGET[@]}"
 
-    echo \'Native\' UI TypeScript has been compiled into the $INTERMEDIATE/ folder 
+    echo \'Native\' UI TypeScript has been compiled into the $INTERMEDIATE/ folder
 
     if [ $DO_MINIFY = true ]; then
         echo Minify ToolBar UI

--- a/web/unit_tests/test.sh
+++ b/web/unit_tests/test.sh
@@ -101,7 +101,7 @@ while [[ $# -gt 0 ]] ; do
         -help)
             display_usage
             ;;
-        -?)
+        -\?)
             display_usage
             ;;
     esac

--- a/windows/src/desktop/locale/crowdin-control.sh
+++ b/windows/src/desktop/locale/crowdin-control.sh
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]] ; do
     download)
       ACTION=download
       ;;
-    -h|-?|-help|--help)
+    -h|-\?|-help|--help)
       display_usage
       ;;
     *)


### PR DESCRIPTION
When working on a new build script, I tripped over the `-?` question mark help parameter here, as it needs to be escaped. Opted to fix all the instances in our scripts, although AFAICT there would not have been current bugs arising from this, as there were no conflicting one character options lower in the case list.