### PR TITLE
chore(developer): remove Package for Distribution action ✂

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
@@ -21,12 +21,6 @@ object modActionsKeyboardEditor: TmodActionsKeyboardEditor
       OnExecute = actKeyboardIncludeDebugInformationExecute
       OnUpdate = actKeyboardIncludeDebugInformationUpdate
     end
-    object actKeyboardCreatePackage: TAction
-      Category = 'Keyboard'
-      Caption = 'Package for Distribution...'
-      ImageIndex = 40
-      OnExecute = actKeyboardCreatePackageExecute
-    end
     object actKeyboardInstall: TAction
       Category = 'Keyboard'
       Caption = '&Install...'

--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -48,7 +48,6 @@ type
     actionsKeyboardEditor: TActionList;
     actKeyboardCompile: TAction;
     actKeyboardIncludeDebugInformation: TAction;
-    actKeyboardCreatePackage: TAction;
     actKeyboardInstall: TAction;
     actKeyboardUninstall: TAction;
     actionsDebug: TActionList;
@@ -80,7 +79,6 @@ type
     procedure actionsKeyboardEditorUpdate(Action: TBasicAction;
       var Handled: Boolean);
     procedure actKeyboardIncludeDebugInformationExecute(Sender: TObject);
-    procedure actKeyboardCreatePackageExecute(Sender: TObject);
     procedure actDebugViewElementsExecute(Sender: TObject);
     procedure actDebugSetClearBreakpointExecute(Sender: TObject);
     procedure actDebugSetClearBreakpointUpdate(Sender: TObject);
@@ -480,11 +478,6 @@ begin
 
   frmKeymanDeveloper.mnuKeyboard.Visible := actKeyboardCompile.Enabled;
   frmKeymanDeveloper.mnuDebug.Visible := ActiveEditor <> nil;
