### PR TITLE
feat(ios): adds option for Simulator-compatible testing artifact

### DIFF
--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@keymanapp/lexical-model-layer",
-			"version": "15.0.80",
+			"version": "15.0.94",
 			"license": "MIT",
 			"dependencies": {
 				"es6-shim": "^0.35.5",

--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@keymanapp/lexical-model-layer",
-			"version": "15.0.94",
+			"version": "15.0.80",
 			"license": "MIT",
 			"dependencies": {
 				"es6-shim": "^0.35.5",

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -24,7 +24,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 verify_on_mac
 
 display_usage ( ) {
-    echo "build.sh [-clean] [-no-kmw] [-only-framework] [-no-codesign] [-no-archive] [-all-artifacts] [-no-build] [-upload-sentry]"
+    echo "build.sh [-clean] [-no-kmw] [-only-framework] [-no-codesign] [-no-archive] [-add-sim-artifact] [-no-build] [-upload-sentry]"
     echo
     echo "  -clean                  Removes all previously-existing build products for KMEI and the Keyman app before building."
     echo "  -no-kmw                 Uses existing keyman.js, doesn't try to build"
@@ -37,7 +37,7 @@ display_usage ( ) {
     echo "  -upload-sentry          Uploads debug symbols, etc, to Sentry"
     echo "  -debug                  Sets the configuration to debug mode instead of release."
     echo "  -download-resources     Download up-to-date versions of the engine's default resources from downloads.keyman.com."
-    echo "  -all-artifacts          Produces all build artifacts, including a Simulator-installable copy of the .app"
+    echo "  -add-sim-artifact       Produces all build artifacts, including a Simulator-installable copy of the .app"
 exit 1
 }
 
@@ -106,7 +106,7 @@ while [[ $# -gt 0 ]] ; do
         -download-resources)
             DO_KMP_DOWNLOADS=true
             ;;
-        -all-artifacts)
+        -add-sim-artifact)
             DO_SIMULATOR_TARGET=true
             ;;
     esac

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -302,7 +302,7 @@ if [ $DO_KEYMANAPP = true ]; then
 
     if [ $DO_CODE_SIGN == true ]; then
       echo "Preparing .ipa file for deployment to real devices"
-      xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
+      xcodebuild $XCODEFLAGS_EXT -exportArchive -archivePath $ARCHIVE_PATH \
                   -exportOptionsPlist exportAppStore.plist \
                   -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates
     fi

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -37,7 +37,7 @@ display_usage ( ) {
     echo "  -upload-sentry          Uploads debug symbols, etc, to Sentry"
     echo "  -debug                  Sets the configuration to debug mode instead of release."
     echo "  -download-resources     Download up-to-date versions of the engine's default resources from downloads.keyman.com."
-    echo "  -add-sim-artifact       Produces all build artifacts, including a Simulator-installable copy of the .app"
+    echo "  -add-sim-artifact       Also produce a Simulator-installable .app build artifact"
 exit 1
 }
 

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -302,7 +302,9 @@ if [ $DO_KEYMANAPP = true ]; then
 
     if [ $DO_CODE_SIGN == true ]; then
       echo "Preparing .ipa file for deployment to real devices"
-      xcodebuild $XCODEFLAGS_EXT -exportArchive -archivePath $ARCHIVE_PATH \
+      # Do NOT use the _EXT variant here; there's no scheme to ref, which will lead
+      # Xcode to generate a build error.
+      xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
                   -exportOptionsPlist exportAppStore.plist \
                   -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates
     fi

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -24,7 +24,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 verify_on_mac
 
 display_usage ( ) {
-    echo "build.sh [-clean] [-no-kmw] [-only-framework] [-no-codesign] [-no-archive] [-no-build] [-upload-sentry]"
+    echo "build.sh [-clean] [-no-kmw] [-only-framework] [-no-codesign] [-no-archive] [-all-artifacts] [-no-build] [-upload-sentry]"
     echo
     echo "  -clean                  Removes all previously-existing build products for KMEI and the Keyman app before building."
     echo "  -no-kmw                 Uses existing keyman.js, doesn't try to build"
@@ -37,6 +37,7 @@ display_usage ( ) {
     echo "  -upload-sentry          Uploads debug symbols, etc, to Sentry"
     echo "  -debug                  Sets the configuration to debug mode instead of release."
     echo "  -download-resources     Download up-to-date versions of the engine's default resources from downloads.keyman.com."
+    echo "  -all-artifacts          Produces all build artifacts, including a Simulator-installable copy of the .app"
 exit 1
 }
 
@@ -55,6 +56,7 @@ BUILD_PATH=$DERIVED_DATA/Build/Products
 DO_KMW_BUILD=true
 DO_KEYMANAPP=true
 DO_ARCHIVE=true
+DO_SIMULATOR_TARGET=false
 DO_CARTHAGE=true
 CLEAN_ONLY=false
 CONFIG=Release
@@ -103,6 +105,9 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -download-resources)
             DO_KMP_DOWNLOADS=true
+            ;;
+        -all-artifacts)
+            DO_SIMULATOR_TARGET=true
             ;;
     esac
     shift # past argument
@@ -284,7 +289,7 @@ if [ $DO_KEYMANAPP = true ]; then
   else
     # Time to prepare the deployment archive data.
     echo ""
-    echo "Preparing .xcarchive."
+    echo "Preparing .xcarchive for real devices."
     xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
                 -archivePath $ARCHIVE_PATH \
                 archive -allowProvisioningUpdates \
@@ -296,11 +301,21 @@ if [ $DO_KEYMANAPP = true ]; then
     assertDirExists "$ARCHIVE_PATH"
 
     if [ $DO_CODE_SIGN == true ]; then
-      echo "Preparing .ipa file for deployment"
+      echo "Preparing .ipa file for deployment to real devices"
       xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
                   -exportOptionsPlist exportAppStore.plist \
                   -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates
     fi
+  fi
+
+  if [ $DO_SIMULATOR_TARGET == true ]; then
+    echo "Preparing .app file for simulator-targeted artifact for testing"
+    xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
+                -sdk iphonesimulator \
+                VERSION=$VERSION \
+                VERSION_WITH_TAG=$VERSION_WITH_TAG \
+                VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
+                UPLOAD_SENTRY=$UPLOAD_SENTRY 
   fi
 
   echo ""

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -89,8 +89,14 @@ cd $WORK_DIR
 KEYMANAPP_IPA="build/Build/Products/Release-iphoneos/Keyman.ipa"
 KEYMANAPP_IPA_DST="keyman-ios-${BUILD_NUMBER}.ipa"
 
-echo "Copying Keyman IPA ${KEYMANAPP_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_IPA/DST}..."
+echo "Copying Keyman IPA ${KEYMANAPP_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}..."
 cp "${KEYMANAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}"
+
+KEYMANAPP_SIM_IPA="build/Build/Products/Release-iphonesimulator/Keyman.ipa"
+KEYMANAPP_SIM_IPA_DST="keyman-ios-simulator-${BUILD_NUMBER}.ipa"
+
+echo "Copying Keyman simulator artifact ${KEYMANAPP_SIM_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}..."
+cp "${KEYMANAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}"
 
 #
 # FirstVoices app
@@ -100,8 +106,14 @@ if [ ${RELEASE_OEM_FIRSTVOICES} = true ]; then
   FIRSTVOICESAPP_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphoneos/FirstVoices.ipa"
   FIRSTVOICESAPP_IPA_DST="firstvoices-ios-${BUILD_NUMBER}.ipa"
 
-  echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA/DST}..."
+  echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}..."
   cp "${FIRSTVOICESAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}"
