### PR TITLE
chore(linux): Remove Groovy and Impish builds

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -5,6 +5,6 @@
 @Library('lsdev-pipeline-library') _
 
 keymanPackaging {
-	distributionsToPackage = 'bionic focal groovy hirsute impish'
+	distributionsToPackage = 'bionic focal hirsute'
 	arches = 'amd64 i386'
 }

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -40,7 +40,7 @@ echo "ppa: ${ppa}"
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="bionic focal groovy hirsute impish"
+    distributions="bionic focal hirsute impish"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then


### PR DESCRIPTION
- **Groovy** is EOL
- llso is not yet capable of processing **Impish** packages because of an too old version of _reprepro_ (which currently can't be 
  updated because of an tool old version of the OS). Therefore Jenkins builds for Impish fail, so this change removes Impish from 
  Jenkins builds. We continue to build for Impish on Launchpad.