### PR TITLE
chore(common): more on report-history 🏰

### DIFF
--- a/resources/build/report-history.sh
+++ b/resources/build/report-history.sh
@@ -18,6 +18,10 @@ BUILD=false
 BASE=`git branch --show-current`
 GITHUB_TOKEN=
 GITHUB_PR=
+FROM=
+FROM_VALUE=
+TO=
+TO_VALUE=
 
 display_usage() {
   echo "Usage: report-history.sh [options] --token <github-token>"
@@ -25,11 +29,13 @@ display_usage() {
   echo "  --token|-t <github-token>   Specifies a GitHub login token"
   echo "  --base|-b  <base>           Specifies branch to report on: master, beta, stable-x.y (default: master)"
   echo "  --rebuild|-r                Rebuild version.js used in this script"
+  echo "  --from <version|commit>     Starting version to report from (must be on same branch)"
+  echo "  --to <version|commit>       Finishing version to report to (must be on same branch)"
   echo "  --help|-?                   Show this help"
   echo "  --github-pr                 Query GitHub for Pull Request number and title instead of parsing from merge commit comments"
   echo
-  echo "Prints a report of outstanding changes on the branch <base> that will "
-  echo "be incorporated into the next build."
+  echo "If --from and --to are not specified, then prints a report of outstanding changes on the branch <base> that will "
+  echo "be incorporated into the next build, otherwise prints a report of all changes between those two builds."
 }
 
 # Parse args
@@ -55,6 +61,16 @@ while [[ $# -gt 0 ]] ; do
       ;;
     --github-pr)
       GITHUB_PR=$key
+      ;;
+    --from)
+      FROM=--from
+      FROM_VALUE="$2"
+      shift
+      ;;
+    --to)
+      TO=--to
+      TO_VALUE="$2"
+      shift
       ;;
     *)
       fail "Invalid parameters. Use --help for help"
@@ -83,5 +99,5 @@ if $BUILD; then
 fi
 
 pushd "$KEYMAN_ROOT" > /dev/null
-node resources/build/version/lib/index.js report-history -t "$GITHUB_TOKEN" -b "$BASE" $GITHUB_PR
+node resources/build/version/lib/index.js report-history -t "$GITHUB_TOKEN" -b "$BASE" $GITHUB_PR $FROM "$FROM_VALUE" $TO "$TO_VALUE"
 popd > /dev/null

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -31,8 +31,18 @@ const argv = yargs
       type: 'boolean'
     },
 
+    'from': {
+      description: 'Version tag or commit for starting version to report from (must be on same branch)',
+      type: 'string'
+    },
+
+    'to': {
+      description: 'Version tag or commit for finishing version to report to (must be on same branch)',
+      type: 'string'
+    },
+
     'github-pr': {
-      description: 'Query GitHub for Pull Request number and title instead of parsing from merge commit comments',
+      description: 'Query GitHub for Pull Request number and title instead of parsing from merge commit comments (not valid with --from, --to)',
       type: 'boolean'
     }
   })
