### PR TITLE
feat(windows): preserving keyboard options in engine

### DIFF
--- a/common/core/desktop/src/km_kbp_options_api.cpp
+++ b/common/core/desktop/src/km_kbp_options_api.cpp
@@ -25,9 +25,9 @@ km_kbp_options_list_size(km_kbp_option_item const *opts)
   if (!opts)  return 0;
 
   auto n = 0;
-  for (; opts->key; ++opts)
+  for (; opts->key; ++opts){
     ++n;
-    
+  }
 
   return n;
 }

--- a/common/core/desktop/src/km_kbp_options_api.cpp
+++ b/common/core/desktop/src/km_kbp_options_api.cpp
@@ -25,7 +25,9 @@ km_kbp_options_list_size(km_kbp_option_item const *opts)
   if (!opts)  return 0;
 
   auto n = 0;
-  while (opts->key) ++n;
+  for (; opts->key; ++opts)
+    ++n;
+    
 
   return n;
 }

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -248,7 +248,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
         _td->app->RestoreContextOnly(savedContextUsingCore);
         RestoreKeyboardOptionsCore(_td->lpActiveKeyboard->lpCoreKeyboardState, SavedKBDOptions);
         DisposeKeyboardOptionsCore(&SavedKBDOptions);
-        SavedKBDOptions = NULL;
         delete savedContextUsingCore;
         savedContextUsingCore = NULL;
       }

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -233,16 +233,6 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
       savedContextUsingCore = new AppContext();
       _td->app->CopyContext(savedContextUsingCore);
       SavedKBDOptions = SaveKeyboardOptionsCore(_td->lpActiveKeyboard);
-      // TODO: 5653  ---- Alternate option ---
-      // Instead of allocating memory for each option
-      // just update the changed options. Consider the commented out method UpdateCoreKeyboard
-      // options.
-      /*if (_td->lpActiveKeyboard->lpCoreKeyboardOptions) {
-        UpdateKeyboardOptionsCore(_td->lpActiveKeyboard->lpCoreKeyboardState, _td->lpActiveKeyboard->lpCoreKeyboardOptions);
-      } else {
-        _td->lpActiveKeyboard->lpCoreKeyboardOptions = SaveKeyboardOptionsCore(_td->lpActiveKeyboard);
-      }*/
-      //////// End alternate option
     } else {                                                                                   // I4370
       savedContext = new AppContextWithStores(_td->lpActiveKeyboard->Keyboard->cxStoreArray);  // I4978
       _td->app->SaveContext(savedContext);
@@ -257,11 +247,8 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPProcessKey(WPARAM wParam, LPARAM
         // Reset the context if match found
         _td->app->RestoreContextOnly(savedContextUsingCore);
         RestoreKeyboardOptionsCore(_td->lpActiveKeyboard->lpCoreKeyboardState, SavedKBDOptions);
-        delete SavedKBDOptions;
+        DisposeKeyboardOptionsCore(&SavedKBDOptions);
         SavedKBDOptions = NULL;
-        // TODO: 5653  ---- Alternate option --- Instead of allocating memory for each option
-        //RestoreKeyboardOptionsCore(_td->lpActiveKeyboard->lpCoreKeyboardState, _td->lpActiveKeyboard->lpCoreKeyboardOptions);
-        /// --- End Alternate option
         delete savedContextUsingCore;
         savedContextUsingCore = NULL;
       }

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -332,12 +332,12 @@ SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp) {
           0, sdmKeyboard, 0, "SaveCoreOptions: km_kbp_state_option_lookup failed with error status [%d]", err_status);
       continue;
     }
-    SavedkeyboardOpts[i].key   = CloneKMKBPCP(kbDefaultOpts->key);
-    SavedkeyboardOpts[i].value = CloneKMKBPCP(retValue);
-    SavedkeyboardOpts[i].scope = KM_KBP_OPT_KEYBOARD;
+    savedKeyboardOpts[i].key   = CloneKMKBPCP(kbDefaultOpts->key);
+    savedKeyboardOpts[i].value = CloneKMKBPCP(retValue);
+    savedKeyboardOpts[i].scope = KM_KBP_OPT_KEYBOARD;
   }
