### PR TITLE
fix(web): console errors when using SHIFT w help-text 'osk'

### DIFF
--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -313,7 +313,11 @@ namespace com.keyman.osk {
       source: text.MutableSystemStore,
       newValue: string) {
       if(source.value != newValue) {
-        this.vkbd.layerId = newValue;
+        // Prevents console errors when a keyboard only displays help.
+        // Can occur when using SHIFT with sil_euro_latin on a desktop form-factor.
+        if(this.vkbd) {
+          this.vkbd.layerId = newValue;
+        }
         this._Show();
       }
     }.bind(this);


### PR DESCRIPTION
Noticed this odd behavior when using KMW with a desktop form factor and `sil_euro_latin` - console errors occur when using hardware modifier keys, as there are no actual OSK layers to shift among due to use of "help text" instead of the `VisualKeyboard` class in that mode.