### PR TITLE
fix(web): stuck key highlighting from touchpoint movement

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -727,6 +727,7 @@ namespace com.keyman.osk {
       // Replace the target key, if any, by the new target key
       // Do not replace a null target, as that indicates the key has already been released
       if(key1 && this.keyPending) {
+        this.highlightKey(key0, false);
         this.keyPending = key1;
         this.touchPending = e.touches[0];
       }


### PR DESCRIPTION
Looks like something slipped through the cracks in one of the previous OSK PRs; it's possible for keys to receive 'stuck' highlighting during a touch-move operation.  (First noticed when testing a different, branch-local issue on #5462.) Fortunately... it's an easy fix.

The test below also serves as a repro on the current state of `master`.  Happens for both 'phone' and 'tablet' form-factors, though it's worse for tablets since they don't use key previews.

## User Testing
@keymanapp/testers

**Platform**
- Use the KeymanWeb "Test unminified Keymanweb" test page on any platform/browser combination that allows emulation of a touch device.
    - For example, Windows / Chrome _or_ macOS / Chrome.  Whichever is more convenient for you.
    - Be sure to enter Developer mode and actually turn on mobile device emulation for "iPad".  (The issue is more prominent on tablets.)
    - Use that test page's default keyboard ("English", on the spacebar).

- [ ] TEST:
    1. _**Start**_ a touch event by touching (well, clicking) and holding the `` ` `` key.
        - Do _**not**_ release the touch until _**explicitly**_ told to do so.
    2. With the touch (click) still held, move the touchpoint to the ENTER key.
    3. Now, with it still held, move it to the SHIFT key.
    4. Now move it to the `z` key.
    5. _**Now**_ release the touch (click).

Only one key should ever be highlighted at a time; there should be no stuck highlighting.

If this test is performed on `master`: 

<img width="384" alt="image" src="https://user-images.githubusercontent.com/25213402/127079980-8a4e4f95-447e-4e8d-90e9-8d27a63f7f3a.png">

All keys underneath the dragged touch but the final key (`z`) will have "stuck" highlighting.  That may be removed by using each affected key one time.