### PR TITLE
fix(windows): improve keymanx64 start stability 🍒

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1966,7 +1966,7 @@ begin
     if not DuplicateHandle(GetCurrentProcess, GetCurrentProcess,
         GetCurrentProcess, @processHandle, 0, True, DUPLICATE_SAME_ACCESS) then
       RaiseLastOSError;
-    cmd := Format('%s%s %d %d %d', [ExtractFilePath(ParamStr(0)), 'keymanx64.exe', processHandle, Handle, Application.Handle]);
+    cmd := Format('%s%s %d %d', [ExtractFilePath(ParamStr(0)), 'keymanx64.exe', processHandle, Application.Handle]);
     // Duplicate the string because CreateProcess requires a mutable buffer, so
     // this guarantees it
     v := StrNew(PWideChar(cmd));

--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -176,7 +176,6 @@ type
     FToolbarHintWindow: THintWindow;
     FUpdatingToolbar: Boolean;
     FActivePageSet: Boolean;
-    FRegistered: Boolean;
     FLastTotalKeyboards: Integer;   // I4606
 
     FKeyboardButtons: TArray<TKeymanToolButton>;
@@ -232,9 +231,6 @@ type
     procedure PreRefreshKeyman;
     procedure UpdateToolbar;
     procedure RefreshSelectedKeyboard;  // I2398
-
-    procedure Unregister;
-    procedure Register;
 
     function GetToolbarPositionXML: WideString;
 
@@ -325,7 +321,6 @@ begin
   SnapBuffer := 8;
 
   cmi := TKeymanCustomisationMenuItem_Clone.Create;
-  Register;  // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
 
   FUnicode := True;
 
@@ -623,8 +618,6 @@ end;
 
 procedure TfrmVisualKeyboard.FormDestroy(Sender: TObject);
 begin
-  Unregister; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-
   SaveSettings;
 
   FreeAndNil(FOnScreenKeyboard);
@@ -635,20 +628,6 @@ begin
   cmi := nil;
 
   Application.OnMessage := nil;
-end;
-
-procedure TfrmVisualKeyboard.Register; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-begin
-  if not FRegistered then // I2692
-    kmint.KeymanEngineControl.RegisterControllerWindow(Handle);
-  FRegistered := True;
-end;
-
-procedure TfrmVisualKeyboard.Unregister; // I2444 - Keyman tries to re-init because OSK was not unregistering until after Keyman_Exit
-begin
-  if FRegistered then // I2692
-    kmint.KeymanEngineControl.UnregisterControllerWindow(Handle);
-  FRegistered := False;
 end;
 
 function TfrmVisualKeyboard.FormHelp(Command: Word; Data: NativeInt; var CallHelp: Boolean): Boolean;

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -15,7 +15,7 @@ EXPORTS
 			KMHideIM
 			KMGetActiveKeyboard
 			KMGetKeyboardPath
-			
+
       TIPActivateEx
       TIPActivateKeyboard
 			TIPProcessKey
@@ -23,17 +23,18 @@ EXPORTS
       GetKeyboardPreservedKeys
 
 			GetActiveKeymanID
-			Keyman_RegisterControllerWindow
-			Keyman_UnregisterControllerWindow
+			Keyman_RegisterControllerThread
+			Keyman_UnregisterControllerThread
+      Keyman_RegisterMasterController
+      Keyman_UnregisterMasterController
 			Keyman_RestartEngine
-			
+
       Keyman_SendMasterController
-      Keyman_PostControllers
       Keyman_PostMasterController
-      
+
       Keyman_StartExit
       Keyman_ResetInitialisation
-      
+
   	  Keyman_WriteDebugEvent
 
       Keyman_UpdateTouchPanelVisibility

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -25,8 +25,6 @@ EXPORTS
 			GetActiveKeymanID
 			Keyman_RegisterControllerWindow
 			Keyman_UnregisterControllerWindow
-      Keyman_RegisterMasterController
-      Keyman_UnregisterMasterController
 			Keyman_RestartEngine
 
       Keyman_SendMasterController
@@ -42,5 +40,7 @@ EXPORTS
 
       Keyman_Diagnostic
 
+      Keyman_RegisterMasterController
+      Keyman_UnregisterMasterController
 			Keyman_RegisterControllerThread
 			Keyman_UnregisterControllerThread

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -23,13 +23,14 @@ EXPORTS
       GetKeyboardPreservedKeys
 
 			GetActiveKeymanID
