### PR TITLE
feat(windows): handle key output in testhost

### DIFF
--- a/windows/src/engine/keyman32/KEYMAN32.DEF
+++ b/windows/src/engine/keyman32/KEYMAN32.DEF
@@ -44,3 +44,5 @@ EXPORTS
       Keyman_UnregisterMasterController
 			Keyman_RegisterControllerThread
 			Keyman_UnregisterControllerThread
+
+      SetCustomPostKeyCallback

--- a/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
+++ b/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
@@ -191,9 +191,14 @@ BOOL AIWin2000Unicode::PostKeys()
 		return TRUE;
 	}
 
+  if (_td->CustomPostKeyCallback != nullptr) {
+    BOOL res = _td->CustomPostKeyCallback(Queue, QueueSize);
+    QueueSize = 0;
+    return res;
+  }
+
   int n = 0;
 	/* 6.0.153.0: Fix repeat state for virtual keys */
-
 
   LPINPUT pInputs = new INPUT[QueueSize*100]; // TODO: Tidy this up. Horrid doing a junky alloc like this each event
   int i = 0;

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -188,6 +188,8 @@ typedef struct tagKEYMANHKLPAIR
 
 #define MAXCACHEDKEYBOARDLAYOUTS 128
 
+typedef BOOL (WINAPI *CUSTOMPOSTKEYCALLBACKPROC)(APPACTIONQUEUEITEM* Queue, int QueueSize);
+
 typedef struct tagKEYMAN64THREADDATA
 {
   LPINTKEYBOARDINFO lpKeyboards;			// keyboard definitions
@@ -252,6 +254,10 @@ typedef struct tagKEYMAN64THREADDATA
   ISerialKeyEventClient *pSerialKeyEventClient;
   ISharedBufferManager *pSharedBufferManager;
 
+  /* Test host integration */
+
+  CUSTOMPOSTKEYCALLBACKPROC CustomPostKeyCallback;
+
 } KEYMAN64THREADDATA, *PKEYMAN64THREADDATA;
 
 extern UINT
@@ -292,5 +298,9 @@ BOOL Globals_ProcessInitialised();
 /* Debug flags */
 
 BOOL Reg_GetDebugFlag(LPSTR pszFlagRegistrySetting, BOOL bDefault);
+
+/* Test Host integration */
+
+void WINAPI SetCustomPostKeyCallback(CUSTOMPOSTKEYCALLBACKPROC proc);
 
 #endif

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -711,3 +711,9 @@ void Globals::LoadDebugSettings() {
     f_debug_ToConsole = FALSE;   // I3951
   }
 }
+
+void WINAPI SetCustomPostKeyCallback(CUSTOMPOSTKEYCALLBACKPROC proc) {
+  PKEYMAN64THREADDATA _td = ThreadGlobals();
+  if (!_td) return;
+  _td->CustomPostKeyCallback = proc;
+}

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -58,9 +58,6 @@ void LoadSharedKeyboardOptions(LPINTKEYBOARDINFO kp)
 
 void FreeKeyboardOptions(LPINTKEYBOARDINFO kp)
 {
-  if (!DebugAssert(!Globals::get_CoreIntegration(), "FreeKeyboardOptions: Error called in core integration mode")) {
-    return;
-  }
   // This is a cleanup routine; we don't want to precondition all calls to it
   // so we do not assert
   if (kp == NULL || kp->Keyboard == NULL || kp->KeyboardOptions == NULL)


### PR DESCRIPTION
In order to avoid the test host interfering too badly with the debugger, we will bypass SendInput and instead post all input to the local edit window. This can result in out-of-sequence input for rapid typing, but for a test host this is not important -- it's better that the input doesn't end up in the debugger window due to focus changes!

@keymanapp-test-bot skip