### PR TITLE
fix(common/models): keep/suggestion diacritic sensitivity when de-duping

### DIFF
--- a/common/predictive-text/unit_tests/headless/worker-model-compositor.js
+++ b/common/predictive-text/unit_tests/headless/worker-model-compositor.js
@@ -472,7 +472,10 @@ describe('ModelCompositor', function() {
       var suggestions = composite.predict([thr, the], context);
   
       // Get the top suggest for 'the' and 'thr*'.
-      var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'The' || s.displayAs === '“The”'; })[0];
+      // As of 15.0+, because of #5429, the keep suggestion `"The"` will not be merged
+      // with the model's suggestion of `the`.
+      var capTheSuggestion = suggestions.filter(function (s) { return s.displayAs === '“The”'; })[0];
+      var theSuggestion = suggestions.filter(function (s) { return s.displayAs === 'the'})[0];
       var thrSuggestion = suggestions.filter(function (s) { return s.displayAs.startsWith('thr'); })[0];
   
       // Sanity check: do we have actual real-valued probabilities?
@@ -480,6 +483,7 @@ describe('ModelCompositor', function() {
       assert.isBelow(thrSuggestion.p, 1.0);
       assert.isAbove(theSuggestion.p, 0.0);
       assert.isBelow(theSuggestion.p, 1.0);
+      assert.equal(capTheSuggestion.tag, 'keep'); // The keep suggestion
       // 'the' should be the intended the result here.
       assert.isAbove(theSuggestion.p, thrSuggestion.p);
     });

--- a/common/predictive-text/worker/model-compositor.ts
+++ b/common/predictive-text/worker/model-compositor.ts
@@ -253,8 +253,15 @@ class ModelCompositor {
     for(let prediction of rawPredictions) {
       // Combine duplicate samples.
       let displayText = prediction.sample.displayAs;
+      let preserveAsKeep = displayText == keepOptionText;
 
-      if(displayText == keepOptionText || (lexicalModel.toKey && displayText == lexicalModel.toKey(keepOptionText)) ) {
+      // De-duplication should be case-insensitive, but NOT
+      // diacritic-insensitive.
+      if(this.lexicalModel.languageUsesCasing) {
+        preserveAsKeep = preserveAsKeep || displayText == this.lexicalModel.applyCasing('lower', keepOptionText);
+      }
+
+      if(preserveAsKeep) {
         // Preserve the original, pre-keyed version of the text.
         if(!keepOption) {
           let baseTransform = prediction.sample.transform;


### PR DESCRIPTION
Fixes #5429.

The original behavior that caused the bug was implemented before 14.0, which introduced the `languageUsesCasing` flag.  So, before 14.0, `searchTermToKey` performed double-duty, modeling case-insensitivity _and_ diacritic-insensitivity.  But now... now, those have been split into separate functions.  When de-duplicating the "keep" string and a possible suggestion, we want diacritic-_sensitivity_ but case-_insensitivity_.  Fortunately, we now have the tools for that.

In the lexical model, words are always stored in lower-case.  If a user typed in initial-case, and the only difference is _casing_, that should match.  If, however, the user typed an extra diacritic... that's not a perfect match, and so we shouldn't de-duplicate.

------

Post-change samples:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/25213402/126582803-37a0f44a-c304-4a6b-a846-c3b1b7572fb0.png">

<img width="288" alt="image" src="https://user-images.githubusercontent.com/25213402/126582849-be670021-c2ba-434d-92da-28d045dea4b3.png">

The latter case is to make sure we didn't break things in the opposite direction:  when typed text lacks a diacritic but should have one according to the model.

## User Testing

The "**Prediction - robust testing**" test page should suffice here.  (All code changes are worker-internal and platform independent.)  Use Chrome's mobile-device emulation, enabling use of the touch OSK for testing.

**Alternative**: if it's easier for you, the Android app's build-artifact .apk may be used instead of the KMW test page.

- [ ] TEST.WITH_DIACRITIC_NOCAP:  Type `ŝee`.
- [ ] TEST.WITH_DIACRITIC_CAP:  Type `Ŝee`.  (The resulting suggestions should have their first letter capitalized.)
- [ ] TEST.NEEDS_DIACRITIC_CAP:  Type `Fiance`.
- [ ] TEST.NEEDS_DIACRITIC_NOCAP:  Type `fiance`.  (The resulting suggestions should lack capitalization.)
- [ ] TEST.MATCHED_DIACRITIC:  Type `Fiancé`.  (There should be no 'fiance' or 'Fiance' suggestion.)

Feel free to try a few other text entries that might have caused problems for the original issue as well, should you have any in mind, and ensure that they match your expectations.