### PR TITLE
fix(common/core/web): layer reset on physical keystroke after OSK interaction

### DIFF
--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -661,6 +661,9 @@ namespace com.keyman.text {
       } else {
         this.layerId = 'default';
       }
+
+      let baseModifierState = text.KeyboardProcessor.getModifierState(this.layerId);
+      this.modStateFlags = baseModifierState | keyEvent.Lstates;
     }
 
     static isModifier(Levent: KeyEvent): boolean {

--- a/common/predictive-text/package-lock.json
+++ b/common/predictive-text/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@keymanapp/lexical-model-layer",
-			"version": "15.0.80",
+			"version": "15.0.104",
 			"license": "MIT",
 			"dependencies": {
 				"es6-shim": "^0.35.5",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "keyman",
-			"version": "15.0.80",
+			"version": "15.0.104",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^11.9.4",


### PR DESCRIPTION
Fixes #5635.

On the first physical keystroke after using the OSK, the OSK's layer management will reset to track all incoming physical keystrokes.

The underlying cause:  the `updateLayer` function did not properly update Web-core's tracked modifier state.  For non-'desktop' form factors, other aspects of the control flow were able to fill in the gaps, but since modifier keys can't output to the context for 'desktop' form-factor layouts, those don't run for 'desktop' due to short-circuiting optimizations.  Fortunately, all we need is a simple, focused fix.

## User Testing

TEST_DESKTOP_REPRO:  Confirm that the original error no longer reproduces.  (Your choice of desktop browser.)

<details><summary>Repro instructions + expected behavior</summary>

**To Reproduce**
1. Use KeymanWeb's unminified test page on a 'desktop' form-factor device.
    - Leave "English-English" as the active keyboard.
2. Click on the input field and type `a` with your hardware keyboard.
3. Click the OSK's `shift` key.
4. Click the OSK's `a` key.
5. Type `a` with your hardware keyboard.

**Expected behavior**
The second physical `a` keypress should reset the OSK's layer to the default, unshifted layer.  No shift highlighting, lowercase letters.

</details>

TEST_ANDROID_LAYER_PRESERVATION:  Confirm that the repro does _not_ cause the layer to reset when embedded in the Android app.

<details><summary>Instructions + expected behavior</summary>

1. Prepare a hardware keyboard to pair with your Android device.
2. Set the keyboard to`sil_euro_latin` for English.
2. Click on the input field and type `a` with your hardware keyboard.
3. Click the OSK's `shift` key.
4. Click the OSK's `a` key.
5. Type `a` with your hardware keyboard.

**Expected behavior**
The second physical `a` keypress should not reset the OSK's layer to the default, unshifted layer, as this is not an intended behavior when using a hardware keyboard with a touch device.

</details>