### PR TITLE
fix(linux): Update minimum sentry-sdk version

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -22,7 +22,7 @@ Build-Depends:
  python3-pil,
  python3-pip,
  python3-qrcode,
- python3-sentry-sdk | python3-raven,
+ python3-sentry-sdk (>= 1.1) | python3-raven,
  python3-requests,
  python3-requests-cache,
  python3-setuptools,
@@ -83,7 +83,7 @@ Depends:
  keyman-engine,
  python3-bs4,
  python3-gi,
- python3-sentry-sdk | python3-raven,
+ python3-sentry-sdk (>= 1.1) | python3-raven,
  ${misc:Depends},
  ${python3:Depends},
 Description: Keyman for Linux configuration


### PR DESCRIPTION
This is a follow-up for #5325.

@keymanapp-test-bot skip