### PR TITLE
chore(common/core/desktop): Improve meson build file 🏗️

### DIFF
--- a/common/core/desktop/build.bat
+++ b/common/core/desktop/build.bat
@@ -103,8 +103,9 @@ rem ----------------------------------
 
 rem Standalone build, so we'll make the environment available to the caller
 rem Also setup
+rem Note: Visual Studio 2022 doesn't provide vcvarsall.bat, so we'll have to find a different solution
 endlocal
-for /f "usebackq tokens=*" %%i in (`..\..\..\resources\build\vswhere -latest -requires Microsoft.Component.MSBuild -find **\vcvarsall.bat`) do (
+for /f "usebackq tokens=*" %%i in (`..\..\..\resources\build\vswhere -version [15^,17^) -latest -requires Microsoft.Component.MSBuild -find **\vcvarsall.bat`) do (
   set VCVARSALL="%%i"
 )
 %VCVARSALL% %1

--- a/common/core/desktop/meson.build
+++ b/common/core/desktop/meson.build
@@ -1,4 +1,4 @@
-# Copyright:    © 2018-2020 SIL International.
+# Copyright:    © 2018-2022 SIL International.
 # Description:  Cross platform build script to compile libkmnkbp, documentation
 #               and tests.
 # Create Date:  2 Oct 2018
@@ -10,19 +10,27 @@ project('keyboardprocessor', 'cpp', 'c',
         license: 'MIT',
         default_options : ['buildtype=release',
                            'cpp_std=c++14',
-                           'b_vscrt=static_from_buildtype'])
+                           'b_vscrt=static_from_buildtype',
+                           'warning_level=2'],
+        meson_version: '>=0.45.0')
 
-message('meson.project_version(): ' + meson.project_version() + '\n')
 compiler = meson.get_compiler('cpp')
 
 lib_version = '0.0.0'
 
+if meson.version().version_compare('>=0.46')
+  py = import('python')
+  python = py.find_installation()
+else
+  py = import('python3')
+  python = py.find_python()
+endif
+
+# Once we can assume meson 0.60 we can delete this
+# (https://mesonbuild.com/Release-notes-for-0-60-0.html#msvc-compiler-now-assumes-utf8-source-code-by-default)
 if compiler.get_id() == 'msvc'
   add_global_arguments('/source-charset:utf-8', language: ['c', 'cpp'])
 endif
-
-py = import('python3')
-python = py.find_python()
 
 message('host_machine.system(): ' + host_machine.system())
 message('compiler.get_id(): ' + compiler.get_id())

--- a/common/core/desktop/src/debug.hpp
+++ b/common/core/desktop/src/debug.hpp
@@ -47,13 +47,13 @@ void debug_items::assert_push_entry() {
 inline
 void debug_items::push_begin(km_kbp_state_debug_key_info *key_info, uint32_t flags) {
   assert_push_entry();
-  emplace_back(km_kbp_state_debug_item{ KM_KBP_DEBUG_BEGIN, flags, {*key_info, } });
+  emplace_back(km_kbp_state_debug_item{ KM_KBP_DEBUG_BEGIN, flags, {*key_info, }, { }});
 }
 
 inline
 void debug_items::push_end(uint16_t first_action, uint32_t flags) {
   assert_push_entry();
-  emplace_back(km_kbp_state_debug_item{ KM_KBP_DEBUG_END, flags, { }, { u"", nullptr, nullptr, { }, first_action } });
+  emplace_back(km_kbp_state_debug_item{ KM_KBP_DEBUG_END, flags, { }, { u"", nullptr, nullptr, { }, first_action, {} } });
 }
 
 inline

--- a/common/core/desktop/src/kmx/kmx_context.cpp
+++ b/common/core/desktop/src/kmx/kmx_context.cpp
@@ -21,8 +21,8 @@ void KMX_Context::Add(KMX_WCHAR ch)
   if(pos == MAXCONTEXT - 1)
   {
     auto p = incxstr(CurContext);
-    auto n = p - CurContext;
-    memmove(CurContext, p, (MAXCONTEXT - n) * 2);
+    auto n = (int)(p - CurContext);
+    memmove(CurContext, p, (MAXCONTEXT - n) * sizeof(KMX_WCHAR));
     pos -= n;
   }
 

--- a/common/core/desktop/src/kmx/kmx_file.cpp
+++ b/common/core/desktop/src/kmx/kmx_file.cpp
@@ -83,14 +83,14 @@ const unsigned long CRCTable[256] = {
   0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
   0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
   0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
-}; 
+};
 /*
  * This routine calculates the CRC for a block of data using the
  * table lookup method. It accepts an original value for the crc,
  * and returns the updated value.
  */
 
