### PR TITLE
fix(linux): Exclude s390x from package builds for ibus-keyman 🍒

### DIFF
--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -18,7 +18,7 @@ Vcs-Browser: https://github.com/keymanapp/keyman/tree/master/linux/ibus-keyman
 Homepage: https://www.keyman.com
 
 Package: ibus-keyman
-Architecture: any
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el
 Depends:
  ibus (>= 1.3.7),
  sudo,


### PR DESCRIPTION
ibus-keyman depends on keyman-keyboardprocessor which we don't build for s390x because we currently don't support big-endian.
We only build for the same architectures as keyman-keyboardprocessor.

🍒-pick of #5213 
