### PR TITLE
fix(linux): Improve bitmap conversion

### DIFF
--- a/linux/keyman-config/keyman_config/convertico.py
+++ b/linux/keyman-config/keyman_config/convertico.py
@@ -5,8 +5,9 @@ import numpy as np
 import os
 import sys
 import struct
-from PIL import Image
+from PIL import Image, ImageFile
 Image.LOAD_TRUNCATED_IMAGES = True
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 def changeblacktowhite(im):


### PR DESCRIPTION
Converting some bitmaps fail with a truncation error. This change
allows to successfully convert the bitmap files.

Fixes #5400.