### PR TITLE
fix(web): error in floating osk view when no keyboard active ✂

### DIFF
--- a/web/source/osk/floatingOskView.ts
+++ b/web/source/osk/floatingOskView.ts
@@ -77,7 +77,9 @@ namespace com.keyman.osk {
       // Add header element to OSK only for desktop browsers
       const layout = this.desktopLayout;
       layout.attachToView(this);
-      this.desktopLayout.titleBar.setTitleFromKeyboard(this.activeKeyboard);
+      if(this.activeKeyboard) {
+        this.desktopLayout.titleBar.setTitleFromKeyboard(this.activeKeyboard);
+      }
 
       if(this.vkbd) {
         this.footerView = layout.resizeBar;
@@ -517,7 +519,7 @@ namespace com.keyman.osk {
       }
 
       this.specifiedPosition = Px >= 0 || Py >= 0; //probably never happens, legacy support only
-      if(this.specifiedPosition) { 
+      if(this.specifiedPosition) {
         this.x = Px;
         this.y = Py;
       }


### PR DESCRIPTION
This fixes an issue that arises when loading the Keyman Developer Server home page and there are registered keyboards, but no keyboards active. The floating osk view would throw an exception because it would attempt to set the title of the view from the active keyboard, which is `null`.

@keymanapp-test-bot skip