### PR TITLE
fix(linux): Fix trigger script

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -103,7 +103,7 @@ function triggerJenkinsBuild() {
   for line in "${jobs[@]}"; do
     if [[ $line == \"$JENKINS_JOB/$JENKINS_BRANCH* ]]; then
       echo "$line"
-      ((count++))
+      count=$((++count))
     fi
   done
   if [[ $count < 1 ]]; then


### PR DESCRIPTION
The previous PR #6337 introduced a bug when run with `set -e` which this change fixes.

@keymanapp-test-bot skip