### PR TITLE
fix(developer): include Keyman Core in Keyman Developer 🐞

### DIFF
--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -88,6 +88,7 @@ clean: def-clean
 
 signcode:
     $(SIGNCODE) /d "Keyman Developer" $(PROGRAM)\developer\tike.exe
+    $(SIGNCODE) /d "Keyman Core" $(PROGRAM)\developer\kmnkbp0-0.dll
 
 wrap-symbols:
     $(SYMSTORE) $(PROGRAM)\developer\tike.exe /t keyman-developer

--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -4,7 +4,7 @@
 
 !include ..\..\Defines.mak
 
-build: version.res manifest.res icons dirs xml
+build: version.res manifest.res icons dirs xml pull-core
     cd $(ROOT)\src\developer\tike
     $(DELPHI_MSBUILD) tike.dproj /p:Platform=Win32
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\tike.exe -dpr tike.dpr
@@ -23,6 +23,22 @@ xml: pull-keymanweb pull-npm sentry-init.js
 sentry-init.js:
     cd $(ROOT)\src\developer\tike\xml\app\lib\sentry
     $(MKVER_U) init.js.in init.js
+
+pull-core:
+    cd $(ROOT)\..\common\core\desktop
+!ifdef GIT_BASH_FOR_KEYMAN
+!ifdef DEBUG
+    $(GIT_BASH_FOR_KEYMAN) build.sh --debug
+!else
+    $(GIT_BASH_FOR_KEYMAN) build.sh
+!endif
+!else
+!ifdef DEBUG
+    start /wait ./build.sh --debug
+!else
+    start /wait ./build.sh
+!endif
+!endif
 
 pull-npm:
     #

--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -11,6 +11,7 @@ build: version.res manifest.res icons dirs xml
     $(TDS2DBG) $(WIN32_TARGET_PATH)\tike.exe
     $(COPY) $(WIN32_TARGET_PATH)\tike.exe $(PROGRAM)\developer
     $(COPY) kmlmc.cmd $(PROGRAM)\developer
+    $(COPY) $(ROOT)\..\common\core\desktop\build\x86\$(TARGET_PATH)\src\kmnkbp0-0.dll $(PROGRAM)\developer
     if exist $(WIN32_TARGET_PATH)\tike.dbg $(COPY) $(WIN32_TARGET_PATH)\tike.dbg $(DEBUGPATH)\developer
 
 xml: pull-keymanweb pull-npm sentry-init.js
@@ -78,6 +79,7 @@ wrap-symbols:
 
 install:
     $(COPY) $(PROGRAM)\developer\tike.exe "$(INSTALLPATH_KEYMANDEVELOPER)\tike.exe"
+    $(COPY) $(PROGRAM)\developer\kmnkbp0-0.dll "$(INSTALLPATH_KEYMANDEVELOPER)\kmnkbp0-0.dll"
 
 test-manifest:
     # test that linked manifest exists and correct

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -200,6 +200,10 @@
       </Component>
 
       <Component>
+        <File Name="kmnkbp0-0.dll" KeyPath="yes" />
+      </Component>
+
+      <Component>
         <File Name="keyboard_info.distribution.json" Source="..\..\global\inst\data\keyboard_info\" KeyPath="yes" />
       </Component>
 

--- a/windows/src/developer/kmanalyze/Makefile
+++ b/windows/src/developer/kmanalyze/Makefile
@@ -22,7 +22,7 @@ wrap-symbols:
 test-manifest:
     @rem
 
-#install:
-#    $(COPY) $(PROGRAM)\developer\kmanalyze.exe "$(INSTALLPATH_KEYMANDEVELOPER)\kmanalyze.exe"
+install:
+    $(COPY) $(PROGRAM)\developer\kmanalyze.exe "$(INSTALLPATH_KEYMANDEVELOPER)\kmanalyze.exe"
 
 !include ..\..\Target.mak

--- a/windows/src/test/test_i3633/verify.dpr
+++ b/windows/src/test/test_i3633/verify.dpr
@@ -62,6 +62,13 @@ begin
     end;
   end;
 
+  if str[0].ToLower.Contains('kmnkbp0-0') then
+  begin
+    // Keyman Core does not include version information
+    // TODO: this will be resolved in #5672
+    Exit('');
+  end;
+
   if str[3] <> 'SIL International' then
   begin
     Exit('File has wrong company name');


### PR DESCRIPTION
Fixes #5648.

Includes kmnkbp0-0.dll in the installer for Keyman Developer.

# User Testing

* TEST_BASIC: Load a keyboard in Keyman Developer, and press F5 to start debugging. It should start!