### PR TITLE
chore(windows): build without delphi ✈

### DIFF
--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -148,24 +148,25 @@ refreshenv
 # choco meson (0.55) is too old, 0.56 required:
 python -m pip install meson
 
-*** ADD TO PATH 
->>> e.g. C:\Users\mcdurdin\AppData\Roaming\Python\Python310\Scripts
-
 # choco rustup is not currently working:
 Invoke-WebRequest -Uri https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe -OutFile $env:TEMP\rustup-init.exe
 & "$env:TEMP\rustup-init.exe"
 refreshenv
+```
 
-*** restart powershell, because refreshenv doesn't cut it...
-
+Restart PowerShell (because `refreshenv` doesn't seem to pick up the rust environment), then
+```ps1
+# Elevated Powershell
 rustup target add i686-pc-windows-msvc
 ```
 
 **Environment variables**:
 * [`KEYMAN_ROOT`](#keyman_root)
+* `PATH`: add your Python scripts folder to your path: it will normally be `%appdata%\Python\Python310\Scripts`.
 
 ```bat
 SET KEYMAN_ROOT=c:\Projects\keyman\keyman
+SET PATH=%path%;%appdata%\Python\Python310\Scripts
 ```
 
 To check whether environment variables are set, run `SET <variable>` in command

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -236,7 +236,7 @@ Invoke-WebRequest -Uri https://github.com/rustwasm/wasm-pack/releases/download/v
     Currently many components are Delphi-based, but if you are working just in
     Keyman Core, the compiler, or Keyman Engine's C++ components, you may be
     able to get away without building them. In this situation, we recommend
-    copying the relevant Delphi-built components into bin folders from a
+    copying the relevant Delphi-built components into windows/bin folders from a
     compatible installed version of Keyman for testing and debugging purposes.
 
 * Visual C++ 2019 Community or Professional

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -147,10 +147,17 @@ choco install git jq python ninja pandoc
 refreshenv
 # choco meson (0.55) is too old, 0.56 required:
 python -m pip install meson
+
+*** ADD TO PATH 
+>>> e.g. C:\Users\mcdurdin\AppData\Roaming\Python\Python310\Scripts
+
 # choco rustup is not currently working:
 Invoke-WebRequest -Uri https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe -OutFile $env:TEMP\rustup-init.exe
 & "$env:TEMP\rustup-init.exe"
 refreshenv
+
+*** restart powershell, because refreshenv doesn't cut it...
+
 rustup target add i686-pc-windows-msvc
 ```
 

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -231,6 +231,14 @@ Invoke-WebRequest -Uri https://github.com/rustwasm/wasm-pack/releases/download/v
   Start Delphi IDE once after installation as it will create various environment
   files and take you through required registration.
 
