### PR TITLE
fix(web): Fix layers for embedded longpress keys

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -238,7 +238,8 @@
         var keyPos = x.toString() + ',' + y.toString();
         for(i=0; i<obj.length; i++)
         {
-          s=s+obj[i].layer+'-'+obj[i].coreID;
+          // elementID contains the layer and coreID
+          s=s+obj[i].elementID;
           if(obj[i].sp == 1 || obj[i].sp == 2) shift = true;
           if(typeof(obj[i].text) != 'undefined' && obj[i].text != null && obj[i].text != '') s=s+':'+toHex(obj[i].text);
           if(i < (obj.length -1)) s=s+';'

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -389,7 +389,7 @@ namespace com.keyman.text {
       }
 
       // Determine the "functional" layer
-      let layer = 'default';
+      let layer = displayLayer;
       separatorIndex = keyName.lastIndexOf('+');
       if (separatorIndex > 0) {
         layer = keyName.substring(separatorIndex+1);

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -374,18 +374,25 @@ namespace com.keyman.text {
       /* Clear any pending (non-popup) key */
       osk.vkbd.keyPending = null;
 
-      // Changes for Build 353 to resolve KMEI popup key issues      
+      // Changes for Build 353 to resolve KMEI popup key issues
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
 
       // Can't just split on '-' because some layers like ctrl-shift contain it.
       let separatorIndex = keyName.lastIndexOf('-');
-      var layer = core.keyboardProcessor.layerId;
+      var displayLayer = core.keyboardProcessor.layerId;
       if (separatorIndex > 0) {
-        layer = keyName.substring(0, separatorIndex);
+        displayLayer = keyName.substring(0, separatorIndex);
         keyName = keyName.substring(separatorIndex+1);
       }
-      if(layer == 'undefined') {
-        layer=core.keyboardProcessor.layerId;
+      if(displayLayer == 'undefined') {
+        displayLayer=core.keyboardProcessor.layerId;
+      }
+
+      // Determine the "functional" layer
+      let layer = 'default';
+      separatorIndex = keyName.lastIndexOf('+');
+      if (separatorIndex > 0) {
+        layer = keyName.substring(separatorIndex+1);
       }
 
       // Note:  this assumes Lelem is properly attached and has an element interface.
@@ -425,6 +432,11 @@ namespace com.keyman.text {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");
       }
 
+      // Now that we've checked if key is found, split "functional layer" from keyName
+      if (separatorIndex > 0) {
+        keyName = keyName.substring(0, separatorIndex);
+      }
+
       let Codes = com.keyman.text.Codes;
       
       // Check the virtual key 
@@ -435,6 +447,8 @@ namespace com.keyman.text {
         Lcode: Codes.keyCodes[keyName],
         LisVirtualKey: true,
         kName: keyName,
+        kLayer: layer,
+        kbdLayer: displayLayer,
         kNextLayer: nextLayer,
         vkCode: null, // was originally undefined
         isSynthetic: true,


### PR DESCRIPTION
Follow-on to #5351 and fixes #5610

Some longpress keys on the shift layer weren't working on Keyman for Android (e.g. sil_madi).
This fixes how the "functional" layer and "display" layers are determined in kmwembedded.ts.

This fills out `kLayer` and `kbdLayer` so it matches what KeymanWeb on desktop uses
![longpress a](https://user-images.githubusercontent.com/7358010/131092540-aaca2ef6-e2d2-48e6-98b8-8310d6111ee3.png)

The keyboards seem to work in 15.0 (`master`) so maybe don't need to 🍒 pick?

## User Testing
<details><summary>Setup</summary>
1.  Install the test build
2.  Install sil_madi and sil_cameroon_qwerty keyboards
</details>

* **TEST_MADI:** Longpress on shift layer
1. Change the keyboard to sil_madi
2. On the default layer, longpress on a vowel and select it
3. Verify the correct character is output
4. Press <kbd>Shift</kbd> to switch to the "Shift" layer
5. Longpress on the <kbd>A</kbd> and select one of the caps longpresses.
6. Verify the correct character is output

* **TEST_NEXT_LAYER:** Test application of nextlayer
<detail>These steps are based on  #5351</detail>
1. Change the keyboard to sil_cameroon_qwerty
2. Press <kbd>Shift</kbd> to switch to the "Shift" layer
3. Longpress on the <kbd>W</kbd> or <kbd>E</kbd> keys and select one of the caps longpresses
4. Verify the correct character is output
5. Verify the keyboard switches to the to the default layer
6. Press <kbd>Shift</kbd> to switch to the "Shift" layer
7. Press the spacebar
8. Verify the layer remains on "Shift"
9. For each of the following:
    * switch to the symbolic layer
    * longpress on the base key and select any of the longpress keys
    * verify the correct character is output
    * verify the keyboard **switches** to the default layer
    **Base Key**
    <kbd><<</kbd> 
    <kbd>>></kbd> 
    <kbd>'</kbd> (single quote)
    <kbd>"</kbd> (double quote)
10. For each of the following:
    * switch to the symbolic layer
    * longpress on the base key and select any of the longpress keys
    * verify the correct character is output
    * verify the keyboard **remains** on the symbolic layer
    **Base Key**
    <kbd>(</kbd> 
    <kbd>)</kbd> 
    <kbd>?</kbd> (Note, the basekey <kbd>?</kbd> will switch to the default layer
    <kbd>!</kbd> (Note, the basekey <kbd>!</kbd> will switch to the default layer


As only subkeys are affected, testing with other keyboards that utilize subkeys isn't a bad idea. Try with sil_bunong since that was also reported in the issue

