### PR TITLE
fix(developer): prevent crash on build dblclicked file

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmKeymanWizard
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    23 Feb 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     01 Aug 2006 - mcdurdin - Rework for Keyman 7 part 1
                     02 Aug 2006 - mcdurdin - Rework menus as sp-TBX
@@ -752,7 +752,10 @@ begin
   cmdEditFeature.Enabled := gridFeatures.RowCount > 1;   // I4587   // I4427
   cmdRemoveFeature.Enabled := gridFeatures.RowCount > 1;   // I4587   // I4427
 
-  cmdOpenProjectFolder.Enabled := Assigned(ProjectFile.Project);
+  // Prevent side-effect creation of FStandaloneProjectFile, e.g. in FormCreate #6149
+  if not Assigned(FStandaloneProjectFile) or not Assigned(FProjectFile)
+    then cmdOpenProjectFolder.Enabled := False
+    else cmdOpenProjectFolder.Enabled := Assigned(ProjectFile.Project);
 end;
 
 procedure TfrmKeymanWizard.FocusTab;


### PR DESCRIPTION
Fixes #6149.

# User Testing

**TEST_CLICK:** Verify that the crash from #6149 is resolved.

1. Start Keyman Developer. Select Project/Close Project, and exit Keyman Developer.
2. Start Keyman Developer by double-clicking on a .kmn file.
3. Go to the Build tab, select Test Keyman on web.