### PR TITLE
fix(web): Use regex to determine display layer and functional layers

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -248,7 +248,8 @@
         var keyPos = x.toString() + ',' + y.toString();
         for(i=0; i<obj.length; i++)
         {
-          s=s+obj[i].layer+'-'+obj[i].coreID;
+          // elementID contains the layer and coreID
+          s=s+obj[i].elementID;
           if(obj[i].sp == 1 || obj[i].sp == 2) shift = true;
           if(typeof(obj[i].text) != 'undefined' && obj[i].text != null && obj[i].text != '') s=s+':'+toHex(obj[i].text);
           if(i < (obj.length -1)) s=s+';'

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -365,24 +365,18 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
 
-      let displayLayer = keymanweb.core.keyboardProcessor.layerId;
-
       // Regex for 'display layer'-'virtual key name'+'optional functional layer'
       // Can't just split on '-' because some layers like ctrl-shift contain it.
-      // Virtual key can be T_, U_, K_, or ISO 9995
-      let rx = new RegExp("(.*)-([TKU]_[^+]*|[A-E]\\d\\d)\\+?(.*)?");
-      let matches = keyName.match(rx);
+      // Virtual key name starts with T_, K_, or U_
+      // matches[1]: displayLayer (not used)
+      // matches[2]: keyId
+      // matches[3]: optional functionalLayer
+      let matches = keyName.match(/^(.+)-([TKU]_[^+]+)\+?(.+)?$/);
       if (matches == null) {
         return false;
       }
-      displayLayer = matches[1];
-      keyName = matches[2];
-      let functionalLayer = '';
-      if (matches[3]) {
-        functionalLayer = matches[3];
-        keyName += '+' + functionalLayer;
-      }
-
+      keyName = matches[2] + (matches[3] ? '+' + matches[3] : '');
+ 
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
       var Lelem=keymanweb.domManager.lastActiveElement;

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -366,23 +366,21 @@ namespace com.keyman.text {
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
 
       let displayLayer = keymanweb.core.keyboardProcessor.layerId;
-      let functionalLayer = '';
 
       // Regex for 'display layer'-'virtual key name'+'optional functional layer'
       // Can't just split on '-' because some layers like ctrl-shift contain it.
       // Virtual key can be T_, U_, K_, or ISO 9995
       let rx = new RegExp("(.*)-([TKU]_[^+]*|[A-E]\\d\\d)\\+?(.*)?");
       let matches = keyName.match(rx);
+      if (matches == null) {
+        return false;
+      }
       displayLayer = matches[1];
       keyName = matches[2];
+      let functionalLayer = '';
       if (matches[3]) {
-        // Optional function layer
-        functionalLayer = matches[3]
+        functionalLayer = matches[3];
         keyName += '+' + functionalLayer;
-      }
-
-      if(displayLayer == 'undefined') {
-        displayLayer=keymanweb.core.keyboardProcessor.layerId;
       }
 
       // Note:  this assumes Lelem is properly attached and has an element interface.

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -365,27 +365,24 @@ namespace com.keyman.text {
       // Changes for Build 353 to resolve KMEI popup key issues
       keyName=keyName.replace('popup-',''); //remove popup prefix if present (unlikely)
 
-      // Determine display layer (and ignore functional layer if it exists).
-      // Can't just split on '-' because some layers like ctrl-shift contain it.
-      let originalKeyName = keyName;
       let displayLayer = keymanweb.core.keyboardProcessor.layerId;
-      let functionalLayerSeparatorIndex = keyName.indexOf('+');
-      let separatorIndex = (functionalLayerSeparatorIndex > 0) ?
-        keyName.substring(0, functionalLayerSeparatorIndex).lastIndexOf('-') :
-        keyName.lastIndexOf('-');
-      if (separatorIndex > 0) {
-        displayLayer = keyName.substring(0, separatorIndex);
-        keyName = keyName.substring(separatorIndex+1);
-      }
-      if(displayLayer == 'undefined') {
-        displayLayer=keymanweb.core.keyboardProcessor.layerId;
+      let functionalLayer = '';
+
+      // Regex for 'display layer'-'virtual key name'+'optional functional layer'
+      // Can't just split on '-' because some layers like ctrl-shift contain it.
+      // Virtual key can be T_, U_, K_, or ISO 9995
+      let rx = new RegExp("(.*)-([TKU]_[^+]*|[A-E]\\d\\d)\\+?(.*)?");
+      let matches = keyName.match(rx);
+      displayLayer = matches[1];
+      keyName = matches[2];
+      if (matches[3]) {
+        // Optional function layer
+        functionalLayer = matches[3]
+        keyName += '+' + functionalLayer;
       }
 
-      // Determine the "functional" layer from the coreID
-      let layer = displayLayer;
-      separatorIndex = originalKeyName.lastIndexOf('+');
-      if (separatorIndex > 0) {
-        layer = originalKeyName.substring(separatorIndex+1);
+      if(displayLayer == 'undefined') {
+        displayLayer=keymanweb.core.keyboardProcessor.layerId;
       }
 
       // Note:  this assumes Lelem is properly attached and has an element interface.
@@ -400,11 +397,6 @@ namespace com.keyman.text {
         osk.vkbd.subkeyGesture = null;
       } else {
         console.warn("No base key exists for the subkey being executed: '" + origArg + "'");
-      }
-
-      // Now that we've checked if key is found, split "functional" layer from keyName
-      if (separatorIndex > 0) {
-        keyName = keyName.substring(0, separatorIndex);
       }
   };
 


### PR DESCRIPTION
fixes #6089

> A longpress key with reference to a key with Shift+RightAlt in the computer layout does not output anything.
It works just fine though when testing on Chrome emulator.

I initially started porting the changes in #5651 from stable-14.0, but Makara reported seeing the issue in 14.0 too. Thus, portions of this PR will need to be 🍒 picked back to stable-14.0

The complication in kmwembedded.ts comes from parsing `keyName` which contains:
[display layer]-[virtual key name]+[optional function layer] where display layer and function layer can contain multiple `-` delimiters.
For example: 'ctrl-shift' or 'rightalt-shift'

The virtual key name  can also be T_* , K_* , U_*, ~or ISO 9995 format~

In @MakaraSok 's issue, the displayLayer is 'shift' while the functional layer is 'rightalt-shift' from the longpress key.

## User Testing
Setup:
For each platform test, install the following keyboards (some were used in testing #5651):
1. ukwuani (zip of [source](https://github.com/keymanapp/keyman/files/7845806/ukwuani.zip))
2. sil_madi
3. sil_cameroon_qwerty

* **TEST_ANDROID**
1. Launch Keyman
2. Test and verify sil_euro_latin keyboard:
    a. Use the globe key to switch to sil_euro_latin keyboard
    b. On the "default" layer, longpress a key and select
    c. Verify the output character matches the longpress key
    d. Repeat for "shift" and "symbol" layers
3. Test and verify ukwuani keyboard:
    a. Use the globe key to switch to ukwuani keyboard
    b. On the default layer, Longpress on the <kbd>o</kbd>, <kbd>i</kbd>, <kbd>u</kbd>, <kbd>e</kbd>, or <kbd>n</kbd> keys and select the longpress key
    c. Verify the output character matches the longpress key
    d. Press <kbd>Shift</kbd> to switch to the "Shift" layer
    e. Longpress on the <kbd>O</kbd>, <kbd>I</kbd>, <kbd>U</kbd>, <kbd>E</kbd>, or <kbd>N</kbd> keys and select the longpress key
    f. Verify the output character matches the longpress key
4. Test and verify sil_madi keyboard:
    a. Use the globe key to switch to sil_madi keyboard
    b. On the default layer, longpress on a vowel and select it
    c. Verify the correct character is output
    d. Press <kbd>Shift</kbd> to switch to the "Shift" layer
    e. Longpress on the <kbd>A</kbd> and select one of the caps longpresses.
    f. Verify the correct character is output
5. Test and verify sil_cameroon_qwerty (verifies application of nextlayer)
    a. Use the globe key to switch to sil_cameroon_qwerty
    b. Press <kbd>Shift</kbd> to switch to the "Shift" layer
    c. Longpress on the <kbd>W</kbd> or <kbd>E</kbd> keys and select one of the caps longpresses
    d. Verify the correct character is output
    e. Verify the keyboard switches to the to the default layer
    f. Press <kbd>Shift</kbd> to switch to the "Shift" layer
    g. Press the spacebar
    h. Verify the layer remains on "Shift"
    i. For each of the following:
        * switch to the symbolic layer
        * longpress on the base key and select any of the longpress keys
        * verify the correct character is output
        * verify the keyboard **switches** to the default layer
        **Base Key**
        <kbd><<</kbd> 
        <kbd>>></kbd> 
        <kbd>'</kbd> (single quote)
        <kbd>"</kbd> (double quote)
    j. For each of the following:
        * switch to the symbolic layer
        * longpress on the base key and select any of the longpress keys
        * verify the correct character is output
        * verify the keyboard **remains** on the symbolic layer
        **Base Key**
        <kbd>(</kbd> 
        <kbd>)</kbd> 
        <kbd>?</kbd> (Note, the basekey <kbd>?</kbd> will switch to the default layer
        <kbd>!</kbd> (Note, the basekey <kbd>!</kbd> will switch to the default layer

* **TEST_IOS**
1. Repeat the same steps as ANDROID