### PR TITLE
fix(linux): fix release version number for Sentry reporting

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -80,7 +80,7 @@ else:
 
             # Note, legacy raven API requires secret (https://github.com/keymanapp/keyman/pull/5787#discussion_r721457909)
             SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@o1005580.ingest.sentry.io/5983525"
-            client = Client(SentryUrl, environment=__environment__, release=__version__)
+            client = Client(SentryUrl, environment=__environment__, release='release-' + __versionwithtag__)
             client.user_context({'id': hash(getpass.getuser())})
             client.tags_context({
                 'app': os.path.basename(sys.argv[0]),


### PR DESCRIPTION
Forgot to change the second occurrence of the version number for older Sentry SDK.

@keymanapp-test-bot skip