### PR TITLE
chore(android): Update Play publishing plugin to 3.5.0

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'io.sentry.android.gradle'
     // https://github.com/Triple-T/gradle-play-publisher/issues/947#issuecomment-843634852
-    id 'com.github.triplet.play' version '3.4.0-agp4.2' apply false
+    id 'com.github.triplet.play' version '3.5.0' apply false
     id 'name.remal.default-plugins'
 }
 

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'io.sentry.android.gradle'
-    id 'com.github.triplet.play' version '3.4.0-agp4.2' apply false
+    id 'com.github.triplet.play' version '3.5.0' apply false
 }
 
 ext.rootPath = '../../../../android'


### PR DESCRIPTION
This is an attempt to address #6216 where the FV Android app failed to publish to the Play Store.
Will see after the next alpha build goes to the Play Store.

Upgrading to 3.6.0+ will involve more pain since those 
> release are only compatible with the Android Gradle Plugin v7.x.

@keymanapp-test-bot skip