### PR TITLE
chore(ios,windows): Update crowdin strings for Azerbaijani

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
@@ -1,32 +1,32 @@
 /* A descriptive message used for errors when the app is already busy downloading */
-"alert-download-error-busy" = "Onsuz da yükləməklə məşğuldur.";
+"alert-download-error-busy" = "Artıq endirilir.";
 
 /* A descriptive message used when a download fails */
-"alert-download-error-detail" = "Yükləmə və ya quraşdırma zamanı xəta baş verdi.";
+"alert-download-error-detail" = "Endirmə və ya quraşdırma zamanı xəta baş verdi.";
 
 /* Title for a "download failed" alert */
-"alert-download-error-title" = "Yükləmə xətası";
+"alert-download-error-title" = "Endirmə xətası";
 
 /* Title for a general alert about errors */
 "alert-error-title" = "Xəta";
 
 /* A descriptive message used when no internet connection is detected */
-"alert-no-connection-detail" = "Keyman serverinə çata bilmədi. Zəhmət olmasa bir az sonra yenə cəhd edin.";
+"alert-no-connection-detail" = "Keyman serverinə çata bilmədi. Zəhmət olmasa daha sonra yenidən sınayın.";
 
 /* Title for a "no connection" alert */
-"alert-no-connection-title" = "Əlaqə xətası";
+"alert-no-connection-title" = "Bağlantı xətası";
 
 /* Short text for a 'back' navigational command.  Used to return to the previous screen */
 "command-back" = "Geri";
 
 /* Short text for a 'cancel' command.  Used to back out of a menu or install process without making changes */
-"command-cancel" = "Ləğv etmək";
+"command-cancel" = "İmtina";
 
 /* Short text for a 'done' command.  Used to back out of settings menus after changes have been made */
-"command-done" = "Bitdi";
+"command-done" = "Hazırdır";
 
 /* Short text for an 'install' command.  Used to confirm installation of a package. */
-"command-install" = "Yüklemek";
+"command-install" = "Quraşdır";
 
 /* Short text for a 'next' navigational command.  Used to advance to the next screen */
 "command-next" = "Növbəti";
@@ -38,25 +38,25 @@
 "command-uninstall" = "Sil";
 
 /* Text for the command to uninstall a keyboard */
-"command-uninstall-keyboard" = "Klaviaturanı silin";
+"command-uninstall-keyboard" = "Klaviaturanı sil";
 
 /* Confirmation text to display before uninstalling a keyboard */
 "command-uninstall-keyboard-confirm" = "Bu klaviaturanı silmək istəyirsiniz?";
 
 /* Text for the command to uninstall a lexical model */
-"command-uninstall-lexical-model" = "Lüğəti silmək";
+"command-uninstall-lexical-model" = "Lüğəti sil";
 
 /* Confirmation text to display before uninstalling a lexical model */
 "command-uninstall-lexical-model-confirm" = "Bu lüğəti silmək istəyirsiniz?";
 
 /* Text for error when an installed file is unexpectedly missing */
-"error-missing-file" = "Lazımi bir fayl tapılmadı.";
+"error-missing-file" = "Tələb olunan fayl tapıla bilmədi.";
 
 /* Text for error when an installed file is unexpectedly missing */
-"error-missing-file-critical" = "Həlledici bir fayl tapılmadı. Tətbiqi yenidən quraşdırmağa cəhd edin.";
+"error-missing-file-critical" = "Kritik fayl tapıla bilmədi. Tətbiqi yenidən quraşdırmağı sınayın.";
 
 /* Text for errors in data received from search queries */
-"error-query-decoding" = "Server hazırda texniki çətinliklərlə üzləşir";
+"error-query-decoding" = "Hal-hazırda server texniki çətinliklər yaşayır";
 
 /* A descriptive message used when a download fails */
 "error-query-general" = "Serverlə əlaqə qurma xətası";
@@ -65,7 +65,7 @@
 "error-query-no-data" = "Server cavab vermədi";
 
 /* Text for general errors where not much information is known */
-"error-unknown" = "Gözlənilməz bir səhv baş verdi";
+"error-unknown" = "Gözlənilməz bir xəta baş verdi";
 
 /* Text for error when updating a resource:  cannot download because no source is available */
 "error-update-no-link" = "Bu paket üçün yeniləmə mənbəyi mövcud deyil";
