### PR TITLE
refactor(web): subkey abstraction (embedded step 3) - encapsulates subkey lookup, cancellation

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -62,7 +62,7 @@ namespace com.keyman.osk {
         // #3718: No longer prepend base key to subkey array
 
         let _this = this;
-        let pendingLongpress = new embedded.PendingLongpress(key);
+        let pendingLongpress = new embedded.PendingLongpress(this, key);
         pendingLongpress.promise.then(function(delegator) {
           _this.subkeyDelegator = delegator;
           if(delegator) {
@@ -297,7 +297,7 @@ namespace com.keyman.text {
 
     if(!isVisible) {
       if(delegator) {
-        delegator.resolve(null, null);
+        delegator.resolve(null);
         osk.vkbd.subkeyDelegator = null;
       }
     }
@@ -382,7 +382,7 @@ namespace com.keyman.text {
         delegator = osk.vkbd.subkeyDelegator as com.keyman.osk.embedded.SubkeyDelegator;
 
         try {
-          delegator.resolve(keyName, osk.vkbd);
+          delegator.resolve(keyName);
         } catch (e) {
           let err = e as Error;
           console.warn(err.message);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -297,7 +297,7 @@ namespace com.keyman.text {
 
     if(!isVisible) {
       if(delegator) {
-        delegator.resolve(null);
+        delegator.resolve(null, null);
         osk.vkbd.subkeyDelegator = null;
       }
     }
@@ -377,42 +377,20 @@ namespace com.keyman.text {
       keymanweb.domManager.initActiveElement(Lelem);
 
       var delegator: com.keyman.osk.embedded.SubkeyDelegator = null;
-      let selectedKey: com.keyman.osk.OSKKeySpec = null;
       // This should be set if we're within this method... but it's best to guard against nulls here, just in case.
       if(osk.vkbd.subkeyDelegator) {
         delegator = osk.vkbd.subkeyDelegator as com.keyman.osk.embedded.SubkeyDelegator;
 
-        // This is set with the base key of our current subkey elsewhere within the engine.
-        var baseKey: com.keyman.osk.OSKKeySpec = delegator.baseKey.key.spec;
-        var found = false;
-
-        if(baseKey.coreID == keyName) {
-          selectedKey = baseKey;
-          found = true;
-        } else {
-          // ... yeah, there are some funky type shenanigans between the two.
-          // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
-          selectedKey = (baseKey as com.keyman.keyboards.ActiveKey).getSubkey(keyName) as com.keyman.osk.OSKKeySpec;
-          found = !!selectedKey;
-        }
-
-        if(!found) {
-          console.warn("Could not find subkey '" + origArg + "' under the current base key '" + baseKey.coreID + "'!");
+        try {
+          delegator.resolve(keyName, osk.vkbd);
+        } catch (e) {
+          let err = e as Error;
+          console.warn(err.message);
         }
 
         osk.vkbd.subkeyDelegator = null;
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");
-      }
-
-      let Lkc: com.keyman.text.KeyEvent = null;
-      if(selectedKey) {
-        Lkc = osk.vkbd.keyEventFromSpec(selectedKey as com.keyman.keyboards.ActiveKey, null);
-        Lkc.vkCode=Lkc.Lcode;
-      }
-
-      if(delegator) {
-        delegator.resolve(Lkc);
       }
   };
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -493,7 +493,7 @@ namespace com.keyman.osk {
       // Utilized by the mobile apps; allows them to 'take over' touch handling,
       // blocking it within KMW when the apps are already managing an ongoing touch-hold.
       let keyman = com.keyman.singleton;
-      return keyman['osk'].vkbd.popupVisible;
+      return keyman['osk'].vkbd.subkeyDelegator;
     }
 
     protected dealiasSubTarget(target: HTMLDivElement): HTMLDivElement {

--- a/web/source/osk/embedded/pendingLongpress.ts
+++ b/web/source/osk/embedded/pendingLongpress.ts
@@ -1,0 +1,25 @@
+/// <reference path="subkeyDelegator.ts" />
+
+namespace com.keyman.osk.embedded {
+  export class PendingLongpress {
+    private resolver: (delegator: SubkeyDelegator) => void;
+
+    public readonly baseKey: KeyElement;
+    public readonly promise: Promise<SubkeyDelegator>;
+
+    constructor(e: KeyElement) {
+      let _this = this;
+      this.promise = new Promise<SubkeyDelegator>(function(resolve) {
+        _this.resolver = resolve;
+      });
+      this.baseKey = e;
+    }
+
+    public markActiveSubkeys() {
+      if(this.resolver) {
+        this.resolver(new SubkeyDelegator(this.baseKey));
+      }
+      this.resolver = null;
+    }
+  }
+}

--- a/web/source/osk/embedded/pendingLongpress.ts
+++ b/web/source/osk/embedded/pendingLongpress.ts
@@ -3,11 +3,13 @@
 namespace com.keyman.osk.embedded {
   export class PendingLongpress {
     private resolver: (delegator: SubkeyDelegator) => void;
+    private readonly vkbd: VisualKeyboard;
 
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<SubkeyDelegator>;
 
-    constructor(e: KeyElement) {
+    constructor(vkbd: VisualKeyboard, e: KeyElement) {
+      this.vkbd = vkbd;
       let _this = this;
       this.promise = new Promise<SubkeyDelegator>(function(resolve) {
         _this.resolver = resolve;
@@ -17,7 +19,7 @@ namespace com.keyman.osk.embedded {
 
     public markActiveSubkeys() {
       if(this.resolver) {
-        this.resolver(new SubkeyDelegator(this.baseKey));
+        this.resolver(new SubkeyDelegator(this.vkbd, this.baseKey));
       }
       this.resolver = null;
     }

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -3,9 +3,14 @@ namespace com.keyman.osk.embedded {
     private resolver: (keyEvent: text.KeyEvent) => void;
 
     public readonly baseKey: KeyElement;
+    public readonly promise: Promise<text.KeyEvent>;
 
-    constructor(e: KeyElement, resolve: (keyEvent: text.KeyEvent) => void) {
-      this.resolver = resolve;
+    constructor(e: KeyElement) {
+      let _this = this;
+      this.promise = new Promise<text.KeyEvent>(function(resolve) {
+        _this.resolver = resolve;
+      });
+
       this.baseKey = e;
     }
 

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -14,8 +14,34 @@ namespace com.keyman.osk.embedded {
       this.baseKey = e;
     }
 
-    public resolve(keyEvent: text.KeyEvent) {
+    public resolve(keyCoreID: string, vkbd: VisualKeyboard) {
       if(this.resolver) {
+        // This is set with the base key of our current subkey elsewhere within the engine.
+        var baseKey: OSKKeySpec = this.baseKey.key.spec;
+        var found = false;
+        let selectedKey: OSKKeySpec;
+
+        if(baseKey.coreID == keyCoreID) {
+          selectedKey = baseKey;
+          found = true;
+        } else {
+          // ... yeah, there are some funky type shenanigans between the two.
+          // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
+          selectedKey = (baseKey as keyboards.ActiveKey).getSubkey(keyCoreID) as OSKKeySpec;
+          found = !!selectedKey;
+        }
+
+        if(!found) {
+          this.resolver(null); // Maintains existing behavior.
+          throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
+        }
+
+        let keyEvent: text.KeyEvent = null;
+        if(selectedKey) {
+          keyEvent = vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
+          keyEvent.vkCode=keyEvent.Lcode;
+        }
+
         this.resolver(keyEvent);
       }
       this.resolver = null;

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -19,30 +19,33 @@ namespace com.keyman.osk.embedded {
 
     public resolve(keyCoreID: string) {
       if(this.resolver) {
-        // This is set with the base key of our current subkey elsewhere within the engine.
-        var baseKey: OSKKeySpec = this.baseKey.key.spec;
-        var found = false;
-        let selectedKey: OSKKeySpec;
-
-        if(baseKey.coreID == keyCoreID) {
-          selectedKey = baseKey;
-          found = true;
-        } else {
-          // ... yeah, there are some funky type shenanigans between the two.
-          // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
-          selectedKey = (baseKey as keyboards.ActiveKey).getSubkey(keyCoreID) as OSKKeySpec;
-          found = !!selectedKey;
-        }
-
-        if(!found) {
-          this.resolver(null); // Maintains existing behavior.
-          throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
-        }
-
         let keyEvent: text.KeyEvent = null;
-        if(selectedKey) {
-          keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
-          keyEvent.vkCode=keyEvent.Lcode;
+
+        if(keyCoreID != null) {
+          // This is set with the base key of our current subkey elsewhere within the engine.
+          var baseKey: OSKKeySpec = this.baseKey.key.spec;
+          var found = false;
+          let selectedKey: OSKKeySpec;
+
+          if(baseKey.coreID == keyCoreID) {
+            selectedKey = baseKey;
+            found = true;
+          } else {
+            // ... yeah, there are some funky type shenanigans between the two.
+            // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
+            selectedKey = (baseKey as keyboards.ActiveKey).getSubkey(keyCoreID) as OSKKeySpec;
+            found = !!selectedKey;
+          }
+
+          if(!found) {
+            this.resolver(null); // Maintains existing behavior.
+            throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
+          }
+
+          if(selectedKey) {
+            keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
+            keyEvent.vkCode=keyEvent.Lcode;
+          }
         }
 
         this.resolver(keyEvent);

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -1,11 +1,14 @@
 namespace com.keyman.osk.embedded {
   export class SubkeyDelegator {
     private resolver: (keyEvent: text.KeyEvent) => void;
+    private readonly vkbd: VisualKeyboard;
 
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<text.KeyEvent>;
 
-    constructor(e: KeyElement) {
+    constructor(vkbd: VisualKeyboard, e: KeyElement) {
+      this.vkbd = vkbd;
+
       let _this = this;
       this.promise = new Promise<text.KeyEvent>(function(resolve) {
         _this.resolver = resolve;
@@ -14,7 +17,7 @@ namespace com.keyman.osk.embedded {
       this.baseKey = e;
     }
 
-    public resolve(keyCoreID: string, vkbd: VisualKeyboard) {
+    public resolve(keyCoreID: string) {
       if(this.resolver) {
         // This is set with the base key of our current subkey elsewhere within the engine.
         var baseKey: OSKKeySpec = this.baseKey.key.spec;
@@ -38,7 +41,7 @@ namespace com.keyman.osk.embedded {
 
         let keyEvent: text.KeyEvent = null;
         if(selectedKey) {
-          keyEvent = vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
+          keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
           keyEvent.vkCode=keyEvent.Lcode;
         }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -45,7 +45,6 @@ namespace com.keyman.osk {
 
     // State-related properties
     ddOSK: boolean = false;
-    popupVisible: boolean;
     keyPending: KeyElement;
     touchPending: Touch;
     deleteKey: KeyElement;
@@ -70,6 +69,7 @@ namespace com.keyman.osk {
     menuEvent: KeyElement; // Used by embedded-mode.
     keytip: KeyTip;
     subkeyPopup: browser.SubkeyPopup;
+    embeddedPendingLongpress: any; // a temp, intermediate property during subkey abstraction work
     subkeyDelegator: any; // a temp, intermediate property during subkey abstraction work
 
     get layerId(): string {
@@ -518,7 +518,7 @@ namespace com.keyman.osk {
 
       // Prevent multi-touch if popup displayed
       var sk = document.getElementById('kmw-popup-keys');
-      if((sk && sk.style.visibility == 'visible') || this.popupVisible) {
+      if((sk && sk.style.visibility == 'visible') || this.subkeyDelegator) {
         return;
       }
 
@@ -615,7 +615,7 @@ namespace com.keyman.osk {
       //
       // Note that on iOS (at least), this.release() will trigger before kmwembedded.ts's
       // executePopupKey() function.
-      if(this.popupVisible) {
+      if(this.subkeyDelegator) {
         return;
       }
 
@@ -715,7 +715,7 @@ namespace com.keyman.osk {
       }
 
       // Do not move over keys if device popup visible
-      if(this.popupVisible) {
+      if(this.subkeyDelegator) {
         if(key1 == null) {
           if(key0) {
             this.highlightKey(key0,false);


### PR DESCRIPTION
For this next step (actually, _pair_ of steps), we now break the control flow for subkeys into two separate steps:

1. a "pending longpress"
    - This part is responsible for detecting and recognizing a complete longpress gesture, which then results in the display of a  subkey menu.
    - The gesture may be 'cancelled' or 'fulfilled', the latter of which results in display of the menu.
2. a "realized longpress" -> display of the subkey popup
    - Note that the `VisualKeyboard` class has code conditioned upon whether or not a subkey popup is visible in one form or other.
        - This was the role of the old `VisualKeyboard.popupVisible`, though just for the embedded codepath.

You might see where this is going in the arc overview - `PendingGesture` and `RealizedGesture`.

We would like to better encapsulate the code path into an object-oriented form that may be used to configure the OSK within the upcoming OSK-core module if possible.  The OSK-core won't have access to kmwembedded.ts, but there is a significant amount of its code that may be relocated into something that can be extracted and included within that module.

As it turns out, this is something a "two birds with one stone" scenario.  By determining a good encapsulation for the embedded code path that can also be hosted by the OSK-core, we can clarify the embedded control flow and identify its critical aspects.

------

Arc overview:

1. #5294
    - Step 1 theme:  subkey commands as async events (as _gestures_ are inherently async)
2. #5295
3. #5354
    - Step 2 theme:  code path cleanup / clarification
4. #5355
5. #5356
    - Step 3 theme:  prep for common abstraction for the two control flows
6. #5357
    - that's right - "Gesture".  These aren't intended for _just_ longpresses, though they'll be the only supported gesture at first.
    - As gestures are events that evaluate over intervals of time, they are inherently asynchronous.  Hence, the use of `Promise`s by earlier PRs in the chain.
7. #5358
    - Given a "gesture" abstraction, establishes gesture-oriented patterns 

A rough breakdown of some of the design goals + patterns may be found in the description of #5294.