### PR TITLE
fix(linux): Don't crash displaying keyboard details 🍒

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -107,7 +107,7 @@ class KeyboardDetailsView(Gtk.Dialog):
         label.set_selectable(True)
         grid.attach_next_to(label, lbl_pkg_vrs, Gtk.PositionType.RIGHT, 1, 1)
 
-        if kbdata:
+        if kbdata and kbdata.get('description'):
             lbl_pkg_desc = Gtk.Label()
             lbl_pkg_desc.set_text(_("Package description:   "))
             lbl_pkg_desc.set_halign(Gtk.Align.END)


### PR DESCRIPTION
At least one user got a crash trying to click on the "About" button to display keyboard details for the ekwtamil99uni keyboard. I can't reproduce the problem, but this change adds additional code that should prevent the crash from happening.

Fixes #5756.

# User testing

- TEST_TAMIL: "About" doesn't crash for ekwtamil99uni keyboard
    - install ekwtamil99uni keyboard
    - open keyman-config
    - select 'Thamizha Tamil99' keyboard and click "About" button
    - verify that the keyboard details dialog shows

- TEST_OTHER: "About" doesn't crash for keyboard that contains a description
    - install a keyboard that does contain a package description, e.g. gff_amharic
    - follow similar steps as above

(:cherries:-picked from #5757)