### PR TITLE
chore(common): Update crowdin strings for Amharic 📜

### DIFF
--- a/android/KMEA/app/src/main/res/values-am-rET/strings.xml
+++ b/android/KMEA/app/src/main/res/values-am-rET/strings.xml
@@ -8,6 +8,11 @@
         <item quantity="other">የፊደል ገበታዎች</item>
     </plurals>
     <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+        <item quantity="one">የሚቀጥለውን የመቀበያ ዘዴ</item>
+        <item quantity="other">የሚቀጥለውን የመቀበያ ዘዴዎች</item>
+    </plurals>
+    <!-- Context: Title for list -->
     <string name="title_add_keyboard" comment="Add a new keyboard">አዲስ ኪቦርድ ጨምር</string>
     <!-- Context: Title for list -->
     <string name="title_languages_settings" comment="List of installed languages">የተጫኑ ቋንዎች</string>
@@ -21,7 +26,7 @@
     <string name="label_cancel" comment="Button to cancel an action">ይቅር</string>
     <!-- Context: Button label -->
     <string name="label_close" comment="Close a dialog">ዝጋ</string>
-    <!-- Context: Button label -->
+    <!-- Context: Button label. Removed in Keyman 15 -->
     <string name="label_close_keyman" comment="Close the Keyman application">ኪይማኑን ዝጋ</string>
     <!-- Context: Button label -->
     <string name="label_forward" comment="Button to go forward">ወደፊት</string>

--- a/ios/engine/KMEI/KeymanEngine/am.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/am.lproj/Localizable.strings
@@ -118,11 +118,17 @@
 /* Error opening a Keyman package - package is not valid */
 "kmp-error-invalid" = "የፓኬጁ ፋይል ተበላሽቷል።";
 
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "የተመረጠው ፓኬጅ የለም።";
+
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "ይህ ፓኬጅ የተጠየቀውን የፊደል ገበታ ሰሌዳ ወይም መዝገበ ቃላት አልያዘም።";
 
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "ይህ ፓኬጅ በትክክል አልተሰራም - ይዘቶቹ አይታወቁም።";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "ይህ ፓኬጅ የርስዎን ዲቫይስ ሰፖርት አያደርግም።";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "ይህ ፓኬጅ የሚፈለገውን ሪሶርስ አይነት አልያዘም።";

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -139,6 +139,12 @@
 		29B42A612728343B00EDD5D3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/KMKeyboardHelpWindowController.xib; sourceTree = "<group>"; };
 		29B42A642728343F00EDD5D3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
 		29B42A682728344600EDD5D3 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
+		29DD8400276C49E20066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/KMAboutWindowController.strings; sourceTree = "<group>"; };
+		29DD8401276C49E20066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/preferences.strings; sourceTree = "<group>"; };
+		29DD8402276C49E30066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/KMInfoWindowController.strings; sourceTree = "<group>"; };
+		29DD8403276C49E40066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
+		29DD8404276C49E50066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		29DD8408276C4D2F0066A16E /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/Localizable.strings; sourceTree = "<group>"; };
 		370E44542564E1EE00642929 /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		37589AD422E52DA20097D39D /* Keyman.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Keyman.entitlements; sourceTree = "<group>"; };
 		37A00ED4239AA25700D2C837 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -636,6 +642,7 @@
 				en,
 				Base,
 				km,
+				am,
 			);
 			mainGroup = 989C9BFF1A7876DE00A20425;
 			productRefGroup = 989C9C091A7876DE00A20425 /* Products */;
@@ -865,6 +872,7 @@
 				293EA3E727140D8100545EED /* Base */,
 				293EA3EA27140D8E00545EED /* en */,
 				29B348AA2726F1C1009B1C82 /* km */,
+				29DD8400276C49E20066A16E /* am */,
 			);
 			name = KMAboutWindowController.xib;
 			sourceTree = "<group>";
@@ -875,6 +883,7 @@
 				293EA3EC27140DEC00545EED /* Base */,
 				293EA3EF27140DFA00545EED /* en */,
 				29B348AB2726F1C2009B1C82 /* km */,
+				29DD8401276C49E20066A16E /* am */,
 			);
 			name = preferences.xib;
 			path = Keyman4MacIM/KMConfiguration;
@@ -885,6 +894,7 @@
 			children = (
 				293EA3F527181FDA00545EED /* en */,
 				29B348AE2726F1C7009B1C82 /* km */,
+				29DD8408276C4D2F0066A16E /* am */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -895,6 +905,7 @@
 				29B42A582728339900EDD5D3 /* Base */,
 				29B42A5B2728339E00EDD5D3 /* en */,
 				29B42A5F272833A600EDD5D3 /* km */,
+				29DD8402276C49E30066A16E /* am */,
 			);
 			name = KMInfoWindowController.xib;
 			path = Keyman4MacIM/KMInfoWindow;
