### PR TITLE
fix(ios/engine): engine migration always precedes installs

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -198,20 +198,11 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
 
     URLProtocol.registerClass(KeymanURLProtocol.self)
 
-    Migrations.migrate(storage: Storage.active)
-    Migrations.updateResources(storage: Storage.active)
-
-    if Storage.active.userDefaults.userKeyboards?.isEmpty ?? true {
-      Storage.active.userDefaults.userKeyboards = [Defaults.keyboard]
-
-      // Ensure the default keyboard is installed in this case.
-      do {
-        try Storage.active.installDefaultKeyboard(from: Resources.bundle)
-      } catch {
-        SentryManager.captureAndLog(error, message: "Failed to copy default keyboard from bundle: \(error)")
-      }
-    }
-    Migrations.engineVersion = Version.latestFeature
+    /**
+     * As of 14.0, ResourceFileManager is responsible for handlng resources... including
+     * any necessary "migration" of their internal storage structure & tracked metadata.
+     */
+    ResourceFileManager.shared.runMigrationsIfNeeded()
 
     if Util.isSystemKeyboard || Storage.active.userDefaults.bool(forKey: Key.keyboardPickerDisplayed) {
       isKeymanHelpOn = false

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -328,6 +328,18 @@ public class ResourceFileManager {
       throw KMPError.resourceNotInPackage
     }
 
+    /**
+     * A surprisingly critical line.  The Manager.shared instance must be initialized at some
+     * point before the resources are _actually_ stored and reigstered.  Otherwise, the initial
+     * Migrations pass (called early in Manager.init) will interpret the installation as from a
+     * different engine version and will break anything installed before it's run.
+     *
+     * Fortunately... all 14.0's installation methods pass through this single method in order to
+     * do the actual "storing" and "registering".  So, it's a decent-enough place to force
+     * Manager.shared's init.
+     */
+    _ = Manager.shared
+
     do {
       try copyWithOverwrite(from: package.sourceFolder,
                             to: Storage.active.packageDir(for: package)!)

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -17,7 +17,36 @@ import UIKit
 public class ResourceFileManager {
   public static let shared = ResourceFileManager()
 
+  private var haveRunMigrations: Bool = false
+
   fileprivate init() {
+  }
+
+  func runMigrationsIfNeeded() {
+    if !haveRunMigrations {
+      // Set here in order to prevent recursively calling itself in case
+      // Migrations itself needs to use installation methods.
+      haveRunMigrations = true
+
+      // We must make sure that all resources are properly migrated before
+      // allowing any new resources to be installed.
+      Migrations.migrate(storage: Storage.active)
+      Migrations.updateResources(storage: Storage.active)
+
+      if Storage.active.userDefaults.userKeyboards?.isEmpty ?? true {
+        Storage.active.userDefaults.userKeyboards = [Defaults.keyboard]
+
+        // Ensure the default keyboard is installed in this case.
+        do {
+          try Storage.active.installDefaultKeyboard(from: Resources.bundle)
+        } catch {
+          SentryManager.captureAndLog(error, message: "Failed to copy default keyboard from bundle: \(error)")
+        }
+      }
+      Migrations.engineVersion = Version.latestFeature
+    }
+
+    haveRunMigrations = true
   }
 
   public var installedPackages: [KeymanPackage] {
@@ -328,17 +357,13 @@ public class ResourceFileManager {
       throw KMPError.resourceNotInPackage
     }
 
-    /**
-     * A surprisingly critical line.  The Manager.shared instance must be initialized at some
-     * point before the resources are _actually_ stored and reigstered.  Otherwise, the initial
-     * Migrations pass (called early in Manager.init) will interpret the installation as from a
-     * different engine version and will break anything installed before it's run.
-     *
-     * Fortunately... all 14.0's installation methods pass through this single method in order to
-     * do the actual "storing" and "registering".  So, it's a decent-enough place to force
-     * Manager.shared's init.
-     */
-    _ = Manager.shared
+    // Resources should only be installed after Migrations have been run.
+    // Otherwise, the Migrations engine may misinterpret the installed format
+    // on an app's first install.
+    //
+    // It is possible for a KeymanEngine framework consumer to reach this point
+    // without `Manager.init` having been run.
+    runMigrationsIfNeeded()
 
     do {
       try copyWithOverwrite(from: package.sourceFolder,

--- a/ios/samples/KMSample2/KMSample2/AppDelegate.swift
+++ b/ios/samples/KMSample2/KMSample2/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     KeymanEngine.log.logAppDetails()
 
     // Replace with your application group id
+    // Ensure this happens before installing any keyboards or models within the engine
+    // whenever using App Group Identifiers.
     Manager.applicationGroupIdentifier = "group.KMSample"
     return true
   }


### PR DESCRIPTION
Fixes an issue reported through other channels by a third-party KeymanEngine user that seemed to obliterate keyboards installed on their app's first launch (and _only_ during that first launch).  Should be 🍒-picked, as the underlying issue can cause similar unintuitive issues for other 3rd-party framework users.

------

The changes to resource installation in 14.0 did a lot to disentangle the process for installing keyboards and models from KeymanEngine's `Manager` monolith-class.  Unfortunately, it turns out there was one subtle but critical strand of entanglement that wasn't quite removed.

While resource installation itself isn't dependent on a `Manager` instance existing, the `Migrations` system called early on in `Manager`'s init _must_ run _before_ any resources are installed; otherwise, its current logic will obliterate anything newly installed.  Think of it this way: for new installs, it's very much like installing resources for the 14.0 format, then saying "now update those resources from the 2.0 format to the 14.0 format."  _Technically_, it's an issue with the `Migrations` subsystem, but it's actually rather hard to fix within it due to limitations with the last-engine-version detection system.  (Especially in a way that would be safe to 🍒-pick for `stable`.)

Fortunately, all that modularity makes it possible for us to transplant the code responsible for running `Migrations`.  (I ran a trace and performed a test run to ensure there are no accidental recursion shenanigans occurring.)  Making it part of `ResourceFileManager` now makes sense.  While it can't be run as part of the class's `init`, as `Migrations` does need to refer back to `ResourceFileManager`, a little state tracking will pave a way for the class to ensure that the `Migrations` subsystem always runs first.

## User Testing

@keymanapp/testers 

- [ ] TEST_DIRTY:  Ensure that the iOS app successfully launches when installed over a previous, customized installation.
    - Verify that all previously-installed keyboards are still installed.
    - Swapping among the keyboards via the picker is enough to tell us what we need.

- [ ] TEST_CLEAN:  Ensure that the iOS app successfully launches from a _clean_ install.
    - There are two ways to do this:
        - Set Xcode to target a device that you have not previously used for any tests.
        - Reset a simulated device that you have previously used:

            <img width="466" alt="image" src="https://user-images.githubusercontent.com/25213402/126731993-a1e6f3b1-ad1a-4343-b704-6d3e9a11148d.png">

            Run that to reset a simulated device, which will erase all existing Keyman settings on said simulated device.