### PR TITLE
fix(developer): Improve active tab visibility ✂

### DIFF
--- a/windows/src/global/delphi/comp/CloseButtonPageControl.pas
+++ b/windows/src/global/delphi/comp/CloseButtonPageControl.pas
@@ -378,6 +378,7 @@ begin
       CloseBtnRect.Top := Rect.Top + 4;
       CloseBtnRect.Right := Rect.Right - 5;
       TabCaption.X := Rect.Left + 6;
+      Canvas.Brush.Color := $DAC379; // Keyman Light Blue
     end
     else
     begin

--- a/windows/src/global/delphi/comp/LeftTabbedPageControl.pas
+++ b/windows/src/global/delphi/comp/LeftTabbedPageControl.pas
@@ -1,18 +1,18 @@
 (*
   Name:             LeftTabbedPageControl
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      4 May 2015
 
   Modified Date:    24 Jul 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          04 May 2015 - mcdurdin - I4693 - V9.0 - Fix crash when creating left tabbed page control without images
                     24 Jul 2015 - mcdurdin - I4796 - Refresh Keyman Developer look and feel for release
 *)
@@ -126,10 +126,11 @@ procedure TLeftTabbedPageControl.DrawTab(TabIndex: Integer; const Rect: TRect;
 begin
   TabIndex := GetPageIndexFromTabIndex(TabIndex);
 
-//  ARect := Rect;
-//  InflateRect(ARect, 4, 4);
-//  Canvas.Brush.Color := $c0c000;
-//  Canvas.FillRect(ARect);
+  if Active then
+  begin
+    Canvas.Brush.Color := $DAC379; // Keyman Light Blue
+    Canvas.FillRect(Rect);
+  end;
 
   if Images <> nil then   // I4693
     Images.Draw(Canvas,


### PR DESCRIPTION
Fixes #845.
Fixes #3224.

Makes the active tab more visible both in the horizontal file tabs, and in the vertical activity tabs by changing the background colour to Keyman Light Blue (css: `#79C3DA`).

![image](https://user-images.githubusercontent.com/4498365/156253253-4147ead5-2948-4d6a-94ea-800b3292f6f1.png)

@keymanapp-test-bot skip