+  * Note: It is possible to build all components that do _not_ require Delphi by
+    adding the environment variable `NODELPHI=1` before starting the build.
+    Currently many components are Delphi-based, but if you are working just in
+    Keyman Core, the compiler, or Keyman Engine's C++ components, you may be
+    able to get away without building them. In this situation, we recommend
+    copying the relevant Delphi-built components into bin folders from a
+    compatible installed version of Keyman for testing and debugging purposes.
+
 * Visual C++ 2019 Community or Professional
 
   ```ps1

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -15,7 +15,9 @@ EXT=$(ROOT)\src\ext
 INCLUDE=$(ROOT)\src\global\inc;$(INCLUDE)
 
 !ifndef EXCLUDEPATHDEFINES
+!ifndef NODELPHI
 !include $(ROOT)\src\PathDefines.mak
+!endif
 !endif
 
 PROGRAM=$(ROOT)\bin
@@ -143,6 +145,13 @@ DCC64="$(DCC32PATH)\dcc64.exe" $(DELPHIDPRPARAMS64) -N0x64\ -Ex64\
 
 DELPHI_MSBUILD=$(ROOT)\src\buildtools\msbuild-wrapper.bat "$(DCC32PATH)" $(DELPHI_MSBUILD_FLAG_DEBUG)
 
+!IFDEF NODELPHI
+DCC32=echo skipping 
+DCC32DPK=echo skipping 
+DCC64=echo skipping 
+DELPHI_MSBUILD=echo skipping
+!ENDIF
+
 # Visual C++ x86, x64
 WIN32_TARGET_PATH=bin\Win32\$(TARGET_PATH)
 X64_TARGET_PATH=bin\x64\$(TARGET_PATH)
@@ -254,7 +263,7 @@ PLATFORM=Win32
 !ifdef GIT_BASH_FOR_KEYMAN
 MKVER_SH=$(GIT_BASH_FOR_KEYMAN) $(ROOT)\src\buildtools\mkver.sh
 !else
-MKVER_SH=start /wait .\build.sh $(ROOT)\src\buildtools\mkver.sh
+MKVER_SH=start /wait $(ROOT)\src\buildtools\mkver.sh
 !endif
 
 MKVER_M=$(MKVER_SH) manifest.in manifest.xml

--- a/windows/src/Makefile
+++ b/windows/src/Makefile
@@ -286,14 +286,17 @@ build-tools: global-versions
 !ifdef NODELPHI
     echo Skipping build-tools
 !else
-    $(MAKE) devtools-app
+# we need to build devtools directly because otherwise we have a
+# chicken-and-egg issue with PathDefines.mak
+    cd $(ROOT)\src\buildtools\devtools
+    $(MAKE)
 # We'll build a default PathDefines.mak if it is missing here so we can
 # go on and do the rest of the build
     $(PROGRAM)\buildtools\devtools -ti
 !endif
 
 message-constants: build-tools
-!ifdef NODELPHI 
+!ifdef NODELPHI
     echo Skipping message-constants
 !else
     $(PROGRAM)\buildtools\devtools -buildmessageconstants $(ROOT)\src\desktop\kmshell\xml\strings.xml $(ROOT)\src\global\delphi\cust\MessageIdentifierConsts.pas

--- a/windows/src/Makefile
+++ b/windows/src/Makefile
@@ -283,15 +283,21 @@ global-versions:
     $(MKVER_U) $(ROOT)\src\global\delphi\general\keymanversion_build.in $(ROOT)\src\global\delphi\general\keymanversion_build.inc
 
 build-tools: global-versions
-    cd $(ROOT)\src\buildtools\devtools
-    $(MAKE)
-
+!ifdef NODELPHI
+    echo Skipping build-tools
+!else
+    $(MAKE) devtools-app
 # We'll build a default PathDefines.mak if it is missing here so we can
 # go on and do the rest of the build
     $(PROGRAM)\buildtools\devtools -ti
+!endif
 
 message-constants: build-tools
+!ifdef NODELPHI 
+    echo Skipping message-constants
+!else
     $(PROGRAM)\buildtools\devtools -buildmessageconstants $(ROOT)\src\desktop\kmshell\xml\strings.xml $(ROOT)\src\global\delphi\cust\MessageIdentifierConsts.pas
+!endif
 
 #
 # Remove all files from output folders to ensure no legacy files left in a release

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -7,26 +7,36 @@
 ## Building Keyman for Windows and Keyman Developer
 
 1. Start 'Developer Command Prompt for VS 2019'.
-2. Run `make build` from the **windows/src** folder.
+2. Run `nmake build` from the **windows/src** folder.
 3. Artifacts from a successful build will be placed in **windows/bin** folder.
 
-*Note*: running `make build` will currently reset the packages and path settings
+*Note*: running `nmake build` will currently reset the packages and path settings
 in your Delphi environment. If you use Delphi for other projects, you should
 consider building Keyman under a login user dedicated to it, or in a VM.
 
-Type `make` to see build targets. Common build targets are:
+Type `nmake` to see build targets. Common build targets are:
 
-* `make build`
+* `nmake build`
 : builds Keyman for Windows and Keyman Developer
 
-* `make clean`
+* `nmake clean`
 : remove temporary files and build artifacts
 
-* `make release`
+* `nmake release`
 : makes a release of all Keyman Windows projects
 
-* `make install`
+* `nmake install`
 : install some or all components to Program Files (requires elevated command prompt).
+
+### Building without Delphi
+
+It is possible to build all components that do _not_ require Delphi by adding
+the environment variable `NODELPHI=1` before starting the build. Currently many
+components are Delphi-based, but if you are working just in Keyman Core, the
+compiler, or Keyman Engine's C++ components, you may be able to get away without
+building them. In this situation, we recommend copying the relevant Delphi-built
+components into bin folders from a compatible installed version of Keyman for
+testing and debugging purposes.
 
 ### Release builds
 
@@ -36,7 +46,7 @@ Certificates, below. Official release builds for Keyman are built in the Keyman
 project's CI environment.
 
 1. Start 'Developer Command Prompt for VS 2019'.
-2. Run `make release` from the **windows/src** folder.
+2. Run `nmake release` from the **windows/src** folder.
 3. Artifacts from a successful build will be placed in **windows/release**
    folder.
 4. **buildtools/help-keyman-com.sh** will push updated documentation to

--- a/windows/src/README.md
+++ b/windows/src/README.md
@@ -35,8 +35,8 @@ the environment variable `NODELPHI=1` before starting the build. Currently many
 components are Delphi-based, but if you are working just in Keyman Core, the
 compiler, or Keyman Engine's C++ components, you may be able to get away without
 building them. In this situation, we recommend copying the relevant Delphi-built
-components into bin folders from a compatible installed version of Keyman for
-testing and debugging purposes.
+components into windows/bin folders from a compatible installed version of
+Keyman for testing and debugging purposes.
 
 ### Release builds
 

--- a/windows/src/buildtools/Makefile
+++ b/windows/src/buildtools/Makefile
@@ -4,8 +4,13 @@
 
 NOTARGET_SIGNCODE=yes
 
+!ifdef NODELPHI
+TARGETS=.virtual
+!else
 TARGETS=devtools sentrytool tds2dbg \
   buildunidata build_standards_data buildpkg test-klog delphiprojectmanager
+!endif
+
 CLEANS=clean-buildtools
 
 !include ..\Header.mak
@@ -29,8 +34,12 @@ delphiprojectmanager: .virtual
     $(MAKE) $(TARGET)
 
 devtools: .virtual
+!ifdef NODELPHI
+    echo Skipping devtools
+!else
     cd $(ROOT)\src\buildtools\devtools
     $(MAKE) $(TARGET)
+!endif
 
 buildpkg: .virtual
     cd $(ROOT)\src\buildtools\buildpkg

--- a/windows/src/desktop/Makefile
+++ b/windows/src/desktop/Makefile
@@ -2,7 +2,12 @@
 # Keyman for Windows Makefile
 #
 
+!ifdef NODELPHI
+TARGETS=.virtual
+!else
 TARGETS=kmshell kmconfig kmbrowserhost setup insthelp
+!endif
+
 RELEASE_TARGETS=help
 CLEANS=inst clean-desktop
 MANIFESTS=kmshell setup insthelp

--- a/windows/src/developer/Makefile
+++ b/windows/src/developer/Makefile
@@ -2,8 +2,12 @@
 # Keyman dev Makefile
 #
 
-
+!ifdef NODELPHI
+TARGETS=kmcmpdll kmanalyze kmdecomp
+!else
 TARGETS=kmcmpdll kmcomp kmanalyze kmconvert tike samples setup inst kmdecomp
+!endif
+
 MANIFESTS=kmcomp tike setup
 CLEANS=clean-developer
 

--- a/windows/src/engine/Makefile
+++ b/windows/src/engine/Makefile
@@ -4,7 +4,11 @@
 
 # ----------------------------------------------------------------------
 
+!ifdef NODELPHI
+TARGETS=keymanmc keyman32 keyman64 keymanx64 mcompile kmtip kmrefresh
+!else
 TARGETS=keymanmc keyman32 kmcomapi keyman tsysinfox64 tsysinfo keyman64 keymanx64 mcompile inst kmtip kmrefresh
+!endif
 MANIFESTS=keyman tsysinfo tsysinfox64 keymanx64 mcompile
 CLEANS=clean-engine
 

--- a/windows/src/ext/Makefile
+++ b/windows/src/ext/Makefile
@@ -4,7 +4,11 @@
 
 NOTARGET_SIGNCODE=yes
 
+!ifdef NODELPHI
+TARGETS=.virtual
+!else
 TARGETS=dcpcrypt jedi mbcolor regexpr scfontcombobox cef4delphi
+!endif
 
 # jedi, regexpr have no packages
 

--- a/windows/src/global/Makefile
+++ b/windows/src/global/Makefile
@@ -2,6 +2,9 @@
 !include ..\Defines.mak
 
 build:
+!ifdef NODELPHI
+  echo Skipping global
+!else
   cd $(ROOT)\src\global\delphi
   $(MAKE) $(TARGET)
 
@@ -13,6 +16,7 @@ build:
 
   cd $(ROOT)\src\global\wix
   $(MAKE) $(TARGET)
+!endif
 
 build-release:
   @rem

--- a/windows/src/support/Makefile
+++ b/windows/src/support/Makefile
@@ -2,7 +2,11 @@
 # Support Makefile
 #
 
+!ifdef NODELPHI
+TARGETS=etl2log
+!else
 TARGETS=oskbulkrenderer etl2log
+!endif
 CLEANS=clean-support
 
 !include ..\Header.mak

--- a/windows/src/test/Makefile
+++ b/windows/src/test/Makefile
@@ -4,7 +4,11 @@
 
 # ----------------------------------------------------------------------
 
+!ifdef NODELPHI
+TARGETS=.virtual
+!else
 TARGETS=test_i3633
+!endif
 CLEAN=test_i3633
 
 test: test-manifest-exec


### PR DESCRIPTION
This makes it possible to run `set NODELPHI=1`, `nmake build` and then only non-Delphi projects will be built.

@keymanapp-test-bot skip