### PR TITLE
fix(android/engine): Display dictionary help link

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LexicalModel.java
@@ -65,7 +65,7 @@ public class LexicalModel extends LanguageResource implements Serializable {
       String version = lexicalModelJSON.optString(KMManager.KMKey_Version, "1.0");
       version = lexicalModelJSON.optString(KMManager.KMKey_LexicalModelVersion, version);
 
-      String helpLink = ""; // TOODO: Handle help links
+      String helpLink = lexicalModelJSON.optString(KMManager.KMKey_CustomHelpLink, "");
 
       // language ID and language name from lexicalModelJSON. Iterate through language array
       String languageID = "", languageName = "";
@@ -95,9 +95,8 @@ public class LexicalModel extends LanguageResource implements Serializable {
   public LexicalModel(String packageID, String lexicalModelID, String lexicalModelName,
                       String languageID, String languageName,  String version,
                       String helpLink, String kmp) {
-    // TODO: handle help links
     super(packageID, lexicalModelID, lexicalModelName, languageID, languageName,
-        version, "", kmp);
+        version, helpLink, kmp);
   }
 
   @Override


### PR DESCRIPTION
Fixes #5426 

Resolve some trivial TODOs so that dictionary help links (welcome.htm) can be displayed.

## User Testing
@keymanapp/testers 
1. Load the PR build
2. Install gff_amharic keyboard
3. After a while, the associated dictionary will download and install (the lexical model package includes a welcome.htm file while the default nrc.en.mtnt does not)
4. Go to Settings --> Languages --> Amharic --> Dictionary --> GFF Amharic --> Help Link
5. Verify the welcome.htm page displays

Ignore the styling issue with the help arrow #4715