### PR TITLE
fix(common/core/desktop): Add num and scroll lock mask to VKeyToChar

### DIFF
--- a/common/core/desktop/src/kmx/kmx_file.h
+++ b/common/core/desktop/src/kmx/kmx_file.h
@@ -281,8 +281,6 @@ namespace kmx {
 #define ISVIRTUALKEY  0x4000    // It is a Virtual Key Sequence
 #define VIRTUALCHARKEY  0x8000    // Keyman 6.0: Virtual Key Cap Sequence NOT YET
 
-#define NUM_SCROLL_LOCK_MASK 0x3C00 // Numlock and Scroll lock on & NOT on FLAGS
-
 #define K_MODIFIERFLAG  0x007F
 #define K_NOTMODIFIERFLAG 0xFF00   // I4548
 

--- a/common/core/desktop/src/kmx/kmx_file.h
+++ b/common/core/desktop/src/kmx/kmx_file.h
@@ -281,6 +281,8 @@ namespace kmx {
 #define ISVIRTUALKEY  0x4000    // It is a Virtual Key Sequence
 #define VIRTUALCHARKEY  0x8000    // Keyman 6.0: Virtual Key Cap Sequence NOT YET
 
+#define NUM_SCROLL_LOCK_MASK 0x3C00 // Numlock and Scroll lock on & NOT on FLAGS
+
 #define K_MODIFIERFLAG  0x007F
 #define K_NOTMODIFIERFLAG 0xFF00   // I4548
 

--- a/common/core/desktop/src/kmx/kmx_processevent.cpp
+++ b/common/core/desktop/src/kmx/kmx_processevent.cpp
@@ -35,7 +35,7 @@ KMX_ProcessEvent::~KMX_ProcessEvent() {
 char VKeyToChar(KMX_UINT modifiers, KMX_UINT vk) {
   // We only map SHIFT and UNSHIFTED, and CAPS LOCK
 
-  if ((modifiers & ~(K_SHIFTFLAG | CAPITALFLAG)) != 0) {
+  if ((modifiers & ~(K_SHIFTFLAG | CAPITALFLAG | NUM_SCROLL_LOCK_MASK)) != 0) {
     return 0;
   }
 

--- a/common/core/desktop/src/kmx/kmx_processevent.cpp
+++ b/common/core/desktop/src/kmx/kmx_processevent.cpp
@@ -33,8 +33,9 @@ KMX_ProcessEvent::~KMX_ProcessEvent() {
 }
 
 char VKeyToChar(KMX_UINT modifiers, KMX_UINT vk) {
-  // We only map SHIFT and UNSHIFTED, and CAPS LOCK
+  // We only map keys that are unmodified, shifted, or caps locked
 
+  // Test for modifier flags excluding Shift, Caps, Num and Scroll Lock
   if ((modifiers & ~(K_SHIFTFLAG | CAPITALFLAG | NUM_SCROLL_LOCK_MASK)) != 0) {
     return 0;
   }

--- a/common/core/desktop/src/kmx/kmx_processevent.cpp
+++ b/common/core/desktop/src/kmx/kmx_processevent.cpp
@@ -35,8 +35,8 @@ KMX_ProcessEvent::~KMX_ProcessEvent() {
 char VKeyToChar(KMX_UINT modifiers, KMX_UINT vk) {
   // We only map keys that are unmodified, shifted, or caps locked
 
-  // Test for modifier flags excluding Shift, Caps, Num and Scroll Lock
-  if ((modifiers & ~(K_SHIFTFLAG | CAPITALFLAG | NUM_SCROLL_LOCK_MASK)) != 0) {
+  // Test for modifier flags excluding Shift, Caps
+  if ((modifiers & ~(K_SHIFTFLAG | CAPITALFLAG)) != 0) {
     return 0;
   }
 

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -108,10 +108,11 @@ Process_Event_Core(PKEYMAN64THREADDATA _td) {
   km_kbp_context_items_dispose(citems);
   SendDebugMessageFormat(
       0, sdmGlobal, 0, "ProcessEvent: vkey[%d] ShiftState[%d] isDown[%d]", _td->state.vkey,
-      static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown);
+      static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown);
+  //  Mask the bits supported according to `km_kbp_modifier_state` enum, update the mask if this enum is expanded.
   if (KM_KBP_STATUS_OK != km_kbp_process_event(
     _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
-    static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown)) {
+    static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown)) {
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ", FALSE);
     return FALSE;
   }


### PR DESCRIPTION
Fixes #6204
This change removes the `K_MODIFIERFLAG` from the windows platforms call to the core processor's process_event call.
It then adds a mask for num and scroll lock to the `VKeyToChar` function.