+
+  FIRSTVOICESAPP_SIM_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphonesimulator/FirstVoices.ipa"
+  FIRSTVOICESAPP_SIM_IPA_DST="firstvoices-ios-simulator-${BUILD_NUMBER}.ipa"
+
+  echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_SIM_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}..."
+  cp "${FIRSTVOICESAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}"
 fi
 
 #

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -92,28 +92,35 @@ KEYMANAPP_IPA_DST="keyman-ios-${BUILD_NUMBER}.ipa"
 echo "Copying Keyman IPA ${KEYMANAPP_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}..."
 cp "${KEYMANAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}"
 
-KEYMANAPP_SIM_IPA="build/Build/Products/Release-iphonesimulator/Keyman.app"
-KEYMANAPP_SIM_IPA_DST="keyman-ios-simulator-${BUILD_NUMBER}.app"
+KEYMANAPP_SIM_FOLDER="build/Build/Products/Release-iphonesimulator"
+KEYMANAPP_SIM_APP="$KEYMANAPP_SIM_FOLDER/Keyman.app"
+KEYMANAPP_SIM_APP_DST="keyman-ios-simulator-${BUILD_NUMBER}.app.zip"
 
-echo "Copying Keyman simulator artifact ${KEYMANAPP_SIM_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}..."
-cp "${KEYMANAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}"
+echo "Zipping Keyman simulator artifact ${KEYMANAPP_SIM_APP} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}..."
+cd "${KEYMANAPP_SIM_FOLDER}"
+zip -qrX "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}" "Keyman.app"
+echo "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}"
+cd $WORK_DIR
 
 #
 # FirstVoices app
 #
 
