### PR TITLE
fix(windows): disable new hotkey modifier check

### DIFF
--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -127,11 +127,11 @@ BOOL UseRegisterHotkey() {
 }
 
 BOOL UseCachedHotkeyModifierState() {
-  static BOOL flag_UseCachedHotkeyModifierState = FALSE;
+  static BOOL flag_UseCachedHotkeyModifierState = TRUE; // 14.0.276: disabling new hotkey modifier check by default
   static BOOL loaded = FALSE;
   if (!loaded) {
     loaded = TRUE;
-    flag_UseCachedHotkeyModifierState = Reg_GetDebugFlag(REGSZ_Flag_UseCachedHotkeyModifierState, FALSE);
+    flag_UseCachedHotkeyModifierState = Reg_GetDebugFlag(REGSZ_Flag_UseCachedHotkeyModifierState, TRUE);
   }
   return flag_UseCachedHotkeyModifierState;
 }

--- a/windows/src/global/delphi/general/Keyman.System.Settings.pas
+++ b/windows/src/global/delphi/general/Keyman.System.Settings.pas
@@ -401,12 +401,12 @@ const
     (
       ID: 'engine.compatibility.old_cached_hotkey_modifier_state';
       Name: SRegValue_Flag_UseCachedHotkeyModifierState;
-      DefaultInt: 1; // 14.0.276: disabling new hotkey modifier check by default
       RootKey: HKCU;
       Key: SRegKey_KeymanEngineDebug_CU;
       Description: 'Set to 1 to use a cached modifier state when checking hotkeys; if '+
                    'set to 0 then engine.compatibility.old_hotkey_registration may not '+
                    'work';
+      DefaultInt: 1; // 14.0.276: disabling new hotkey modifier check by default
       ValueType: kstInteger
     ),
 

--- a/windows/src/global/delphi/general/Keyman.System.Settings.pas
+++ b/windows/src/global/delphi/general/Keyman.System.Settings.pas
@@ -401,9 +401,10 @@ const
     (
       ID: 'engine.compatibility.old_cached_hotkey_modifier_state';
       Name: SRegValue_Flag_UseCachedHotkeyModifierState;
+      DefaultInt: 1; // 14.0.276: disabling new hotkey modifier check by default
       RootKey: HKCU;
       Key: SRegKey_KeymanEngineDebug_CU;
-      Description: 'Set to 1 to use a cached modifer state when checking hotkeys; if '+
+      Description: 'Set to 1 to use a cached modifier state when checking hotkeys; if '+
                    'set to 0 then engine.compatibility.old_hotkey_registration may not '+
                    'work';
       ValueType: kstInteger


### PR DESCRIPTION
Disables the new modifier check added in #5189.