### PR TITLE
chore(windows): patches for Delphi 10.4

### DIFF
--- a/windows/src/buildtools/devtools/DevDelphiCompileWrapper.pas
+++ b/windows/src/buildtools/devtools/DevDelphiCompileWrapper.pas
@@ -20,23 +20,16 @@ unit DevDelphiCompileWrapper;  // I3339
 
 interface
 
+uses
+  SourceRootPath;
+
 type
   TDelphiCompileWrapper = class
   public
     class function Run(Quiet: Boolean = False; Silent: Boolean = False): Boolean;  // I3378
   end;
 
-{$IFDEF VER310}
-const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\18.0\bin\DCC32.EXE';
-{$ELSE}
-{$IFDEF VER320}
-const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\DCC32.EXE';
-{$ELSE}
-{$IFDEF VER330}
-const dcc32 = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\DCC32.EXE';
-{$ENDIF}
-{$ENDIF}
-{$ENDIF}
+const dcc32 = DelphiBasePath + 'bin\DCC32.exe';
 
 implementation
 

--- a/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
+++ b/windows/src/buildtools/devtools/DevDelphiStarterCompileWrapper.pas
@@ -8,6 +8,9 @@ unit DevDelphiStarterCompileWrapper;
 
 interface
 
+uses
+  SourceRootPath;
+
 type
   TDelphiStarterCompileWrapper = class
   private
@@ -18,17 +21,8 @@ type
     class function Run(Quiet: Boolean = False; Silent: Boolean = False): Boolean;  // I3378
   end;
 
-{$IFDEF VER320}
 const
-  SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\BDS.EXE';
-{$ELSE}
-{$IFDEF VER330}
-const
-  SBDSExe = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\BDS.EXE';
-{$ELSE}
-ERROR: SBDSExe is not defined
-{$ENDIF}
-{$ENDIF}
+  SBDSExe = DelphiMajorVersion + 'bin\BDS.EXE';
 
 implementation
 

--- a/windows/src/buildtools/devtools/DevIncludePaths.pas
+++ b/windows/src/buildtools/devtools/DevIncludePaths.pas
@@ -20,6 +20,9 @@ unit DevIncludePaths;
 
 interface
 
+uses
+  DevDelphiCompileWrapper;
+
 type
   TIncludePaths = class
     //class function Get: string;
@@ -55,25 +58,9 @@ const
   ///SKey_IncludePaths = 'Software\S4S\Developer\Paths';
   ///SValue_DevIncludePaths = 'Include Paths';
 
-  // These paths may need updating when changing releases
-{$IFDEF VER310}
-  SKey_DelphiLibrary = 'Software\Embarcadero\BDS\18.0\Library\Win32';
-  SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\18.0\EnvOptions.proj';
-{$ELSE}
-{$IFDEF VER320}
-  SKey_DelphiLibrary = 'Software\Embarcadero\BDS\19.0\Library\Win32';
-  SKey_DelphiLibrary64 = 'Software\Embarcadero\BDS\19.0\Library\Win64';
-  SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\19.0\EnvOptions.proj';
-{$ELSE}
-{$IFDEF VER330}
-  SKey_DelphiLibrary = 'Software\Embarcadero\BDS\20.0\Library\Win32';
-  SKey_DelphiLibrary64 = 'Software\Embarcadero\BDS\20.0\Library\Win64';
-  SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\20.0\EnvOptions.proj';
-{$ELSE}
-  ERROR: New version of compiler needs new defines
-{$ENDIF VER330}
-{$ENDIF VER320}
-{$ENDIF VER310}
+  SKey_DelphiLibrary = 'Software\Embarcadero\BDS\'+DelphiMajorVersion+'\Library\Win32';
+  SKey_DelphiLibrary64 = 'Software\Embarcadero\BDS\'+DelphiMajorVersion+'\Library\Win64';
+  SFile_DelphiEnvironmentProject = '%AppData%\Embarcadero\BDS\'+DelphiMajorVersion+'\EnvOptions.proj';
 
   SValue_DelphiBrowsingPath = 'Browsing Path';
   SValue_DelphiSearchPath = 'Search Path';

--- a/windows/src/buildtools/devtools/DevInstallPackages.pas
+++ b/windows/src/buildtools/devtools/DevInstallPackages.pas
@@ -43,25 +43,9 @@ uses
 { TInstallPackages }
 
 const
