### PR TITLE
chore(linux): Update changelog files

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -4,6 +4,13 @@ keyman (15.0.90-1) UNRELEASED; urgency=medium
 
  -- Eberhard Beilharz <eb1@sil.org>  Mon, 02 Aug 2021 18:13:58 +0200
 
+keyman-config (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:22 +0200
+
 keyman-config (14.0.276-2) experimental; urgency=medium
 
   * Team upload

--- a/linux/legacy/ibus-kmfl/debian/changelog
+++ b/linux/legacy/ibus-kmfl/debian/changelog
@@ -1,3 +1,10 @@
+ibus-kmfl (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:14 +0200
+
 ibus-kmfl (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/linux/legacy/kmflcomp/debian/changelog
+++ b/linux/legacy/kmflcomp/debian/changelog
@@ -1,3 +1,10 @@
+kmflcomp (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:37:57 +0200
+
 kmflcomp (14.0.276-1) experimental; urgency=medium
 
   * New upstream release

--- a/linux/legacy/libkmfl/debian/changelog
+++ b/linux/legacy/libkmfl/debian/changelog
@@ -1,3 +1,10 @@
+libkmfl (14.0.280-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 23 Aug 2021 17:38:05 +0200
+
 libkmfl (14.0.276-1) experimental; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
This updates the changelog files to match what got uploaded into Debian unstable (sid).

Almost a :cherries:-pick of #5636. 

@keymanapp-test-bot skip