### PR TITLE
fix(android/engine): Fix backspace on Android 5.0

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -44,6 +44,7 @@
       kmw['setActiveElement'](ta);
 
       ta.readOnly = false;
+      checkTextArea();
 
       // Tell KMW the default banner height to use
       com.keyman.osk.Banner.DEFAULT_HEIGHT =
@@ -341,6 +342,27 @@
         hexString += theHex;
       }
       return hexString;
+    }
+
+    /**
+     * Check the WebView version and determine if the textarea that KeymanWeb uses needs to be "visible".
+     * Normally, this textarea is not displayed to avoid redundant layout calculations.
+     * In older WebViews on Android 5.0 though, selectionStart and selectionEnd positions fail to
+     * update unless the textarea is visible.
+     * Reference: Issue #5376
+     */
+    function checkTextArea() {
+      var uaRe = /Chrome\/([0-9]*)./g;
+      var chromeMajorVersion = uaRe.exec(navigator.userAgent);
+      if (chromeMajorVersion && parseInt(chromeMajorVersion[1]) <= 37) {
+        var ta = document.getElementById('ta');
+        if (ta != null) {
+          ta.style.display = '';
+          ta.style.position = 'absolute';
+          ta.style.left = '-500px';
+          ta.style.top = '0px';
+        }
+      }
     }
 
   </script>


### PR DESCRIPTION
Fixes #5576

The internal textarea that KeymanWeb uses was hidden in #5376 for performance (avoid redundant layout calculations).
On Android 5.0 (Lollipop) devices with WebView 37.0 though, hiding the textarea prevents KeymanWeb from getting `selectionStart` and `selectionEnd` positions (they remain at 0). 

Note, Android 5.1 (also Lollipop) devices have WebView 39.0 and function fine with the hidden textarea.

This PR updates keyboard.html to check the WebView version. If <= 37, it will revert #5576. Even though we take a performance hit, it's more important that KeymanWeb can remain in sync with the context.

Will need to 🍒 pick to stable-14.0

## User Testing
Setup: Install the test build
Devices needed: 
    * phone emulator with Android 5.0 Lollipop (SDK 21)
    * tablet emulator with Android 5.0 Lollipop (SDK 21)
    * phone emulator with Android 5.1 Lollipop (SDK 22)
    
* **TEST_PHONE_21**: Phone with Android 5.0 Lollipop
1. On the Phone emulator with Android 5.0 Lollipop 
2. Open Keyman
3. With the default sil_euro_latin keyboard, type some characters
4. Press <kbd>backspace</kbd>
5. Verify the previous character is deleted.

* **TEST_TABLET_21**: Tablet with Android 5.0 Lollipop
1. On the tablet emulator with Android 5.0 Lollipop
2. Open Keyman
3. With the default sil_euro_latin keyboard, type some characters
4. Press <kbd>backspace</kbd>
5. Verify the previous character is deleted.

* **TEST_PHONE_22**: Phone with Android 5.1 Lollipop
1. On the phone emulator with Android 5.1 Lollipop
2. Open Keyman
3. With the default sil_euro_latin keyboard, type some characters
4. Press <kbd>backspace</kbd>
5. Verify the previous character is deleted.
 