### PR TITLE
fix(developer): get Test Mode working again 🐞

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -1,18 +1,18 @@
 (*
   Name:             dmActionsKeyboardEditor
   Copyright:        Copyright (C) SIL International.
-  Documentation:
-  Description:
+  Documentation:    
+  Description:      
   Create Date:      23 Aug 2006
 
   Modified Date:    4 May 2015
   Authors:          mcdurdin
-  Related Files:
-  Dependencies:
+  Related Files:    
+  Dependencies:     
 
-  Bugs:
-  Todo:
-  Notes:
+  Bugs:             
+  Todo:             
+  Notes:            
   History:          23 Aug 2006 - mcdurdin - Initial version
                     14 Sep 2006 - mcdurdin - Add debugger actions
                     28 Sep 2006 - mcdurdin - Added Test Keyboard menu item
@@ -33,7 +33,7 @@
                     04 Nov 2014 - mcdurdin - I4504 - V9.0 - Consolidate the compile action into single command
                     04 May 2015 - mcdurdin - I4686 - V9.0 - Refactor compile into project file action
                     04 May 2015 - mcdurdin - I4687 - V9.0 - Split project UI actions into separate classes
-
+                    
 *)
 unit dmActionsKeyboardEditor;  // I3306  // I3323
 
@@ -213,7 +213,7 @@ end;
 
 procedure TmodActionsKeyboardEditor.actDebugDebuggerModeUpdate(Sender: TObject);
 begin
-  actDebugDebuggerMode.Checked := actDebugDebuggerMode.Enabled and (ActiveEditor.DebugForm.UIStatus <> duiTest);
+  actDebugDebuggerMode.Checked := (ActiveEditor <> nil) and (ActiveEditor.DebugForm.UIStatus <> duiTest);
 end;
 
 procedure TmodActionsKeyboardEditor.actDebugPauseExecute(Sender: TObject);
@@ -243,7 +243,7 @@ end;
 
 procedure TmodActionsKeyboardEditor.actDebugRunUpdate(Sender: TObject);
 begin
-  actDebugRun.Enabled := IsDebuggerVisible and not IsDebuggerInTestMode and
+  actDebugRun.Enabled := IsDebuggerVisible and not IsDebuggerInTestMode and 
     (ActiveEditor.DebugForm.UIStatus = duiDebugging);
 end;
 

--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -1,18 +1,18 @@
 (*
   Name:             dmActionsKeyboardEditor
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      23 Aug 2006
 
   Modified Date:    4 May 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          23 Aug 2006 - mcdurdin - Initial version
                     14 Sep 2006 - mcdurdin - Add debugger actions
                     28 Sep 2006 - mcdurdin - Added Test Keyboard menu item
@@ -33,7 +33,7 @@
                     04 Nov 2014 - mcdurdin - I4504 - V9.0 - Consolidate the compile action into single command
                     04 May 2015 - mcdurdin - I4686 - V9.0 - Refactor compile into project file action
                     04 May 2015 - mcdurdin - I4687 - V9.0 - Split project UI actions into separate classes
-                    
+
 *)
 unit dmActionsKeyboardEditor;  // I3306  // I3323
 
@@ -213,7 +213,6 @@ end;
 
 procedure TmodActionsKeyboardEditor.actDebugDebuggerModeUpdate(Sender: TObject);
 begin
-  actDebugDebuggerMode.Enabled := (ActiveEditor <> nil) and (ActiveEditor.DebugForm.CanDebug);
   actDebugDebuggerMode.Checked := actDebugDebuggerMode.Enabled and (ActiveEditor.DebugForm.UIStatus <> duiTest);
 end;
 
@@ -244,7 +243,7 @@ end;
 
 procedure TmodActionsKeyboardEditor.actDebugRunUpdate(Sender: TObject);
 begin
