### PR TITLE
fix(ios): prevents installation of packages without JS

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeyboardKeymanPackage.swift
@@ -14,7 +14,7 @@ public class KeyboardKeymanPackage : TypedKeymanPackage<InstallableKeyboard> {
   override internal init(metadata: KMPMetadata, folder: URL) {
     super.init(metadata: metadata, folder: folder)
     self.keyboards = []
-    
+
     if let packagedKeyboards = metadata.keyboards {
       for keyboard in packagedKeyboards {
         keyboard.packageId = self.id
@@ -22,7 +22,7 @@ public class KeyboardKeymanPackage : TypedKeymanPackage<InstallableKeyboard> {
         if(keyboard.isValid && FileManager.default.fileExists(atPath: self.sourceFolder.appendingPathComponent("\(keyboard.keyboardId).js").path)) {
           keyboards.append(keyboard)
         } else {
-          log.debug("\(keyboard.name) not valid / corresponding file not found")
+          SentryManager.breadcrumbAndLog("\(keyboard.name) not valid / corresponding file not found")
         }
       }
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LexicalModelKeymanPackage.swift
@@ -24,7 +24,7 @@ public class LexicalModelKeymanPackage : TypedKeymanPackage<InstallableLexicalMo
         if(model.isValid && FileManager.default.fileExists(atPath: self.sourceFolder.appendingPathComponent("\(model.lexicalModelId).model.js").path)) {
           models.append(model)
         } else {
-          log.debug("\(model.name) not valid / corresponding file not found")
+          SentryManager.breadcrumbAndLog("\(model.name) not valid / corresponding file not found")
         }
       }
     }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -625,7 +625,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     
   // MARK: - Adhoc keyboards
   public func parseKbdKMP(_ folder: URL, isCustom: Bool) throws -> Void {
-    guard let kmp = KeymanPackage.parse(folder) as? KeyboardKeymanPackage else {
+    guard let kmp = try? KeymanPackage.parse(folder) as? KeyboardKeymanPackage else {
       throw KMPError.wrongPackageType
     }
 
@@ -640,7 +640,7 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     
   // MARK: - Adhoc lexical models
   static public func parseLMKMP(_ folder: URL, isCustom: Bool) throws -> Void {
-    guard let kmp = KeymanPackage.parse(folder) as? LexicalModelKeymanPackage else {
+    guard let kmp = try? KeymanPackage.parse(folder) as? LexicalModelKeymanPackage else {
       throw KMPError.wrongPackageType
     }
 

--- a/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
@@ -118,11 +118,17 @@
 /* Error opening a Keyman package - package is not valid */
 "kmp-error-invalid" = "The package's file is corrupted.";
 
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "The specified package does not exist.";
+
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "This package does not contain the requested keyboard or dictionary.";
 
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "This package was not properly built - contents unknown.";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "The package's contents are not supported on mobile devices.";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "This package does not contain the expected resource type.";

--- a/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
@@ -128,7 +128,7 @@
 "kmp-error-no-metadata" = "This package was not properly built - contents unknown.";
 
 /* Error opening a Keyman package - package's contents are for desktop platforms only */
-"kmp-error-unsupported" = "The package's contents are not supported on mobile devices.";
+"kmp-error-unsupported" = "This package does not include support for your device.";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "This package does not contain the expected resource type.";

--- a/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/PackageBrowserViewController.swift
@@ -65,7 +65,15 @@ class PackageBrowserViewController: UIDocumentPickerViewController, UIDocumentPi
       return
     }
 
-    if let package = rfm.prepareKMPInstall(from: destinationUrl, alertHost: self) {
+    // The package browser view has usually self-dismissed at this point and cannot
+    // present error message alerts.  We need to find something in the view
+    // hierarchy that can present the error.
+    var alertVC: UIViewController = self
+    if self.view.superview == nil && self.navVC != nil {
+      alertVC = self.navVC!
+    }
+
+    if let package = rfm.prepareKMPInstall(from: destinationUrl, alertHost: alertVC) {
       // These type checks are necessary due to generic constraints.
       if let kbdPackage = package as? KeyboardKeymanPackage {
         doPrompt(for: kbdPackage, withAssociators: [.lexicalModels])


### PR DESCRIPTION
Fixes #5694.

Also fixes up how package-opening errors are handled and forwarded.  The package parser wasn't actually surfacing errors that arose internally, causing any error condition to report a "corrupted package," even when the cause was different.

Adds two new strings that'll need localization - these provide better, more specific messages for package problems:
- A "package is missing" message.  Shouldn't ever be seen from the app, but then again, most errors "shouldn't ever be seen".  It's best to keep it around "just in case."
- A "package is only for desktop" message.  (See `TEST_HIEROGLYPHIC` below.)

## User Testing

TEST_HIEROGLYPHIC:  Attempt to install the hieroglyphic package from https://keyman.com/keyboards/hieroglyphic.

You should see a popup message like the following:

![image](https://user-images.githubusercontent.com/25213402/133380831-dcaf3dc3-f33a-493a-b9c7-dbaa16bf3978.png)

But with this text instead:

> "This package does not include support for your device."

TEST_CAM_QWERTY:  Attempt to install the `sil_cameroon_qwerty` package from https://keyman.com/keyboards/sil_cameroon_qwerty.

It should install successfully.