### PR TITLE
fix(mac): add support for M1 processor 🍒

### DIFF
--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -12,4 +12,6 @@ Carthage/**
 **/output
 localenv.sh
 setup/textinputsource/textinputsource
+setup/textinputsource/textinputsource.arm64
+setup/textinputsource/textinputsource.x86_64
 setup/Install Keyman.app

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -29,6 +29,13 @@ fi
 osacompile -o "$SOURCEAPP" -x source/install.applescript
 cp source/applet.icns "$SOURCEAPP/Contents/Resources/applet.icns"
 
+# Add arm64 to plist so that the script is not marked as requiring Rosetta
+# ... LSArchitecturePriority
+# https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Specify-the-Launch-Behavior-of-Your-App
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority array" "$SOURCEAPP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:0 string 'arm64'" "$SOURCEAPP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:1 string 'x86_64'" "$SOURCEAPP/Contents/Info.plist"
+
 #
 # Build textinputsource
 #

--- a/mac/setup/textinputsource/Makefile
+++ b/mac/setup/textinputsource/Makefile
@@ -1,0 +1,9 @@
+# Build textinputsource for multiple architectures
+textinputsource: textinputsource.x86_64 textinputsource.arm64
+	lipo -create -output $@ $<
+
+textinputsource.x86_64: main.c
+	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target x86_64-apple-macos10.12
+
+textinputsource.arm64: main.c
+	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target arm64-apple-macos11

--- a/mac/setup/textinputsource/Makefile
+++ b/mac/setup/textinputsource/Makefile
@@ -1,9 +1,12 @@
 # Build textinputsource for multiple architectures
 textinputsource: textinputsource.x86_64 textinputsource.arm64
-	lipo -create -output $@ $<
+	lipo -create -output $@ $^
 
 textinputsource.x86_64: main.c
-	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target x86_64-apple-macos10.12
+	xcrun -sdk macosx $(CC) $^ -framework Carbon -o $@ -target x86_64-apple-macos10.12
 
 textinputsource.arm64: main.c
-	xcrun -sdk macosx $(CC) $< -framework Carbon -o $@ -target arm64-apple-macos11
+	xcrun -sdk macosx $(CC) $^ -framework Carbon -o $@ -target arm64-apple-macos11
+
+clean:
+	-rm textinputsource textinputsource.arm64 textinputsource.x86_64

--- a/mac/setup/textinputsource/build.sh
+++ b/mac/setup/textinputsource/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 set -u
-gcc -framework Carbon -o textinputsource main.c
+make textinputsource


### PR DESCRIPTION
Fixes #5700.

Cherry pick of #5701.

Adds support for arm64 (M1) to textinputsource in the Keyman app. All other executables are already fat with support for both x86_64 and arm64.

Note: https://help.keyman.com/knowledge-base/107 needs to be updated once this and a cherry-picked to 14 version are released.

# User Testing

* TEST_INSTALL_M1: Make sure Keyman installs on an M1 mac (I will run this test as I have the M1 mac on my desk).
* TEST_INSTALL_INTEL: Make sure Keyman installs and runs on Intel-based mac.