### PR TITLE
chore(android): Specify build tools version on other projects

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -111,6 +111,7 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
 ```gradle
 android {
     compileSdkVersion 30
+    buildToolsVersion "30.0.2"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 android {
     compileSdkVersion 30
+    buildToolsVersion "30.0.2"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -9,6 +9,7 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 30
+    buildToolsVersion "30.0.2"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
While Android Studio Gradle plugin should automatically use a default version of build tools, we can specify it:
https://developer.android.com/studio/releases/build-tools

Attempting to resolve lint exceptions on the build agent.

@keymanapp-test-bot skip