### PR TITLE
chore(ios): certificate update again

### DIFF
--- a/ios/exportAppStore.plist
+++ b/ios/exportAppStore.plist
@@ -7,9 +7,9 @@
     <key>teamID</key>
     <string>3YE4W86L3G</string>
     <key>signingCertificate</key>
-    <string>1E6DA40CAF7E22D3BB93FA4B88065254BC649379</string>
+    <string>3F2AB892E24387929F51C36E7A03EF33502D341A</string>
     <key>installerSigningCertificate</key>
-    <string>1E6DA40CAF7E22D3BB93FA4B88065254BC649379</string>
+    <string>3F2AB892E24387929F51C36E7A03EF33502D341A</string>
     <key>provisioningProfiles</key>
     <dict>
         <key>Tavultesoft.Keyman</key>


### PR DESCRIPTION
The iOS distribution certificate was revoked, so this references the replaced certificate.

@keymanapp-test-bot skip