### PR TITLE
chore(linux): Remove obsolete Ubuntu 21.04 Hirsute

### DIFF
--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='bionic focal hirsute impish jammy'
+distributions='bionic focal impish jammy'
 
 dpkgcheck=`dpkg-query -l cowbuilder`
 if [ $? != 0 ]; then

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -40,7 +40,7 @@ echo "ppa: ${ppa}"
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="bionic focal hirsute impish jammy"
+    distributions="bionic focal impish jammy"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then


### PR DESCRIPTION
We no longer build for Hirsute which is EOL and so no longer available for building on ppa.

@keymanapp-test-bot skip