### PR TITLE
fix(web): add readonly mode for rule behavior finalization 🎢

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -122,7 +122,7 @@ namespace com.keyman.text {
 
       // Create a "mock" backup of the current outputTarget in its pre-input state.
       // Current, long-existing assumption - it's DOM-backed.
-      let preInputMock = Mock.from(outputTarget, false);
+      let preInputMock = Mock.from(outputTarget, true);
 
       const startingLayerId = this.keyboardProcessor.layerId;
 

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -64,7 +64,7 @@ namespace com.keyman.text {
       const ruleBehavior = this.keyboardProcessor.processNewContextEvent(this.device, outputTarget);
 
       if(ruleBehavior) {
-        ruleBehavior.finalize(this.keyboardProcessor, outputTarget);
+        ruleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
       }
       return ruleBehavior;
     }
@@ -122,7 +122,7 @@ namespace com.keyman.text {
 
       // Create a "mock" backup of the current outputTarget in its pre-input state.
       // Current, long-existing assumption - it's DOM-backed.
-      let preInputMock = Mock.from(outputTarget);
+      let preInputMock = Mock.from(outputTarget, false);
 
       const startingLayerId = this.keyboardProcessor.layerId;
 
@@ -204,7 +204,7 @@ namespace com.keyman.text {
                 break;
               }
 
-              let mock = Mock.from(windowedMock);
+              let mock = Mock.from(windowedMock, false);
 
               let altKey = activeLayout.getLayer(keyEvent.kbdLayer).getKey(pair.keyId);
               if(!altKey) {
@@ -242,7 +242,7 @@ namespace com.keyman.text {
 
         // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
         // by the actual keystroke occur.
-        ruleBehavior.finalize(this.keyboardProcessor, outputTarget);
+        ruleBehavior.finalize(this.keyboardProcessor, outputTarget, false);
 
         // -- All keystroke (and 'alternate') processing is now complete.  Time to finalize everything! --
 
@@ -270,7 +270,7 @@ namespace com.keyman.text {
 
         let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(keyEvent.device, outputTarget);
         if(postRuleBehavior) {
-          postRuleBehavior.finalize(this.keyboardProcessor, outputTarget);
+          postRuleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
         }
       }
 

--- a/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/core/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -158,7 +158,7 @@ namespace com.keyman.text.prediction {
       if(!this.isActive) {
         return;
       } else if(outputTarget) {
-        let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null);
+        let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
         this.predict_internal(transcription, true);
       } else {
         // Shouldn't be possible, and we'll want to know if and when it is.
@@ -171,7 +171,7 @@ namespace com.keyman.text.prediction {
         return null;
       }
 
-      let context = new ContextWindow(Mock.from(target), this.configuration);
+      let context = new ContextWindow(Mock.from(target, false), this.configuration);
       return this.lmEngine.wordbreak(context);
     }
 
@@ -209,7 +209,7 @@ namespace com.keyman.text.prediction {
         // Apply the Suggestion!
 
         // Step 1:  determine the final output text
-        let final = text.Mock.from(original.preInput);
+        let final = text.Mock.from(original.preInput, false);
         final.apply(suggestion.transform);
 
         // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
@@ -224,7 +224,7 @@ namespace com.keyman.text.prediction {
 
         // Build a 'reversion' Transcription that can be used to undo this apply() if needed,
         // replacing the suggestion transform with the original input text.
-        let preApply = text.Mock.from(original.preInput);
+        let preApply = text.Mock.from(original.preInput, false);
         preApply.apply(original.transform);
 
         // Builds the reversion option according to the loaded lexical model's known
@@ -279,7 +279,7 @@ namespace com.keyman.text.prediction {
       // Apply the Reversion!
 
       // Step 1:  determine the final output text
-      let final = text.Mock.from(original.preInput);
+      let final = text.Mock.from(original.preInput, false);
       final.apply(reversion.transform); // Should match original.transform, actually. (See applySuggestion)
 
       // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
@@ -306,7 +306,7 @@ namespace com.keyman.text.prediction {
         return null;
       }
 
-      let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null);
+      let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
       return this.predict(transcription);
     }
 

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -962,7 +962,7 @@ namespace com.keyman.text {
       if(!this.activeKeyboard) {
         throw "No active keyboard for keystroke processing!";
       }
-      return this.process(this.activeKeyboard.processNewContextEvent.bind(this.activeKeyboard), outputTarget, keystroke);
+      return this.process(this.activeKeyboard.processNewContextEvent.bind(this.activeKeyboard), outputTarget, keystroke, true);
     }
 
     /**
@@ -977,7 +977,7 @@ namespace com.keyman.text {
       if(!this.activeKeyboard) {
         throw "No active keyboard for keystroke processing!";
       }
-      return this.process(this.activeKeyboard.processPostKeystroke.bind(this.activeKeyboard), outputTarget, keystroke);
+      return this.process(this.activeKeyboard.processPostKeystroke.bind(this.activeKeyboard), outputTarget, keystroke, true);
     }
 
     /**
@@ -992,10 +992,10 @@ namespace com.keyman.text {
       if(!this.activeKeyboard) {
         throw "No active keyboard for keystroke processing!";
       }
-      return this.process(this.activeKeyboard.process.bind(this.activeKeyboard), outputTarget, keystroke);
+      return this.process(this.activeKeyboard.process.bind(this.activeKeyboard), outputTarget, keystroke, false);
     }
 
-    private process(callee, outputTarget: OutputTarget, keystroke: KeyEvent): RuleBehavior {
+    private process(callee, outputTarget: OutputTarget, keystroke: KeyEvent, readonly: boolean): RuleBehavior {
       // Clear internal state tracking data from prior keystrokes.
       if(!outputTarget) {
         throw "No target specified for keyboard output!";
@@ -1011,7 +1011,7 @@ namespace com.keyman.text {
       this.resetContextCache();
 
       // Capture the initial state of the OutputTarget before any rules are matched.
-      let preInput = Mock.from(outputTarget);
+      let preInput = Mock.from(outputTarget, readonly);
 
       // Capture the initial state of any variable stores
       const cachedVariableStores = this.activeKeyboard.variableStores;
@@ -1029,7 +1029,7 @@ namespace com.keyman.text {
       this.activeTargetOutput = null;
 
       // Finalize the rule's results.
-      this.ruleBehavior.transcription = outputTarget.buildTranscriptionFrom(preInput, keystroke);
+      this.ruleBehavior.transcription = outputTarget.buildTranscriptionFrom(preInput, keystroke, readonly);
 
       // We always backup the changes to variable stores to the RuleBehavior, to
       // be applied during finalization, then restore them to the cached initial

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -1011,7 +1011,7 @@ namespace com.keyman.text {
       this.resetContextCache();
 
       // Capture the initial state of the OutputTarget before any rules are matched.
-      let preInput = Mock.from(outputTarget, readonly);
+      let preInput = Mock.from(outputTarget, true);
 
       // Capture the initial state of any variable stores
       const cachedVariableStores = this.activeKeyboard.variableStores;

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -112,8 +112,8 @@ namespace com.keyman.text {
      * @param   {boolean} outputTarget  The OutputTarget receiving the KeyEvent
      * @return  {string}
      */
-    defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
-      let preInput = Mock.from(outputTarget);
+    defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTarget, readonly: boolean): RuleBehavior {
+      let preInput = Mock.from(outputTarget, readonly);
       let ruleBehavior = new RuleBehavior();
 
       let matched = false;
@@ -176,7 +176,7 @@ namespace com.keyman.text {
         return ruleBehavior;
       }
 
-      let transcription = outputTarget.buildTranscriptionFrom(preInput, Lkc);
+      let transcription = outputTarget.buildTranscriptionFrom(preInput, Lkc, readonly);
       ruleBehavior.transcription = transcription;
 
       return ruleBehavior;
@@ -257,7 +257,7 @@ namespace com.keyman.text {
 
         // Match against the 'default keyboard' - rules to mimic the default string output when typing in a browser.
         // Many keyboards rely upon these 'implied rules'.
-        let defaultBehavior = this.defaultRuleBehavior(keyEvent, outputTarget);
+        let defaultBehavior = this.defaultRuleBehavior(keyEvent, outputTarget, false);
         if(defaultBehavior) {
           if(!matchBehavior) {
             matchBehavior = defaultBehavior;

--- a/common/core/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/core/web/keyboard-processor/src/text/outputTarget.ts
@@ -84,12 +84,12 @@ namespace com.keyman.text {
 
     /**
      * Should be called by each output target immediately before text mutation operations occur.
-     * 
+     *
      * Maintains solutions to old issues:  I3318,I3319
      * @param {number} delta  Use negative values if characters were deleted, positive if characters were added.
      */
     protected adjustDeadkeys(delta: number) {
-      this.deadkeys().adjustPositions(this.getDeadkeyCaret(), delta); 
+      this.deadkeys().adjustPositions(this.getDeadkeyCaret(), delta);
     }
 
     /**
@@ -103,7 +103,7 @@ namespace com.keyman.text {
     /**
      * Determines the basic operations needed to reconstruct the current OutputTarget's text from the prior state specified
      * by another OutputTarget based on their text and caret positions.
-     * 
+     *
      * This is designed for use as a "before and after" comparison to determine the effect of a single keyboard rule at a time.
      * As such, it assumes that the caret is immediately after any inserted text.
      * @param from An output target (preferably a Mock) representing the prior state of the input/output system.
@@ -190,12 +190,12 @@ namespace com.keyman.text {
       return new TextTransform(delta, deletedLeft, deletedRight);
     }
 
-    buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent, alternates?: Alternate[]): Transcription {
+    buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent, readonly: boolean, alternates?: Alternate[]): Transcription {
       let transform = this.buildTransformFrom(original);
 
       // If we ever decide to re-add deadkey tracking, this is the place for it.
 
-      return new Transcription(keyEvent, transform, Mock.from(original), alternates);
+      return new Transcription(keyEvent, transform, Mock.from(original, readonly), alternates);
     }
 
     /**
@@ -232,7 +232,7 @@ namespace com.keyman.text {
     /**
      * Helper to `restoreTo` - allows directly setting the 'before' context to that of another
      * `OutputTarget`.
-     * @param s 
+     * @param s
      */
     protected setTextBeforeCaret(s: string): void {
       // This one's easy enough to provide a default implementation for.
@@ -243,7 +243,7 @@ namespace com.keyman.text {
     /**
      * Helper to `restoreTo` - allows directly setting the 'after' context to that of another
      * `OutputTarget`.
-     * @param s 
+     * @param s
      */
     protected abstract setTextAfterCaret(s: string): void;
 
@@ -257,7 +257,7 @@ namespace com.keyman.text {
      * Clears any cached selection-related state values.
      */
     abstract invalidateSelection(): void;
-    
+
     /**
      * Indicates whether or not the underlying element has its own selection (input, textarea)
      * or is part of (or possesses) the DOM's active selection.
@@ -268,7 +268,7 @@ namespace com.keyman.text {
      * Returns an index corresponding to the caret's position for use with deadkeys.
      */
     abstract getDeadkeyCaret(): number;
-    
+
     /**
      * Relative to the caret, gets the current context within the wrapper's element.
      */
@@ -288,7 +288,7 @@ namespace com.keyman.text {
     /**
      * Performs context deletions (from the left of the caret) as needed by the KeymanWeb engine and
      * corrects the location of any affected deadkeys.
-     * 
+     *
      * Does not delete deadkeys (b/c KMW 1 & 2 behavior maintenance).
      * @param dn The number of characters to delete.  If negative, context will be left unchanged.
      */
@@ -297,7 +297,7 @@ namespace com.keyman.text {
     /**
      * Inserts text immediately before the caret's current position, moving the caret after the
      * newly inserted text in the process along with any affected deadkeys.
-     * 
+     *
      * @param s Text to insert before the caret's current position.
      */
     abstract insertTextBeforeCaret(s: string): void;
@@ -322,7 +322,7 @@ namespace com.keyman.text {
      * ops to facilitate more-seamless web-dev and user interactions.
      */
     restoreProperties(){
-      // Most element interfaces won't need anything here. 
+      // Most element interfaces won't need anything here.
     }
 
     /**
@@ -347,7 +347,7 @@ namespace com.keyman.text {
     }
 
     // Clones the state of an existing EditableElement, creating a Mock version of its state.
-    static from(outputTarget: OutputTarget) {
+    static from(outputTarget: OutputTarget, readonly: boolean) {
       let clone: Mock;
 
       if(outputTarget instanceof Mock) {
@@ -359,12 +359,20 @@ namespace com.keyman.text {
         // If we're 'cloning' a different OutputTarget type, we don't have a
         // guaranteed way to more efficiently get these values; these are the
         // best methods specified by the abstraction.
-        let preText = outputTarget.getTextBeforeCaret();
-        let caretIndex = preText._kmwLength();
 
-        // We choose to ignore (rather, pre-emptively remove) any actively-selected text,
-        // as since it's always removed instantly during any text mutation operations.
-        clone = new Mock(preText + outputTarget.getTextAfterCaret(), caretIndex);
+        if(readonly) {
+          // for NewContext and PostOutput, we want the whole text
+          let text = outputTarget.getText();
+          let afterText = outputTarget.getTextAfterCaret();
+          let caretIndex = text._kmwLength() - afterText._kmwLength();
+          clone = new Mock(text, caretIndex);
+        } else {
+          // We choose to ignore (rather, pre-emptively remove) any actively-selected text,
+          // as since it's always removed instantly during any text mutation operations.
+          let preText = outputTarget.getTextBeforeCaret();
+          let caretIndex = preText._kmwLength();
+          clone = new Mock(preText + outputTarget.getTextAfterCaret(), caretIndex);
+        }
       }
 
       // Also duplicate deadkey state!  (Needed for fat-finger ops.)
@@ -372,7 +380,7 @@ namespace com.keyman.text {
 
       return clone;
     }
-    
+
     clearSelection(): void {
       return;
     }

--- a/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
+++ b/common/core/web/keyboard-processor/src/text/ruleBehavior.ts
@@ -59,7 +59,7 @@ namespace com.keyman.text {
      */
     triggerKeyDefault?: boolean;
 
-    finalize(processor: KeyboardProcessor, outputTarget: OutputTarget) {
+    finalize(processor: KeyboardProcessor, outputTarget: OutputTarget, readonly: boolean) {
       if(!this.transcription) {
         throw "Cannot finalize a RuleBehavior with no transcription.";
       }
@@ -123,11 +123,11 @@ namespace com.keyman.text {
 
       this.triggersDefaultCommand = this.triggersDefaultCommand || other.triggersDefaultCommand;
 
-      let mergingMock = Mock.from(this.transcription.preInput);
+      let mergingMock = Mock.from(this.transcription.preInput, false);
       mergingMock.apply(this.transcription.transform);
       mergingMock.apply(other.transcription.transform);
 
-      this.transcription = mergingMock.buildTranscriptionFrom(this.transcription.preInput, keystroke, this.transcription.alternates);
+      this.transcription = mergingMock.buildTranscriptionFrom(this.transcription.preInput, keystroke, false, this.transcription.alternates);
     }
   }
 }

--- a/web/source/dom/domOverrides.ts
+++ b/web/source/dom/domOverrides.ts
@@ -17,10 +17,15 @@ namespace com.keyman.dom {
   }
 
   let headlessRuleBehaviorFinalize = text.RuleBehavior.prototype.finalize;
-  text.RuleBehavior.prototype.finalize = function(this: text.RuleBehavior, processor: text.KeyboardProcessor, outputTarget: text.OutputTarget) {
+  text.RuleBehavior.prototype.finalize = function(this: text.RuleBehavior, processor: text.KeyboardProcessor, outputTarget: text.OutputTarget, readonly: boolean) {
     let keyman = com.keyman.singleton;
     // Execute the standard baseline stuff first.
     headlessRuleBehaviorFinalize.call(this, processor);
+
+    // newContext and postKeystroke events cannot emit content
+    if(readonly) {
+      return;
+    }
 
     // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.
     let ruleTransform = this.transcription.transform;

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -407,7 +407,7 @@ namespace com.keyman.osk {
       keyman.core.keyboardProcessor.processPostKeystroke(this.hostDevice, outputTarget)
         // If we have a RuleBehavior as a result, run it on the target. This should
         // only change system store and variable store values.
-        ?.finalize(keyman.core.keyboardProcessor, outputTarget);
+        ?.finalize(keyman.core.keyboardProcessor, outputTarget, true);
 
       return true;
     };


### PR DESCRIPTION
Relates to #5853, #6177.

Two things happened here:

1. Construction of Mocks made an assumption that the selection should always be deleted. However, for NewContext and PostKeystroke processes, we don't want to change anything. https://github.com/keymanapp/keyman/blob/ee14b17b12dafc2b99149dfc67c93da12e19946a/common/core/web/keyboard-processor/src/text/outputTarget.ts#L365-L367

2. Even if nothing is changed, the transcription would emit what is in theory a no-op ruleTransform (insert="", deleteLeft=0, deleteRight=0). But apps would treat this as deleting the selection.

This fix goes a little broader than I would have preferred, but adds a readonly mode to the transcription and mock model, so that we can control explicitly when changes are applied to the text store.

I think we still have some over-eager NewContext calls on Android that we need to diagnose separately; see #6257. I have not checked this on iOS.

@keymanapp-test-bot skip Moving tests to descendant PRs