-static unsigned long CalculateBufferCRC(unsigned long count, KMX_BYTE *p)
+static unsigned long CalculateBufferCRC(size_t count, KMX_BYTE *p)
 {
   unsigned long temp1;
   unsigned long temp2;

--- a/common/core/desktop/src/kmx/kmx_processevent.h
+++ b/common/core/desktop/src/kmx/kmx_processevent.h
@@ -43,7 +43,7 @@ private:
 
   kmx::KMX_DebugItems *m_debug_items;
 
-  INTKEYBOARDINFO m_keyboard = { 0 };
+  INTKEYBOARDINFO m_keyboard = { 0, {}, {}, {} };
   KMX_DWORD m_modifiers = 0;
 
   /* File loading */

--- a/common/core/desktop/src/kmx/kmx_xstring.h
+++ b/common/core/desktop/src/kmx/kmx_xstring.h
@@ -12,8 +12,8 @@ namespace kmx {
 
 #define Uni_SurrogateToUTF32(ch, cl) (((ch) - 0xD800) * 0x400 + ((cl) - 0xDC00) + 0x10000)
 
-#define Uni_UTF32ToSurrogate1(ch) (((ch) - 0x10000) / 0x400 + 0xD800)
-#define Uni_UTF32ToSurrogate2(ch) (((ch) - 0x10000) % 0x400 + 0xDC00)
+#define Uni_UTF32ToSurrogate1(ch) (char16_t)(((ch) - 0x10000) / 0x400 + 0xD800)
+#define Uni_UTF32ToSurrogate2(ch) (char16_t)(((ch) - 0x10000) % 0x400 + 0xDC00)
 
 PKMX_WCHAR incxstr(PKMX_WCHAR p);
 PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart);

--- a/common/core/desktop/src/meson.build
+++ b/common/core/desktop/src/meson.build
@@ -1,4 +1,4 @@
-# Copyright:    © 2018 SIL International.
+# Copyright:    © 2018-2022 SIL International.
 # Description:  Cross platform build script to compile libkmnkbp.
 # Create Date:  2 Oct 2018
 # Authors:      Tim Eves (TSE)
@@ -9,11 +9,9 @@ version_res = []
 
 if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
   warns = [
-     '-Wall',
      '-Wctor-dtor-privacy',
      '-Wdouble-promotion',
      '-Wendif-labels',
-     '-Wextra',
      '-Wno-unknown-pragmas',
      '-Wno-missing-field-initializers',
      '-Wnon-virtual-dtor',

--- a/common/core/desktop/src/state.hpp
+++ b/common/core/desktop/src/state.hpp
@@ -84,7 +84,7 @@ void actions::push_alert() {
 inline
 void actions::push_backspace(km_kbp_backspace_type expected_type, uintptr_t expected_value) {
   assert(empty() || (!empty() && back().type != KM_KBP_IT_END));
-  km_kbp_action_item item = {KM_KBP_IT_BACK};
+  km_kbp_action_item item = {KM_KBP_IT_BACK, {}, {}};
   item.backspace.expected_type = expected_type;
   item.backspace.expected_value = expected_value;
   emplace_back(item);

--- a/common/core/desktop/src/utfcodec.hpp
+++ b/common/core/desktop/src/utfcodec.hpp
@@ -217,7 +217,8 @@ public:
 
     _utf_iterator   & operator ++ ()    { cp += abs(sl); return *this; }
 
-    bool operator == (const _utf_iterator & rhs) const throw() { sz = std::min(ptrdiff_t(rhs.cp - cp),ptrdiff_t(127)); return 0 >= sz; }
+    bool operator == (const _utf_iterator & rhs) const throw() { sz = (int8_t)std::min(ptrdiff_t(rhs.cp - cp),ptrdiff_t(127)); return 0 >= sz;
+    }
     bool operator != (const _utf_iterator & rhs) const throw() { return !operator==(rhs); }
 
     reference   operator * () const throw() { return *this; }

--- a/common/core/desktop/tests/unit/kmnkbd/action_items.hpp
+++ b/common/core/desktop/tests/unit/kmnkbd/action_items.hpp
@@ -89,7 +89,7 @@ bool action_items(
   auto act = km_kbp_state_action_items(state, &n);
 
   for (auto &rhs: expected) {
-    if(--n < 0) {
+    if ((int)--n < 0) {
       std::cout << "expected longer than actual" << std::endl;
       print_action_item("next expected item:", rhs);
       return false;

--- a/common/core/desktop/tests/unit/kmnkbd/debug_api.cpp
+++ b/common/core/desktop/tests/unit/kmnkbd/debug_api.cpp
@@ -61,7 +61,7 @@ void setup(const char *keyboard) {
 
   // Ensure the pre-run debug item state is not empty
   assert(debug_items(test_state, {
-    km_kbp_state_debug_item{KM_KBP_DEBUG_END}
+    km_kbp_state_debug_item{KM_KBP_DEBUG_END, {}, {}, {}}
   }));
 
   try_status(km_kbp_context_set(km_kbp_state_context(test_state), citems));

--- a/common/core/desktop/tests/unit/kmnkbd/debug_items.hpp
+++ b/common/core/desktop/tests/unit/kmnkbd/debug_items.hpp
@@ -171,7 +171,7 @@ bool debug_items(
   auto act = km_kbp_state_debug_items(state, &n);
 
   for (auto &rhs: expected) {
-    if(--n < 0) {
+    if ((int)--n < 0) {
       std::cout << "expected longer than actual" << std::endl;
       print_debug_item("next expected item:", rhs);
       return false;

--- a/common/core/desktop/tests/unit/kmnkbd/meson.build
+++ b/common/core/desktop/tests/unit/kmnkbd/meson.build
@@ -4,6 +4,15 @@
 # Authors:      Tim Eves (TSE)
 #
 
+if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
+  warns = [
+     '-Wno-missing-field-initializers',
+     '-Wno-unused-parameter'
+  ]
+else
+  warns = []
+endif
+
 defns=['-DKMN_KBP_STATIC']
 tests = [
   ['context-api', 'context_api.cpp'],
@@ -17,7 +26,7 @@ tests = [
 
 foreach t : tests
   bin = executable(t[0], t[1],
-    cpp_args: defns,
+    cpp_args: defns + warns,
     include_directories: [inc, libsrc],
     link_args: links,
     objects: lib.extract_all_objects())

--- a/common/core/desktop/tests/unit/kmnkbd/state_api.cpp
+++ b/common/core/desktop/tests/unit/kmnkbd/state_api.cpp
@@ -17,6 +17,18 @@
 
 #include "../test_assert.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#define PRAGMA(X)                   _Pragma(#X)
+#define DISABLE_WARNING_PUSH        PRAGMA(GCC diagnostic push)
+#define DISABLE_WARNING_POP         PRAGMA(GCC diagnostic pop)
+#define DISABLE_WARNING(W)          PRAGMA(GCC diagnostic ignored #W)
+#define DISABLE_WARNING_TYPE_LIMITS DISABLE_WARNING(-Wtype-limits)
+#else
+#define DISABLE_WARNING_PUSH
+#define DISABLE_WARNING_POP
+#define DISABLE_WARNING_TYPE_LIMITS
+#endif
+
 namespace
 {
   std::string get_json_doc(km_kbp_state const& state)
@@ -134,10 +146,14 @@ int main(int argc, char * argv[])
 
   // Test the engine
   auto attrs = km_kbp_get_engine_attrs(test_state);
+
+  DISABLE_WARNING_PUSH
+  DISABLE_WARNING_TYPE_LIMITS
   // Check the lib supplies our required interface.
   if (attrs->current - attrs->age > KM_KBP_LIB_CURRENT
       || attrs->current < KM_KBP_LIB_CURRENT) return __LINE__;
   if (attrs->max_context < 16) return __LINE__;
+  DISABLE_WARNING_POP
 
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,
                                   KM_KBP_MODIFIER_SHIFT, 1));

--- a/common/core/desktop/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/common/core/desktop/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -20,7 +20,7 @@ using namespace std;
 #define U_1F609_WINKING_FACE u"\U0001F609"
 
 PKMX_WCHAR find_ptr_to_last_character(PKMX_WCHAR p_first) {
-  int length = std::u16string(p_first).length();
+  auto length = std::u16string(p_first).length();
   if (length > 0)
     return p_first + length - 1;
   else

--- a/common/core/desktop/tests/unit/kmx/kmx.cpp
+++ b/common/core/desktop/tests/unit/kmx/kmx.cpp
@@ -82,7 +82,7 @@ apply_action(
       text_store.push_back(Uni_UTF32ToSurrogate1(act.character));
       text_store.push_back(Uni_UTF32ToSurrogate2(act.character));
     } else {
-      text_store.push_back(act.character);
+      text_store.push_back((char16_t)act.character);
     }
     // std::cout << "char(" << act.character << ") size=" << cp->size() << std::endl;
     break;

--- a/common/core/desktop/tests/unit/kmx/kmx_test_source.cpp
+++ b/common/core/desktop/tests/unit/kmx/kmx_test_source.cpp
@@ -208,7 +208,7 @@ KmxTestSource::get_keyboard_options(kmx_options options) {
 
 key_event
 KmxTestSource::char_to_event(char ch) {
-  assert(ch >= 32 && ch <= 127);
+  assert(ch >= 32);
   return {
       km::kbp::kmx::s_char_to_vkey[(int)ch - 32].vk,
       (uint16_t)(km::kbp::kmx::s_char_to_vkey[(int)ch - 32].shifted ? KM_KBP_MODIFIER_SHIFT : 0)};

--- a/common/core/desktop/tests/unit/kmx/meson.build
+++ b/common/core/desktop/tests/unit/kmx/meson.build
@@ -5,6 +5,16 @@
 # History:      19  Oct 2018 - TSE - Added test for context API functions.
 #
 
+if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
+  warns = [
+     '-Wno-missing-field-initializers',
+     '-Wno-unused-parameter'
+  ]
+else
+  warns = []
+endif
+
+
 if compiler.get_id() == 'emscripten'
   tests_flags = ['--embed-file', join_paths(meson.current_source_dir(),'@/')]
   source_path = '/'
@@ -18,7 +28,7 @@ endif
 kmx = executable('kmx',
     'kmx.cpp',
     'kmx_test_source.cpp',
-    cpp_args: defns,
+    cpp_args: defns + warns,
     include_directories: [inc, libsrc],
     link_args: links + tests_flags,
     objects: lib.extract_all_objects())
@@ -205,7 +215,8 @@ endif
 # test for km_kbp_keyboard_get_key_list
 
 key_e = executable('key_list', 'kmx_key_list.cpp',
-                cpp_args: defns,include_directories: [inc, libsrc],
+                cpp_args: defns + warns,
+                include_directories: [inc, libsrc],
                 link_args: links,
                 objects: lib.extract_all_objects())
 test_kbd = 'kmx_key_list'
@@ -217,7 +228,7 @@ if kmcomp.found()
     input: kbd_src,
     command: kmcomp_cmd + ['-s', '-d', '@INPUT@', kbd_obj, '@OUTPUT@']
   )
-    test('key_list', key_e,  depends: kbd_log, args: [kbd_obj] )
+  test('key_list', key_e,  depends: kbd_log, args: [kbd_obj] )
 else
   kbd_obj = join_paths(meson.current_source_dir(), test_kbd) + '.kmx'
   test('key_list', key_e, args: [kbd_obj] )
@@ -226,7 +237,8 @@ endif
 # test for imx list
 
 imx_e = executable('imx_list', 'kmx_imx.cpp',
-                cpp_args: defns,include_directories: [inc, libsrc],
+                cpp_args: defns + warns,
+                include_directories: [inc, libsrc],
                 link_args: links,
                 objects: lib.extract_all_objects())
 

--- a/common/core/desktop/tests/unit/utftest/utftest.cpp
+++ b/common/core/desktop/tests/unit/utftest/utftest.cpp
@@ -40,7 +40,7 @@ int run_tests(char const *prog_name, test<UTF> const (&tests)[N])
 
   for (auto const & test: tests)
   {
-    auto const test_num = &test - &tests[0] + 1;
+    auto const test_num = (int)(&test - &tests[0] + 1);
     size_t res = count_unicode_characters<UTF>(test.str, error);
     if (test.error >= 0)
     {


### PR DESCRIPTION
Based on the suggestions of @eli-schwartz (in #5797).

Unfortunately we currently still have to support meson 0.45 (because that's what ships with Ubuntu 18.04), so we can't
implement everything suggested.

Also fixed some warnings triggered by the changes.

@keymanapp-test-bot skip