### PR TITLE
fix(developer): compile package fileVersion from keyboard FileVersion

### DIFF
--- a/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
+++ b/windows/src/developer/TIKE/compile/MergeKeyboardInfo.pas
@@ -479,7 +479,7 @@ var
   v: TJSONValue;
   alangs: TJSONArray;
   olangs, o: TJSONObject;
-  pair: TJSONPair; 
+  pair: TJSONPair;
   i: Integer;
   id: string;
 begin
@@ -858,7 +858,8 @@ begin
       MinVersion := FPackageKMXFileInfos[i].Info.FileVersion;
 
   FJSMinVersionString := '';
-  with TRegEx.Match(FJSFileInfo.Data, 'this\.KMINVER=([''"])([^''"]+)(\1)') do
+  // See also Keyman.System.KeyboardJSInfo.pas, CompilePackage.pas
+  with TRegEx.Match(FJSFileInfo.Data, 'this.KMINVER\s*=\s*([''"])(.*?)\1') do
   begin
     if Success then
     begin

--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -57,7 +57,8 @@ uses
   Keyman.System.PackageInfoRefreshLexicalModels,
 
   RedistFiles,
-  TempFileManager;
+  TempFileManager,
+  VersionINfo;
 
 type
   TCompilePackage = class
@@ -282,19 +283,38 @@ begin
 
     kmpinf.RemoveFilePaths;
 
-    if kmpinf.LexicalModels.Count = 0
-      then kmpinf.Options.FileVersion := SKeymanVersion70
-      else kmpinf.Options.FileVersion := SKeymanVersion120;
+    //
+    // Find the minimum package version based on keyboard version
+    // See also MergeKeyboardInfo.pas
+    //
 
-    if kmpinf.Options.FileVersion = SKeymanVersion70 then
+    if kmpinf.LexicalModels.Count = 0 then
     begin
+      kmpinf.Options.FileVersion := SKeymanVersion70;
+
+      for i := 0 to kmpinf.Keyboards.Count - 1 do
+      begin
+        if CompareVersions(kmpinf.Options.FileVersion, kmpinf.Keyboards[i].MinKeymanVersion) > 0 then
+          kmpinf.Options.FileVersion := kmpinf.Keyboards[i].MinKeymanVersion;
+      end;
+
       psf := TPackageContentFile.Create(kmpinf);
       psf.FileName := 'kmp.inf';
       psf.Description := 'Package information';
       psf.CopyLocation := pfclPackage;
 
       kmpinf.Files.Add(psf);
+    end
+    else
+    begin
+      // TODO: min model version is always 12.0 currently
+      // but we may need to support this in future
+      kmpinf.Options.FileVersion := SKeymanVersion120;
     end;
+
+    //
+    // Prepare and save
+    //
 
     psf := TPackageContentFile.Create(kmpinf);
     psf.FileName := 'kmp.json';

--- a/windows/src/global/delphi/general/KeymanVersion.pas
+++ b/windows/src/global/delphi/general/KeymanVersion.pas
@@ -30,6 +30,7 @@ const
   TIER_STABLE = 'stable';
 
 const
+  SKeymanVersion150 = '15.0';
   SKeymanVersion140 = '14.0';
   SKeymanVersion130 = '13.0';
   SKeymanVersion120 = '12.0';
@@ -60,6 +61,9 @@ const
   // via filename or parameter), then this option will only be applied if
   // the installed Keyman version is this version or later.
   SKeymanVersion_Min_SpecifyLanguage = '14.0.104';
+
+  // U_1234_5678 identifiers require 15.0+ on iOS and Android #5894
+  SKeymanVersion_Min_MulticharUIdentifiers = SKeymanVersion150;
 
 const
   SKeymanDeveloperName = 'Keyman Developer';

