### PR TITLE
fix(developer): support KM_KBP_IT_CAPSLOCK

### DIFF
--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -905,6 +905,7 @@ begin
       KM_KBP_IT_ALERT:          DoBell;
       KM_KBP_IT_BACK:           DoBackspace(km_kbp_backspace_type(dwData));
       KM_KBP_IT_PERSIST_OPT: ; //TODO
+      KM_KBP_IT_CAPSLOCK:    ; //TODO
       KM_KBP_IT_INVALIDATE_CONTEXT: ; // no-op
     end;
 //    AddDEBUG(Format('%d: %d [%s]', [ActionType, dwData, Text]));

--- a/windows/src/developer/TIKE/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/windows/src/developer/TIKE/debug/Keyman.System.Debug.DebugEvent.pas
@@ -143,6 +143,7 @@ begin
     KM_KBP_IT_BACK:           Action_DeleteBack(action.backspace.expected_type, action.backspace.expected_value);
     KM_KBP_IT_PERSIST_OPT:    ; // TODO: The indicated option needs to be stored.
     KM_KBP_IT_EMIT_KEYSTROKE: Action_EmitKeystroke(key);
+    KM_KBP_IT_CAPSLOCK:       ; // TODO: Caps lock state needs to be updated
     else Assert(False, 'Action type '+IntToStr(Ord(action._type))+' is unexpected.');
   end;
 end;

--- a/windows/src/developer/TIKE/debug/UfrmDebugStatus_Events.pas
+++ b/windows/src/developer/TIKE/debug/UfrmDebugStatus_Events.pas
@@ -124,6 +124,7 @@ begin
     KM_KBP_IT_BACK:        AddItem('back', action);
     KM_KBP_IT_PERSIST_OPT: AddItem('persist_opt', action);
     KM_KBP_IT_INVALIDATE_CONTEXT:  AddItem('invalidate_context', action);
+    KM_KBP_IT_CAPSLOCK:    AddItem('capslock', action);
     else             AddItem('Unknown action ???', action);
   end;
 end;

--- a/windows/src/global/delphi/general/Keyman.System.KeymanCore.pas
+++ b/windows/src/global/delphi/general/Keyman.System.KeymanCore.pas
@@ -168,6 +168,7 @@ type
             // for applications where context is cached, this clears the context;
             // for applications where context is read from the focused text store,
             // the context is just re-read and markers flushed.
+    KM_KBP_IT_CAPSLOCK    = 8,  // Enable or disable capsLock
     KM_KBP_IT_MAX_TYPE_ID
   );
 
@@ -194,7 +195,8 @@ type
     0: (marker: uintptr_t);
     1: (option: pkm_kbp_option_item);
     2: (character: km_kbp_usv);
-    3: (backspace: km_kbp_backspace_item)
+    3: (backspace: km_kbp_backspace_item);
+    4: (capsLock: uint8_t);  // CAPSLOCK type, 1 to turn on, 0 to turn off
   end;
 
   pkm_kbp_action_item = ^km_kbp_action_item;


### PR DESCRIPTION
Keyman Developer Debugger would crash due to receiving an unknown action type. This turned out to be the new KM_KBP_IT_CAPSLOCK.

Crash report: https://sentry.io/share/issue/50c09af4a0ab424784d9d2189b492bd5/

# User Testing

* TEST_CAPS_LOCK: Load gff_tigrinya_ethiopia keyboard in Keyman Developer, start debugging (F5) and press <kbd>e</kbd>. Keyman Developer should no longer crash.