-if [ ${RELEASE_OEM_FIRSTVOICES} = true ]; then
+if [ "${RELEASE_OEM_FIRSTVOICES}" = true ]; then
   FIRSTVOICESAPP_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphoneos/FirstVoices.ipa"
   FIRSTVOICESAPP_IPA_DST="firstvoices-ios-${BUILD_NUMBER}.ipa"
 
   echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}..."
   cp "${FIRSTVOICESAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}"
 
-  FIRSTVOICESAPP_SIM_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphonesimulator/FirstVoices.app"
-  FIRSTVOICESAPP_SIM_IPA_DST="firstvoices-ios-simulator-${BUILD_NUMBER}.app"
+  FIRSTVOICESAPP_SIM_FOLDER="../oem/firstvoices/ios/build/Build/Products/Release-iphonesimulator/"
+  FIRSTVOICESAPP_SIM_APP="$FIRSTVOICESAPP_SIM_FOLDER/FirstVoices.app"
+  FIRSTVOICESAPP_SIM_APP_DST="firstvoices-ios-simulator-${BUILD_NUMBER}.app.zip"
 
-  echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_SIM_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}..."
-  cp "${FIRSTVOICESAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}"
+  echo "Zipping FirstVoices simulator artifact ${FIRSTVOICESAPP_SIM_APP} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}..."
+  cd "${FIRSTVOICESAPP_SIM_FOLDER}"
+  zip -qrX "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_APP_DST}" "FirstVoices.app"
+  cd $WORK_DIR
 fi
 
 #

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -96,7 +96,7 @@ KEYMANAPP_SIM_IPA="build/Build/Products/Release-iphonesimulator/Keyman.ipa"
 KEYMANAPP_SIM_IPA_DST="keyman-ios-simulator-${BUILD_NUMBER}.ipa"
 
 echo "Copying Keyman simulator artifact ${KEYMANAPP_SIM_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}..."
-cp "${KEYMANAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}"
+cp "${KEYMANAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}"
 
 #
 # FirstVoices app

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -100,7 +100,7 @@ echo "Zipping Keyman simulator artifact ${KEYMANAPP_SIM_APP} => ${UPLOAD_DIR}/${
 cd "${KEYMANAPP_SIM_FOLDER}"
 zip -qrX "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}" "Keyman.app"
 echo "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}"
-cd $WORK_DIR
+cd "$WORK_DIR"
 
 #
 # FirstVoices app
@@ -120,7 +120,7 @@ if [ "${RELEASE_OEM_FIRSTVOICES}" = true ]; then
   echo "Zipping FirstVoices simulator artifact ${FIRSTVOICESAPP_SIM_APP} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_APP_DST}..."
   cd "${FIRSTVOICESAPP_SIM_FOLDER}"
   zip -qrX "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_APP_DST}" "FirstVoices.app"
-  cd $WORK_DIR
+  cd "$WORK_DIR"
 fi
 
 #

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -92,8 +92,8 @@ KEYMANAPP_IPA_DST="keyman-ios-${BUILD_NUMBER}.ipa"
 echo "Copying Keyman IPA ${KEYMANAPP_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}..."
 cp "${KEYMANAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_IPA_DST}"
 
-KEYMANAPP_SIM_IPA="build/Build/Products/Release-iphonesimulator/Keyman.ipa"
-KEYMANAPP_SIM_IPA_DST="keyman-ios-simulator-${BUILD_NUMBER}.ipa"
+KEYMANAPP_SIM_IPA="build/Build/Products/Release-iphonesimulator/Keyman.app"
+KEYMANAPP_SIM_IPA_DST="keyman-ios-simulator-${BUILD_NUMBER}.app"
 
 echo "Copying Keyman simulator artifact ${KEYMANAPP_SIM_IPA} => ${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}..."
 cp "${KEYMANAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${KEYMANAPP_SIM_IPA_DST}"
