### PR TITLE
fix(developer): move web osk beneath text area

### DIFF
--- a/windows/src/developer/TIKE/xml/kmw/index.html
+++ b/windows/src/developer/TIKE/xml/kmw/index.html
@@ -58,16 +58,16 @@
     <div class='clear'></div>
 
     <div id='content'>
-      <div id='osk-host-frame'>
-        <div id='osk-host'>
-          <!-- Contains the inline OSK -->
-        </div>
-      </div>
       <div id='character-grid'>
         <!-- contains the breakdown of characters from the input-area -->
       </div>
       <div id='input-area'>
         <textarea id='ta1' class='test'></textarea><br/>
+      </div>
+      <div id='osk-host-frame'>
+        <div id='osk-host'>
+          <!-- Contains the inline OSK -->
+        </div>
       </div>
     </div>
 

--- a/windows/src/developer/TIKE/xml/kmw/test.css
+++ b/windows/src/developer/TIKE/xml/kmw/test.css
@@ -190,7 +190,7 @@ h2 {
   background-repeat: no-repeat;
   padding-left: 97px;
   background-position-y: -358px;
-  height: 360px;
+  height: 384px;
   width: 927px;
   padding-top: 62px;
 }
@@ -205,7 +205,7 @@ h2 {
   background-image: url(phone-iphone5-portrait.png);
   background-position-x: 0px;
   background-position-y: -794px;
-  height: 374px;
+  height: 444px;
   width: 600px;
   background-repeat: no-repeat;
   padding-left: 91px;
@@ -216,6 +216,10 @@ h2 {
 #osk-host-frame.iPhone .kmw-osk-frame,
 #osk-host-frame.iPhone .kmw-key-layer-group {
   border-radius: 0 0 3px 3px;
+}
+
+#input-area {
+  line-height: 0;
 }
 
 #input-area, #character-grid {


### PR DESCRIPTION
Fixes #5926.

This gives space for the popups to appear, even if they are large.

![image](https://user-images.githubusercontent.com/4498365/142349407-fe511dd8-9414-45ad-901f-20a7dfd9c1cc.png)


@keymanapp-test-bot skip