### PR TITLE
refactor(web): polishes management of OSK keys

### DIFF
--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -359,45 +359,6 @@ namespace com.keyman {
       return Device._GetIEVersion();
     }
 
-    getFontSizeStyle(e: HTMLElement|string): {val: number, absolute: boolean} {
-      var val: number;
-      var fs: string;
-
-      if(typeof e == 'string') {
-        fs = e;
-      } else {
-        fs = e.style.fontSize;
-        if(!fs) {
-          fs = getComputedStyle(e).fontSize;
-        }
-      }
-
-      if(fs.indexOf('em') != -1) {
-        val = parseFloat(fs.substr(0, fs.indexOf('em')));
-        return {val: val, absolute: false};
-      } else if(fs.indexOf('px') != -1) {
-        val = parseFloat(fs.substr(0, fs.indexOf('px')));
-        return {val: val, absolute: true};
-      } else if(fs.indexOf('pt') != -1) {
-        // 16 px ~= 12 pt.
-        // Reference: https://kyleschaeffer.com/css-font-size-em-vs-px-vs-pt-vs-percent
-        val = parseFloat(fs.substr(0, fs.indexOf('pt')));
-        return {val: (4 * val / 3), absolute: true};
-      } else if(fs.indexOf('%') != -1) {
-        val = parseFloat(fs.substr(0, fs.indexOf('%')));
-        return {val: val/100, absolute: false};
-      } else if(!isNaN(val = Number(fs))) {
-        // Note:  this one is NOT natively handled by browsers!
-        //        We'll treat it as if it were 'pt', since that's likely the user's
-        //        most familiar font size unit.
-        return {val: (4 * val / 3), absolute: true};
-      } else {
-        // Cannot parse.
-        console.error("Could not properly parse specified fontsize info: '" + fs + "'.");
-        return null;
-      }
-    }
-
     /**
      * Get browser-independent computed style value for element
      *

--- a/web/source/osk/utils.ts
+++ b/web/source/osk/utils.ts
@@ -1,0 +1,40 @@
+namespace com.keyman.osk {
+  export function getFontSizeStyle(e: HTMLElement|string): {val: number, absolute: boolean} {
+    var val: number;
+    var fs: string;
+
+    if(typeof e == 'string') {
+      fs = e;
+    } else {
+      fs = e.style.fontSize;
+      if(!fs) {
+        fs = getComputedStyle(e).fontSize;
+      }
+    }
+
+    if(fs.indexOf('em') != -1) {
+      val = parseFloat(fs.substr(0, fs.indexOf('em')));
+      return {val: val, absolute: false};
+    } else if(fs.indexOf('px') != -1) {
+      val = parseFloat(fs.substr(0, fs.indexOf('px')));
+      return {val: val, absolute: true};
+    } else if(fs.indexOf('pt') != -1) {
+      // 16 px ~= 12 pt.
+      // Reference: https://kyleschaeffer.com/css-font-size-em-vs-px-vs-pt-vs-percent
+      val = parseFloat(fs.substr(0, fs.indexOf('pt')));
+      return {val: (4 * val / 3), absolute: true};
+    } else if(fs.indexOf('%') != -1) {
+      val = parseFloat(fs.substr(0, fs.indexOf('%')));
+      return {val: val/100, absolute: false};
+    } else if(!isNaN(val = Number(fs))) {
+      // Note:  this one is NOT natively handled by browsers!
+      //        We'll treat it as if it were 'pt', since that's likely the user's
+      //        most familiar font size unit.
+      return {val: (4 * val / 3), absolute: true};
+    } else {
+      // Cannot parse.
+      console.error("Could not properly parse specified fontsize info: '" + fs + "'.");
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
A small stepping-stone toward #5023.

There are no real user-facing benefits to speak of here, but this eliminates nearly all references to the root `com` namespace and the KMW root `window.keyman` object from within the OSK key classes; the few remaining references (solely to the former) are supported by the Web-core module.  This will be necessary for modularizing the OSK, which won't have access to things like `window.keyman.util`.

There's also some code centralization and consistency work.  I'm fine with having a number of OSKKey (+ subclass) methods require a `VisualKeyboard` reference as parameter, as they'll only ever be called by the `VisualKeyboard` class to begin with.  (The OSKKey classes are effectively internal classes of `VisualKeyboard`.)

I plan to follow this PR up with another that places the OSK key classes within their own, separate source file.  The transplant will be quite simple... but unfortunately, quite unhelpful for reviewing before-and-after code changes here.  The benefit there:  ~560 code lines cleanly separated from a ~2860 line file.