### PR TITLE
feat(android): Spacebar text controls

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -5,6 +5,7 @@
 package com.keyman.android;
 
 import com.tavultesoft.kmapro.BuildConfig;
+import com.tavultesoft.kmapro.KeymanSettingsActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMManager.KeyboardType;
 import com.tavultesoft.kmea.KMHardwareKeyboardInterpreter;
@@ -63,6 +64,11 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
     interpreter = new KMHardwareKeyboardInterpreter(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
     KMManager.setInputMethodService(this); // for HW interface
+
+    SharedPreferences prefs = getApplicationContext().getSharedPreferences(getApplicationContext().getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    KMManager.SpacebarText spacebarText = KMManager.SpacebarText.fromString(prefs.getString(KeymanSettingsActivity.spacebarTextKey, KMManager.SpacebarText.LANGUAGE_KEYBOARD.toString()));
+    KMManager.setSpacebarText(spacebarText);
+
     KMManager.executeResourceUpdate(this);
   }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
@@ -12,6 +12,7 @@ public class KeymanSettingsActivity extends BaseActivity {
   protected static final String installKeyboardOrDictionaryKey = "InstallKeyboardOrDictionary";
   protected static final String showBannerKey = "ShowBanner";
   protected static final String sendCrashReport = "SendCrashReport";
+  public static final String spacebarTextKey = "SpacebarText";
 
   protected KeymanSettingsFragment innerFragment;
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsFragment.java
@@ -11,6 +11,7 @@ import android.provider.Settings;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.preference.CheckBoxPreference;
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
@@ -20,11 +21,14 @@ import com.tavultesoft.kmea.DisplayLanguages;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.data.Dataset;
 
+import java.util.HashMap;
+
 public class KeymanSettingsFragment extends PreferenceFragmentCompat {
   private static final String TAG = "SettingsFragment";
   private static Context context;
 
   private Preference languagesPreference, installKeyboardOrDictionary, displayLanguagePreference;
+  private ListPreference spacebarTextPreference;
   private CheckBoxPreference setSystemKeyboardPreference;
   private CheckBoxPreference setDefaultKeyboardPreference;
 
@@ -57,6 +61,49 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     displayLanguagePreference.setWidgetLayoutResource(R.layout.preference_translate_icon_layout);
     Intent displayLanguageIntent = new Intent(context, KeymanSettingsLocalizeActivity.class);
     displayLanguagePreference.setIntent(displayLanguageIntent);
+
+    /* Spacebar Caption Preference */
+
+    spacebarTextPreference = new ListPreference(context);
+    spacebarTextPreference.setKey(KeymanSettingsActivity.spacebarTextKey);
+
+    spacebarTextPreference.setTitle(getString(R.string.spacebar_caption)); // getString(R.string.change_display_language));
+
+    CharSequence[] entries = {
+      getString(R.string.spacebar_caption_language),
+      getString(R.string.spacebar_caption_keyboard),
+      getString(R.string.spacebar_caption_language_keyboard),
+      getString(R.string.spacebar_caption_blank)
+    };
+
+    HashMap<KMManager.SpacebarText,String> captions = new HashMap<>();
+    captions.put(KMManager.SpacebarText.LANGUAGE, getString(R.string.spacebar_caption_hint_language));
+    captions.put(KMManager.SpacebarText.KEYBOARD, getString(R.string.spacebar_caption_hint_keyboard));
+    captions.put(KMManager.SpacebarText.LANGUAGE_KEYBOARD, getString(R.string.spacebar_caption_hint_language_keyboard));
+    captions.put(KMManager.SpacebarText.BLANK, getString(R.string.spacebar_caption_hint_blank));
+
+    CharSequence[] entryValues = {
+      KMManager.SpacebarText.LANGUAGE.toString(),
+      KMManager.SpacebarText.KEYBOARD.toString(),
+      KMManager.SpacebarText.LANGUAGE_KEYBOARD.toString(),
+      KMManager.SpacebarText.BLANK.toString()
+    };
+
+    spacebarTextPreference.setEntries(entries);
+    spacebarTextPreference.setEntryValues(entryValues);
+    spacebarTextPreference.setValue(KMManager.getSpacebarText().toString());
+    spacebarTextPreference.setSummary(captions.get(KMManager.getSpacebarText()));
+    spacebarTextPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+      @Override
+      public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if(newValue == null)
+          return false;
+        KMManager.SpacebarText mode = KMManager.SpacebarText.fromString((String) newValue);
+        KMManager.setSpacebarText(mode);
+        spacebarTextPreference.setSummary(captions.get(mode));
+        return true;
+      }
+    });
 
     /*
       Automatically does the following:
@@ -121,6 +168,7 @@ public class KeymanSettingsFragment extends PreferenceFragmentCompat {
     screen.addPreference(languagesPreference);
     screen.addPreference(installKeyboardOrDictionary);
     screen.addPreference(displayLanguagePreference);
+    screen.addPreference(spacebarTextPreference);
 
     screen.addPreference(setSystemKeyboardPreference);
     screen.addPreference(setDefaultKeyboardPreference);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -177,6 +177,9 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       editor.commit();
     }
 
+    KMManager.SpacebarText spacebarText = KMManager.SpacebarText.fromString(prefs.getString(KeymanSettingsActivity.spacebarTextKey, KMManager.SpacebarText.LANGUAGE_KEYBOARD.toString()));
+    KMManager.setSpacebarText(spacebarText);
+
     setContentView(R.layout.activity_main);
 
     toolbar = (Toolbar) findViewById(R.id.titlebar);

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -96,7 +96,35 @@
   <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">Install Keyboard or Dictionary</string>
 
   <!-- Context: Keyman Settings menu -->
-  <string name="change_display_language" comment="Menu action to change interface language">Change display language</string>
+  <string name="change_display_language" comment="Menu action to change interface language">Display language</string>
+
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">Spacebar caption</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">Keyboard</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">Language</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">Language + Keyboard</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">Blank</string>
+
+
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">Show keyboard name on spacebar</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">Show language name on spacebar</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">Language and keyboard on spacebar</string>
+
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">Do not show caption on spacebar</string>
 
   <!-- Context: Keyman Settings menu -->
   <string name="show_banner" comment="text suggestions banner">Always show banner</string>

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -41,7 +41,7 @@
       ta.readOnly = false;
 
       // Tell KMW the default banner height to use
-      com.keyman.osk.Banner.DEFAULT_HEIGHT = 
+      com.keyman.osk.Banner.DEFAULT_HEIGHT =
         Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
@@ -131,6 +131,11 @@
     function setKeymanLanguage(k) {
       KeymanWeb.registerStub(k);
       keyman.setActiveKeyboard(k.KP + '::'+k.KI, k.KLC);
+      keyman.osk.show(true);
+    }
+
+    function setSpacebarText(mode) {
+      keyman.options['spacebarText'] = mode;
       keyman.osk.show(true);
     }
 
@@ -281,7 +286,7 @@
 
     function executePopupKey(keyID, keyText) {
       var kmw=window['keyman'];
-      
+
       // KMW only needs keyID to process the popup key. keyText merely logged to console
       //window.console.log('executePopupKey('+keyID+'); keyText: ' + keyText);
       kmw['executePopupKey'](keyID);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -399,7 +399,8 @@ final class KMKeyboard extends WebView {
         k.getKeyboardName(),
         k.getLanguageName(),
         k.getFont(),
-        k.getOSKFont());
+        k.getOSKFont(),
+        k.getDisplayName());
     }
 
     return retVal;
@@ -478,7 +479,16 @@ final class KMKeyboard extends WebView {
     return retVal;
   }
 
-  public boolean setKeyboard(String packageID, String keyboardID, String languageID, String keyboardName, String languageName, String kFont, String kOskFont) {
+  public boolean setKeyboard(String packageID, String keyboardID, String languageID,
+                             String keyboardName, String languageName, String kFont,
+                             String kOskFont) {
+    return setKeyboard(packageID, keyboardID, languageID, keyboardName, languageName,
+                       kFont, kOskFont, null);
+  }
+
+  public boolean setKeyboard(String packageID, String keyboardID, String languageID,
+                             String keyboardName, String languageName, String kFont,
+                             String kOskFont, String displayName) {
     if (packageID == null || keyboardID == null || languageID == null || keyboardName == null || languageName == null) {
       return false;
     }
@@ -532,6 +542,7 @@ final class KMKeyboard extends WebView {
 
       if (jDisplayFont != null) reg.put("KFont", jDisplayFont);
       if (jOskFont != null) reg.put("KOskFont", jOskFont);
+      if (displayName != null) reg.put("displayName", displayName);
     } catch(JSONException e) {
       KMLog.LogException(TAG, "", e);
       return false;
@@ -1314,6 +1325,11 @@ final class KMKeyboard extends WebView {
     if (kbEventListeners != null) {
       kbEventListeners.remove(listener);
     }
+  }
+
+  public void setSpacebarText(KMManager.SpacebarText mode) {
+    String jsString = KMString.format("setSpacebarText('%s')", mode.toString());
+    loadJavascript(jsString);
   }
 
   /* Implement handleTouchEvent to catch long press gesture without using Android system default time

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1045,7 +1045,7 @@ final class KMKeyboard extends WebView {
    */
   private JSONObject makeFontPaths(String font) {
 
-    if(font == null) {
+    if(font == null || font.equals("")) {
       return null;
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -121,6 +121,30 @@ public final class KMManager {
     STABLE
   }
 
+  public enum SpacebarText {
+    LANGUAGE,
+    KEYBOARD,
+    LANGUAGE_KEYBOARD,
+    BLANK;
+
+    // Maps to enum SpacebarText in kmwbase.ts
+    public static SpacebarText fromString(String mode) {
+      if(mode == null) return LANGUAGE_KEYBOARD;
+      switch(mode) {
+        case "language": return LANGUAGE;
+        case "keyboard": return KEYBOARD;
+        case "languageKeyboard": return LANGUAGE_KEYBOARD;
+        case "blank": return BLANK;
+      }
+      return LANGUAGE_KEYBOARD;
+    }
+
+    public String toString()  {
+      String modes[] = { "language", "keyboard", "languageKeyboard", "blank" };
+      return modes[this.ordinal()];
+    }
+  };
+
   private static InputMethodService IMService;
   private static boolean debugMode = false;
   private static boolean shouldAllowSetKeyboard = true;
@@ -132,6 +156,8 @@ public final class KMManager {
   private static GlobeKeyAction sysKbGlobeKeyAction = GlobeKeyAction.GLOBE_KEY_ACTION_SHOW_MENU;
   // This is used to keep track of the starting system keyboard index while the screen is locked
   private static int sysKbStartingIndexOnLockScreen = -1;
+
+  private static KMManager.SpacebarText spacebarText = KMManager.SpacebarText.LANGUAGE_KEYBOARD; // must match default given in kmwbase.ts
 
   protected static boolean InAppKeyboardLoaded = false;
   protected static boolean SystemKeyboardLoaded = false;
@@ -417,7 +443,6 @@ public final class KMManager {
   /**
    * Adjust the keyboard dimensions. If the suggestion banner is active, use the
    * combined banner height and keyboard height
-   * @param keyboard KeyboardType
    * @return RelativeLayout.LayoutParams
    */
   private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
@@ -1778,6 +1803,20 @@ public final class KMManager {
 
     if (SystemKeyboard != null) {
       SystemKeyboard.isHelpBubbleEnabled = newValue;
+    }
+  }
+
+  public static SpacebarText getSpacebarText() {
+    return spacebarText;
+  }
+
+  public static void setSpacebarText(SpacebarText mode) {
+    spacebarText = mode;
+    if(InAppKeyboard != null) {
+      InAppKeyboard.setSpacebarText(mode);
+    }
+    if(SystemKeyboard != null) {
+      SystemKeyboard.setSpacebarText(mode);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1929,6 +1929,7 @@ public final class KMManager {
         }, 2000);
 
         InAppKeyboard.callJavascriptAfterLoad();
+        InAppKeyboard.setSpacebarText(spacebarText);
 
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_INAPP, EventType.KEYBOARD_LOADED, null);
 
@@ -2178,6 +2179,7 @@ public final class KMManager {
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_SYSTEM, EventType.KEYBOARD_LOADED, null);
 
         SystemKeyboard.callJavascriptAfterLoad();
+        SystemKeyboard.setSpacebarText(spacebarText);
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -150,7 +150,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
-      this.displayName = installedObj.getString(KB_DISPLAY_NAME_KEY);
+      this.displayName = installedObj.optString(KB_DISPLAY_NAME_KEY, null);
     } catch (JSONException e) {
       KMLog.LogException(TAG, "fromJSON exception: ", e);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -30,11 +30,13 @@ public class Keyboard extends LanguageResource implements Serializable {
   private boolean isNewKeyboard;
   private String font;
   private String oskFont;
+  private String displayName;
 
   // JSON keys
   private static String KB_NEW_KEYBOARD_KEY = "isNewKeyboard";
   private static String KB_FONT_KEY = "font";
   private static String KB_OSK_FONT_KEY = "oskFont";
+  private static String KB_DISPLAY_NAME_KEY = "displayName";
 
   private static Keyboard FALLBACK_KEYBOARD;
 
@@ -100,6 +102,7 @@ public class Keyboard extends LanguageResource implements Serializable {
     this.isNewKeyboard = false;
     this.font = k.getFont();
     this.oskFont = k.getOSKFont();
+    this.displayName = k.getDisplayName();
   }
 
   public String getKeyboardID() { return getResourceID(); }
@@ -111,6 +114,9 @@ public class Keyboard extends LanguageResource implements Serializable {
   public String getFont() { return font; }
 
   public String getOSKFont() { return oskFont; }
+
+  public String getDisplayName() { return displayName; }
+  public void setDisplayName(String displayName) { this.displayName = displayName; }
 
   public Bundle buildDownloadBundle() {
     Bundle bundle = new Bundle();
@@ -144,6 +150,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
+      this.displayName = installedObj.getString(KB_DISPLAY_NAME_KEY);
     } catch (JSONException e) {
       KMLog.LogException(TAG, "fromJSON exception: ", e);
     }
@@ -156,6 +163,7 @@ public class Keyboard extends LanguageResource implements Serializable {
         o.put(KB_NEW_KEYBOARD_KEY, this.isNewKeyboard);
         o.put(KB_FONT_KEY, this.font);
         o.put(KB_OSK_FONT_KEY, this.oskFont);
+        o.put(KB_DISPLAY_NAME_KEY, this.displayName);
       } catch (JSONException e) {
         KMLog.LogException(TAG, "toJSON exception: ", e);
       }

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -193,5 +193,7 @@ mv $KMA_ROOT/KMEA/app/build/outputs/aar/$ARTIFACT $KMA_ROOT/KMAPro/kMAPro/libs/k
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample1/app/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample2/app/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Tests/KeyboardHarness/app/libs/keyman-engine.aar
-
+if [ ! -z ${RELEASE_OEM+x} ]; then
+  cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/../oem/firstvoices/android/app/libs/keyman-engine.aar
+fi
 cd ..\

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -272,6 +272,7 @@ final class FVShared {
                       keyboard.id,
                       null); // get first associated language ID
                     if (kbd != null) {
+                      kbd.setDisplayName(keyboard.name);
                       // TODO: Override fonts to NotoSansCanadianAboriginal.ttf
                       KMManager.addKeyboard(context, kbd);
                     }


### PR DESCRIPTION
Relates to #949.

* Adds setSpacebarText() API to Keyman Engine for Android
* Adds displayName API to Keyman Engine for Android
* Adds Preference for spacebar text to Keyman for Android
* Sets default spacebar text to keyboard name for FirstVoices Keyboards

New settings preference:
![image](https://user-images.githubusercontent.com/4498365/123186480-9523a680-d4db-11eb-9fee-da70463318ab.png)

Touching that preference shows:
![image](https://user-images.githubusercontent.com/4498365/123186500-9d7be180-d4db-11eb-8dee-fd290d7454f8.png)

Result:
![image](https://user-images.githubusercontent.com/4498365/123186518-a5d41c80-d4db-11eb-9180-846a0e77c277.png)