@@ -109,8 +109,8 @@ if [ ${RELEASE_OEM_FIRSTVOICES} = true ]; then
   echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}..."
   cp "${FIRSTVOICESAPP_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_IPA_DST}"
 
-  FIRSTVOICESAPP_SIM_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphonesimulator/FirstVoices.ipa"
-  FIRSTVOICESAPP_SIM_IPA_DST="firstvoices-ios-simulator-${BUILD_NUMBER}.ipa"
+  FIRSTVOICESAPP_SIM_IPA="../oem/firstvoices/ios/build/Build/Products/Release-iphonesimulator/FirstVoices.app"
+  FIRSTVOICESAPP_SIM_IPA_DST="firstvoices-ios-simulator-${BUILD_NUMBER}.app"
 
   echo "Copying FirstVoices IPA ${FIRSTVOICESAPP_SIM_IPA} => ${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}..."
   cp "${FIRSTVOICESAPP_SIM_IPA}" "${WORK_DIR}/${UPLOAD_DIR}/${FIRSTVOICESAPP_SIM_IPA_DST}"

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -29,7 +29,7 @@ display_usage ( ) {
     echo "  -no-carthage       Disables downloading and building for dependencies."
     echo "  -no-codesign       Performs the build without code signing."
     echo "  -debug             Sets the configuration to debug mode instead of release."
-    echo "  -add-sim-artifact  Produces all build artifacts, including a Simulator-installable copy of the .app"
+    echo "  -add-sim-artifact  Also produce a Simulator-installable .app build artifact"
     echo
     echo "  If no settings are specified this script will grab a copy of the most recent build of KeymanEngine,"
     echo "  performing an initial build of it if necessary."

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -198,7 +198,10 @@ if [ $CODE_SIGN = true ]; then
 
     assertDirExists "$ARCHIVE_PATH"
 
-    xcodebuild $XCODEFLAGS_EXT -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
+
+    # Do NOT use the _EXT variant here; there's no scheme to ref, which will lead
+    # Xcode to generate a build error.
+    xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
                -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -22,14 +22,14 @@ fi
 display_usage ( ) {
     echo "build.sh [-no-update] | [-no-archive] | [-lib-build] | [-lib-ignore] | [-clean]"
     echo
-    echo "  -clean          Removes all previously-existing build products for this project before building."
-    echo "  -no-update      If an in-place copy of KeymanEngine.framework exists, does not seek out an updated copy."
-    echo "  -lib-build      Actively rebuilds KMEI before copying its build products to project resources."
-    echo "  -lib-nobuild    Prevents the build script from building KeymanEngine under any circumstances."
-    echo "  -no-carthage    Disables downloading and building for dependencies."
-    echo "  -no-codesign    Performs the build without code signing."
-    echo "  -debug          Sets the configuration to debug mode instead of release."
-    echo "  -all-artifacts  Produces all build artifacts, including a Simulator-installable copy of the .app"
+    echo "  -clean             Removes all previously-existing build products for this project before building."
+    echo "  -no-update         If an in-place copy of KeymanEngine.framework exists, does not seek out an updated copy."
+    echo "  -lib-build         Actively rebuilds KMEI before copying its build products to project resources."
+    echo "  -lib-nobuild       Prevents the build script from building KeymanEngine under any circumstances."
+    echo "  -no-carthage       Disables downloading and building for dependencies."
+    echo "  -no-codesign       Performs the build without code signing."
+    echo "  -debug             Sets the configuration to debug mode instead of release."
+    echo "  -add-sim-artifact  Produces all build artifacts, including a Simulator-installable copy of the .app"
     echo
     echo "  If no settings are specified this script will grab a copy of the most recent build of KeymanEngine,"
     echo "  performing an initial build of it if necessary."
@@ -105,7 +105,7 @@ while [[ $# -gt 0 ]] ; do
             CONFIG=Debug
             KMEI_FLAGS="$KMEI_FLAGS -debug"
             ;;
-        -all-artifacts)
+        -add-sim-artifact)
             DO_SIMULATOR_TARGET=true
             ;;
     esac


### PR DESCRIPTION
I may need some guidance ensuring things are handled properly on the build-agent side, but I've added the `-all-artifacts` build option to both the Keyman app and FV app build scripts.  This produces an extra artifact - a `.app` version that can be dragged and dropped straight to the Simulator.  This'll _greatly_ facilitate testing... once we can direct our tester(s) to the artifact.

(This is one of our postmortem actions from spacebarText)