### PR TITLE
fix(android/engine): Truncate language name in list

### DIFF
--- a/android/KMEA/app/src/main/res/layout/list_row_layout3.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout3.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:layout_toStartOf="@id/imageButton1"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:orientation="vertical" >
@@ -22,6 +23,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
+            android:ellipsize="end"
+            android:singleLine="true"
             android:textSize="16sp"
             android:textStyle="bold" />
 


### PR DESCRIPTION
Fixes #5876 

This updates list_row_layout3 to truncate the keyboard language name so it doesn't collide with the help icon.

![Screenshot_1635931413](https://user-images.githubusercontent.com/7358010/140036164-99d8f037-1e41-4414-8420-d473c9ca4140.png)

## User Testing
Setup:
Load the PR build in an Android emulator with a small/medium screen (e.g. Nexus 5 with Android API 23)

* **TEST_KEYBOARD_PICKER**
1. Start Keyman for Android
2. Dismiss the "Get Started" menu
3. From the "Settings" menu, search and install the "khmer_angkor" keyboard
4. Proceed through the installation wizard until khmer_angkor is installed
5. In the Keyman app, long-press on the globe key to display the keyboard picker
6. Verify the language name does not collide with the help icon

