### PR TITLE
fix(web): remove canvas use for iOS compatibility

### DIFF
--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -99,7 +99,7 @@ namespace com.keyman.osk.browser {
           this.cap.style.left = (canvasWidth - xWidth) + 'px';
           xLeft -= xOverflow;
         } else {
-          this.cap.style.left = ((canvasWidth - xWidth) / 2) + 'px';
+          this.cap.style.left = xOverflow + 'px';
         }
 
         kts.left=(xLeft - xOverflow) + 'px';

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -4,10 +4,19 @@ namespace com.keyman.osk.browser {
     public key: KeyElement;
     public state: boolean = false;
 
-    private canvas: HTMLCanvasElement;
-    private label: HTMLSpanElement;
+    //  -----
+    // |     | <-- tip
+    // |  x  | <-- label
+    // |_   _|
+    //  |   |
+    //  |   |  <-- cap
+    //  |___|
 
-    private constrain: boolean;
+    private readonly cap: HTMLDivElement;
+    private readonly tip: HTMLDivElement;
+    private readonly label: HTMLSpanElement;
+
+    private readonly constrain: boolean;
 
     // constrain:  keep the keytip within the bounds of the overall OSK.
     // Will probably be handled via function in a later pass.
@@ -18,10 +27,15 @@ namespace com.keyman.osk.browser {
 
       // The following style is critical, so do not rely on external CSS
       tipElement.style.pointerEvents='none';
+      tipElement.style.display='none';
 
-      // Add CANVAS element for outline and SPAN for key label
-      tipElement.appendChild(this.canvas = document.createElement('canvas'));
-      tipElement.appendChild(this.label = document.createElement('span'));
+      tipElement.appendChild(this.tip = document.createElement('div'));
+      tipElement.appendChild(this.cap = document.createElement('div'));
+      this.tip.appendChild(this.label = document.createElement('span'));
+
+      this.tip.className = 'kmw-keytip-tip';
+      this.cap.className = 'kmw-keytip-cap';
+      this.label.className = 'kmw-keytip-label';
 
       this.constrain = constrain;
     }
@@ -38,19 +52,20 @@ namespace com.keyman.osk.browser {
         // in turn, relative to its row.  Rows take 100% width, so this is sufficient.
         //
         // May need adjustment for borders if ever enabled for the desktop form-factor target.
-        var xLeft = (key.offsetParent as HTMLElement).offsetLeft,
-            xWidth = key.offsetWidth,
-            xHeight = key.offsetHeight,
+        let r = key.getClientRects()[0];
+        let xLeft = r.left,
+            xWidth = r.width,
+            xHeight = r.height,
             kc = key.key.label,
-            edge = 0,
             previewFontScale = 1.8;
 
         // Canvas dimensions must be set explicitly to prevent clipping
-        this.canvas.width = 1.6 * xWidth;
-        this.canvas.height = 2.3 * xHeight;
+        let canvasWidth = 1.6 * xWidth;
+        let canvasHeight = 2.3 * xHeight;
 
         let kts = this.element.style;
         kts.top = 'auto';
+
         // Matches how the subkey positioning is set.
         let rowElement = (key.key as OSKBaseKey).row.element;
         const _Box = vkbd.element.parentNode as HTMLDivElement;
@@ -58,8 +73,8 @@ namespace com.keyman.osk.browser {
         kts.textAlign = 'center';
         kts.overflow = 'visible';
         kts.fontFamily = util.getStyleValue(kc,'font-family');
-        kts.width = this.canvas.width+'px';
-        kts.height = this.canvas.height+'px';
+        kts.width = canvasWidth+'px';
+        kts.height = canvasHeight+'px';
 
         var px=util.getStyleInt(kc, 'font-size');
         if(px != 0) {
@@ -75,39 +90,37 @@ namespace com.keyman.osk.browser {
 
         this.label.textContent = kc.textContent;
 
-        let ktls = this.label.style;
-        ktls.display = 'block';
-        ktls.position = 'absolute';
-        ktls.textAlign = 'center';
-        ktls.width='100%';
-        ktls.top = '2%';
-        ktls.bottom = 'auto';
-
-        // Adjust canvas shape if at edges
-        var xOverflow = (this.canvas.width - xWidth) / 2;
+        // Adjust shape if at edges
+        var xOverflow = (canvasWidth - xWidth) / 2;
         if(xLeft < xOverflow) {
-          edge = -1;
+          this.cap.style.left = '0px';
           xLeft += xOverflow;
         } else if(xLeft > window.innerWidth - xWidth - xOverflow) {
-          edge = 1;
+          this.cap.style.left = (canvasWidth - xWidth) + 'px';
           xLeft -= xOverflow;
+        } else {
+          this.cap.style.left = ((canvasWidth - xWidth) / 2) + 'px';
         }
+
+        kts.left=(xLeft - xOverflow) + 'px';
 
         let cs = getComputedStyle(this.element);
         let oskHeight = keyman.osk.computedHeight;
         let bottomY = parseInt(cs.bottom, 10);
         let tipHeight = parseInt(cs.height, 10);
 
-        let delta = 0;
+        this.cap.style.width = xWidth + 'px';
+        this.tip.style.height = (canvasHeight / 2) + 'px';
+        this.cap.style.top = (canvasHeight / 2) + 'px';
+        this.cap.style.height = (canvasHeight / 2 - 1) + 'px';
+
         if(this.constrain && tipHeight + bottomY > oskHeight) {
-          delta = tipHeight + bottomY - oskHeight;
-          this.canvas.height = this.canvas.height - delta;
-          kts.height = this.canvas.height + 'px';
+          const delta = tipHeight + bottomY - oskHeight;
+          kts.height = (canvasHeight-delta) + 'px';
+          const hx = Math.max(0, (canvasHeight-delta)-(canvasHeight/2));
+          this.cap.style.height = hx + 'px';
         }
 
-        this.drawPreview(this.canvas, vkbd.device, xWidth, xHeight, edge, delta);
-
-        kts.left=(xLeft - xOverflow) + 'px';
         kts.display = 'block';
       } else { // Hide the key preview
         this.element.style.display = 'none';
@@ -117,80 +130,5 @@ namespace com.keyman.osk.browser {
       this.key = key;
       this.state = on;
     }
-
-    /**
-     * Draw key preview in element using CANVAS
-     *  @param  {Object}  canvas CANVAS element
-     *  @param  {number}  w width of touched key, px
-     *  @param  {number}  h height of touched key, px
-     *  @param  {number}  edge  -1 left edge, 1 right edge, else 0
-     */
-    drawPreview(canvas: HTMLCanvasElement, device: com.keyman.utils.DeviceSpec, w: number, h: number, edge: number, delta?: number) {
-      delta = delta || 0;
-
-      var ctx = canvas.getContext('2d'), dx = (canvas.width - w)/2, hMax = canvas.height + delta,
-          w0 = 0, w1 = dx, w2 = w + dx, w3 = w + 2 * dx,
-          h1 = 0.5 * hMax, h2 = 0.6 * hMax, h3 = hMax, r = 8;
-
-      let hBoundedMax = canvas.height;
-
-      h2 = h2 > hBoundedMax ? hBoundedMax : h2;
-      h3 = hMax > hBoundedMax ? hBoundedMax : h3;
-
-      if(device.OS == utils.OperatingSystem.Android) {
-        r = 3;
-      }
-
-      // Adjust the preview shape at the edge of the keyboard
-      switch(edge) {
-        case -1:
-          w1 -= dx;
-          w2 -= dx;
-          break;
-        case 1:
-          w1 += dx;
-          w2 += dx;
-          break;
-      }
-
-      // Clear the canvas
-      ctx.clearRect(0,0,canvas.width,canvas.height);
-
-      // Define appearance of preview (cannot be done directly in CSS)
-      if(device.OS == utils.OperatingSystem.Android) {
-        var wx=(w1+w2)/2;
-        w1 = w2 = wx;
-      }
-
-      let styleConsts = new utils.StyleConstants(device);
-      ctx.fillStyle = styleConsts.popupCanvasBackgroundColor;
-      ctx.lineWidth = 1;
-      ctx.strokeStyle = '#cccccc';
-
-      // Draw outline
-      ctx.save();
-      ctx.beginPath();
-      ctx.moveTo(w0+r,0);
-      ctx.arcTo(w3,0,w3,r,r);
-      if(device.OS == utils.OperatingSystem.Android) {
-        ctx.arcTo(w3,h1,w2,h2,r);
-        ctx.arcTo(w2,h2,w1,h2,r);
-      } else {
-        let lowerR = 0;
-        if(h3 > h2) {
-          lowerR = h3-h2 > r ? r : h3-h2;
-        }
-        ctx.arcTo(w3,h1,w2,h2,r);
-        ctx.arcTo(w2,h2,w2-lowerR,h3,lowerR);
-        ctx.arcTo(w2,h3,w1,h3,lowerR);
-        ctx.arcTo(w1,h3,w1,h2-lowerR,lowerR);
-      }
-      ctx.arcTo(w1,h2,w0,h1-r,r);
-      ctx.arcTo(w0,h1,w0,r,r);
-      ctx.arcTo(w0,0,w0+r,0,r);
-      ctx.fill();
-      ctx.stroke();
-      ctx.restore();
-    };
   }
 }

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -323,8 +323,58 @@ body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;f
 }
 
 /* Key preview styles */
+
 div.ios div.kmw-keytip {
-  position:absolute; left:0; top:0; width:3em; height:3em; background-color:rgb(0,0,0,0);overflow:visible;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 3em;
+  height: 3em;
+  background-color: rgb(0, 0, 0, 0);
+  overflow: visible;
+}
+
+div.ios div.kmw-keytip-tip {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  border-radius: 6px 6px 4px 4px;
+  border: solid 1px #cccccc;
+  border-bottom: solid 1px #8a8d90;
+}
+
+div.ios div.kmw-keytip-cap {
+  position: absolute;
+  border-radius: 0 0 5px 5px;
+  border-top: solid 1px white;
+  border-bottom: solid 1px #8a8d90;
+}
+
+span.kmw-keytip-label {
+  display: block;
+  transform: translateY(-50%);
+  top: 50%;
+  position: relative;
+}
+
+div.ios div.kmw-keytip-cap,
+div.ios div.kmw-keytip-tip {
+  background:white;
+}
+
+div.android div.kmw-keytip {
+  position:absolute;
+  left: 0;
+  top: 0;
+  width: 3em;
+  height: 3em;
+  color: white;
+  overflow: visible;
+}
+
+div.android div.kmw-keytip-tip {
+  border-radius: 6px;
+  background: #999;
 }
 
 /* Dark mode - ensure text is colored appropriately for key tips. */
@@ -333,20 +383,20 @@ div.ios div.kmw-keytip {
     color:#fff;
   }
 
+  div.ios div.kmw-keytip-cap,
+  div.ios div.kmw-keytip-tip {
+    background: #0f1319;
+  }
+
+  div.ios div.kmw-keytip-cap {
+    border-top: solid 1px #0f1319;
+  }
+
   /* Style for callout used on phones */
   #kmw-popup-callout {
     background-color: #0f1319;
   }
 }
