### PR TITLE
refactor(linux): Centralize paths

### DIFF
--- a/linux/keyman-config/keyman_config/deprecated_decorator.py
+++ b/linux/keyman-config/keyman_config/deprecated_decorator.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+# based on https://stackoverflow.com/a/40301488
+import logging
+
+
+string_types = (type(b''), type(u''))
+
+
+def deprecated(reason):
+    if isinstance(reason, string_types):
+        # The @deprecated is used with a 'reason'.
+        def decorator(func1):
+            def new_func1(*args, **kwargs):
+                logging.warning("Call to deprecated function '{name}': {reason}.".format(
+                    name=func1.__name__, reason=reason))
+                return func1(*args, **kwargs)
+            return new_func1
+        return decorator
+    else:
+        # The @deprecated is used without any 'reason'.
+        def new_func2(*args, **kwargs):
+            func2 = reason
+            logging.warning("Call to deprecated function '{name}'.".format(name=func2.__name__))
+            return func2(*args, **kwargs)
+        return new_func2

--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -19,9 +19,9 @@ def get_package_download_data(packageID, weekCache=False):
     Returns:
         dict: Keyboard data
     """
-    logging.info("Getting download data for package %s", packageID)
-    api_url = KeymanDownloadsUrl + "/api/keyboard/1.0/" + packageID
-    logging.debug("At URL %s", api_url)
+    logging.info('Getting download data for package %s', packageID)
+    api_url = KeymanDownloadsUrl + '/api/keyboard/1.0/' + packageID
+    logging.debug('At URL %s', api_url)
     cache_dir = keyman_cache_dir()
     current_dir = os.getcwd()
     if weekCache:
@@ -32,7 +32,7 @@ def get_package_download_data(packageID, weekCache=False):
     requests_cache.install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
     now = time.ctime(int(time.time()))
     response = requests.get(api_url)
-    logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
+    logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
     os.chdir(current_dir)
     requests_cache.core.uninstall_cache()
     if response.status_code == 200:
@@ -51,9 +51,9 @@ def get_keyboard_data(keyboardID, weekCache=False):
     Returns:
         dict: Keyboard data
     """
-    logging.info("Getting data for keyboard %s", keyboardID)
-    api_url = KeymanApiUrl + "/keyboard/" + keyboardID
-    logging.debug("At URL %s", api_url)
+    logging.info('Getting data for keyboard %s', keyboardID)
+    api_url = KeymanApiUrl + '/keyboard/' + keyboardID
+    logging.debug('At URL %s', api_url)
     cache_dir = keyman_cache_dir()
     current_dir = os.getcwd()
     if weekCache:
@@ -64,7 +64,7 @@ def get_keyboard_data(keyboardID, weekCache=False):
     requests_cache.install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
     now = time.ctime(int(time.time()))
     response = requests.get(api_url)
-    logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
+    logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
     os.chdir(current_dir)
     requests_cache.core.uninstall_cache()
     if response.status_code == 200:
@@ -91,9 +91,9 @@ def keyman_cache_dir():
     Returns:
         str: path of user keyman cache folder
     """
-    home = os.path.expanduser("~")
-    cachebase = os.environ.get("XDG_CACHE_HOME", os.path.join(home, ".cache"))
-    km_cache = os.path.join(cachebase, "keyman")
+    home = os.path.expanduser('~')
+    cachebase = os.environ.get('XDG_CACHE_HOME', os.path.join(home, '.cache'))
+    km_cache = os.path.join(cachebase, 'keyman')
     if not os.path.isdir(km_cache):
         os.mkdir(km_cache)
     return km_cache
@@ -126,7 +126,7 @@ def get_kmp_file(downloaddata, cache=False):
         str: path where kmp file has been downloaded
     """
     if 'kmp' not in downloaddata:
-        logging.info("get_kmp.py: Package does not have a kmp file available")
+        logging.info('get_kmp.py: Package does not have a kmp file available')
         return None
 
     downloadfile = os.path.join(get_download_folder(), os.path.basename(downloaddata['kmp']))
