### PR TITLE
fix(android/engine): Fix font file path

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -517,6 +517,8 @@ final class KMKeyboard extends WebView {
         KMManager.getLatestKeyboardFileVersion(getContext(), packageID, keyboardID) : null;
     }
 
+    setKeyboardRoot(packageID);
+
     if(kOskFont == null || kOskFont.isEmpty())
       kOskFont = kFont;
 
@@ -528,7 +530,6 @@ final class KMKeyboard extends WebView {
 
     String kbKey = KMString.format("%s_%s", languageID, keyboardID);
 
-    setKeyboardRoot(packageID);
     String keyboardPath = makeKeyboardPath(packageID, keyboardID, keyboardVersion);
 
     JSONObject reg = new JSONObject();


### PR DESCRIPTION
Fixes #5418 and will need to get added to #5407 for stable-14.0

`setKeyboardRoot(packageID)` sets up the full filepaths for keyboard assets, so it needs to be called before any font path handling.

(Refer to comment https://github.com/keymanapp/keyman/pull/5338/files#r663754313)

## User Testing
@keymanapp/testers 
1. On clean build, install sil_cameroon_qwerty keyboard
2. Show sil_cameroon_qwerty and verify OSK ok (no tofu on the diacritics)
3. Close app, and restart Keyman
4. When sil_cameroon_qwerty OSK appears, verify OSK ok (no tofu on the diacritics)
