### PR TITLE
fix(web): subkey touch position after scroll

### DIFF
--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -509,26 +509,8 @@ namespace com.keyman.osk {
       let y = input.y;
 
       let btn = this.btn;
-      // These functions do not account for 'fixed' positioning.
       let x0 = dom.Utils.getAbsoluteX(btn);
       let y0 = dom.Utils.getAbsoluteY(btn);
-
-      let isFixed = false;
-      let node: HTMLElement = btn;
-      while(node) {
-        if(getComputedStyle(node).position == 'fixed') {
-          isFixed = true;
-          break;
-        } else {
-          node = node.offsetParent as HTMLElement;
-        }
-      }
-
-      if(isFixed) {
-        x0 += window.pageXOffset;
-        y0 += window.pageYOffset;
-      }
-
       let x1 = x0 + btn.offsetWidth;
       let y1 = y0 + btn.offsetHeight;
 

--- a/web/testing/unminified.html
+++ b/web/testing/unminified.html
@@ -83,6 +83,10 @@
     <h3><a href="./">Return to testing home page</a></h3>
   </div>
 
+  <!-- include a blank div to enable scrolling -->
+  <div style="height:1000px"></div>
+  <p>--End of Document--</p>
+
   </body>
 
   <!--


### PR DESCRIPTION
Fixes #5964.

It seems that the test for subkey position was incorrect when the document had been scrolled. Removing the test for `fixed` positioning resolves the issue.

# User Testing

This needs to be tested on more than one device type.

## Device Types

* **GROUP_IPHONE:** Test on Safari on latest iOS
* **GROUP_ANDROID:** Test on Chrome on recent version of Android
* **GROUP_EMULATOR:** Test on Chrome on Windows, using mobile emulation

## Tests

* **TEST_SCROLL:** Verify that longpress when the document is scrolled is working correctly

1. Load the keymanweb/testing/unminified test page.
2. Select the SIL Euro Latin keyboard (Swedish).
3. Longpress on various letters and make sure that the coloured key tracks the finger correctly.
4. Scroll the document down from the top.
5. Refocus the text field, and perform the same longpress actions.
6. Verify that the longpress still tracks the finger correctly.