### PR TITLE
chore(windows): Add obj cod and pdb to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@
 
 # /engine/keyman32/
 /windows/src/engine/keyman32/Keyman32.opensdf
+/windows/src/engine/keyman32/*.obj
+/windows/src/engine/keyman32/*.cod
+/windows/src/engine/keyman32/*.pdb
 
 # /engine/keymanx64/
 /windows/src/engine/keymanx64/x64


### PR DESCRIPTION
Building Keyman Engine and Keymand Engine Tests for debug in Visual Studio 2019 procuces obj, cod and pdb files which can be added to gitignore

@keymanapp-test-bot skip