### PR TITLE
fix(web): bounding rect offset was incorrect

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -457,9 +457,8 @@ namespace com.keyman.osk {
      */
     private getInteractiveBoundingRect(): BoundingRect {
       // Determine the important geometric values involved
-      const _Box = this.element.offsetParent as HTMLElement;
-      let oskX = this.element.offsetLeft + (_Box?.offsetLeft || 0);
-      let oskY = this.element.offsetTop + (_Box?.offsetTop || 0);
+      let oskX = dom.Utils.getAbsoluteX(this.element);
+      let oskY = dom.Utils.getAbsoluteY(this.element);
 
       // Determine the out-of-bounds threshold at which touch-cancellation should automatically occur.
       // Assuming square key-squares, we'll use 1/3 the height of a row for bounds detection
@@ -475,15 +474,6 @@ namespace com.keyman.osk {
         top: oskY - buffer,
         bottom: oskY + this.height + buffer
       };
-
-      // If the OSK is using fixed positioning (thus, viewport-relative), we need to
-      // convert the 'clientX'-like values into 'pageX'-like values.
-      if (this.usesFixedPositioning) {
-        boundingRect.left += window.pageXOffset;
-        boundingRect.right += window.pageXOffset;
-        boundingRect.top += window.pageYOffset;
-        boundingRect.bottom += window.pageYOffset;
-      }
 
       return boundingRect;
     }


### PR DESCRIPTION
Fixes #6140.

When embedding the On Screen Keyboard into a page, the calculation for the bounding rectangle only took into account the first offsetParent, which meant it would get the offset incorrect when there were multiple layers of offsetParents.

Once I changed to using getAbsoluteX / getAbsoluteY, this also corrects for scroll with window.pageOffsetY, so we can eliminate that special case for fixed positioning.

This was observable in the Web Developer test window, where interaction with the bottom row of the keyboard in touch mode was not working correctly, in 15.0.210-beta.

# User Testing

For this test, you can use any keyboard that has both touch and desktop modes (e.g. Khmer Angkor).

**TEST_WEB_DEBUGGER:** Test that keys on every row of the On Screen Keyboard work correctly in the Developer Web Debugger, in each of the platforms in the web debugger. For touch platforms, verify longpress on all rows, if possible.

**TEST_IOS:** Test that keys on every row of the OSK work correctly in Keyman for iPhone and iPad. Test both in-app and system keyboards. Verify longpress on all rows, if possible.

**TEST_ANDROID:** Test that keys on every row of the OSK work correctly in Keyman for Android. Test both in-app and system keyboards. Verify longpress on all rows, if possible.

**TEST_WEB_EMULATOR:** Test that keys on every row of the OSK work correctly in the Unminified Test Page, in mobile view -- Chrome emulator. Verify longpress on all rows, if possible.

**TEST_WEB_ANDROID:** Test that keys on every row of the OSK work correctly in the Unminified Test Page, on an Android device or Android emulator (not Chrome emulator). Verify longpress on all rows, if possible.

**TEST_WEB_IOS:** Test that keys on every row of the OSK work correctly in the Unminified Test Page, on an iOS device or simulator (not Chrome emulator). Verify longpress on all rows, if possible.