### PR TITLE
fix(android): displayName for keyboard was not optional

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -150,7 +150,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
-      this.displayName = installedObj.getString(KB_DISPLAY_NAME_KEY);
+      this.displayName = installedObj.optString(KB_DISPLAY_NAME_KEY);
     } catch (JSONException e) {
       KMLog.LogException(TAG, "fromJSON exception: ", e);
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java
@@ -150,7 +150,7 @@ public class Keyboard extends LanguageResource implements Serializable {
       this.isNewKeyboard = installedObj.getBoolean(KB_NEW_KEYBOARD_KEY);
       this.font = installedObj.getString(KB_FONT_KEY);
       this.oskFont = installedObj.getString(KB_OSK_FONT_KEY);
-      this.displayName = installedObj.optString(KB_DISPLAY_NAME_KEY);
+      this.displayName = installedObj.optString(KB_DISPLAY_NAME_KEY, null);
     } catch (JSONException e) {
       KMLog.LogException(TAG, "fromJSON exception: ", e);
     }


### PR DESCRIPTION
Fixes an accidental discrepancy in the 🍒-pick of #5349 in #5407; somehow, one of the changes didn't get ported to `stable-14.0` properly, and that's affecting some 3rd party users of our Android `KeymanEngine` library.
