### PR TITLE
feat(linux): add support for Wayland

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -1,11 +1,11 @@
 #!groovy
-// Copyright (c) 2019-2021 SIL International
+// Copyright (c) 2019-2022 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 
 @Library('lsdev-pipeline-library') _
 
 keymanPackaging {
-  distributionsToPackage = 'bionic focal hirsute jammy'
+  distributionsToPackage = 'bionic focal impish jammy'
   arches = 'amd64 i386'
   packagesToBuild = ['keyman', 'kmflcomp', 'libkmfl', 'ibus-kmfl']
 }


### PR DESCRIPTION
This allows to use Keyman with the Wayland display server. 

One thing that doesn't yet work completely with this change is caps-lock.

Partially implements #4273.

# User Testing

## Environment

Use Ubuntu 21.10 Impish with Gnome shell and Wayland

- when login in, click the cog and select "Ubuntu" (not "Ubuntu on Xorg")

![Screenshot from 2022-01-19 18-28-11](https://user-images.githubusercontent.com/181336/150183345-f07c7191-b12b-4739-b4fc-c585148db56c.png)

- verify that you're using Wayland by running the following command in a terminal:

```
echo $XDG_SESSION_TYPE
```

This should output `wayland`.

## Tests

**TEST_WAYLAND:** Keyman keyboards work with Wayland

- install any Keyman keyboard
- verify that the keyboard works as expected

**NOTE:** Turning caps-lock on and off doesn't yet work on Wayland (**shiftfreescaps**, **capsononly** and **capsalwaysoff** stores in Keyman).

