### PR TITLE
chore(windows): split keyman64 header to keymanengine

### DIFF
--- a/windows/src/engine/keyman32/Keyman32.vcxproj
+++ b/windows/src/engine/keyman32/Keyman32.vcxproj
@@ -362,6 +362,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\global\inc\keymanengine.h" />
     <ClInclude Include="addins.h" />
     <ClInclude Include="appint\aiTIP.h" />
     <ClInclude Include="appint\aiWin2000Unicode.h" />

--- a/windows/src/engine/keyman32/Keyman32.vcxproj.filters
+++ b/windows/src/engine/keyman32/Keyman32.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClInclude Include="serialkeyeventserver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\global\inc\keymanengine.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="keyman-debug-etw.man" />

--- a/windows/src/engine/keyman32/keyman-engine.vcxproj
+++ b/windows/src/engine/keyman32/keyman-engine.vcxproj
@@ -374,6 +374,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\global\inc\keymanengine.h" />
     <ClInclude Include="addins.h" />
     <ClInclude Include="appint\aiTIP.h" />
     <ClInclude Include="appint\aiWin2000Unicode.h" />

--- a/windows/src/engine/keyman32/keyman-engine.vcxproj.filters
+++ b/windows/src/engine/keyman32/keyman-engine.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClInclude Include="serialkeyeventserver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\global\inc\keymanengine.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="keyman-debug-etw.man" />

--- a/windows/src/engine/keyman32/pch.h
+++ b/windows/src/engine/keyman32/pch.h
@@ -2,5 +2,6 @@
 #define PCH_H
 
 #include "keyman64.h"
+#include "keymanengine.h"
 
 #endif //PCH_H

--- a/windows/src/engine/keyman32/tests/keyman32-tests/pch.h
+++ b/windows/src/engine/keyman32/tests/keyman32-tests/pch.h
@@ -8,3 +8,4 @@
 #include "gtest/gtest.h"
 #include <Windows.h>
 #include "keyman64.h"
+#include "keymanengine.h"

--- a/windows/src/engine/keyman64/keyman64.vcxproj
+++ b/windows/src/engine/keyman64/keyman64.vcxproj
@@ -279,6 +279,7 @@
     <ResourceCompile Include="Keyman64.RC" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\global\inc\keymanengine.h" />
     <ClInclude Include="..\keyman32\addins.h" />
     <ClInclude Include="..\keyman32\appint\aiTIP.h" />
     <ClInclude Include="..\keyman32\appint\aiWin2000Unicode.h" />

--- a/windows/src/engine/keyman64/keyman64.vcxproj.filters
+++ b/windows/src/engine/keyman64/keyman64.vcxproj.filters
@@ -83,6 +83,7 @@
     <ClInclude Include="..\..\global\inc\unicode.h" />
     <ClInclude Include="..\..\global\inc\Vkeys.h" />
     <ClInclude Include="..\keyman32\vkscancodes.h" />
+    <ClInclude Include="..\..\global\inc\keymanengine.h" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\keyman32\keyman-debug-etw.man" />

--- a/windows/src/global/inc/keyman64.h
+++ b/windows/src/global/inc/keyman64.h
@@ -138,295 +138,68 @@
 #define KMF_WINDOWCHANGED 1
 
 /***************************************************************************/
