### PR TITLE
feat(android): Automatically install keyboard through Play Store

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -55,7 +55,7 @@ android {
 
     buildTypes {
         debug {
-            applicationIdSuffix ".debug"
+            // applicationIdSuffix ".debug"
             pseudoLocalesEnabled true
             debuggable true
         }
@@ -128,6 +128,7 @@ dependencies {
     api(name: 'keyman-engine', ext: 'aar')
     implementation 'io.sentry:sentry-android:4.3.0'
     implementation 'androidx.preference:preference:1.1.1'
+    implementation "com.android.installreferrer:installreferrer:2.2"
 
     // Add dependency for generating QR Codes
     // (Even though it's embedded in KMEA, because we're manually copying keyman-engine.aar,

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -55,7 +55,7 @@ android {
 
     buildTypes {
         debug {
-            // applicationIdSuffix ".debug"
+            applicationIdSuffix ".debug"
             pseudoLocalesEnabled true
             debuggable true
         }

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2021 SIL International. All rights reserved.
+ *
+ * Uses Google Play Install Referrer API to check for default keyboard to install alongside the app
+ * itself. Details are passed in the `referrer` query value in the Play Store url, e.g.
+ *
+ *   https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro&
+ *   referrer=source%3Dkeyman%26package%3Dgff_amharic%26bcp47%3Dam
+ *
+ * The referrer value in the example unencodes to:
+ *   source=keyman&package=gff_amharic&bcp47=am
+ *
+ * Parameters:
+ *   - `source` must be 'keyman'
+ *   - `package` must be a package id from Keyman Cloud
+ *   - `bcp47` is optional but if present must be a valid BCP 47 code
+ */
+
+package com.keyman.android;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.RemoteException;
+import android.util.Log;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
+import com.tavultesoft.kmapro.MainActivity;
+import com.tavultesoft.kmapro.R;
+import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
+
+public class CheckInstallReferrer {
+  private static final String TAG = "CheckInstallReferrer";
+  private static final String hasGooglePlayInstallReferrerBeenCheckedKey =
+    "HasGooglePlayInstallReferrerBeenChecked";
+
+  /**
+   * Contact Google Play Install Referrer API to find out if the Keyman site gave us a default
+   * keyboard to install.
+   * @param mainActivity  TODO: refactor downloadKMP so we don't need backrefs like this
+   * @param context
+   */
+  public static void checkGooglePlayInstallReferrer(MainActivity mainActivity, Context context) {
+    InstallReferrerClient referrerClient;
+
+    // We check the referrer value only once after installing the app,
+    // even if it fails.
+    SharedPreferences prefs = context.getSharedPreferences(
+      context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    boolean hasGooglePlayInstallReferrerBeenChecked = prefs.getBoolean(
+      hasGooglePlayInstallReferrerBeenCheckedKey, false);
+    if(hasGooglePlayInstallReferrerBeenChecked) return;
+
+    SharedPreferences.Editor editor = prefs.edit();
+    editor.putBoolean(hasGooglePlayInstallReferrerBeenCheckedKey, true);
+    editor.commit();
+
+    Log.i(TAG, "Started checkGooglePlayInstallReferrer");
+
+    // Connect to Google Play Install Referrer API
+    referrerClient = InstallReferrerClient.newBuilder(context).build();
+    referrerClient.startConnection(new InstallReferrerStateListener() {
+      @Override
+      public void onInstallReferrerSetupFinished(int responseCode) {
+        switch (responseCode) {
+          case InstallReferrerClient.InstallReferrerResponse.OK:
+            // Connection established.
+            Log.i(TAG, "onInstallReferrerSetupFinished:OK");
+            processGooglePlayInstallReferrerData();
+            break;
+          case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+            // API not available on the current Play Store app; log to Sentry
+            KMLog.LogError(TAG, "onInstallReferrerSetupFinished:FEATURE_NOT_SUPPORTED");
+            break;
+          case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
+            // Connection couldn't be established; log to Sentry
+            KMLog.LogError(TAG, "onInstallReferrerSetupFinished:SERVICE_UNAVAILABLE");
+            break;
+          default:
+            // There are some other error codes; log to Sentry
+            KMLog.LogError(TAG, "onInstallReferrerSetupFinished: Unexpected code: " +
+              responseCode);
+            break;
+        }
+        // We have finished with the API so tidy up
+        referrerClient.endConnection();
+      }
+
+      @Override
+      public void onInstallReferrerServiceDisconnected() {
+        // Try to restart the connection on the next request to
+        // Google Play by calling the startConnection() method.
+
+        // Note: the documentation on this is unclear, and examples I found typically have no
+        // implementation here, so for now, we'll just log this to Sentry so that we can be aware
+        // of it happening.
+        KMLog.LogError(TAG, "onInstallReferrerServiceDisconnected");
+      }
+
+      private void processGooglePlayInstallReferrerData() {
+        ReferrerDetails response;
+        try {
+          response = referrerClient.getInstallReferrer();
+        } catch (RemoteException e) {
+          KMLog.LogException(TAG, "Failed to get install referrer", e);
+          return;
+        }
+
+        String referrerUrl = response.getInstallReferrer();
+        if(referrerUrl == null) {
+          KMLog.LogError(TAG, "getInstallReferrer() returned null");
+          return;
+        }
+
+        Log.i(TAG, "Referrer URL: "+referrerUrl);
+        installPackageFromInstallReferrer(mainActivity, referrerUrl);
+      }
+    });
+  }
+
+  private static void installPackageFromInstallReferrer(MainActivity mainActivity,
+                                                        String urlReferrer) {
+    // We're going to try to and parse the string; if it looks like a valid referrer then we'll
+    // try and install the package. A valid referrer looks like:
+    //   source=keyman&package=<package>[&bcp47=<code>]
+    // Note that this will be encoded into a referrer url like this (i.e. = and & must be
+    // double-encoded to fit into the referrer parameter):
+    //   https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro&
+    //   referrer=source%3Dkeyman%26package%3D<package>%26bcp47%3D<code>
+    // so we can use a standard URI parser to extract the parameters
+    Uri referrerUri = Uri.parse("https://example?" + urlReferrer);
+    String source = referrerUri.getQueryParameter("source");
+    String packageId = referrerUri.getQueryParameter("package");
+    String bcp47 = referrerUri.getQueryParameter("bcp47");
+
+    Log.i(TAG, KMString.format("source=%s package=%s bcp47=%s", new Object[]{source, packageId, bcp47}));
+
+    // We use the 'source' parameter as a basic sanity check as anything could be passed in referrer
+    if(source == null || !source.equals("keyman")) return;
+    if(packageId == null) return;
+
+    mainActivity.downloadKMP(packageId, bcp47);
+  }
+}

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -136,7 +136,8 @@ public class CheckInstallReferrer {
     String packageId = referrerUri.getQueryParameter("package");
     String bcp47 = referrerUri.getQueryParameter("bcp47");
 
-    Log.i(TAG, KMString.format("source=%s package=%s bcp47=%s", new Object[]{source, packageId, bcp47}));
+    KMLog.LogInfo(TAG, KMString.format("Install referrer details from Google Play: %s source=%s package=%s bcp47=%s",
+      new Object[]{urlReferrer, source, packageId, bcp47}));
 
     // We use the 'source' parameter as a basic sanity check as anything could be passed in referrer
     if(source == null || !source.equals("keyman")) return;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -473,13 +473,6 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     resizeTextView(false);
   }
 
-  /**
-   * Parse the URI data to determine the filename and URL for the .kmp keyboard package.
-   * If URL is valid, download the kmp.
-   * @param packageUri URI to download the package.
-   * TODO: only ever pass packageId and bcp47 from callers, as KMPLink should be responsible for
-   *       URL parsing, not this function.
-   */
   public void downloadKMP(String packageId, String bcp47) {
     Uri downloadUri = bcp47 == null ?
       Uri.parse(KMString.format("https://keyman.com/go/package/download/%s", new Object[]{packageId})) :
@@ -487,6 +480,13 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     downloadKMP(downloadUri);
   }
 
+  /**
+   * Parse the URI data to determine the filename and URL for the .kmp keyboard package.
+   * If URL is valid, download the kmp.
+   * @param packageUri URI to download the package.
+   * TODO: only ever pass packageId and bcp47 from callers, as KMPLink should be responsible for
+   *       URL parsing, not this function.
+   */
   public void downloadKMP(Uri packageUri) {
     if (packageUri == null) {
       KMLog.LogError(TAG,"null uri passed to downloadKmp");


### PR DESCRIPTION
Resolves #5219.

Uses the Google Play Install Referrer API to automatically discover the keyboard to install together with Keyman; this keyboard is passed in a `referrer` parameter to the Play Store page for the Keyman app from the Keyman website.

When the app launches for the first time, the Get Started screen appears and then a moment later, the Install Keyboard process starts for the associated keyboard. Once that completes, the first checkbox in Get Started is automatically checked.

This can be a little tricky to test because it only runs first-time after installing the app from the Play Store (by design). But the test version is not yet in the Play Store. However, you can test on an Android device by:

1. Uninstall the Keyman app
2. Open a link to the play store with an embedded referrer value -- but don't click Install. See below for some example links. The Play Store will record the referrer for later use by the Keyman app.
3. Click the Home button.
4. Install the test .apk associated with this PR, or load it from adb.

Example install links:
* [Install Keyman + GFF Amharic](https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro&referrer=source%3Dkeyman%26package%3Dgff_amharic%26bcp47%3Dam)
* [Install Keyman + Khmer Angkor](https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro&referrer=source%3Dkeyman%26package%3Dkhmer_angkor)
* [Install Keyman + Cameroon QWERTY, Adamawa Fulfulde](https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro&referrer=source%3Dkeyman%26package%3Dsil_cameroon_qwerty%26bcp47%3Dfub-latn)

I have done a first round of cleanup of the `downloadKMP` pathway, eliminating the class variable `data` which was (a) obscure, and (b) only required for a single path in the download process (requesting permissions), replacing it with local variables and parameters as required. However, the pathways are still overly convoluted and there are mixed responsibilities for URL parsing which should ideally be done *only* in the `KMPLink` class. I didn't want to go overboard here, as it was not relevant to this PR, so the changes I have made are really to support the new download pattern that this PR needs. I'd love to see further cleanup of keyboard downloads.

An associated PR for the Keyman website is on its way.