### PR TITLE
feat(android): Spacebar text controls 🍒

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -128,49 +128,10 @@
       return true;
     }
 
-    function setKeymanLanguage(keyboardName, internalName, languageName, langId, kbdFile, font, oskFont, package) {
-      var kmw=window['keyman'];
-      var kbdInterface=window.KeymanWeb;
-
-      // Defaults for missing arguments
-      switch (arguments.length) {
-        case 1:
-          internalName = keyboardName;
-          if (keyboardName == 'English') {
-              internalName = 'us';
-          }
-          break;
-        case 2:
-          languageName = keyboardName;
-          break;
-        case 3:
-          langId='';
-          break;
-        case 6:
-          oskFont = font;
-          break;
-      }
-
-      var k = {
-        KN:keyboardName,
-        KI:'Keyboard_'+internalName,
-        KLC:langId,
-        KL:languageName,
-        KF:kbdFile,
-        KP:package
-      };
-      if (font) {
-        k.KFont = font;
-        //window.console.log('keyboard.html assigning k.KFont = ' + font);
-      }
-      if (oskFont) {
-        k.KOskFont = oskFont;
-        //window.console.log('keyboard.html assigning k.KOskFont = ' + oskFont);
-      }
-      kbdInterface.registerStub(k);
-
-      kmw['setActiveKeyboard'](package + '::Keyboard_'+internalName,langId);
-      kmw['osk']['show'](true);
+    function setKeymanLanguage(k) {
+      KeymanWeb.registerStub(k);
+      keyman.setActiveKeyboard(k.KP + '::'+k.KI, k.KLC);
+      keyman.osk.show(true);
     }
 
     /**

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -134,6 +134,11 @@
       keyman.osk.show(true);
     }
 
+    function setSpacebarText(mode) {
+      keyman.options['spacebarText'] = mode;
+      keyman.osk.show(true);
+    }
+
     /**
      * Inserts the selected string <i>s</i>
      * @param dn  Number of pre-caret code points (UTF+8 characters) to delete

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1032,7 +1032,7 @@ final class KMKeyboard extends WebView {
    * 1. Replace "source" keys for "files" keys
    * 2. Create full font paths for .ttf or .svg
    * @param font String font JSON object as a string
-   * @return String of modified font information with full paths. If font is invalid, return "''"
+   * @return JSONObject of modified font information with full paths. If font is invalid, return `null`
    */
   private JSONObject makeFontPaths(String font) {
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -505,60 +505,37 @@ final class KMKeyboard extends WebView {
         KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
     }
 
+    if(kOskFont == null || kOskFont.isEmpty())
+      kOskFont = kFont;
+
+    JSONObject jDisplayFont = makeFontPaths(kFont);
+    JSONObject jOskFont = makeFontPaths(kOskFont);
+
+    txtFont = getFontFilename(jDisplayFont);
+    oskFont = getFontFilename(jOskFont);
+
     String kbKey = KMString.format("%s_%s", languageID, keyboardID);
 
     setKeyboardRoot(packageID);
     String keyboardPath = makeKeyboardPath(packageID, keyboardID, keyboardVersion);
 
-    String tFont = "''";
-    String oFont = null;
-    if (kFont == null) {
-      txtFont = "";
-    } else {
-      if (FileUtils.hasFontExtension(kFont)) {
-        txtFont = kFont;
-        tFont = KMString.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kFont.substring(0, kFont.length() - 4), keyboardRoot, kFont);
-      } else {
-        txtFont = getFontFilename(kFont);
-        if (!txtFont.isEmpty()) {
-          tFont = makeFontPaths(kFont);
-        }
-      }
+    JSONObject reg = new JSONObject();
+    try {
+      reg.put("KN", keyboardName);
+      reg.put("KI", "Keyboard_" + keyboardID);
+      reg.put("KLC", languageID);
+      reg.put("KL", languageName);
+      reg.put("KF", keyboardPath);
+      reg.put("KP", packageID);
+
+      if (jDisplayFont != null) reg.put("KFont", jDisplayFont);
+      if (jOskFont != null) reg.put("KOskFont", jOskFont);
+    } catch(JSONException e) {
+      KMLog.LogException(TAG, "", e);
+      return false;
     }
 
-    if (kOskFont == null || kOskFont.isEmpty()) {
-      oskFont = null;
-    } else {
-      if (FileUtils.hasFontExtension(kOskFont)) {
-        oskFont = kOskFont;
-        oFont = KMString.format("{\"family\":\"font_family_%s\",\"files\":[\"%s%s\"]}", kOskFont.substring(0, kOskFont.length() - 4), keyboardRoot, kOskFont);
-      } else {
-        oskFont = getFontFilename(kOskFont);
-        if (!oskFont.isEmpty()) {
-          oFont = makeFontPaths(kOskFont);
-        } else {
-          oskFont = null;
-        }
-      }
-    }
-
-    if (oFont == null) {
-      oFont = tFont;
-    }
-
-    if (tFont.equals("''")) {
-      tFont = fontUndefined;
-    }
-    if (oFont.equals("''")) {
-      oFont = fontUndefined;
-    }
-
-    // Escape single-quoted names for javascript call
-    keyboardName = keyboardName.replaceAll("\'", "\\\\'"); // Double-escaped-backslash b/c regex.
-    languageName = languageName.replaceAll("\'", "\\\\'");
-
-    String jsFormat = "setKeymanLanguage('%s','%s','%s','%s','%s', %s, %s, '%s')";
-    String jsString = KMString.format(jsFormat, keyboardName, keyboardID, languageName, languageID, keyboardPath, tFont, oFont, packageID);
+    String jsString = KMString.format("setKeymanLanguage(%s)", reg.toString());
     loadJavascript(jsString);
 
     this.packageID = packageID;
@@ -693,17 +670,16 @@ final class KMKeyboard extends WebView {
   /**
    * getFontFilename
    * Parse a Font JSON object and return the font filename (ending in .ttf or .otf)
-   * @param jsonString String - Font JSON object as a string
+   * @param fontObj JSONObject - Font JSON object
    * @return String - Filename for the font. If font is invalid, return ""
    */
-  private String getFontFilename(String jsonString) {
+  private String getFontFilename(JSONObject fontObj) {
     String font = "";
-    if (jsonString == null || jsonString.isEmpty()) {
+    if (fontObj == null) {
       return font;
     }
     try {
-      JSONObject fontObj = new JSONObject(jsonString);
-      JSONArray sourceArray = fontObj.optJSONArray(KMManager.KMKey_FontSource);
+      JSONArray sourceArray = fontObj.optJSONArray(KMManager.KMKey_FontFiles);
       if (sourceArray != null) {
         String fontFile;
         int length = sourceArray.length();
@@ -715,7 +691,7 @@ final class KMKeyboard extends WebView {
           }
         }
       } else {
-        String fontFile = fontObj.optString(KMManager.KMKey_FontSource);
+        String fontFile = fontObj.optString(KMManager.KMKey_FontFiles);
         if (fontFile != null) {
           if (FileUtils.hasFontExtension(fontFile)) {
             font = fontFile;
@@ -1058,8 +1034,22 @@ final class KMKeyboard extends WebView {
    * @param font String font JSON object as a string
    * @return String of modified font information with full paths. If font is invalid, return "''"
    */
-  private String makeFontPaths(String font) {
+  private JSONObject makeFontPaths(String font) {
+
+    if(font == null) {
+      return null;
+    }
+
     try {
+      if (FileUtils.hasFontExtension(font)) {
+        JSONObject jfont = new JSONObject();
+        jfont.put(KMManager.KMKey_FontFamily, font.substring(0, font.length()-4));
+        JSONArray jfiles = new JSONArray();
+        jfiles.put(keyboardRoot + font);
+        jfont.put(KMManager.KMKey_FontFiles, jfiles);
+        return jfont;
+      }
+
       JSONObject fontObj = new JSONObject(font);
       JSONArray sourceArray;
       String fontFile;
@@ -1074,7 +1064,7 @@ final class KMKeyboard extends WebView {
       if (obj instanceof String) {
         fontFile = fontObj.getString(KMManager.KMKey_FontFiles);
         fontObj.put(KMManager.KMKey_FontFiles, keyboardRoot + obj);
-        return fontObj.toString();
+        return fontObj;
       } else if (obj instanceof JSONArray) {
         sourceArray = fontObj.optJSONArray(KMManager.KMKey_FontFiles);
         if (sourceArray != null) {
@@ -1083,17 +1073,17 @@ final class KMKeyboard extends WebView {
             if (FileUtils.hasFontExtension(fontFile)) {
               fontObj.put(KMManager.KMKey_FontFiles, keyboardRoot + fontFile);
               fontObj.remove(KMManager.KMKey_FontSource);
-              return fontObj.toString();
+              return fontObj;
             }
           }
         }
       }
     } catch (JSONException e) {
       KMLog.LogException(TAG, "", e);
-      return "''";
+      return null;
     }
 
-    return font;
+    return null;
   }
 
   @SuppressLint("InflateParams")

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -397,7 +397,8 @@ final class KMKeyboard extends WebView {
         k.getKeyboardName(),
         k.getLanguageName(),
         k.getFont(),
-        k.getOSKFont());
+        k.getOSKFont(),
+        k.getDisplayName());
     }
 
     return retVal;
@@ -476,7 +477,16 @@ final class KMKeyboard extends WebView {
     return retVal;
   }
 
-  public boolean setKeyboard(String packageID, String keyboardID, String languageID, String keyboardName, String languageName, String kFont, String kOskFont) {
+  public boolean setKeyboard(String packageID, String keyboardID, String languageID,
+                             String keyboardName, String languageName, String kFont,
+                             String kOskFont) {
+    return setKeyboard(packageID, keyboardID, languageID, keyboardName, languageName,
+                       kFont, kOskFont, null);
+  }
+
+  public boolean setKeyboard(String packageID, String keyboardID, String languageID,
+                             String keyboardName, String languageName, String kFont,
+                             String kOskFont, String displayName) {
     if (packageID == null || keyboardID == null || languageID == null || keyboardName == null || languageName == null) {
       return false;
     }
@@ -530,6 +540,7 @@ final class KMKeyboard extends WebView {
 
       if (jDisplayFont != null) reg.put("KFont", jDisplayFont);
       if (jOskFont != null) reg.put("KOskFont", jOskFont);
+      if (displayName != null) reg.put("displayName", displayName);
     } catch(JSONException e) {
       KMLog.LogException(TAG, "", e);
       return false;
@@ -1316,6 +1327,11 @@ final class KMKeyboard extends WebView {
     if (kbEventListeners != null) {
       kbEventListeners.remove(listener);
     }
+  }
+
+  public void setSpacebarText(KMManager.SpacebarText mode) {
+    String jsString = KMString.format("setSpacebarText('%s')", mode.toString());
+    loadJavascript(jsString);
   }
 
   /* Implement handleTouchEvent to catch long press gesture without using Android system default time

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -121,6 +121,30 @@ public final class KMManager {
     STABLE
   }
 
+  public enum SpacebarText {
+    LANGUAGE,
+    KEYBOARD,
+    LANGUAGE_KEYBOARD,
+    BLANK;
+
+    // Maps to enum SpacebarText in kmwbase.ts
+    public static SpacebarText fromString(String mode) {
+      if(mode == null) return LANGUAGE_KEYBOARD;
+      switch(mode) {
+        case "language": return LANGUAGE;
+        case "keyboard": return KEYBOARD;
+        case "languageKeyboard": return LANGUAGE_KEYBOARD;
+        case "blank": return BLANK;
+      }
+      return LANGUAGE_KEYBOARD;
+    }
+
+    public String toString()  {
+      String modes[] = { "language", "keyboard", "languageKeyboard", "blank" };
+      return modes[this.ordinal()];
+    }
+  };
+
   private static InputMethodService IMService;
   private static boolean debugMode = false;
   private static boolean shouldAllowSetKeyboard = true;
@@ -132,6 +156,8 @@ public final class KMManager {
   private static GlobeKeyAction sysKbGlobeKeyAction = GlobeKeyAction.GLOBE_KEY_ACTION_SHOW_MENU;
   // This is used to keep track of the starting system keyboard index while the screen is locked
   private static int sysKbStartingIndexOnLockScreen = -1;
+
+  private static KMManager.SpacebarText spacebarText = KMManager.SpacebarText.LANGUAGE_KEYBOARD; // must match default given in kmwbase.ts
 
   protected static boolean InAppKeyboardLoaded = false;
   protected static boolean SystemKeyboardLoaded = false;
@@ -417,7 +443,6 @@ public final class KMManager {
   /**
    * Adjust the keyboard dimensions. If the suggestion banner is active, use the
    * combined banner height and keyboard height
-   * @param keyboard KeyboardType
    * @return RelativeLayout.LayoutParams
    */
   private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
@@ -1778,6 +1803,20 @@ public final class KMManager {
 
     if (SystemKeyboard != null) {
       SystemKeyboard.isHelpBubbleEnabled = newValue;
+    }
+  }
+
+  public static SpacebarText getSpacebarText() {
+    return spacebarText;
+  }
+
+  public static void setSpacebarText(SpacebarText mode) {
+    spacebarText = mode;
+    if(InAppKeyboard != null) {
+      InAppKeyboard.setSpacebarText(mode);
+    }
+    if(SystemKeyboard != null) {
+      SystemKeyboard.setSpacebarText(mode);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -190,6 +190,7 @@ public final class KMManager {
   public static final String KMKey_OskFont = "oskFont";
   public static final String KMKey_FontSource = "source";
   public static final String KMKey_FontFiles = "files";
+  public static final String KMKey_FontFamily = "family";
   public static final String KMKey_KeyboardModified = "lastModified";
   public static final String KMKey_KeyboardRTL = "rtl";
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -30,11 +30,13 @@ public class Keyboard extends LanguageResource implements Serializable {
   private boolean isNewKeyboard;
   private String font;
   private String oskFont;
+  private String displayName;
 
   // JSON keys
   private static String KB_NEW_KEYBOARD_KEY = "isNewKeyboard";
   private static String KB_FONT_KEY = "font";
   private static String KB_OSK_FONT_KEY = "oskFont";
+  private static String KB_DISPLAY_NAME_KEY = "displayName";
 
   private static Keyboard FALLBACK_KEYBOARD;
 
@@ -100,6 +102,7 @@ public class Keyboard extends LanguageResource implements Serializable {
     this.isNewKeyboard = false;
     this.font = k.getFont();
     this.oskFont = k.getOSKFont();
+    this.displayName = k.getDisplayName();
   }
 
   public String getKeyboardID() { return getResourceID(); }
@@ -111,6 +114,9 @@ public class Keyboard extends LanguageResource implements Serializable {
   public String getFont() { return font; }
 
   public String getOSKFont() { return oskFont; }
+
+  public String getDisplayName() { return displayName; }
+  public void setDisplayName(String displayName) { this.displayName = displayName; }
 
   public Bundle buildDownloadBundle() {
     Bundle bundle = new Bundle();
@@ -144,6 +150,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
+      this.displayName = installedObj.getString(KB_DISPLAY_NAME_KEY);
     } catch (JSONException e) {
       KMLog.LogException(TAG, "fromJSON exception: ", e);
     }
@@ -156,6 +163,7 @@ public class Keyboard extends LanguageResource implements Serializable {
         o.put(KB_NEW_KEYBOARD_KEY, this.isNewKeyboard);
         o.put(KB_FONT_KEY, this.font);
         o.put(KB_OSK_FONT_KEY, this.oskFont);
+        o.put(KB_DISPLAY_NAME_KEY, this.displayName);
       } catch (JSONException e) {
         KMLog.LogException(TAG, "toJSON exception: ", e);
       }

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -193,5 +193,7 @@ mv $KMA_ROOT/KMEA/app/build/outputs/aar/$ARTIFACT $KMA_ROOT/KMAPro/kMAPro/libs/k
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample1/app/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Samples/KMSample2/app/libs/keyman-engine.aar
 cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/Tests/KeyboardHarness/app/libs/keyman-engine.aar
-
+if [ ! -z ${RELEASE_OEM+x} ]; then
+  cp $KMA_ROOT/KMAPro/kMAPro/libs/keyman-engine.aar $KMA_ROOT/../oem/firstvoices/android/app/libs/keyman-engine.aar
+fi
 cd ..\

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -272,6 +272,7 @@ final class FVShared {
                       keyboard.id,
                       null); // get first associated language ID
                     if (kbd != null) {
+                      kbd.setDisplayName(keyboard.name);
                       // TODO: Override fonts to NotoSansCanadianAboriginal.ttf
                       KMManager.addKeyboard(context, kbd);
                     }


### PR DESCRIPTION
Cherry-pick of #5349, #5338.

Relates to #949.

* Refactors the cross-boundary call to `setKeymanLanguage` to use JSON wrapping for the content. This is (a) safer, and (b) less mucking around anyway.
* Adds setSpacebarText() API to Keyman Engine for Android
* Adds displayName API to Keyman Engine for Android
* Sets default spacebar text to keyboard name for FirstVoices Keyboards
* Does not include the preference changes to Keyman for Android -- these will be surfaced as a feature in 15.0.