### PR TITLE
fix(web): restore `dragEnd` function 🔥

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -776,6 +776,14 @@ namespace com.keyman.dom {
     }
 
     /**
+     * Handle the touch end event for an input element
+     */
+    dragEnd: (e: TouchEvent|MouseEvent) => void = function(this: DOMTouchHandlers, e: TouchEvent|MouseEvent) {
+      e.stopPropagation();
+      this.firstTouch = null;
+    }.bind(this);
+
+    /**
      * Handle the touch move event for an input element
      */
     dragInput: (e: TouchEvent|MouseEvent) => void = function(this: DOMTouchHandlers, e: TouchEvent|MouseEvent) {


### PR DESCRIPTION
Relates to #5947.

I resolved a merge conflict in #5947 in the wrong direction and accidentally deleted the `dragEnd` function. This restores it.

@keymanapp-test-bot skip