### PR TITLE
feat(ios): add spacebar text controls 🍒 🌌

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -62,6 +62,7 @@ public enum Key {
   // Settings-related keys
   static let optShouldReportErrors = "ShouldReportErrors"
   static let optShouldShowBanner = "ShouldShowBanner"
+  static let optSpacebarText = "SpacebarText"
   // This one SHOULD be app-only, but is needed by the currently
   // in-engine Settings menus.  Alas.
   static let optShouldShowGetStarted = "ShouldShowGetStarted"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -280,15 +280,16 @@ public extension UserDefaults {
   
   var optSpacebarText: SpacebarText {
     get {
-      if let valueString = string(forKey: Key.optSpacebarText) {
-        return SpacebarText.fromString(mode: valueString)
+      if let valueString = string(forKey: Key.optSpacebarText),
+         let value = SpacebarText(rawValue: valueString) {
+        return value
       } else {
         return SpacebarText.LANGUAGE_KEYBOARD
       }
     }
     
     set(value) {
-      set(value.toString(), forKey: Key.optSpacebarText)
+      set(value.rawValue, forKey: Key.optSpacebarText)
     }
   }
  

--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/UserDefaults+Types.swift
@@ -278,6 +278,20 @@ public extension UserDefaults {
     }
   }
   
+  var optSpacebarText: SpacebarText {
+    get {
+      if let valueString = string(forKey: Key.optSpacebarText) {
+        return SpacebarText.fromString(mode: valueString)
+      } else {
+        return SpacebarText.LANGUAGE_KEYBOARD
+      }
+    }
+    
+    set(value) {
+      set(value.toString(), forKey: Key.optSpacebarText)
+    }
+  }
+ 
   // stores a dictionary of predict-enablement settings keyed to language ids, i.e., [langID: Bool]
   var predictionEnablements: [String: Bool]? {
     get {

--- a/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/InputViewController.swift
@@ -438,6 +438,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   func updateShowBannerSetting() {
     keymanWeb.updateShowBannerSetting()
   }
+  
+  func updateSpacebarText() {
+    keymanWeb.updateSpacebarText()
+  }
 
   func menuKeyHeld(_ keymanWeb: KeymanWebViewController) {
     if isSystemKeyboard {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanWebViewController.swift
@@ -206,7 +206,7 @@ extension KeymanWebViewController {
   }
 
   private func setSpacebarText(_ mode: SpacebarText) {
-    webView!.evaluateJavaScript("setSpacebarText('\(mode.toString())');", completionHandler: nil);
+    webView!.evaluateJavaScript("setSpacebarText('\(mode.rawValue)');", completionHandler: nil);
   }
 
   func updateSpacebarText() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -33,31 +33,12 @@ public enum VibrationSupport {
   case taptic // Has the Taptic engine, allowing use of UIImpactFeedbackGenerator for customizable vibrations
 }
 
-public enum SpacebarText {
-  case LANGUAGE
-  case KEYBOARD
-  case LANGUAGE_KEYBOARD
-  case BLANK
-
+public enum SpacebarText: String {
   // Maps to enum SpacebarText in kmwbase.ts
-  public static func fromString(mode: String) -> SpacebarText {
-    switch(mode) {
-      case "language": return LANGUAGE
-      case "keyboard": return KEYBOARD
-      case "languageKeyboard": return LANGUAGE_KEYBOARD
-      case "blank": return BLANK
-      default: return LANGUAGE_KEYBOARD
-    }
-  }
-
-  public func toString() -> String {
-    switch(self) {
-    case .LANGUAGE: return "language"
-    case .KEYBOARD: return "keyboard"
-    case .LANGUAGE_KEYBOARD: return "languageKeyboard"
-    case .BLANK: return "blank"
-    }
-  }
+  case LANGUAGE = "language"
+  case KEYBOARD = "keyboard"
+  case LANGUAGE_KEYBOARD = "languageKeyboard"
+  case BLANK = "blank"
 };
 
 /**

--- a/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Model/InstallableKeyboard.swift
@@ -26,6 +26,7 @@ public struct InstallableKeyboard: Codable, KMPInitializableLanguageResource {
     case font
     case oskFont
     case isCustom
+    case displayName
   }
 
   public private(set) var id: String
@@ -38,6 +39,7 @@ public struct InstallableKeyboard: Codable, KMPInitializableLanguageResource {
   public var font: Font?
   public var oskFont: Font?
   public var isCustom: Bool
+  public var displayName: String?
 
   public static let sharingLink = "\(KeymanHosts.KEYMAN_COM)/go/keyboard/%@/share"
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -33,7 +33,7 @@
               hostPlatform: "ios"
             });
             sentryManager.init();
-            
+
             window.addEventListener('load', init, false);
             
             function init() {
@@ -318,6 +318,11 @@
               });
 
               keyman.modelManager.register(model);
+            }
+        
+            function setSpacebarText(mode) {
+                keyman.options['spacebarText'] = mode;
+                keyman.osk.show(true);
             }
         
             </script>

--- a/oem/firstvoices/ios/FirstVoices/AppDelegate.swift
+++ b/oem/firstvoices/ios/FirstVoices/AppDelegate.swift
@@ -31,6 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Replace with your application group id
     Manager.applicationGroupIdentifier = FVConstants.groupID
+    Manager.shared.spacebarText = SpacebarText.KEYBOARD
     return true
   }
 }

--- a/oem/firstvoices/ios/FirstVoices/AppDelegate.swift
+++ b/oem/firstvoices/ios/FirstVoices/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Replace with your application group id
     Manager.applicationGroupIdentifier = FVConstants.groupID
-    Manager.shared.spacebarText = SpacebarText.KEYBOARD
+    Manager.shared.spacebarText = .KEYBOARD
     return true
   }
 }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1915,8 +1915,10 @@ namespace com.keyman.osk {
           t.className='kmw-spacebar-caption';
         }
 
-        // It sounds redundant, but this dramatically cuts down on browser DOM processing.
-        if(t.innerText != displayName) {
+        // It sounds redundant, but this dramatically cuts down on browser DOM processing;
+        // but sometimes innerText is reported empty when it actually isn't, so set it
+        // anyway in that case (Safari, iOS 14.4)
+        if(t.innerText != displayName || displayName == '') {
           t.innerText = displayName;
         }
       }


### PR DESCRIPTION
Cherry-pick of #5365.

Relates to #949.

Mirror of #5349 (Android), for iOS.

* Adds setSpacebarText() API to Keyman Engine for iOS
* Adds displayName API to Keyman Engine for iOS
* Sets default spacebar text to keyboard name for FirstVoices Keyboards
* Does not add preference UI