-
+/* In memory keyboard information */
 typedef struct tagSTORE
 {
-	DWORD dwSystemID;
-	PWSTR dpName;
-	PWSTR dpString;
-} STORE, *LPSTORE;
-
+  DWORD dwSystemID;
+  PWSTR dpName;
+  PWSTR dpString;
+} STORE, * LPSTORE;
 
 typedef struct tagKEY
 {
-	WCHAR Key;
-	DWORD Line;
-	DWORD ShiftFlags;
-	PWSTR dpOutput;
-	PWSTR dpContext;
-} KEY, *LPKEY;
-
+  WCHAR Key;
+  DWORD Line;
+  DWORD ShiftFlags;
+  PWSTR dpOutput;
+  PWSTR dpContext;
+} KEY, * LPKEY;
 
 typedef struct tagGROUP
 {
-	PWSTR dpName;
-	LPKEY dpKeyArray;		// [LPKEY] address of first item in key array
-	PWSTR dpMatch;
-	PWSTR dpNoMatch;
-	DWORD cxKeyArray;		// in array entries
-	BOOL  fUsingKeys;		// group(xx) [using keys] <-- specified or not
-} GROUP, *LPGROUP;
-
+  PWSTR dpName;
+  LPKEY dpKeyArray;		// [LPKEY] address of first item in key array
+  PWSTR dpMatch;
+  PWSTR dpNoMatch;
+  DWORD cxKeyArray;		// in array entries
+  BOOL  fUsingKeys;		// group(xx) [using keys] <-- specified or not
+} GROUP, * LPGROUP;
 
 typedef struct tagKEYBOARD
 {
-	DWORD dwIdentifier;		// Keyman compiled keyboard id
+  DWORD dwIdentifier;		// Keyman compiled keyboard id
 
-	DWORD dwFileVersion;	// Version of the file - Keyman 4.0 is 0x0400
+  DWORD dwFileVersion;	// Version of the file - Keyman 4.0 is 0x0400
 
-	DWORD dwCheckSum;		// As stored in keyboard
-	DWORD xxkbdlayout;    	// as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
-	DWORD IsRegistered;		// layout id, from same registry key
-	DWORD version;			// keyboard version
+  DWORD dwCheckSum;		// As stored in keyboard
+  DWORD xxkbdlayout;    	// as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
+  DWORD IsRegistered;		// layout id, from same registry key
+  DWORD version;			// keyboard version
 
-	DWORD cxStoreArray;		// in array entries
-	DWORD cxGroupArray;		// in array entries
+  DWORD cxStoreArray;		// in array entries
+  DWORD cxGroupArray;		// in array entries
 
-	LPSTORE dpStoreArray;	// [LPSTORE] address of first item in store array, from start of file
-	LPGROUP dpGroupArray;	// [LPGROUP] address of first item in group array, from start of file
+  LPSTORE dpStoreArray;	// [LPSTORE] address of first item in store array, from start of file
+  LPGROUP dpGroupArray;	// [LPGROUP] address of first item in group array, from start of file
 
-	DWORD StartGroup[2];	// index of starting groups [2 of them]
-							// Ansi=0, Unicode=1
+  DWORD StartGroup[2];	// index of starting groups [2 of them]
+              // Ansi=0, Unicode=1
 
-	DWORD dwFlags;			// Flags for the keyboard file
+  DWORD dwFlags;			// Flags for the keyboard file
 
-	DWORD dwHotKey;			// standard windows hotkey (hiword=shift/ctrl/alt stuff, loword=vkey)
+  DWORD dwHotKey;			// standard windows hotkey (hiword=shift/ctrl/alt stuff, loword=vkey)
 
-	//PWSTR dpName;			// offset of name
-	//PWSTR dpLanguageName;	// offset of language name;
-	//PWSTR dpCopyright;		// offset of copyright
-	//PWSTR dpMessage;		// offset of message in Keyboard About box
+  //PWSTR dpName;			// offset of name
+  //PWSTR dpLanguageName;	// offset of language name;
+  //PWSTR dpCopyright;		// offset of copyright
+  //PWSTR dpMessage;		// offset of message in Keyboard About box
 
-	HBITMAP	hBitmap;		// handle to the bitmap in the file;
-} KEYBOARD, *LPKEYBOARD;
+  HBITMAP	hBitmap;		// handle to the bitmap in the file;
+} KEYBOARD, * LPKEYBOARD;
 
