### PR TITLE
fix(mac): externalize strings for package info window localization

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/km.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/km.lproj/KMAboutWindowController.strings
@@ -1,9 +1,9 @@
 
-/* Class = "NSButtonCell"; title = "Close"; ObjectID = "Kab-Up-fYH"; */
+/* button text to close the About window */
 "Kab-Up-fYH.title" = "បិទ";
 
-/* Class = "NSButtonCell"; title = "License Agreement"; ObjectID = "hYC-Bx-aoP"; */
+/* text of link to the license agreement */
 "hYC-Bx-aoP.title" = "កិច្ចព្រមព្រៀងអាជ្ញាបណ្ណ";
 
-/* Class = "NSButtonCell"; title = "Configuration"; ObjectID = "vkh-b5-vO7"; */
+/* button text to open Configuration window  */
 "vkh-b5-vO7.title" = "ការកំណត់រចនាសម្ព័ន្ធ";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/en.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/en.lproj/preferences.strings
@@ -17,8 +17,8 @@
 /* button text to go back to previous page */
 "JOK-JV-n8w.title" = "Back";
 
-/* Class = "NSTabViewItem"; label = "Keyboard Layouts"; ObjectID = "MPN-9N-wWc"; */
-"MPN-9N-wWc.label" = "Keyboard Layouts";
+/* Class = "NSTabViewItem"; label = "Keyboards"; ObjectID = "MPN-9N-wWc"; */
+"MPN-9N-wWc.label" = "Keyboards";
 
 /* text to explain verbose Console logging option */
 "MrI-GM-7d6.title" = "When the verbose logging option is on, Keyman will log actions that might help Keyman Support diagnose a problem. The Console program can be used to see a log of messages from Keyman. In Console, filter to show all messages from the \"Keyman\" process. This log can be exported and sent to Keyman support if needed.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/en.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/en.lproj/preferences.strings
@@ -5,7 +5,7 @@
 /* Checkbox text to enable verbose Console logging */
 "7J6-zy-R20.title" = "Use verbose Console logging";
 
-/* Support buton text  */
+/* Support button text  */
 "93O-x6-RLF.label" = "Support";
 
 /* Download Keyboard button text */
@@ -17,7 +17,7 @@
 /* button text to go back to previous page */
 "JOK-JV-n8w.title" = "Back";
 
-/* Class = "NSTabViewItem"; label = "Keyboards"; ObjectID = "MPN-9N-wWc"; */
+/* Keyboards button text */
 "MPN-9N-wWc.label" = "Keyboards";
 
 /* text to explain verbose Console logging option */

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/km.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/km.lproj/preferences.strings
@@ -1,39 +1,39 @@
 
-/* Class = "NSButtonCell"; title = "Always show on-screen keyboard"; ObjectID = "4UX-80-0Vo"; */
+/* Checkbox text to always show on-screen keyboard */
 "4UX-80-0Vo.title" = "បង្ហាញក្ដារចុចលើអេក្រង់ជានិច្ច";
 
-/* Class = "NSButtonCell"; title = "Use verbose Console logging"; ObjectID = "7J6-zy-R20"; */
+/* Checkbox text to enable verbose Console logging */
 "7J6-zy-R20.title" = "ប្រើកំណត់ហេតុកុងសូលលម្អិត";
 
-/* Class = "NSTabViewItem"; label = "Support"; ObjectID = "93O-x6-RLF"; */
+/* Support button text  */
 "93O-x6-RLF.label" = "គាំទ្រ";
 
-/* Class = "NSButtonCell"; title = "Download keyboard..."; ObjectID = "CTw-kf-WNS"; */
+/* Download Keyboard button text */
 "CTw-kf-WNS.title" = "ទាញយកក្ដារចុច...";
 
-/* Class = "NSWindow"; title = "Keyman Configuration"; ObjectID = "F0z-JX-Cv5"; */
+/* Keyman Configuration window title */
 "F0z-JX-Cv5.title" = "ការកំណត់រចនាសម្ព័ន្ធ Keyman";
 
