### PR TITLE
fix(android/app): Check KMP file exists before attempting to extract

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -65,6 +65,11 @@ public class PackageActivity extends AppCompatActivity implements
     Bundle bundle = getIntent().getExtras();
     if (bundle != null) {
       kmpFile = new File(bundle.getString("kmpFile"));
+      if (!kmpFile.exists()) {
+        KMLog.LogError(TAG, kmpFile.getAbsolutePath() + " not found. Unable to extract");
+        showErrorToast(context, getString(R.string.failed_to_extract));
+        return;
+      }
       installMode = (KmpInstallMode) bundle.getSerializable("installMode");
       if(installMode == null) installMode = KmpInstallMode.Full;
       lastInstallMode = installMode;
@@ -230,6 +235,7 @@ public class PackageActivity extends AppCompatActivity implements
     setResult(1);
     cleanup();
     finish();
+    MainActivity.cleanupPackageInstall();
   }
 
   /**

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -65,6 +65,7 @@ public class PackageActivity extends AppCompatActivity implements
     Bundle bundle = getIntent().getExtras();
     if (bundle != null) {
       kmpFile = new File(bundle.getString("kmpFile"));
+      kmpFile.delete(); // TEST CODE: Do not merge to production
       if (!kmpFile.exists()) {
         KMLog.LogError(TAG, kmpFile.getAbsolutePath() + " not found. Unable to extract");
         showErrorToast(context, getString(R.string.failed_to_extract));


### PR DESCRIPTION
Fixes #5848 and will need to 🍒 pick to stable-14.0

This checks that the downloaded kmp file exists before attempting to extract it.

---

# DO NOT MERGE
**Note for reviewers, this contains test code in https://github.com/keymanapp/keyman/commit/6fb6238ea9f772bf6f5742a8bc8a1ac51f1472d6 
After user testing, I will revert the test code before merging to production**

---

## User Testing
Note: This will only pass while the test code above is in.
* **TEST_KMP_EXISTS** - Checks kmp file exists before PackageActivity() attempts to extract it
1. Load the PR build
2. From the "Settings" menu, search for the "basic_kbdsora" keyboard and download to install
3. Verify a Toast notification briefly appears saying "Failed to extract" (The kmp file no longer exists, so the PackageActivity finishes)
