### PR TITLE
docs(linux): Add missing dependency

### DIFF
--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -6,14 +6,13 @@ On Linux, you can build the following projects:
 
 * [Keyman for Linux](#keyman-for-linux)
 * [Keyman Core](#keyman-core) (Linux only) (aka common/core/desktop)
-
-The following projects **cannot** be built on Linux because of outdated dependencies:
-
-<!-- TODO: can we build Android, Web, Core-Wasm and Common/Web on Linux? -->
+<!-- TODO: document how to build for Android, Web, Core-Wasm and Common/Web on Linux. See TC build agent for details. -->
 * Keyman for Android
 * Keyman Core (wasm targets)
 * Common/Web (aka common/core/web)
 * KeymanWeb
+
+The following projects **cannot** be built on Linux:
 
 * Keyman for Windows
 * Keyman Developer
@@ -46,7 +45,7 @@ They are most easily installed with the `mk-build-deps` tool:
 
 ```bash
 sudo apt update
-sudo apt install devscripts
+sudo apt install devscripts equivs
 sudo mk-build-deps --install linux/debian/control
 ```
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -97,7 +97,7 @@ Nightly and release builds upload the most recent new master build to <https://d
 
 ## Building packages
 
-See [Linux packaging doc](https://github.com/keymanapp/keyman/blob/master/docs/linux-packaging.md)
+See [Linux packaging doc](../docs/linux-packaging.md)
 for details on building Linux packages for Keyman.
 
 ## Testing


### PR DESCRIPTION
@keymanapp-test-bot skip