### PR TITLE
fix(ios): properly handle selection 🎢

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -298,8 +298,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     let selection = textDocumentProxy.selectedText ?? ""
     let contextAfterInput = textDocumentProxy.documentContextAfterInput ?? ""
     let context = "\(contextBeforeInput)\(selection)\(contextAfterInput)"
-    let bLength = contextBeforeInput.unicodeScalars.count
-    let sLength = selection.unicodeScalars.count
+    let bLength = contextBeforeInput.utf16.count
+    let sLength = selection.utf16.count
     setContextState(text: context, range: NSMakeRange(bLength, sLength))
     // Within the app, this is triggered after every keyboard input.
     // We should NOT call .resetContext() here for this reason.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -295,17 +295,12 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     }
     
     let contextBeforeInput = textDocumentProxy.documentContextBeforeInput ?? ""
+    let selection = textDocumentProxy.selectedText ?? ""
     let contextAfterInput = textDocumentProxy.documentContextAfterInput ?? ""
-    let context = "\(contextBeforeInput)\(contextAfterInput)"
-
-    let newRange: Range<String.Index>
-    if let range = context.range(of: contextBeforeInput) {
-      newRange = range.upperBound..<range.upperBound
-    } else {
-      newRange = context.startIndex..<context.startIndex
-    }
-
-    setContextState(text: context, range: NSRange(newRange, in: context))
+    let context = "\(contextBeforeInput)\(selection)\(contextAfterInput)"
+    let bLength = contextBeforeInput.unicodeScalars.count
+    let sLength = selection.unicodeScalars.count
+    setContextState(text: context, range: NSMakeRange(bLength, sLength))
     // Within the app, this is triggered after every keyboard input.
     // We should NOT call .resetContext() here for this reason.
   }
@@ -322,17 +317,19 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       isInputClickSoundEnabled = false
       perform(#selector(self.enableInputClickSound), with: nil, afterDelay: 0.1)
     }
+    
+    var hasDeletedSelection = false
+    
+    if let selected = textDocumentProxy.selectedText {
+      if selected.count > 0 {
+        textDocumentProxy.deleteBackward()
+        hasDeletedSelection = true
+      }
+    }
 
-    if numCharsToDelete <= 0 {
+    if numCharsToDelete <= 0 || hasDeletedSelection {
       textDocumentProxy.insertText(newText)
 
-      // A full-context deletion will report numCharsToDelete == 0 and won't
-      // otherwise delete selected text.
-      if let selected = textDocumentProxy.selectedText {
-        if selected.count > 0 {
-          textDocumentProxy.deleteBackward()
-        }
-      }
       return
     }
 


### PR DESCRIPTION
Relates to #5853
~~Fixes 6041~~ Looks like this is still a separate issue (per discussion with @sgschantz)

This deals with deleting the selection with the new interface for KeymanWeb. It also ensures that the selection is always correctly sent to KeymanWeb.

# User Testing

(Note: these tests are very good candidates for general acceptance tests!)

Where requested, these tests should be run using the attached [web_context_tests keyboard](https://drive.google.com/file/d/1C1I39AxR9egfuQKXRbwwyK4T9YBw6Ji-/view?usp=sharing).

* **GROUP_IOS_INAPP:** Test on Keyman for iPhone and iPad, in-app
* **GROUP_IOS_SYSTEM:** Test on Keyman for iPhone and iPad, system keyboard

**TEST_BASELINE:** Using a keyboard with some complex behaviours, such as Khmer Angkor, verify that input sequences are correct. For example, type <kbd>x</kbd><kbd>E</kbd><kbd>j</kbd><kbd>m</kbd><kbd>r</kbd> (desktop: <kbd>ខ</kbd><kbd>ែ</kbd><kbd>្</kbd><kbd>ម</kbd><kbd>រ</kbd> touch: <kbd>ខ</kbd><kbd>ែ (longpress េ)</kbd><kbd>្ម (longpress ម)</kbd><kbd>រ</kbd>) and verify that the emitted output is actually `ខ្មែរ` (you may need to use a tool to view the Unicode values, which should be as in the image below).

![image](https://user-images.githubusercontent.com/4498365/153732875-71312511-7784-4ae0-8833-7f7fc23188ef.png)

**TEST_SELECTION:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select `bc` and type <kbd>q</kbd>. The output after the final key should be `aqx`. (This is testing selection replacement with no matching keyboard rule.)

**TEST_SELECTION_2:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select `bc` and type <kbd>p</kbd>. The output after the final key should be `aqx`. (This is testing selection replacement with a matching keyboard rule.)

**TEST_CONTEXT_BASE:** Using the web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and type <kbd>d</kbd>. The output after the final key should be `abcd`.

**TEST_CONTEXT_SELECTION_2:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and delete it with <kbd>Backspace</kbd>. Type <kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION_3:** Using the attached web_context_tests keyboard, type <kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `x` character, and type <kbd>y</kbd>. Press <kbd>Backspace</kbd>, and type <kbd>d</kbd>. The output after the final key should be `!`.

**TEST_CONTEXT_SELECTION_4:** Using the attached web_context_tests keyboard, type <kbd>x</kbd><kbd>a</kbd><kbd>b</kbd><kbd>c</kbd><kbd>x</kbd>. Select the `abc` characters, and type <kbd>d</kbd>. The output after the final key should be `xdx`.

## SMP Tests

**TEST_SELECTION_SMP:** Using the web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select `𐌁𐌂` and type <kbd>o</kbd>. The output after the final key should be `𐌀𐍈𐌈`.

**TEST_CONTEXT_BASE_SMP:** Using the web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and type <kbd>i</kbd>. The output after the final key should be `𐌀𐌁𐌂i`.

**TEST_CONTEXT_SELECTION_SMP_2:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and delete it with <kbd>Backspace</kbd>. Type <kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP_3:** Using the attached web_context_tests keyboard, type <kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>j</kbd>. Select the `𐌈` character, and type <kbd>k</kbd>. Press <kbd>Backspace</kbd>, and type <kbd>i</kbd>. The output after the final key should be `𐌙`.

**TEST_CONTEXT_SELECTION_SMP_4:** Using the attached web_context_tests keyboard, type <kbd>k</kbd><kbd>f</kbd><kbd>g</kbd><kbd>h</kbd><kbd>k</kbd>. Select the `𐌀𐌁𐌂` characters, and type <kbd>i</kbd>. The output after the final key should be `𐌰i𐌰`.

## ~~Multi-line backspace Crash Test~~

~~TEST_MULTI_LINE_BACKSPACE: (following the steps from #6041, using the [start_of_sentence_3621.kmp](https://drive.google.com/uc?id=1WbiesUOgI5Nby8xJM_vSy-Ip_-98nLCf&export=download)) Type <kbd>S</kbd><kbd>Return</kbd><kbd>S</kbd><kbd>Return</kbd><kbd>S</kbd><kbd>Return</kbd>, then use the OSK backspace key to delete all content. Keyman should no longer crash.~~
