### PR TITLE
fix(mac): use xcframework to support m1

### DIFF
--- a/mac/Cartfile.private
+++ b/mac/Cartfile.private
@@ -1,1 +1,1 @@
-github "erikdoe/ocmock" ~> 3.4.1
+github "erikdoe/ocmock" ~> 3.9.1

--- a/mac/Cartfile.resolved
+++ b/mac/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "erikdoe/ocmock" "v3.4.1"
+github "erikdoe/ocmock" "v3.9.1"

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		37A245C12565DFA6000BBF92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37A245C02565DFA6000BBF92 /* Assets.xcassets */; };
 		37AE5C9D239A7B770086CC7C /* qrcode.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 37AE5C9C239A7B770086CC7C /* qrcode.min.js */; };
 		37C2B0CB25FF2C350092E16A /* Help in Resources */ = {isa = PBXBuildFile; fileRef = 37C2B0CA25FF2C340092E16A /* Help */; };
+		37CA0FCF2745DCFE00266259 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37CA0FCE2745DCFE00266259 /* OCMock.xcframework */; };
 		9800EC5A1C02940300BF0FB5 /* keyman-for-mac-os-license.html in Resources */ = {isa = PBXBuildFile; fileRef = 9800EC591C02940300BF0FB5 /* keyman-for-mac-os-license.html */; };
 		9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9803C9D71B0EFB3B0082A6F9 /* WebKit.framework */; };
 		983247281A9EA28F0010B90C /* KeymanEngine4Mac.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -66,13 +67,11 @@
 		E2585A7F20DD6C3C00CBB994 /* KMMethodEventHandlerTests.kmx in Resources */ = {isa = PBXBuildFile; fileRef = E2585A7E20DD6C3C00CBB994 /* KMMethodEventHandlerTests.kmx */; };
 		E2585A8120DD7CF100CBB994 /* TestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E2585A8020DD7CF100CBB994 /* TestAppDelegate.m */; };
 		E27BA9CE2020322000D273E7 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27BA9CD2020322000D273E7 /* OCMock.framework */; };
-		E27BA9D1202036E200D273E7 /* OCMock.framework.dSYM in CopyFiles */ = {isa = PBXBuildFile; fileRef = E27BA9D0202036E200D273E7 /* OCMock.framework.dSYM */; };
 		E27BA9D32020D8BF00D273E7 /* SimpleTest.kmx in Resources */ = {isa = PBXBuildFile; fileRef = E27BA9D22020D8BF00D273E7 /* SimpleTest.kmx */; };
 		E28914D32024D1B80048E71E /* KeymanEngine4Mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; };
 		E28914D52024E3DF0048E71E /* KMInputMethodBrowserClientEventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E24C79E91FFFCC7500D8E46F /* KMInputMethodBrowserClientEventHandler.m */; };
 		E28914D62024E4010048E71E /* KMInputMethodEventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E21799041FC5B7BC00F2D66A /* KMInputMethodEventHandler.m */; };
 		E28914D72024E6220048E71E /* KeymanEngine4Mac.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E28914D92028A78C0048E71E /* OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E28914D82028A78C0048E71E /* OCMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E29F22F4201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E29F22F3201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m */; };
 		E2D5529D20DD8E0200D77CFB /* LegacyTestClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D5529C20DD8E0200D77CFB /* LegacyTestClient.m */; };
 		F9B9814A51575496B5DA2948 /* Pods_KeymanTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A71FD8BA8404531DFBD861B6 /* Pods_KeymanTests.framework */; };
@@ -116,9 +115,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E28914D92028A78C0048E71E /* OCMock.framework in CopyFiles */,
 				E28914D72024E6220048E71E /* KeymanEngine4Mac.framework in CopyFiles */,
-				E27BA9D1202036E200D273E7 /* OCMock.framework.dSYM in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +138,7 @@
 		37A245C02565DFA6000BBF92 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		37AE5C9C239A7B770086CC7C /* qrcode.min.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = qrcode.min.js; sourceTree = "<group>"; };
 		37C2B0CA25FF2C340092E16A /* Help */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Help; path = Keyman4MacIM/Help; sourceTree = "<group>"; };
+		37CA0FCE2745DCFE00266259 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = ../Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
 		7844A655E38A234DE5D29DF9 /* Pods-Keyman.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.release.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.release.xcconfig"; sourceTree = "<group>"; };
 		8577C0C788461AFE564DDF4F /* Pods-KeymanTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KeymanTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KeymanTests/Pods-KeymanTests.debug.xcconfig"; sourceTree = "<group>"; };
 		878287E1B18ED4EE910C4BC7 /* Pods-Keyman.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Keyman.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Keyman/Pods-Keyman.debug.xcconfig"; sourceTree = "<group>"; };
@@ -234,9 +232,7 @@
 		E2585A8020DD7CF100CBB994 /* TestAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestAppDelegate.m; sourceTree = "<group>"; };
 		E2585A8220DD7D3F00CBB994 /* TestAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestAppDelegate.h; sourceTree = "<group>"; };
 		E27BA9CD2020322000D273E7 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = ../Carthage/Build/Mac/OCMock.framework; sourceTree = "<group>"; };
-		E27BA9D0202036E200D273E7 /* OCMock.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = OCMock.framework.dSYM; path = ../Carthage/Build/Mac/OCMock.framework.dSYM; sourceTree = "<group>"; };
 		E27BA9D22020D8BF00D273E7 /* SimpleTest.kmx */ = {isa = PBXFileReference; lastKnownFileType = file; path = SimpleTest.kmx; sourceTree = "<group>"; };
