### PR TITLE
chore(common): cleanup sh global color variables

### DIFF
--- a/common/core/web/input-processor/test.sh
+++ b/common/core/web/input-processor/test.sh
@@ -54,7 +54,7 @@ if [ $FETCH_DEPS = true ]; then
 fi
 
 # Ensures that the lexical model compiler has been built locally.
-echo "${TERM_HEADING}Preparing Lexical Model Compiler for test use${NORMAL}"
+echo_heading "Preparing Lexical Model Compiler for test use"
 pushd $WORKING_DIRECTORY/node_modules/@keymanapp/lexical-model-compiler
 npm run build
 popd

--- a/common/core/web/input-processor/test.sh
+++ b/common/core/web/input-processor/test.sh
@@ -75,5 +75,5 @@ if [ $FETCH_DEPS = true ]; then
 fi
 
 # Now we run our local tests.
-echo "${TERM_HEADING}Running Input Processor test suite${NORMAL}"
+echo_heading "Running Input Processor test suite"
 test-headless || fail "Input Processor tests failed!"

--- a/common/core/web/keyboard-processor/test.sh
+++ b/common/core/web/keyboard-processor/test.sh
@@ -64,6 +64,6 @@ pushd "$KEYMAN_ROOT/common/core/web/tools/recorder/src"
 popd
 
 # Run headless (browserless) tests.
-echo "${TERM_HEADING}Running Keyboard Processor test suite${NORMAL}"
+echo_heading "Running Keyboard Processor test suite"
 test-headless || fail "Keyboard Processor tests failed!"
 

--- a/common/predictive-text/testing/one-stage-embedded-webworker/build.sh
+++ b/common/predictive-text/testing/one-stage-embedded-webworker/build.sh
@@ -1,31 +1,20 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications.
 # Designed for optimal compatibility with the Keyman Suite.
 #
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../../resources/build/build-utils.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 display_usage ( ) {
   echo "build.sh [-clean]"
   echo
   echo "  -clean              to erase pre-existing build products before a re-build"
-}
-
-# Fails the build if a specified file does not exist.
-assert ( ) {
-  if ! [ -f $1 ]; then
-    fail "Build failed."
-    exit 1
-  fi
-}
-
-# Prints a nice, common error message.
-fail ( ) {
-  FAILURE_MSG="$1"
-  if [[ "$FAILURE_MSG" == "" ]]; then
-    FAILURE_MSG="Unknown failure."
-  fi
-  echo "${ERROR_RED}$FAILURE_MSG${NORMAL}"
-  exit 1
 }
 
 SOURCE="testing/one-stage-embedded-webworker"

--- a/common/predictive-text/testing/two-stage-embedded-webworker/build.sh
+++ b/common/predictive-text/testing/two-stage-embedded-webworker/build.sh
@@ -1,31 +1,20 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications.
 # Designed for optimal compatibility with the Keyman Suite.
 #
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../../resources/build/build-utils.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 display_usage ( ) {
   echo "build.sh [-clean]"
   echo
   echo "  -clean              to erase pre-existing build products before a re-build"
-}
-
-# Fails the build if a specified file does not exist.
-assert ( ) {
-  if ! [ -f $1 ]; then
-    fail "Build failed."
-    exit 1
-  fi
-}
-
-# Prints a nice, common error message.
-fail ( ) {
-  FAILURE_MSG="$1"
-  if [[ "$FAILURE_MSG" == "" ]]; then
-    FAILURE_MSG="Unknown failure."
-  fi
-  echo "${ERROR_RED}$FAILURE_MSG${NORMAL}"
-  exit 1
 }
 
 SOURCE="testing/two-stage-embedded-webworker"

--- a/ios/i18n-export.sh
+++ b/ios/i18n-export.sh
@@ -19,7 +19,7 @@ verify_on_mac
 
 
 #xcodebuild -exportLocalizations -project "engine/KMEI/KeymanEngine.xcodeproj"
