### PR TITLE
fix(common/models/types): fixes test script config

### DIFF
--- a/common/models/types/package.json
+++ b/common/models/types/package.json
@@ -4,7 +4,7 @@
   "description": "Type definitions in used in the modeling (lexical model/predictive text) component of Keyman.",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "tsc test.ts"
+    "test": "tsc test.ts -lib es6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Looks like something in the npm audit fix PRs caused the default settings used by the "test" script to change, which caused a breakage on our `master` build.  This small tweak seems to be enough to fix it.