### PR TITLE
refactor(android): setKeyboard and setKeymanLanguage

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -128,49 +128,10 @@
       return true;
     }
 
-    function setKeymanLanguage(keyboardName, internalName, languageName, langId, kbdFile, font, oskFont, package) {
-      var kmw=window['keyman'];
-      var kbdInterface=window.KeymanWeb;
-
-      // Defaults for missing arguments
-      switch (arguments.length) {
-        case 1:
-          internalName = keyboardName;
-          if (keyboardName == 'English') {
-              internalName = 'us';
-          }
-          break;
-        case 2:
-          languageName = keyboardName;
-          break;
-        case 3:
-          langId='';
-          break;
-        case 6:
-          oskFont = font;
-          break;
-      }
-
-      var k = {
-        KN:keyboardName,
-        KI:'Keyboard_'+internalName,
-        KLC:langId,
-        KL:languageName,
-        KF:kbdFile,
-        KP:package
-      };
-      if (font) {
-        k.KFont = font;
-        //window.console.log('keyboard.html assigning k.KFont = ' + font);
-      }
-      if (oskFont) {
-        k.KOskFont = oskFont;
-        //window.console.log('keyboard.html assigning k.KOskFont = ' + oskFont);
-      }
-      kbdInterface.registerStub(k);
-
-      kmw['setActiveKeyboard'](package + '::Keyboard_'+internalName,langId);
-      kmw['osk']['show'](true);
+    function setKeymanLanguage(k) {
+      KeymanWeb.registerStub(k);
+      keyman.setActiveKeyboard(k.KP + '::'+k.KI, k.KLC);
+      keyman.osk.show(true);
     }
 
     /**

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1030,7 +1030,7 @@ final class KMKeyboard extends WebView {
    * 1. Replace "source" keys for "files" keys
    * 2. Create full font paths for .ttf or .svg
    * @param font String font JSON object as a string
-   * @return String of modified font information with full paths. If font is invalid, return "''"
+   * @return JSONObject of modified font information with full paths. If font is invalid, return `null`
    */
   private JSONObject makeFontPaths(String font) {
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -190,6 +190,7 @@ public final class KMManager {
   public static final String KMKey_OskFont = "oskFont";
   public static final String KMKey_FontSource = "source";
   public static final String KMKey_FontFiles = "files";
+  public static final String KMKey_FontFamily = "family";
   public static final String KMKey_KeyboardModified = "lastModified";
   public static final String KMKey_KeyboardRTL = "rtl";
 


### PR DESCRIPTION
This refactors the cross-boundary call to `setKeymanLanguage` to use JSON wrapping for the content. This is (a) safer, and (b) less mucking around anyway.