### PR TITLE
fix(developer): render OSK nicely on touch devices

### DIFF
--- a/windows/src/developer/TIKE/xml/kmw/index.html
+++ b/windows/src/developer/TIKE/xml/kmw/index.html
@@ -24,19 +24,19 @@
 
       <div class='control' id='keymanweb-control-host'>
         <!--<div id='KeymanWebControl'></div>-->
-        <div>
+        <div id='control-keyboards'>
           <label for='keyboard-select'>Keyboard:</label>
           <select id='keyboard-select'>
             <option value=''>(system keyboard)</option>
           </select>
         </div>
-        <div>
+        <div id='control-models'>
           <label for='model-list'>Model:</label>
           <select id='model-list'>
             <option value=''>(no model)</option>
           </select>
         </div>
-        <div>
+        <div id='control-devices'>
           <label for='device-select'>Device:</label>
           <select id='device-select'>
             <option value='Windows'>Windows desktop</option>

--- a/windows/src/developer/TIKE/xml/kmw/test.css
+++ b/windows/src/developer/TIKE/xml/kmw/test.css
@@ -109,6 +109,10 @@ h2 {
 
 /** Mobile, Tablet **/
 
+.touch-device #control-devices {
+  display: none;
+}
+
 .install-link .ios,
 .install-link .android {
   display: none;

--- a/windows/src/developer/TIKE/xml/kmw/test.js
+++ b/windows/src/developer/TIKE/xml/kmw/test.js
@@ -182,16 +182,23 @@ window.onload = function() {
   );
 
   let newOSK = null;
-  let deviceSelect = document.getElementById('device-select');
-  if(deviceSelect.value == '') deviceSelect.value = 'desktop';
+  let deviceSelect = null;
 
-  deviceSelect.addEventListener('change', function() {
-    setOSK();
-    ta1.focus();
-  });
+  if(!keyman.util.isTouchDevice()) {
+    deviceSelect = document.getElementById('device-select');
+    if(deviceSelect.value == '') deviceSelect.value = 'desktop';
 
+    deviceSelect.addEventListener('change', function() {
+      setOSK();
+      ta1.focus();
+    });
+  }
 
   function setOSK() {
+    if(keyman.util.isTouchDevice()) {
+      return;
+    }
+
     const devices = {
       Windows:         { browser: 'chrome', formFactor: 'desktop', OS: 'windows', touchable: false, dimensions: [640, 300] },
       macOS:           { browser: 'chrome', formFactor: 'desktop', OS: 'macosx',  touchable: false, dimensions: [640, 300] },
@@ -228,8 +235,10 @@ window.onload = function() {
   setOSK();
 
   keyman.addEventListener('keyboardchange', function(keyboardProperties) {
-    keyman.osk = newOSK;
-    newOSK.activeKeyboard = keyman.core.activeKeyboard;
+    if(newOSK) {
+      keyman.osk = newOSK;
+      newOSK.activeKeyboard = keyman.core.activeKeyboard;
+    }
     keyboardSelect.value = keyboardProperties.internalName;
     keyman.alignInputs();
     //console.log('keyboardchange:'+JSON.stringify(keyboardProperties)+' [active='+keyman.getActiveKeyboard()+';'+keyman.core.activeKeyboard+']');


### PR DESCRIPTION
Fixes #5905.

Touch devices now use a touch keyboard only in the web debugger; desktop browsers continue to present the option to switch between device types. Given the limited real estate on phones, and the trickiness of navigating a mouse-oriented environment with fingers, I've opted not to allow users to test desktop keyboard OSKs on touch devices.

# Screenshots

### iPhone (emulated)
![image](https://user-images.githubusercontent.com/4498365/142136708-47bddaec-7404-497e-822c-11bf86150a7b.png)

### Chrome on Windows
![image](https://user-images.githubusercontent.com/4498365/142136772-700a7519-afaa-47bf-9025-53fc211e187c.png)

![image](https://user-images.githubusercontent.com/4498365/142136832-59ec26e3-fc6f-4e8f-b290-644d560e8d08.png)

# User Testing

* TEST_DEBUGGER_DESKTOP: Load the web debugger in Chrome and verify that each of the OSK device modes render correctly.
* TEST_DEBUGGER_MOBILE: Load the web debugger on a mobile device (or in emulation in Chrome) and verify that the only OSK presented is the touch mobile one, at the bottom of the screen.