### PR TITLE
chore(android/samples): Add -no-daemon flag to KMSample2 build script

### DIFF
--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -1,10 +1,61 @@
-#!/bin/sh
+#!/bin/bash
 # Build KMSample2
+
+set -e
+set -u
+
+display_usage ( ) {
+    echo "build.sh [-no-daemon] [-debug]"
+    echo
+    echo "Build KM Sample 2"
+    echo "  -no-daemon              Don't start the Gradle daemon. Use for CI"
+    echo "  -debug                  Compile only Debug variant"
+    exit 1
+}
+
+echo Build KMSample2
 
 #
 # Prevents 'clear' on exit of mingw64 bash shell
 #
 SHLVL=0
 
-echo Build KMSample2
-./gradlew clean build
+NO_DAEMON=false
+ONLY_DEBUG=false
+
+# Parse args
+while [[ $# -gt 0 ]] ; do
+    key="$1"
+    case $key in
+        -no-daemon)
+            NO_DAEMON=true
+            ;;
+        -debug)
+            ONLY_DEBUG=true
+            ;;
+        -h|-\?)
+            display_usage
+            ;;
+    esac
+    shift # past argument
+done
+
+echo
+echo "NO_DAEMON: $NO_DAEMON"
+echo "ONLY_DEBUG: $ONLY_DEBUG"
+echo
+
+if [ "$NO_DAEMON" = true ]; then
+  DAEMON_FLAG=--no-daemon
+else
+  DAEMON_FLAG=
+fi
+
+if [ "$ONLY_DEBUG" = true ]; then
+  BUILD_FLAG=assembleDebug
+else
+  BUILD_FLAG=build
+fi
+
+./gradlew $DAEMON_FLAG clean $BUILD_FLAG
+

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build KMSample2
 
 set -e


### PR DESCRIPTION
Fixes #6075 and follow-on to #603

#603 added a `-no-daemon` build flag for the sample projects to build on CI, but KMSample2/build.sh inadvertently wasn't updated.

This PR updates KMSample2 so hopefully will stop the CI from hanging.
Will need to 🍒-pick to stable-14.0

## User Testing
* TEST_KMSAMPLE2 - Tests KMSample2 project still runs
1. Load the test build and launch KMSample2
2. Using the menus, set KMSample2 as a system IME
3. Launch a separate app (e.g. Chrome) and select a text field to type
4. When KMSample2 is the selected IME, verify it can type
