### PR TITLE
fix(linux): Use first keyboard language if none given

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -72,7 +72,7 @@ def get_ibus_keyboard_id(keyboard, packageDir, language=None, ignore_language=Fa
     kmx_file = os.path.join(packageDir, keyboard['id'] + ".kmx")
     if ignore_language:
         return kmx_file
-    if language is not None:
+    if language is not None and language != '':
         logging.debug(language)
         return "%s:%s" % (language, kmx_file)
     if "languages" in keyboard and len(keyboard["languages"]) > 0:


### PR DESCRIPTION
This fixes a bug introduced in #3290 where we added using the language from search. Unfortunately that broke things in a lot of other places because we didn't test for the empty string.

# User Testing

- **TEST_LANG_1**: keyboard installed with double clicking on .kmp file appears in system keyboard dropdown list

  <details><summary>Steps</summary>
  - download a .kmp file, e.g. Dzongkha (SIL) keyboard
  - install the .kmp file by double clicking the file (if double clicking opens the .kmp file in another application, you'll have to
    right-click the file, select "Open With Other Application" and select "Keyman Keyboards" from the list.
  - verify that "Dzongkha (Dzongkha (SIL))" appears in the system keyboard dropdown list. If no Keyman keyboards appear in the
    dropdown you might have to restart gnome-shell (press Alt-F2, then type `r` in the textbox and hit `Enter` key), or reboot your
    machine
  </details>

- **TEST_LANG_2**: .kmp file installed in km-config appears in system keyboard dropdown list

  <details><summary>Steps</summary>
  - open `km-config`
  - if necessary uninstall Dzongkha (SIL) keyboard
  - press the `Install` button and select and install the `.kmp` file
  - verify that "Dzongkha (SIL)" appears in the list of installed keyboards in "Keyman Configuration"
  - verify that "Dzongkha (Dzongkha (SIL))" appears in the system keyboard dropdown list. If no Keyman keyboards appear in the
    dropdown you might have to restart gnome-shell (press Alt-F2, then type `r` in the textbox and hit `Enter` key), or reboot your
    machine
  </details>

- **TEST_LANG_3**: downloaded keyboard installs under searched-for language

  <details><summary>Steps</summary>
  - open `km-config`
  - press `Download` button
  - search for `corsican` and install the "EuroLatin (SIL) keyboard"
  - verify that "EuroLatin (SIL)" appears in the list of installed keyboards in "Keyman Configuration"
  - verify that "Corsican (EuroLatin (SIL))" appears in the system keyboard dropdown list. If no Keyman keyboards appear in the
    dropdown you might have to restart gnome-shell (press Alt-F2, then type `r` in the textbox and hit `Enter` key), or reboot your
    machine
  </details>