@@ -146,7 +146,7 @@ def download_kmp_file(url, kmpfile, cache=False):
     Returns:
         str: path where kmp file has been downloaded
     """
-    logging.info("Download URL: %s", url)
+    logging.info('Download URL: %s', url)
     downloadfile = None
 
     if cache:
@@ -162,11 +162,11 @@ def download_kmp_file(url, kmpfile, cache=False):
     try:
         response = requests.get(url)  # , stream=True)
     except requests.exceptions.ConnectionError:
-        logging.error("Connection error downloading %s", url)
+        logging.error('Connection error downloading %s', url)
         return downloadfile
 
     if cache:
-        logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
+        logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
         os.chdir(current_dir)
         requests_cache.core.uninstall_cache()
 
@@ -190,6 +190,6 @@ def get_kmp(packageID):
     if (downloaddata):
         return get_kmp_file(downloaddata)
     else:
-        logging.warning("get_kmp.py: Could not get download information about keyboard package.")
+        logging.warning('get_kmp.py: Could not get download information about keyboard package.')
         return None
     return

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -10,7 +10,8 @@ from enum import Enum
 from keyman_config import _
 from keyman_config.canonical_language_code_utils import CanonicalLanguageCodeUtils
 from keyman_config.fcitx_util import is_fcitx_running, restart_fcitx
-from keyman_config.get_kmp import get_keyboard_data, user_keyboard_dir, user_keyman_font_dir
+from keyman_config.get_kmp import get_keyboard_data, get_keyboard_dir, get_keyman_doc_dir
+from keyman_config.get_kmp import get_keyman_font_dir, InstallLocation
 from keyman_config.kmpmetadata import get_metadata, KMFileTypes
 from keyman_config.convertico import extractico, checkandsaveico
 from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
@@ -89,17 +90,17 @@ class InstallKmp():
             _("You do not have permissions to install the font files to the shared font area "
               "/usr/local/share/fonts"))
 
-        return self._install_kmp(inputfile, online, language)
+        return self._install_kmp(inputfile, online, language, InstallLocation.Shared)
 
     def install_kmp_user(self, inputfile, online=False, language=None):
+        return self._install_kmp(inputfile, online, language, InstallLocation.User)
+
+    def _install_kmp(self, inputfile, online, language, area):
         self.packageID = self._extract_package_id(inputfile)
-        self.packageDir = user_keyboard_dir(self.packageID)
-        self.kmpdocdir = self.packageDir
-        self.kmpfontdir = os.path.join(user_keyman_font_dir(), self.packageID)
+        self.packageDir = get_keyboard_dir(area, self.packageID)
+        self.kmpdocdir = get_keyman_doc_dir(area, self.packageID)
+        self.kmpfontdir = get_keyman_font_dir(area, self.packageID)
 
-        return self._install_kmp(inputfile, online, language)
-
-    def _install_kmp(self, inputfile, online, language):
         if not os.path.isdir(self.packageDir):
             os.makedirs(self.packageDir)
 

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -11,26 +11,26 @@ import webbrowser
 import tempfile
 import gi
 
-from keyman_config.fcitx_util import is_fcitx_running
 gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit2', '4.0')
 
 from gi.repository import Gtk, WebKit2
 from distutils.version import StrictVersion
 from keyman_config import _
+from keyman_config.fcitx_util import is_fcitx_running
 from keyman_config.install_kmp import install_kmp, extract_kmp, get_metadata, InstallError, InstallStatus
 from keyman_config.list_installed_kmp import get_kmp_version
 from keyman_config.kmpmetadata import get_fonts
 from keyman_config.welcome import WelcomeView
 from keyman_config.uninstall_kmp import uninstall_kmp
-from keyman_config.get_kmp import user_keyboard_dir
+from keyman_config.get_kmp import InstallLocation, get_keyboard_dir, get_keyman_dir
 from keyman_config.accelerators import bind_accelerator, init_accel
 
 
 def find_keyman_image(image_file):
-    img_path = os.path.join("/usr/share/keyman/icons", image_file)
+    img_path = os.path.join(get_keyman_dir(InstallLocation.OS), "icons", image_file)
     if not os.path.isfile(img_path):
-        img_path = os.path.join("/usr/local/share/keyman/icons/", image_file)
+        img_path = os.path.join(get_keyman_dir(InstallLocation.Shared), "icons", image_file)
         if not os.path.isfile(img_path):
             img_path = os.path.join("keyman_config/icons/", image_file)
             if not os.path.isfile(img_path):
@@ -302,7 +302,7 @@ class InstallKmpWindow(Gtk.Dialog):
             result = install_kmp(self.kmpfile, self.online, language=self.language)
             if result:
                 # If install_kmp returns a string, it is an instruction for the end user,
-                # because for fcitx they will need to take extra steps to complete 
+                # because for fcitx they will need to take extra steps to complete
                 # installation themselves.
                 dialog = Gtk.MessageDialog(
                     self, 0, Gtk.MessageType.INFO,
@@ -315,7 +315,8 @@ class InstallKmpWindow(Gtk.Dialog):
             if self.viewwindow:
                 self.viewwindow.refresh_installed_kmp()
             keyboardid = os.path.basename(os.path.splitext(self.kmpfile)[0])
-            welcome_file = os.path.join(user_keyboard_dir(keyboardid), "welcome.htm")
+            welcome_file = os.path.join(get_keyboard_dir(InstallLocation.User, keyboardid),
+                                        "welcome.htm")
             if os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.debug(uri_path)

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -2,41 +2,14 @@
 
 import os
 import json
-from gi.repository import GObject
 from keyman_config.kmpmetadata import parsemetadata, parseinfdata
-from keyman_config.get_kmp import user_keyman_dir
+from keyman_config.get_kmp import get_keyman_dir, InstallLocation
+from keyman_config.deprecated_decorator import deprecated
 
 
-class InstallArea(GObject.GEnum):
-    IA_OS = 1
-    IA_SHARED = 2
-    IA_USER = 3
-    IA_UNKNOWN = 99
-
-
+@deprecated('Use get_keyman_dir(area) instead')
 def get_install_area_path(area):
-    """
-    Get the path of an install area.
-
-    Args:
-      area (InstallArea): install area to check
-            InstallArea.IA_USER: ~/.local/share/keyman
-            InstallArea.IA_SHARED: /usr/local/share/keyman
-            InstallArea.IA_OS: /usr/share/keyman
-            InstallArea.IA_UNKNOWN: /usr/share/keyman
-
-    Returns:
-        string: path of the install area
-    """
-    check_path = "/usr/share/keyman"
-    if area == InstallArea.IA_USER:
-        check_path = user_keyman_dir()
-    elif area == InstallArea.IA_SHARED:
-        check_path = "/usr/local/share/keyman"
-    elif area == InstallArea.IA_OS:
-        check_path = "/usr/share/keyman"
-
-    return check_path
+    return get_keyman_dir(area)
 
 
 def get_installed_kmp(area):
@@ -44,10 +17,10 @@ def get_installed_kmp(area):
     Get list of installed kmp in an install area.
 
     Args:
-        area (InstallArea): install area to check
-            InstallArea.IA_USER: ~/.local/share/keyman
-            InstallArea.IA_SHARED: /usr/local/share/keyman
-            InstallArea.IA_OS: /usr/share/keyman
+        area (InstallLocation): install area to check
+            InstallLocation.User: ~/.local/share/keyman
+            InstallLocation.Shared: /usr/local/share/keyman
+            InstallLocation.OS: /usr/share/keyman
     Returns:
         list: Installed kmp
             dict: Keyboard
@@ -59,7 +32,7 @@ def get_installed_kmp(area):
                 path (str): base path where keyboard is installed
                 description (str): Keyboard description
     """
