### PR TITLE
test: experiment using non-chiral modifiers for SendInput

### DIFF
--- a/windows/src/engine/keyman32/serialkeyeventserver.cpp
+++ b/windows/src/engine/keyman32/serialkeyeventserver.cpp
@@ -11,21 +11,21 @@
   due to restricted permissions, all SendInput must be done from this thread, which runs
   in the Keyman main process.
 
-  NOTE: Postponing writing architecture technical note because of change to architecture 
+  NOTE: Postponing writing architecture technical note because of change to architecture
   below...
 
-  TODO: For simplicity of proof-of-concept data sharing, we ran two copies of the key event 
-  sender thread: one in the 32 bit space, and one in the 64 bit space. This means that we 
+  TODO: For simplicity of proof-of-concept data sharing, we ran two copies of the key event
+  sender thread: one in the 32 bit space, and one in the 64 bit space. This means that we
   can still have a race condition because we lose serialization guarantees. Input is first
   processed in the Low Level Keyboard Hook which runs in the keyman.exe 32 bit space. This
   then gets forwarded to the target application with the necessary flags on the message to
-  tell Keyman to not reprocess it. However, after keystroke processing, the target 
-  application fills the shared data structure and signals the key event sender thread in its 
-  own bitness space (32 or 64 bit). The key event sender thread then takes the final shared 
-  data and sends it to the target app. And that breaks the serialization guarantee because 
+  tell Keyman to not reprocess it. However, after keystroke processing, the target
+  application fills the shared data structure and signals the key event sender thread in its
+  own bitness space (32 or 64 bit). The key event sender thread then takes the final shared
+  data and sends it to the target app. And that breaks the serialization guarantee because
   the 64 bit apps are not serialized with the original 32 bit captured input.
 
-  The fix is to redesign the shared data to use a memory mapped file, which can be shared 
+  The fix is to redesign the shared data to use a memory mapped file, which can be shared
   across the 32-64 boundary. Must tweak the permissions on this file, of course.
 
   TODO: Console apps still not working
@@ -73,7 +73,7 @@ public:
     m_pInputs = NULL;
     m_pSharedData = NULL;
 
