### PR TITLE
fix(windows): cleanup edge cases in k32_load

### DIFF
--- a/common/core/desktop/src/kmx/kmx_file.cpp
+++ b/common/core/desktop/src/kmx/kmx_file.cpp
@@ -238,8 +238,8 @@ LPKEYBOARD KMX_Processor::CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base)
     i < kbp->cxGroupArray;
     i++, gp++, cgp++)
   {
-    gp->dpName = (PKMX_WCHAR)(base + cgp->dpName);
-    gp->dpKeyArray = (LPKEY) bufp;
+    gp->dpName = StringOffset(base, cgp->dpName);
+    gp->dpKeyArray = cgp->cxKeyArray > 0 ? (LPKEY) bufp : NULL;
     gp->cxKeyArray = cgp->cxKeyArray;
     bufp += sizeof(KEY) * gp->cxKeyArray;
     gp->dpMatch = StringOffset(base, cgp->dpMatch);


### PR DESCRIPTION
Matches work completed in #5169 for Keyman Core, kmx_file.cpp.

While this code will hopefully disappear in 15.0, it's good to make sure we aren't diverging beforehand.

Also tidies up a couple of other cases in `CopyKeyboard` in Keyman Core.