### PR TITLE
feat(developer): support commas in frequency in wordlists ✂

### DIFF
--- a/developer/js/source/lexical-model-compiler/build-trie.ts
+++ b/developer/js/source/lexical-model-compiler/build-trie.ts
@@ -78,7 +78,8 @@ export function parseWordListFromContents(wordlist: WordList, contents: string):
  *  - column 1 (REQUIRED): the wordform: can have any character except tab, CR,
  *    LF. Surrounding whitespace characters are trimmed.
  *  - column 2 (optional): the count: a non-negative integer specifying how many
- *    times this entry has appeared in the corpus. Blank means 'indeterminate'.
+ *    times this entry has appeared in the corpus. Blank means 'indeterminate';
+ *    commas are permissible in the digits.
  *  - column 3 (optional): comment: an informative comment, ignored by the tool.
  *
  * @param wordlist word list to merge entries into (may have existing entries)
@@ -117,11 +118,11 @@ function _parseWordList(wordlist: WordList, source:  WordListSource): void {
 
     wordform = wordform.trim()
 
-    countText = (countText || '').trim();
+    countText = (countText || '').trim().replace(/,/g, '');
     let count = parseInt(countText, 10);
 
     // When parsing a decimal integer fails (e.g., blank or something else):
-    if (!isFinite(count)) {
+    if (!isFinite(count) || count < 0) {
       // TODO: is this the right thing to do?
       // Treat it like a hapax legonmenom -- it exist, but only once.
       count = 1;

--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UframeWordlistEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UframeWordlistEditor.pas
@@ -210,6 +210,8 @@ procedure TframeWordlistEditor.gridWordlistSetEditText(Sender: TObject; ACol,
   ARow: Integer; const Value: string);
 var
   w: TWordlistWord;
+  TrimmedValue: string;
+  Frequency: Integer;
 begin
   if FSetup > 0 then Exit;
 
@@ -229,11 +231,13 @@ begin
     end
     else
     begin
+      TrimmedValue := Value.Trim;
+      Frequency := StrToIntDef(TrimmedValue.Replace(',', '', [rfReplaceAll]), 0);
       w := FWordlist.Word[ARow-1];
       case ACol of
-        0: if w.Word = Value then Exit else w.Word := Value;
-        1: if w.Frequency = StrToIntDef(Value, 0) then Exit else w.Frequency := StrToIntDef(Value, 0);
-        2: if w.Comment = Value then Exit else w.Comment := Value;
+        0: if w.Word = TrimmedValue then Exit else w.Word := TrimmedValue;
+        1: if w.Frequency = Frequency then Exit else w.Frequency := Frequency;
+        2: if w.Comment = TrimmedValue then Exit else w.Comment := TrimmedValue;
       end;
       FWordlist.Word[ARow-1] := w;
     end;

--- a/windows/src/global/delphi/lexicalmodels/Keyman.System.WordlistTsvFile.pas
+++ b/windows/src/global/delphi/lexicalmodels/Keyman.System.WordlistTsvFile.pas
@@ -148,7 +148,7 @@ begin
   else
   begin
     Word := StrToken(s, #9);
-    Frequency := StrToIntDef(StrToken(s, #9), 0);
+    Frequency := StrToIntDef(StrToken(s, #9).Replace(',','', [rfReplaceAll]), 0);
     Comment := s;
   end;
 end;


### PR DESCRIPTION
Fixes #3174.

Google Sheets can export TSV files with formatted numbers, including having commas as thousands separators. Let's ignore those commas.

# User Testing

* **TEST_COMMAS_IMPORT:** Verify that numbers with commas in them import into the Model Editor.

1. In the Model Editor, import a wordlist .TSV with commas in the frequency column, such as from Google Sheets.
2. Verify that the numbers appear in the grid view in the Model Editor.

* **TEST_COMMAS_COMPILE:** Verify that the compiled frequencies are correct.

1. Create a wordlist with one or two entries in it, with commas in the frequency column, and compile the model.
2. Load the compiled .model.js file and examine the trie data model therein to verify that the frequency data is correct.

For example, I had a wordlist with the word `the` in it, with a frequency of `1,100`. This compiled down to the following data:

```
{"key":"the","weight":1100,"content":"the"}
```