### PR TITLE
docs(linux): Fix readme for ibus-keyman

### DIFF
--- a/linux/ibus-keyman/README.md
+++ b/linux/ibus-keyman/README.md
@@ -21,11 +21,9 @@ For a debug build:
 ./configure CPPFLAGS=-DG_MESSAGES_DEBUG CFLAGS="-g -O0" CXXFLAGS="-g -O0"
 ```
 
-To use the header files from the source repo, add the additional parameter
-`KEYMAN_PROC_CFLAGS="-I../../common/core/desktop/build/arch/debug/include -I../../common/core/desktop/include"`
-to `./configure`:
+To use the header files from the source repo, you need to specify paths to the include files in core:
 
 ```bash
-./configure CPPFLAGS=-DG_MESSAGES_DEBUG CFLAGS="-g -O0" CXXFLAGS="-g -O0" \
-  KEYMAN_PROC_CFLAGS="-I../../common/core/desktop/build/arch/debug/include -I../../common/core/desktop/include"
+./configure CPPFLAGS="-DG_MESSAGES_DEBUG -I../../common/core/desktop/build/arch/debug/include/ -I../../common/core/desktop/include/" \
+  CFLAGS="-g -O0" CXXFLAGS="-g -O0"
 ```


### PR DESCRIPTION
Turns out setting `KEYMAN_PROC_CFLAGS` isn't sufficient to use header files from source repo.