### PR TITLE
fix(web): Null check for calculating globe key position

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -322,7 +322,7 @@ namespace com.keyman.text {
    **/
   keymanweb['touchMenuPos'] = function() {
     let osk = keymanweb.osk;
-    if(osk.vkbd.lgKey == null) {
+    if(osk.vkbd == null || osk.vkbd.lgKey == null) {
       return '';
     }
 


### PR DESCRIPTION
Fixes #5725 and Sentry issue [#4292](http://sentry.keyman.com/organizations/keyman/issues/4292/?project=7)

> Uncaught TypeError: Cannot read property 'lgKey' of null

## User Testing
Load the PR build in an Android 5.1 or Android 6.0 emulator

* **TEST_GLOBE** Tests that there's no exceptions getting the globe key position
1. Start the app in portrait orientation
2. Verify no Toast notifications appear about keyboard error
3. Rotate the device between portrait and landscape orientation several times
4. Verify after each rotation no keyboard errors appear
