### PR TITLE
chore: keyboard_info.source.json 1.0.6

### DIFF
--- a/windows/src/global/inst/data/keyboard_info/README.md
+++ b/windows/src/global/inst/data/keyboard_info/README.md
@@ -9,6 +9,12 @@ New versions should be deployed to **keymanapp/keyman/windows/src/global/inst/ke
 
 # .keyboard_info version history
 
+## 2019-09-06 1.0.6 stable
+* No changes (see api.keyman.com#36 and api.keyman.com#59. Reverted in 2020-06-10.).
+
+## 2018-12-18 1.0.5 stable
+* Deprecate languages[] array. Update KeyboardLanguageInfo object to include subtag names.
+
 ## 2018-11-26 1.0.4 stable
 * Add helpLink field - a link to a keyboard's help page on help.keyman.com if it exists.
 

--- a/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
+++ b/windows/src/global/inst/data/keyboard_info/keyboard_info.source.json
@@ -1,7 +1,7 @@
-{ 
+{
   "$schema": "http://json-schema.org/schema#",
   "$ref": "#/definitions/KeyboardInfo",
-  
+
   "definitions": {
     "KeyboardInfo": {
       "type": "object",
@@ -28,23 +28,23 @@
         "encodings": { "type": "array", "items": { "type": "string", "enum": ["ansi", "unicode"] }, "additionalItems": false },
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
         "version": { "type": "string" },
-        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.\\d$" },
         "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
         "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
         "legacyId": { "type": "number" },
         "sourcePath": { "type": "string", "pattern": "^(release|legacy|experimental)/.+/.+$" },
-        "related": { "type": "object", "patternProperties": { 
+        "related": { "type": "object", "patternProperties": {
           ".": { "$ref": "#/definitions/KeyboardRelatedInfo" }
           },
           "additionalProperties": false
-        }
+        },
+        "deprecated": { "type": "boolean" }
       },
       "required": [
         "license", "languages"
-      ],
-      "additionalProperties": false
+      ]
     },
-  
+
     "KeyboardLanguageInfo": {
       "type": "object",
       "patternProperties": {
@@ -52,18 +52,22 @@
       },
       "additionalProperties": false
     },
-    
+
     "KeyboardLanguageInfoItem": {
       "type": "object",
       "properties": {
         "font": { "$ref": "#/definitions/KeyboardFontInfo" },
         "oskFont": { "$ref": "#/definitions/KeyboardFontInfo" },
-        "example": { "$ref": "#/definitions/KeyboardExampleInfo" }
+        "example": { "$ref": "#/definitions/KeyboardExampleInfo" },
+        "displayName": { "type": "string" },
+        "languageName": { "type": "string" },
+        "scriptName": { "type": "string" },
+        "regionName": { "type": "string" }
       },
       "required": [],
       "additionalProperties": false
     },
-    
+
     "KeyboardFontInfo": {
       "type": "object",
       "properties": {
@@ -81,9 +85,9 @@
     "KeyboardExampleInfo": {
       "type": "object",
       "properties": {
-        "keys": { "anyOf": [ 
+        "keys": { "anyOf": [
           { "type": "string" },
-          { "type": "array", "items": { 
+          { "type": "array", "items": {
             "anyOf": [
               { "type": "string" },
               { "$ref": "#/definitions/KeyboardExampleKeyInfo" }
@@ -96,7 +100,7 @@
       "required": [],
       "additionalProperties": false
     },
-    
+
     "KeyboardExampleKeyInfo": {
       "type": "object",
       "properties": {
@@ -106,7 +110,7 @@
           "K_N", "K_O", "K_P", "K_Q", "K_R", "K_S", "K_T", "K_U", "K_V", "K_W", "K_X", "K_Y", "K_Z",
           "K_1", "K_2", "K_3", "K_4", "K_5", "K_6", "K_7", "K_8", "K_9", "K_0",
           "K_BKQUOTE", "K_HYPHEN", "K_EQUAL", "K_LBRKT", "K_RBRKT", "K_BKSLASH", "K_COLON",
-          "K_QUOTE", "K_COMMA", "K_PERIOD", "K_SLASH", 
+          "K_QUOTE", "K_COMMA", "K_PERIOD", "K_SLASH",
           "K_oE2", "K_BKSP", "K_TAB", "K_ENTER", "K_ESC",
           "K_LEFT", "K_UP", "K_RIGHT", "K_DOWN", "K_PGUP", "K_PGDN", "K_HOME", "K_END", "K_INS", "K_DEL",
           "K_F1", "K_F2", "K_F3", "K_F4", "K_F5", "K_F6", "K_F7", "K_F8", "K_F9", "K_F10", "K_F11", "K_F12",
@@ -135,7 +139,7 @@
       "required": ["key"],
       "additionalProperties": false
     },
-    
+
     "KeyboardLinkInfo": {
       "type": "object",
       "properties": {
@@ -145,7 +149,7 @@
       "required": ["name", "url"],
       "additionalProperties": false
     },
-    
+
     "KeyboardPlatformInfo": {
       "type": "object",
       "patternProperties": {
@@ -154,7 +158,7 @@
       "required": [],
       "additionalProperties": false
     },
-    
+
     "KeyboardRelatedInfo": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Brings this file up to date with the version found on [api.keyman.com](https://api.keyman.com/schemas/keyboard_info.source/1.0.6/keyboard_info.source.json)