### PR TITLE
chore(android/engine): Remove visual gaps in keyboard picker menu

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -214,7 +214,8 @@ public final class KeyboardPickerActivity extends BaseActivity {
           imeListAdapter = new SimpleAdapter(this, imeList, R.layout.list_row_layout5, from, to);
           imeListView.setAdapter(imeListAdapter);
           // Rescale IME listview so entire list is visible (wrap_content not working)
-          imeListView.getLayoutParams().height = actionBarHeight * imeListAdapter.getCount();
+          imeListView.getLayoutParams().height = ((int) context.getResources().getDimension(R.dimen.other_ime_row_height)) *
+            imeListAdapter.getCount();
           imeListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {

--- a/android/KMEA/app/src/main/res/layout/ime_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/ime_list_layout.xml
@@ -16,8 +16,7 @@
     android:ellipsize="end"
     android:singleLine="true"
     android:textSize="@dimen/titlebar_label_textsize"
-    android:textStyle="bold"
-    android:layout_marginTop="@dimen/fab_margin"/>
+    android:textStyle="bold" />
 
   <!-- ListView of other enabled keyboards -->
   <include layout="@layout/list_layout"

--- a/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
+++ b/android/KMEA/app/src/main/res/layout/list_row_layout5.xml
@@ -7,7 +7,7 @@
     <LinearLayout
         android:background="@android:color/transparent"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/other_ime_row_height"
         android:layout_marginStart="16dp"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"

--- a/android/KMEA/app/src/main/res/values-sw720dp/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw720dp/dimens.xml
@@ -14,4 +14,6 @@
     <dimen name="help_bubble_height">80dp</dimen>
     <dimen name="help_bubble_offset_x">0.5dp</dimen>
     <dimen name="help_bubble_offset_y">10dp</dimen>
+    <dimen name="other_ime_title_height">50dp</dimen>
+    <dimen name="other_ime_row_height">60dp</dimen>
 </resources>

--- a/android/KMEA/app/src/main/res/values/dimens.xml
+++ b/android/KMEA/app/src/main/res/values/dimens.xml
@@ -16,6 +16,7 @@
     <dimen name="help_bubble_offset_x">0.5dp</dimen>
     <dimen name="help_bubble_offset_y">6dp</dimen>
     <dimen name="other_ime_title_height">35dp</dimen>
+    <dimen name="other_ime_row_height">50dp</dimen>
     <dimen name="fab_margin">10dp</dimen>
     <dimen name="fab_padding">70dp</dimen>
     <dimen name="qr_height">250dp</dimen>


### PR DESCRIPTION
Fixes #6361 
This updates the styling for the Keyman keyboard picker menu to remove the stray lines.

The gap at the top was from the inadvertent `fab_margin` in `ime_list_layout.xml`.
Specifying a height dimension for `list_row_layout5` also fixed the stray lines at the bottom.
![keyboard picker styling](https://user-images.githubusercontent.com/7358010/158114461-85fe5ee8-4416-4eea-88a7-6c70cb0b038a.png)

## User Testing
* **TEST_KEYBOARD_PICKER**
1. Load the PR build of Keyman for Android
2. From the "Get Started" menu, enable Keyman as a system keyboard and set as a default system keyboard
3. Launch a separate app (e,g. Chrome) and select a textfield to display the Keyman system keyboard
4. Long-press the globe button to bring up the keyboard picker menu
5. Verify there's no display artifacts in the menu (before "Other Input methods" or at the end)