--- a/windows/src/global/delphi/general/kmxfile.pas
+++ b/windows/src/global/delphi/general/kmxfile.pas
@@ -1,18 +1,18 @@
 (*
   Name:             kmxfile
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    4 Nov 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Fix packing of TKeyboardFileKey
                     23 Aug 2006 - mcdurdin - Add TSS_VISUALKEYBOARD, TSS_KMW_RTL, TSS_KMWHELPFILE, TSS_KMW_HELPTEXT, TSS_KMWEMBEDJS
                     23 Aug 2006 - mcdurdin - Add TSS_MNEMONIC, TSS_INCLUDECODES, TSS_OLDCHARPOSMATCHING, TSS_KEYMANCOPYRIGHT
@@ -82,6 +82,7 @@ type
     ISO6393Languages: WideString;
     KeyboardVersion: WideString;   // I4136
     Targets: WideString;
+    function FileVersionAsString: string;
   end;
 
   PKeyboardInfo = ^TKeyboardInfo;
@@ -297,7 +298,7 @@ begin
 
       if (ki.KeyboardID <> 0) and (Pos('x'+IntToHex(ki.KeyboardID, 4), string(ki.WindowsLanguages)) = 0) then
         ki.WindowsLanguages := Trim('x'+IntToHex(ki.KeyboardID, 4) + ' ' + ki.WindowsLanguages);
-      
+
       ki.Icon := nil;
       ki.Bitmap := nil;
       if FReturnBitmap then
@@ -467,6 +468,13 @@ begin
       AddLanguage(FLanguageID);
     end;
   end;
+end;
+
+{ TKeyboardInfo }
+
+function TKeyboardInfo.FileVersionAsString: string;
+begin
+  Result := Format('%d.%d', [(FileVersion and VERSION_MASK_MAJOR) shr 8, FileVersion and VERSION_MASK_MINOR]);
 end;
 
 end.

--- a/windows/src/global/delphi/keyboards/Keyman.System.KeyboardJSInfo.pas
+++ b/windows/src/global/delphi/keyboards/Keyman.System.KeyboardJSInfo.pas
@@ -13,6 +13,7 @@ type
     FName: string;
     FMnemonic: Boolean;
     FRTL: Boolean;
+    FMinKeymanVersion: string;
 
     procedure Parse(data: string);
   public
@@ -22,6 +23,7 @@ type
     property Name: string read FName;
     property Version: string read FVersion;
     property RTL: Boolean read FRTL;
+    property MinKeymanVersion: string read FMinKeymanVersion;
     property Mnemonic: Boolean read FMnemonic;
   end;
 
@@ -29,7 +31,8 @@ implementation
 
 uses
   System.RegularExpressions,
-  Keyman.System.RegExGroupHelperRSP19902;
+  Keyman.System.RegExGroupHelperRSP19902,
+  KeymanVersion;
 
 { TKeyboardJSInfo }
 
@@ -88,6 +91,12 @@ begin
   if m.Success
     then FVersion := TGroupHelperRSP19902.Create(m.Groups[2], data).FixedValue
     else FVersion := '';
+
+  // Extract keyboard version - see also MergeKeyboardInfo.pas
+  m := TRegEx.Match(data, 'this.KMINVER\s*=\s*([''"])(.*?)\1');
+  if m.Success
+    then FMinKeymanVersion := TGroupHelperRSP19902.Create(m.Groups[2], data).FixedValue
+    else FMinKeymanVersion := SKeymanVersion70;
 
   // Extract RTL status
   m := TRegEx.Match(data, 'this.KRTL\s*=\s*(.*?)\s*;');

--- a/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/windows/src/global/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -28,7 +28,7 @@ type
     function IsModelFileByName(f: TPackageContentFile): Boolean;
   public
     type TPackageKeyboardInfo = record
-      Name, ID, Version: string;
+      Name, ID, Version, MinKeymanVersion: string;
       RTL: Boolean;
     end;
 
@@ -123,6 +123,7 @@ begin
         k.Name := pki.Name;
         k.ID := pki.ID;
         k.Version := pki.Version;
+        k.MinKeymanVersion := pki.MinKeymanVersion;
         if IsKeyboardFileByName(pack.Files[i]) = ftJavascript then
           // RTL flag is currently only relevant for KMW so although the
           // information can be read from .kmx we only copy it over for
@@ -333,6 +334,7 @@ begin
       GetKeyboardInfo(f.FileName, False, ki, False);
       pki.Name := ki.KeyboardName;
       pki.Version := ki.KeyboardVersion;
+      pki.MinKeymanVersion := ki.FileVersionAsString;
       pki.RTL := ki.KMW_RTL;
     except
       on E:EKMXError do Result := False;
@@ -347,6 +349,7 @@ begin
         pki.Name := Name;
         pki.Version := Version;
         pki.RTL := RTL;
+        pki.MinKeymanVersion := MinKeymanVersion;
       finally
         Free;
       end;

--- a/windows/src/test/unit-tests/keyboard-js-info/KeyboardJSInfoTestSuite.dpr
+++ b/windows/src/test/unit-tests/keyboard-js-info/KeyboardJSInfoTestSuite.dpr
@@ -14,7 +14,8 @@ uses
   Keyman.Test.System.KeyboardJSInfoTest in 'Keyman.Test.System.KeyboardJSInfoTest.pas',
   Keyman.System.KeyboardJSInfo in '..\..\..\global\delphi\keyboards\Keyman.System.KeyboardJSInfo.pas',
   Keyman.System.RegExGroupHelperRSP19902 in '..\..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas',
-  DUnitX.Loggers.TeamCity in '..\..\..\global\delphi\general\DUnitX.Loggers.TeamCity.pas';
+  DUnitX.Loggers.TeamCity in '..\..\..\global\delphi\general\DUnitX.Loggers.TeamCity.pas',
+  KeymanVersion in '..\..\..\global\delphi\general\KeymanVersion.pas';
 
 var
   runner : ITestRunner;

--- a/windows/src/test/unit-tests/keyboard-js-info/KeyboardJSInfoTestSuite.dproj
+++ b/windows/src/test/unit-tests/keyboard-js-info/KeyboardJSInfoTestSuite.dproj
@@ -95,6 +95,7 @@
         <DCCReference Include="..\..\..\global\delphi\keyboards\Keyman.System.KeyboardJSInfo.pas"/>
         <DCCReference Include="..\..\..\global\delphi\general\Keyman.System.RegExGroupHelperRSP19902.pas"/>
         <DCCReference Include="..\..\..\global\delphi\general\DUnitX.Loggers.TeamCity.pas"/>
+        <DCCReference Include="..\..\..\global\delphi\general\KeymanVersion.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -146,7 +147,7 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Win32\Debug\KeyboardJSInfoTestSuite.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Debug\KeyboardJSInfoTestSuite.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>KeyboardJSInfoTestSuite.exe</RemoteName>
                         <Overwrite>true</Overwrite>


### PR DESCRIPTION
Fixes #5992.

Updates package fileVersion property to be minimum keyboard version, to avoid issues with app crashing if functionality is not supported.

As far as I can tell, only Keyman for Windows currently checks the package fileVersion.

This could be quite nasty, except that the online keyboard repository build process also extracts the min Keyman version from the keyboard .kmx and .js, and records it in the .keyboard_info, preventing older versions of Keyman from seeing unsupported keyboards in the cloud repository.

Thus, the only gap is for peer distributed keyboards. So we should fix this gap but it is less urgent than it might otherwise be.

# User Testing 

## SUITE_COMPILER: Test build of package

**TEST_KMX:** Validate that the package compiler sets the right FileVersion from .kmx.

1. Create a keyboard, set `store(&version) "15.0"`, compile it and include only the resulting keyboard .kmx in a package. Compile the package.
2. Rename the resulting .kmp to a .zip, and look at the kmp.json file in it. It should have, among other content:

   ```json
   "system": {
     "fileVersion": "15.0"
   },
   ```

3. Look at the .kmp.inf file inside the same .kmp. It should have, among other content:

   ```
   [Package]
   Version=15.0
   ```
   
**TEST_JS:** Validate that the package compiler sets the right FileVersion from .js.

1. Create a keyboard, set `store(&version) "15.0"`, compile it and include only the resulting keyboard .js in a package. Compile the package.
2. Rename the resulting .kmp to a .zip, and look at the kmp.json file in it. It should have, among other content:

   ```json
   "system": {
     ...
     "fileVersion": "15.0"
   },
   ```

3. Look at the .kmp.inf file inside the same .kmp. It should have, among other content:

   ```
   [Package]
   Version=15.0
   ```

## SUITE_APPS: Test installation of package

I am expecting four out of five of these tests to fail. Do not be concerned :grin:

Take the package you created in SUITE_COMPILER, but add both the .js and the .kmx to it and rebuild it. Attempt to install it on each platform:

**TEST_KEYMAN_ANDROID:** Install the package on Keyman 14. It should not install (but probably will...)

**TEST_KEYMAN_IOS:** Install the package on Keyman 14. It should not install (but probably will...)

**TEST_KEYMAN_LINUX:** Install the package on Keyman 14. It should not install (but probably will...)

**TEST_KEYMAN_MAC:** Install the package on Keyman 14. It should not install (but probably will...)

**TEST_KEYMAN_WINDOWS:** Install the package on Keyman 14. It should not install.