-#xcodebuild -exportLocalizations -project "keyman/Keyman/Keyman.xcodeproj" 
+#xcodebuild -exportLocalizations -project "keyman/Keyman/Keyman.xcodeproj"
 
 BASE_EXPORT_FOLDER="build/crowdin"
 START_DIRECTORY=`pwd`
@@ -52,8 +52,8 @@ echo ""
 echo "---------------------------------------------"
 echo "iOS base i18n files have been exported."
 echo "Examine the contents of the folder at"
-echo "${SUCCESS_GREEN}$KEYMAN_ROOT/ios/$BASE_EXPORT_FOLDER${NORMAL}"
+echo "${COLOR_GREEN}$KEYMAN_ROOT/ios/$BASE_EXPORT_FOLDER${COLOR_RESET}"
 echo "and compare against the iOS entries within"
-echo "${SUCCESS_GREEN}$KEYMAN_ROOT/crowdin.yml${NORMAL}"
+echo "${COLOR_GREEN}$KEYMAN_ROOT/crowdin.yml${COLOR_RESET}"
 echo "---------------------------------------------"
 

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -207,7 +207,7 @@ update_bundle ( ) {
       downloadKeyboardPackage "$DEFAULT_KBD_ID" "$base_dir/$BUNDLE_PATH/$DEFAULT_KBD_ID.kmp"
       downloadModelPackage "$DEFAULT_LM_ID" "$base_dir/$BUNDLE_PATH/$DEFAULT_LM_ID.model.kmp"
 
-      echo "${SUCCESS_GREEN}Packages successfully updated${NORMAL}"
+      echo "${COLOR_GREEN}Packages successfully updated${COLOR_RESET}"
 
       # If we aren't downloading resources, make sure copies of them already exist!
     fi
@@ -317,7 +317,7 @@ if [ $DO_KEYMANAPP = true ]; then
                 VERSION=$VERSION \
                 VERSION_WITH_TAG=$VERSION_WITH_TAG \
                 VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
-                UPLOAD_SENTRY=$UPLOAD_SENTRY 
+                UPLOAD_SENTRY=$UPLOAD_SENTRY
   fi
 
   echo ""

--- a/mac/bashHelperFunctions.sh
+++ b/mac/bashHelperFunctions.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# TODO: deprecate and replace with shellHelperFunctions.sh.
+
 # The following allows coloring of warning and error lines, but only works if there's a
 # terminal attached, so not on the build machine.
 if ! [[ "$TERM" == "" || "$TERM" == "dumb" ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -85,21 +85,21 @@ get_platform_folder() {
 # The following allows coloring of warning and error lines, but only works if there's a
 # terminal attached, so not on the build machine.
 if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]]; then
-    ERROR_RED=$(tput setaf 1)
-    SUCCESS_GREEN=$(tput setaf 2)
-    WARNING_YELLOW=$(tput setaf 3)
-    NORMAL=$(tput sgr0)
-    TERM_HEADING=$(tput setaf 4)
+    COLOR_RED=$(tput setaf 1)
+    COLOR_GREEN=$(tput setaf 2)
+    COLOR_BLUE=$(tput setaf 4)
+    COLOR_YELLOW=$(tput setaf 3)
+    COLOR_RESET=$(tput sgr0)
 else
-    ERROR_RED=
-    SUCCESS_GREEN=
-    WARNING_YELLOW=
-    NORMAL=
-    TERM_HEADING=
+    COLOR_RED=
+    COLOR_GREEN=
+    COLOR_BLUE=
+    COLOR_YELLOW=
+    COLOR_RESET=
 fi
 
 echo_heading() {
-  echo "${TERM_HEADING}$*${NORMAL}"
+  echo "${COLOR_BLUE}$*${COLOR_RESET}"
 }
 
 fail() {
@@ -107,11 +107,11 @@ fail() {
     if [[ "$FAILURE_MSG" == "" ]]; then
         FAILURE_MSG="Unknown failure"
     fi
-    echo "${ERROR_RED}$FAILURE_MSG${NORMAL}"
+    echo "${COLOR_RED}$FAILURE_MSG${COLOR_RESET}"
     exit 1
 }
 
-warn() { echo "${WARNING_YELLOW}$*${NORMAL}"; }
+warn() { echo "${COLOR_YELLOW}$*${COLOR_RESET}"; }
 
 displayInfo() {
     if [ "$QUIET" != true ]; then

--- a/web/bulk_rendering/build.sh
+++ b/web/bulk_rendering/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# 
+#
 # Compile the KeymanWeb bulk-renderer module for use with developing/running engine tests.
 
 ## START STANDARD BUILD SCRIPT INCLUDE
@@ -8,23 +8,6 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 . "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
-
-# Fails the build if a specified file does not exist.
-assert ( ) {
-    if ! [ -f $1 ]; then
-        fail "Build failed."
-        exit 1
-    fi
-}
-
-fail() {
-    FAILURE_MSG="$1"
-    if [[ "$FAILURE_MSG" == "" ]]; then
-        FAILURE_MSG="Unknown failure"
-    fi
-    echo "${ERROR_RED}$FAILURE_MSG${NORMAL}"
-    exit 1
-}
 
 # Ensure the dependencies are downloaded.  --no-optional should help block fsevents warnings.
 verify_npm_setup

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -355,11 +355,11 @@ if [ $BUILD_CORE = true ]; then
     CORE_FLAGS="-skip-package-install"
 
     # Build the sentry-manager module - it's used in embedded contexts and on one testing page.
-    echo "${TERM_HEADING}Compiling KeymanWeb's sentry-manager module...${NORMAL}"
+    echo_heading "Compiling KeymanWeb's sentry-manager module..."
     pushd ../../common/core/web/tools/sentry-manager/src
     ./build.sh $CORE_FLAGS || fail "Failed to compile the sentry-manager module"
     popd
-    echo "${TERM_HEADING}sentry-manager module compiled successfully.${NORMAL}"
+    echo_heading "sentry-manager module compiled successfully."
 
     if [ $BUILD_LMLAYER = false ]; then
         CORE_FLAGS="$CORE_FLAGS -test"
@@ -368,10 +368,10 @@ if [ $BUILD_CORE = true ]; then
     # Ensure that the Input Processor module compiles properly.
     cd ../../common/core/web/input-processor/src
     echo ""
-    echo "${TERM_HEADING}Compiling local KeymanWeb dependencies...${NORMAL}"
+    echo_heading "Compiling local KeymanWeb dependencies..."
     ./build.sh $CORE_FLAGS || fail "Failed to compile KeymanWeb dependencies"
     cd $WORKING_DIRECTORY
-    echo "${TERM_HEADING}Local KeymanWeb dependency compilations completed successfully.${NORMAL}"
+    echo_heading "Local KeymanWeb dependency compilations completed successfully."
     echo ""
 fi
 

--- a/web/unit_tests/test.sh
+++ b/web/unit_tests/test.sh
@@ -135,7 +135,7 @@ pushd $WORKING_DIRECTORY/node_modules/@keymanapp/input-processor
 # Once done, now we run the integrated (KeymanWeb) tests.
 popd
 
-echo "${TERM_HEADING}Running KeymanWeb integration test suite${NORMAL}"
+echo_heading "Running KeymanWeb integration test suite"
 npm --no-color run modernizr -- -c unit_tests/modernizr.config.json -d unit_tests/modernizr.js
 npm --no-color run karma -- start $FLAGS $BROWSERS unit_tests/$CONFIG
 


### PR DESCRIPTION
Some of the global color variables in shellHelperFunctions.sh were a little dangerously named. This cleans that up and removes a couple of redundant functions from other locations.

mac/bashHelperFunctions.sh should be removed and replaced with references to shellHelperFunctions.sh -- but I wanted to leave that for a separate branch.

@keymanapp-test-bot skip