### PR TITLE
fix(developer): bundle.sh must succeed

### DIFF
--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -eu
-set -x
 
 display_usage() {
   echo "Usage: $0 --build-path path"
@@ -92,7 +91,7 @@ cp "$KEYMAN_MODELCOMPILER_ROOT/package-lock.json" "$KEYMAN_WIX_TEMP_MODELCOMPILE
 # Yuck! ref: https://github.com/npm/cli/issues/3975#issuecomment-985305678
 # ref: https://github.com/npm/cli/issues/2921
 # can't use npm uninstall because it depends on @keymanapp/models-types being present!
-cat package.json | grep -v "@keymanapp/models-templates" | grep -v "@keymanapp/models-wordbreakers" > package.json
+cat package.json | grep -v "@keymanapp/models-templates" | grep -v "@keymanapp/models-wordbreakers" > package.json || true
 
 npm install kmtypes.tgz --production --no-optional
 npm install --production --no-optional


### PR DESCRIPTION
Fixes a build failure after #6074 was merged. The final grep statement in the line

  cat package.json | grep -v "@keymanapp/models-templates" | grep -v "@keymanapp/models-wordbreakers" > package.json

would fail to find anything to exclude, and return an error value, so the script would fail, as we use `set -e`. We didn't care that it didn't find anything to exclude... so we will ignore the return value.

@keymanapp-test-bot skip