### PR TITLE
fix(windows): remove unused variable

### DIFF
--- a/windows/src/global/delphi/comp/OnScreenKeyboard.pas
+++ b/windows/src/global/delphi/comp/OnScreenKeyboard.pas
@@ -391,7 +391,6 @@ var
   minsz: Integer;
   i: Integer;
   n: Integer;
-  Canvas: TCanvas;
   b: TBitmap;
 begin
   b := TBitmap.Create;


### PR DESCRIPTION
The build was failing due to unused variable error.

@keymanapp-test-bot skip