### PR TITLE
refactor(common/core/web, web): target-agnostic key events

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -58,12 +58,8 @@ namespace com.keyman.text {
      * @returns     {Object}             A RuleBehavior object describing the cumulative effects of
      *                                   all matched keyboard rules.
      */
-    processKeyEvent(keyEvent: KeyEvent): RuleBehavior {
+    processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
       let formFactor = keyEvent.device.formFactor;
-
-      // Determine the current target for text output and create a "mock" backup
-      // of its current, pre-input state.  Current, long-existing assumption - it's DOM-backed.
-      let outputTarget = keyEvent.Ltarg;
       let fromOSK = keyEvent.isSynthetic;
 
       // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
@@ -78,7 +74,7 @@ namespace com.keyman.text {
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
       // of state management.
-      if(!fromOSK && this.keyboardProcessor.doModifierPress(keyEvent, !fromOSK)) {
+      if(!fromOSK && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
         return new RuleBehavior();
       }
 
@@ -99,6 +95,8 @@ namespace com.keyman.text {
 
       // // ...end I3363 (Build 301)
 
+      // Create a "mock" backup of the current outputTarget in its pre-input state.
+      // Current, long-existing assumption - it's DOM-backed.
       let preInputMock = Mock.from(outputTarget);
       let ruleBehavior = this.keyboardProcessor.processKeystroke(keyEvent, outputTarget);
 
@@ -129,7 +127,7 @@ namespace com.keyman.text {
                 continue;
               }
 
-              let altEvent = altKey.constructKeyEvent(this.keyboardProcessor, mock, keyEvent.device);
+              let altEvent = altKey.constructKeyEvent(this.keyboardProcessor, keyEvent.device);
               let alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
               
               // If alternateBehavior.beep == true, ignore it.  It's a disallowed key sequence,
@@ -157,7 +155,7 @@ namespace com.keyman.text {
 
         // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
         // by the actual keystroke occur.
-        ruleBehavior.finalize(this.keyboardProcessor);
+        ruleBehavior.finalize(this.keyboardProcessor, outputTarget);
 
         // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
         

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -54,9 +54,10 @@ namespace com.keyman.text {
      *
      * Handles default output and keyboard processing for both OSK and physical keystrokes.
      * 
-     * @param       {Object}      e      The abstracted KeyEvent to use for keystroke processing
-     * @returns     {Object}             A RuleBehavior object describing the cumulative effects of
-     *                                   all matched keyboard rules.
+     * @param       {Object}      keyEvent      The abstracted KeyEvent to use for keystroke processing
+     * @param       {Object}      outputTarget  The OutputTarget receiving the KeyEvent
+     * @returns     {Object}                    A RuleBehavior object describing the cumulative effects of
+     *                                          all matched keyboard rules.
      */
     processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
       let formFactor = keyEvent.device.formFactor;

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -162,7 +162,6 @@ namespace com.keyman.keyboards {
 
       // First check the virtual key, and process shift, control, alt or function keys
       var Lkc: text.KeyEvent = {
-        Ltarg: null, // set later, in constructKeyEvent.
         Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: keyName ? text.Codes.keyCodes[keyName] : 0,
@@ -195,7 +194,7 @@ namespace com.keyman.keyboards {
         if(!keyboard.definesPositionalOrMnemonic) {
           // Not the best pattern, but currently safe - we don't look up any properties of any of the
           // arguments in this use case, and the object's scope is extremely limited.
-          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(this.constructKeyEvent(null, null, null));
+          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(this.constructKeyEvent(null, null));
           Lkc.LisVirtualKey=false;
         }
       }
@@ -203,10 +202,9 @@ namespace com.keyman.keyboards {
       this.baseKeyEvent = Lkc;
     }
 
-    constructKeyEvent(keyboardProcessor: text.KeyboardProcessor, target: text.OutputTarget, device: utils.DeviceSpec): text.KeyEvent {
+    constructKeyEvent(keyboardProcessor: text.KeyboardProcessor, device: utils.DeviceSpec): text.KeyEvent {
       // Make a deep copy of our preconstructed key event, filling it out from there.
       let Lkc = utils.deepCopy(this.baseKeyEvent);
-      Lkc.Ltarg = target;
       Lkc.device = device;
 
       if(this.isMnemonic) {

--- a/common/core/web/keyboard-processor/src/text/defaultOutput.ts
+++ b/common/core/web/keyboard-processor/src/text/defaultOutput.ts
@@ -24,17 +24,17 @@ namespace com.keyman.text {
      * Serves as a default keycode lookup table.  This may be referenced safely by mnemonic handling without fear of side-effects.
      * Also used by Processor.defaultRuleBehavior to generate output after filtering for special cases.
      */
-    public static forAny(Lkc: KeyEvent, isMnemonic: boolean) {
+    public static forAny(Lkc: KeyEvent, isMnemonic: boolean, ruleBehavior?: RuleBehavior) {
       var char = '';
 
       // A pretty simple table of lookups, corresponding VERY closely to the original defaultKeyOutput.
-      if((char = DefaultOutput.forSpecialEmulation(Lkc)) != null) {
+      if((char = DefaultOutput.forSpecialEmulation(Lkc, ruleBehavior)) != null) {
         return char;
-      } else if(!isMnemonic && ((char = DefaultOutput.forNumpadKeys(Lkc)) != null)) {
+      } else if(!isMnemonic && ((char = DefaultOutput.forNumpadKeys(Lkc, ruleBehavior)) != null)) {
         return char;
-      } else if((char = DefaultOutput.forUnicodeKeynames(Lkc)) != null) {
+      } else if((char = DefaultOutput.forUnicodeKeynames(Lkc, ruleBehavior)) != null) {
         return char;
-      } else if((char = DefaultOutput.forBaseKeys(Lkc)) != null) {
+      } else if((char = DefaultOutput.forBaseKeys(Lkc, ruleBehavior)) != null) {
         return char;
       } else {
         // // For headless and embeddded, we may well allow '\t'.  It's DOM mode that has other uses.
@@ -76,7 +76,7 @@ namespace com.keyman.text {
      * 
      * Note:  is extended by DOM-aware KeymanWeb code.
      */
-    public static applyCommand(Lkc: KeyEvent): void {
+    public static applyCommand(Lkc: KeyEvent, outputTarget: OutputTarget): void {
       // Notes for potential default-handling extensions:
       // 
       // switch(code) {
@@ -107,7 +107,7 @@ namespace com.keyman.text {
      * Codes matched here generally have default implementations when in a browser but require emulation
      * for 'synthetic' `OutputTarget`s like `Mock`s, which have no default text handling.
      */
-    public static forSpecialEmulation(Lkc: KeyEvent): EmulationKeystrokes {
+    public static forSpecialEmulation(Lkc: KeyEvent, ruleBehavior?: RuleBehavior): EmulationKeystrokes {
       let code = DefaultOutput.codeForEvent(Lkc);
 
       switch(code) {
@@ -123,7 +123,7 @@ namespace com.keyman.text {
     }
 
     // Should not be used for mnenomic keyboards.  forAny()'s use of this method checks first.
-    public static forNumpadKeys(Lkc: KeyEvent) {
+    public static forNumpadKeys(Lkc: KeyEvent, ruleBehavior?: RuleBehavior) {
       // Translate numpad keystrokes into their non-numpad equivalents
       if(Lkc.Lcode >= Codes.keyCodes["K_NP0"]  &&  Lkc.Lcode <= Codes.keyCodes["K_NPSLASH"]) {
         // Number pad, numlock on

--- a/common/core/web/keyboard-processor/src/text/keyEvent.ts
+++ b/common/core/web/keyboard-processor/src/text/keyEvent.ts
@@ -10,7 +10,10 @@ namespace com.keyman.text {
    * having to actually load the entirety of KMW.
    */
   export class KeyEvent {
-    Ltarg: OutputTarget;
+    /**
+     * @deprecated
+     */
+    Ltarg?: OutputTarget;
     Lcode: number;
     Lstates: number;
     LmodifierChange?: boolean;

--- a/common/core/web/keyboard-processor/src/text/keyEvent.ts
+++ b/common/core/web/keyboard-processor/src/text/keyEvent.ts
@@ -10,10 +10,6 @@ namespace com.keyman.text {
    * having to actually load the entirety of KMW.
    */
   export class KeyEvent {
-    /**
-     * @deprecated
-     */
-    Ltarg?: OutputTarget;
     Lcode: number;
     Lstates: number;
     LmodifierChange?: boolean;

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -108,8 +108,7 @@ namespace com.keyman.text {
      * @param   {boolean} usingOSK
      * @return  {string}
      */
-    defaultRuleBehavior(Lkc: KeyEvent): RuleBehavior {
-      let outputTarget = Lkc.Ltarg;
+    defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
       let preInput = Mock.from(outputTarget);
       let ruleBehavior = new RuleBehavior();
 
@@ -154,7 +153,7 @@ namespace com.keyman.text {
           special = DefaultOutput.forSpecialEmulation(Lkc)
           if(special == EmulationKeystrokes.Backspace) {
             // A browser's default backspace may fail to delete both parts of an SMP character.
-            this.keyboardInterface.defaultBackspace(Lkc.Ltarg);
+            this.keyboardInterface.defaultBackspace(outputTarget);
           } else if(special || DefaultOutput.isCommand(Lkc)) { // Filters out 'commands' like TAB.
             // We only do the "for special emulation" cases under the condition above... aside from backspace
             // Let the browser handle those.
@@ -236,7 +235,7 @@ namespace com.keyman.text {
 
         // Match against the 'default keyboard' - rules to mimic the default string output when typing in a browser.
         // Many keyboards rely upon these 'implied rules'.
-        matchBehavior = this.defaultRuleBehavior(keyEvent);
+        matchBehavior = this.defaultRuleBehavior(keyEvent, outputTarget);
 
         this.keyboardInterface.activeTargetOutput = null;
       }
@@ -259,7 +258,6 @@ namespace com.keyman.text {
         // To facilitate storing relevant commands, we should probably reverse-lookup
         // the actual keyname instead.
         mappingEvent.kName = 'K_xxxx';
-        mappingEvent.Ltarg = new Mock(); // helps prevent breakage for mnemonics.
         mappingEvent.Lmodifiers = (shifted ? 0x10 : 0);  // mnemonic lookups only exist for default & shift layers.
         var mappedChar: string = DefaultOutput.forAny(mappingEvent, true);
         
@@ -639,9 +637,7 @@ namespace com.keyman.text {
 
     // Returns true if the key event is a modifier press, allowing keyPress to return selectively
     // in those cases.
-    doModifierPress(Levent: KeyEvent, isKeyDown: boolean): boolean {
-      let outputTarget = Levent.Ltarg;
-
+    doModifierPress(Levent: KeyEvent, outputTarget: OutputTarget, isKeyDown: boolean): boolean {
       if(!this.activeKeyboard) {
         return false;
       }

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -104,8 +104,8 @@ namespace com.keyman.text {
      * Get the default RuleBehavior for the specified key, attempting to mimic standard browser defaults 
      * where and when appropriate.
      *
-     * @param   {object}  Lkc  The pre-analyzed key event object
-     * @param   {boolean} usingOSK
+     * @param   {object}  Lkc           The pre-analyzed KeyEvent object
+     * @param   {boolean} outputTarget  The OutputTarget receiving the KeyEvent
      * @return  {string}
      */
     defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTarget): RuleBehavior {

--- a/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
+++ b/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
@@ -44,12 +44,10 @@ namespace com.keyman.text {
      */
     predictionPromise?: Promise<Suggestion[]>;
 
-    finalize(processor: KeyboardProcessor) {
+    finalize(processor: KeyboardProcessor, outputTarget: OutputTarget) {
       if(!this.transcription) {
         throw "Cannot finalize a RuleBehavior with no transcription.";
       }
-
-      let outputTarget = this.transcription.keystroke.Ltarg;
 
       if(processor.beepHandler && this.beep) {
         processor.beepHandler(outputTarget);

--- a/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
+++ b/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
@@ -76,7 +76,7 @@ namespace com.keyman.text {
 
       if(this.triggersDefaultCommand) {
         let keyEvent = this.transcription.keystroke;
-        DefaultOutput.applyCommand(keyEvent);
+        DefaultOutput.applyCommand(keyEvent, outputTarget);
       }
 
       if(processor.warningLogger && this.warningLog) {

--- a/common/core/web/tools/recorder/src/nodeProctor.ts
+++ b/common/core/web/tools/recorder/src/nodeProctor.ts
@@ -55,7 +55,6 @@ namespace KMWRecorder {
             // Use the keystroke's stored data to reconstruct the KeyEvent.
             keyEvent = {
               Lcode: keystroke.keyCode,
-              Ltarg: target,
               Lmodifiers: keystroke.modifiers,
               LmodifierChange: keystroke.modifierChanged,
               vkCode: keystroke.vkCode,
@@ -67,11 +66,10 @@ namespace KMWRecorder {
             }
           } else if(keystroke instanceof RecordedSyntheticKeystroke) {
             let key = this.keyboard.layout(this.device.formFactor).getLayer(keystroke.layer).getKey(keystroke.keyName);
-            keyEvent = key.constructKeyEvent(processor, target, this.device);
+            keyEvent = key.constructKeyEvent(processor, this.device);
           }
 
           // Fill in the final details of the KeyEvent...
-          keyEvent.Ltarg = target;
           keyEvent.device = this.device;
 
           // And now, execute the keystroke!

--- a/web/source/dom/domDefaultOutput.ts
+++ b/web/source/dom/domDefaultOutput.ts
@@ -24,14 +24,14 @@ namespace com.keyman.dom {
   /**
    * applyCommand - used when a RuleBehavior represents a non-text "command" within the Engine.
    */
-  DefaultOutput.applyCommand = function(Lkc: KeyEvent): void {
+  DefaultOutput.applyCommand = function(Lkc: KeyEvent, outputTarget: text.OutputTarget): void {
     let code = DefaultOutput.codeForEvent(Lkc);
     let domManager = com.keyman.singleton.domManager;
 
     let hideCaret: () => void;
-    if(Lkc.Ltarg instanceof com.keyman.dom.targets.TouchAlias) {
+    if(outputTarget instanceof com.keyman.dom.targets.TouchAlias) {
       hideCaret = function() {
-        let target = Lkc.Ltarg as com.keyman.dom.targets.TouchAlias;
+        let target = outputTarget as com.keyman.dom.targets.TouchAlias;
         target.root.hideCaret();
       }
     } else {
@@ -53,6 +53,6 @@ namespace com.keyman.dom {
         break;
     }
 
-    coreApplyCommand(Lkc);
+    coreApplyCommand(Lkc, outputTarget);
   }
 }

--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -477,13 +477,14 @@ namespace com.keyman.dom {
       if(Levent == null || !osk.ready) {
         return true;
       }
-      var inputEle = (Levent.Ltarg as targets.OutputTarget).getElement();
+      let outputTarget = PreProcessor.getEventOutputTarget(e) as dom.targets.OutputTarget;
+      var inputEle = outputTarget.getElement();
 
       // Since this part concerns DOM element + browser interaction management, we preprocess it for
       // browser form commands before passing control to the Processor module.
       if(Levent.Lcode == 13) {
         var ignore = false;
-        if(Levent.Ltarg instanceof inputEle.ownerDocument.defaultView.HTMLTextAreaElement) {
+        if(outputTarget instanceof inputEle.ownerDocument.defaultView.HTMLTextAreaElement) {
           ignore = true;
         }
       

--- a/web/source/dom/domOverrides.ts
+++ b/web/source/dom/domOverrides.ts
@@ -17,9 +17,7 @@ namespace com.keyman.dom {
   }
 
   let headlessRuleBehaviorFinalize = text.RuleBehavior.prototype.finalize;
-  text.RuleBehavior.prototype.finalize = function(this: text.RuleBehavior, processor: text.KeyboardProcessor) {
-    let outputTarget = this.transcription.keystroke.Ltarg;
-
+  text.RuleBehavior.prototype.finalize = function(this: text.RuleBehavior, processor: text.KeyboardProcessor, outputTarget: text.OutputTarget) {
     // Execute the standard baseline stuff first.
     headlessRuleBehaviorFinalize.call(this, processor);
 

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -429,7 +429,6 @@ namespace com.keyman.text {
       
       // Check the virtual key 
       let Lkc: com.keyman.text.KeyEvent = {
-        Ltarg: com.keyman.dom.Utils.getOutputTarget(Lelem),
         Lmodifiers: keyShiftState,
         Lstates: 0,
         Lcode: Codes.keyCodes[keyName],
@@ -464,7 +463,7 @@ namespace com.keyman.text {
 
       // Now that we have a valid key event, hand it off to the Processor for execution.
       // This allows the Processor to also handle any predictive-text tasks necessary.
-      let retVal = com.keyman.osk.PreProcessor.handleClick(Lkc, null);
+      let retVal = com.keyman.osk.PreProcessor.handleClick(Lkc, com.keyman.dom.Utils.getOutputTarget(Lelem), null);
 
       // Special case for embedded to pass K_TAB back to device to process
       if(Lkc.Lcode == Codes.keyCodes["K_TAB"] || Lkc.Lcode == Codes.keyCodes["K_TABBACK"] 
@@ -501,7 +500,6 @@ namespace com.keyman.text {
 
     // Check the virtual key 
     var Lkc: com.keyman.text.KeyEvent = {
-      Ltarg: com.keyman.dom.Utils.getOutputTarget(keyman.domManager.getActiveElement()),
       Lmodifiers: shift,
       vkCode: code,
       Lcode: code,
@@ -517,7 +515,7 @@ namespace com.keyman.text {
       // off to the processor for its actual execution.
 
       // Should return 'false' when KMW _has_ fully handled the event and 'true' when not.
-      return !keyman.core.processKeyEvent(Lkc);
+      return !keyman.core.processKeyEvent(Lkc, com.keyman.dom.Utils.getOutputTarget(Lelem));
     } catch (err) {
       console.error(err.message, err);
       return false;

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -7,7 +7,7 @@ namespace com.keyman.osk {
       // Start:  mirrors _GetKeyEventProperties
 
       // First check the virtual key, and process shift, control, alt or function keys
-      let Lkc = e.constructKeyEvent(core.keyboardProcessor, dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
+      let Lkc = e.constructKeyEvent(core.keyboardProcessor, keyman.util.device.coreSpec);
 
       // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
       switch(Lkc.kName) {
@@ -73,7 +73,7 @@ namespace com.keyman.osk {
           com.keyman.dom.DOMEventHandlers.states._IgnoreNextSelChange = 0;
         }
 
-        let retVal = PreProcessor.handleClick(Lkc, e);
+        let retVal = PreProcessor.handleClick(Lkc, outputTarget, e);
 
         // Now that processing is done, we can do a bit of post-processing, too.
         keyman.uiManager.setActivatingUI(false);	// I2498 - KeymanWeb OSK does not accept clicks in FF when using automatic UI
@@ -87,7 +87,7 @@ namespace com.keyman.osk {
     // after the KeyEvent object has been properly instantiated.  This should help catch any 
     // mutual last-minute DOM-side interactions before passing control to the processor... such as
     // the UI-control command keys as seen below.
-    static handleClick(Lkc: text.KeyEvent, e: KeyElement) {
+    static handleClick(Lkc: text.KeyEvent, outputTarget: text.OutputTarget, e: KeyElement) {
       let keyman = com.keyman.singleton;
         // Exclude menu and OSK hide keys from normal click processing
       if(Lkc.kName == 'K_LOPT' || Lkc.kName == 'K_ROPT') {
@@ -95,7 +95,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      let retVal = (keyman.core.processKeyEvent(Lkc) != null);
+      let retVal = (keyman.core.processKeyEvent(Lkc, outputTarget) != null);
 
       return retVal;
     }


### PR DESCRIPTION
After some investigation and analysis, I noticed that in KMW 12 we started tracking the active output target as part of the key event object.  Storing it on the key event object would cause said objects to have a rather awkward construction process once Web OSK-Core stuff is well under way.

The issue:  the OSK itself won't track the active OutputTarget whatsoever, which makes it quite hard for the OSK to specify this property for the event.  The object would be near-fully constructed, with this one property `undefined` until much later with little in the object's design signaling the need to fill it in before passing it to the `KeyboardProcessor` part of Core.  (It's _just_ that single field - `Ltarg` - that's the issue.)

But... there's little need for it to _actually be_ on that object; keyboards receive the output target as a separate parameter already.  After adjustment of some method signatures, we can remove it from `KeyEvent` and still maintain access where needed, passing it as an extra parameter to relevant Core methods.  This avoids the delayed-construction problem and removes one of the "spaghetti strands" currently entangling our OSK code.

While it _is_ a bit awkward to change some of the method signatures of Core like this... fortunately, Core's API isn't exactly documented or in wide use yet.  Presenting something cleaner whenever we do properly document and promote its independent use would be wise.