### PR TITLE
fix (ios) backspace crashes in app

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -287,7 +287,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       return
     }
 
-    // What the actual heck, Apple.  Apparently, in system-keyboard mode, this is also self-triggered if we erase back to a newline.
+    // Apparently, in system-keyboard mode, this is also self-triggered if we erase back to a newline.
     // Refer to https://github.com/keymanapp/keyman/pull/2770 for context.
     if self.swallowBackspaceTextChange && Manager.shared.isSystemKeyboard && textDocumentProxy.documentContextBeforeInput == "\n" {
       self.swallowBackspaceTextChange = false
@@ -333,6 +333,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       return
     }
 
+    if numCharsToDelete > 0 && textDocumentProxy.documentContextBeforeInput == nil {
+      textDocumentProxy.deleteBackward()
+      return
+    }
+    
     for _ in 0..<numCharsToDelete {
       let oldContext = textDocumentProxy.documentContextBeforeInput ?? ""
       textDocumentProxy.deleteBackward()


### PR DESCRIPTION
Fixes #6041.
This may also fix #5300 and #5888

In-app keyboard was causing Keyman to crash when the user backspaced over multiple lines of text
# User Testing

* TEST_BACKSPACE: backspace in-app over multiple lines without crashing

1. Run Keyman and use the in-app keyboard for typing
2. tap 'a', then tap the return key
3. tap 'b', then tap the return key
4. tap 'c', then tap the return key
5. tap the backspace key mutlpile times until only the letter a remains
6. confirm that you can continue to use the keyboard and tap other keys


