### PR TITLE
fix(web): popupBaseKey null check

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1218,7 +1218,7 @@ namespace com.keyman.osk {
         }
 
         // Cancel (but do not execute) pending key if neither a popup key or the base key
-        if((t == null) || ((t.id.indexOf('popup') < 0) && (t.id != this.popupBaseKey.id))) {
+        if(t == null || (t.id.indexOf('popup') < 0 && (t?.id != this.popupBaseKey?.id))) {
           this.highlightKey(this.keyPending,false);
           this.clearPopup();
           this.keyPending = null;


### PR DESCRIPTION
Fixes #5912.

Corresponds loosely to #5949.

# User Testing

* TEST_ANDROID: Verify that popup keys work correctly on Keyman for Android. Try various ways of using them and sliding on/off them
* TEST_IOS: Verify that popup keys work correctly on Keyman for iPhone and iPad. Try various ways of using them and sliding on/off them
* TEST_WEB: Verify that popup keys work correctly on KeymanWeb in touch mode (Chrome emulation okay). Try various ways of using them and sliding on/off them. Use the testing/unminified page.