### PR TITLE
feat(developer): cache web debug objects across sessions 🛒

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -292,7 +292,7 @@ uses
   Keyman.UI.Debug.CharacterGridRenderer in 'debug\Keyman.UI.Debug.CharacterGridRenderer.pas',
   UfrmDebugStatus_Platform in 'debug\UfrmDebugStatus_Platform.pas' {frmDebugStatus_Platform},
   UfrmDebugStatus_Options in 'debug\UfrmDebugStatus_Options.pas' {frmDebugStatus_Options},
-  Keyman.Developer.System.KeymanDeveloperPaths in 'main\Keyman.Developer.System.KeymanDeveloperPaths.pas' {$R *.RES},
+  Keyman.Developer.System.KeymanDeveloperPaths in 'main\Keyman.Developer.System.KeymanDeveloperPaths.pas',
   Keyman.Developer.System.ValidateKpsFile in '..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas';
 
 {$R *.RES}
@@ -325,8 +325,12 @@ begin
           //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-  Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
-  Application.Run;
+          try
+            Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
+            Application.Run;
+          finally
+            FreeAndNil(modWebHttpServer);
+          end;
         end;
       finally
         FInitializeCEF.Free;

--- a/windows/src/developer/TIKE/actions/dmActionsMain.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.dfm
@@ -477,6 +477,11 @@ object modActionsMain: TmodActionsMain
       OnExecute = actProjectCloseExecute
       OnUpdate = actProjectCloseUpdate
     end
+    object actToolsClearCachedDebugObjects: TAction
+      Category = 'Tools'
+      Caption = 'Clear Cached Debug Objects'
+      OnExecute = actToolsClearCachedDebugObjectsExecute
+    end
   end
   object ActionManager1: TActionManager
     ActionBars = <

--- a/windows/src/developer/TIKE/actions/dmActionsMain.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.pas
@@ -134,6 +134,7 @@ type
     actViewCode: TAction;   // I4678
     actViewCharacterIdentifier: TAction;   // I4807
     actProjectClose: TAction;
+    actToolsClearCachedDebugObjects: TAction;
     procedure actFileNewExecute(Sender: TObject);
     procedure DataModuleCreate(Sender: TObject);
     procedure actFileOpenAccept(Sender: TObject);
@@ -229,6 +230,7 @@ type
     procedure actProjectSettingsUpdate(Sender: TObject);
     procedure actFileNewUpdate(Sender: TObject);
     procedure actFileOpenUpdate(Sender: TObject);
+    procedure actToolsClearCachedDebugObjectsExecute(Sender: TObject);
   private
     function CheckFilenameConventions(FileName: string): Boolean;
     function SaveAndCloseAllFiles: Boolean;
@@ -280,6 +282,7 @@ uses
   UfrmOptions,
   UfrmOSKEditor,
   UfrmPackageEditor,
+  UmodWebHttpServer,
   Keyman.Developer.UI.Project.UfrmProject,
   Keyman.Developer.UI.Project.UfrmProjectSettings,
   Upload_Settings,
@@ -668,6 +671,12 @@ begin
   begin
     actSearchFind.Enabled := True;
   end;
+end;
+
+procedure TmodActionsMain.actToolsClearCachedDebugObjectsExecute(
+  Sender: TObject);
+begin
+  modWebHttpServer.Debugger.ClearCache;
 end;
 
 procedure TmodActionsMain.actToolsFileFormatExecute(Sender: TObject);

--- a/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Debugger.pas
+++ b/windows/src/developer/TIKE/http/Keyman.Developer.System.HttpServer.Debugger.pas
@@ -947,7 +947,7 @@ procedure TDebuggerHttpResponder.LoadFromCache;
           keyboard.Free;
           Continue;
         end;
-        Self.FKeyboards.AddOrSetValue(ExtractFileName(keyboard.FFilename), keyboard);
+        Self.FKeyboards.AddOrSetValue(keyboard.WebFilename, keyboard);
       end;
     end;
   end;

--- a/windows/src/developer/TIKE/web/UmodWebHttpServer.pas
+++ b/windows/src/developer/TIKE/web/UmodWebHttpServer.pas
@@ -260,8 +260,7 @@ begin
       Exit;
     end;
 
-    if Assigned(FDebugger) then
-      FDebugger.ProcessRequest(AContext, ARequestInfo, AResponseInfo);
+    Self.GetDebugger.ProcessRequest(AContext, ARequestInfo, AResponseInfo);
   finally
     CoUninitialize;
   end;

--- a/windows/src/global/delphi/general/KeyboardFonts.pas
+++ b/windows/src/global/delphi/general/KeyboardFonts.pas
@@ -32,6 +32,10 @@ type
     Enabled: Boolean;
   end;
 
+const
+  KeyboardFontId: array[TKeyboardFont] of string = (
+    'Code', 'Char', 'Osk', 'TouchLayoutPhone', 'TouchLayoutTablet', 'TouchLayoutDesktop'
+  );
 implementation
 
 end.


### PR DESCRIPTION
Merges into #6035.

Keyman Developer now remembers the 10 most recently debugged keyboards, models and packages in the web debugger, across sessions. It determines the recency of use by the last access time of the object, and caches at most 10 of each type of object when the IDE session ends.

The cache data is stored in %appdata%\Keyman\Keyman Developer\WebDebugCache.json.

The web debugger is now always available when Keyman Developer is running, even if the user has not yet clicked 'Start Web Debugging', as otherwise cached web debug objects would not be immediately available.

Keyman Developer will verify that files listed in the cache are still available, and will remove them on startup if the file disappears.

# User Testing

* **TEST_CACHING:** Load a keyboard in the web debugger, close and restart Keyman Developer. Verify that the keyboard is still available in the web debugger when you reload the page, even though you haven't opened it in Keyman Developer.
* **TEST_EXPIRY:** Load 11 keyboards in Keyman Developer, and test each one in the web debugger. Close and restart Keyman Developer. Verify that only the last 10 keyboards are listed in the web debugger (you may need to reload the web debugger page if you leave it open across sessions).