-  actDebugRun.Enabled := IsDebuggerVisible and not IsDebuggerInTestMode and 
+  actDebugRun.Enabled := IsDebuggerVisible and not IsDebuggerInTestMode and
     (ActiveEditor.DebugForm.UIStatus = duiDebugging);
 end;
 

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -1044,63 +1044,58 @@ procedure TfrmKeymanWizard.StartDebugging(FStartTest: Boolean);
     end;
   end;
 
+var
+  FContainsDebugInformation: Boolean;
 begin
   if IsInParserMode then   // I4557
     MoveParserToSource;
 
   pages.ActivePage := pageLayout; //pageSource; { For debugging }
   pagesLayout.ActivePage := pageLayoutCode;
-  
+
   if not IsDebugVisible then
   begin
-    if not KeyboardContainsDebugInformation or FStartTest then
+    FContainsDebugInformation := KeyboardContainsDebugInformation;
+
+    if not FContainsDebugInformation and
+        not FKeymanDeveloperOptions.DebuggerAutoRecompileWithDebugInfo then
     begin
-      if not FStartTest and not FKeymanDeveloperOptions.DebuggerAutoRecompileWithDebugInfo then
-      begin
-        with TfrmMustIncludeDebug.Create(Application.MainForm) do
-        try
-          case ShowModal of
-            mrOK:     ;
-            mrYes:    frmKeymanDeveloper.RefreshOptions;
-            mrCancel: Exit;
-            mrNo:     FStartTest := True;
-          end;
-        finally
-          Free;
+      with TfrmMustIncludeDebug.Create(Application.MainForm) do
+      try
+        case ShowModal of
+          mrOK:     ; // will recompile with debug
+          mrYes:    frmKeymanDeveloper.RefreshOptions;
+          mrCancel: Exit;
         end;
+      finally
+        Free;
       end;
     end;
 
-    if FStartTest then
+    if FStartTest
+      then FDebugForm.UIStatus := duiTest
+      else FDebugForm.UIStatus := duiReadyForInput;
+
+    (ProjectFileUI as TkmnProjectFileUI).Debug := True;   // I4687
+
+    frmMessages.Clear;   // I4686
+
+    if not (ProjectFileUI as TkmnProjectFileUI).DoAction(pfaCompile, False) then
     begin
-      FDebugForm.CanDebug := False;
-      FDebugForm.UIStatus := duiTest;
-    end
-    else
+      ShowMessage(SKErrorsInCompile);
+      Exit;
+    end;
+
+    if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
     begin
-      FDebugForm.CanDebug := True;
-      FDebugForm.UIStatus := duiReadyForInput;
-      (ProjectFileUI as TkmnProjectFileUI).Debug := True;   // I4687
+      ShowMessage(SKKeyboardKMXDoesNotExist);
+      Exit;
+    end;
 
-      frmMessages.Clear;   // I4686
-
-      if not (ProjectFileUI as TkmnProjectFileUI).DoAction(pfaCompile, False) then
-      begin
-        ShowMessage(SKErrorsInCompile);
-        Exit;
-      end;
-
-      if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
-      begin
-        ShowMessage(SKKeyboardKMXDoesNotExist);
-        Exit;
-      end;
-
-      if not KeyboardContainsDebugInformation then
-      begin
-        ShowMessage(SKMustIncludeDebug);
-        Exit;
-      end;
+    if not KeyboardContainsDebugInformation then
+    begin
+      ShowMessage(SKMustIncludeDebug);
+      Exit;
     end;
 
     if FDebugForm.DefaultFont then

--- a/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.dfm
@@ -6,14 +6,10 @@ inherited frmMustIncludeDebug: TfrmMustIncludeDebug
   Caption = 'Keyman Developer Debugger'
   ClientHeight = 133
   ClientWidth = 393
-  Color = clBtnFace
-  Font.Charset = DEFAULT_CHARSET
-  Font.Color = clWindowText
-  Font.Height = -11
   Font.Name = 'MS Sans Serif'
