### PR TITLE
chore(linux): Remove lintian warning :package:  :cherries: 

### DIFF
--- a/linux/legacy/ibus-kmfl/debian/rules
+++ b/linux/legacy/ibus-kmfl/debian/rules
@@ -3,7 +3,7 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \

--- a/linux/legacy/kmflcomp/debian/rules
+++ b/linux/legacy/kmflcomp/debian/rules
@@ -4,4 +4,4 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@

--- a/linux/legacy/libkmfl/debian/rules
+++ b/linux/legacy/libkmfl/debian/rules
@@ -4,4 +4,4 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@ --with autoreconf
+	dh $@


### PR DESCRIPTION
Lintian complained "missing-build-dependency-for-dh-addon" which I'm not entirely sure is correct. However, there is an easy
workaround by removing an unnecessary parameter.

:cherries:-pick of #5993.

@keymanapp-test-bot skip