### PR TITLE
feat(developer): validate .kps files during compile

### DIFF
--- a/common/schemas/kps/README.md
+++ b/common/schemas/kps/README.md
@@ -1,0 +1,6 @@
+# kps.xsd
+
+Master version: https://github.com/keymanapp/api.keyman.com/blob/master/schemas/kps/7.0/kps.xsd
+
+## 2021-07-19 7.0
+* Initial version 7.0

--- a/common/schemas/kps/kps.xsd
+++ b/common/schemas/kps/kps.xsd
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  .kps file schema, version 7.0
+
+  Copyright (C) SIL International
+
+  Supports KPS files for Keyman Developer 7+
+
+  Expects FileVersion 7.0
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="Package">
+  <xs:complexType>
+    <xs:all>
+
+
+      <xs:element minOccurs="1" maxOccurs="1" name="System">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="1" maxOccurs="1" name="KeymanDeveloperVersion" type="km-version" />
+            <xs:element minOccurs="1" maxOccurs="1" name="FileVersion" type="km-version" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Options">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="ExecuteProgram" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="ReadMeFile" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="GraphicFile" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="MSIFileName" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="MSIOptions" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="FollowKeyboardVersion" type="km-empty" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="StartMenu">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="Folder" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="AddUninstallEntry" type="km-empty" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Items">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" name="Item">
+                    <xs:complexType>
+                      <xs:all>
+                        <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="FileName" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Arguments" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Icon" type="xs:string" />
+                        <xs:element minOccurs="0" maxOccurs="1" name="Location" type="km-start-menu-location" />
+                      </xs:all>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Info">
+        <xs:complexType>
+          <xs:all>
+            <xs:element minOccurs="0" maxOccurs="1" name="Name" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Version" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Copyright" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="Author" type="km-info" />
+            <xs:element minOccurs="0" maxOccurs="1" name="WebSite" type="km-info" />
+          </xs:all>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Files">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="File">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Description" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="CopyLocation" type="km-file-copy-location" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="FileType" type="xs:string" />
+                </xs:all>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Keyboards">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="Keyboard">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="OSKFont" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="DisplayFont" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
+                </xs:all>
+              </xs:complexType>
+              </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="LexicalModels">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="LexicalModel">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
+                </xs:all>
+              </xs:complexType>
+              </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Strings">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="String">
+              <xs:complexType>
+                <xs:attribute name="Name" type="xs:string" />
+                <xs:attribute name="Value" type="xs:string" />
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- Deprecated elements: we won't validate as processors ignore them -->
+
+      <xs:element minOccurs="0" maxOccurs="1" name="Buttons" type="km-any" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Registry" type="km-any" />
+
+    </xs:all>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="km-empty">
+  <xs:sequence/>
+</xs:complexType>
+
+<xs:complexType name="km-any">
+  <xs:sequence>
+    <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType name="km-version">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="(\d+\.)+(\d+)"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="km-info">
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <xs:attribute name="URL" type="xs:anyURI" />
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<xs:simpleType name="km-file-copy-location">
+  <xs:restriction base="xs:integer">
+    <xs:minInclusive value="0" />
+    <xs:maxInclusive value="3"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="km-start-menu-location">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="psmelStartMenu|psmelDesktop"></xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="km-keyboard-languages">
+  <xs:sequence>
+    <xs:element minOccurs="0" maxOccurs="unbounded" name="Language">
+      <xs:complexType>
+        <xs:simpleContent>
+          <xs:extension base="xs:string">
+            <xs:attribute name="ID" type="xs:string" />
+          </xs:extension>
+        </xs:simpleContent>
+      </xs:complexType>
+    </xs:element>
+  </xs:sequence>
+</xs:complexType>
+
+</xs:schema>

--- a/windows/src/developer/TIKE/Makefile
+++ b/windows/src/developer/TIKE/Makefile
@@ -4,7 +4,7 @@
 
 !include ..\..\Defines.mak
 
-build: version.res manifest.res icons dirs xml pull-core
+build: version.res manifest.res icons dirs xml xsd pull-core
     cd $(ROOT)\src\developer\tike
     $(DELPHI_MSBUILD) tike.dproj /p:Platform=Win32
     $(SENTRYTOOL_DELPHIPREP) $(WIN32_TARGET_PATH)\tike.exe -dpr tike.dpr
