### PR TITLE
fix(windows): restore endpoints for interface stability

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Determine if we need to do a build based on rules in
 # trigger-definitions.inc.sh, rather than calculating changes in
@@ -18,7 +18,9 @@ else
 fi
 
 function debug_echo() {
-  #echo "DEBUG: $1"
+  if [ ! -z ${DEBUG:-} ]; then
+    echo "DEBUG: $1"
+  fi
   true
 }
 

--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Determine if we need to do a build based on rules in
 # trigger-definitions.inc.sh, rather than calculating changes in
@@ -18,9 +18,7 @@ else
 fi
 
 function debug_echo() {
-  if [ ! -z ${DEBUG:-} ]; then
-    echo "DEBUG: $1"
-  fi
+  #echo "DEBUG: $1"
   true
 }
 

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -25,8 +25,6 @@ EXPORTS
 			GetActiveKeymanID
 			Keyman_RegisterControllerWindow
 			Keyman_UnregisterControllerWindow
-      Keyman_RegisterMasterController
-      Keyman_UnregisterMasterController
 			Keyman_RestartEngine
 
       Keyman_SendMasterController
@@ -42,5 +40,7 @@ EXPORTS
 
       Keyman_Diagnostic
 
+      Keyman_RegisterMasterController
+      Keyman_UnregisterMasterController
 			Keyman_RegisterControllerThread
 			Keyman_UnregisterControllerThread

--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -23,13 +23,14 @@ EXPORTS
       GetKeyboardPreservedKeys
 
 			GetActiveKeymanID
-			Keyman_RegisterControllerThread
-			Keyman_UnregisterControllerThread
+			Keyman_RegisterControllerWindow
+			Keyman_UnregisterControllerWindow
       Keyman_RegisterMasterController
       Keyman_UnregisterMasterController
 			Keyman_RestartEngine
 
       Keyman_SendMasterController
+			Keyman_PostControllers
       Keyman_PostMasterController
 
       Keyman_StartExit
@@ -40,3 +41,6 @@ EXPORTS
       Keyman_UpdateTouchPanelVisibility
 
       Keyman_Diagnostic
+
+			Keyman_RegisterControllerThread
+			Keyman_UnregisterControllerThread

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -551,6 +551,12 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
   return dwResult;
 }
 
+extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+  // no-op (removed as part of #5060)
+  return 0;
+}
+
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   Globals::PostMasterController(msg, wParam, lParam);
@@ -559,6 +565,12 @@ extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT ms
 extern "C" LRESULT  _declspec(dllexport) WINAPI Keyman_SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   return Globals::SendMasterController(msg, wParam, lParam);
