### PR TITLE
fix(mac): add support for M1 processor

### DIFF
--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -1,13 +1,15 @@
 # Setup your Keyman build environment on macOS
 
+This document describes prerequisites and tools required for building various Keyman projects on macOS. Each project will also have additional notes linked below.
+
 ## Target Projects
 
 On macOS, you can build the following projects:
 
-* Keyman for Android
-* Keyman for iOS
-* Keyman for macOS
-* KeymanWeb
+* Keyman for Android ([additional details](../../android/README.md))
+* Keyman for iOS ([additional details](../../ios/README.md))
+* Keyman for macOS ([additional details](../../mac/README.md))
+* KeymanWeb ([additional details](../../web/README.md))
 
 The following libraries can also be built:
 
@@ -24,11 +26,13 @@ The following projects **cannot** be built on macOS:
 
 * Minimum macOS version: macOS Catalina 10.15 or Big Sur 11.0
 
+**Note:** to make a fully M1-compatible release build of Keyman for macOS (for the setup Applescript), Big Sur 11.0 is required, as osacompile on earlier versions does not build for arm64 (M1). The build will still work on earlier versions, but the installer won't be able to run on M1 Macs that do not have Rosetta 2 installed.
+
 ## Prerequisites
 
 Many dependencies are only required for specific projects.
 
-* XCode (iOS, macOS)
+* XCode (iOS, macOS) 12.4 or later
   * Install from App Store
   * Accept the Xcode license: `sudo xcodebuild -license accept`
 

--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -12,4 +12,6 @@ Carthage/**
 **/output
 localenv.sh
 setup/textinputsource/textinputsource
+setup/textinputsource/textinputsource.arm64
+setup/textinputsource/textinputsource.x86_64
 setup/Install Keyman.app

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,5 +1,7 @@
 # Keyman for macOS
 
+## Prerequisites
+See [build configuration](../docs/build/index.md) for details on how to configure your build environment.
 
 ## Keyman for macOS Development
 

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -29,6 +29,13 @@ fi
 osacompile -o "$SOURCEAPP" -x source/install.applescript
 cp source/applet.icns "$SOURCEAPP/Contents/Resources/applet.icns"
 
+# Add arm64 to plist so that the script is not marked as requiring Rosetta
+# ... LSArchitecturePriority
+# https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Specify-the-Launch-Behavior-of-Your-App
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority array" "$SOURCEAPP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:0 string 'arm64'" "$SOURCEAPP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:1 string 'x86_64'" "$SOURCEAPP/Contents/Info.plist"
+
 #
 # Build textinputsource
 #

--- a/mac/setup/textinputsource/Makefile
+++ b/mac/setup/textinputsource/Makefile
@@ -1,0 +1,9 @@
+# Build textinputsource for multiple architectures
+textinputsource: textinputsource.x86_64 textinputsource.arm64
+	lipo -create -output $@ $<
+
+textinputsource.x86_64: main.c
+	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target x86_64-apple-macos10.12
+
+textinputsource.arm64: main.c
+	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target arm64-apple-macos11

--- a/mac/setup/textinputsource/Makefile
+++ b/mac/setup/textinputsource/Makefile
@@ -1,9 +1,12 @@
 # Build textinputsource for multiple architectures
 textinputsource: textinputsource.x86_64 textinputsource.arm64
-	lipo -create -output $@ $<
+	lipo -create -output $@ $^
 
 textinputsource.x86_64: main.c
-	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target x86_64-apple-macos10.12
+	xcrun -sdk macosx $(CC) $^ -framework Carbon -o $@ -target x86_64-apple-macos10.12
 
 textinputsource.arm64: main.c
-	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target arm64-apple-macos11
+	xcrun -sdk macosx $(CC) $^ -framework Carbon -o $@ -target arm64-apple-macos11
+
+clean:
+	-rm textinputsource textinputsource.arm64 textinputsource.x86_64

--- a/mac/setup/textinputsource/build.sh
+++ b/mac/setup/textinputsource/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 set -u
-gcc -framework Carbon -o textinputsource main.c
+make textinputsource


### PR DESCRIPTION
Fixes #5700.

Adds support for arm64 (M1) to textinputsource in the Keyman app. All other executables are already fat with support for both x86_64 and arm64.

Note: https://help.keyman.com/knowledge-base/107 needs to be updated once this and a cherry-picked to 14 version are released.

# User Testing

* TEST_INSTALL_M1: Make sure Keyman installs on an M1 mac (I will run this test as I have the M1 mac on my desk).
* TEST_INSTALL_INTEL: Make sure Keyman installs and runs on Intel-based mac.