@@ -13,6 +13,9 @@ build: version.res manifest.res icons dirs xml pull-core
     $(COPY) kmlmc.cmd $(PROGRAM)\developer
     $(COPY) $(ROOT)\..\common\core\desktop\build\x86\$(TARGET_PATH)\src\kmnkbp0-0.dll $(PROGRAM)\developer
     if exist $(WIN32_TARGET_PATH)\tike.dbg $(COPY) $(WIN32_TARGET_PATH)\tike.dbg $(DEBUGPATH)\developer
+
+xsd:
+    $(COPY) $(KEYMAN_ROOT)\common\schemas\kps\kps.xsd $(PROGRAM)\developer
 
 xml: pull-keymanweb pull-npm sentry-init.js
     cd $(ROOT)\src\developer\tike\xml

--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -292,7 +292,8 @@ uses
   Keyman.UI.Debug.CharacterGridRenderer in 'debug\Keyman.UI.Debug.CharacterGridRenderer.pas',
   UfrmDebugStatus_Platform in 'debug\UfrmDebugStatus_Platform.pas' {frmDebugStatus_Platform},
   UfrmDebugStatus_Options in 'debug\UfrmDebugStatus_Options.pas' {frmDebugStatus_Options},
-  Keyman.Developer.System.KeymanDeveloperPaths in 'main\Keyman.Developer.System.KeymanDeveloperPaths.pas';
+  Keyman.Developer.System.KeymanDeveloperPaths in 'main\Keyman.Developer.System.KeymanDeveloperPaths.pas' {$R *.RES},
+  Keyman.Developer.System.ValidateKpsFile in '..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -560,6 +560,7 @@
         <DCCReference Include="main\Keyman.Developer.System.KeymanDeveloperPaths.pas">
             <Form>$R *.RES</Form>
         </DCCReference>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kpsProjectFileAction.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.System.Project.kpsProjectFileAction.pas
@@ -29,12 +29,14 @@ uses
   compile,
   CompilePackage,
   CompilePackageInstaller,
+  Keyman.Developer.System.ValidateKpsFile,
   PackageInfo,
   utilexecute;
 
 function TkpsProjectFileAction.CompilePackage(APack: TKPSFile; FSilent: Boolean): Boolean;
 var
   pack: TKPSFile;
+  ASchemaPath: string;
 begin
   HasCompileWarning := False;   // I4706
   if APack = nil then
@@ -45,6 +47,16 @@ begin
   end
   else
     pack := APack;
+
+  ASchemaPath := ExtractFilePath(ParamStr(0));
+  if (ASchemaPath <> '') and (FileExists(ASchemaPath + 'kps.xsd')) then
+  begin
+    if not TValidateKpsFile.Execute(FileName, ASchemaPath + 'kps.xsd', OwnerProject.Log) then
+    begin
+      Log(plsFailure, 'Package '+FileName+' had validation errors.', 0, 0);
+      Exit(False);
+    end;
+  end;
 
   try
     try

--- a/windows/src/developer/inst/kmdev.wxs
+++ b/windows/src/developer/inst/kmdev.wxs
@@ -214,6 +214,10 @@
       <!-- Data Files -->
 
       <Component>
+        <File Name="kps.xsd" KeyPath="yes" />
+      </Component>
+
+      <Component>
         <File Name="unicodedata.mdb" Source="..\..\global\inst\data\" KeyPath="yes" />
       </Component>
 

--- a/windows/src/developer/kmcomp/kccompilepackage.pas
+++ b/windows/src/developer/kmcomp/kccompilepackage.pas
@@ -33,13 +33,14 @@ uses
   kpsfile;
 
 function DoKCCompilePackage(FileName: string; AWarnAsError, ACheckFilenameConventions, AInstaller: Boolean;
-  const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
+  const AInstallerMSI: string; AUpdateInstaller: Boolean; const ASchemaPath: string): Boolean;   // I4706
 
 implementation
 
 uses
   Keyman.Developer.System.Project.ProjectLog,
-  Keyman.Developer.System.Project.ProjectLogConsole;
+  Keyman.Developer.System.Project.ProjectLogConsole,
+  Keyman.Developer.System.ValidateKpsFile;
 
 type
   TKCCompilePackage = class
@@ -52,7 +53,8 @@ begin
   TProjectLogConsole.Instance.Log(State, pack.Filename, Msg, 0, 0);
 end;
 
