### PR TITLE
feat(oem/fv/android): Add keyboard and dictionary controls

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -182,15 +182,15 @@ public class PackageProcessor {
    */
   public Map<String, String>[] processEntry(JSONObject jsonEntry, String packageId, String packageVersion, ArrayList<String> languageList) throws JSONException {
     JSONArray languages = jsonEntry.getJSONArray(PP_LANGUAGES_KEY);
-    int preferredLanguageCount = (languageList != null & !languageList.isEmpty()) ? languageList.size() : 1;
+    int preferredLanguageCount = (languageList != null && !languageList.isEmpty()) ? languageList.size() : 1;
     String defaultLanguageID = languages.getJSONObject(0).getString("id");
     if (languageList == null || languageList.isEmpty()) {
       languageList = new ArrayList<String>();
       languageList.add(defaultLanguageID);
     }
 
-
     String keyboardId = jsonEntry.getString(PP_KEYBOARD_ID_KEY);
+    // Check that package has touch keyboards.
     if (touchKeyboardExists(packageId, keyboardId)) {
       HashMap<String, String>[] keyboards = new HashMap[preferredLanguageCount];
       boolean firstLanguageAdded = false;
@@ -561,7 +561,7 @@ public class PackageProcessor {
       File kmpFile = new File(packageId + ".kmp");
       File packageDir = constructPath(kmpFile, false);
       File[] files = packageDir.listFiles(touchKeyboardFilter);
-      if (files.length > 0) {
+      if (files != null && files.length > 0) {
         return true;
       }
     }

--- a/android/KMEA/app/src/main/res/layout/models_list_row_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/models_list_row_layout.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/list_item" >
@@ -10,6 +11,7 @@
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
         android:src="@drawable/ic_check"
+        app:tint="@android:color/holo_blue_light"
         android:layout_alignParentStart="true"
         android:layout_marginStart="12dp"
         android:layout_marginEnd="12dp"

--- a/oem/firstvoices/android/.editorconfig
+++ b/oem/firstvoices/android/.editorconfig
@@ -5,4 +5,4 @@ root = true
 indent_style = space
 
 [*.{java, sh, css, html, xml}]
-indent_size = 4
+indent_size = 2

--- a/oem/firstvoices/android/.gitignore
+++ b/oem/firstvoices/android/.gitignore
@@ -22,7 +22,6 @@
 app/src/main/assets/packages
 app/src/main/assets/keyboards.csv
 app/src/main/assets/fv_all.kmp
-app/src/main/assets/nrc.str.sencoten.model.kmp
 
 # Legacy Eclipse IDE files
 .classpath

--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.firstvoices.keyboards" >
 
-    <!-- Keyman Engine removes INTERNET permission, so add it back for crash reporting -->
+    <!-- Keyman Engine removes INTERNET permission, so add it back for crash reporting and get dictionaries -->
     <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"
@@ -41,7 +42,8 @@
 
         <activity
             android:name="com.firstvoices.keyboards.MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -59,10 +61,26 @@
             android:theme="@style/AppTheme.Light.Dialog" >
         </activity>
         <activity
+            android:name="com.firstvoices.keyboards.FVKeyboardSettingsActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.Light.Dialog" >
+        </activity>
+        <activity
             android:name="com.firstvoices.keyboards.SetupActivity"
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:theme="@style/AppTheme.Light.Dialog" >
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/android/FVKmpInstallMode.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/android/FVKmpInstallMode.java
@@ -1,0 +1,8 @@
+package com.firstvoices.android;
+
+public enum FVKmpInstallMode {
+  Silent,       // Show no UI while installing a package. Errors may be shown as toasts
+  WelcomeOnly,  // Show only the welcome screen after installing a package; language will
+  // be automatically selected if not provided as an input parameter
+  Full          // Show readme, language picker (if applicable), and welcome after install.
+}

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/android/FVKmpInstallMode.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/android/FVKmpInstallMode.java
@@ -3,6 +3,6 @@ package com.firstvoices.android;
 public enum FVKmpInstallMode {
   Silent,       // Show no UI while installing a package. Errors may be shown as toasts
   WelcomeOnly,  // Show only the welcome screen after installing a package; language will
-  // be automatically selected if not provided as an input parameter
+                // be automatically selected if not provided as an input parameter
   Full          // Show readme, language picker (if applicable), and welcome after install.
 }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVDownloadResultReceiver.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVDownloadResultReceiver.java
@@ -1,0 +1,52 @@
+package com.firstvoices.keyboards;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.ResultReceiver;
+import android.widget.Toast;
+
+import com.firstvoices.android.FVKmpInstallMode;
+import com.tavultesoft.kmea.BaseActivity;
+import com.tavultesoft.kmea.util.FileUtils;
+
+import java.io.File;
+
+public class FVDownloadResultReceiver extends ResultReceiver {
+  private Context context;
+
+  public FVDownloadResultReceiver(Handler handler, Context context) {
+    super(handler);
+
+    this.context = context;
+  }
+
+  @Override
+  protected void onReceiveResult(int resultCode, Bundle resultData) {
+    switch(resultCode) {
+      case FileUtils.DOWNLOAD_ERROR :
+        BaseActivity.makeToast(context, R.string.download_failed, Toast.LENGTH_SHORT);
+        break;
+      case FileUtils.DOWNLOAD_SUCCESS :
+        String downloadedFilename = resultData.getString("filename");
+        String languageID = resultData.getString("language");
+        String kmpFilename = resultData.getString("destination") + File.separator + downloadedFilename;
+        FVKmpInstallMode installMode = (FVKmpInstallMode) resultData.getSerializable("installMode");
+        if(installMode == null) installMode = FVKmpInstallMode.Silent; // Default to silent installs
+
+        Bundle bundle = new Bundle();
+        bundle.putString("kmpFile", kmpFilename);
+        bundle.putString("language", languageID);
+        bundle.putSerializable("installMode", installMode);
+        Intent packageIntent = new Intent(context, PackageActivity.class);
+        packageIntent.putExtras(bundle);
+        context.startActivity(packageIntent);
+        break;
+      case FileUtils.DOWNLOAD_CANCELLED :
+        // NO-OP
+        break;
+    }
+    super.onReceiveResult(resultCode, resultData);
+  }
+}

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -1,0 +1,300 @@
+package com.firstvoices.keyboards;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
+import androidx.appcompat.widget.Toolbar;
+
+import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.ModelPickerActivity;
+import com.tavultesoft.kmea.cloud.CloudApiTypes;
+import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
+import com.tavultesoft.kmea.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
+import com.tavultesoft.kmea.data.CloudRepository;
+import com.tavultesoft.kmea.data.Dataset;
+import com.tavultesoft.kmea.data.KeyboardController;
+import com.tavultesoft.kmea.util.KMLog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Displays an FV Keyboard enable and some lexical model switches.
+ */
+public final class FVKeyboardSettingsActivity extends AppCompatActivity {
+  private Context context;
+  private static Toolbar toolbar = null;
+  private static TextView fvKeyboardTextView = null;
+  private static TextView fvVersionTextView = null;
+  private static TextView lexicalModelTextView = null;
+  private static TextView correctionsTextView = null;
+  private static SwitchCompat fvKeyboardToggle = null;
+  private static SwitchCompat correctionsToggle = null;
+  private String associatedLexicalModel = "";
+  private String lgCode;
+  private String lgName;
+  private String kbId;
+  private String kbName;
+  private String customHelpLink;
+  private String version;
+  private SharedPreferences prefs;
+
+  private static Dataset repo;
+  private boolean didExecuteParser = false;
+
+  private final static String TAG = "FVKbdSettingsAct";
+
+  private class PreferenceToggleListener implements View.OnClickListener {
+    String prefsKey;
+    String lgCode;
+
+    public PreferenceToggleListener(String prefsKey, String lgCode) {
+      this.prefsKey = prefsKey;
+      this.lgCode = lgCode;
+    }
+
+    @Override
+    public void onClick(View v) {
+      // For predictions/corrections toggle
+      SwitchCompat toggle = (SwitchCompat) v;
+
+      SharedPreferences.Editor prefEditor = prefs.edit();
+
+      // predictionsToggle overrides correctionToggle and correctionsTextView
+      if (prefsKey.endsWith(KMManager.predictionPrefSuffix)) {
+        boolean override = toggle.isChecked();
+        overrideCorrectionsToggle(override);
+      }
+
+      // This will allow preemptively making settings for languages without models.
+      // Seems more trouble than it's worth to block this.
+      prefEditor.putBoolean(prefsKey, toggle.isChecked());
+      prefEditor.apply();
+
+      // Don't use/apply language modeling settings for languages without models.
+      if (associatedLexicalModel.isEmpty()) {
+        return;
+      }
+
+      // If the active keyboard is for this language, immediately enact the new pref setting.
+      String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
+      if (kbdLgCode.equals(lgCode)) {
+        // Not only registers the model but also applies our modeling preferences.
+        KMManager.registerAssociatedLexicalModel(lgCode);
+      }
+    }
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    context = this;
+    setContentView(R.layout.fv_keyboard_settings_list_layout);
+
+    Bundle bundle = getIntent().getExtras();
+    if (bundle == null) {
+      // Should never actually happen.
+      KMLog.LogError(TAG, "Language data not specified for FVKeyboardSettingsActivity!");
+      finish();
+
+      if(KMManager.isDebugMode()) {
+        throw new NullPointerException("Language data not specified for FVKeyboardSettingsActivity!");
+      } else {
+        return;
+      }
+    }
+
+    // Force the cloud catalog to update
+    if (!didExecuteParser) {
+      didExecuteParser = true;
+      repo = CloudRepository.shared.fetchDataset(context);
+    }
+
+    kbId = bundle.getString(KMManager.KMKey_KeyboardID);
+    kbName = bundle.getString(KMManager.KMKey_KeyboardName);
+    lgCode = bundle.getString(KMManager.KMKey_LanguageID);
+    lgName = bundle.getString(KMManager.KMKey_LanguageName);
+    version = bundle.getString(KMManager.KMKey_Version);
+
+    toolbar = (Toolbar) findViewById(R.id.list_toolbar);
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setDisplayShowHomeEnabled(true);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+    TextView textView = (TextView) findViewById(R.id.bar_title);
+
+    textView.setText(String.format(getString(R.string.keyboard_settings), kbName));
+    RelativeLayout layout = (RelativeLayout)findViewById(R.id.keyboard_toggle);
+    fvKeyboardTextView = (TextView) layout.findViewById(R.id.text1);
+    fvKeyboardTextView.setText(getString(R.string.enable_keyboard));
+    fvVersionTextView = (TextView) layout.findViewById(R.id.text2);
+    fvVersionTextView.setText(String.format(getString(R.string.keyboard_version), version));
+    fvKeyboardToggle = layout.findViewById(R.id.toggle);
+    fvKeyboardToggle.setChecked(KeyboardController.getInstance().keyboardExists(FVShared.FVDefault_PackageID, kbId, null));
+    fvKeyboardToggle.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+          // If keyboard enabled, determine if associated lexical model should be downloaded
+          // Check if associated model is not already installed
+          if (fvKeyboardToggle.isChecked() && (KMManager.getAssociatedLexicalModel(lgCode) == null) && KMManager.hasConnection(context)) {
+            String _downloadid = CloudLexicalModelMetaDataDownloadCallback.createDownloadId(lgCode);
+            CloudLexicalModelMetaDataDownloadCallback _callback = new CloudLexicalModelMetaDataDownloadCallback();
+
+            Toast.makeText(context,
+              context.getString(R.string.query_associated_model),
+              Toast.LENGTH_SHORT).show();
+
+            ArrayList<CloudApiTypes.CloudApiParam> aPreparedCloudApiParams = new ArrayList<>();
+            String url = CloudRepository.prepareLexicalModelQuery(lgCode);
+            aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
+              CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
+
+            CloudDownloadMgr.getInstance().executeAsDownload(
+              context, _downloadid, null, _callback,
+              aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+          }
+
+           FVShared.getInstance().setCheckState(kbId, fvKeyboardToggle.isChecked());
+        }
+    });
+
+    // The following two layouts/toggles will need to link with these objects.
+    Context appContext = this.getApplicationContext();
+    prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    boolean mayPredict = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(lgCode), true);
+    boolean mayCorrect = prefs.getBoolean(KMManager.getLanguageCorrectionPreferenceKey(lgCode), true);
+
+    layout = (RelativeLayout)findViewById(R.id.corrections_toggle);
+
+    correctionsTextView = (TextView) layout.findViewById(R.id.text1);
+    correctionsTextView.setText(getString(R.string.enable_corrections));
+    correctionsToggle = layout.findViewById(R.id.toggle);
+    correctionsToggle.setChecked(mayCorrect); // Link to persistent option storage!  Also needs handler.
+    String prefsKey = KMManager.getLanguageCorrectionPreferenceKey(lgCode);
+    correctionsToggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
+
+    layout = (RelativeLayout)findViewById(R.id.predictions_toggle);
+
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.enable_predictions));
+    SwitchCompat predictionsToggle = layout.findViewById(R.id.toggle);
+    predictionsToggle.setChecked(mayPredict); // Link to persistent option storage!  Also needs handler.
+    prefsKey = KMManager.getLanguagePredictionPreferenceKey(lgCode);
+    predictionsToggle.setOnClickListener(new PreferenceToggleListener(prefsKey, lgCode));
+
+    overrideCorrectionsToggle(mayPredict);
+
+    layout = (RelativeLayout)findViewById(R.id.model_picker);
+    textView = (TextView) layout.findViewById(R.id.text1);
+    textView.setText(getString(R.string.model_label));
+
+    lexicalModelTextView = layout.findViewById(R.id.text2);
+
+    updateActiveLexicalModel();
+
+    ImageView imageView = (ImageView) layout.findViewById(R.id.image1);
+    imageView.setImageResource(R.drawable.ic_arrow_forward);
+    layout.setEnabled(true);
+    layout.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        // Start ModelPickerActivity
+        Bundle bundle = new Bundle();
+        bundle.putString(KMManager.KMKey_LanguageID, lgCode);
+        bundle.putString(KMManager.KMKey_LanguageName, lgName);
+        bundle.putString(KMManager.KMKey_CustomHelpLink, customHelpLink);
+        Intent i = new Intent(context, ModelPickerActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        i.putExtras(bundle);
+        startActivity(i);
+      }
+    });
+
+    /**
+     * This is a placeholder for "Manage dictionary" settings
+     *
+     * layout = (RelativeLayout)findViewById(R.id.manage_dictionary);
+     * textView = (TextView) layout.findViewById(R.id.text1);
+     * textView.setText(getString(R.string.manage_dictionary));
+     * imageView = (ImageView) layout.findViewById(R.id.image1);
+     * imageView.setImageResource(R.drawable.ic_arrow_forward);
+     */
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+
+    updateActiveLexicalModel();
+  }
+
+  /**
+   * Updates the active lexical model label with the name of the associated lexical model.
+   * If there's no associated lexical model, the label displays a prompt to check for an available model.
+   */
+  public void updateActiveLexicalModel() {
+    HashMap<String, String> lexModelMap = KMManager.getAssociatedLexicalModel(lgCode);
+    if(lexModelMap != null) {
+      associatedLexicalModel = lexModelMap.get(KMManager.KMKey_LexicalModelName);
+    } else {
+      // Prompt to check for available dictionary
+      associatedLexicalModel = getString(R.string.check_available_model);
+    }
+
+    lexicalModelTextView.setText(associatedLexicalModel);
+    lexicalModelTextView.setEnabled(true);
+  }
+
+  public static void setActiveLexicalModelLabel(String lexicalModelLabel) {
+    if (lexicalModelTextView != null && lexicalModelLabel != null && !lexicalModelLabel.isEmpty()) {
+      lexicalModelTextView.setText(lexicalModelLabel);
+      lexicalModelTextView.setEnabled(true);
+    }
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+  }
+
+  @Override
+  public boolean onSupportNavigateUp() {
+    onBackPressed();
+    return true;
+  }
+
+  @Override
+  public void onBackPressed() {
+    finish();
+  }
+
+  /**
+   * Overrides the enable and visibility of corrections toggle,
+   * and overrides the enable of the corrections text view.
+   * Does not change the corrections toggle value.
+   * @param override boolean - Value from predictions toggle
+   *     When true, enables corrections toggle and text field, and makes corrections toggle visible
+   *     When false, disables corrections toggle and text field, and makes corrections toggle invisible
+   */
+  private void overrideCorrectionsToggle(boolean override) {
+    if (correctionsTextView != null) {
+      correctionsTextView.setEnabled(override);
+    }
+    if (correctionsToggle != null) {
+      correctionsToggle.setEnabled(override);
+      int visibility = override ? View.VISIBLE : View.INVISIBLE;
+      correctionsToggle.setVisibility(visibility);
+    }
+  }
+}

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -23,6 +23,7 @@ import com.tavultesoft.kmea.cloud.impl.CloudLexicalModelMetaDataDownloadCallback
 import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.KeyboardController;
