### PR TITLE
refactor(web): OSK modularization - view components, layout cleanup ✂️

### DIFF
--- a/web/source/osk/bannerManager.ts
+++ b/web/source/osk/bannerManager.ts
@@ -1,4 +1,5 @@
 /// <reference path="banner.ts" />
+/// <reference path="oskViewComponent.ts" />
 
 namespace com.keyman.osk {
   /**
@@ -49,7 +50,7 @@ namespace com.keyman.osk {
    *       needs to reserve this space (i.e: Keyman for iOS),
    *       rather than as its standalone app.
    */
-  export class BannerManager {
+  export class BannerManager implements OSKViewComponent {
     private _activeType: BannerType;
     private _options: BannerOptions = {};
     private bannerContainer: HTMLDivElement;
@@ -278,5 +279,11 @@ namespace com.keyman.osk {
         this.activeBanner.height = h;
       }
     }
+
+    public get layoutHeight(): ParsedLengthStyle {
+      return ParsedLengthStyle.inPixels(this.height);
+    }
+
+    public refreshLayout() {};
   }
 }

--- a/web/source/osk/emptyView.ts
+++ b/web/source/osk/emptyView.ts
@@ -13,5 +13,11 @@ namespace com.keyman.osk {
     // No operations needed; this is a stand-in for the desktop OSK when no keyboard is active.
     public postInsert() { }
     public updateState() { }
+
+    public refreshLayout() { }
+
+    public get layoutHeight(): ParsedLengthStyle {
+      return ParsedLengthStyle.inPixels(0);
+    }
   }
 }

--- a/web/source/osk/helpPageView.ts
+++ b/web/source/osk/helpPageView.ts
@@ -30,5 +30,10 @@ namespace com.keyman.osk {
     }
 
     public updateState() { }
+    public refreshLayout() { }
+
+    public get layoutHeight(): ParsedLengthStyle {
+      return ParsedLengthStyle.inPercent(100);
+    }
   }
 }

