### PR TITLE
 fix(linux): Fix restarting ibus when running with sudo 

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 import time
 import gi
 import logging
@@ -68,15 +69,21 @@ def restart_ibus_subp():
 
 
 def restart_ibus(bus=None):
-    try:
-        if not bus:
-            bus = get_ibus_bus()
-        logging.info("restarting IBus")
-        bus.exit(True)
-        bus.destroy()
-    except Exception as e:
-        logging.warning("Failed to restart IBus")
-        logging.warning(e)
+    realuser = os.environ.get('SUDO_USER')
+    if realuser:
+        # we have been called with `sudo`. Restart ibus for the real user.
+        logging.info('restarting IBus by subprocess for user %s', realuser)
+        subprocess.run(['sudo', '-u', realuser, 'ibus', 'restart'])
+    else:
+        try:
+            if not bus:
+                bus = get_ibus_bus()
+            logging.info("restarting IBus")
+            bus.exit(True)
+            bus.destroy()
+        except Exception as e:
+            logging.warning("Failed to restart IBus")
+            logging.warning(e)
 
 
 def bus_has_engine(bus, name):

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -51,7 +51,7 @@ class InstallKmp():
         self.kmpdocdir = ''
         self.kmpfontdir = ''
 
-    def _check_keyman_dir(basedir, error_message):
+    def _check_keyman_dir(self, basedir, error_message):
         # check if keyman subdir exists
         keyman_dir = os.path.join(basedir, "keyman")
         if os.path.isdir(keyman_dir):


### PR DESCRIPTION
When installing in the shared area the user has to run `km-package-install` with sudo so that he has sufficient permissions.
In that case we have to do extra work to restart ibus for the logged-in user instead of root.

Fixes #5309.

Also fixes a crash in `km-package-install -p foo`.