### PR TITLE
fix(common): get handle caller buffer size small than internal Fixes …

### DIFF
--- a/common/core/desktop/src/kmx/kmx_context.cpp
+++ b/common/core/desktop/src/kmx/kmx_context.cpp
@@ -35,7 +35,8 @@ KMX_WCHAR *KMX_Context::BufMax(int n)
 	if(CurContext == p || n == 0) return p; // empty context or 0 characters requested, return pointer to end of context
 
   KMX_WCHAR *q = p;
-	for(; p != NULL && p > CurContext && (intptr_t)(q-p) < n; p = decxstr(p, CurContext));
+	for(; p != NULL && p > CurContext && (intptr_t)(q-p) < n; p = decxstr(p, CurContext))
+  ; // ; on new line to tell compiler empty loop is intentional
 
   if((intptr_t)(q-p) > n) p = incxstr(p); // Copes with deadkey or supplementary pair at start of returned buffer making it too long
 

--- a/common/core/desktop/src/kmx/kmx_context.cpp
+++ b/common/core/desktop/src/kmx/kmx_context.cpp
@@ -29,6 +29,18 @@ void KMX_Context::Add(KMX_WCHAR ch)
   //DebugLog("KMX_Context::Add(%x):  EXIT [%d]: %s", ch, pos, Debug_UnicodeString(CurContext));
 }
 
+KMX_WCHAR *KMX_Context::BufMax(int n)
+{
+  KMX_WCHAR *p = (KMX_WCHAR *) u16chr(CurContext, 0);
+	if(CurContext == p || n == 0) return p; // empty context or 0 characters requested, return pointer to end of context
+
+  KMX_WCHAR *q = p;
+	for(; p != NULL && p > CurContext && (intptr_t)(q-p) < n; p = decxstr(p, CurContext));
+
+  if((intptr_t)(q-p) > n) p = incxstr(p); // Copes with deadkey or supplementary pair at start of returned buffer making it too long
+
+  return p;
+}
 
 KMX_WCHAR *KMX_Context::Buf(int n)
 {
@@ -63,11 +75,17 @@ void KMX_Context::Reset()
 
 void KMX_Context::Get(KMX_WCHAR *buf, int bufsize)
 {
-  for(KMX_WCHAR *p = CurContext; *p && bufsize > 0; p++, bufsize--)
+  for (KMX_WCHAR *p = this->BufMax(bufsize); *p && bufsize > 0; p++, bufsize--)
   {
-    *buf = *p; buf++;
-    if(*p >= 0xD800 && *p <= 0xDBFF) { *buf = *(++p); bufsize--; buf++; }
+    *buf = *p;
+    if(Uni_IsSurrogate1(*p) && bufsize - 2 > 0) {
+      buf++; p++;
+      *buf = *p;
+      bufsize--;
+    }
+    buf++;
   }
+
   *buf = 0;
 }
 

--- a/common/core/desktop/src/kmx/kmx_context.h
+++ b/common/core/desktop/src/kmx/kmx_context.h
@@ -21,15 +21,89 @@ private:
 
 public:
   KMX_Context();
+
+  /**
+   * @brief Copy "source" AppContext to this AppContext
+   *
+   * @param source KMX_Context to copy
+   */
   void CopyFrom(KMX_Context *source);
+
+  /**
+   * @brief  Add a single code unit to the Current Context. Not necessarily a complete code point
+   *
+   * @param Code unit to add
+   */
   void Add(KMX_WCHAR ch);
+
+  /**
+   * @brief  Removes a single code point from the end of the CurContext closest to the caret;
+   *         i.e. it will be both code units if a surrogate pair. If it is a deadkey it will
+   *         remove three code points: UC_SENTINEL, CODE_DEADKEY and deadkey value.
+   */
   void Delete();
+
+   /**
+   * @brief Clears the CurContext and resets the position - pos - index
+   */
   void Reset();
+
+   /**
+   * @brief  Copies the characters in CurContext to supplied buffer.
+   *         If bufsize is reached before the entire context was copied, the buf
+   *         will be truncated to number of valid characters possible with null character
+   *         termination. e.g. it will be one code unit less than bufsize if that would
+   *         have meant splitting a surrogate pair
+   * @param buf      The data buffer to copy current context
+   * @param bufsize  The number of code units ie size of the KMX_WCHAR buffer - not the code points
+   */
   void Get(KMX_WCHAR *buf, int bufsize);
+
+   /**
+   * @brief Sets the CurContext to the supplied buf character array and updates the pos index.
+   *
+   * @param buf
+   */
   void Set(const KMX_WCHAR *buf);
+
+  /**
+   * @brief  Returns a pointer to the character in the current context buffer which
+   *         will have at most n valid xstring units remaining until the null terminating
+   *         character. It will be one code unit less than bufsize if that would
+   *         have meant splitting a surrogate pair or deadkey.
+   *
+   * @param n        The maximum number of valid xstring units (not code points or code units)
+   * @return WCHAR*  Pointer to the start postion for a buffer of maximum n xstring units
+   */
   KMX_WCHAR *Buf(int n);
-  KMX_WCHAR *GetFullContext() { return CurContext; }
+
+  /**
+   * @brief  Returns a pointer to the character in the current context buffer which
+   *         will have at most n code units remaining until the the null terminating character.
+   *         Note: Unlike BufMax there is no checking for truncation of code points.
+   *         e.g. the pointer may point to a code unit that is half of a surrogate pair.
+   *
+   * @param n
+   * @return WCHAR* Pointer to the start postion for a buffer of maximum n characters
+   */
+  KMX_WCHAR *BufMax(int n);
+
+  /**
+   * @brief Return a pointer to the CurContext buffer
+   *
+   * @return KMX_WCHAR*
+   */
+  const KMX_WCHAR *GetFullContext() { return CurContext; }
+  /**
+   * @brief Returns TRUE if the last xstring unit in the context is a deadkey
+   *
+   * @return BOOL
+   */
   KMX_BOOL CharIsDeadkey();
+  /**
+  * @brief Returns TRUE if the last xstring unit in the CurContext is a surrogate pair.
+  * @return BOOL
+  */
   KMX_BOOL CharIsSurrogatePair();
 };
 

--- a/common/core/desktop/src/kmx/kmx_context.h
+++ b/common/core/desktop/src/kmx/kmx_context.h
@@ -73,7 +73,7 @@ public:
    *         have meant splitting a surrogate pair or deadkey.
    *
    * @param n        The maximum number of valid xstring units (not code points or code units)
-   * @return WCHAR*  Pointer to the start postion for a buffer of maximum n xstring units
+   * @return KMX_WCHAR*  Pointer to the start postion for a buffer of maximum n xstring units
    */
   KMX_WCHAR *Buf(int n);
 
@@ -84,7 +84,7 @@ public:
    *         e.g. the pointer may point to a code unit that is half of a surrogate pair.
    *
    * @param n
-   * @return WCHAR* Pointer to the start postion for a buffer of maximum n characters
+   * @return KMX_WCHAR* Pointer to the start postion for a buffer of maximum n characters
    */
   KMX_WCHAR *BufMax(int n);
 

--- a/windows/src/engine/keyman32/appint/appint.h
+++ b/windows/src/engine/keyman32/appint/appint.h
@@ -110,7 +110,6 @@ public:
 
   /**
    * @brief Clears the CurContext and resets the position - pos - index
-   *
    */
   void Reset();
 


### PR DESCRIPTION
This is equivalent to the #5383 PR. Which was for the AppContext class this is KMX_context class in the core engine.
Fixes #5336
Also made the GetFullContext return a const for safety