### PR TITLE
fix(linux): Fix installation of shared packages

### DIFF
--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -81,3 +81,6 @@ $(MOFILES): %/LC_MESSAGES/keyman-config.mo: %.po
 	msgfmt -v --check --output-file=$@ $^
 
 compile-po: $(MOFILES)
+
+check:
+	./run-tests.sh

--- a/linux/keyman-config/README.md
+++ b/linux/keyman-config/README.md
@@ -1,4 +1,4 @@
-# Linux KMP installer
+# Linux km-config
 
 ## Preparing to run
 
@@ -181,3 +181,20 @@ This will create `.mo` files, e.g. `locale/de/LC_MESSAGES/keyman-config.mo`.
 ```bash
 LANGUAGE=de ./km-config
 ```
+
+## Debugging unit tests
+
+* Add the following lines to your workspace settings file (`.vscode/settings`),
+  or copy `docs/settings/linux/settings` to `.vscode/settings`)
+
+  ```settings
+  "python.envFile": "${workspaceFolder}/linux/keyman-config/tests/python.env",
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s", "linux/keyman-config/tests",
+    "-p", "test_*.py"
+  ],
+  "python.testing.unittestEnabled": true,
+  ```
+
+* The tests will show up in the _Test Explorer_ in VSCode and can be debugged there

--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -1,81 +1,22 @@
 #!/usr/bin/python3
 import logging
 import os
-import subprocess
-from gi.repository import Gio
 
-from gi.overrides.GLib import Variant
+from keyman_config.gsettings import GSettings
 
 
 class GnomeKeyboardsUtil():
     def __init__(self):
-        if os.environ.get('SUDO_USER'):
-            self.input_sources = None
-            self.is_sudo = True
-            logging.debug('Running with sudo. Real user: %s', os.environ.get('SUDO_USER'))
-        else:
-            self.input_sources = Gio.Settings.new("org.gnome.desktop.input-sources")
-            self.is_sudo = False
-            logging.debug('Running as regular user')
+        self.input_sources = GSettings('org.gnome.desktop.input-sources')
 
     def read_input_sources(self):
-        if self.is_sudo:
-            process = subprocess.run(
-                ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
-                 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%s/bus' % os.environ.get('SUDO_UID'),
-                 'gsettings', 'get', 'org.gnome.desktop.input-sources', 'sources'],
-                capture_output=True)
-            if process.returncode == 0:
-                sources = eval(process.stdout)
-                logging.debug('sources before change: %s', sources)
-            else:
-                sources = None
-                logging.warning('Could not convert to sources')
-        else:
-            sourcesVal = self.input_sources.get_value("sources")
-            sources = self._convert_variant_to_array(sourcesVal)
+        sources = self.input_sources.get('sources')
+        logging.debug('read sources: %s', sources)
         return sources
 
     def write_input_sources(self, sources):
-        if self.is_sudo:
-            logging.debug('Setting sources to: %s', sources)
-            sourcesVal = str(sources)
-            subprocess.run(
-                ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
-                 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%s/bus' % os.environ.get('SUDO_UID'),
-                 'gsettings', 'set', 'org.gnome.desktop.input-sources', 'sources', sourcesVal])
-        else:
-            sourcesVal = self._convert_array_to_variant(sources)
-            self.input_sources.set_value("sources", sourcesVal)
-
-    def _convert_variant_to_array(self, variant):
-        if variant is None:
-            return []
-
-        values = []
-        # Process variant of type "a(ss)" (array of tuples with two strings)
-        nChildren = variant.n_children()
-        for i in range(nChildren):
-            # Process variant of type "(ss)" (tuple with two strings)
-            val = variant.get_child_value(i)
-            typeVariant = val.get_child_value(0)
-            type = typeVariant.get_string()
-            idVariant = val.get_child_value(1)
-            id = idVariant.get_string()
-            values.append((type, id))
-        return values
-
-    def _convert_array_to_variant(self, array):
-        if len(array) == 0:
-            return Variant('a(ss)', None)
-
-        children = []
-        for (type, id) in array:
-            typeVariant = Variant.new_string(type)
-            idVariant = Variant.new_string(id)
-            child = Variant.new_tuple(typeVariant, idVariant)
-            children.append(child)
-        return Variant.new_array(None, children)
+        logging.debug('Setting sources to: %s', sources)
+        self.input_sources.set('sources', sources)
 
 
 __is_gnome_shell = None

