### PR TITLE
fix(linux): Don't crash with corrupt keyboard 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -62,10 +62,13 @@ class InstallKmpWindow(Gtk.Dialog):
         with tempfile.TemporaryDirectory() as tmpdirname:
             extract_kmp(kmpfile, tmpdirname)
             info, system, options, keyboards, files = get_metadata(tmpdirname)
-            self.kbname = keyboards[0]['name']
+            if len(keyboards) > 0 and 'name' in keyboards[0]:
+                self.kbname = keyboards[0]['name']
+            else:
+                self.kbname = keyboardid
             self.checkcontinue = True
 
-            if installed_kmp_ver:
+            if installed_kmp_ver and info and 'version' in info and 'description' in info['version']:
                 if info['version']['description'] == installed_kmp_ver:
                     dialog = Gtk.MessageDialog(
                         viewkmp, 0, Gtk.MessageType.QUESTION,
@@ -132,9 +135,10 @@ class InstallKmpWindow(Gtk.Dialog):
             label = Gtk.Label()
             keyboardlayout = ""
             for kb in keyboards:
-                if keyboardlayout != "":
-                    keyboardlayout = keyboardlayout + "\n"
-                keyboardlayout = keyboardlayout + kb['name']
+                if 'name' in kb:
+                    if keyboardlayout != "":
+                        keyboardlayout = keyboardlayout + "\n"
+                    keyboardlayout = keyboardlayout + kb['name']
             label.set_text(keyboardlayout)
             label.set_halign(Gtk.Align.START)
             label.set_selectable(True)
@@ -151,13 +155,14 @@ class InstallKmpWindow(Gtk.Dialog):
                 label = Gtk.Label()
                 fontlist = ""
                 for font in fonts:
-                    if fontlist != "":
-                        fontlist = fontlist + "\n"
-                    if font['description'][:5] == "Font ":
-                        fontdesc = font['description'][5:]
-                    else:
-                        fontdesc = font['description']
-                    fontlist = fontlist + fontdesc
+                    if 'description' in font:
+                        if fontlist != "":
+                            fontlist = fontlist + "\n"
+                        if font['description'][:5] == "Font ":
+                            fontdesc = font['description'][5:]
+                        else:
+                            fontdesc = font['description']
+                        fontlist = fontlist + fontdesc
                 label.set_text(fontlist)
                 label.set_halign(Gtk.Align.START)
                 label.set_selectable(True)
@@ -169,24 +174,26 @@ class InstallKmpWindow(Gtk.Dialog):
             grid.attach_next_to(label3, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
             prevlabel = label3
             label = Gtk.Label()
-            label.set_text(info['version']['description'])
+            if info and 'version' in info and 'description' in info['version']:
+                label.set_text(info['version']['description'])
             label.set_halign(Gtk.Align.START)
             label.set_selectable(True)
             grid.attach_next_to(label, label3, Gtk.PositionType.RIGHT, 1, 1)
 
             if info and 'author' in info:
+                author = info['author']
                 label4 = Gtk.Label()
                 label4.set_text(_("Author:   "))
                 label4.set_halign(Gtk.Align.END)
                 grid.attach_next_to(label4, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
                 prevlabel = label4
                 label = Gtk.Label()
-                if 'url' in info['author']:
+                if 'url' in author and 'description' in author:
                     label.set_markup(
-                        "<a href=\"" + info['author']['url'] + "\" title=\"" +
-                        info['author']['url'] + "\">" + info['author']['description'] + "</a>")
-                else:
-                    label.set_text(info['author']['description'])
+                        "<a href=\"" + author['url'] + "\" title=\"" +
+                        author['url'] + "\">" + author['description'] + "</a>")
+                elif 'description' in author:
+                    label.set_text(author['description'])
                 label.set_halign(Gtk.Align.START)
                 label.set_selectable(True)
                 grid.attach_next_to(label, label4, Gtk.PositionType.RIGHT, 1, 1)
@@ -199,9 +206,10 @@ class InstallKmpWindow(Gtk.Dialog):
                 grid.attach_next_to(label5, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
                 prevlabel = label5
                 label = Gtk.Label()
-                label.set_markup(
-                    "<a href=\"" + info['website']['description'] + "\">" +
-                    info['website']['description'] + "</a>")
+                if 'description' in info['website']:
+                    label.set_markup(
+                        "<a href=\"" + info['website']['description'] + "\">" +
+                        info['website']['description'] + "</a>")
                 label.set_halign(Gtk.Align.START)
                 label.set_selectable(True)
                 grid.attach_next_to(label, label5, Gtk.PositionType.RIGHT, 1, 1)
@@ -212,7 +220,8 @@ class InstallKmpWindow(Gtk.Dialog):
                 label6.set_halign(Gtk.Align.END)
                 grid.attach_next_to(label6, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
                 label = Gtk.Label()
-                label.set_text(info['copyright']['description'])
+                if 'description' in info['copyright']:
+                    label.set_text(info['copyright']['description'])
                 label.set_halign(Gtk.Align.START)
                 label.set_selectable(True)
                 grid.attach_next_to(label, label6, Gtk.PositionType.RIGHT, 1, 1)


### PR DESCRIPTION
If we try to install a keyboard that's missing some metadata we shouldn't crash.

Fixes #5384, #5385. 🍒-pick of #5414.