### PR TITLE
chore(android): Allow Info Activity to navigate back

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -81,7 +81,12 @@ public class InfoActivity extends BaseActivity {
 
   @Override
   public void onBackPressed() {
-    finish();
-    overridePendingTransition(0, android.R.anim.fade_out);
+    if (webView != null && webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      super.onBackPressed();
+      finish();
+      overridePendingTransition(0, android.R.anim.fade_out);
+    }
   }
 }


### PR DESCRIPTION
Follow-on to #5621

I noticed when navigating the InfoActivity help, the back button abruptly kills the activity, which is a nuisance when navigating between help screens.

This updates `onBackPressed()` so the help menus can go back and forth.