### PR TITLE
feat(android): hide textarea for perf

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -41,7 +41,7 @@
       ta.readOnly = false;
 
       // Tell KMW the default banner height to use
-      com.keyman.osk.Banner.DEFAULT_HEIGHT = 
+      com.keyman.osk.Banner.DEFAULT_HEIGHT =
         Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
 
       kmw.addEventListener('keyboardloaded', setIsChiral);
@@ -320,7 +320,7 @@
 
     function executePopupKey(keyID, keyText) {
       var kmw=window['keyman'];
-      
+
       // KMW only needs keyID to process the popup key. keyText merely logged to console
       //window.console.log('executePopupKey('+keyID+'); keyText: ' + keyText);
       kmw['executePopupKey'](keyID);
@@ -366,8 +366,6 @@
   </style>
 </head>
 <body class="kmw-embedded keyman-app">
-<center>
-  <textarea id="ta" cols="1" rows="1" style="position:absolute; left:-500px; top:0px;"></textarea>
-</center>
+  <textarea id="ta" cols="1" rows="1" style="display: none;"></textarea>
 </body>
 </html>


### PR DESCRIPTION
Relates to #5258.

Unnecessary layout recalc eliminated by hiding the backing
textarea with `display:none`. This improved performance by roughly
20%.