-end;
-
-procedure TmodActionsKeyboardEditor.actKeyboardCreatePackageExecute(Sender: TObject);
-begin
-  (ActiveProjectFile.UI as TProjectFileUI).DoAction(pfaPackage, False);   // I4687
 end;
 
 procedure TmodActionsKeyboardEditor.actKeyboardFontHelperExecute(

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.dfm
@@ -1116,9 +1116,9 @@ inherited frmKeymanWizard: TfrmKeymanWizard
           object lblCompileTargetHeader: TLabel
             Left = 9
             Top = 6
-            Width = 219
+            Width = 247
             Height = 17
-            Caption = 'Windows and Mac OS X Targets'
+            Caption = 'Windows, macOS and Linux Targets'
             Font.Charset = DEFAULT_CHARSET
             Font.Color = clWindowText
             Font.Height = -14
@@ -1140,14 +1140,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
             Width = 152
             Height = 25
             Action = modActionsKeyboardEditor.actKeyboardUninstall
-            TabOrder = 2
-          end
-          object cmdPackageForDistribution: TButton
-            Left = 9
-            Top = 126
-            Width = 152
-            Height = 25
-            Action = modActionsKeyboardEditor.actKeyboardCreatePackage
             TabOrder = 1
           end
         end

--- a/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
+++ b/windows/src/developer/TIKE/child/UfrmKeymanWizard.pas
@@ -241,7 +241,6 @@ type
     lblCompileTargetHeader: TLabel;
     cmdInstall: TButton;
     cmdUninstall: TButton;
-    cmdPackageForDistribution: TButton;
     panBuildKMW: TPanel;
     lblDebugHostCaption: TLabel;
     lblCrossPlatform: TLabel;

--- a/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
+++ b/windows/src/developer/TIKE/child/UfrmPackageEditor.pas
@@ -325,8 +325,6 @@ type
   public
     function GetPack: TKPSFile;
 
-    procedure CreateFromCompiledKeyboard(FKMXFilename, FJSFilename: string);
-
     procedure NotifyStartedWebDebug;
 
     procedure FindError(const Filename: string; s: string; line: Integer); override;   // I4081
@@ -597,7 +595,7 @@ procedure TfrmPackageEditor.cmdInsertCopyrightClick(Sender: TObject);
 begin
   Modified := True;
   editInfoCopyright.SelLength := 0;
-  editInfoCopyright.SelText := '©';
+  editInfoCopyright.SelText := 'ï¿½';
 end;
 
 procedure TfrmPackageEditor.editInfoAuthorChange(Sender: TObject);
@@ -1369,12 +1367,6 @@ begin
     lbDebugHosts.ItemIndex := 0;
   UpdateQRCode;
   EnableCompileTabControls;
-end;
-
-procedure TfrmPackageEditor.CreateFromCompiledKeyboard(FKMXFilename, FJSFilename: string);
-begin
-  if (FKMXFilename <> '') and FileExists(FKMXFilename) then AddFile(FKMXFilename);
-  if (FJSFilename <> '') and FileExists(FJSFilename) then AddFile(FJSFilename);
 end;
 
 {-------------------------------------------------------------------------------

--- a/windows/src/developer/TIKE/main/UfrmMain.dfm
+++ b/windows/src/developer/TIKE/main/UfrmMain.dfm
@@ -2979,12 +2979,6 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
       object N29: TMenuItem
         Caption = '-'
       end
-      object PackageforDistribution1: TMenuItem
-        Action = modActionsKeyboardEditor.actKeyboardCreatePackage
-      end
-      object N30: TMenuItem
-        Caption = '-'
-      end
       object Install1: TMenuItem
         Action = modActionsKeyboardEditor.actKeyboardInstall
       end

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -220,10 +220,8 @@ type
     CompileKeyboard1: TMenuItem;
     N28: TMenuItem;
     N29: TMenuItem;
-    N30: TMenuItem;
     IncludeDebugInformation1: TMenuItem;
     estKeyboard1: TMenuItem;
-    PackageforDistribution1: TMenuItem;
     Install1: TMenuItem;
     Uninstall1: TMenuItem;
     N31: TMenuItem;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.ProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.ProjectFileUI.pas
@@ -33,7 +33,7 @@ uses
   TempFileManager;
 
 type
-  TProjectFileAction = (pfaCompile, pfaInstall, pfaUninstall, pfaDebug, pfaPackage, pfaEncrypt,
+  TProjectFileAction = (pfaCompile, pfaInstall, pfaUninstall, pfaDebug,
     pfaTestKeymanWeb, pfaCompileInstaller, pfaFontHelper, pfaFontDialog, pfaClean);   // I4057
 
   TProjectUI = class(TProject)

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -38,7 +38,6 @@ type
     function FontDialog(FSilent: Boolean): Boolean;   // I4057
     function InstallKeyboard: Boolean;
     function UninstallKeyboard: Boolean;
-    function PackageFile(FSilent: Boolean): Boolean;
     function GetProjectFile: TkmnProjectFileAction;
 
     function GetDebug: Boolean;
@@ -87,7 +86,6 @@ begin
     pfaInstall:   Result := InstallKeyboard;
     pfaUninstall: Result := UninstallKeyboard;
     pfaDebug:     Result := DebugKeyboard(FSilent);
-    pfaPackage:   Result := PackageFile(FSilent);
     pfaFontHelper: Result := FontHelper(FSilent);
     pfaFontDialog: Result := FontDialog(FSilent);   // I4057
     pfaClean:      Result := ProjectFile.Clean;
@@ -187,25 +185,6 @@ end;
 function TkmnProjectFileUI.GetProjectFile: TkmnProjectFileAction;
 begin
   Result := FOwner as TkmnProjectFileAction;
-end;
-
-function TkmnProjectFileUI.PackageFile(FSilent: Boolean): Boolean;
-var
-  FKMXTarget, FJSTarget: string;
-begin
-  Result := False;
-  FKMXTarget := ProjectFile.TargetFilename;
-  FJSTarget := ProjectFile.JSTargetFilename;
-
-  if (FKMXTarget <> '') and not TestKeyboardState(FKMXTarget, FSilent) then
-    Exit;
-
-  if (FJSTarget <> '') and not TestKeyboardState(FJSTarget, FSilent) then
-    Exit;
-
-  with TfrmPackageEditor.Create(frmKeymanDeveloper) do
-    CreateFromCompiledKeyboard(FKMXTarget, FJSTarget);
-  Result := True;
 end;
 
 procedure TkmnProjectFileUI.SetDebug(const Value: Boolean);


### PR DESCRIPTION
Fixes #4168.

This button no longer makes sense when we have template projects, as it encourages keyboard developers to create multiple packages. The template project should already have a package.

It is also not hard to create a package if you don't already have one; this does not reduce the complexity significantly, apart from the mini feature of adding both the .js and the .kmx in a single step (the .kvk is added also by virtue of the .kmx being added, but that is done in any case if you manually add a .kmx to a package).

@keymanapp-test-bot skip