### PR TITLE
fix(web): Have util.wait check useAlerts option

### DIFF
--- a/web/source/kmwnative.ts
+++ b/web/source/kmwnative.ts
@@ -53,7 +53,7 @@ if(!window['keyman']['initialized']) {
       if(s) {
         bg.pending=true;
         window.setTimeout(function() {
-            if(bg.pending) {
+            if(bg.pending && keymanweb.options.useAlerts) {
               window.scrollTo(0,0);
               nn[0].style.display='none';
               nn[1].className='kmw-wait-text'; nn[1].innerHTML=s;

--- a/web/testing/index.html
+++ b/web/testing/index.html
@@ -54,6 +54,7 @@
   <h2><a href="./rotation-events">Test page for evaluating issues with mobile device rotation events.</a></h2>
   <h2><a href="./issue382">Test page for automatic key-cap scaling.</a></h2>
   <h2><a href="./issue3701">Test page for fat-finger interaction with beep feedback</a></h2>
+  <h2><a href="./issue5455/index.html">Test page for util.wait checking options.useAlerts</a></h2>
   <h2><a href="./issue917-context-and-notany/">Test page for context() and notany() interaction</a></h2>
   <h2><a href="./spacebar-text/">Test SpacebarText APIs (#949)</a></h2>
   <p><a href="../">Return to main index.</a>

--- a/web/testing/issue5455/index.html
+++ b/web/testing/issue5455/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <title>KeymanWeb Testing Page - util.wait checks options.useAlerts</title>
+
+    <!-- Your page CSS -->
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../release/unminified/web/keymanweb.js" type="application/javascript"></script>
+
+    <!--
+      For desktop browsers, a script for the user interface must be inserted here.
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
+      a large number of languages.
+    -->
+    <script src="../../release/unminified/web/kmwuitoggle.js"></script>
+
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+      const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
+      var alertText = alertType ? 'enabled(default)' : 'disabled';
+
+      var kmw=window.keyman;
+
+      kmw.init({
+        useAlerts: alertType
+      });
+      kmw.addKeyboards('french','@he');
+
+      // Call util.wait on a timer
+      window.setTimeout(function(){kmw.util.wait('This is a waiting message');}, 2000);
+      window.setTimeout(function(){kmw.util.wait();}, 5000);
+    </script>
+
+  </head>
+
+<!-- Sample page HTML -->
+  <body>
+    <h2>KeymanWeb Sample Page - Issue 5455</h2>
+    <p>This page is for testing that util.wait() checks for options.useAlerts.
+      See <a href="https://github.com/keymanapp/keyman/issues/5455">Issue #5455.</a>
+    </p>
+    <p>
+      About 2 seconds after this test page loads, you should see a util.wait modal "This is a waiting message"
+      if the option for useAlerts is enabled.
+    </p>
+    <p>
+      After another 5 seconds, the modal should disappear.
+    </p>
+
+    <p id="modeSelect">You are currently testing under the internal alerts <em id="mode"> </em> mode.
+    Two alert modes are available:
+    <a id="alert_disabled" href="./index.html?useAlerts=false">Disabled</a> or
+    <a id="alert_default" href="./index.html">Enabled (Default)</a></p>
+    <p>This will only affect whether or not KeymanWeb's alert and wait modals are displayed.
+    </p>
+
+<script>
+      document.getElementById("mode").textContent = alertText;
+    </script>
+
+    <div>
+    <!--
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>
+
+    <h3>Type in your language in this text area:</h3>
+    <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <h3>or in this input field:</h3>
+    <input class='test' value='' placeholder='or here'/>
+
+    <h3><a href="../index.html">Return to testing home page</a></h3>
+  </div>
+
+  </body>
+
+  <!--
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *
+    ***
+  -->
+</html>


### PR DESCRIPTION
#5302 added an option useAlerts that controlled whether internal alerts are displayed.
This fixes #5455 by having util.wait also check the option.

* Also added a test page to display util.wait and then dismiss