### PR TITLE
fix(common/core/web): error from early fat-finger termination due to OS interruptions

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -171,6 +171,11 @@ namespace com.keyman.text {
               if(pair.p < KEYSTROKE_EPSILON) {
                 break;
               } else if(timer && timer() >= TIMEOUT_THRESHOLD) {
+                // It's always possible that the thread _executing_ our JS got paused,
+                // even if JS itself is single-threaded.
+                if(alternates.length == 0) {
+                  alternates = undefined;
+                }
                 break;
               }
 

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -171,11 +171,11 @@ namespace com.keyman.text {
               if(pair.p < KEYSTROKE_EPSILON) {
                 break;
               } else if(timer && timer() >= TIMEOUT_THRESHOLD) {
-                // It's always possible that the thread _executing_ our JS got paused,
-                // even if JS itself is single-threaded.
-                if(alternates.length == 0) {
-                  alternates = undefined;
-                }
+                // Note:  it's always possible that the thread _executing_ our JS
+                // got paused by the OS, even if JS itself is single-threaded.
+                //
+                // The case where `alternates` is initialized (line 167) but empty
+                // (because of net-zero loop iterations) MUST be handled.
                 break;
               }
 
@@ -192,6 +192,8 @@ namespace com.keyman.text {
               
               // If alternateBehavior.beep == true, ignore it.  It's a disallowed key sequence,
               // so we expect users to never intend their use.
+              //
+              // Also possible that this set of conditions fail for all evaluated alternates.
               if(alternateBehavior && !alternateBehavior.beep && pair.p > 0) {
                 let transform: Transform = alternateBehavior.transcription.transform;
                 
@@ -220,7 +222,9 @@ namespace com.keyman.text {
         // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
         
         // Notify the ModelManager of new input - it's predictive text time!
-        ruleBehavior.transcription.alternates = alternates;
+        if(alternates && alternates.length > 0) {
+          ruleBehavior.transcription.alternates = alternates;
+        }
         // Yes, even for ruleBehavior.triggersDefaultCommand.  Those tend to change the context.
         ruleBehavior.predictionPromise = this.languageProcessor.predict(ruleBehavior.transcription);
 

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -332,7 +332,7 @@ namespace com.keyman.text.prediction {
       }
 
       let transform = transcription.transform;
-      var promise = this.currentPromise = this.lmEngine.predict(alternates || transcription.transform, context);
+      var promise = this.currentPromise = this.lmEngine.predict(alternates, context);
 
       let lp = this;
       return promise.then(function(suggestions: Suggestion[]) {

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -323,8 +323,16 @@ namespace com.keyman.text.prediction {
         this.lmEngine.resetContext(context);
       }
 
+      let alternates = transcription.alternates;
+      if(!alternates || alternates.length == 0) {
+        alternates = [{
+          sample: transcription.transform,
+          p: 1.0
+        }];
+      }
+
       let transform = transcription.transform;
-      var promise = this.currentPromise = this.lmEngine.predict(transcription.alternates || transcription.transform, context);
+      var promise = this.currentPromise = this.lmEngine.predict(alternates || transcription.transform, context);
 
       let lp = this;
       return promise.then(function(suggestions: Suggestion[]) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -73,6 +73,14 @@ class ModelCompositor {
 
     if(!(transformDistribution instanceof Array)) {
       transformDistribution = [ {sample: transformDistribution, p: 1.0} ];
+    } else if(transformDistribution.length == 0) {
+      transformDistribution.push({
+        sample: {
+          insert: '',
+          deleteLeft: 0
+        },
+        p: 1.0
+      })
     }
 
     let inputTransform = transformDistribution.sort(function(a, b) {

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -74,6 +74,17 @@ class ModelCompositor {
     if(!(transformDistribution instanceof Array)) {
       transformDistribution = [ {sample: transformDistribution, p: 1.0} ];
     } else if(transformDistribution.length == 0) {
+      /*
+         Robust stop-gap: if our other filters somehow fail, this fixes the 
+         zero-length array by making it match the form of the array that
+         would result if it were instead called with the other legal 
+         parameter type - a single Transform.
+
+         Unfortunately, the method will lack all data about even 
+         the original keystroke that resulted in the call... but this way, 
+         we can at least get some predictions rather than shortcutting 
+         and producing none whatsoever.      
+      */
       transformDistribution.push({
         sample: {
           insert: '',


### PR DESCRIPTION
Fixes #5467.

No wonder it was an elusive little bugger.  I knew something smelled like a race condition as I started investigating... turns out it's probably a race condition caused by the interaction of standard OS context-swapping (or garbage collection) with that of a timer based on the system clock.  Hence why a direct repro is nigh-impossible to find or construct.

I should note that some of the Sentry issues do indicate occasions where they arose before [14.0.277](https://github.com/keymanapp/keyman/blob/stable-14.0/HISTORY.md#140277-stable-2021-06-29), which was when #5352 landed.  That said, the lion's share of the reports for the tagged issues are indeed since that release, which is why it's become as prominent now as it is.

So, while it's not exactly _perfect_ to just give up immediately once control returns to the engine... at least we've noticed that the correction algorithm itself is fairly capable on its own.  So, to keep things responsive, even though the delay is not in our algorithm but rather due to external pressure from the OS or the browser, we'll simply maintain the current logic, which thus bypasses fat-finger calculations as a result of the externally-caused delay.

## User Testing

@keymanapp/testers 

Much of this is taken from standard KMW acceptance testing and adapted toward the aspects of KMW modified by this PR, though we'll only worry about testing against a single platform here.

**Platform**:  Chrome emulation / Android

Ensure that you see the "Console" tab while performing these tests.
  - [ ] TEST_CRITICAL:  If any errors (red text entries in the "Console" area) or warnings appear during these tests, fail this test entry and report a screenshot of them.

Console tab:

<img width="783" alt="image" src="https://user-images.githubusercontent.com/25213402/126600152-19cf8905-9182-47f3-bfa5-637294cead36.png">

It should resemble Windows' `CMD` prompt and the macOS Terminal.

Utilize the "Test unminified Keymanweb" testing page to ensure the following:
  - [ ] TEST_1: KMW properly handles input to the controls.
  - Attempt to add the following keyboards:
    - [ ] TEST_2: By keyboard name:  `sil_ipa`.  (For our currently-deprecated IPA keyboard.)
      - [ ] TEST_3: `ŋ` should be a subkey of `n` - ensure it works.
    - [ ] TEST_4: By language code:  "km".
      - Note that if "km" doesn't return the `khmer_angkor` keyboard, you'll want to load that one by keyboard name for these tests.
      - [ ] TEST_5: Type in the following sequence:  ស, ុ, ្រ (subkey of រ), ក.  You should see ស្រុក.
      - [ ] TEST_6:  Continuing from the last test, hit backspace in sequence.  As this is a reorder (keyboard) rule test, you should see:
        - ស្រុ
        - ស្រ
        - ស
    - [ ] TEST_7:  By language name:  `spanish`.

Utilize the "Prediction - robust testing" testing page for the following:
  - Swap to the "English - EuroLatin (SIL)" keyboard.
    - [ ] TEST_8:  Use long-press `.` to output `'` and then press `e`.  The two characters should not combine.
    - [ ] TEST_9:  Ensure that long-press `p` and SHIFT + long-press `g` displays properly and that the subkeys produce the expected output.
    - [ ] TEST_10:  Type the following sequence, pressing near the center of the key each time:
      - `L` (shift layer)
      - `k` (default layer)
      - `v` (default layer)
      - Expected result:  you should see suggestions for `Love` and `Live`, along with one other random suggestion.