### PR TITLE
docs(windows): add note to caps-lock-stores test

### DIFF
--- a/windows/src/test/manual-tests/caps-lock-stores/TestReadme.md
+++ b/windows/src/test/manual-tests/caps-lock-stores/TestReadme.md
@@ -107,6 +107,7 @@ Any keyboard with that store set will work; if you don't have one at hand you ca
   - output: `ncaps_little_a`
 
 **Note:** For `Test caps off 5` using a soft keyboard provided in virtual box will fail to turn the cap lock indicator off. This because the soft keyboard does pre processing of the shift key combined with any key pressed and the shift key stroke does not get sent to the keyman engine.
+
 ## CapsOnOnly/ShiftFreesCaps
 
 For these tests, use a keyboard with the `CapsOnOnly` and `ShiftFreesCaps` stores set. We call this keyboard _shift_frees_caps_ below.


### PR DESCRIPTION
Add a note the caps lock stores manual test describing the problem with the virtual box soft keyboard and the <kbd>shift</kbd> key for test-caps-off-5 test.

@keymanapp-test-bot skip