### PR TITLE
fix(common): allow custom keyboard builds

### DIFF
--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -124,18 +124,24 @@ if ! $QUIET; then
 fi
 
 clean() {
-  local kpj="$1.kpj" ss=
+  local kpj="$1.kpj" ss= s=
   if $QUIET; then
     ss=-ss
+    s=-s
   fi
   pushd "$1" > /dev/null
-  $KMCOMP_LAUNCHER "$KMCOMP" -c $ss "$kpj"
+  if [ -f build.sh ]; then
+    ./build.sh -c $s
+  else
+    $KMCOMP_LAUNCHER "$KMCOMP" -c $ss "$kpj"
+  fi
   popd > /dev/null
 }
 
 build() {
-  local kpj="$1.kpj" d= t= ss= target=
+  local kpj="$1.kpj" d= t= ss= target= s= k=
   if $KEYBOARDS_ONLY; then
+    k=-k
     t=-t
     target="$1.kmn"
   fi
@@ -143,12 +149,17 @@ build() {
     d=-d
   fi
   if $QUIET; then
+    s=-s
     ss=-ss
   fi
   # -w - treat warnings as errors, we'll force this
   # -cfc - check filename conventions
   pushd "$1" > /dev/null
-  $KMCOMP_LAUNCHER "$KMCOMP" $d $ss -w -cfc "$kpj" $t "$target"
+  if [ -f build.sh ]; then
+    ./build.sh $d $k $s
+  else
+    $KMCOMP_LAUNCHER "$KMCOMP" $d $ss -w -cfc "$kpj" $t "$target"
+  fi
   popd > /dev/null
 }
 
@@ -156,14 +167,18 @@ build() {
 
 for TARGET in "${TARGETS[@]}"; do
   if $CLEAN; then
-    echo
-    echo_heading "Cleaning target $TARGET"
-    echo
+    if ! $QUIET; then
+      echo
+      echo_heading "Cleaning target $TARGET"
+      echo
+    fi
     clean "$TARGET"
   else
-    echo
-    echo_heading "Building target $TARGET"
-    echo
+    if ! $QUIET; then
+      echo
+      echo_heading "Building target $TARGET"
+      echo
+    fi
     build "$TARGET"
   fi
 done

--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -37,6 +37,7 @@ QUIET=false
 DEBUG=false
 CLEAN=false
 KEYBOARDS_ONLY=false
+CUSTOM_KMCOMP=
 KMCOMP="$KEYMAN_ROOT/windows/bin/developer/kmcomp.exe"
 TARGETS=()
 
@@ -64,6 +65,7 @@ while [[ $# -gt 0 ]] ; do
     --kmcomp)
       shift
       KMCOMP="$1"
+      CUSTOM_KMCOMP=true
       ;;
     *)
       TARGETS+=("$key")
@@ -75,35 +77,35 @@ done
 # don't currently have a binary version of kmcomp available
 # during Linux and macOS builds, so that will need to be
 # manually sourced.
+KMCOMP_LAUNCHER=
 
-case "${OSTYPE}" in
-  "cygwin")
-    KMCOMP_LAUNCHER=
-    ;;
-  "msys")
-    KMCOMP_LAUNCHER=
-    ;;
-  "darwin"*)
-    # For Catalina (10.15) onwards, must use wine64
-    base_macos_ver=10.15
-    macos_ver=$(sw_vers -productVersion)
-    if verlt "$macos_ver" "$base_macos_ver"; then
+if ! $CUSTOM_KMCOMP; then
+  case "${OSTYPE}" in
+    "cygwin")
+      ;;
+    "msys")
+      ;;
+    "darwin"*)
+      # For Catalina (10.15) onwards, must use wine64
+      base_macos_ver=10.15
+      macos_ver=$(sw_vers -productVersion)
+      if verlt "$macos_ver" "$base_macos_ver"; then
+        KMCOMP_LAUNCHER=wine
+      else
+        # On Catalina, and later versions:
+        # wine-4.12.1 works; wine-5.0, wine-5.7 do not.
+        # retrieve these from:
+        # `brew tap gcenx/wine && brew install --cask --no-quarantine wine-crossover`
+        # may also need to `sudo spctl --master-disable`
+        KMCOMP_LAUNCHER=wine64
+        KMCOMP="$(dirname $KMCOMP)/kmcomp.x64.exe"
+      fi
+      ;;
+    *)
       KMCOMP_LAUNCHER=wine
-    else
-      # On Catalina, and later versions:
-      # wine-4.12.1 works; wine-5.0, wine-5.7 do not.
-      # retrieve these from:
-      # `brew tap gcenx/wine && brew install --cask --no-quarantine wine-crossover`
-      # may also need to `sudo spctl --master-disable`
-      KMCOMP_LAUNCHER=wine64
-      KMCOMP="$(dirname $KMCOMP)/kmcomp.x64.exe"
-    fi
-    ;;
-  *)
-    KMCOMP_LAUNCHER=wine
-    ;;
-esac
-
+      ;;
+  esac
+fi
 
 # Build list of available targets from subfolders, if none specified
 if [ ${#TARGETS[@]} == 0 ]; then

--- a/common/test/keyboards/the_99/build.sh
+++ b/common/test/keyboards/the_99/build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../../../resources/build/build-utils.sh"
+# . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+THIS_DIR="$(dirname "$THIS_SCRIPT")"
+
+display_usage() {
+  echo "Usage: build.sh [-c]"
+  exit $1
+}
+
+# Parse args
+shopt -s nocasematch
+
+CLEAN=false
+DEBUG=false
+QUIET=false
+KEYBOARDS_ONLY=false
+
+while [[ $# -gt 0 ]] ; do
+  key="$1"
+  case $key in
+    --help|-h|-\?)
+      display_usage 0
+      ;;
+    --clean|-c)
+      CLEAN=true
+      ;;
+    --debug|-d)
+      DEBUG=true
+      ;;
+    --silent|-s)
+      QUIET=true
+      ;;
+    --keyboard|-k)
+      KEYBOARDS_ONLY=true
+      ;;
+    *)
+      display_usage 1
+      ;;
+  esac
+  shift
+done
+
+if $CLEAN; then
+  if ! $QUIET; then
+    echo Cleaning the_99.kmp from build/
+  fi
+  rm -rf "$THIS_DIR"/build
+else
+  if ! $QUIET; then
+    echo Copying the_99.kmp to build/
+  fi
+  mkdir -p "$THIS_DIR"/build
+  cp "$THIS_DIR"/the_99.kmp build/the_99.kmp
+fi


### PR DESCRIPTION
This allows for custom builds of keyboards, e.g. where a keyboard is manually constructed for testing purposes.

@keymanapp-test-bot skip