### PR TITLE
chore(common/core): Compile test keyboards to .kmp 🎫

### DIFF
--- a/common/core/desktop/tests/meson.build
+++ b/common/core/desktop/tests/meson.build
@@ -21,8 +21,4 @@ if get_option('default_library') != 'static'
   endif
 endif
 
-subdir('unit/json')
-subdir('unit/utftest')
-subdir('unit/kmnkbd')
-subdir('unit/kmx')
-subdir('unit/rust_mock')
+subdir('unit')

--- a/common/core/desktop/tests/unit/kmx/meson.build
+++ b/common/core/desktop/tests/unit/kmx/meson.build
@@ -81,6 +81,7 @@ if build_machine.system() == 'windows'
   kmcomp = find_program('kmcomp.exe', required: false)
   kmcomp_cmd = [kmcomp]
   copy_cmd = [find_program('cmd.exe', required: true), '/c', 'copy']
+  cat_cmd = [find_program('cmd.exe', required: true), '/c', 'type']
 else
   kmcomp = find_program('kmcomp', required: false)
   kmcomp_cmd = [kmcomp]
@@ -93,6 +94,7 @@ else
     endif
   endif
   copy_cmd = [find_program('cp', required: true)]
+  cat_cmd = [find_program('cat', required: true)]
 endif
 
 if compiler.get_id() == 'emscripten'
@@ -146,7 +148,7 @@ if kmcomp.found()
     kbd_basename = 'k_' + kbd.underscorify().to_lower()
 
     content = run_command(
-      'cat', files(kbd + '.kmn'),
+      cat_cmd, files(kbd + '.kmn'),
     ).stdout().strip()
 
     cfg = configuration_data()

--- a/common/core/desktop/tests/unit/kmx/meson.build
+++ b/common/core/desktop/tests/unit/kmx/meson.build
@@ -107,9 +107,10 @@ foreach kbd : tests
     test_keyboards += ''',
   '''
   endif
+  kbd_basename = 'k_' + kbd.underscorify().to_lower()
   test_keyboards +=  '''{
-    "name": "''' + kbd + '''",
-    "id": "''' + kbd + '''",
+    "name": "''' + kbd_basename + '''",
+    "id": "''' + kbd_basename + '''",
     "version": "0.0",
     "languages": [
       {
@@ -118,16 +119,16 @@ foreach kbd : tests
       }
     ]
   }'''
-  configure_file(
-    command: copy_cmd + ['@INPUT@', '@OUTPUT@'],
-    input: kbd + '.kmn',
-    output: kbd + '.kmn'
-  )
   if not kmcomp.found()
     configure_file(
       command: copy_cmd + ['@INPUT@', '@OUTPUT@'],
+      input: kbd + '.kmn',
+      output: kbd_basename + '.kmn'
+    )
+    configure_file(
+      command: copy_cmd + ['@INPUT@', '@OUTPUT@'],
       input: kbd + '.kmx',
-      output: kbd + '.kmx'
+      output: kbd_basename + '.kmx'
     )
   endif
 endforeach
