### PR TITLE
fix(android/engine): Fix font paths 🍒 

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -363,9 +363,7 @@ final class KMKeyboard extends WebView {
    * @return String
    */
   public static String textFontFilename() {
-    String fontPath = (txtFont.contains(KMManager.KMDefault_KeyboardFont)) ?
-      KMManager.getResourceRoot() : keyboardRoot;
-    return txtFont.isEmpty() ? "" : fontPath + txtFont;
+    return txtFont;
   }
 
   /**
@@ -373,9 +371,7 @@ final class KMKeyboard extends WebView {
    * @return String
    */
   public static String oskFontFilename() {
-    String fontPath = (oskFont.contains(KMManager.KMDefault_KeyboardFont)) ?
-      KMManager.getResourceRoot() : keyboardRoot;
-    return fontPath + oskFont;
+    return oskFont;
   }
 
   /**


### PR DESCRIPTION
🍒 pick of #5987 to stable-14.0

This fixes the font paths since they already contain the full path.

## User Testing
Setup: Install on Android emulator with SDK 21

* **TEST_FONT_PATHS** - Verifies font is applied for OSK keys and subkeys
1. Load the PR build of Keyman
2. Launch Keyman and exit the "Get Started" menu
3. Verify the keys and subkeys for the default sil_euro_latin keyboard are correct
4. Note how the sil_euro_latin OSK is rendered (for comparison later)
5. From the "Settings" menu, install keyboards that use a TTF font. For example
    a. sil_cameroon_qwerty (Not using test U_xxxx_yyyy keyboard because 14.0 will crash trying to render those subkeys)
    b. khmer_angkor (this verifies font is applied in reported issue bug(android): the base keys and the subkeys are in different font face #5985)
6. After the keyboard installs, verify the OSK is correct (no tofu boxes)
7. Select the sil_cameroon_qwerty keyboard
8. Verify the OSK uses a different font from sil_euro_latin.
9. Long-press a key
10. Verify the popup key is correct (no tofu boxes)
11. Release the popup key and verify the output is correct
12. Select khmer_angkor keyboard
13. Long-press a key and verify the font rendering is consistent with base keys.