### PR TITLE
fix(developer): project should not steal focus on load ✂

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -601,7 +601,8 @@ begin
   if csDestroying in ComponentState then
     Exit;
 
-  if (frmKeymanDeveloper.ActiveChild = Self) and (Screen.ActiveForm = frmKeymanDeveloper) then
+  if (frmKeymanDeveloper.ActiveChild = Self) and (Screen.ActiveForm = frmKeymanDeveloper) and
+    (GetWindowThreadProcessId(GetForegroundWindow, nil) = GetCurrentThreadId) then
   begin
     cef.SetFocus;
   end;


### PR DESCRIPTION
When starting Keyman Developer, you might try and switch back to another app, only to have it jump back to Developer as the Project window finishes loading. How rude!

This fixes that.

(This was also completed during The Great Tasmanian Internet Outage of 2022, so it gets the ✂ theme)

@keymanapp-test-bot skip