### PR TITLE
fix(developer): F6 in debugger and cef focus 🐞

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
@@ -187,6 +187,13 @@ object modActionsKeyboardEditor: TmodActionsKeyboardEditor
       OnExecute = actDebugViewStateExecute
       OnUpdate = actDebugViewStateUpdate
     end
+    object actDebugSwitchToDebuggerWindow: TAction
+      Category = 'Debug Control'
+      Caption = 'Switch to debugger'
+      ShortCut = 117
+      OnExecute = actDebugSwitchToDebuggerWindowExecute
+      OnUpdate = actDebugSwitchToDebuggerWindowUpdate
+    end
   end
   object dlgFont: TFontDialog
     Font.Charset = DEFAULT_CHARSET

--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -75,6 +75,7 @@ type
     actDebugViewState: TAction;
     actKeyboardFontHelper: TAction;
     actKeyboardFonts: TAction;
+    actDebugSwitchToDebuggerWindow: TAction;
     procedure actKeyboardCompileExecute(Sender: TObject);
     procedure actionsKeyboardEditorUpdate(Action: TBasicAction;
       var Handled: Boolean);
@@ -122,6 +123,8 @@ type
     procedure actKeyboardFontHelperExecute(Sender: TObject);
     procedure actKeyboardFontsExecute(Sender: TObject);
     procedure actKeyboardCompileUpdate(Sender: TObject);
+    procedure actDebugSwitchToDebuggerWindowUpdate(Sender: TObject);
+    procedure actDebugSwitchToDebuggerWindowExecute(Sender: TObject);
   private
     function IsDebuggerVisible: Boolean;
     function IsDebuggerInTestMode: Boolean;
@@ -330,6 +333,19 @@ end;
 procedure TmodActionsKeyboardEditor.actDebugStopDebuggerUpdate(Sender: TObject);
 begin
   actDebugStopDebugger.Enabled := (ActiveEditor <> nil) and ActiveEditor.IsDebugVisible;
+end;
+
+procedure TmodActionsKeyboardEditor.actDebugSwitchToDebuggerWindowExecute(
+  Sender: TObject);
+begin
+  ActiveEditor.DebugForm.SetFocus;
+end;
+
+procedure TmodActionsKeyboardEditor.actDebugSwitchToDebuggerWindowUpdate(
+  Sender: TObject);
+begin
+  actDebugSwitchToDebuggerWindow.Enabled := (ActiveEditor <> nil) and ActiveEditor.IsDebugVisible and
+    ((Screen.ActiveControl = nil) or (Screen.ActiveControl.Owner <> ActiveEditor.DebugForm));
 end;
 
 procedure TmodActionsKeyboardEditor.actDebugTestModeExecute(Sender: TObject);

--- a/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.pas
+++ b/windows/src/global/delphi/chromium/Keyman.UI.UframeCEFHost.pas
@@ -735,7 +735,7 @@ end;
 procedure TframeCEFHost.cefSetFocus(Sender: TObject; const browser: ICefBrowser;
   source: TCefFocusSource; out Result: Boolean);
 begin
-  Result := source = FOCUS_SOURCE_SYSTEM;
+  Result := source = FOCUS_SOURCE_NAVIGATION;
 end;
 
 procedure TframeCEFHost.cefTitleChange(Sender: TObject;


### PR DESCRIPTION
Relates to #5013.

If user presses F6 in the debugger (while not in run mode), will now switch to editor view, and vice-versa.

Also fixes the inversion of the focus test in CEF so that focus controls work correctly for web hosts.