### PR TITLE
fix(web): touch-move cancellation

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1364,7 +1364,7 @@ namespace com.keyman.osk {
         let _Box = this.kbdDiv.parentElement ? this.kbdDiv.parentElement : keyman.osk._Box;
         let height = this.kbdDiv.offsetHeight;
 
-        // We need to adjust the offset properties by any offsets related to the active banner.
+        // Determine the y-threshold at which touch-cancellation should automatically occur.
         let rowCount = this.layers[this.layerIndex].row.length;
         let yBufferThreshold = (0.333 * height / rowCount); // Allows vertical movement by 1/3 the height of a row.
         var yMin = (this.kbdDiv && _Box) ? Math.max(5, this.kbdDiv.offsetTop - yBufferThreshold) : 5;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1363,9 +1363,11 @@ namespace com.keyman.osk {
         // _Box has (most of) the useful client values.
         let _Box = this.kbdDiv.parentElement ? this.kbdDiv.parentElement : keyman.osk._Box;
         let height = this.kbdDiv.offsetHeight;
-        // We need to adjust the offset properties by any offsets related to the active banner.
 
-        var yMin = (this.kbdDiv && _Box) ? Math.max(5, this.kbdDiv.offsetTop + _Box.offsetTop - 0.25*height) : 5;
+        // We need to adjust the offset properties by any offsets related to the active banner.
+        let rowCount = this.layers[this.layerIndex].row.length;
+        let yBufferThreshold = (0.333 * height / rowCount); // Allows vertical movement by 1/3 the height of a row.
+        var yMin = (this.kbdDiv && _Box) ? Math.max(5, this.kbdDiv.offsetTop - yBufferThreshold) : 5;
         if(key0 && e.touches[0].pageY < yMin) {
           this.highlightKey(key0,false);
           this.showKeyTip(null,false);


### PR DESCRIPTION
Fixes an issue accidentally introduced by commit https://github.com/keymanapp/keyman/pull/5278/commits/d582e69b73abef05cee27b44a846ea1584fe2a88 of #5278.

Changing the styling property of the `VisualKeyboard` root to fixed caused the `yMin` calculation to receive markedly different values than it did before, causing `touchMove`s before the appearance of popup keys to instantly break the touch gesture.  I found it simplest to maintain the 'spirit' of the original logic, opting for a threshold of 1/3 a row's height above the top of the layer group.

## User Testing
@MakaraSok 

Please load up Keyman on Android and ensure that touch-based behaviors still work as expected.  In particular, try moving your finger to a side immediately after touching a key - does the keytip or highlighting (whichever occurs on the device) properly track the key under your finger as you move it?