### PR TITLE
feat(developer): kmcompx - remove Windows dependencies 🍃

### DIFF
--- a/common/core/desktop/src/kmx/kmx_kmcomp_inc.h
+++ b/common/core/desktop/src/kmx/kmx_kmcomp_inc.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+
+
+typedef uint32_t            KMX_DWORD;
+//typedef int32_t             KMX_BOOL;
+//typedef uint8_t             KMX_BYTE;
+//typedef uint16_t            KMX_WORD;

--- a/windows/src/developer/kmcmpdll/Compiler.cpp
+++ b/windows/src/developer/kmcmpdll/Compiler.cpp
@@ -64,7 +64,9 @@
                     23 Feb 2016 - mcdurdin - I4982 - Defined character constants cannot be referenced correctly in other stores
                     25 Oct 2016 - mcdurdin - I5135 - Remove product and licensing references from Developer projects
 */
+#include "../../../../common/core/desktop/src/kmx/kmx_kmcomp_inc.h"
 #include "pch.h"
+
 
 #include <compfile.h>
 #include <compiler.h>
@@ -96,7 +98,7 @@ int GetDeadKey(PFILE_KEYBOARD fk, PWSTR p);
 
 BOOL IsValidCallStore(PFILE_STORE fs);
 BOOL IsSameToken(PWSTR *p, WCHAR const * token);
-DWORD GetRHS(PFILE_KEYBOARD fk, PWSTR p, PWSTR buf, int bufsize, int offset, int IsUnicode);
+KMX_DWORD GetRHS(PFILE_KEYBOARD fk, PWSTR p, PWSTR buf, int bufsize, int offset, int IsUnicode);
 PWSTR GetDelimitedString(PWSTR *p, WCHAR const * Delimiters, WORD Flags);
 DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, WCHAR const * token, PWSTR output, int max, int offset, PWSTR *newp, int isVKey,
   int isUnicode);
@@ -104,10 +106,10 @@ DWORD GetXString(PFILE_KEYBOARD fk, PWSTR str, WCHAR const * token, PWSTR output
 int GetGroupNum(PFILE_KEYBOARD fk, PWSTR p);
 int LineTokenType(PWSTR *str);
 
-DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str);
+KMX_DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str);
 
-DWORD ProcessGroupFinish(PFILE_KEYBOARD fk);
-DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p);
+KMX_DWORD ProcessGroupFinish(PFILE_KEYBOARD fk);
+KMX_DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p);
 DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PWSTR p);
 DWORD AddDebugStore(PFILE_KEYBOARD fk, WCHAR const * str);
 DWORD ProcessKeyLine(PFILE_KEYBOARD fk, PWSTR str, BOOL IsUnicode);
@@ -613,11 +615,11 @@ DWORD ValidateMatchNomatchOutput(PWSTR p) {
   return CERR_None;
 }
 
-DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
+KMX_DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 {
   PWSTR p, q, pp;
   PFILE_GROUP gp;
-  DWORD msg;
+  KMX_DWORD msg;
   int IsUnicode = TRUE; // For NOW!
 
   p = str;
@@ -830,7 +832,7 @@ DWORD ParseLine(PFILE_KEYBOARD fk, PWSTR str)
 
 //**********************************************************************************************************************
 
-DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p)
+KMX_DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PWSTR p)
 {
   PFILE_GROUP gp;
   PWSTR q;
@@ -896,7 +898,7 @@ int cmpkeys(const void *key, const void *elem)
   return(char_key - char_elem); // akey->Key - aelem->Key);
 }
 
-DWORD ProcessGroupFinish(PFILE_KEYBOARD fk)
+KMX_DWORD ProcessGroupFinish(PFILE_KEYBOARD fk)
 {
   PFILE_GROUP gp;
   DWORD msg;
@@ -3289,7 +3291,7 @@ DWORD ReadLine(HANDLE hInfile, PWSTR wstr, BOOL PreProcess)
   return CERR_None;
 }
 
-DWORD GetRHS(PFILE_KEYBOARD fk, PWSTR p, PWSTR buf, int bufsize, int offset, int IsUnicode)
+KMX_DWORD GetRHS(PFILE_KEYBOARD fk, PWSTR p, PWSTR buf, int bufsize, int offset, int IsUnicode)
 {
   PWSTR q;
 


### PR DESCRIPTION
[Kmcompx_FirstIdeas.docx](https://github.com/keymanapp/keyman/files/7466818/Kmcompx_FirstIdeas.docx)

this is what I am about to do for the kmcompx-project:

My idea was to create a new .h-file (kmx_kmcomp_inc.h) where I include everything that is necessary for changing variable types and functions. This file then would be included in Compiler.cpp and all the other files where changes need to be made in VarTypes and functions. 

![image](https://user-images.githubusercontent.com/4498365/140172535-961e792b-44db-4ebe-a18f-7080521e3277.png)

![image](https://user-images.githubusercontent.com/4498365/140172573-cb666873-e1d1-4485-8d4d-be369ba69f47.png)

I am right at the beginning and have just included a typedef for KMX_DWORD in my new kmx_kmcomp_inc.h. In Compiler.cpp I started to change some return-variables of a few functions. 
Before going further I just want to make sure that I understood right and am on the right track. Therefore I have some questions:

* You wrote:The list of source files that you will need to work with will be found in the meson.build files in that pull request, under developer/kmcompx. (kmcompx is a 'working title' for this project!). 

  As I understand **the files found in developer/kmcompx/src/meson.build are the ones to change?** 

  ![image](https://user-images.githubusercontent.com/4498365/140172704-dd66d468-f062-4355-adb4-66a3432350af.png)

* **Is it OK to create a seperate .h-file for kmcompx?** 
* **Is there any naming convention for a .h-file in keyman?** (Is there a more appropriate name for kmx_kmcomp_inc.h ?) 
* At the moment kmx_kmcomp_inc.h is located at the same location as kmx_base.h: \common\core\desktop\src\kmx. **Is there a better location?**
