### PR TITLE
fix(windows): handle edge cases using default language

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -299,7 +299,7 @@ begin
         if tags.Count > 0 then
         begin
           BCP47 := tags[0].Trim;
-          if r.OpenKeyReadOnly('\' + SRegKey_ControlPanelInternationalUserProfile + '\' + tags[0].Trim) then
+          if r.OpenKeyReadOnly('\' + SRegKey_ControlPanelInternationalUserProfile + '\' + BCP47) then
             LangID := GetLangIDFromValueName;
         end;
       finally

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -169,12 +169,12 @@ begin
         if Length(FilenameBCP47) > 1
           then RegisterKeyboardPackageLanguage(FPackage, FilenameBCP47[1])
           else RegisterKeyboardPackageLanguage(FPackage, '');
-          // The keyboard will be installed for current user as a separate step
+        // The keyboard will be installed for current user as a separate step
       end
       else
       begin
         FKeyboard := (kmcom.Keyboards as IKeymanKeyboardsInstalled2).Install2(FileName, True);
-        if Length(FilenameBCP47) > 1
+        if (Length(FilenameBCP47) > 1) and (Trim(FilenameBCP47[1]) <> '')
           then BCP47Tag := FilenameBCP47[1]
           else BCP47Tag := TTIPMaintenance.GetFirstLanguage(FKeyboard);
         TTIPMaintenance.DoRegister(FKeyboard.ID, BCP47Tag);

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboard.pas
@@ -303,7 +303,8 @@ begin
         Manager.UpdateProgress('Installing Keyboard', 0, 0);
         t := TTempFileManager.Get('.log');
         try
-          if WaitForElevatedConfiguration(GetForegroundWindow, '-log "'+t.Name+'" -s -i "'+FInstallFile+'='+BCP47Tag+'" -nowelcome') = 0 then
+          if WaitForElevatedConfiguration(GetForegroundWindow, '-log "'+t.Name+'" -s -i "'+FInstallFile+'='+BCP47Tag+'"'+
+            ' -nowelcome '+TTIPMaintenance.GetUserDefaultLangParameterString) = 0 then
           begin
             // install the keyboard tip
             if not InstallTipForKeyboard(BCP47Tag) then

--- a/windows/src/engine/kmcomapi/com/keyman_implementation.pas
+++ b/windows/src/engine/kmcomapi/com/keyman_implementation.pas
@@ -48,7 +48,7 @@ uses
   keymansysteminfo;
 
 type
-  TKeyman = class(TAutoObject, IKeyman, IIntKeyman, IKeymanBCP47Canonicalization)
+  TKeyman = class(TAutoObject, IKeyman, IIntKeyman, IKeymanBCP47Canonicalization, IKeymanDefaultLanguage)
   private
     FInitialized: Boolean;
     FContext: TKeymanContext;
@@ -84,6 +84,8 @@ type
     // Reimplement as a special case for this interface
     function SerializeXML(Flags: TOleEnum; const ImagePath: WideString; out References: OleVariant): WideString; safecall;
 
+    { IKeymanDefaultLanguage }
+    procedure SetDefaultLanguage(const BCP47: WideString; LangID: Integer); safecall;
   public
     procedure Initialize; override;
     destructor Destroy; override;
@@ -288,6 +290,12 @@ begin
   finally
     FControl.AutoApply := AutoApply;
   end;
+end;
+
+procedure TKeyman.SetDefaultLanguage(const BCP47: WideString; LangID: Integer);
+begin
+  FContext.DefaultBCP47 := BCP47;
+  FContext.DefaultLangID := LangID;
 end;
 
 procedure TKeyman.Set_AutoApply(Value: WordBool);

--- a/windows/src/engine/kmcomapi/keymanapi_TLB.pas
+++ b/windows/src/engine/kmcomapi/keymanapi_TLB.pas
@@ -12,7 +12,7 @@ unit keymanapi_TLB;
 // ************************************************************************ //
 
 // $Rev: 52393 $
-// File generated on 1/02/2021 8:52:41 AM from Type Library described below.
+// File generated on 16/09/2021 6:54:44 PM from Type Library described below.
 
 // ************************************************************************  //
 // Type Lib: C:\Projects\keyman\app\windows\src\engine\kmcomapi\kmcomapi (1)
@@ -93,6 +93,7 @@ const
   IID_IKeymanKeyboardLanguageInstalled2: TGUID = '{414C26E6-BFAC-4A70-9EA1-E525BA9BBA7E}';
   IID_IKeymanKeyboardLanguagesInstalled2: TGUID = '{628FF2E6-B490-462E-8FC7-7AE53B9D392C}';
   CLASS_Keyman: TGUID = '{CF46549D-4D2D-4679-A2E1-23A815F172F8}';
+  IID_IKeymanDefaultLanguage: TGUID = '{77BAB934-B7DF-4304-AFA6-B8F6BEC16516}';
 
 // *********************************************************************//
 // Declaration of Enumerations defined in Type Library
@@ -257,6 +258,8 @@ type
   IKeymanKeyboardLanguageInstalled2Disp = dispinterface;
   IKeymanKeyboardLanguagesInstalled2 = interface;
   IKeymanKeyboardLanguagesInstalled2Disp = dispinterface;
+  IKeymanDefaultLanguage = interface;
+  IKeymanDefaultLanguageDisp = dispinterface;
 
 // *********************************************************************//
 // Declaration of CoClasses defined in Type Library
@@ -1763,6 +1766,26 @@ type
     procedure Refresh; dispid 2;
     function SerializeXML(Flags: tagKeymanSerializeFlags; const ImagePath: WideString;
                           out References: OleVariant): WideString; dispid 401;
+  end;
+
+// *********************************************************************//
+// Interface: IKeymanDefaultLanguage
+// Flags:     (4416) Dual OleAutomation Dispatchable
+// GUID:      {77BAB934-B7DF-4304-AFA6-B8F6BEC16516}
+// *********************************************************************//
+  IKeymanDefaultLanguage = interface(IDispatch)
+    ['{77BAB934-B7DF-4304-AFA6-B8F6BEC16516}']
+    procedure SetDefaultLanguage(const DefaultBCP47: WideString; DefaultLangID: Integer); safecall;
+  end;
+
+// *********************************************************************//
+// DispIntf:  IKeymanDefaultLanguageDisp
+// Flags:     (4416) Dual OleAutomation Dispatchable
+// GUID:      {77BAB934-B7DF-4304-AFA6-B8F6BEC16516}
+// *********************************************************************//
+  IKeymanDefaultLanguageDisp = dispinterface
+    ['{77BAB934-B7DF-4304-AFA6-B8F6BEC16516}']
+    procedure SetDefaultLanguage(const DefaultBCP47: WideString; DefaultLangID: Integer); dispid 201;
   end;
 
 // *********************************************************************//

--- a/windows/src/engine/kmcomapi/keymancontext.pas
+++ b/windows/src/engine/kmcomapi/keymancontext.pas
@@ -32,6 +32,8 @@ type
   private
     FKeyman: TObject;
     FController: TKeymanController;
+    FDefaultBCP47: string;
+    FDefaultLangID: Integer;
     function GetErrors: IIntKeymanErrors;
     function GetKeyboards: IIntKeymanKeyboardsInstalled;
     function GetPackages: IIntKeymanPackagesInstalled;
@@ -50,6 +52,9 @@ type
     property SystemInfo: IIntKeymanSystemInfo read GetSystemInfo;
     property Control: IIntKeymanControl read GetControl;
     property Controller: TKeymanController read FController;
+
+    property DefaultBCP47: string read FDefaultBCP47 write FDefaultBCP47;
+    property DefaultLangID: Integer read FDefaultLangID write FDefaultLangID;
   end;
 
 implementation

--- a/windows/src/engine/kmcomapi/kmcomapi.dproj
+++ b/windows/src/engine/kmcomapi/kmcomapi.dproj
@@ -124,7 +124,7 @@
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_SYMBOL_PLATFORM>false</DCC_SYMBOL_PLATFORM>
         <DCC_UNIT_PLATFORM>false</DCC_UNIT_PLATFORM>
-        <Debugger_HostApplication>..\..\desktop\kmshell\kmshell.exe</Debugger_HostApplication>
+        <Debugger_HostApplication>..\..\desktop\kmshell\bin\win32\debug\kmshell.exe</Debugger_HostApplication>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
         <Debugger_RunParams>-c</Debugger_RunParams>
         <DCC_UseMSBuildExternally>false</DCC_UseMSBuildExternally>

--- a/windows/src/engine/kmcomapi/kmcomapi.ridl
+++ b/windows/src/engine/kmcomapi/kmcomapi.ridl
@@ -6,7 +6,7 @@
 // However, when applying changes via the Editor this file will be regenerated
 // and comments or formatting changes will be lost.
 // ************************************************************************ //
-// File generated on 1/02/2021 8:52:42 AM (- $Rev: 12980 $, 9519671).
+// File generated on 16/09/2021 6:54:45 PM (- $Rev: 12980 $, 32940875).
 
 [
   uuid(F16E2A9A-DA46-4EA3-BFF3-BA46B480C961),
@@ -66,6 +66,7 @@ library keymanapi
   interface IKeymanKeyboardLanguageInstalled2;
   interface IKeymanKeyboardLanguagesInstalled2;
   interface IKeymanBCP47Canonicalization;
+  interface IKeymanDefaultLanguage;
 
 
   [
@@ -1017,6 +1018,17 @@ library keymanapi
     HRESULT _stdcall GetCanonicalTag([in] BSTR Tag, [out, retval] BSTR* Result);
     [id(0x0000012E)]
     HRESULT _stdcall GetFullTagList([in] BSTR Tag, [out, retval] VARIANT* Result);
+  };
+
+  [
+    uuid(77BAB934-B7DF-4304-AFA6-B8F6BEC16516),
+    dual,
+    oleautomation
+  ]
+  interface IKeymanDefaultLanguage: IDispatch
+  {
+    [id(0x000000C9)]
+    HRESULT _stdcall SetDefaultLanguage([in] BSTR DefaultBCP47, [in] long DefaultLangID);
   };
 
   [

--- a/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
+++ b/windows/src/global/delphi/general/Keyman.System.CanonicalLanguageCodeUtils.pas
@@ -14,6 +14,7 @@ implementation
 
 uses
   BCP47Tag,
+  GetOsVersion,
   Keyman.System.LanguageCodeUtils,
   Keyman.System.Standards.LangTagsRegistry,
   System.SysUtils;
@@ -34,6 +35,12 @@ var
   t: TBCP47Tag;
   LangTag: TLangTag;
 begin
+  // We do not try and canonicalize language tags on Windows 7, because it does
+  // not follow the same patterns as for later versions of Windows. For example,
+  // zh-CN is not canonicalized to zh-Hans-CN
+  if GetOs = osWin7 then
+    Exit(Tag);
+
   if Tag = '' then
     Exit('');
 

--- a/windows/src/global/delphi/general/klog.pas
+++ b/windows/src/global/delphi/general/klog.pas
@@ -1,18 +1,18 @@
 (*
   Name:             klog
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    8 Jun 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Disable logging with KLOGGING define
                     14 Sep 2006 - mcdurdin - Add Current Tick Count to logs (for correlation with system.log)
                     04 May 2012 - mcdurdin - I3309 - V9.0 - Migrate to Delphi XE2, VS2010, svn 1.7
@@ -22,8 +22,6 @@
 unit klog;  // I3309
 
 interface
-
-{TNT-IGNORE-UNIT}
 
 {DEFINE KLOGGING}
 
@@ -41,6 +39,7 @@ type
     FLogFile: TextFile;
     FMethodStack: TStringList;
     FFileOpen: Boolean;
+    function VarRecToString(const vr: TVarRec): string;
 {$ENDIF}
   public
     constructor Create;
@@ -50,7 +49,8 @@ type
     procedure LogError(const msg: string); overload;
     procedure LogError(const msg: string; const fmt: array of const); overload;
     procedure MethodEnter(instance: TObject; const name: string; const parameters: array of const);
-    procedure MethodExit(instance: TObject; const name: string);
+    procedure MethodExit(instance: TObject; const name: string); overload;
+    procedure MethodExit(instance: TObject; const name: string; const result: array of const); overload;
   end;
 
 function KL: TKLog;
@@ -60,8 +60,7 @@ implementation
 
 {$IFDEF KLOGGING}
 uses
-  Variants, Windows, SysUtils, ErrorControlledRegistry, ErrLogPath, VersionInfo, Unicode;
-
+  Variants, Windows, SysUtils, ErrorControlledRegistry, KeymanPaths, VersionInfo, Unicode;
 {$ENDIF}
 
 var
@@ -75,6 +74,7 @@ end;
 
 { TKLog }
 
+{$WARN SYMBOL_PLATFORM OFF}
 constructor TKLog.Create;
 {$IFDEF KLOGGING}
 
@@ -88,21 +88,21 @@ constructor TKLog.Create;
 
 var
   buf: array[0..260] of char;
-  FRootPath: string;
 begin
   inherited Create;
-  FRootPath := GetErrLogPath;
 
   FMethodStack := TStringList.Create;
-  GetModuleFileName(hInstance, buf, 260); FAppName := buf;
-  FLogFileName := FRootPath+ChangeFileExt(ExtractFileName(FAppName), '') + IntToStr(GetCurrentProcessId) + '.log';
+  GetModuleFileName(hInstance, buf, 260); FAppName := ChangeFileExt(ExtractFileName(buf),'');
+  FLogFileName := TKeymanPaths.ErrorLogPath(FAppName);
   Log(StringOfChar('=', 160));
-  Log('Starting application '+FAppName+', version '+GetFileVersionString(FAppName));
+  Log('Starting application %s, version %s', [FAppName, GetFileVersionString(FAppName)]);
+  Log('Command line: %s', [String(CmdLine)]);
 {$ELSE}
 begin
   inherited Create;
 {$ENDIF}
 end;
+{$WARN SYMBOL_PLATFORM DEFAULT}
 
 destructor TKLog.Destroy;
 {$IFDEF KLOGGING}
@@ -163,26 +163,7 @@ begin
   begin
     vr := TVarRec(parameters[i]);
     if i > Low(parameters) then s := s + ', ';
-    case vr.VType of
-      vtInteger:    s := s + IntToStr(vr.VInteger);
-      vtBoolean:    if vr.VBoolean then s := s + 'True' else s := s + 'False';
-      vtChar:       s := s + ''''+Char(vr.VChar)+'''';  // I3310
-      vtExtended:   s := s + FloatToStr(vr.VExtended^);
-      vtString:     s := s + ''''+String_AtoU(vr.VString^)+'''';  // I3310  // I3310
-      vtPointer:    s := s + '$'+IntToHex(Integer(vr.VPointer), 8);
-      vtPChar:      s := s + ''''+String_AtoU(vr.VPChar)+'''';  // I3310
-      vtObject:     if vr.VObject = nil then s := s + 'object <nil>' else s := s + 'object '+vr.VObject.ClassName+' [$'+IntToHex(Integer(Pointer(vr.VObject)), 8)+']';
-      vtClass:      if vr.VClass = nil then s := s + 'class <nil>' else s := s + 'class '+vr.VClass.ClassName;
-      vtWideChar:   s := s + ''''+vr.VWideChar+'''';
-      vtPWideChar:  s := s + ''''+vr.VPWideChar+'''';
-      vtAnsiString: s := s + ''''+string(vr.VAnsiString)+'''';
-      vtCurrency:   s := s + CurrToStr(vr.VCurrency^);
-      vtVariant:    try s := s + VarToStr(vr.VVariant^); except s := s + '<error reading variant>'; end;
-      vtInterface:  s := s + 'interface $'+IntToHex(Integer(vr.VInterface), 8);
-      vtWideString: s := s + ''''+widestring(vr.VWideString)+'''';
-      vtInt64:      s := s + IntToStr(vr.VInt64^);
-      vtUnicodeString: s := s + ''''+WideString(vr.VUnicodeString)+'''';  // I3309
-    end;
+    s := s + VarRecToString(vr);
   end;
   if Assigned(instance) then
   begin
@@ -194,6 +175,26 @@ begin
     Log(name+'('+s+') enter');
     FMethodStack.Add(name);
   end;
+{$ELSE}
+begin
+{$ENDIF}
+end;
+
+procedure TKLog.MethodExit(instance: TObject; const name: string; const result: array of const);
+{$IFDEF KLOGGING}
+var
+  s: string;
+begin
+  if Assigned(instance)
+    then s := instance.ClassName+'.'+name
+    else s := name;
+  while (FMethodStack.Count > 0) and (FMethodStack[FMethodStack.Count-1] <> s) do
+  begin
+    Log(FMethodStack[FMethodStack.Count-1] + ' not exiting properly!');
+    FMethodStack.Delete(FMethodStack.Count-1);
+  end;
+  if FMethodStack.Count > 0 then FMethodStack.Delete(FMethodStack.Count-1);
+  Log(s+'() exit('+VarRecToString(TVarRec(result[0]))+')');
 {$ELSE}
 begin
 {$ENDIF}
@@ -225,6 +226,33 @@ begin
   Log(Format(msg, fmt));
 {$ENDIF}
 end;
+
+{$IFDEF KLOGGING}
+function TKLog.VarRecToString(const vr: TVarRec): string;
+begin
+  case vr.VType of
+    vtInteger:    Result := IntToStr(vr.VInteger);
+    vtBoolean:    if vr.VBoolean then Result := 'True' else Result := 'False';
+    vtChar:       Result := ''''+Char(vr.VChar)+'''';  // I3310
+    vtExtended:   Result := FloatToStr(vr.VExtended^);
+    vtString:     Result := ''''+String_AtoU(vr.VString^)+'''';  // I3310  // I3310
+    vtPointer:    Result := '$'+IntToHex(Integer(vr.VPointer), 8);
+    vtPChar:      Result := ''''+String_AtoU(vr.VPChar)+'''';  // I3310
+    vtObject:     if vr.VObject = nil then Result := 'object <nil>' else Result := 'object '+vr.VObject.ClassName+' [$'+IntToHex(Integer(Pointer(vr.VObject)), 8)+']';
+    vtClass:      if vr.VClass = nil then Result := 'class <nil>' else Result := 'class '+vr.VClass.ClassName;
+    vtWideChar:   Result := ''''+vr.VWideChar+'''';
+    vtPWideChar:  Result := ''''+vr.VPWideChar+'''';
+    vtAnsiString: Result := ''''+string(vr.VAnsiString)+'''';
+    vtCurrency:   Result := CurrToStr(vr.VCurrency^);
+    vtVariant:    try Result := VarToStr(vr.VVariant^); except Result := '<error reading variant>'; end;
+    vtInterface:  Result := 'interface $'+IntToHex(Integer(vr.VInterface), 8);
+    vtWideString: Result := ''''+widestring(vr.VWideString)+'''';
+    vtInt64:      Result := IntToStr(vr.VInt64^);
+    vtUnicodeString: Result := ''''+UnicodeString(vr.VUnicodeString)+'''';  // I3309
+    else Result := '???';
+  end;
+end;
+{$ENDIF}
 
 function KLEnabled: Boolean;
 begin

--- a/windows/src/test/unit-tests/standards-data/GetOsVersion.pas
+++ b/windows/src/test/unit-tests/standards-data/GetOsVersion.pas
@@ -1,0 +1,18 @@
+unit GetOsVersion;
+
+interface
+
+// This is a stub version of GetOsVersion for unit tests
+type
+  TOS = (osLegacy, osVista, osWin7, osWin8, osWin10, osOther);
+
+function GetOs: TOS;
+
+implementation
+
+function GetOs: TOS;
+begin
+  Result := osWin10;
+end;
+
+end.

--- a/windows/src/test/unit-tests/standards-data/standardsdata.dpr
+++ b/windows/src/test/unit-tests/standards-data/standardsdata.dpr
@@ -22,7 +22,8 @@ uses
   Keyman.System.Standards.LangTagsRegistry in '..\..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
   Keyman.System.Standards.LCIDToBCP47Registry in '..\..\..\global\delphi\standards\Keyman.System.Standards.LCIDToBCP47Registry.pas',
   utilstr in '..\..\..\global\delphi\general\utilstr.pas',
-  Unicode in '..\..\..\global\delphi\general\Unicode.pas';
+  Unicode in '..\..\..\global\delphi\general\Unicode.pas',
+  GetOsVersion in 'GetOsVersion.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/test/unit-tests/standards-data/standardsdata.dproj
+++ b/windows/src/test/unit-tests/standards-data/standardsdata.dproj
@@ -100,6 +100,7 @@
         <DCCReference Include="..\..\..\global\delphi\standards\Keyman.System.Standards.LCIDToBCP47Registry.pas"/>
         <DCCReference Include="..\..\..\global\delphi\general\utilstr.pas"/>
         <DCCReference Include="..\..\..\global\delphi\general\Unicode.pas"/>
+        <DCCReference Include="GetOsVersion.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -141,7 +142,7 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Win32\Debug\standardsdata.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Debug\standardsdata.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>standardsdata.exe</RemoteName>
                         <Overwrite>true</Overwrite>


### PR DESCRIPTION
Fixes #5091.

Will cherry-pick to stable-14.0 after approval.

If the user has a default language that is not a minimal BCP47 tag, such as `zh-Hans-CN` vs `zh-CN`, or if the default language does not have a mapping in our `TLanguageCodeUtils.TranslateWindowsLanguagesToBCP47` function, then kmshell would crash on install of a keyboard that had no language metadata specified (i.e. neither legacy metadata in .kmx nor modern metadata in .kmp).

This crash arose because the elevated instance of kmshell would install a local-machine reference to `zh-CN` (as it back-translated from a LangID), but the current user install would look for `zh-Hans-CN`, read from the Windows registry `HKCU\Control Panel\International\User Profile`.

To further complicate matters, it is possible for the current user to have a different default language than the elevated user on the machine. Keyman was assuming that the default language was the same in both cases.

This fix passes in the current user's default BCP47 and LangID to the elevated portion of the keyboard install, so we can guarantee that keyboard install which needs to use the default language, actually installs for the current user's actual language code, and not a canonicalized version (or a totally different code in the case of elevation to an alternate admin user account).

# User Testing

GROUP_WINDOWS_10: Run these tests with Windows 10
GROUP_WINDOWS_7: Run these tests with Windows 7

* **TEST_BASELINE:** Make sure that well-specified keyboards install

1. Use US English as your system default input language.
2. Make sure that keyboards such as Khmer Angkor, SIL Euro Latin, GFF Amharic, etc, install correctly. Try a keyboard such as Brao as well to ensure that transient language tags are working.

* **TEST_LEGACY:** Test installation of keyboards without language metadata

1. Use US English as your system default input language.
2. Install the keyboards included in #5091 ([hmd.zip](https://github.com/keymanapp/keyman/files/6490913/hmd.zip)). They should have US English as their associated language.

* **TEST_BASELINE_ZH:** Make sure that well-specified keyboards install with Chinese as default language

1. Select Chinese (Simplifed) as your default input method language in Windows -- add it as a Windows input method, and then drag it to the top of the list.
2. Try installing various keyboard such as Khmer Angkor, SIL Euro Latin, GFF Amharic. Try a keyboard such as Brao as well to ensure that transient language tags are working.

* **TEST_LEGACY_ZH:** Test installation of keyboards without language metadata with Chinese as default language

1. Select Chinese (Simplifed) as your default input method language in Windows -- add it as a Windows input method, and then drag it to the top of the list.
2. Install the keyboards included in #5091 ([hmd.zip](https://github.com/keymanapp/keyman/files/6490913/hmd.zip)). They should have Chinese as their associated language -- and should no longer cause a crash!