### PR TITLE
chore(common): buf now uses decxstr so remove comment

### DIFF
--- a/common/core/desktop/src/kmx/kmx_context.h
+++ b/common/core/desktop/src/kmx/kmx_context.h
@@ -84,8 +84,6 @@ public:
    * Returns NULL if there are less than n valid xstring units in the current context.
    * Background this was historically for performance during rule evaluation, if there
    * are not enough characters to compare, don't event attempt the comparison.
-   * Note: Unlike BufMax there is no checking for truncation of code points.
-   *        e.g. the pointer may point to a code unit that is half of a surrogate pair.
    *
    * @param n  The number of valid xstring units (not code points or code units)
    * @return KMX_WCHAR* Pointer to the start postion for a buffer of maximum n characters

--- a/windows/src/engine/keyman32/appint/appint.h
+++ b/windows/src/engine/keyman32/appint/appint.h
@@ -149,8 +149,6 @@ public:
    * Returns NULL if there are less than n valid xstring units in the current context.
    * Background this was historically for performance during rule evaluation, if there
    * are not enough characters to compare, don't event attempt the comparison.
-   * Note:  Unlike BufMax there is no checking for truncation of code points.
-   *        e.g. the pointer may point to a code unit that is half of a surrogate pair.
    *
    * @param n  The number of valid xstring units (not code points or code units)
    * @return KMX_WCHAR* Pointer to the start postion for a buffer of maximum n characters


### PR DESCRIPTION
remove comment about it splitting surrogate pairs and
deadkeys
This address a review comment that was made after the PR was already merged.
@keymanapp-test-bot skip