### PR TITLE
fix(oem/fv/android): Check keyboard exists before registering a model

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -22,6 +22,7 @@ import com.tavultesoft.kmea.cloud.CloudDownloadMgr;
 import com.tavultesoft.kmea.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
 import com.tavultesoft.kmea.data.CloudRepository;
 import com.tavultesoft.kmea.data.Dataset;
+import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.util.BCP47;
 import com.tavultesoft.kmea.util.KMLog;
@@ -88,8 +89,8 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
       }
 
       // If the active keyboard is for this language, immediately enact the new pref setting.
-      String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-      if (BCP47.languageEquals(kbdLgCode, lgCode)) {
+      Keyboard currentKeyboard = KMManager.getCurrentKeyboardInfo(context);
+      if (currentKeyboard != null && BCP47.languageEquals(currentKeyboard.getLanguageID(), lgCode)) {
         // Not only registers the model but also applies our modeling preferences.
         KMManager.registerAssociatedLexicalModel(lgCode);
       }


### PR DESCRIPTION
Fixes pre-launch report crash for FV Android and follow-on to #6282 

The Predictions toggle was checking if the active keyboard matched the current language before registering the lexical model.
During setup before a keyboard is enabled, this would cause a null pointer exception.

Note, a separate  follow-on PR will disable predictions by default until a dictionary is installed.

## User Testing
* **TEST_NO_ACTIVE_KEYBOARD**
1. Install the PR build of "FirstVoices for Android" and launch the app
2. On the main Setup menu, click "Select keyboards" --> BC Coast --> SENCOTEN
3. Before enabling the Sencoten keyboard, disable the toggle for "Enable predictions"
4. Verify the app does not crash