-  SavedkeyboardOpts[listSize] = KM_KBP_OPTIONS_END;
-  return SavedkeyboardOpts;
+  savedKeyboardOpts[listSize] = KM_KBP_OPTIONS_END;
+  return savedKeyboardOpts;
 }
 
 BOOL
@@ -350,5 +350,16 @@ RestoreKeyboardOptionsCore(
         0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_state_options_update failed with error status [%d]", err_status);
     return FALSE;
   }
+  return TRUE;
+}
+
+BOOL
+DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions) {
+  size_t listSize          = km_kbp_options_list_size(*lpCoreKeyboardOptions);
+  for (int i = 0; i < (int)listSize; i++) {
+    delete[] (*lpCoreKeyboardOptions)[i].key;
+    delete[] (*lpCoreKeyboardOptions)[i].value;
+  }
+  delete[] *lpCoreKeyboardOptions;
   return TRUE;
 }

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -283,7 +283,7 @@ UpdateKeyboardOptionsCore(
   km_kbp_state* const lpCoreKeyboardState,
   km_kbp_option_item *lpCoreKeyboardOptions) {
 
-  int listSize = km_kbp_options_list_size(lpCoreKeyboardOptions);
+  int listSize = (int)km_kbp_options_list_size(lpCoreKeyboardOptions);
   // Create a option list based on this size look up each key and store the return value in it.
   // then at the end return this options list.
   BOOL changed = FALSE;
@@ -317,7 +317,7 @@ SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp) {
         0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
     return nullptr;
   }
-  int listSize                  = km_kbp_options_list_size(keyboardAttrs->default_options);
+  int listSize                  = (int)km_kbp_options_list_size(keyboardAttrs->default_options);
   km_kbp_option_item* SavedkeyboardOpts = new km_kbp_option_item[listSize + 1];
   km_kbp_cp const* retValue               = nullptr;
 

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -293,7 +293,7 @@ UpdateKeyboardOptionsCore(
         &retValue);
     if (err_status != KM_KBP_STATUS_OK) {
       SendDebugMessageFormat(
-          0, sdmKeyboard, 0, "SaveCoreOptions: km_kbp_state_option_lookup failed with error status [%d]", err_status);
+          0, sdmKeyboard, 0, "UpdateKeyboardOptionsCore: km_kbp_state_option_lookup failed with error status [%d]", err_status);
       continue;
     }
     // compare to see if changed