-function DoKCCompilePackage(FileName: string; AWarnAsError, ACheckFilenameConventions, AInstaller: Boolean; const AInstallerMSI: string; AUpdateInstaller: Boolean): Boolean;   // I4706
+function DoKCCompilePackage(FileName: string; AWarnAsError, ACheckFilenameConventions, AInstaller: Boolean;
+  const AInstallerMSI: string; AUpdateInstaller: Boolean; const ASchemaPath: string): Boolean;   // I4706
 var
   tcp: TKCCompilePackage;
   pack: TKPSFile;
@@ -68,6 +70,17 @@ begin
       TProjectLogConsole.Instance.Log(plsFatal, FileName, 'Package file does not exist', 0, 0);
       Exit;
     end;
+
+    if (ASchemaPath <> '') and (FileExists(ASchemaPath + 'kps.xsd')) then
+    begin
+      if not TValidateKpsFile.Execute(FileName, ASchemaPath + 'kps.xsd',
+        TProjectLogConsole.Instance.Log) then
+      begin
+        TProjectLogConsole.Instance.Log(plsFailure, FileName, 'Package '+FileName+' had validation errors.', 0, 0);
+        Exit;
+      end;
+    end;
+
     pack.FileName := FileName;
     pack.LoadXML;
 

--- a/windows/src/developer/kmcomp/kmcomp.dpr
+++ b/windows/src/developer/kmcomp/kmcomp.dpr
@@ -121,7 +121,8 @@ uses
   Keyman.System.Standards.LangTagsRegistry in '..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
   Keyman.Developer.System.Project.UrlRenderer in '..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas',
   Keyman.Developer.System.ValidateRepoChanges in 'Keyman.Developer.System.ValidateRepoChanges.pas',
-  Keyman.Developer.System.KeymanDeveloperPaths in '..\TIKE\main\Keyman.Developer.System.KeymanDeveloperPaths.pas';
+  Keyman.Developer.System.KeymanDeveloperPaths in '..\TIKE\main\Keyman.Developer.System.KeymanDeveloperPaths.pas',
+  Keyman.Developer.System.ValidateKpsFile in '..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/windows/src/developer/kmcomp/kmcomp.dproj
+++ b/windows/src/developer/kmcomp/kmcomp.dproj
@@ -110,7 +110,7 @@
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
-        <Debugger_RunParams>-validate-repo-changes C:\Projects\keyman\keyboards compare-bcp47-scripts</Debugger_RunParams>
+        <Debugger_RunParams>c:\temp\foo.kps -schema-path C:\Projects\keyman\app\common\schemas\kps\</Debugger_RunParams>
         <DCC_AssertionsAtRuntime>true</DCC_AssertionsAtRuntime>
         <DCC_DebugInformation>2</DCC_DebugInformation>
         <VerInfo_Locale>1033</VerInfo_Locale>
@@ -277,6 +277,7 @@
         <DCCReference Include="..\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <DCCReference Include="Keyman.Developer.System.ValidateRepoChanges.pas"/>
         <DCCReference Include="..\TIKE\main\Keyman.Developer.System.KeymanDeveloperPaths.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -348,13 +349,13 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="kmcomp.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Release\kmcomp.exe" Configuration="Release" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>kmcomp.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="bin\Win32\Release\kmcomp.exe" Configuration="Release" Class="ProjectOutput">
+                <DeployFile LocalName="kmcomp.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>kmcomp.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -272,7 +272,7 @@ begin
     else if LowerCase(ExtractFileExt(FParamInfile)) = '.kpj' then   // I4699
       Ferror := not DoKCCompileProject(FParamInfile, FDebug, FClean, FWarnAsError, FCheckFilenameConventions, FParamTarget)   // I4706   // I4707
     else if LowerCase(ExtractFileExt(FParamInfile)) = '.kps' then
-      FError := not DoKCCompilePackage(FParamInfile, FWarnAsError, FInstaller, FCheckFilenameConventions, FInstallerMSI, FUpdateInstaller)   // I4706
+      FError := not DoKCCompilePackage(FParamInfile, FWarnAsError, FInstaller, FCheckFilenameConventions, FInstallerMSI, FUpdateInstaller, FJsonSchemaPath)   // I4706
     else
       FError := not CompileKeyboard(FParamInfile, FParamOutfile, FDebug, FWarnAsError);   // I4706
 