-		E28914D82028A78C0048E71E /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = ../Carthage/Build/Mac/OCMock.framework; sourceTree = "<group>"; };
 		E29F22F1201A59B1005EA234 /* KeymanTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeymanTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E29F22F3201A59B1005EA234 /* KMInputMethodBrowserClientEventHandlerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KMInputMethodBrowserClientEventHandlerTests.m; sourceTree = "<group>"; };
 		E29F22F5201A59B2005EA234 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -256,6 +252,7 @@
 				984C2B221A79DF1B0023F89D /* KeymanEngine4Mac.framework in Frameworks */,
 				9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */,
 				B90818AF7ED302187DE0E026 /* Pods_Keyman.framework in Frameworks */,
+				37CA0FCF2745DCFE00266259 /* OCMock.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -381,8 +378,6 @@
 				37589AD422E52DA20097D39D /* Keyman.entitlements */,
 				E2C92D4720B46CEA00742A7D /* KeymanEngine4Mac.framework.dSYM */,
 				E211CCF520B600A500505C36 /* KeymanEngine4Mac.framework.dSYM */,
-				E28914D82028A78C0048E71E /* OCMock.framework */,
-				E27BA9D0202036E200D273E7 /* OCMock.framework.dSYM */,
 				989C9C0A1A7876DE00A20425 /* Keyman4MacIM */,
 				E29F22F2201A59B1005EA234 /* KeymanTests */,
 				37A00ED3239AA25700D2C837 /* ConfigurationHost */,
@@ -516,6 +511,7 @@
 		E27BA9CC2020321F00D273E7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				37CA0FCE2745DCFE00266259 /* OCMock.xcframework */,
 				370E44542564E1EE00642929 /* Sentry.framework */,
 				37A00F2E239AD4D000D2C837 /* KeymanEngine4Mac.framework */,
 				37A00F2C239AD4C300D2C837 /* KeymanEngine4Mac.framework */,

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		37A245C12565DFA6000BBF92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37A245C02565DFA6000BBF92 /* Assets.xcassets */; };
 		37AE5C9D239A7B770086CC7C /* qrcode.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 37AE5C9C239A7B770086CC7C /* qrcode.min.js */; };
 		37C2B0CB25FF2C350092E16A /* Help in Resources */ = {isa = PBXBuildFile; fileRef = 37C2B0CA25FF2C340092E16A /* Help */; };
-		37CA0FCF2745DCFE00266259 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37CA0FCE2745DCFE00266259 /* OCMock.xcframework */; };
+		37CA0FD12746010300266259 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37CA0FCE2745DCFE00266259 /* OCMock.xcframework */; };
 		9800EC5A1C02940300BF0FB5 /* keyman-for-mac-os-license.html in Resources */ = {isa = PBXBuildFile; fileRef = 9800EC591C02940300BF0FB5 /* keyman-for-mac-os-license.html */; };
 		9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9803C9D71B0EFB3B0082A6F9 /* WebKit.framework */; };
 		983247281A9EA28F0010B90C /* KeymanEngine4Mac.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -66,7 +66,6 @@
 		E2585A7D20DD68BA00CBB994 /* KMInputMethodEventHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2585A7C20DD68BA00CBB994 /* KMInputMethodEventHandlerTests.m */; };
 		E2585A7F20DD6C3C00CBB994 /* KMMethodEventHandlerTests.kmx in Resources */ = {isa = PBXBuildFile; fileRef = E2585A7E20DD6C3C00CBB994 /* KMMethodEventHandlerTests.kmx */; };
 		E2585A8120DD7CF100CBB994 /* TestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E2585A8020DD7CF100CBB994 /* TestAppDelegate.m */; };
-		E27BA9CE2020322000D273E7 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27BA9CD2020322000D273E7 /* OCMock.framework */; };
 		E27BA9D32020D8BF00D273E7 /* SimpleTest.kmx in Resources */ = {isa = PBXBuildFile; fileRef = E27BA9D22020D8BF00D273E7 /* SimpleTest.kmx */; };
 		E28914D32024D1B80048E71E /* KeymanEngine4Mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 984C2B211A79DF1B0023F89D /* KeymanEngine4Mac.framework */; };
 		E28914D52024E3DF0048E71E /* KMInputMethodBrowserClientEventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E24C79E91FFFCC7500D8E46F /* KMInputMethodBrowserClientEventHandler.m */; };
@@ -252,7 +251,6 @@
 				984C2B221A79DF1B0023F89D /* KeymanEngine4Mac.framework in Frameworks */,
 				9803C9D81B0EFB3B0082A6F9 /* WebKit.framework in Frameworks */,
 				B90818AF7ED302187DE0E026 /* Pods_Keyman.framework in Frameworks */,
-				37CA0FCF2745DCFE00266259 /* OCMock.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,8 +259,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				E28914D32024D1B80048E71E /* KeymanEngine4Mac.framework in Frameworks */,
-				E27BA9CE2020322000D273E7 /* OCMock.framework in Frameworks */,
 				F9B9814A51575496B5DA2948 /* Pods_KeymanTests.framework in Frameworks */,
+				37CA0FD12746010300266259 /* OCMock.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -291,7 +291,7 @@ if $CLEAN ; then
 fi
 
 if [ "$TEST_ACTION" == "test" ]; then
-    carthage bootstrap
+    carthage bootstrap --use-xcframeworks
 fi
 
 execBuildCommand() {


### PR DESCRIPTION
@keymanapp-test-bot skip﻿

This allows us to build Keyman for macOS on an M1