### PR TITLE
fix(developer): support chiral modifiers in debugger 🐞

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -339,8 +339,7 @@ begin
       (GetKeyState(VK_SHIFT) < 0) and
       (UIStatus = duiPaused) then
     UIStatus := duiFocusedForInput
-  else if (Message.Msg = WM_KEYDOWN) and
-    (UIStatus in [duiTest, duiFocusedForInput]) then
+  else if UIStatus in [duiTest, duiFocusedForInput] then
   begin
     Exit(ProcessKeyEvent(Message));
   end
@@ -361,7 +360,8 @@ begin
   end;
 
   case Message.Msg of
-    WM_KEYDOWN:
+    WM_KEYDOWN,
+    WM_SYSKEYDOWN:
       Handled := HandleMemoKeydown(Message);
     WM_SYSCHAR:
       Handled := FUIDisabled;
@@ -454,10 +454,10 @@ var
 begin
   Assert(Assigned(FDebugCore));
   modifier := 0;
-  if GetKeyState(VK_LCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_LCTRL or KM_KBP_MODIFIER_CTRL;
-  if GetKeyState(VK_RCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_RCTRL or KM_KBP_MODIFIER_CTRL;
-  if GetKeyState(VK_LMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_LALT or KM_KBP_MODIFIER_ALT;
-  if GetKeyState(VK_RMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_RALT or KM_KBP_MODIFIER_ALT;
+  if GetKeyState(VK_LCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_LCTRL;
+  if GetKeyState(VK_RCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_RCTRL;
+  if GetKeyState(VK_LMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_LALT;
+  if GetKeyState(VK_RMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_RALT;
   if GetKeyState(VK_SHIFT) < 0 then modifier := modifier or KM_KBP_MODIFIER_SHIFT;
   if (GetKeyState(VK_CAPITAL) and 1) = 1 then modifier := modifier or KM_KBP_MODIFIER_CAPS;
 


### PR DESCRIPTION
The ralt, rctrl, lalt, lctrl modifiers were not working correctly in the debugger.

Relates to #5013.

# User Testing

* **TEST_CHIRALITY:** test various rules with chiral modifiers

1. Start a new keyboard.
2. Chiral modifiers are `LALT`, `LCTRL`, `RALT`, `RCTRL`. Add rules to test these, along with the non-chiral modifier `SHIFT`, and verify that the rules can be matched in the debugger. For example:

  ```
  + [RALT K_A] > 'RightAlt+A works!'
  ```

3. Try and test combinations of the modifiers as well as modifiers on their own.

**Note:** you should not mix chiral and non-chiral versions of the same modifier (e.g. ALT and RALT) in the same keyboard, for the avoidance of confusion.

* **TEST_NONCHIRALITY:** test various rules with non-chiral modifiers.

1. Start a new keyboard.
2. Add rules to test various combinations of `SHIFT`, `CTRL`, `ALT` and ensure that they can be matched in the debugger.