### PR TITLE
feat(ios): refinement of spacebar-captioning PR

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -280,15 +280,16 @@ public extension UserDefaults {
   
   var optSpacebarText: SpacebarText {
     get {
-      if let valueString = string(forKey: Key.optSpacebarText) {
-        return SpacebarText.fromString(mode: valueString)
+      if let valueString = string(forKey: Key.optSpacebarText),
+         let value = SpacebarText(rawValue: valueString) {
+        return value
       } else {
         return SpacebarText.LANGUAGE_KEYBOARD
       }
     }
     
     set(value) {
-      set(value.toString(), forKey: Key.optSpacebarText)
+      set(value.rawValue, forKey: Key.optSpacebarText)
     }
   }
  

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -209,7 +209,7 @@ extension KeymanWebViewController {
   }
     
   private func setSpacebarText(_ mode: SpacebarText) {
-    webView!.evaluateJavaScript("setSpacebarText('\(mode.toString())');", completionHandler: nil);
+    webView!.evaluateJavaScript("setSpacebarText('\(mode.rawValue)');", completionHandler: nil);
   }
   
   func updateSpacebarText() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -33,31 +33,12 @@ public enum VibrationSupport {
   case taptic // Has the Taptic engine, allowing use of UIImpactFeedbackGenerator for customizable vibrations
 }
 
-public enum SpacebarText {
-  case LANGUAGE
-  case KEYBOARD
-  case LANGUAGE_KEYBOARD
-  case BLANK
-
+public enum SpacebarText: String {
   // Maps to enum SpacebarText in kmwbase.ts
-  public static func fromString(mode: String) -> SpacebarText {
-    switch(mode) {
-      case "language": return LANGUAGE
-      case "keyboard": return KEYBOARD
-      case "languageKeyboard": return LANGUAGE_KEYBOARD
-      case "blank": return BLANK
-      default: return LANGUAGE_KEYBOARD
-    }
-  }
-
-  public func toString() -> String {
-    switch(self) {
-    case .LANGUAGE: return "language"
-    case .KEYBOARD: return "keyboard"
-    case .LANGUAGE_KEYBOARD: return "languageKeyboard"
-    case .BLANK: return "blank"
-    }
-  }
+  case LANGUAGE = "language"
+  case KEYBOARD = "keyboard"
+  case LANGUAGE_KEYBOARD = "languageKeyboard"
+  case BLANK = "blank"
 };
 
 /**

--- a/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
@@ -263,7 +263,7 @@ open class SettingsViewController: UITableViewController {
         break
       case "spacebartext":
         cell.accessoryType = .disclosureIndicator
-        cell.detailTextLabel?.text = NSLocalizedString("menu-settings-spacebar-hint-"+Manager.shared.spacebarText.toString(), bundle: engineBundle, comment: "")
+        cell.detailTextLabel?.text = NSLocalizedString("menu-settings-spacebar-hint-"+Manager.shared.spacebarText.rawValue, bundle: engineBundle, comment: "")
         cell.detailTextLabel?.isEnabled = true
         break
       case "showbanner", "showgetstarted":

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -26,6 +26,7 @@ display_usage ( ) {
     echo "  -no-update      If an in-place copy of KeymanEngine.framework exists, does not seek out an updated copy."
     echo "  -lib-build      Actively rebuilds KMEI before copying its build products to project resources."
     echo "  -lib-nobuild    Prevents the build script from building KeymanEngine under any circumstances."
+    echo "  -no-carthage    Disables downloading and building for dependencies."
     echo "  -no-codesign    Performs the build without code signing."
     echo "  -debug          Sets the configuration to debug mode instead of release."
     echo
@@ -85,6 +86,7 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -no-carthage)
             DO_CARTHAGE=false
+            KMEI_FLAGS="$KMEI_FLAGS -no-carthage"
             ;;
         -no-archive)
             DO_ARCHIVE=false


### PR DESCRIPTION
This is a patch PR for #5365.

The main thing here is refactoring the enum into something that leverages Swift-style `enum`s, which come with a lot of nice benefits.  We can use built-in features instead of the helper methods that were there before.