-typedef BOOL (WINAPI *IMDLLHOOKProc)(HWND hwndFocus, WORD KeyStroke, WCHAR KeyChar, DWORD shiftFlags);
-
-typedef struct tagIMDLLHOOK
-{
-	char name[32];
-	DWORD storeno;
-	IMDLLHOOKProc function;
-} IMDLLHOOK, *LPIMDLLHOOK;
-
-typedef struct tagIMDLL
-{
-	char        Filename[256];
-	HMODULE		hModule;
-	DWORD       nHooks;
-	LPIMDLLHOOK Hooks;
-} IMDLL, *LPIMDLL;
-
-typedef struct tagINTKEYBOARDOPTIONS
-{
-  PWCHAR Value;
-  PWCHAR OriginalStore;
-} INTKEYBOARDOPTIONS, *LPINTKEYBOARDOPTIONS;
-
-typedef struct tagINTKEYBOARDPROFILE
-{
-  //WCHAR Locale[LOCALE_NAME_MAX_LENGTH]; This is not currently used in keyman32/64 so we won't load it
-  LANGID LangID;
-  GUID Guid;
-} INTKEYBOARDPROFILE, *LPINTKEYBOARDPROFILE;
-
-// The members of this structure, from first through to IMDLLs, must match KEYBOARDINFO from keymanapi.h
-typedef struct tagINTKEYBOARDINFO
-{
-	DWORD      KeymanID;
-	DWORD      __filler_Hotkey;
-  DWORD      __filler; // makes same as KEYBOARDINFO   // I4462
-	char       Name[256];
-	LPKEYBOARD Keyboard;
-	DWORD      nIMDLLs;
-	LPIMDLL    IMDLLs;
-	int        __filler2; // makes same as KEYBOARDINFO
-  LPINTKEYBOARDOPTIONS KeyboardOptions;
-  int        nProfiles;
-  LPINTKEYBOARDPROFILE Profiles;
-} INTKEYBOARDINFO, *LPINTKEYBOARDINFO;
-
-typedef struct tagINI
-{
-	int MsgStackSize;
-	int MaxKeyboards;
-	int ContextStackSize;
-} INI;
-
-
-typedef struct tagKMSTATE
-{
-	BOOL NoMatches;
-	BOOL StopOutput;
-	int LoopTimes;
-	MSG msg;
-	WORD vkey; // I934
-	WCHAR charCode;   // I4582
-	BOOL windowunicode;   // I4287
-	LPKEYBOARD lpkb;
-	LPGROUP startgroup;
-} KMSTATE;
-   // I3616
-enum ProcessStringReturn {psrPostMessages, psrCheckMatches};
-
-LRESULT WINAPI kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam);
-LRESULT WINAPI kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam);
-LRESULT CALLBACK kmnLowLevelKeyboardProc(   // I4124
-  _In_  int nCode,
-  _In_  WPARAM wParam,
-  _In_  LPARAM lParam
-);
-
-BOOL ReleaseKeyboardMemory(LPKEYBOARD kbd);
-
-void PostGETNEXT(HWND hwnd);
-BOOL CompareMsg(LPMSG MsgA, LPMSG MsgB);
-BOOL ProcessHook();	// returns FALSE on error or key not matched [only for AITip]
-BOOL ProcessMessage( LPMSG mp );
-BOOL ProcessGroup(LPGROUP gp);
-BOOL ContextMatch(LPKEY kkp);
-int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr);
-BOOL LoadAllKeymanKeyboards(DWORD layout);
-
-BOOL IsSysTrayWindow(HWND hwnd);
-
-#define ShowDlgItem(hdlg, id, fShow ) ShowWindow( GetDlgItem( (hdlg), (id) ), (fShow) ? SW_SHOW : SW_HIDE )
-#define EnableDlgItem(hdlg, id, fEnable ) EnableWindow( GetDlgItem( (hdlg), (id) ), (fEnable) )
-
-BOOL InitialiseProcess(HWND hwnd);
-BOOL UninitialiseProcess(BOOL Lock);
-BOOL IsKeyboardUnicode();
-
-BOOL IsFocusedThread();
-
-BOOL SelectKeyboard(DWORD KeymanID);
-
-extern "C" DWORD  _declspec(dllexport) WINAPI GetActiveKeymanID();
-
-BOOL GetKeyboardFileName(LPSTR kbname, LPSTR buf, int nbuf);
-BOOL LoadKeyboard(LPSTR fileName, LPKEYBOARD *lpKeyboard);
-BOOL LoadlpKeyboard(int i);
-
-PSTR wstrtostr(PWSTR in);
-PWSTR strtowstr(PSTR in);
-
-WCHAR MapVirtualKeys(WORD keyCode, UINT shiftFlags);
-
-void SelectApplicationIntegration();   // I4287
-
-void PostDummyKeyEvent();  // I3301 - Handle I3250 regression with inadvertent menu activation with Alt keys   // I3534   // I4844
-
-/* Debugging functions */
-
-#ifndef SendDebugMessage
-   // I4379
-typedef enum ATSDMState { sdmInternat, sdmAIDefault, sdmMessage, sdmKeyboard, sdmGlobal, sdmMenu, sdmDebug, sdmLoad, sdmOther } TSDMState;
-
-void InitDebugging();
-void UninitDebugging();
-
-extern "C" void _declspec(dllexport) WINAPI Keyman_WriteDebugEvent(char *file, int line, PWCHAR msg);
-
-#define SendDebugMessage(hwnd,state,kmn_lineno,msg) (ShouldDebug((state)) ? SendDebugMessage_1((hwnd),(state),(kmn_lineno), __FILE__, __LINE__, (msg)) : 0)
-#define SendDebugMessageFormat(hwnd,state,kmn_lineno,msg,...) (ShouldDebug((state)) ? SendDebugMessageFormat_1((hwnd),(state),(kmn_lineno), __FILE__, __LINE__, (msg),__VA_ARGS__) : 0)
-#define ShouldDebug(state) ShouldDebug_1()
-#define DebugLastError(context) (DebugLastError_1(GetLastError(), (context), __FILE__,__LINE__,__FUNCTION__))
-#define DebugLastError0(error, context) (DebugLastError_1((error), (context), __FILE__,__LINE__,__FUNCTION__))
-int SendDebugMessage_1(HWND hwnd, TSDMState state, int kmn_lineno, char *file, int line, char *msg);
-int SendDebugMessageFormat_1(HWND hwnd, TSDMState state, int kmn_lineno, char *file, int line, char *fmt, ...);
-void DebugLastError_1(DWORD err, char *context, char *file, int line, char *func);
-void DebugMessage(LPMSG msg, WPARAM wParam);
-void DebugShift(char *function, char *point);
-BOOL DebugSignalPause(BOOL fIsUp);
-char *Debug_VirtualKey(WORD vk);
-char *Debug_UnicodeString(PWSTR s, int x = 0);
-
-BOOL ShouldDebug_1(); // TSDMState state);
-
-#endif
-
-#ifdef _DEBUG
-#define OutputThreadDebugString(s) _OutputThreadDebugString(s)
-void _OutputThreadDebugString(char *s);
-#else
-#define OutputThreadDebugString(s)
-#endif
-
-/* Keyboard selection functions */
-
-void HandleRefresh(int code, LONG tag);
-void RefreshKeyboards(BOOL Initialising);
-void CheckScheduledRefresh();
-void ScheduleRefresh();
-void ReleaseKeyboards(BOOL Lock);
-void CheckScheduledRefresh();
-void ScheduleRefresh();
-
-/* Glossary conversion functions */
-
-HKL ForceKeymanIDToHKL(DWORD KeymanID); // sign extends DWORD to HKL on Win64
-DWORD ForceHKLToKeymanID(HKL hkl);      // truncates HKL to DWORD on Win64
-   // I4220
-DWORD HKLToKeyboardID(HKL hkl);
-WORD HKLToLanguageID(HKL hkl);
-WORD HKLToLayoutNumber(HKL hkl);
-WORD HKLToLayoutID(HKL hkl);
-DWORD EthnologueCodeToKeymanID(DWORD EthCode);
-DWORD EthnologueStringCodeToDWord(PWSTR EthCode);
-
-PWSTR  GetSystemStore(LPKEYBOARD kb, DWORD SystemID);
-
-DWORD ExceptionMessage(LPSTR Proc, LPEXCEPTION_POINTERS ep);
-
-void keybd_shift(LPINPUT pInputs, int *n, BOOL isReset, LPBYTE const kbd);
-
-//#define KEYEVENT_EXTRAINFO_KEYMAN 0xF00F0000   // I4370
-
-#ifndef _KEYMAN64_LIGHT
-
-#ifndef _WIN64   // I4326
-#include "hotkeys.h"
-#endif
-
-#include "appint\appint.h"
-#include "appint\aitip.h"
-#include "appint\aiwin2000unicode.h"
-#include "globals.h"
-
-#include "capsstate.h"
-#include "keystate.h"
-#endif
-
+/*********************************************************************/
 #include "registry.h"
