### PR TITLE
fix(developer): prevent execution point breaking editor location ✂

### DIFF
--- a/windows/src/developer/TIKE/xml/app/editor/editor.js
+++ b/windows/src/developer/TIKE/xml/app/editor/editor.js
@@ -190,11 +190,15 @@ async function loadSettings() {
   };
 
   context.updateExecutionPoint = function (row) {
-    executionPoint = editor.deltaDecorations(
-      executionPoint,
-      row >= 0 ? [{ range: new monaco.Range(row + 1, 1, row + 1, 1), options: { isWholeLine: true, linesDecorationsClassName: 'km_executionPoint' } }] : []
-    );
-    context.moveCursor({ row: row, column: 0 });
+    if(row >= 0) {
+      executionPoint = editor.deltaDecorations(
+        executionPoint,
+        [{ range: new monaco.Range(row + 1, 1, row + 1, 1), options: { isWholeLine: true, linesDecorationsClassName: 'km_executionPoint' } }]
+      );
+      context.moveCursor({ row: row, column: 0 });
+    } else {
+      executionPoint = editor.deltaDecorations(executionPoint, []);
+    }
   };
 
   //


### PR DESCRIPTION
When using Keyman Developer Debugger, each key pressed would reset the cursor location to the top of the .kmn file. Super annoying!

This fixes that! (This was also completed during The Great Tasmanian Internet Outage of 2022, so it gets the ✂ theme)

@keymanapp-test-bot skip