### PR TITLE
feat(android/engine): Add other IME's to the Keyboard Picker menu

### DIFF
--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   package="com.tavultesoft.kmea" >
+    <!-- Query other IME's for keyboard picker menu -->
+    <queries>
+      <intent>
+        <action android:name="android.view.InputMethod" />
+      </intent>
+    </queries>
 
     <uses-permission android:name="android.permission.VIBRATE" />
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -449,6 +449,7 @@ public final class KMManager {
   public static void setInputMethodService(InputMethodService service) {
     IMService = service;
   }
+  public static InputMethodService getInputMethodService() { return IMService; }
 
   public static boolean executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
     if (SystemKeyboard != null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -25,6 +25,7 @@ import com.tavultesoft.kmea.util.MapCompat;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.inputmethodservice.InputMethodService;
@@ -530,6 +531,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     ArrayList<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
     InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
     List<InputMethodInfo> imeList = imManager.getEnabledInputMethodList();
+    PackageManager packageManager = context.getPackageManager();
     for (InputMethodInfo imeInfo : imeList) {
       String id = imeInfo.getId();
       if (!id.startsWith(selfPackageName)) {
@@ -539,9 +541,9 @@ public final class KeyboardPickerActivity extends BaseActivity {
         if (componentName != null) {
           String packageName = componentName.getPackageName();
           try {
-            PackageManager packageManager = context.getPackageManager();
-            ApplicationInfo info = packageManager.getApplicationInfo(packageName, 0);
-            String imeName = info.loadLabel(packageManager).toString();
+            //PackageInfo info = packageManager.getPackageInfo(packageName, 0);
+            ApplicationInfo info = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            String imeName = (String)packageManager.getApplicationLabel(info);
             HashMap<String, String> hashMap = new HashMap<String, String>();
             hashMap.put(titleKey, imeName);
             hashMap.put(subtitleKey, id);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -12,9 +12,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import com.tavultesoft.kmea.cloud.CloudDataJsonUtil;
 import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
@@ -24,23 +22,26 @@ import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.app.AlertDialog;
+import android.content.ComponentName;
 import android.content.Context;
-import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.graphics.Typeface;
-//import android.inputmethodservice.Keyboard;
+import android.inputmethodservice.InputMethodService;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.Window;
+import android.view.inputmethod.InputMethodInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.BaseAdapter;
-import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.PopupMenu;
+import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -51,8 +52,14 @@ public final class KeyboardPickerActivity extends BaseActivity {
   //TODO: view instances should not be static
   private static Toolbar toolbar = null;
   private static ListView listView = null;
-  private static Button closeButton = null;
+  private static ListView imeListView = null;
+  private static final String titleKey = "title";
+  private static final String subtitleKey = "subtitle";
+  private static final String iconKey = "icon";
+
+  private static ArrayList<HashMap<String, String>> imeList = null;
   private static KMKeyboardPickerAdapter listAdapter = null;
+  private static ListAdapter imeListAdapter = null;
 
   public static final String  KMKEY_INTERNAL_NEW_KEYBOARD = "_internal_new_keyboard_";
 
@@ -83,27 +90,12 @@ public final class KeyboardPickerActivity extends BaseActivity {
 
     toolbar = (Toolbar) findViewById(R.id.list_toolbar);
     setSupportActionBar(toolbar);
+    int actionBarHeight = toolbar.getLayoutParams().height;
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     getSupportActionBar().setDisplayShowHomeEnabled(true);
     getSupportActionBar().setDisplayShowTitleEnabled(false);
     TextView textView = (TextView) findViewById(R.id.bar_title);
     textView.setText(getResources().getQuantityString(R.plurals.title_keyboards, 2));
-
-    closeButton = (Button) findViewById(R.id.close_keyman_button);
-    Bundle bundle = getIntent().getExtras();
-    if (bundle != null) {
-      if (!bundle.getBoolean(KMManager.KMKey_DisplayKeyboardSwitcher)) {
-        closeButton.setVisibility(View.GONE);
-      }
-    }
-    closeButton.setOnClickListener(new View.OnClickListener() {
-      public void onClick(View v) {
-        KMManager.advanceToNextInputMode();
-        if (dismissOnSelect) {
-          finish();
-        }
-      }
-    });
 
     listView = (ListView) findViewById(R.id.listView);
 
@@ -124,6 +116,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     listAdapter.listFont = listFont;
     listView.setAdapter(listAdapter);
     listView.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+
     listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
@@ -200,6 +193,49 @@ public final class KeyboardPickerActivity extends BaseActivity {
 
       }
     });
+
+    Bundle bundle = getIntent().getExtras();
+    if (bundle != null) {
+      if (bundle.getBoolean(KMManager.KMKey_DisplayKeyboardSwitcher)) {
+        // Create list of other Enabled IME's (excluding self)
+        View view = getLayoutInflater().inflate(R.layout.ime_list_layout, null);
+        LinearLayout imeLinearLayout = (LinearLayout) view.findViewById(R.id.ime_linear_layout);
+        imeListView = (ListView) imeLinearLayout.findViewById(R.id.listView);
+        imeList = getIMEList(context);
+        if (imeListView != null && imeList != null && imeList.size() > 0) {
+          // "Other Input Methods" titlebar
+          TextView imeTextView = (TextView) view.findViewById(R.id.other_ime_title);
+          imeTextView.setText(getResources().getQuantityString(R.plurals.title_other_input_methods, imeList.size()));
+
+          String[] from = new String[]{titleKey, subtitleKey, iconKey};
+          int[] to = new int[]{R.id.text1, R.id.text2, R.id.image1};
+          // Using list_row_layout5 to hide displaying subtitle (IME ID)
+          imeListAdapter = new SimpleAdapter(this, imeList, R.layout.list_row_layout5, from, to);
+          imeListView.setAdapter(imeListAdapter);
+          // Rescale IME listview so entire list is visible (wrap_content not working)
+          imeListView.getLayoutParams().height = actionBarHeight * imeListAdapter.getCount();
+          imeListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+              HashMap<String, String> hashMap = (HashMap<String, String>) parent.getItemAtPosition(position);
+              if (hashMap == null) {
+                return;
+              }
+
+              String imeID = MapCompat.getOrDefault(hashMap, subtitleKey, "");
+              InputMethodService ims = KMManager.getInputMethodService();
+              if (!imeID.equals("") && ims != null) {
+                ims.switchInputMethod(imeID);
+              }
+              finish();
+            }
+          });
+
+          // Append the IME list to the overall listView
+          listView.addFooterView(imeLinearLayout);
+        }
+      }
+    }
   }
 
   @Override
@@ -212,6 +248,13 @@ public final class KeyboardPickerActivity extends BaseActivity {
 
     int curKbPos = KeyboardController.getInstance().getKeyboardIndex(KMKeyboard.currentKeyboard());
     setSelection(curKbPos);
+
+    imeList = getIMEList(this);
+    BaseAdapter imeAdapter = (BaseAdapter)imeListAdapter;
+    if (imeListAdapter != null) {
+      imeAdapter.notifyDataSetChanged();
+    }
+
     if (!shouldCheckKeyboardUpdates)
       return;
   }
@@ -478,6 +521,38 @@ public final class KeyboardPickerActivity extends BaseActivity {
       }
     }
 
+    return list;
+  }
+
+  // Get the list of IME's excluding self
+  private static ArrayList<HashMap<String, String>> getIMEList(Context context) {
+    String selfPackageName = context.getApplicationContext().getPackageName();
+    ArrayList<HashMap<String, String>> list = new ArrayList<HashMap<String, String>>();
+    InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    List<InputMethodInfo> imeList = imManager.getEnabledInputMethodList();
+    for (InputMethodInfo imeInfo : imeList) {
+      String id = imeInfo.getId();
+      if (!id.startsWith(selfPackageName)) {
+        // Attempt to get a readable name
+        // Reference: https://stackoverflow.com/questions/62512501/get-human-readable-name-of-default-keyboard-not-package-name
+        ComponentName componentName = ComponentName.unflattenFromString(id);
+        if (componentName != null) {
+          String packageName = componentName.getPackageName();
+          try {
+            PackageManager packageManager = context.getPackageManager();
+            ApplicationInfo info = packageManager.getApplicationInfo(packageName, 0);
+            String imeName = info.loadLabel(packageManager).toString();
+            HashMap<String, String> hashMap = new HashMap<String, String>();
+            hashMap.put(titleKey, imeName);
+            hashMap.put(subtitleKey, id);
+            list.add(hashMap);
+
+          } catch (PackageManager.NameNotFoundException e) {
+            KMLog.LogException(TAG, "Name not found", e);
+          }
+        }
+      }
+    }
     return list;
   }
 

--- a/android/KMEA/app/src/main/res/layout/ime_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/ime_list_layout.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/ime_linear_layout"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
+
+  <!-- "Other Input Methods" title -->
+  <TextView
+    android:id="@+id/other_ime_title"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/other_ime_title_height"
+    android:layout_gravity="center_horizontal"
+    android:background="@android:color/darker_gray"
+    android:gravity="center"
+    android:ellipsize="end"
+    android:singleLine="true"
+    android:textSize="@dimen/titlebar_label_textsize"
+    android:textStyle="bold"
+    android:layout_marginTop="@dimen/fab_margin"/>
+
+  <!-- ListView of other enabled keyboards -->
+  <include layout="@layout/list_layout"
+    android:id="@+id/ime_list_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/android/KMEA/app/src/main/res/layout/keyboard_picker_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/keyboard_picker_list_layout.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -10,33 +8,11 @@
     <include layout="@layout/list_toolbar" />
 
     <include layout="@layout/list_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
         android:id="@+id/keyboard_list_layout"
-        android:layout_below="@id/list_appbar"/>
-
-    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:orientation="horizontal">
+        android:layout_below="@id/list_appbar" />
 
-        <Button
-            android:id="@+id/close_keyman_button"
-            style="@style/Widget.AppCompat.Button.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            android:layout_marginStart="@dimen/close_button_margin"
-            android:layout_weight="1"
-            android:singleLine="true"
-            android:text="@string/label_next_input_method" />
+    <!-- ime_list_layout gets programmatically added as needed -->
 
-        <Space
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="10"
-            android:layout_gravity="center"/>
-
-    </LinearLayout>
 </RelativeLayout>

--- a/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/list_item" >
+    
+    <LinearLayout
+        android:background="@android:color/transparent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:orientation="vertical" >
+ 
+        <TextView
+            android:id="@+id/text1"
+            android:background="@android:color/transparent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <!-- test2 string is hidden but we can still access the info -->
+        <TextView
+            android:id="@+id/text2"
+            android:background="@android:color/transparent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:visibility="invisible"
+            android:layout_marginBottom="5dp"
+            android:textSize="14sp" />
+    </LinearLayout>
+    
+    <ImageView
+        android:id="@+id/image1"
+        android:background="@android:color/transparent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="12dp"
+        android:contentDescription="@string/image_view"/>
+    
+</RelativeLayout>

--- a/android/KMEA/app/src/main/res/values-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land/dimens.xml
@@ -14,7 +14,6 @@
     <dimen name="help_bubble_height">60dp</dimen>
     <dimen name="help_bubble_offset_x">0.5dp</dimen>
     <dimen name="help_bubble_offset_y">6dp</dimen>
-    <dimen name="close_button_margin">12dp</dimen>
     <dimen name="fab_margin">10dp</dimen>
     <dimen name="fab_padding">70dp</dimen>
 </resources>

--- a/android/KMEA/app/src/main/res/values/dimens.xml
+++ b/android/KMEA/app/src/main/res/values/dimens.xml
@@ -15,7 +15,7 @@
     <dimen name="help_bubble_height">60dp</dimen>
     <dimen name="help_bubble_offset_x">0.5dp</dimen>
     <dimen name="help_bubble_offset_y">6dp</dimen>
-    <dimen name="close_button_margin">12dp</dimen>
+    <dimen name="other_ime_title_height">35dp</dimen>
     <dimen name="fab_margin">10dp</dimen>
     <dimen name="fab_padding">70dp</dimen>
     <dimen name="qr_height">250dp</dimen>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -14,6 +14,12 @@
     </plurals>
 
     <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+      <item quantity="one">Other Input Method</item>
+      <item quantity="other">Other Input Methods</item>
+    </plurals>
+
+    <!-- Context: Title for list -->
     <string name="title_add_keyboard" comment="Add a new keyboard">Add New Keyboard</string>
 
     <!-- Context: Title for list -->

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <!-- Context: Button label -->
     <string name="label_close" comment="Close a dialog">Close</string>
 
-    <!-- Context: Button label -->
+    <!-- Context: Button label. Removed in Keyman 15 -->
     <string name="label_close_keyman" comment="Close the Keyman application">Close Keyman</string>
 
     <!-- Context: Button label -->


### PR DESCRIPTION
Fixes #5834 by making the following changes to the Keyman system keyboard "keyboard picker" menu (no change to the in-app keyboard picker):
* Allows other system IME's to be selected
* Remove the "Close Keyman" button previously used to switch to other IME

Screenshot from system keyboard "Keyboard Picker" menu
![keyboard picker - Android 11](https://user-images.githubusercontent.com/7358010/143393243-9f56aae7-4d24-4ce7-8b68-e949656bdbe4.jpg)
Note on the screenshot: "Google" refers to Google's voice-activated keyboard, which is separate from "Gboard".

Note, due to how Android 11 handles privacy, this PR also adds the permission to query for other IME's in the AndroidManifest.xml.
Reference: https://developer.android.com/training/package-visibility/declaring#intent-filter-signature

## User Testing
Setup:
1. Install test build of Keyman on Android 11 device (actual device preferable)
2. In Keyman, install sil_cameroon_qwerty keyboard for 12+ languages. (Associate many languages in order to verify during the test that the keyboard picker menu correctly scrolls)
3. Enable Keyman as a system keyboard
4. On the device, install another IME (e.g. ~alpha build of FirstVoices~ [PR test build of FV](https://build.palaso.org/repository/download/KeymanAndroid_TestPullRequests/298446:id/release/FirstVoices/app-debug.apk))
    * If using FirstVoices, setup FirstVoices keyboard and enable as system keyboard 
   
* **TEST_KEYMAN_KEYBOARD_PICKER** - Tests that other IMEs can be selected in Keyman keyboard picker
1. Launch Keyman
2. In the Keyman app, long-press on the globe key to pull up the keyboard picker
3. In the Keyboard picker menu, scroll to the end and verify only Keyman keyboards are listed
4. Select a different Keyman keyboard
5. Verify the keyboard is switched to the selection
6. On the device, launch a browser (Chrome) and click on the searchbar
7. With Keyman selected, long-press on the globe key to pull up the keyboard picker
8. In the Keyboard picker menu, scroll to the end and verify other Input methods are listed
    * Also verify FirstVoices is one of the options
9. Select another input method (e.g. Gboard)
10. Verify the other keyboard is selected. If needed, click on the search bar to display the OSK (The OSK may disappear when switching keyboards. See issue #4476)

* **TEST_FV_KEYBOARD_PICKER** - Tests keyboard picker from another app that uses KMEA
1. On the device, set FirstVoices as the system keyboard
2. Launch a browser (Chrome) and click on the searchbar
3. With FirstVoices selected, long-press on the globe key to pull up the keyboard picker
4. In the Keyboard picker menu, scroll to the end and verify other Input methods are listed
    * Also verify Keyman is one of the options
5. Select another input method
6. Verify the other keyboard is selected. Again, the OSK may disappear so you may need to click on the search bar to display the OSK.
