### PR TITLE
fix(web): Blank spacebar text when displayName is empty string

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1020,7 +1020,7 @@ namespace com.keyman.osk {
       let activeStub = keyman.keyboardManager.activeStub;
 
       if(activeStub) {
-        if(activeStub['displayName']) {
+        if(activeStub['displayName'] != null) {
           displayName = activeStub['displayName'];
         } else {
           let

--- a/web/testing/spacebar-text/index.html
+++ b/web/testing/spacebar-text/index.html
@@ -41,6 +41,12 @@
         },
         filename:'rac_balti.js',
         displayName: 'My Custom Name'
+      }, {id:'lao_2008_basic',name:'Lao 2008 Basic',
+        languages:{
+          id:'lo',name:'Lao'
+        },
+        filename:'../lao_2008_basic-1.2.js',
+        displayName: ''
       },
       '@en');
     }, false);
@@ -57,10 +63,12 @@
 <!-- Sample page HTML -->
 <body>
   <h2>KeymanWeb Sample Page - SpacebarText Testing</h2>
-  <p>See <a href='https://github.com/keymanapp/keyman/pull/5348'>PR #5348</a> for details.</p>
+  <p>See <a href='https://github.com/keymanapp/keyman/pull/5348'>PR #5348</a>
+    and <a href='https://github.com/keymanapp/keyman/issue/5524'>issue #5524</a> for details.</p>
   <p>The English keyboard should have its spacebar caption modified by the radio controls,
     whereas the Balti keyboard has a custom caption specified in its `addKeyboards` call.
   </p>
+  <p>Lao 2008 has a custom blank caption (empty string "")</p>
 
   <hr/>
   <div>


### PR DESCRIPTION
Fixes #5524 and follow-on to #5349 (Adding controls for the spacebar caption)

In the reported issue, a blank display name `""` was still showing a spacebar caption. This is because when activeStub['displayName'] is `""`, the check for displayName was falsy.

This PR changes the check to 
`if (activeStub['displayName'] != null) {`

## User Testing
@keymanapp/testers 
Wait until other developers get a chance to review and comment

### KeymanWeb
* load web/testing/spacebar-text/index.html
* If not already selected, set the keyboard to RAC Balti 
* Verify the spacebar text is "My Custom Name"
* Set the keyboard to Lao 2008 Basic
* Verify the spacebar text is blank
* Set the keyboard to US
* Verify the spacebar text adjust according to the radio button setting

### Keyman for Android
* Load the test app
* Install a keyboard
* Verify the Keyboard and language names appear on the spacebar
* Go to the "Settings" menu  --> Spacebar caption
* Change the caption setting
* Verify the keyboard spacebar caption changes to match the setting

### Keyman for iPhone and iPad
Repeat the same test steps as Keyaman for Android. I don't know the specific menu navigation for the spacebar caption setting.
