### PR TITLE
fix(developer): repatch #6074

### DIFF
--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -eu
+set -x
 
 display_usage() {
   echo "Usage: $0 --build-path path"
@@ -91,7 +92,8 @@ cp "$KEYMAN_MODELCOMPILER_ROOT/package-lock.json" "$KEYMAN_WIX_TEMP_MODELCOMPILE
 # Yuck! ref: https://github.com/npm/cli/issues/3975#issuecomment-985305678
 # ref: https://github.com/npm/cli/issues/2921
 # can't use npm uninstall because it depends on @keymanapp/models-types being present!
-cat package.json | grep -v "@keymanapp/models-templates" | grep -v "@keymanapp/models-wordbreakers" > package.json || true
+
+cat "$KEYMAN_MODELCOMPILER_ROOT/package.json" | grep -v "@keymanapp/models-templates" | grep -v "@keymanapp/models-wordbreakers" > package.json || true
 
 npm install kmtypes.tgz --production --no-optional
 npm install --production --no-optional

--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -eu
-set -x
 
 display_usage() {
   echo "Usage: $0 --build-path path"


### PR DESCRIPTION
The previous patch in #6091 was not _quite_ correct. Unfortunately, this code path is not executed when we do a test build, but only on release builds, because we don't want to be publishing to npm for test builds...

@keymanapp-test-bot skip