### PR TITLE
feat(developer): remember test page preferences on reload 🛒

### DIFF
--- a/windows/src/developer/TIKE/xml/kmw/test.js
+++ b/windows/src/developer/TIKE/xml/kmw/test.js
@@ -293,7 +293,7 @@ function selectModel(modelId) {
       path: 'http://'+location.host+'/model/'+model.src
     });
   }
-  window.sessionStorage.setItem('current-model', model.id);
+  window.sessionStorage.setItem('current-model', model ? model.id : '');
 }
 
 /**


### PR DESCRIPTION
Emerges from ELTW demos.

Remembers the user's selected model and device when they refresh the page.

# User Testing

* **TEST_MODEL_MEMORY:** Load a model in the web keyboard debugger in Developer. Switch the model on, and press F5 to refresh the page. Verify that the model is still selected. (Do this a couple of times with model selected or off.)

* **TEST_DEVICE_MEMORY:** Switch between various devices in the device picker. Verify that the device stays selected after you refresh the page.