### PR TITLE
fix(web): disable fat-finger predictions for perf

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -41,7 +41,7 @@
       ta.readOnly = false;
 
       // Tell KMW the default banner height to use
-      com.keyman.osk.Banner.DEFAULT_HEIGHT = 
+      com.keyman.osk.Banner.DEFAULT_HEIGHT =
         Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
@@ -320,7 +320,7 @@
 
     function executePopupKey(keyID, keyText) {
       var kmw=window['keyman'];
-      
+
       // KMW only needs keyID to process the popup key. keyText merely logged to console
       //window.console.log('executePopupKey('+keyID+'); keyText: ' + keyText);
       kmw['executePopupKey'](keyID);
@@ -366,8 +366,6 @@
   </style>
 </head>
 <body class="kmw-embedded keyman-app">
-<center>
-  <textarea id="ta" cols="1" rows="1" style="position:absolute; left:-500px; top:0px;"></textarea>
-</center>
+<textarea id="ta" cols="1" rows="1" style="display: none;"></textarea>
 </body>
 </html>

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -53,7 +53,7 @@ namespace com.keyman.text {
      * Simulate a keystroke according to the touched keyboard button element
      *
      * Handles default output and keyboard processing for both OSK and physical keystrokes.
-     * 
+     *
      * @param       {Object}      keyEvent      The abstracted KeyEvent to use for keystroke processing
      * @param       {Object}      outputTarget  The OutputTarget receiving the KeyEvent
      * @returns     {Object}                    A RuleBehavior object describing the cumulative effects of
@@ -105,9 +105,10 @@ namespace com.keyman.text {
       if(keyEvent.kNextLayer) {
         this.keyboardProcessor.selectLayer(keyEvent);
       }
-      
+
       // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
       if(ruleBehavior != null) {
+/* #5258: Disable 'fat finger algorithm for performance reasons
         let alternates: Alternate[];
 
         // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
@@ -117,11 +118,11 @@ namespace com.keyman.text {
           if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
             let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
             alternates = [];
-    
+
             let totalMass = 0; // Tracks sum of non-error probabilities.
             for(let pair of keyEvent.keyDistribution) {
               let mock = Mock.from(preInputMock);
-              
+
               let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
               if(!altKey) {
                 console.warn("Potential fat-finger key could not be found in layer!");
@@ -130,12 +131,12 @@ namespace com.keyman.text {
 
               let altEvent = altKey.constructKeyEvent(this.keyboardProcessor, keyEvent.device);
               let alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
-              
+
               // If alternateBehavior.beep == true, ignore it.  It's a disallowed key sequence,
               // so we expect users to never intend their use.
               if(alternateBehavior && !alternateBehavior.beep && pair.p > 0) {
                 let transform: Transform = alternateBehavior.transcription.transform;
-                
+
                 // Ensure that the alternate's token id matches that of the current keystroke, as we only
                 // record the matched rule's context (since they match)
                 transform.id = ruleBehavior.transcription.token;
@@ -153,15 +154,17 @@ namespace com.keyman.text {
             });
           }
         }
-
+*/
         // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
         // by the actual keystroke occur.
         ruleBehavior.finalize(this.keyboardProcessor, outputTarget);
 
         // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
-        
+
         // Notify the ModelManager of new input - it's predictive text time!
+/* #5258: disable fat finger algorithm for performance reasons
         ruleBehavior.transcription.alternates = alternates;
+*/
         // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
         ruleBehavior.predictionPromise = this.languageProcessor.predict(ruleBehavior.transcription);
 

--- a/common/core/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/core/web/keyboard-processor/src/text/outputTarget.ts
@@ -100,19 +100,6 @@ namespace com.keyman.text {
       this._dks = dks.clone();
     }
 
-    private preventSurrogatePairSplit(text, pos) {
-      if(pos == 0 || pos >= text.length()) {
-        return pos;
-      }
-      let potentialHigh = text.charCodeAt(pos-1);
-      let potentialLow  = text.charCodeAt(pos);
-      if(potentialHigh >= 0xD800 && potentialHigh <= 0xDBFF &&
-          potentialLow >= 0xDC00 && potentialLow <= 0xDFFF) {
-        return pos - 1;
-      }
-      return pos;
-    }
-
     /**
      * Determines the basic operations needed to reconstruct the current OutputTarget's text from the prior state specified
      * by another OutputTarget based on their text and caret positions.
@@ -137,7 +124,6 @@ namespace com.keyman.text {
 
       // 1.1:  use a non-SMP-aware binary search to determine the divergence point.
       let start = Math.max(0, maxLeftMatch-128);
-      //start = this.preventSurrogatePairSplit(from, start);
       let end = maxLeftMatch;  // the index AFTER the last possible matching char.
 
       // This search is O(maxLeftMatch).  1/2 + 1/4 + 1/8 + ... converges to = 1.


### PR DESCRIPTION
Fixes #5258. And a little bit more.

The core change here is disabling fat finger predictions. The changes here improve perf from 380ms/keystroke to <10msec/keystroke.

The downside to this is obviously that fat-finger based predictions are no longer available. In my (limited) tests, I was not able to observe a visible reduction in prediction quality. In my opinion, reduction in prediction quality is outweighed by improvement in performance. (This is a shame and makes me sad, but I think we need to be willing to make significant decisions like this, even if we have invested a lot of effort into the code. See sunk cost fallacy.)

But this is not a complete solution. I have left the code in, commented out. If we decide to remove fat finger altogether, there is a lot of additional code we strip out. I think we need to do this, with a view to re-adding it later if we can bring performance up to scratch.

---

Three changes. Tested on Samsung Galaxy A90, 3800 character document in Keyman app.

Before: 380ms/keystroke.

1. Implement sliding window for `buildTransformFrom` (not currently used, see point 3). But did improve performance by about 30msec, so thought I'd leave it in.

2. Set CSS for the input backing textarea to `display: none`, as we never actually need to focus it. Improved performance further by 60msec by eliminating a Layout recalc in the webview.

3. It was clear after making those changes, that the vast majority of the calc time left was in fat finger calculations. Disabled fat fingering . Improved performance further by 280msec (310msec total incl. point 1).

After: 10ms/keystroke.