### PR TITLE
fix(common/core/web): OSK state-key management 🍒

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -78,9 +78,13 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.
-      if(!fromOSK && this.keyboardProcessor.doModifierPress(keyEvent, !fromOSK)) {
-        return new RuleBehavior();
+      // of state management.  `doModifierPress` must always run.
+      if(this.keyboardProcessor.doModifierPress(keyEvent, !fromOSK)) {
+        // If run on a desktop platform, we know that modifier & state key presses may not
+        // produce output, so we may make an immediate return safely.
+        if(!fromOSK) {
+          return new RuleBehavior();
+        }
       }
 
       // If suggestions exist AND space is pressed, accept the suggestion and do not process the keystroke.

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -220,18 +220,12 @@ namespace com.keyman.keyboards {
 
         // If it's a state key modifier, trigger its effects as part of the
         // keystroke.
-        let bitmask = 0;
-        switch(Lkc.kName) {
-          case 'K_CAPS':
-            bitmask = text.Codes.stateBitmasks.CAPS;
-            break;
-          case 'K_NUMLOCK':
-            bitmask = text.Codes.stateBitmasks.NUM_LOCK;
-            break;
-          case 'K_SCROLL':
-            bitmask = text.Codes.stateBitmasks.SCROLL_LOCK;
-            break;
-        }
+        const bitmap = {
+          'K_CAPS': text.Codes.stateBitmasks.CAPS,
+          'K_NUMLOCK': text.Codes.stateBitmasks.NUM_LOCK,
+          'K_SCROLL': text.Codes.stateBitmasks.SCROLL_LOCK
+        };
+        const bitmask = bitmap[Lkc.kName];
 
         if(bitmask) {
           Lkc.Lstates ^= bitmask;

--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -217,6 +217,26 @@ namespace com.keyman.keyboards {
       // This part depends on the keyboard processor's active state.
       if(keyboardProcessor) {
         keyboardProcessor.setSyntheticEventDefaults(Lkc);
+
+        // If it's a state key modifier, trigger its effects as part of the
+        // keystroke.
+        let bitmask = 0;
+        switch(Lkc.kName) {
+          case 'K_CAPS':
+            bitmask = text.Codes.stateBitmasks.CAPS;
+            break;
+          case 'K_NUMLOCK':
+            bitmask = text.Codes.stateBitmasks.NUM_LOCK;
+            break;
+          case 'K_SCROLL':
+            bitmask = text.Codes.stateBitmasks.SCROLL_LOCK;
+            break;
+        }
+
+        if(bitmask) {
+          Lkc.Lstates ^= bitmask;
+          Lkc.LmodifierChange = true;
+        }
       }
 
       return Lkc;

--- a/web/source/osk/preProcessor.ts
+++ b/web/source/osk/preProcessor.ts
@@ -9,14 +9,6 @@ namespace com.keyman.osk {
       // First check the virtual key, and process shift, control, alt or function keys
       let Lkc = e.constructKeyEvent(core.keyboardProcessor, dom.Utils.getOutputTarget(Lelem), keyman.util.device.coreSpec);
 
-      // If it's actually a state key modifier, trigger its effects immediately, as KeyboardEvents would do the same.
-      switch(Lkc.kName) {
-        case 'K_CAPS':
-        case 'K_NUMLOCK':
-        case 'K_SCROLL':
-          core.keyboardProcessor.stateKeys[Lkc.kName] = ! core.keyboardProcessor.stateKeys[Lkc.kName];
-      }
-
       // End - mirrors _GetKeyEventProperties
       return Lkc;
     }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -602,7 +602,7 @@ namespace com.keyman.osk {
     layers: keyboards.LayoutLayer[];
     private layerId: string = "default";
     readonly isRTL: boolean;
-    layerIndex: number;
+    layerIndex: number = 0; // the index of the default layer
 
     device: Device;
     isStatic: boolean = false;

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1022,6 +1022,12 @@ namespace com.keyman.osk {
     layerChangeHandler: text.SystemStoreMutationHandler = function(this: VisualKeyboard,
                                                                    source: text.MutableSystemStore,
                                                                    newValue: string) {
+      // This handler is also triggered on state-key state changes (K_CAPS) that 
+      // may not actually change the layer.
+      if(this) {
+        this._UpdateVKShiftStyle();
+      }
+
       if(source.value != newValue) {
         this.layerId = newValue;
         let keyman = com.keyman.singleton;


### PR DESCRIPTION
A 🍒-pick of #5456.

This fixes issues with the caps and numlock state management, mostly for the desktop OSK.  There are some core-internal effects though, especially in regard to complications with layer management for mnemonic keyboards' touch OSKs.

The 🍒-pick process was a bit complicated this time because some of the affected code blocks were in different files in 14.0 than they currently are in 15.0.  Made sure to inspect the resulting changeset and compare the results directly.

## User Testing

**IF** we want them, we can just use the same set of tests that was used for #5456.

And, well, knowing the way things usually go... yeah, @keymanapp/testers.  (But prioritize #5491 first!)

### Test suite 1: `desktop`

- [ ] Platform:  macOS / Safari

<details>
<summary>Instructions & Tests</summary>

Using the "Test unminified KeymanWeb" test page:

- [ ] TEST.STD.HARDWARE:
    <details>
    <summary><strong>Test sequence</strong></summary>
    
    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Select the "English - English" entry if not already selected.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's copy of the key should become highlighted here.
    4.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    5.  Press and release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT highlights only while the physical SHIFT is pressed.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should no longer be highlighted.
    7.  Refresh the page.
    8. **Before displaying the OSK** or clicking anywhere within the page, activate your hardware keyboard's CAPS LOCK state.
    9. Display the OSK
        - [ ] The OSK's CAPS key should not be highlighted.  (It's a system limitation.)
    10. Press and release your hardware keyboard's `A` key.
        - [ ] The OSK's CAPS key should become highlighted.

    </details>

- [ ] TEST.STD.MIXED
    <details>
    <summary><strong>Test sequence</strong></summary>

    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Select the "English - English" entry if not already selected.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Click the OSK's CAPS LOCK key.
        - [ ] It should become highlighted here.
    4.  Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    5.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should lose its highlighting.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should become highlighted.
    7.  Click your OSK's CAPS key.
        - [ ] It should lose highlighting.
    8. Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    9. Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should regain its highlighting.

    </details>

- [ ] TEST.MNEMONIC.HARDWARE:
    <details>
    <summary><strong>Test sequence</strong></summary>
    
    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Add the `sil_philippines` keyboard and select it.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's copy of the key should become highlighted here.
    4.  Press and release your hardware keyboard's `A` key.
        - [ ] A capitalized `A` should result with no other effects.
    5.  Press and release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT highlights only while the physical SHIFT is pressed.
    6. Press, but do _not_ release your hardware keyboard's SHIFT.
        - [ ] The OSK's CAPS key should remain highlighted, while SHIFT also becomes highlighted.
    7. Press and release your hardware keyboard's `A` key.
        - [ ] A lowercased `a` should result with no other effects.
    8.  Release your hardware keyboard's SHIFT key.
        - [ ] The OSK's CAPS key should remain highlighted.

    </details>

- [ ] TEST.MNEMONIC.MIXED
    <details>
    <summary><strong>Test sequence</strong></summary>

    1.  Ensure that your hardware keyboard's CAPS LOCK state is "off".
    2.  Add the `sil_philippines` keyboard and select it.
        - The OSK's CAPS LOCK key should not be highlighted.
    3.  Click the OSK's CAPS LOCK key.
        - [ ] It should become highlighted here.
    4.  Click your OSK's `A` key.
        - [ ] A capitalized `A` should result with no other effects.
    5.  Press and release your hardware keyboard's `A` key.
        - [ ] A lowercase `a` should result _and_ the OSK's CAPS LOCK key should lose its highlighting.
    6.  Press and release your hardware keyboard's CAPS LOCK key.
        - [ ] The OSK's CAPS key should become highlighted.
    7.  Click your OSK's CAPS key.
        - [ ] It should lose highlighting.
    8. Click your OSK's `A` key.
        - [ ] A lowercase `a` should result with no other effects.
    9. Press and release your hardware keyboard's `A` key.
        - [ ] A capitalized `A` should result _and_ the OSK's CAPS LOCK key should regain its highlighting.

    </details>

</details>

### Test suite 2:  `mobile`

- [ ] Platform:  Chrome emulation / iOS

<details>
<summary>Instructions & Tests</summary>

Using the "Test unminified KeymanWeb" test page:

- [ ] TEST.MOBILE.NUM_LOCK:  Using the `khmer_angkor` keyboard, swap back and forth between the 'default' and the 'numeric' layers.
    - Expected result:  there should be no "stuck highlighting" effect on the default layer's numeric key.

</details>