@@ -314,7 +314,7 @@ SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp) {
   km_kbp_status err_status = km_kbp_keyboard_get_attrs(kp->lpCoreKeyboard, &keyboardAttrs);
   if (err_status != KM_KBP_STATUS_OK) {
     SendDebugMessageFormat(
-        0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
+        0, sdmKeyboard, 0, "SaveKeyboardOptionsCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
     return nullptr;
   }
   int listSize = (int)km_kbp_options_list_size(keyboardAttrs->default_options);
@@ -329,7 +329,7 @@ SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp) {
         km_kbp_state_option_lookup(kp->lpCoreKeyboardState, KM_KBP_OPT_KEYBOARD, kbDefaultOpts->key, &retValue);
     if (err_status != KM_KBP_STATUS_OK) {
       SendDebugMessageFormat(
-          0, sdmKeyboard, 0, "SaveCoreOptions: km_kbp_state_option_lookup failed with error status [%d]", err_status);
+          0, sdmKeyboard, 0, "SaveKeyboardOptionsCore: km_kbp_state_option_lookup failed with error status [%d]", err_status);
       continue;
     }
     savedKeyboardOpts[i].key   = CloneKMKBPCP(kbDefaultOpts->key);
@@ -347,13 +347,13 @@ RestoreKeyboardOptionsCore(
   km_kbp_status err_status = km_kbp_state_options_update(lpCoreKeyboardState, lpCoreKeyboardOptions);
   if (err_status != KM_KBP_STATUS_OK) {
     SendDebugMessageFormat(
-        0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_state_options_update failed with error status [%d]", err_status);
+        0, sdmKeyboard, 0, "RestoreKeyboardOptionsCore: km_kbp_state_options_update failed with error status [%d]", err_status);
     return FALSE;
   }
   return TRUE;
 }
 
-BOOL
+void
 DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions) {
   size_t listSize          = km_kbp_options_list_size(*lpCoreKeyboardOptions);
   for (int i = 0; i < (int)listSize; i++) {

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -317,9 +317,9 @@ SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp) {
         0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
     return nullptr;
   }
-  int listSize                  = (int)km_kbp_options_list_size(keyboardAttrs->default_options);
-  km_kbp_option_item* SavedkeyboardOpts = new km_kbp_option_item[listSize + 1];
-  km_kbp_cp const* retValue               = nullptr;
+  int listSize = (int)km_kbp_options_list_size(keyboardAttrs->default_options);
+  km_kbp_option_item* savedKeyboardOpts = new km_kbp_option_item[listSize + 1];
+  km_kbp_cp const* retValue = nullptr;
 
   km_kbp_option_item const* kbDefaultOpts = keyboardAttrs->default_options;
   for (int i = 0; i < listSize; i++, ++kbDefaultOpts) {

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -361,5 +361,5 @@ DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions) {
     delete[] (*lpCoreKeyboardOptions)[i].value;
   }
   delete[] *lpCoreKeyboardOptions;
-  return TRUE;
+  *lpCoreKeyboardOptions = NULL;
 }

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -26,7 +26,7 @@ void LoadSharedKeyboardOptions(LPINTKEYBOARDINFO kp);
  * Updates the supplied Keyboard processor options list from the keyboard processor pointed
  * to by the state pointer.
  *
- * @param         lpCoreKeyboardState   The core keyboardprocessor state which as the source options
+ * @param         lpCoreKeyboardState   The core keyboardprocessor state which has the source options
  * @param[in,out] lpCoreKeyboardOptions The core keyboard options to be updated
  * @return        BOOL      True if one or more options were updated
  */
@@ -36,7 +36,7 @@ BOOL UpdateKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_o
  * Returns a copy of the core keyboard processors current keyboard options
  * The caller is responsible for freeing the returned km_kbp_option_item's list.
  *
- * @param  kp                  A pointer the keyboard info object that constains the
+ * @param  kp                  A pointer to the keyboard info object that contains the
  *                             keyboardprocessor state and keyboard for the source options list.
  *
  * @return km_kbp_option_item* The copy of the options list or NULL if copy failed
@@ -44,7 +44,7 @@ BOOL UpdateKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_o
 km_kbp_option_item* SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp);
 
 /**
- * Restore the core keyboard processor options to from the supplied keyboard
+ * Restore the core keyboard processor options to the supplied keyboard
  * list of `km_kbp_option_item`s
  *
  * @param lpCoreKeyboardState   The state pointer for the keyboard processor
@@ -79,4 +79,4 @@ void SaveKeyboardOptionREGCore(LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value);
  *
  * @param  lpCoreKeyboardOptions  keyboard options items to be freed
  */
-BOOL DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions);
+void DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions);

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -22,7 +22,37 @@ void SetKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToSet, int nStoreToRead);
 void ResetKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToReset);
 void SaveKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToSave);
 void LoadSharedKeyboardOptions(LPINTKEYBOARDINFO kp);
