### PR TITLE
chore(android/app): Clarify help on switching keyboards

### DIFF
--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -7,7 +7,14 @@ Here are some of the new features we have added to Keyman 15.0 for Android:
 * Add a menu to adjust keyboard height
 * Add a settings option to change the displayed keyboard name on the spacebar
 * Improve the globe key experience for switching keyboards:
-    * Short press and release the globe key to immediately switch to next keyboard
-    * Long press and release the globe key to bring up the keyboard picker menu
+
+    | Keyboard Type | # Keyman Keyboards | Short press and release to |
+    |---------------|:------------------:|----------------------------|
+    | In-app        | 1                  | Display keyboard picker menu |
+    | In-app        | 2+                 | Quickly switch to next Keyman keyboard |
+    | System        | 1                  | Quickly switch to previous system keyboard |
+    | System        | 2+                 | Quickly switch to next Keyman keyboard |
+
+    * Long press and release the globe key to bring up the keyboard picker menu. On a Keyman system keyboard, the bottom of this menu will also display other enabled system keyboards that can be selected.
 
     Note: On the lock screen, the keyboard picker menu is not displayed.

--- a/android/help/basic/switching-between-keyboards.md
+++ b/android/help/basic/switching-between-keyboards.md
@@ -10,7 +10,12 @@ With the keyboard visible, press and release the globe key:
 
 ![](../android_images/globe-ap.png)
 
-If only one Keyman keyboard is installed, a short press on the globe key will bring up a list of all currently installed languages. Otherwise a short press on the globe key will switch to the next language/keyboard. 
+| Keyboard Type | # Keyman Keyboards | Short press and release to |
+|---------------|:------------------:|----------------------------|
+| In-app        | 1                  | Display keyboard picker menu |
+| In-app        | 2+                 | Quickly switch to next Keyman keyboard |
+| System        | 1                  | Quickly switch to previous system keyboard |
+| System        | 2+                 | Quickly switch to next Keyman keyboard |
 
 A long press on the globe key will bring up a list of all currently installed languages (the default is **English EuroLatin (SIL)**). 
 


### PR DESCRIPTION
Clarifies in-app help on switching keyboards. Similar to keymanapp/help.keyman.com#499

@keymanapp-test-bot skip
