### PR TITLE
chore(linux): Update changelog files for 14.0.282

### DIFF
--- a/common/core/desktop/debian/changelog
+++ b/common/core/desktop/debian/changelog
@@ -1,3 +1,10 @@
+keyman-keyboardprocessor (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:01 +0200
+
 keyman-keyboardprocessor (14.0.280-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/ibus-keyman/debian/changelog
+++ b/linux/ibus-keyman/debian/changelog
@@ -1,3 +1,10 @@
+ibus-keyman (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:36 +0200
+
 ibus-keyman (14.0.280-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/ibus-kmfl/debian/changelog
+++ b/linux/ibus-kmfl/debian/changelog
@@ -1,3 +1,10 @@
+ibus-kmfl (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:21 +0200
+
 ibus-kmfl (14.0.280-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/keyman-config/debian/changelog
+++ b/linux/keyman-config/debian/changelog
@@ -1,3 +1,10 @@
+keyman-config (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:28 +0200
+
 keyman-config (14.0.280-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/kmflcomp/debian/changelog
+++ b/linux/kmflcomp/debian/changelog
@@ -1,3 +1,10 @@
+kmflcomp (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:08 +0200
+
 kmflcomp (14.0.280-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/libkmfl/debian/changelog
+++ b/linux/libkmfl/debian/changelog
@@ -1,3 +1,10 @@
+libkmfl (14.0.282-1) unstable; urgency=medium
+
+  * New upstream release
+  * Re-release to Debian
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 29 Sep 2021 12:47:15 +0200
+
 libkmfl (14.0.280-1) unstable; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
This updates the changelog files to match what got uploaded into Debian unstable (sid).

@keymanapp-test-bot skip