### PR TITLE
feat(linux): Fix Linux packaging on i386

### DIFF
--- a/common/core/desktop/debian/rules
+++ b/common/core/desktop/debian/rules
@@ -12,7 +12,7 @@ export LC_ALL=C.UTF-8
 	dh $@
 
 override_dh_auto_configure:
-	./build.sh configure -- --wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/$(DEB_TARGET_GNU_TYPE) --libexecdir=lib/$(DEB_TARGET_GNU_TYPE)
+	./build.sh configure -- --wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/$(DEB_TARGET_MULTIARCH) --libexecdir=lib/$(DEB_TARGET_MULTIARCH)
 
 override_dh_auto_build:
 	./build.sh build

--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  libgtk-3-dev,
  libibus-1.0-dev (>= 1.2),
  libjson-glib-dev (>= 1.4.0),
- libkmnkbp-dev (>=11.0.100),
+ libkmnkbp-dev (>= 15.0.44),
  pkg-config,
 Standards-Version: 4.5.1
 Vcs-Git: https://github.com/keymanapp/keyman.git


### PR DESCRIPTION
Debian defines multiple similar environment variables. On most architectures the results are the same.
But on i386 libraries are expected in `/usr/lib/i386-linux-gnu`. `DEB_TARGET_MULTIARCH` gives that value (`i386-linux-gnu`), whereas the previous `DEB_TARGET_GNU_TYPE` gives `i686-linux-gnu` which then results in our libraries not being found.