@@ -89,7 +89,7 @@
 "installer-label-package-info" = "Paket məlumatı";
 
 /* Label used for the language-selection tab with the package installation prompt on phones. */
-"installer-label-select-languages" = "Dil (lər) seçin";
+"installer-label-select-languages" = "Dil(lər)i seçin";
 
 /* Label used with a package's version, as seen within the package installation prompt.  Example:  "Version: 14.0.0" */
 "installer-label-version" = "Versiya: %@";
@@ -98,22 +98,22 @@
 "installer-section-available-languages" = "Mövcud Dillər";
 
 /* Text for the help popup for changing keyboards with the globe key */
-"keyboard-help-change" = "Klaviaturanı dəyişdirmək üçün buraya vurun";
+"keyboard-help-change" = "Klaviaturanı dəyişdirmək üçün buraya toxunun";
 
 /* Text for the command to exit the Keyman keyboard in favor of other keyboards installed on the system */
-"keyboard-menu-exit" = "Bağlamaq %@";
+"keyboard-menu-exit" = "%@ bağla";
 
 /* Error installing a Keyman package - could not allocate a location to install it */
-"kmp-error-file-system" = "Paketin quraşdırılması zamanı səhv - fayl sistemi xətası";
+"kmp-error-file-system" = "Paket quraşdırma xətası - fayl sistem xətası";
 
 /* Error installing a Keyman package - could not copy package files */
-"kmp-error-file-copying" = "Paketin quraşdırılması zamanı səhv - tələb olunan faylları köçürə bilmədi";
+"kmp-error-file-copying" = "Paket quraşdırma xətası - tələb olunan fayllar köçürə bilmədi";
 
 /* Error opening a Keyman package - package is not valid */
-"kmp-error-invalid" = "Paketin faylı pozulub.";
+"kmp-error-invalid" = "Paketin faylı zədəlidir.";
 
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
-"kmp-error-missing-resource" = "Bu paketdə tələb olunan klaviatura və ya lüğət yoxdur.";
+"kmp-error-missing-resource" = "Bu paket tələb olunan klaviatura və ya lüğəti ehtiva etmir.";
 
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "Bu paket düzgün qurulmamışdır - məzmunu bilinmir.";
@@ -134,16 +134,16 @@
 "menu-langsettings-section-settings" = "Dil parametrləri";
 
 /* Title for the language-specific settings menus */
-"menu-langsettings-title" = "%@ Parametrlər";
+"menu-langsettings-title" = "%@ Parametrləri";
 
 /* Label for the toggle that enables corrections that is displayed within a language-specific settings menu */
-"menu-langsettings-toggle-correct" = "Düzəlişləri aktivləşdirmək";
+"menu-langsettings-toggle-correct" = "Düzəlişləri fəallaşdır";
 
 /* Label for the toggle that enables predictions that is displayed within a language-specific settings menu */
-"menu-langsettings-toggle-predict" = "Proqnozları aktivləşdirmək";
+"menu-langsettings-toggle-predict" = "Təxminləri fəallaşdır";
 
 /* Help message for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
-"menu-lexical-model-install-message" = "Bu lüğəti qurmaq istərdinizmi?";
+"menu-lexical-model-install-message" = "Bu lüğəti quraşdırmaq istəyirsiniz?";
 
 /* Title for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
 "menu-lexical-model-install-title" = "%1$@:%2$@";
@@ -152,55 +152,55 @@
 "menu-lexical-model-none-message" = "Heç bir lüğət yoxdur";
 
 /* Title for the lexical model menu, a submenu of the language-specific settings menus */
-"menu-lexical-model-title" = "%@ Lüğətlər";
+"menu-lexical-model-title" = "%@ Lüğətləri";
 
 /* Title for the keyboard picker */
 "menu-picker-title" = "Klaviaturalar";
 
 /* Primary text for the Settings menu option to report keyboard crashes */
-"menu-settings-error-report" = "Xəta Bildirilməsinə icazə verin";
+"menu-settings-error-report" = "Xəta bildirməyə icazə ver";
 
 /* Secondary text for the Settings menu option to report keyboard crashes */
-"menu-settings-error-report-description" = "\"Tam giriş\" tələb edə bilər";
+"menu-settings-error-report-description" = "\"Tam müraciət\" tələb edə bilər";
 
 /* Primary text for the Settings menu local-file package installation option */
 "menu-settings-install-from-file" = "Fayldan quraşdırın";
 
 /* Secondary text for the Settings menu local-file package installation option */
