### PR TITLE
chore(developer): remove obsolete InitClasses

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -317,7 +317,6 @@ begin
           Application.Title := 'Keyman Developer';
           //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
-          InitClasses;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
           Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
           Application.Run;

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmMain
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    24 Aug 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     01 Aug 2006 - mcdurdin - Rework ui using sp-TBX
                     02 Aug 2006 - mcdurdin - Remove old menu
@@ -410,15 +410,12 @@ type
 var
   frmKeymanDeveloper: TfrmKeymanDeveloper;
 
-procedure InitClasses;
-
 implementation
 
 uses
   System.Math,
   Winapi.WinInet,
   Winapi.ShlObj,
-  Winapi.Urlmon,
   Winapi.UxTheme,
   System.Win.ComObj,
   Vcl.Themes,
@@ -1542,13 +1539,6 @@ begin
   // Tell project window to refresh!
   if ProjectForm <> nil then
     ProjectForm.SetGlobalProject;
-end;
-
-procedure InitClasses;  // I3350
-const
-  CUserAgent: AnsiString = 'Mozilla/5.0 (compatible; MSIE 11.0; Windows NT 6.1; WOW64; Trident/5.0; TIKE/'+SKeymanVersion+')';   // I4045
-begin
-   OleCheck(UrlMkSetSessionOption(URLMON_OPTION_USERAGENT, PAnsiChar(CUserAgent), Length(CUserAgent), 0));   // I4045
 end;
 
 end.


### PR DESCRIPTION
This function is no longer necessary as we no longer use the Trident (IE) engine for hosting web pages.