-
-div.android div.kmw-keytip {
-  position:absolute; left:0; top:0; width:3em; height:3em;
-  color:#fff;
-  background-color: rgb(0,0,0,0);
-  overflow:visible;
-}
-
-div.android #keytip {background-color:#f00;}
 
 /* Box styles for keyboard-specific OSK (e.g. EuroLatin) and if no keyboard active (desktop only) */
 .kmw-osk-static, .kmw-osk-none{text-align:left;font:12px sans-serif;border:solid 1px #ad4a28;color:blue;background-color:white;}


### PR DESCRIPTION
Fixes #5831.

iOS 15 has a significant crashing bug whereby use of a canvas element completely crashes the browser in some contexts. In particular, we have observed this when using a WKWebView in a keyboard extension without 'Allow Full Access' switched on.

Keyman uses canvas element to draw a nice looking key preview (key tip) on iPhones. This is a critical issue for Keyman for iPhone. Keyman for iPad is not affected because the iPad version does not use key previews.

The resolution here is to remove use of the canvas drawing for key tips and use a simplified pure HTML/CSS shape. I have not conditioned this fix on platform; I have currently opted to apply this to all platforms.

This fix will be backported to Keyman 14.0-stable.

This issue will be reported to Apple for resolution. The issue applies so far to iOS 15.0, 15.1.

# Screenshots

Android phone preview. Simplified as we can no longer use the triangle shape easily:

![image](https://user-images.githubusercontent.com/4498365/141930219-e919c2c8-5b1c-4376-9f79-36ab43c9988d.png)

iPhone preview:

![image](https://user-images.githubusercontent.com/4498365/141930291-28e09488-bba5-4cbf-ad24-39d7f8bc39c2.png)

![image](https://user-images.githubusercontent.com/4498365/141930318-e61c716d-a8b4-41a9-adb6-af360ce5bf61.png)

# User Testing

## SUITE_STABILITY

Load the system keyboard on iOS 15 on a real iPhone (**simulator not sufficient**). Ensure that 'Allow Full Access' is switched off.

Note: this will require building on a local machine and testing. @sgschantz can you do these two tests?

* TEST_IOS_APP_STABILITY: Verify that Keyman for iPhone no longer crashes (that is, it does not go blank) with this fix in place, by loading one or more Keyman system keyboards and typing several keystrokes.
* TEST_IOS_FV_APP_STABILITY: Verify that FirstVoices Keyboards for iPhone no longer crashes (that is, it does not go blank) with this fix in place, by loading one or more FVKeyboards system keyboards and typing several keystrokes.

## SUITE_DISPLAY: Test that the key preview looks acceptable

We need to test across a variety of platforms as this change removes the canvas element and replaces it. The key preview will not look identical to earlier, and this is acceptable. However, it does need to look reasonable.

* TEST_ANDROID_APP_DISPLAY: Verify that display of key previews is still adequate on Android phones - both in-app and system (emulator acceptable).
* TEST_IOS_APP_DISPLAY: Verify that Keyman for iPhone key previews still look good - both in-app and system. The system preview may overlap the key on the top row if the banner is switched off (simulator acceptable).
* TEST_IOS_APP_DARKMODE_DISPLAY: Verify that Keyman for iPhone key previews still look good in dark mode - both in-app and system. The system preview may overlap the key on the top row if the banner is switched off (simulator acceptable).
* TEST_ANDROID_WEB_DISPLAY: In KeymanWeb, verify that display of key previews is still adequate on Android phones (emulator acceptable).
* TEST_IOS_WEB_DISPLAY: In KeymanWeb, verify that display of key previews is still adequate on an iPhone (simulator acceptable).