### PR TITLE
fix(developer): handle Core failure to load

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebug.dfm
+++ b/windows/src/developer/TIKE/child/UfrmDebug.dfm
@@ -40,6 +40,7 @@ inherited frmDebug: TfrmDebug
     OnExit = memoLostFocus
     OnKeyUp = memoKeyUp
     OnMessage = memoMessage
+    IsDebugging = False
   end
   object sgChars: TStringGrid
     Left = 0

--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -137,7 +137,7 @@ type
     procedure UpdateDeadkeys;
     procedure SetSingleStepMode(const Value: Boolean);
     procedure ResetDebug;
-    procedure SetupDebug;
+    function SetupDebug: Boolean;
     procedure UpdateCharacterGrid;
 
     function ProcessKeyEvent(var Message: TMessage): Boolean;
@@ -956,7 +956,8 @@ begin
   FDebugVisible := True;
 
   //UpdateFont(nil);
-  SetupDebug;
+  if not SetupDebug then
+    Exit;
 
   memo.SetFocus;
 end;
@@ -976,7 +977,7 @@ begin
   memo.Text := '';
 end;
 
-procedure TfrmDebug.SetupDebug;
+function TfrmDebug.SetupDebug: Boolean;
 var
   buf: array[0..KL_NAMELENGTH] of Char;
 begin
@@ -993,8 +994,8 @@ begin
       CleanupCoreState;
       Winapi.Windows.SetFocus(0);
       HideDebugForm;
-      ShowMessage(E.Message);
-      Exit;
+      ShowMessage('Unable to start the debugger: '+E.Message);
+      Exit(False);
     end;
   end;
 
@@ -1002,6 +1003,8 @@ begin
   frmDebugStatus.RegTest.RegTestSetup(buf, FFileName, False);   // I3655
   frmDebugStatus.SetDebugKeyboard(debugkeyboard);
   frmDebugStatus.Elements.ClearStores;
+
+  Result := True;
 end;
 
 {-------------------------------------------------------------------------------

--- a/windows/src/developer/TIKE/debug/Keyman.System.Debug.DebugCore.pas
+++ b/windows/src/developer/TIKE/debug/Keyman.System.Debug.DebugCore.pas
@@ -86,7 +86,12 @@ begin
   if not KeymanCoreLoaded then
   begin
     path := TKeymanPaths.KeymanCoreLibraryPath(kmnkbp0);
-    _km_kbp_set_library_path(path);
+    try
+      _km_kbp_set_library_path(path);
+    except
+      on E:Exception do
+        raise EDebugCore.CreateFmt('Unable to load Keyman Core library at %s: %s %s', [path, E.ClassName, E.Message]);
+    end;
     KeymanCoreLoaded := True;
   end;
 end;


### PR DESCRIPTION
If Core fails to load when starting the debugger, avoid a crash and report details of the error back to the user.

@keymanapp-test-bot skip