### PR TITLE
fix(web): remove canvas use for iOS compatibility 🍒

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -32,7 +32,7 @@ namespace com.keyman.osk {
       }
     } else if(keyName.indexOf('K_ROPT') >= 0) {
       if(keyDown) {
-        this.highlightKey(e,false);            
+        this.highlightKey(e,false);
         if(typeof keyman['hideKeyboard'] == 'function') {
           keyman['hideKeyboard']();
         }
@@ -47,10 +47,10 @@ namespace com.keyman.osk {
   if(device.OS == 'Android') { // assumption - if this file is being loaded, keyman.isEmbedded == true.
     // Send the subkey array to iOS, with centre,top of base key position
     /**
-     * Create a popup key array natively 
-     * 
+     * Create a popup key array natively
+     *
      * @param {Object}  key   base key element
-     */            
+     */
     VisualKeyboard.prototype.touchHold = function(this: VisualKeyboard, key: KeyElement) {
       let util = com.keyman.singleton.util;
       if(key['subKeys'] && (typeof(window['oskCreatePopup']) == 'function')) {
@@ -89,7 +89,7 @@ namespace com.keyman.osk {
             break;
           }
         }
-          
+
         if(key.className.indexOf('kmw-key-default') >= 0 && key.id.indexOf('K_SPACE') < 0) {
           showPreview(xBase, yBase, key.offsetWidth, key.offsetHeight, kc.innerHTML);
         }
@@ -111,10 +111,6 @@ namespace com.keyman.osk {
     };
 
     VisualKeyboard.prototype.highlightSubKeys = function(this: VisualKeyboard, k, x, y) {
-      // a dummy function; it's only really used for 'native' KMW.
-    }
-
-    VisualKeyboard.prototype.drawPreview = function(this: VisualKeyboard, w, h, edge) {
       // a dummy function; it's only really used for 'native' KMW.
     }
 
@@ -173,27 +169,27 @@ namespace com.keyman.text {
 
   // Allow definition of application name
   keymanweb.options['app']='';
-  
+
   // Flag to control refreshing of a keyboard that is already loaded
   keymanweb.mustReloadKeyboard = true;
-  
+
   // Skip full page initialization - skips native-mode only code
   keymanweb.isEmbedded = true;
 
-  com.keyman.osk.VisualKeyboard.prototype.popupDelay = 400;  // Delay must be less than native touch-hold delay 
-  
+  com.keyman.osk.VisualKeyboard.prototype.popupDelay = 400;  // Delay must be less than native touch-hold delay
+
   // Set default device options
   keymanweb.setDefaultDeviceOptions = function(opt) {
     opt['attachType'] = 'manual';
     device.app=opt['app'];
-    device.touchable=true; 
-    device.formFactor='phone'; 
+    device.touchable=true;
+    device.formFactor='phone';
     if(navigator && navigator.userAgent && navigator.userAgent.indexOf('iPad') >= 0) device.formFactor='tablet';
     if(device.app.indexOf('Mobile') >= 0) device.formFactor='phone';
     if(device.app.indexOf('Tablet') >= 0) device.formFactor='tablet';
     device.browser='native';
   };
-  
+
   // Get default style sheet path
   keymanweb.getStyleSheetPath = function(ssName) {
     return keymanweb.rootPath+ssName;
@@ -237,7 +233,7 @@ namespace com.keyman.text {
 
     /**
    * Force reload of resource
-   * 
+   *
    *  @param  {string}  s unmodified URL
    *  @return {string}    modified URL
    */
@@ -246,7 +242,7 @@ namespace com.keyman.text {
     s = s + '?v=' + t;
     return s;
   };
-  
+
   util.wait = function() {
     // Empty stub - this function should not be implemented or used within embedded code routes.
     console.warn("util.wait() call attempted in embedded mode!");  // Sends log message to embedding app.
@@ -259,39 +255,39 @@ namespace com.keyman.text {
 
   /**
    * Refresh element content after change of text (if required)
-   * 
+   *
    *  @param  {Object}  Pelem   input element
-   */         
-  keymanweb.refreshElementContent = function(Pelem) 
+   */
+  keymanweb.refreshElementContent = function(Pelem)
   {
     if('ontextchange' in keymanweb) keymanweb['ontextchange'](Pelem);
   };
 
   /**
    * Set target element text direction (LTR or RTL): not functional for KMEI, KMEA
-   *    
+   *
    * @param       {Object}      Ptarg      Target element
-   */    
+   */
   keymanweb.domManager._SetTargDir = function(Ptarg){};
-  
+
   /**
    * Align input fields (should not be needed with KMEI, KMEA)
-   * 
+   *
    *  @param  {object}   eleList    A list of specific elements to align.  If nil, selects all elements.
-   * 
+   *
    **/
   keymanweb.alignInputs = function(eleList: HTMLElement[]) {};
 
   /**
    * Use rotation events to adjust OSK element positions and scaling if necessary
-   */     
+   */
   keymanweb.handleRotationEvents = function() {};
-  
+
   /**
    * Caret position always determined from the active (but hidden) element
-   * 
+   *
    * @return  {boolean}
-   **/          
+   **/
   keymanweb.isPositionSynthesized = function()
   {
     return false;
@@ -308,7 +304,7 @@ namespace com.keyman.text {
 
   /**
    * Register a lexical model
-   * 
+   *
    * @param {com.keyman.text.prediction.ModelSpec} model  Spec of the lexical model
    */
   keymanweb['registerModel']=function(model: com.keyman.text.prediction.ModelSpec) {
@@ -317,9 +313,9 @@ namespace com.keyman.text {
 
   /**
    * Function called by Android and iOS when a device-implemented keyboard popup is displayed or hidden
-   * 
+   *
    *  @param  {boolean}  isVisible
-   *     
+   *
    **/
   keymanweb['popupVisible'] = function(isVisible)
   {
@@ -328,9 +324,9 @@ namespace com.keyman.text {
 
   /**
    *  Return position of language menu key to KeymanTouch
-   *  
+   *
    *  @return  {string}      comma-separated x,y,w,h of language menu key
-   *  
+   *
    **/
   keymanweb['touchMenuPos'] = function()
   {
@@ -341,14 +337,14 @@ namespace com.keyman.text {
     var key: HTMLElement = osk.vkbd.lgKey;
     // A CSS change of kmd-key-square from position:fixed to position:static was needed
     // for Android 4.3 to display the OSK correctly, but resulted in the position of
-    // the menu key not being returned correctly.  The following line gets the 
-    // key element, instead of the key-square element, fixes this.  It should be 
+    // the menu key not being returned correctly.  The following line gets the
+    // key element, instead of the key-square element, fixes this.  It should be
     // removed again when the key-square elements are all removed as planned.
     if(typeof key.firstChild != 'undefined' && key.firstChild != null && util.hasClass(key.firstChild,'kmw-key')) {
       key = <HTMLElement> key.firstChild;
     }
 
-    var w=key.offsetWidth, 
+    var w=key.offsetWidth,
         h=key.offsetHeight,
         // Since the full OSKManager '_Box' is displayed within the keyboards' WebViews,
         // these calculations should be performed with respect to that, rather than osk.vkbd.kbdDiv.
@@ -357,12 +353,12 @@ namespace com.keyman.text {
 
     return x+','+y+','+w+','+h;
   };
-  
+
  /**
    *  Accept an external key ID (from KeymanTouch) and pass to the keyboard mapping
-   *  
+   *
    *  @param  {string}  keyName   key identifier
-   **/            
+   **/
   keymanweb['executePopupKey'] = function(keyName: string) {
       let core = (<KeymanBase> keymanweb).core;
 
@@ -398,7 +394,7 @@ namespace com.keyman.text {
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
       var Lelem=keymanweb.domManager.getLastActiveElement(),keyShiftState=com.keyman.text.KeyboardProcessor.getModifierState(layer);
-      
+
       keymanweb.domManager.initActiveElement(Lelem);
 
       var nextLayer: string;
@@ -438,8 +434,8 @@ namespace com.keyman.text {
       }
 
       let Codes = com.keyman.text.Codes;
-      
-      // Check the virtual key 
+
+      // Check the virtual key
       let Lkc: com.keyman.text.KeyEvent = {
         Ltarg: com.keyman.dom.Utils.getOutputTarget(Lelem),
         Lmodifiers: keyShiftState,
@@ -457,7 +453,7 @@ namespace com.keyman.text {
 
       // Process modifier key action
       if(core.keyboardProcessor.selectLayer(Lkc, true)) { // ignores key's 'nextLayer' property for this check
-        return true;      
+        return true;
       }
 
       // While we can't source the base KeyEvent properties for embedded subkeys the same way as native,
@@ -465,8 +461,8 @@ namespace com.keyman.text {
       core.keyboardProcessor.setSyntheticEventDefaults(Lkc);
 
       //if(!Lkc.Lcode) return false;  // Value is now zero if not known (Build 347)
-      //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014      
-      if(isNaN(Lkc.Lcode) || !Lkc.Lcode) { 
+      //Build 353: revert to prior test to try to fix lack of KMEI output, May 1, 2014
+      if(isNaN(Lkc.Lcode) || !Lkc.Lcode) {
         // Addresses modifier SHIFT keys.
         if(nextLayer) {
           core.keyboardProcessor.selectLayer(Lkc);
@@ -481,7 +477,7 @@ namespace com.keyman.text {
       let retVal = com.keyman.osk.PreProcessor.handleClick(Lkc, null);
 
       // Special case for embedded to pass K_TAB back to device to process
-      if(Lkc.Lcode == Codes.keyCodes["K_TAB"] || Lkc.Lcode == Codes.keyCodes["K_TABBACK"] 
+      if(Lkc.Lcode == Codes.keyCodes["K_TAB"] || Lkc.Lcode == Codes.keyCodes["K_TABBACK"]
           || Lkc.Lcode == Codes.keyCodes["K_TABFWD"]) {
         return false;
       }
@@ -491,13 +487,13 @@ namespace com.keyman.text {
 
   /**
    *  API endpoint for hardware keystroke events from Android external keyboards
-   *  
+   *
    *  @param  {number}  code   key identifier
    *  @param  {number}  shift  shift state (0x01=left ctrl 0x02=right ctrl 0x04=left alt 0x08=right alt
    *                                        0x10=shift 0x20=ctrl 0x40=alt)
    *  @param  {number}  lstates lock state (0x0200=no caps 0x0400=num 0x0800=no num 0x1000=scroll 0x2000=no scroll locks)
    *  @return {boolean} false when KMW _has_ fully handled the event and true when not.
-   **/            
+   **/
   keymanweb['executeHardwareKeystroke'] = function(code, shift, lstates = 0): boolean {
     let keyman = com.keyman.singleton;
     if(!keyman.core.activeKeyboard || code == 0) {
@@ -506,14 +502,14 @@ namespace com.keyman.text {
 
     // Clear any pending (non-popup) key
     osk.vkbd.keyPending = null;
-    
+
     // Note:  this assumes Lelem is properly attached and has an element interface.
     // Currently true in the Android and iOS apps.
     var Lelem = keymanweb.domManager.getLastActiveElement();
-    
+
     keyman.domManager.initActiveElement(Lelem);
 
-    // Check the virtual key 
+    // Check the virtual key
     var Lkc: com.keyman.text.KeyEvent = {
       Ltarg: com.keyman.dom.Utils.getOutputTarget(keyman.domManager.getActiveElement()),
       Lmodifiers: shift,
@@ -524,7 +520,7 @@ namespace com.keyman.text {
       kName: '',
       device: keyman.util.physicalDevice.coreSpec, // As we're executing a hardware keystroke.
       isSynthetic: false
-    }; 
+    };
 
     try {
       // Now that we've manually constructed a proper keystroke-sourced KeyEvent, pass control

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -2578,9 +2578,9 @@ namespace com.keyman.osk {
       }
 
       let r = key.getClientRects()[0];
-      let xLeft = r.left,
-          xWidth = r.width,
-          xHeight = r.height,
+      let xLeft = r ? r.left : dom.Utils.getAbsoluteX(key),
+          xWidth = r ? r.width : key.offsetWidth,
+          xHeight = r ? r.height : key.offsetHeight,
           previewFontScale = 1.8;
 
       // Canvas dimensions must be set explicitly to prevent clipping

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -5,13 +5,13 @@
 
 /*
   kmwosk.css: main CSS for keymanweb on-screen keyboard and other objects.
-*/  
+*/
 
 @font-face {
   font-family: SpecialOSK;
   font-style:  normal;
   font-weight: normal;
-  src: url('keymanweb-osk.ttf')  format('truetype');     
+  src: url('keymanweb-osk.ttf')  format('truetype');
 }
 
 /* kmw-key-square applies only to OSK key elements, kmw-key-square-ex applies only to popup key elements */
@@ -54,7 +54,7 @@
 
 .phone.ios .kmw-key-layer-group {background-color: #cfd3d9}
 .phone.ios .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 5px;}
-.phone.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;} 
+.phone.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;}
 .phone.ios .kmw-key.kmw-key-shift,
 .phone.ios .kmw-key.kmw-key-special {color:#fff;background-color:#b2b9c5;}
 .phone.ios .kmw-key.kmw-key-shift-on,
@@ -76,10 +76,10 @@
 }
 
 .ios .kmw-banner-bar {
-  background-color: #cfd3d9; 
+  background-color: #cfd3d9;
   position: absolute;
-  top: 6px; 
-  height: 100%; 
+  top: 6px;
+  height: 100%;
   width: 100%;
 }
 
@@ -112,13 +112,13 @@
 /* Probably best to make this its own CSS that can be optionally included? */
 @media (prefers-color-scheme: dark) {
   .ios .kmw-banner-bar {
-    background-color: #0f1319; 
+    background-color: #0f1319;
   }
 
   .ios .kmw-banner-bar .kmw-banner-separator {
     border-left: solid 1px #8a8d90
   }
-  
+
   .ios .kmw-suggestion-text {
     color: #fff;
   }
@@ -126,10 +126,10 @@
   .phone.ios.kmw-osk-frame,
   .tablet.ios.kmw-osk-frame {
     background-color: #0f1319;
-  } 
+  }
 }
 
-.phone.android .kmw-key-layer-group {background-color: #333;}  
+.phone.android .kmw-key-layer-group {background-color: #333;}
 .phone.android .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 3px;}
 .phone.android .kmw-key.kmw-key-default {color:#fff;background-color:#777;}
 .phone.android .kmw-key.kmw-key-shift,
@@ -146,11 +146,11 @@
 .phone.android.kmw-osk-frame { background-color: #222;}
 
 .phone.android .kmw-banner-bar {
-  background-color: #222;  
-  position: absolute; 
+  background-color: #222;
+  position: absolute;
   top: 4px;
-  height: 100%; 
-  width: 100%; 
+  height: 100%;
+  width: 100%;
 }
 
 .phone.android .kmw-banner-bar .kmw-suggest-option {
@@ -172,25 +172,25 @@
 .tablet .kmw-key-layer{position:fixed;left:0;bottom:0;width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
 .tablet .kmw-key-row {position:fixed;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .tablet .kmw-key-square {position:fixed; display:inline-block; height:100%; max-height:100%; overflow:hidden; margin:0 0 0 0; z-index: 10000; padding:0 0 0 0; background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
-.tablet .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001; padding:0; background-color:transparent; cursor:default;}  
+.tablet .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001; padding:0; background-color:transparent; cursor:default;}
 .tablet .kmw-key {display:block;position:fixed;margin:0px;border-radius:8px;text-align:center;box-sizing:border-box;overflow:visible;
         border:solid 2px #999999;
         box-shadow: 0px -1px 1px 0px rgba(0,0,0,1) inset;
  }
 
 .tablet .kmw-key-label{position:absolute;left:7%;top:2%;font:0.5em Arial;color:#aaa;background-color:transparent;z-index:10000;}
-.tablet .kmw-key-text{position:relative;left:0;top:0;-webkit-user-select:none;} 
+.tablet .kmw-key-text{position:relative;left:0;top:0;-webkit-user-select:none;}
 
 .tablet.ios .kmw-key-layer-group {background-color: #cfd3d9}
 .tablet.ios .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 5px;}
-.tablet.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;} 
+.tablet.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;}
 .tablet.ios .kmw-key.kmw-key-shift,
 .tablet.ios .kmw-key.kmw-key-special {color:#fff;background-color:#b2b9c5;}
 .tablet.ios .kmw-key.kmw-key-shift-on,
 .tablet.ios .kmw-key.kmw-key-special-on {color:#fff;background-color:#88f;}
 .tablet.ios .kmw-key.kmw-key-touched {background-color:#447;}
 .tablet.ios .kmw-suggest-option.kmw-suggest-touched {background-color:#88f;}
-.tablet.ios .kmw-key-deadkey{color:#048204;background-color:#fdfdfe;} 
+.tablet.ios .kmw-key-deadkey{color:#048204;background-color:#fdfdfe;}
 
 /* Probably best to make this its own CSS that can be optionally included? */
 @media (prefers-color-scheme: dark) {
@@ -206,7 +206,7 @@
 
 .tablet .kmw-key-row {-webkit-touch-callout:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 
-.tablet.android .kmw-key-layer-group {background-color: #333;}  
+.tablet.android .kmw-key-layer-group {background-color: #333;}
 .tablet.android .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 5px;}
 .tablet.android .kmw-key.kmw-key-default {color:#fff;background-color:#777;}
 .tablet.android .kmw-key.kmw-key-shift,
@@ -217,19 +217,19 @@
 .tablet.android .kmw-key.kmw-spacebar {background-color: #777;}
 .tablet.android .kmw-key.kmw-spacebar.kmw-key-touched {background-color: #447;}
 .tablet.android .kmw-spacebar-caption {color: #aaa;}
-.tablet.android .kmw-key-deadkey{color:#0d0;background-color:#777;}      
+.tablet.android .kmw-key-deadkey{color:#0d0;background-color:#777;}
 
 .tablet.android .kmw-banner-bar {
-  background-color: #b4b4b8; 
+  background-color: #b4b4b8;
   position: absolute;
   top: 4px;
-  height: 100%; 
+  height: 100%;
   width: 100%;
 }
 
 .tablet.android .kmw-banner-bar .kmw-suggest-option {
-  display:inline-block; 
-  text-align: center; 
+  display:inline-block;
+  text-align: center;
   vertical-align: middle;
 }
 
@@ -238,18 +238,18 @@
 }
 .tablet.android .kmw-suggest-option.kmw-suggest-touched {background-color:#447;}
 
-/* Vertical centering of text labels on keys */ 
+/* Vertical centering of text labels on keys */
 .kmw-key {text-align:center; white-space:nowrap;}
 .kmw-key:before {content:'.'; display:inline-block; height:100%; vertical-align:middle; max-width:0px; visibility:hidden;}
-.kmw-key span {display:inline-block}        
+.kmw-key span {display:inline-block}
 
-        
+
 .desktop .kmw-osk-frame{position:absolute;width:auto;height:auto;left:0;top:0;display:none;margin:0;padding:0;
           border:2px solid #ad4a28;border-radius:2px;background-color:#666;box-sizing:border-box;-moz-box-sizing:border-box;}
 .desktop .kmw-osk-inner-frame{margin:0;background-color:#666;border:2px solid #ad4a28;box-sizing:border-box;-moz-box-sizing:border-box;}
 .desktop .kmw-key-layer-group{width:100%;height:100%;margin:0;padding:0;border:none;background:transparent;}
 .desktop .kmw-key-layer{width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
-.desktop .kmw-key-row{position:static;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}        
+.desktop .kmw-key-row{position:static;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .desktop .kmw-key-square{position:relative;height:100%;display:inline-block;float:left;margin:0 0 0 5px;z-index:10000; font-size:0.8em;overflow:hidden;
           padding:1px 0 1px 0;background-color:transparent;cursor:default;box-sizing:border-box;-moz-box-sizing:border-box;border:solid 1px transparent}
 .desktop .kmw-key {display:block;margin:0;border-radius:6px;text-align:center;box-sizing:border-box;-moz-box-sizing:border-box;
@@ -285,15 +285,15 @@
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;
           font-family:SpecialOSK;color:white;}
 .kmw-footer-resize:hover{font-weight:bold;}
-.kmw-footer-resize:before {content:'\e023';}          
+.kmw-footer-resize:before {content:'\e023';}
 
-.kmw-title-bar-image {cursor: default; float:right; padding: 2px 2px 0 0; width:16px; height:16px; 
+.kmw-title-bar-image {cursor: default; float:right; padding: 2px 2px 0 0; width:16px; height:16px;
           font-family:SpecialOSK; color:white;}
 .kmw-title-bar-image:hover{font-weight:bold;}
 #kmw-pin-image:before{content:'\e024';}
 #kmw-config-image:before{content:'\e030';}
 #kmw-help-image:before{content:'\e042';}
-#kmw-close-button:before {content:'\e025';}          
+#kmw-close-button:before {content:'\e025';}
 
 /* Common key appearance styles (can override with form-factor styles if necessary) */
 .kmw-key-default{color:#000;background-color:#eee;}
@@ -309,20 +309,70 @@
 .tablet .kmw-key-shift, .tablet .kmw-key-shift-on{font-size:0.8em !important;}
 .phone .kmw-key-shift, .phone .kmw-key-shift-on{font-size:0.7em !important;}
 
-/* Set special font and style for modifier and special key images */  
+/* Set special font and style for modifier and special key images */
 body div.kmw-key-shift span.kmw-key-text {font-family:SpecialOSK !important;font-size:1em !important;}
-body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;font-size:1em !important;}      
+body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;font-size:1em !important;}
 #kmw-popup-keys div.kmw-key-shift span.kmw-key-text {font-family:SpecialOSK !important;}
 
 /* Style for callout used on phones */
 #kmw-popup-callout {
-  position:fixed; display:block; background-color: #fdfdfe; 
+  position:fixed; display:block; background-color: #fdfdfe;
   border-radius: 0 0 6px 6px; z-index:10001; pointer-events:none;
 }
 
 /* Key preview styles */
+
 div.ios div.kmw-keytip {
-  position:fixed; left:0; top:0; width:3em; height:3em; background-color:rgb(0,0,0,0);overflow:visible;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 3em;
+  height: 3em;
+  background-color: rgb(0, 0, 0, 0);
+  overflow: visible;
+}
+
+div.ios div.kmw-keytip-tip {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  border-radius: 6px 6px 4px 4px;
+  border: solid 1px #cccccc;
+  border-bottom: solid 1px #8a8d90;
+}
+
+div.ios div.kmw-keytip-cap {
+  position: absolute;
+  border-radius: 0 0 5px 5px;
+  border-top: solid 1px white;
+  border-bottom: solid 1px #8a8d90;
+}
+
+span.kmw-keytip-label {
+  display: block;
+  transform: translateY(-50%);
+  top: 50%;
+  position: relative;
+}
+
+div.ios div.kmw-keytip-cap,
+div.ios div.kmw-keytip-tip {
+  background:white;
+}
+
+div.android div.kmw-keytip {
+  position:fixed;
+  left: 0;
+  top: 0;
+  width: 3em;
+  height: 3em;
+  color: white;
+  overflow: visible;
+}
+
+div.android div.kmw-keytip-tip {
+  border-radius: 6px;
+  background: #999;
 }
 
 /* Dark mode - ensure text is colored appropriately for key tips. */
@@ -331,51 +381,51 @@ div.ios div.kmw-keytip {
     color:#fff;
   }
 
+  div.ios div.kmw-keytip-cap,
+  div.ios div.kmw-keytip-tip {
+    background: #0f1319;
+  }
+
+  div.ios div.kmw-keytip-cap {
+    border-top: solid 1px #0f1319;
+  }
+
   /* Style for callout used on phones */
   #kmw-popup-callout {
     background-color: #0f1319;
   }
 }
 
-div.android div.kmw-keytip {
-  position:fixed; left:0; top:0; width:3em; height:3em; 
-  color:#fff;
-  background-color: rgb(0,0,0,0);
-  overflow:visible;
-}
-
-div.android #keytip {background-color:#f00;}
-
 /* Box styles for keyboard-specific OSK (e.g. EuroLatin) and if no keyboard active (desktop only) */
 .kmw-osk-static, .kmw-osk-none{text-align:left;font:12px sans-serif;border:solid 1px #ad4a28;color:blue;background-color:white;}
 .kmw-osk-none{padding:4px 6px 6px}
 .kmw-osk-none:before{content:'Installing keyboard...';}
-      
+
 /* OSK language menu styles */
 #kmw-language-menu{position:fixed;left:0;width:232px;max-width:232px;z-index:10004;background-color:rgba(128,128,128,1);
         border:3px solid #888;padding:0;border-radius:4px;-webkit-border-radius:4px;
-        box-shadow:3px 3px 2px #ccc;-webkit-box-shadow:3px 3px 2px #ccc; 
+        box-shadow:3px 3px 2px #ccc;-webkit-box-shadow:3px 3px 2px #ccc;
         overflow:hidden;
         -ms-touch-action:none;-webkit-user-select:none;
         }
-        
+
 #kmw-language-menu *{-ms-touch-action:none;-webkit-user-select:none;}
-    
-#kmw-language-menu p{font-family:Arial,Helvetica,sans-serif; font-size:16px; 
-        border-top:1px dotted #989898; border-bottom:1px dotted #989898; 
+
+#kmw-language-menu p{font-family:Arial,Helvetica,sans-serif; font-size:16px;
+        border-top:1px dotted #989898; border-bottom:1px dotted #989898;
         margin:0; padding:10px 0px 10px 10px; overflow:hidden;
         color:#0000ff; background-color:transparent; white-space:nowrap;
-        } 
+        }
 
-#kmw-language-menu div.kbd-list-open p.kbd-list-entry {display: block;} 
+#kmw-language-menu div.kbd-list-open p.kbd-list-entry {display: block;}
 #kmw-language-menu div.kbd-list-closed p.kbd-list-entry {display: none;}
-#kmw-language-menu-background{position:fixed;left:0;top:0;width:100%;height:100%;background-color:transparent;z-index:10003;}    
+#kmw-language-menu-background{position:fixed;left:0;top:0;width:100%;height:100%;background-color:transparent;z-index:10003;}
 
 #kmw-menu-scroll-container{position:absolute;left:0;top:0px;width:200px;max-width:200px;overflow:auto;z-index:10005;}
 #kmw-menu-scroller{position:absolute;left:0;top:0;width:200px;max-width:200px;background-color:#e0e0e0;overflow:auto;overflow-x:hidden;}
 
 #kmw-menu-index {position:absolute;right:0;width:32px;font-size:14px;}
-#kmw-menu-index p {text-align:center;border:none;padding:0px 2px;margin:0;color:white;} 
+#kmw-menu-index p {text-align:center;border:none;padding:0px 2px;margin:0;color:white;}
 
 #kmw-menu-footer{height:2px;background-color:#808080;}
 
@@ -389,15 +439,15 @@ div.android #keytip {background-color:#f00;}
 #kmw-popup-keys {position:fixed;display:block;width:auto;height:auto;overflow-y:visible;
         padding: 4px; border: 1px solid #ddd; border-radius:8px;
         background-color:#fdfdfe; border:none; z-index:10000;}
- 
+
 .tablet.ios #kmw-popup-keys {padding: 4px 7px 0px 0px;}
 .phone.ios #kmw-popup-keys {padding: 4px 5px 0px 0px;}
- 
+
 .tablet.ios #kmw-popup-keys .kmw-key{border:none;}
 .phone.ios  #kmw-popup-keys .kmw-key{border:none;}
 
-.phone.android #kmw-popup-keys {border:none; border-radius: 2px; background-color:#ccc; padding:5px 5px 0 0;} 
-.tablet.android #kmw-popup-keys {border:1px solid #eee; border-radius: 3px; background-color:#888; padding:8px 12px 4px 4px;} 
+.phone.android #kmw-popup-keys {border:none; border-radius: 2px; background-color:#ccc; padding:5px 5px 0 0;}
+.tablet.android #kmw-popup-keys {border:1px solid #eee; border-radius: 3px; background-color:#888; padding:8px 12px 4px 4px;}
 
 @media (prefers-color-scheme: dark) {
   #kmw-popup-keys {
@@ -406,9 +456,9 @@ div.android #keytip {background-color:#f00;}
 }
 
 /* Filter (shim) to darken screen and highlight popup keys */
-#kmw-popup-shim { 
+#kmw-popup-shim {
     position: fixed; width: 100%; height: 100%; bottom: 0; left: 0;
-    display: block; ; opacity: 0.15; background-color: #000; pointer-events: none;  
+    display: block; ; opacity: 0.15; background-color: #000; pointer-events: none;
     }
 
 /* Styles for other KMW elements (keyboard loading wait notification, etc.) */
@@ -416,12 +466,12 @@ div.android #keytip {background-color:#f00;}
         background-color:rgba(0,0,0,0.0);z-index:11000;}
 .kmw-wait-box{width:240px; height:80px;margin-top:20%;margin-left:auto;margin-right:auto;
         border:3px solid #ad4a28;border-radius:8px;text-align:center;padding:0px;background:white;}
-.kmw-alert-close{float:right; height:24px; width:24px; font:1em bold Arial,sans-serif;color:#ad4a28;} 
+.kmw-alert-close{float:right; height:24px; width:24px; font:1em bold Arial,sans-serif;color:#ad4a28;}
 /*.kmw-alert-close{float:right; height:24px; width:24px; font:2em bold Arial,sans-serif;color:#ad4a28;} */
-.kmw-alert-close:before{content:'\00d7'} 
-/*.kmw-alert-close{float:right;background:url('icons.gif') no-repeat -30px 0; height:13px; width:15px;}*/ 
+.kmw-alert-close:before{content:'\00d7'}
+/*.kmw-alert-close{float:right;background:url('icons.gif') no-repeat -30px 0; height:13px; width:15px;}*/
 .kmw-wait-text{clear:both; margin:4px;white-space:nowrap;}
-.kmw-wait-graphic{width:100%;height:75%;background:url('ajax-loader.gif') no-repeat;background-position:center top;} 
+.kmw-wait-graphic{width:100%;height:75%;background:url('ajax-loader.gif') no-repeat;background-position:center top;}
 .kmw-alert-text{margin:10px;white-space:default;font-family:Arial,sans-serif;}
 
 .kmw-spacebar-caption{font:0.6em Arial !important;color:rgba(0,0,0,0.25);}
@@ -436,7 +486,7 @@ div.android #keytip {background-color:#f00;}
 .desktop-static.kmw-osk-inner-frame{margin:0;background-color:#666;border:2px solid #ad4a28;box-sizing:border-box;-moz-box-sizing:border-box;}
 .desktop-static .kmw-key-layer-group{width:100%;height:100%;margin:0;padding:0;border:none;background:transparent;}
 .desktop-static .kmw-key-layer{width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
-.desktop-static .kmw-key-row{position:static;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}        
+.desktop-static .kmw-key-row{position:static;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .desktop-static .kmw-key-square{position:relative;height:100%;display:inline-block;float:left;margin:0 0 0 5px;z-index:10000; font-size:0.8em;overflow:hidden;
           padding:1px 0 1px 0;background-color:transparent;cursor:default;box-sizing:border-box;-moz-box-sizing:border-box;border:solid 1px transparent}
 .desktop-static .kmw-key {display:block;margin:0;border-radius:6px;text-align:center;box-sizing:border-box;-moz-box-sizing:border-box;
@@ -447,7 +497,7 @@ div.android #keytip {background-color:#f00;}
 .phone-static.kmw-osk-inner-frame{margin:0;background-color:#666;border:2px solid #ad4a28;box-sizing:border-box;-moz-box-sizing:border-box;}
 .phone-static .kmw-key-layer-group{width:100%;height:100%;margin:0;padding:0;border:none;background:transparent;}
 .phone-static .kmw-key-layer{width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
-.phone-static .kmw-key-row{position:relative;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}        
+.phone-static .kmw-key-row{position:relative;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .phone-static .kmw-key-square{position:absolute;height:100%;display:inline-block;float:left;margin:0 0 0 5px;z-index:10000; font-size:0.8em;overflow:hidden;
           padding:1px 0 1px 0;background-color:transparent;cursor:default;box-sizing:border-box;-moz-box-sizing:border-box;}
 .phone-static .kmw-key {display:block;margin:0;border-radius:6px;text-align:center;box-sizing:border-box;-moz-box-sizing:border-box;
@@ -458,7 +508,7 @@ div.android #keytip {background-color:#f00;}
 .tablet-static.kmw-osk-inner-frame{margin:0;background-color:#666;border:2px solid #ad4a28;box-sizing:border-box;-moz-box-sizing:border-box;}
 .tablet-static .kmw-key-layer-group{width:100%;height:100%;margin:0;padding:0;border:none;background:transparent;}
 .tablet-static .kmw-key-layer{width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
-.tablet-static .kmw-key-row{position:relative;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}        
+.tablet-static .kmw-key-row{position:relative;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .tablet-static .kmw-key-square{position:absolute;height:100%;display:inline-block;float:left;margin:0 0 0 5px;z-index:10000; font-size:0.8em;overflow:hidden;
           padding:1px 0 1px 0;background-color:transparent;cursor:default;box-sizing:border-box;-moz-box-sizing:border-box;}
 .tablet-static .kmw-key {display:block;margin:0;border-radius:6px;text-align:center;box-sizing:border-box;-moz-box-sizing:border-box;


### PR DESCRIPTION
Fixes #5831.

Cherry-pick of #5915.

iOS 15 has a significant crashing bug whereby use of a canvas element completely crashes the browser in some contexts. In particular, we have observed this when using a WKWebView in a keyboard extension without 'Allow Full Access' switched on.

Keyman uses canvas element to draw a nice looking key preview (key tip) on iPhones. This is a critical issue for Keyman for iPhone. Keyman for iPad is not affected because the iPad version does not use key previews.

The resolution here is to remove use of the canvas drawing for key tips and use a simplified pure HTML/CSS shape. I have not conditioned this fix on platform; I have currently opted to apply this to all platforms.

This fix will be backported to Keyman 14.0-stable.

This issue will be reported to Apple for resolution. The issue applies so far to iOS 15.0, 15.1.

# Screenshots

Android phone preview. Simplified as we can no longer use the triangle shape easily:

![image](https://user-images.githubusercontent.com/4498365/141930219-e919c2c8-5b1c-4376-9f79-36ab43c9988d.png)

iPhone preview:

![image](https://user-images.githubusercontent.com/4498365/141930291-28e09488-bba5-4cbf-ad24-39d7f8bc39c2.png)

![image](https://user-images.githubusercontent.com/4498365/141930318-e61c716d-a8b4-41a9-adb6-af360ce5bf61.png)

# User Testing

Sadly, we do need to replicate the 15.0 tests in 14.0, as the code is significantly different.

## SUITE_STABILITY

Load the system keyboard on iOS 15 on a real iPhone (**simulator not sufficient**). Ensure that 'Allow Full Access' is switched off.

Note: this will require building on a local machine and testing. @sgschantz can you do these two tests?

* TEST_IOS_APP_STABILITY: Verify that Keyman for iPhone no longer crashes (that is, it does not go blank) with this fix in place, by loading one or more Keyman system keyboards and typing several keystrokes.
* TEST_IOS_FV_APP_STABILITY: Verify that FirstVoices Keyboards for iPhone no longer crashes (that is, it does not go blank) with this fix in place, by loading one or more FVKeyboards system keyboards and typing several keystrokes.

## SUITE_DISPLAY: Test that the key preview looks acceptable

We need to test across a variety of platforms as this change removes the canvas element and replaces it. The key preview will not look identical to earlier, and this is acceptable. However, it does need to look reasonable.

* TEST_ANDROID_APP_DISPLAY: Verify that display of key previews is still adequate on Android phones - both in-app and system (emulator acceptable).
* TEST_IOS_APP_DISPLAY: Verify that Keyman for iPhone key previews still look good - both in-app and system. The system preview may overlap the key on the top row if the banner is switched off (simulator acceptable).
* TEST_IOS_APP_DARKMODE_DISPLAY: Verify that Keyman for iPhone key previews still look good in dark mode - both in-app and system. The system preview may overlap the key on the top row if the banner is switched off (simulator acceptable).

* TEST_ANDROID_WEB_DISPLAY: In KeymanWeb, verify that display of key previews is still adequate on Android phones (emulator acceptable).
* TEST_IOS_WEB_DISPLAY: In KeymanWeb, verify that display of key previews is still adequate on an iPhone (simulator acceptable).