### PR TITLE
feat(common/core/web): engine correction-prep optimizations

### DIFF
--- a/common/core/web/input-processor/src/text/contextWindow.ts
+++ b/common/core/web/input-processor/src/text/contextWindow.ts
@@ -1,0 +1,37 @@
+namespace com.keyman.text {
+  export class ContextWindow implements Context {
+    // Used to limit the range of context replicated for use of keyboard rules within
+    // the engine, as used for fat-finger prep / `Alternate` generation.
+    public static readonly ENGINE_RULE_WINDOW: Configuration = {
+      leftContextCodePoints: 64,
+      rightContextCodePoints: 32
+    };
+
+    left: string;
+    right?: string;
+
+    startOfBuffer: boolean;
+    endOfBuffer: boolean;
+
+    constructor(mock: Mock, config: Configuration) {
+      this.left = mock.getTextBeforeCaret();
+      this.startOfBuffer = this.left._kmwLength() <= config.leftContextCodePoints;
+      if(!this.startOfBuffer) {
+        // Our custom substring version will return the last n characters if param #1 is given -n.
+        this.left = this.left._kmwSubstr(-config.leftContextCodePoints);
+      }
+
+      this.right = mock.getTextAfterCaret();
+      this.endOfBuffer = this.right._kmwLength() <= config.rightContextCodePoints;
+      if(!this.endOfBuffer) {
+        this.right = this.right._kmwSubstr(0, config.rightContextCodePoints);
+      }
+    }
+
+    public toMock(): Mock {
+      let caretPos = this.left._kmwLength();
+
+      return new Mock(this.left + (this.right || ""), caretPos);
+    }
+  }
+}

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -133,7 +133,24 @@ namespace com.keyman.text {
             //
             // Consider use of https://developer.mozilla.org/en-US/docs/Web/API/Performance/now instead?
             // Would allow finer-tuned control.
-            let TIMEOUT_THRESHOLD = Date.now() + 16; // + 16ms.
+            let TIMEOUT_THRESHOLD: number = Number.MAX_VALUE;
+            let _globalThis = com.keyman.utils.getGlobalObject();
+            let timer: () => number;
+
+            // Available by default on `window` in browsers, but _not_ on `global` in Node, 
+            // surprisingly.  Since we can't use code dependent on `require` statements
+            // at present, we have to condition upon it actually existing.
+            if(_globalThis['performance'] && _globalThis['performance']['now']) {
+              timer = function() {
+                return _globalThis['performance']['now']();
+              };
+
+              TIMEOUT_THRESHOLD = timer() + 16; // + 16ms.
+            } // else {
+              // We _could_ just use Date.now() as a backup... but that (probably) only matters
+              // when unit testing.  So... we actually don't _need_ time thresholding when in 
+              // a Node environment.
+            // }
 
             // Tracks a minimum probability for keystroke probability.  Anything less will not be
             // included in alternate calculations. 
@@ -155,7 +172,7 @@ namespace com.keyman.text {
             for(let pair of keyDistribution) {
               if(pair.p < KEYSTROKE_EPSILON) {
                 break;
-              } else if(Date.now() >= TIMEOUT_THRESHOLD) {
+              } else if(timer && timer() >= TIMEOUT_THRESHOLD) {
                 break;
               }
 

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -1,6 +1,7 @@
 // Defines a 'polyfill' of sorts for NPM's events module
 /// <reference path="../includes/events.ts" />
 /// <reference path="../../node_modules/@keymanapp/keyboard-processor/src/text/keyboardProcessor.ts" />
+/// <reference path="contextWindow.ts" />
 /// <reference path="prediction/languageProcessor.ts" />
 
 namespace com.keyman.text {
@@ -99,6 +100,9 @@ namespace com.keyman.text {
       // Create a "mock" backup of the current outputTarget in its pre-input state.
       // Current, long-existing assumption - it's DOM-backed.
       let preInputMock = Mock.from(outputTarget);
+
+      // We presently need the true keystroke to run on the FULL context.  That index is still
+      // needed for some indexing operations when comparing two different output targets.
       let ruleBehavior = this.keyboardProcessor.processKeystroke(keyEvent, outputTarget);
 
       // Swap layer as appropriate.
@@ -114,6 +118,13 @@ namespace com.keyman.text {
         // Also, don't do fat-finger stuff if predictive text isn't enabled.
         if(this.languageProcessor.isActive && !ruleBehavior.triggersDefaultCommand) {
           let keyDistribution = keyEvent.keyDistribution;
+
+          // We don't need to track absolute indexing during alternate-generation; 
+          // only position-relative, so it's better to use a sliding window for context
+          // when making alternates.  (Slightly worse for short text, matters greatly
+          // for long text.)
+          let contextWindow = new ContextWindow(preInputMock, ContextWindow.ENGINE_RULE_WINDOW);
+          let windowedMock = contextWindow.toMock();
 
           // Note - we don't yet do fat-fingering with longpress keys.
           if(keyDistribution && keyEvent.kbdLayer) {
@@ -148,7 +159,7 @@ namespace com.keyman.text {
                 break;
               }
 
-              let mock = Mock.from(preInputMock);
+              let mock = Mock.from(windowedMock);
               
               let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
               if(!altKey) {

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -113,13 +113,41 @@ namespace com.keyman.text {
         // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
         // Also, don't do fat-finger stuff if predictive text isn't enabled.
         if(this.languageProcessor.isActive && !ruleBehavior.triggersDefaultCommand) {
+          let keyDistribution = keyEvent.keyDistribution;
+
           // Note - we don't yet do fat-fingering with longpress keys.
-          if(keyEvent.keyDistribution && keyEvent.kbdLayer) {
+          if(keyDistribution && keyEvent.kbdLayer) {
+            // Tracks a 'deadline' for fat-finger ops, just in case both context is long enough
+            // and device is slow enough that the calculation takes too long.
+            //
+            // Consider use of https://developer.mozilla.org/en-US/docs/Web/API/Performance/now instead?
+            // Would allow finer-tuned control.
+            let TIMEOUT_THRESHOLD = Date.now() + 16; // + 16ms.
+
+            // Tracks a minimum probability for keystroke probability.  Anything less will not be
+            // included in alternate calculations. 
+            //
+            // Seek to match SearchSpace.EDIT_DISTANCE_COST_SCALE from the predictive-text engine.
+            // Reasoning for the selected value may be seen there.  Short version - keystrokes 
+            // that _appear_ very precise may otherwise not even consider directly-neighboring keys.
+            let KEYSTROKE_EPSILON = Math.exp(-5);
+
+            // Sort the distribution into probability-descending order.
+            keyDistribution.sort(function(a, b) {
+              return b.p - a.p;
+            });
+
             let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
             alternates = [];
     
             let totalMass = 0; // Tracks sum of non-error probabilities.
-            for(let pair of keyEvent.keyDistribution) {
+            for(let pair of keyDistribution) {
+              if(pair.p < KEYSTROKE_EPSILON) {
+                break;
+              } else if(Date.now() >= TIMEOUT_THRESHOLD) {
+                break;
+              }
+
               let mock = Mock.from(preInputMock);
               
               let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -161,9 +161,7 @@ namespace com.keyman.text {
             let KEYSTROKE_EPSILON = Math.exp(-5);
 
             // Sort the distribution into probability-descending order.
-            keyDistribution.sort(function(a, b) {
-              return b.p - a.p;
-            });
+            keyDistribution.sort((a, b) => b.p - a.p);
 
             let activeLayout = this.activeKeyboard.layout(keyEvent.device.formFactor);
             alternates = [];

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -2,6 +2,7 @@
 ///<reference path="../../../node_modules/@keymanapp/lexical-model-layer/message.d.ts" />
 ///<reference path="../../../node_modules/@keymanapp/lexical-model-layer/index.ts" />
 ///<reference path="../../includes/events.ts" />
+/// <reference path="../contextWindow.ts" />
 
 namespace com.keyman.text.prediction {
   export interface ModelSpec {

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -51,29 +51,6 @@ namespace com.keyman.text.prediction {
    */
   export type InvalidateSuggestionsHandler = (source: InvalidateSourceEnum) => boolean;
 
-  export class TranscriptionContext implements Context {
-    left: string;
-    right?: string;
-
-    startOfBuffer: boolean;
-    endOfBuffer: boolean;
-
-    constructor(mock: Mock, config: Configuration) {
-      this.left = mock.getTextBeforeCaret();
-      this.startOfBuffer = this.left._kmwLength() <= config.leftContextCodePoints;
-      if(!this.startOfBuffer) {
-        // Our custom substring version will return the last n characters if param #1 is given -n.
-        this.left = this.left._kmwSubstr(-config.leftContextCodePoints);
-      }
-
-      this.right = mock.getTextAfterCaret();
-      this.endOfBuffer = this.right._kmwLength() <= config.rightContextCodePoints;
-      if(!this.endOfBuffer) {
-        this.right = this.right._kmwSubstr(0, config.rightContextCodePoints);
-      }
-    }
-  }
-
   export class ReadySuggestions {
     suggestions: Suggestion[];
     transcriptionID: number;
@@ -193,7 +170,7 @@ namespace com.keyman.text.prediction {
         return null;
       }
 
-      let context = new TranscriptionContext(Mock.from(target), this.configuration);
+      let context = new ContextWindow(Mock.from(target), this.configuration);
       return this.lmEngine.wordbreak(context);
     }
 
@@ -247,7 +224,7 @@ namespace com.keyman.text.prediction {
 
         // Builds the reversion option according to the loaded lexical model's known
         // syntactic properties.
-        let suggestionContext = new TranscriptionContext(original.preInput, this.configuration);
+        let suggestionContext = new ContextWindow(original.preInput, this.configuration);
 
         // We must accept the Suggestion from its original context, which was before
         // `original.transform` was applied.
@@ -307,7 +284,7 @@ namespace com.keyman.text.prediction {
       outputTarget.apply(transform);
 
       // The reason we need to preserve the additive-inverse 'transformId' property on Reversions.
-      let promise = this.lmEngine.revertSuggestion(reversion, new TranscriptionContext(original.preInput, this.configuration))
+      let promise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput, this.configuration))
 
       let lp = this;
       return promise.then(function(suggestions: Suggestion[]) {
@@ -338,7 +315,7 @@ namespace com.keyman.text.prediction {
         return null;
       }
 
-      let context = new TranscriptionContext(transcription.preInput, this.configuration);
+      let context = new ContextWindow(transcription.preInput, this.configuration);
       this.recordTranscription(transcription);
 
       if(resetContext) {

--- a/common/core/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/core/web/input-processor/tests/cases/inputProcessor.js
@@ -41,5 +41,111 @@ describe('InputProcessor', function() {
       assert.isFalse(core.languageProcessor.isActive);
       assert.isTrue(core.languageProcessor.mayPredict);
     });
+
+    describe('efficiently generates alternate contexts from fat-fingers', function() {
+      let testDistribution = [];
+      var keyboard;
+      let device = {
+        formFactor: 'phone',
+        OS: 'ios',
+        browser: 'safari'
+      }
+
+      // Easy peasy long context:  use the input processor's full source!
+      let coreSourceCode = fs.readFileSync('dist/index.js', 'utf-8');
+
+      // At the time this test block was written...  810485 chars.
+      // Let's force it to the same order of magnitude, even if the codebase grows.
+      if(coreSourceCode._kmwLength() > 1000000) {
+        coreSourceCode = coreSourceCode._kmwSubstring(0, 1000000);
+      }
+
+      this.beforeAll(function() {
+        testDistribution = [];
+
+        for(let c = 'A'.charCodeAt(0); c <= 'Z'.charCodeAt(0); c++) {
+          let char = String.fromCharCode(c);
+
+          testDistribution.push({
+            keyId: "K_" + char,
+            p: 1 / 26
+          });
+        }
+
+        // Load the keyboard.  We'll need an InputProcessor instance as an intermediary.
+        let core = new InputProcessor();
+
+        // These two lines will load a keyboard from its file; headless-mode `registerKeyboard` will
+        // automatically set the keyboard as active.
+        let kbdScript = new vm.Script(fs.readFileSync('../tests/resources/keyboards/test_chirality.js'));
+        kbdScript.runInThisContext();
+
+        keyboard = core.activeKeyboard;
+      });
+
+      it('with minimal context (no fat-fingers)', function() {
+        this.timeout(32); // ms
+        let core = new InputProcessor();
+        let context = new com.keyman.text.Mock("", 0);
+
+        core.activeKeyboard = keyboard;
+        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
+        let key = layout.getLayer('default').getKey('K_A');
+        let event = key.constructKeyEvent(core.keyboardProcessor, device);
+        
+        let behavior = core.processKeyEvent(event, context);
+        assert.isNotNull(behavior);
+      });
+
+      it('with minimal context (with fat-fingers)', function() {
+        this.timeout(32); // ms
+        let core = new InputProcessor();
+        let context = new com.keyman.text.Mock("", 0);
+
+        core.activeKeyboard = keyboard;
+        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
+        let key = layout.getLayer('default').getKey('K_A');
+        key.keyDistribution = testDistribution;
+        let event = key.constructKeyEvent(core.keyboardProcessor, device);
+        
+        let behavior = core.processKeyEvent(event, context);
+        assert.isNotNull(behavior);
+      });
+
+      it('with extremely long context (' + coreSourceCode._kmwLength() + ' chars, no fat-fingers)', function() {
+        // Assumes no SMP chars in the source, which is fine.
+        let context = new com.keyman.text.Mock(coreSourceCode, coreSourceCode._kmwLength());
+
+        this.timeout(250); // 250 ms, excluding text import.
+        let core = new InputProcessor();  // I mean, it IS long context, and time
+                                          // thresholding is disabled within Node.
+
+        core.activeKeyboard = keyboard;
+        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
+        let key = layout.getLayer('default').getKey('K_A');
+        let event = key.constructKeyEvent(core.keyboardProcessor, device);
+        
+        let behavior = core.processKeyEvent(event, context);
+        assert.isNotNull(behavior);
+      });
+
+      it('with extremely long context (' + coreSourceCode._kmwLength() + ' chars, with fat-fingers)', function() {
+        // Assumes no SMP chars in the source, which is fine.
+        let context = new com.keyman.text.Mock(coreSourceCode, coreSourceCode._kmwLength());
+
+        this.timeout(250); // 250 ms, excluding text import.
+        let core = new InputProcessor();  // I mean, it IS long context, and time
+                                          // thresholding is disabled within Node.
+
+        core.activeKeyboard = keyboard;
+        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
+        let key = layout.getLayer('default').getKey('K_A');
+        key.keyDistribution = testDistribution;
+        let event = key.constructKeyEvent(core.keyboardProcessor, device);
+        
+        let behavior = core.processKeyEvent(event, context);
+        assert.isNotNull(behavior);
+      });
+    });
   });
 });

--- a/common/core/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/core/web/input-processor/tests/cases/inputProcessor.js
@@ -57,8 +57,8 @@ describe('InputProcessor', function() {
 
     // At the time this test block was written...  810485 chars.
     // Let's force it to the same order of magnitude, even if the codebase grows.
-    if(coreSourceCode._kmwLength() > 1000000) {
-      coreSourceCode = coreSourceCode._kmwSubstring(0, 1000000);
+    if(coreSourceCode.length > 1000000) {
+      coreSourceCode = coreSourceCode.substring(0, 1000000);
     }
 
     this.beforeAll(function() {

--- a/common/core/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/core/web/input-processor/tests/cases/inputProcessor.js
@@ -41,53 +41,55 @@ describe('InputProcessor', function() {
       assert.isFalse(core.languageProcessor.isActive);
       assert.isTrue(core.languageProcessor.mayPredict);
     });
+  });
 
-    describe('efficiently generates alternate contexts from fat-fingers', function() {
-      let testDistribution = [];
-      var keyboard;
-      let device = {
-        formFactor: 'phone',
-        OS: 'ios',
-        browser: 'safari'
+  describe('efficiency tests', function() {
+    let testDistribution = [];
+    var keyboard;
+    let device = {
+      formFactor: 'phone',
+      OS: 'ios',
+      browser: 'safari'
+    }
+
+    // Easy peasy long context:  use the input processor's full source!
+    let coreSourceCode = fs.readFileSync('dist/index.js', 'utf-8');
+
+    // At the time this test block was written...  810485 chars.
+    // Let's force it to the same order of magnitude, even if the codebase grows.
+    if(coreSourceCode._kmwLength() > 1000000) {
+      coreSourceCode = coreSourceCode._kmwSubstring(0, 1000000);
+    }
+
+    this.beforeAll(function() {
+      testDistribution = [];
+
+      for(let c = 'A'.charCodeAt(0); c <= 'Z'.charCodeAt(0); c++) {
+        let char = String.fromCharCode(c);
+
+        testDistribution.push({
+          keyId: "K_" + char,
+          p: 1 / 26
+        });
       }
 
-      // Easy peasy long context:  use the input processor's full source!
-      let coreSourceCode = fs.readFileSync('dist/index.js', 'utf-8');
+      // Load the keyboard.  We'll need an InputProcessor instance as an intermediary.
+      let core = new InputProcessor();
 
-      // At the time this test block was written...  810485 chars.
-      // Let's force it to the same order of magnitude, even if the codebase grows.
-      if(coreSourceCode._kmwLength() > 1000000) {
-        coreSourceCode = coreSourceCode._kmwSubstring(0, 1000000);
-      }
+      // These two lines will load a keyboard from its file; headless-mode `registerKeyboard` will
+      // automatically set the keyboard as active.
+      let kbdScript = new vm.Script(fs.readFileSync('../tests/resources/keyboards/test_chirality.js'));
+      kbdScript.runInThisContext();
 
-      this.beforeAll(function() {
-        testDistribution = [];
+      keyboard = core.activeKeyboard;
+    });
 
-        for(let c = 'A'.charCodeAt(0); c <= 'Z'.charCodeAt(0); c++) {
-          let char = String.fromCharCode(c);
-
-          testDistribution.push({
-            keyId: "K_" + char,
-            p: 1 / 26
-          });
-        }
-
-        // Load the keyboard.  We'll need an InputProcessor instance as an intermediary.
-        let core = new InputProcessor();
-
-        // These two lines will load a keyboard from its file; headless-mode `registerKeyboard` will
-        // automatically set the keyboard as active.
-        let kbdScript = new vm.Script(fs.readFileSync('../tests/resources/keyboards/test_chirality.js'));
-        kbdScript.runInThisContext();
-
-        keyboard = core.activeKeyboard;
-      });
-
+    describe('without fat-fingering', function() {
       it('with minimal context (no fat-fingers)', function() {
         this.timeout(32); // ms
         let core = new InputProcessor();
         let context = new com.keyman.text.Mock("", 0);
-
+  
         core.activeKeyboard = keyboard;
         let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -96,12 +98,31 @@ describe('InputProcessor', function() {
         let behavior = core.processKeyEvent(event, context);
         assert.isNotNull(behavior);
       });
+  
+      it('with extremely long context (' + coreSourceCode._kmwLength() + ' chars, no fat-fingers)', function() {
+        // Assumes no SMP chars in the source, which is fine.
+        let context = new com.keyman.text.Mock(coreSourceCode, coreSourceCode._kmwLength());
+  
+        this.timeout(250); // 250 ms, excluding text import.
+        let core = new InputProcessor();  // I mean, it IS long context, and time
+                                          // thresholding is disabled within Node.
+  
+        core.activeKeyboard = keyboard;
+        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
+        let key = layout.getLayer('default').getKey('K_A');
+        let event = key.constructKeyEvent(core.keyboardProcessor, device);
+        
+        let behavior = core.processKeyEvent(event, context);
+        assert.isNotNull(behavior);
+      });
+    });
 
+    describe('with fat-fingering', function() {
       it('with minimal context (with fat-fingers)', function() {
         this.timeout(32); // ms
         let core = new InputProcessor();
         let context = new com.keyman.text.Mock("", 0);
-
+  
         core.activeKeyboard = keyboard;
         let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -111,32 +132,15 @@ describe('InputProcessor', function() {
         let behavior = core.processKeyEvent(event, context);
         assert.isNotNull(behavior);
       });
-
-      it('with extremely long context (' + coreSourceCode._kmwLength() + ' chars, no fat-fingers)', function() {
-        // Assumes no SMP chars in the source, which is fine.
-        let context = new com.keyman.text.Mock(coreSourceCode, coreSourceCode._kmwLength());
-
-        this.timeout(250); // 250 ms, excluding text import.
-        let core = new InputProcessor();  // I mean, it IS long context, and time
-                                          // thresholding is disabled within Node.
-
-        core.activeKeyboard = keyboard;
-        let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
-        let key = layout.getLayer('default').getKey('K_A');
-        let event = key.constructKeyEvent(core.keyboardProcessor, device);
-        
-        let behavior = core.processKeyEvent(event, context);
-        assert.isNotNull(behavior);
-      });
-
+  
       it('with extremely long context (' + coreSourceCode._kmwLength() + ' chars, with fat-fingers)', function() {
         // Assumes no SMP chars in the source, which is fine.
         let context = new com.keyman.text.Mock(coreSourceCode, coreSourceCode._kmwLength());
-
+  
         this.timeout(250); // 250 ms, excluding text import.
         let core = new InputProcessor();  // I mean, it IS long context, and time
                                           // thresholding is disabled within Node.
-
+  
         core.activeKeyboard = keyboard;
         let layout = keyboard.layout(com.keyman.utils.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');

--- a/common/core/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/core/web/keyboard-processor/src/text/outputTarget.ts
@@ -348,13 +348,26 @@ namespace com.keyman.text {
 
     // Clones the state of an existing EditableElement, creating a Mock version of its state.
     static from(outputTarget: OutputTarget) {
-      let preText = outputTarget.getTextBeforeCaret();
-      let caretIndex = preText._kmwLength();
+      let clone: Mock;
 
-      // We choose to ignore (rather, pre-emptively remove) any actively-selected text,
-      // as since it's always removed instantly during any text mutation operations.
-      let clone = new Mock(preText + outputTarget.getTextAfterCaret(), caretIndex);
+      if(outputTarget instanceof Mock) {
+        // Avoids the need to run expensive kmwstring.ts / `_kmwLength()`
+        // calculations when deep-copying Mock instances.
+        let priorMock = outputTarget as Mock;
+        clone = new Mock(priorMock.text, priorMock.caretIndex);
+      } else {
+        // If we're 'cloning' a different OutputTarget type, we don't have a
+        // guaranteed way to more efficiently get these values; these are the
+        // best methods specified by the abstraction.
+        let preText = outputTarget.getTextBeforeCaret();
+        let caretIndex = preText._kmwLength();
 
+        // We choose to ignore (rather, pre-emptively remove) any actively-selected text,
+        // as since it's always removed instantly during any text mutation operations.
+        clone = new Mock(preText + outputTarget.getTextAfterCaret(), caretIndex);
+      }
+
+      // Also duplicate deadkey state!  (Needed for fat-finger ops.)
       clone.setDeadkeys(outputTarget.deadkeys());
 
       return clone;


### PR DESCRIPTION
An alternate approach from #5314.

Rather than outright turning off base fat-finger modeling, why not just threshold it within a tight time window?  As seen here, it's quite simple to do.

Furthermore, after a bit of investigation as to what could _possibly_ be responsible for #5314's point 3 making such a huge difference... I realized that the core `Mock.from` function was likely responsible.

1. `Mock.from` did _not_ get the sliding-context-window treatment
2. `Mock.from` relies on the kmwstring.ts utility functions.

The thing is... there's no reason for point 2 to be necessary if provided an initial Mock.  Which _**is**_ the case for modeling potential fat-fingers, even before applying engine rules - so this "simple" optimization should actually have a very significant impact.

In testing, I've noticed that touch-alias elements may still be slow to 'load' whenever they receive focus.  TouchAliasElement caret-positioning logic doesn't appear optimized for long text.  That's a separate, though related, issue.

------

While everything needed for a proper "sliding window" approach isn't yet fully clear, I will say that all alternates should probably use the same base for their window.  In particular, the starting index (within the context) of all windows should match, even if some keys output longer context than others.  (So, no 'extra' sliding based on output.)

Such a rule should help simplify other aspects of the engine - particularly, application of suggestions and reversions - if maintaining existing behavior turns out to be non-trivial when that is introduced.