-{$IFDEF VER310}
-  SKey_Delphi = 'Software\Embarcadero\BDS\18.0';
-  SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\18.0\bpl\';
-  SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\18.0\dcp\';
-{$ELSE}
-{$IFDEF VER320}
-  SKey_Delphi = 'Software\Embarcadero\BDS\19.0';
-  SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\19.0\bpl\';
-  SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\19.0\dcp\';
-{$ELSE}
-{$IFDEF VER330}
-  SKey_Delphi = 'Software\Embarcadero\BDS\20.0';
-  SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\20.0\bpl\';
-  SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\20.0\dcp\';
-{$ELSE}
-  ERROR: New version of compiler needs new defines
-{$ENDIF VER330}
-{$ENDIF VER320}
-{$ENDIF VER310}
+  SKey_Delphi = 'Software\Embarcadero\BDS\'+DelphiMajorVersion;
+  SPath_DelphiCommonPackageBPLFiles = '%0:sEmbarcadero\Studio\'+DelphiMajorVersion+'\bpl\';
+  SPath_DelphiCommonPackageDCPFiles = '%0:sEmbarcadero\Studio\'+DelphiMajorVersion+'\dcp\';
 
   SKey_DelphiKnownPackages = SKey_Delphi + '\Known Packages';
   SKey_DelphiDisabledPackages = SKey_Delphi + '\Disabled Packages';

--- a/windows/src/buildtools/devtools/SourceRootPath.pas
+++ b/windows/src/buildtools/devtools/SourceRootPath.pas
@@ -2,6 +2,26 @@ unit SourceRootPath;
 
 interface
 
+{$IFDEF VER310}
+const DelphiMajorVersion = '18.0'; 
+{$ELSE}
+{$IFDEF VER320}
+const DelphiMajorVersion = '19.0'; 
+{$ELSE}
+{$IFDEF VER330}
+const DelphiMajorVersion = '20.0'; 
+{$ELSE}
+{$IFDEF VER340}
+const DelphiMajorVersion = '21.0';
+{$ELSE}
+ERROR: must define Delphi version
+{$ENDIF}
+{$ENDIF}
+{$ENDIF}
+{$ENDIF}
+
+const DelphiBasePath = 'C:\Program Files (x86)\Embarcadero\Studio\' + DelphiMajorVersion + '\';
+
 function CSourcePath: string;
 function CSourceRootPath: string; //='C:\Projects\keyman\open\windows\src';
 function CSourceBinRootPath: string; //='C:\Projects\keyman\open\windows\bin';

--- a/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
+++ b/windows/src/buildtools/devtools/UfrmCompilerErrors.pas
@@ -106,22 +106,10 @@ uses
   RegExpr,
   Registry,
   RegistryKeys,
-  shellapi;
+  shellapi,
+  SourceRootPath;
 
-{$IFDEF VER310}
-const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\18.0\bin\bds.EXE';
-{$ELSE}
-{$IFDEF VER320}
-const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\19.0\bin\bds.EXE';
-{$ELSE}
-{$IFDEF VER330}
-const BDSPath = 'C:\Program Files (x86)\Embarcadero\Studio\20.0\bin\bds.EXE';
-{$ELSE}
-ERROR: BDSPath is not defined
-{$ENDIF}
-{$ENDIF}
-{$ENDIF}
-
+const BDSPath = DelphiBasePath + 'bin\bds.exe';
 
 {$R *.DFM}
 

--- a/windows/src/developer/samples/imsample/IMSample.vcxproj
+++ b/windows/src/developer/samples/imsample/IMSample.vcxproj
@@ -14,18 +14,18 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{0C9DB8F9-B788-8782-A97D-4F8294AA0B4E}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/windows/src/ext/jedi/jcl/jcl/source/windows/JclCLR.pas
+++ b/windows/src/ext/jedi/jcl/jcl/source/windows/JclCLR.pas
@@ -1161,7 +1161,8 @@ end;
 
 destructor TJclClrTableStream.Destroy;
 begin
-  FreeAndNil(FTables);
+  // MCD 2021-07-27: FTables was never an object -- looks like a bug in this (unused) unit
+  //FreeAndNil(FTables);
   inherited Destroy;
 end;
 

--- a/windows/src/ext/jedi/jcl/jcl/source/windows/JclSvcCtrl.pas
+++ b/windows/src/ext/jedi/jcl/jcl/source/windows/JclSvcCtrl.pas
@@ -526,7 +526,7 @@ begin
         ReallocMem(PBuf, BytesNeeded);
         ServicesReturned := 0;
         Ret := EnumDependentServices(FHandle, SERVICE_STATE_ALL,
-          PEnumServiceStatus(PBuf){$IFNDEF FPC}^{$ENDIF}, BytesNeeded, BytesNeeded, ServicesReturned);
+          PEnumServiceStatus(PBuf){$IFNDEF FPC}{$IFNDEF VER340}^{$ENDIF}{$ENDIF}, BytesNeeded, BytesNeeded, ServicesReturned);
       until Ret or (GetLastError <> ERROR_INSUFFICIENT_BUFFER);
       Win32Check(Ret);
 
