### PR TITLE
fix(windows): support Esc key in Download Keyboard dialog

### DIFF
--- a/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
@@ -52,13 +52,6 @@
             }
         </style>
 <script type="text/javascript"><![CDATA[
-	document.onkeydown = function()
-	{
-	  if(event.keyCode == 27) location.href='keyman:footer_cancel';
-		else return;
-		event.cancelBubble = true; event.returnValue = false;
-  }
-
   // This function is called by the Delphi code when browse events
   // happen, because we cannot determine the state of history adequately
   // from within the browser context.


### PR DESCRIPTION
The Escape key does not work in the search iframe when in the parent web document. However, it is easy to test for it in the hosting form.