### PR TITLE
chore(developer): disable upload for server except localhost

### DIFF
--- a/developer/server/src/routes.ts
+++ b/developer/server/src/routes.ts
@@ -27,10 +27,15 @@ export default function setupRoutes(app: express.Express, upload: multer.Multer,
     next();
   });
 
+  function isLocalhost(req: express.Request) {
+    return (
+      req.socket.remoteAddress == '127.0.0.1' ||
+      req.socket.remoteAddress == '::1' ||
+      req.socket.remoteAddress == '::ffff:127.0.0.1' // ipv4 localhost over ipv6
+    );
+  }
   function localhostOnly(req: express.Request, res: express.Response, next: express.NextFunction) {
-    if(req.socket.remoteAddress != '127.0.0.1' &&
-       req.socket.remoteAddress != '::1' &&
-       req.socket.remoteAddress != '::ffff:127.0.0.1') {  // ipv4 localhost over ipv6
+    if(!isLocalhost(req)) {
       res.sendStatus(401);
     } else {
       next();
@@ -85,7 +90,7 @@ export default function setupRoutes(app: express.Express, upload: multer.Multer,
   app.get('/inc/packages.json', handleIncPackagesJson);
 
   app.get('/api-public/version', (req,res,next)=>{
-    res.json({version: environment.versionWithTag});
+    res.json({version: environment.versionWithTag, isApiAvailable: isLocalhost(req)});
     next();
   });
 

--- a/developer/server/src/site/packages.js
+++ b/developer/server/src/site/packages.js
@@ -1,19 +1,11 @@
 const menuDropdown = new DropdownMenu('menu');
 let packages = null;
 let packagesJSON = null;
-let helpUrl = '';
-let versionMajor = '15.0'; // will be updated from the server below
 
-fetch('/api-public/version').
-  then(response => response.json()).
-  then(value => {
-    const versionMajorRx = /^(\d+\.\d+)/.exec(value.version);
-    versionMajor = versionMajorRx[1];
-    helpUrl = 'https://help.keyman.com/developer/'+versionMajor+'/context/server';
-    document.getElementById('about-version').innerText = value.version;
-    document.getElementById('about-help-link').href = helpUrl;
-    document.getElementById('keyman-developer-logo').title = 'Keyman Developer Server '+value.version;
-  });
+let menuDropdownElement = document.getElementById('dropdown-menu');
+menuDropdownElement.addEventListener('show.bs.dropdown', function () {
+  fillDropdownMenu(packages);
+});
 
 menuDropdown.onclick = (value) => {
   menuDropdown.set(''); // we never show an 'active' package
@@ -28,7 +20,7 @@ menuDropdown.onclick = (value) => {
       default:        href = 'https://keyman.com/downloads'; break;
     }
     location.href = href;
-  } else if(value == '#upload') {
+  } else if(value == '#upload' && isApiAvailable()) {
     document.getElementById('drop-file').click();
   } else if(value == '#help') {
     window.open(helpUrl);
@@ -47,10 +39,13 @@ function updatePackages(data) {
   packagesJSON = dataJSON;
   packages = data;
 
+  fillDropdownMenu(packages);
+}
+
+function fillDropdownMenu(data) {
   if(!data.packages) {
     return false;
   }
-
   menuDropdown.removeAll();
   menuDropdown.add('#install-keyman', 'Download and install Keyman');
   menuDropdown.addDivider();
@@ -58,8 +53,11 @@ function updatePackages(data) {
     let name = 'Install ' + (data.packages[i].name ? data.packages[i].name + ' (' + data.packages[i].filename + ')' : data.packages[i].filename);
     menuDropdown.add(data.packages[i].id, name);
   }
-  menuDropdown.addDivider();
-  menuDropdown.add('#upload', 'Upload file...');
+
+  if(isApiAvailable()) {
+    menuDropdown.addDivider();
+    menuDropdown.add('#upload', 'Upload file...');
+  }
   menuDropdown.addDivider();
   menuDropdown.add('#help', 'Help...');
   menuDropdown.add('#about', 'About Keyman Developer Server');

--- a/developer/server/src/site/test.js
+++ b/developer/server/src/site/test.js
@@ -1,3 +1,8 @@
+/* Global Variables */
+
+let helpUrl = ''; // Will be updated when we retrieve the server API version
+let versionMajor = '15.0'; // will be updated from the server when we retrieve the server API version
+
 const ta1 = document.getElementById('ta1');
 
 const devices = {
@@ -32,6 +37,28 @@ keyman.init({
   attachType:'auto',
   setActiveOnRegister:false
 });
+
+/* Initialization */
+
+fetch('/api-public/version').
+  then(response => response.json()).
+  then(value => {
+    const versionMajorRx = /^(\d+\.\d+)/.exec(value.version);
+    versionMajor = versionMajorRx[1];
+    helpUrl = 'https://help.keyman.com/developer/'+versionMajor+'/context/server';
+    document.getElementById('about-version').innerText = value.version;
+    document.getElementById('about-help-link').href = helpUrl;
+    document.getElementById('keyman-developer-logo').title = 'Keyman Developer Server '+value.version;
+    if(!value.isApiAvailable) {
+      document.body.classList.add('disable-upload');
+    } else {
+      initDropArea();
+    }
+  });
+
+function isApiAvailable() {
+  return !document.body.classList.contains('disable-upload');
+}
 
 /* Dropdown menus */
 

--- a/developer/server/src/site/upload.js
+++ b/developer/server/src/site/upload.js
@@ -75,7 +75,7 @@ function showToast(message, type) {
   toast.show();
 }
 
-(function() {
+function initDropArea() {
   let dropArea = document.getElementById('drop-area');
   ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
     dropArea.addEventListener(eventName, preventDefaults, false)
@@ -120,5 +120,4 @@ function showToast(message, type) {
     unhighlight(e);
     handleFiles(files);
   }
-
-})();
+}


### PR DESCRIPTION
Fixes #6299.

Moved some of the init to test.js from packages.js. If not on localhost, then the UI for upload is disabled -- note that backend for upload is already disabled for non-localhost.

This is necessary to prevent non-local site users uploading arbitrary files to the cache, which could lead to security bypass.

On localhost:

![image](https://user-images.githubusercontent.com/4498365/156273082-b6881e81-7a1e-4ec1-877e-02bf943b8075.png)

When running not on localhost, the Upload menu item, and the file drop target, are both disabled.

@keymanapp-test-bot skip