### PR TITLE
fix(linux): Properly compare versions in km-package-install

### DIFF
--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+from distutils.version import StrictVersion
 import logging
 import sys
 import os
@@ -136,19 +137,21 @@ def main():
             sys.exit(2)
         try_install_kmp(args.file, "file " + args.file, False, args.shared)
     elif args.package:
-        installed_kmp_ver = get_kmp_version(args.package)
+        installed_kmp_v = get_kmp_version(args.package)
         kbdata = get_keyboard_data(args.package)
         if not kbdata:
             logging.error("km-package-install: error: Could not download keyboard data for %s", args.package)
             sys.exit(3)
-        kbdata_version = secure_lookup(kbdata, 'version')
-        if installed_kmp_ver and kbdata_version:
+        kbdata_v = secure_lookup(kbdata, 'version')
+        if installed_kmp_v and kbdata_v:
+            kbdata_version = StrictVersion(kbdata_v)
+            installed_kmp_ver = StrictVersion(installed_kmp_v)
             if kbdata_version == installed_kmp_ver:
                 logging.error(
                     "km-package-install: The %s version of the %s keyboard package is already installed.",
                     installed_kmp_ver, args.package)
                 sys.exit(1)
-            elif float(kbdata_version) > float(installed_kmp_ver):
+            elif kbdata_version > installed_kmp_ver:
                 logging.error(
                     "km-package-install: A newer version of %s keyboard package is available. " +
                     "Uninstalling old version %s then downloading and installing new version %s.",

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -147,15 +147,13 @@ def main():
             kbdata_version = StrictVersion(kbdata_v)
             installed_kmp_ver = StrictVersion(installed_kmp_v)
             if kbdata_version == installed_kmp_ver:
-                logging.error(
-                    "km-package-install: The %s version of the %s keyboard package is already installed.",
-                    installed_kmp_ver, args.package)
+                print("km-package-install: Version %s of the %s keyboard package is already installed."
+                      % (installed_kmp_ver, args.package))
                 sys.exit(1)
             elif kbdata_version > installed_kmp_ver:
-                logging.error(
-                    "km-package-install: A newer version of %s keyboard package is available. " +
-                    "Uninstalling old version %s then downloading and installing new version %s.",
-                    args.package, installed_kmp_ver, kbdata_version)
+                print("km-package-install: A newer version of %s keyboard package is available. Uninstalling old "
+                      "version %s then downloading and installing new version %s."
+                      % (args.package, installed_kmp_ver, kbdata_version))
                 uninstall_kmp(args.package, args.shared)
 
         kmpfile = get_kmp(args.package)


### PR DESCRIPTION
This change will fix a bug with comparing version numbers with more than two sections (e.g. '1.2.3').

Fixes #6182.

# User Testing

## Preparations

- The Linux version doesn't matter for these tests
- Install build artifacts of this PR
- Download and unzip the attached **gff_amharic.kmp** file
- Install the unzipped gff_amharic keyboard in the attached older version:

  ```bash
  cd Downloads # (or wherever you unzipped the .kmp file)
  km-package-install -f gff_amharic.kmp
  ```

- run `km-package-list-installed` and verify that the "GFF Amharic Keyboard" shows up with version 1.9.1 and id `gff_amharic`.

## Tests

- **TEST_UPDATE**: Update to new version of gff_amharic
  - from the command line, run:
    ```bash
    km-package-install -p gff_amharic
    ```
  - verify that this outputs a message saying that a newer version is available and that the old version 1.9.1 will be uninstalled and the new version 2.2 downloaded and installed.
  - run `km-package-list-installed` and verify that the previous "GFF Amharic Keyboard" line got replaced by a line "Amharic", version 2.2 (or newer) and id `gff_amharic`.

- **TEST_SAMEVERSION**: Reinstall same version of the keyboard
  - from the command line, run:
    ```bash
    km-package-install -p gff_amharic
    ```
  - verify that this outputs a message that version 2.2 is already installed

## Attachments

[gff_amharic_1.9.1.zip](https://github.com/keymanapp/keyman/files/8125210/gff_amharic_1.9.1.zip)

