### PR TITLE
chore(common): Don't check for conventional commit for fixups

### DIFF
--- a/resources/git-hooks/commit-msg
+++ b/resources/git-hooks/commit-msg
@@ -90,7 +90,11 @@ function build_regex() {
   remessage=".{$min_length,$max_length}[^.]"
   refixes="(\. Fixes #[[:digit:]]+)?"
 
-  regexp="^${retypes}${rescope}: ${remessage}${refixes}[[:space:]]*$"
+  # Regex for the commit message title. It's ok if the commit message starts with "fixup!".
+  # (This allows to run `git commit --fixup=<sha>` without complaining about the commit
+  # message not being in conventional commit format. This helps in squashing with a previous
+  # commit.)
+  regexp="^(fixup\! )?${retypes}${rescope}: ${remessage}${refixes}[[:space:]]*$"
 }
 
 # Print out a standard error message which explains


### PR DESCRIPTION
This change allows to add fixup commits by running the command `git commit --fixup=<sha>` without complaining about the commit message not being in conventional commit format. (Running the git command will result in the commit title of the referenced commit with `fixup!` prepended. It will later be squashed with the referenced commit in a git rebase.)

@keymanapp-test-bot skip