@@ -906,6 +917,7 @@
 				29B42A612728343B00EDD5D3 /* Base */,
 				29B42A642728343F00EDD5D3 /* en */,
 				29B42A682728344600EDD5D3 /* km */,
+				29DD8403276C49E40066A16E /* am */,
 			);
 			name = KMKeyboardHelpWindowController.xib;
 			path = Keyman4MacIM/KMKeyboardHelpWindow;
@@ -917,6 +929,7 @@
 				293EA3E527140D3A00545EED /* Base */,
 				293EA3F02714158600545EED /* en */,
 				29B348AC2726F1C2009B1C82 /* km */,
+				29DD8404276C49E50066A16E /* am */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/am.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/am.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "ዝጋ";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "ፈቃዱን አሳይ";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "ማቀነባበሪያ...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/am.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/am.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "የስክሪን ላይ ኪቦርዱን ሁልጊዜ አሳይ";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "የቃል መዝገብ ማስታወሻ ተጠቀም";
+
+/* Support buton text  */
+"93O-x6-RLF.label" = "ድጋፍ";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "የፊደል ገበታ ሰሌዳ አውርድ...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "ኪይማንን ለአጠቃቀም ማዘጋጃ";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "ተመለስ";
+
+/* Class = "NSTabViewItem"; label = "Keyboard Layouts"; ObjectID = "MPN-9N-wWc"; */
+"MPN-9N-wWc.label" = "የፊደል ገበታ ሰሌዳ";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "የቃል መዝግብ ማስታወሻ አማራጩ ሲበራ ኪይማን የኬይማን ድጋፍ ችግርን ለመመርመር የሚረዱ ድርጊቶችን ይመዘግባል። የኮንሶል ፕሮግራሙ ከኪይማን የመልእክት ምዝግብ ማስታወሻን ለማየት ሊያገለግል ይችላል። በኮንሶል ውስጥ ሁሉንም የ\"ኪይማን\" መልእክቶችን ለማሳየት ያጣሩ። ይህ የምዝገባ ማስታወሻ ከተፈለገ ወደ ውጭ ሊላክ እና ለየ ኪይማን ድጋፍ ሊላክ ይችላል።";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "ወደፊት";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "መግቢያ ገጽ";
+
+/* Options button text */
+"frd-No-seV.label" = "ምርጫዎች";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "የፊደል ሰሌዳን መጫን";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "በአንድ የተወሰነ የቁልፍ ሰሌዳ ወይም በአጠቃላይ ከኪይማን ጋር ችግሮች ካጋጠሙዎት ይህንን ቁልፍ ያብሩት።";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/am.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/am.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Information window title */
+"F0z-JX-Cv5.title" = "የፊደል ገበታ ሰሌዳ መረጃ";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "ዝርዝሮች";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "የሚነበብ";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/am.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/am.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "የፊደል ገበታ እርዳታ";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "እሺ";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "አትም...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/am.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/am.lproj/Localizable.strings
@@ -1,0 +1,44 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "የፊደል ገበታውን ማስወገድ ይፈልጋሉ '%@'?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "ይህንን እርምጃ ወደነበረበት መመለስ አልችልም።";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "ይቅር";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "ሰርዝ";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "የኪይማን የፊደል ገበታ ሰሌዳን ትጭናለህ?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "ኪይማን የፈደል ገበታን ከፋይል ላይ መጫን ይፈልጋሉ '%@'?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "ይቅር";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "ጫን";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "የኪይማኑን ፋይል ማንበብ አልቻልኩም። '%@'";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "ይሁን";
+
+/* label text to identify Keyman version */
+"version-label-text" = "ስሪት፦ %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "በማውረድ ላይ…";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "ዳውንሎድ አልቋል!";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "ይቅር";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "አልቋል";

--- a/mac/Keyman4MacIM/Keyman4MacIM/am.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/am.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "ማቀነባበሪያ...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "የፊደል ገበታዎች";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "የፊደል ገበታዎች";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "ስለ እኛ";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "የስክሪን ላይ የፊደል ገበታ";


### PR DESCRIPTION
This adds Amharic localization for macOS.

Also updates Amharic strings for Android and iOS.

## User Testing
Only testing macOS platform, since other platforms are just updating strings

* **TEST_MAC** - Tests Amharic localization on Keyman for macOS
1. Load the macOS PR build
2. Set the system language to Amharic
3. Launch Keyman for macOS
4. Verify strings are in Amharic.
