### PR TITLE
feat(developer): live reload of web debugger 🛒

### DIFF
--- a/windows/src/developer/TIKE/xml/kmw/packages.js
+++ b/windows/src/developer/TIKE/xml/kmw/packages.js
@@ -1,22 +1,6 @@
 // The following dynamic script will register each of the additional packages
 var packagesJSON = '';
 
-function ajaxRequest(){
-  var activexmodes=["Msxml2.XMLHTTP", "Microsoft.XMLHTTP"] //activeX versions to check for in IE
-  if (window.ActiveXObject) { //Test for support for ActiveXObject in IE first (as XMLHttpRequest in IE7 is broken)
-    for (var i=0; i<activexmodes.length; i++) {
-      try {
-        return new ActiveXObject(activexmodes[i]);
-      } catch(e) {
-        //suppress error
-      }
-    }
-  } else if (window.XMLHttpRequest) { // if Mozilla, Safari etc
-    return new XMLHttpRequest();
-  }
- return false;
-}
-
 function updatePackages(data) {
   var dataJSON = JSON.stringify(data);
   if(packagesJSON !== dataJSON) {
@@ -52,7 +36,7 @@ function updatePackages(data) {
 }
 
 function checkPackages() {
-  var req=new ajaxRequest();
+  var req=new XMLHttpRequest();
   req.onreadystatechange = function() {
     if (req.readyState==4) {
       if (req.status==200) {


### PR DESCRIPTION
Merges into #6033.

Adds polling for changes to keyboards or models under test in the web debugger. When changes are detected, the keyboards and/or models are instantly reloaded automatically.

# User Testing

* **TEST_WEB_DEBUGGER:** Follow the steps below

1. Check interactions in the web debugger continue to work as before.
2. Verify that making changes to the keyboard and recompiling (F7) cause the keyboard to reload automatically. (You can probably observe these most easily by changing the OSK or touch keyboard)
3. Verify that making changes to a lexical model and recompiling (F7) cause the model to reload automatically.
(You can probably observe these most easily by changing the most frequent word offered)
4. Make sure that the keyboard and model selection is correct with reloads.