### PR TITLE
fix(android/engine): Activate menu on globe longpress before release

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -189,11 +189,8 @@ final class KMKeyboard extends WebView {
           showSubKeys(context);
           return;
         } else if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
-          // Shortcut to keyboard picker menu (Ignore if system keyboard on lock screen)
-          // Do we need to make KMManager.doGlobeKeyLongpressAction() public?
-          if ((keyboardType != KeyboardType.KEYBOARD_TYPE_SYSTEM) || !KMManager.isLocked()) {
-            KMManager.showKeyboardPicker(context, keyboardType);
-          }
+          KMManager.setGlobeKeyState(KMManager.GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS);
+          KMManager.handleGlobeKeyAction(context, true, keyboardType);
           return;
         /* For future implementation
         else if(suggestionJSON != null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -189,7 +189,11 @@ final class KMKeyboard extends WebView {
           showSubKeys(context);
           return;
         } else if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
-          KMManager.setGlobeKeyState(KMManager.GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS);
+          // Shortcut to keyboard picker menu (Ignore if system keyboard on lock screen)
+          // Do we need to make KMManager.doGlobeKeyLongpressAction() public?
+          if ((keyboardType != KeyboardType.KEYBOARD_TYPE_SYSTEM) || !KMManager.isLocked()) {
+            KMManager.showKeyboardPicker(context, keyboardType);
+          }
           return;
         /* For future implementation
         else if(suggestionJSON != null) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2103,7 +2103,7 @@ public final class KMManager {
    * Return if the lock screen is locked (prevents keyboard picker menu from being displayed)
    * @return boolean
    */
-  public static boolean isLocked() {
+  private static boolean isLocked() {
     KeyguardManager keyguardManager = (KeyguardManager) appContext.getSystemService(Context.KEYGUARD_SERVICE);
     // inKeyguardRestrictedInputMode() deprecated, so check isKeyguardLocked() to determine if screen is locked
     return keyguardManager.isKeyguardLocked();
@@ -2114,7 +2114,7 @@ public final class KMManager {
    * @param globeKeyDown boolean if the globe key state is GLOBE_KEY_STATE_DOWN
    * @param keyboardType KeyboardType KEYBOARD_TYPE_INAPP or KEYBOARD_TYPE_SYSTEM
    */
-  private static void handleGlobeKeyAction(Context context, boolean globeKeyDown, KeyboardType keyboardType) {
+  public static void handleGlobeKeyAction(Context context, boolean globeKeyDown, KeyboardType keyboardType) {
     // Update globeKeyState
     if (globeKeyState != GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS) {
       globeKeyState = globeKeyDown ? GlobeKeyState.GLOBE_KEY_STATE_DOWN : GlobeKeyState.GLOBE_KEY_STATE_UP;

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2100,6 +2100,16 @@ public final class KMManager {
   }
 
   /**
+   * Return if the lock screen is locked (prevents keyboard picker menu from being displayed)
+   * @return boolean
+   */
+  public static boolean isLocked() {
+    KeyguardManager keyguardManager = (KeyguardManager) appContext.getSystemService(Context.KEYGUARD_SERVICE);
+    // inKeyguardRestrictedInputMode() deprecated, so check isKeyguardLocked() to determine if screen is locked
+    return keyguardManager.isKeyguardLocked();
+  }
+
+  /**
    * Handle the globe key action
    * @param globeKeyDown boolean if the globe key state is GLOBE_KEY_STATE_DOWN
    * @param keyboardType KeyboardType KEYBOARD_TYPE_INAPP or KEYBOARD_TYPE_SYSTEM
@@ -2111,9 +2121,8 @@ public final class KMManager {
     }
 
     if (KMManager.shouldAllowSetKeyboard()) {
-      KeyguardManager keyguardManager = (KeyguardManager) appContext.getSystemService(Context.KEYGUARD_SERVICE);
       // inKeyguardRestrictedInputMode() deprecated, so check isKeyguardLocked() to determine if screen is locked
-      if (keyguardManager.isKeyguardLocked()) {
+      if (isLocked()) {
         if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && globeKeyState == GlobeKeyState.GLOBE_KEY_STATE_UP) {
           doGlobeKeyLockscreenAction(context);
         }


### PR DESCRIPTION
Addresses #6267 for 15.0 beta.

This updates the globekey longpress logic to trigger the keyboard picker menu before the globe key is released.
We still want to block the keybard picker menu for system keyboard on lock screen.

~Question: Should we make `KMManager.doGlobeKeyLongpressAction()` a public API?~
I ended up making `KMManager.handleGlobeKeyAction()` a public API

## User testing
Setup 
1. On an Android device or emulator, install PR build of Keyman
2. From the Android settings menu, also set a simple password (e.g. `1234` as password, not PIN). If using a physical device, I 
recommend adding a second unlock like fingerprint
3. From Keyman, install another Keyman keyboard (e.g. Khmer Angkor)

* **TEST_GLOBE_SHORTPRESS**
1. In the Keyman app, short press the globe key and release
2. Verify Keyman quickly switches to the next Keyman keyboard

* **TEST_GLOBE_LONGPRESS**
1. In the Keyman app, longpress the globe key and hold it down
2. After a while, verify the Keyman keyboard picker menu appears
3. Select a Keyman keyboard and verify Keyman switches to the selected keyboard
4. From the Keyman "Settings" menu, enable Keyman as a default system keyboard
5. Lock the device
6. Attempt to unlock the device with the Keyman keyboard, but don't enter the password yet
7. Longpress on the globe key and release
8. Verify instead of the keyboard picker menu, Keyman switches to another keyboard (still on lock screen). The next keyboard can be either Keyman or system keyboard. Depending on the lock screen timing, it could cycle through all the Keyman keyboards before getting to a system keyboard.
9. While still on the lock screen (you may need to hit the power button again if the lock screen times out), short press on the globe and release
10. Enter the password to unlock the device.