### PR TITLE
fix(ios): keyboard swapping

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -134,7 +134,7 @@
 
                 KeymanWeb.registerStub(stub);
 
-                kmw.setActiveKeyboard(stub.KI, stub.KLC);
+                kmw.setActiveKeyboard(stub.KP + '::' + stub.KI, stub.KLC);
                 kmw.osk.show(true);
             }
             


### PR DESCRIPTION
Turns out #5438 accidentally broke keyboard swapping for iOS.  Fortunately, the fix is pretty simple.

Since `.registerStub` is no longer pass-by-reference, we have to manually construct the value that used to result from the call.  No biggie.

## User Testing

I've already done what's needed, I believe.

But, if you _really_ want it tested...

- [ ] TEST.THE_ONLY_ONE:  load up the Keyman app in iOS and attempt to swap keyboards.
    - If it works, success!  (`master` currently fails here.)