### PR TITLE
fix(linux): Fix ibus-keyman integration tests 🎫

### DIFF
--- a/common/core/desktop/tests/unit/kmx/041 - long context and deadkeys.kmn
+++ b/common/core/desktop/tests/unit/kmx/041 - long context and deadkeys.kmn
@@ -1,4 +1,4 @@
-c Description: Tests that we don't split a dk in context:set
+c Description: Tests that we don't split a dk in context:set. Note that we start with a context with length MAXCONTEXT.
 c keys: [K_1][K_2][K_3]
 c context: \u00ffff\u000008\u00000001abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh
 c expected: \u00ffff\u000008\u00000001abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh123

--- a/common/core/desktop/tests/unit/kmx/042 - long context and split deadkeys.kmn
+++ b/common/core/desktop/tests/unit/kmx/042 - long context and split deadkeys.kmn
@@ -1,4 +1,4 @@
-c Description: Tests that we don't split a dk in context
+c Description: Tests that we don't split a dk in context. Note that we start with a context with length MAXCONTEXT.
 c keys: [K_SPACE]
 c context: \u00ffff\u000008\u00000001abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh
 c expected: \u00ffff\u000008\u00000001abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh\u0020


### PR DESCRIPTION
Previously we overwrote our test data, so we basically ran the same test repeatedly under different names.

Properly running them showed some failures which this change also fixes or skips.

Part of #5613.

@keymanapp-test-bot skip