-BOOL UpdateKeyboardOptions(km_kbp_state* const kpState, km_kbp_option_item *kbOptions);
+/**
+ * Updates the supplied Keyboard processor options list from the keyboard processor pointed
+ * to by the state pointer.
+ *
+ * @param         lpCoreKeyboardState   The core keyboardprocessor state which as the source options
+ * @param[in,out] lpCoreKeyboardOptions The core keyboard options to be updated
+ * @return        BOOL      True if one or more options were updated
+ */
+BOOL UpdateKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_option_item *lpCoreKeyboardOptions);
+
+/**
+ * Returns a copy of the core keyboard processors current keyboard options
+ * The caller is responsible for freeing the returned km_kbp_option_item's list.
+ *
+ * @param  kp                  A pointer the keyboard info object that constains the
+ *                             keyboardprocessor state and keyboard for the source options list.
+ *
+ * @return km_kbp_option_item* The copy of the options list or NULL if copy failed
+ */
+km_kbp_option_item* SaveKeyboardOptionsCore(LPINTKEYBOARDINFO kp);
+
+/**
+ * Restore the core keyboard processor options to from the supplied keyboard
+ * list of `km_kbp_option_item`s
+ *
+ * @param lpCoreKeyboardState   The state pointer for the keyboard processor
+ * @param lpCoreKeyboardOptions The list of `km_kbp_option_item`s to restore
+ *
+ * return BOOL TRUE when the call to update keyboard processor was successful
+ */
+BOOL RestoreKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_option_item* lpCoreKeyboardOptions);
 
 /* Common core integration functions */
 

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -22,6 +22,7 @@ void SetKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToSet, int nStoreToRead);
 void ResetKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToReset);
 void SaveKeyboardOption(LPINTKEYBOARDINFO kp, int nStoreToSave);
 void LoadSharedKeyboardOptions(LPINTKEYBOARDINFO kp);
+BOOL UpdateKeyboardOptions(km_kbp_state* const kpState, km_kbp_option_item *kbOptions);
 
 /* Common core integration functions */
 

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -72,3 +72,11 @@ void LoadKeyboardOptionsREGCore(LPINTKEYBOARDINFO kp, km_kbp_state* state);
  * @param  value  keyboard option value to save
  */
 void SaveKeyboardOptionREGCore(LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value);
+
+/**
+ *  Free the allocated resources belonging to a key_kbp_option_items object
+ *  that was created on the heap most likely using SaveKeyboardOptionREGCore
+ *
+ * @param  lpCoreKeyboardOptions  keyboard options items to be freed
+ */
+BOOL DisposeKeyboardOptionsCore(km_kbp_option_item** lpCoreKeyboardOptions);

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/gtest_main.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/gtest_main.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file
+ * @copyright (c) 2013 Stephan Brenner
+ * @license   This project is released under the MIT License.
+ *
+ * Adapted in 2021 from the gtest_mem.cpp
+ * This file implements a main() function for Google Test that runs all tests
+ * and detects memory leaks.
+ */
+#include "pch.h"
+#include <crtdbg.h>
+#include <gtest/gtest.h>
+#include <iostream>
+
+using namespace std;
+using namespace testing;
+
+namespace testing {
+class MemoryLeakDetector : public EmptyTestEventListener {
+#ifdef _DEBUG
+public:
+  virtual void
+  OnTestStart(const TestInfo&) {
+    _CrtMemCheckpoint(&memState_);
+  }
+
+  virtual void
+  OnTestEnd(const TestInfo& test_info) {
+    if (test_info.result()->Passed()) {
+      _CrtMemState stateNow, stateDiff;
+      _CrtMemCheckpoint(&stateNow);
+      int diffResult = _CrtMemDifference(&stateDiff, &memState_, &stateNow);
+      if (diffResult) {
+        FAIL() << "Memory leak of " << stateDiff.lSizes[1] << " byte(s) detected.";
+      }
+    }
+  }
+
+private:
+  _CrtMemState memState_;
+#endif  // _DEBUG
+};
+}  // namespace testing
+
+GTEST_API_ int
+main(int argc, char** argv) {
+  cout << "Running main() from pch.cpp" << endl;
+
+  InitGoogleTest(&argc, argv);
+  UnitTest::GetInstance()->listeners().Append(new MemoryLeakDetector());
+
+  return RUN_ALL_TESTS();
+}

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/gtest_main.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/gtest_main.cpp
@@ -2,7 +2,7 @@
  * @file
  * @copyright (c) 2013 Stephan Brenner
  * @license   This project is released under the MIT License.
