### PR TITLE
fix(common/models): predictive-text engine use of NFD input

### DIFF
--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -150,6 +150,8 @@ namespace correction {
             char = char + transform.insert[i];
           }
 
+          // In case of NFD input, filter out any empty-strings that may arise
+          // when 'keying' raw diacritics.
           let keyedChar = this.toKey(char);
           if(keyedChar) {
             edgeCalc = edgeCalc.addInputChar({key: keyedChar});

--- a/common/predictive-text/worker/correction/distance-modeler.ts
+++ b/common/predictive-text/worker/correction/distance-modeler.ts
@@ -150,7 +150,10 @@ namespace correction {
             char = char + transform.insert[i];
           }
 
-          edgeCalc = edgeCalc.addInputChar({key: this.toKey(char)});
+          let keyedChar = this.toKey(char);
+          if(keyedChar) {
+            edgeCalc = edgeCalc.addInputChar({key: keyedChar});
+          }
         }
 
         let childEdge = new SearchNode(this);


### PR DESCRIPTION
When text provided to the correction-search algorithm uses NFD input, it is possible for a keystroke to correspond to an unattached diacritic.  Search-term keying this results in an empty string; empty strings should _not_ correspond to correction-search graph edges.

(Fixes a user-reported issue with custom search-term keying for a `bcc-arab` model; the keyboard they used emits NFD text.)