### PR TITLE
fix(linux): Fix attribute error :cherries: 

### DIFF
--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -34,7 +34,7 @@ def get_package_download_data(packageID, weekCache=False):
     response = requests.get(api_url)
     logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
     os.chdir(current_dir)
-    requests_cache.core.uninstall_cache()
+    requests_cache.uninstall_cache()
     if response.status_code == 200:
         return response.json()
     else:
@@ -66,7 +66,7 @@ def get_keyboard_data(keyboardID, weekCache=False):
     response = requests.get(api_url)
     logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
     os.chdir(current_dir)
-    requests_cache.core.uninstall_cache()
+    requests_cache.uninstall_cache()
     if response.status_code == 200:
         return response.json()
     else:
@@ -168,7 +168,7 @@ def download_kmp_file(url, kmpfile, cache=False):
     if cache:
         logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
         os.chdir(current_dir)
-        requests_cache.core.uninstall_cache()
+        requests_cache.uninstall_cache()
 
     if response.status_code == 200:
         with open(kmpfile, 'wb') as f:


### PR DESCRIPTION
Newer versions of requests-cache (>= 0.6) restructure some code so that the _core_ namespace is no longer available. However, it turns out that we don't need to specify that namespace at all, so this change will work with both older and newer versions of
`requests-cache`.

This will fix #6085.

:cherries:-pick from #6086.

# User Testing

**TEST_OLD**: install a keyboard while `python3-requests-cache` package is installed (<0.6)

- open a terminal window
- start Keyman Configuration by typing `km-config`
- install any keyboard
- verify that the command line didn't print a line similar to `AttributeError: module 'requests_cache' has no attribute 'core'`   during the installation of the keyboard
- verify that the keyboard gets properly installed

**TEST_NEW**: install a keyboard with a newer requests-cache version

- open a terminal window
- run `sudo apt update && sudo apt install python3-pip`
- install new version of requests-cache by running: `pip install requests-cache==0.9.0`
- follow the steps from above
