### PR TITLE
fix(web): spacebar caption when functional layer differs from display layer

### DIFF
--- a/web/source/osk/oskBaseKey.ts
+++ b/web/source/osk/oskBaseKey.ts
@@ -21,6 +21,10 @@ namespace com.keyman.osk {
       return this.spec.coreID;
     }
 
+    getBaseId(): string {
+      return this.spec.baseKeyID;
+    }
+
     // Produces a small reference label for the corresponding physical key on a US keyboard.
     private generateKeyCapLabel(): HTMLDivElement {
       // Create the default key cap labels (letter keys, etc.)

--- a/web/source/osk/oskLayer.ts
+++ b/web/source/osk/oskLayer.ts
@@ -76,10 +76,10 @@ namespace com.keyman.osk {
      *  @param    {string}  keyId   key identifier
      *  @return   {Object}          Reference to key
      */
-    public findKey(coreID: string): OSKBaseKey {
+    private findKey(keyId: string): OSKBaseKey {
       for(const row of this.rows) {
         for(const key of row.keys) {
-          if(key.getCoreId() == coreID) {
+          if(key.getBaseId() == keyId) {
             return key;
           }
         }


### PR DESCRIPTION
Fixes a bug detected during testing of #5633.  Turns out it's a bug on `master` that began in 15.0.96, literally one alpha version after the previous spacebar caption fix.  This one was actually my fault this time, rather than the result of the configurable spacebar caption change.

The bug only affects scenarios like the following:

<img width="523" alt="image" src="https://user-images.githubusercontent.com/25213402/133224772-d4cd21aa-eb09-421e-99be-2791dfe351f9.png">

(From `khmer_angkor`'s numeric layer.)

As the spacebar's "functional layer" (its modifier set) doesn't match its display layer, the key-finding method wasn't actually matching the `K_SPACE` lookup.  This actually could have been affecting other related operations, the most prominent alternative being the layer's globe key... though I think there are extra checks in place there that avoided the problem.

## User Testing

Use Chrome's remote-device emulation mode to test the following while targeting a phone-form-factor device.  Use the "Test unminified KeymanWeb" test page for this.

- **TEST_LAYER_CAPTIONING**:  Touch-OSK layer shifting + spacebar captioning

    Using the `khmer_angkor` keyboard, ensure that both the `default` and `numeric` layers properly display spacebar caption text.