### PR TITLE
chore(ios,android,windows): Update crowdin strings for Amharic

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-am-rET/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-am-rET/strings.xml
@@ -45,7 +45,7 @@
   <!-- Context: Get Started menu -->
   <string name="more_info" comment="Open the Keyman for Android help page">ተጨማሪ መረጃ</string>
   <!-- Context: Get Started menu -->
-  <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">በሚነሳበት ሰአት ይታይ\"%1$s\"</string>
+  <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">በሚነሳበት ሰአት ይታይ \"%1$s\"</string>
   <!-- Context: Android Storage Permission -->
   <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">የፊደል ገበታውን ሰሌዳ ጥቅሎችን ለመጫን ለኪይማኑ ውጫዊ ማከማቻ ለማንበብ ፈቃድ ይስጡት።</string>
   <!-- Context: Android Storage Permission -->
@@ -54,7 +54,7 @@
   <string name="keyman_settings" comment="Settings menu title">አደረጃጀት</string>
   <!-- Context: Keyman Settings menu -->
   <plurals name="installed_languages">
-    <item quantity="one">የተጫኑ ቋንዎች (%1$d)</item>
+    <item quantity="one">የተጫኑ ቋንቋዎች (%1$d)</item>
     <item quantity="other">የተጫኑ ቋንዎች (%1$d)</item>
   </plurals>
   <!-- Context: Keyman Settings menu -->

--- a/android/KMAPro/kMAPro/src/main/res/values-am-rET/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-am-rET/strings.xml
@@ -18,6 +18,10 @@
   <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">ማሻሻያዎችን ይጫኑ</string>
   <!-- Context: Title -->
   <string name="title_version" comment="Title of Keyman for Android version">ስሪት %1$s</string>