-  Font.Style = []
-  OldCreateOrder = False
   Position = poScreenCenter
+  ExplicitWidth = 399
+  ExplicitHeight = 162
   PixelsPerInch = 96
   TextHeight = 13
   object Label1: TLabel
@@ -23,19 +19,22 @@ inherited frmMustIncludeDebug: TfrmMustIncludeDebug
     Height = 39
     Caption = 
       'You must include debug information in the compiled keyboard befo' +
-      're you can use the debugger.  You can do this yourself by select' +
-      'ing the "Include debug information" option in the Keyboard menu.'
+      're you can use the debugger or test window.  You can do this you' +
+      'rself by selecting the "Include debug information" option in the' +
+      ' Keyboard menu.'
     WordWrap = True
   end
   object Label2: TLabel
     Left = 8
     Top = 52
-    Width = 298
+    Width = 343
     Height = 13
-    Caption = 'Recompile now with debug information and start the debugger?'
+    Caption = 
+      'Recompile now with debug information and start the debug/test se' +
+      'ssion?'
   end
   object cmdOK: TButton
-    Left = 56
+    Left = 120
     Top = 100
     Width = 73
     Height = 25
@@ -44,17 +43,8 @@ inherited frmMustIncludeDebug: TfrmMustIncludeDebug
     TabOrder = 1
     OnClick = cmdOKClick
   end
-  object cmdTestWithoutDebugger: TButton
-    Left = 216
-    Top = 100
-    Width = 121
-    Height = 25
-    Caption = '&Test without debugger'
-    ModalResult = 7
-    TabOrder = 3
-  end
   object cmdCancel: TButton
-    Left = 136
+    Left = 200
     Top = 100
     Width = 73
     Height = 25
@@ -66,9 +56,11 @@ inherited frmMustIncludeDebug: TfrmMustIncludeDebug
   object chkAutoRecompile: TCheckBox
     Left = 8
     Top = 72
-    Width = 333
+    Width = 343
     Height = 17
-    Caption = '&Always recompile with debug information before debugging.'
+    Caption = 
+      '&Always recompile with debug information before debugging or tes' +
+      'ting.'
     TabOrder = 0
   end
 end

--- a/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmMustIncludeDebug.pas
@@ -28,7 +28,6 @@ type
     Label1: TLabel;
     Label2: TLabel;
     cmdOK: TButton;
-    cmdTestWithoutDebugger: TButton;
     cmdCancel: TButton;
     chkAutoRecompile: TCheckBox;
     procedure cmdOKClick(Sender: TObject);


### PR DESCRIPTION
Relates to #5013.

This resolves the broken Test Mode with Keyman Core. Previously, Test Mode just dumped the keyboard into Keyman for Windows, and let it do its thing. Given that we no longer have the dependency on Keyman for Windows, the Test window must use Keyman Core to process keystrokes, and that means there are some differences in how Test Mode operates in 15.0:

* Behind the scenes, the Test mode is just the Debug mode with breakpoints and single step disabled, and the Debug Status window hidden
* Test mode requires debug information in the keyboard (see note below)
* You can always switch between Test and Debug mode
* Deadkeys are always shown in the debug window

Test Mode now requires debug information to be included in the keyboard in order for deadkeys to be tracked correctly in the editor. While it would be possible to remove the need for this, it does not add any significant benefit to do so -- doing so would mean that the tester would have less visibility into deadkeys, and complicate the Core marker tracking in the debug window.

I considered removing Test Mode altogether, but it still feels like a useful view for playing with a keyboard without all the debugging paraphernalia cluttering the display. It's a little slower than full native Keyman for Windows (aka the 14.0 Test Mode), because the debug hooks are still running in the background, but it is quite usable.

Note the removal of `Application.ProcessMessages`. This resolves the issue of keystrokes being swallowed by the debugger during non-interactive debug runs, making rapid input work properly in both Debug Mode and Test Mode.