@@ -142,20 +143,58 @@ configure_file(
 
 if kmcomp.found()
   foreach kbd : tests
-    kbd_src = files(join_paths(source_path, kbd) + '.kmn')
-    kbd_obj = join_paths(test_path, kbd) + '.kmx'
-    kbd_log = custom_target(kbd + '.kmx'.underscorify(),
-      output: kbd + '.log',
-      input: kbd_src,
-      command: kmcomp_cmd + ['-s', '-d', '@INPUT@', kbd_obj, '@OUTPUT@']
-    )
+    kbd_basename = 'k_' + kbd.underscorify().to_lower()
 
-    test(kbd, kmx, depends: kbd_log, args: [kbd_src, kbd_obj])
+    content = run_command(
+      'cat', files(kbd + '.kmn'),
+    ).stdout().strip()
+
+    cfg = configuration_data()
+    cfg.set('keyboard', kbd)
+    cfg.set('keyboard_underscore', kbd_basename)
+    cfg.set('id1', 'id_' + kbd_basename + '_1')
+    cfg.set('id2', 'id_' + kbd_basename + '_2')
+    cfg.set('id3', 'id_' + kbd_basename + '_3')
+    cfg.set('build_dir', meson.current_build_dir())
+    cfg.set('NAME', kbd)
+    cfg.set('CONTENT', content)
+
+    kbd_kmn = configure_file(
+      configuration: cfg,
+      input: join_paths('template', 'keyboard.kmn.in'),
+      output: kbd_basename + '.kmn'
+    )
+    kbd_kpj = configure_file(
+      configuration: cfg,
+      input: join_paths('template', 'keyboard.kpj.in'),
+      output: kbd_basename + '.kpj'
+    )
+    kbd_kps = configure_file(
+      configuration: cfg,
+      input: join_paths('template', 'keyboard.kps.in'),
+      output: kbd_basename + '.kps'
+    )
+    kbd_kmp = custom_target(kbd_basename + '.kmp',
+      input: kbd_kpj,
+      output: [kbd_basename + '.kmp', kbd_basename + '.kmx'],
+      depend_files: [kbd_kps, kbd_kmn],
+      depfile: kbd_basename + '.dep',
+      command: kmcomp_cmd + ['-s', '-d', '@INPUT@'])
+
+    kbd_src = files(join_paths(test_path, kbd_basename) + '.kmn')
+    kbd_obj = join_paths(test_path, kbd_basename) + '.kmx'
+    # kbd_log = custom_target(kbd.underscorify() + '.kmx',
+    #   output: kbd + '.log',
+    #   input: kbd_src,
+    #   command: kmcomp_cmd + ['-s', '-d', '@INPUT@', kbd_obj, '@OUTPUT@']
+    # )
+
+    test(kbd, kmx, depends: [kbd_kmp], args: [kbd_src, kbd_obj])
   endforeach
 else
   foreach kbd : tests
-    kbd_src = join_paths(source_path, kbd) + '.kmn'
-    kbd_obj = join_paths(test_path, kbd) + '.kmx'
+    kbd_src = join_paths(test_path, kbd_basename) + '.kmn'
+    kbd_obj = join_paths(test_path, kbd_basename) + '.kmx'
 
     test(kbd, kmx, args: [kbd_src, kbd_obj])
   endforeach

--- a/common/core/desktop/tests/unit/kmx/template/keyboard.kmn.in
+++ b/common/core/desktop/tests/unit/kmx/template/keyboard.kmn.in
@@ -1,0 +1,2 @@
+store(&NAME) '@NAME@'
+@CONTENT@

--- a/common/core/desktop/tests/unit/kmx/template/keyboard.kpj.in
+++ b/common/core/desktop/tests/unit/kmx/template/keyboard.kpj.in
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<KeymanDeveloperProject>
+  <Options>
+    <BuildPath>$PROJECTPATH</BuildPath>
+    <CompilerWarningsAsErrors>false</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>false</WarnDeprecatedCode>
+    <CheckFilenameConventions>false</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
+  </Options>
+  <Files>
+    <File>
+      <ID>@id1@</ID>
+      <Filename>@keyboard_underscore@.kmn</Filename>
+      <Filepath>@build_dir@/@keyboard_underscore@.kmn</Filepath>
+      <FileVersion>1.0</FileVersion>
+      <FileType>.kmn</FileType>
+      <Details>
+        <Name>@keyboard@</Name>
+        <Copyright>Copyright (C) Keyman Team</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>@id2@</ID>
+      <Filename>@keyboard_underscore@.kps</Filename>
+      <Filepath>@build_dir@/@keyboard_underscore@.kps</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.kps</FileType>
+      <Details>
+        <Name>@keyboard@</Name>
+        <Copyright>Copyright (C) Keyman Team</Copyright>
+      </Details>
+    </File>
+    <File>
+      <ID>@id3@</ID>
+      <Filename>@keyboard_underscore@.kmx</Filename>
+      <Filepath>@build_dir@/@keyboard_underscore@.kmx</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.kmx</FileType>
+      <ParentFileID>@id2@</ParentFileID>
+    </File>
+  </Files>
+</KeymanDeveloperProject>

--- a/common/core/desktop/tests/unit/kmx/template/keyboard.kps.in
+++ b/common/core/desktop/tests/unit/kmx/template/keyboard.kps.in
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Options>
+    <ExecuteProgram></ExecuteProgram>
+    <ReadMeFile></ReadMeFile>
+    <MSIFileName></MSIFileName>
+    <MSIOptions></MSIOptions>
+    <FollowKeyboardVersion/>
+  </Options>
+  <StartMenu>
+    <Folder></Folder>
+    <Items/>
+  </StartMenu>
+  <Info>
+    <Name URL="">@keyboard@</Name>
+    <Copyright URL="">Copyright (C) Keyman Team</Copyright>
+    <Author URL="">Keyman Team</Author>
+    <Version URL=""></Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>@keyboard_underscore@.kmx</Name>
+      <Description></Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>@keyboard@</Name>
+      <ID>@keyboard_underscore@</ID>
+      <Version>1.0</Version>
+      <Languages>
+        <Language ID="en">English</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+  <Strings/>
+</Package>

--- a/common/core/desktop/tests/unit/meson.build
+++ b/common/core/desktop/tests/unit/meson.build
@@ -1,0 +1,5 @@
+subdir('json')
+subdir('utftest')
+subdir('kmnkbd')
+subdir('kmx')
+subdir('rust_mock')


### PR DESCRIPTION
This change adds package templates to the test folder and compiles a keyboard package for each of the test keyboards. These
packages are useful for manual testing in addition to the automated tests.

@keymanapp-test-bot skip