### PR TITLE
fix(ios/engine): engine migration always precedes installs 🍒

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -201,20 +201,11 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
 
     URLProtocol.registerClass(KeymanURLProtocol.self)
 
-    Migrations.migrate(storage: Storage.active)
-    Migrations.updateResources(storage: Storage.active)
-
-    if Storage.active.userDefaults.userKeyboards?.isEmpty ?? true {
-      Storage.active.userDefaults.userKeyboards = [Defaults.keyboard]
-
-      // Ensure the default keyboard is installed in this case.
-      do {
-        try Storage.active.installDefaultKeyboard(from: Resources.bundle)
-      } catch {
-        log.error("Failed to copy default keyboard from bundle: \(error)")
-      }
-    }
-    Migrations.engineVersion = Version.latestFeature
+    /**
+     * As of 14.0, ResourceFileManager is responsible for handlng resources... including
+     * any necessary "migration" of their internal storage structure & tracked metadata.
+     */
+    ResourceFileManager.shared.runMigrationsIfNeeded()
 
     if Util.isSystemKeyboard || Storage.active.userDefaults.bool(forKey: Key.keyboardPickerDisplayed) {
       isKeymanHelpOn = false

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -328,6 +328,18 @@ public class ResourceFileManager {
       throw KMPError.resourceNotInPackage
     }
 
+    /**
+     * A surprisingly critical line.  The Manager.shared instance must be initialized at some
+     * point before the resources are _actually_ stored and reigstered.  Otherwise, the initial
+     * Migrations pass (called early in Manager.init) will interpret the installation as from a
+     * different engine version and will break anything installed before it's run.
+     *
+     * Fortunately... all 14.0's installation methods pass through this single method in order to
+     * do the actual "storing" and "registering".  So, it's a decent-enough place to force
+     * Manager.shared's init.
+     */
+    _ = Manager.shared
+
     do {
       try copyWithOverwrite(from: package.sourceFolder,
                             to: Storage.active.packageDir(for: package)!)

--- a/ios/samples/KMSample2/KMSample2/AppDelegate.swift
+++ b/ios/samples/KMSample2/KMSample2/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     KeymanEngine.log.logAppDetails()
 
     // Replace with your application group id
+    // Ensure this happens before installing any keyboards or models within the engine
+    // whenever using App Group Identifiers.
     Manager.applicationGroupIdentifier = "group.KMSample"
     return true
   }


### PR DESCRIPTION
A 🍒-pick of #5484.

## User Testing

@keymanapp/testers 

- [ ] TEST_DIRTY:  Ensure that the iOS app successfully launches when installed over a previous, customized installation.
    - Verify that all previously-installed keyboards are still installed.
    - Swapping among the keyboards via the picker is enough to tell us what we need.

- [ ] TEST_CLEAN:  Ensure that the iOS app successfully launches from a _clean_ install.
    - There are two ways to do this:
        - Set Xcode to target a device that you have not previously used for any tests.
        - Reset a simulated device that you have previously used:

            <img width="466" alt="image" src="https://user-images.githubusercontent.com/25213402/126731993-a1e6f3b1-ad1a-4343-b704-6d3e9a11148d.png">

            Run that to reset a simulated device, which will erase all existing Keyman settings on said simulated device.