-/* Class = "NSButtonCell"; title = "< Back"; ObjectID = "JOK-JV-n8w"; */
+/* button text to go back to previous page */
 "JOK-JV-n8w.title" = "ថយក្រោយ";
 
-/* Class = "NSTabViewItem"; label = "Keyboard Layouts"; ObjectID = "MPN-9N-wWc"; */
-"MPN-9N-wWc.label" = "ប្លង់ក្ដារចុច";
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "ក្ដារចុច";
 
-/* Class = "NSTextFieldCell"; title = "When the verbose logging option is on, Keyman will log actions that might help Keyman Support diagnose a problem. The Console program can be used to see a log of messages from Keyman. In Console, filter to show all messages from the \"Keyman\" process. This log can be exported and sent to Keyman support if needed."; ObjectID = "MrI-GM-7d6"; */
+/* text to explain verbose Console logging option */
 "MrI-GM-7d6.title" = "នៅពេលបើកជម្រើសកំណត់ហេតុលម្អិត Keyman នឹងរក្សារទុកកំណត់ហេតុសកម្មភាពដែលអាចជួយក្រុមការងារ​ Keyman វិភាគបញ្ហា។ កម្មវិធីកុងសូលអាចប្រើបើកមើលសារកំណត់ហេតុពី Keyman។ ក្នុងកុងសូល ត្រងដើម្បីបង្ហាញសារទាំងអស់ពីដំណើរការរបស់ \"Keyman\"។ បើចាំបាច់ អ្នកអាចនាំចេញ ឬផ្ញើកំណត់ហេតុនេទៅក្រុមការងារ Keyman។";
 
-/* Class = "NSButtonCell"; title = "Forward >"; ObjectID = "eXr-8V-h1g"; */
+/* button text to move forward to the next page */
 "eXr-8V-h1g.title" = "ទៅមុខ";
 
-/* Class = "NSButtonCell"; title = "Home"; ObjectID = "fXS-aC-CMH"; */
+/* button text to return to the home help page */
 "fXS-aC-CMH.title" = "ដើម";
 
-/* Class = "NSTabViewItem"; label = "Options"; ObjectID = "frd-No-seV"; */
+/* Options button text */
 "frd-No-seV.label" = "ជម្រើស";
 
-/* Class = "NSTableColumn"; headerCell.title = "Installed Keyboard"; ObjectID = "jex-Nd-Qzg"; */
+/* Installed Keyboard column heading */
 "jex-Nd-Qzg.headerCell.title" = "បានដំឡើង​ក្ដារចុច";
 
-/* Class = "NSButton"; ibShadowedToolTip = "Turn this on if you are having problems with a specific keyboard or with Keyman in general."; ObjectID = "uWx-3J-U0D"; */
+/* Verbose logging tooltip text */
 "uWx-3J-U0D.ibShadowedToolTip" = "បើកចុះ ប្រសិនបើអ្នកកំពុងមានបញ្ហាជាមួយ Keyman ឬក្ដារចុចណាមួយជាក់លាក់។";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
@@ -29,8 +29,7 @@
 
 - (void)windowDidLoad {
     [super windowDidLoad];
-    // TODO: rename
-    [self.window setTitle:@"Keyboard/Package Info"];
+  
     [self.tabView setDelegate:self];
     [self.detailsView setFrameLoadDelegate:(id<WebFrameLoadDelegate>)self];
     [self.detailsView setPolicyDelegate:(id<WebPolicyDelegate>)self];
@@ -82,7 +81,11 @@
     return YES;
 }
 
