### PR TITLE
fix(common): Fix cherry-pick labeling (:cherries:)

### DIFF
--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -64,4 +64,4 @@ labels:
 
   - label: 'cherry-pick'
     matcher:
-      title: '\(🍒|:cherries:\)'
+      title: '(🍒|:cherries:)'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@8afa186ed03230c98fe24ebf9fe35093072ad46e
+      uses: fuxingloh/multi-labeler@8afa186ed03230c98fe24ebf9fe35093072ad46e # v1.4.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
My previous commit escaped the parens which should be part of the regex.

(:cherries:-picked from PR #5782)

@keymanapp-test-bot skip