### PR TITLE
fix(android/app): Fix cleanup when progress dialog cancelled

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/DownloadIntentService.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/DownloadIntentService.java
@@ -30,8 +30,8 @@ public class DownloadIntentService extends IntentService {
     try {
       int result = FileUtils.download(getApplicationContext(), url, destination, filename);
       if (result == FileUtils.DOWNLOAD_SUCCESS) {
-        bundle.putString("filename", filename);
         if (!this.cancelDownload) {
+          bundle.putString("filename", filename);
           bundle.putString("destination", destination);
           bundle.putString("language", languageID);
           bundle.putSerializable("installMode", installMode);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -47,6 +47,12 @@ public class DownloadResultReceiver extends ResultReceiver {
         packageIntent.putExtras(bundle);
         context.startActivity(packageIntent);
         break;
+      case FileUtils.DOWNLOAD_CANCELLED :
+        downloadedFilename = resultData.getString("filename");
+        String message = String.format(context.getString(R.string.cancelled_downloading_package), downloadedFilename);
+        Toast.makeText(context, message,
+          Toast.LENGTH_SHORT).show();
+        break;
     }
     super.onReceiveResult(resultCode, resultData);
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/DownloadResultReceiver.java
@@ -48,10 +48,7 @@ public class DownloadResultReceiver extends ResultReceiver {
         context.startActivity(packageIntent);
         break;
       case FileUtils.DOWNLOAD_CANCELLED :
-        downloadedFilename = resultData.getString("filename");
-        String message = String.format(context.getString(R.string.cancelled_downloading_package), downloadedFilename);
-        Toast.makeText(context, message,
-          Toast.LENGTH_SHORT).show();
+        // NO-OP
         break;
     }
     super.onReceiveResult(resultCode, resultData);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguagesSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguagesSettingsActivity.java
@@ -4,13 +4,9 @@
 
 package com.tavultesoft.kmapro;
 
-import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,28 +16,21 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
-import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.adapters.AdapterFilter;
 import com.tavultesoft.kmea.data.adapters.NestedAdapter;
-import com.tavultesoft.kmea.logic.ResourcesUpdateTool;
 import com.tavultesoft.kmea.KeyboardPickerActivity;
 import com.tavultesoft.kmea.KMManager;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Keyman Settings --> Languages Settings

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -527,12 +527,6 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         url = url.toLowerCase();
         try {
           if (progressDialog == null) {
-            progressDialog = new ProgressDialog(MainActivity.this);
-            progressDialog.setMessage(String.format(getString(R.string.downloading_keyboard_package), filename));
-            progressDialog.setCancelable(true); // Cancelable in case there's exceptions
-            progressDialog.show();
-
-            // Download the KMP to app cache
             Intent downloadIntent = new Intent(MainActivity.this, DownloadIntentService.class);
             downloadIntent.putExtra("url", url);
             downloadIntent.putExtra("filename", filename);
@@ -541,6 +535,19 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             downloadIntent.putExtra("receiver", resultReceiver);
             downloadIntent.putExtra("installMode", installMode);
 
+            progressDialog = new ProgressDialog(MainActivity.this);
+            progressDialog.setMessage(String.format(getString(R.string.downloading_keyboard_package), filename));
+            progressDialog.setCancelable(true); // Cancelable in case there's exceptions
+            progressDialog.show();
+            progressDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+              @Override
+              public void onCancel(DialogInterface dialog) {
+                // stopService(downloadIntent); has no effect
+                cleanupPackageInstall();
+              }
+            });
+
+            // Download the KMP to app cache
             startService(downloadIntent);
           }
         } catch (Exception e) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -542,7 +542,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             progressDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
               @Override
               public void onCancel(DialogInterface dialog) {
-                // stopService(downloadIntent); has no effect
+                stopService(downloadIntent);
                 cleanupPackageInstall();
               }
             });

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -194,9 +194,6 @@
   <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>
 
   <!-- Context: KMP Package strings -->
-  <string name="cancelled_downloading_package" comment="Cancelled download of package">Cancelled downloading %1$s package</string>
-
-  <!-- Context: KMP Package strings -->
   <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">Downloading keyboard package\n%1$s&#8230;</string>
 
   <!-- Context: KMP Package strings -->

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -194,6 +194,9 @@
   <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>
 
   <!-- Context: KMP Package strings -->
+  <string name="cancelled_downloading_package" comment="Cancelled download of package">Cancelled downloading %1$s package</string>
+
+  <!-- Context: KMP Package strings -->
   <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">Downloading keyboard package\n%1$s&#8230;</string>
 
   <!-- Context: KMP Package strings -->

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -29,6 +29,7 @@ public final class FileUtils {
 
   public static final int DOWNLOAD_ERROR = -1;
   public static final int DOWNLOAD_SUCCESS = 1;
+  public static final int DOWNLOAD_CANCELLED = 2;
 
   public static final int VERSION_INVALID = -2;
   public static final int VERSION_EQUAL = 0;


### PR DESCRIPTION
Fixes #5242

When the progress dialog for downloading a kmp is cancelled, sometimes it gets left in a state preventing further kmp's from being downloaded.

* This sets the cancel handler on progressDialog to do cleanup.
* Also cleaned up imports on LanguagesSettingsActivity (when I was searching for references of progressDialog)

Initially putting the PR in draft since I haven't been able to repro the reported issue.