### PR TITLE
refactor(web): subkey abstraction (step 4) - PendingGesture and RealizedGesture 

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -341,8 +341,6 @@ namespace com.keyman.text {
    *  @param  {string}  keyName   key identifier
    **/            
   keymanweb['executePopupKey'] = function(keyName: string) {
-      let core = (<KeymanBase> keymanweb).core;
-
       var origArg = keyName;
       if(!keymanweb.core.activeKeyboard || !osk.vkbd) {
         return false;
@@ -356,19 +354,14 @@ namespace com.keyman.text {
 
       // Can't just split on '-' because some layers like ctrl-shift contain it.
       let separatorIndex = keyName.lastIndexOf('-');
-      var layer = core.keyboardProcessor.layerId;
+      //var layer = core.keyboardProcessor.layerId;
       if (separatorIndex > 0) {
-        layer = keyName.substring(0, separatorIndex);
         keyName = keyName.substring(separatorIndex+1);
-      }
-      if(layer == 'undefined') {
-        layer=core.keyboardProcessor.layerId;
       }
 
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
-      var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=com.keyman.text.KeyboardProcessor.getModifierState(layer);
-      
+      var Lelem=keymanweb.domManager.getLastActiveElement();
       keymanweb.domManager.initActiveElement(Lelem);
 
       // This should be set if we're within this method... but it's best to guard against nulls here, just in case.

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -63,11 +63,11 @@ namespace com.keyman.osk {
 
         let _this = this;
         let pendingLongpress = new embedded.PendingLongpress(this, key);
-        pendingLongpress.promise.then(function(delegator) {
-          _this.subkeyDelegator = delegator;
-          if(delegator) {
-            delegator.promise.then(function(keyEvent) {
-              _this.subkeyDelegator = null;
+        pendingLongpress.promise.then(function(gesture) {
+          _this.subkeyGesture = gesture;
+          if(gesture) {
+            gesture.promise.then(function(keyEvent) {
+              _this.subkeyGesture = null;
               // Allow active cancellation, even if the source should allow passive.
               // It's an easy and cheap null guard.
               if(keyEvent) {
@@ -290,13 +290,13 @@ namespace com.keyman.text {
    *     
    **/
   keymanweb['popupVisible'] = function(isVisible) {
-    let delegator = osk.vkbd.subkeyDelegator as com.keyman.osk.embedded.SubkeyDelegator;
+    let delegator = osk.vkbd.subkeyGesture as com.keyman.osk.embedded.SubkeyDelegator;
     let pendingLongpress = osk.vkbd.embeddedPendingLongpress as com.keyman.osk.embedded.PendingLongpress;
 
     if(!isVisible) {
       if(delegator) {
         delegator.resolve(null);
-        osk.vkbd.subkeyDelegator = null;
+        osk.vkbd.subkeyGesture = null;
       }
     }
 
@@ -374,19 +374,18 @@ namespace com.keyman.text {
       
       keymanweb.domManager.initActiveElement(Lelem);
 
-      var delegator: com.keyman.osk.embedded.SubkeyDelegator = null;
       // This should be set if we're within this method... but it's best to guard against nulls here, just in case.
-      if(osk.vkbd.subkeyDelegator) {
-        delegator = osk.vkbd.subkeyDelegator as com.keyman.osk.embedded.SubkeyDelegator;
+      if(osk.vkbd.subkeyGesture) {
+        let gesture = osk.vkbd.subkeyGesture as com.keyman.osk.embedded.SubkeyDelegator;
 
         try {
-          delegator.resolve(keyName);
+          gesture.resolve(keyName);
         } catch (e) {
           let err = e as Error;
           console.warn(err.message);
         }
 
-        osk.vkbd.subkeyDelegator = null;
+        osk.vkbd.subkeyGesture = null;
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");
       }

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -493,7 +493,7 @@ namespace com.keyman.osk {
       // Utilized by the mobile apps; allows them to 'take over' touch handling,
       // blocking it within KMW when the apps are already managing an ongoing touch-hold.
       let keyman = com.keyman.singleton;
-      return keyman['osk'].vkbd.subkeyDelegator;
+      return keyman['osk'].vkbd.subkeyGesture && keyman.isEmbedded;
     }
 
     protected dealiasSubTarget(target: HTMLDivElement): HTMLDivElement {

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -3,11 +3,10 @@
 namespace com.keyman.osk.browser {
   export class PendingLongpress {
     public readonly baseKey: KeyElement;
+    public readonly promise: Promise<SubkeyPopup>;
     //public readonly initialTouch: Touch;
 
     public readonly subkeyUI: SubkeyPopup;
-
-    public readonly promise: Promise<SubkeyPopup>;
 
     private readonly vkbd: VisualKeyboard;
     private resolver: (subkeyPopup: SubkeyPopup) => void;
@@ -30,10 +29,6 @@ namespace com.keyman.osk.browser {
             _this.showSubkeys();
           }, _this.popupDelay);
       });
-    }
-
-    updateTouch(touch: Touch) {
-      this.subkeyUI.updateTouch(touch);
     }
 
     public cancel() {

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -1,7 +1,8 @@
 /// <reference path="subkeyPopup.ts" />
+/// <reference path="../pendingGesture.interface.ts" />
 
 namespace com.keyman.osk.browser {
-  export class PendingLongpress {
+  export class PendingLongpress implements PendingGesture {
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<SubkeyPopup>;
     //public readonly initialTouch: Touch;
@@ -26,7 +27,7 @@ namespace com.keyman.osk.browser {
           function() {
             // It's no longer deferred; it's being fulfilled.
             // Even if the actual subkey itself is still async.
-            _this.showSubkeys();
+            _this.resolve();
           }, _this.popupDelay);
       });
     }
@@ -43,7 +44,7 @@ namespace com.keyman.osk.browser {
       }
     }
 
-    public showSubkeys() {
+    public resolve() {
       if(this.resolver) {
         this.resolver(new SubkeyPopup(this.vkbd, this.baseKey));
       }

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -235,21 +235,13 @@ namespace com.keyman.osk.browser {
     }
 
     updateTouch(touch: Touch) {
-      let x = touch.clientX;
-      let y = touch.clientY;
-
       this.currentSelection = null;
 
       for(let i=0; i < this.baseKey['subKeys'].length; i++) {
         try {
           let sk= this.element.childNodes[i].firstChild as KeyElement;
-          let x0 = dom.Utils.getAbsoluteX(sk); 
-          let y0 = dom.Utils.getAbsoluteY(sk);//-document.body.scrollTop;
-          
-          let x1=x0+sk.offsetWidth;
-          let y1=y0+sk.offsetHeight;
 
-          let onKey=(x > x0 && x < x1 && y > y0 && y < y1);
+          let onKey = sk.key.isUnderTouch(touch)
           if(onKey) {
             this.baseKey.key.highlight(false);
             this.currentSelection = sk;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -1,17 +1,18 @@
 /// <reference path="oskSubKey.ts" />
+/// <reference path="../realizedGesture.interface.ts" />
 
 namespace com.keyman.osk.browser {
-  export class SubkeyPopup {
+  export class SubkeyPopup implements RealizedGesture {
     public readonly element: HTMLDivElement;
     public readonly shim: HTMLDivElement;
 
     private vkbd: VisualKeyboard;
-    public readonly baseKey: KeyElement;
     private currentSelection: KeyElement;
-    
+
     private callout: HTMLDivElement;
 
-    public promise: Promise<text.KeyEvent>;
+    public readonly baseKey: KeyElement;
+    public readonly promise: Promise<text.KeyEvent>;
 
     // Resolves the promise that generated this SubkeyPopup.
     private resolver: (keyEvent: text.KeyEvent) => void;
@@ -207,6 +208,10 @@ namespace com.keyman.osk.browser {
         // Subkeys never get key previews, so we can directly highlight the subkey.
         bk.key.highlight(true);
       }
+    }
+
+    isVisible(): boolean {
+      return this.element.style.visibility == 'visible';
     }
 
     clear() {

--- a/web/source/osk/embedded/pendingLongpress.ts
+++ b/web/source/osk/embedded/pendingLongpress.ts
@@ -1,7 +1,8 @@
 /// <reference path="subkeyDelegator.ts" />
+/// <reference path="../pendingGesture.interface.ts" />
 
 namespace com.keyman.osk.embedded {
-  export class PendingLongpress {
+  export class PendingLongpress implements PendingGesture {
     private resolver: (delegator: SubkeyDelegator) => void;
     private readonly vkbd: VisualKeyboard;
 
@@ -11,17 +12,25 @@ namespace com.keyman.osk.embedded {
     constructor(vkbd: VisualKeyboard, e: KeyElement) {
       this.vkbd = vkbd;
       let _this = this;
+
       this.promise = new Promise<SubkeyDelegator>(function(resolve) {
         _this.resolver = resolve;
       });
       this.baseKey = e;
     }
 
-    public markActiveSubkeys() {
+    public resolve() {
       if(this.resolver) {
         this.resolver(new SubkeyDelegator(this.vkbd, this.baseKey));
       }
       this.resolver = null;
+    }
+
+    public cancel() {
+      if(this.resolver) {        
+        this.resolver(null);
+        this.resolver = null;
+      }
     }
   }
 }

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -1,5 +1,7 @@
+/// <reference path="../realizedGesture.interface.ts" />
+
 namespace com.keyman.osk.embedded {
-  export class SubkeyDelegator {
+  export class SubkeyDelegator implements RealizedGesture {
     private resolver: (keyEvent: text.KeyEvent) => void;
     private readonly vkbd: VisualKeyboard;
 
@@ -51,6 +53,14 @@ namespace com.keyman.osk.embedded {
         this.resolver(keyEvent);
       }
       this.resolver = null;
+    }
+
+    public isVisible(): boolean {
+      return true;
+    }
+
+    public clear() {
+      // no-op; it's fully controlled on the app side.
     }
   }
 }

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -62,5 +62,9 @@ namespace com.keyman.osk.embedded {
     public clear() {
       // no-op; it's fully controlled on the app side.
     }
+
+    updateTouch(touch: Touch) {
+      this.baseKey.key.highlight(this.baseKey.key.isUnderTouch(touch));
+    }
   }
 }

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -8,6 +8,9 @@ namespace com.keyman.osk.embedded {
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<text.KeyEvent>;
 
+    private movedFromBaseKey: boolean = false;
+    private baseKeySelected: boolean = false;
+
     constructor(vkbd: VisualKeyboard, e: KeyElement) {
       this.vkbd = vkbd;
 
@@ -23,7 +26,10 @@ namespace com.keyman.osk.embedded {
       if(this.resolver) {
         let keyEvent: text.KeyEvent = null;
 
-        if(keyCoreID != null) {
+        if(keyCoreID == null && this.baseKeySelected) {
+          keyEvent = this.vkbd.keyEventFromSpec(this.baseKey.key.spec as keyboards.ActiveKey, null);
+          this.baseKey.key.highlight(false);
+        } else {
           // This is set with the base key of our current subkey elsewhere within the engine.
           var baseKey: OSKKeySpec = this.baseKey.key.spec;
           var found = false;
@@ -64,7 +70,15 @@ namespace com.keyman.osk.embedded {
     }
 
     updateTouch(touch: Touch) {
-      this.baseKey.key.highlight(this.baseKey.key.isUnderTouch(touch));
+      let baseKeyTouched = this.baseKey.key.isUnderTouch(touch);
+      this.baseKeySelected = this.baseKey.key.isUnderTouch(touch)
+
+      // Prevent highlighting & selection before the touch has moved from the base key.
+      if(this.movedFromBaseKey) {
+        this.baseKey.key.highlight(this.baseKeySelected);
+      } else {
+        this.movedFromBaseKey = !baseKeyTouched;
+      }
     }
   }
 }

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -430,5 +430,19 @@ namespace com.keyman.osk {
 
       return t;
     }
+
+    public isUnderTouch(touch: Touch): boolean {
+      let x = touch.clientX;
+      let y = touch.clientY;
+
+      let btn = this.btn;
+      let x0 = dom.Utils.getAbsoluteX(btn); 
+      let y0 = dom.Utils.getAbsoluteY(btn);//-document.body.scrollTop;
+      
+      let x1=x0 + btn.offsetWidth;
+      let y1=y0 + btn.offsetHeight;
+
+      return (x > x0 && x < x1 && y > y0 && y < y1);
+    }
   }
 }

--- a/web/source/osk/pendingGesture.interface.ts
+++ b/web/source/osk/pendingGesture.interface.ts
@@ -1,0 +1,9 @@
+namespace com.keyman.osk {
+  export interface PendingGesture {
+    readonly baseKey: KeyElement;
+    readonly promise: Promise<RealizedGesture>;
+
+    cancel(): void;
+    resolve?(): void;
+  }
+}

--- a/web/source/osk/realizedGesture.interface.ts
+++ b/web/source/osk/realizedGesture.interface.ts
@@ -5,5 +5,6 @@ namespace com.keyman.osk {
 
     clear(): void;
     isVisible(): boolean;
+    updateTouch(touch: Touch): void;
   }
 }

--- a/web/source/osk/realizedGesture.interface.ts
+++ b/web/source/osk/realizedGesture.interface.ts
@@ -1,0 +1,9 @@
+namespace com.keyman.osk {
+  export interface RealizedGesture {
+    readonly baseKey: KeyElement;
+    readonly promise: Promise<text.KeyEvent>;
+
+    clear(): void;
+    isVisible(): boolean;
+  }
+}

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1669,6 +1669,7 @@ namespace com.keyman.osk {
           // Must be placed after its `.element` has been inserted into the DOM.
           subkeyPopup.reposition(_this);
         }
+        _this.clearPopup();
       });
 
       if(force) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -510,8 +510,7 @@ namespace com.keyman.osk {
       this.cancelDelete();
 
       // Prevent multi-touch if popup displayed
-      var sk = document.getElementById('kmw-popup-keys');
-      if((sk && sk.style.visibility == 'visible') || this.subkeyGesture) {
+      if(this.subkeyGesture && this.subkeyGesture.isVisible()) {
         return;
       }
 
@@ -697,45 +696,28 @@ namespace com.keyman.osk {
         return;
       }
 
-      // Clear previous key highlighting
-      if(!this.subkeyPopup && key0 && key1 && key1 !== key0) {
-        this.highlightKey(key0,false);
-      }
-
-      // Do not move over keys if device popup visible
-      if(this.subkeyDelegator) {
-        if(key1 == null) {
-          if(key0) {
-            this.highlightKey(key0,false);
-          }
-          this.keyPending=null;
-          this.touchPending=null;
-        } else {
-          // Re-apply highlighting to the key if it's the current popup's base key.
-          if(this.subkeyDelegator && key1 == this.subkeyDelegator.baseKey) {
-            if(!key1.classList.contains('kmw-key-touched')) {
-              this.highlightKey(key1,true);
-            }
-            this.keyPending = key1;
-            this.touchPending = e.touches[0];
-          } else {
-            if(key0) {
-              this.highlightKey(key0,false);
-            }
-            this.keyPending = null;
-            this.touchPending = null;
-          }
+      // Clear previous key highlighting, allow subkey controller to
+      // highlight as appropriate.
+      if(this.subkeyGesture) {
+        if(key0) {
+          key0.key.highlight(false);
         }
+        this.subkeyGesture.updateTouch(e.touches[0]);
+
+        this.keyPending = null;
+        this.touchPending = null;
+
         return;
       }
 
       this.currentTarget = null;
 
       // If popup is visible, need to move over popup, not over main keyboard
+      // TODO:  responsible for the shortcutting gesture for early subkey display.
       this.highlightSubKeys(key1,x,y);
 
-      if(this.subkeyPopup) {
-        this.subkeyPopup.updateTouch(e.touches[0]);
+      // As the previous line can trigger the start of the subkey gesture...
+      if(this.subkeyGesture) {
         return;
       }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -714,8 +714,9 @@ namespace com.keyman.osk {
       this.currentTarget = null;
 
       // If popup is visible, need to move over popup, not over main keyboard
-      // TODO:  responsible for the shortcutting gesture for early subkey display.
-
+      // Could be turned into a browser-longpress specific implementation within browser.PendingLongpress?
+      // Not completely sure what the correct, generalized abstraction would be for that...
+      // and this PR's already big enough, anyway.
       if(key1 && key1['subKeys'] != null) {
         // Show popup keys immediately if touch moved up towards key array (KMEW-100, Build 353)
         if((this.touchY - e.touches[0].pageY > 5) && this.pendingSubkey && this.pendingSubkey instanceof browser.PendingLongpress) {
@@ -1628,7 +1629,7 @@ namespace com.keyman.osk {
         if(_this.pendingSubkey == pendingLongpress) {
           _this.pendingSubkey = null;
         }
-        
+
         if(subkeyPopup) {
           // Clear key preview if any
           _this.showKeyTip(null,false);

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1651,7 +1651,6 @@ namespace com.keyman.osk {
           // Must be placed after its `.element` has been inserted into the DOM.
           subkeyPopup.reposition(_this);
         }
-        _this.clearPopup();
       });
 
       if(force && this.pendingSubkey instanceof browser.PendingLongpress) {


### PR DESCRIPTION
This is what #5354 and #5355 were working toward:  the ability to define a common abstraction for individual instances of the longpress -> subkey selection control flow.

------

Arc overview:

1. #5294
    - Step 1 theme:  subkey commands as async events (as _gestures_ are inherently async)
2. #5295
3. #5354
    - Step 2 theme:  code path cleanup / clarification
4. #5355
5. #5356
    - Step 3 theme:  prep for common abstraction for the two control flows
6. #5357
    - that's right - "Gesture".  These aren't intended for _just_ longpresses, though they'll be the only supported gesture at first.
    - As gestures are events that evaluate over intervals of time, they are inherently asynchronous.  Hence, the use of `Promise`s by earlier PRs in the chain.
7. #5358
    - Given a "gesture" abstraction, establishes gesture-oriented patterns 

A rough breakdown of some of the design goals + patterns may be found in the description of #5294.

------

With few exceptions, `VisualKeyboard` doesn't actually care whether or not the _embedded_ subkey popup or the _browser-based_ subkey popup is being displayed - it only cares that _one_ of them is displayed.  Similar things may be stated for the "longpress started" aspect represented by the new `PendingLongpress` abstraction.

While instantiation of the preferred derivation of `PendingLongpress` is not yet possible to abstract, the rest of the control flow after that point _is_.  As a result, code conditioned on either state of a longpress/subkey operation can now be made significantly cleaner.