### PR TITLE
fix(developer): kmconvert help match reality

### DIFF
--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
@@ -60,7 +60,7 @@ begin
     Exit(False);
 
   i := 2;
-  while i < ParamCount do
+  while i <= ParamCount do
   begin
     if ParamStr(i) = '-nologo' then
     begin
@@ -93,23 +93,25 @@ begin
   writeln('  Creates a wordlist lexical model project in the repository template format');
   writeln;
   writeln('Parameters:');
-  writeln('  -nologo               Don''t show the program description and copyright banner');
-  writeln('  -klid <source-klid>   The KLID of the keyboard to import, per LoadKeyboardLayout');
-  writeln('  -id <keyboard_id>     The id of the keyboard to create');
-  writeln('                        (in `import-windows` mode, can be a format string)');
-  writeln('  -o <destination>      The target folder to write the project into, defaults to "."');
-  writeln('  -author <data>        Name of author of the keyboard/model, no default');
-  writeln('  -name <data>          Name of the keyboard/model, e.g. "My First Keyboard", "%s Basic" ');
-  writeln('                        (format strings are only valid in `import-windows` mode)');
-  writeln('  -copyright <data>     Copyright string for the keyboard/model, defaults to "Copyright (C)"');
-  writeln('  -fullcopyright <data> Longer copyright string for the keyboard/model, defaults to "Copyright (C) yyyy"');
-  writeln('  -version <data>       Version number of the keyboard/model, defaults to "1.0"');
-  writeln('  -languages <data>     Space-separated list of BCP 47 tags, e.g. "en-US tpi-PG"');
+  writeln('  -nologo                Don''t show the program description and copyright banner');
+  writeln('  -klid <source-klid>    The KLID of the keyboard to import, per LoadKeyboardLayout');
+  writeln('  -id <keyboard_id>      The id of the keyboard to create');
+  writeln('                         (in `import-windows` mode, can be a format string)');
+  writeln('  -o <destination>       The target folder to write the project into, defaults to "."');
+  writeln('  -author <data>         Name of author of the keyboard/model, no default');
+  writeln('  -name <data>           Name of the keyboard/model, e.g. "My First Keyboard", "%s Basic" ');
+  writeln('                         (format strings are only valid in `import-windows` mode)');
+  writeln('  -copyright <data>      Copyright string for the keyboard/model, defaults to "Copyright (C)"');
+  writeln('  -full-copyright <data> Longer copyright string for the keyboard/model, defaults to "Copyright (C) yyyy"');
+  writeln('  -version <data>        Version number of the keyboard/model, defaults to "1.0"');
+  writeln('  -languages <data>      Space-separated list of BCP 47 tags, e.g. "en-US tpi-PG"');
+  writeln('  -targets <data>        Space-separate list of targets, e.g. "linux windows phone"');
+  writeln;
   // Model parameters
   writeln('Note: model identifiers are constructed from params: <id-author>.<id-language>.<id-uniq>');
-  writeln('  -id-author <data>     Identifier for author of model');
-  writeln('  -id-language <data>   Single BCP 47 tag identifying primary language of model');
-  writeln('  -id-uniq <data>       Unique name for the model');
+  writeln('  -id-author <data>      Identifier for author of model');
+  writeln('  -id-language <data>    Single BCP 47 tag identifying primary language of model');
+  writeln('  -id-uniq <data>        Unique name for the model');
 end;
 
 { TKMConvertParameters }

--- a/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
+++ b/windows/src/developer/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
@@ -105,7 +105,7 @@ begin
   writeln('  -full-copyright <data> Longer copyright string for the keyboard/model, defaults to "Copyright (C) yyyy"');
   writeln('  -version <data>        Version number of the keyboard/model, defaults to "1.0"');
   writeln('  -languages <data>      Space-separated list of BCP 47 tags, e.g. "en-US tpi-PG"');
-  writeln('  -targets <data>        Space-separate list of targets, e.g. "linux windows phone"');
+  writeln('  -targets <data>        Space-separate list of targets, e.g. "linux windows mobile"');
   writeln;
   // Model parameters
   writeln('Note: model identifiers are constructed from params: <id-author>.<id-language>.<id-uniq>');


### PR DESCRIPTION
kmconvert built-in help was missing `-targets`, misspelled `-full-copyright`, and the parameter checking was skipping the last parameter (which only mattered if the last parameter was `-nologo`, but still...).