### PR TITLE
fix(web): clear longpress timeout if user does a flick up

### DIFF
--- a/web/source/osk/browser/pendingLongpress.ts
+++ b/web/source/osk/browser/pendingLongpress.ts
@@ -7,12 +7,12 @@ namespace com.keyman.osk.browser {
    * whether or not a series of touch events corresponds to a longpress
    * touch input.  The `resolve` method may be used to trigger the
    * subkey menu early, as with the upward quick-display shortcut.
-   * 
+   *
    * This is the default implementation of longpress behavior for KMW.
    * Alterate implementations are modeled through the `embedded`
    * namespace's equivalent, which is designed to facilitate custom
    * modeling for such gestures.
-   * 
+   *
    * Once the conditions to recognize a longpress gesture have been
    * fulfilled, this class's `promise` will resolve with a `SubkeyPopup`
    * matching the gesture's 'base' key, which itself provides a
@@ -50,16 +50,24 @@ namespace com.keyman.osk.browser {
         this.timerId = null;
       }
 
-      if(this.resolver) {        
+      if(this.resolver) {
         this.resolver(null);
         this.resolver = null;
       }
     }
 
     public resolve() {
+      // User has flicked up to get to the longpress, before
+      // the timeout has expired. We need to cancel the timeout.
+      // See #5950
+      if(this.timerId) {
+        window.clearTimeout(this.timerId);
+        this.timerId = null;
+      }
+
       if(this.resolver) {
         this.resolver(new SubkeyPopup(this.vkbd, this.baseKey));
       }
-    } 
+    }
   }
 }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -819,7 +819,7 @@ namespace com.keyman.osk {
       }
 
       if (this.keyPending) {
-        if (key0 != key1 || key1.className.indexOf('kmw-key-touched') < 0) {
+        if (key0 != key1 || key1.className.indexOf(OSKKey.HIGHLIGHT_CLASS) < 0) {
           this.highlightKey(key1, true);
         }
       }


### PR DESCRIPTION
Fixes #5950.

If a user starts a longpress gesture and then flicks up, that immediately brings up the longpress menu, and the timeout for display of the menu should be cancelled -- otherwise the end result is a key that stays 'stuck' on.

# User Testing

1. Test longpress menus in a keyboard such as sil_euro_latin, both by waiting for the menu to appear, and also by flicking up.
2. Try various combinations to get it to leave a highlighted key.
3. These tests pass if no key is ever left highlighted after ending the touch gesture.

* TEST_IOS: Run the test above in Keyman for iOS (system and/or in-app keyboard).
* TEST_ANDROID: Run the test above in Keyman for Android (system and/or in-app keyboard).
* TEST_WEB: Run the test above in KeymanWeb (testing/unminified), on a mobile device or emulating in Chrome.