-"menu-settings-install-from-file-description" = ".Kmp faylları axtarmaq";
+"menu-settings-install-from-file-description" = ".kmp fayllarını axtar";
 
 /* Primary text for the Settings menu option that displays the iOS system menu options for the app's keyboard */
 "menu-settings-system-keyboard-menu" = "Sistem Klaviatura Parametrləri";
 
 /* Label for the "Show Banner" toggle on the main settings screen */
-"menu-settings-show-banner" = "Banner göstərmək";
+"menu-settings-show-banner" = "Banneri göstər";
 
 /* Label for the "Get Started" automatic display toggle seen in the Settings menu */
-"menu-settings-startup-get-started" = "Başlanğıcda 'Başlayın' göstərmək";
+"menu-settings-startup-get-started" = "Başlanğıcda 'Başlayın' göstər";
 
 /* Title for the main Settings menu */
 "menu-settings-title" = "Keyman Parametrləri";
 
 /* Short text for notification:  download failure for keyboard */
-"notification-download-failure-keyboard" = "Klaviatura yüklənmədi";
+"notification-download-failure-keyboard" = "Klaviatura endirilmədi";
 
 /* Short text for notification:  download failure for lexical model */
-"notification-download-failure-lexical-model" = "Lüğət yüklənmədi";
+"notification-download-failure-lexical-model" = "Lüğət endirilmədi";
 
 /* Short text for notification:  download success for keyboard */
 "notification-download-success-keyboard" = "Klaviatura uğurla endirildi";
 
 /* Short text for notification:  download success for lexical model */
-"notification-download-success-lexical-model" = "Leksik model uğurla yükləndi";
+"notification-download-success-lexical-model" = "Leksik model uğurla endirildi";
 
 /* Short text for notification:  downloading a keyboard */
-"notification-downloading-keyboard" = "Klaviatura yüklənir \\ U2026";
+"notification-downloading-keyboard" = "Klaviatura endirilir\U2026";
 
 /* Short text for notification:  downloading a lexical model */
-"notification-downloading-lexical-model" = "Lüğət yüklənir \U2026";
+"notification-downloading-lexical-model" = "Lüğət endirilir\U2026";
 
 /* Short text for notification:  an update is available */
-"notification-update-available" = "Yeniləmə mümkündür";
+"notification-update-available" = "Yeniləmə mövcuddur";
 
 /* Short text for notification:  currently updating */
 "notification-update-processing" = "Yenilənir\U2026";
@@ -209,4 +209,4 @@
 "success-install" = "Uğurla quraşdırıldı.";
 
 /* A title to use in alerts indicating 'success' at whatever task the user requested */
-"success-title" = "Uğur";
+"success-title" = "Uğurlu";

--- a/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
@@ -107,7 +107,7 @@
 "kmp-error-file-system" = "Paket quraşdırma xətası - fayl sistem xətası";
 
 /* Error installing a Keyman package - could not copy package files */
-"kmp-error-file-copying" = "Paket quraşdırma xətası - tələb olunan fayllar köçürə bilmədi";
+"kmp-error-file-copying" = "Paket quraşdırma xətası - tələb olunan fayllar kopyalana bilmədi";
 
 /* Error opening a Keyman package - package is not valid */
 "kmp-error-invalid" = "Paketin faylı zədəlidir.";

--- a/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.stringsdict
+++ b/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.stringsdict
@@ -13,9 +13,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>u</string>
         <key>one</key>
-        <string>%u lüğət quraşdırılıb</string>
+        <string>%u lüğət quraşdırıldı</string>
         <key>other</key>
-        <string>%u lüğətlər quraşdırıldı</string>
+        <string>%u lüğət quraşdırıldı</string>
       </dict>
     </dict>
     <key>notification-update-failed</key>

--- a/ios/keyman/Keyman/Keyman/Classes/GetStartedViewController/GetStartedViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/GetStartedViewController/GetStartedViewController.swift
@@ -28,6 +28,7 @@ class GetStartedViewController: UIViewController, UITableViewDelegate, UITableVi
     NotificationCenter.default.addObserver(self, selector: #selector(self.refreshTable),
                                            name: UIApplication.didBecomeActiveNotification, object: nil)
 
