### PR TITLE
fix(developer): handle shortcut keys in debugger

### DIFF
--- a/windows/src/developer/TIKE/main/RedistFiles.pas
+++ b/windows/src/developer/TIKE/main/RedistFiles.pas
@@ -124,8 +124,15 @@ begin
 end;
 
 function GetRedistProjectTemplatePath: string;
+var
+  root: string;
+const
+  DevProjectTemplatePath = 'windows\src\developer\kmconvert\data\';
 begin
-  Result := GetDebugPath('Debug_RedistTemplatePath', ExtractFilePath(ParamStr(0))+'projects\templates\');
+  if TKeymanPaths.RunningFromSource(root)
+    then Result := root + DevProjectTemplatePath
+    else Result := ExtractFilePath(ParamStr(0))+'projects\templates\';
+  Result := GetDebugPath('Debug_RedistTemplatePath', Result);
 end;
 
 function GetDebugKMCmpDllPath: string;

--- a/windows/src/global/delphi/comp/KeymanDeveloperDebuggerMemo.pas
+++ b/windows/src/global/delphi/comp/KeymanDeveloperDebuggerMemo.pas
@@ -23,6 +23,7 @@ uses
   System.Classes,
   Winapi.Messages,
   Winapi.Windows,
+  Vcl.Controls,
   Vcl.StdCtrls;
 
 type
@@ -37,9 +38,11 @@ type
   private
     FOnMessage: TKeymanDeveloperDebuggerMessageEvent;
     FAllowUnicodeInput: Boolean;
+    FIsDebugging: Boolean;
     procedure SetAllowUnicode(const Value: Boolean);
     function GetSelection: TMemoSelection;
     procedure SetSelection(const Value: TMemoSelection);
+    procedure CNKeyDown(var Message: TWMKeyDown); message CN_KEYDOWN;
   protected
     procedure CreateHandle; override;
     procedure WndProc(var Message: TMessage); override;
@@ -49,6 +52,7 @@ type
     property AllowUnicode: Boolean read FAllowUnicodeInput write SetAllowUnicode default True;
     property OnMessage: TKeymanDeveloperDebuggerMessageEvent read FOnMessage write FOnMessage;
     property Selection: TMemoSelection read GetSelection write SetSelection;
+    property IsDebugging: Boolean read FIsDebugging write FIsDebugging;
   end;
 
 procedure Register;
@@ -56,6 +60,18 @@ procedure Register;
 implementation
 
 { TKeymanDeveloperDebuggerMemo }
+
+procedure TKeymanDeveloperDebuggerMemo.CNKeyDown(var Message: TWMKeyDown);
+begin
+  // Shortcuts for actions are handled with CN_KEYDOWN before we get WM_KEYDOWN,
+  // so if we are debugging we want to filter those out so that the debugger
+  // gets access to them instead of us. Note that this means that editor
+  // shortcuts such as Ctrl+A (select all) will not be processed in the normal
+  // way, so the host of this control needs to look after that.
+  if IsDebugging
+    then Exit
+    else inherited;
+end;
 
 constructor TKeymanDeveloperDebuggerMemo.Create(AOwner: TComponent);
 begin


### PR DESCRIPTION
Fixes #5718.

The debugger memo control will now filter out action shortcut keys such as Ctrl+A, Ctrl+O, so that the keyboard being debugged can get the first chance to look at them and handle them if it wishes.

If the keyboard does not handle the keystroke, then a set of editor shortcut keys will be handled by the debugger, namely:

* Ctrl+A - select all
* Ctrl+C - copy
* Ctrl+V - paste
* Ctrl+X - cut
* Ctrl+Z - undo

Note that undo semantics are a little weird with the debugger, but that is not related to this fix. By a little weird, I mean that characters emitted by the keyboard being debugged do not flow into the undo buffer, so undo often has no effect. I am not planning to fix this idiosyncrasy at this time.

# User Testing

All these tests should be performed in the debugger.

* **TEST_BASELINE:** Make sure that general debugging works in a Keyman keyboard, and that text selection keys work.
* **TEST_SHORTCUT:** When debugging a keyboard that does not define Ctrl+A, press Ctrl+A and verify that it selects all text in the debug window.
* **TEST_HANDLED:** Create a keyboard that defines `+ [CTRL K_A]`. Test it and verify that Ctrl+A is handled by the keyboard and *doesn'* select all.