### PR TITLE
fix(android/engine): Don't pass selected text to KeymanWeb

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1889,9 +1889,12 @@ public final class KMManager {
 
   public static boolean updateSelectionRange(KeyboardType kbType, int selStart, int selEnd) {
     boolean result = false;
+    // Currently, KMW doesn't support selection on touch alias elements
+    // so pass null context to KMW. See issue #5853
+    int selectionEnd = Math.max(selStart, selEnd);
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (InAppKeyboard != null && InAppKeyboardLoaded && !InAppKeyboardShouldIgnoreSelectionChange) {
-        InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selectionEnd, selectionEnd));
         result = true;
       }
 
@@ -1906,7 +1909,7 @@ public final class KMManager {
           }
         }
 
-        SystemKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
+        SystemKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selectionEnd, selectionEnd));
         result = true;
       }
 


### PR DESCRIPTION
Fixes Android portion of #5853 and replaces #5854
Because KeymanWeb currently doesn't support selection on touch alias elements, this updates Keyman Engine for Android to not pass the selected context to KeymanWeb engine. This way, Keyman Engine for Android handles the deletion of selected text and inserts the typed string per KeymanWeb.

### User Testing
Setup: Load test build of Keyman for Android and set Keyman as a system keyboard
Can also install another keyboard (e.g. khmer_angkor)
Note: if you click an available suggestion to replace selected text, this is still buggy and beyond the scope of this PR.

* **TEST_INAPP_KEYBOARD** - Tests how selected text is handled in the Keyman app
1. Start Keyman
2. Type some text
3. Drag and select some of the typed text
4. Click a key/longpress key
5. Verify the selected text is replaced with the pressed key.

* **TEST_SYSTEM_KEYBOARD** - Tests how selected text is handled in the Keyman system keyboard
1. Launch a separate app where you can type in a text field / text area (e.g. Contacts). Don't use Chrome omnibar as it may apply its own auto-corrections
2. With the Keyman keyboard, type some text
3. Drag and select some of the typed text
4. Click a key/longpress key
5. Verify the selected text is replaced with the pressed key.