+// TODO: refactor: any reason for this to be HTML? hard to read stringWithFormat applied to template with 16 arguments
 - (NSString *)detailsHtml {
+  
+  NSString *errorString = NSLocalizedString(@"message-keyboard-file-unreadable", nil);
+
     @try {
         NSString *htmlFormat =
         @"<html>"
@@ -110,16 +113,16 @@
           "<div id='qrcode-caption'>Scan this code to load this keyboard on another device or "
           "<a href='%@'>share online</a></div>"
         "</div>"
-        "<p class='title'>Keyboard Layouts:</p><br>"
+        "<p class='title'>%@</p><br>"
         "%@"
         "<br>"
-        "<p class='title'>Fonts:</p><br>"
+        "<p class='title'>%@</p><br>"
         "%@"
         "<br>"
-        "<p class='title'>Package version: </p><p class='body'>%@</p><br>"
-        "<p class='title'>Author: </p><p class='body'>%@</p><br>"
-        "<p class='title'>Website: </p><p class='body'>%@</p><br>"
-        "<p class='title'>Copyright: </p><p class='body'>%@</p>"
+        "<p class='title'>%@ </p><p class='body'>%@</p><br>"
+        "<p class='title'>%@ </p><p class='body'>%@</p><br>"
+        "<p class='title'>%@ </p><p class='body'>%@</p><br>"
+        "<p class='title'>%@ </p><p class='body'>%@</p>"
         "</div>"
         "</body>"
         "</html>";
@@ -179,8 +182,19 @@
         if (self.packageInfo.copyright.length)
             copyright = self.packageInfo.copyright;
         
+        // get localized label strings
+        NSString *keyboardsLabel = NSLocalizedString(@"keyboards-label", nil);
+        NSString *fontsLabel = NSLocalizedString(@"fonts-label", nil);
+        NSString *packageVersionLabel = NSLocalizedString(@"package-version-label", nil);
+        NSString *authorLabel = NSLocalizedString(@"author-label", nil);
+        NSString *websiteLabel = NSLocalizedString(@"website-label", nil);
+        NSString *copyrightLabel = NSLocalizedString(@"copyright-label", nil);
+
+      
         NSString *htmlStr = [NSString stringWithFormat:htmlFormat, name, shareUrl, shareUrl,
-                             keyboardString, fontsStr, version, author, website, copyright];
+                             keyboardsLabel, keyboardString, fontsLabel, fontsStr,
+                             packageVersionLabel, version, authorLabel, author,
+                             websiteLabel, website, copyrightLabel, copyright];
         
         return htmlStr;
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/en.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/en.lproj/KMInfoWindowController.strings
@@ -1,5 +1,5 @@
 
-/* Keyboard Information window title */
+/* Package Information window title */
 "F0z-JX-Cv5.title" = "Package Information";
 
 /* button text to show Details */

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/en.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/en.lproj/KMInfoWindowController.strings
@@ -1,6 +1,6 @@
 
 /* Keyboard Information window title */
-"F0z-JX-Cv5.title" = "Keyboard Information";
+"F0z-JX-Cv5.title" = "Package Information";
 
 /* button text to show Details */
 "Fvy-XJ-s38.label" = "Details";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/km.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/km.lproj/KMInfoWindowController.strings
@@ -1,9 +1,9 @@
 
-/* Class = "NSWindow"; title = "Window"; ObjectID = "F0z-JX-Cv5"; */
-"F0z-JX-Cv5.title" = "ព័ត៌មានក្ដារចុច";
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "ព័ត៌មានកញ្ចប់";
 
-/* Class = "NSTabViewItem"; label = "Details"; ObjectID = "Fvy-XJ-s38"; */
+/* button text to show Details */
 "Fvy-XJ-s38.label" = "លម្អិត";
 
-/* Class = "NSTabViewItem"; label = "Read Me"; ObjectID = "waA-IW-Qyn"; */
+/* button text to show Read Me */
 "waA-IW-Qyn.label" = "អានខ្ញុំ";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/km.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/km.lproj/KMKeyboardHelpWindowController.strings
@@ -1,9 +1,9 @@
 
-/* Class = "NSWindow"; title = "Window"; ObjectID = "F0z-JX-Cv5"; */
+/* Keyboard Help window title */
 "F0z-JX-Cv5.title" = "Window - វីនដូ";
 
-/* Class = "NSButtonCell"; title = "OK"; ObjectID = "Zla-QF-m0K"; */
+/* OK button text */
 "Zla-QF-m0K.title" = "យល់ព្រម";
 
-/* Class = "NSButtonCell"; title = "Print..."; ObjectID = "fYY-Uj-y4S"; */
+/* Print button text */
 "fYY-Uj-y4S.title" = "ព្រីន...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
@@ -43,3 +43,23 @@
 
 /* Button text keyboard download complete  */
 "button-download-complete" = "Done";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "Keyboards:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "Fonts:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "Package Version:";
+
+/* author label in the Package Information window */
+"author-label" = "Author:";
+
+/* website label in the Package Information window */
+"website-label" = "Website:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "Copyright:";
+
+

--- a/mac/Keyman4MacIM/Keyman4MacIM/km.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/km.lproj/Localizable.strings
@@ -43,3 +43,21 @@
 
 /* Button text keyboard download complete  */
 "button-download-complete" = "រួចរាល់";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "ក្ដារចុច៖";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "ពុម្ពអក្សរ៖";
+
+/* package version label in the Package Information window */
+"package-version-label" = "ជំនាន់កញ្ចប់៖";
+
+/* author label in the Package Information window */
+"author-label" = "អ្នកបង្កើត៖";
+
+/* website label in the Package Information window */
+"website-label" = "គេហទំព័រ៖";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "រក្សាសិទ្ធិ៖";

--- a/mac/Keyman4MacIM/Keyman4MacIM/km.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/km.lproj/MainMenu.strings
@@ -1,15 +1,15 @@
 
-/* Class = "NSMenuItem"; title = "Configuration..."; ObjectID = "P1b-lE-yFw"; */
+/* Configuration window menu text */
 "P1b-lE-yFw.title" = "ការកំណត់រចនាសម្ព័ន្ធ...";
 
-/* Class = "NSMenuItem"; title = "Keyboards"; ObjectID = "bQa-j9-nHe"; */
+/* Keyboards menu text */
 "bQa-j9-nHe.title" = "ក្ដារចុច";
 
-/* Class = "NSMenu"; title = "Keyboards"; ObjectID = "goP-aK-3WB"; */
+/* Keyboards menu text */
 "goP-aK-3WB.title" = "ក្ដារចុច";
 
-/* Class = "NSMenuItem"; title = "About"; ObjectID = "kb2-ww-RS3"; */
+/* About menu text */
 "kb2-ww-RS3.title" = "អំពី";
 
-/* Class = "NSMenuItem"; title = "On-Screen Keyboard"; ObjectID = "s96-JI-YDh"; */
+/* On-Screen Keyboard menu text */
 "s96-JI-YDh.title" = "ក្ដារចុចលើអេក្រង់";


### PR DESCRIPTION
fixes #6081
The Package Information window in Keyman for Mac is composed with HTML and could not be localized because label strings were still hard-coded in HTML. This change externalizes the labels so that this window can be included with localization.

I also changed some of the terminology in the related UI for consistency and simplicity:
"Keyboard Layouts" to "Keyboards", in the Configuration tab and within the Package Information window
"Keyboard/Package Info" window title to "Package Information"

Previous naming:
![image](https://user-images.githubusercontent.com/89134789/148633666-7d982f99-f5e9-4c34-94b7-6f6d25cb1ed4.png)

New naming:
![image](https://user-images.githubusercontent.com/89134789/148633673-ff3d8bab-0fdf-4cf7-9868-ba10befc0d1f.png)
![image](https://user-images.githubusercontent.com/89134789/148633678-2c23c2fb-9daa-4d4a-bcba-a5b08b4ad48c.png)
