### PR TITLE
fix(web): Always pass kill_browserstack

### DIFF
--- a/web/source/build_kill_browserstack.sh
+++ b/web/source/build_kill_browserstack.sh
@@ -15,5 +15,8 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 get_builder_OS
 
 if [ ${os_id} == 'win' ]; then
-  taskkill //f //im BrowserStackLocal.exe
+  # BrowserStackLocal may not exist, so always pass
+  taskkill //f //im BrowserStackLocal.exe || true
 fi
+
+exit 0


### PR DESCRIPTION
Follow-on to #5136

The CI test build step of cleaning up Browserstack can fail because the task BrowserStackLocal doesn't always exist.
This PR forces the step to always pass.