### PR TITLE
refactor(web): subkey abstraction (step 5) - longpress gesture management

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -367,16 +367,7 @@ namespace com.keyman.text {
       // This should be set if we're within this method... but it's best to guard against nulls here, just in case.
       if(osk.vkbd.subkeyGesture) {
         let gesture = osk.vkbd.subkeyGesture as com.keyman.osk.embedded.SubkeyDelegator;
-
-        try {
-          // Can trigger an error if the corresponding subkey cannot be found.
-          gesture.resolve(keyName);
-        } catch (e) {
-          let err = e as Error;
-          // Prevent the Android app from triggering a "fatal error" keyboard reset.
-          console.warn(err.message);
-        }
-
+        gesture.resolve(keyName);
         osk.vkbd.subkeyGesture = null;
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -53,31 +53,17 @@ namespace com.keyman.osk {
      * 
      * @param {Object}  key   base key element
      */            
-    VisualKeyboard.prototype.touchHold = function(this: VisualKeyboard, key: KeyElement) {
-      if(key['subKeys'] && (typeof(window['oskCreatePopup']) == 'function')) {
+    VisualKeyboard.prototype.startLongpress = function(this: VisualKeyboard, key: KeyElement): PendingGesture {
+      if(typeof(window['oskCreatePopup']) == 'function') {
         var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
             yBase = dom.Utils.getAbsoluteY(key);
 
         // #3718: No longer prepend base key to subkey array
-
-        let _this = this;
         window['oskCreatePopup'](key['subKeys'], xBase, yBase, key.offsetWidth, key.offsetHeight);
 
-        let pendingLongpress = new embedded.PendingLongpress(this, key);
-        pendingLongpress.promise.then(function(gesture) {
-          _this.subkeyGesture = gesture;
-          if(gesture) {
-            gesture.promise.then(function(keyEvent) {
-              _this.subkeyGesture = null;
-              // Allow active cancellation, even if the source should allow passive.
-              // It's an easy and cheap null guard.
-              if(keyEvent) {
-                PreProcessor.raiseKeyEvent(keyEvent);
-              }
-            });
-          }
-        });
-        this.pendingSubkey = pendingLongpress;
+        return new embedded.PendingLongpress(this, key);
+      } else {
+        return null;
       }
     };
 

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -5,7 +5,6 @@ namespace com.keyman.osk.browser {
   export class PendingLongpress implements PendingGesture {
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<SubkeyPopup>;
-    //public readonly initialTouch: Touch;
 
     public readonly subkeyUI: SubkeyPopup;
 
@@ -15,10 +14,9 @@ namespace com.keyman.osk.browser {
     private timerId: number;
     private popupDelay: number = 500;
 
-    constructor(vkbd: VisualKeyboard, baseKey: KeyElement/*, initialTouch: Touch*/) {
+    constructor(vkbd: VisualKeyboard, baseKey: KeyElement) {
       this.vkbd = vkbd;
       this.baseKey = baseKey;
-      //this.initialTouch = initialTouch;
 
       let _this = this;
       this.promise = new Promise<SubkeyPopup>(function(resolve, reject) {

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -2,6 +2,23 @@
 /// <reference path="../pendingGesture.interface.ts" />
 
 namespace com.keyman.osk.browser {
+  /**
+   * (Conceptually) represents a finite-state-machine that determines
+   * whether or not a series of touch events corresponds to a longpress
+   * touch input.  The `resolve` method may be used to trigger the
+   * subkey menu early, as with the upward quick-display shortcut.
+   * 
+   * This is the default implementation of longpress behavior for KMW.
+   * Alterate implementations are modeled through the `embedded`
+   * namespace's equivalent, which is designed to facilitate custom
+   * modeling for such gestures.
+   * 
+   * Once the conditions to recognize a longpress gesture have been
+   * fulfilled, this class's `promise` will resolve with a `SubkeyPopup`
+   * matching the gesture's 'base' key, which itself provides a
+   * `promise` field that will resolve to a `KeyEvent` once the touch
+   * sequence is completed.
+   */
   export class PendingLongpress implements PendingGesture {
     public readonly baseKey: KeyElement;
     public readonly promise: Promise<SubkeyPopup>;

--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -23,12 +23,9 @@ namespace com.keyman.osk.browser {
       let _this = this;
       this.promise = new Promise<SubkeyPopup>(function(resolve, reject) {
         _this.resolver = resolve;
-        _this.timerId = window.setTimeout(
-          function() {
-            // It's no longer deferred; it's being fulfilled.
-            // Even if the actual subkey itself is still async.
-            _this.resolve();
-          }, _this.popupDelay);
+        // After the timeout, it's no longer deferred; it's being fulfilled.
+        // Even if the actual subkey itself is still async.
+        _this.timerId = window.setTimeout(_this.resolve, _this.popupDelay);
       });
     }
 

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -236,6 +236,7 @@ namespace com.keyman.osk.browser {
 
     updateTouch(touch: Touch) {
       this.currentSelection = null;
+      let matchFound = false;
 
       for(let i=0; i < this.baseKey['subKeys'].length; i++) {
         try {
@@ -245,9 +246,16 @@ namespace com.keyman.osk.browser {
           if(onKey) {
             this.baseKey.key.highlight(false);
             this.currentSelection = sk;
+            matchFound = true;
           }
           sk.key.highlight(onKey);
         } catch(ex){}
+      }
+
+      // Use the popup duplicate of the base key if a phone with a visible popup array
+      if(!matchFound && this.baseKey.key.isUnderTouch(touch)) {
+        this.baseKey.key.highlight(true);
+        this.currentSelection = this.baseKey;
       }
     }
   }

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -263,7 +263,13 @@ namespace com.keyman.osk.browser {
             this.currentSelection = sk;
           }
           sk.key.highlight(onKey);
-        } catch(ex){}
+        } catch(ex) {
+          if(ex.message) {
+            console.error("Unexpected error when attempting to update selected subkey:" + ex.message);
+          } else {
+            console.error("Unexpected error (and error type) when attempting to update selected subkey.");
+          }
+        }
       }
 
       // Use the popup duplicate of the base key if a phone with a visible popup array

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -2,6 +2,22 @@
 /// <reference path="../realizedGesture.interface.ts" />
 
 namespace com.keyman.osk.browser {
+  /**
+   * Represents a 'realized' longpress gesture's default implementation
+   * within KeymanWeb.  Once a touch sequence has been confirmed to 
+   * correspond to a longpress gesture, implementations of this class
+   * provide the following:
+   * * The UI needed to present a subkey menu
+   * * The state management needed to present feedback about the
+   * currently-selected subkey to the user
+   * * A `Promise` that will resolve to the user's selected subkey
+   * once the longpress operation is complete.
+   * 
+   * As selection of the subkey occurs after the subkey popup is
+   * displayed, selection of the subkey is inherently asynchronous.
+   * The `Promise` may also resolve to `null` if the user indicates
+   * the desire to cancel subkey selection.
+   */
   export class SubkeyPopup implements RealizedGesture {
     public readonly element: HTMLDivElement;
     public readonly shim: HTMLDivElement;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -240,9 +240,9 @@ namespace com.keyman.osk.browser {
 
       for(let i=0; i < this.baseKey['subKeys'].length; i++) {
         try {
-          let sk= this.element.childNodes[i].firstChild as KeyElement;
+          let sk = this.element.childNodes[i].firstChild as KeyElement;
 
-          let onKey = sk.key.isUnderTouch(touch)
+          let onKey = sk.key.isUnderTouch(touch);
           if(onKey) {
             this.baseKey.key.highlight(false);
             this.currentSelection = sk;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -236,7 +236,6 @@ namespace com.keyman.osk.browser {
 
     updateTouch(touch: Touch) {
       this.currentSelection = null;
-      let matchFound = false;
 
       for(let i=0; i < this.baseKey['subKeys'].length; i++) {
         try {
@@ -246,14 +245,13 @@ namespace com.keyman.osk.browser {
           if(onKey) {
             this.baseKey.key.highlight(false);
             this.currentSelection = sk;
-            matchFound = true;
           }
           sk.key.highlight(onKey);
         } catch(ex){}
       }
 
       // Use the popup duplicate of the base key if a phone with a visible popup array
-      if(!matchFound && this.baseKey.key.isUnderTouch(touch)) {
+      if(this.currentSelection && this.baseKey.key.isUnderTouch(touch)) {
         this.baseKey.key.highlight(true);
         this.currentSelection = this.baseKey;
       }

--- a/web/source/osk/embedded/pendingLongpress.ts
+++ b/web/source/osk/embedded/pendingLongpress.ts
@@ -2,6 +2,16 @@
 /// <reference path="../pendingGesture.interface.ts" />
 
 namespace com.keyman.osk.embedded {
+  /**
+   * As control over the subkey display timer and the subkey popup are
+   * both handled by the host app within the Android app, this class
+   * serves mostly to communicate longpress state management from the
+   * app to the VisualKeyboard.
+   * 
+   * The `resolve()` function should be triggered, in some fashion, by
+   * the host app whenever it has recognized a completed longpress and
+   * will begin displaying its subkey popup.
+   */
   export class PendingLongpress implements PendingGesture {
     private resolver: (delegator: SubkeyDelegator) => void;
     private readonly vkbd: VisualKeyboard;

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -35,21 +35,20 @@ namespace com.keyman.osk.embedded {
         } else {
           // This is set with the base key of our current subkey elsewhere within the engine.
           let baseKey: OSKKeySpec = this.baseKey.key.spec;
-          var found = false;
           let selectedKey: OSKKeySpec;
 
           if(baseKey.coreID == keyCoreID) {
             selectedKey = baseKey;
-            found = true;
           } else {
             // ... yeah, there are some funky type shenanigans between the two.
             // OSKKeySpec is the OSK's... reinterpretation of the ActiveKey type.
             selectedKey = (baseKey as keyboards.ActiveKey).getSubkey(keyCoreID) as OSKKeySpec;
-            found = !!selectedKey;
           }
 
-          if(!found) {
-            this.resolver(null); // Maintains existing behavior.
+          if(!selectedKey) {
+            // While we can't complete successfully, the subkey operation is done; we
+            // should still signal that and update related gesture state management.
+            this.resolver(null);
             throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
           }
 

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -1,6 +1,8 @@
 /// <reference path="../realizedGesture.interface.ts" />
 
 namespace com.keyman.osk.embedded {
+  // "Delegator", rather than "Popup", because KMW delegates display + selection
+  // of subkeys to the host app when in the embedded context.
   export class SubkeyDelegator implements RealizedGesture {
     private resolver: (keyEvent: text.KeyEvent) => void;
     private readonly vkbd: VisualKeyboard;

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -27,6 +27,7 @@ namespace com.keyman.osk.embedded {
         let keyEvent: text.KeyEvent = null;
 
         if(keyCoreID == null && this.baseKeySelected) {
+          // Handle selection of base key underneath the subkey array.
           keyEvent = this.vkbd.keyEventFromSpec(this.baseKey.key.spec as keyboards.ActiveKey, null);
           this.baseKey.key.highlight(false);
         } else {

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -53,7 +53,7 @@ namespace com.keyman.osk.embedded {
           // Handle selection of base key underneath the subkey array.
           keyEvent = this.vkbd.keyEventFromSpec(this.baseKey.key.spec as keyboards.ActiveKey, null);
           this.baseKey.key.highlight(false);
-        } else {
+        } else if(keyCoreID != null) {
           // This is set with the base key of our current subkey elsewhere within the engine.
           let baseKey: OSKKeySpec = this.baseKey.key.spec;
           let selectedKey: OSKKeySpec;

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -34,7 +34,7 @@ namespace com.keyman.osk.embedded {
           this.baseKey.key.highlight(false);
         } else {
           // This is set with the base key of our current subkey elsewhere within the engine.
-          var baseKey: OSKKeySpec = this.baseKey.key.spec;
+          let baseKey: OSKKeySpec = this.baseKey.key.spec;
           var found = false;
           let selectedKey: OSKKeySpec;
 
@@ -53,10 +53,8 @@ namespace com.keyman.osk.embedded {
             throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
           }
 
-          if(selectedKey) {
-            keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
-            keyEvent.vkCode=keyEvent.Lcode;
-          }
+          keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);
+          keyEvent.vkCode=keyEvent.Lcode;
         }
 
         this.resolver(keyEvent);
@@ -73,14 +71,13 @@ namespace com.keyman.osk.embedded {
     }
 
     updateTouch(touch: Touch) {
-      let baseKeyTouched = this.baseKey.key.isUnderTouch(touch);
-      this.baseKeySelected = this.baseKey.key.isUnderTouch(touch)
+      this.baseKeySelected = this.baseKey.key.isUnderTouch(touch);
 
       // Prevent highlighting & selection before the touch has moved from the base key.
       if(this.movedFromBaseKey) {
         this.baseKey.key.highlight(this.baseKeySelected);
       } else {
-        this.movedFromBaseKey = !baseKeyTouched;
+        this.movedFromBaseKey = !this.baseKeySelected;
       }
     }
   }

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -70,7 +70,8 @@ namespace com.keyman.osk.embedded {
             // While we can't complete successfully, the subkey operation is done; we
             // should still signal that and update related gesture state management.
             this.resolver(null);
-            throw new Error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
+            console.error("Could not find subkey '" + keyCoreID + "' under base key '" + baseKey.coreID + "'!");
+            return;
           }
 
           keyEvent = this.vkbd.keyEventFromSpec(selectedKey as keyboards.ActiveKey, null);

--- a/web/source/osk/embedded/subkeyDelegator.ts
+++ b/web/source/osk/embedded/subkeyDelegator.ts
@@ -1,8 +1,18 @@
 /// <reference path="../realizedGesture.interface.ts" />
 
 namespace com.keyman.osk.embedded {
-  // "Delegator", rather than "Popup", because KMW delegates display + selection
-  // of subkeys to the host app when in the embedded context.
+  /**
+   * As the subkey popup view is handled by the host app when in embedded mode,
+   * this class represents the fact that KMW has "delegated" subkey UI and 
+   * selection to the host app.  Hence, "Delegator", rather than "Popup".
+   * 
+   * The `resolve` method should be triggered, in some fashion, by the host app
+   * whenever the user has completed their longpress, potentially selecting
+   * a subkey.
+   * 
+   * This class will also track the ongoing touch event in case the base key is
+   * reselected, which _is_ managed by this class, not the host app.
+   */
   export class SubkeyDelegator implements RealizedGesture {
     private resolver: (keyEvent: text.KeyEvent) => void;
     private readonly vkbd: VisualKeyboard;
@@ -24,6 +34,17 @@ namespace com.keyman.osk.embedded {
       this.baseKey = e;
     }
 
+    /**
+     * Resolves the ongoing longpress -> subkey gesture, fulfilling this
+     * `SubkeyDelegator`'s `promise` of a `KeyEvent`.
+     * 
+     * If no subkey is selected but the original base key is, `resolve(null)`
+     * will return a key event corresponding to the base key.
+
+     * 
+     * @param keyCoreID   {string}  The 'core ID' (id + modifier layer) of
+     *                              a selected subkey.  May be `null`.
+     */
     public resolve(keyCoreID: string) {
       if(this.resolver) {
         let keyEvent: text.KeyEvent = null;
@@ -69,6 +90,11 @@ namespace com.keyman.osk.embedded {
       // no-op; it's fully controlled on the app side.
     }
 
+    /**
+     * Allows this class to detect if the user may have changed their mind and
+     * re-selected the base key.
+     * @param touch 
+     */
     updateTouch(touch: Touch) {
       this.baseKeySelected = this.baseKey.key.isUnderTouch(touch);
 

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -439,8 +439,8 @@ namespace com.keyman.osk {
       let x0 = dom.Utils.getAbsoluteX(btn); 
       let y0 = dom.Utils.getAbsoluteY(btn);//-document.body.scrollTop;
       
-      let x1=x0 + btn.offsetWidth;
-      let y1=y0 + btn.offsetHeight;
+      let x1 = x0 + btn.offsetWidth;
+      let y1 = y0 + btn.offsetHeight;
 
       return (x > x0 && x < x1 && y > y0 && y < y1);
     }

--- a/web/source/osk/pendingGesture.interface.ts
+++ b/web/source/osk/pendingGesture.interface.ts
@@ -1,4 +1,40 @@
 namespace com.keyman.osk {
+  /**
+   * Used for evaluating potential gestures.  Classes adhering to this interface
+   * should instantiated whenever the (implied) state-machine allows a new touch
+   * event to mark the start of a potential new gesture.
+   * 
+   * For example, whenever a user touches a base key and there are no "realized"
+   * (fully-completed, but as-of-yet unresolved) gestures, that state allows the
+   * start of a potential new longpress event.
+   * 
+   * The role of the `PendingGesture` is complete whenever all touch-events and
+   * conditions necessary for a modeled gesture have been met.  As this point,
+   * it should be `resolve`d, fulfilling its `promise`.  This results in a
+   * `RealizedGesture` appropriate for the gesture type that is used to obtain
+   * the final `KeyEvent` for the overall gesture sequence.
+   * 
+   * For example, a "longpress" is considered resolved once the user has maintained
+   * an active, stationary touch point on the same key for a sufficiently long
+   * period without releasing it.
+   * * Were it released earlier, that would result in selection of a base key.
+   * 
+   * Alternatively, a "flick" might be considered resolved if:
+   * * a user has rapidly moved a touch point in a consistent direction
+   * * for a long enough distance
+   * * and _then_ releases that touch point within a short timeframe.
+   * 
+   * The pending gesture should only `resolve` to a realized gesture once
+   * _all_ such conditions are met, confirming that this specific gesture,
+   * and _only_ this specific gesture, could have resulted from the active
+   * touch sequence.
+   * 
+   * The `RealizedGesture` that results and is 'returned' via the Promise will
+   * be handled by the `VisualKeyboard` class, which will retrieve and forward
+   * any `KeyEvent` that results from the overall gesture input sequence. 
+   * 
+   * @see `RealizedGesture`
+   */
   export interface PendingGesture {
     readonly baseKey: KeyElement;
     readonly promise: Promise<RealizedGesture>;

--- a/web/source/osk/realizedGesture.interface.ts
+++ b/web/source/osk/realizedGesture.interface.ts
@@ -1,4 +1,28 @@
 namespace com.keyman.osk {
+  /*
+   * Implementations of this interface allow individual types of gestures to
+   * specify any additional user interaction and functionality (which may
+   * include UI elements) appropriate for obtaining a key event that may be
+   * produced by the modeled gesture type.  These should only be instantiated
+   * once the associated `PendingLongpress` is no longer 'pending' - once it
+   * has become clear that the input touch-event sequence could only correspond
+   * to the modeled gesture.
+   * 
+   * For example, when a longpress gesture completes - and hence, the user has
+   * kept their finger stationary on the same key for a long enough period -
+   * we display a popup view presenting subkeys corresponding to the gesture's
+   * underlying element.  This popup view accepts touch input and completes only
+   * upon release of the ongoing touch sequence.
+   * 
+   * Gestures are events that occur over intervals of time, and since some of them
+   * will require time and user interaction after becoming 'realized', these cases
+   * will be inherently async.  The simplest way to model this is with `Promise`s.
+   * 
+   * If appropriate for the modeled gesture type, an implementation may supply an
+   * instantly-resolving `Promise``.  This may be appropriate for modeling "flick"
+   * or "swipe" gestures in the future, which may require no additional input once
+   * such a gesture is fully realized.
+   */
   export interface RealizedGesture {
     readonly baseKey: KeyElement;
     readonly promise: Promise<text.KeyEvent>;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1655,8 +1655,7 @@ namespace com.keyman.osk {
       let key0 = previousKey;
       let key1 = currentKey;
 
-      // Clear previous key highlighting, allow subkey controller to
-      // highlight as appropriate.
+      // Clear previous key highlighting, allow subkey controller to highlight as appropriate.
       if(this.subkeyGesture) {
         if(key0) {
           key0.key.highlight(false);
@@ -1689,7 +1688,8 @@ namespace com.keyman.osk {
       }
 
       if(key0 && key1 && (key1 != key0) && (key1.id != '')) {
-        //  Display the touch-hold keys (after a pause)
+        // While there may not be an active subkey menu, we should probably update which base key
+        // is being highlighted by the current touch & start a pending longpress for it.
         this.clearPopup();
         this.initGestures(key1, touch);
       }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -626,7 +626,6 @@ namespace com.keyman.osk {
       // Process and clear highlighting of pending target
       if(this.keyPending) {
         this.highlightKey(this.keyPending,false);
-        
         // Output character unless moved off key
         if(this.keyPending.className.indexOf('hidden') < 0 && tc > 0 && !beyondEdge) {
           this.modelKeyClick(this.keyPending, e.changedTouches[0]);

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1671,8 +1671,6 @@ namespace com.keyman.osk {
 
       // If popup is visible, need to move over popup, not over main keyboard
       // Could be turned into a browser-longpress specific implementation within browser.PendingLongpress?
-      // Not completely sure what the correct, generalized abstraction would be for that...
-      // and this PR's already big enough, anyway.
       if(key1 && key1['subKeys'] != null) {
         // Show popup keys immediately if touch moved up towards key array (KMEW-100, Build 353)
         if((this.touchY - touch.pageY > 5) && this.pendingSubkey && this.pendingSubkey instanceof browser.PendingLongpress) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1672,9 +1672,9 @@ namespace com.keyman.osk {
       this.currentTarget = null;
 
       // If popup is visible, need to move over popup, not over main keyboard
-      // TODO:  responsible for the shortcutting gesture for early subkey display.
-
-      // TODO: Could be made part of the browser-specific implementation's update func?
+      // Could be turned into a browser-longpress specific implementation within browser.PendingLongpress?
+      // Not completely sure what the correct, generalized abstraction would be for that...
+      // and this PR's already big enough, anyway.
       if(key1 && key1['subKeys'] != null) {
         // Show popup keys immediately if touch moved up towards key array (KMEW-100, Build 353)
         if((this.touchY - touch.pageY > 5) && this.pendingSubkey && this.pendingSubkey instanceof browser.PendingLongpress) {
@@ -1682,7 +1682,8 @@ namespace com.keyman.osk {
         }
       }
 
-      // As the previous block can trigger the start of the subkey gesture...
+      // If there is an active popup menu (which can occur from the previous block),
+      // a subkey popup exists; do not allow base key output.
       if(this.subkeyGesture) {
         return true;
       }


### PR DESCRIPTION
While we're not yet to a point where a full-on separate gesture-management module is possible to build, we can recognize some of the general patterns that any additional gestures added in the future (like LDML's `flick`) are likely to follow.  For now, we can settle with restructuring some of the `VisualKeyboard` code required to start and update gestures into something that could be extended to work with other gesture types in the future.

------

Arc overview:

1. #5294
    - Step 1 theme:  subkey commands as async events (as _gestures_ are inherently async)
2. #5295
3. #5354
    - Step 2 theme:  code path cleanup / clarification
4. #5355
5. #5356
    - Step 3 theme:  prep for common abstraction for the two control flows
6. #5357
    - that's right - "Gesture".  These aren't intended for _just_ longpresses, though they'll be the only supported gesture at first.
    - As gestures are events that evaluate over intervals of time, they are inherently asynchronous.  Hence, the use of `Promise`s by earlier PRs in the chain.
7. #5358
    - Given a "gesture" abstraction, establishes gesture-oriented patterns 

A rough breakdown of some of the design goals + patterns may be found in the description of #5294.

------

Note that this (finally) achieves implementation of a very useful design goal:  `VisualKeyboard.startLongpress()`, which simply starts returns the appropriate `PendingGesture` for a subkey.

That `PendingGesture` is directly linked to a `Promise<text.KeyEvent>` that resolves to the user's selected subkey.  Thus, the method's caller (an internal part of `VisualKeyboard`) has a single, common point at which it can capture any and all types of subkeys the OSK may need.  From there, it can register `then` clauses in order to pass those `KeyEvent`s through its event-raising mechanism as needed for the OSK-Core module.

Further work will still be needed to properly modularize `startLongpress` in its current form, rather than relying upon JS's "method extension" paradigm, but this is already far enough along to celebrate the milestone and swap gears.  Further work, to fully modularize the in-browser vs embedded paths for proper, OO-based configuration by distinct engines, would best be done at a later point in the OSK-Core implementation.  (The 'configuration objects' will probably be / involve 'factory' types.)  `VisualKeyboard` is still too entangled with site-integration code and singleton-reliance to achieve such a goal at this point.

Instead, my next planned work items will be that event-raising mechanism itself (and use thereof) - which will facilitate removal of a lot of said singleton-reliance.