### PR TITLE
fix(windows): create Keyman/Diag folder in redirected profile

### DIFF
--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -934,6 +934,25 @@ begin
   end;
 end;
 
+//
+// See #6221.
+//
+// If Keyman is being installed under the SYSTEM profile, e.g. when using tools
+// such as SCCM or Intune, then the installer runs with a redirected folder for
+// %LocalAppData%, under C:\Windows\SysWow64\config, but is given the name
+// C:\Windows\System32\config....
+//
+// Keyman Setup then creates %LocalAppData%\Keyman\Diag, which it thinks is in
+// C:\Windows\System32\config... But in reality it is in SysWow64... Keyman
+// Setup passes a file under this folder to Windows Installer, running as 64
+// bit, which immediately falls over because the path does not exist to it, in
+// the real System32\config folder.
+//
+// This patch disables redirection temporarily just to create the folder under
+// both 32 and 64 bit versions of the profile. It has no effect on normal user
+// accounts (apart from verifying that the folder is present twice rather than
+// once).
+//
 procedure TRunTools.ApplyWow64SystemProfilePatch;
 type
   TWow64DisableWow64FsRedirection = function(out cookie: PVOID): BOOL; stdcall;


### PR DESCRIPTION
Fixes #6221.

If Keyman is being installed under the SYSTEM profile, e.g. when using tools such as SCCM or Intune, then the installer runs with a redirected folder for %LocalAppData%, under C:\Windows\SysWow64\config, but is given the name C:\Windows\System32\config\....

Keyman Setup then creates %LocalAppData%\Keyman\Diag, which it thinks is in C:\Windows\System32\config\... But in reality it is in SysWow64\... Keyman Setup passes a file under this folder to Windows Installer, running as 64 bit, which immediately falls over because the path does not exist to it, in the real System32\config folder.

This patch disables redirection temporarily just to create the folder under both 32 and 64 bit versions of the profile. It has no effect on normal user accounts (apart from verifying that the folder is present twice rather than once).

# User Testing

TEST_NORMAL: Verify that Keyman for Windows installs on a computer which has NEVER had Keyman installed previously (brand new Windows install essential).

TEST_REINSTALL: Verify that Keyman for Windows installs on a computer which has an earlier version of Keyman already installed.

TEST_SUPER: Verify that Keyman for Windows installs with the SYSTEM profile.

This must be run on a brand new 64-bit install of Windows (VM fine), which has never had Keyman installed previously.

1. Download [psexec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec).
2. Download the keyman-14.0.VER.exe installer from this PR (replace `VER` with appropriate version).
3. Start an elevated command prompt and run `psexec -s cmd`. This starts a command prompt with the SYSTEM profile.
4. A new command prompt will start, probably in C:\Windows\System32.
5. Locate `keyman-14.0.VER.exe` that you downloaded previously, and run it from in this SYSTEM command prompt, with the `-s -o` parameters, something like: `c:\Users\foo\Downloads\keyman-14.0.VER.exe -s -o`.
6. Wait a minute for the install to run, silently.
7. Verify that Keyman has been installed; try to start it.
8. Using Windows Explorer, navigate to `C:\Windows\System32\config\systemprofile\AppData\Local\Keyman\Diag` and verify that a `keymandesktop-xxxx.log` file exists. (Note, you may not be able to paste that path -- you may have to navigate manually in for permission to access the folder to be granted). This verifies that Keyman actually installed under the SYSTEM account.