### PR TITLE
fix(developer): add version info to Core 🐞

### DIFF
--- a/common/core/desktop/include/keyman/keyboardprocessor_version.h.in
+++ b/common/core/desktop/include/keyman/keyboardprocessor_version.h.in
@@ -1,0 +1,7 @@
+#define stringify(x) to_string(x)
+#define to_string(x) #x
+
+#define VERSION_MAJOR @majorver@
+#define VERSION_MINOR @minorver@
+#define VERSION_PATCH @patchver@
+#define VERSION_STRING stringify(@majorver@ ## . ## @minorver@ ## . ## @patchver@ ## .0)

--- a/common/core/desktop/include/keyman/meson.build
+++ b/common/core/desktop/include/keyman/meson.build
@@ -8,6 +8,8 @@
 
 ver = lib_version.split('.')
 
+# TODO: consider if 0.0.0 is an appropriate or useful library version
+
 cfg = configuration_data()
 cfg.set('lib_curr', ver[0])
 cfg.set('lib_age', ver[1])
@@ -17,6 +19,19 @@ configure_file(
   configuration: cfg,
   input: 'keyboardprocessor.h.in',
   output: 'keyboardprocessor.h',
+)
+
+project_ver = meson.project_version().split('.')
+
+vercfg = configuration_data()
+vercfg.set('majorver', project_ver[0])
+vercfg.set('minorver', project_ver[1])
+vercfg.set('patchver', project_ver[2])
+
+configure_file(
+  configuration: vercfg,
+  input: 'keyboardprocessor_version.h.in',
+  output: 'keyboardprocessor_version.h',
 )
 
 install_headers(join_paths(meson.current_build_dir(), 'keyboardprocessor.h'),

--- a/common/core/desktop/src/meson.build
+++ b/common/core/desktop/src/meson.build
@@ -5,6 +5,7 @@
 #
 
 defns = ['-DKMN_KBP_EXPORTING']
+version_res = []
 
 if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
   warns = [
@@ -46,6 +47,10 @@ if compiler.get_id() == 'msvc'
     '-DUNICODE'
   ]
   links = []
+
+  # /n = append null
+  # /c65001 = utf-8 file format
+  version_res += import('windows').compile_resources('version.rc', args:['/n','/c65001'])
 endif
 
 if compiler.get_id() == 'emscripten'
@@ -82,6 +87,7 @@ lib = library('kmnkbp0',
   'kmx/kmx_processor.cpp',
   'kmx/kmx_xstring.cpp',
   'utfcodec.cpp',
+  version_res,
   cpp_args: defns + warns + flags,
   link_args: links,
   dependencies: [rust_mock_processor],

--- a/common/core/desktop/src/version.rc
+++ b/common/core/desktop/src/version.rc
@@ -1,0 +1,36 @@
+#include <windows.h>
+#include "include/keyman/keyboardprocessor_version.h"
+
+// Encoding: UTF8 (compile with rc /c65001)
+// Use rc /n to append null to all strings
+
+1 VERSIONINFO
+  FILEVERSION		VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, 0
+  PRODUCTVERSION	VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, 0
+  FILEFLAGSMASK		0x3fL
+  FILEFLAGS		0x0L
+  FILEOS		VOS_NT_WINDOWS32
+  FILETYPE		VFT_DLL
+  FILESUBTYPE		0x0L
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "0C0904E4"
+      BEGIN
+        VALUE "CompanyName", "SIL International"
+        VALUE "FileDescription", "Keyman Core"
+        VALUE "FileVersion", VERSION_STRING
+        VALUE "InternalName", "Keyman Core"
+        VALUE "LegalCopyright", "© SIL International"
+        VALUE "LegalTrademarks", ""
+        VALUE "OriginalFilename", "KMNKBP0-0.DLL"
+        VALUE "ProductName", "Keyman Core"
+        VALUE "ProductVersion", VERSION_STRING
+        VALUE "Comments", ""
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0xc09, 1252
+    END
+  END

--- a/windows/src/test/test_i3633/verify.dpr
+++ b/windows/src/test/test_i3633/verify.dpr
@@ -62,13 +62,6 @@ begin
     end;
   end;
 
-  if str[0].ToLower.Contains('kmnkbp0-0') then
-  begin
-    // Keyman Core does not include version information
-    // TODO: this will be resolved in #5672
-    Exit('');
-  end;
-
   if str[3] <> 'SIL International' then
   begin
     Exit('File has wrong company name');


### PR DESCRIPTION
Fixes #5672.

* Adds version information to meson build for Keyman Core DLL
* Removes verify.dpr patch added in #5649 so it will be tested at build

@keymanapp-test-bot skip