+import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.KMLog;
 
 import java.util.ArrayList;
@@ -88,7 +89,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
 
       // If the active keyboard is for this language, immediately enact the new pref setting.
       String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-      if (kbdLgCode.equals(lgCode)) {
+      if (BCP47.languageEquals(kbdLgCode, lgCode)) {
         // Not only registers the model but also applies our modeling preferences.
         KMManager.registerAssociatedLexicalModel(lgCode);
       }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 final class FVShared {
     private static FVShared instance = null;
+    private boolean isInitialized = false;
 
     private static final String FVLoadedKeyboardList = "loaded_keyboards.dat";
 
@@ -37,9 +38,14 @@ final class FVShared {
     private static final String FVUpgrade_KeyboardFilenameKey = "FVKeyboardFilename";
     private static final String FVUpgrade_KeyboardCheckStateKey = "FVKeyboardCheckState";
 
+    private Context context;
+    private FVRegionList regionList;
+    private FVLoadedKeyboardList loadedKeyboards;
+
     private static final String FVKeyboardHelpLink = "http://help.keyman.com/keyboard/";
 
     public static final String FVDefault_PackageID = "fv_all";
+    public static final String TAG = "FVShared";
 
     /// Describes a keyboard used in FirstVoices Keyboards
     static class FVKeyboard {
@@ -93,28 +99,30 @@ final class FVShared {
         }
     }
 
-    FVShared(Context context) {
-        // We only want a single instance
-        assert(instance == null);
-        instance = this;
+    public synchronized void initialize(Context context) {
+        if (isInitialized) {
+          Log.w(TAG, "initialize called multiple times");
+          return;
+        }
 
         this.context = context.getApplicationContext();
         this.regionList = loadRegionList();
         this.loadedKeyboards = loadLoadedKeyboardList();
+
+        isInitialized = true;
     }
 
-    private final Context context;
-    private final FVRegionList regionList;
-    private final FVLoadedKeyboardList loadedKeyboards;
-
-    static FVShared getInstance() {
-        // This 'singleton' requires initialization, so
-        // we cannot lazily instantiate.
-        assert(instance != null);
-        return instance;
+  /**
+   * @return get or create shared singleton instance.
+   */
+  public static FVShared getInstance() {
+    if (instance == null) {
+      instance = new FVShared();
     }
+    return instance;
+  }
 
-    private FVRegionList loadRegionList() {
+  private FVRegionList loadRegionList() {
         FVRegionList list = new FVRegionList();
         try {
             // At this point in initialization, fv_all.kmp hasn't been extracted, so

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -6,15 +6,10 @@ import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import android.util.Log;
-
-import com.tavultesoft.kmea.JSONParser;
 import com.tavultesoft.kmea.KMManager;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.packages.PackageProcessor;
-import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
-
-import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardDownloa
 
         setContentView(R.layout.activity_main);
 
-        new FVShared(this);
+        FVShared.getInstance().initialize(this);
 
         FVShared.getInstance().upgradeTo12();
         FVShared.getInstance().upgradeTo14();

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -4,12 +4,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-//import android.support.v8.app.ActionBarActivity;
+import android.os.Handler;
 import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -17,20 +18,31 @@ import io.sentry.android.core.SentryAndroid;
 
 import com.tavultesoft.kmea.*;
 import com.tavultesoft.kmea.data.Keyboard;
+import com.tavultesoft.kmea.util.DownloadFileUtils;
+import com.tavultesoft.kmea.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 
-import java.util.ArrayList;
+import java.io.File;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements OnKeyboardDownloadEventListener {
+    public static Context context;
+
+    FVDownloadResultReceiver resultReceiver;
+
     @SuppressWarnings("SetJavascriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        context = this;
 
-        SentryAndroid.init(this, options -> {
+        SentryAndroid.init(context, options -> {
             options.setRelease("release-"+com.firstvoices.keyboards.BuildConfig.VERSION_NAME);
             options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
         });
+
+        resultReceiver = new FVDownloadResultReceiver(new Handler(), context);
 
         setContentView(R.layout.activity_main);
 
@@ -44,8 +56,6 @@ public class MainActivity extends AppCompatActivity {
             KMManager.setDebugMode(true);
         }
         KMManager.initialize(getApplicationContext(), KMManager.KeyboardType.KEYBOARD_TYPE_INAPP);
-
-        final Context context = this;
 
         /**
          * We need to set the default (fallback) keyboard to sil_euro_latin inside the fv_all package
@@ -69,22 +79,6 @@ public class MainActivity extends AppCompatActivity {
                 KMManager.KMDefault_KeyboardFont,
                 KMManager.KMDefault_KeyboardFont)
         );
-
-        ArrayList<HashMap<String, String>> modelsList = KMManager.getLexicalModelsList(context);
-        if (modelsList == null || modelsList.size() == 0) {
-          String lexicalModelVersion = KMManager.getLexicalModelPackageVersion(
-            context, FVShared.FVDefault_DictionaryPackageID);
-
-          // Add default dictionaries
-          HashMap<String, String> lexicalModelInfo = new HashMap<String, String>();
-          lexicalModelInfo.put(KMManager.KMKey_PackageID, FVShared.FVDefault_DictionaryPackageID);
-          lexicalModelInfo.put(KMManager.KMKey_LanguageID, FVShared.FVDefault_DictionaryLanguageID);
-          lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, FVShared.FVDefault_DictionaryModelID);
-          lexicalModelInfo.put(KMManager.KMKey_LexicalModelName, FVShared.FVDefault_DictionaryModelName);
-          lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, lexicalModelVersion);
-          KMManager.addLexicalModel(context, lexicalModelInfo);
-          KMManager.registerAssociatedLexicalModel(FVShared.FVDefault_DictionaryLanguageID);
-        }
 
       final String htmlPath = "file:///android_asset/setup/main.html";
         WebView webView = findViewById(R.id.webView);
@@ -136,9 +130,56 @@ public class MainActivity extends AppCompatActivity {
         webView.loadUrl(htmlPath);
     }
 
+    public static void useLocalKMP(Context context, Uri data, boolean silentInstall) {
+      DownloadFileUtils.Info info = DownloadFileUtils.cacheDownloadFile(context, data);
+      boolean isKMP = info.isKMP();
+      String filename = info.getFilename();
+      File cacheKMPFile = info.getFile();
+
+      if (filename == null || filename.isEmpty() || cacheKMPFile == null || !cacheKMPFile.exists()) {
+        // failed to retrieve downloaded file
+        String message = context.getString(R.string.failed_to_retrieve_file);
+        Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+        return;
+      } else if (!isKMP) {
+        String noKeyboardsInstalledMessage = String.format(
+          context.getString(R.string.not_valid_package_file), filename, context.getString(R.string.no_targets_to_install));
+        Toast.makeText(context, noKeyboardsInstalledMessage, Toast.LENGTH_LONG).show();
+        return;
+      }
+
+      if (cacheKMPFile != null) {
+        Bundle bundle = new Bundle();
+        bundle.putString("kmpFile", cacheKMPFile.getAbsolutePath());
+        bundle.putBoolean("silentInstall", silentInstall);
+
+        Intent packageIntent = new Intent(context, PackageActivity.class);
+        packageIntent.putExtras(bundle);
+        context.startActivity(packageIntent);
+      }
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
+
+        KMManager.onResume();
+        KMKeyboardDownloaderActivity.addKeyboardDownloadEventListener(this);
+        PackageActivity.addKeyboardDownloadEventListener(this);
+
+        Intent intent = getIntent();
+        Uri loadingIntentUri = intent.getData();
+
+        if (loadingIntentUri != null) {
+          String scheme = loadingIntentUri.getScheme().toLowerCase();
+          switch (scheme) {
+            // content:// Android DownloadManager
+            case "content":
+              // TODO: checkStoragePermission(loadingIntentUri);
+              useLocalKMP(context, loadingIntentUri, true);
+              break;
+          }
+        }
 
         WebView webView = findViewById(R.id.webView);
         if (webView != null) {
@@ -152,6 +193,15 @@ public class MainActivity extends AppCompatActivity {
             else
                 webView.loadUrl("javascript:setCheckBoxOff('checkbox2');");
         }
+    }
+
+    @Override
+    protected void onPause() {
+      super.onPause();
+      KMManager.onPause();
+
+      // Intentionally not removing KeyboardDownloadEventListener to
+      // ensure onKeyboardDownloadFinished() gets called
     }
 
     /*
@@ -209,4 +259,49 @@ public class MainActivity extends AppCompatActivity {
 
         return SetupActivity.isDefaultKB(this);
     }
+
+    @Override
+    public void onKeyboardDownloadStarted(HashMap<String, String> keyboardInfo) {
+      // Do nothing
+    }
+
+    @Override
+    public void onKeyboardDownloadFinished(HashMap<String, String> keyboardInfo, int result) {
+      // Do nothing
+    }
+
+    @Override
+    public void onPackageInstalled(List<Map<String, String>> keyboardsInstalled) {
+      // Do nothing
+    }
+
+    @Override
+    public void onLexicalModelInstalled(List<Map<String, String>> lexicalModelsInstalled) {
+      String langId = (KMManager.getCurrentKeyboardInfo(this) != null) ?
+        KMManager.getCurrentKeyboardInfo(this).getLanguageID() :
+        KMManager.KMDefault_LanguageID;
+      boolean matchingModel = false;
+      String lexicalModelName = "";
+
+      for(int i=0; i<lexicalModelsInstalled.size(); i++) {
+        HashMap<String, String>lexicalModelInfo = new HashMap<>(lexicalModelsInstalled.get(i));
+        if(lexicalModelInfo.get(KMManager.KMKey_LanguageID).equals(langId)) {
+          matchingModel = true;
+          lexicalModelName = lexicalModelInfo.get(KMManager.KMKey_LexicalModelName);
+        }
+        KMManager.addLexicalModel(this, lexicalModelInfo);
+      }
+
+      // We're on the main thread, so if the active keyboard's language code matches,
+      // let's register the associated lexical model.
+      if(matchingModel) {
+        KMManager.registerAssociatedLexicalModel(langId);
+
+        // Update associated dictionary string if applicable
+        FVKeyboardSettingsActivity.setActiveLexicalModelLabel(lexicalModelName);
+
+      }
+
+    }
+
 }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/PackageActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/PackageActivity.java
@@ -1,0 +1,298 @@
+package com.firstvoices.keyboards;
+
+import android.annotation.SuppressLint;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AlertDialog;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+
+import android.widget.Toast;
+
+import com.firstvoices.android.FVKmpInstallMode;
+import com.tavultesoft.kmea.KMManager;
+import com.tavultesoft.kmea.KeyboardEventHandler;
+import com.tavultesoft.kmea.packages.PackageProcessor;
+import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
+import com.tavultesoft.kmea.util.FileUtils;
+import com.tavultesoft.kmea.util.KMLog;
+
+import org.json.JSONObject;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PackageActivity extends AppCompatActivity {
+  private final static String TAG = "PackageActivity";
+  private AlertDialog alertDialog;
+  private File kmpFile;
+  private File tempPackagePath;
+  private static ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener> kbDownloadEventListeners = null;
+  private PackageProcessor kmpProcessor;
+
+  // Due to the disconnection between the package install and the welcome
+  // display, this flag currently has to be globally accessible.
+  public static FVKmpInstallMode lastInstallMode = FVKmpInstallMode.Silent;
+
+  @SuppressLint({"SetJavaScriptEnabled", "InflateParams"})
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    FVKmpInstallMode installMode = FVKmpInstallMode.Silent;
+    String languageID = null;
+    ArrayList<String> languageList = new ArrayList<String>();
+
+    final Context context = this;
+    Bundle bundle = getIntent().getExtras();
+    if (bundle != null) {
+      kmpFile = new File(bundle.getString("kmpFile"));
+      if (!kmpFile.exists()) {
+        KMLog.LogError(TAG, kmpFile.getAbsolutePath() + " not found. Unable to extract");
+        showErrorToast(context, getString(R.string.failed_to_extract));
+        return;
+      }
+      installMode = (FVKmpInstallMode) bundle.getSerializable("installMode");
+      if(installMode == null) installMode = FVKmpInstallMode.Silent;
+      lastInstallMode = installMode;
+      languageID = bundle.getString("language", null);
+      if (languageID != null && !languageID.isEmpty()) {
+        languageList.add(languageID);
+      }
+    }
+
+    File resourceRoot =  new File(context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
+    kmpProcessor =  new PackageProcessor(resourceRoot);
+    final String pkgId = kmpProcessor.getPackageID(kmpFile);
+    final String pkgTarget = kmpProcessor.getPackageTarget(kmpFile);
+
+    try {
+      if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
+        kmpProcessor = new LexicalModelPackageProcessor(resourceRoot);
+      } else if (!pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
+        showErrorToast(context, getString(R.string.no_targets_to_install));
+        return;
+      }
+      tempPackagePath = kmpProcessor.unzipKMP(kmpFile);
+
+    } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
+      showErrorToast(context, getString(R.string.failed_to_extract));
+      return;
+    }
+
+    JSONObject pkgInfo = kmpProcessor.loadPackageInfo(tempPackagePath);
+    if (pkgInfo == null) {
+      showErrorToast(context, getString(R.string.invalid_metadata));
+      return;
+    }
+
+    final int keyboardCount = kmpProcessor.getKeyboardCount(pkgInfo);
+
+    // Number of languages associated with the first keyboard in a keyboard package.
+    // lexical-model packages will be 0
+    final int languageCount = kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0);
+
+    // Sanity check for keyboard packages
+    if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
+      if (keyboardCount == 0) {
+        showErrorToast(context, getString(R.string.no_new_touch_keyboards_to_install));
+      } else if (languageCount == 0) {
+        showErrorToast(context, getString(R.string.no_associated_languages));
+      }
+    }
+
+    // For Silent or WelcomeOnly installation, skip Readme and language selection
+    if (installMode != FVKmpInstallMode.Full) {
+      installPackage(context, pkgTarget, pkgId, languageList, installMode);
+      return;
+    }
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+    // Use the result of SelectLanguageActivity and install the package
+    if (resultCode == 2 && data != null) {
+      String pkgTarget = data.getStringExtra("pkgTarget");
+      String pkgId = data.getStringExtra("packageID");
+      ArrayList<String> languageList = (ArrayList)data.getSerializableExtra("languageList");
+      installPackage(this, pkgTarget, pkgId, languageList, FVKmpInstallMode.Silent);
+    }
+  }
+
+  @Override
+  public void onDestroy(){
+    super.onDestroy();
+    if ( alertDialog !=null && alertDialog.isShowing() ){
+      alertDialog.dismiss();
+    }
+  }
+
+  private void cleanup() {
+    try {
+      if (kmpFile != null && kmpFile.exists()) {
+        kmpFile.delete();
+      }
+      if (tempPackagePath != null && tempPackagePath.exists()) {
+        FileUtils.deleteDirectory(tempPackagePath);
+      }
+    } catch (Exception e) {
+      KMLog.LogException(TAG, "cleanup() failed with error ", e);
+    } finally {
+      // Don't finish() because we still need to display welcome.htm
+    }
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+  }
+
+  @Override
+  public void onBackPressed() {
+    finish();
+    overridePendingTransition(0, android.R.anim.fade_out);
+  }
+
+  private void showErrorToast(Context context, String message) {
+    Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+    // Setting result to 1 so calling activity will finish too
+    setResult(1);
+    cleanup();
+    finish();
+  }
+
+  /**
+   * Installs the keyboard or lexical model package, and then notifies the corresponding listeners
+   * @param context Context   The activity context
+   * @param pkgTarget String: PackageProcessor.PP_TARGET_KEYBOARDS or PP_TARGET_LEXICAL_MODELS
+   * @param pkgId String      The Keyman package ID
+   * @param preferredLanguages ArrayList<String>  The optional array of language ID's to use
+   * @param installMode       How much of the install UI to show
+   */
+  private void installPackage(Context context, String pkgTarget, String pkgId,
+                              ArrayList<String> preferredLanguages, FVKmpInstallMode installMode) {
+    try {
+      if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
+        // processKMP will remove currently installed package and install
+        ArrayList<String> languageList;
+        if (preferredLanguages != null && !preferredLanguages.isEmpty()) {
+          languageList = preferredLanguages;
+        } else {
+          languageList = new ArrayList<String>();
+        }
+
+        List<Map<String, String>> installedPackageKeyboards =
+          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_KEYBOARDS_KEY, languageList);
+        // Do the notifications!
+        boolean success = installedPackageKeyboards.size() != 0;
+        boolean _cleanup = true;
+        if (success) {
+          if(installMode != FVKmpInstallMode.Silent) {
+            String keyboardName = installedPackageKeyboards.get(0).get(KMManager.KMKey_KeyboardName);
+            Toast.makeText(context,
+              String.format(context.getString(R.string.keyboard_install_toast), keyboardName),
+              Toast.LENGTH_SHORT).show();
+          }
+          _cleanup = true;
+          if (installedPackageKeyboards != null) {
+            notifyPackageInstallListeners(KeyboardEventHandler.EventType.PACKAGE_INSTALLED,
+              installedPackageKeyboards, 1);
+          }
+          if(_cleanup)
+            cleanup();
+        } else {
+          // Use Toast so it will linger when PackageActivity finishes
+          showErrorToast(context, getString(R.string.no_new_touch_keyboards_to_install));
+        }
+      } else if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
+        List<Map<String, String>> installedLexicalModels =
+          kmpProcessor.processKMP(kmpFile, tempPackagePath, PackageProcessor.PP_LEXICAL_MODELS_KEY);
+        // Do the notifications
+        boolean success = installedLexicalModels.size() != 0;
+        boolean _cleanup = true;
+        if (success) {
+          if(installMode != FVKmpInstallMode.Silent)
+            Toast.makeText(context,
+              context.getString(R.string.model_install_toast),
+              Toast.LENGTH_SHORT).show();
+
+          _cleanup = true;
+          if (installedLexicalModels != null) {
+            notifyLexicalModelInstallListeners(KeyboardEventHandler.EventType.LEXICAL_MODEL_INSTALLED,
+              installedLexicalModels, 1);
+          }
+          if(_cleanup)
+            cleanup();
+        } else {
+          // Use Toast so it will linger when PackageActivity finishes
+          showErrorToast(context, getString(R.string.no_new_predictive_text_to_install));
+        }
+      }
+
+      if(installMode != FVKmpInstallMode.Full) {
+        finish();
+      }
+    } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
+      // Use Toast so it will linger when PackageActivity finishes
+      showErrorToast(context, getString(R.string.no_targets_to_install));
+    }
+  }
+
+  private void showErrorDialog(Context context, String pkgId, String message) {
+    AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
+
+    alertDialogBuilder.setTitle(String.format(getString(R.string.title_package_failed_to_install), pkgId));
+    alertDialogBuilder
+      .setMessage(message)
+      .setCancelable(false)
+      .setPositiveButton(getString(R.string.label_close),new DialogInterface.OnClickListener() {
+        public void onClick(DialogInterface dialog,int id) {
+          if (dialog != null) {
+            dialog.dismiss();
+          }
+          cleanup();
+        }
+      });
+
+    alertDialog = alertDialogBuilder.create();
+    alertDialog.show();
+  }
+
+  void notifyPackageInstallListeners(KeyboardEventHandler.EventType eventType,
+                                     List<Map<String, String>> keyboards, int result) {
+    if (kbDownloadEventListeners != null) {
+      KeyboardEventHandler.notifyListeners(kbDownloadEventListeners, eventType, keyboards, result);
+    }
+  }
+
+  void notifyLexicalModelInstallListeners(KeyboardEventHandler.EventType eventType,
+                                          List<Map<String, String>> models, int result) {
+    if (kbDownloadEventListeners != null) {
+      KeyboardEventHandler.notifyListeners(kbDownloadEventListeners, eventType, models, result);
+    }
+  }
+
+  public static void addKeyboardDownloadEventListener(KeyboardEventHandler.OnKeyboardDownloadEventListener listener) {
+    if (kbDownloadEventListeners == null) {
+      kbDownloadEventListeners = new ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener>();
+    }
+
+    if (listener != null && !kbDownloadEventListeners.contains(listener)) {
+      kbDownloadEventListeners.add(listener);
+    }
+  }
+
+  public static void removeKeyboardDownloadEventListener(KeyboardEventHandler.OnKeyboardDownloadEventListener listener) {
+    if (kbDownloadEventListeners != null) {
+      kbDownloadEventListeners.remove(listener);
+    }
+  }
+
+}

--- a/oem/firstvoices/android/app/src/main/res/layout/fv_keyboard_settings_list_layout.xml
+++ b/oem/firstvoices/android/app/src/main/res/layout/fv_keyboard_settings_list_layout.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/list_toolbar" />
+
+    <include
+        android:id="@+id/keyboard_toggle"
+        layout="@layout/fv_list_row_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/list_appbar"/>
+
+    <LinearLayout
+        android:id="@+id/modeling_settings_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/keyboard_toggle"
+        android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/separator"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:background="?attr/colorAccent" />
+
+        <include
+            android:id="@+id/predictions_toggle"
+            layout="@layout/list_row_layout4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <include
+            android:id="@+id/corrections_toggle"
+            layout="@layout/list_row_layout4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <include
+            android:id="@+id/model_picker"
+            layout="@layout/list_row_layout2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <!-- Enable corrections toggle -->
+
+    <!-- Enable predictions toggle -->
+
+    <!-- Model picker -->
+
+    <!-- Model dictionary -->
+    <!-- Currently a placeholder
+    <include layout="@layout/list_row_layout1"
+        android:id="@+id/manage_dictionary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/model_picker"/> -->
+
+</RelativeLayout>

--- a/oem/firstvoices/android/app/src/main/res/layout/fv_list_row_layout.xml
+++ b/oem/firstvoices/android/app/src/main/res/layout/fv_list_row_layout.xml
@@ -2,23 +2,26 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@drawable/list_item">
-    
+    android:background="@drawable/list_item" >
+
     <LinearLayout
         android:background="@android:color/transparent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
+        android:layout_marginStart="16dp"
+        android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:orientation="vertical" >
- 
+
         <TextView
             android:id="@+id/text1"
             android:background="@android:color/transparent"
+            android:textColor="@drawable/textview_item"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="5dp"
+            android:ellipsize="end"
+            android:singleLine="true"
             android:textSize="16sp"
             android:textStyle="bold" />
 
@@ -27,21 +30,18 @@
             android:background="@android:color/transparent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
+            android:layout_marginBottom="5dp"
             android:textSize="14sp" />
- 
-        </LinearLayout>
-    
-    <ImageView
-        android:id="@+id/imageNext"
-        android:background="@android:color/transparent"
+
+    </LinearLayout>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/toggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:layout_marginRight="10dp"
-        android:src="@drawable/ic_arrow_forward"
-        app:tint="@android:color/black"
+        android:layout_marginEnd="12dp"
         android:contentDescription="@string/image_view" />
-    
+
 </RelativeLayout>

--- a/oem/firstvoices/android/app/src/main/res/layout/keyboard_row_layout.xml
+++ b/oem/firstvoices/android/app/src/main/res/layout/keyboard_row_layout.xml
@@ -1,19 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/list_item" >
-    
+
     <LinearLayout
         android:background="@android:color/transparent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="10dp"
-        android:layout_alignParentLeft="true"
+        android:layout_toStartOf="@+id/linearLayout2"
+        android:layout_marginStart="5dp"
+        android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:orientation="vertical"
+        android:orientation="horizontal"
         android:id="@+id/linearLayout">
- 
+
+        <ImageView
+            android:id="@+id/image1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:tint="@android:color/holo_blue_light"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@string/image_view" />
+
         <TextView
             android:id="@+id/text1"
             android:background="@android:color/transparent"
@@ -30,11 +43,11 @@
         android:background="@android:color/transparent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginRight="10dp"
-        android:layout_alignParentRight="true"
+        android:layout_marginEnd="10dp"
+        android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:orientation="horizontal"
-        android:id="@+id/linearLayout2">
+        android:id="@id/linearLayout2">
 
         <ImageButton
             android:id="@+id/buttonHelp"
@@ -42,13 +55,19 @@
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"
             android:src="@drawable/ic_action_help"
+            android:layout_gravity="center_vertical"
+            app:tint="@android:color/black"
             android:contentDescription="@string/image_button" />
 
-        <CheckBox
-            android:id="@+id/checkBox1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
+      <ImageButton
+        android:id="@+id/imageNext"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:background="@android:color/transparent"
+        android:contentDescription="@string/image_view"
+        android:src="@drawable/ic_arrow_forward"
+        app:tint="@android:color/black" />
     </LinearLayout>
 
 </RelativeLayout>

--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,41 @@
     <string name="setup">Setup</string>
     <string name="regions">Regions</string>
     <string name="keyboards">Keyboards</string>
+    <string name="keyboard_settings">%1$s Settings</string>
+    <string name="enable_keyboard">Enable keyboard</string>
+    <string name="keyboard_version">Version %1$s</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">Downloading keyboard package\n%1$s&#8230;</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="failed_to_extract" comment="Notification that keyboard package failed to unzip">Failed to extract</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="install_keyboard_package" comment="Title to install keyboard package">Install Keyboard</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="install_predictive_text_package" comment="Title to install dictionary package">Install Dictionary</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="not_valid_package_file" comment="Notification when invalid package file cannot be installed">%1$s is not a valid Keyman package file.\n%2$s"</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">Keyboard package has no touch-optimized keyboards to install</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">No new predictive text to install</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">No keyboards or predictive text to install</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">Keyboard package has no associated languages to install</string>
+
+    <!-- Context: KMP Package strings -->
+    <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Invalid/Missing metadata in package</string>
+
 </resources>

--- a/oem/firstvoices/android/app/src/main/res/xml/file_paths.xml
+++ b/oem/firstvoices/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- path is relative to /data/data/com.firstvoices.keyboards/files/ -->
+    <files-path name="cloud" path="../app_data/cloud/" />
+    <files-path name="models" path="../app_data/models/" />
+    <files-path name="packages" path="../app_data/packages/" />
+    <files-path name="root" path="../app_data/" />
+</paths>

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -24,7 +24,8 @@ display_usage ( ) {
   echo "  -no-update              Don't copy or build the Keyman Engine library in (assumes already present)"
   echo "  -lib-build              Force rebuild of the Keyman Engine library"
   echo "  -no-lib-build           Only rebuild the Keyman Engine library if it doesn't exist in /android"
-  echo "  -download-resources     Download fv_all.kmp and nrc.str.sencoten.model.kmp from downloads.keyman.com"
+  echo "  -download-resources     Download fv_all.kmp from downloads.keyman.com"
+  echo "                          (dictionaries will be downloaded within the app)"
   echo ""
   exit 1
 }
@@ -32,9 +33,8 @@ display_usage ( ) {
 export TARGET=FirstVoices
 KEYBOARD_PACKAGE_ID="fv_all"
 KEYBOARDS_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/${KEYBOARD_PACKAGE_ID}.kmp"
+KEYBOARDS_CSV="$KEYMAN_ROOT/oem/firstvoices/keyboards.csv"
 KEYBOARDS_CSV_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/keyboards.csv"
-MODEL_PACKAGE_ID="nrc.str.sencoten"
-MODELS_TARGET="$KEYMAN_ROOT/oem/firstvoices/android/app/src/main/assets/${MODEL_PACKAGE_ID}.model.kmp"
 
 # This build script assumes that the https://github.com/keymanapp/keyboards repo is in
 # the same parent folder as this repo, with the default name 'keyboards'
@@ -45,14 +45,12 @@ PARAM_NO_UPDATE=
 PARAM_LIB_BUILD=
 PARAM_NO_LIB_BUILD=
 DO_KEYBOARDS_DOWNLOAD=false
-DO_MODELS_DOWNLOAD=false
 
 while [[ $# -gt 0 ]] ; do
   key="$1"
   case $key in
     -download-resources)
       DO_KEYBOARDS_DOWNLOAD=true
-      DO_MODELS_DOWNLOAD=true
       ;;
     -h|-\?)
       display_usage
@@ -76,15 +74,10 @@ while [[ $# -gt 0 ]] ; do
   shift
 done
 
-# Verify default keyboard and dictionary packages exists
+# Verify default keyboard package exists
 if [[ ! -f "$KEYBOARDS_TARGET" || ! -f "$KEYBOARDS_CSV_TARGET" ]]; then
   echo "$KEYBOARDS_TARGET and $KEYBOARDS_CSV_TARGET required. Will download the latest version"
   DO_KEYBOARDS_DOWNLOAD=true
-fi
-
-if [[ ! -f "$MODELS_TARGET" ]]; then
-  echo "$MODELS_TARGET doesn't exist. Will download the latest version"
-  DO_MODELS_DOWNLOAD=true
 fi
 
 if [ ! -z "$PARAM_LIB_BUILD" ] && [ ! -z "$PARAM_NO_LIB_BUILD" ]; then
@@ -92,16 +85,12 @@ if [ ! -z "$PARAM_LIB_BUILD" ] && [ ! -z "$PARAM_NO_LIB_BUILD" ]; then
   exit 1
 fi
 
-# Download default keyboard and dictionary packages
+# Download default keyboard package
 if [ "$DO_KEYBOARDS_DOWNLOAD" = true ]; then
   echo "Copying keyboards.csv"
-  cp "$KEYMAN_ROOT/oem/firstvoices/keyboards.csv" "$KEYBOARDS_CSV_TARGET"
+  cp "$KEYBOARDS_CSV" "$KEYBOARDS_CSV_TARGET"
 
   downloadKeyboardPackage "$KEYBOARD_PACKAGE_ID" "$KEYBOARDS_TARGET"
-fi
-
-if [ "$DO_MODELS_DOWNLOAD" = true ]; then
-  downloadModelPackage "$MODEL_PACKAGE_ID" "$MODELS_TARGET"
 fi
 
 # TODO: in the future build_common.sh should probably be shared with all oem products?


### PR DESCRIPTION
This adds a feature to the FirstVoices Android app for keyboard and dictionary management. 

Several of these "new" files are direct copies from the Keyman for Android app (kmapro) to handle the kmp download, installation, and settings menus. The dictionary kmp installations are hard-coded to "silent" install (doesn't display help documentation).

Changed workflow:
The current FV app has checkboxes in the keyboard list to add/remove keyboards during setup. These have been replaced with forward arrows that go to keyboard settings menu. Enabling the toggle there will add the keyboard and check for associated dictionary to download. If there's a matching dictionary from api.keyman.com, the kmp will download in the background and silently install.

This also incorporates changes from #2255 and #4696 to disable suggestions when entering password field, and re-enabling when exiting.

Tagging @madebybridget

## Screenshots

Region menu - no change
![regions](https://user-images.githubusercontent.com/7358010/155473940-0d7a654b-f269-407a-8cd1-95e8a02ae21f.png)

BC Coast menu - left blue checkbox shows currently installed keyboards; checkboxes replaced with forward arrows
![bc coast](https://user-images.githubusercontent.com/7358010/155473843-6103509b-5527-4978-8019-47ceb3d280f6.png)

Haisla keyboard settings
![haisla](https://user-images.githubusercontent.com/7358010/155474039-48299070-50f3-489b-a0e4-e2e7eb2d406a.png)

Sencoten keyboard settings (dictionary name updates after it's installed)
![sencoten](https://user-images.githubusercontent.com/7358010/155474059-1137b56d-4088-4900-a86e-aebec60c3087.png)

Model Picker menu (copied from kmapro)
![str dictionaries](https://user-images.githubusercontent.com/7358010/155474166-20074067-c354-4d2d-80d5-d549c8df05ac.png)

str dictionary info (also copied)
![dictionary info](https://user-images.githubusercontent.com/7358010/155474205-4419ba29-e2f8-46e7-93d8-3997457c0252.png)

## User Testing
* **TEST_FV_ANDROID**
1. On an Android device/emulator, install and load the PR build of FV Android
2. When the FirstVoices app loads, click the "Select keyboards" button
3. Select "BC Coast" region --> forward arrow --> "Sencoten"
4. When the Sencoten keyboard setting menu is displayed, toggle the enable button to add the keyboard
5. Verify a notification appears on the bottom about checking for an associated dictionary to install
6. Allow time for the associated dictionary to download and install in the background. This may take minutes depending on network connection
7. Click on the Dictionary row
8. Verify the "Straits Salish (Latin) dictionaries" menu appears with SENCOTEN dictionary and a blue checkbox appear
9. Click the forward arrow
10. Verify the Sencoten dictionary info menu appears and shows
    * version
    * help link
    * Uninstall dictionary
11. Click the back arrow several times to return to the main menu
12. Click the "Setup" button to finish setting up FirstVoices as a system keyboard
13. Launch a separate app (e.g. Chrome)
14. In the Chrome browser searchbox, select the FirstVoices keyboard
15. Verify the Sencoten keyboard and dictionary appear
16. Return to the FV app and navigate to the Sencoten Settings menu
17. Disable predictions and verify corrections are also disabled
18. Return to Chrome and verify the Sencoten suggestions no longer appear
19. Return to the FV app and enable predictions
20. Return to Chrome and verify the Sencoten suggestions appear
21. Return to the FV app and navigate to the Sencoten dictionary info menu
22. Click "Uninstall dictionary"
23. Return to Chrome and verify the Sencoten suggestions no longer appear

* **TEST_PASSWORD_FIELD** - Tests that suggestions are disabled on password field and re-enabled leaving it
1. On an Android device/emulator, install and load the PR build of FV Android
2. Following the keyboard setup to install "BC Coast" region --> "Sencoten" along with its associated dictionary
3. Finish the FV setup to enable FV as a system keyboard
4. Launch Chrome and go to https://darcywong00.github.io/examples/form
5. Select the "Visible text field" and verify Sencoten suggestions appear as you type
7. Select the "Search field" and verify Sencoten suggestions appear as you type
8. Select the "Password field" and verify Sencoten suggestions are disabled as you type
9. Go back to "Visible text field" and verify Sencoten suggestions appear as you type

