### PR TITLE
feat(linux): Don't create Sentry events for errors

### DIFF
--- a/linux/keyman-config/keyman_config/convertico.py
+++ b/linux/keyman-config/keyman_config/convertico.py
@@ -51,7 +51,7 @@ def checkandsaveico(icofile):
         # Using .bmp.png file extension so it won't conflict if the package already contains .png
         im4.save(bmpfile + '.png', 'png')
     except (IOError, OSError):
-        logging.critical("Cannot convert %s to png", icofile)
+        logging.error("Cannot convert %s to png", icofile)
         pass
     finally:
         # Clean up intermediary .bmp file if it was generated

--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -20,17 +20,17 @@ def download_and_install_package(url):
     """
     parsedUrl = urlparse(url)
     bcp47 = _extract_bcp47(parsedUrl.query)
-    severity = logging.CRITICAL
+    severity = logging.ERROR
 
     if parsedUrl.scheme == 'keyman':
         logging.info("downloading " + url)
         if not url.startswith('keyman://download/keyboard/'):
-            logging.critical("Don't know what to do with URL " + url)
+            logging.error("Don't know what to do with URL " + url)
             return
 
         packageId = parsedUrl.path[len('/keyboard/'):]
         if not packageId:
-            logging.critical("Missing package id")
+            logging.error("Missing package id")
             return
 
         downloadFile = os.path.join(get_download_folder(), packageId)
@@ -38,13 +38,12 @@ def download_and_install_package(url):
         packageFile = download_kmp_file(downloadUrl, downloadFile)
     elif parsedUrl.scheme == '' or parsedUrl.scheme == 'file':
         packageFile = parsedUrl.path
-        severity = logging.ERROR
     else:
-        logging.critical("Invalid URL: " + url)
+        logging.error("Invalid URL: " + url)
         return
 
     if not is_zipfile(packageFile):
-        logging.critical("Not a valid KMP package: " + url)
+        logging.error("Not a valid KMP package: " + url)
         return
 
     if packageFile and not _install_package(packageFile, bcp47):

--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -459,7 +459,7 @@ def parsemetadata(jsonfile, verbose=False):
             try:
                 data = json.load(read_file)
             except JSONDecodeError as e:
-                logging.critical("parsemetadata: %s invalid: %s (line %d, col %d)",
+                logging.error("parsemetadata: %s invalid: %s (line %d, col %d)",
                                  jsonfile, e.msg, e.lineno, e.colno)
                 # Use empty details
                 data = {"nonexistent": "none"}

--- a/linux/keyman-config/keyman_config/kvk2ldml.py
+++ b/linux/keyman-config/keyman_config/kvk2ldml.py
@@ -213,7 +213,7 @@ def get_nstring(file, fileContent, offset):
     stringlength = struct.unpack_from("<H", fileContent, offset)
     file.seek(offset + 2)
     if stringlength[0] > 256:
-        logging.critical("error: suspiciously long string. ABORT.")
+        logging.error("error: suspiciously long string. ABORT.")
         sys.exit(5)
     if stringlength[0]:
         # don't read the null string terminator


### PR DESCRIPTION
We don't want to send events to Sentry for errors that we handled.

@keymanapp-test-bot skip