### PR TITLE
fix(developer): font for Package and Model Editors ✂

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -153,6 +153,9 @@ type
     function GetFileNameFilter: string; override;
     function GetDefaultExt: string; override;
 
+    procedure CodeFontChanged; override;
+    procedure CharFontChanged; override;
+
     function GetProjectFile: TProjectFile; override;
 
   public
@@ -855,6 +858,32 @@ begin
   finally
     Free;
   end;
+end;
+
+procedure TfrmModelEditor.CodeFontChanged;
+var
+  i: Integer;
+begin
+  inherited;
+  // We always use the CodeFont for the source frame at present because it is
+  // a .ts file
+  frameSource.CharFont := CodeFont;
+  frameSource.CodeFont := CodeFont;
+  for i := 0 to wordlists.Count - 1 do
+    wordlists[i].Frame.CodeFont := CodeFont;
+end;
+
+procedure TfrmModelEditor.CharFontChanged;
+var
+  i: Integer;
+begin
+  inherited;
+  // We always use the CodeFont for the source frame at present because it is
+  // a .ts file
+  frameSource.CharFont := CodeFont;
+  frameSource.CodeFont := CodeFont;
+  for i := 0 to wordlists.Count - 1 do
+    wordlists[i].Frame.CharFont := CharFont;
 end;
 
 { TfrmModelEditor.TWordlist }

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmPackageEditor
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      20 Jun 2006
 
   Modified Date:    3 Aug 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          20 Jun 2006 - mcdurdin - Initial version
                     01 Aug 2006 - mcdurdin - Support tab child format
                     23 Aug 2006 - mcdurdin - Rework UI with new Unicode controls
@@ -321,6 +321,9 @@ type
 
     procedure FocusTab;
     function GetProjectFile: TProjectFile; override;   // I4702
+
+    procedure CodeFontChanged; override;
+    procedure CharFontChanged; override;
 
   public
     function GetPack: TKPSFile;
@@ -1359,6 +1362,18 @@ begin
       Result := False;
     end;
   end;
+end;
+
+procedure TfrmPackageEditor.CodeFontChanged;
+begin
+  inherited;
+  frameSource.CodeFont := CodeFont;
+end;
+
+procedure TfrmPackageEditor.CharFontChanged;
+begin
+  inherited;
+  frameSource.CharFont := CharFont;
 end;
 
 procedure TfrmPackageEditor.NotifyStartedWebDebug;


### PR DESCRIPTION
Fixes #6029.

Allows the user to specify the character and/or code font (where applicable) for the Package and Model Editors.

# User Testing

* **TEST_MODEL_EDITOR_FONT:** Verify that changing the Code and Character fonts (Edit menu) for the Model Editor applies as expected to the views in the editor.
* **TEST_PACKAGE_EDITOR_FONT:** Verify that changing the Code and Character fonts (Edit menu) for the Package Editor applies as expected to the views in the editor.