### PR TITLE
feat(common): zip and index keyboard artifacts

### DIFF
--- a/common/test/keyboards/.gitignore
+++ b/common/test/keyboards/.gitignore
@@ -1,1 +1,3 @@
 */build/
+*/*_source.zip
+index.html


### PR DESCRIPTION
Adds `--index` and `--zip-sources` parameters. These will be used by the Developer test-14.0 build to produce easily accessible keyboard artifacts on TeamCity, which the test bot will then link to.

@keymanapp-test-bot skip