### PR TITLE
chore(android): improve error reporting for kmw 🍒

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -662,7 +662,7 @@ final class KMKeyboard extends WebView {
         breadcrumb.setData("keyboardVersion", this.keyboardVersion);
       }
       Sentry.addBreadcrumb(breadcrumb);
-      Sentry.captureMessage("sendKMWError", SentryLevel.ERROR);
+      Sentry.captureMessage(message, SentryLevel.ERROR);
     }
   }
 


### PR DESCRIPTION
Cherry-pick of #5468.

Reports the actual error message instead of 'sendKMWError' as the primary message to Sentry.