### PR TITLE
fix(web): Check parent element is defined before assigning

### DIFF
--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1728,7 +1728,7 @@ namespace com.keyman.dom {
             if(typeof(p) != 'undefined' && p != null) {
               if(p.className.indexOf('keymanweb-input') >= 0) return false;
               if(p.className.indexOf('kmw-key-') >= 0) return false;
-              if(typeof(p.parentElement) != 'undefined') {
+              if(typeof(p.parentElement) != 'undefined' && p.parentElement != null) {
                 p=p.parentElement;
                 if(p.className.indexOf('keymanweb-input') >= 0) return false;
                 if(p.className.indexOf('kmw-key-') >= 0) return false;


### PR DESCRIPTION
Fixes #5873 by checking that `parentElement` isn't `null` before assigning.
Follows the pattern from 
https://github.com/keymanapp/keyman/blob/ce7a08f30fecdf29ef216da598ae2f11f629d487/web/source/dom/domManager.ts#L1728

## User Testing

* **TEST_MOBILE_VIEW**
Uses Chrome in mobile viewport with the developer console (F12)
1. Load the web/testing/prediction-ui/index.html test page
2. Click on the area from the screenshot below
3. Verify no console errors appear
![test page](https://user-images.githubusercontent.com/7358010/139786726-36aa2e2a-e23a-4289-97b1-07e7b0334812.png)
r
