### PR TITLE
chore(linux): Build also on riscv64 to facilitate migration on Ubuntu 🍒

### DIFF
--- a/common/core/desktop/debian/changelog
+++ b/common/core/desktop/debian/changelog
@@ -1,3 +1,10 @@
+keyman-keyboardprocessor (14.0.276-2) experimental; urgency=medium
+
+  * Team upload
+  * Build also on riscv64 to facilitate migration on Ubuntu
+
+ -- Gunnar Hjalmarsson <gunnarhj@debian.org>  Fri, 18 Jun 2021 11:15:38 +0200
+
 keyman-keyboardprocessor (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/common/core/desktop/debian/control
+++ b/common/core/desktop/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/keymanapp/keyman/tree/master/common/core/desktop
 Homepage: https://www.keyman.com
 
 Package: libkmnkbp-dev
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Section: libdevel
 Depends:
  libkmnkbp0-0 (= ${binary:Version}),
@@ -41,7 +41,7 @@ Description: Development files for Keyman keyboard processing library
  This package contains development headers and libraries.
 
 Package: libkmnkbp0-0
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Section: libs
 Pre-Depends:
  ${misc:Pre-Depends},

--- a/linux/ibus-keyman/debian/changelog
+++ b/linux/ibus-keyman/debian/changelog
@@ -1,3 +1,10 @@
+ibus-keyman (14.0.276-2) experimental; urgency=medium
+
+  * Team upload
+  * Build also on riscv64 to facilitate migration on Ubuntu
+
+ -- Gunnar Hjalmarsson <gunnarhj@debian.org>  Fri, 18 Jun 2021 11:14:59 +0200
+
 ibus-keyman (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/linux/ibus-keyman/debian/control
+++ b/linux/ibus-keyman/debian/control
@@ -18,7 +18,7 @@ Vcs-Browser: https://github.com/keymanapp/keyman/tree/master/linux/ibus-keyman
 Homepage: https://www.keyman.com
 
 Package: ibus-keyman
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Depends:
  ibus (>= 1.3.7),
  sudo,


### PR DESCRIPTION
🍒-pick of #5322