### PR TITLE
feat(linux): implement capslock handling with Wayland 🛤️

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -281,8 +281,20 @@ ibus_keyman_engine_init(IBusKeymanEngine *keyman) {
 #endif
 #ifdef GDK_WINDOWING_WAYLAND
   if (GDK_IS_WAYLAND_DISPLAY(gdkDisplay)) {
+    // The Wayland support of ibus is currently non-working. It only works with
+    // XWayland. Also there are still some APIs in Wayland missing that would allow
+    // us to toggle capslock etc, so we use XWayland if available. If XWayland is
+    // not available I guess things won't completely work, but there's currently not
+    // much we can do about that with ibus.
     g_debug("Using Wayland");
     keyman->wldisplay = GDK_WAYLAND_DISPLAY(gdkDisplay);
+
+#ifdef GDK_WINDOWING_X11
+    if (getenv("DISPLAY")) {
+      g_debug("Also using XWayland");
+      keyman->xdisplay = XOpenDisplay(NULL);
+    }
+#endif
   } else
 #endif
   {
@@ -683,12 +695,12 @@ process_capslock_action(
     XSync(keyman->xdisplay, False);
   }
 #endif
-#ifdef GDK_WINDOWING_WAYLAND
-  // TODO
-  if (keyman->wldisplay) {
+// #ifdef GDK_WINDOWING_WAYLAND
+//   // TODO
+//   if (keyman->wldisplay) {
 
-  }
-#endif
+//   }
+// #endif
   return TRUE;
 }
 

--- a/linux/ibus-keyman/tests/run-tests.sh
+++ b/linux/ibus-keyman/tests/run-tests.sh
@@ -100,10 +100,15 @@ function run_tests() {
     echo "Running on Wayland..."
     TMPFILE=$(mktemp)
     # mutter-Message: 18:56:15.422: Using Wayland display name 'wayland-1'
-    mutter --wayland --headless --no-x11 --virtual-monitor 1024x768 &> $TMPFILE &
+    # ibus doesn't yet fully support Wayland - it only works with XWayland. If that ever
+    # changes we can pass `--no-x11` to mutter.
+    mutter --wayland --headless --virtual-monitor 1024x768 &> $TMPFILE &
     echo "kill -9 $!" >> $PID_FILE
     sleep 1s
+    # mutter-Message: 18:40:45.081: Using Wayland display name 'wayland-1'
     export WAYLAND_DISPLAY=$(cat $TMPFILE | grep "Using Wayland display" | cut -d"'" -f2)
+    # mutter-Message: 18:40:45.080: Using public X11 display :2, (using :3 for managed services)
+    export DISPLAY=:$(cat $TMPFILE | grep "Using public X11 display" | cut -d":" -f6 | cut -d"," -f1)
     rm $TMPFILE
   else
     echo "Starting Xvfb..."

--- a/linux/ibus-keyman/tests/testfixture.cpp
+++ b/linux/ibus-keyman/tests/testfixture.cpp
@@ -78,6 +78,11 @@ ibus_keyman_tests_fixture_set_up(IBusKeymanTestsFixture *fixture, gconstpointer 
 #ifdef GDK_WINDOWING_WAYLAND
   if (use_wayland && !wldisplay && GDK_IS_WAYLAND_DISPLAY(gdkDisplay)) {
     wldisplay = GDK_WAYLAND_DISPLAY(gdkDisplay);
+#ifdef GDK_WINDOWING_X11
+    if (getenv("DISPLAY")) {
+      display = XOpenDisplay(NULL);
+    }
+#endif
   }
 #endif
 
@@ -115,7 +120,7 @@ ibus_keyman_tests_fixture_tear_down(IBusKeymanTestsFixture *fixture, gconstpoint
 static void
 set_caps_lock_state(IBusKeymanTestsFixture *fixture, bool caps_lock_on) {
 #ifdef GDK_WINDOWING_X11
-  if (!use_wayland && display) {
+  if (display) {
     XkbLockModifiers(display, XkbUseCoreKbd, LockMask, caps_lock_on ? LockMask : 0);
     XSync(display, False);
   }
@@ -130,7 +135,7 @@ set_caps_lock_state(IBusKeymanTestsFixture *fixture, bool caps_lock_on) {
 static bool
 get_caps_lock_state(IBusKeymanTestsFixture *fixture) {
 #ifdef GDK_WINDOWING_X11
-  if (!use_wayland && display) {
+  if (display) {
     XKeyboardState state;
     XGetKeyboardControl(display, &state);
     return state.led_mask & 1;
@@ -543,7 +548,7 @@ main(int argc, char *argv[]) {
 
   // Cleanup
 #ifdef GDK_WINDOWING_X11
-  if (!use_wayland && display) {
+  if (display) {
     XCloseDisplay(display);
     display = NULL;
   }


### PR DESCRIPTION
The Wayland support of ibus is currently non-working. AFAICT it only works with XWayland. Also there are still some APIs in Wayland missing that would allow us to toggle capslock etc, so we use XWayland if available. If XWayland is not available I guess things won't completely work, but there's currently not much we can do about that with ibus.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_JAMMY_WAYLAND**: Ubuntu 22.04 Jammy with Gnome Shell and Wayland

**NOTE:** The capslock LED won't properly update if these tests are run in a VM. If possible test on hardware.

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot
- Download and unzip these [keyboards](https://github.com/keymanapp/keyman/files/8562135/PR6213_keyboards.zip)
- Install the keyboards by running these commands (in the directory where you unzipped them):

   ```
   km-package-install -f k_031___caps_lock.kmp
   km-package-install -f k_032___caps_control.kmp
   km-package-install -f k_033___caps_always_off.kmp
   ```

## Tests

**TEST_CAPSLOCK**: Caps lock works

- switch to _"031 - caps lock"_ keyboard
  - verify the capslock LED is on
- press and release capslock key, then press and release the following keys `1`, `Shift+2`, `Shift+3`, `A` and `Shift+B`
  - verify the output is `pass.pass.pass.pass.pass.`
  - verify the capslock LED is still on
- press and release capslock key
  - verify the capslock LED is off

**TEST_CAPSCONTROL**: Shift releases caps

- make sure capslock is off
- switch to _"032 - caps control"_ keyboard
  - verify the capslock LED is off
- press and release `1` key
  - verify the capslock LED is off
- press and release capslock key
  - verify the capslock LED is on
- press and release `2`, `Shift+3`, `4`
  - verify the capslock LED is off
- press and release capslock key
  - verify the capslock LED is on
- press and release `5` and capslock key
  - verify the capslock LED is still on
- press and release `6`, `Shift`, `7` (note: press and release `Shift` on it's own here!)
  - verify the capslock LED is off
  - verify the output is `pass.pass.pass.pass.pass.pass.pass.`

**TEST_CAPSOFF**: Caps always off

- make sure capslock is off
- switch to _"033 - caps always off"_ keyboard
- press and release the following keys. After each key verify the capslock LED is still off.
  `1`, `capslock`, `2`, `capslock`, `3`
  - verify the output is `pass.pass.pass.`


