### PR TITLE
fix(common/core/web): OSK state-key management

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -76,7 +76,7 @@ namespace com.keyman.text {
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
       // of state management.
-      if(!fromOSK && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK) && !fromOSK) {
         return new RuleBehavior();
       }
 

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -75,9 +75,13 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.
-      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK) && !fromOSK) {
-        return new RuleBehavior();
+      // of state management.  `doModifierPress` must always run.
+      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+        // If run on a desktop platform, we know that modifier & state key presses may not
+        // produce output, so we may make an immediate return safely.
+        if(!fromOSK) {
+          return new RuleBehavior();
+        }
       }
 
       // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -216,6 +216,26 @@ namespace com.keyman.keyboards {
       // This part depends on the keyboard processor's active state.
       if(keyboardProcessor) {
         keyboardProcessor.setSyntheticEventDefaults(Lkc);
+
+        // If it's a state key modifier, trigger its effects as part of the
+        // keystroke.
+        let bitmask = 0;
+        switch(Lkc.kName) {
+          case 'K_CAPS':
+            bitmask = text.Codes.stateBitmasks.CAPS;
+            break;
+          case 'K_NUMLOCK':
+            bitmask = text.Codes.stateBitmasks.NUM_LOCK;
+            break;
+          case 'K_SCROLL':
+            bitmask = text.Codes.stateBitmasks.SCROLL_LOCK;
+            break;
+        }
+
+        if(bitmask) {
+          Lkc.Lstates ^= bitmask;
+          Lkc.LmodifierChange = true;
+        }
       }
 
       return Lkc;

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -404,7 +404,7 @@ namespace com.keyman.text {
 
         for(i=0; i < lockNames.length; i++) {
           if(lockStates & Codes.stateBitmasks[lockNames[i]]) {
-            this.stateKeys[lockKeys[i]] = lockStates & Codes.modifierCodes[lockNames[i]];
+            this.stateKeys[lockKeys[i]] = !!(lockStates & Codes.modifierCodes[lockNames[i]]);
           }
         }
       } else if(d) {
@@ -425,8 +425,42 @@ namespace com.keyman.text {
         }
       }
 
+      this.updateStates();
+
+      if(this.activeKeyboard.isMnemonic && this.stateKeys['K_CAPS']) {
+        // Modifier keypresses doesn't trigger mnemonic manipulation of modifier state.
+        // Only an output key does; active use of Caps will also flip the SHIFT flag.
+        if(!e || !KeyboardProcessor.isModifier(e)) {
+          // Mnemonic keystrokes manipulate the SHIFT property based on CAPS state.
+          // We need to unflip them when tracking the OSK layer.
+          keyShiftState ^= Codes.modifierCodes['SHIFT'];
+        }
+      }
+
       this.layerId = this.getLayerId(keyShiftState);
       return true;
