### PR TITLE
fix(common/core/web): optimizes transform construction

### DIFF
--- a/common/core/web/keyboard-processor/tests/cases/transcriptions.js
+++ b/common/core/web/keyboard-processor/tests/cases/transcriptions.js
@@ -85,6 +85,36 @@ describe("Transcriptions and Transforms", function() {
       assert.equal(transcription.transform.deleteRight, 11, "Incorrect count for right-of-caret deletions");
     });
 
+    it("handles operations with long text", function() {
+      var Mock = com.keyman.text.Mock;
+
+      // Eh... had to pick SOMETHING.
+      let text = `Did you ever hear the Tragedy of Darth Plagueis the wise? I thought not.
+It's not a story the Jedi would tell you. It's a Sith legend. Darth Plagueis was a
+Dark Lord of the Sith, so powerful and so wise he could use the Force to influence
+the midichlorians to create life... He had such a knowledge of the dark side that
+he could even keep the ones he cared about from dying. The dark side of the Force
+is a pathway to many abilities some consider to be unnatural. He became so powerful...
+the only thing he was afraid of was losing his power, which eventually, of course,
+he did. Unfortunately, he taught his apprentice everything he knew, then his
+apprentice killed him in his sleep. It's ironic he could save others from death,
+but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
+
+      var target = new Mock(text, text.length);
+      var original = Mock.from(target);
+      target.deleteCharsBeforeCaret(1);
+      target.insertTextBeforeCaret("!");
+
+      /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+      * Other modules coming later will need it, though.
+      */
+      var transcription = target.buildTranscriptionFrom(original, null);
+
+      assert.equal(transcription.transform.insert, "!", "Reported inserted text when only deletions exist");
+      assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+      assert.equal(transcription.transform.deleteRight, 0, "Incorrect count for right-of-caret deletions");
+    });
+
     it("handles deletions around the caret without text insertion", function() {
       var Mock = com.keyman.text.Mock;
 

--- a/common/core/web/keyboard-processor/tests/cases/transcriptions.js
+++ b/common/core/web/keyboard-processor/tests/cases/transcriptions.js
@@ -7,6 +7,17 @@ global.com = KeyboardProcessor.com; // exports all keyboard-processor namespacin
 String.kmwEnableSupplementaryPlane(false);
 
 describe("Transcriptions and Transforms", function() {
+  var toSupplementaryPairString = function(code){
+    var H = Math.floor((code - 0x10000) / 0x400) + 0xD800;
+    var L = (code - 0x10000) % 0x400 + 0xDC00;
+  
+    return String.fromCharCode(H, L);
+  }
+
+  // Built in-line via function.  Looks functionally equivalent to "apple", but with SMP characters.
+  let u = toSupplementaryPairString;
+  let smpApple = u(0x1d5ba)+u(0x1d5c9)+u(0x1d5c9)+u(0x1d5c5)+u(0x1d5be);
+
   it("does not store an alias for related OutputTargets", function() {
     var Mock = com.keyman.text.Mock;
 
@@ -55,11 +66,28 @@ describe("Transcriptions and Transforms", function() {
       assert.equal(transcription.transform.deleteRight, 0);
     });
 
+    it("handles operations with moderately long text", function() {
+      var Mock = com.keyman.text.Mock;
+
+      var target = new Mock("The quick brown cat jumped onto the lazy dog.", 19);
+      var original = Mock.from(target);
+      target.setDeadkeyCaret(30); // 19 + 11:  moves it to after "onto".
+      target.deleteCharsBeforeCaret(14); // delete:  "cat jumped onto"
+      target.insertTextBeforeCaret("fox jumped over");
+
+      /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+      * Other modules coming later will need it, though.
+      */
+      var transcription = target.buildTranscriptionFrom(original, null);
+
+      assert.equal(transcription.transform.insert, "fox jumped over", "Reported inserted text when only deletions exist");
+      assert.equal(transcription.transform.deleteLeft, 3, "Incorrect count for left-of-caret deletions");
+      assert.equal(transcription.transform.deleteRight, 11, "Incorrect count for right-of-caret deletions");
+    });
+
     it("handles deletions around the caret without text insertion", function() {
       var Mock = com.keyman.text.Mock;
 
-      // We have other texts validating Mocks; by using them as our base 'element', this unit test file
-      // could eventually run in 'headless' mode.
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
       target.setDeadkeyCaret(3);
@@ -73,6 +101,29 @@ describe("Transcriptions and Transforms", function() {
       assert.equal(transcription.transform.insert, "", "Reported inserted text when only deletions exist");
       assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
       assert.equal(transcription.transform.deleteRight, 1, "Incorrect count for right-of-caret deletions");
+    });
+
+    it("handles deletions around the caret without text insertion (SMP text)", function() {
+      try {
+        String.kmwEnableSupplementaryPlane(true);
+        var Mock = com.keyman.text.Mock;
+
+        var target = new Mock(smpApple, 2);
+        var original = Mock.from(target);
+        target.setDeadkeyCaret(3);
+        target.deleteCharsBeforeCaret(2); // "ale"
+
+        /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+        * Other modules coming later will need it, though.
+        */
+        var transcription = target.buildTranscriptionFrom(original, null);
+
+        assert.equal(transcription.transform.insert, "", "Reported inserted text when only deletions exist");
+        assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+        assert.equal(transcription.transform.deleteRight, 1, "Incorrect count for right-of-caret deletions");
+      } finally {
+        String.kmwEnableSupplementaryPlane(false);
+      }
     });
 
     it("handles deletions around the caret with text insertion", function() {
@@ -146,6 +197,89 @@ describe("Transcriptions and Transforms", function() {
       assert.equal(transcription.transform.insert, "les", "Reported inserted text when only deletions exist");
       assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
       assert.equal(transcription.transform.deleteRight, 3, "Incorrect count for right-of-caret deletions");
+    });
+
+    it("handles deletions around the caret with text insertion (SMP text)", function() {
+      try {
+        String.kmwEnableSupplementaryPlane(true);
+        var Mock = com.keyman.text.Mock;
+
+        // We have other texts validating Mocks; by using them as our base 'element', this unit test file
+        // could eventually run in 'headless' mode.
+        var target = new Mock(smpApple, 2);
+        let smpLE = u(0x1d5c5)+u(0x1d5be);
+        var original = Mock.from(target);
+        target.setDeadkeyCaret(3);
+        target.deleteCharsBeforeCaret(2);
+        target.insertTextBeforeCaret(smpLE); // "alele"
+
+        /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+        * Other modules coming later will need it, though.
+        *
+        * This will trigger the "step 1.2" component of buildTransformFrom.
+        */
+        var transcription = target.buildTranscriptionFrom(original, null);
+
+        assert.equal(transcription.transform.insert, smpLE, "Reported inserted text when only deletions exist");
+        assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+        assert.equal(transcription.transform.deleteRight, 1, "Incorrect count for right-of-caret deletions");
+
+        // CASE 2
+
+        var target = new Mock(smpApple, 2);
+        let smpB = u(0x1d5bb);
+        var original = Mock.from(target);
+        target.setDeadkeyCaret(4);
+        target.deleteCharsBeforeCaret(3);
+        target.insertTextBeforeCaret(smpB); // "aPe"
+
+        /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+        * Other modules coming later will need it, though.
+        */
+        var transcription = target.buildTranscriptionFrom(original, null);
+
+        assert.equal(transcription.transform.insert, smpB, "Reported inserted text when only deletions exist");
+        assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+        assert.equal(transcription.transform.deleteRight, 2, "Incorrect count for right-of-caret deletions");
+
+        // CASE 3
+
+        var target = new Mock(smpApple, 2);
+        var original = Mock.from(target);
+        target.setDeadkeyCaret(4);
+        target.deleteCharsBeforeCaret(3);
+        target.insertTextBeforeCaret("aaaaaaaaaaaaaa"); // "aaaaaaaaaaaaaaae"
+
+        /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+        * Other modules coming later will need it, though.
+        */
+        var transcription = target.buildTranscriptionFrom(original, null);
+
+        assert.equal(transcription.transform.insert, "aaaaaaaaaaaaaa", "Reported inserted text when only deletions exist");
+        assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+        assert.equal(transcription.transform.deleteRight, 2, "Incorrect count for right-of-caret deletions");
+
+        // CASE 4
+
+        var target = new Mock(smpApple, 2);
+        let smpLES = u(0x1d5c5)+u(0x1d5be)+u(0x1d5cb);
+        var original = Mock.from(target);
+        target.setDeadkeyCaret(5);
+        target.deleteCharsBeforeCaret(4);
+        target.insertTextBeforeCaret(smpLES); // "ales" - since we've appended a letter at the very end, the whole right-hand is indeed an insertion.
+
+        /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
+          * Other modules coming later will need it, though.
+          */
+        var transcription = target.buildTranscriptionFrom(original, null);
+
+        // Again, while the "le" portion is original text, the appended "s" means it must have been re-inserted.
+        assert.equal(transcription.transform.insert, smpLES, "Reported inserted text when only deletions exist");
+        assert.equal(transcription.transform.deleteLeft, 1, "Incorrect count for left-of-caret deletions");
+        assert.equal(transcription.transform.deleteRight, 3, "Incorrect count for right-of-caret deletions");
+      } finally {
+        String.kmwEnableSupplementaryPlane(false);
+      }
     });
   });
 


### PR DESCRIPTION
Addresses #5246.

In an isolated, headless unit test environment, this didn't seem to get that much improvement despite changing a particularly inefficient part of the algorithm from O(N^2) to O(N).  (Maybe there were caching effects somehow?)

That said... it _did_ make a remarkable difference in responsiveness when I used the KMW "predictive text: robust testing" page; keystroke processing as a whole took less time than focusing operations as a result.

I want to test it out a bit more before leaving draft, but it does seem to yield some significant improvement.  Things still struggle with _very_ long text, of course.