### PR TITLE
chore(android): Separate CI step to generate Play Store notes

### DIFF
--- a/android/KMAPro/build-play-store-notes.sh
+++ b/android/KMAPro/build-play-store-notes.sh
@@ -1,0 +1,48 @@
+# Set sensible script defaults:
+# set -e: Terminate script if a command returns an error
+set -e
+# set -u: Terminate script if an unset variable is used
+set -u
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+QUIET=0
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+THIS_DIR="$(dirname "$THIS_SCRIPT")"
+
+#
+# Copy release notes for Gradle Play Publisher to upload
+# Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
+#
+PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
+if [ $TIER = "stable" ]; then
+  PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
+fi
+echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
+echo "" > "$PLAY_RELEASE_NOTES"
+
+# Copy whatsnew.md to release notes 1 line at a time,
+# filtering for lines that start with "*".
+# Play Store release notes have a limit of 500 characters
+FILTERED_LINES=`grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md"`
+IFS=$'\n'      # Change IFS to new line
+for line in $FILTERED_LINES
+do
+  CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
+  CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
+  if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
+    # Copy line to Play Store release notes
+    echo "$line" >> $PLAY_RELEASE_NOTES
+  else
+    # 450 chars reached
+    warn "Warning: Play Store release notes approaching 500 character limit"
+    echo '* Additional bug fixes and improvements' >> $PLAY_RELEASE_NOTES
+    break
+  fi  
+done

--- a/android/build-help.sh
+++ b/android/build-help.sh
@@ -107,34 +107,3 @@ if $DO_HTM; then
   cp android_images/* "$DESTHTM/android_images/"
 
 fi
-
-#
-# Copy release notes for Gradle Play Publisher to upload
-# Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
-#
-PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
-if [ $TIER = "stable" ]; then
-  PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
-fi
-echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
-echo "" > "$PLAY_RELEASE_NOTES"
-
-# Copy whatsnew.md to release notes 1 line at a time,
-# filtering for lines that start with "*".
-# Play Store release notes have a limit of 500 characters
-FILTERED_LINES=`grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md"`
-IFS=$'\n'      # Change IFS to new line
-for line in $FILTERED_LINES
-do
-  CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
-  CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
-  if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
-    # Copy line to Play Store release notes
-    echo "$line" >> $PLAY_RELEASE_NOTES
-  else
-    # 450 chars reached
-    warn "Warning: Play Store release notes approaching 500 character limit"
-    echo '* Additional bug fixes and improvements' >> $PLAY_RELEASE_NOTES
-    break
-  fi  
-done

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -75,6 +75,9 @@ echo "BUILD_FLAGS $BUILD_FLAGS"
 # Publish Keyman for Android
 if [ "$DO_KMAPRO" = true ]; then
   cd "$KEYMAN_ROOT/android/KMAPro/"
+  # Copy Release Notes
+  ./build-play-store-notes.sh
+
   ./gradlew $DAEMON_FLAG $BUILD_FLAGS
 fi
 

--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -15,6 +15,6 @@ Here are some of the new features we have added to Keyman 15.0 for Android:
     | System        | 1                  | Quickly switch to previous system keyboard |
     | System        | 2+                 | Quickly switch to next Keyman keyboard |
 
-    * Long press and release the globe key to bring up the keyboard picker menu. On a Keyman system keyboard, the bottom of this menu will also display other enabled system keyboards that can be selected.
+    * Long press the globe key to bring up the keyboard picker menu. On a Keyman system keyboard, the bottom of this menu will also display other enabled system keyboards that can be selected.
 
     Note: On the lock screen, the keyboard picker menu is not displayed.


### PR DESCRIPTION
In preparation for cleaning up build.sh across the platforms, this moves the "Play Store" specific portion of `android/build-help.sh` into a separate `build-play-store-notes.sh` script. This way, we can refactor build-help.sh for all the platforms since they're essentially the same.

@keymanapp-test-bot skip