### PR TITLE
fix(android/engine): Fix font paths

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -372,9 +372,7 @@ final class KMKeyboard extends WebView {
    * @return String
    */
   public static String textFontFilename() {
-    String fontPath = (txtFont.contains(KMManager.KMDefault_KeyboardFont)) ?
-      KMManager.getResourceRoot() : keyboardRoot;
-    return txtFont.isEmpty() ? "" : fontPath + txtFont;
+    return txtFont;
   }
 
   /**
@@ -382,9 +380,7 @@ final class KMKeyboard extends WebView {
    * @return String
    */
   public static String oskFontFilename() {
-    String fontPath = (oskFont.contains(KMManager.KMDefault_KeyboardFont)) ?
-      KMManager.getResourceRoot() : keyboardRoot;
-    return fontPath + oskFont;
+    return oskFont;
   }
 
   /**


### PR DESCRIPTION
Fixes #5914 

During the 14.0 refactoring of keyboard info (keyboard controller, Keyboard data object), the font info already contains the full paths to the .ttf files.

This fixes the font paths in KMKeyboard.

## User Testing
Setup: Install on Android emulator with SDK 21

* **TEST_FONT_PATHS** - Verifies font is applied for OSK keys and subkeys
1. Load the PR build of Keyman
2. Launch Keyman and exit the "Get Started" menu
3. Verify the keys and subkeys for the default sil_euro_latin keyboard are correct
3. From the "Settings" menu, install keyboards that use a TTF font. For example
    a. Test [U_xxxx_yyyy](https://darcywong00.github.io/examples/u2858/u_xxxx_yyyy_2858.kmp) keyboard 
    b. khmer_angkor (this verifies font is applied in reported issue #5985)
4. After the keyboard installs, verify the OSK is correct (no tofu boxes)
5. Select the U_xxxx_yyyy keyboard
6. Press the first Amharic key (under the `q` key and verify the output (two chars) is correct
7. Long-press the Old Italic key (3 characters under the `w` and `e` keys)
8. Verify the popup key is correct (no tofu boxes)
9. Release the popup key and verify the output is correct
10. Select khmer_angkor keyboard
11. Long-press a key and verify the font rendering is consistent with base keys.

### Screenshots of U_xxxx_yyyy keys
![Screenshot_1638264938](https://user-images.githubusercontent.com/7358010/144023721-fd322503-b444-473d-9460-553d758512f7.png)

![subkey](https://user-images.githubusercontent.com/7358010/144023739-8b8f2975-bfc8-4583-b40c-b50b3b48d430.png)

