### PR TITLE
chore(linux): Update changelog files

### DIFF
--- a/common/core/desktop/debian/changelog
+++ b/common/core/desktop/debian/changelog
@@ -1,3 +1,10 @@
+keyman-keyboardprocessor (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:37:42 +0200
+
 keyman-keyboardprocessor (14.0.276-2) experimental; urgency=medium
 
   * Team upload

--- a/linux/ibus-keyman/debian/changelog
+++ b/linux/ibus-keyman/debian/changelog
@@ -1,3 +1,10 @@
+ibus-keyman (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:31 +0200
+
 ibus-keyman (14.0.276-2) experimental; urgency=medium
 
   * Team upload

--- a/linux/ibus-kmfl/debian/changelog
+++ b/linux/ibus-kmfl/debian/changelog
@@ -1,3 +1,10 @@
+ibus-kmfl (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:14 +0200
+
 ibus-kmfl (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/linux/keyman-config/debian/changelog
+++ b/linux/keyman-config/debian/changelog
@@ -1,3 +1,10 @@
+keyman-config (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:22 +0200
+
 keyman-config (14.0.276-2) experimental; urgency=medium
 
   * Team upload

--- a/linux/kmflcomp/debian/changelog
+++ b/linux/kmflcomp/debian/changelog
@@ -1,3 +1,10 @@
+kmflcomp (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:37:57 +0200
+
 kmflcomp (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/linux/libkmfl/debian/changelog
+++ b/linux/libkmfl/debian/changelog
@@ -1,3 +1,10 @@
+libkmfl (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:05 +0200
+
 libkmfl (14.0.276-1) experimental; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
This updates the changelog files to match what got uploaded into Debian unstable (sid).

@keymanapp-test-bot skip