### PR TITLE
fix(developer): crash exporting OSK on European keyboard

### DIFF
--- a/windows/src/global/delphi/comp/OnScreenKeyboard.pas
+++ b/windows/src/global/delphi/comp/OnScreenKeyboard.pas
@@ -391,20 +391,27 @@ var
   minsz: Integer;
   i: Integer;
   n: Integer;
+  Canvas: TCanvas;
+  b: TBitmap;
 begin
-  minsz := MAXINT;
-  for i := 0 to FKeys.Count - 1 do
-    if FKeys[i].KeyType <> kktNormal then
-    begin
-      n := FKeys[i].CalcFontSize(Canvas);
-      if (n > 0) and (n < minsz) then
-        minsz := n;
-    end;
+  b := TBitmap.Create;
+  try
+    minsz := MAXINT;
+    for i := 0 to FKeys.Count - 1 do
+      if FKeys[i].KeyType <> kktNormal then
+      begin
+        n := FKeys[i].CalcFontSize(b.Canvas);
+        if (n > 0) and (n < minsz) then
+          minsz := n;
+      end;
 
-  if minsz = MAXINT then minsz := 0;
-  for i := 0 to FKeys.Count - 1 do
-    if FKeys[i].KeyType <> kktNormal then
-      FKeys[i].FontSize := minsz;
+    if minsz = MAXINT then minsz := 0;
+    for i := 0 to FKeys.Count - 1 do
+      if FKeys[i].KeyType <> kktNormal then
+        FKeys[i].FontSize := minsz;
+  finally
+    b.Free;
+  end;
 end;
 
 procedure TOnScreenKeyboard.CreateParams(var params: TCreateParams);
@@ -852,13 +859,16 @@ begin
 
   ResizeKeys;
 
-  if FDisplay102Key or FEuroLayout then
+  if HandleAllocated then
   begin
-    r := Rect(k.FX, k.FY, F102Key.FX+F102Key.FW, F102Key.FY+F102Key.FH);
-    FillBkRect(Canvas.Handle, r);
+    if FDisplay102Key or FEuroLayout then
+    begin
+      r := Rect(k.FX, k.FY, F102Key.FX+F102Key.FW, F102Key.FY+F102Key.FH);
+      FillBkRect(Canvas.Handle, r);
+    end;
+    DoDrawKey(Canvas, k);
+    DoDrawKey(Canvas, F102Key);
   end;
-  DoDrawKey(Canvas, k);
-  DoDrawKey(Canvas, F102Key);
 end;
 
 procedure TOnScreenKeyboard.SetDisplayUnderlyingChar(const Value: Boolean);
@@ -1028,7 +1038,8 @@ begin
 
   CalcKeyFontSizes;
 
-  InvalidateRect(Handle, nil, True);
+  if HandleAllocated then
+    InvalidateRect(Handle, nil, True);
 end;
 
 { TOnScreenKeyboardKeys }


### PR DESCRIPTION
Fixes #5609.

If a user attempted to export the OSK to a BMP or PNG, and their base keyboard was a European layout (102 key), then Keyman Developer would crash as it attempted to recalculate and redraw the keyboard when constructing the OSK object, and there would be no window for the OSK object to draw to (or measure dimensions against).

This fix uses a temporary off-screen canvas to facilitate calculation of dimensions, and avoids drawing or invalidating if no window is available.

# User Testing

To export an OSK, load or create a keyboard with an OSK in Keyman Developer. On the OSK tab, click Export, select file type .png, and enter a filename.

* TEST_US: With a US English base keyboard selected, export the OSK in Keyman Developer to a .png file. Ensure that the file is exported and Developer doesn't crash.

* TEST_UK: With a UK English base keyboard selected, export the OSK in Keyman Developer to a .png file. Ensure that the file is exported and Developer doesn't crash.

Note: a UK English keyboard has the 102nd key which would have triggered this issue.