+    }
+
+    private updateStates(): void {
+      var lockNames  = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'];
+      var lockKeys   = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'];
+
+      for(let i=0; i < lockKeys.length; i++) {
+        const key = lockKeys[i];
+        const flag = this.stateKeys[key];
+        const onBit = lockNames[i];
+        const offBit = 'NO_' + lockNames[i];
+
+        // Ensures that the current mod-state info properly matches the currently-simulated
+        // state key states.
+        if(flag) {
+          this.modStateFlags |= Codes.modifierCodes[onBit];
+          this.modStateFlags &= ~Codes.modifierCodes[offBit];
+        } else {
+          this.modStateFlags &= ~Codes.modifierCodes[onBit];
+          this.modStateFlags |= Codes.modifierCodes[offBit];
+        }
+      }
     }
 
     getLayerId(modifier: number): string {

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -312,6 +312,12 @@ namespace com.keyman.osk {
     private layerChangeHandler: text.SystemStoreMutationHandler = function(this: OSKManager,
       source: text.MutableSystemStore,
       newValue: string) {
+      // This handler is also triggered on state-key state changes (K_CAPS) that 
+      // may not actually change the layer.
+      if(this.vkbd) {
+        this.vkbd._UpdateVKShiftStyle();
+      }
+
       if(source.value != newValue) {
         // Prevents console errors when a keyboard only displays help.
         // Can occur when using SHIFT with sil_euro_latin on a desktop form-factor.

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -893,25 +893,6 @@ namespace com.keyman.osk {
       // First check the virtual key, and process shift, control, alt or function keys
       let Lkc = keySpec.constructKeyEvent(core.keyboardProcessor, this.device.coreSpec);
 
-      // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
-      let bitmask = 0;
-      switch(Lkc.kName) {
-        case 'K_CAPS':
-          bitmask = text.Codes.stateBitmasks.CAPS;
-          break;
-        case 'K_NUMLOCK':
-          bitmask = text.Codes.stateBitmasks.NUM_LOCK;
-          break;
-        case 'K_SCROLL':
-          bitmask = text.Codes.stateBitmasks.SCROLL_LOCK;
-          break;
-      }
-
-      if(bitmask) {
-        Lkc.Lstates ^= bitmask;
-        Lkc.LmodifierChange = true;
-      }
-
       // End - mirrors _GetKeyEventProperties
 
       if(core.languageProcessor.isActive && touch) {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -20,8 +20,8 @@ namespace com.keyman.osk {
     layout: keyboards.ActiveLayout;
     layers: keyboards.LayoutLayer[];
     private _layerId: string = "default";
+    layerIndex: number = 0; // the index of the default layer
     readonly isRTL: boolean;
-    layerIndex: number;
 
     device: Device;
     isStatic: boolean = false;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -894,11 +894,22 @@ namespace com.keyman.osk {
       let Lkc = keySpec.constructKeyEvent(core.keyboardProcessor, this.device.coreSpec);
 
       // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
+      let bitmask = 0;
       switch(Lkc.kName) {
         case 'K_CAPS':
+          bitmask = text.Codes.stateBitmasks.CAPS;
+          break;
         case 'K_NUMLOCK':
+          bitmask = text.Codes.stateBitmasks.NUM_LOCK;
+          break;
         case 'K_SCROLL':
-          core.keyboardProcessor.stateKeys[Lkc.kName] = ! core.keyboardProcessor.stateKeys[Lkc.kName];
+          bitmask = text.Codes.stateBitmasks.SCROLL_LOCK;
+          break;
+      }
+
+      if(bitmask) {
+        Lkc.Lstates ^= bitmask;
+        Lkc.LmodifierChange = true;
       }
 
       // End - mirrors _GetKeyEventProperties


### PR DESCRIPTION
Ran into this one while testing related aspects of #5451... turns out it was actually a bug on `master` _and_ `stable-14.0`.  (So, it'll need a 🍒-pick.)

## Base issue components & repros

Using either keymanweb.com (for stable) or the standard unminified test page:

1. Load a KMW-enabled page in your preferred Desktop browser.
    - The bugs are browser-independent.
2. Choose an input area (in order to display the OSK)
3. Press your keyboard's caps lock key:  it won't update.
4. Type an 'a' keypress - still no CAPS update.
5. Press the SHIFT key:  _now_ the OSK's caps key updates.

Then:

1. Refresh the page
2. Choose an input area (in order to display the OSK)
3. Press the OSK's caps-lock key:  it won't update
4. Press the OSK's 'a' key:  still no update
4. Press the OSK's SHIFT key:  still no update.  (So, broken OSK caps-lock.)
5. Press the keyboard's SHIFT key: still no caps-lock.  (The OSK should also drop out of SHIFT once the key is released.)

## More Description

Turns out I got related code "wrong" a bit during the 14.0 Core-Web refactor.  This PR will fix both issue components above:  the OSK will auto-update on any caps-lock keypress and will also toggle whenever the OSK's caps-lock key is pressed.
    - Note that a CAPS keypress after an OSK caps-press may not cause a change; physical keystrokes will immediately override the CAPS state with the physical keyboard's current caps-lock state.

## Notes

Remaining limitation:  if the active element loses focus with an active mnemonic keyboard and the caps-lock state is enabled, then regains it, the OSK currently tends to automatically select the SHIFT layer when redisplayed.  A physical SHIFT press & release will reset this.  (This is, at least, much better than auto-enabling the OSK's SHIFT for most keypresses whenever CAPS is on.)

## User Testing
@keymanapp/testers 

### Test suite 1: `desktop`

- [ ] Platform:  macOS / Safari

<details>
<summary>Instructions & Tests</summary>

Using the "Test unminified KeymanWeb" test page:

- [ ] TEST.STD.HARDWARE:
    <details>
    <summary><strong>Test sequence</strong></summary>
    
    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Select the "English - English" entry if not already selected.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's copy of the key should become highlighted here.
    4.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    5.  Press and release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT highlights only while the physical SHIFT is pressed.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should no longer be highlighted.
    7.  Refresh the page.
    8. **Before displaying the OSK** or clicking anywhere within the page, activate your hardware keyboard's CAPS LOCK state.
    9. Display the OSK
        - [ ] The OSK's CAPS key should not be highlighted.  (It's a system limitation.)
    10. Press and release your hardware keyboard's `A` key.
        - [ ] The OSK's CAPS key should become highlighted.

    </details>

- [ ] TEST.STD.MIXED
    <details>
    <summary><strong>Test sequence</strong></summary>

    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Select the "English - English" entry if not already selected.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Click the OSK's CAPS LOCK key.
        - [ ] It should become highlighted here.
    4.  Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    5.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should lose its highlighting.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should become highlighted.
    7.  Click your OSK's CAPS key.
        - [ ] It should lose highlighting.
    8. Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    9. Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should regain its highlighting.

    </details>

- [ ] TEST.MNEMONIC.HARDWARE:
    <details>
    <summary><strong>Test sequence</strong></summary>
    
    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Add the `sil_philippines` keyboard and select it.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's copy of the key should become highlighted here.
    4.  Press and release your hardware keyboard's `A` key.
        - [ ] A capitalized `A` should result with no other effects.
    5.  Press and release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT highlights only while the physical SHIFT is pressed.
    6. Press, but do _not_ release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT also becomes highlighted.
    7. Press and release your hardware keyboard's `A` key.
        - [ ] A lowercased `a` should result with no other effects.
    8.  Release your hardware keyboard's SHIFT key.
        - [ ] The OSK's CAPS key should remain highlighted.

    </details>

- [ ] TEST.MNEMONIC.MIXED
    <details>
    <summary><strong>Test sequence</strong></summary>

    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Add the `sil_philippines` keyboard and select it.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Click the OSK's CAPS LOCK key.
        - [ ] It should become highlighted here.
    4.  Click your OSK's `A` key.
        - [ ] A capitalized `A` should result with no other effects.
    5.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should lose its highlighting.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should become highlighted.
    7.  Click your OSK's CAPS key.
        - [ ] It should lose highlighting.
    8. Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    9. Press and release your hardware keyboard's `A` key.
        - [ ] A capitalized `A` should result _and_ the OSK's CAPS LOCK key should regain its highlighting.

    </details>

</details>

### Test suite 2:  `mobile`

- [ ] Platform:  Chrome emulation / iOS

<details>
<summary>Instructions & Tests</summary>

Using the "Test unminified KeymanWeb" test page:

- [ ] TEST.MOBILE.NUM_LOCK:  Using the `khmer_angkor` keyboard, swap back and forth between the 'default' and the 'numeric' layers.
    - Expected result:  there should be no "stuck highlighting" effect on the default layer's numeric key.

</details>