--- a/linux/keyman-config/keyman_config/gsettings.py
+++ b/linux/keyman-config/keyman_config/gsettings.py
@@ -9,6 +9,9 @@ from gi.overrides.GLib import Variant
 
 class GSettings():
     def __init__(self, schema_id):
+        """
+        Wrapper around Gio Settings that deals with running under sudo
+        """
         self.schema_id = schema_id
         if os.environ.get('SUDO_USER'):
             self.is_sudo = True

--- a/linux/keyman-config/keyman_config/gsettings.py
+++ b/linux/keyman-config/keyman_config/gsettings.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+import logging
+import os
+import subprocess
+from gi.repository import Gio
+
+from gi.overrides.GLib import Variant
+
+
+class GSettings():
+    def __init__(self, schema_id):
+        self.schema_id = schema_id
+        if os.environ.get('SUDO_USER'):
+            self.is_sudo = True
+            logging.debug('Running with sudo. Real user: %s', os.environ.get('SUDO_USER'))
+        else:
+            self.schema = Gio.Settings.new(self.schema_id)
+            self.is_sudo = False
+            logging.debug('Running as regular user')
+
+    def _convert_variant_to_array(self, variant):
+        if variant is None:
+            return []
+
+        values = []
+        # Process variant of type "a(ss)" (array of tuples with two strings)
+        nChildren = variant.n_children()
+        for i in range(nChildren):
+            # Process variant of type "(ss)" (tuple with two strings)
+            val = variant.get_child_value(i)
+            typeVariant = val.get_child_value(0)
+            type = typeVariant.get_string()
+            idVariant = val.get_child_value(1)
+            id = idVariant.get_string()
+            values.append((type, id))
+        return values
+
+    def _convert_array_to_variant(self, array):
+        if len(array) == 0:
+            return Variant('a(ss)', None)
+
+        children = []
+        for (type, id) in array:
+            typeVariant = Variant.new_string(type)
+            idVariant = Variant.new_string(id)
+            child = Variant.new_tuple(typeVariant, idVariant)
+            children.append(child)
+        return Variant.new_array(None, children)
+
+    def get(self, key):
+        if self.is_sudo:
+            process = subprocess.run(
+                ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
+                 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%s/bus' % os.environ.get('SUDO_UID'),
+                 'gsettings', 'get', self.schema_id, key],
+                capture_output=True)
+            if process.returncode == 0:
+                value = eval(process.stdout)
+            else:
+                value = None
+                logging.warning('Could not convert to sources')
+        else:
+            variant = self.schema.get_value(key)
+            value = self._convert_variant_to_array(variant)
+        return value
+
+    def set(self, key, value):
+        if self.is_sudo:
+            variant = str(value)
+            subprocess.run(
+                ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
+                 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%s/bus' % os.environ.get('SUDO_UID'),
+                 'gsettings', 'set', self.schema_id, key, variant])
+        else:
+            variant = self._convert_array_to_variant(value)
+            self.schema.set_value(key, variant)

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -211,13 +211,14 @@ class InstallKmp():
 
     def _install_keyboards_to_ibus(self, keyboards, packageDir, language=None):
         bus = get_ibus_bus()
-        if bus:
+        if bus or os.environ.get('SUDO_USER'):
             # install all kmx for first lang not just packageID
             for kb in keyboards:
                 ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir, language)
                 install_to_ibus(bus, ibus_keyboard_id)
             restart_ibus(bus)
