### PR TITLE
fix(android): gracefully handle errors in KMW keyboards

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -22,6 +22,10 @@
 
     window.addEventListener('load', init, false);
 
+    function loadDefaultKeyboard() {
+      notifyHost('reloadAfterError');
+    }
+
     function init() {
       //document.body.style.backgroundColor="transparent";
       //window.console.log('Device type = '+device);
@@ -47,6 +51,8 @@
       kmw.addEventListener('keyboardloaded', setIsChiral);
       kmw.addEventListener('keyboardchange', setIsChiral);
       kmw.core.languageProcessor.on('statechange', onStateChange);
+
+      document.body.addEventListener('touchend', loadDefaultKeyboard);
 
       notifyHost('pageLoaded');
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1335,6 +1335,17 @@ final class KMKeyboard extends WebView {
     }
   }
 
+  public void reloadAfterError() {
+    Keyboard firstKeyboard = KeyboardController.getInstance().getKeyboardInfo(0);
+    if (firstKeyboard != null) {
+      // Revert to first keyboard in the list
+      setKeyboard(firstKeyboard);
+    } else {
+      // Fallback to sil_euro_latin (though 3rd party keyboards wont have it)
+      setKeyboard(KMManager.getDefaultKeyboard(context));
+    }
+  }
+
   public void setSpacebarText(KMManager.SpacebarText mode) {
     String jsString = KMString.format("setSpacebarText('%s')", mode.toString());
     loadJavascript(jsString);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -80,6 +80,8 @@ final class KMKeyboard extends WebView {
   private boolean ShouldShowHelpBubble = false;
   private boolean isChiral = false;
 
+  private int currentKeyboardErrorReports = 0;
+
   protected boolean keyboardSet = false;
   protected boolean keyboardPickerEnabled = true;
   protected boolean isHelpBubbleEnabled = true;
@@ -153,7 +155,6 @@ final class KMKeyboard extends WebView {
 
         // Send console errors to Sentry in case they're missed by KMW sentryManager
         // (Ignoring spurious message "No keyboard stubs exist = ...")
-        // TODO: Analyze if this error warrants reverting to default keyboard
         // TODO: Fix base error rather than trying to ignore it "No keyboard stubs exist"
 
         if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
@@ -163,14 +164,6 @@ final class KMKeyboard extends WebView {
           String sourceID = cm.sourceId().replaceAll(NAVIGATION_PATTERN, "$1$2");
           sendKMWError(cm.lineNumber(), sourceID, cm.message());
           sendError(packageID, keyboardID, "");
-          Keyboard firstKeyboard = KeyboardController.getInstance().getKeyboardInfo(0);
-          if (firstKeyboard != null) {
-            // Revert to first keyboard in the list
-            setKeyboard(firstKeyboard);
-          } else {
-            // Fallback to sil_euro_latin (though 3rd party keyboards wont have it)
-            setKeyboard(KMManager.getDefaultKeyboard(context));
-          }
         }
 
         return true;
@@ -493,6 +486,9 @@ final class KMKeyboard extends WebView {
       return false;
     }
 
+    // Reset the counter for showing / sending errors related to the selected keybard
+    currentKeyboardErrorReports = 0;
+
     boolean retVal = true;
     // keyboardVersion only needed for legacy cloud/ keyboards.
     // Otherwise, no need for the JSON overhead of determining the keyboard version from kmp.json
@@ -586,12 +582,20 @@ final class KMKeyboard extends WebView {
   // Display localized Toast notification that keyboard selection failed, so loading default keyboard.
   // Also sends a message to Sentry (not localized)
   private void sendError(String packageID, String keyboardID, String languageID) {
-    BaseActivity.makeToast(context, R.string.fatal_keyboard_error, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
+    this.currentKeyboardErrorReports++;
 
-    // Don't use localized string R.string.fatal_keyboard_error msg for Sentry
-    String msg = KMString.format("Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.",
-      packageID, keyboardID, languageID);
-    Sentry.captureMessage(msg);
+    if(this.currentKeyboardErrorReports == 1) {
+      BaseActivity.makeToast(context, R.string.fatal_keyboard_error_short, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
+    }
+
+    if(this.currentKeyboardErrorReports < 5) {
+      // We'll only report up to 5 errors in a given keyboard to avoid spamming
+      // errors and using unnecessary bandwidth doing so
+      // Don't use localized string R.string.fatal_keyboard_error msg for Sentry
+      String msg = KMString.format("Error in keyboard %1$s:%2$s for %3$s language.",
+        packageID, keyboardID, languageID);
+      Sentry.captureMessage(msg);
+    }
   }
 
   // Set the base path of the keyboard depending on the package ID

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2104,6 +2104,8 @@ public final class KMManager {
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
         */
+      } else if (url.indexOf("reloadAfterError") >= 0) {
+        InAppKeyboard.reloadAfterError();
       }
       return false;
     }
@@ -2375,8 +2377,9 @@ public final class KMManager {
           Log.v("KMEA", "JSON parsing error: " + e.getMessage());
         }
         */
+      } else if (url.indexOf("reloadAfterError") >= 0) {
+        SystemKeyboard.reloadAfterError();
       }
-
       return false;
     }
   }

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -114,6 +114,10 @@
     <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">
       Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.</string>
 
+  <!-- Context: Fatal keyboard error.  -->
+  <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">
+      Error in keyboard %1$s:%2$s for %3$s language.</string>
+
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Checking for associated dictionary to download</string>
 


### PR DESCRIPTION
Fixes #5397.

This disables the fallback to default keyboard in Keyman Engine for Android, and prevents a toast from appearing more than once for a given error. The first five errors will be reported to Sentry and then subsequent errors will be ignored, until a different keyboard is selected, to prevent spamming the error log and wasting bandwidth for the user.