@@ -64,9 +74,23 @@ const main = async (): Promise<void> => {
   //
 
   if(argv._.includes('report-history')) {
-    let pulls = await reportHistory(octokit, argv.base, argv.force, argv['github-pr']);
-    for(const pull of pulls) {
-      logInfo(`* ${pull.title}: ${pull.number}`);
+    let pulls = await reportHistory(octokit, argv.base, argv.force, argv['github-pr'], argv.from, argv.to);
+    let versions = {};
+    pulls.forEach((item) => {
+      if(typeof item.version == 'string') {
+        if(typeof versions[item.version] == 'undefined')  {
+          versions[item.version] = {data: item.tag_data, pulls: []};
+       }
+       // We want to invert the order of the pulls as we go to
+       // match what we get when we generate HISTORY.md automatically
+       versions[item.version].pulls.unshift(item);
+      }
+    });
+    for(const version of Object.keys(versions)) {
+      logInfo(`\n## ${versions[version].data}\n`);
+      for(const pull of versions[version].pulls) {
+        logInfo(`* ${pull.title} (#${pull.number})`);
+      }
     }
     process.exit(0);
   }

--- a/resources/build/version/src/reportHistory.ts
+++ b/resources/build/version/src/reportHistory.ts
@@ -139,7 +139,7 @@ export const reportHistory = async (
         const e = re.exec(git_pr_data);
         if(e) {
           if(this_git_tag != '') {
-            const this_git_date = (await spawnChild('git', ['log', '--format=%cs','-n', '1', git_tag])).trim();
+            const this_git_date = (await spawnChild('git', ['log', '--format=%cs','-n', '1', this_git_tag])).trim();
             // Transform the tag into our regular HISTORY.md format
             const tag_format = /^release-(\d+\.\d+\.\d+)(-(.+))?$/.exec(this_git_tag);
             if(tag_format) {

--- a/resources/build/version/src/reportHistory.ts
+++ b/resources/build/version/src/reportHistory.ts
@@ -34,6 +34,8 @@ const getPullRequestInformation = async (
 interface PRInformation {
   title: string;
   number: number;
+  version?: string;
+  tag_data?: string;
 }
 
 const getAssociatedPRInformation = async (
@@ -82,7 +84,8 @@ const getAssociatedPRInformation = async (
  */
 
 export const reportHistory = async (
-  octokit: GitHub, base: string, force: boolean, useGitHubPRInfo: boolean
+  octokit: GitHub, base: string, force: boolean, useGitHubPRInfo: boolean,
+  fromVersion?: string, toVersion?: string
 ): Promise<PRInformation[]> => {
 
   //
@@ -98,7 +101,13 @@ export const reportHistory = async (
   // Now, use git log to retrieve list of merge commit refs since then
   //
 
-  const git_result = (await spawnChild('git', ['log', '--merges', '--first-parent', '--format=%H', `origin/${base}`, `${commit_id}..origin/${base}`])).trim();
+  let args=['log', '--merges', '--first-parent', '--format=%H'];
+  if(fromVersion != undefined && toVersion != undefined) {
+    args.push(fromVersion + '..' + toVersion);
+  } else {
+    args.push(`origin/${base}`, `${commit_id}..origin/${base}`);
+  }
+  const git_result = (await spawnChild('git', args)).trim();
   if(git_result.length == 0 && !force) {
     // We won't throw on this
     logWarning('No pull requests found since previous increment');
@@ -118,16 +127,32 @@ export const reportHistory = async (
       number: 0
     });
   } else {
+    let git_tag = 'Next Version', git_tag_data = 'Next Version';
     const re = /#(\d+)/;
+    const emojiRE = /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu;
     for(const commit of new_commits) {
       if(!useGitHubPRInfo) {
-        const git_pr_title = (await spawnChild('git', ['log', '--format=%b', '-n', '1', commit])).trim();
+        const git_pr_title = (await spawnChild('git', ['log', '--format=%b', '-n', '1', commit])).replace(emojiRE, ' ').trim();
+        if(git_pr_title.match(/^auto\:/)) continue;
         const git_pr_data = (await spawnChild('git', ['log', '--format=%s', '-n', '1', commit])).trim();
+        const this_git_tag = (await spawnChild('git', ['tag', '--points-at', commit])).trim();
         const e = re.exec(git_pr_data);
         if(e) {
+          if(this_git_tag != '') {
+            const this_git_date = (await spawnChild('git', ['log', '--format=%cs','-n', '1', git_tag])).trim();
+            // Transform the tag into our regular HISTORY.md format
+            const tag_format = /^release-(\d+\.\d+\.\d+)(-(.+))?$/.exec(this_git_tag);
+            if(tag_format) {
+              git_tag_data = tag_format[1] + ' ' + (tag_format[3] == null ? 'stable' : tag_format[3]) + ' ' + this_git_date;
+            }
+            git_tag = this_git_tag;
+          }
+
           const pr: PRInformation = {
             title: git_pr_title,
-            number: parseInt(e[1], 10)
+            number: parseInt(e[1], 10),
+            version: git_tag,
+            tag_data: git_tag_data
           };
           if(pulls.find(p => p.number == pr.number) == undefined) {
             pulls.push(pr);
@@ -140,6 +165,9 @@ export const reportHistory = async (
           continue;
         }
         if(pulls.find(p => p.number == pr.number) == undefined) {
+          pr.tag_data = git_tag_data;
+          pr.version = git_tag;
+          pr.title = pr.title.replace(emojiRE, ' ').trim();
           pulls.push(pr);
         }
       }


### PR DESCRIPTION
Relates to #5172.

* Adds support for reporting historical release ranges (--from, --to)
* Filters emoji out of titles
* Uses HISTORY.md formatting for report-history

Note: once approved, I'll cherry-pick this and #5527 to stable-14.0