### PR TITLE
chore(linux): Update changelogs to match Debian

### DIFF
--- a/common/core/desktop/debian/changelog
+++ b/common/core/desktop/debian/changelog
@@ -1,4 +1,11 @@
-keyman-keyboardprocessor (14.0.273-1) unstable; urgency=medium
+keyman-keyboardprocessor (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:10 +0200
+
+keyman-keyboardprocessor (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 

--- a/linux/ibus-keyman/debian/changelog
+++ b/linux/ibus-keyman/debian/changelog
@@ -1,4 +1,11 @@
-ibus-keyman (14.0.273-1) unstable; urgency=medium
+ibus-keyman (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:56 +0200
+
+ibus-keyman (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 

--- a/linux/ibus-kmfl/debian/changelog
+++ b/linux/ibus-kmfl/debian/changelog
@@ -1,4 +1,11 @@
-ibus-kmfl (14.0.273-1) unstable; urgency=medium
+ibus-kmfl (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:38 +0200
+
+ibus-kmfl (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 

--- a/linux/keyman-config/debian/changelog
+++ b/linux/keyman-config/debian/changelog
@@ -1,4 +1,11 @@
-keyman-config (14.0.273-1) unstable; urgency=medium
+keyman-config (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:46 +0200
+
+keyman-config (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 

--- a/linux/kmflcomp/debian/changelog
+++ b/linux/kmflcomp/debian/changelog
@@ -1,4 +1,11 @@
-kmflcomp (14.0.273-1) unstable; urgency=medium
+kmflcomp (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:20 +0200
+
+kmflcomp (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 

--- a/linux/libkmfl/debian/changelog
+++ b/linux/libkmfl/debian/changelog
@@ -1,4 +1,11 @@
-libkmfl (14.0.273-1) unstable; urgency=medium
+libkmfl (14.0.276-1) experimental; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 11 Jun 2021 14:43:29 +0200
+
+libkmfl (14.0.273-1) experimental; urgency=medium
 
   * Keyman 14
 


### PR DESCRIPTION
The changelogs should match what got uploaded (and accepted) to Debian so that the changelog reflects the upload history to Debian.