### PR TITLE
fix(developer): compiler use and match behavior for Web should be same as Core

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -2115,6 +2115,30 @@ begin
   fgp := fk.dpGroupArray;
 	for i := 0 to Integer(fk.cxGroupArray)-1 do  // I1964
   begin
+    {
+      Note on `r` and `m` variables in a group function:
+
+      `m` can have one of three values:
+        0: no rule from this group was matched
+        1: a rule from this group was matched and did not include a `use`
+           statement
+        2: a rule from this group matched and did include a `use` statement
+           (#5440)
+
+      `m` is only used within a rule group to control the firing of the
+      `match` and `nomatch` rules.
+
+      `r` can have one of two values:
+        0: no rule from the final group matched (even if a rule from an
+           higher-level group did)
+        1: a rule from the final group did match;
+
+      `r` serves as the rule group's return value and is forwarded
+      recursively, best serving as a flag for whether or not default
+      output for a key should be emitted (0 means yes, emit the
+      default character output for that key).
+    }
+
     Result := Result + Format(
       '%sthis.g%s=function(t,e) {%s'+
       '%svar k=KeymanWeb,r=%d,m=0;%s',     //I1959

--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -1121,6 +1121,7 @@ begin
           begin
             if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
             Result := Result + nlt+Format('r=this.g%s(t,e);', [JavaScript_Name(rec.Use.GroupIndex, rec.Use.Group.szName)]);    // I1959   // I3681
+            Result := Result + nlt+'m=2;';  // #5440 - match desktop behavior
             len := -1;
           end;
         CODE_CALL:
@@ -1130,6 +1131,7 @@ begin
             if n = -1 then
               n := FCallFunctions.Add(CallFunctionName(rec.Call.Store.dpString));
             Result := Result + nlt+Format('r=this.c%d(t,e);', [n]);    // I1959   // I3681
+            Result := Result + nlt+'m=2;';  // #5440 - match desktop behavior
             len := -1;
           end;
         CODE_SETOPT:    // I3429
@@ -2173,7 +2175,7 @@ begin
 
 		if Assigned(fgp.dpMatch) then
       Result := Result + Format(
-        '%sif(m) {%s'+
+        '%sif(m==1) {%s'+
         '%s%s%s'+
         '%s}%s',
         [FTabstop+FTabstop, nl,


### PR DESCRIPTION
Fixes #5440.

Currently, the behavior of `use()` and `match` for KeymanWeb compiled keyboards is not identical to the Windows (or Core) behavior. The example keyboard in #5440 generates 'foo' instead of 'abc' on web.

This fixes that by ensuring that `match` is not called when `use()` is found in a group rule match.

Take note of https://github.com/keymanapp/keyman/issues/5440#issuecomment-889624379 when finishing this.

Given this keyboard (from #5440):
```
group(Main) using keys

+ [K_1] > 'a'
'b' + [K_2] > context use(b)

match > use(a)
```

The following code block shows the differences in the compiled code to ensure that we match the Windows behavior:
```diff
  this.gs=function(t,e) {
    return this.g_Main_0(t,e);
  };
  this.g_Main_0=function(t,e) {
    var k=KeymanWeb,r=0,m=0;
    if(k.KKM(e, modCodes.VIRTUAL_KEY /* 0x4000 */, keyCodes.K_1 /* 0x31 */)) {
      if(1){
        r=m=1;   // Line 15
        k.KDC(0,t);
        k.KO(-1,t,"a");
      }
    }
    else if(k.KKM(e, modCodes.VIRTUAL_KEY /* 0x4000 */, keyCodes.K_2 /* 0x32 */)) {
      if(k.KFCM(1,t,['b'])){
        r=m=1;   // Line 16
        k.KDC(1,t);
        k.KO(-1,t,"b");
        r=this.g_b_2(t,e);
+       m=2;
      }
    }
-   if(m) {
+   if(m==1) {
      k.KDC(-1,t);
      r=this.g_a_1(t,e);
+     m=2;
    }
    return r;
  };
```