### PR TITLE
docs(windows): Add note on split user/admin accounts

### DIFF
--- a/windows/src/desktop/help/start/download-and-install-keyboard.md
+++ b/windows/src/desktop/help/start/download-and-install-keyboard.md
@@ -71,6 +71,11 @@ Here's how to download and install a Keyman keyboard within Keyman:
 
     ![](../desktop_images/download-keyboard-step6.png)
 
+    **Note:** If you have a separate administrator account -- that is, you are
+    prompted to enter a username and password at this point -- you may need to
+    [add a language association](configure-computer) for your keyboard on your
+    user account after completing the keyboard installation.
+
 10. The keyboard will now be installed; you can close Keyman Configuration.
 
 ## Installing a Keyman Keyboard from a Folder on Your Computer


### PR DESCRIPTION
If the computer has split user/admin accounts, then language association may not be completed automatically, and the user may need to add a language association themselves.

Ref https://community.software.sil.org/t/what-security-permissions-are-needed-to-install-a-keyboard-configuration-in-keyman/5695/10

Note: the topic `configure-computer` has a terrible url but I won't fix that here. Suggested future fix -- turn `configure-computer` into a redirect to `link-keyboard-to-language` or `associate-keyboard-with-language`?

@keymanapp-test-bot skip