### PR TITLE
chore(linux): fix failing ibus-keyman tests 🎫

### DIFF
--- a/linux/ibus-keyman/.gitignore
+++ b/linux/ibus-keyman/.gitignore
@@ -7,3 +7,4 @@ src/print_kmp
 src/print_kmpdetails
 *.log
 *.trs
+.dirstamp

--- a/linux/ibus-keyman/src/keymanutil.h
+++ b/linux/ibus-keyman/src/keymanutil.h
@@ -66,6 +66,8 @@
 #define KEYMAN_DCONF_PATH "/desktop/ibus/keyman/options/"
 #define KEYMAN_DCONF_OPTIONS_KEY "options"
 
+G_BEGIN_DECLS
+
 void             ibus_keyman_init           (void);
 GList           *ibus_keyman_list_engines   (void);
 IBusComponent   *ibus_keyman_get_component  (void);
@@ -108,5 +110,7 @@ void keyman_put_options_todconf
                                              gchar *keyboard_id,
                                              gchar *option_key,
                                              gchar *option_value);
+
+G_END_DECLS
 
 #endif

--- a/linux/ibus-keyman/tests/Makefile.am
+++ b/linux/ibus-keyman/tests/Makefile.am
@@ -81,6 +81,10 @@ ibus_keyman_tests_SOURCES = \
   ../../../common/core/desktop/tests/unit/kmx/kmx_test_source.cpp \
   ../../../common/core/desktop/tests/unit/kmx/kmx_test_source.hpp \
   ../src/keycodes.h \
+  ../src/keymanutil.c \
+  ../src/keymanutil.h \
+  ../src/kmpdetails.c \
+  ../src/kmpdetails.h \
   $(NULL)
 
 ibus_keyman_tests_CFLAGS = \
@@ -94,6 +98,7 @@ ibus_keyman_tests_CFLAGS = \
   -I$(top_srcdir)/../../common/core/desktop/src/kmx \
   -I$(top_srcdir)/../../common/core/desktop/tests/unit/kmx \
   -I$(top_srcdir)/src \
+  -I$(top_builddir)/src \
   $(NULL)
 
 ibus_keyman_tests_CPPFLAGS = \
@@ -107,6 +112,7 @@ ibus_keyman_tests_CPPFLAGS = \
   -I$(top_srcdir)/../../common/core/desktop/src/kmx \
   -I$(top_srcdir)/../../common/core/desktop/tests/unit/kmx \
   -I$(top_srcdir)/src \
+  -I$(top_builddir)/src \
   $(NULL)
 
 ibus_keyman_tests_LDFLAGS = \

--- a/linux/ibus-keyman/tests/ibusimcontext.c
+++ b/linux/ibus-keyman/tests/ibusimcontext.c
@@ -1014,6 +1014,11 @@ static gboolean
 _delete_surrounding(IBusIMContext *ibusimcontext, gint offset_from_cursor, guint nchars) {
   // g_signal_emit(ibusimcontext, _signal_delete_surrounding_id, 0);
   if (offset_from_cursor < 0) {
+    for (guint val = nchars;
+         val <= ibusimcontext->text->len && (guint)ibusimcontext->text->str[ibusimcontext->text->len - val] >= 0x80;
+         val++) {
+      nchars = val;
+    }
     g_string_erase(ibusimcontext->text, ibusimcontext->text->len - nchars, nchars);
   } else {
     g_string_erase(ibusimcontext->text, offset_from_cursor, nchars);

--- a/linux/ibus-keyman/tests/run-tests.sh
+++ b/linux/ibus-keyman/tests/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASEDIR=$(dirname $0)
+BASEDIR=$(realpath $(dirname $0))
 TESTDIR=${XDG_DATA_HOME:-$HOME/.local/share}/keyman/test_kmx
 
 if [ "$DISPLAY" == ":0" ]; then
@@ -9,7 +9,14 @@ if [ "$DISPLAY" == ":0" ]; then
 fi
 
 if [ ! -d $TESTDIR ]; then
-  ln -sf $BASEDIR/../../../common/core/desktop/build/arch/debug/tests/unit/kmx $TESTDIR
+  if [ -d $BASEDIR/../../../common/core/desktop/build/arch/debug ]; then
+    ln -sf $(realpath $BASEDIR/../../../common/core/desktop/build/arch/debug/tests/unit/kmx) $TESTDIR
+  elif [ -d $BASEDIR/../../../common/core/desktop/build/arch/release ]; then
+    ln -sf $(realpath $BASEDIR/../../../common/core/desktop/build/arch/release/tests/unit/kmx) $TESTDIR
+  else
+    echo "Can't find kmx files in common/core/desktop/build/arch/*/tests/unit/kmx"
+    exit 2
+  fi
 fi
 
 if [ $# -gt 0 ]; then

--- a/linux/ibus-keyman/tests/testmodule.h
+++ b/linux/ibus-keyman/tests/testmodule.h
@@ -1,5 +1,5 @@
-#ifndef __TESTMODULE__
-#define __TESTMODULE__
+#ifndef __TESTMODULE_H__
+#define __TESTMODULE_H__
 
 G_BEGIN_DECLS
 
@@ -30,4 +30,4 @@ void test_module_unuse(GTypeModule* test_module);
 
 G_END_DECLS
 
-#endif /* __TESTMODULE__ */
+#endif // __TESTMODULE_H__


### PR DESCRIPTION
This change fixes the ibus-keyman test client so that now all tests pass.

@keymanapp-test-bot skip