-            bus.destroy()
+            if bus:
+                bus.destroy()
         else:
             logging.debug("could not install keyboards to IBus")
         return ''

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -78,7 +78,7 @@ def uninstall_kmp_shared(packageID):
 
 def uninstall_keyboards_from_ibus(keyboards, packageDir):
     bus = get_ibus_bus()
-    if bus:
+    if bus or os.environ.get('SUDO_USER'):
         # install all kmx for first lang not just packageID
         for kb in keyboards:
             ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir)

--- a/linux/keyman-config/tests/test_gnome_keyboards_util.py
+++ b/linux/keyman-config/tests/test_gnome_keyboards_util.py
@@ -2,74 +2,12 @@
 import unittest
 from unittest.mock import patch
 
-from keyman_config.gnome_keyboards_util import GnomeKeyboardsUtil
 from keyman_config.gnome_keyboards_util import is_gnome_shell, _reset_gnome_shell
 
 
 class GnomeKeyboardsUtilTests(unittest.TestCase):
     def setUp(self):
         _reset_gnome_shell()
-        patcher = patch('keyman_config.ibus_util.Gio.Settings.new')
-        self.MockSettingsClass = patcher.start()
-        self.addCleanup(patcher.stop)
-
-    def test_ConvertArrayToVariantToArray_Empty(self):
-        # Setup
-        children = []
-        sut = GnomeKeyboardsUtil()
-        # Execute
-        variant = sut._convert_array_to_variant(children)
-        array = sut._convert_variant_to_array(variant)
-
-        # Verify
-        self.assertEqual(array, children)
-
-    def test_ConvertArrayToVariantToArray_OneElement(self):
-        # Setup
-        children = [('t1', 'id1')]
-        sut = GnomeKeyboardsUtil()
-        # Execute
-        variant = sut._convert_array_to_variant(children)
-        array = sut._convert_variant_to_array(variant)
-
-        # Verify
-        self.assertEqual(array, children)
-
-    def test_ConvertArrayToVariantToArray_MultipleElements(self):
-        # Setup
-        children = [('t1', 'id1'), ('t2', 'id2')]
-        sut = GnomeKeyboardsUtil()
-        # Execute
-        variant = sut._convert_array_to_variant(children)
-        array = sut._convert_variant_to_array(variant)
-
-        # Verify
-        self.assertEqual(array, children)
-
-    @patch.object(GnomeKeyboardsUtil, '_convert_variant_to_array')
-    def test_ReadInputSources(self, convertVariantToArrayMethod):
-        # Setup
-        keyboards = [('xkb', 'en')]
-        mock_settingsInstance = self.MockSettingsClass.return_value
-        mock_settingsInstance.get_value.return_value = keyboards
-        convertVariantToArrayMethod.side_effect = lambda value: value
-        sut = GnomeKeyboardsUtil()
-        # Execute
-        result = sut.read_input_sources()
-        # Verify
-        self.assertEqual(result, keyboards)
-
-    @patch.object(GnomeKeyboardsUtil, '_convert_array_to_variant')
-    def test_WriteInputSources(self, convertArrayToVariantMethod):
-        # Setup
-        convertArrayToVariantMethod.side_effect = lambda value: value
-        sut = GnomeKeyboardsUtil()
-        keyboards = [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
-        # Execute
-        sut.write_input_sources(keyboards)
-        # Verify
-        self.MockSettingsClass.return_value.set_value.assert_called_once_with(
-            "sources", keyboards)
 
     @patch('keyman_config.os.system')
     def test_IsGnomeShell_RunningGnomeShell(self, mockSystem):

--- a/linux/keyman-config/tests/test_gsettings.py
+++ b/linux/keyman-config/tests/test_gsettings.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+import unittest
+from unittest.mock import patch
+
+from keyman_config.gsettings import GSettings
+
+class GSettingsTests(unittest.TestCase):
+    def setUp(self):
+        patcher = patch('keyman_config.gsettings.Gio.Settings.new')
+        self.MockSettingsClass = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_ConvertArrayToVariantToArray_Empty(self):
+        # Setup
+        children = []
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_OneElement(self):
+        # Setup
+        children = [('t1', 'id1')]
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_MultipleElements(self):
+        # Setup
+        children = [('t1', 'id1'), ('t2', 'id2')]
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children)
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    @patch.object(GSettings, '_convert_variant_to_array')
+    def test_GSettings_get(self, convertVariantToArrayMethod):
+        # Setup
+        keyboards = [('xkb', 'en')]
+        mock_settingsInstance = self.MockSettingsClass.return_value
+        mock_settingsInstance.get_value.return_value = keyboards
+        convertVariantToArrayMethod.side_effect = lambda value: value
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        result = sut.get('sources')
+        # Verify
+        self.assertEqual(result, keyboards)
+
+    @patch.object(GSettings, '_convert_array_to_variant')
+    def test_GSettings_set(self, convertArrayToVariantMethod):
+        # Setup
+        convertArrayToVariantMethod.side_effect = lambda value: value
+        sut = GSettings('org.gnome.desktop.input-sources')
+        keyboards = [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+        # Execute
+        sut.set('sources', keyboards)
+        # Verify
+        self.MockSettingsClass.return_value.set_value.assert_called_once_with(
+            'sources', keyboards)

--- a/linux/keyman-config/tests/test_ibus_util.py
+++ b/linux/keyman-config/tests/test_ibus_util.py
@@ -38,58 +38,66 @@ class IbusUtilTests(unittest.TestCase):
         self.assertTrue(MockIbusBusClass.called, "IBus.Bus called")
         self.assertFalse(mock_ibusBusInstance.destroy.called)
 
-    @patch('keyman_config.ibus_util.Gio.Settings.new')
-    def test_installToIbus_AlreadyInstalled(self, MockSettingsClass, MockIbusBusClass):
+    @patch('keyman_config.gsettings.GSettings.get')
+    @patch('keyman_config.gsettings.GSettings.set')
+    def test_installToIbus_AlreadyInstalled(self, MockSettingsSet, MockSettingsGet, MockIbusBusClass):
         # Setup
-        mock_settingsInstance = MockSettingsClass.return_value
-        mock_settingsInstance.get_strv.return_value = ['k1', 'k2', 'k3']
+        mock_settingsGet = MockSettingsGet
+        mock_settingsSet = MockSettingsSet
+        mock_settingsGet.return_value = ['k1', 'k2', 'k3']
         mock_ibusBusInstance = MockIbusBusClass.return_value
         # Execute
         install_to_ibus(mock_ibusBusInstance, 'k3')
         # Verify
-        mock_settingsInstance.set_strv.assert_called_once_with(
+        mock_settingsSet.assert_called_once_with(
             "preload-engines", ['k1', 'k2', 'k3'])
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3'])
 
-    @patch('keyman_config.ibus_util.Gio.Settings.new')
-    def test_installToIbus_InstallsNewKb(self, MockSettingsClass, MockIbusBusClass):
+    @patch('keyman_config.gsettings.GSettings.get')
+    @patch('keyman_config.gsettings.GSettings.set')
+    def test_installToIbus_InstallsNewKb(self, MockSettingsSet, MockSettingsGet, MockIbusBusClass):
         # Setup
-        mock_settingsInstance = MockSettingsClass.return_value
-        mock_settingsInstance.get_strv.return_value = ['k1', 'k2', 'k3']
+        mock_settingsGet = MockSettingsGet
+        mock_settingsSet = MockSettingsSet
+        mock_settingsGet.return_value = ['k1', 'k2', 'k3']
         mock_ibusBusInstance = MockIbusBusClass.return_value
         # Execute
         install_to_ibus(mock_ibusBusInstance, 'k4')
         # Verify
-        mock_settingsInstance.set_strv.assert_called_once_with(
+        mock_settingsSet.assert_called_once_with(
             "preload-engines", ['k1', 'k2', 'k3', 'k4'])
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3', 'k4'])
 
-    @patch('keyman_config.ibus_util.Gio.Settings.new')
-    def test_uninstallFromIbus_KbInstalled(self, MockSettingsClass, MockIbusBusClass):
+    @patch('keyman_config.gsettings.GSettings.get')
+    @patch('keyman_config.gsettings.GSettings.set')
+    def test_uninstallFromIbus_KbInstalled(self, MockSettingsSet, MockSettingsGet, MockIbusBusClass):
         # Setup
-        mock_settingsInstance = MockSettingsClass.return_value
-        mock_settingsInstance.get_strv.return_value = ['k1', 'k2', 'k3']
+        mock_settingsGet = MockSettingsGet
+        mock_settingsSet = MockSettingsSet
+        mock_settingsGet.return_value = ['k1', 'k2', 'k3']
         mock_ibusBusInstance = MockIbusBusClass.return_value
         # Execute
         uninstall_from_ibus(mock_ibusBusInstance, 'k2')
         # Verify
-        mock_settingsInstance.set_strv.assert_called_once_with(
+        mock_settingsSet.assert_called_once_with(
             "preload-engines", ['k1', 'k3'])
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k3'])
 
-    @patch('keyman_config.ibus_util.Gio.Settings.new')
-    def test_uninstallFromIbus_KbNotInstalled(self, MockSettingsClass, MockIbusBusClass):
+    @patch('keyman_config.gsettings.GSettings.get')
+    @patch('keyman_config.gsettings.GSettings.set')
+    def test_uninstallFromIbus_KbNotInstalled(self, MockSettingsSet, MockSettingsGet, MockIbusBusClass):
         # Setup
-        mock_settingsInstance = MockSettingsClass.return_value
-        mock_settingsInstance.get_strv.return_value = ['k1', 'k2', 'k3']
+        mock_settingsGet = MockSettingsGet
+        mock_settingsSet = MockSettingsSet
+        mock_settingsGet.return_value = ['k1', 'k2', 'k3']
         mock_ibusBusInstance = MockIbusBusClass.return_value
         # Execute
         uninstall_from_ibus(mock_ibusBusInstance, 'k4')
         # Verify
-        mock_settingsInstance.set_strv.assert_called_once_with(
+        mock_settingsSet.assert_called_once_with(
             "preload-engines", ['k1', 'k2', 'k3'])
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3'])


### PR DESCRIPTION
This change fixes the installation of shared packages, so that they show up in the list of the installed keyboards.

Fixes #5311.

# User Testing

### SUITE_INSTALL_PKG: Install a package

- Install a keyboard to the shared area using the command line (e.g. `sudo km-package-install -s -p isis_bangla`). Check that the new keyboard appears in the dropdown with installed keyboards:

![Screenshot from 2021-12-07 09-41-51](https://user-images.githubusercontent.com/181336/144995721-f04f16cc-7659-4613-b995-4f70ff24adef.png)

**TEST_INSTALL_PKG_GNOME:** Use a Linux version that uses Gnome (e.g. Ubuntu).

**TEST_INSTALL_PKG_IBUS:** same test on Wasta Linux

### SUITE_UNINSTALL: Uninstall a package

- Uninstall the keyboard installed above with `sudo km-package-uninstall -s isis_bangla`. This should remove the keyboard from the dropdown.

**TEST_UNINSTALL_PKG_GNOME:**  Use a Linux version that uses Gnome (e.g. Ubuntu).

**TEST_UNINSTALL_PKG_IBUS:** same test on Wasta Linux

### SUITE_INSTALL_KMP: Install a .kmp file

- Similar to the previous tests, but with a .kmp file already downloaded on the local machine: e.g. `sudo km-package-install -s -f khmer_angkor.kmp`

**TEST_INSTALL_KMP_GNOME:** Use a Linux version that uses Gnome (e.g. Ubuntu).

**TEST_INSTALL_KMP_IBUS:** same test on Wasta Linux

