### PR TITLE
fix(web): Non-integer OSK sizes

### DIFF
--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -414,13 +414,13 @@ namespace com.keyman.osk {
         return;
       }
 
-      if(Number.isInteger(width as number)) {
+      if(Number.isFinite(width as number)) {
         parsedWidth = ParsedLengthStyle.inPixels(width as number);
       } else {
         parsedWidth = new ParsedLengthStyle(width as LengthStyle);
       }
 
-      if(Number.isInteger(height as number)) {
+      if(Number.isFinite(height as number)) {
         parsedHeight = ParsedLengthStyle.inPixels(height as number);
       } else {
         parsedHeight = new ParsedLengthStyle(height as LengthStyle);


### PR DESCRIPTION
If the OSK had a non-integer width or height stored in the OSK cookie, then the width and height would be parsed incorrectly and the OSK would fail to be sized correctly on first load; this also caused a script error and made the OSK impossible to interact with.

@keymanapp-test-bot skip This would be somewhat difficult to test, involving manual editing of cookies...