### PR TITLE
fix(android): removes duplicated line

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -328,8 +328,6 @@ final class KMKeyboard extends WebView {
     loadJavascript(KMString.format("setOskWidth(%d)", newConfig.screenWidthDp));
     loadJavascript(KMString.format("setOskHeight(%d)", oskHeight));
 
-    RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
-    this.setLayoutParams(params);
     if (dismissHelpBubble()) {
       Handler handler = new Handler();
       handler.postDelayed(new Runnable() {


### PR DESCRIPTION
#5459 included the #5521's fix among its changes due to affecting similar areas.  Unfortunately, the location was off by a few lines - just enough for `git merge` to not conflate the two changes and thus result in duplicate lines.  As one of these lines includes a variable declaration, this is enough to cause the Java build to fail with an error.

Fortunately, it's a simple fix.