### PR TITLE
chore(common): Enhance cherry-pick labeling 🍒 

### DIFF
--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -64,4 +64,4 @@ labels:
 
   - label: 'cherry-pick'
     matcher:
-      title: '🍒'
+      title: '\(🍒|:cherries:\)'


### PR DESCRIPTION
So far we only check for the :cherries: emoji character to add the cherry-pick label. GitHub now also supports emoticons as text
in PR titles. This change adds the detection of the `:cherries:` text.

(:cherries:-picked from PR #5759)

@keymanapp-test-bot skip