+}
+
+extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerWindow(HWND hwnd)
+{
+  // no-op (removed as part of #5060)
+  return TRUE;
 }
 
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerThread(DWORD tid)
@@ -596,6 +608,12 @@ extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterMasterController(HWN
   f_MasterController = hwnd;
 
   Globals::Unlock();
+  return TRUE;
+}
+
+extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_UnregisterControllerWindow(HWND hwnd)
+{
+  // no-op (removed as part of #5060)
   return TRUE;
 }
 

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -554,6 +554,9 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   // no-op (removed as part of #5060)
+  UNREFERENCED_PARAMETER(msg);
+  UNREFERENCED_PARAMETER(wParam);
+  UNREFERENCED_PARAMETER(lParam);
 }
 
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
@@ -569,6 +572,7 @@ extern "C" LRESULT  _declspec(dllexport) WINAPI Keyman_SendMasterController(UINT
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterControllerWindow(HWND hwnd)
 {
   // no-op (removed as part of #5060)
+  UNREFERENCED_PARAMETER(hwnd);
   return TRUE;
 }
 
@@ -613,6 +617,7 @@ extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_RegisterMasterController(HWN
 extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_UnregisterControllerWindow(HWND hwnd)
 {
   // no-op (removed as part of #5060)
+  UNREFERENCED_PARAMETER(hwnd);
   return TRUE;
 }
 

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -554,7 +554,6 @@ LRESULT Globals::SendMasterController(UINT msg, WPARAM wParam, LPARAM lParam)
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostControllers(UINT msg, WPARAM wParam, LPARAM lParam)
 {
   // no-op (removed as part of #5060)
-  return 0;
 }
 
 extern "C" void  _declspec(dllexport) WINAPI Keyman_PostMasterController(UINT msg, WPARAM wParam, LPARAM lParam)

--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -143,10 +143,8 @@ type
     procedure StartKeyman32Engine; safecall;    // 32 bit only
     procedure StopKeyman32Engine; safecall;    // 32 bit only
     procedure ResetKeyman32Engine; safecall;    // 32 bit only
-    procedure RegisterMasterController(Value: LongWord); safecall;     // 32 bit only
-    procedure UnregisterMasterController(Value: LongWord); safecall;    // 32 bit only
-    procedure RegisterControllerThread(Value: LongWord); safecall;     // 32 bit only
-    procedure UnregisterControllerThread(Value: LongWord); safecall;    // 32 bit only
+    procedure RegisterControllerWindow(Value: LongWord); safecall;     // deprecated in #5060
+    procedure UnregisterControllerWindow(Value: LongWord); safecall;    // deprecated in #5060
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;
@@ -154,6 +152,12 @@ type
     procedure DiagnosticTestException; safecall;
 
     function LastRefreshToken: IntPtr; safecall;
+
+    // #5060:
+    procedure RegisterMasterController(Value: LongWord); safecall;     // 32 bit only
+    procedure UnregisterMasterController(Value: LongWord); safecall;    // 32 bit only
+    procedure RegisterControllerThread(Value: LongWord); safecall;     // 32 bit only
+    procedure UnregisterControllerThread(Value: LongWord); safecall;    // 32 bit only
 
     { IIntKeymanControl }
     procedure AutoApplyKeyman;
@@ -533,6 +537,11 @@ begin
 {$ENDIF}
 end;
 
+procedure TKeymanControl.RegisterControllerWindow(Value: LongWord);
+begin
+  // no-op (removed as part of #5060)
+end;
+
 procedure TKeymanControl.RegisterMasterController(Value: LongWord);
 begin
 {$IFDEF WIN64}
@@ -575,6 +584,11 @@ begin
   else if not FKeyman_UnregisterControllerThread(Value) then
     KL.LogError('UnregisterControllerThread: Could not unregister controller thread %x', [Value]);
 {$ENDIF}
+end;
+
+procedure TKeymanControl.UnregisterControllerWindow(Value: LongWord);
+begin
+  // no-op (removed as part of #5060)
 end;
 
 procedure TKeymanControl.UnregisterMasterController(Value: LongWord);

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -27,10 +27,8 @@ type
     procedure StartKeyman32Engine; safecall;   // I5133
     procedure StopKeyman32Engine; safecall;   // I5133
     procedure ResetKeyman32Engine; safecall;   // I5133
-    procedure RegisterMasterController(Value: LongWord); safecall;
-    procedure UnregisterMasterController(Value: LongWord); safecall;
-    procedure RegisterControllerThread(Value: LongWord); safecall;
-    procedure UnregisterControllerThread(Value: LongWord); safecall;
+    procedure RegisterControllerWindow(Value: LongWord); safecall; // deprecated in #5060; remains for interface stability
+    procedure UnregisterControllerWindow(Value: LongWord); safecall; // deprecated in #5060; remains for interface stability
     procedure DisableUserInterface; safecall;
     procedure EnableUserInterface; safecall;
     procedure UpdateTouchPanelVisibility(Value: Boolean); safecall;
@@ -38,6 +36,13 @@ type
     procedure DiagnosticTestException; safecall;
 
     function LastRefreshToken: IntPtr; safecall;
+
+    // New in #5060:
+
+    procedure RegisterMasterController(Value: LongWord); safecall;
+    procedure UnregisterMasterController(Value: LongWord); safecall;
+    procedure RegisterControllerThread(Value: LongWord); safecall;
+    procedure UnregisterControllerThread(Value: LongWord); safecall;
   end;
 
 implementation


### PR DESCRIPTION
Fixes #5245 on 15.0-alpha.

Interfaces should remain stable between versions of Keyman, so that an upgraded kmcomapi.dll or keyman32.dll will not crash older clients, even if they may not behave entirely as expected.