### PR TITLE
refactor(web): subkey abstraction (in-browser step 3) - encapsulates pending subkey vs subkey menu state

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -150,8 +150,6 @@ namespace com.keyman.text {
   // Skip full page initialization - skips native-mode only code
   keymanweb.isEmbedded = true;
 
-  com.keyman.osk.VisualKeyboard.prototype.popupDelay = 400;  // Delay must be less than native touch-hold delay 
-  
   // Set default device options
   keymanweb.setDefaultDeviceOptions = function(opt) {
     opt['attachType'] = 'manual';

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -1,0 +1,60 @@
+/// <reference path="subkeyPopup.ts" />
+
+namespace com.keyman.osk.browser {
+  export class PendingLongpress {
+    public readonly baseKey: KeyElement;
+    //public readonly initialTouch: Touch;
+
+    public readonly subkeyUI: SubkeyPopup;
+
+    public readonly promise: Promise<SubkeyPopup>;
+
+    private readonly vkbd: VisualKeyboard;
+    private resolver: (subkeyPopup: SubkeyPopup) => void;
+
+    private timerId: number;
+    private popupDelay: number = 500;
+
+    constructor(vkbd: VisualKeyboard, baseKey: KeyElement/*, initialTouch: Touch*/) {
+      this.vkbd = vkbd;
+      this.baseKey = baseKey;
+      //this.initialTouch = initialTouch;
+
+      let _this = this;
+      this.promise = new Promise<SubkeyPopup>(function(resolve, reject) {
+        _this.timerId = window.setTimeout(
+          function() {
+            // It's no longer deferred; it's being fulfilled.
+            // Even if the actual subkey itself is still async.
+            _this.showSubkeys();
+          }, _this.popupDelay);
+      });
+
+      this.promise = new Promise(function(resolve) {
+        _this.resolver = resolve;
+      });
+    }
+
+    updateTouch(touch: Touch) {
+      this.subkeyUI.updateTouch(touch);
+    }
+
+    public cancel() {
+      if(this.timerId) {
+        window.clearTimeout(this.timerId);
+        this.timerId = null;
+      }
+
+      if(this.resolver) {        
+        this.resolver(null);
+        this.resolver = null;
+      }
+    }
+
+    public showSubkeys() {
+      if(this.resolver) {
+        this.resolver(new SubkeyPopup(this.vkbd, this.baseKey));
+      }
+    } 
+  }
+}

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -22,16 +22,13 @@ namespace com.keyman.osk.browser {
 
       let _this = this;
       this.promise = new Promise<SubkeyPopup>(function(resolve, reject) {
+        _this.resolver = resolve;
         _this.timerId = window.setTimeout(
           function() {
             // It's no longer deferred; it's being fulfilled.
             // Even if the actual subkey itself is still async.
             _this.showSubkeys();
           }, _this.popupDelay);
-      });
-
-      this.promise = new Promise(function(resolve) {
-        _this.resolver = resolve;
       });
     }
 

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -11,12 +11,18 @@ namespace com.keyman.osk.browser {
     
     private callout: HTMLDivElement;
 
+    public promise: Promise<text.KeyEvent>;
+
     // Resolves the promise that generated this SubkeyPopup.
     private resolver: (keyEvent: text.KeyEvent) => void;
 
-    constructor(vkbd: VisualKeyboard, e: KeyElement, resolve: (keyEvent: text.KeyEvent) => void) {
+    constructor(vkbd: VisualKeyboard, e: KeyElement) {
       let keyman = com.keyman.singleton;
-      this.resolver = resolve;
+      let _this = this;
+
+      this.promise = new Promise<text.KeyEvent>(function(resolve) {
+        _this.resolver = resolve;
+      })
       
       this.vkbd = vkbd;
       this.baseKey = e;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1655,13 +1655,13 @@ namespace com.keyman.osk {
             _this.clearPopup();
           });
 
-           // Otherwise append the touch-hold (subkey) array to the OSK
-           let keyman = com.keyman.singleton;
-           keyman.osk._Box.appendChild(subkeyPopup.element);
-           keyman.osk._Box.appendChild(subkeyPopup.shim);
+          // Otherwise append the touch-hold (subkey) array to the OSK
+          let keyman = com.keyman.singleton;
+          keyman.osk._Box.appendChild(subkeyPopup.element);
+          keyman.osk._Box.appendChild(subkeyPopup.shim);
 
-           // Must be placed after its `.element` has been inserted into the DOM.
-           subkeyPopup.reposition(_this);
+          // Must be placed after its `.element` has been inserted into the DOM.
+          subkeyPopup.reposition(_this);
         }
       });
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1055,6 +1055,7 @@ namespace com.keyman.osk {
 
       if(this.browserPendingLongpress) {
         this.browserPendingLongpress.cancel();
+        this.browserPendingLongpress = null;
       }
     }
 
@@ -1631,6 +1632,7 @@ namespace com.keyman.osk {
     // Clear and restart the popup timer
     if(this.browserPendingLongpress) {
       this.browserPendingLongpress.cancel();
+      this.browserPendingLongpress = null;
     }
 
     if(typeof key['subKeys'] != 'undefined' && key['subKeys'] != null) {
@@ -1638,9 +1640,13 @@ namespace com.keyman.osk {
 
       // First-level object/Promise:  will produce a subkey popup when the longpress gesture completes.
       // 'Returns' a second-level object/Promise:  resolves when a subkey is selected or is cancelled.
-      this.browserPendingLongpress = new browser.PendingLongpress(this, key);
+      let pl = this.browserPendingLongpress = new browser.PendingLongpress(this, key);
       this.browserPendingLongpress.promise.then(function(subkeyPopup) {
-        _this.browserPendingLongpress = null;
+        // Clear the longpress field upon any sort of fulfillment if it is still the current one.
+        if(_this.browserPendingLongpress == pl) {
+          _this.browserPendingLongpress = null;
+        }
+
         if(subkeyPopup) {
           // Clear key preview if any
           _this.showKeyTip(null,false);


### PR DESCRIPTION
Having determined a good breakdown of the two-step "detect, then display" control flow used to display and receive embedded-mode subkeys, we now wish to do the same for 'in-browser'/'native' mode subkeys.  This will not only help clarify the in-browser control flow for subkeys - it will also facilitate a mutual abstraction for the control flow used by both.

As such, the focus here is (also, with respect to #5355) on establishing the "pending longpress" vs "realized longpress" pattern.

------

Arc overview:

1. #5294
    - Step 1 theme:  subkey commands as async events (as _gestures_ are inherently async)
2. #5295
3. #5354
    - Step 2 theme:  code path cleanup / clarification
4. #5355
5. #5356
    - Step 3 theme:  prep for common abstraction for the two control flows
6. #5357
    - that's right - "Gesture".  These aren't intended for _just_ longpresses, though they'll be the only supported gesture at first.
    - As gestures are events that evaluate over intervals of time, they are inherently asynchronous.  Hence, the use of `Promise`s by earlier PRs in the chain.
7. #5358
    - Given a "gesture" abstraction, establishes gesture-oriented patterns 

A rough breakdown of some of the design goals + patterns may be found in the description of #5294.