### PR TITLE
chore(windows): use findstr instead of Borland grep ✈

### DIFF
--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -306,7 +306,4 @@ SYMSTORE="C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\symstore.exe" add
     /c "Version: $(__VERSION_WITH_TAG)" \
     /compress /f
 
-# nmake is crashing with straight grep?
-GREP=cmd /c grep
-
 CLEAN=-del /S /Q

--- a/windows/src/engine/keyman/Makefile
+++ b/windows/src/engine/keyman/Makefile
@@ -43,13 +43,13 @@ install:
     $(COPY) $(PROGRAM)\engine\keyman.exe "$(INSTALLPATH_KEYMANENGINE)"
 
 test-uiaccess:
-    $(GREP) -c "uiAccess=\"true\"" manifest.in
+    findstr "uiAccess=\"true\"" manifest.in >nul
 
 test-manifest:
 # test that (a) linked manifest exists and correct, and (b) has uiAccess=true
     $(MT) -nologo -inputresource:$(PROGRAM)\engine\keyman.exe -validate_manifest
     $(MT) -nologo -inputresource:$(PROGRAM)\engine\keyman.exe -out:temp.manifest
-    $(GREP) -c "uiAccess=\"true\"" temp.manifest
+    findstr "uiAccess=\"true\"" temp.manifest >nul
     -del temp.manifest
 
 !include ..\..\Target.mak

--- a/windows/src/engine/keymanx64/Makefile
+++ b/windows/src/engine/keymanx64/Makefile
@@ -30,13 +30,13 @@ install:
     $(COPY) $(PROGRAM)\engine\keymanx64.exe "$(INSTALLPATH_KEYMANENGINE)"
 
 test-uiaccess:
-    $(GREP) -c "uiAccess=\"true\"" manifest.in
+    findstr "uiAccess=\"true\"" manifest.in >nul
 
 test-manifest:
 # test that (a) linked manifest exists and correct, and (b) has uiAccess=true
     $(MT) -nologo -inputresource:$(PROGRAM)\engine\keymanx64.exe -validate_manifest
     $(MT) -nologo -inputresource:$(PROGRAM)\engine\keymanx64.exe -out:temp.manifest
-    $(GREP) -c "uiAccess=\"true\"" temp.manifest
+    findstr "uiAccess=\"true\"" temp.manifest >nul
     -del temp.manifest
 
 !include ..\..\Target.mak

--- a/windows/src/test/unit-tests/compile-supplementary-support/Makefile
+++ b/windows/src/test/unit-tests/compile-supplementary-support/Makefile
@@ -4,38 +4,36 @@
 
 KMCOMP="..\..\..\..\bin\developer\kmcomp.exe"
 KMCOMPD=$(KMCOMP) -d
-# grep crashes if called directly from nmake?
-GREP=cmd /c grep
 
 test: test-nodebug test-debug
 
 test-nodebug:
 	$(KMCOMP) i3317_nosupp.kmn i3317_nosupp-1.0.js
-	$(GREP) -vl "KS=1" i3317_nosupp-1.0.js
+	findstr /v /m "KS=1" i3317_nosupp-1.0.js
 	$(KMCOMP) i3317_withsupp.kmn i3317_withsupp-1.0.js
-	$(GREP) -l "KS=1" i3317_withsupp-1.0.js
+	findstr /m "KS=1" i3317_withsupp-1.0.js
 	$(KMCOMP) i3317_withsupp_incontext.kmn i3317_withsupp_incontext-1.0.js
-	$(GREP) -l "KS=1" i3317_withsupp_incontext-1.0.js
+	findstr /m "KS=1" i3317_withsupp_incontext-1.0.js
 	$(KMCOMP) i3317_withsupp_inmatch.kmn i3317_withsupp_inmatch-1.0.js
-	$(GREP) -l "KS=1" i3317_withsupp_inmatch-1.0.js
+	findstr /m "KS=1" i3317_withsupp_inmatch-1.0.js
 	$(KMCOMP) i3317_withsupp_innomatch.kmn i3317_withsupp_innomatch-1.0.js
-	$(GREP) -l "KS=1" i3317_withsupp_innomatch-1.0.js
+	findstr /m "KS=1" i3317_withsupp_innomatch-1.0.js
 	$(KMCOMP) i3317_withsupp_instore.kmn i3317_withsupp_instore-1.0.js
-	$(GREP) -l "KS=1" i3317_withsupp_instore-1.0.js
+	findstr /m "KS=1" i3317_withsupp_instore-1.0.js
 
 test-debug:
 	$(KMCOMPD) i3317_nosupp.kmn i3317_nosupp-1.0.js
-	$(GREP) -vl "KS=1" i3317_nosupp-1.0.js
+	findstr /v /m "KS=1" i3317_nosupp-1.0.js
 	$(KMCOMPD) i3317_withsupp.kmn i3317_withsupp-1.0.js
-	$(GREP) "KS=1" i3317_withsupp-1.0.js
+	findstr /m "KS=1" i3317_withsupp-1.0.js
 	$(KMCOMPD) i3317_withsupp_incontext.kmn i3317_withsupp_incontext-1.0.js
-	$(GREP) "KS=1" i3317_withsupp_incontext-1.0.js
+	findstr /m "KS=1" i3317_withsupp_incontext-1.0.js
 	$(KMCOMPD) i3317_withsupp_inmatch.kmn i3317_withsupp_inmatch-1.0.js
-	$(GREP) "KS=1" i3317_withsupp_inmatch-1.0.js
+	findstr /m "KS=1" i3317_withsupp_inmatch-1.0.js
 	$(KMCOMPD) i3317_withsupp_innomatch.kmn i3317_withsupp_innomatch-1.0.js
-	$(GREP) "KS=1" i3317_withsupp_innomatch-1.0.js
+	findstr /m "KS=1" i3317_withsupp_innomatch-1.0.js
 	$(KMCOMPD) i3317_withsupp_instore.kmn i3317_withsupp_instore-1.0.js
-	$(GREP) "KS=1" i3317_withsupp_instore-1.0.js
+	findstr /m "KS=1" i3317_withsupp_instore-1.0.js
 
 clean:
 	-del *.js


### PR DESCRIPTION
Merges into #6020.

Removes one more dependency on Delphi tools

@keymanapp-test-bot skip