### PR TITLE
fix(android/engine): Fix localization on Android M

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/ContextUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/ContextUtils.java
@@ -33,7 +33,7 @@ public class ContextUtils extends ContextWrapper {
       LocaleList.setDefault(localeList);
       configuration.setLocales(localeList);
     } else {
-      configuration.locale = localeToSwitchTo;
+      configuration.setLocale(localeToSwitchTo);
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {


### PR DESCRIPTION
Fixes #5540 
Android Studio doesn't provide an emulator SDK for Android 6.0.1, so I can't repro the issue.

This PR is for @keymanapp/testers to try the PR build on a physical device with Android 6.0.1 

## User Testing
Setup: Load the PR build on an Android 6.0.1 device

* **TEST_LOCALE** Test that the Android UI language can change to different locales
1. Load Keyman for Android
2. Go to "Settings" and change the Display Language to Khmer
3. Exit the menus and go back to "Settings"
4. Verify the UI uses Khmer
5. Repeat with other Display Languages and verify the UI updates accordingly