### PR TITLE
fix(web): Add checks for empty rows in OSK

### DIFF
--- a/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/core/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -49,7 +49,7 @@ namespace com.keyman.keyboards {
      * Matches the key code as set within Keyman Developer for the layout.
      * For example, K_R or U_0020.  Denotes either physical keys or virtual keys with custom output,
      * with no additional metadata like layer or active modifiers.
-     * 
+     *
      * Is used to determine the keycode for input events, rule-matching, and keystroke processing.
      */
     public get baseKeyID(): string {
@@ -62,20 +62,20 @@ namespace com.keyman.keyboards {
 
     /**
      * A unique identifier based on both the key ID & the 'desktop layer' to be used for the key.
-     * 
+     *
      * Allows diambiguation of scenarios where the same key ID is used twice within a layer, but
      * with different innate modifiers.  (Refer to https://github.com/keymanapp/keyman/issues/4617)
      * The 'desktop layer' may be omitted if it matches the key's display layer.
-     * 
+     *
      * Examples, given a 'default' display layer, matching keys to Keyman keyboard language:
-     * 
+     *
      * ```
-     * "K_Q" 
+     * "K_Q"
      * + [K_Q]
      * "K_Q+shift"
      * + [K_Q SHIFT]
      * ```
-     * 
+     *
      * Useful when the active layer of an input-event is already known.
      */
     public get coreID(): string {
@@ -84,7 +84,7 @@ namespace com.keyman.keyboards {
       }
 
       let baseID = this.id || '';
-      
+
       if(this.displayLayer != this.layer) {
         baseID = baseID + '+' + this.layer;
       }
@@ -95,19 +95,19 @@ namespace com.keyman.keyboards {
     /**
      * A keyboard-unique identifier to be used for any display elements representing this key
      * in user interfaces and/or on-screen keyboards.
-     * 
+     *
      * Distinguishes between otherwise-identical keys on different layers of an OSK.
      * Includes identifying information about the key's display layer.
-     * 
+     *
      * Examples, given a 'default' display layer, matching keys to Keyman keyboard language:
-     * 
+     *
      * ```
-     * "default-K_Q" 
+     * "default-K_Q"
      * + [K_Q]
      * "default-K_Q+shift"
      * + [K_Q SHIFT]
      * ```
-     * 
+     *
      * Useful when only the active keyboard is known about an input event.
      */
     public get elementID(): string {
@@ -265,8 +265,11 @@ namespace com.keyman.keyboards {
     }
 
     static polyfill(row: LayoutRow, layout: ActiveLayout, displayLayer: string, totalWidth: number, proportionalY: number) {
-      // Apply defaults, setting the width and other undefined properties for each key
       let keys=row['key'];
+      if (typeof keys === 'undefined') {
+        return;
+      }
+      // Apply defaults, setting the width and other undefined properties for each key
       for(let j=0; j<keys.length; j++) {
         let key=keys[j];
         for(var tp in ActiveKey.DEFAULT_KEY) {
@@ -402,9 +405,11 @@ namespace com.keyman.keyboards {
         var width=0;
         let row=rows[i];
         let keys=row['key'];
+        if (typeof keys === 'undefined') {
+          continue;
+        }
         for(let j=0; j<keys.length; j++) {
           let key=keys[j];
-
           // Test for a trailing comma included in spec, added as null object by IE
           if(key == null) {
             keys.length = keys.length-1;
@@ -458,6 +463,9 @@ namespace com.keyman.keyboards {
     private constructKeyMap(): {[keyId: string]: ActiveKey} {
       let map: {[keyId: string]: ActiveKey} = {};
       this.row.forEach(function(row: ActiveRow) {
+        if (typeof row === 'undefined' || typeof row.populateKeyMap !== 'function') {
+          return;
+        }
         row.populateKeyMap(map);
       });
 
@@ -544,7 +552,7 @@ namespace com.keyman.keyboards {
                 return;
               default:
                 // Refer to text/codes.ts - these are Keyman-custom "keycodes" used for
-                // layer shifting keys.  To be safe, we currently let K_TABBACK and 
+                // layer shifting keys.  To be safe, we currently let K_TABBACK and
                 // K_TABFWD through, though we might be able to drop them too.
                 let code = com.keyman.text.Codes[key.baseKeyID];
                 if(code > 50000 && code < 50011) {
@@ -639,11 +647,11 @@ namespace com.keyman.keyboards {
      * Refer to https://github.com/keymanapp/keyman/issues/254, which mentions
      * KD-11 from a prior issue-tracking system from the closed-source days that
      * resulted in an unintended extra empty row.
-     * 
+     *
      * It'll be pretty rare to see a keyboard affected by the bug, but we don't
      * 100% control all keyboards out there, so it's best we make sure the edge
      * case is covered.
-     * 
+     *
      * @param layers The layer group to be loaded for the form factor.  Will be
      *               mutated by this operation.
      */

--- a/web/source/osk/oskRow.ts
+++ b/web/source/osk/oskRow.ts
@@ -19,9 +19,11 @@ namespace com.keyman.osk {
       this.heightFraction = 1 / layerSpec.row.length;
 
       // Apply defaults, setting the width and other undefined properties for each key
-      const keys=rowSpec.key;
       this.keys = [];
-
+      const keys=rowSpec.key;
+      if (typeof keys === 'undefined') {
+        return;
+      }
       // Calculate actual key widths by multiplying by the OSK's width and rounding appropriately,
       // adjusting the width of the last key to make the total exactly 100%.
       // Overwrite the previously-computed percent.


### PR DESCRIPTION
Addresses KeymanWeb portion of #5327

If a touch keyboard has an empty row, several of the `keys` calculations generate exceptions.

## User Testing
Please wait for review comments before testing
* Use emulator for Android 5.0 (SDK 21) which exercises the polyfill code.

* **TEST_EMPTY_ROW** Verify that an OSK with an empty row displays
1. Install the PR build
2. Download and install [afghan_turkmen.kmp](https://darcywong00.github.io/examples/afghan/afghan_turkmen.kmp) which has an empty top row in the OSK
3. When the keyboard is installed, verify the OSK displays fine with an empty top row. There's no associated dictionary, so the appearance will look like a broken suggestion banner.

![Screenshot_1631609760](https://user-images.githubusercontent.com/7358010/133228771-9ce6d780-51d5-40c2-a31c-22b4b78dd10b.png)