-    check_paths = [get_install_area_path(area)]
+    check_paths = [get_keyman_dir(area)]
 
     return get_installed_kmp_paths(check_paths)
 
@@ -143,9 +116,9 @@ def get_kmp_version(packageID):
         None: if not found
     """
     version = None
-    user_kmp = get_installed_kmp(InstallArea.IA_USER)
-    shared_kmp = get_installed_kmp(InstallArea.IA_SHARED)
-    os_kmp = get_installed_kmp(InstallArea.IA_OS)
+    user_kmp = get_installed_kmp(InstallLocation.User)
+    shared_kmp = get_installed_kmp(InstallLocation.Shared)
+    os_kmp = get_installed_kmp(InstallLocation.OS)
 
     if packageID in os_kmp:
         version = os_kmp[packageID]['version']
@@ -180,7 +153,7 @@ def get_kmp_version_user(packageID):
         str: kmp version if kmp ID is installed
         None: if not found
     """
-    user_kmp = get_installed_kmp(InstallArea.IA_USER)
+    user_kmp = get_installed_kmp(InstallLocation.User)
     if packageID in user_kmp:
         return user_kmp[packageID]['version']
     else:

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -4,7 +4,8 @@ import logging
 import os.path
 from shutil import rmtree
 
-from keyman_config.get_kmp import user_keyboard_dir, user_keyman_font_dir
+from keyman_config.fcitx_util import is_fcitx_running
+from keyman_config.get_kmp import InstallLocation, get_keyboard_dir, get_keyman_doc_dir, get_keyman_font_dir
 from keyman_config.kmpmetadata import get_metadata
 from keyman_config.ibus_util import uninstall_from_ibus, get_ibus_bus, restart_ibus
 from keyman_config.gnome_keyboards_util import GnomeKeyboardsUtil, get_ibus_keyboard_id, is_gnome_shell
