### PR TITLE
fix(windows): add null pointer checks imsample keyboard

### DIFF
--- a/windows/src/developer/samples/imsample/IMSample.txt
+++ b/windows/src/developer/samples/imsample/IMSample.txt
@@ -1,6 +1,8 @@
 [Config]
 Font=Arial Unicode MS
-Size=20
+Size=15
+gridx=30
+gridy=30
 
 [Groups]
 IPA

--- a/windows/src/developer/samples/imsample/imsample.cpp
+++ b/windows/src/developer/samples/imsample/imsample.cpp
@@ -432,16 +432,9 @@ LRESULT CALLBACK IMSampleChildWndProc(HWND hwndChild, UINT msg, WPARAM wParam, L
 
 		return 0;
 	case WM_PAINT:
-    if (!curkbd) {
-       return 0;
+    if (!curkbd || !curkbd->hFont || !curkbd->groups || !PrepIM()) {
+      return DefWindowProc(hwndChild, msg, wParam, lParam);
     }
-    if (!curkbd->hFont) {
-       return 0;
-    }
-    if (!curkbd->groups) {
-      return 0;
-    }
-		if(!PrepIM()) return DefWindowProc(hwndChild, msg, wParam, lParam);
 
 		int vpos = GetScrollPos(hwndChild, SB_VERT) * curkbd->gridy;
 
@@ -524,7 +517,7 @@ LRESULT CALLBACK IMSampleChildWndProc(HWND hwndChild, UINT msg, WPARAM wParam, L
 
 BOOL FindRule(group *g, rule **rp, WCHAR KeyChar)
 {
-	if(!g){
+	if (!g || !rp) {
     return FALSE;
   }
   WCHAR buf[48];
@@ -586,8 +579,7 @@ extern "C" BOOL __declspec(dllexport) WINAPI DFWindow(HWND hwndFocus, WORD KeySt
 extern "C" BOOL __declspec(dllexport) WINAPI DFText(HWND hwndFocus, WORD KeyStroke, WCHAR KeyChar, DWORD shiftFlags)
 {
 	WCHAR buf[32];
-	if(!curkbd) return FALSE;
-  if (!curkbd->groups) {
+	if (!curkbd || !curkbd->groups) {
     return FALSE;
   }
 	if(!currule)

--- a/windows/src/engine/keyman32/calldll.cpp
+++ b/windows/src/engine/keyman32/calldll.cpp
@@ -409,7 +409,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMSetOutput(PWSTR buf, DWORD backlen
       _td->app->QueueAction(QIT_CHAR, *buf++);
     return TRUE;
   } else {
-    if (!_td->lpActiveKeyboard->lpCoreKeyboardState) {
+    if (!_td->lpActiveKeyboard || !_td->lpActiveKeyboard->lpCoreKeyboardState) {
       SendDebugMessageFormat(0, sdmKeyboard, 0, "KMSetOutputCore: no active state");
       return FALSE;
     }
@@ -499,7 +499,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMQueueAction(int ItemType, DWORD dw
   if (!Globals::get_CoreIntegration()) {
     return _td->app->QueueAction(ItemType, dwData);  // TODO: 5442 Remove
   } else {
-    if (!_td->lpActiveKeyboard->lpCoreKeyboardState) {
+    if (!_td->lpActiveKeyboard || !_td->lpActiveKeyboard->lpCoreKeyboardState) {
       return FALSE;
     }
 
@@ -535,7 +535,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMGetContext(PWSTR buf, DWORD len)
     wcscpy_s(buf, len + 1, q);  // I3091
     return TRUE;
   } else {
-    if (!_td->lpActiveKeyboard->lpCoreKeyboardState) {
+    if (!_td->lpActiveKeyboard || !_td->lpActiveKeyboard->lpCoreKeyboardState) {
       return FALSE;
     }
     km_kbp_context_item *citems = nullptr;


### PR DESCRIPTION
tl;dr  add null ptr checks to pointers before access.

The tester discovered crashed when loading the imsample keyboard after installing it.    I went through and added checks throughout the code. I built in and attached to the PR the tester was verifying. I am just now checking in this branch.

Note: I made the coding style the current Keyman style. Normally on an old project like this, I would be happy to make the new code match the current code. If that is what you prefer please comment and I will change it.
