### PR TITLE
fix(developer): builder and editor commands were ignored

### DIFF
--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -389,7 +389,7 @@ async function loadSettings() {
   var commands = [];
 
   var command = function (cmd) {
-    if (navigator.userAgent.indexOf('TIKE') < 0) {
+    if (navigator.userAgent.indexOf('Keyman') < 0) {
       // Don't execute command if not in the correct host application (allows for browser-based testing)
       return false;
     }

--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1119,7 +1119,7 @@ $(function () {
   this.commands = [];
 
   this.command = function (cmd) {
-    if (navigator.userAgent.indexOf('TIKE') < 0) {
+    if (navigator.userAgent.indexOf('Keyman') < 0) {
       return false;
     }
     // queue commands to build a single portmanteau command when we return to idle


### PR DESCRIPTION
As we changed the User Agent string to have 'Keyman' instead of 'TIKE', the builder and editor commands were being ignored. This meant that changes to files would not be saved, among other terrible things.

This change was introduced with the Chromium update.