### PR TITLE
chore(android/engine): Remove bold styling in lists

### DIFF
--- a/android/KMEA/app/src/main/res/layout/list_row_layout1.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout1.xml
@@ -21,8 +21,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:layout_marginBottom="15dp"
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:textSize="16sp" />
  
     </LinearLayout>
     

--- a/android/KMEA/app/src/main/res/layout/list_row_layout2.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout2.xml
@@ -19,8 +19,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:textSize="16sp" />
  
         <TextView
             android:id="@+id/text2"
@@ -28,6 +27,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="5dp"
+            android:textColor="@color/material_grey_600"
             android:textSize="14sp" />
     </LinearLayout>
     

--- a/android/KMEA/app/src/main/res/layout/list_row_layout3.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout3.xml
@@ -25,8 +25,7 @@
             android:layout_marginTop="5dp"
             android:ellipsize="end"
             android:singleLine="true"
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:textSize="16sp" />
 
         <TextView
             android:id="@+id/text2"

--- a/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout4.xml
@@ -21,8 +21,7 @@
           android:layout_height="wrap_content"
           android:layout_marginTop="15dp"
           android:layout_marginBottom="15dp"
-          android:textSize="16sp"
-          android:textStyle="bold" />
+          android:textSize="16sp" />
 
     </LinearLayout>
 

--- a/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
@@ -19,8 +19,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:textSize="16sp" />
 
         <!-- test2 string is hidden but we can still access the info -->
         <TextView

--- a/android/KMEA/app/src/main/res/layout/models_list_row_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/models_list_row_layout.xml
@@ -35,8 +35,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:layout_marginBottom="15dp"
-            android:textSize="16sp"
-            android:textStyle="bold" />
+            android:textSize="16sp" />
 
     </LinearLayout>
 


### PR DESCRIPTION
Relates to upcoming follow-on work to #6282 (consolidating FV Android dictionary list into the Keyboard settings menu)

Conforming to the Material Design guideline examples which only use bold in headings/titles, this removes the Bold typeface currently used in lists.
https://material.io/components/lists#interactive-demo

Also changed subtext color from black to grey

### Screenshot 

Updated keyboard picker
![keyboard picker](https://user-images.githubusercontent.com/7358010/157184015-8650f47b-1022-4f08-9a01-bfcf2b64ef33.png)

Updated installed languages (subtext in grey)
![installed languages](https://user-images.githubusercontent.com/7358010/157186325-550adc22-6bf4-49dd-ab5d-36642d9aa11f.png)

@keymanapp-test-bot skip

