### PR TITLE
fix(developer): remove empty touch rows on save

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1811,6 +1811,11 @@ $(function () {
       layer.row.push(row);
     });
 
+    builder.saveJSON(json, force);
+  };
+
+  this.saveJSON = function(force) {
+    builder.removeEmptyRows();
     var newJson = JSON.stringify(KVKL, null, '  ');
     if(force || newJson != json) {
       // When adding or deleting layers and platforms, we need to force because
@@ -2261,6 +2266,23 @@ $(function () {
         }
       }
     );
+  };
+
+  builder.removeEmptyRows = function() {
+    var json = JSON.stringify(KVKL, null, '  ');
+    for (var platform in KVKL) {
+      for (let layer of KVKL[platform].layer) {
+        let newRow = [], n = 1;
+        for(let row of layer.row) {
+          if(row.key.length > 0) {
+            row.id = n;
+            n++;
+            newRow.push(row);
+          }
+        }
+        layer.row = newRow;
+      }
+    }
   };
 
   builder.preparePlatforms();


### PR DESCRIPTION
Fixes #5327.

# User Testing

This is in the touch layout editor.

* **TEST_BASELINE**: Run through basic editing scenarios for any touch layout, and make sure that files continue to load and save and be editable.
* **TEST_CLEANUP**: Verify that empty rows are removed.

  1. Using the afghan_turkmen.zip attached to #5327, look at afghan_turkmen_1_1.keyman-touch-layout **in a text editor**.
  2. In the text editor (not in Keyman Developer), verify that the `phone` layout has a blank first row:

      ```json
      {
        "id": 1,
        "key": []
      },
      ```
  3. Load afghan_turkmen_1_1.kmn, make a single change to the touch layout, and save.
  4. In the text editor, reload the file, and verify that the `phone` layout in afghan_turkmen.keyman-touch-layout no longer has a blank first row.