### PR TITLE
fix(windows): handle restoring modal dialogs consistently

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmHTML.dfm
+++ b/windows/src/desktop/kmshell/main/UfrmHTML.dfm
@@ -70,9 +70,4 @@ object frmHTML: TfrmHTML
     TabOrder = 4
     OnClick = cmdForwardClick
   end
-  object ApplicationEvents1: TApplicationEvents
-    OnMessage = ApplicationEvents1Message
-    Left = 232
-    Top = 160
-  end
 end

--- a/windows/src/desktop/kmshell/main/UfrmHTML.pas
+++ b/windows/src/desktop/kmshell/main/UfrmHTML.pas
@@ -42,14 +42,12 @@ type
     cmdPrint: TButton;
     cmdBack: TButton;
     cmdForward: TButton;
-    ApplicationEvents1: TApplicationEvents;
     procedure FormDestroy(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure cmdPrintClick(Sender: TObject);
     procedure cmdBackClick(Sender: TObject);
     procedure cmdForwardClick(Sender: TObject);
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
-    procedure ApplicationEvents1Message(var Msg: tagMSG; var Handled: Boolean);
   private
     cef: TframeCEFHost;
     FFileName: string;
@@ -100,18 +98,6 @@ begin
   end;
 
   ShowFile(FFileName);
-end;
-
-procedure TfrmHTML.ApplicationEvents1Message(var Msg: tagMSG;
-  var Handled: Boolean);
-begin
-  if (Msg.message = WM_SYSCOMMAND) and (Msg.wParam = SC_RESTORE) then
-  begin
-    // Handle the case where Win+M pressed, window never restores
-    SendMessage(Application.Handle, WM_SHOWWINDOW, 1, 0);
-    SendMessage(Handle, WM_SHOWWINDOW, 1, SW_PARENTOPENING);
-    OpenIcon(Handle);
-  end;
 end;
 
 procedure TfrmHTML.cmdBackClick(Sender: TObject);

--- a/windows/src/desktop/kmshell/startup/UfrmSplash.dfm
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.dfm
@@ -11,9 +11,4 @@ inherited frmSplash: TfrmSplash
   ExplicitHeight = 452
   PixelsPerInch = 96
   TextHeight = 13
-  object ApplicationEvents1: TApplicationEvents
-    OnMessage = ApplicationEvents1Message
-    Left = 192
-    Top = 152
-  end
 end

--- a/windows/src/desktop/kmshell/startup/UfrmSplash.pas
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.pas
@@ -49,17 +49,15 @@ uses
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   ExtCtrls, StdCtrls, UfrmKeymanBase, keymanapi_TLB, jpeg,
   UfrmWebContainer,
-  UserMessages, Vcl.AppEvnts;
+  UserMessages;
 
 type
   TfrmSplash = class(TfrmWebContainer)
-    ApplicationEvents1: TApplicationEvents;
     procedure TntFormCreate(Sender: TObject);
     procedure Command_Start;
     procedure Command_Exit;
     procedure TntFormShow(Sender: TObject);
     procedure TntFormActivate(Sender: TObject);
-    procedure ApplicationEvents1Message(var Msg: tagMSG; var Handled: Boolean);
   private
     FShouldDisplay: Boolean;
     FShowConfigurationOnLoad: Boolean;
@@ -178,17 +176,6 @@ end;
 function TfrmSplash.ShouldSetAppTitle: Boolean;  // I2786
 begin
   Result := True;
-end;
-
-procedure TfrmSplash.ApplicationEvents1Message(var Msg: tagMSG;
-  var Handled: Boolean);   // I4356
-begin
-  if (Msg.message = WM_SYSCOMMAND) and (Msg.wParam = SC_RESTORE) then
-  begin
-    // Handle the case where Win+M pressed, window never restores
-    // Only really happens with Splash.
-    PostMessage(Handle, WM_SHOWWINDOW, 1, SW_PARENTOPENING);
-  end;
 end;
 
 procedure TfrmSplash.Command_Start;


### PR DESCRIPTION
Fixes #5574.

When a user presses Win+M, Win+D, or clicks the desktop button on the taskbar, all windows get minimized, even those that do not have the `WS_MINIMIZE` flag. Delphi modal dialog forms are not expecting this, and do not restore correctly later.

This scenario arises only when a form is created with a `nil` owner and then `form.ShowModal` is called.

The fix was already implemented on Splash and HTML forms, but differently; I have chosen to use the implementation from the Splash form as it is simpler and seems to work correctly.