### PR TITLE
refactor(linux): Cleanup import of os.path

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -2,7 +2,7 @@ import getpass
 import gettext
 import importlib
 import logging
-import os.path
+import os
 import platform
 import sys
 

--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import logging
-import os.path
+import os
 import urllib.parse
 
 import gi

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-import os.path
+import os
 import zipfile
 from shutil import rmtree
 from enum import Enum

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -3,7 +3,7 @@
 # Install confirmation with details window
 
 import logging
-import os.path
+import os
 import pathlib
 import subprocess
 import sys

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -4,7 +4,7 @@ import json
 import configparser
 import logging
 import sys
-import os.path
+import os
 import magic
 from enum import Enum
 from json.decoder import JSONDecodeError

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import logging
-import os.path
+import os
 from shutil import rmtree
 
 from keyman_config.fcitx_util import is_fcitx_running

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import logging
-import os.path
+import os
 import pathlib
 import subprocess
 import sys

--- a/linux/keyman-config/km-kvk2ldml
+++ b/linux/keyman-config/km-kvk2ldml
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-import os.path
+import os
 import sys
 
 from keyman_config import __version__


### PR DESCRIPTION
This change imports `os` instead of `os.path`. This is the recommended way. It also reduces confusion whether to use `os.path.whatever()` or just `path.whatever()`.