-    // We create the file mapping and global data on the main thread but release it on the 
+    // We create the file mapping and global data on the main thread but release it on the
     // local thread. This ensures that these objects are available for other processes to
     // open even if we haven't completed startup of the local thread.
     if (!InitSharedData()) {
@@ -117,7 +117,7 @@ public:
 
     // Normally, this is cleaned up by thread termination, but this
     // handles error conditions better
-    CloseSharedData(); 
+    CloseSharedData();
   }
 
   virtual HWND GetWindow() const {
@@ -295,7 +295,7 @@ private:
 
   /**
     Main message loop for thread. Terminates on error or when
-    m_hThreadExitEvent is signaled. Sleeps until either a 
+    m_hThreadExitEvent is signaled. Sleeps until either a
     window message is received or a key event is signaled from
     a client app.
   */
@@ -332,7 +332,7 @@ private:
     HANDLE handles[2] = { m_hThreadExitEvent, m_hKeyMutex };
 
     //
-    // Wait for access to the shared data (must also watch out for 
+    // Wait for access to the shared data (must also watch out for
     // shutdown event so we don't stall forever here)
     //
     switch (WaitForMultipleObjects(2, handles, FALSE, INFINITE)) {
@@ -377,7 +377,7 @@ private:
   }
 
   /**
-    Add modifier state adjustment events and then copy the new input 
+    Add modifier state adjustment events and then copy the new input
     events from the shared buffer
   */
   void PrepareInjectedInput() {
@@ -406,7 +406,7 @@ private:
     if (server == NULL) {
       return DefWindowProc(hwnd, msg, wParam, lParam);
     }
-      
+
     return server->WndProc(hwnd, msg, wParam, lParam);
   }
 
@@ -439,12 +439,12 @@ private:
     if (msg == wm_keyman_keyevent && flag_ShouldSerializeInput  /*&& _td->lpActiveKeyboard*/) {
 
       if (wParam == VK_RMENU && (lParam & (KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP)) == (KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP) && GetKeyState(VK_LCONTROL) < 0) {
-        /* 
-          When Windows has a European layout that uses AltGr installed, it can emit an additional LCtrl down via software 
+        /*
+          When Windows has a European layout that uses AltGr installed, it can emit an additional LCtrl down via software
           when RAlt is pressed. However, the corresponding LCtrl up is never received, seemingly because when Keyman
           re-emits the LCtrl+RAlt, there are subtle differences in the event flags which we cannot duplicate -- specifically
-          the flag that emits WM_SYSKEYDOWN for the VK_LCONTROL, even though it is received before the VK_RALT event. It 
-          appears that Windows figures this out by giving this VK_LCONTROL the scan code 0x21D instead of 0x1D. But we 
+          the flag that emits WM_SYSKEYDOWN for the VK_LCONTROL, even though it is received before the VK_RALT event. It
+          appears that Windows figures this out by giving this VK_LCONTROL the scan code 0x21D instead of 0x1D. But we
           are unable to emit that scan code: Windows truncates the scan code sent through SendInput so that we can only
           send 0x1D.
 
@@ -504,7 +504,11 @@ private:
       else {
         INPUT input;
         input.type = INPUT_KEYBOARD;
-        input.ki.wVk = (WORD)wParam;
+
+        if(wParam == VK_RSHIFT || wParam == VK_LSHIFT) input.ki.wVk = VK_SHIFT;
+        else if(wParam == VK_RMENU || wParam == VK_LMENU) input.ki.wVk = VK_MENU;
+        else if(wParam == VK_RCONTROL || wParam == VK_LCONTROL) input.ki.wVk = VK_CONTROL;
+        else input.ki.wVk = (WORD)wParam;
         input.ki.wScan = (lParam & 0xFFF0000) >> 16;
         input.ki.time = GetMessageTime();
         input.ki.dwExtraInfo = EXTRAINFO_FLAG_SERIALIZED_USER_KEY_EVENT;
@@ -527,10 +531,10 @@ private:
   }
 
   /**
-   When a physical key event is received by the serializer, we know that this will 
-   reflect the key state that the app sees at the time that the input is sent. 
+   When a physical key event is received by the serializer, we know that this will
+   reflect the key state that the app sees at the time that the input is sent.
    We maintain a local modifier state here rather than using GetKeyState because that
-   ensures that we are keeping the keyboard state consistent with our version of 
+   ensures that we are keeping the keyboard state consistent with our version of
    reality.
   */
   void UpdateLocalModifierState(BYTE bVk, BOOL fIsExtendedKey, BYTE bScan, BOOL fIsUp) {


### PR DESCRIPTION
This is an experimental fix for a user-reported issue on the Community Forum (PM).

The symptoms are that the `wm_keyman_keyevent` handler receives a `VK_RSHIFT` (extended flag bit set), and then emits that with `SendInput`, but the `kmnLowLevelKeyboardProc` receives a  `VK_00` (`0`) value instead of the expected `VK_SHIFT`. This then never makes it through to the app. There may be some interaction with another app or the system that is triggering this, because I am unable to reproduce this in-house.

Symptomatic trace:

```
keyman	-	NUM 	kmnLowLevelKeyboardProc: wparam: 100  lparam: 19f96c [vk:['?RShift' 0xa1] scan:36 flags:1 extra:0]
keyman	-	NUM 	LowLevelHook: Active=231354 Focus=2d11f2 Key=['?RShift' 0xa1] flags=360001
keyman	-	NUM 	DebugMessage(140bc8, wm_keyman_keyevent: ['?RShift' 0xa1] lParam: 360001) [message flags: 1 time: 247569921]
keyman	-	NUM 	kmnLowLevelKeyboardProc: wparam: 100  lparam: 19f96c [vk:['?00' 0x0] scan:36 flags:11 extra:4b4d0000]
```

My asymptomatic trace for comparison:

```
keyman	-	NUM 	kmnLowLevelKeyboardProc: wparam: 100  lparam: 19fdf4 [vk:['?RShift' 0xa1] scan:36 flags:1 extra:0]
keyman	-	NUM 	LowLevelHook: Active=5012a Focus=33199c Key=['?RShift' 0xa1] flags=360001
keyman	-	NUM 	DebugMessage(33190c, wm_keyman_keyevent: ['?RShift' 0xa1] lParam: 360001) [message flags: 1 time: 352016812]
keyman	-	NUM 	kmnLowLevelKeyboardProc: wparam: 100  lparam: 19fdf4 [vk:['?RShift' 0xa1] scan:36 flags:11 extra:4b4d0000]
OUTLOOK	NUM 	NUM 	DebugMessage(33199c, WM_KEYDOWN, wParam: ['?Shift' 0x10], lParam: 1360001) [message flags: 0 time: 352016812 extra: 4b4d0000]
OUTLOOK	SHIFT NUM 	NUM 	ProcessModifierChange(10, 0, 1) -> shift state from 400 to 410
```

The fix should be appropriate because the extended bit is set correctly by the message sender for `wm_keyman_keyevent` and that then should filter through, giving the correct chirality for the modifier keys. But it is not yet clear to me if this fix will actually do anything, until we test on the end user's machine.