-
-#ifndef _KEYMAN64_LIGHT
-#include "calldll.h"
-#include "addins.h"
-#include "keymancontrol.h"
-#include "keyboardoptions.h"
-#endif
-
 #include "unicode.h"
 #include "xstring.h"
-
-#ifndef _KEYMAN64_LIGHT
-#include "syskbd.h"
-#include "vkscancodes.h"
-#include "rc4.h"
-
-#include "testkeymanfunctioning.h"
-#include "keynames.h"
-
-#include "crc32.h"
-
-#include "k32_tsf.h"
-
-void ReportActiveKeyboard(WORD wCommand);   // I3933   // I3949
-void SelectKeyboardHKL(DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4271
-BOOL SelectKeyboardTSF(DWORD KeymanID, BOOL foreground);   // I3933   // I3949   // I4271
-BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL hkl, GUID clsid, GUID guidProfile);
-void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
-
-#endif
 
 #endif	// _KEYMAN64_H

--- a/windows/src/global/inc/keymanengine.h
+++ b/windows/src/global/inc/keymanengine.h
@@ -1,0 +1,254 @@
+/*
+ * Keyman is copyright (C) SIL International. MIT License.
+ *
+ * Name:             KeymanEngine
+ * Description:      Main header file for windows engine
+ *
+*/
+/***************************************************************************/   // I4006   // I4169
+
+#ifndef _KEYMANENGINE_H
+#define _KEYMANENGINE_H
+
+#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
+#define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
+#endif
+
+#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT
+#define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT 1
+#endif
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+#ifndef STRICT
+#define STRICT
+#endif
+
+#include <windows.h>
+#include <assert.h>
+#include <msctf.h>
+#include "compiler.h"
+
+/***************************************************************************/
+
+typedef BOOL(WINAPI* IMDLLHOOKProc)(HWND hwndFocus, WORD KeyStroke, WCHAR KeyChar, DWORD shiftFlags);
+
+typedef struct tagIMDLLHOOK
+{
+  char name[32];
+  DWORD storeno;
+  IMDLLHOOKProc function;
+} IMDLLHOOK, * LPIMDLLHOOK;
+
+typedef struct tagIMDLL
+{
+  char        Filename[256];
+  HMODULE		hModule;
+  DWORD       nHooks;
+  LPIMDLLHOOK Hooks;
+} IMDLL, * LPIMDLL;
+
+typedef struct tagINTKEYBOARDOPTIONS
+{
+  PWCHAR Value;
+  PWCHAR OriginalStore;
+} INTKEYBOARDOPTIONS, * LPINTKEYBOARDOPTIONS;
+
+typedef struct tagINTKEYBOARDPROFILE
+{
+  //WCHAR Locale[LOCALE_NAME_MAX_LENGTH]; This is not currently used in keyman32/64 so we won't load it
+  LANGID LangID;
+  GUID Guid;
+} INTKEYBOARDPROFILE, * LPINTKEYBOARDPROFILE;
+
+// The members of this structure, from first through to IMDLLs, must match KEYBOARDINFO from keymanapi.h
+typedef struct tagINTKEYBOARDINFO
+{
+  DWORD      KeymanID;
+  DWORD      __filler_Hotkey;
+  DWORD      __filler; // makes same as KEYBOARDINFO   // I4462
+  char       Name[256];
+  LPKEYBOARD Keyboard;
+  DWORD      nIMDLLs;
+  LPIMDLL    IMDLLs;
+  int        __filler2; // makes same as KEYBOARDINFO
+  LPINTKEYBOARDOPTIONS KeyboardOptions;
+  int        nProfiles;
+  LPINTKEYBOARDPROFILE Profiles;
+} INTKEYBOARDINFO, * LPINTKEYBOARDINFO;
+
+typedef struct tagINI
+{
+  int MsgStackSize;
+  int MaxKeyboards;
+  int ContextStackSize;
+} INI;
+
+typedef struct tagKMSTATE
+{
+  BOOL NoMatches;
+  BOOL StopOutput;
+  int LoopTimes;
+  MSG msg;
+  WORD vkey; // I934
+  WCHAR charCode;   // I4582
+  BOOL windowunicode;   // I4287
+  LPKEYBOARD lpkb;
+  LPGROUP startgroup;
+} KMSTATE;
+
+// I3616
+enum ProcessStringReturn { psrPostMessages, psrCheckMatches };
+
+LRESULT WINAPI kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam);
+LRESULT WINAPI kmnCallWndProc(int nCode, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK kmnLowLevelKeyboardProc(   // I4124
+  _In_  int nCode,
+  _In_  WPARAM wParam,
+  _In_  LPARAM lParam
+);
+
+BOOL ReleaseKeyboardMemory(LPKEYBOARD kbd);
+
+void PostGETNEXT(HWND hwnd);
+BOOL CompareMsg(LPMSG MsgA, LPMSG MsgB);
+BOOL ProcessHook();	// returns FALSE on error or key not matched [only for AITip]
+BOOL ProcessMessage( LPMSG mp );
+BOOL ProcessGroup(LPGROUP gp);
+BOOL ContextMatch(LPKEY kkp);
+int PostString(PWSTR str, LPMSG mp, LPKEYBOARD lpkb, PWSTR endstr);
+BOOL LoadAllKeymanKeyboards(DWORD layout);
+
+BOOL IsSysTrayWindow(HWND hwnd);
+
+#define ShowDlgItem(hdlg, id, fShow ) ShowWindow( GetDlgItem( (hdlg), (id) ), (fShow) ? SW_SHOW : SW_HIDE )
+#define EnableDlgItem(hdlg, id, fEnable ) EnableWindow( GetDlgItem( (hdlg), (id) ), (fEnable) )
+
+BOOL InitialiseProcess(HWND hwnd);
+BOOL UninitialiseProcess(BOOL Lock);
+BOOL IsKeyboardUnicode();
+
+BOOL IsFocusedThread();
+
+BOOL SelectKeyboard(DWORD KeymanID);
+
+extern "C" DWORD  _declspec(dllexport) WINAPI GetActiveKeymanID();
+
+BOOL GetKeyboardFileName(LPSTR kbname, LPSTR buf, int nbuf);
+BOOL LoadKeyboard(LPSTR fileName, LPKEYBOARD *lpKeyboard);
+BOOL LoadlpKeyboard(int i);
+
+PSTR wstrtostr(PWSTR in);
+PWSTR strtowstr(PSTR in);
+
+WCHAR MapVirtualKeys(WORD keyCode, UINT shiftFlags);
+
+void SelectApplicationIntegration();   // I4287
+
+void PostDummyKeyEvent();  // I3301 - Handle I3250 regression with inadvertent menu activation with Alt keys   // I3534   // I4844
+
+/* Debugging functions */
+
+#ifndef SendDebugMessage
+   // I4379
+typedef enum ATSDMState { sdmInternat, sdmAIDefault, sdmMessage, sdmKeyboard, sdmGlobal, sdmMenu, sdmDebug, sdmLoad, sdmOther } TSDMState;
+
+void InitDebugging();
+void UninitDebugging();
+
+extern "C" void _declspec(dllexport) WINAPI Keyman_WriteDebugEvent(char* file, int line, PWCHAR msg);
+
+#define SendDebugMessage(hwnd,state,kmn_lineno,msg) (ShouldDebug((state)) ? SendDebugMessage_1((hwnd),(state),(kmn_lineno), __FILE__, __LINE__, (msg)) : 0)
+#define SendDebugMessageFormat(hwnd,state,kmn_lineno,msg,...) (ShouldDebug((state)) ? SendDebugMessageFormat_1((hwnd),(state),(kmn_lineno), __FILE__, __LINE__, (msg),__VA_ARGS__) : 0)
+#define ShouldDebug(state) ShouldDebug_1()
+#define DebugLastError(context) (DebugLastError_1(GetLastError(), (context), __FILE__,__LINE__,__FUNCTION__))
+#define DebugLastError0(error, context) (DebugLastError_1((error), (context), __FILE__,__LINE__,__FUNCTION__))
+int SendDebugMessage_1(HWND hwnd, TSDMState state, int kmn_lineno, char* file, int line, char* msg);
+int SendDebugMessageFormat_1(HWND hwnd, TSDMState state, int kmn_lineno, char* file, int line, char* fmt, ...);
+void DebugLastError_1(DWORD err, char* context, char* file, int line, char* func);
+void DebugMessage(LPMSG msg, WPARAM wParam);
+void DebugShift(char* function, char* point);
+BOOL DebugSignalPause(BOOL fIsUp);
+char* Debug_VirtualKey(WORD vk);
+char* Debug_UnicodeString(PWSTR s, int x = 0);
+
+BOOL ShouldDebug_1(); // TSDMState state);
+
+#endif
+
+#ifdef _DEBUG
+#define OutputThreadDebugString(s) _OutputThreadDebugString(s)
+void _OutputThreadDebugString(char* s);
+#else
+#define OutputThreadDebugString(s)
+#endif
+
+/* Keyboard selection functions */
+
+void HandleRefresh(int code, LONG tag);
+void RefreshKeyboards(BOOL Initialising);
+void CheckScheduledRefresh();
+void ScheduleRefresh();
+void ReleaseKeyboards(BOOL Lock);
+void CheckScheduledRefresh();
+void ScheduleRefresh();
+
+/* Glossary conversion functions */
+
+HKL ForceKeymanIDToHKL(DWORD KeymanID); // sign extends DWORD to HKL on Win64
+DWORD ForceHKLToKeymanID(HKL hkl);      // truncates HKL to DWORD on Win64
+   // I4220
+DWORD HKLToKeyboardID(HKL hkl);
+WORD HKLToLanguageID(HKL hkl);
+WORD HKLToLayoutNumber(HKL hkl);
+WORD HKLToLayoutID(HKL hkl);
+DWORD EthnologueCodeToKeymanID(DWORD EthCode);
+DWORD EthnologueStringCodeToDWord(PWSTR EthCode);
+
+PWSTR  GetSystemStore(LPKEYBOARD kb, DWORD SystemID);
+
+DWORD ExceptionMessage(LPSTR Proc, LPEXCEPTION_POINTERS ep);
+
+void keybd_shift(LPINPUT pInputs, int* n, BOOL isReset, LPBYTE const kbd);
+
+//#define KEYEVENT_EXTRAINFO_KEYMAN 0xF00F0000   // I4370
+#ifndef _KEYMAN64_LIGHT
+
+#ifndef _WIN64   // I4326
+#include "hotkeys.h"
+#endif
+
+#include "appint\appint.h"
+#include "appint\aitip.h"
+#include "appint\aiwin2000unicode.h"
+#include "globals.h"
+
+#include "capsstate.h"
+#include "keystate.h"
+
+#include "calldll.h"
+#include "addins.h"
+#include "keymancontrol.h"
+#include "keyboardoptions.h"
+
+#include "syskbd.h"
+#include "vkscancodes.h"
+#include "rc4.h"
+
+#include "testkeymanfunctioning.h"
+#include "keynames.h"
+
+#include "crc32.h"
+
+#include "k32_tsf.h"
+
+void ReportActiveKeyboard(WORD wCommand);   // I3933   // I3949
+void SelectKeyboardHKL(DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4271
+BOOL SelectKeyboardTSF(DWORD KeymanID, BOOL foreground);   // I3933   // I3949   // I4271
+BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL hkl, GUID clsid, GUID guidProfile);
+void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
+
+#endif  // _KEYMAN64_LIGHT
+#endif	// _KEYMANENGINE_H

--- a/windows/src/global/inc/keymanengine.h
+++ b/windows/src/global/inc/keymanengine.h
@@ -251,4 +251,4 @@ BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL 
 void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
 
 #endif  // _KEYMAN64_LIGHT
-#endif	// _KEYMANENGINE_H
+#endif  // _KEYMANENGINE_H


### PR DESCRIPTION
Ground work for #5011 . This PR breaks out the include files and definitions from keyman64.h into keymanengine.h This will allow for projects like kmanalyze to just include keyman64.h and not keymanengine.h and therefore the whole keyman core library. 