### PR TITLE
chore(linux): Remove lintian warning

### DIFF
--- a/linux/ibus-keyman/debian/rules
+++ b/linux/ibus-keyman/debian/rules
@@ -3,7 +3,7 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \

--- a/linux/ibus-kmfl/debian/rules
+++ b/linux/ibus-kmfl/debian/rules
@@ -3,7 +3,7 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \

--- a/linux/kmflcomp/debian/rules
+++ b/linux/kmflcomp/debian/rules
@@ -4,4 +4,4 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@

--- a/linux/libkmfl/debian/rules
+++ b/linux/libkmfl/debian/rules
@@ -4,4 +4,4 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@


### PR DESCRIPTION
Lintian complained "missing-build-dependency-for-dh-addon" which I'm not entirely sure is correct. However, there is an easy
workaround by removing an unnecessary parameter.

@keymanapp-test-bot skip