--- a/web/source/osk/keyboardView.interface.ts
+++ b/web/source/osk/keyboardView.interface.ts
@@ -4,7 +4,7 @@ namespace com.keyman.osk {
    * OSKManager / OSKView.  Most keyboards will default to use of a VisualKeyboard,
    * though some will use HelpPage for certain form factors.
    */
-  export interface KeyboardView {
+  export interface KeyboardView extends OSKViewComponent {
     readonly element: HTMLDivElement;
 
     /**

--- a/web/source/osk/layouts/resizeBar.ts
+++ b/web/source/osk/layouts/resizeBar.ts
@@ -1,7 +1,11 @@
+/// <reference path="../oskViewComponent.ts" />
+
 namespace com.keyman.osk.layouts {
-  export class ResizeBar {
+  export class ResizeBar implements OSKViewComponent {
     private _element: HTMLDivElement;
     private _resizeHandle: HTMLDivElement;
+
+    private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(16); // As set in kmwosk.css
 
     private mouseCancellingHandler: (ev: MouseEvent) => boolean = function(ev: MouseEvent) {
       ev.preventDefault();
@@ -15,6 +19,10 @@ namespace com.keyman.osk.layouts {
       if(dragHandler) {
         this._resizeHandle.onmousedown = dragHandler.mouseDownHandler;
       }
+    }
+
+    public get layoutHeight(): ParsedLengthStyle {
+      return ResizeBar.DISPLAY_HEIGHT;
     }
 
     public get element(): HTMLDivElement {
@@ -77,6 +85,10 @@ namespace com.keyman.osk.layouts {
       this._resizeHandle=Limg;
       //TODO: the image never appears in IE8, have no idea why!
       return bar;
+    }
+
+    public refreshLayout() {
+      // The title bar is adaptable as it is and needs no adjustments.
     }
   }
 }

--- a/web/source/osk/layouts/targetedFloatLayout.ts
+++ b/web/source/osk/layouts/targetedFloatLayout.ts
@@ -148,8 +148,8 @@ namespace com.keyman.osk.layouts {
             return;
           }
 
-          this.startWidth = layout.oskView.vkbd.kbdDiv.offsetWidth;
-          this.startHeight = layout.oskView.vkbd.kbdDiv.offsetHeight;
+          this.startWidth = layout.oskView.computedWidth;
+          this.startHeight = layout.oskView.computedHeight;
 
           let keymanweb = com.keyman.singleton;
 
@@ -200,8 +200,8 @@ namespace com.keyman.osk.layouts {
           }
 
           if(layout.oskView.vkbd) {
-            this.startWidth  = layout.oskView.vkbd.kbdDiv.offsetWidth;
-            this.startHeight = layout.oskView.vkbd.kbdDiv.offsetHeight;
+            this.startWidth  = layout.oskView.computedWidth;
+            this.startHeight = layout.oskView.computedHeight;
           }
           layout.oskView.refreshLayout(); // Finalize the resize.
           layout.oskView.doResizeMove();

--- a/web/source/osk/layouts/titleBar.ts
+++ b/web/source/osk/layouts/titleBar.ts
@@ -1,13 +1,16 @@
 /// <reference path="mouseDragOperation.ts" />
+/// <reference path="../oskViewComponent.ts" />
 
 namespace com.keyman.osk.layouts {
-  export class TitleBar {
+  export class TitleBar implements OSKViewComponent {
     private _element: HTMLDivElement;
     private _unpinButton: HTMLDivElement;
     private _closeButton: HTMLDivElement;
     private _helpButton: HTMLDivElement;
     private _configButton: HTMLDivElement;
     private _caption: HTMLSpanElement;
+
+    private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(20); // As set in kmwosk.css
 
     public constructor(dragHandler?: MouseDragOperation) {
       this._element = this.buildTitleBar();
@@ -16,6 +19,10 @@ namespace com.keyman.osk.layouts {
       if(dragHandler) {
         this.element.onmousedown = dragHandler.mouseDownHandler;
       }
+    }
+
+    public get layoutHeight(): ParsedLengthStyle {
+      return TitleBar.DISPLAY_HEIGHT;
     }
 
     private mouseCancellingHandler: (ev: MouseEvent) => boolean = function(ev: MouseEvent) {
@@ -162,6 +169,10 @@ namespace com.keyman.osk.layouts {
       Limg.onmousedown = this.mouseCancellingHandler;
 
       return Limg;
+    }
+
+    public refreshLayout() {
+      // The title bar is adaptable as it is and needs no adjustments.
     }
   }
 }

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -540,10 +540,14 @@ namespace com.keyman.osk {
       this.y = util.toNumber(c['top'],-1);
 
       // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
-      var dfltWidth=0.3*screen.width;
+      let dfltWidth=0.3*screen.width;
+      let dfltHeight=0.15*screen.height;
       //if(util.toNumber(c['width'],0) == 0) dfltWidth=0.5*screen.width;
-      var newWidth=util.toNumber(c['width'],dfltWidth),
-          newHeight=util.toNumber(c['height'],0.15*screen.height);
+      let newWidth  = parseInt(c['width'], 10);
+      let newHeight = parseInt(c['height'], 10);
+      let isNewCookie = isNaN(newHeight);
+      newWidth  = isNaN(newWidth)  ? dfltWidth  : newWidth;
+      newHeight = isNaN(newHeight) ? dfltHeight : newHeight;
 
       // Limit the OSK dimensions to reasonable values
       if(newWidth < 0.2*screen.width) {
@@ -557,6 +561,17 @@ namespace com.keyman.osk {
       }
       if(newHeight > 0.5*screen.height) {
         newHeight=0.5*screen.height;
+      }
+
+      if(isNewCookie) {
+        // Adds some space to account for the OSK's header and footer, should they exist.
+        if(this.headerView && this.headerView.layoutHeight.absolute) {
+          newHeight += this.headerView.layoutHeight.val;
+        }
+
+        if(this.footerView && this.footerView.layoutHeight.absolute) {
+          newHeight += this.footerView.layoutHeight.val;
+        }
       }
 
       this.setSize(newWidth, newHeight);

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -515,6 +515,7 @@ namespace com.keyman.osk {
       c['userSet'] = this.userPositioned ? 1 : 0;
       c['left'] = p.left;
       c['top'] = p.top;
+      c['_version'] = utils.Version.CURRENT.toString();
 
       if(this.vkbd) {
         c['width'] = this.width.val;
@@ -538,6 +539,7 @@ namespace com.keyman.osk {
       this.userPositioned = util.toNumber(c['userSet'], 0) == 1;
       this.x = util.toNumber(c['left'],-1);
       this.y = util.toNumber(c['top'],-1);
+      let cookieVersionString = c['_version'];
 
       // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
       let dfltWidth=0.3*screen.width;
@@ -563,7 +565,10 @@ namespace com.keyman.osk {
         newHeight=0.5*screen.height;
       }
 
-      if(isNewCookie) {
+      // if(!cookieVersionString) - this component was not tracked until 15.0.
+      // Before that point, the OSK's title bar and resize bar heights were not included
+      // in the OSK's cookie-persisted height.
+      if(isNewCookie || !cookieVersionString) {
         // Adds some space to account for the OSK's header and footer, should they exist.
         if(this.headerView && this.headerView.layoutHeight.absolute) {
           newHeight += this.headerView.layoutHeight.val;

--- a/web/source/osk/oskManager.ts
+++ b/web/source/osk/oskManager.ts
@@ -24,8 +24,23 @@ namespace com.keyman.osk {
   export class OSKManager {
     // Important OSK elements (and container classes)
     _Box: HTMLDivElement;
-    banner: BannerManager;
-    vkbd: VisualKeyboard;
+
+    headerView:   OSKViewComponent;
+    bannerView:   BannerManager; // Which implements OSKViewComponent
+    keyboardView: KeyboardView;  // Which implements OSKViewComponent
+    footerView:   OSKViewComponent;
+
+    public get vkbd(): VisualKeyboard {
+      if(this.keyboardView instanceof VisualKeyboard) {
+        return this.keyboardView;
+      } else {
+        return null;
+      }
+    }
+
+    public get banner(): BannerManager {  // Maintains old reference point used by embedding apps.
+      return this.bannerView;
+    }
 
     desktopLayout: layouts.TargetedFloatLayout;
 
@@ -125,7 +140,7 @@ namespace com.keyman.osk {
       this.loadCookie();
 
       // Predictive-text hooks.
-      const bannerMgr = this.banner = new BannerManager();
+      const bannerMgr = this.bannerView = new BannerManager();
       const _this = this;
 
       // Register a listener for model change events so that we can hot-swap the banner as needed.
@@ -149,8 +164,8 @@ namespace com.keyman.osk {
      * Description  Clears OSK variables prior to exit (JMD 1.9.1 - relocation of local variables 3/9/10)
      */
     _Unload() {
-      this.vkbd = null;
-      this.banner = null;
+      this.keyboardView = null;
+      this.bannerView = null;
       this._Box = null;
     }
 
@@ -174,7 +189,7 @@ namespace com.keyman.osk {
       if(this.vkbd) {
         this.vkbd.shutdown();
       }
-      this.vkbd = null;
+      this.keyboardView = null;
 
       // Instantly resets the OSK container, erasing / delinking the previously-loaded keyboard.
       this._Box.innerHTML = '';
@@ -189,6 +204,7 @@ namespace com.keyman.osk {
       if(util.device.formFactor == 'desktop') {
         layout = this.desktopLayout = new layouts.TargetedFloatLayout();
         layout.attachToView(this);
+        this.headerView = layout.titleBar;
         this.desktopLayout.titleBar.setTitleFromKeyboard(activeKeyboard);
         this._Box.appendChild(layout.titleBar.element);
       }
@@ -199,10 +215,9 @@ namespace com.keyman.osk {
         this.banner.element.style.fontSize = this.baseFontSize;
       }
 
-      let kbdView: KeyboardView = this._GenerateKeyboardView(activeKeyboard);
+      let kbdView: KeyboardView = this.keyboardView = this._GenerateKeyboardView(activeKeyboard);
       this._Box.appendChild(kbdView.element);
       if(kbdView instanceof VisualKeyboard) {
-        this.vkbd = kbdView;
         kbdView.fontSize = this.parsedBaseFontSize;
       }
       kbdView.postInsert();
@@ -211,6 +226,7 @@ namespace com.keyman.osk {
       if(this.desktopLayout) {
         if(kbdView instanceof VisualKeyboard) {
           this._Box.appendChild(layout.resizeBar.element);
+          this.footerView = layout.resizeBar;
         }
       }
 
@@ -583,7 +599,11 @@ namespace com.keyman.osk {
       this.needsLayout = this.needsLayout || mutatedFlag;
 
       if(this.vkbd) {
-        this.vkbd.setSize(width, height - this.getBannerHeight(), pending);
+        let availableHeight = height - this.computeFrameHeight();
+        if(this.bannerView.height > 0) {
+          availableHeight -= this.bannerView.height + 5;
+        }
+        this.vkbd.setSize(width, availableHeight, pending);
       }
     }
 
@@ -839,6 +859,10 @@ namespace com.keyman.osk {
       }
     }
 
+    /* private */ computeFrameHeight(): number {
+      return (this.headerView?.layoutHeight.val || 0) + (this.footerView?.layoutHeight.val || 0);
+    }
+
     /**
      * Display KMW OSK at specified position (returns nothing)
      *
@@ -993,9 +1017,13 @@ namespace com.keyman.osk {
 
       // Step 3:  perform layout operations.
       if(this.vkbd) {
-        // +5:  from kmw-banner-bar's 'top' attribute.
-        const vkbdHeight = this.computedHeight - (this.banner.height ? this.banner.height + 5 : 0);
-        this.vkbd.setSize(this.computedWidth, vkbdHeight);
+        let availableHeight = this.computedHeight - this.computeFrameHeight();
+
+        // +5:  from kmw-banner-bar's 'top' attribute when active
+        if(this.bannerView.height > 0) {
+          availableHeight -= this.bannerView.height + 5;
+        }
+        this.vkbd.setSize(this.computedWidth, availableHeight);
         this.vkbd.refreshLayout();
 
         if(this.vkbd.usesFixedHeightScaling) {

--- a/web/source/osk/oskViewComponent.ts
+++ b/web/source/osk/oskViewComponent.ts
@@ -1,6 +1,6 @@
 namespace com.keyman.osk {
   export interface OSKViewComponent {
-    get layoutHeight(): ParsedLengthStyle;
+    readonly layoutHeight: ParsedLengthStyle;
     refreshLayout(): void;
   }
 }

--- a/web/source/osk/oskViewComponent.ts
+++ b/web/source/osk/oskViewComponent.ts
@@ -1,0 +1,6 @@
+namespace com.keyman.osk {
+  export interface OSKViewComponent {
+    get layoutHeight(): ParsedLengthStyle;
+    refreshLayout(): void;
+  }
+}


### PR DESCRIPTION
This relatively lightweight PR adds an abstraction for use by the OSK and its subcomponents.  By having each subcomponent implement a common interface, this increases nomenclature consistency and should facilitate code readability and maintenance.

Follows #5530.  (The 👆 set.)

This PR also polishes up some of the internal layout calculations, using thematically-named fields and methods that better describe the purpose of the values being used.  There _is_ a mild shift in the values' source when it comes to `.computedWidth` and `.computedHeight`, which are intended to serve as the "master" layout value for active OSKs and are recalculated during layout-refreshes.  (Refer to changes made in https://github.com/keymanapp/keyman/pull/5462.)
- These changes also include fixes for desktop OSK `.computed__` value calculations; these were previously incorrect.
- **CHANGE**:  `setSize` now sets the size of the full OSK, _including the 'frame'_ - the header and footer components.
    - That is, it sets the size of the `kmw-osk-frame` element, rather than a select subset of the inner components.
        - Does **_not_** affect help-page keyboards like `sil_euro_latin`; `setSize` will _continue_ to have no effect on them.
            - Is pre-existing behavior.  I'm not claiming that this is _ideal_ behavior... just that it's the same behavior as before.
    - Before, the header and footer bars were ignored!
        - If an OSK-sizing cookie exists from a prior version of KMW, the desktop OSK will appear somewhat squashed (compared to before) until resized.
        - APIs that set the OSK's size will now function more precisely as a result.  (Unless showing a help-page keyboard.)
            - While technically **BREAKING**, this should be a net plus to site developers.
            - Only affects the OSK's display / layout calculations, not its functionality.

# User Testing

This PR's user tests will be delegated to #5620, as the combined number of changes is going to require a significant amount of testing.