### PR TITLE
fix(android): keyboard's black bar bug

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -52,6 +52,7 @@ import android.widget.FrameLayout;
 import android.widget.GridLayout;
 import android.widget.PopupWindow;
 import android.widget.PopupWindow.OnDismissListener;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -324,6 +325,10 @@ final class KMKeyboard extends WebView {
     super.onConfigurationChanged(newConfig);
     dismissKeyPreview(0);
     dismissSubKeysWindow();
+
+    RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
+    this.setLayoutParams(params);
+
     int bannerHeight = KMManager.getBannerHeight(context);
     int oskHeight = KMManager.getKeyboardHeight(context);
     loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -483,7 +483,7 @@ public final class KMManager {
    * combined banner height and keyboard height
    * @return RelativeLayout.LayoutParams
    */
-  private static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
+  public static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
     int bannerHeight = getBannerHeight(appContext);
     int kbHeight = getKeyboardHeight(appContext);
     RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(


### PR DESCRIPTION
Fixes #5252.

I figured out the solution while working on embedded keyboard layout issues in #5459 after asking @darcywong00 how the WebView sets its height.

----------

## User Testing

@keymanapp/testers 

Gonna be kinda lazy with this one.

- [ ] TEST_WITH_PREDICTIONS:  load up the Keyman app with `sil_euro_latin` as the active keyboard, predictive text on.
    - Rotate the phone and confirm that the layout looks correct.
    - Rotate the phone back to its original orientation and confirm that the layout looks correct.
- [ ] TEST_WITHOUT_PREDICTIONS:  this time, use a keyboard without predictive text - say, `kbd_basicmyan` - and repeat the test.