### PR TITLE
fix(common/core): insure list pntr is incremented

### DIFF
--- a/common/core/desktop/src/km_kbp_options_api.cpp
+++ b/common/core/desktop/src/km_kbp_options_api.cpp
@@ -25,7 +25,7 @@ km_kbp_options_list_size(km_kbp_option_item const *opts)
   if (!opts)  return 0;
 
   auto n = 0;
-    for (; opts->key; ++opts){
+  for (; opts->key; ++opts) {
     ++n;
   }
 

--- a/common/core/desktop/src/km_kbp_options_api.cpp
+++ b/common/core/desktop/src/km_kbp_options_api.cpp
@@ -25,7 +25,9 @@ km_kbp_options_list_size(km_kbp_option_item const *opts)
   if (!opts)  return 0;
 
   auto n = 0;
-  while (opts->key) ++n;
+    for (; opts->key; ++opts){
+    ++n;
+  }
 
   return n;
 }

--- a/common/core/desktop/tests/unit/kmnkbd/meson.build
+++ b/common/core/desktop/tests/unit/kmnkbd/meson.build
@@ -9,7 +9,7 @@ defns=['-DKMN_KBP_STATIC']
 tests = [
   ['context-api', 'context_api.cpp'],
   ['keyboard-api', 'keyboard_api.cpp'],
-#  ['options-api', 'options_api.cpp'],
+  ['options-api', 'options_api.cpp'],
   ['state-api', 'state_api.cpp'],
   ['debug-api', 'debug_api.cpp'],
 ]

--- a/common/core/desktop/tests/unit/kmnkbd/options_api.cpp
+++ b/common/core/desktop/tests/unit/kmnkbd/options_api.cpp
@@ -17,6 +17,7 @@
 
 namespace
 {
+#if 0
   km_kbp_option_item const test_env[] =
   {
     {u"isdummy",   u"yes", 0},
@@ -48,7 +49,7 @@ namespace
     {u"hello",   u"!", KM_KBP_OPT_UNKNOWN},
     KM_KBP_OPTIONS_END
   };
-
+#endif
   km_kbp_option_item const empty_options_list[] = {KM_KBP_OPTIONS_END};
 
   km_kbp_option_item const api_mock_options[] =
@@ -62,7 +63,7 @@ namespace
 #if 0
   km::kbp::state mock_state(test_kb, test_env);
   km::kbp::state empty_state(empty_options_list, empty_options_list);
-#endif
+
 
   std::string get_json_doc(km_kbp_state * const state)
   {
@@ -77,16 +78,13 @@ namespace
   #define assert_lookup_equals(k,v,s) {if (!_assert_lookup_equals(k,v,s)) return __LINE__; }
   bool _assert_lookup_equals(std::u16string const key, std::u16string value, km_kbp_option_scope scope)
   {
-#if 0
+
     km_kbp_cp const * ret = nullptr;
     auto s = km_kbp_state_option_lookup(api_mock_options, scope,
                                          key.c_str(),
                                          &ret);
     bool v = s == KM_KBP_STATUS_OK && ret == value;
     return v;
-#else
-    return true;
-#endif
   }
 
 constexpr char const *empty_json = "\
@@ -117,7 +115,7 @@ constexpr char const *mock_json = "\
         }\n\
     }\n\
 }\n";
-
+#endif
 }
 
 int main(int, char * [])

--- a/common/core/desktop/tests/unit/kmnkbd/options_api.cpp
+++ b/common/core/desktop/tests/unit/kmnkbd/options_api.cpp
@@ -51,6 +51,14 @@ namespace
 
   km_kbp_option_item const empty_options_list[] = {KM_KBP_OPTIONS_END};
 
+  km_kbp_option_item const api_mock_options[] =
+  {
+    {u"hello",   u"world", KM_KBP_OPT_KEYBOARD},
+    {u"isdummy",     u"yes", KM_KBP_OPT_ENVIRONMENT},
+    {u"testing",     u"maybe", KM_KBP_OPT_ENVIRONMENT},
+    KM_KBP_OPTIONS_END
+  };
+
 #if 0
   km::kbp::state mock_state(test_kb, test_env);
   km::kbp::state empty_state(empty_options_list, empty_options_list);
@@ -114,10 +122,15 @@ constexpr char const *mock_json = "\
 
 int main(int, char * [])
 {
-#if 0
-  // Simple sanity tests on an empty options.
+
+  // Simple sanity tests on an empty options and mock options with 3 items.
   if (km_kbp_options_list_size(empty_options_list) != 0)
     return __LINE__;
+
+  if (km_kbp_options_list_size(api_mock_options) != 3)
+    return __LINE__;
+
+#if 0
   km_kbp_cp const *value;
   auto s = km_kbp_options_lookup(api_empty_options,
                                      KM_KBP_OPT_ENVIRONMENT,


### PR DESCRIPTION
There was a bug in `km_kbp_options_list_size` which meant it would never exit if there was at least 1 item in the list. 
The option_api unit tests are incomplete so this was not picked up. 