### PR TITLE
refactor(web): Visual Keyboard disentanglement - pass 1

### DIFF
--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -648,7 +648,7 @@ namespace com.keyman {
      *  @return {Object}                          DIV object with filled keyboard layer content
      */
     ['BuildVisualKeyboard'](PInternalName, Pstatic, argFormFactor, argLayerId): HTMLElement {
-      return com.keyman.osk.VisualKeyboard.buildDocumentationKeyboard(PInternalName, Pstatic, argFormFactor, argLayerId);
+      return com.keyman.osk.VisualKeyboard.buildDocumentationKeyboard(PInternalName, argFormFactor, argLayerId, this.osk);
     }
   }
 }

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -648,7 +648,24 @@ namespace com.keyman {
      *  @return {Object}                          DIV object with filled keyboard layer content
      */
     ['BuildVisualKeyboard'](PInternalName, Pstatic, argFormFactor, argLayerId): HTMLElement {
-      return com.keyman.osk.VisualKeyboard.buildDocumentationKeyboard(PInternalName, argFormFactor, argLayerId, this.osk);
+      let PKbd: com.keyman.keyboards.Keyboard = null;
+
+      if(PInternalName != null) {
+        var p=PInternalName.toLowerCase().replace('keyboard_','');
+        var keyboardsList = this.keyboardManager.keyboards;
+
+        for(let Ln=0; Ln<keyboardsList.length; Ln++) {
+          if(p == keyboardsList[Ln]['KI'].toLowerCase().replace('keyboard_','')) {
+            // Requires the Keyboard wrapping object now.
+            PKbd = new com.keyman.keyboards.Keyboard(keyboardsList[Ln]);
+            break;
+          }
+        }
+      }
+
+      PKbd = PKbd || this.core.activeKeyboard;
+
+      return com.keyman.osk.VisualKeyboard.buildDocumentationKeyboard(PKbd, argFormFactor, argLayerId, this.osk);
     }
   }
 }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -301,7 +301,7 @@ namespace com.keyman.text {
    * correctOSKTextSize handles rotation event -- currently rebuilds keyboard and adjusts font sizes
    */
   keymanweb['correctOSKTextSize']=function() {
-    if(osk && osk.vkbd && osk.vkbd.adjustHeights()) {
+    if(osk && osk.vkbd && osk.vkbd.adjustHeights(osk)) {
       osk._Load();
     }
   };

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -302,15 +302,6 @@ namespace com.keyman {
       return false;
     }
 
-    /**
-     * Default mouse down event handler (to replace multiple inline handlers) (Build 360)
-     */
-    mouseDownPreventDefaultHandler(e: MouseEvent) {
-      if(e) {
-        e.preventDefault();
-      }
-    }
-
     // Found a bit of magic formatting that allows dynamic return typing for a specified element tag!
     _CreateElement<E extends "p"|"style"|"script"|"div"|"canvas"|"span">(nodeName:E) {
       var e = document.createElement<E>(nodeName);

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -309,6 +309,15 @@ namespace com.keyman.osk {
       }
     }
 
+    private layerChangeHandler: text.SystemStoreMutationHandler = function(this: OSKManager,
+      source: text.MutableSystemStore,
+      newValue: string) {
+      if(source.value != newValue) {
+        this.vkbd.layerId = newValue;
+        this._Show();
+      }
+    }.bind(this);
+
     /**
      * Function     _GenerateVisualKeyboard
      * Scope        Private
@@ -324,7 +333,11 @@ namespace com.keyman.osk {
       }
 
       let util = com.keyman.singleton.util;
-      this.vkbd = new com.keyman.osk.VisualKeyboard(keyboard, util.device);
+      this.vkbd = new VisualKeyboard(keyboard, util.device);
+
+      // Ensure the OSK's current layer is kept up to date.
+      let core = com.keyman.singleton.core; // Note:  will eventually be a class field.
+      core.keyboardProcessor.layerStore.handler = this.layerChangeHandler;
 
       // Set box class - OS and keyboard added for Build 360
       this._Box.className=util.device.formFactor+' '+ util.device.OS.toLowerCase() + ' kmw-osk-frame';

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -322,8 +322,9 @@ namespace com.keyman.osk {
       if(this.vkbd) {
         this.vkbd.shutdown();
       }
-      this.vkbd = new com.keyman.osk.VisualKeyboard(keyboard);
+
       let util = com.keyman.singleton.util;
+      this.vkbd = new com.keyman.osk.VisualKeyboard(keyboard, util.device);
 
       // Set box class - OS and keyboard added for Build 360
       this._Box.className=util.device.formFactor+' '+ util.device.OS.toLowerCase() + ' kmw-osk-frame';

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -360,7 +360,7 @@ namespace com.keyman.osk {
         this._Box.appendChild(this.resizeBar());
         // For other devices, adjust the object heights, allowing for viewport scaling
       } else {
-        this.vkbd.adjustHeights();
+        this.vkbd.adjustHeights(this);
       }
     }
 
@@ -1280,7 +1280,7 @@ namespace com.keyman.osk {
       // The following code will always be executed except for externally created OSK such as EuroLatin
       if(this.vkbd && this.vkbd.ddOSK) {
         // Enable the currently active keyboard layer and update the default nextLayer member
-        this.vkbd.show();
+        this.vkbd.show(this);
 
         // Extra style changes and overrides for touch-mode.
         if(device.touchable) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2372,11 +2372,12 @@ namespace com.keyman.osk {
      * Create copy of the OSK that can be used for embedding in documentation or help
      * The currently active keyboard will be returned if PInternalName is null
      *
-     *  @param  {string}          PInternalName   internal name of keyboard, with or without Keyboard_ prefix
-     *  @param  {number}          Pstatic         static keyboard flag  (unselectable elements)
-     *  @param  {string=}         argFormFactor   layout form factor, defaulting to 'desktop'
-     *  @param  {(string|number)=}  argLayerId    name or index of layer to show, defaulting to 'default'
-     *  @return {Object}                          DIV object with filled keyboard layer content
+     *  @param  {Object}            PKbd            the keyboard object to be displayed
+     *  @param  {string=}           argFormFactor   layout form factor, defaulting to 'desktop'
+     *  @param  {(string|number)=}  argLayerId      name or index of layer to show, defaulting to 'default'
+     *  @param  {Object}            host            KeymanWeb's active OSKManager instance 
+     *                                              (currently required for legacy reasons)
+     *  @return {Object}                            DIV object with filled keyboard layer content
      */
     static buildDocumentationKeyboard(PKbd: com.keyman.keyboards.Keyboard, argFormFactor,argLayerId, host: OSKManager): HTMLElement { // I777
       if(!PKbd) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -622,7 +622,7 @@ namespace com.keyman.osk {
      */
     layout: keyboards.ActiveLayout;
     layers: keyboards.LayoutLayer[];
-    private layerId: string = "default";
+    private _layerId: string = "default";
     readonly isRTL: boolean;
     layerIndex: number;
 
@@ -672,6 +672,14 @@ namespace com.keyman.osk {
     keytip: {key: KeyElement, state: boolean, element?: HTMLDivElement};
     popupCallout: HTMLDivElement;
 
+    get layerId(): string {
+      return this._layerId;
+    }
+
+    set layerId(value: string) {
+      this._layerId = value;
+    }
+
     //#region OSK constructor and helpers
 
     /**
@@ -682,10 +690,6 @@ namespace com.keyman.osk {
      * Description  Generates the base visual keyboard element, prepping for attachment to KMW
      */
     constructor(keyboard: keyboards.Keyboard, device: Device, isStatic?: boolean) {
-      let keyman = com.keyman.singleton;
-      // Ensure the OSK's current layer is kept up to date.
-      keyman.core.keyboardProcessor.layerStore.handler = this.layerChangeHandler;
-
       this.device = device;
       if(isStatic) {
         this.isStatic = isStatic;
@@ -1041,16 +1045,6 @@ namespace com.keyman.osk {
       return lDiv;
     }
     //#endregion
-
-    layerChangeHandler: text.SystemStoreMutationHandler = function(this: VisualKeyboard,
-                                                                   source: text.MutableSystemStore,
-                                                                   newValue: string) {
-      if(source.value != newValue) {
-        this.layerId = newValue;
-        let keyman = com.keyman.singleton;
-        keyman.osk._Show();
-      }
-    }.bind(this);
 
     //#region OSK touch handlers
     getTouchCoordinatesOnKeyboard(touch: Touch) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2378,10 +2378,12 @@ namespace com.keyman.osk {
      *  @param  {(string|number)=}  argLayerId    name or index of layer to show, defaulting to 'default'
      *  @return {Object}                          DIV object with filled keyboard layer content
      */
-    static buildDocumentationKeyboard(PInternalName,argFormFactor,argLayerId, host: OSKManager): HTMLElement { // I777
-      let keymanweb = com.keyman.singleton;
-      var PKbd=keymanweb.core.activeKeyboard,Ln,
-          formFactor=(typeof(argFormFactor) == 'undefined' ? 'desktop' : argFormFactor),
+    static buildDocumentationKeyboard(PKbd: com.keyman.keyboards.Keyboard, argFormFactor,argLayerId, host: OSKManager): HTMLElement { // I777
+      if(!PKbd) {
+        return null;
+      }
+
+      var formFactor=(typeof(argFormFactor) == 'undefined' ? 'desktop' : argFormFactor),
           layerId=(typeof(argLayerId) == 'undefined' ? 'default' : argLayerId),
           device = new Device();
 
@@ -2389,24 +2391,6 @@ namespace com.keyman.osk {
       device.formFactor = formFactor;
       if(formFactor != 'desktop') {
         device.OS = 'iOS';
-      }
-
-      var keyboardsList = keymanweb.keyboardManager.keyboards;
-
-      if(PInternalName != null) {
-        var p=PInternalName.toLowerCase().replace('keyboard_','');
-
-        for(Ln=0; Ln<keyboardsList.length; Ln++) {
-          if(p == keyboardsList[Ln]['KI'].toLowerCase().replace('keyboard_','')) {
-            // Requires the Keyboard wrapping object now.
-            PKbd = new com.keyman.keyboards.Keyboard(keyboardsList[Ln]);
-            break;
-          }
-        }
-      }
-
-      if(!PKbd) {
-        return null;
       }
 
       let layout = PKbd.layout(formFactor);

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -887,9 +887,6 @@ namespace com.keyman.osk {
       var tKey=this.getDefaultKeyObject();
       tKey['fontsize']=ls.fontSize;
 
-      // Identify key labels (e.g. *Shift*) that require the special OSK font
-      var specialLabel=/\*\w+\*/;
-
       // ***Delete any empty rows at the end added by compiler bug...
       for(n=0; n<layers.length; n++) {
         let layer=layers[n];
@@ -1627,7 +1624,7 @@ namespace com.keyman.osk {
      * Description  Updates the OSK's visual style for any toggled state keys
      */
     _UpdateVKShiftStyle(layerId?: string) {
-      var i, n, layer=null, layerElement=null;
+      var i, n, layer=null;
       let core = com.keyman.singleton.core;
 
       if(layerId) {
@@ -1721,8 +1718,6 @@ namespace com.keyman.osk {
       // position:static and display:inline-block
       var subKeys=document.createElement('DIV'),i;
 
-      var tKey = this.getDefaultKeyObject();
-
       subKeys.id='kmw-popup-keys';
       this.popupBaseKey = e;
 
@@ -1758,7 +1753,7 @@ namespace com.keyman.osk {
         let layer = e['key'].layer;
         if(typeof(layer) != 'string' || layer == '') {
           // Use the currently-active layer.
-          layer = keyman.core.keyboardProcessor.layerId;
+          layer = this.layerId;
         }
         let keyGenerator = new com.keyman.osk.OSKSubKey(subKeySpec[i], layer);
         let kDiv = keyGenerator.construct(this, <KeyElement> e, needsTopMargin);
@@ -2535,7 +2530,6 @@ namespace com.keyman.osk {
   showKeyTip(key: KeyElement, on: boolean) {
     let keyman = com.keyman.singleton;
     let util = keyman.util;
-    let oskManager = keyman.osk;
 
     var tip=this.keytip;
 
@@ -2549,14 +2543,10 @@ namespace com.keyman.osk {
 
     // Create and display the preview
     if(on && !popup) {
-      var y0 = dom.Utils.getAbsoluteY(oskManager._Box),
-          h0 = oskManager._Box.offsetHeight,
-          xLeft = dom.Utils.getAbsoluteX(key),
-          xTop = dom.Utils.getAbsoluteY(key),
+      var xLeft = dom.Utils.getAbsoluteX(key),
           xWidth = key.offsetWidth,
           xHeight = key.offsetHeight,
           kc = <HTMLElement> key.firstChild,
-          kcs = kc.style,
           kts = tip.element.style,
           ktLabel = <HTMLElement> tip.element.childNodes[1],
           ktls = ktLabel.style,


### PR DESCRIPTION
Another small stepping-stone toward #5023.  Nothing noteworthy from the user perspective here; it's prep work to enable features down the line.

Some noteworthy references:

Now that we don't need to worry about IE, the `classList` property can replace the old `util.hasClass` method.
- https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/contains#browser_compatibility

See the base PR (#5257) for notes on replacement of `util._CreateElement`.

I avoided use of `node.parentElement` due to concerns that some browsers may not provide this property on text nodes, as text nodes could conceivably be targeted an the event.

Most of the other code alterations are in service of removing references to `com.keyman.singleton`, which would prevent modularization if left in place.