### PR TITLE
chore(oem/firstvoices): Add fv_haisla keyboard

### DIFF
--- a/oem/firstvoices/keyboards.csv
+++ b/oem/firstvoices/keyboards.csv
@@ -12,6 +12,7 @@ fv,fv_dexwlesucid,Dəxʷləšucid,BC Coast,fv_dexwlesucid_kmw-9.0.js
 fv,fv_diitiidatx,Diidiitidq,BC Coast,fv_diitiidatx_kmw-9.0.js
 fv,fv_gitsenimx,Gitsenimx̱,BC Coast,fv_gitsenimx_kmw-9.0.js
 fv,fv_hailzaqvla,Haiɫzaqvla,BC Coast,fv_hailzaqvla_kmw-9.0.js
+fv,fv_haisla,Haisla,BC Coast,fv_haisla,fv_haisla.js
 fv,fv_halqemeylem,Halq'eméylem,BC Coast,fv_halqemeylem_kmw-9.0.js
 fv,fv_henqeminem,Hǝn̓q̓ǝmin̓ǝm,BC Coast,fv_henqeminem_kmw-9.0.js
 fv,fv_klahoose,Homalco-Klahoose-Sliammon,BC Coast,fv_klahoose_kmw-9.0.js


### PR DESCRIPTION
The OEM FirstVoices apps use keyboards.csv to map the FirstVoices keyboards with their Regions.
The keyboard package fv_all.kmp includes fv_haisla, but keyboards.csv needs an entry added in order for the Haisla keyboard to appear in the Regions list.

Note, the fv_haisla keyboard doesn't have a legacy 9.0 KeymanWeb keyboard (-9.0.js), so I'm just using fv_haisla.js for the entry. The actual value isn't used in 15.0.

## User Testing

* **TEST_ANDROID**
1. Load the Android FirstVoices app
2. In "Setup" go to "BC Coast" region
3. Verify "Haisla" is an available keyboard and select it
![BC Coast](https://user-images.githubusercontent.com/7358010/151749298-a9a55b90-26ee-46ad-83bb-16330f1c3f22.png)
4. Continue the FV Setup as a System keyboard
5. Launch a separate app (e.g. Chrome) and select a text area to type
6. Select FirstVoices as the system keyboard
7. Verify Haisla keyboard is available to use
![haisla osk](https://user-images.githubusercontent.com/7358010/151749323-f82cefab-0095-4ab5-b69b-2daa0331d6ad.png)

* **TEST_IOS**
1. Load the iOS FirstVoices app
2. Do the corresponding steps as Android 
3. Verify "Haisla" is an available keyboard and select it
4. Continue the FV Setup as a System keyboard
5. Launch a separate app and select a text area to type
6. Select FirstVoices as the system keyboard
7. Verify Haisla keyboard is available to use

Tagging @madebybridget