### PR TITLE
chore(developer): hide debug events panel 🐞

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebugStatus.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebugStatus.pas
@@ -86,6 +86,8 @@ type
     procedure SetDisplayFont(const Value: TFont);
     procedure SetCurrentEvent(const Value: TDebugEvent);
 
+    class var FShowDebuggerEventsPanel: Boolean;
+    class procedure SetShowDebuggerEventsPanel(Value: Boolean); static;
   protected
     function GetHelpTopic: string; override;
   public
@@ -101,6 +103,8 @@ type
     property DeadKeys: TfrmDebugStatus_DeadKeys read FDeadKeys;
     property RegTest: TfrmDebugStatus_RegTest read FRegTest;
     property Events: TfrmDebugStatus_Events read FEvents;
+
+    class property ShowDebuggerEventsPanel: Boolean read FShowDebuggerEventsPanel write SetShowDebuggerEventsPanel;
   end;
 
 implementation
@@ -146,6 +150,7 @@ begin
   FEvents.Parent := tabDebugEvents;
   FEvents.Visible := True;
   FChildren[5] := FEvents;
+  tabDebugEvents.TabVisible := FShowDebuggerEventsPanel;
 end;
 
 function TfrmDebugStatus.GetHelpTopic: string;
@@ -199,6 +204,20 @@ begin
   for child in FChildren do
   begin
     child.SetDisplayFont(Value);
+  end;
+end;
+
+class procedure TfrmDebugStatus.SetShowDebuggerEventsPanel(Value: Boolean);
+var
+  i: Integer;
+begin
+  if FShowDebuggerEventsPanel <> Value then
+  begin
+    FShowDebuggerEventsPanel := Value;
+
+    for i := 0 to Screen.FormCount - 1 do
+      if Screen.Forms[i] is TfrmDebugStatus then
+        (Screen.Forms[i] as TfrmDebugStatus).tabDebugEvents.TabVisible := Value;
   end;
 end;
 

--- a/windows/src/developer/TIKE/main/UfrmMain.dfm
+++ b/windows/src/developer/TIKE/main/UfrmMain.dfm
@@ -3076,9 +3076,9 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
         Action = modActionsKeyboardEditor.actDebugSelectSystemKeyboard
       end
     end
-    object ools1: TMenuItem
+    object mnuTools: TMenuItem
       Caption = '&Tools'
-      OnClick = ools1Click
+      OnClick = mnuToolsClick
       object VirtualKeyIdentifier1: TMenuItem
         Action = modActionsMain.actToolsVirtualKeyIdentifier
       end
@@ -3093,6 +3093,13 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
       end
       object mnuToolsDebugTests: TMenuItem
         Caption = 'Debug Tests'
+        object mnuToolsDebugTestsShowDebuggerEventsPanel: TMenuItem
+          Caption = 'Show Debugger Events panel'
+          OnClick = mnuToolsDebugTestsShowDebuggerEventsPanelClick
+        end
+        object N3: TMenuItem
+          Caption = '-'
+        end
         object mnuToolsDebugTestsExceptionTest: TMenuItem
           Caption = '&Exception Test'
           OnClick = mnuToolsDebugTestsExceptionTestClick

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -159,7 +159,7 @@ type
     Project1: TMenuItem;
     mnuKeyboard: TMenuItem;
     mnuDebug: TMenuItem;
-    ools1: TMenuItem;
+    mnuTools: TMenuItem;
     Help1: TMenuItem;
     New1: TMenuItem;
     Open1: TMenuItem;
@@ -275,6 +275,8 @@ type
     N2: TMenuItem;
     estLexicalModel1: TMenuItem;
     mnuToolsDebugTestsCompilerExceptionTest: TMenuItem;
+    mnuToolsDebugTestsShowDebuggerEventsPanel: TMenuItem;
+    N3: TMenuItem;
     procedure FormCreate(Sender: TObject);
     procedure FormShow(Sender: TObject);
     procedure mnuFileClick(Sender: TObject);
@@ -292,8 +294,9 @@ type
     procedure mnuDebugSetWindowSizeForScreenshotsClick(Sender: TObject);
     procedure pagesChange(Sender: TObject);
     procedure pagesCloseTab(Sender: TObject; Index: Integer);
-    procedure ools1Click(Sender: TObject);
+    procedure mnuToolsClick(Sender: TObject);
     procedure mnuToolsDebugTestsCompilerExceptionTestClick(Sender: TObject);
+    procedure mnuToolsDebugTestsShowDebuggerEventsPanelClick(Sender: TObject);
 
   private
     AppStorage: TJvAppRegistryStorage;
@@ -1366,9 +1369,10 @@ begin
   end;
 end;
 
-procedure TfrmKeymanDeveloper.ools1Click(Sender: TObject);
+procedure TfrmKeymanDeveloper.mnuToolsClick(Sender: TObject);
 begin
   mnuToolsDebugTests.Visible := (GetKeyState(VK_CONTROL) < 0) and (GetKeyState(VK_SHIFT) < 0);
+  mnuToolsDebugTestsShowDebuggerEventsPanel.Checked := TfrmDebugStatus.ShowDebuggerEventsPanel;
 end;
 
 procedure TfrmKeymanDeveloper.mnuProjectClick(Sender: TObject);
@@ -1414,6 +1418,12 @@ end;
 procedure TfrmKeymanDeveloper.mnuToolsDebugTestsExceptionTestClick(Sender: TObject);
 begin
   TKeymanSentryClient.Validate(True);
+end;
+
+procedure TfrmKeymanDeveloper.mnuToolsDebugTestsShowDebuggerEventsPanelClick(
+  Sender: TObject);
+begin
+  TfrmDebugStatus.ShowDebuggerEventsPanel := not TfrmDebugStatus.ShowDebuggerEventsPanel;
 end;
 
 procedure TfrmKeymanDeveloper.SetActiveChild(const Value: TfrmTikeChild);


### PR DESCRIPTION
Relates to #5013.

Hide the debug events panel by default, and add a Tools menu item to make it visible for dev purposes (Ctrl+Shift+click on Tools menu to view).