### PR TITLE
fix(linux): Don't crash with non-keyboard package file 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -65,6 +65,15 @@ class InstallKmpWindow(Gtk.Dialog):
         with tempfile.TemporaryDirectory() as tmpdirname:
             extract_kmp(kmpfile, tmpdirname)
             info, system, options, keyboards, files = get_metadata(tmpdirname)
+            if not keyboards:
+                # Likely not a keyboard .kmp file
+                logging.info("%s is not a Keyman keyboard package" % kmpfile)
+                dialog = Gtk.MessageDialog(viewkmp, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+                    _("The file '{kmpfile}' is not a Keyman keyboard package!").format(kmpfile=kmpfile))
+                dialog.run()
+                dialog.destroy()
+                self.checkcontinue = False
+                return
             if len(keyboards) > 0 and 'name' in keyboards[0]:
                 self.kbname = keyboards[0]['name']
             else:


### PR DESCRIPTION
If a user tries to a install a model .kmp file, we now display a message box instead of crashing.

Fixes #5753.

(:cherries:-picked from #5754)

New message box:
![Screenshot from 2021-09-27 17-00-00](https://user-images.githubusercontent.com/181336/134934048-fec8a93c-bf95-4d3e-afba-31d452328e11.png)

# User Testing

- TEST_FIX: verify message box appears when trying to install model file

    - download a model file, e.g. https://downloads.keyman.com/models/aozcq.rar-latn.cook_islands_maori/1.2/aozcq.rar-latn.cook_islands_maori.model.kmp
    - try to install the model file by running `km-config -i $HOME/Downloads/aozcq.rar-latn.cook_islands_maori.model.kmp` (you might have to adjust the path to the .kmp file)
    - verify a message box similar to the above one is shown
