### PR TITLE
fix(linux): Improve ibus-keyman tests

### DIFF
--- a/linux/ibus-keyman/tests/testfixture.cpp
+++ b/linux/ibus-keyman/tests/testfixture.cpp
@@ -347,6 +347,7 @@ static void test_source(IBusKeymanTestsFixture *fixture, gconstpointer user_data
       keyman_put_options_todconf(data->test_name, data->test_name, key, value);
     }
   }
+  g_settings_sync();
 
   switch_keyboard(fixture, kmxfile.c_str());
   if (test_source.caps_lock_state() != get_caps_lock_state(fixture)) {


### PR DESCRIPTION
This change will hopefully help some tests that occasionally fail on TC. After setting the options during the test setup we sync the
settings before running the test scenario.

@keymanapp-test-bot skip because this change affects tests only.