-			Keyman_RegisterControllerThread
-			Keyman_UnregisterControllerThread
+			Keyman_RegisterControllerWindow
+			Keyman_UnregisterControllerWindow
       Keyman_RegisterMasterController
       Keyman_UnregisterMasterController
 			Keyman_RestartEngine
 
       Keyman_SendMasterController
+			Keyman_PostControllers
       Keyman_PostMasterController
 
       Keyman_StartExit
@@ -40,3 +41,6 @@ EXPORTS
       Keyman_UpdateTouchPanelVisibility
 
       Keyman_Diagnostic
+
+			Keyman_RegisterControllerThread
+			Keyman_UnregisterControllerThread

--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -699,8 +699,9 @@ void HandleRefresh(int code, LONG tag)
     // of keyman32/keyman64 that a refresh is coming through
     Globals::PostMasterController(wm_keyman_refresh, KR_PRE_REFRESH, 0);
 
-    // We need to tell the controller windows to refresh themselves also
-    Globals::PostControllers(wm_keyman_control, KMC_REFRESH, 0);
+    // We need to tell the controller window to refresh itself also
+    // TODO: eliminate this message (we can hop onto the above message)
+    Globals::PostMasterController(wm_keyman_control, KMC_REFRESH, 0);
     break;
 
   case KR_PRE_REFRESH:

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -91,7 +91,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateEx(BOOL FActivate) {  //
   if(!FActivate)
     SelectKeyboard(KEYMANID_NONKEYMAN);   // I3594
   Globals::PostMasterController(wm_keyman_control, KMC_SETFOCUSINFO, 0);   // I3961
-	UpdateKeymanUI();
 	return TRUE;
 }
 

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -137,9 +137,7 @@ public:
 
   static BOOL ResetControllers();
 
-	static void PostControllers(UINT msg, WPARAM wParam, LPARAM lParam);
-  static void PostProcessControllers(UINT msg, WPARAM wParam, LPARAM lParam);
-  static BOOL IsControllerProcess();
+  static BOOL IsControllerThread(DWORD tid);
 
   static BOOL InitHandles();
   static BOOL InitSettings();

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -361,11 +361,10 @@ BOOL Globals::get_debug_ToConsole() { return f_debug_ToConsole; }
 void Globals::SetBaseKeyboardName(wchar_t *baseKeyboardName, wchar_t *baseKeyboardNameAlt) {   // I4583
   wcscpy_s(f_BaseKeyboardName, baseKeyboardName);
   wcscpy_s(f_BaseKeyboardNameAlt, baseKeyboardNameAlt);
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardName(name='%ws', nameAlt='%ws')", baseKeyboardName, baseKeyboardNameAlt);
 }
 
 void Globals::SetBaseKeyboardFlags(char *baseKeyboard, BOOL simulateAltGr, BOOL mnemonicDeadkeyConversionMode) {   // I4583   // I4552
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d)",
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d",
     baseKeyboard, simulateAltGr, mnemonicDeadkeyConversionMode);
   strcpy_s(f_BaseKeyboard, baseKeyboard);
   f_SimulateAltGr = simulateAltGr;

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -361,10 +361,11 @@ BOOL Globals::get_debug_ToConsole() { return f_debug_ToConsole; }
 void Globals::SetBaseKeyboardName(wchar_t *baseKeyboardName, wchar_t *baseKeyboardNameAlt) {   // I4583
   wcscpy_s(f_BaseKeyboardName, baseKeyboardName);
   wcscpy_s(f_BaseKeyboardNameAlt, baseKeyboardNameAlt);
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardName(name='%ws', nameAlt='%ws')", baseKeyboardName, baseKeyboardNameAlt);
 }
 
 void Globals::SetBaseKeyboardFlags(char *baseKeyboard, BOOL simulateAltGr, BOOL mnemonicDeadkeyConversionMode) {   // I4583   // I4552
-  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d",
+  SendDebugMessageFormat(0, sdmAIDefault, 0, "Globals::SetBaseKeyboardFlags(baseKeyboard='%s', simulateAltGr=%d, mnemonicDeadkeyConversionMode=%d)",
     baseKeyboard, simulateAltGr, mnemonicDeadkeyConversionMode);
   strcpy_s(f_BaseKeyboard, baseKeyboard);
   f_SimulateAltGr = simulateAltGr;

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -551,6 +551,12 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
   return dwResult;
 }
 
+extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+  // no-op (removed as part of #5060)
+  return 0;
+}
+
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   Globals::PostMasterController(msg, wParam, lParam);
@@ -559,6 +565,12 @@ extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT ms
 extern "C" LRESULT  _declspec(dllexport) WINAPI Keyman_SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   return Globals::SendMasterController(msg, wParam, lParam);
+}
+
+extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerWindow(HWND hwnd)
+{
+  // no-op (removed as part of #5060)
+  return TRUE;
 }
 
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerThread(DWORD tid)
@@ -596,6 +608,12 @@ extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterMasterController(HWN
   f_MasterController = hwnd;
 
   Globals::Unlock();
+  return TRUE;
+}
+
+extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_UnregisterControllerWindow(HWND hwnd)
+{
+  // no-op (removed as part of #5060)
   return TRUE;
 }
 

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -553,6 +553,9 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
 {
+  UNREFERENCED_PARAMETER(msg);
+  UNREFERENCED_PARAMETER(wParam);
+  UNREFERENCED_PARAMETER(lParam);
   // no-op (removed as part of #5060)
 }
 
@@ -569,6 +572,7 @@ extern "C" LRESULT  _declspec(dllexport) WINAPI Keyman_SendMasterController(UINT
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerWindow(HWND hwnd)
 {
   // no-op (removed as part of #5060)
+  UNREFERENCED_PARAMETER(hwnd);
   return TRUE;
 }
 
@@ -613,6 +617,7 @@ extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterMasterController(HWN
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_UnregisterControllerWindow(HWND hwnd)
 {
   // no-op (removed as part of #5060)
+  UNREFERENCED_PARAMETER(hwnd);
   return TRUE;
 }
 

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -554,7 +554,6 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   // no-op (removed as part of #5060)
-  return 0;
 }
 
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT msg, WPARAM wParam, LPARAM lParam)

--- a/windows/src/engine/keyman32/kmhook_callwndproc.cpp
+++ b/windows/src/engine/keyman32/kmhook_callwndproc.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmhook_callwndproc
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    22 Apr 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Visual keyboard updating
                     30 May 2007 - mcdurdin - I864 - Log exceptions in hook procedures
                     11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
@@ -111,11 +111,11 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
     {
       //DebugLastError("get_Keyman_Initialised");
     }
