### PR TITLE
fix(linux): Don't start ibus-daemon multiple times 🚌

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -80,7 +80,6 @@ def restart_ibus_subp():
 
 
 def verify_ibus_daemon(start):
-    logging.info('**** Verify ibus running')
     realuser = os.environ.get('SUDO_USER')
     user = os.environ.get('USER')
     if realuser:
@@ -90,8 +89,6 @@ def verify_ibus_daemon(start):
 
     try:
         ps = subprocess.run(('ps', '--user', user, '-o', 's=', '-o', 'cmd'), stdout=subprocess.PIPE).stdout
-        debugps = subprocess.run(('bash', '-c', 'ps -ef | grep ibus-daemon'), stdout=subprocess.PIPE).stdout
-        logging.info('**** running processes: %s', debugps.decode('utf-8'))
         ibus_daemons = re.findall('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE)
         if len(ibus_daemons) <= 0:
             if start:
@@ -100,7 +97,7 @@ def verify_ibus_daemon(start):
             logging.error('More than one ibus-daemon instance running! Keyman keyboards might not work as expected. '
                           'Please reboot your machine.')
         else:
-            logging.info('ibus already running')
+            logging.debug('ibus already running')
     except subprocess.CalledProcessError as e:
         # Log critical error in order to track down #6237
         logging.critical('getting ibus-daemon failed (%s: %s)', type(e), e.args)

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -91,7 +91,9 @@ def _verify_ibus_daemon():
         ps = subprocess.run(('ps', '--user', user, '-o', 's=', '-o', 'cmd'), stdout=subprocess.PIPE).stdout
         if not re.search('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE):
             _start_ibus_daemon(realuser)
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
+        # Log criticial error in order to track down #6237
+        logging.critical('getting ibus-daemon failed (%s: %s)', type(e), e.args)
         _start_ibus_daemon(realuser)
 
 
@@ -130,6 +132,7 @@ def restart_ibus(bus=None):
         except Exception as e:
             logging.warning("Failed to restart IBus")
             logging.warning(e)
+    time.sleep(1)  # 1s
     _verify_ibus_daemon()
 
 

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -79,7 +79,7 @@ def restart_ibus_subp():
     subprocess.run(["ibus", "restart"])
 
 
-def _verify_ibus_daemon():
+def verify_ibus_daemon(start):
     logging.info('**** Verify ibus running')
     realuser = os.environ.get('SUDO_USER')
     user = os.environ.get('USER')
@@ -90,10 +90,12 @@ def _verify_ibus_daemon():
 
     try:
         ps = subprocess.run(('ps', '--user', user, '-o', 's=', '-o', 'cmd'), stdout=subprocess.PIPE).stdout
-        logging.info('**** running processes: %s', ps.decode('utf-8'))
+        debugps = subprocess.run(('bash', '-c', 'ps -ef | grep ibus-daemon'), stdout=subprocess.PIPE).stdout
+        logging.info('**** running processes: %s', debugps.decode('utf-8'))
         ibus_daemons = re.findall('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE)
         if len(ibus_daemons) <= 0:
-            _start_ibus_daemon(realuser)
+            if start:
+                _start_ibus_daemon(realuser)
         elif len(ibus_daemons) > 1:
             logging.error('More than one ibus-daemon instance running! Keyman keyboards might not work as expected. '
                           'Please reboot your machine.')
@@ -102,7 +104,8 @@ def _verify_ibus_daemon():
     except subprocess.CalledProcessError as e:
         # Log critical error in order to track down #6237
         logging.critical('getting ibus-daemon failed (%s: %s)', type(e), e.args)
-        _start_ibus_daemon(realuser)
+        if start:
+            _start_ibus_daemon(realuser)
 
 
 def _start_ibus_daemon(realuser):
@@ -124,6 +127,7 @@ def _start_ibus_daemon(realuser):
 
 
 def restart_ibus(bus=None):
+    verify_ibus_daemon(False)
     realuser = os.environ.get('SUDO_USER')
     if realuser:
         # we have been called with `sudo`. Restart ibus for the real user.
@@ -136,14 +140,17 @@ def restart_ibus(bus=None):
                 bus = get_ibus_bus()
             if bus:
                 logging.info("restarting IBus")
-                bus.exit(True)
+                # we no longer try to restart since we sometimes ended up with more than one
+                # ibus-daemon process (#6237). Instead we only exit ibus here, and start
+                # ibus again below.
+                bus.exit(False)
                 bus.destroy()
         except Exception as e:
             logging.warning("Failed to restart IBus")
             logging.warning(e)
     # give ibus a chance to shutdown (#6237)
     time.sleep(1)  # 1s
-    _verify_ibus_daemon()
+    verify_ibus_daemon(True)
 
 
 def bus_has_engine(bus, name):

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -91,12 +91,16 @@ def _verify_ibus_daemon():
     try:
         ps = subprocess.run(('ps', '--user', user, '-o', 's=', '-o', 'cmd'), stdout=subprocess.PIPE).stdout
         logging.info('**** running processes: %s', ps.decode('utf-8'))
-        if not re.search('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE):
+        ibus_daemons = re.findall('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE)
+        if len(ibus_daemons) <= 0:
             _start_ibus_daemon(realuser)
+        elif len(ibus_daemons) > 1:
+            logging.error('More than one ibus-daemon instance running! Keyman keyboards might not work as expected. '
+                          'Please reboot your machine.')
         else:
             logging.info('ibus already running')
     except subprocess.CalledProcessError as e:
-        # Log criticial error in order to track down #6237
+        # Log critical error in order to track down #6237
         logging.critical('getting ibus-daemon failed (%s: %s)', type(e), e.args)
         _start_ibus_daemon(realuser)
 

--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -38,6 +38,8 @@ if __name__ == '__main__':
     else:
         logging.basicConfig(format='%(levelname)s:%(message)s')
 
+    logging.info('Keyman version %s %s', __versionwithtag__, __pkgversion__)
+
     if args.install:
         download_and_install_package(args.install)
     elif args.url:

--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -5,6 +5,7 @@ import logging
 
 from keyman_config import __versionwithtag__, __pkgversion__
 from keyman_config.handle_install import download_and_install_package
+from keyman_config.ibus_util import verify_ibus_daemon
 
 
 if __name__ == '__main__':
@@ -39,6 +40,8 @@ if __name__ == '__main__':
         logging.basicConfig(format='%(levelname)s:%(message)s')
 
     logging.info('Keyman version %s %s', __versionwithtag__, __pkgversion__)
+
+    verify_ibus_daemon(False)
 
     if args.install:
         download_and_install_package(args.install)


### PR DESCRIPTION
This change adds a 1s sleep after restarting ibus before checking that it actually runs. Hopefully this will solve the problem. Since
this bug is hard to reproduce, we also log a critical error for the other code path this could happen.

Fixes #6237.

# User Testing

## Preparations

- Since this bug is hard to reliably reproduce, the tests should be run on all Linux platforms:
  - GROUP_BIONIC: Ubuntu 18.04 Bionic with Gnome Shell and X11
  - GROUP_FOCAL: Ubuntu 20.04 Focal with Gnome Shell and X11
  - GROUP_IMPISH_X11: Ubuntu 21.10 Impish with Gnome Shell and X11
  - GROUP_IMPISH_WAYLAND: Ubuntu 21.10 Impish with Gnome Shell and Wayland
  - GROUP_WASTA: Wasta 20.04 with Cinnamon

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot

## Tests

- **TEST_KB_INSTALL1**: Download and install a keyboard
  - On the command line, run:
    ```bash
    km-config -v 2>&1 | tee /tmp/km-config.log
    ```
  - click "Download", enter search for "Khmer", and install the "Khmer Angkor" keyboard
  - On the command line, run:
    ```bash
    ps --user $USER -o cmd -o pid= -o s= | grep -e "^ibus-daemon"
    ```
  - Verify that this outputs exactly one line starting with `ibus-daemon`
  - If the test fails, attach the file `/tmp/km-config.log` or paste the content of `/tmp/km-config.log`

- **TEST_KB_INSTALL2**: Download and install a second keyboard
  - repeat the previous test with a different keyboard:
  - On the command line, run:
    ```bash
    km-config -v 2>&1 | tee /tmp/km-config2.log
    ```
  - click "Download", enter search for "Icelandic", and install the "EuroLatin (SIL)" keyboard
  - On the command line, run:
    ```bash
    ps --user $USER -o cmd -o pid= -o s= | grep -e "^ibus-daemon"
    ```
  - Verify that this outputs exactly one line starting with `ibus-daemon`
  - If the test fails, attach the file `/tmp/km-config2.log` or paste the content of `/tmp/km-config2.log`
