### PR TITLE
chore(common/core): Allow shell script for kmcomp

### DIFF
--- a/common/core/desktop/tests/unit/kmx/meson.build
+++ b/common/core/desktop/tests/unit/kmx/meson.build
@@ -20,8 +20,6 @@ kmx = executable('kmx', 'kmx.cpp',
     dependencies: [rust_mock_processor],
     objects: lib.extract_all_objects())
 
-kmcomp = find_program('kmcomp.exe', required: false)
-
 tests = [
   '000 - null keyboard',
   '001 - basic input UnicodeI',
@@ -75,12 +73,18 @@ tests = [
 ]
 
 if build_machine.system() == 'windows'
+  kmcomp = find_program('kmcomp.exe', required: false)
   kmcomp_cmd = [kmcomp]
 else
-  wine = find_program('wine', required: false)
-  kmcomp_cmd = [wine, kmcomp]
-  if not wine.found()
-    kmcomp = disabler()
+  kmcomp = find_program('kmcomp', required: false)
+  kmcomp_cmd = [kmcomp]
+  if not kmcomp.found()
+    wine = find_program('wine', required: false)
+    kmcomp = find_program('kmcomp.exe', required: false)
+    kmcomp_cmd = [wine, kmcomp]
+    if not wine.found()
+      kmcomp = disabler()
+    endif
   endif
 endif
 


### PR DESCRIPTION
This change allows to build the keyboards on Linux if a `kmcomp` script can be found in PATH. Otherwise we check for and use `wine` and `kmcomp.exe`.