### PR TITLE
fix(android/app): Check Play Store release notes less than 500 chars

### DIFF
--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -117,12 +117,23 @@ if [ $TIER = "stable" ]; then
   PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
 fi
 echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
+echo "" > "$PLAY_RELEASE_NOTES"
 
-# Filtering for lines starting with '*'
-grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md" > $PLAY_RELEASE_NOTES
-
-# Check release notes are under Play Store limit of 500 characters
-if test "$( wc -m < $PLAY_RELEASE_NOTES )" -gt 500; then
-  warn "Warning: Play Store release notes over 500 characters"
-  echo '* Bug fixes and improvements' > $PLAY_RELEASE_NOTES
-fi
+# Copy whatsnew.md to release notes 1 line at a time,
+# filtering for lines that start with "*".
+# Play Store release notes have a limit of 500 characters
+wc=0
+FILTERED_LINES=`grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md"`
+IFS=$'\n'      # Change IFS to new line
+for line in $FILTERED_LINES
+do
+  CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
+  CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
+  if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
+    # Copy line to Play Store release notes
+    echo $line >> $PLAY_RELEASE_NOTES
+  else
+    # 450 chars reached
+    break
+  fi  
+done

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -117,4 +117,12 @@ if [ $TIER = "stable" ]; then
   PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
 fi
 echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
-cp $KEYMAN_ROOT/android/help/about/whatsnew.md $PLAY_RELEASE_NOTES
+
+# Filtering for lines starting with '*'
+grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md" > $PLAY_RELEASE_NOTES
+
+# Check release notes are under Play Store limit of 500 characters
+if test "$( wc -m < $PLAY_RELEASE_NOTES )" -gt 500; then
+  warn "Warning: Play Store release notes over 500 characters"
+  echo '* Bug fixes and improvements' > $PLAY_RELEASE_NOTES
+fi

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -122,7 +122,6 @@ echo "" > "$PLAY_RELEASE_NOTES"
 # Copy whatsnew.md to release notes 1 line at a time,
 # filtering for lines that start with "*".
 # Play Store release notes have a limit of 500 characters
-wc=0
 FILTERED_LINES=`grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md"`
 IFS=$'\n'      # Change IFS to new line
 for line in $FILTERED_LINES
@@ -131,9 +130,10 @@ do
   CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
   if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
     # Copy line to Play Store release notes
-    echo $line >> $PLAY_RELEASE_NOTES
+    echo "$line" >> $PLAY_RELEASE_NOTES
   else
     # 450 chars reached
+    echo '* Additional bug fixes and improvements' >> $PLAY_RELEASE_NOTES
     break
   fi  
 done

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -133,6 +133,7 @@ do
     echo "$line" >> $PLAY_RELEASE_NOTES
   else
     # 450 chars reached
+    warn "Warning: Play Store release notes approaching 500 character limit"
     echo '* Additional bug fixes and improvements' >> $PLAY_RELEASE_NOTES
     break
   fi  


### PR DESCRIPTION
Fixes #5533 

#5132 copied `whatsnew.md` to use as Play Store release notes. However, there's a 500 character limit.

This updates `build-help.sh` to: 
* Only use lines starting with `*` or indented `*`
* Check the character count < 500. If more, then add a general note `* Additional bug fixes and improvements`