@@ -1087,7 +1087,7 @@ procedure TJclSCManager.Refresh(const RefreshAll: Boolean);
         ReallocMem(PBuf, BytesNeeded);
         ServicesReturned := 0;
         Ret := EnumServicesStatus(FHandle, SERVICE_TYPE_ALL, SERVICE_STATE_ALL,
-          PEnumServiceStatus(PBuf){$IFNDEF FPC}^{$ENDIF},
+          PEnumServiceStatus(PBuf){$IFNDEF FPC}{$IFNDEF VER340}^{$ENDIF}{$ENDIF},
           BytesNeeded, BytesNeeded, ServicesReturned, ResumeHandle);
         LastError := GetLastError;
 

--- a/windows/src/ext/mbcolor/mxs.inc
+++ b/windows/src/ext/mbcolor/mxs.inc
@@ -1,3 +1,12 @@
+    {$ifdef VER340}
+     {$define DELPHI_5_UP}
+     {$define DELPHI_6_UP}
+     {$define DELPHI_7_UP}
+     {$define DELPHI_8_UP}
+     {$define DELPHI_9_UP}
+     {$define DELPHI_10_UP}
+    {$endif}
+
     {$ifdef VER330}
      {$define DELPHI_5_UP}
      {$define DELPHI_6_UP}

--- a/windows/src/global/delphi/comp/FixedTrackbar.pas
+++ b/windows/src/global/delphi/comp/FixedTrackbar.pas
@@ -66,9 +66,12 @@ end;
   Tested on VER330 (10.3) - 29 Oct 2019 - mcdurdin
 }
 
+{$IFNDEF VER340}
+{$MESSAGE WARN 'Not yet checked against Delphi 10.4'}
 {$IFNDEF VER330}
 {$IFNDEF VER320}
 {$MESSAGE ERROR 'Check that this fix is still applicable for a new version of Delphi. Checked against Delphi 10.2, 10.3' }
+{$ENDIF}
 {$ENDIF}
 {$ENDIF}
 

--- a/windows/src/global/delphi/general/CleartypeDrawCharacter.pas
+++ b/windows/src/global/delphi/general/CleartypeDrawCharacter.pas
@@ -591,7 +591,11 @@ begin
   StrPCopy(lf.lfFaceName, FFontName); //'Code2000');
   hdc := GetDC(0);
   //FPlane0FontName := 'Code2000';
+{$IFDEF VER340}
+  if EnumFontFamiliesEx(hdc, lf, @EnumFallbackFonts, 0, 0) <> 0 then
+{$ELSE}
   if EnumFontFamiliesEx(hdc, lf, @EnumFallbackFonts, 0, 0) then
+{$ENDIF}
   begin
     FPlane0FontName := FFontName;
     Result := True;

--- a/windows/src/global/delphi/general/utilicon.pas
+++ b/windows/src/global/delphi/general/utilicon.pas
@@ -83,7 +83,11 @@ function ConvertBitmapsToAlphaIcon(b: array of Vcl.Graphics.TBitmap; const IconF
 var
   bmp: array of TGPBitmap;
   i: Integer;
+{$IFDEF VER330}
   gdiptoken: Cardinal;
+{$ELSE}
+  gdiptoken: ULong_ptr;
+{$ENDIF}
   StartupInput: TGdiplusStartupInput;
 begin
   StartupInput.DebugEventCallback := nil;
@@ -124,7 +128,11 @@ var
   bmp: array[0..5] of TGPBitmap;
   i: Integer;
   bm: Vcl.Graphics.TBitmap;
+{$IFDEF VER330}
   gdiptoken: Cardinal;
+{$ELSE}
+  gdiptoken: ULong_ptr;
+{$ENDIF}
   StartupInput: TGdiplusStartupInput;
 begin
   StartupInput.DebugEventCallback := nil;


### PR DESCRIPTION
Updates Keyman for Windows and Keyman Developer sources so that they build under Delphi 10.4. No validation has been performed to ensure that there are no other issues. The intent here is to get a baseline build working.

Note also IMSample.vcxproj which has its WinSDK version updated for VS2019.

This will not allow us to build in Delphi 10.4 Community Edition because of the missing command line compiler. That will be handled separately.