### PR TITLE
feat(linux): Try to start ibus if not running

### DIFF
--- a/linux/debian/ibus-keyman.postinst
+++ b/linux/debian/ibus-keyman.postinst
@@ -8,23 +8,48 @@ case "$1" in
     # if don't have sudo and ps then don't attempt to restart ibus
     if which sudo > /dev/null && which ps > /dev/null; then
 
+      # check for gnome-shell as it works differently
+      ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
+      if [ "x$gspid" != "x" ]; then
+        # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
+        is_gnome_shell=1
+      else
+        is_gnome_shell=0
+      fi
+
       # Restart IBus if it is running
       ! ibuspid=`ps -C ibus-daemon -o pid=|head -n 1`
 
       if [ "x$ibuspid" != "x" ]; then
-        # check for gnome-shell as it works differently
-        ! gspid=`ps -C gnome-shell -o pid=|head -n 1`
-        if [ "x$gspid" != "x" ]; then
-          # gnome-shell has multiple ibus-daemon processes and needs exit instead of restart
+        if [ "x$is_gnome_shell" = "x1" ]; then
           ibususers=`ps -C ibus-daemon -o user=|grep -v gdm|uniq`
           for ibususer in $ibususers; do
             sudo -H -u "$ibususer" ibus exit || true
+            sleep 1s
           done
         else
           ibususers=`ps -C ibus-daemon -o user=|uniq`
           for ibususer in $ibususers; do
             sudo -H -u "$ibususer" ibus restart || true
+            sleep 1s
           done
+        fi
+      fi
+
+      # Verify that it's running now
+      ! ibusdaemon=`ps --user ${SUDO_USER} -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*"`
+      if [ "x$ibusdaemon" = "x" ]; then
+        # otherwise try to start it for the user installing the package
+        if [ "x$is_gnome_shell" = "x1" ]; then
+          for session in $(loginctl show-user ${SUDO_USER} -p Sessions --value); do
+            case $(loginctl show-session ${session} -p Type --value) in
+              wayland) sudo -H -u "${SUDO_USER}" -i WAYLAND_DISPLAY=wayland-0 -- ibus-daemon -d -r --xim --panel disable;;
+              x11) sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim --panel disable;;
+              *) ;;
+            esac
+          done
+        else
+          sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim
         fi
       fi
     fi

--- a/linux/debian/ibus-keyman.postrm
+++ b/linux/debian/ibus-keyman.postrm
@@ -27,6 +27,9 @@ case "$1" in
           done
         fi
       fi
+
+      # No need to verify that ibus is running - we're uninstalling keyman
+      # and so we don't care if it's not running
     fi
   ;;
 


### PR DESCRIPTION
When we try to restart ibus and that fails and ibus isn't running afterwards we directly try to start ibus-daemon.

# User Testing

<details>
<summary>Expand to see user tests</summary>

## Preparations

- install the current alpha version of Keyman
- install a second system keyboard, e.g. French
- install a Keyman keyboard
- verify that the keyboard shows up in the keyboards dropdown

## Tests

### SUITE_INSTALL: Package installation 

- **GROUP_BIONIC**: Ubuntu 18.04 Bionic with Gnome shell and X11
- **GROUP_IMPISH**: Ubuntu 21.10 Impish with Gnome shell and X11

  - when login in, click the cog and select "Ubuntu on Xorg"

![Screenshot from 2022-01-19 18-28-11](https://user-images.githubusercontent.com/181336/150183345-f07c7191-b12b-4739-b4fc-c585148db56c.png)

  - once logged in, open a terminal window and verify that running `echo $XDG_SESSION_TYPE`  outputs `x11`.

- **GROUP_IMPISH_WAYLAND**: Ubuntu 21.10 Impish with Gnome shell and Wayland

  - when login in, click the cog and select "Ubuntu"
  - once logged in, open a terminal window and verify that running `echo $XDG_SESSION_TYPE`  outputs `wayland`.

- **GROUP_WASTA**: Wasta 20.04 with Cinnamon

**TEST_INST_RUN**: Install Keyman packages while ibus is running

- download the Keyman packages for this PR
- install the packages with: 
    ```
    sudo dpkg -i \
    {ibus-keyman,libkmnkbp0}*$(lsb_release -s -c)*$(dpkg --print-architecture).deb \
    {keyman,python3-keyman-config}*$(lsb_release -s -c)*all.deb
    ```
- **verify** that ibus is still running by checking that keyboard still shows up in the keyboards dropdown

**TEST_INST_NOIBUS**: Install Keyman packages while ibus is not running

(skip this test on **Bionic** - `ibus-daemon` gets automatically restarted, so it's not possible to run this test)

- exit ibus by running: `killall ibus-daemon`
- verify that ibus is no longer running: Keyman keyboard should no longer show up in keyboards dropdown. It's OK if the keyboards dropdown icon no longer shows.
- re-install the packages for this PR by running:
    ```
    sudo dpkg -i \
    {ibus-keyman,libkmnkbp0}*$(lsb_release -s -c)*$(dpkg --print-architecture).deb \
    {keyman,python3-keyman-config}*$(lsb_release -s -c)*all.deb
    ```
- **verify** that the installation restarted ibus by checking that the keyman keyboard again shows up in the keyboard dropdown. Note that it is OK if a warning shows up in the terminal window that it can't connect to ibus.

### SUITE_ADD_KEYBOARD: Adding keyboards

- **GROUP_BIONIC**: Ubuntu 18.04 Bionic with Gnome shell and X11
- **GROUP_IMPISH**: Ubuntu 21.10 Impish with Gnome shell and X11
- **GROUP_IMPISH_WAYLAND**: Ubuntu 21.10 Impish with Gnome shell and Wayland
- **GROUP_WASTA**: Wasta 20.04 with Cinnamon

**TEST_ADD_RUN**: Add a new Keyman keyboard while ibus is running

- start Keyman Configuration
- add a new Keyman keyboard
- **verify** that ibus is still running by checking that the new keyboard shows up in the keyboard dropdown

**TEST_ADD_NOIBUS**: Add a new Keyman keyboard while ibus is not running

(skip this test on **Bionic** - `ibus-daemon` gets automatically restarted, so it's not possible to run this test)

- exit ibus by running: `killall ibus-daemon`
- verify that ibus is no longer running: Keyman keyboard should no longer show up in keyboards dropdown.  It's OK if the keyboards dropdown icon no longer shows.
- start Keyman Configuration
- add a new Keyman keyboard
- **verify** that ibus got started by checking that the new keyboard shows up in the keyboard dropdown. Note that it is OK if a warning shows up in the terminal window that it can't connect to ibus.
</details>