### PR TITLE
fix(android): Fix Chrome version ranges for Keyman engine functionality

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -40,7 +40,6 @@ import com.keyman.android.DownloadIntentService;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMPLink;
 import com.tavultesoft.kmea.util.KMString;
-import com.tavultesoft.kmea.util.WebViewUtils;
 import com.tavultesoft.kmea.util.WebViewUtils.EngineWebViewVersionStatus;
 
 import android.Manifest;
@@ -780,7 +779,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   }
 
   private void checkChromeVersion(WebView webView) {
-    if (WebViewUtils.getEngineWebViewVersionStatus(context, webView, "") != EngineWebViewVersionStatus.FULL) {
+    if (KMManager.getEngineWebViewVersionStatus() != EngineWebViewVersionStatus.FULL) {
       LinearLayout updateChromeLayout = (LinearLayout) findViewById(R.id.updateChromeLayout);
       updateChromeLayout.setVisibility(View.VISIBLE);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -179,6 +179,8 @@ public final class KMManager {
   protected static KMKeyboard InAppKeyboard = null;
   protected static KMKeyboard SystemKeyboard = null;
   protected static HashMap<String, String> currentLexicalModel = null;
+  protected static WebViewUtils.EngineWebViewVersionStatus engineWebViewVersionStatus =
+    WebViewUtils.EngineWebViewVersionStatus.UNDETERMINED;
 
   public final static String predictionPrefSuffix = ".mayPredict";
   public final static String correctionPrefSuffix = ".mayCorrect";
@@ -371,13 +373,20 @@ public final class KMManager {
   }
 
   /**
-   * Get the Keyman Engine mode based on the Chrome version
-   * @param aContext
-   * @param webView - If provided, the Chrome version of webView is deterermined
+   * Get the Keyman Engine mode.
    * @return WebViewUtils.EngineWebViewVersionStatus
    */
-  public static WebViewUtils.EngineWebViewVersionStatus getEngineWebViewVersionStatus(Context aContext, WebView webView) {
-    return WebViewUtils.getEngineWebViewVersionStatus(aContext, webView, "");
+  public static WebViewUtils.EngineWebViewVersionStatus getEngineWebViewVersionStatus() {
+    return engineWebViewVersionStatus;
+  }
+
+  /**
+   * Set the Keyman Engine mode based on the Chrome version
+   * @param aContext
+   * @param webView - If provided, the Chrome version of the WebView is determined
+   */
+  public static void setEngineWebViewVersionStatus(Context aContext, WebView webView) {
+    engineWebViewVersionStatus = WebViewUtils.getEngineWebViewVersionStatus(aContext, webView, "");
   }
 
   // Check if a keyboard namespace is reserved
@@ -515,6 +524,8 @@ public final class KMManager {
       InAppKeyboard.setWebViewClient(new KMInAppKeyboardWebViewClient(appContext));
       InAppKeyboard.addJavascriptInterface(new KMInAppKeyboardJSHandler(appContext, InAppKeyboard), "jsInterface");
       InAppKeyboard.loadKeyboard();
+
+      setEngineWebViewVersionStatus(appContext, InAppKeyboard);
     }
   }
 
@@ -528,6 +539,8 @@ public final class KMManager {
       SystemKeyboard.setWebViewClient(new KMSystemKeyboardWebViewClient(appContext));
       SystemKeyboard.addJavascriptInterface(new KMSystemKeyboardJSHandler(appContext, SystemKeyboard), "jsInterface");
       SystemKeyboard.loadKeyboard();
+
+      setEngineWebViewVersionStatus(appContext, SystemKeyboard);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/WebViewUtils.java
@@ -16,9 +16,10 @@ public final class WebViewUtils {
 
   // Keyman Engine functionality based on Chrome version
   public enum EngineWebViewVersionStatus {
-    DISABLED, // WebView doesn't support touch keyboard features
-    DEGRADED, // WebView supports touch keyboards but not LDML keyboards
-    FULL;     // WebView supports touch keyboards and LDML keyboards
+    UNDETERMINED, // Functionality not determined yet
+    DISABLED,     // WebView doesn't support touch keyboard features
+    DEGRADED,     // WebView supports touch keyboards but not LDML keyboards
+    FULL;         // WebView supports touch keyboards and LDML keyboards
   }
 
   private static final String CHROME_INSTALL_PATTERN_FORMATSTR = "^.*Chrome/([\\d.]+).*$";
@@ -41,13 +42,13 @@ public final class WebViewUtils {
       chromeVersion = getChromeVersion(context, webView);
     }
 
-    if (FileUtils.compareVersions(chromeVersion, "57.0") == FileUtils.VERSION_GREATER) {
-      return EngineWebViewVersionStatus.FULL;
-    } else if (FileUtils.compareVersions(chromeVersion, "37.0") == FileUtils.VERSION_GREATER) {
+    if (FileUtils.compareVersions("37.0", chromeVersion) == FileUtils.VERSION_GREATER) {
+      return EngineWebViewVersionStatus.DISABLED;
+    } else if (FileUtils.compareVersions("57.0", chromeVersion) == FileUtils.VERSION_GREATER) {
       return EngineWebViewVersionStatus.DEGRADED;
     }
 
-    return EngineWebViewVersionStatus.DISABLED;
+    return EngineWebViewVersionStatus.FULL;
   }
 
   // Inject a meta viewport tag into the head of the file if it doesn't exist

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/WebViewUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/WebViewUtilsTest.java
@@ -38,15 +38,22 @@ public class WebViewUtilsTest {
   }
 
   @Test
-  public void test_Chrome57_EngineWebViewVersionStatusDegraded() {
-    String chromeVersion = "57.0";
+  public void test_Chrome37_EngineWebViewVersionStatusDegraded() {
+    String chromeVersion = "37.0";
     Assert.assertEquals(WebViewUtils.getEngineWebViewVersionStatus(context, null, chromeVersion),
       WebViewUtils.EngineWebViewVersionStatus.DEGRADED);
   }
 
   @Test
-  public void test_Chrome58_EngineWebViewVersionStatusFull() {
-    String chromeVersion = "58.0";
+  public void test_Chrome56_EngineWebViewVersionStatusDegraded() {
+    String chromeVersion = "56.0";
+    Assert.assertEquals(WebViewUtils.getEngineWebViewVersionStatus(context, null, chromeVersion),
+      WebViewUtils.EngineWebViewVersionStatus.DEGRADED);
+  }
+
+  @Test
+  public void test_Chrome57_EngineWebViewVersionStatusFull() {
+    String chromeVersion = "57.0";
     Assert.assertEquals(WebViewUtils.getEngineWebViewVersionStatus(context, null, chromeVersion),
       WebViewUtils.EngineWebViewVersionStatus.FULL);
   }


### PR DESCRIPTION
Follow-on to #5520 and addresses #5017

In the discussion of what "degraded" engine mode looks like, I saw the Chrome version ranges originally implemented in #5520 should now be the following:

Chrome Version | Keyman Engine mode
----------------- | --------------------
< 37.0 | DISABLED
37.0 <= and < 57.0 | DEGRADED
57.0 <= | FULL

This PR also changes KMManager:
* Add a state variable `engineWebViewVersionStatus`
* Add the corresponding `getEngineWebViewVersionStatus()` and `setEngineWebViewVersionStatus()` API

Since the Android 5.0 emulators include M37 WebView (https://developer.android.com/about/versions/lollipop#WebView), it seems we don't need to implement the DISABLED mode.