### PR TITLE
fix(developer): ensure file modified after import from layout 🍒

### DIFF
--- a/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/windows/src/developer/TIKE/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -292,6 +292,8 @@ begin
     end;
   end;
 
+  FSavedLayoutJS := '';
+
   DoModified;
 end;
 


### PR DESCRIPTION
Fixes #5577.

Cherry-pick of #5676.

This ensures that the touch layout file is marked as modified after running Import From Layout in Keyman Developer, so that changes are not lost when you save.

@keymanapp-test-bot skip: user testing done in #5676.