### PR TITLE
feat(linux): Allow to run ibus tests on Wayland 🛤️

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -275,11 +275,13 @@ ibus_keyman_engine_init(IBusKeymanEngine *keyman) {
   GdkDisplay *gdkDisplay = gdk_display_get_default();
 #ifdef GDK_WINDOWING_X11
   if (GDK_IS_X11_DISPLAY(gdkDisplay)) {
+    g_debug("Using X11");
     keyman->xdisplay = GDK_DISPLAY_XDISPLAY(gdkDisplay);
   } else
 #endif
 #ifdef GDK_WINDOWING_WAYLAND
   if (GDK_IS_WAYLAND_DISPLAY(gdkDisplay)) {
+    g_debug("Using Wayland");
     keyman->wldisplay = GDK_WAYLAND_DISPLAY(gdkDisplay);
   } else
 #endif

--- a/linux/ibus-keyman/tests/run-tests.sh
+++ b/linux/ibus-keyman/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOP_SRCDIR=${top_srcdir:-$(realpath $(dirname $0)/..)}
 BASEDIR=$(realpath $(dirname $0))
@@ -15,8 +15,8 @@ if [ -v DEB_BUILD_MULTIARCH ]; then
   exit 0
 fi
 
-if ! which Xvfb > /dev/null || ! which Xephyr > /dev/null || ! which metacity > /dev/null; then
-  echo "Please install Xvfb, Xephyr and metacity before running these tests!"
+if ! which Xvfb > /dev/null || ! which Xephyr > /dev/null || ! which metacity > /dev/null || ! which mutter > /dev/null; then
+  echo "Please install Xvfb, Xephyr, metacity and mutter before running these tests!"
   exit 1
 fi
 
@@ -32,19 +32,141 @@ function cleanup() {
 
 function help() {
   echo "Usage:"
-  echo "  $0 [-k] [--tap] [--surrounding-text] [--no-surrounding-text] [[--] TEST...]"
+  echo "  $0 [-k] [--tap] [--surrounding-text] [--no-surrounding-text] [--no-wayland] [--no-x11] [[--] TEST...]"
   echo
   echo "Arguments:"
   echo "  --help, -h, -?          Display this help"
+  echo "  --verbose, -v           Run tests verbosely"
+  echo "  --debug                 debug test logging output"
   echo "  -k                      passed to GLib testing framework"
   echo "  --tap                   output in TAP format. Passed to GLib testing framework"
   echo "  --surrounding-text      run tests with surrounding texts enabled"
   echo "  --no-surrounding-text   run tests without support for surrounding text"
+  echo "  --no-wayland            don't run tests with Wayland"
+  echo "  --no-x11                don't run tests with X11"
   echo
   echo "If no TESTs are specified then all tests are run."
   echo "If neither --surrounding-text nor --no-surrounding-text are specified then the tests run with both settings."
   exit 0
 }
+
+function can_run_wayland() {
+  local MUTTER_VERSION
+  MUTTER_VERSION=$(mutter --version | head -1 | cut -f2 -d' ' | cut -f1 -d'.')
+  if (( $MUTTER_VERSION < 40 )); then
+    return 1
+  else
+    return 0
+  fi
+}
+
+function run_tests() {
+  DISPLAY_SERVER=$1
+  shift
+
+  echo > $PID_FILE
+  TEMP_DATA_DIR=$(mktemp --directory)
+  echo "rm -rf ${TEMP_DATA_DIR}" >> $PID_FILE
+
+  COMMON_ARCH_DIR=
+  [ -d ${TOP_SRCDIR}/../../common/core/desktop/build/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../../common/core/desktop/build/arch
+  [ -d ${TOP_SRCDIR}/../keyboardprocessor/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../keyboardprocessor/arch
+
+  if [ -d ${COMMON_ARCH_DIR}/release ]; then
+    COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/release
+  elif [ -d ${COMMON_ARCH_DIR}/debug ]; then
+    COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/debug
+  else
+    echo "Can't find neither ${COMMON_ARCH_DIR}/release nor ${COMMON_ARCH_DIR}/debug"
+    exit 2
+  fi
+
+  if [ ! -d $TESTDIR ] || ! [[ $(ls -x ${TESTDIR}/*.kmx 2>/dev/null | wc -l) > 0 ]]; then
+    if [[ $(ls -x ${COMMON_ARCH_DIR}/tests/unit/kmx/*.kmx 2>/dev/null | wc -l) > 0 ]]; then
+      mkdir -p $(realpath --canonicalize-missing $TESTDIR/..)
+      ln -sf $(realpath ${COMMON_ARCH_DIR}/tests/unit/kmx) $TESTDIR
+    else
+      echo "Can't find kmx files in ${COMMON_ARCH_DIR}/tests/unit/kmx"
+      exit 3
+    fi
+  fi
+
+  if [ "$DISPLAY_SERVER" == "wayland" ]; then
+    if ! can_run_wayland; then
+      # support for --headless got added in mutter 40.x
+      echo "ERROR: mutter doesn't support running headless. Can't run Wayland tests."
+      exit 7
+    fi
+    echo "Running on Wayland..."
+    TMPFILE=$(mktemp)
+    # mutter-Message: 18:56:15.422: Using Wayland display name 'wayland-1'
+    mutter --wayland --headless --no-x11 --virtual-monitor 1024x768 &> $TMPFILE &
+    echo "kill -9 $!" >> $PID_FILE
+    sleep 1s
+    export WAYLAND_DISPLAY=$(cat $TMPFILE | grep "Using Wayland display" | cut -d"'" -f2)
+    rm $TMPFILE
+  else
+    echo "Starting Xvfb..."
+    Xvfb -screen 0 1024x768x24 :33 &> /dev/null &
+    echo "kill -9 $!" >> $PID_FILE
+    sleep 1
+    echo "Starting Xephyr..."
+    DISPLAY=:33 Xephyr :32 -screen 1024x768 &> /dev/null &
+    echo "kill -9 $!" >> $PID_FILE
+    sleep 1
+    echo "Starting metacity"
+    metacity --display=:32 &> /dev/null &
+    echo "kill -9 $!" >> $PID_FILE
+
+    export DISPLAY=:32
+  fi
+
+  # Install schema to temporary directory. This removes the build dependency on the keyman package.
+  SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
+  export XDG_DATA_DIRS=$TEMP_DATA_DIR:$XDG_DATA_DIRS
+
+  mkdir -p $SCHEMA_DIR
+  cp ${TOP_SRCDIR}/../keyman-config/com.keyman.gschema.xml $SCHEMA_DIR/
+  glib-compile-schemas $SCHEMA_DIR
+
+  if [ $# -gt 0 ]; then
+    TESTFILES=($@)
+  else
+    pushd $TESTDIR > /dev/null
+    TESTFILES=(*.kmx)
+    popd > /dev/null
+  fi
+
+  export LD_LIBRARY_PATH=${COMMON_ARCH_DIR}/src:$LD_LIBRARY_PATH
+
+  # Ubuntu 18.04 Bionic doesn't have ibus-memconf, and glib is not compiled with the keyfile
+  # backend enabled, so we just use the default backend. Otherwise we use the keyfile
+  # store which interferes less when running on a dev machine.
+  if [ -f /usr/libexec/ibus-memconf ]; then
+    export GSETTINGS_BACKEND=keyfile
+    IBUS_CONFIG=--config=/usr/libexec/ibus-memconf
+  fi
+
+  ibus-daemon ${ARG_VERBOSE-} --panel=disable ${IBUS_CONFIG-} &> /tmp/ibus-daemon.log &
+  echo "kill -9 $!" >> $PID_FILE
+  sleep 1s
+
+  ../src/ibus-engine-keyman ${ARG_VERBOSE-} &> /tmp/ibus-engine-keyman.log &
+  echo "kill -9 $!" >> $PID_FILE
+  sleep 1s
+
+  echo "Starting tests..."
+  # Note: -k and --tap are consumed by the GLib testing framework
+  ./ibus-keyman-tests ${ARG_K-} ${ARG_TAP-} ${ARG_VERBOSE-} ${ARG_DEBUG-} \
+    ${ARG_SURROUNDING_TEXT-} ${ARG_NO_SURROUNDING_TEXT-} \
+    --directory $TESTDIR --${DISPLAY_SERVER} "${TESTFILES[@]}"
+  echo "Finished tests."
+
+  cleanup
+}
+
+USE_WAYLAND=1
+USE_X11=1
 
 while (( $# )); do
   case $1 in
@@ -53,88 +175,38 @@ while (( $# )); do
     --tap) ARG_TAP=$1 ;;
     --surrounding-text) ARG_SURROUNDING_TEXT=$1 ;;
     --no-surrounding-text) ARG_NO_SURROUNDING_TEXT=$1 ;;
+    --no-wayland) USE_WAYLAND=0;;
+    --no-x11) USE_X11=0;;
+    --verbose|-v) ARG_VERBOSE=--verbose;;
+    --debug) ARG_DEBUG=--debug-log;;
     --) shift && break ;;
     *) echo "Error: Unexpected argument \"$1\". Exiting." ; exit 4 ;;
   esac
   shift || (echo "Error: The last argument is missing a value. Exiting."; false) || exit 5
 done
 
-echo > $PID_FILE
-trap cleanup EXIT SIGINT
-
-TEMP_DATA_DIR=$(mktemp --directory)
-echo "rm -rf ${TEMP_DATA_DIR}" >> $PID_FILE
-
-COMMON_ARCH_DIR=
-[ -d ${TOP_SRCDIR}/../../common/core/desktop/build/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../../common/core/desktop/build/arch
-[ -d ${TOP_SRCDIR}/../keyboardprocessor/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../keyboardprocessor/arch
-
-if [ -d ${COMMON_ARCH_DIR}/release ]; then
-  COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/release
-elif [ -d ${COMMON_ARCH_DIR}/debug ]; then
-  COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/debug
-else
-  echo "Can't find neither ${COMMON_ARCH_DIR}/release nor ${COMMON_ARCH_DIR}/debug"
-  exit 2
-fi
-
-if [ ! -d $TESTDIR ] || ! [[ $(ls -x ${TESTDIR}/*.kmx 2>/dev/null | wc -l) > 0 ]]; then
-  if [[ $(ls -x ${COMMON_ARCH_DIR}/tests/unit/kmx/*.kmx 2>/dev/null | wc -l) > 0 ]]; then
-    mkdir -p $(realpath --canonicalize-missing $TESTDIR/..)
-    ln -sf $(realpath ${COMMON_ARCH_DIR}/tests/unit/kmx) $TESTDIR
-  else
-    echo "Can't find kmx files in ${COMMON_ARCH_DIR}/tests/unit/kmx"
-    exit 3
+if ! can_run_wayland; then
+  # support for --headless got added in mutter 40.x
+  echo "WARNING: mutter doesn't support running headless. Skipping Wayland tests."
+  USE_WAYLAND=0
+  if [ "$USE_X11" == "0" ]; then
+    echo "ERROR: no tests to run. Can't run Wayland tests, and --no-x11 is specified."
+    exit 8
   fi
 fi
 
-echo "Starting Xvfb..."
-Xvfb -screen 0 1024x768x24 :33 &> /dev/null &
-echo "kill -9 $!" >> $PID_FILE
-sleep 1
-echo "Starting Xephyr..."
-DISPLAY=:33 Xephyr :32 -screen 1024x768 &> /dev/null &
-echo "kill -9 $!" >> $PID_FILE
-sleep 1
-echo "Starting metacity"
-metacity --display=:32 &> /dev/null &
-echo "kill -9 $!" >> $PID_FILE
-
-export DISPLAY=:32
-
-# Install schema to temporary directory. This removes the build dependency on the keyman package.
-SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
-export XDG_DATA_DIRS=$TEMP_DATA_DIR:$XDG_DATA_DIRS
-
-mkdir -p $SCHEMA_DIR
-cp ${TOP_SRCDIR}/../keyman-config/com.keyman.gschema.xml $SCHEMA_DIR/
-glib-compile-schemas $SCHEMA_DIR
-
-if [ $# -gt 0 ]; then
-  TESTFILES=($@)
-else
-  pushd $TESTDIR > /dev/null
-  TESTFILES=(*.kmx)
-  popd > /dev/null
+if [ "$USE_WAYLAND" == "0" -a "$USE_X11" == "0" ]; then
+  echo "ERROR: I'll have to run somewhere. Specifying both --no-wayland and --no-x11 is not allowed."
+  exit 6
 fi
 
-export LD_LIBRARY_PATH=${COMMON_ARCH_DIR}/src:$LD_LIBRARY_PATH
+echo > $PID_FILE
+trap cleanup EXIT SIGINT
 
-# Ubuntu 18.04 Bionic doesn't have ibus-memconf, and glib is not compiled with the keyfile
-# backend enabled, so we just use the default backend. Otherwise we use the keyfile
-# store which interferes less when running on a dev machine.
-if [ -f /usr/libexec/ibus-memconf ]; then
-  export GSETTINGS_BACKEND=keyfile
-  IBUS_CONFIG=--config=/usr/libexec/ibus-memconf
+if [ "$USE_WAYLAND" == "1" ]; then
+  run_tests wayland "$@"
 fi
 
-ibus-daemon --panel=disable ${IBUS_CONFIG-} &> /tmp/ibus-daemon.log &
-echo "kill -9 $!" >> $PID_FILE
-../src/ibus-engine-keyman &> /tmp/ibus-engine-keyman.log &
-echo "kill -9 $!" >> $PID_FILE
-sleep 1s
-
-echo "Starting tests..."
-# Note: -k and --tap are consumed by the GLib testing framework
-./ibus-keyman-tests ${ARG_K-} ${ARG_TAP-} ${ARG_SURROUNDING_TEXT-} ${ARG_NO_SURROUNDING_TEXT-} --directory $TESTDIR "${TESTFILES[@]}"
-echo "Finished tests."
+if [ "$USE_X11" == "1" ]; then
+  run_tests x11 "$@"
+fi

--- a/linux/ibus-keyman/tests/testfixture.cpp
+++ b/linux/ibus-keyman/tests/testfixture.cpp
@@ -20,6 +20,9 @@
 #include <X11/XKBlib.h>
 #include <gdk/gdkx.h>
 #endif
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
 
 typedef struct {
   IBusBus *bus;
@@ -35,10 +38,16 @@ typedef struct {
 } TestData;
 
 static gboolean loaded        = FALSE;
+static gboolean use_wayland   = FALSE;
 static GdkWindow *window      = NULL;
 static GMainLoop *thread_loop = NULL;
 static GTypeModule *module    = NULL;
-static Display *display       = NULL;
+#ifdef GDK_WINDOWING_X11
+static Display *display = NULL;
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+static GdkWaylandDisplay *wldisplay = NULL;
+#endif
 
 static void
 module_register(GTypeModule *module) {
@@ -60,13 +69,17 @@ ibus_keyman_tests_fixture_set_up(IBusKeymanTestsFixture *fixture, gconstpointer 
     window = gtk_widget_get_window(widget);
   }
 
-  if (!display) {
+  GdkDisplay *gdkDisplay = gdk_display_get_default();
 #ifdef GDK_WINDOWING_X11
-    if (GDK_IS_X11_DISPLAY(gdk_display_get_default())) {
-      display = GDK_DISPLAY_XDISPLAY(gdk_display_get_default());
-    }
-#endif
+  if (!use_wayland && !display && GDK_IS_X11_DISPLAY(gdkDisplay)) {
+    display = GDK_DISPLAY_XDISPLAY(gdkDisplay);
   }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+  if (use_wayland && !wldisplay && GDK_IS_WAYLAND_DISPLAY(gdkDisplay)) {
+    wldisplay = GDK_WAYLAND_DISPLAY(gdkDisplay);
+  }
+#endif
 
   if (!loaded) {
     ibus_init();
@@ -102,9 +115,14 @@ ibus_keyman_tests_fixture_tear_down(IBusKeymanTestsFixture *fixture, gconstpoint
 static void
 set_caps_lock_state(IBusKeymanTestsFixture *fixture, bool caps_lock_on) {
 #ifdef GDK_WINDOWING_X11
-  if (display) {
+  if (!use_wayland && display) {
     XkbLockModifiers(display, XkbUseCoreKbd, LockMask, caps_lock_on ? LockMask : 0);
     XSync(display, False);
+  }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+  if (use_wayland && wldisplay) {
+    // TODO
   }
 #endif
 }
@@ -112,10 +130,15 @@ set_caps_lock_state(IBusKeymanTestsFixture *fixture, bool caps_lock_on) {
 static bool
 get_caps_lock_state(IBusKeymanTestsFixture *fixture) {
 #ifdef GDK_WINDOWING_X11
-  if (display) {
+  if (!use_wayland && display) {
     XKeyboardState state;
     XGetKeyboardControl(display, &state);
     return state.led_mask & 1;
+  }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+  if (use_wayland && wldisplay) {
+    // TODO
   }
 #endif
 
@@ -384,20 +407,23 @@ test_skip(IBusKeymanTestsFixture *fixture, gconstpointer user_data) {
 
 void
 print_usage() {
-  printf("Usage: %s --directory <keyboarddir> [--surrounding-text] [--no-surrounding-text] test1 [test2 ...]\n\n", g_get_prgname());
+  printf("Usage: %s --directory <keyboarddir> [--surrounding-text] [--no-surrounding-text] [--wayland|--x11] test1 [test2 ...]\n\n", g_get_prgname());
   printf("Arguments:\n");
+  printf("\t--wayland\tRun tests on Wayland\n");
+  printf("\t--x11\tRun tests on X11\n");
   printf("\t--surrounding-text\tRun tests with surrounding text support\n");
   printf("\t--no-surrounding-text\tRun tests without surrounding text support\n");
   printf("\nIf neither --surrounding-text nor --no-surrounding-text are specified then the tests run with both settings.\n");
 }
 
 void
-add_test(const char* directory, const char* filename, gboolean use_surrounding_text, const char* skip_reason) {
+add_test(const char* directory, const char* filename, gboolean use_surrounding_text, const char* skip_reason, bool useWayland) {
   auto file         = g_file_new_for_commandline_arg(filename);
   auto testfilebase = g_file_get_basename(file);
   auto testname     = g_string_new(NULL);
   g_string_append_printf(
-      testname, "/integration-tests/%s/%s", use_surrounding_text ? "surrounding-text" : "no-surrounding-text", testfilebase);
+      testname, "/%s/integration-tests/%s/%s", useWayland ? "wayland" : "x11",
+      use_surrounding_text ? "surrounding-text" : "no-surrounding-text", testfilebase);
   auto testfile = g_file_new_build_filename(directory, testfilebase, NULL);
   auto testdata                  = new TestData();
   testdata->test_name            = strdup(filename);
@@ -425,6 +451,8 @@ main(int argc, char *argv[]) {
 
   int iArg;
   char *directory = NULL;
+  bool argWayland = false;
+  bool argX11 = false;
   bool seenDirectory = false;
   bool seenSurroundingTextOption = false;
   bool runSurroundingTextTests = true;
@@ -435,6 +463,10 @@ main(int argc, char *argv[]) {
       iArg++;
       directory = argv[iArg];
       seenDirectory = true;
+    } else if (strcmp(argv[iArg], "--wayland") == 0) {
+      argWayland = true;
+    } else if (strcmp(argv[iArg], "--x11") == 0) {
+      argX11 = true;
     } else if (strcmp(argv[iArg], "--surrounding-text") == 0) {
       if (!seenSurroundingTextOption) {
         runNoSurroundingTextTests = false;
@@ -455,6 +487,30 @@ main(int argc, char *argv[]) {
     }
   }
 
+  if (argWayland && argX11) {
+    printf("ERROR: --wayland and --x11 can't both be specified");
+    print_usage();
+    return 2;
+  }
+
+  if (!argWayland && !argX11) {
+    GdkDisplay *gdkDisplay = gdk_display_get_default();
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_DISPLAY(gdkDisplay)) {
+      argWayland = true;
+    } else
+#endif
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_DISPLAY(gdkDisplay)) {
+      argX11 = true;
+    } else
+#endif
+    {
+      g_error("Neither X11 nor Wayland display!");
+    }
+  }
+
+  use_wayland     = argWayland;
   int nTests      = argc - iArg;
   char **tests    = &argv[iArg];
 
@@ -473,10 +529,10 @@ main(int argc, char *argv[]) {
     }
 
     if (runSurroundingTextTests) {
-      add_test(directory, filename->str, TRUE, skipReason);
+      add_test(directory, filename->str, TRUE, skipReason, use_wayland);
     }
     if (runNoSurroundingTextTests) {
-      add_test(directory, filename->str, FALSE, skipReason);
+      add_test(directory, filename->str, FALSE, skipReason, use_wayland);
     }
 
     g_string_free(filename, TRUE);
@@ -487,9 +543,15 @@ main(int argc, char *argv[]) {
 
   // Cleanup
 #ifdef GDK_WINDOWING_X11
-  if (display) {
+  if (!use_wayland && display) {
     XCloseDisplay(display);
     display = NULL;
+  }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+  if (use_wayland) {
+    // REVIEW: do we have to call something for cleanup?
+    wldisplay = NULL;
   }
 #endif
 


### PR DESCRIPTION
This change modifies the `run-tests.sh` script so that tests run on both Wayland (if supported) and X11 unless `--no-wayland` or `--no-x11` is specified.

This change also adds the new argument `--wayland` to the `ibus-keyman-tests` executable which runs the tests under
Wayland.

Note that running Wayland tests is only possible in Ubuntu 21.10+ because it requires a version of `mutter` that supports the headless option which got added in mutter 40.

@keymanapp-test-bot skip