### PR TITLE
fix(android/engine): Remove unnecessary permissions from Manifest

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -3,11 +3,9 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.tavultesoft.kmapro">
 
-  <!-- Keyman Engine removes INTERNET permission, so replace that -->
+  <!-- Keyman Engine removes INTERNET permission, so add it back -->
   <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
-
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.VIBRATE" />
 

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.tavultesoft.kmapro">
 
-  <uses-permission android:name="android.permission.INTERNET" />
+  <!-- Keyman Engine removes INTERNET permission, so replace that -->
+  <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
+
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.tavultesoft.kmea" >
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Ensure these permissions aren't added by dependencies unless calling app intentionally adds them -->

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.tavultesoft.kmea" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="com.tavultesoft.kmea" >
 
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
+
+    <!-- Ensure these permissions aren't added by dependencies unless calling app intentionally adds them -->
+    <uses-permission android:name="android.permission.INTERNET" tools:node="remove" />
 
     <application
         android:theme="@style/AppTheme" >

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -127,8 +127,8 @@ final class KMKeyboard extends WebView {
 
     // Normally, this would be true to prevent the WebView from accessing the network.
     // But this needs to false for sending embedded KMW crash reports to Sentry (keymanapp/keyman#3825)
-    // Throws SecurityException if INTERNET permission not granted
     if (KMManager.hasInternetPermission(context)) {
+      // Throws SecurityException if INTERNET permission not granted
       getSettings().setBlockNetworkLoads(!KMManager.getMaySendCrashReport());
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -23,9 +23,11 @@ import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMString;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -125,7 +127,10 @@ final class KMKeyboard extends WebView {
 
     // Normally, this would be true to prevent the WebView from accessing the network.
     // But this needs to false for sending embedded KMW crash reports to Sentry (keymanapp/keyman#3825)
-    getSettings().setBlockNetworkLoads(!KMManager.getMaySendCrashReport());
+    // Throws SecurityException if INTERNET permission not granted
+    if (KMManager.hasInternetPermission(context)) {
+      getSettings().setBlockNetworkLoads(!KMManager.getMaySendCrashReport());
+    }
 
     getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
     getSettings().setSupportZoom(false);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -724,23 +724,40 @@ public final class KMManager {
     }
   }
 
+  /**
+   * Query the AndroidManifest file to see if a permission is granted.
+   * @param permission - The manifest permission to query
+   * @return boolean - true if the manifest permission is granted
+    */
+  protected static boolean hasPermission(Context context, String permission) {
+    // API to check permission depends on Android SDK level
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED);
+    }
+
+    return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+  }
+
+  /**
+   * Check if KMManager has an active network connection.
+   * Requires Manifest.permission.ACCESS_NETWORK_STATE to be granted
+   * @param context - The context
+   * @return boolean - true if manifest permission ACCESS_NETWORK_STATE is granted and the device
+   * has an active network connection
+   */
+  @SuppressLint("MissingPermission")
   public static boolean hasConnection(Context context) {
-    ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    NetworkInfo networkInfo = cm.getActiveNetworkInfo();
-    if (networkInfo != null && networkInfo.isConnectedOrConnecting()) {
-      return true;
+    if (hasPermission(context, Manifest.permission.ACCESS_NETWORK_STATE)) {
+      ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+      NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+      return networkInfo != null && networkInfo.isConnectedOrConnecting();
     }
 
     return false;
   }
 
   public static boolean hasInternetPermission(Context context) {
-    // Check if the Internet permission has been granted
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return (context.checkSelfPermission(Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED);
-    }
-
-    return ContextCompat.checkSelfPermission(context, Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED;
+    return hasPermission(context, Manifest.permission.INTERNET);
   }
 
   private static void copyAssets(Context context) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -16,12 +16,14 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -52,6 +54,8 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
+
+import androidx.core.content.ContextCompat;
 
 import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
@@ -722,23 +726,21 @@ public final class KMManager {
 
   public static boolean hasConnection(Context context) {
     ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-
-    NetworkInfo wifiNetwork = cm.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-    if (wifiNetwork != null && wifiNetwork.isConnected()) {
-      return true;
-    }
-
-    NetworkInfo mobileNetwork = cm.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
-    if (mobileNetwork != null && mobileNetwork.isConnected()) {
-      return true;
-    }
-
-    NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-    if (activeNetwork != null && activeNetwork.isConnected()) {
+    NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+    if (networkInfo != null && networkInfo.isConnectedOrConnecting()) {
       return true;
     }
 
     return false;
+  }
+
+  public static boolean hasInternetPermission(Context context) {
+    // Check if the Internet permission has been granted
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return (context.checkSelfPermission(Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED);
+    }
+
+    return ContextCompat.checkSelfPermission(context, Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED;
   }
 
   private static void copyAssets(Context context) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -367,6 +367,9 @@ public class CloudRepository {
 
     if(cacheValid && shouldUseMemCache(context)) {
       return; // isn't null - checked by `shouldUseCache`.
+    } else if (!KMManager.hasInternetPermission(context) || !KMManager.hasConnection(context)) {
+      // noop if no internet permission or network connection
+      return;
     }
 
     // check if cache file is valid

--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.firstvoices.keyboards" >
 
-    <!-- Keyman Engine removes INTERNET permission, so replace that -->
+    <!-- Keyman Engine removes INTERNET permission, so add it back for crash reporting -->
     <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
 
     <application

--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.firstvoices.keyboards" >
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Keyman Engine removes INTERNET permission, so replace that -->
+    <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Starts to address #5396 

The Keyman Engine for Android classes for `cloud/`, `data/`, and `logic/` are too entangled to move from Keyman Engine to the Keyman app.
As a stopgap, this PR removes the unnecessary permissions from the engine's Android_Manifest.xml file:
*  INTERNET
* READ_EXTERNAL_STORAGE
* ACCESS_NETWORK_STATE (per review comment)
 
Some internal calls also updated to handle when those permissions aren't available.

Apps using Keyman Engine for Android can then add those permissions back in their Manifest file (e.g. Keyman and FirstVoices).

## User Testing

* **TEST_KEYMAN_SDK_21** - Tests Keyman on Android 5.0
1. Start an Android 5.0 emulator (SDK 21) and disable network access
2. Load the PR build of Keyman
3. On the "Get Started" menu -->Add a keyboard for your language
4. On the next menu, select "Install from keyman.com"
5. Verify a "Cannot connect to Keyman server!" dialog appears
6. Click "OK" to dismiss
7. On the device, enable network access
8. On the same Keyman menu, select "Install from keyman.com"
9. Verify a keyboard search page appears
10. Search for "khmer_angkor" keyboard and click through to Install the keyboard
11. Verify the keyboard package downloads and the keyboard installation wizard appears
12. Click "Install" and "OK"
13. Verify the khmer_angkor keyboard is installed
14. Open the "Chrome" app and save [sil_cameroon_qwertry.kmp](https://downloads.keyman.com/keyboards/sil_cameroon_qwerty/6.0.5/sil_cameroon_qwerty.kmp) to the device
15. Return to the Keyman app to the yellow text area
16. Go to "Settings" --> Install Keyboard or Dictionary --> Install from local file
17. Browse to Downloads --> select the downloaded sil_cameroon_qwerty.kmp file
18. Verify the keyboard installation wizard appears
19. Click "Next" --> select a language --> Install --> OK
20. Verify the sil_cameroon_qwerty keyboard is installed

* **TEST_KEYMAN_SDK_30** - Tests Keyman on Android 11.0

1. Repeat the steps for TEST_KEYMAN_SDK_21 using an Android 11.0 emulator (SDK 30). Remember the test starts with disabled network access.

* **TEST_KMSAMPLE1_SDK_30** - Tests app without INTERNET and ACCESS_NETWORK_STATE permissions
1. Start an Android 11 emulator (SDK 30) and disable network access
2. Load the PR build of KMSample1
3. Verify the app launches without crashing
4. Press various keys and suggestions and verify they work
 