### PR TITLE
chore(android/engine): Address globe key TODO

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -159,7 +159,7 @@ public final class KMManager {
 
   private static InputMethodService IMService;
   private static boolean debugMode = false;
-  private static boolean shouldAllowSetKeyboard = false; // TEST CODE to remove after user testing: Do not merge to production
+  private static boolean shouldAllowSetKeyboard = true;
   private static boolean didCopyAssets = false;
 
   private static boolean didLogHardwareKeystrokeException = false;


### PR DESCRIPTION
Addresses TODO from https://github.com/keymanapp/keyman/pull/5570#discussion_r689151866

In `handleGlobeKeyAction`, if `KMManager.shouldAllowSetKeyboard()` is false, then `switchToNextKEyboard()` should not be allowed.

At the time this PR is created, the branch contains test code https://github.com/keymanapp/keyman/commit/140e45d93736a102e045815e56bae71fb998938a which disables `shouldAllowSetKeyboard` to enable user testing. 

Because this test code needs to be reverted before merging to production, reviewers should wait until user testing is complete.

## User Testing
* **TEST_DISABLED_GLOBE_ACTION** - This test can only be run before the test code (mentioned above) gets reverted.
1. Load the PR build
2. From the "Settings" menu, search for another keyboard and install (e.g. khmer_angkor)
3. When the keyboard package finishes installing, verify the keyboard remains the default sil_euro_latin keyboard
4. Short press the globe key
5. Verify the keyboard does **not** switch
6. Long press the globe key
7. Verify the keyboard does **not** switch
