### PR TITLE
fix(windows): fix loadkeyboardoptions core memory error

### DIFF
--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             keyboardoptions
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      25 May 2010
 
   Modified Date:    28 Nov 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          25 May 2010 - mcdurdin - I1632 - Keyboard Options
                     31 May 2010 - mcdurdin - I2397 - Assertion failure - keyboard options loading twice
                     28 Nov 2012 - mcdurdin - I3594 - V9.0 - Remove old SelectKeyboard code and related messages
@@ -230,63 +230,62 @@ void LoadKeyboardOptionsREGCore(LPINTKEYBOARDINFO kp, km_kbp_state* const state)
   IntLoadKeyboardOptionsCore(REGSZ_KeyboardOptions, kp, state);
 }
 
-BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* state)
+BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* const state)
 {
   assert(key != NULL);
   assert(kp != NULL);
 
   RegistryReadOnly r(HKEY_CURRENT_USER);
-  if (r.OpenKeyReadOnly(REGSZ_KeymanActiveKeyboards) && r.OpenKeyReadOnly(kp->Name) && r.OpenKeyReadOnly(key))
-  {
-    WCHAR buf[256];
-    int n = 0;
-    // Get the list of default options to determine size of list
-    const km_kbp_keyboard_attrs* keyboardAttrs;
-    km_kbp_status err_status = km_kbp_keyboard_get_attrs(kp->lpCoreKeyboard, &keyboardAttrs);
-    if (err_status != KM_KBP_STATUS_OK) {
-      SendDebugMessageFormat(
-          0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
-      return FALSE;
-    }
-    size_t listSize = km_kbp_options_list_size(keyboardAttrs->default_options);
-    km_kbp_option_item* keyboardOpts = new  km_kbp_option_item[listSize+1];
 
-    while ((r.GetValueNames(buf, sizeof(buf) / sizeof(buf[0]), n)) && (n < (int)listSize))
-    {
-      buf[255] = 0;
-      WCHAR val[256];
-
-      if (r.ReadString(buf, val, sizeof(val) / sizeof(val[0])) && val[0])
-      {
-        val[255] = 0;
-        keyboardOpts[n].scope = KM_KBP_OPT_KEYBOARD;
-
-        km_kbp_cp* cp = new km_kbp_cp[wcslen(buf) + 1];
-        wcscpy_s(reinterpret_cast<LPWSTR>(cp), wcslen(buf) + 1, buf);
-        keyboardOpts[n].key = cp;
-
-        cp = new km_kbp_cp[wcslen(val) + 1];
-        wcscpy_s(reinterpret_cast<LPWSTR>(cp), wcslen(val) + 1, val);
-        keyboardOpts[n].value = cp;
-      }
-      n++;
-    }
-
-    keyboardOpts[n] = KM_KBP_OPTIONS_END;
-    // once we have the option list we can then update the options using the public api call
-    err_status = km_kbp_state_options_update(state, keyboardOpts);
-    if (err_status != KM_KBP_STATUS_OK) {
-      SendDebugMessageFormat(
-          0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_state_options_update failed with error status [%d]", err_status);
-    }
-    for (int i = 0; i < (int)listSize + 1; i++) {
-      delete[] keyboardOpts[i].key;
-      delete[] keyboardOpts[i].value;
-    }
-    delete[] keyboardOpts;
-    return TRUE;
+  if (!(r.OpenKeyReadOnly(REGSZ_KeymanActiveKeyboards) && r.OpenKeyReadOnly(kp->Name) && r.OpenKeyReadOnly(key))) {
+    return FALSE;
   }
-  return FALSE;
+
+  // Get the list of default options to determine size of list
+  const km_kbp_keyboard_attrs* keyboardAttrs;
+  km_kbp_status err_status = km_kbp_keyboard_get_attrs(kp->lpCoreKeyboard, &keyboardAttrs);
+  if (err_status != KM_KBP_STATUS_OK) {
+    SendDebugMessageFormat(
+        0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_keyboard_get_attrs failed with error status [%d]", err_status);
+    return FALSE;
+  }
+  size_t listSize = km_kbp_options_list_size(keyboardAttrs->default_options);
+  km_kbp_option_item* keyboardOpts = new km_kbp_option_item[listSize + 1];
+
+  int n = 0;
+  for (auto kpc = keyboardAttrs->default_options; *kpc->key; kpc++) {
+    keyboardOpts[n].scope = KM_KBP_OPT_KEYBOARD;
+    keyboardOpts[n].key   = kpc->key;
+    LPCWSTR coreKey = reinterpret_cast<LPCWSTR>(kpc->key);
+    WCHAR val[256];
+    if (r.ReadString(coreKey, val, sizeof(val) / sizeof(val[0])) && val[0]) {
+      km_kbp_cp* cp = new km_kbp_cp[wcslen(val) + 1];
+      wcscpy_s(reinterpret_cast<LPWSTR>(cp), wcslen(val) + 1, val);
+      keyboardOpts[n].value = cp;
+    } else {
+      keyboardOpts[n].value = CloneKMKBPCP(kpc->value);
+
+      // Write default value from the keyboard to the registry
+      LPWSTR value = new WCHAR[sizeof(kpc->value) + 1];
+      wcscpy_s(value, sizeof(kpc->value) + 1, reinterpret_cast<LPCWSTR>(kpc->value));
+      IntSaveKeyboardOptionREGCore(REGSZ_KeyboardOptions, kp, coreKey, value);
+    }
+    n++;
+  }
+
+  keyboardOpts[n] = KM_KBP_OPTIONS_END;
+
+  // once we have the option list we can then update the options using the public api call
+  err_status = km_kbp_state_options_update(state, keyboardOpts);
+  if (err_status != KM_KBP_STATUS_OK) {
+    SendDebugMessageFormat(
+        0, sdmKeyboard, 0, "LoadKeyboardOptionsREGCore: km_kbp_state_options_update failed with error status [%d]", err_status);
+  }
+  for (int i = 0; i < n; i++) {
+    delete[] keyboardOpts[i].value;
+  }
+  delete[] keyboardOpts;
+  return TRUE;
 }
 
 BOOL

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -237,7 +237,7 @@ BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* 
 
   RegistryReadOnly r(HKEY_CURRENT_USER);
 
-  if (!(r.OpenKeyReadOnly(REGSZ_KeymanActiveKeyboards) && r.OpenKeyReadOnly(kp->Name) && r.OpenKeyReadOnly(key))) {
+  BOOL hasData = r.OpenKeyReadOnly(REGSZ_KeymanActiveKeyboards) && r.OpenKeyReadOnly(kp->Name) && r.OpenKeyReadOnly(key);
     return FALSE;
   }
 
@@ -258,7 +258,7 @@ BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* 
     keyboardOpts[n].key   = kpc->key;
     LPCWSTR coreKey = reinterpret_cast<LPCWSTR>(kpc->key);
     WCHAR val[256];
-    if (r.ReadString(coreKey, val, sizeof(val) / sizeof(val[0])) && val[0]) {
+    if (hasData && r.ReadString(coreKey, val, sizeof(val) / sizeof(val[0])) && val[0]) {
       km_kbp_cp* cp = new km_kbp_cp[wcslen(val) + 1];
       wcscpy_s(reinterpret_cast<LPWSTR>(cp), wcslen(val) + 1, val);
       keyboardOpts[n].value = cp;

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -253,7 +253,7 @@ BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* 
   km_kbp_option_item* keyboardOpts = new km_kbp_option_item[listSize + 1];
 
   int n = 0;
-  for (auto kpc = keyboardAttrs->default_options; *kpc->key; kpc++) {
+  for (auto kpc = keyboardAttrs->default_options; kpc->key; kpc++) {
     keyboardOpts[n].scope = KM_KBP_OPT_KEYBOARD;
     keyboardOpts[n].key   = kpc->key;
     LPCWSTR coreKey = reinterpret_cast<LPCWSTR>(kpc->key);
@@ -264,11 +264,6 @@ BOOL IntLoadKeyboardOptionsCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_kbp_state* 
       keyboardOpts[n].value = cp;
     } else {
       keyboardOpts[n].value = CloneKMKBPCP(kpc->value);
-
-      // Write default value from the keyboard to the registry
-      LPWSTR value = new WCHAR[sizeof(kpc->value) + 1];
-      wcscpy_s(value, sizeof(kpc->value) + 1, reinterpret_cast<LPCWSTR>(kpc->value));
-      IntSaveKeyboardOptionREGCore(REGSZ_KeyboardOptions, kp, coreKey, value);
     }
     n++;
   }

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -57,7 +57,11 @@ BOOL RestoreKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_
 /* Common core integration functions */
 
 /**
- *  Loads the keyboard options from the windows registry
+ * Loads the keyboard options from the windows registry.
+ *
+ * If the registry does not have an entry for keyboard option belonging
+ * to the keyboard, it (the registry) will be modified adding the key and
+ * default value.
  *
  * @param  kp     keyboard info object with options to be updated
  * @param  state  core keyboard state used to update keyboard options

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -57,11 +57,7 @@ BOOL RestoreKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_
 /* Common core integration functions */
 
 /**
- * Loads the keyboard options from the windows registry.
- *
- * If the registry does not have an entry for keyboard option belonging
- * to the keyboard, it (the registry) will be modified adding the key and
- * default value.
+ * Loads the keyboard options from the windows registry
  *
  * @param  kp     keyboard info object with options to be updated
  * @param  state  core keyboard state used to update keyboard options

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -57,7 +57,7 @@ BOOL RestoreKeyboardOptionsCore(km_kbp_state* const lpCoreKeyboardState, km_kbp_
 /* Common core integration functions */
 
 /**
- * Loads the keyboard options from the windows registry
+ *  Loads the keyboard options from the windows registry
  *
  * @param  kp     keyboard info object with options to be updated
  * @param  state  core keyboard state used to update keyboard options


### PR DESCRIPTION
Fixes #5951 

LoadKeyboardOptionsCore no longer frees the memory that has not been allocated.

# User Testing

**TEST_KEYBOARDOPTIONS_CHANGE**:  make sure changing the default keyboard options don't cause a crash.

This test requires IPA (SIL) keyboard to be installed (or a keyboard that has modifiable keyboard options).
Step 1. Go to `Keyman Configuration`, select the IPA (SIL) keyboard, click on `Keyboard options` and choose `Before`. You may need to exit Keyman configuration before the default behaviour changes.  
Step 2. Open Notepad, start typing anything and notepad should NOT crash.


Note: `Before` `After` setting. This will change the sequence to produce the IPA character for example `>b` => `ɓ`  for before and if the setting is after it is `b>` => `ɓ`
