### PR TITLE
fix(linux): Gracefully handle keyboard download failure

### DIFF
--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -36,6 +36,8 @@ def download_and_install_package(url):
         downloadFile = os.path.join(get_download_folder(), packageId)
         downloadUrl = KeymanComUrl + '/go/package/download/' + packageId + '?platform=linux&tier=' + __tier__
         packageFile = download_kmp_file(downloadUrl, downloadFile)
+        if packageFile is None:
+            return
     elif parsedUrl.scheme == '' or parsedUrl.scheme == 'file':
         packageFile = parsedUrl.path
     else:


### PR DESCRIPTION
In the past we already gracefully handled keyboard download failures when the user triggered the download from the km-config UI. This change deals with the command line side of things, most often when the user clicks on the "Install keyboard" button on keyman.com. If the download fails we already output an error message and now don't try to install the non-existing .kmp file.

Fixes #6284.

@keymanapp-test-bot skip