### PR TITLE
fix(linux): Add test targets to Makefile 🎫

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -52,3 +52,10 @@ releasedeb: reconf origdist cow debnocow # it will prompt for sudo if required f
 nightlydist: reconf sources
 	echo "Built nightly source release in dist/"
 
+check:
+	cd keyman-config && ./run-tests.sh
+
+tmpcheck:
+	cd keyman-config && ./run-tests.sh
+
+tests: check


### PR DESCRIPTION
The test targets got added on the `master` branch and the TC configuration adjusted so that PR builds run the tests. This change
adds these targets (but without running ibus-keyman tests) to the stable branch, so that TC builds for PRs will work.

@keymanapp-test-bot skip