-	  else 
+	  else
 	  {
   /*
 		  SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "kmnCallWndProc %s %x %x "
-		  "{hwnd:%d msg:%d wp:%d lp:%d} ctrl: %x/%x alt: %x/%x shift: %x/%x", 
+		  "{hwnd:%d msg:%d wp:%d lp:%d} ctrl: %x/%x alt: %x/%x shift: %x/%x",
 		  MessageName(cp->message), cp->wParam, cp->lParam,
 		  cp->hwnd, cp->message, cp->wParam, cp->lParam,
 		  GetKeyState(VK_CONTROL), GetAsyncKeyState(VK_CONTROL),
@@ -125,7 +125,7 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
       PKEYMAN64THREADDATA _td = ThreadGlobals();
       if(!_td)
       {
-        if(!Globals::CheckControllers()) 
+        if(!Globals::CheckControllers())
         {
           DebugLastError("CheckControllers");
           return CallNextHookEx(Globals::get_hhookCallWndProc(), nCode, wParam, lParam);
@@ -165,10 +165,10 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         {
           CheckScheduledRefresh();
           HWND hwnd = IsLanguageSwitchWindowVisible();   // I4326
-          if(hwnd != NULL && !Globals::IsControllerProcess()) SendToLanguageSwitchWindow(hwnd, VK_ESCAPE, 0); // I3025
+          if(hwnd != NULL && !Globals::IsControllerThread(GetCurrentThreadId())) SendToLanguageSwitchWindow(hwnd, VK_ESCAPE, 0); // I3025
 
           SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_KILLFOCUS %x -> %x", cp->hwnd, cp->wParam);  // I3226   // I3531
-          if(!IsSysTrayWindow(cp->hwnd) && !Globals::IsControllerWindow(cp->hwnd) && !Globals::IsControllerProcess())   // I2443 - always do the focus change now? really unsure about this one
+          if(!IsSysTrayWindow(cp->hwnd) && !Globals::IsControllerThread(GetCurrentThreadId()))   // I2443 - always do the focus change now? really unsure about this one
           {
   			    PostMessage(cp->hwnd, wm_keyman, KM_FOCUSCHANGED, 0);
 	  		    SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_KILLFOCUS -- Telling Keyman focus has changed");
@@ -181,10 +181,8 @@ LRESULT _kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam)
         CheckScheduledRefresh();
         if (IsSysTrayWindow(cp->hwnd))      // I2443 - always do the focus change now? really unsure about this one
           SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsSysTrayWindow");
-        else if (Globals::IsControllerWindow(cp->hwnd))
-          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerWindow");
-        else if (Globals::IsControllerProcess())
-          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerProcess");
+        else if (Globals::IsControllerThread(GetCurrentThreadId()))
+          SendDebugMessageFormat(cp->hwnd, sdmGlobal, 0, "WM_SETFOCUS -- not hooking because IsControllerThread");
         else
         {
           PostMessage(cp->hwnd, wm_keyman, KM_FOCUSCHANGED, KMF_WINDOWCHANGED);

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -403,7 +403,8 @@ void ProcessWMKeymanControlInternal(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
 void UpdateKeymanUI()
 {
-	Globals::PostControllers(wm_keyman_control, KMC_CHANGEUISTATE, 2);  // TODO: Fixup constant
+  //TODO: this does not appear to be used; remove as separate patch
+	Globals::PostMasterController(wm_keyman_control, KMC_CHANGEUISTATE, 2);
 }
 
 /*

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -279,9 +279,6 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 		return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
 	}
 
-	if(mp->message == WM_ACTIVATEAPP && mp->wParam)
-		UpdateKeymanUI();
-
 	if(*Globals::hwndIM() != 0)
 	{
 		if(mp->message == wm_keymanim_close)
@@ -342,11 +339,9 @@ void ProcessWMKeyman(HWND hwnd, WPARAM wParam, LPARAM lParam)
 	{
 	case KM_DISABLEUI:
 		_td->KeymanUIDisabled = TRUE;
-		UpdateKeymanUI();
 		break;
 	case KM_ENABLEUI:
 		_td->KeymanUIDisabled = FALSE;
-		UpdateKeymanUI();
 		break;
 	case KM_FOCUSCHANGED:
     if(lParam & KMF_WINDOWCHANGED)
@@ -399,12 +394,6 @@ void ProcessWMKeymanControlInternal(HWND hwnd, WPARAM wParam, LPARAM lParam)
     SetForegroundWindow(hwnd);
     break;
 	}
-}
-
-void UpdateKeymanUI()
-{
-  //TODO: this does not appear to be used; remove as separate patch
-	Globals::PostMasterController(wm_keyman_control, KMC_CHANGEUISTATE, 2);
 }
 
 /*

--- a/windows/src/engine/keyman32/kmhook_keyboard.cpp
+++ b/windows/src/engine/keyman32/kmhook_keyboard.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmhook_keyboard
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    25 Oct 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Hotkeys testing
                     14 Sep 2006 - mcdurdin - Initialise process when no messages have been passed
                     30 May 2007 - mcdurdin - I864 - Log exceptions in hook procedures
@@ -72,7 +72,7 @@ BOOL ForegroundWindowIsRDP();   // I4197
 
 BOOL InLanguageSwitchKeySequence = FALSE;
 HWND hwndLanguageSwitch = 0;
-		
+
 BOOL ForegroundWindowIsRDP() {   // I4197
   //TODO: Cache result
   DWORD dwProcessId;
@@ -139,12 +139,12 @@ BOOL KeyLanguageSwitchPress(WPARAM wParam, BOOL extended, BOOL isUp, DWORD Shift
       {
         InLanguageSwitchKeySequence = FALSE;
         //ReportActiveKeyboard(_td, PC_UPDATE);
-        Globals::PostControllers(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
+        Globals::PostMasterController(wm_keyman_control, MAKELONG(KMC_INTERFACEHOTKEY, hotkey->Target), 0);
         PostDummyKeyEvent();   // I4124   // I4844
         keybd_event(VK_SHIFT, SCAN_FLAG_KEYMAN_KEY_EVENT, KEYEVENTF_KEYUP, 0);    // I4203
         return TRUE;
       }
-      
+
       return FALSE;
     }
     else
@@ -176,15 +176,15 @@ int ProcessLanguageSwitchShiftKey(WPARAM wParam, BOOL isUp)
   {
     case VK_LSHIFT:
     case VK_RSHIFT:
-    case VK_SHIFT:   
-    case VK_CONTROL: 
+    case VK_SHIFT:
+    case VK_CONTROL:
     case VK_LCONTROL:   // I4124
     case VK_RCONTROL:   // I4124
-    case VK_MENU:    
+    case VK_MENU:
     case VK_LMENU:   // I4124
     case VK_RMENU:   // I4124
       break;
-    default:         
+    default:
       return 1;
   }
 

--- a/windows/src/engine/keymanx64/keymanx64.cpp
+++ b/windows/src/engine/keymanx64/keymanx64.cpp
@@ -331,7 +331,7 @@ BOOL SendPlatformComms32(WPARAM wParam, LPARAM lParam)
   {
     // TODO: Perhaps we should trigger a shutdown here, because
     // keyman.exe was not found. Right now, there is some confusion
-    // in regards to responsibility.
+    // in regards to responsibility. See #4976  
     MessageBox(0, szError_Keymanx86NotFound_Comms, szTitle, MB_OK);
     return FALSE;
   }

--- a/windows/src/engine/keymanx64/keymanx64.cpp
+++ b/windows/src/engine/keymanx64/keymanx64.cpp
@@ -117,7 +117,10 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 	MSG msg;
 
   if (!UniqueInstance()) {
-    Fail(0, szError_CannotRunMultipleInstances);
+    // If keymanx64 is already running, let's not
+    // report an error. This can happen if keyman.exe
+    // fails unexpectedly, and is then restarted.
+    //Fail(0, szError_CannotRunMultipleInstances);
     keyman_sentry_shutdown();
     return 1;
   }
@@ -129,7 +132,15 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
   }
 
   if (!InitInstance(hInstance, nCmdShow)) {
-    Fail(0, szError_FailedToInitInstance);
+    if (GetLastError() != ERROR_SUCCESS) {
+      // If WM_CREATE returns -1, then CreateWindow fails but
+      // GetLastError returns ERROR_SUCCESS. In this situation,
+      // we know that the error has already been reported via
+      // StartKeyman() so we don't want to re-report it. If
+      // CreateWindow fails for another reason, then we should
+      // be reporting it.
+      Fail(0, szError_FailedToInitInstance);
+    }
     keyman_sentry_shutdown();
     return 1;
   }
@@ -201,9 +212,13 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 //
 BOOL Fail(HWND hwnd, PWSTR msg)
 {
+#ifndef _DEBUG
+  UNREFERENCED_PARAMETER(hwnd);
+#endif
+
   WCHAR buf[512], outbuf[1024];
   DWORD err = GetLastError();
-  if(err != 0)
+  if(err != ERROR_SUCCESS)
   {
     if(!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, buf, _countof(buf), NULL))  // I3093   // I3547
     {
@@ -227,7 +242,9 @@ BOOL Fail(HWND hwnd, PWSTR msg)
 
   free(buffer);
 
+#ifdef _DEBUG
   MessageBox(hwnd, outbuf, szTitle, MB_OK | MB_ICONERROR);
+#endif
 
   return FALSE;
 }
@@ -266,8 +283,9 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 //
 //   COMMENTS:
 //
-//        Shows an error message box if it fails.  Tries to find
-//        the Keyman Engine x86 windows for communications
+//        Shows an error message box if it fails, in debug mode.
+//        Sends a Sentry error report on failure.  Tries to find
+//        the Keyman Engine x86 windows for communications.
 //
 BOOL StartKeyman(HWND hWnd)
 {
@@ -311,6 +329,9 @@ BOOL SendPlatformComms32(WPARAM wParam, LPARAM lParam)
   HWND hwndLocalController = FindWindow(szWindowClass_x86_Wnd, NULL);
   if(hwndLocalController == NULL)
   {
+    // TODO: Perhaps we should trigger a shutdown here, because
+    // keyman.exe was not found. Right now, there is some confusion
+    // in regards to responsibility.
     MessageBox(0, szError_Keymanx86NotFound_Comms, szTitle, MB_OK);
     return FALSE;
   }

--- a/windows/src/engine/keymanx64/keymanx64.cpp
+++ b/windows/src/engine/keymanx64/keymanx64.cpp
@@ -164,21 +164,14 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 //
 //   COMMENTS:
 //
-//        Reads parent process handle, parent process main window and
-//        parent process application window handle from the command
-//        line and validates them.
+//        Reads parent process handle and master controller window
+//        handle from the command line and validates them.
 //
 BOOL ParseCmdLine(LPTSTR lpCmdLine) {
   while (iswspace(*lpCmdLine)) lpCmdLine++;
   if (!*lpCmdLine) return FALSE;
   hParentProcessHandle = (HANDLE)wcstoull(lpCmdLine, &lpCmdLine, 10);
   if (hParentProcessHandle == 0 || hParentProcessHandle == (HANDLE) ULLONG_MAX) return FALSE;
-
-  // TODO: remove this now-unused parameter as separate patch
-  while (iswspace(*lpCmdLine)) lpCmdLine++;
-  if (!*lpCmdLine) return FALSE;
-  HWND __ = (HWND) wcstoull(lpCmdLine, &lpCmdLine, 10);
-  if (__ == 0 || __ == (HWND) ULLONG_MAX) return FALSE;
 
   while (iswspace(*lpCmdLine)) lpCmdLine++;
   if (!*lpCmdLine) return FALSE;

--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -143,10 +143,8 @@ type
     procedure StartKeyman32Engine; safecall;    // 32 bit only
     procedure StopKeyman32Engine; safecall;    // 32 bit only
     procedure ResetKeyman32Engine; safecall;    // 32 bit only
-    procedure RegisterMasterController(Value: LongWord); safecall;     // 32 bit only
-    procedure UnregisterMasterController(Value: LongWord); safecall;    // 32 bit only
-    procedure RegisterControllerThread(Value: LongWord); safecall;     // 32 bit only
-    procedure UnregisterControllerThread(Value: LongWord); safecall;    // 32 bit only
+    procedure RegisterControllerWindow(Value: LongWord); safecall;     // deprecated in #5060
+    procedure UnregisterControllerWindow(Value: LongWord); safecall;    // deprecated in #5060
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;
@@ -154,6 +152,12 @@ type
     procedure DiagnosticTestException; safecall;
 
     function LastRefreshToken: IntPtr; safecall;
+
+    // #5060:
+    procedure RegisterMasterController(Value: LongWord); safecall;     // 32 bit only
+    procedure UnregisterMasterController(Value: LongWord); safecall;    // 32 bit only
+    procedure RegisterControllerThread(Value: LongWord); safecall;     // 32 bit only
+    procedure UnregisterControllerThread(Value: LongWord); safecall;    // 32 bit only
 
     { IIntKeymanControl }
     procedure AutoApplyKeyman;
@@ -533,6 +537,11 @@ begin
 {$ENDIF}
 end;
 
+procedure TKeymanControl.RegisterControllerWindow(Value: LongWord);
+begin
+  // no-op (removed as part of #5060)
+end;
+
 procedure TKeymanControl.RegisterMasterController(Value: LongWord);
 begin
 {$IFDEF WIN64}
@@ -575,6 +584,11 @@ begin
   else if not FKeyman_UnregisterControllerThread(Value) then
     KL.LogError('UnregisterControllerThread: Could not unregister controller thread %x', [Value]);
 {$ENDIF}
+end;
+
+procedure TKeymanControl.UnregisterControllerWindow(Value: LongWord);
+begin
+  // no-op (removed as part of #5060)
 end;
 
 procedure TKeymanControl.UnregisterMasterController(Value: LongWord);

--- a/windows/src/global/delphi/general/KeymanControlMessages.pas
+++ b/windows/src/global/delphi/general/KeymanControlMessages.pas
@@ -1,18 +1,18 @@
 (*
   Name:             KeymanControlMessages
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      27 Mar 2008
 
   Modified Date:    13 Oct 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          27 Mar 2008 - mcdurdin - Initial version
                     20 Jul 2008 - mcdurdin - I1412 - Improve performance of tutorial
                     11 Dec 2009 - mcdurdin - I934 - x64 - platform comms - focus info
@@ -28,7 +28,7 @@ interface
 
 const
   //KMC_KEYBOARDCHANGED = 1;   // I3949
-  KMC_CHANGEUISTATE = 2;
+  //KMC_CHANGEUISTATE = 2;
   KMC_GETLOADED = 3;
   KMC_REFRESH = 4;
   KMC_INTERFACEHOTKEY = 5;

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -27,8 +27,10 @@ type
     procedure StartKeyman32Engine; safecall;   // I5133
     procedure StopKeyman32Engine; safecall;   // I5133
     procedure ResetKeyman32Engine; safecall;   // I5133
-    procedure RegisterControllerWindow(Value: LongWord); safecall;
-    procedure UnregisterControllerWindow(Value: LongWord); safecall;
+    procedure RegisterMasterController(Value: LongWord); safecall;
+    procedure UnregisterMasterController(Value: LongWord); safecall;
+    procedure RegisterControllerThread(Value: LongWord); safecall;
+    procedure UnregisterControllerThread(Value: LongWord); safecall;
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -27,10 +27,8 @@ type
     procedure StartKeyman32Engine; safecall;   // I5133
     procedure StopKeyman32Engine; safecall;   // I5133
     procedure ResetKeyman32Engine; safecall;   // I5133
-    procedure RegisterMasterController(Value: LongWord); safecall;
-    procedure UnregisterMasterController(Value: LongWord); safecall;
-    procedure RegisterControllerThread(Value: LongWord); safecall;
-    procedure UnregisterControllerThread(Value: LongWord); safecall;
+    procedure RegisterControllerWindow(Value: LongWord); safecall; // deprecated in #5060; remains for interface stability
+    procedure UnregisterControllerWindow(Value: LongWord); safecall; // deprecated in #5060; remains for interface stability
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;
@@ -38,6 +36,13 @@ type
     procedure DiagnosticTestException; safecall;
 
     function LastRefreshToken: IntPtr; safecall;
+
+    // New in #5060:
+
+    procedure RegisterMasterController(Value: LongWord); safecall;
+    procedure UnregisterMasterController(Value: LongWord); safecall;
+    procedure RegisterControllerThread(Value: LongWord); safecall;
+    procedure UnregisterControllerThread(Value: LongWord); safecall;
   end;
 
 implementation

--- a/windows/src/global/delphi/general/UserMessages.pas
+++ b/windows/src/global/delphi/general/UserMessages.pas
@@ -31,7 +31,6 @@ const
   WM_USER_Start = WM_USER+101;
   WM_USER_ParameterPass = WM_USER+100;
   WM_USER_SendFontChange = WM_USER+102;
-  WM_USER_PlatformComms = WM_USER+103;
   WM_USER_VisualKeyboardClosed = WM_USER+105;   // I4242
 
 const

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -286,10 +286,7 @@ BOOL ProcessMessage( LPMSG mp );
 BOOL ProcessGroup(LPGROUP gp);
 BOOL ContextMatch(LPKEY kkp);
 int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr);
-//void PostKey( int keystroke, int msgflags, LPMSG msg );
-//void GetINIAdvanced( void );
 BOOL LoadAllKeymanKeyboards(DWORD layout);
-void UpdateKeymanUI();
 
 BOOL IsSysTrayWindow(HWND hwnd);
 

--- a/windows/src/global/inc/keymancontrol.h
+++ b/windows/src/global/inc/keymancontrol.h
@@ -1,18 +1,18 @@
 /*
   Name:             keymancontrol
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    13 Oct 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Add KMC_REFRESH and KMC_INTERFACEHOTKEY wm_keyman_control messages
                     11 Dec 2009 - mcdurdin - I934 - x64 platfrom comms add KMC_SETFOCUSINFO
                     06 Apr 2010 - mcdurdin - I2271 - Select Keyboard tidy up
@@ -23,7 +23,7 @@
 */
 
 //#define KMC_KEYBOARDCHANGED	1   // I3949
-#define KMC_CHANGEUISTATE  	2
+//#define KMC_CHANGEUISTATE  	2
 //#define KMC_GETLOADED	    	3
 #define KMC_REFRESH			    4
 #define KMC_INTERFACEHOTKEY	5


### PR DESCRIPTION
Fixes #5067.
Fixes #5066.

Cherry-pick of #4989, #5002, #5060, #5061, #5062, #5202.

Fixes KEYMAN-WINDOWS-3F.
Fixes KEYMAN-WINDOWS-5A.
Fixes KEYMAN-WINDOWS-3E.
Fixes KEYMAN-WINDOWS-AC.
Fixes KEYMAN-WINDOWS-F5.
Probably fixes KEYMAN-WINDOWS-EH.
Probably fixes KEYMAN-WINDOWS-HH.
Probably fixes KEYMAN-WINDOWS-6M.