### PR TITLE
fix(developer): move ampersand to shift+7 on touch

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/template-basic.keyman-touch-layout
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/template-basic.keyman-touch-layout
@@ -377,7 +377,7 @@
               {"id": "K_2","layer":"shift","text": "@"},
               {"id": "K_3","layer":"shift","text": "#"},
               {"id": "K_5","layer":"shift","text": "%"},
-              {"id": "K_6","layer":"shift","text": "&"},
+              {"id": "K_7","layer":"shift","text": "&"},
               {"id": "K_HYPHEN","layer":"shift","text": "_"},
               {"id": "K_EQUAL","text": "=","layer":"default"},
               {"id": "K_BKSLASH","layer":"shift","text": "|"},

--- a/windows/src/developer/TIKE/xml/layoutbuilder/template-traditional.keyman-touch-layout
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/template-traditional.keyman-touch-layout
@@ -22,7 +22,7 @@
               {"id": "K_EQUAL","text": "="},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -38,7 +38,7 @@
               {"id": "K_P","text":"p"},
               {"id": "K_LBRKT","text":"["},
               {"id": "K_RBRKT","text":"]"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -84,7 +84,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "1"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "1"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}
             ]
           }
         ]
@@ -109,7 +109,7 @@
               {"id": "K_EQUAL","text": "+"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -125,7 +125,7 @@
               {"id": "K_P","text":"P"},
               {"id": "K_LBRKT","text":"{"},
               {"id": "K_RBRKT","text":"}"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -171,7 +171,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "1"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "1"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}
             ]
           }
         ]
@@ -196,7 +196,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -212,7 +212,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -258,7 +258,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "1"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "1"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}
             ]
           }
         ]
@@ -283,7 +283,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -299,7 +299,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -345,7 +345,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "1"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "1"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}
             ]
           }
         ]
@@ -370,7 +370,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -386,7 +386,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -432,7 +432,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "2"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "2"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}
             ]
           }
         ]
@@ -457,7 +457,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -473,7 +473,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -519,7 +519,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "2"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "2"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "1"}
             ]
           }
         ]
@@ -544,7 +544,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -560,7 +560,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -606,7 +606,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "2"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "2"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}
             ]
           }
         ]
@@ -631,7 +631,7 @@
               {"id": "K_EQUAL"},
               {"id": "K_BKSP","text": "*BkSp*","width": "100","sp": "1"}
             ]
-          },         
+          },
           {
             "id": 2,
             "key": [
@@ -647,7 +647,7 @@
               {"id": "K_P"},
               {"id": "K_LBRKT"},
               {"id": "K_RBRKT"},
-              {"sp":"10","width":"10"}              
+              {"sp":"10","width":"10"}
             ]
           },
           {
@@ -693,7 +693,7 @@
               {"id": "K_LALT","text": "*Alt*","width": "130","sp": "2"},
               {"id": "K_SPACE","text": "","width": "675","sp": "0"},
               {"id": "K_RALT","text": "*AltGr*","width": "130","sp": "2"},
-              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}              
+              {"id": "K_RCONTROL","text": "*Ctrl*","width": "130","sp": "2"}
             ]
           }
         ]
@@ -733,7 +733,7 @@
               {"id": "K_J","text":"j"},
               {"id": "K_K","text":"k"},
               {"id": "K_L","text":"l"},
-              {"text": "","width": "10","sp": "10"}                            
+              {"text": "","width": "10","sp": "10"}
             ]
           },
           {
@@ -802,7 +802,7 @@
               {"id": "K_J","text":"J"},
               {"id": "K_K","text":"K"},
               {"id": "K_L","text":"L"},
-              {"text": "","width": "10","sp": "10"}                            
+              {"text": "","width": "10","sp": "10"}
             ]
           },
           {
@@ -866,7 +866,7 @@
               {"id": "K_2","layer":"shift","text": "@"},
               {"id": "K_3","layer":"shift","text": "#"},
               {"id": "K_5","layer":"shift","text": "%"},
-              {"id": "K_6","layer":"shift","text": "&"},
+              {"id": "K_7","layer":"shift","text": "&"},
               {"id": "K_HYPHEN","layer":"shift","text": "_"},
               {"id": "K_EQUAL","text": "=","layer":"default"},
               {"id": "K_BKSLASH","layer":"shift","text": "|"},


### PR DESCRIPTION
Fixes #5702.

On the phone layout for two templates, ampersand (`&`) was on <kbd>Shift</kbd>+<kbd>6</kbd> instead of on <kbd>Shift</kbd>+<kbd>7</kbd>.

# User Testing

TEST_IMPORT: Follow the steps in #5702 to import a template and confirm that the ampersand is on <kbd>Shift</kbd>+<kbd>7</kbd> on phone and tablet layouts, numeric layer. Check this in both Basic and Traditional templates.