### PR TITLE
fix(android): fixes application of nextlayer for subkeys with customized layer setting

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -272,7 +272,7 @@
         var keyPos = x.toString() + ',' + y.toString();
         for(i=0; i<obj.length; i++)
         {
-          s=s+obj[i].layer+'-'+obj[i].id;
+          s=s+obj[i].layer+'-'+obj[i].coreID;
           if(obj[i].sp == 1 || obj[i].sp == 2) shift = true;
           if(typeof(obj[i].text) != 'undefined' && obj[i].text != null && obj[i].text != '') s=s+':'+toHex(obj[i].text);
           if(i < (obj.length -1)) s=s+';'

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1044,6 +1044,10 @@ final class KMKeyboard extends WebView {
   private String getSubkeyText(String keyID, String keyText) {
     String text = keyText;
     if (text.isEmpty()) {
+      if(keyID.indexOf("U_") != -1 && keyID.indexOf("+") != -1 ) {
+        // Chop off any appended '+____' portion of the key ID.
+        keyID = keyID.substring(0, keyID.indexOf("+"));
+      }
       text = keyID.replaceAll("U_", "\\\\u");
     }
     return text;


### PR DESCRIPTION
Fixes #5339.

This change is necessary due to changes implemented within #4703.  The issue _is_ pretty niche, so I can understand how it was missed at the time - _especially_ since `executePopupKey` was robust enough to prevent total breakage of such subkeys.

## User Testing
@MakaraSok

The effective changes are most easily noted with "before and after" testing using the `sil_cameroon_qwerty` keyboard, following the repro on #5339.  The subkeys for `W` and `E` (on the shift layer) only go back to the default layer with these changes in place, while (for comparison) the subkey for `U` (same layer) works as expected both before and after.

As only subkeys are affected, testing with other keyboards that utilize subkeys isn't a bad idea.
- `gff_amharic` is often recommended for subkey testing... though I didn't find anything of note testing with it either before or after.