### PR TITLE
fix(windows): fix size of splash

### DIFF
--- a/windows/src/desktop/kmshell/startup/UfrmSplash.dfm
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.dfm
@@ -3,12 +3,12 @@ inherited frmSplash: TfrmSplash
   Top = 239
   BorderIcons = []
   BorderStyle = bsNone
-  ClientHeight = 332
-  ClientWidth = 409
+  ClientHeight = 452
+  ClientWidth = 632
   OldCreateOrder = True
   OnActivate = TntFormActivate
-  ExplicitWidth = 409
-  ExplicitHeight = 332
+  ExplicitWidth = 632
+  ExplicitHeight = 452
   PixelsPerInch = 96
   TextHeight = 13
   object ApplicationEvents1: TApplicationEvents

--- a/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.dfm
+++ b/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.dfm
@@ -40,7 +40,6 @@ object frameCEFHost: TframeCEFHost
   end
   object cef: TChromium
     OnWidgetCompMsg = cefWidgetCompMsg
-    OnProcessMessageReceived = cefProcessMessageReceived
     OnLoadEnd = cefLoadEnd
     OnLoadingStateChange = cefLoadingStateChange
     OnSetFocus = cefSetFocus

--- a/windows/src/global/delphi/ui/UfrmWebContainer.pas
+++ b/windows/src/global/delphi/ui/UfrmWebContainer.pas
@@ -71,7 +71,6 @@ type
     procedure cefKeyEvent(Sender: TObject; e: TCEFHostKeyEventData; wasShortcut, wasHandled: Boolean); virtual;
     procedure cefCommand(Sender: TObject; const command: string;
       params: TStringList); virtual;
-    procedure cefResizeFromDocument(Sender: TObject; awidth, aheight: Integer); virtual;
     procedure cefHelpTopic(Sender: TObject); virtual;
 
     procedure FireCommand(const command: WideString; params: TStringList); virtual;
@@ -163,7 +162,6 @@ begin
   if command = 'link' then OpenLink(params)
   else if command = 'uilanguage' then UILanguage(params)
   else if command = 'contributeuilanguages' then ContributeUILanguages   // I4989
-  else if command = 'resize' then cef.DoResizeByContent
   else ShowMessage(command + '?' + params.Text);
 end;
 
@@ -213,7 +211,6 @@ begin
   cef.OnLoadEnd := cefLoadEnd;
   cef.OnKeyEvent := cefKeyEvent;
   cef.OnPreKeySyncEvent := cefPreKeySyncEvent;
-  cef.OnResizeFromDocument := cefResizeFromDocument;
   cef.OnHelpTopic := cefHelpTopic;
   cef.OnTitleChange := cefTitleChange;
 end;
@@ -258,7 +255,6 @@ end;
 procedure TfrmWebContainer.cefLoadEnd(Sender: TObject);
 begin
   AssertVclThread;
-  cef.DoResizeByContent;
   Screen.Cursor := crDefault;
 end;
 
@@ -270,15 +266,6 @@ begin
       Handled := True
     else if e.event.windows_key_code = VK_F1 then
       Handled := True;
-end;
-
-procedure TfrmWebContainer.cefResizeFromDocument(Sender: TObject; awidth,
-  aheight: Integer);
-begin
-  ClientWidth := awidth;
-  ClientHeight := aheight;
-  Left := (Screen.Width - Width) div 2;
-  Top := (Screen.Height - Height) div 2;
 end;
 
 procedure TfrmWebContainer.cefTitleChange(Sender: TObject; const title: string);


### PR DESCRIPTION
Fixes #5195.
Fixes KEYMAN-WINDOWS-M0.

The splash screen for Keyman would crash on start with the latest Chromium update. This fix resolves the issue, which related to the resize-to-content code, by removing the resize-to-content code and instead hardcoding the window size in the .dfm.

This is a significant simplification of the browser host and I think it is worthwhile. The only place the resizing code was still used was in the splash screen.