### PR TITLE
feat(android): silent install for referred kbd

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         android:resource="@xml/method" />
     </service>
     <service
-      android:name="com.tavultesoft.kmea.util.DownloadIntentService"
+      android:name="com.keyman.android.DownloadIntentService"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:exported="true" />
 

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -143,6 +143,6 @@ public class CheckInstallReferrer {
     if(source == null || !source.equals("keyman")) return;
     if(packageId == null) return;
 
-    mainActivity.downloadKMP(packageId, bcp47);
+    mainActivity.downloadKMP(packageId, bcp47, true);
   }
 }

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -143,6 +143,6 @@ public class CheckInstallReferrer {
     if(source == null || !source.equals("keyman")) return;
     if(packageId == null) return;
 
-    mainActivity.downloadKMP(packageId, bcp47, true);
+    mainActivity.downloadKMP(packageId, bcp47, KmpInstallMode.WelcomeOnly);
   }
 }

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/DownloadIntentService.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/DownloadIntentService.java
@@ -1,9 +1,12 @@
-package com.tavultesoft.kmea.util;
+package com.keyman.android;
 
 import android.app.IntentService;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+
+import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
 
 public class DownloadIntentService extends IntentService {
   private static final String TAG = "DownloadIntentSvc";
@@ -18,7 +21,8 @@ public class DownloadIntentService extends IntentService {
     String filename = intent.getStringExtra("filename");
     String destination = intent.getStringExtra("destination");
     String languageID = intent.getStringExtra("language");
-    boolean silentInstall = intent.getBooleanExtra("silentInstall", false);
+    KmpInstallMode installMode = (KmpInstallMode) intent.getSerializableExtra("installMode");
+    if(installMode == null) installMode = KmpInstallMode.Full;
     final ResultReceiver receiver = intent.getParcelableExtra("receiver");
     Bundle bundle = new Bundle();
 
@@ -28,7 +32,7 @@ public class DownloadIntentService extends IntentService {
         bundle.putString("destination", destination);
         bundle.putString("filename", filename);
         bundle.putString("language", languageID);
-        bundle.putBoolean("silentInstall", silentInstall);
+        bundle.putSerializable("installMode", installMode);
         receiver.send(FileUtils.DOWNLOAD_SUCCESS, bundle);
       } else {
         receiver.send(FileUtils.DOWNLOAD_ERROR, bundle);

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/KmpInstallMode.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/KmpInstallMode.java
@@ -1,7 +1,8 @@
 package com.keyman.android;
 
 public enum KmpInstallMode {
-  Silent,
-  WelcomeOnly,
-  Full
+  Silent,       // Show no UI while installing a package. Errors may be shown as toasts
+  WelcomeOnly,  // Show only the welcome screen after installing a package; language will
+                // be automatically selected if not provided as an input parameter
+  Full          // Show readme, language picker (if applicable), and welcome after install.
 }

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/KmpInstallMode.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/KmpInstallMode.java
@@ -1,0 +1,7 @@
+package com.keyman.android;
+
+public enum KmpInstallMode {
+  Silent,
+  WelcomeOnly,
+  Full
+}

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -35,10 +35,12 @@ public class DownloadResultReceiver extends ResultReceiver {
         String downloadedFilename = resultData.getString("filename");
         String languageID = resultData.getString("language");
         String kmpFilename = resultData.getString("destination") + File.separator + downloadedFilename;
+        boolean silentInstall = resultData.getBoolean("silentInstall");
 
         Bundle bundle = new Bundle();
         bundle.putString("kmpFile", kmpFilename);
         bundle.putString("language", languageID);
+        bundle.putBoolean("silentInstall", silentInstall);
         Intent packageIntent = new Intent(context, PackageActivity.class);
         packageIntent.putExtras(bundle);
         context.startActivity(packageIntent);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.ResultReceiver;
 import android.widget.Toast;
 
+import com.keyman.android.KmpInstallMode;
 import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.util.FileUtils;
 
@@ -35,12 +36,13 @@ public class DownloadResultReceiver extends ResultReceiver {
         String downloadedFilename = resultData.getString("filename");
         String languageID = resultData.getString("language");
         String kmpFilename = resultData.getString("destination") + File.separator + downloadedFilename;
-        boolean silentInstall = resultData.getBoolean("silentInstall");
+        KmpInstallMode installMode = (KmpInstallMode) resultData.getSerializable("installMode");
+        if(installMode == null) installMode = KmpInstallMode.Full;
 
         Bundle bundle = new Bundle();
         bundle.putString("kmpFile", kmpFilename);
         bundle.putString("language", languageID);
-        bundle.putBoolean("silentInstall", silentInstall);
+        bundle.putSerializable("installMode", installMode);
         Intent packageIntent = new Intent(context, PackageActivity.class);
         packageIntent.putExtras(bundle);
         context.startActivity(packageIntent);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.keyman.android.CheckInstallReferrer;
+import com.keyman.android.KmpInstallMode;
 import com.tavultesoft.kmea.BaseActivity;
 import com.tavultesoft.kmea.KMHelpFileActivity;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
@@ -35,7 +36,7 @@ import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.LexicalModel;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.DownloadFileUtils;
-import com.tavultesoft.kmea.util.DownloadIntentService;
+import com.keyman.android.DownloadIntentService;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMPLink;
 import com.tavultesoft.kmea.util.KMString;
@@ -275,7 +276,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           if (KMPLink.isKeymanInstallLink(link)) {
             loadingIntentUri = KMPLink.getKeyboardDownloadLink(link);
           }
-          downloadKMP(loadingIntentUri, false);
+          downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           break;
         case "keyman" :
           // TODO: Only accept download links from Keyman browser activities when universal links work
@@ -288,11 +289,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
               .appendPath("keyboards")
               .encodedQuery(loadingIntentUri.getEncodedQuery());
             loadingIntentUri = Uri.parse(builder.build().toString());
-            downloadKMP(loadingIntentUri, false);
+            downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           } else if (KMPLink.isLegacyKeymanDownloadLink(loadingIntentUri.toString())) {
             link = loadingIntentUri.toString();
             loadingIntentUri = KMPLink.getLegacyKeyboardDownloadLink(link);
-            downloadKMP(loadingIntentUri, false);
+            downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           } else {
             String msg = "Unrecognized scheme: " + scheme;
             KMLog.LogError(TAG, msg);
@@ -473,11 +474,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     resizeTextView(false);
   }
 
-  public void downloadKMP(String packageId, String bcp47, boolean silentInstall) {
+  public void downloadKMP(String packageId, String bcp47, KmpInstallMode installMode) {
     Uri downloadUri = bcp47 == null ?
       Uri.parse(KMString.format("https://keyman.com/go/package/download/%s", new Object[]{packageId})) :
       Uri.parse(KMString.format("https://keyman.com/go/package/download/%s?bcp47=%s", new Object[]{packageId, bcp47}));
-    downloadKMP(downloadUri, silentInstall);
+    downloadKMP(downloadUri, installMode);
   }
 
   /**
@@ -487,7 +488,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
    * TODO: only ever pass packageId and bcp47 from callers, as KMPLink should be responsible for
    *       URL parsing, not this function.
    */
-  public void downloadKMP(Uri packageUri, boolean silentInstall) {
+  public void downloadKMP(Uri packageUri, KmpInstallMode installMode) {
     if (packageUri == null) {
       KMLog.LogError(TAG,"null uri passed to downloadKmp");
       String message = "Download failed. Invalid URL.";
@@ -535,7 +536,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             downloadIntent.putExtra("language", languageID);
             downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
             downloadIntent.putExtra("receiver", resultReceiver);
-            downloadIntent.putExtra("silentInstall", silentInstall);
+            downloadIntent.putExtra("installMode", installMode);
 
             startService(downloadIntent);
           }
@@ -979,8 +980,9 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       }
     }
 
-    // Display welcome.htm help file
-    if (customHelpLink != null && !customHelpLink.isEmpty() &&
+    // Display welcome.htm help file -- if we are not doing a silent install
+    if (PackageActivity.lastInstallMode != KmpInstallMode.Silent &&
+        customHelpLink != null && !customHelpLink.isEmpty() &&
         packageID != null && !packageID.isEmpty() && FileUtils.isWelcomeFile(customHelpLink)) {
       // Display local welcome.htm help file, including associated assets
       Intent i = new Intent(this, KMHelpFileActivity.class);
@@ -989,6 +991,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       i.putExtra(KMManager.KMKey_CustomHelpLink, customHelpLink);
       startActivity(i);
     }
+
+    // We'll reset the global installMode flag now so that future package
+    // installs that don't go through PackageActivity are not affected.
+    PackageActivity.lastInstallMode  = KmpInstallMode.Full;
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -275,7 +275,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           if (KMPLink.isKeymanInstallLink(link)) {
             loadingIntentUri = KMPLink.getKeyboardDownloadLink(link);
           }
-          downloadKMP(loadingIntentUri);
+          downloadKMP(loadingIntentUri, false);
           break;
         case "keyman" :
           // TODO: Only accept download links from Keyman browser activities when universal links work
@@ -288,11 +288,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
               .appendPath("keyboards")
               .encodedQuery(loadingIntentUri.getEncodedQuery());
             loadingIntentUri = Uri.parse(builder.build().toString());
-            downloadKMP(loadingIntentUri);
+            downloadKMP(loadingIntentUri, false);
           } else if (KMPLink.isLegacyKeymanDownloadLink(loadingIntentUri.toString())) {
             link = loadingIntentUri.toString();
             loadingIntentUri = KMPLink.getLegacyKeyboardDownloadLink(link);
-            downloadKMP(loadingIntentUri);
+            downloadKMP(loadingIntentUri, false);
           } else {
             String msg = "Unrecognized scheme: " + scheme;
             KMLog.LogError(TAG, msg);
@@ -473,11 +473,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     resizeTextView(false);
   }
 
-  public void downloadKMP(String packageId, String bcp47) {
+  public void downloadKMP(String packageId, String bcp47, boolean silentInstall) {
     Uri downloadUri = bcp47 == null ?
       Uri.parse(KMString.format("https://keyman.com/go/package/download/%s", new Object[]{packageId})) :
       Uri.parse(KMString.format("https://keyman.com/go/package/download/%s?bcp47=%s", new Object[]{packageId, bcp47}));
-    downloadKMP(downloadUri);
+    downloadKMP(downloadUri, silentInstall);
   }
 
   /**
@@ -487,7 +487,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
    * TODO: only ever pass packageId and bcp47 from callers, as KMPLink should be responsible for
    *       URL parsing, not this function.
    */
-  public void downloadKMP(Uri packageUri) {
+  public void downloadKMP(Uri packageUri, boolean silentInstall) {
     if (packageUri == null) {
       KMLog.LogError(TAG,"null uri passed to downloadKmp");
       String message = "Download failed. Invalid URL.";
@@ -535,6 +535,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             downloadIntent.putExtra("language", languageID);
             downloadIntent.putExtra("destination", MainActivity.this.getCacheDir().toString());
             downloadIntent.putExtra("receiver", resultReceiver);
+            downloadIntent.putExtra("silentInstall", silentInstall);
 
             startService(downloadIntent);
           }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/DownloadIntentService.java
@@ -18,6 +18,7 @@ public class DownloadIntentService extends IntentService {
     String filename = intent.getStringExtra("filename");
     String destination = intent.getStringExtra("destination");
     String languageID = intent.getStringExtra("language");
+    boolean silentInstall = intent.getBooleanExtra("silentInstall", false);
     final ResultReceiver receiver = intent.getParcelableExtra("receiver");
     Bundle bundle = new Bundle();
 
@@ -27,6 +28,7 @@ public class DownloadIntentService extends IntentService {
         bundle.putString("destination", destination);
         bundle.putString("filename", filename);
         bundle.putString("language", languageID);
+        bundle.putBoolean("silentInstall", silentInstall);
         receiver.send(FileUtils.DOWNLOAD_SUCCESS, bundle);
       } else {
         receiver.send(FileUtils.DOWNLOAD_ERROR, bundle);


### PR DESCRIPTION
Relates to #5230, #5219.

Adds an `installMode` parameter to the `downloadKMP` function and makes the install `welcomeOnly` for referred keyboards.

1. We need to be able to control silent levels:
   * Completely silent
   * Only welcome
   * Full install

2. When `silentInstall` was true, currently welcome was still shown, but the paging controls are not configured correctly and a blank screen (an incomplete `PackageActivity`) was shown after install, because the `PackageActivity` was never `finish()`ed.