### PR TITLE
refactor(web): osk key highlighting/preview behavior

### DIFF
--- a/web/source/osk/browser/oskSubKey.ts
+++ b/web/source/osk/browser/oskSubKey.ts
@@ -60,5 +60,9 @@ namespace com.keyman.osk.browser {
 
       return kDiv;
     }
+
+    public allowsKeyTip(): boolean {
+      return false;
+    }
   }
 }

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -176,7 +176,8 @@ namespace com.keyman.osk.browser {
 
       if(bk) {
         vkbd.keyPending = bk;
-        vkbd.highlightKey(bk,true);//bk.className = bk.className+' kmw-key-touched';
+        // Subkeys never get key previews, so we can directly highlight the subkey.
+        bk.key.highlight(true);
       }
     }
 

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -201,8 +201,10 @@ namespace com.keyman.osk {
     public highlight(on: boolean) {
       var classes=this.btn.classList;
 
-      if(on && !classes.contains(OSKKey.HIGHLIGHT_CLASS)) {
-        classes.add(OSKKey.HIGHLIGHT_CLASS);
+      if(on) {
+        if(!classes.contains(OSKKey.HIGHLIGHT_CLASS)) {
+          classes.add(OSKKey.HIGHLIGHT_CLASS);
+        }
       } else {
         classes.remove(OSKKey.HIGHLIGHT_CLASS);
       }

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -69,7 +69,7 @@ namespace com.keyman.osk {
   export abstract class OSKKey {
     // Defines the PUA code mapping for the various 'special' modifier/control keys on keyboards.
     // `specialCharacters` must be kept in sync with the same variable in builder.js. See also CompileKeymanWeb.pas: CSpecialText10
-    static specialCharacters = {
+    static readonly specialCharacters = {
       '*Shift*':    8,
       '*Enter*':    5,
       '*Tab*':      6,
@@ -113,7 +113,23 @@ namespace com.keyman.osk {
       '*ZWNJiOS*':        0x75, // The iOS version will be used by default, but the
       '*ZWNJAndroid*':    0x76, // Android platform has its own default glyph.
     };
-    
+
+    static readonly BUTTON_CLASSES = [
+      'default',
+      'shift',
+      'shift-on',
+      'special',
+      'special-on',
+      '',
+      '',
+      '',
+      'deadkey',
+      'blank',
+      'hidden'
+    ];
+
+    static readonly HIGHLIGHT_CLASS = 'kmw-key-touched';
+
     spec: OSKKeySpec;
     btn: KeyElement;
     label: HTMLSpanElement;
@@ -139,7 +155,7 @@ namespace com.keyman.osk {
       let key = this.spec;
       let btn = this.btn;
 
-      var n=0, keyTypes=['default','shift','shift-on','special','special-on','','','','deadkey','blank','hidden'];
+      var n=0;
       if(typeof key['dk'] == 'string' && key['dk'] == '1') {
         n=8;
       }
@@ -155,9 +171,40 @@ namespace com.keyman.osk {
       // Apply an overriding class for 5-row layouts
       var nRows=vkbd.layout['layer'][0]['row'].length;
       if(nRows > 4 && vkbd.device.formFactor == 'phone') {
-        btn.className='kmw-key kmw-5rows kmw-key-'+keyTypes[n];
+        btn.className='kmw-key kmw-5rows kmw-key-'+OSKKey.BUTTON_CLASSES[n];
       } else {
-        btn.className='kmw-key kmw-key-'+keyTypes[n];
+        btn.className='kmw-key kmw-key-'+OSKKey.BUTTON_CLASSES[n];
+      }
+    }
+
+    // "Frame key" - generally refers to non-linguistic keys on the keyboard
+    public isFrameKey(): boolean {
+      let classIndex = this.spec['sp'] || 0;
+      switch(OSKKey.BUTTON_CLASSES[classIndex]) {
+        case 'default':
+        case 'deadkey':
+          // Note:  will (generally) include the spacebar.
+          return false;
+        default:
+          return true;
+      }
+    }
+
+    public allowsKeyTip(): boolean {
+      if(this.isFrameKey()) {
+        return false;
+      } else {
+        return !this.btn.classList.contains('kmw-spacebar');
+      }
+    }
+
+    public highlight(on: boolean) {
+      var classes=this.btn.classList;
+
+      if(on && !classes.contains(OSKKey.HIGHLIGHT_CLASS)) {
+        classes.add(OSKKey.HIGHLIGHT_CLASS);
+      } else {
+        classes.remove(OSKKey.HIGHLIGHT_CLASS);
       }
     }
 

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -120,7 +120,7 @@ namespace com.keyman.osk {
       'shift-on',
       'special',
       'special-on',
-      '',
+      '', // Key classes 5 through 7 are reserved for future use.
       '',
       '',
       'deadkey',

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1168,7 +1168,7 @@ namespace com.keyman.osk {
       if(!key || !key.key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
 
       // For phones, use key preview rather than highlighting the key,
-      var usePreview = ((this.keytip != null)) && key.key.allowsKeyTip();
+      var usePreview = (this.keytip != null) && key.key.allowsKeyTip();
 
       if(usePreview) {
         this.showKeyTip(key,on);

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1165,37 +1165,19 @@ namespace com.keyman.osk {
      **/
     highlightKey(key: KeyElement, on: boolean) {
       // Do not change element class unless a key
-      if(!key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
-
-      var classes=key.className, cs = ' kmw-key-touched';
+      if(!key || !key.key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
 
       // For phones, use key preview rather than highlighting the key,
-      var usePreview = ((this.keytip != null) && (key.id.indexOf('popup') < 0 ));
-
-      if(usePreview) {
-        // Previews are not permitted for keys using any of the following CSS styles.
-        var excludedClasses = ['kmw-key-shift',      // special keys
-                               'kmw-key-shift-on',   // active special keys (shift, when in shift layer
-                               'kmw-key-special',    // special keys that require the keyboard's OSK font
-                               'kmw-key-special-on', // active special keys requiring the keyboard's OSK font
-                               'kmw-spacebar',       // space
-                               'kmw-key-blank',      // Keys that are only used for layout control
-                               'kmw-key-hidden'];
-
-        for(let c=0; c < excludedClasses.length; c++) {
-          usePreview = usePreview && (classes.indexOf(excludedClasses[c]) < 0);
-        }
-      }
+      var usePreview = ((this.keytip != null)) && key.key.allowsKeyTip();
 
       if(usePreview) {
         this.showKeyTip(key,on);
       } else {
-        if(on && classes.indexOf(cs) < 0) {
-          key.className=classes+cs;
-          this.showKeyTip(null,false);     // Moved here by Serkan
-        } else {
-          key.className=classes.replace(cs,'');
+        if(on) {
+          // May be called on already-unhighlighted keys, so we don't remove the tip here.
+          this.showKeyTip(null,false);
         }
+        key.key.highlight(on);
       }
     }
 


### PR DESCRIPTION
Follows from #5291.

This allows the osk-key classes to encapsulate highlighting behavior and logic for whether or not a key should be "previewable".