--- a/windows/src/global/delphi/general/Keyman.Developer.System.ValidateKpsFile.pas
+++ b/windows/src/global/delphi/general/Keyman.Developer.System.ValidateKpsFile.pas
@@ -1,0 +1,70 @@
+unit Keyman.Developer.System.ValidateKpsFile;
+
+interface
+
+uses
+  Keyman.Developer.System.Project.ProjectLog;
+
+type
+  TValidateKpsFile = class
+  private
+    FOnLogEvent: TProjectLogObjectEvent;
+    FKpsFile: string;
+    FKpsXsdPath: string;
+    constructor Create(const AKpsFile, AKpsXsdPath: string);
+    function Validate: Boolean;
+    property OnLogEvent: TProjectLogObjectEvent read FOnLogEvent write FOnLogEvent;
+  public
+    class function Execute(const KpsFile, KpsXsdPath: string; FCallback: TProjectLogObjectEvent): Boolean;
+  end;
+
+implementation
+
+uses
+  Winapi.MsXml;
+
+{ TValidateKpsFile }
+
+constructor TValidateKpsFile.Create(const AKpsFile, AKpsXsdPath: string);
+begin
+  inherited Create;
+  FKpsFile := AKpsFile;
+  FKpsXsdPath := AKpsXsdPath;
+end;
+
+class function TValidateKpsFile.Execute(const KpsFile, KpsXsdPath: string;
+  FCallback: TProjectLogObjectEvent): Boolean;
+var
+  v: TValidateKpsFile;
+begin
+  v := TValidateKpsFile.Create(KpsFile, KpsXsdPath);
+  try
+    v.OnLogEvent := FCallback;
+    Result := v.Validate;
+  finally
+    v.Free;
+  end;
+end;
+
+function TValidateKpsFile.Validate: Boolean;
+var
+  xml, xsd: IXMLDOMDocument2;
+  cache: IXMLDOMSchemaCollection;
+begin
+  xsd := CoDOMDocument60.Create;
+  xsd.Async := False;
+  xsd.load(FKpsXsdPath);
+
+  cache := CoXMLSchemaCache60.Create;
+  cache.add('', xsd);
+
+  xml := CoDOMDocument60.Create;
+  xml.async := False;
+  xml.schemas := cache;
+
+  Result := xml.load(FKpsFile);
+  if not Result then
+    FOnLogEvent(plsError, FKpsFile, 'Validation error: '+xml.parseError.reason, 1, xml.parseError.line);
+end;
+
+end.

--- a/windows/src/test/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
+++ b/windows/src/test/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dpr
@@ -99,7 +99,8 @@ uses
   Keyman.System.PackageInfoRefreshLexicalModels in '..\..\..\global\delphi\packages\Keyman.System.PackageInfoRefreshLexicalModels.pas',
   Keyman.System.Standards.LangTagsRegistry in '..\..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas',
   Keyman.Developer.System.Project.UrlRenderer in '..\..\..\developer\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas',
-  KeymanPaths in '..\..\..\global\delphi\general\KeymanPaths.pas';
+  KeymanPaths in '..\..\..\global\delphi\general\KeymanPaths.pas',
+  Keyman.Developer.System.ValidateKpsFile in '..\..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/test/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
+++ b/windows/src/test/unit-tests/keyboard-package-versions/KeyboardPackageVersionsTestSuite.dproj
@@ -181,6 +181,7 @@
         <DCCReference Include="..\..\..\global\delphi\standards\Keyman.System.Standards.LangTagsRegistry.pas"/>
         <DCCReference Include="..\..\..\developer\TIKE\project\Keyman.Developer.System.Project.UrlRenderer.pas"/>
         <DCCReference Include="..\..\..\global\delphi\general\KeymanPaths.pas"/>
+        <DCCReference Include="..\..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
Fixes #5464.

The keyboards repository already has code to validate .xsd files, using xmllint. This adds the same functionality directly into kmcomp and TIKE.

# User Testing

* TEST_SCHEMA: Verify that existing .kps files compile correctly -- choose at random!
* TEST_DODGY_SCHEMA: Manually edit a .kps file in a text editor to introduce an unsupported XML element, for example, add a `<Foo />` element somewhere. The compile of this file should fail with a "helpful" error message.