### PR TITLE
fix(developer): building kmw keyboard had wrong message callback signature

### DIFF
--- a/windows/src/developer/kmcomp/Keyman.Developer.System.Project.ProjectLogConsole.pas
+++ b/windows/src/developer/kmcomp/Keyman.Developer.System.Project.ProjectLogConsole.pas
@@ -31,7 +31,7 @@ type
   end;
 
 function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;   // I3310
-
+function CompilerMessageW( line: Integer; msgcode: LongWord; const text: string): Integer;
 implementation
 
 uses
@@ -169,11 +169,9 @@ begin
   end;
 end;
 
-function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;   // I3310
+function CompilerMessageW( line: Integer; msgcode: LongWord; const text: string): Integer;
 var
   state: TProjectLogState;
-const
-	nlstr: array[0..2] of ansichar = (#$D, #$A, #$0);   // I3310
 begin
   if (msgcode = CWARN_Info) then state := plsInfo
   else if (msgcode and CERR_ERROR) <> 0   then state := plsError
@@ -181,9 +179,14 @@ begin
   else if (msgcode and CERR_FATAL) <> 0   then state := plsFatal
   else state := plsFatal;
 
-  TProjectLogConsole.Instance.Log(state, string(AnsiString(text)), msgcode, line);
+  TProjectLogConsole.Instance.Log(state, text, msgcode, line);
 
   Result := 1;
+end;
+
+function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall;   // I3310
+begin
+  Result := CompilerMessageW(line, msgcode, string(AnsiString(text)));
 end;
 
 end.

--- a/windows/src/developer/kmcomp/main.pas
+++ b/windows/src/developer/kmcomp/main.pas
@@ -293,7 +293,7 @@ begin
   begin
     with TCompileKeymanWeb.Create do
     try
-      Result := Compile(nil, FInFile, FOutFile, FDebug, @CompilerMessage);   // I3681   // I4865   // I4866
+      Result := Compile(nil, FInFile, FOutFile, FDebug, @CompilerMessageW);   // I3681   // I4865   // I4866
     finally
       Free;
     end;


### PR DESCRIPTION
Picked up during #5963 development.

If you ran `kmcomp <file.kmn> <out.js>`, compiler messages were passed to a function with an incorrect signature, resulting in an exception. This was a mode that was not widely used, which is why we haven't picked it up earlier.

@keymanapp-test-bot skip