- *
+ * repo: https://github.com/stbrenner/gtest_mem
  * Adapted in 2021 from the gtest_mem.cpp
  * This file implements a main() function for Google Test that runs all tests
  * and detects memory leaks.
@@ -44,7 +44,7 @@ private:
 
 GTEST_API_ int
 main(int argc, char** argv) {
-  cout << "Running main() from pch.cpp" << endl;
+  cout << "Running main() from gtest_main.cpp" << endl;
 
   InitGoogleTest(&argc, argv);
   UnitTest::GetInstance()->listeners().Append(new MemoryLeakDetector());

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyboardoptionstests.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyboardoptionstests.cpp
@@ -31,6 +31,9 @@ TEST(KEYBOARDOPTIONS, UpdateKeyboardOptionsCore) {
   value         = kp->lpCoreKeyboardOptions[0].value;
   expectedValue = u"triggered";
   EXPECT_TRUE(value == expectedValue);
+  DisposeKeyboardOptionsCore(&kp->lpCoreKeyboardOptions);
+  ReleaseStateMemoryCore(&kp->lpCoreKeyboardState);
+  ReleaseKeyboardMemoryCore(&kp->lpCoreKeyboard);
   delete kp;
 
 }
@@ -61,12 +64,15 @@ TEST(KEYBOARDOPTIONS, SaveRestoreKeyboardOptionsCore) {
   km_kbp_cp const *retValue = nullptr;
   EXPECT_TRUE(RestoreKeyboardOptionsCore(kp->lpCoreKeyboardState, SavedKBDOptions));
   EXPECT_EQ(km_kbp_state_option_lookup(kp->lpCoreKeyboardState, KM_KBP_OPT_KEYBOARD, test_env_opts[0].key, &retValue), KM_KBP_STATUS_OK);
-  
+
   value         = retValue;
   expectedValue                     = u"not tiggered";
   EXPECT_TRUE(value == expectedValue);
 
-  delete NewKBDOptions;
-  delete SavedKBDOptions;
+  DisposeKeyboardOptionsCore(&NewKBDOptions);
+  DisposeKeyboardOptionsCore(&SavedKBDOptions);
+
+  ReleaseStateMemoryCore(&kp->lpCoreKeyboardState);
+  ReleaseKeyboardMemoryCore(&kp->lpCoreKeyboard);
   delete kp;
 }

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyboardoptionstests.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyboardoptionstests.cpp
@@ -1,0 +1,72 @@
+
+#include "pch.h"
+#include <locale>
+#include <codecvt>
+#include <string>
+#include <iostream>
+
+// Test UpdateKeyboardOptionsCore, also uses SaveKeyboardOptionsCore
+TEST(KEYBOARDOPTIONS, UpdateKeyboardOptionsCore) {
+  LPINTKEYBOARDINFO kp  = new INTKEYBOARDINFO;
+  memset(kp, 0, sizeof(INTKEYBOARDINFO));
+
+  km_kbp_option_item test_env_opts[] = {
+      {u"__test_point", u"not tiggered", KM_KBP_OPT_KEYBOARD}, {u"hello", u"-", KM_KBP_OPT_ENVIRONMENT}, KM_KBP_OPTIONS_END};
+
+  km_kbp_path_name dummyPath = L"dummyActions.mock";
+  EXPECT_EQ(km_kbp_keyboard_load(dummyPath, &kp->lpCoreKeyboard), KM_KBP_STATUS_OK);
+  EXPECT_EQ(km_kbp_state_create(kp->lpCoreKeyboard, test_env_opts, &kp->lpCoreKeyboardState), KM_KBP_STATUS_OK);
+
+  kp->lpCoreKeyboardOptions           = SaveKeyboardOptionsCore(kp);
+  // No Change
+  EXPECT_FALSE(UpdateKeyboardOptionsCore(kp->lpCoreKeyboardState, kp->lpCoreKeyboardOptions));
+  std::u16string value = kp->lpCoreKeyboardOptions[0].value;
+  std::u16string expectedValue = u"not tiggered";
+  EXPECT_TRUE(value == expectedValue);
+
+  km_kbp_option_item update_key_opts[] = {{u"__test_point", u"triggered", KM_KBP_OPT_KEYBOARD}, KM_KBP_OPTIONS_END};
+  EXPECT_EQ(km_kbp_state_options_update(kp->lpCoreKeyboardState, update_key_opts), KM_KBP_STATUS_OK);
+  // Change value to triggered
+  EXPECT_TRUE(UpdateKeyboardOptionsCore(kp->lpCoreKeyboardState, kp->lpCoreKeyboardOptions));
+  value         = kp->lpCoreKeyboardOptions[0].value;
+  expectedValue = u"triggered";
+  EXPECT_TRUE(value == expectedValue);
+  delete kp;
+
+}
+
+// Test SaveKeyboardOptionsCore and RestoreKeyboardOptionsCORE
+TEST(KEYBOARDOPTIONS, SaveRestoreKeyboardOptionsCore) {
+
+  LPINTKEYBOARDINFO kp = new INTKEYBOARDINFO;
+  memset(kp, 0, sizeof(INTKEYBOARDINFO));
+
+  km_kbp_option_item test_env_opts[] = {
+      {u"__test_point", u"not tiggered", KM_KBP_OPT_KEYBOARD}, {u"hello", u"-", KM_KBP_OPT_ENVIRONMENT}, KM_KBP_OPTIONS_END};
+  km_kbp_path_name dummyPath = L"dummyActions.mock";
+  EXPECT_EQ(km_kbp_keyboard_load(dummyPath, &kp->lpCoreKeyboard), KM_KBP_STATUS_OK);
+  EXPECT_EQ(km_kbp_state_create(kp->lpCoreKeyboard, test_env_opts, &kp->lpCoreKeyboardState), KM_KBP_STATUS_OK);
+
+  km_kbp_option_item *SavedKBDOptions = SaveKeyboardOptionsCore(kp);
+
+  std::u16string value         = SavedKBDOptions[0].value;
+  std::u16string expectedValue = u"not tiggered";
+  km_kbp_option_item update_key_opts[] = {{u"__test_point", u"triggered", KM_KBP_OPT_KEYBOARD}, KM_KBP_OPTIONS_END};
+  EXPECT_EQ(km_kbp_state_options_update(kp->lpCoreKeyboardState, update_key_opts), KM_KBP_STATUS_OK);
+
+  km_kbp_option_item *NewKBDOptions = SaveKeyboardOptionsCore(kp);
+  value = NewKBDOptions[0].value;
+  expectedValue = u"triggered";
+  EXPECT_TRUE(value == expectedValue);
+  km_kbp_cp const *retValue = nullptr;
+  EXPECT_TRUE(RestoreKeyboardOptionsCore(kp->lpCoreKeyboardState, SavedKBDOptions));
+  EXPECT_EQ(km_kbp_state_option_lookup(kp->lpCoreKeyboardState, KM_KBP_OPT_KEYBOARD, test_env_opts[0].key, &retValue), KM_KBP_STATUS_OK);
+  
+  value         = retValue;
+  expectedValue                     = u"not tiggered";
+  EXPECT_TRUE(value == expectedValue);
+
+  delete NewKBDOptions;
+  delete SavedKBDOptions;
+  delete kp;
+}

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
@@ -38,6 +38,7 @@
     <OutDir>$(ProjectDir)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
     <LibraryPath>$(ProjectDir)..\..\..\..\..\..\common\core\desktop\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\..\..\common\core\desktop\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>
+    <Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static-Disable-gtest_main>true</Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static-Disable-gtest_main>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(ProjectDir)..\..\..\..\global\inc;$(ProjectDir)..\..;$(IncludePath)</IncludePath>

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="appinttests.cpp" />
+    <ClCompile Include="keyboardoptionstests.cpp" />
     <ClCompile Include="kmprocessactionstests.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="appinttests.cpp" />
+    <ClCompile Include="gtest_main.cpp" />
     <ClCompile Include="keyboardoptionstests.cpp" />
     <ClCompile Include="kmprocessactionstests.cpp" />
     <ClCompile Include="pch.cpp">

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "kmprocessactions.cpp"
 
-// Test the Process Actions private functions 
+// Test the Process Actions private functions
 // Note: The following actions are not tested KM_KBP_IT_ALERT, KM_KBP_IT_PERSIST_OPT, KM_KBP_IT_EMIT_KEYSTROKE
 
 // KM_KBP_IT_CHAR - processUnicodeChar
@@ -16,7 +16,7 @@
   processUnicodeChar(&testApp, &itemAddChar);
   WCHAR *contextBuf = testApp.ContextBufMax(MAXCONTEXT);
   EXPECT_STREQ(contextBuf, expectedContext);
- 
+
   km_kbp_usv testSurrogateChar    = Uni_SurrogateToUTF32(0xD801, 0xDC37);  //𐐷';
   km_kbp_action_item itemAddChar2 = {KM_KBP_IT_CHAR, {0,}, {testSurrogateChar}};
   WCHAR expectedStringSurrogate[] = {'A', 0xD801, 0xDC37, 0};
@@ -46,11 +46,10 @@ TEST(AITIP, processMarkertest) {
   Globals_UninitProcess();
 }
 
-// KM_KBP_IT_BACK - processBack 
+// KM_KBP_IT_BACK - processBack
 // First test processing a backspace for a deadkey
 TEST(AITIP, processBackDeadkeytest) {
   Globals_InitProcess();
-  Globals_InitThread();
 
   WCHAR callbuf[MAXCONTEXT];
   AITIP testApp;
@@ -77,7 +76,6 @@ TEST(AITIP, processBackDeadkeytest) {
 // Also test for Unknown Character
 TEST(AITIP, processBackCharactertest) {
   Globals_InitProcess();
-  Globals_InitThread();
 
   WCHAR callbuf[MAXCONTEXT];
   AITIP testApp;
@@ -110,7 +108,6 @@ TEST(AITIP, processBackCharactertest) {
 // Note currently we don't check for a character match this should be updated
 TEST(AITIP, processBackUnexpectedChartest) {
   Globals_InitProcess();
-  Globals_InitThread();
 
   WCHAR callbuf[MAXCONTEXT];
   AITIP testApp;
@@ -135,7 +132,6 @@ TEST(AITIP, processBackUnexpectedChartest) {
 // KM_KBP_IT_INVALIDATE_CONTEXT - processInvalidateContext
 TEST(AITIP, processInvalidateContextTest) {
   Globals_InitProcess();
-  Globals_InitThread();
 
   WCHAR callbuf[MAXCONTEXT];
   AITIP testApp;
@@ -147,11 +143,10 @@ TEST(AITIP, processInvalidateContextTest) {
   processUnicodeChar(&testApp, &itemAddChar);
 
   // A keyboard a state is need to test processInvalidateContext
-  km_kbp_option_item test_env_opts[] = {{u"hello", u"world", 0}, KM_KBP_OPTIONS_END};
+  km_kbp_option_item test_env_opts[] = {{u"hello", u"world", KM_KBP_OPT_KEYBOARD}, KM_KBP_OPTIONS_END};
   km_kbp_keyboard *testKB = nullptr;
-  km_kbp_state *testState = nullptr, *test_clone = nullptr;
-  km_kbp_path_name dummyPath = L"dummyActions.mock";
-  km_kbp_status err_status = km_kbp_keyboard_load(dummyPath, &testKB);
+  km_kbp_state *testState = nullptr;
+  km_kbp_path_name dummyPath      = L"dummyActions.mock";
   EXPECT_EQ(km_kbp_keyboard_load(dummyPath, &testKB), KM_KBP_STATUS_OK);
   EXPECT_EQ(km_kbp_state_create(testKB, test_env_opts, &testState), KM_KBP_STATUS_OK);
 
@@ -162,7 +157,6 @@ TEST(AITIP, processInvalidateContextTest) {
   // dispose keyboard
   km_kbp_state_dispose(testState);
   km_kbp_keyboard_dispose(testKB);
-
   UninitialiseProcess(FALSE);
   Globals_UninitProcess();
 }

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/pch.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/pch.cpp
@@ -1,6 +1,53 @@
-//
-// pch.cpp
-// Include the standard header and generate the precompiled header.
-//
-
+/**
+ * @file
+ * @copyright (c) 2013 Stephan Brenner
+ * @license   This project is released under the MIT License.
+ *
+ * Adapted in 2021 from the gtest_mem.cpp
+ * This file implements a main() function for Google Test that runs all tests
+ * and detects memory leaks.
+ */
 #include "pch.h"
+#include <iostream>
+#include <crtdbg.h>
+#include <gtest/gtest.h>
+
+using namespace std;
+using namespace testing;
+
+namespace testing {
+class MemoryLeakDetector : public EmptyTestEventListener {
+#ifdef _DEBUG
+public:
+  virtual void
+  OnTestStart(const TestInfo&) {
+    _CrtMemCheckpoint(&memState_);
+  }
+
+  virtual void
+  OnTestEnd(const TestInfo& test_info) {
+    if (test_info.result()->Passed()) {
+      _CrtMemState stateNow, stateDiff;
+      _CrtMemCheckpoint(&stateNow);
+      int diffResult = _CrtMemDifference(&stateDiff, &memState_, &stateNow);
+      if (diffResult) {
+        FAIL() << "Memory leak of " << stateDiff.lSizes[1] << " byte(s) detected.";
+      }
+    }
+  }
+
+private:
+  _CrtMemState memState_;
+#endif  // _DEBUG
+};
+}  // namespace testing
+
+GTEST_API_ int
+main(int argc, char** argv) {
+  cout << "Running main() from pch.cpp" << endl;
+
+  InitGoogleTest(&argc, argv);
+  UnitTest::GetInstance()->listeners().Append(new MemoryLeakDetector());
+
+  return RUN_ALL_TESTS();
+}

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/pch.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/pch.cpp
@@ -1,53 +1,6 @@
-/**
- * @file
- * @copyright (c) 2013 Stephan Brenner
- * @license   This project is released under the MIT License.
- *
- * Adapted in 2021 from the gtest_mem.cpp
- * This file implements a main() function for Google Test that runs all tests
- * and detects memory leaks.
- */
+//
+// pch.cpp
+// Include the standard header and generate the precompiled header.
+//
+
 #include "pch.h"
-#include <iostream>
-#include <crtdbg.h>
-#include <gtest/gtest.h>
-
-using namespace std;
-using namespace testing;
-
-namespace testing {
-class MemoryLeakDetector : public EmptyTestEventListener {
-#ifdef _DEBUG
-public:
-  virtual void
-  OnTestStart(const TestInfo&) {
-    _CrtMemCheckpoint(&memState_);
-  }
-
-  virtual void
-  OnTestEnd(const TestInfo& test_info) {
-    if (test_info.result()->Passed()) {
-      _CrtMemState stateNow, stateDiff;
-      _CrtMemCheckpoint(&stateNow);
-      int diffResult = _CrtMemDifference(&stateDiff, &memState_, &stateNow);
-      if (diffResult) {
-        FAIL() << "Memory leak of " << stateDiff.lSizes[1] << " byte(s) detected.";
-      }
-    }
-  }
-
-private:
-  _CrtMemState memState_;
-#endif  // _DEBUG
-};
-}  // namespace testing
-
-GTEST_API_ int
-main(int argc, char** argv) {
-  cout << "Running main() from pch.cpp" << endl;
-
-  InitGoogleTest(&argc, argv);
-  UnitTest::GetInstance()->listeners().Append(new MemoryLeakDetector());
-
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Fixes #5653 
Three functions are added  `SaveKeyboardOptionsCore` `UpdateKeyboardOptionsCore` and  `RestoreKeyboardOptionsCore`. 
To facilitate in saving the keyboard processors keyboard options and then also restoring them.
Unit tests have also been added to test the added functions.

