### PR TITLE
chore(common): Add GitHub action to upload sources to crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,4 +1,4 @@
-name: Crowdin Action
+name: Upload translation sources to Crowdin translate.keyman.com
 
 on:
   schedule:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # At 06:00 every two weeks
     - cron: '0 6 1,15 * *'
-  push:
-    branches: [ chore/common/gh-sync-crowdin ] #master ]
 
 jobs:
   upload-sources-to-crowdin:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,38 @@
+name: Crowdin Action
+
+on:
+  schedule:
+    # At 06:00 every two weeks
+    - cron: '0 6 1,15 * *'
+  push:
+    branches: [ chore/common/gh-sync-crowdin ] #master ]
+
+jobs:
+  upload-sources-to-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: crowdin action
+      uses: crowdin/github-action@1.0.4
+      with:
+        upload_sources: true
+
+        # This is the name of the top-level directory that Crowdin will use for files.
+        # Note that this is not a "branch" in the git sense, but more like a top-level directory in your Crowdin project.
+        # This branch does NOT need to be manually created. It will be created automatically by the action.
+        crowdin_branch_name: master
+        config: 'crowdin.yml'
+
+        # TODO if we want action to auto create PRs
+        #GITHUB_TOKEN: $
+
+        # See https://translate.keyman.com/project/keyman/integrations/api
+        project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+
+        # A personal access token
+        # See https://crowdin.com/settings#api-key to generate a token
+        token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -2,9 +2,11 @@
 
 Localization for Keyman is maintained at https://translate.keyman.com
 
-Downloading and updating files between Keyman and Crowdin happens automatically
+Downloading and updating files between Keyman and Crowdin happens 
 on GitHub by way of the Crowdin git integration. The configuration file for all platforms
 is a YAML file named `/crowdin.yml`. Currently, the git integration tracks the `master` branch.
+
+A GitHub action runs every two weeks to update the source files in Crowdin, which are organized in a top-level folder "master".
 
 For most of our platforms, the only thing that needs to be done manually is to update `crowdin.yml` if new files get added
 (and of course translating the strings on the [Crowdin website](https://crowdin.com/project/keyman)).

--- a/resources/build/l10n/README.md
+++ b/resources/build/l10n/README.md
@@ -83,8 +83,10 @@ crowdin download -b master --dryrun
 To upload source files to Crowdin:
 
 ```bash
-crowdin upload sources
+crowdin upload sources -b master
 ```
+
+Note: this command uses the crowdin "branch" name (top-level folder), and doesn't necessarily correspond to the GitHub "branch" name.
 
 ### Updating DisplayLanguages.java in Keyman Engine for Android
 In Keyman for Android, the settings menu for changing display languages is maintained in


### PR DESCRIPTION
This PR adds an action to upload sources per https://support.crowdin.com/github-crowdin-action/

The source files are organized at a top level folder named "master".

For now, I've set the action to trigger every two weeks (one sprint cycle) which should suffice.

@keymanapp-test-bot skip
