### PR TITLE
fix(web): Copy the keyboard stubs for registration

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -130,7 +130,8 @@
 
     function setKeymanLanguage(k) {
       KeymanWeb.registerStub(k);
-      keyman.setActiveKeyboard(k.KP + '::'+k.KI, k.KLC);
+      // KMW will handle the k.KP:: namespacing
+      keyman.setActiveKeyboard(k.KI, k.KLC);
       keyman.osk.show(true);
     }
 

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -130,8 +130,7 @@
 
     function setKeymanLanguage(k) {
       KeymanWeb.registerStub(k);
-      // registerStub will mutate k.KI to have k.KP:: namespacing that setActiveKeyboard expects
-      keyman.setActiveKeyboard(k.KI, k.KLC);
+      keyman.setActiveKeyboard(k.KP + '::'+k.KI, k.KLC);
       keyman.osk.show(true);
     }
 

--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -130,7 +130,7 @@
 
     function setKeymanLanguage(k) {
       KeymanWeb.registerStub(k);
-      // KMW will handle the k.KP:: namespacing
+      // registerStub will mutate k.KI to have k.KP:: namespacing that setActiveKeyboard expects
       keyman.setActiveKeyboard(k.KI, k.KLC);
       keyman.osk.show(true);
     }

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1518,13 +1518,12 @@ namespace com.keyman.keyboards {
      * and a keyboard stub must be registered before the keyboard is loaded
      * for the keyboard to be usable.
      *
-     * @param       {Object}      kStub     Keyboard stub object
+     * @param       {Object}      Pstub     Keyboard stub object
      * @return      {?number}               1 if already registered, else null
      */
-    _registerStub(kStub): number {
+    _registerStub(Pstub): number {
       var Lk;
-      // Make a copy of the stubs to mutate and register
-      let Pstub = Object.assign({}, kStub);
+      Pstub = { ... Pstub}; // shallow clone the stub object
 
       // In initialization not complete, list the stub to be registered on completion of initialization
       if(!this.keymanweb.initialized) {

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -1518,11 +1518,13 @@ namespace com.keyman.keyboards {
      * and a keyboard stub must be registered before the keyboard is loaded
      * for the keyboard to be usable.
      *
-     * @param       {Object}      Pstub     Keyboard stub object
+     * @param       {Object}      kStub     Keyboard stub object
      * @return      {?number}               1 if already registered, else null
      */
-    _registerStub(Pstub): number {
+    _registerStub(kStub): number {
       var Lk;
+      // Make a copy of the stubs to mutate and register
+      let Pstub = Object.assign({}, kStub);
 
       // In initialization not complete, list the stub to be registered on completion of initialization
       if(!this.keymanweb.initialized) {


### PR DESCRIPTION
Will need to 🍒 pick to #5407

From comment https://github.com/keymanapp/keyman/pull/5437#discussion_r664965071
> If this is an unrelated fix, can we extract it into a separate PR for testing and rebase this PR on it?

Originally this PR adjusted `KI` passed to KeymanWeb for registration.
Per review comments, this PR now has KeymanWeb make a copy of stubs that can be mutated and used for registration.

## Symptom
In `setKeymanLanguage()`, the KeymanWeb call `registerStub()` is handling the package namespacing adds the k.KP+:: prefix to `k.KI`.
This caused weirdness when installing or switching keyboards (where the OSK didn't match selected or the associated lexical model didn't appear). (Comment https://github.com/keymanapp/keyman/pull/5407#issuecomment-874397635)

## User Testing
@keymanapp/testers 
1. Install the PR build for Android
2. Install another Keyman keyboard
3. When the installation completes, verify the keyboard switches to the installed keyboard.
4. If there's an associated lexical model installed, verify suggestion banner appears (e.g. sil_euro_latin)