### PR TITLE
refactor(web): subkey abstraction (embedded step 2) - DRYer code

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -221,10 +221,10 @@ namespace com.keyman.keyboards {
       return Lkc;
     }
 
-    public getSubkey(id: string): ActiveKey {
+    public getSubkey(coreID: string): ActiveKey {
       if(this.sk) {
         for(let key of this.sk) {
-          if(key.id == id) {
+          if(key.coreID == coreID) {
             return key;
           }
         }

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -374,15 +374,10 @@ namespace com.keyman.text {
           selectedKey = baseKey;
           found = true;
         } else {
-          // Search for the specified subkey so we can retrieve its useful properties.
-          // It should be within the popupBaseKey's subkey list.
-          for(let subKey of baseKey.sk) {
-            if(subKey.coreID == keyName) {
-              selectedKey = subKey;
-              found = true;
-              break;
-            }
-          }
+          // ... yeah, there are some funky type shenanigans between the two.
+          // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
+          selectedKey = (baseKey as com.keyman.keyboards.ActiveKey).getSubkey(keyName) as com.keyman.osk.OSKKeySpec;
+          found = !!selectedKey;
         }
 
         if(!found) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -960,8 +960,6 @@ namespace com.keyman.osk {
       // Turn off key highlighting (or preview)
       this.highlightKey(e,false);
 
-      let core = com.keyman.singleton.core; // only singleton-based ref currently needed here.
-
       // Future note:  we need to refactor osk.OSKKeySpec to instead be a 'tag field' for
       // keyboards.ActiveKey.  (Prob with generics, allowing the Web-only parts to
       // be fully specified within the tag.)  
@@ -973,7 +971,13 @@ namespace com.keyman.osk {
         console.error("OSK key with ID '" + e.id + "', keyID '" + e.keyId + "' missing needed specification");
         return null;
       }
+      
+      // Return the event object.
+      return this.keyEventFromSpec(keySpec, touch);
+    }
 
+    keyEventFromSpec(keySpec: keyboards.ActiveKey, touch?: Touch) {
+      let core = com.keyman.singleton.core; // only singleton-based ref currently needed here.
 
       // Start:  mirrors _GetKeyEventProperties
 
@@ -994,8 +998,7 @@ namespace com.keyman.osk {
         Lkc.source = touch;
         Lkc.keyDistribution = this.getTouchProbabilities(touch);;
       }
-      
-      // Return the event object.
+
       return Lkc;
     }
 


### PR DESCRIPTION
There's a lot of code in kmwembedded.ts's popup-key handling that's a near duplicate of code that already exists within KMW core.  This aims to get the code DRYer before it's further refactored.  It's always much harder to review changes when code is simultaneously relocated and changed.

------

Arc overview:

1. #5294
    - Step 1 theme:  subkey commands as async events (as _gestures_ are inherently async)
2. #5295
3. #5354
    - Step 2 theme:  code path cleanup / clarification
4. #5355
5. #5356
    - Step 3 theme:  prep for common abstraction for the two control flows
6. #5357
    - that's right - "Gesture".  These aren't intended for _just_ longpresses, though they'll be the only supported gesture at first.
    - As gestures are events that evaluate over intervals of time, they are inherently asynchronous.  Hence, the use of `Promise`s by earlier PRs in the chain.
7. #5358
    - Given a "gesture" abstraction, establishes gesture-oriented patterns 

A rough breakdown of some of the design goals + patterns may be found in the description of #5294.