### PR TITLE
fix(mac): increase OSK character size by 50%

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -16,7 +16,7 @@ CGFloat r = 7.0;
 const NSTimeInterval delayBeforeRepeating = 0.5f;
 const NSTimeInterval repeatInterval = 0.05f;
 
-static CGFloat const kRelativeCharacterLabelHeight = 0.42f;
+static CGFloat const kRelativeCharacterLabelHeight = 0.45f;
 static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 
 @interface KeyView ()

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -121,7 +121,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 }
 
 - (void)setKey:(OSKKey *)key {
-   _key = key;
+    _key = key;
     [self setKeyCode:key.keyCode];
     [self setTag:key.keyCode|0x1000];
     if ([self isSpecialKey])

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -21,6 +21,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 @property (nonatomic, assign) BOOL hasKeyCaption;
 @property (nonatomic, assign) BOOL isModifierKey;
 @property (nonatomic, assign) BOOL isSpecialKey;
+@property (nonatomic, assign) BOOL isCharacterKey;
 @property (nonatomic, strong) KeyLabel *label;
 @property (nonatomic, strong) NSTextField *caption;
 @property (nonatomic, strong) NSImageView *bitmapView;
@@ -40,7 +41,6 @@ const NSTimeInterval repeatInterval = 0.05f;
         CGSize size = frame.size;
         CGFloat x = size.width*0.05;
         NSRect labelFrame = NSMakeRect(x, 0, size.width -lw -2*x, size.height);
-        CGFloat fontSize = labelFrame.size.height*0.3;
         _label = [[KeyLabel alloc] initWithFrame:labelFrame];
         [_label setEditable:NO];
         [_label setBordered:NO];
@@ -49,9 +49,12 @@ const NSTimeInterval repeatInterval = 0.05f;
         if ([_caption respondsToSelector:@selector(setLineBreakMode:)]) {
             [_label setLineBreakMode:NSLineBreakByClipping];
         } // There might be some problem not calling this, but it seems to be okay as far as I can tell
+        
+        CGFloat fontSize = labelFrame.size.height*0.3;
         [_label setFont:[NSFont systemFontOfSize:fontSize]];
         [_label setTextColor:[NSColor blackColor]];
         [_label setStringValue:@""];
+        [_label setLineBreakMode:NSLineBreakByClipping];
         [self addSubview:_label];
 
         bgColor1 = [self getOpaqueColorWithRed:209 green:211 blue:212];
@@ -115,7 +118,7 @@ const NSTimeInterval repeatInterval = 0.05f;
 }
 
 - (void)setKey:(OSKKey *)key {
-    _key = key;
+   _key = key;
     [self setKeyCode:key.keyCode];
     [self setTag:key.keyCode|0x1000];
     if ([self isSpecialKey])
@@ -141,6 +144,26 @@ const NSTimeInterval repeatInterval = 0.05f;
         _isSpecialKey = YES;
     else
         _isSpecialKey = NO;
+    
+    if (!_isSpecialKey && !_isModifierKey)
+        _isCharacterKey = YES;
+    else
+        _isCharacterKey = NO;
+    
+    // having changed the keycode, adjust the font size of the key label to optimize for available space
+    [self adjustLabelFontSize];
+}
+
+// set the size of the font relative to the key height, depending on what type of key it is
+// this allows larger more readable character key text
+- (void)adjustLabelFontSize {
+    CGFloat relativeFontSize = 0.45;
+    
+    if (!self.isCharacterKey)
+        relativeFontSize = 0.3;
+        
+    CGFloat fontSize = self.label.bounds.size.height*relativeFontSize;
+    [self.label setFont:[NSFont systemFontOfSize:fontSize]];
 }
 
 - (void)setLabelText:(NSString *)text {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -16,7 +16,7 @@ CGFloat r = 7.0;
 const NSTimeInterval delayBeforeRepeating = 0.5f;
 const NSTimeInterval repeatInterval = 0.05f;
 
-static CGFloat const kRelativeCharacterLabelHeight = 0.45f;
+static CGFloat const kRelativeCharacterLabelHeight = 0.42f;
 static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 
 @interface KeyView ()

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -16,6 +16,9 @@ CGFloat r = 7.0;
 const NSTimeInterval delayBeforeRepeating = 0.5f;
 const NSTimeInterval repeatInterval = 0.05f;
 
+static CGFloat const kRelativeCharacterLabelHeight = 0.45f;
+static CGFloat const kRelativeModifierLabelHeight = 0.30f;
+
 @interface KeyView ()
 @property (nonatomic, assign) NSUInteger keyCode;
 @property (nonatomic, assign) BOOL hasKeyCaption;
@@ -50,7 +53,7 @@ const NSTimeInterval repeatInterval = 0.05f;
             [_label setLineBreakMode:NSLineBreakByClipping];
         } // There might be some problem not calling this, but it seems to be okay as far as I can tell
         
-        CGFloat fontSize = labelFrame.size.height*0.3;
+        CGFloat fontSize = labelFrame.size.height*kRelativeModifierLabelHeight;
         [_label setFont:[NSFont systemFontOfSize:fontSize]];
         [_label setTextColor:[NSColor blackColor]];
         [_label setStringValue:@""];
@@ -145,23 +148,28 @@ const NSTimeInterval repeatInterval = 0.05f;
     else
         _isSpecialKey = NO;
     
-    if (!_isSpecialKey && !_isModifierKey)
+    if (!_isSpecialKey && !_isModifierKey) {
         _isCharacterKey = YES;
-    else
+    } else {
         _isCharacterKey = NO;
-    
-    // having changed the keycode, adjust the font size of the key label to optimize for available space
-    [self adjustLabelFontSize];
+    }
+  
+  // having changed the keycode, adjust the font size of the key label to optimize for available space
+  [self adjustLabelFontSize];
 }
 
-// set the size of the font relative to the key height, depending on what type of key it is
-// this allows larger more readable character key text
+
+/**
+ * Set the size of the font relative to the key height, depending on what type of key it is.
+ * This allows larger more readable character key text.
+ */
 - (void)adjustLabelFontSize {
-    CGFloat relativeFontSize = 0.45;
+    CGFloat relativeFontSize = kRelativeCharacterLabelHeight;
     
-    if (!self.isCharacterKey)
-        relativeFontSize = 0.3;
-        
+    if (!self.isCharacterKey) {
+        relativeFontSize = kRelativeModifierLabelHeight;
+    }
+
     CGFloat fontSize = self.label.bounds.size.height*relativeFontSize;
     [self.label setFont:[NSFont systemFontOfSize:fontSize]];
 }


### PR DESCRIPTION
Increases the size of character labels in the Keyman for Mac onscreen keyboard by 50% (from using 0.3 of the key height to 0.45 of the key height). The font size for labels on modifier and special keys remains as is. Fixes #5600 

![OSK Hebrew 0 5 600](https://user-images.githubusercontent.com/89134789/144559530-8868c4cc-3448-463a-8518-afe771f529c6.png)
![OSK Hebrew 03 600](https://user-images.githubusercontent.com/89134789/144559537-f593f2f4-db4c-447f-9641-8b0e3277a582.png)


# User Testing
* TEST_MAC: load keyboards for a variety of languages and view the OSK for each to verify that characters fit cleanly within the bounds of the key 
