### PR TITLE
fix(linux): fix release version number for Sentry reporting

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -61,7 +61,7 @@ else:
         sentry_sdk.init(
             dsn=SentryUrl,
             environment=__environment__,
-            release=__version__,
+            release='release-' + __versionwithtag__,
             integrations=[sentry_logging],
         )
         set_user({'id': hash(getpass.getuser())})


### PR DESCRIPTION
Fixes #5817.

@keymanapp-test-bot skip