### PR TITLE
fix(linux): Don't crash when installing keyboards in Wasta

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -16,7 +16,7 @@ class GnomeKeyboardsUtil():
 
     def write_input_sources(self, sources):
         logging.debug('Setting sources to: %s', sources)
-        self.input_sources.set('sources', sources)
+        self.input_sources.set('sources', sources, 'a(ss)')
 
 
 __is_gnome_shell = None

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -20,7 +20,7 @@ class IbusUtil():
         return self.ibus_settings.get('preload-engines')
 
     def write_preload_engines(self, bus, preload_engines):
-        self.ibus_settings.set('preload-engines', preload_engines)
+        self.ibus_settings.set('preload-engines', preload_engines, 'as')
         if bus:
             bus.preload_engines(preload_engines)
 

--- a/linux/keyman-config/tests/test_gsettings.py
+++ b/linux/keyman-config/tests/test_gsettings.py
@@ -10,34 +10,67 @@ class GSettingsTests(unittest.TestCase):
         self.MockSettingsClass = patcher.start()
         self.addCleanup(patcher.stop)
 
-    def test_ConvertArrayToVariantToArray_Empty(self):
+    def test_ConvertArrayToVariantToArray_Empty_Gnome(self):
         # Setup
         children = []
         sut = GSettings('org.gnome.desktop.input-sources')
         # Execute
-        variant = sut._convert_array_to_variant(children)
+        variant = sut._convert_array_to_variant(children, 'a(ss)')
         array = sut._convert_variant_to_array(variant)
 
         # Verify
         self.assertEqual(array, children)
 
-    def test_ConvertArrayToVariantToArray_OneElement(self):
+    def test_ConvertArrayToVariantToArray_OneElement_Gnome(self):
         # Setup
         children = [('t1', 'id1')]
         sut = GSettings('org.gnome.desktop.input-sources')
         # Execute
-        variant = sut._convert_array_to_variant(children)
+        variant = sut._convert_array_to_variant(children, 'a(ss)')
         array = sut._convert_variant_to_array(variant)
 
         # Verify
         self.assertEqual(array, children)
 
-    def test_ConvertArrayToVariantToArray_MultipleElements(self):
+    def test_ConvertArrayToVariantToArray_MultipleElements_Gnome(self):
         # Setup
         children = [('t1', 'id1'), ('t2', 'id2')]
         sut = GSettings('org.gnome.desktop.input-sources')
         # Execute
-        variant = sut._convert_array_to_variant(children)
+        variant = sut._convert_array_to_variant(children, 'a(ss)')
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_Empty_Ibus(self):
+        # Setup
+        children = []
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children, 'as')
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_OneElement_Ibus(self):
+        # Setup
+        children = ['t1']
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children, 'as')
+        array = sut._convert_variant_to_array(variant)
+
+        # Verify
+        self.assertEqual(array, children)
+
+    def test_ConvertArrayToVariantToArray_MultipleElements_Ibus(self):
+        # Setup
+        children = ['t1', 'id1', 't2', 'id2']
+        sut = GSettings('org.gnome.desktop.input-sources')
+        # Execute
+        variant = sut._convert_array_to_variant(children, 'as')
         array = sut._convert_variant_to_array(variant)
 
         # Verify
@@ -57,13 +90,25 @@ class GSettingsTests(unittest.TestCase):
         self.assertEqual(result, keyboards)
 
     @patch.object(GSettings, '_convert_array_to_variant')
-    def test_GSettings_set(self, convertArrayToVariantMethod):
+    def test_GSettings_set_gnome(self, convertArrayToVariantMethod):
         # Setup
-        convertArrayToVariantMethod.side_effect = lambda value: value
+        convertArrayToVariantMethod.side_effect = lambda value, type: value
         sut = GSettings('org.gnome.desktop.input-sources')
         keyboards = [('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
         # Execute
-        sut.set('sources', keyboards)
+        sut.set('sources', keyboards, 'a(ss)')
+        # Verify
+        self.MockSettingsClass.return_value.set_value.assert_called_once_with(
+            'sources', keyboards)
+
+    @patch.object(GSettings, '_convert_array_to_variant')
+    def test_GSettings_set_ibus(self, convertArrayToVariantMethod):
+        # Setup
+        convertArrayToVariantMethod.side_effect = lambda value, type: value
+        sut = GSettings('org.freedesktop.ibus.general')
+        keyboards = ['xkb:us::eng', 'de:fooDir/foo1.kmx', 'fr:fooDir/foo2.kmx']
+        # Execute
+        sut.set('sources', keyboards, 'as')
         # Verify
         self.MockSettingsClass.return_value.set_value.assert_called_once_with(
             'sources', keyboards)

--- a/linux/keyman-config/tests/test_ibus_util.py
+++ b/linux/keyman-config/tests/test_ibus_util.py
@@ -50,7 +50,7 @@ class IbusUtilTests(unittest.TestCase):
         install_to_ibus(mock_ibusBusInstance, 'k3')
         # Verify
         mock_settingsSet.assert_called_once_with(
-            "preload-engines", ['k1', 'k2', 'k3'])
+            "preload-engines", ['k1', 'k2', 'k3'], 'as')
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3'])
 
@@ -66,7 +66,7 @@ class IbusUtilTests(unittest.TestCase):
         install_to_ibus(mock_ibusBusInstance, 'k4')
         # Verify
         mock_settingsSet.assert_called_once_with(
-            "preload-engines", ['k1', 'k2', 'k3', 'k4'])
+            "preload-engines", ['k1', 'k2', 'k3', 'k4'], 'as')
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3', 'k4'])
 
@@ -82,7 +82,7 @@ class IbusUtilTests(unittest.TestCase):
         uninstall_from_ibus(mock_ibusBusInstance, 'k2')
         # Verify
         mock_settingsSet.assert_called_once_with(
-            "preload-engines", ['k1', 'k3'])
+            "preload-engines", ['k1', 'k3'], 'as')
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k3'])
 
@@ -98,7 +98,7 @@ class IbusUtilTests(unittest.TestCase):
         uninstall_from_ibus(mock_ibusBusInstance, 'k4')
         # Verify
         mock_settingsSet.assert_called_once_with(
-            "preload-engines", ['k1', 'k2', 'k3'])
+            "preload-engines", ['k1', 'k2', 'k3'], 'as')
         mock_ibusBusInstance.preload_engines.assert_called_once_with(
             ['k1', 'k2', 'k3'])
 


### PR DESCRIPTION
Fixes #6158.

(this got introduced in #6015).

# User Testing

- **GROUP_IMPISH:** Ubuntu 21.10 Impish with Gnome shell and X11
- **GROUP_WASTA:** Wasta 20.04

**TEST_ADD_KEYBOARD**: install a Keyman keyboard

- install a Keyman keyboard in km-config
- verify that the new Keyboard shows up in the keyboard dropdown
