### PR TITLE
chore(android): improve error reporting for kmw

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -653,7 +653,7 @@ final class KMKeyboard extends WebView {
         breadcrumb.setData("keyboardVersion", this.keyboardVersion);
       }
       Sentry.addBreadcrumb(breadcrumb);
-      Sentry.captureMessage("sendKMWError", SentryLevel.ERROR);
+      Sentry.captureMessage(message, SentryLevel.ERROR);
     }
   }
 


### PR DESCRIPTION
Reports the actual error message instead of 'sendKMWError' as the primary message to Sentry.

A further improvement would be to capture the details of the error as data on the error rather than as a breadcrumb.

Yet further would be if we could report the error back from the web browser itself, giving us source context rather than Android context...