### PR TITLE
fix(web): Check keyboard before marking layout calibrated

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -181,7 +181,9 @@ namespace com.keyman.osk {
       // Now that we've properly processed the keyboard's layout, mark it as calibrated.
       // TODO:  drop the whole 'calibration' thing.  The newer layout system supersedes the
       // need for it.  (Is no longer really used, so the drop ought be clean.)
-      keyboard.markLayoutCalibrated(formFactor);
+      if (keyboard) {
+        keyboard.markLayoutCalibrated(formFactor);
+      }
       
       // Append the OSK layer group container element to the containing element
       //osk.keyMap = divLayerContainer;


### PR DESCRIPTION
Fixes #5571

> In the latest `master` branch, I get the following KMW exception after installing khmer_angkor on the Android 5.0 emulator
> 
> ```
> TypeError: Cannot read property 'markLayoutCalibrated' of null
> ```
> 
> I think from this line added in #5451
> https://github.com/keymanapp/keyman/blob/c71ae6c2251364abe04e4814c5382bfbff53f90e/web/source/osk/visualKeyboard.ts#L184

This PR just adds a null check on keyboard.

## User Testing
@keymanapp/testers 
Setup: Android 5.0 emulator with the test build loaded

### Install Khmer Angkor keyboard
1. From the "Settings" menu, search for khmer_angkor and install the keyboard. (Disregard the blankscreen on the keyboard search since that's a previously reported issue)
2. After khmer_angkor installs, verify there's no Toast notifications about a keyboard error