+    navItem.title = NSLocalizedString("menu-get-started", comment: "")
     tableView.isScrollEnabled = false
 
     let icon = UIImageView(image: #imageLiteral(resourceName: "887-notepad.png"))

--- a/ios/keyman/Keyman/Keyman/az.lproj/Localizable.strings
+++ b/ios/keyman/Keyman/Keyman/az.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 /* Title for the bookmarks menu within the embedded browser */
-"browser-bookmarks-add-title" = "Əlfəcin əlavə etmək";
+"browser-bookmarks-add-title" = "Əlfəcin əlavə et";
 
 /* Title for the bookmarks menu within the embedded browser */
 "browser-bookmarks-none" = "Əlfəcin yoxdur";
@@ -17,7 +17,7 @@
 "error-opening-page" = "Səhifə açıla bilmir";
 
 /* Long-form used when installing a font in order to display a language properly. */
-"font-install-description" = "Bütün tətbiqlərinizdə %@ görüntüsünü düzgün görünmək üçün Quraşdır'a toxunun";
+"font-install-description" = "Bütün tətbiqlərinizdə %@ in düzgün görünməsi üçün \"Quraşdır\"a toxunun";
 
 /* The name of the iOS Settings menu option for keyboards */
 "ios-settings-keyboards" = "Klaviaturalar";
@@ -30,13 +30,13 @@ underneath the app's name within the app-specific keyboard menu.) */
 "language-for-font" = "%@ Şrift";
 
 /* Used for 'add' options within menus */
-"menu-add" = "Əlavə etmək";
+"menu-add" = "Əlavə et";
 
 /* Used to indicate a sequence of menu options that a user needs to copy.  May be chained.  Example:  "Keyboards (1) > Enable Keyman (2)" */
 "menu-breadcrumbing" = "%1$@ > %2$@";
 
 /* Used to exit a menu without choosing an option */
-"menu-cancel" = "Ləğv etmək";
+"menu-cancel" = "İmtina";
 
 /* Menu option that erases all previously-typed text. */
 "menu-clear-text" = "Mətni təmizlə";
@@ -51,13 +51,13 @@ underneath the app's name within the app-specific keyboard menu.) */
 "menu-more" = "Daha çox";
 
 /* Menu option used to edit keyboard and dictionary settings */
-"menu-settings" = "Parametrlər";
+"menu-settings" = "Tənzimləmələr";
 
 /* Menu option that displays the iOS Share menu */
 "menu-share" = "Paylaş";
 
 /* Menu option that displays an embedded web browser. */
-"menu-show-browser" = "Brauzer";
+"menu-show-browser" = "Səyyah";
 
 /* Menu option used to control in-app font size. */
 "menu-text-size" = "Mətn ölçüsü";
@@ -66,16 +66,16 @@ underneath the app's name within the app-specific keyboard menu.) */
 "text-size-label" = "Mətn ölçüsü:%i";
 
 /* Text to indicate that a user should set a toggle within iOS Settings to 'active'. */
-"toggle-to-enable" = "%@ İşə salmaq";
+"toggle-to-enable" = "Fəallaşdır: %@";
 
 /* First option on the Get Started tutorial - Add a keyboard for your language */
-"tutorial-add-keyboard" = "Sizin diliniz üçün klaviaturanı əlavə edin";
+"tutorial-add-keyboard" = "Diliniz üçün klaviatura əlavə edin";
 
 /* Third option on the Get Started tutorial - Displays app help. */
 "tutorial-show-help" = "Ətraflı məlumat";
 
 /* Second option on the Get Started tutorial - Set up Keyman as system-wide keyboard */
-"tutorial-system-keyboard" = "Keyman ümumsistem klaviatura kimi işə salmaq";
+"tutorial-system-keyboard" = "\"Keyman\"ı geniş sistem klaviaturası kimi quraşdırın";
 
 /* Used to display app version (as in \"Version: 1.0.2\" */
-"version-label" = "Versiya %@";
+"version-label" = "Versiya: %@";

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -31,11 +31,11 @@
   <!-- Context: General Strings -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Button_Cancel" comment="Cancel button term">Ləğv etmək</string>
+  <string name="S_Button_Cancel" comment="Cancel button term">İmtina</string>
   <!-- Context: General Strings -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Button_Close" comment="Close button term">Bağlamaq</string>
+  <string name="S_Button_Close" comment="Close button term">Bağla</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
@@ -43,7 +43,7 @@
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKButtonCancel" comment="Cancel button in message boxes">Ləğv etmək</string>
+  <string name="SKButtonCancel" comment="Cancel button in message boxes">İmtina</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.330.0 -->

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -51,11 +51,11 @@
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.330.0 -->
-  <string name="SKBalloonOSKClosed" comment="Balloon that shows when OSK is closed">Keyman hələ də çalışır. Dil klaviaturanızı istənilən vaxt istifadə etmək üçün bu işarəni vurun</string>
+  <string name="SKBalloonOSKClosed" comment="Balloon that shows when OSK is closed">Keyman hələ də işləyir. Dil klaviaturanızı istənilən vaxt istifadə etmək üçün bu nişana klikləyin</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 14.0.234 -->
-  <string name="SKBalloonKeymanIsRunning" comment="Balloon that shows when user tries to start Keyman but it is already running">Keyman artıq çalışır. Dil klaviaturanızı istifadə etmək üçün sistem bildiriş sahəsindəki Keyman simgesini vurun</string>
+  <string name="SKBalloonKeymanIsRunning" comment="Balloon that shows when user tries to start Keyman but it is already running">Keyman artıq işləyir. Dil klaviaturanızı istifadə etmək üçün sistem bildiriş sahəsindəki Keyman nişanına klikləyin</string>
   <!-- Context: Configuration Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -67,7 +67,7 @@
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Keyboards" comment="Keyboard Layouts tab name">Klaviatura tərtibləri</string>
+  <string name="S_Keyboards" comment="Keyboard Layouts tab name">Klaviatura düzülüşləri</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -79,7 +79,7 @@
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Options_AccessChar" comment="Direct access to the Options tab using alt+">O</string>
+  <string name="S_Options_AccessChar" comment="Direct access to the Options tab using alt+">S</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -87,7 +87,7 @@
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Hotkeys_AccessChar" comment="Direct access to the Hotkeys tab using alt+">H</string>
+  <string name="S_Hotkeys_AccessChar" comment="Direct access to the Hotkeys tab using alt+">Q</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -95,15 +95,15 @@
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Support_AccessChar" comment="Direct access to the Support tab using alt+">S</string>
+  <string name="S_Support_AccessChar" comment="Direct access to the Support tab using alt+">D</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.493.0 -->
-  <string name="S_KeepInTouch" comment="Keep in touch tab name">Əlaqə saxlayın</string>
+  <string name="S_KeepInTouch" comment="Keep in touch tab name">Əlaqədə qalın</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.492.0 -->
-  <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">T</string>
+  <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">Ə</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -115,7 +115,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.442.0 -->
-  <string name="S_Caption_KeyboardVersion" comment="Keyboard download window, etc. - term for keyboard version">Klaviatura versiyası</string>
+  <string name="S_Caption_KeyboardVersion" comment="Keyboard download window, etc. - term for keyboard version">Klaviatura versiyası:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -123,7 +123,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_Website" comment="Keyboard download window, etc. - term for website">Veb səhifə:</string>
+  <string name="S_Caption_Website" comment="Keyboard download window, etc. - term for website">Veb sayt:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -135,11 +135,11 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_Keyboards" comment="Keyboard download window, etc. - term for keyboard layouts">Klaviatura tərtibləri:</string>
+  <string name="S_Caption_Keyboards" comment="Keyboard download window, etc. - term for keyboard layouts">Klaviatura düzülüşləri:</string>
   <!-- Context: Keyboard Install Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 14.0 -->
-  <string name="S_Caption_Keyboard" comment="Keyboard install dialog - term for a single keyboard layout">Klaviatura tərtibləri:</string>
+  <string name="S_Caption_Keyboard" comment="Keyboard install dialog - term for a single keyboard layout">Klaviatura düzülüşü:</string>
   <!-- Context: Keyboard Install Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 14.0 -->
@@ -155,11 +155,11 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_LayoutType_Positional" comment="Keyboard download window, etc. - term for the fixed keyboard layout type">Fixed (Mövqə)</string>
+  <string name="S_LayoutType_Positional" comment="Keyboard download window, etc. - term for the fixed keyboard layout type">Sabit (Mövqe)</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_LayoutType_Mnemonic" comment="Keyboard download window, etc. - term for the mnemonic keyboard layout type">Windows tərtibatına uyğunlaşdırıldı (Yadda salıcı)</string>
+  <string name="S_LayoutType_Mnemonic" comment="Keyboard download window, etc. - term for the mnemonic keyboard layout type">Windows düzülüşünə gətirildi (Xatırladıcı)</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
@@ -171,43 +171,43 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Install" comment="Add language profile">Dil əlavə etmək</string>
+  <string name="S_Languages_Install" comment="Add language profile">Dil əlavə et</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_OnScreenKeyboard" comment="Term for the On Screen Keyboard">Ekran klaviaturasında:</string>
+  <string name="S_Caption_OnScreenKeyboard" comment="Term for the On Screen Keyboard">Ekran klaviaturası:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.306.0 -->
-  <string name="S_OnScreenKeyboard_Custom" comment="(OSK) Custom term">Fərdiləşdirilən</string>
+  <string name="S_OnScreenKeyboard_Custom" comment="(OSK) Custom term">Özəl</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_OnScreenKeyboard_Installed" comment="(OSK) Installed term">Qurulmuş</string>
+  <string name="S_OnScreenKeyboard_Installed" comment="(OSK) Installed term">Quraşdırılmış</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_OnScreenKeyboard_NotInstalled" comment="(OSK) Not installed term">Qurulmamış</string>
+  <string name="S_OnScreenKeyboard_NotInstalled" comment="(OSK) Not installed term">Quraşdırılmamış</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.306.0 -->
-  <string name="S_Caption_Documentation" comment="Term for the Documentation">Sənədləşməsi</string>
+  <string name="S_Caption_Documentation" comment="Term for the Documentation">Sənədləşdirmə:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.306.0 -->
-  <string name="S_Documentation_Installed" comment="(Documentation) Installed term">Qurulmuş</string>
+  <string name="S_Documentation_Installed" comment="(Documentation) Installed term">Quraşdırılmış</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.306.0 -->
-  <string name="S_Documentation_NotInstalled" comment="(Documentation) Not installed term">Qurulmamış</string>
+  <string name="S_Documentation_NotInstalled" comment="(Documentation) Not installed term">Quraşdırılmamış</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_Message" comment="Keyboard download window, etc. - term for additional messages">Mesaj</string>
+  <string name="S_Caption_Message" comment="Keyboard download window, etc. - term for additional messages">Mesaj:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_Copyright" comment="Keyboard download window, etc. - term for copyright">Müəllif hüquqları:</string>
+  <string name="S_Caption_Copyright" comment="Keyboard download window, etc. - term for copyright">Müəllif hüququ:</string>
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 14.0 -->
@@ -215,11 +215,11 @@
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">Klaviaturanı quraşdırmaq</string>
+  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">Klaviaturanı quraşdır...</string>
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Button_DownloadKeyboard" comment="Keyboard Layouts - download keyboard button">Klaviatura yüklənir...</string>
+  <string name="S_Button_DownloadKeyboard" comment="Keyboard Layouts - download keyboard button">Klaviaturanı endir...</string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.287.0 -->
@@ -227,24 +227,24 @@
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Keyboards_NoKeyboardsInstalled" comment="Keyboard Layouts - notice of no keyboard layouts installed">Quraşdırılmış klaviatura yoxdur. Keyman veb saytından klaviatura düzeni qurmaq üçün Klaviaturanı Yüklə düyməsini vurun.</string>
+  <string name="S_Keyboards_NoKeyboardsInstalled" comment="Keyboard Layouts - notice of no keyboard layouts installed">Qurulu heç bir klaviaturanız yoxdur. Keyman veb saytından klaviatura düzülüşünü quraşdırmaq üçün Klaviatura Endir düyməsini klikləyin.</string>
   <!-- Parameters: %1$s = keyboard layout name -->
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- Introduced: 7.1.251.0 -->
   <!-- String Type: PlainText -->
-  <string name="SKUninstallRequireAdmin" comment="Keyboard Layouts - notice of ineligibility to uninstall a keyboard">Yalnız bir idarəedicisinizsə \'%1$s\' klaviaturasını silə bilərsiniz</string>
+  <string name="SKUninstallRequireAdmin" comment="Keyboard Layouts - notice of ineligibility to uninstall a keyboard">Əgər administratorsunuzsa, \"%1$s\" klaviaturasını silə bilərsiniz</string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 13.0.40.0 -->
-  <string name="S_Keyboard_Share" comment="Keyboard Layouts - share selected keyboard button">Klaviaturanı paylaşmaq</string>
+  <string name="S_Keyboard_Share" comment="Keyboard Layouts - share selected keyboard button">Klaviaturanı paylaş</string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 13.0.40.0 -->
-  <string name="S_Keyboard_Share_QRCode" comment="Keyboard Layouts - caption explaining QRCode, plus prefix to link to share">Bu klaviaturanı başqa bir cihaza yükləmək üçün bu kodu tarayın</string>
+  <string name="S_Keyboard_Share_QRCode" comment="Keyboard Layouts - caption explaining QRCode, plus prefix to link to share">Bu klaviaturanı başqa bir cihazda yükləmək üçün bu kodu skan edin və ya </string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 13.0.40.0 -->
-  <string name="S_Keyboard_Share_Link" comment="Keyboard Layouts - text for link to share">onlayn paylaşmaq</string>
+  <string name="S_Keyboard_Share_Link" comment="Keyboard Layouts - text for link to share">onlayn paylaşın</string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 13.0.40.0 -->
@@ -256,35 +256,35 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="kogStartup" comment="Options section - Startup">Başlamaq</string>
+  <string name="kogStartup" comment="Options section - Startup">Açılış</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.244.0 -->
-  <string name="kogOSK" comment="Options section - OSK">Ekran klaviaturasında</string>
+  <string name="kogOSK" comment="Options section - OSK">Ekran klaviaturası</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="kogAdvanced" comment="Options section - Advanced">Genişləndirilmiş</string>
+  <string name="kogAdvanced" comment="Options section - Advanced">Qabaqcıl</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koKeyboardHotkeysAreToggle" comment="General options - hotkeys toggle on AND off a keyboard layout">Klaviatura qısa yol düymələri klaviatura aktivləşdirməsini dəyişir</string>
+  <string name="koKeyboardHotkeysAreToggle" comment="General options - hotkeys toggle on AND off a keyboard layout">Klaviatura qısayol düymələri klaviatura aktivləşdirməsini dəyişdirir</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koAltGrCtrlAlt" comment="General options - Ctrl+Alt simulates AltGr on computers without AltGr">Ctrl + Alt ilə AltGr simulyasiya edin</string>
+  <string name="koAltGrCtrlAlt" comment="General options - Ctrl+Alt simulates AltGr on computers without AltGr">Ctrl + Alt ilə \"AltGr\"i simulyasiya edin</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 9.0.480.0 -->
-  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">Donanım açar düymələrini düz açarlar kimi qəbul edin</string>
+  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">Aparat təminatı özəl düymələrinə düz düymələr kimi davran</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.244.0 -->
-  <string name="koShowHints" comment="General options - show/hide hint messages (resets hint messages individually disabled)">Eyham mesajlarını göstərin</string>
+  <string name="koShowHints" comment="General options - show/hide hint messages (resets hint messages individually disabled)">Məsləhət mesajlarını göstər</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 14.0 -->
-  <string name="koAutomaticallyReportErrors" comment="General options - report errors to Keyman team automatically">Səhvləri avtomatik olaraq keyman.com saytına bildirmək</string>
+  <string name="koAutomaticallyReportErrors" comment="General options - report errors to Keyman team automatically">Xətaları avtomatik olaraq keyman.com-da bildir</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 14.0 -->

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -641,11 +641,11 @@
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKUILanguageName" comment="User interface language name in the UI language">İngilis dili</string>
+  <string name="SKUILanguageName" comment="User interface language name in the UI language">Azərbaycanca (Azəricə)</string>
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">İngilis dili</string>
+  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">Azərbaycanca (Azerbaijani)</string>
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->


### PR DESCRIPTION
One of the translators on translate.keyman.com flagged 3 Windows strings for Azerbaijani as incorrect. Here's the 3 strings.

*Update:*
It's grown to 40+ strings. Per Ken
> I read through several of the issues, and I think his translation is okay.

## User Testing
@keymanapp/testers 

We generally haven't done any special testing when updating Crowdin strings. You can:

### Test 1 - Keyman for Windows
* Get the test build installer and select "Azerbaycanca" (closest resemblance  of  typing "Azerbaijani") during Setup
![keyman setup - az](https://user-images.githubusercontent.com/7358010/127426090-b42e228a-6b0e-4a68-91b1-74464c6d8e5b.png)
* After Setup finishes, open Keyman Configuration --> Display In --> Azerbaijani
* Spot check the Keyman UI

### Test 2 - Keyman for iPhone and iPad
* This probably involves building the app from this branch. I'm not familiar with how you'd set the locale for Azerbaijani
