### PR TITLE
fix(ios): version-tagging for errors logged from the system keyboard

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Errors/SentryManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Errors/SentryManager.swift
@@ -32,7 +32,7 @@ public class SentryManager {
       log.debug("Sentry error logging enabled.")
     #endif
 
-    let infoDict = Bundle.main.infoDictionary
+    let infoDict = Bundle(for: SentryManager.self).infoDictionary
     let versionWithTag = infoDict?["KeymanVersionWithTag"] as? String ?? ""
     let environment = infoDict?["KeymanVersionEnvironment"] as? String ?? ""
     let release = "release-\(versionWithTag)"


### PR DESCRIPTION
While this doesn't address the actual error, I noticed an issue in the logs for this logged error in Sentry: https://sentry.keyman.com/share/issue/07929f28738c4be9861f858cec3363d8/

![image](https://user-images.githubusercontent.com/25213402/133374143-fc2a335b-a3c6-41cb-bedf-e0f6a00f8d88.png)

This is happening for 15.0 when the errors are logged from the system keyboard, as `Bundle.main` for the app extension is _separate_ from the main app's `Bundle.main`.  We don't set version info on the app-extension's bundle, which leads to the tag seen above.

Fortunately, we also put the version information on the framework's bundle, so we'll get more consistent tagging if we base off of that instead.

----

The actual error has been documented at #5694.