### PR TITLE
fix(android): avoid error with empty font data

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1048,7 +1048,7 @@ final class KMKeyboard extends WebView {
    */
   private JSONObject makeFontPaths(String font) {
 
-    if(font == null) {
+    if(font == null || font.equals("")) {
       return null;
     }
 


### PR DESCRIPTION
Fixes #5509.

If a keyboard has empty font data string, then we should avoid attempting to parse it.