### PR TITLE
fix(developer): run kmlmc from Keyman source path

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -291,7 +291,8 @@ uses
   Keyman.System.VisualKeyboardImportKMX in 'main\Keyman.System.VisualKeyboardImportKMX.pas',
   Keyman.UI.Debug.CharacterGridRenderer in 'debug\Keyman.UI.Debug.CharacterGridRenderer.pas',
   UfrmDebugStatus_Platform in 'debug\UfrmDebugStatus_Platform.pas' {frmDebugStatus_Platform},
-  UfrmDebugStatus_Options in 'debug\UfrmDebugStatus_Options.pas' {frmDebugStatus_Options};
+  UfrmDebugStatus_Options in 'debug\UfrmDebugStatus_Options.pas' {frmDebugStatus_Options},
+  Keyman.Developer.System.KeymanDeveloperPaths in 'main\Keyman.Developer.System.KeymanDeveloperPaths.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -557,6 +557,9 @@
             <Form>frmDebugStatus_Options</Form>
             <FormType>dfm</FormType>
         </DCCReference>
+        <DCCReference Include="main\Keyman.Developer.System.KeymanDeveloperPaths.pas">
+            <Form>$R *.RES</Form>
+        </DCCReference>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/main/Keyman.Developer.System.KeymanDeveloperPaths.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.System.KeymanDeveloperPaths.pas
@@ -1,0 +1,33 @@
+unit Keyman.Developer.System.KeymanDeveloperPaths;
+
+interface
+
+uses
+  System.SysUtils,
+
+  KeymanPaths;
+
+type
+  TKeymanDeveloperPaths = class sealed
+  private
+  public
+    const S_LexicalModelCompiler = 'kmlmc.cmd';
+    class function LexicalModelCompilerPath: string; static;
+  end;
+
+implementation
+
+{ TKeymanDeveloperPaths }
+
+class function TKeymanDeveloperPaths.LexicalModelCompilerPath: string;
+var
+  KeymanRoot: string;
+begin
+  if TKeymanPaths.RunningFromSource(KeymanRoot)
+    then Result := KeymanRoot + 'windows\src\developer\tike\'
+    else Result := ExtractFilePath(ParamStr(0));
+
+  Result := Result + S_LexicalModelCompiler;
+end;
+
+end.

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -120,7 +120,8 @@ uses
   Keyman.System.CanonicalLanguageCodeUtils in '..\..\global\delphi\general\Keyman.System.CanonicalLanguageCodeUtils.pas',
   Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
   Keyman.Developer.System.Project.UrlRenderer in '..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas',
-  Keyman.Developer.System.ValidateRepoChanges in 'Keyman.Developer.System.ValidateRepoChanges.pas';
+  Keyman.Developer.System.ValidateRepoChanges in 'Keyman.Developer.System.ValidateRepoChanges.pas',
+  Keyman.Developer.System.KeymanDeveloperPaths in '..\TIKE\main\Keyman.Developer.System.KeymanDeveloperPaths.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -276,6 +276,7 @@
         <DCCReference Include="..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <DCCReference Include="Keyman.Developer.System.ValidateRepoChanges.pas"/>
+        <DCCReference Include="..\TIKE\main\Keyman.Developer.System.KeymanDeveloperPaths.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -353,7 +354,7 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Win32\Release\kmcomp.exe" Configuration="Release" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Release\kmcomp.exe" Configuration="Release" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>kmcomp.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/windows/src/global/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
+++ b/windows/src/global/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
@@ -4,7 +4,8 @@ interface
 
 uses
   Keyman.Developer.System.Project.ProjectFile,
-  Keyman.Developer.System.Project.ProjectLog;
+  Keyman.Developer.System.Project.ProjectLog,
+  Keyman.Developer.System.KeymanDeveloperPaths;
 
 function CompileModelFile(ProjectFile: TProjectFile; infile, outfile: string; debug: Boolean): Boolean;
 
@@ -25,7 +26,8 @@ var
 begin
   ec := 0;
   logtext := '';
-  cmdline := Format('"%skmlmc.cmd" "%s" -o "%s"', [ExtractFilePath(ParamStr(0)), infile, outfile]);
+
+  cmdline := Format('"%s" "%s" -o "%s"', [TKeymanDeveloperPaths.LexicalModelCompilerPath, infile, outfile]);
   Result := TUtilExecute.Console(cmdline, ExtractFileDir(infile), logtext, ec);
 
   logtext := UTF8ToString(AnsiString(logtext));


### PR DESCRIPTION
Makes it possible to run the kmlmc.cmd compiler wrapper script from Keyman Developer while debugging from source.

Adds a new class `TKeymanDeveloperPaths` which is similar to `TKeymanPaths`, to provide a future single location for all Keyman Developer path-related functions. There are a number scattered through the source at present, e.g. in `RedistFiles.pas`, so this is just a starting point.

@keymanapp-test-bot skip