### PR TITLE
fix(web): simplify hide transition

### DIFF
--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -22,7 +22,7 @@ namespace com.keyman.osk {
     manual      = "manual",
     automatic = "automatic"
   }
-  
+
   export abstract class OSKView {
     _Box: HTMLDivElement;
 
@@ -34,23 +34,23 @@ namespace com.keyman.osk {
     protected device: com.keyman.utils.DeviceSpec;
     protected readonly hostDevice: com.keyman.utils.DeviceSpec;
 
-    private _boxBaseMouseDown:        (e: MouseEvent) => boolean; 
+    private _boxBaseMouseDown:        (e: MouseEvent) => boolean;
     private _boxBaseTouchStart:       (e: TouchEvent) => boolean;
     private _boxBaseTouchEventCancel: (e: TouchEvent) => boolean;
 
     private keyboard: keyboards.Keyboard;
 
     private _target:  text.OutputTarget;
-    
+
     /**
      * The configured width for this OSKManager.  May be `undefined` or `null`
-     * to allow automatic width scaling. 
+     * to allow automatic width scaling.
      */
     private _width: ParsedLengthStyle;
 
     /**
      * The configured height for this OSKManager.  May be `undefined` or `null`
-     * to allow automatic height scaling. 
+     * to allow automatic height scaling.
      */
     private _height: ParsedLengthStyle;
 
@@ -79,7 +79,6 @@ namespace com.keyman.osk {
     private _displayIfActive: boolean = true;
 
     private _animatedHideTimeout: number;
-    private _animatedHideResolver: () => void;
 
     constructor(deviceSpec: com.keyman.utils.DeviceSpec, hostDevice?: com.keyman.utils.DeviceSpec) {
       this.device = deviceSpec;
@@ -111,7 +110,7 @@ namespace com.keyman.osk {
       // Register a listener for model change events so that we can hot-swap the banner as needed.
       // Handled here b/c banner changes may trigger a need to re-layout the OSK.
       const _this = this;
-      keymanweb.core.languageProcessor.on('statechange', 
+      keymanweb.core.languageProcessor.on('statechange',
                                           function(state: text.prediction.StateChangeEnum) {
         let currentType = _this.bannerView.activeType;
         _this.bannerView.selectBanner(state);
@@ -182,7 +181,7 @@ namespace com.keyman.osk {
     /**
      * Gets and sets the IME-like interface (`OutputTarget`) to be affected by events from
      * the OSK.
-     * 
+     *
      * If `activationMode` is `'conditional'`, this property's state controls the visibility
      * of the OSKView.
      */
@@ -259,11 +258,11 @@ namespace com.keyman.osk {
 
     /**
      * A property denoting whether or not the OSK should be presented if it meets its
-     * activation conditions. 
-     * 
+     * activation conditions.
+     *
      * When `activationMode == 'manual'`, `displayIfActive == true` is the lone
      * activation condition.
-     * 
+     *
      * Note: cannot be set to `false` if `activationMode == 'static'`.
      */
     get displayIfActive(): boolean {
@@ -318,7 +317,7 @@ namespace com.keyman.osk {
 
     /**
      * The configured width for this VisualKeyboard.  May be `undefined` or `null`
-     * to allow automatic width scaling. 
+     * to allow automatic width scaling.
      */
     get width(): ParsedLengthStyle {
       return this._width;
@@ -326,7 +325,7 @@ namespace com.keyman.osk {
 
     /**
      * The configured height for this VisualKeyboard.  May be `undefined` or `null`
-     * to allow automatic height scaling. 
+     * to allow automatic height scaling.
      */
     get height(): ParsedLengthStyle {
       return this._height;
@@ -357,7 +356,7 @@ namespace com.keyman.osk {
     }
 
     /**
-     * The top-level style string for the font size used by the predictive banner 
+     * The top-level style string for the font size used by the predictive banner
      * and the primary keyboard visualization elements.
      */
     get baseFontSize(): string {
@@ -397,7 +396,7 @@ namespace com.keyman.osk {
         return ParsedLengthStyle.special(fontScale, 'em');
       } else {
         return this.computedHeight ? ParsedLengthStyle.inPixels(this.computedHeight / 8) : undefined;
-      } 
+      }
     }
 
     public get activeKeyboard(): keyboards.Keyboard {
@@ -614,7 +613,7 @@ namespace com.keyman.osk {
     private layerChangeHandler: text.SystemStoreMutationHandler = function(this: OSKView,
       source: text.MutableSystemStore,
       newValue: string) {
-      // This handler is also triggered on state-key state changes (K_CAPS) that 
+      // This handler is also triggered on state-key state changes (K_CAPS) that
       // may not actually change the layer.
       if(this.vkbd) {
         this.vkbd._UpdateVKShiftStyle();
@@ -691,7 +690,7 @@ namespace com.keyman.osk {
 
     /**
      * The main function for presenting the OSKView.
-     * 
+     *
      * This includes:
      * - refreshing its layout
      * - displaying it
@@ -719,7 +718,7 @@ namespace com.keyman.osk {
 
       /* In case it's still '0' from a hide() operation.
        *
-       * (Opacity is only modified when device.touchable = true, 
+       * (Opacity is only modified when device.touchable = true,
        * though a couple of extra conditions may apply.)
        */
       this._Box.style.opacity = '1';
@@ -808,7 +807,7 @@ namespace com.keyman.osk {
     }
 
     /**
-     * 
+     *
      * @returns `false` if the OSK is in an invalid state for being presented to the user.
      */
     protected mayShow(): boolean {
@@ -829,8 +828,8 @@ namespace com.keyman.osk {
     }
 
     /**
-     * 
-     * @param hiddenByUser 
+     *
+     * @param hiddenByUser
      * @returns `false` if the OSK is in an invalid state for being hidden from the user.
      */
     protected mayHide(hiddenByUser: boolean): boolean {
@@ -851,22 +850,56 @@ namespace com.keyman.osk {
     /**
      * Applies CSS styling and handling needed to perform a fade animation when
      * hiding the OSK.
-     * 
+     *
      * Note:  currently reflects an effectively-dead code path, though this is
      * likely not intentional.  Other parts of the KMW engine seem to call hideNow()
      * synchronously after each and every part of the engine that calls this function,
      * cancelling the Promise.
-     * 
+     *
      * @returns A Promise denoting either cancellation of the hide (`false`) or
      * completion of the hide & its animation (`true`)
      */
+
     protected useHideAnimation(): Promise<boolean> {
       const os = this._Box.style;
       const _this = this;
-      const promise = new Promise<void>(function(resolve) {
-        os.transition='opacity 0.5s linear 0';
 
-        _this._animatedHideResolver = resolve;
+      return new Promise<boolean>(function(resolve) {
+        const cleanup = function() {
+          // TODO(lowpri): attach event listeners on create and leave them there
+          _this._Box.removeEventListener('transitionend', cleanup, false);
+          _this._Box.removeEventListener('webkitTransitionEnd', cleanup, false);
+          _this._Box.removeEventListener('transitioncancel', cleanup, false);
+          _this._Box.removeEventListener('webkitTransitionCancel', cleanup, false);
+          if(_this._animatedHideTimeout != 0) {
+            window.clearTimeout(_this._animatedHideTimeout);
+          }
+          _this._animatedHideTimeout = 0;
+
+          if(_this._Visible && _this.activationConditionsMet) {
+            // Leave opacity alone and clear transition if another element activated
+            os.transition='';
+            os.opacity='1';
+            resolve(false);
+            return false;
+          } else {
+            resolve(true);
+            return true;
+          }
+        }, startup = function() {
+          _this._Box.removeEventListener('transitionrun', startup, false);
+          _this._Box.removeEventListener('webkitTransitionRun', startup, false);
+          _this._Box.addEventListener('transitionend', cleanup, false);
+          _this._Box.addEventListener('webkitTransitionEnd', cleanup, false);
+          _this._Box.addEventListener('transitioncancel', cleanup, false);
+          _this._Box.addEventListener('webkitTransitionCancel', cleanup, false);
+        };
+
+        _this._Box.addEventListener('transitionrun', startup, false);
+        _this._Box.addEventListener('webkitTransitionRun', startup, false);
+
+        os.transition='opacity 0.5s linear 0';
+        os.opacity='0';
 
         // Cannot hide the OSK smoothly using a transitioned drop, since for
         // position:fixed elements transitioning is incompatible with translate3d(),
@@ -874,45 +907,8 @@ namespace com.keyman.osk {
         // Opacity can be transitioned and is probably the simplest alternative.
         // We must condition on osk._Visible in case focus has since been moved to another
         // input (in which case osk._Visible will be non-zero)
-        _this._animatedHideTimeout = window.setTimeout(function(this: AnchoredOSKView) {
-          if(_this._animatedHideResolver) {
-            _this._animatedHideResolver();
-          }
-
-          _this._animatedHideTimeout = 0;
-          _this._animatedHideResolver = null;
-        }.bind(_this), 200); // Wait a bit before starting, to allow for moving to another element
-      });
-
-      return promise.then(function() {
-        // Repro for passing this condition:
-        // 1.  Touch an input element of the page
-        // 2.  Within a second (before the focusing timer expires), touch the base page.
-        //     See domEventHandlers.ts, `focusTimer` / `setFocusTimer`.
-        // 3.  After the timer expires, touch the base page again.
-        if(_this._Visible && _this.activationConditionsMet) {
-          // Leave opacity alone and clear transition if another element activated
-          os.transition='';
-          return false;
-        } else {
-          // Set opacity to zero, should decrease smoothly.  Starts the actual animation.
-          os.opacity='0';
-
-          // Listen for the animation's end.
-          return new Promise<void>(function(resolve) {
-            _this._animatedHideResolver = resolve;
-            // Actually hide the OSK at the end of the transition
-            _this._Box.addEventListener('transitionend', _this._animatedHideResolver, false);
-            _this._Box.addEventListener('webkitTransitionEnd', _this._animatedHideResolver, false);
-          }).then(function() {
-            // Remove the promise's resolver method from future handling.
-            _this._Box.removeEventListener('transitionend', _this._animatedHideResolver, false);
-            _this._Box.removeEventListener('webkitTransitionEnd', _this._animatedHideResolver, false);
-
-            // The hide animation is considered complete now.
-            return true;
-          });
-        }
+        _this._animatedHideTimeout = window.setTimeout(cleanup,
+          200); // Wait a bit before starting, to allow for moving to another element
       });
     }
 
@@ -933,21 +929,14 @@ namespace com.keyman.osk {
       // Was an animated hide waiting to start?  Just cancel it.
       if(this._animatedHideTimeout) {
         window.clearTimeout(this._animatedHideTimeout);
-        this._animatedHideResolver = null;
         this._animatedHideTimeout = 0;
       }
 
       // Was an animated hide already in progress?  If so, just trigger it early.
-      if(this._animatedHideResolver) {
-        this._animatedHideResolver();  // also triggers finalizeHide().
-        this._animatedHideResolver = null;
-      } else {
-        const os = this._Box.style;
-        os.transition='';
-        os.opacity='0';
-
-        this.finalizeHide();
-      }
+      const os = this._Box.style;
+      os.transition='';
+      os.opacity='0';
+      this.finalizeHide();
     }
 
     ['shutdown']() {
@@ -993,10 +982,10 @@ namespace com.keyman.osk {
 
     /**
      * Display build number
-     * 
+     *
      * In the future, this should raise an event that the consuming KeymanWeb
      * engine may listen for & respond to, rather than having it integrated
-     * as part of the OSK itself. 
+     * as part of the OSK itself.
      */
     showBuild() {
       let keymanweb = com.keyman.singleton;
@@ -1006,11 +995,11 @@ namespace com.keyman.osk {
 
     /**
      * Display list of installed keyboards in pop-up menu
-     * 
+     *
      * In the future, this language menu should be defined as a UI module like the standard
      * desktop UI modules.  The globe key should then trigger an event to _request_ that the
      * consuming engine display the active UI module's menu.
-     * 
+     *
      **/
     showLanguageMenu() {
       if(this.hostDevice.touchable) {


### PR DESCRIPTION
Fixes #5907.

The state machine for the Hide transition for the OSK was very complex, and had some peculiarities which caused it to sometimes fail to correctly hide. Once I simplified the state machine, it seems that those edge cases have gone away, and the keyboard always hides correctly.

# User Testing

Note: There is an unrelated issue with focus timeout which can be confusing when testing this; see #5909. **To avoid this:** wait at least one second before clicking outside a text box.

* GROUP_DESKTOP: run this test in Chrome on Windows.
* GROUP_TOUCH: run this test on iOS or Android device.

* TEST_KEYBOARD: in the unminified test page, repeatedly switch between controls and ensure that the OSK shows and hides exactly as expected. Try clicking elsewhere in the document to hide the keyboard. Once the keyboard hides, click where it *was* and make sure that it does not magically re-appear! Basically, the idea is to try and get the keyboard interactions to go wrong.