### PR TITLE
fix(android): properly handle selection 🎢

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -1,4 +1,4 @@
-var _debug = 1;
+var _debug = 0;
 
 // Android harness attachment
 if(window.parent && window.parent.jsInterface && !window.jsInterface) {

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -1,4 +1,4 @@
-let _debug = 0;
+var _debug = 1;
 
 // Android harness attachment
 if(window.parent && window.parent.jsInterface && !window.jsInterface) {
@@ -224,7 +224,7 @@ function updateKMSelectionRange(start, end) {
 
   var selDirection = 'forward';
   if(start > end) {
-    let e0 = end;
+    var e0 = end;
     end = start;
     start = e0;
     selDirection = 'backward';

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2726,6 +2726,7 @@ public final class KMManager {
               textView.getText().delete(start, end);
               textView.setSelection(start);
               end = start;
+              deleteLeft = 0;
             }
             for (int i = 0; i < deleteLeft; i++) {
               CharSequence chars = textView.getText().subSequence(0, start);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2683,17 +2683,24 @@ public final class KMManager {
             start = temp;
           }
 
-          if (dn <= 0) {
+          int deleteLeft = dn;
+
+          if(start != end && dn == 1 && s.length() == 0) {
+            /* Handle backspace with a selection: just delete selection */
+            deleteLeft = 0;
+          }
+
+          if (deleteLeft <= 0) {
             if (start == end) {
               if (s.length() > 0 && s.charAt(0) == '\n') {
                 textView.keyDownUp(KeyEvent.KEYCODE_ENTER);
-              } else {
-                // *** TO DO: Try to find a solution to the bug on API < 17, insert overwrites on next line
-                if (s.length() > 0) {
+              } else if (s.length() > 0) {
+                  // *** TO DO: Try to find a solution to the bug on API < 17, insert overwrites on next line
                   InAppKeyboardShouldIgnoreTextChange = true;
                   InAppKeyboardShouldIgnoreSelectionChange = true;
                   textView.getText().insert(start, s);
-                }
+              } else {
+                textView.getText().delete(start, end);
               }
             } else {
               if (s.length() > 0 && s.charAt(0) == '\n') {
@@ -2712,21 +2719,25 @@ public final class KMManager {
               }
             }
           } else {
-            for (int i = 0; i < dn; i++) {
-              CharSequence chars = textView.getText().subSequence(0, start);
-              if (chars != null && chars.length() > 0) {
-                char c = chars.charAt(start - 1);
-                InAppKeyboardShouldIgnoreTextChange = true;
-                InAppKeyboardShouldIgnoreSelectionChange = true;
-                if (Character.isLowSurrogate(c)) {
-                  textView.getText().delete(start - 2, end);
-                } else {
-                  textView.getText().delete(start - 1, end);
-                }
+            if(start == end) {
+              for (int i = 0; i < deleteLeft; i++) {
+                CharSequence chars = textView.getText().subSequence(0, start);
+                if (chars != null && chars.length() > 0) {
+                  char c = chars.charAt(start - 1);
+                  InAppKeyboardShouldIgnoreTextChange = true;
+                  InAppKeyboardShouldIgnoreSelectionChange = true;
+                  if (Character.isLowSurrogate(c)) {
+                    textView.getText().delete(start - 2, end);
+                  } else {
+                    textView.getText().delete(start - 1, end);
+                  }
 
-                start = textView.getSelectionStart();
-                end = textView.getSelectionEnd();
+                  start = textView.getSelectionStart();
+                  end = textView.getSelectionEnd();
+                }
               }
+            } else {
+              Log.w(TAG, "Unexpected request to selection");
             }
 
             if (s.length() > 0) {
@@ -2736,6 +2747,8 @@ public final class KMManager {
             }
           }
 
+          // Collapse the selection
+          textView.setSelection(start + s.length());
           textView.endBatchEdit();
         }
       });

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2925,7 +2925,17 @@ public final class KMManager {
         return;
       }
 
-      int numPairs = CharSequenceUtil.countSurrogatePairs(charsBackup, dn);
+      // Count the number of characters which are surrogate pairs
+      int index = lastIndex, dnx = dn, numPairs = 0;
+      while(index > 0 && dnx > 0) {
+        if(Character.isLowSurrogate(charsBackup.charAt(index)) &&
+            Character.isHighSurrogate(charsBackup.charAt(index-1))) {
+          numPairs++;
+          index--;
+        }
+        index--;
+        dnx--;
+      }
 
       // Chop dn+numPairs code points from the end of charsBackup
       // subSequence indices are start(inclusive) to end(exclusive)


### PR DESCRIPTION
Part of #5853.

Fixes #6261.
Fixes #6177 (Android).

Building on the fixes in KeymanWeb in #6272, we do similar patches for Android.

I think it is likely that the iOS tests will fail -- in which case, I will work through similar patches for iOS.

# User Testing

(Note: these tests are very good candidates for general acceptance tests!)

Where requested, these tests should be run using the attached [web_context_tests keyboard](https://drive.google.com/file/d/1C1I39AxR9egfuQKXRbwwyK4T9YBw6Ji-/view?usp=sharing).

* **GROUP_ANDROID_INAPP:** Test on Keyman for Android, in-app
* **GROUP_ANDROID_SYSTEM:** Test on Keyman for Android, system keyboard

**TEST_BASELINE:** Using a keyboard with some complex behaviours, such as Khmer Angkor, verify that input sequences are correct. For example, type <kbd>x</kbd><kbd>E</kbd><kbd>j</kbd><kbd>m</kbd><kbd>r</kbd> (desktop: <kbd>ខ</kbd><kbd>ែ</kbd><kbd>្</kbd><kbd>ម</kbd><kbd>រ</kbd> touch: <kbd>ខ</kbd><kbd>ែ (longpress េ)</kbd><kbd>្ម (longpress ម)</kbd><kbd>រ</kbd>) and verify that the emitted output is actually `ខ្មែរ` (you may need to use a tool to view the Unicode values, which should be as in the image below).

![image](https://user-images.githubusercontent.com/4498365/153732875-71312511-7784-4ae0-8833-7f7fc23188ef.png)

**TEST_SELECTION:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select `bc` and type <kbd>q</kbd>. The output after the final key should be `aqx`. (This is testing selection replacement with no matching keyboard rule.)

**TEST_SELECTION_2:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select `bc` and type <kbd>p</kbd>. The output after the final key should be `aqx`. (This is testing selection replacement with a matching keyboard rule.)

**TEST_CONTEXT_BASE:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and type <kbd>d</kbd>. The output after the final key should be `abcd`.

**TEST_CONTEXT_SELECTION_2:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and delete it with <kbd>Backspace</kbd>. Type <kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION_3:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and type <kbd>y</kbd>. Press <kbd>Backspace</kbd>, and type <kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION_4:** Using the attached web_context_tests keyboard, type <kbd>x</kbd><kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `abc` characters, and type <kbd>d</kbd>. The output after the final key should be `xdx`.

## SMP Tests

**TEST_SELECTION_SMP:** Using the web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select `𐌁𐌂` and type <kbd>o</kbd>. The output after the final key should be `𐌀𐍈𐌈`.

**TEST_CONTEXT_BASE_SMP:** Using the web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and type <kbd>i</kbd>. The output after the final key should be `𐌀𐌁𐌂i`.

**TEST_CONTEXT_SELECTION_SMP_2:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and delete it with <kbd>Backspace</kbd>. Type <kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP_3:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and type <kbd>k</kbd>. Press <kbd>Backspace</kbd>, and type <kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP_4:** Using the attached web_context_tests keyboard, type <kbd>k</kbd><kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>k</kbd>. Select the `𐌀𐌁𐌂` characters, and type <kbd>i</kbd>. The output after the final key should be `𐌰i𐌰`.
