### PR TITLE
feat(web): Add option useAlerts to control alerts()

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1474,10 +1474,10 @@ namespace com.keyman.dom {
     /**
      * Function     Initialization
      * Scope        Public
-     * @param       {Object}  arg     object array of user-defined properties
+     * @param       {com.keyman.OptionType}  arg     object of user-defined properties
      * Description  KMW window initialization  
      */    
-    init: (arg:any) => Promise<any> = function(this: DOMManager, arg): Promise<any> { 
+    init: (arg: com.keyman.OptionType) => Promise<any> = function(this: DOMManager, arg): Promise<any> { 
       var i,j,c,e,p,eTextArea,eInput,opt,dTrailer,ds;
       var osk = this.keyman.osk;
       var util = this.keyman.util;

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -570,11 +570,9 @@ namespace com.keyman.keyboards {
                 // Thanks, Closure errors.
                 if(!this.keymanweb.isEmbedded) {
                   util.wait(false);
-                  if (this.keymanweb.options.useAlerts) {
-                    util.alert(altString || msg, function() {
+                  util.internalAlert(altString || msg, function() {
                       this.keymanweb['setActiveKeyboard'](''); // The API call!
-                    }.bind(this));
-                  }
+                  }.bind(this));
                 }
 
                 switch(msgType) { // in case we extend this later.
@@ -949,9 +947,7 @@ namespace com.keyman.keyboards {
 
           if(typeof(x[i]['filename']) == 'string') {
             if(!this.addStub(x[i])) {
-              if (this.keymanweb.options.useAlerts) {
-                this.keymanweb.util.alert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
-              }
+              this.keymanweb.util.internalAlert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
             }
           } else {
             if(x[i]['language']) {
@@ -1331,9 +1327,7 @@ namespace com.keyman.keyboards {
     private alertLanguageUnavailable(languageName: string): string {
       let msg = 'No keyboards are available for '+ languageName + '. '
         +'Does it have another language name?';
-      if (this.keymanweb.options.useAlerts) {
-        this.keymanweb.util.alert(msg);
-      }
+      this.keymanweb.util.internalAlert(msg);
       return msg;
     }
 
@@ -1344,9 +1338,7 @@ namespace com.keyman.keyboards {
      *
      **/
     private serverUnavailable(cmd) {
-      if (this.keymanweb.options.useAlerts) {
-        this.keymanweb.util.alert(cmd == '' ? 'Unable to connect to Keyman Cloud server!' : cmd);
-      }
+      this.keymanweb.util.internalAlert(cmd == '' ? 'Unable to connect to Keyman Cloud server!' : cmd);
       this.keymanweb.warned=true;
     }
 

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1211,13 +1211,12 @@ namespace com.keyman.keyboards {
           if (!languageFound) {
             // TODO: Construct response array of errors (failed-query keyboards)
             // that will be merged with stubs (successfully-queried keyboards)
-            console.error(this.languageUnavailable(lgName));
+            console.error(this.alertLanguageUnavailable(lgName));
           }
         }
 
         if(cmd == '') {
-          let msg = this.languageUnavailable(languages[0]);
-          return Promise.reject(new Error(msg));
+          return Promise.reject(new Error(this.alertLanguageUnavailable(languages[0])));
         } else {
           return this.keymanCloudRequest('&keyboardid='+cmd, false);
         }

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1211,16 +1211,13 @@ namespace com.keyman.keyboards {
           if (!languageFound) {
             // TODO: Construct response array of errors (failed-query keyboards)
             // that will be merged with stubs (successfully-queried keyboards)
-            console.error('No keyboards are available for '+lgName+'. '+
-              'Does it have another language name?');
+            let msg = this.languageUnavailable(lgName);
+            console.error(msg);
           }
         }
 
         if(cmd == '') {
-          // TODO: Check useAlert flag to determine whether or not KeymanWeb should display its own alert messages
-          let msg = 'No keyboards are available for '+languages[0]+'. '
-              +'Does it have another language name?';
-          this.keymanweb.util.alert(msg);
+          let msg = this.languageUnavailable(languages[0]);
           return Promise.reject(new Error(msg));
         } else {
           return this.keymanCloudRequest('&keyboardid='+cmd, false);
@@ -1322,6 +1319,20 @@ namespace com.keyman.keyboards {
       });
 
       return promise;
+    }
+
+    /**
+     * Display warning if language name unavailable to add keyboard
+     * @param {string} languageName
+     * @returns string of Error message
+     */
+    private languageUnavailable(languageName: string): string {
+      let msg = 'No keyboards are available for '+ languageName + '. '
+        +'Does it have another language name?';
+      if (this.keymanweb.options['useAlerts']=='true') {
+        this.keymanweb.util.alert(msg);
+      }
+      return msg;
     }
 
     /**

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1211,8 +1211,7 @@ namespace com.keyman.keyboards {
           if (!languageFound) {
             // TODO: Construct response array of errors (failed-query keyboards)
             // that will be merged with stubs (successfully-queried keyboards)
-            let msg = this.languageUnavailable(lgName);
-            console.error(msg);
+            console.error(this.languageUnavailable(lgName));
           }
         }
 
@@ -1326,7 +1325,7 @@ namespace com.keyman.keyboards {
      * @param {string} languageName
      * @returns string of Error message
      */
-    private languageUnavailable(languageName: string): string {
+    private alertLanguageUnavailable(languageName: string): string {
       let msg = 'No keyboards are available for '+ languageName + '. '
         +'Does it have another language name?';
       this.keymanweb.util.alert(msg);

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1329,9 +1329,7 @@ namespace com.keyman.keyboards {
     private languageUnavailable(languageName: string): string {
       let msg = 'No keyboards are available for '+ languageName + '. '
         +'Does it have another language name?';
-      if (this.keymanweb.options['useAlerts']=='true') {
-        this.keymanweb.util.alert(msg);
-      }
+      this.keymanweb.util.alert(msg);
       return msg;
     }
 

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -570,9 +570,11 @@ namespace com.keyman.keyboards {
                 // Thanks, Closure errors.
                 if(!this.keymanweb.isEmbedded) {
                   util.wait(false);
-                  util.alert(altString || msg, function() {
-                    this.keymanweb['setActiveKeyboard'](''); // The API call!
-                  }.bind(this));
+                  if (this.keymanweb.options.useAlerts) {
+                    util.alert(altString || msg, function() {
+                      this.keymanweb['setActiveKeyboard'](''); // The API call!
+                    }.bind(this));
+                  }
                 }
 
                 switch(msgType) { // in case we extend this later.
@@ -947,7 +949,9 @@ namespace com.keyman.keyboards {
 
           if(typeof(x[i]['filename']) == 'string') {
             if(!this.addStub(x[i])) {
-              alert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
+              if (this.keymanweb.options.useAlerts) {
+                this.keymanweb.util.alert('To use a custom keyboard, you must specify file name, keyboard name, language, language code and region code.');
+              }
             }
           } else {
             if(x[i]['language']) {
@@ -1327,7 +1331,9 @@ namespace com.keyman.keyboards {
     private alertLanguageUnavailable(languageName: string): string {
       let msg = 'No keyboards are available for '+ languageName + '. '
         +'Does it have another language name?';
-      this.keymanweb.util.alert(msg);
+      if (this.keymanweb.options.useAlerts) {
+        this.keymanweb.util.alert(msg);
+      }
       return msg;
     }
 
@@ -1338,7 +1344,9 @@ namespace com.keyman.keyboards {
      *
      **/
     private serverUnavailable(cmd) {
-      this.keymanweb.util.alert(cmd == '' ? 'Unable to connect to Keyman Cloud server!' : cmd);
+      if (this.keymanweb.options.useAlerts) {
+        this.keymanweb.util.alert(cmd == '' ? 'Unable to connect to Keyman Cloud server!' : cmd);
+      }
       this.keymanweb.warned=true;
     }
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -92,6 +92,7 @@ namespace com.keyman {
       resources: '',
       keyboards: '',
       fonts: '',
+      attachType: '',
       ui: null,
       setActiveOnRegister: 'true', // TODO: convert to boolean
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -30,16 +30,16 @@
 namespace com.keyman {
 
   export interface OptionType {
-    root: string;
-    resources: string;
-    keyboards: string;
-    fonts: string;
-    attachType: undefined | 'auto' | 'manual';
-    ui: string;
-    setActiveOnRegister: string; // TODO: Convert to boolean
+    root?: string;
+    resources?: string;
+    keyboards?: string;
+    fonts?: string;
+    attachType?: 'auto' | 'manual';
+    ui?: string;
+    setActiveOnRegister?: string; // TODO: Convert to boolean. Option loader needs to be able to receive this as a string or boolean
 
     // Determines whether or not KeymanWeb should display its own alert messages
-    useAlerts: boolean;
+    useAlerts?: boolean;
   }
 
   export class KeymanBase {
@@ -92,7 +92,6 @@ namespace com.keyman {
       resources: '',
       keyboards: '',
       fonts: '',
-      attachType: undefined,
       ui: null,
       setActiveOnRegister: 'true', // TODO: convert to boolean
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -80,7 +80,10 @@ namespace com.keyman {
       'fonts':'',
       'attachType':'',
       'ui':null,
-      'setActiveOnRegister':'true'
+      'setActiveOnRegister':'true',
+
+      // Determines whether or not KeymanWeb should display its own alert messages
+      'useAlerts':'true' 
     };
 
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -28,6 +28,20 @@
    Copyright 2017-2019 SIL International
 ***/
 namespace com.keyman {
+
+  export interface OptionType {
+    root: string;
+    resources: string;
+    keyboards: string;
+    fonts: string;
+    attachType: string; // 'auto', 'manual', 'default'
+    ui: string;
+    setActiveOnRegister: string; // TODO: Convert to boolean
+
+    // Determines whether or not KeymanWeb should display its own alert messages
+    useAlerts: boolean;
+  }
+
   export class KeymanBase {
     _TitleElement = null;      // I1972 - KeymanWeb Titlebar should not be a link
     _IE = 0;                   // browser version identification
@@ -73,19 +87,18 @@ namespace com.keyman {
     touchAliasing: dom.DOMEventHandlers;
 
     // Defines option-tracking object as a string map.
-    options: { [name: string]: string; } = {
-      'root':'',
-      'resources':'',
-      'keyboards':'',
-      'fonts':'',
-      'attachType':'',
-      'ui':null,
-      'setActiveOnRegister':'true',
+    options: OptionType = {
+      root: '',
+      resources: '',
+      keyboards: '',
+      fonts: '',
+      attachType: '',
+      ui: null,
+      setActiveOnRegister: 'true', // TODO: convert to boolean
 
       // Determines whether or not KeymanWeb should display its own alert messages
-      'useAlerts':'true' 
+      useAlerts: true
     };
-
 
     // Stub functions (defined later in code only if required)
     setDefaultDeviceOptions(opt){}

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -34,7 +34,7 @@ namespace com.keyman {
     resources: string;
     keyboards: string;
     fonts: string;
-    attachType: string; // 'auto', 'manual', 'default'
+    attachType: undefined | 'auto' | 'manual';
     ui: string;
     setActiveOnRegister: string; // TODO: Convert to boolean
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -92,7 +92,7 @@ namespace com.keyman {
       resources: '',
       keyboards: '',
       fonts: '',
-      attachType: '',
+      attachType: undefined,
       ui: null,
       setActiveOnRegister: 'true', // TODO: convert to boolean
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -34,7 +34,7 @@ namespace com.keyman {
     resources?: string;
     keyboards?: string;
     fonts?: string;
-    attachType?: 'auto' | 'manual';
+    attachType?: 'auto' | 'manual' | ''; // If blank or undefined, attachType will be assigned to "auto" or "manual"
     ui?: string;
     setActiveOnRegister?: string; // TODO: Convert to boolean. Option loader needs to be able to receive this as a string or boolean
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -101,7 +101,7 @@ namespace com.keyman {
     };
 
     // Stub functions (defined later in code only if required)
-    setDefaultDeviceOptions(opt){}
+    setDefaultDeviceOptions(opt: OptionType){}
     getStyleSheetPath(s){return s;}
     getKeyboardPath(f, p?){return f;}
     KC_(n, ln, Pelem){return '';}

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -183,7 +183,7 @@ namespace com.keyman.text {
   com.keyman.osk.VisualKeyboard.prototype.popupDelay = 400;  // Delay must be less than native touch-hold delay 
   
   // Set default device options
-  keymanweb.setDefaultDeviceOptions = function(opt) {
+  keymanweb.setDefaultDeviceOptions = function(opt: com.keyman.OptionType) {
     opt['attachType'] = 'manual';
     device.app=opt['app'];
     device.touchable=true; 

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -26,11 +26,13 @@ if(!window['keyman']['initialized']) {
 
     /**
      * Set default device options
-     * @param {Object}  opt device options object
+     * @param {OptionType}  opt device options object
      */
-    keymanweb.setDefaultDeviceOptions=function(opt) {
+    keymanweb.setDefaultDeviceOptions = function(opt : com.keyman.OptionType) {
       // Element attachment type
-      if(opt['attachType'] == '') opt['attachType'] = (device.touchable ? 'manual' : 'auto');
+      if (opt['attachType'] == '' || opt['attachType'] === undefined) {
+        opt['attachType'] = (device.touchable ? 'manual' : 'auto');
+      }
     }
 
   /**
@@ -40,7 +42,7 @@ if(!window['keyman']['initialized']) {
      */
     util.wait = function(s) {
       // Keyboards loaded with page are initialized before the page is ready,
-      // so cannot use the wait indicater (and don't need it, anyway)
+      // so cannot use the wait indicator (and don't need it, anyway)
       // Do not display if a blocking cloud server error has occurred (to prevent multiple errors)
       var bg=this.waiting;
       if(typeof(bg) == 'undefined' || bg == null || keymanweb.warned) {

--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -30,7 +30,7 @@ if(!window['keyman']['initialized']) {
      */
     keymanweb.setDefaultDeviceOptions = function(opt : com.keyman.OptionType) {
       // Element attachment type
-      if (opt['attachType'] == '' || opt['attachType'] === undefined) {
+      if (!opt['attachType']) {
         opt['attachType'] = (device.touchable ? 'manual' : 'auto');
       }
     }

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -972,6 +972,18 @@ namespace com.keyman {
     }
 
     /**
+     * Customized internal alert. This is enabled/disabled by the option flag 'useAlerts'
+     *
+     * @param     {string}        s       alert text
+     * @param     {function()=}   fn      function to call when alert dismissed
+     */
+     internalAlert(s: string, fn?: () => void): void {
+       if (this.keyman.options.useAlerts) {
+         this.alert(s, fn);
+       }
+     }
+
+    /**
      *  Prepare the background and keyboard loading wait message box
      *  Should not be called before options are defined during initialization
      **/

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -715,7 +715,7 @@ namespace com.keyman {
       }
 
       if(eot != '' && (eot.indexOf('/') < 0)) {
-      eot = this.keyman.options['fonts']+eot;
+        eot = this.keyman.options['fonts']+eot;
       }
 
       if(svg != '' && (svg.indexOf('/') < 0)) {
@@ -951,22 +951,24 @@ namespace com.keyman {
     }
 
     /**
-     * Customized alert
+     * Customized alert. This is enabled/disabled by the option flag 'useAlerts'
      *
      * @param     {string}        s       alert text
      * @param     {function()=}   fn      function to call when alert dismissed
      */
     alert(s: string, fn?: () => void): void {
-      var bg = this.waiting, nn=bg.firstChild.childNodes;
-      (nn[0] as HTMLElement).style.display='block';
-      (nn[1] as HTMLElement).className='kmw-alert-text';
-      (nn[1] as HTMLElement).innerHTML=s;
-      (nn[2] as HTMLElement).style.display='none';
-      bg.style.display='block';
-      if(arguments.length > 1) {
-        bg.dismiss=fn;
-      } else {
-        bg.dismiss=null;
+      if (this.keyman.options['useAlerts']=='true') {
+        var bg = this.waiting, nn=bg.firstChild.childNodes;
+        (nn[0] as HTMLElement).style.display='block';
+        (nn[1] as HTMLElement).className='kmw-alert-text';
+        (nn[1] as HTMLElement).innerHTML=s;
+        (nn[2] as HTMLElement).style.display='none';
+        bg.style.display='block';
+        if(arguments.length > 1) {
+          bg.dismiss=fn;
+        } else {
+          bg.dismiss=null;
+        }
       }
     }
 

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -957,7 +957,7 @@ namespace com.keyman {
      * @param     {function()=}   fn      function to call when alert dismissed
      */
     alert(s: string, fn?: () => void): void {
-      if (this.keyman.options.useAlerts == true) {
+      if (this.keyman.options.useAlerts) {
         var bg = this.waiting, nn=bg.firstChild.childNodes;
         (nn[0] as HTMLElement).style.display='block';
         (nn[1] as HTMLElement).className='kmw-alert-text';

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -957,7 +957,7 @@ namespace com.keyman {
      * @param     {function()=}   fn      function to call when alert dismissed
      */
     alert(s: string, fn?: () => void): void {
-      if (this.keyman.options['useAlerts']=='true') {
+      if (this.keyman.options.useAlerts == true) {
         var bg = this.waiting, nn=bg.firstChild.childNodes;
         (nn[0] as HTMLElement).style.display='block';
         (nn[1] as HTMLElement).className='kmw-alert-text';

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -964,11 +964,7 @@ namespace com.keyman {
         (nn[1] as HTMLElement).innerHTML=s;
         (nn[2] as HTMLElement).style.display='none';
         bg.style.display='block';
-        if(arguments.length > 1) {
-          bg.dismiss=fn;
-        } else {
-          bg.dismiss=null;
-        }
+        bg.dismiss = arguments.length > 1 ? fn : null;
       }
     }
 

--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -951,21 +951,19 @@ namespace com.keyman {
     }
 
     /**
-     * Customized alert. This is enabled/disabled by the option flag 'useAlerts'
+     * Customized alert.
      *
      * @param     {string}        s       alert text
      * @param     {function()=}   fn      function to call when alert dismissed
      */
     alert(s: string, fn?: () => void): void {
-      if (this.keyman.options.useAlerts) {
-        var bg = this.waiting, nn=bg.firstChild.childNodes;
-        (nn[0] as HTMLElement).style.display='block';
-        (nn[1] as HTMLElement).className='kmw-alert-text';
-        (nn[1] as HTMLElement).innerHTML=s;
-        (nn[2] as HTMLElement).style.display='none';
-        bg.style.display='block';
-        bg.dismiss = arguments.length > 1 ? fn : null;
-      }
+      var bg = this.waiting, nn=bg.firstChild.childNodes;
+      (nn[0] as HTMLElement).style.display='block';
+      (nn[1] as HTMLElement).className='kmw-alert-text';
+      (nn[1] as HTMLElement).innerHTML=s;
+      (nn[2] as HTMLElement).style.display='none';
+      bg.style.display='block';
+      bg.dismiss = arguments.length > 1 ? fn : null;
     }
 
     // Stub definition to be fleshed out depending upon native/embedded mode.

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -465,10 +465,8 @@ namespace com.keyman.osk {
      */
     showBuild() {
       let keymanweb = com.keyman.singleton;
-      if (keymanweb.options.useAlerts) {
-        keymanweb.util.alert('KeymanWeb Version '+keymanweb['version']+'.'+keymanweb['build']+'<br /><br />'
+      keymanweb.util.internalAlert('KeymanWeb Version '+keymanweb['version']+'.'+keymanweb['build']+'<br /><br />'
           +'<span style="font-size:0.8em">Copyright &copy; 2017 SIL International</span>');
-      }
     }
 
     /**

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -465,8 +465,10 @@ namespace com.keyman.osk {
      */
     showBuild() {
       let keymanweb = com.keyman.singleton;
-      keymanweb.util.alert('KeymanWeb Version '+keymanweb['version']+'.'+keymanweb['build']+'<br /><br />'
-        +'<span style="font-size:0.8em">Copyright &copy; 2017 SIL International</span>');
+      if (keymanweb.options.useAlerts) {
+        keymanweb.util.alert('KeymanWeb Version '+keymanweb['version']+'.'+keymanweb['build']+'<br /><br />'
+          +'<span style="font-size:0.8em">Copyright &copy; 2017 SIL International</span>');
+      }
     }
 
     /**

--- a/web/testing/attachment-api/index.html
+++ b/web/testing/attachment-api/index.html
@@ -41,12 +41,9 @@
       var attachText = attachType ? attachType : "default";
 
       var kmw=window.keyman;
-      if (attachType) {
-        kmw.init({
-          attachType: attachType});
-      } else {
-        kmw.init({});
-      }
+      kmw.init({
+        attachType: attachType ? attachType : ''
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->

--- a/web/testing/attachment-api/index.html
+++ b/web/testing/attachment-api/index.html
@@ -2,79 +2,71 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match phone and tablet device widths -->                         
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
 
     <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
-    <!-- Your page CSS --> 
-    <style type='text/css'>   
+    <!-- Your page CSS -->
+    <style type='text/css'>
       body {font-family: Tahoma,helvetica;}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
-      #KeymanWebControl {width:50%;min-width:600px;}       
-    </style> 
- 
-    <!-- Insert uncompiled KeymanWeb source scripts -->              
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
     <script src="../../release/unminified/web/keymanweb.js" type="application/javascript"></script>
 
-    <!-- 
+    <!--
       For desktop browsers, a script for the user interface must be inserted here.
-       
-      Standard UIs are toggle, button, float and toolbar.  
-      The toolbar UI is best for any page designed to support keyboards for 
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
       a large number of languages.
     -->
     <script src="../../release/unminified/web/kmwuitoggle.js"></script>
- 
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-	// Thank you to https://stackoverflow.com/questions/22607150/getting-the-url-parameters-inside-the-html-page. 
-	var GetURLParameter = function(sParam) {
-		var sPageURL = window.location.search.substring(1);
-		var sURLVariables = sPageURL.split('&');
-		for (var i = 0; i < sURLVariables.length; i++) {
-			var sParameterName = sURLVariables[i].split('=');
-			if (sParameterName[0] == sParam) {
-				return sParameterName[1];
-			}
-		}
-	};
-	
-	var attachType = GetURLParameter("mode");
-	var attachText = attachType ? attachType : "default";
-	
-	var kmw=window.keyman;
-	kmw.init({
-		attachType: attachType ? attachType : '',
-	});
-    </script> 
-    
+      // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+      const attachType = (new URLSearchParams(window.location.search)).get("mode");
+      var attachText = attachType ? attachType : "default";
+
+      var kmw=window.keyman;
+      if (attachType) {
+        kmw.init({
+          attachType: attachType});
+      } else {
+        kmw.init({});
+      }
+    </script>
+
     <!-- Add keyboard management script for local selection of keyboards to use -->
 	<script src="../commonHeader.js"></script>
-    <script src="./utilities.js"></script> 
-  
+    <script src="./utilities.js"></script>
+
 	<script>
 
 	</script>
   </head>
 
-<!-- Sample page HTML -->  
+<!-- Sample page HTML -->
   <body onload='loadKeyboards(1);'>
     <h2>KeymanWeb Sample Page - Attachment API Testing</h2>
 	<p>This page is designed to stress-test the new attachment/enablement API model and its functions.</p>
-	<p id="modeSelect">You are currently testing under the <em id="mode"> </em> attachment mode.  Two other modes are available: 
-	<a id="attach_auto" href="./index.html?mode=auto">Auto</a> <a id="attach_manual" href="./index.html?mode=manual">Manual</a> 
+	<p id="modeSelect">You are currently testing under the <em id="mode"> </em> attachment mode.  Two other modes are available:
+	<a id="attach_auto" href="./index.html?mode=auto">Auto</a> <a id="attach_manual" href="./index.html?mode=manual">Manual</a>
 	<a id="attach_default" href="./index.html">Default</a><p>
 	<p>Be sure to reference the developer console for additional feedback.  </p>
-	</p>Note that the 'attachment' state reported is managed by this page and not reported from KeymanWeb itself; 
+	</p>Note that the 'attachment' state reported is managed by this page and not reported from KeymanWeb itself;
 	take it as a guide at best.  (Especially if on a touch device.)</p>
 	<script>
 		document.getElementById("mode").textContent = attachText;
@@ -88,21 +80,21 @@
 	<input type='button' id='btnEditable' onclick='addEditable();' value='Create editable DIV.' />
 	<hr/>
     <div>
-    <!-- 
+    <!--
       The following DIV is used to position the Button or Toolbar User Interfaces on the page.
       If omitted, those User Interfaces will appear at the top of the document body.
       (It is ignored by other User Interfaces.)
     -->
-    <div id='KeymanWebControl'></div>                                                                                   
+    <div id='KeymanWebControl'></div>
 
     <div id='DynamicInputs'><h3>Inputs:</h3></div>
 		<div id='DynamicTextareas'><h3>Textareas:</h3></div>
 		<div id='DynamicIFrames'><h3>IFrames:</h3>
-			<p><em>Note:</em> The iframe section should not actually attach/enable for touch devices 
+			<p><em>Note:</em> The iframe section should not actually attach/enable for touch devices
 			and does not support <code>setKeyboardForControl</code>.</p>
 		</div>
     <div id='DynamicDesignFrames'><h3>Design-mode IFrames:</h3>
-			<p><em>Note:</em> The iframe section should not actually attach/enable for touch devices 
+			<p><em>Note:</em> The iframe section should not actually attach/enable for touch devices
 			and does not support <code>setKeyboardForControl</code>.</p>
 		</div>
 		<div id='DynamicEditables'><h3><code>contenteditable</code> Elements:</h3>
@@ -112,20 +104,20 @@
 	<hr/>
    <h3><a href="../index.html">Return to testing home page</a></h3>
   </body>
-  
-  <!-- 
+
+  <!--
     *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
     *
     * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
-    * to display the special characters used in the On-Screen Keyboard. 
-    * 
-    * To work around this Firefox bug, navigate to <b>about:config</b> 
-    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b> 
-    * while testing. 
-    * 
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
     * Firefox resolves website-based CSS URI references correctly without needing
     * any configuration change, so this change should only be made for file-based testing.
-    *   
-    ***   
-  -->     
+    *
+    ***
+  -->
 </html>

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -36,9 +36,24 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
+      // Thank you to https://stackoverflow.com/questions/22607150/getting-the-url-parameters-inside-the-html-page.
+      var GetURLParameter = function(sParam) {
+        var sPageURL = window.location.search.substring(1);
+        var sURLVariables = sPageURL.split('&');
+        for (var i = 0; i < sURLVariables.length; i++) {
+          var sParameterName = sURLVariables[i].split('=');
+          if (sParameterName[0] == sParam) {
+            return sParameterName[1];
+          }
+        }
+      };
+
+      var alertType = GetURLParameter("mode");
+      var alertText = alertType ? alertType : 'enabled (default)';
+
       var kmw=window.keyman;
       kmw.init({
-		    attachType:'auto'
+        useAlerts: alertType == "disabled" ? 'false' : 'true'
       }).then(function() {
         loadKeyboards();
       });
@@ -53,8 +68,18 @@
   <body>
     <h2>KeymanWeb Sample Page - Promise API</h2>
     <p>This page is for testing the Promises returned from adding keyboards.
-	  See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044</a>
+      See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044</a>
     </p>
+
+    <p id="modeSelect">You are currently testing under the alerts <em id="mode"> </em> mode.
+    Two alert modes are available:
+    <a id="alert_disabled" href="./index.html?mode=disabled">Disabled</a> or
+    <a id="alert_default" href="./index.html">Enabled (Default)</a><p>
+
+    <script>
+      document.getElementById("mode").textContent = alertText;
+    </script>
+
     <div>
     <!--
       The following DIV is used to position the Button or Toolbar User Interfaces on the page.

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -57,15 +57,26 @@
   <body>
     <h2>KeymanWeb Sample Page - Promise API</h2>
     <p>This page is for testing the Promises returned from adding keyboards.
-      See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044</a>
+      See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044.</a>
+    </p>
+    <p>
+      This test page is best used with Developer mode, as output for both successes
+      and failures will be logged to the JS console.
+    </p>
+    <p>Visible alert-style feedback will only occur for invalid search terms, such as using "foobar"
+      for any of the three keyboard-adding options at the bottom of the page.
     </p>
 
-    <p id="modeSelect">You are currently testing under the alerts <em id="mode"> </em> mode.
+    <p id="modeSelect">You are currently testing under the internal alerts <em id="mode"> </em> mode.
     Two alert modes are available:
     <a id="alert_disabled" href="./index.html?useAlerts=false">Disabled</a> or
     <a id="alert_default" href="./index.html">Enabled (Default)</a></p>
+    <p>This will only affect whether or not KeymanWeb's alert modal is displayed.
+      A native browser alert and dev-console error log will occur regardless of this
+      setting when stub fetch errors occur.
+    </p>
 
-    <script>
+<script>
       document.getElementById("mode").textContent = alertText;
     </script>
 

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -36,24 +36,24 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      // Thank you to https://stackoverflow.com/questions/22607150/getting-the-url-parameters-inside-the-html-page.
+      // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
       var getUrlParameter = function(sParam) {
-        var sPageURL = window.location.search.substring(1);
-        var sURLVariables = sPageURL.split('&');
-        for (var i = 0; i < sURLVariables.length; i++) {
-          var sParameterName = sURLVariables[i].split('=');
-          if (sParameterName[0] == sParam) {
-            return sParameterName[1];
-          }
+        var paramsString = "&mode="
+        var searchParams = new URLSearchParams(paramString);
+
+        if (searchParams.has("mode") === true) {
+          return searchParams.get("mode");
         }
+
+        return false;
       };
 
-      var alertType = GetURLParameter("mode");
+      var alertType = getUrlParameter("mode");
       var alertText = alertType ? alertType : 'enabled (default)';
 
       var kmw=window.keyman;
       kmw.init({
-        useAlerts: alertType == "disabled" ? 'false' : 'true'
+        useAlerts: alertType == "disabled" ? false : true
       }).then(function() {
         loadKeyboards();
       });

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -37,7 +37,7 @@
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       // Thank you to https://stackoverflow.com/questions/22607150/getting-the-url-parameters-inside-the-html-page.
-      var GetURLParameter = function(sParam) {
+      var getUrlParameter = function(sParam) {
         var sPageURL = window.location.search.substring(1);
         var sURLVariables = sPageURL.split('&');
         for (var i = 0; i < sURLVariables.length; i++) {
@@ -74,7 +74,7 @@
     <p id="modeSelect">You are currently testing under the alerts <em id="mode"> </em> mode.
     Two alert modes are available:
     <a id="alert_disabled" href="./index.html?mode=disabled">Disabled</a> or
-    <a id="alert_default" href="./index.html">Enabled (Default)</a><p>
+    <a id="alert_default" href="./index.html">Enabled (Default)</a></p>
 
     <script>
       document.getElementById("mode").textContent = alertText;

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -37,23 +37,23 @@
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
-      var getUrlParameter = function(sParam) {
-        var paramsString = "&mode="
-        var searchParams = new URLSearchParams(paramString);
+      var getUrlParameter = function() {
+        var paramsString = "?useAlerts="
+        var searchParams = new URLSearchParams(window.location.search);
 
-        if (searchParams.has("mode") === true) {
-          return searchParams.get("mode");
+        if (searchParams.has("useAlerts") === true) {
+          return searchParams.get("useAlerts");
         }
 
-        return false;
+        return true;
       };
 
-      var alertType = getUrlParameter("mode");
-      var alertText = alertType ? alertType : 'enabled (default)';
+      var alertType = getUrlParameter();
+      var alertText = alertType == "false" ? 'disabled': 'enabled(default)';
 
       var kmw=window.keyman;
       kmw.init({
-        useAlerts: alertType == "disabled" ? false : true
+        useAlerts: alertType
       }).then(function() {
         loadKeyboards();
       });
@@ -73,7 +73,7 @@
 
     <p id="modeSelect">You are currently testing under the alerts <em id="mode"> </em> mode.
     Two alert modes are available:
-    <a id="alert_disabled" href="./index.html?mode=disabled">Disabled</a> or
+    <a id="alert_disabled" href="./index.html?useAlerts=false">Disabled</a> or
     <a id="alert_default" href="./index.html">Enabled (Default)</a></p>
 
     <script>

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -37,15 +37,8 @@
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
-      var getUrlParameter = function() {
-        var paramsString = "?useAlerts="
-        var searchParams = new URLSearchParams(window.location.search);
-
-        return searchParams.get("useAlerts") == "false" ? false : true;
-      };
-
-      var alertType = getUrlParameter();
-      var alertText = alertType == false ? 'disabled': 'enabled(default)';
+      const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
+      var alertText = alertType ? 'enabled(default)' : 'disabled';
 
       var kmw=window.keyman;
       kmw.init({

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -41,15 +41,11 @@
         var paramsString = "?useAlerts="
         var searchParams = new URLSearchParams(window.location.search);
 
-        if (searchParams.has("useAlerts") === true) {
-          return searchParams.get("useAlerts");
-        }
-
-        return true;
+        return searchParams.get("useAlerts") == "false" ? false : true;
       };
 
       var alertType = getUrlParameter();
-      var alertText = alertType == "false" ? 'disabled': 'enabled(default)';
+      var alertText = alertType == false ? 'disabled': 'enabled(default)';
 
       var kmw=window.keyman;
       kmw.init({


### PR DESCRIPTION
Follow-on to #5260 and addresses this point in spec #5044

> ### C5044.1.1.3 Changes to init
> Init needs to add a flag `useAlerts` (default true) to determine whether or not KeymanWeb should display its own alert messages if a keyboard fails to download or run. Modern consumers of the API will probably prefer to implement their own reject promise handler for `addKeyboards`, and we may also need to add an onalert callback event for other async errors

This also updates the "Promise API" test page to enable/disable alerts.