### PR TITLE
chore(android): Update sentry-android-gradle-plugin to 2.1.0

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
         classpath 'name.remal:gradle-plugins:1.3.1'
 
         // From jcenter() which could be sunset in future

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -79,10 +79,10 @@ android {
 // how to configure the sentry android gradle plugin
 sentry {
     // Disables or enables the automatic configuration of Native symbols
-    uploadNativeSymbols true
+    uploadNativeSymbols = true
 
     // Does or doesn't include the source code of native code for Sentry
-    includeNativeSources true
+    includeNativeSources = true
 }
 
 String env_keys_json_file = System.getenv("keys_json_file")

--- a/android/README.md
+++ b/android/README.md
@@ -128,6 +128,7 @@ repositories {
         dirs 'libs'
     }
     google()
+    mavenCentral()
 }
 
 dependencies {

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -4,10 +4,11 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,5 +19,6 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -41,7 +41,7 @@ repositories {
         dirs 'libs'
     }
     google()
-
+    mavenCentral()
 }
 
 dependencies {

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,5 +18,6 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -66,10 +66,10 @@ android {
 // how to configure the sentry android gradle plugin
 sentry {
     // Disables or enables the automatic configuration of Native symbols
-    uploadNativeSymbols true
+    uploadNativeSymbols = true
 
     // Does or doesn't include the source code of native code for Sentry
-    includeNativeSources true
+    includeNativeSources = true
 }
 
 String env_keys_json_file = System.getenv("oem_firstvoices_keys_json_file")
@@ -104,6 +104,7 @@ repositories {
         dirs 'libs'
     }
     google()
+    mavenCentral()
 }
 
 dependencies {

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -1,16 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'com.google.gms:google-services:4.3.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
-
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Fixes #5347
Gradle warnings during build of FV app
```
getMappingFile(): Cannot query the value of this property because it has no value available.
AGPBI: {"kind":"warning","text":"API 'variant.getMappingFile()' is obsolete and has been replaced with 'variant.getMappingFileProvider()'.\nIt will be removed in version 7.0 of the Android Gradle plugin.\nFor more information, see https://d.android.com/r/tools/task-configuration-avoidance.\nTo determine what is calling variant.getMappingFile(), use -Pandroid.debug.obsoleteApi=true on the command line to display more information.","sources":[{}]}
getMappingFile(): Cannot query the value of this property because it has no value available.
AGPBI: {"kind":"warning","text":"Using flatDirs should be avoided because it doesn't support any meta-data formats.\nCurrently detected usages:\n- repository flatDir used in: project ':app'","sources":[{}]}
AGPBI: {"kind":"warning","text":"Please remove usages of `jcenter()` Maven repository from your build scripts and migrate your build to other Maven repositories.\nThis repository is deprecated and it will be shut down in the future.\nSee http://developer.android.com/r/tools/jcenter-end-of-service for more information.\nCurrently detected usages in: root project 'android', project ':app'","sources":[{}]}
```
were generated by an older version of sentry-android-gradle-plugin.
Updating to 2.1.0 removes those warnings.

I had to make some minor Gradle Sentry syntax changes per the [migration guide](https://docs.sentry.io/platforms/android/migration/#migrating-from-iosentrysentry-android-gradle-plugin-1x-to-iosentrysentry-android-gradle-plugin-200).

I also went ahead and updated all the Android projects to the same version and verified Sentry still reports fine
http://sentry.keyman.com/organizations/keyman/issues/10401/?project=7

Verified the FV android build doesn't generate the reported warnings.