### PR TITLE
feat(common): build test keyboards via script

### DIFF
--- a/common/test/keyboards/build.bat
+++ b/common/test/keyboards/build.bat
@@ -1,0 +1,9 @@
+@echo off
+
+rem Use gosh.bat to launch build.sh
+set gosh=%~dp0%..\..\..\resources\gosh\gosh.bat
+set buildsh=%~dp0%build.sh
+"%gosh%" "%buildsh%" %*
+
+rem If we get this far, then we've failed to launch gosh and/or build.sh
+exit /b 2

--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+THIS_DIR="$(dirname "$THIS_SCRIPT")"
+
+display_usage() {
+  echo "usage: build.sh [build options] [targets]"
+  echo
+  echo "Build options:"
+  echo "  --clean, -c       Clean instead of build"
+  echo "  --debug, -d       Debug build"
+  echo "  --silent, -s      Suppress information messages"
+  echo "  --keyboard, -k    Build only keyboards (not packages)"
+  echo "  --kmcomp path     Specify path to kmcomp.exe, defaults"
+  echo "                    to windows/bin/developer/kmcomp.exe"
+  echo
+  echo "Targets (all unless specified):"
+
+  for d in "$THIS_DIR/"*/; do
+    d="$(basename "$d")"
+    echo "  $d"
+  done
+
+  echo
+  exit 0
+}
+
+QUIET=false
+DEBUG=false
+CLEAN=false
+KEYBOARDS_ONLY=false
+KMCOMP="$KEYMAN_ROOT/windows/bin/developer/kmcomp.exe"
+TARGETS=()
+
+# Parse args
+shopt -s nocasematch
+
+while [[ $# -gt 0 ]] ; do
+  key="$1"
+  case $key in
+    --help|-h|-\?)
+      display_usage
+      ;;
+    --clean|-c)
+      CLEAN=true
+      ;;
+    --debug|-d)
+      DEBUG=true
+      ;;
+    --silent|-s)
+      QUIET=true
+      ;;
+    --keyboard|-k)
+      KEYBOARDS_ONLY=true
+      ;;
+    --kmcomp)
+      shift
+      KMCOMP="$1"
+      ;;
+    *)
+      TARGETS+=("$key")
+  esac
+  shift
+done
+
+# TODO: while this is intended to be cross platform, we
+# don't currently have a binary version of kmcomp available
+# during Linux and macOS builds, so that will need to be
+# manually sourced.
+
+case "${OSTYPE}" in
+  "cygwin")
+    KMCOMP_LAUNCHER=
+    ;;
+  "msys")
+    KMCOMP_LAUNCHER=
+    ;;
+  "darwin"*)
+    # For Catalina (10.15) onwards, must use wine64
+    base_macos_ver=10.15
+    macos_ver=$(sw_vers -productVersion)
+    if verlt "$macos_ver" "$base_macos_ver"; then
+      KMCOMP_LAUNCHER=wine
+    else
+      # On Catalina, and later versions:
+      # wine-4.12.1 works; wine-5.0, wine-5.7 do not.
+      # retrieve these from:
+      # `brew tap gcenx/wine && brew install --cask --no-quarantine wine-crossover`
+      # may also need to `sudo spctl --master-disable`
+      KMCOMP_LAUNCHER=wine64
+      KMCOMP="$(dirname $KMCOMP)/kmcomp.x64.exe"
+    fi
+    ;;
+  *)
+    KMCOMP_LAUNCHER=wine
+    ;;
+esac
+
+
+# Build list of available targets from subfolders, if none specified
+if [ ${#TARGETS[@]} == 0 ]; then
+  for d in "$THIS_DIR/"*/; do
+    d="$(basename "$d")"
+    TARGETS+=("$d")
+  done
+fi
+
+if ! $QUIET; then
+  displayInfo "" \
+      "CLEAN: $CLEAN" \
+      "DEBUG: $DEBUG" \
+      "QUIET: $QUIET" \
+      "KEYBOARDS_ONLY: $KEYBOARDS_ONLY" \
+      "TARGETS: ${TARGETS[@]}" \
+      ""
+fi
+
+clean() {
+  local kpj="$1.kpj" ss=
+  if $QUIET; then
+    ss=-ss
+  fi
+  pushd "$1" > /dev/null
+  $KMCOMP_LAUNCHER "$KMCOMP" -c $ss "$kpj"
+  popd > /dev/null
+}
+
+build() {
+  local kpj="$1.kpj" d= t= ss= target=
+  if $KEYBOARDS_ONLY; then
+    t=-t
+    target="$1.kmn"
+  fi
+  if $DEBUG; then
+    d=-d
+  fi
+  if $QUIET; then
+    ss=-ss
+  fi
+  # -w - treat warnings as errors, we'll force this
+  # -cfc - check filename conventions
+  pushd "$1" > /dev/null
+  $KMCOMP_LAUNCHER "$KMCOMP" $d $ss -w -cfc "$kpj" $t "$target"
+  popd > /dev/null
+}
+
+###
+
+for TARGET in "${TARGETS[@]}"; do
+  if $CLEAN; then
+    echo
+    echo_heading "Cleaning target $TARGET"
+    echo
+    clean "$TARGET"
+  else
+    echo
+    echo_heading "Building target $TARGET"
+    echo
+    build "$TARGET"
+  fi
+done
+
+exit 0


### PR DESCRIPTION
Relates to #5815.

build.sh is a new script that builds any or all of the keyboards in the common/test/keyboards folder. build.bat is a wrapper for build.sh, just for Windows CMD.

Assumes that kmcomp.exe has already been built or allows you to specify your own kmcomp.exe if necessary.

These keyboards will be built as part of the Windows/Developer build and be available as artifacts on that build. Later, may add them to downloads.keyman.com.

@keymanapp-test-bot skip