### PR TITLE
fix(windows): add flag to track core process event

### DIFF
--- a/windows/src/engine/keyman32/calldll.cpp
+++ b/windows/src/engine/keyman32/calldll.cpp
@@ -421,8 +421,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMSetOutput(PWSTR buf, DWORD backlen
     // correctly. To do this need to check the context as we process the
     // backspaces.
     km_kbp_context_item *citems = nullptr;
-    if (KM_KBP_STATUS_OK !=
-        (km_kbp_status_codes)kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
+    if (KM_KBP_STATUS_OK != kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
       delete[] actionItems;
       return FALSE;
     }
@@ -479,8 +478,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMSetOutput(PWSTR buf, DWORD backlen
       idx++;
     }
     actionItems[idx].type   = KM_KBP_IT_END;
-    if (KM_KBP_STATUS_OK !=
-        (km_kbp_status_codes)km_kbp_state_queue_action_items(_td->lpActiveKeyboard->lpCoreKeyboardState, actionItems)) {
+    if (KM_KBP_STATUS_OK != km_kbp_state_queue_action_items(_td->lpActiveKeyboard->lpCoreKeyboardState, actionItems)) {
       delete[] actionItems;
       return FALSE;
     }
@@ -541,8 +539,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMGetContext(PWSTR buf, DWORD len)
       return FALSE;
     }
     km_kbp_context_item *citems = nullptr;
-    if (KM_KBP_STATUS_OK !=
-      (km_kbp_status_codes)kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
+    if (KM_KBP_STATUS_OK != kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
         return FALSE;
     }
 

--- a/windows/src/engine/keyman32/calldll.cpp
+++ b/windows/src/engine/keyman32/calldll.cpp
@@ -384,12 +384,12 @@ extern "C" uint8_t IM_CallBackCore(km_kbp_state *km_state, uint32_t UniqueStoreN
   if (!_td)
     return FALSE;
   //SendDebugMessageFormat(0, sdmKeyboard, 0, "IM_CallBackCore: td loadeded");
-  if (!_td->TIPFUpdateable) {  // Only execute the 3rd party function on the not updateable parse.
-    SendDebugMessageFormat(0, sdmKeyboard, 0, "IM_CallBackCore: td TIPFUpdatable about to call function [%s]", imdh->name);
-    LogContext(_td->lpActiveKeyboard->lpCoreKeyboardState, CONTEXT_CORE);
-    LogContext(_td->lpActiveKeyboard->lpCoreKeyboardState, CONTEXT_INT);
-    (*imdh->function)(_td->state.msg.hwnd, _td->state.vkey, _td->state.charCode, Globals::get_ShiftState());
-  }
+
+  SendDebugMessageFormat(0, sdmKeyboard, 0, "IM_CallBackCore: td TIPFUpdatable about to call function [%s]", imdh->name);
+  LogContext(_td->lpActiveKeyboard->lpCoreKeyboardState, CONTEXT_CORE);
+  LogContext(_td->lpActiveKeyboard->lpCoreKeyboardState, CONTEXT_INT);
+  (*imdh->function)(_td->state.msg.hwnd, _td->state.vkey, _td->state.charCode, Globals::get_ShiftState());
+
   //SendDebugMessageFormat(0, sdmKeyboard, 0, "IM_CallBackCore: Exit");
   return TRUE;
 }

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -225,6 +225,8 @@ typedef struct tagKEYMAN64THREADDATA
 
   BOOL TIPFUpdateable, TIPFPreserved;   // I4290
 
+  BOOL CoreProcessEventRun;  // True if core process event has been run
+
   BOOL FInRefreshKeyboards;
   BOOL RefreshRequired;
   LONG RefreshTag_Thread; // TODO: we may be able to eliminate this with our delayed refresh pattern?

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -296,7 +296,7 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
             if (!_td->lpActiveKeyboard) {
               return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
             }
-            if (KM_KBP_STATUS_OK != (km_kbp_status_codes)km_kbp_process_queued_actions(_td->lpActiveKeyboard->lpCoreKeyboardState)) {
+            if (KM_KBP_STATUS_OK != km_kbp_process_queued_actions(_td->lpActiveKeyboard->lpCoreKeyboardState)) {
               SendDebugMessageFormat(0, sdmGlobal, 0, "_kmnGetMessageProc wm_keymanim_close process event fail");
               return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
             }

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -98,11 +98,10 @@ char *getcontext_debug() {
 
 static BOOL
 Process_Event_Core(PKEYMAN64THREADDATA _td) {
-  PWSTR contextBuf            = _td->app->ContextBufMax(MAXCONTEXT);
+  PWSTR contextBuf = _td->app->ContextBufMax(MAXCONTEXT);
   km_kbp_context_item *citems = nullptr;
   ContextItemsFromAppContext(contextBuf, &citems);
-  if (KM_KBP_STATUS_OK !=
-      (km_kbp_status_codes)km_kbp_context_set(km_kbp_state_context(_td->lpActiveKeyboard->lpCoreKeyboardState), citems)) {
+  if (KM_KBP_STATUS_OK != km_kbp_context_set(km_kbp_state_context(_td->lpActiveKeyboard->lpCoreKeyboardState), citems)) {
     km_kbp_context_items_dispose(citems);
     return FALSE;
   }
@@ -110,9 +109,9 @@ Process_Event_Core(PKEYMAN64THREADDATA _td) {
   SendDebugMessageFormat(
       0, sdmGlobal, 0, "ProcessEvent: vkey[%d] ShiftState[%d] isDown[%d]", _td->state.vkey,
       static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown);
-  if (KM_KBP_STATUS_OK != (km_kbp_status_codes)km_kbp_process_event(
-                              _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
-                              static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown)) {
+  if (KM_KBP_STATUS_OK != km_kbp_process_event(
+    _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
+    static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown)) {
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ", FALSE);
     return FALSE;
   }
@@ -178,8 +177,11 @@ BOOL ProcessHook()
     // if we say yes it will call a second time to actually do the work.
     // We call the core process event only once and use the core's queued actions
     // on the second pass.
-    // For the TSF in most cases kmtip (except OnPreservedKey) will not call the non-updateable test pass.
+    // For the TSF in most cases kmtip (except OnPreservedKey) will not call the non-updateable test parse.
     // Therfore the core process event will need to be called before processing the actions.
+
+    // CoreProcessEventRun would be a sufficient test however testing TIPFUpdateable defines
+    // the status of the keystroke processing more precisely.
     if (!_td->TIPFUpdateable || !_td->CoreProcessEventRun) {
       if (!Process_Event_Core(_td)) {
         return FALSE;

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -89,6 +89,37 @@ char *getcontext_debug() {
 	return Debug_UnicodeString(_td->app->ContextBufMax(128));
 }
 
+/**
+ *  Process the key stroke using the core processor
+ *
+ * @param   _td   Pointer to KEYMAN64THREADDATA
+ * @return  BOOL  Return TRUE if keystroke event is passed successfully
+ */
+
+static BOOL
+Process_Event_Core(PKEYMAN64THREADDATA _td) {
+  PWSTR contextBuf            = _td->app->ContextBufMax(MAXCONTEXT);
+  km_kbp_context_item *citems = nullptr;
+  ContextItemsFromAppContext(contextBuf, &citems);
+  if (KM_KBP_STATUS_OK !=
+      (km_kbp_status_codes)km_kbp_context_set(km_kbp_state_context(_td->lpActiveKeyboard->lpCoreKeyboardState), citems)) {
+    km_kbp_context_items_dispose(citems);
+    return FALSE;
+  }
+  km_kbp_context_items_dispose(citems);
+  SendDebugMessageFormat(
+      0, sdmGlobal, 0, "ProcessEvent: vkey[%d] ShiftState[%d] isDown[%d]", _td->state.vkey,
+      static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown);
+  if (KM_KBP_STATUS_OK != (km_kbp_status_codes)km_kbp_process_event(
+                              _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
+                              static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG), (uint8_t)_td->state.isDown)) {
+    SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ", FALSE);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+
 /*
 *	BOOL ProcessHook();
 *
@@ -121,7 +152,7 @@ BOOL ProcessHook()
   }
 
 	//app->NoSetShift = FALSE;
-	_td->app->ReadContext();
+  _td->app->ReadContext();
 
 	if(_td->state.msg.message == wm_keymankeydown) {   // I4827
     if (ShouldDebug(sdmKeyboard)) {
@@ -141,28 +172,22 @@ BOOL ProcessHook()
 			_td->app->QueueDebugInformation(QID_BEGIN_ANSI, NULL, NULL, NULL, NULL, (DWORD_PTR) &keyinfo);
 	}
 
+
   if (isUsingCoreProcessor) {  // TODO: 5442 Note: Nested if will be reduced once using core only
+    // For applications not using the TSF kmtip calls this function twice for each keystroke,
+    // first to determine if we are doing processing work (TIPFUpdateable == FALSE),
+    // if we say yes it will call a second time to actually do the work.
+    // We call the core process event only once and use the core's queued actions
+    // on the second pass.
+    // For the TSF in most cases kmtip (except OnPreservedKey) will not call the non-updateable test pass.
+    // Therfore the core process event will need to be called before processing the actions.
+    if (!_td->TIPFUpdateable || !_td->CoreProcessEventRun) {
+      if (!Process_Event_Core(_td)) {
+        return FALSE;
+      }
+    }
+
     if (!_td->TIPFUpdateable) {
-      PWSTR contextBuf = _td->app->ContextBufMax(MAXCONTEXT);
-      km_kbp_context_item *citems = nullptr;
-      ContextItemsFromAppContext(contextBuf, &citems);
-      if (KM_KBP_STATUS_OK !=
-        (km_kbp_status_codes)km_kbp_context_set(
-          km_kbp_state_context(_td->lpActiveKeyboard->lpCoreKeyboardState), citems)) {
-        km_kbp_context_items_dispose(citems);
-        return FALSE;
-      }
-      km_kbp_context_items_dispose(citems);
-      SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent: vkey[%d] ShiftState[%d] isDown[%d]", _td->state.vkey,
-                                                    static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG),
-                                                    (uint8_t)_td->state.isDown);
-      if (KM_KBP_STATUS_OK !=
-        (km_kbp_status_codes)km_kbp_process_event(_td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
-                                  static_cast<uint16_t>(Globals::get_ShiftState() & K_MODIFIERFLAG),
-                                                    (uint8_t)_td->state.isDown)) {
-        SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ",FALSE);
-        return FALSE;
-      }
       ProcessActionsTestParse(&fOutputKeystroke);
     } else {
       ProcessActions(&fOutputKeystroke);

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -172,7 +172,6 @@ BOOL ProcessHook()
 			_td->app->QueueDebugInformation(QID_BEGIN_ANSI, NULL, NULL, NULL, NULL, (DWORD_PTR) &keyinfo);
 	}
 
-
   if (isUsingCoreProcessor) {  // TODO: 5442 Note: Nested if will be reduced once using core only
     // For applications not using the TSF kmtip calls this function twice for each keystroke,
     // first to determine if we are doing processing work (TIPFUpdateable == FALSE),

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -120,11 +120,13 @@ BOOL ProcessActions(BOOL* emitKeyStroke)
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if (!_td) return FALSE;
 
+  _td->CoreProcessEventRun = FALSE;
   // Process the action items from the core. This actions will modify the windows context (AppContext).
   // Therefore it is not required to copy the context from the core to the windows context.
 
   for (auto act = km_kbp_state_action_items(_td->lpActiveKeyboard->lpCoreKeyboardState, nullptr); act->type != KM_KBP_IT_END; act++) {
     BOOL continueProcessingActions = TRUE;
+    SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessActions : act->type=%d", act->type);
     switch (act->type) {
     case KM_KBP_IT_CHAR:
       continueProcessingActions = processUnicodeChar(_td->app, act);
@@ -175,6 +177,8 @@ ProcessActionsTestParse(BOOL* emitKeyStroke) {
     return FALSE;
   }
 
+  _td->CoreProcessEventRun = TRUE;
+
   BOOL continueProcessingActions = TRUE;
   for (auto act = km_kbp_state_action_items(_td->lpActiveKeyboard->lpCoreKeyboardState, nullptr); act->type != KM_KBP_IT_END; act++) {
     switch (act->type) {
@@ -182,6 +186,7 @@ ProcessActionsTestParse(BOOL* emitKeyStroke) {
       *emitKeyStroke = TRUE;
       SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessActionsTestParse EMIT_KEYSTROKE: act->type=%d", act->type);
       continueProcessingActions = TRUE;
+      _td->CoreProcessEventRun = FALSE; // If we emit the key stroke on this parse we don't need the second parse
       break;
     case KM_KBP_IT_CAPSLOCK:
       continueProcessingActions = processCapsLock(act, !_td->state.isDown, _td->TIPFUpdateable);


### PR DESCRIPTION
Fixes #6205

For the Text Services Frame (TSF) applications in most cases for keystrokes, there is no test parse with updatable=false. In these cases, we need to call the core process event function and process the actions in one call. A bool flag has been added `CoreProcessEventRun` to track if the core process event has been called for the current keystroke. 
In the case of legacy apps or the `OnPreservedKey` for TSF. That is in the case where it is called twice once with `updateable=false` the core process event is called in the first pass and the bool `CoreProcessEventRun` is set. 

This means on any call with `updateable=true` if `CoreProcessEventRun=false` we know we need to call the core processor to process the keystroke. 
The Processing of the core actions will clear  `CoreProcessEventRun`.