### PR TITLE
fix(windows): wrap text in keyboard installation dialog

### DIFF
--- a/windows/src/desktop/kmshell/xml/installkeyboard.css
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.css
@@ -123,5 +123,6 @@ div {
 }
 .otherdetails {
   font-size: 13.3px;
+  overflow-wrap: anywhere;
   vertical-align: top;
 }


### PR DESCRIPTION
Fixes #4883.

keyboard installation prompt wordwrap

Before:
![image](https://user-images.githubusercontent.com/4498365/128422301-b5760078-b3a8-4e2e-b795-24fd02e0abf4.png)
![image](https://user-images.githubusercontent.com/4498365/128422339-45683ea7-2f17-4641-ba25-ce270be9e4fd.png)

After:
![image](https://user-images.githubusercontent.com/4498365/128422379-8d4bbeb5-c162-450a-b900-77db8a137469.png)
![image](https://user-images.githubusercontent.com/4498365/128422395-7787b40a-059b-4ea3-a1ca-63f61d1b708e.png)