@@ -17,13 +18,13 @@ def uninstall_kmp_shared(packageID):
     Args:
         packageID (str): Keyboard package ID
     """
-    kbdir = os.path.join('/usr/local/share/keyman', packageID)
+    kbdir = get_keyboard_dir(InstallLocation.Shared, packageID)
     if not os.path.isdir(kbdir):
         logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
         exit(3)
 
-    kbdocdir = os.path.join('/usr/local/share/doc/keyman', packageID)
-    kbfontdir = os.path.join('/usr/local/share/fonts/keyman', packageID)
+    kbdocdir = get_keyman_doc_dir(InstallLocation.Shared, packageID)
+    kbfontdir = get_keyman_font_dir(InstallLocation.Shared, packageID)
 
     logging.info("Uninstalling shared keyboard: %s", packageID)
     if not os.access(kbdir, os.X_OK | os.W_OK):  # Check for write access of keyman dir
@@ -99,6 +100,10 @@ def uninstall_keyboards_from_gnome(keyboards, packageDir):
     gnomeKeyboardsUtil.write_input_sources(sources)
 
 
+def _uninstall_keyboards_from_fcitx5():
+    return _('Please use fcitx5-configtool to remove the keyboard from the group')
+
+
 def uninstall_kmp_user(packageID):
     """
     Uninstall a kmp from ~/.local/share/keyman
@@ -106,14 +111,16 @@ def uninstall_kmp_user(packageID):
     Args:
         packageID (str): Keyboard package ID
     """
-    kbdir = user_keyboard_dir(packageID)
+    kbdir = get_keyboard_dir(InstallLocation.User, packageID)
     if not os.path.isdir(kbdir):
         logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
         exit(3)
     logging.info("Uninstalling local keyboard: %s", packageID)
     info, system, options, keyboards, files = get_metadata(kbdir)
     if keyboards:
-        if is_gnome_shell():
+        if is_fcitx_running():
+            _uninstall_keyboards_from_fcitx5()
+        elif is_gnome_shell():
             uninstall_keyboards_from_gnome(keyboards, kbdir)
         else:
             uninstall_keyboards_from_ibus(keyboards, kbdir)
@@ -121,7 +128,7 @@ def uninstall_kmp_user(packageID):
         logging.warning("could not uninstall keyboards")
     rmtree(kbdir)
     logging.info("Removed user keyman directory: %s", kbdir)
-    fontdir = os.path.join(user_keyman_font_dir(), packageID)
+    fontdir = get_keyman_font_dir(InstallLocation.User, packageID)
     if os.path.isdir(fontdir):
         rmtree(fontdir)
         logging.info("Removed user keyman font directory: %s", fontdir)

--- a/linux/keyman-config/km-package-list-installed
+++ b/linux/keyman-config/km-package-list-installed
@@ -25,26 +25,27 @@ def main():
         logging.basicConfig(format='%(levelname)s:%(message)s')
 
     all = not args.user and not args.shared and not args.os
-    from keyman_config.list_installed_kmp import get_installed_kmp, get_install_area_path, InstallArea
+    from keyman_config.list_installed_kmp import get_installed_kmp
+    from keyman_config.get_kmp import get_keyman_dir, InstallLocation
     if args.user or all:
-        installed_kmp = get_installed_kmp(InstallArea.IA_USER)
+        installed_kmp = get_installed_kmp(InstallLocation.User)
         if args.verbose or args.veryverbose:
-            print("--- Installed user Keyman keyboard packages (%s) ---" % (get_install_area_path(InstallArea.IA_USER)))
+            print("--- Installed user Keyman keyboard packages (%s) ---" % (get_keyman_dir(InstallLocation.User)))
         else:
             print("--- Installed user Keyman keyboard packages ---")
         print_keyboards(installed_kmp, args.long)
     if args.shared or all:
-        installed_kmp = get_installed_kmp(InstallArea.IA_SHARED)
+        installed_kmp = get_installed_kmp(InstallLocation.Shared)
         if args.verbose or args.veryverbose:
             print("--- Installed shared Keyman keyboard packages (%s) ---" %
-                  (get_install_area_path(InstallArea.IA_SHARED)))
+                  (get_keyman_dir(InstallLocation.Shared)))
         else:
             print("--- Installed shared Keyman keyboard packages ---")
         print_keyboards(installed_kmp, args.long)
     if args.os or all:
-        installed_kmp = get_installed_kmp(InstallArea.IA_OS)
+        installed_kmp = get_installed_kmp(InstallLocation.OS)
         if args.verbose or args.veryverbose:
-            print("--- Installed OS Keyman keyboard packages (%s) ---" % (get_install_area_path(InstallArea.IA_OS)))
+            print("--- Installed OS Keyman keyboard packages (%s) ---" % (get_keyman_dir(InstallLocation.OS)))
         else:
             print("--- Installed OS Keyman keyboard packages ---")
         print_keyboards(installed_kmp, args.long)


### PR DESCRIPTION
Introduce methods to get paths instead of hard-coding the values. This also deprecates four methods (`user_keyman_dir`,
`user_keyman_font_dir`, `user_keyboard_dir`, and `get_isntall_area_path`).

This change also fixes a crash trying to install a package in the shared area.