### PR TITLE
feat(android): Allow uninstall of sil_euro_latin keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeyboardSettingsActivity.java
@@ -32,6 +32,7 @@ import com.tavultesoft.kmea.KMHelpFileActivity;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.KMKeyboardDownloaderActivity;
 import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.FileProviderUtils;
 import com.tavultesoft.kmea.util.KMLog;
@@ -113,9 +114,8 @@ public final class KeyboardSettingsActivity extends AppCompatActivity {
     hashMap.put(iconKey, icon);
     infoList.add(hashMap);
 
-    // If not default keyboard, display uninstall keyboard
-    if (!(kbID.equalsIgnoreCase(KMManager.KMDefault_KeyboardID) &&
-        languageID.equalsIgnoreCase(KMManager.KMDefault_LanguageID))) {
+    // As long as more than 1 keyboard installed, display uninstall keyboard
+    if (KeyboardController.getInstance().get().size() > 1 && KMManager.canRemoveKeyboard()) {
       hashMap = new HashMap<>();
       hashMap.put(titleKey, getString(R.string.uninstall_keyboard));
       hashMap.put(subtitleKey, "");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -136,8 +136,8 @@ public final class KeyboardPickerActivity extends BaseActivity {
     listView.setOnItemLongClickListener(new OnItemLongClickListener() {
       @Override
       public boolean onItemLongClick(AdapterView<?> parent, View view, final int position, long id) {
-        // Prevent the default keyboard from being removed
-        if (position > 0 && canRemoveKeyboard) {
+        // As long as more than 1 keyboard installed, display uninstall keyboard
+        if (KeyboardController.getInstance().get().size() > 1 && canRemoveKeyboard) {
           PopupMenu popup = new PopupMenu(context, view);
           popup.getMenuInflater().inflate(R.menu.popup, popup.getMenu());
           popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
@@ -370,11 +370,8 @@ public final class KeyboardPickerActivity extends BaseActivity {
   protected static boolean removeKeyboard(Context context, int position) {
     boolean result = false;
 
-    // Prevent the first keyboard (index 0) from being removed
-    if (position > 0) {
-      KeyboardController.getInstance().remove(position);
-      result = KeyboardController.getInstance().save(context);
-    }
+    KeyboardController.getInstance().remove(position);
+    result = KeyboardController.getInstance().save(context);
 
     notifyKeyboardsUpdate(context);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -321,7 +321,7 @@ public class KeyboardController {
    * @param index
    */
   public void remove(int index) {
-    // Check initialized, and disallow removing default keyboard
+    // Check initialized
     if (!isInitialized) {
       return;
     }

--- a/android/help/basic/uninstalling-keyboards.md
+++ b/android/help/basic/uninstalling-keyboards.md
@@ -28,7 +28,7 @@ Step 5)
 The bottom of the keyboard settings menu displays an option to uninstall the keyboard.
 Select 'Uninstall keyboard' to get a prompt to delete the keyboard.
 
-**Note:** The default 'SIL EuroLatin' keyboard for English cannot be removed.
+**Note:** Two or more keyboards need to be installed in order to display this option of uninstalling a keyboard.
 
 ![](../android_images/settings-khmer-info-ap.png)
 


### PR DESCRIPTION
Fixes #5828

Keyman for Android doesn't allow the user to uninstall the default sil_euro_latin keyboard partly because it was used as a fallback keyboard whenever KeymanWeb exceptions happen. #5423 disabled the fallback behavior.

Also, for feature-party with Keyman for iPhone and iPad, this PR allows the user to uninstall the sil_euro_latin keyboard (as long as another keyboard remains)

## User Testing
Setup for each of the tests:
    * Load the PR build
    * Install 2 additional keyboards (khmer_angkor and sil_cameroon_qwerty)


* **TEST_KEYBOARD_PICKER_UNINSTALL** - Tests sil_euro_latin can be uninstalled from the keyboard picker menu
1. Load Keyman for Android
2. Long-press the globe key to display the keyboard picker menu
3. Hold down on the default sil_euro_latin keyboard until the "DELETE" popup appears
4. Click "DELETE" to uninstall sil_euro_latin
5. Verify another keyboard is selected
6. Long-press the globe key to display the keyboard picker menu
7. Verify sil_euro_latin keyboard no longer appears
8. Hold down on either of the two remaining keyboards until the "DELETE" popup appears
9. Click "DELETE" to uninstall the keyboard
10. Verify the remaining keyboard is selected
11. Long-press the globe key to display the keyboard picker menu
12. Verify only the remaining keyboard appears in the keyboard picker menu
13. Hold down on the remaining keyboard and release
14. Verify "DELETE" does **NOT** appear
15. Verify the keyboard picker menu exits

* **TEST_KEYBOARD_SETTINGS_UNINSTALL** - Tests sil_euro_latin can be uninstalled from the keyboard settings menu
1. Load Keyman for Android
2. Go the "Settings" --> Installed Languages --> English --> EuroLatin (SIL) Keyboard -->
3. Verify "Uninstall keyboard" is an option on the keyboard settings page
4. Select "Uninstall keyboard" and exit back to the Keyman text area
5. Verify another keyboard is selected
6. Go the "Settings" --> Installed Languages --> Central Khmer --> Khmer Angkor -->
7. 3. Verify "Uninstall keyboard" is an option on the keyboard settings page
8. Select "Uninstall keyboard" and exit back to the Keyman text area
9. Verify the remaining sil_cameroon_qwerty keyboard is selected
10. Go to "Settings" --> Installed Languages -> (remaining language) --> Cameroon Qwerty -->
11. Verify "Uninstall keyboard" does **NOT** appear on the menu
12.  Exit back to the text area