+  <!-- Context: Text label when old Chrome version installed -->
+  <string name="text_require_chrome_57" comment="Banner text when old version of Chrome is installed">ኪይማን የክሮም ስሪትን 57 ወይም አዲስ ይፈልጋል።</string>
+  <!-- Context: Button label -->
+  <string name="button_update_chrome" comment="Prompt to upgrade Chrome in the Play Store">ክሮምን ማዘመን</string>
   <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
   <string name="textview_hint" comment="Prompt to start typing">እዚህ ጋር መጻፍ ይጀምሩ &#8230;</string>
   <!-- Context: Splash screen (version/copyright info currently disabled -->
@@ -37,7 +41,7 @@
   <!-- Context: Get Started menu -->
   <string name="enable_system_keyboard" comment="Menu item to enable Keyman as system keyboard">ኪይማኑን ለሲስተም ኪቦርድ እንዲሆን ያድርጉ</string>
   <!-- Context: Get Started menu -->
-  <string name="set_keyman_as_default" comment="Menu item to set Keyman as default system keyboard">ኪማኑን መደበና የፊደል ገበታ ይሰይሙ</string>
+  <string name="set_keyman_as_default" comment="Menu item to set Keyman as default system keyboard">ኪማኑን መደበኛ የፊደል ገበታ ይሰይሙ</string>
   <!-- Context: Get Started menu -->
   <string name="more_info" comment="Open the Keyman for Android help page">ተጨማሪ መረጃ</string>
   <!-- Context: Get Started menu -->
@@ -56,7 +60,27 @@
   <!-- Context: Keyman Settings menu -->
   <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">የተጫነ የፊደል ገበታ ወይም መዝገበ ቃላት</string>
   <!-- Context: Keyman Settings menu -->
-  <string name="change_display_language" comment="Menu action to change interface language">የኪማኑን የገጽታ ቋንቋ ይቀይሩ</string>
+  <string name="change_display_language" comment="Menu action to change interface language">የገጽታ ቋንቋ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="adjust_keyboard_height" comment="Menu action to adjust keyboard height">የቋንቋ ገበታውን ቁመት ማስተካከል</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">የስፔስባሩ መግለጫ ጽሁፍ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">የፊደል ገበታ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">ቋንቋ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">ቋንቋና የፊደል ገበታ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">ባዶ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">የፊደል ገበታ ሰሌዳውን በስፔስ ባሩ ላይ አሳይ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">የቋንቋውን ስም በስፔስ ባሩ ላይ አሳይ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">ቋንቋና የፊደል ገበታውን በስፔስ ባሩ ላይ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">የስፔስባሩ መግለጫ ጽሁፍ አታሳይ</string>
   <!-- Context: Keyman Settings menu -->
   <string name="show_banner" comment="text suggestions banner">ሁልጊዜ ባነሩን አሳይ</string>
   <!-- Context: Keyman Settings menu -->
@@ -87,6 +111,12 @@
   <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">%1$s የተጨመረ ቋንቋ %2$s</string>
   <!-- Context: Select Package and Select Languages menu -->
   <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">ሁሉም ቋንቋዎች ቀደም ሲል ተጭኗል</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="drag_the_keyboard" comment="First line of adjusting keyboard height">የፊደል ገበታ ሰሌዳውን በመጎተት ቁመቱን አስተካክል</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="rotate_the_device" comment="Second line of adjusting keyboard height">ዲቫይሱን በማሽከርከር ፖርትሬቱንና ላንድስኬፑን አስተካክል</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="reset_to_defaults" comment="Button to reset to default heights">ወደ ቀደመው ሴቲንግ መልስ</string>
   <!-- Context: Keyman Web Browser -->
   <string name="hint_text" comment="Prompt to type in the browser search bar">ፈልግ ወይም URL ጻፍ</string>
   <!-- Context: Keyman Web Browser -->

--- a/android/KMEA/app/src/main/res/values-am-rET/strings.xml
+++ b/android/KMEA/app/src/main/res/values-am-rET/strings.xml
@@ -24,6 +24,10 @@
     <!-- Context: Button label -->
     <string name="label_close_keyman" comment="Close the Keyman application">ኪይማኑን ዝጋ</string>
     <!-- Context: Button label -->
+    <string name="label_forward" comment="Button to go forward">ወደፊት</string>
+    <!-- Context: Button label -->
+    <string name="label_next_input_method" comment="Switch to next input method (replaces label_close_keyman)">የሚቀጥለውን የመቀበያ ዘዴ</string>
+    <!-- Context: Button label -->
     <string name="label_download" comment="Button to confirm downloading an item">ወርዷል</string>
     <!-- Context: Button label -->
     <string name="label_install" comment="Confirmation to install a package">ጫን</string>
@@ -69,6 +73,8 @@
     <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">የእገዛ ፋይልን ለማየት ፋይል ፕሮቫይደሩ ቤተ መጽሐፍት ያስፈልገዋል %1$s</string>
     <!-- Context: Fatal keyboard error. Will load default keyboard -->
     <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">የገበታ ሰሌዳ ፋታል ችግር ዝርዝር %1$s:%2$s ለ %3$s ቋንቋ፤ መደበኛ ቋንቋ ጭኗል።</string>
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">የፊደል ገበታ ሰሌዳው ችግር %1$s:%2$s ለ %3$s ቋንቋ።</string>
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">ተያያዥነት ያለውን መዝገበ ቃላት ለመጫን እየፈተሸ ነው።</string>
     <!-- Context: Model Updates -->

--- a/ios/engine/KMEI/KeymanEngine/am.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/am.lproj/Localizable.strings
@@ -49,6 +49,12 @@
 /* Confirmation text to display before uninstalling a lexical model */
 "command-uninstall-lexical-model-confirm" = "ይህንን መዝገበ ቃላት ልታጠፋው ትፈልጋለህ?";
 
+/* Text for error when a keyboard cannot load properly */
+"error-loading-keyboard" = "የተጠየቀው የፊደል ገበታ ሰሌዳውን ሊጫን አልተቻለም";
+
+/* Text for error when a lexical model cannot load properly */
+"error-loading-lexical-model" = "የተጠየቀው ዲክሽናሪ ሊጫን አልተቻለም";
+
 /* Text for error when an installed file is unexpectedly missing */
 "error-missing-file" = "የእርዳታ ሰነዱን ማግኘት አልተቻለም።";
 
@@ -180,6 +186,36 @@
 
 /* Title for the main Settings menu */
 "menu-settings-title" = "የኪይማን ቅንብሮች";
+
+/* Secondary text showing current setting for spacebar caption - blank */
+"menu-settings-spacebar-hint-blank" = "የስፔስባሩ መግለጫ ጽሁፍ አታሳይ";
+
+/* Secondary text showing current setting for spacebar caption - keyboard */
+"menu-settings-spacebar-hint-keyboard" = "የፊደል ገበታ ሰሌዳውን ስም በስፔስ ባሩ ላይ አሳይ";
+
+/* Secondary text showing current setting for spacebar caption - language */
+"menu-settings-spacebar-hint-language" = "የቋንቋውን ስም በስፔስ ባሩ ላይ አሳይ";
+
+/* Secondary text showing current setting for spacebar caption - language + keyboard */
+"menu-settings-spacebar-hint-languageKeyboard" = "ቋንቋና የፊደል ገበታውን በስፔስ ባሩ ላይ";
+
+/* Label for the "Spacebar Caption" item on the main settings screen */
+"menu-settings-spacebar-text" = "የስፔስባሩ መግለጫ ጽሁፍ";
+
+/* Title for the "Spacebar Caption" settings screen */
+"menu-settings-spacebar-title" = "የስፔስባሩ መግለጫ ጽሁፍ";
+
+/* Text showing name of spacebar caption - blank */
+"menu-settings-spacebar-item-blank" = "ባዶ";
+
+/* Text showing name of spacebar caption - keyboard */
+"menu-settings-spacebar-item-keyboard" = "የፊደል ገበታ ሰሌዳ";
+
+/* Text showing name of spacebar caption - language */
+"menu-settings-spacebar-item-language" = "ቋንቋ";
+
+/* Text showing name of spacebar caption - language + keyboard */
+"menu-settings-spacebar-item-languageKeyboard" = "ቋንቋና የፊደል ገበታ";
 
 /* Short text for notification:  download failure for keyboard */
 "notification-download-failure-keyboard" = "የፊደል ገበታ ሰሌዳ መውረድ አልቻለም";

--- a/windows/src/desktop/kmshell/locale/am-ET/strings.xml
+++ b/windows/src/desktop/kmshell/locale/am-ET/strings.xml
@@ -215,7 +215,7 @@
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">የፊደል ገበታ ሰሌዳን ጫን...</string>
+  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">የፊደል ገበታ ሰሌዳ ጫን...</string>
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -276,7 +276,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 9.0.480.0 -->
-  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">የሃርድዌር ዴድኪዎችን እንደ ተራ ቁልፍ አድርገው ይይዟቸው</string>
+  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">የሃርድዌር ዴድኪዎችን እንደ ተራ ቁልፍ አድርገው ይያዟቸው</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.244.0 -->
@@ -312,7 +312,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.236.0 -->
-  <string name="koReleaseShiftKeysAfterKeyPress" comment="OSK options - Releases shift/ctrl/alt on OSK after key press">የስክሪን ላይ ኪቦርዱን ፊደሉን ከተጫኑ በኋላ Shift/Ctrl/Alt ይልቀቁ</string>
+  <string name="koReleaseShiftKeysAfterKeyPress" comment="OSK options - Releases shift/ctrl/alt on OSK after key press">የስክሪን ኪቦርድ ላይ ያለውን ፊደል ከተጫኑ በኋላ Shift/Ctrl/Alt ይልቀቁ</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.244.0 -->
@@ -365,11 +365,11 @@
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Hotkey_TurnKeymanOff" comment="Hotkey - Turn Product Off">ኪይማኑን ያጥፉ</string>
+  <string name="S_Hotkey_TurnKeymanOff" comment="Hotkey - Turn Product Off">ኪይማኑን አጥፋ</string>
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Hotkey_OpenKeyboardMenu" comment="Hotkey - Open Keyman system tray menu">የፊደል ገበታውን ዝርዝር ይክፈቱ</string>
+  <string name="S_Hotkey_OpenKeyboardMenu" comment="Hotkey - Open Keyman system tray menu">የፊደል ገበታውን ዝርዝር ክፈት</string>
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -629,7 +629,7 @@
   <!-- Context: _LanguageInfo -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.278.0 -->
-  <string name="S_DisplayIn" comment="'Display In' text label for UI language menu">በውስጥ አሳይ</string>
+  <string name="S_DisplayIn" comment="'Display In' text label for UI language menu">ቋንቋ በ</string>
   <!-- Context: _LanguageInfo -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.278.0 -->
@@ -733,7 +733,7 @@
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">ኪይማኑን ያጥፉ</string>
+  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">ኪይማኑን አጥፋ (&amp;O)</string>
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->


### PR DESCRIPTION
This updates the latest strings for Amharic

## User Testing ##
Install the PR build of Keyman for Android on an Android 5.0 emulator

* **TEST_ANDROID** - Tests for new Amharic strings
1. Start the app
2. From the "Settings" menu --> Display Language -> Amharic
3. Verify the app refreshes with Amharic strings. The Android 5.0 device will have a banner with a blue button prompting the user to upgrade WebView. This is one of the new Amharic strings
![Screenshot_1632105534](https://user-images.githubusercontent.com/7358010/133952455-aeda84b6-7043-4bf0-9cea-e34f33434c8c.png)

* **TEST_IOS**  - Tests for new Amharic strings
1. Start the app
2. Change the UI to Amharic locale
3. Verify the app refreshes with Amharic strings
