### PR TITLE
chore(linux): Remove Groovy builds 🍒

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -5,6 +5,6 @@
 @Library('lsdev-pipeline-library') _
 
 keymanPackaging {
-	distributionsToPackage = 'bionic focal groovy hirsute'
+	distributionsToPackage = 'bionic focal hirsute'
 	arches = 'amd64 i386'
 }

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -40,7 +40,7 @@ echo "ppa: ${ppa}"
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="bionic focal groovy hirsute"
+    distributions="bionic focal hirsute"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then


### PR DESCRIPTION
**Groovy** is end-of-life.

(🍒-pick of #5502)