### PR TITLE
fix(web): ios popup positioning and style

### DIFF
--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -86,7 +86,7 @@ namespace com.keyman.osk.browser {
             height: 1.6 * xHeight + 'px' // as opposed to the canvas height of 2.3 * xHeight.
           };
 
-          kts.fontSize = key.key.getIdealFontSize(vkbd, scaleStyle);
+          kts.fontSize = key.key.getIdealFontSize(vkbd, scaleStyle, true);
         }
 
         this.label.textContent = kc.textContent;

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -18,8 +18,11 @@ namespace com.keyman.osk.browser {
 
     private readonly constrain: boolean;
 
-    // constrain:  keep the keytip within the bounds of the overall OSK.
-    // Will probably be handled via function in a later pass.
+    /**
+     *
+     * @param constrain keep the keytip within the bounds of the overall OSK.
+     *                  Will probably be handled via function in a later pass.
+     */
     constructor(constrain: boolean) {
       let tipElement = this.element=document.createElement('div');
       tipElement.className='kmw-keytip';
@@ -70,7 +73,10 @@ namespace com.keyman.osk.browser {
 
         // Matches how the subkey positioning is set.
         const _Box = vkbd.element.parentNode as HTMLDivElement;
-        kts.bottom = (_Box.offsetHeight - rowElement.offsetHeight - rowElement.offsetTop + key.offsetTop) + 'px';
+        const _BoxRect = _Box.getBoundingClientRect();
+        const keyRect = key.getBoundingClientRect();
+
+        kts.bottom = (_BoxRect.bottom - keyRect.bottom + 3) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';
         kts.fontFamily = util.getStyleValue(kc,'font-family');
@@ -107,8 +113,8 @@ namespace com.keyman.osk.browser {
 
         let cs = getComputedStyle(this.element);
         let oskHeight = keyman.osk.computedHeight;
-        let bottomY = parseInt(cs.bottom, 10);
-        let tipHeight = parseInt(cs.height, 10);
+        let bottomY = parseFloat(cs.bottom);
+        let tipHeight = parseFloat(cs.height);
 
         this.cap.style.width = xWidth + 'px';
         this.tip.style.height = (canvasHeight / 2) + 'px';
@@ -118,7 +124,7 @@ namespace com.keyman.osk.browser {
         if(this.constrain && tipHeight + bottomY > oskHeight) {
           const delta = tipHeight + bottomY - oskHeight;
           kts.height = (canvasHeight-delta) + 'px';
-          const hx = Math.max(0, (canvasHeight-delta)-(canvasHeight/2));
+          const hx = Math.max(0, (canvasHeight-delta)-(canvasHeight/2) + 2);
           this.cap.style.height = hx + 'px';
         }
 

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -64,19 +64,21 @@ namespace com.keyman.osk.browser {
             kc = key.key.label,
             previewFontScale = 1.8;
 
-        // Canvas dimensions must be set explicitly to prevent clipping
-        let canvasWidth = 1.6 * xWidth;
-        let canvasHeight = 2.3 * xHeight;
-
         let kts = this.element.style;
-        kts.top = 'auto';
 
-        // Matches how the subkey positioning is set.
+        // Roughly matches how the subkey positioning is set.
         const _Box = vkbd.element.parentNode as HTMLDivElement;
         const _BoxRect = _Box.getBoundingClientRect();
         const keyRect = key.getBoundingClientRect();
+        let y = (keyRect.bottom - _BoxRect.top - 5);
+        let ySubPixelPadding = y - Math.floor(y);
 
-        kts.bottom = (_BoxRect.bottom - keyRect.bottom + 3) + 'px';
+        // Canvas dimensions must be set explicitly to prevent clipping
+        // This gives us exactly the same number of pixels on left and right
+        let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
+        let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
+
+        kts.top = Math.floor(y - canvasHeight) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';
         kts.fontFamily = util.getStyleValue(kc,'font-family');
@@ -115,11 +117,13 @@ namespace com.keyman.osk.browser {
         let oskHeight = keyman.osk.computedHeight;
         let bottomY = parseFloat(cs.bottom);
         let tipHeight = parseFloat(cs.height);
+        let halfHeight = Math.ceil(canvasHeight / 2);
 
         this.cap.style.width = xWidth + 'px';
-        this.tip.style.height = (canvasHeight / 2) + 'px';
-        this.cap.style.top = (canvasHeight / 2 - 1) + 'px';
-        this.cap.style.height = (canvasHeight / 2 + 2) + 'px';
+        this.tip.style.height = halfHeight + 'px';
+
+        this.cap.style.top = (halfHeight - 1) + 'px';
+        this.cap.style.height = (halfHeight + 2) + 'px';
 
         if(this.constrain && tipHeight + bottomY > oskHeight) {
           const delta = tipHeight + bottomY - oskHeight;

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -70,7 +70,7 @@ namespace com.keyman.osk.browser {
         const _Box = vkbd.element.parentNode as HTMLDivElement;
         const _BoxRect = _Box.getBoundingClientRect();
         const keyRect = key.getBoundingClientRect();
-        let y = (keyRect.bottom - _BoxRect.top - 5);
+        let y = (keyRect.bottom - _BoxRect.top + 1);
         let ySubPixelPadding = y - Math.floor(y);
 
         // Canvas dimensions must be set explicitly to prevent clipping
@@ -102,11 +102,11 @@ namespace com.keyman.osk.browser {
         // Adjust shape if at edges
         var xOverflow = (canvasWidth - xWidth) / 2;
         if(xLeft < xOverflow) {
-          this.cap.style.left = '0px';
-          xLeft += xOverflow;
+          this.cap.style.left = '1px';
+          xLeft += xOverflow - 1;
         } else if(xLeft > window.innerWidth - xWidth - xOverflow) {
-          this.cap.style.left = (canvasWidth - xWidth) + 'px';
-          xLeft -= xOverflow;
+          this.cap.style.left = (canvasWidth - xWidth - 1) + 'px';
+          xLeft -= xOverflow - 1;
         } else {
           this.cap.style.left = xOverflow + 'px';
         }
@@ -122,8 +122,8 @@ namespace com.keyman.osk.browser {
         this.cap.style.width = xWidth + 'px';
         this.tip.style.height = halfHeight + 'px';
 
-        this.cap.style.top = (halfHeight - 1) + 'px';
-        this.cap.style.height = (halfHeight + 2) + 'px';
+        this.cap.style.top = (halfHeight - 3) + 'px';
+        this.cap.style.height = (keyRect.bottom - _BoxRect.top - Math.floor(y - canvasHeight) - (halfHeight)) + 'px'; //(halfHeight + 3 + ySubPixelPadding) + 'px';
 
         if(this.constrain && tipHeight + bottomY > oskHeight) {
           const delta = tipHeight + bottomY - oskHeight;

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -112,8 +112,8 @@ namespace com.keyman.osk.browser {
 
         this.cap.style.width = xWidth + 'px';
         this.tip.style.height = (canvasHeight / 2) + 'px';
-        this.cap.style.top = (canvasHeight / 2) + 'px';
-        this.cap.style.height = (canvasHeight / 2 - 1) + 'px';
+        this.cap.style.top = (canvasHeight / 2 - 1) + 'px';
+        this.cap.style.height = (canvasHeight / 2 + 2) + 'px';
 
         if(this.constrain && tipHeight + bottomY > oskHeight) {
           const delta = tipHeight + bottomY - oskHeight;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -188,7 +188,7 @@ namespace com.keyman.osk.browser {
         let _BoxRect = keyman.osk._Box.getBoundingClientRect();
 
         // Set position and style
-        let top = (keyRect.top - _BoxRect.top - 8 + delta);
+        let top = keyRect.top - _BoxRect.top - 9 + delta;
         // We're going to adjust the top of the box to ensure it stays
         // pixel aligned, otherwise we can get antialiasing artifacts
         // that look ugly
@@ -198,7 +198,7 @@ namespace com.keyman.osk.browser {
         ccs.top = top + 'px';
         ccs.left = (keyRect.left - _BoxRect.left) + 'px';
         ccs.width = keyRect.width + 'px';
-        ccs.height = (height - 2) + 'px';
+        ccs.height = (height - 1) + 'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -150,12 +150,11 @@ namespace com.keyman.osk.browser {
       let cs = getComputedStyle(subKeys);
       let oskHeight = keyman.osk.computedHeight;
       let bottomY = parseInt(cs.bottom, 10);
-      let popupHeight = parseInt(cs.height, 10);
 
       let delta = 0;
-      if(popupHeight + bottomY > oskHeight && constrainPopup) {
-        delta = popupHeight + bottomY - oskHeight;
-        ss.bottom = (bottomY - delta) + 'px';
+      if(bottomY > oskHeight && constrainPopup) {
+        delta = bottomY - oskHeight;
+        ss.bottom = oskHeight + 'px';
       }
 
       // Add the callout
@@ -190,7 +189,7 @@ namespace com.keyman.osk.browser {
 
         // Set position and style
         ccs.top = (xTop-6)+'px'; ccs.left = (xLeft-1)+'px';
-        ccs.width = xWidth+'px'; ccs.height = (xHeight+6)+'px';
+        ccs.width = xWidth+'px'; ccs.height = (xHeight+5)+'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -188,10 +188,17 @@ namespace com.keyman.osk.browser {
         let _BoxRect = keyman.osk._Box.getBoundingClientRect();
 
         // Set position and style
-        ccs.top = (keyRect.top - _BoxRect.top - 8 + delta) + 'px';
+        let top = (keyRect.top - _BoxRect.top - 8 + delta);
+        // We're going to adjust the top of the box to ensure it stays
+        // pixel aligned, otherwise we can get antialiasing artifacts
+        // that look ugly
+        let height = calloutHeight + (Math.ceil(top) - top);
+        top = Math.ceil(top);
+
+        ccs.top = top + 'px';
         ccs.left = (keyRect.left - _BoxRect.left) + 'px';
         ccs.width = keyRect.width + 'px';
-        ccs.height = calloutHeight + 'px';
+        ccs.height = (height - 2) + 'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -139,7 +139,10 @@ namespace com.keyman.osk.browser {
         x=0;
       }
       ss.left=x+'px';
-      ss.bottom = (_Box.offsetHeight - rowElement.offsetTop + subKeys.offsetHeight) + 'px';
+
+      let _BoxRect = _Box.getBoundingClientRect();
+      let rowElementRect = rowElement.getBoundingClientRect();
+      ss.top = (rowElementRect.top - _BoxRect.top - subKeys.offsetHeight - 3) + 'px';
 
       // Make the popup keys visible
       ss.visibility='visible';
@@ -149,12 +152,12 @@ namespace com.keyman.osk.browser {
 
       let cs = getComputedStyle(subKeys);
       let oskHeight = keyman.osk.computedHeight;
-      let bottomY = parseInt(cs.bottom, 10);
+      let topY = parseFloat(cs.top);
 
       let delta = 0;
-      if(bottomY > oskHeight && constrainPopup) {
-        delta = bottomY - oskHeight;
-        ss.bottom = oskHeight + 'px';
+      if(topY < 0 && constrainPopup) {
+        delta = -topY - 3;
+        ss.top = '0px';
       }
 
       // Add the callout
@@ -182,14 +185,19 @@ namespace com.keyman.osk.browser {
         keyman.osk._Box.appendChild(cc);
 
         // Create the callout
+        let keyRect = key.getBoundingClientRect();
+        let _BoxRect = keyman.osk._Box.getBoundingClientRect();
+
         var xLeft = key.offsetLeft + (<HTMLElement>key.offsetParent).offsetLeft,
             xTop = key.offsetTop + (key.key as OSKBaseKey).row.element.offsetTop + delta,
             xWidth = key.offsetWidth + 2,
             xHeight = calloutHeight;
 
         // Set position and style
-        ccs.top = (xTop-6)+'px'; ccs.left = (xLeft-1)+'px';
-        ccs.width = xWidth+'px'; ccs.height = (xHeight+5)+'px';
+        ccs.top = (keyRect.top - _BoxRect.top - 8 + delta) + 'px';
+        ccs.left = (keyRect.left - _BoxRect.left) + 'px';
+        ccs.width = keyRect.width + 'px';
+        ccs.height = (keyRect.height + 6) + 'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -153,10 +153,13 @@ namespace com.keyman.osk.browser {
       let cs = getComputedStyle(subKeys);
       let topY = parseFloat(cs.top);
 
+      // Adjust the vertical position of the popup to keep it within the
+      // bounds of the keyboard rectangle, when on iPhone (system keyboard)
+      const topOffset = 0; // Set this when testing constrainPopup, e.g. to -80px
       let delta = 0;
-      if(topY < 0 && constrainPopup) {
-        delta = -topY;
-        ss.top = '0px';
+      if(topY < topOffset && constrainPopup) {
+        delta = topOffset - topY;
+        ss.top = topOffset + 'px';
       }
 
       // Add the callout
@@ -188,17 +191,14 @@ namespace com.keyman.osk.browser {
         let _BoxRect = keyman.osk._Box.getBoundingClientRect();
 
         // Set position and style
-        let top = keyRect.top - _BoxRect.top - 9 + delta;
         // We're going to adjust the top of the box to ensure it stays
         // pixel aligned, otherwise we can get antialiasing artifacts
         // that look ugly
-        let height = calloutHeight + (Math.ceil(top) - top);
-        top = Math.ceil(top);
-
+        let top = Math.floor(keyRect.top - _BoxRect.top - 9 + delta);
         ccs.top = top + 'px';
         ccs.left = (keyRect.left - _BoxRect.left) + 'px';
         ccs.width = keyRect.width + 'px';
-        ccs.height = (height - 1) + 'px';
+        ccs.height = (keyRect.bottom - _BoxRect.top - top - 1) + 'px'; //(height - 1) + 'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/browser/subkeyPopup.ts
+++ b/web/source/osk/browser/subkeyPopup.ts
@@ -151,12 +151,11 @@ namespace com.keyman.osk.browser {
       let constrainPopup = keyman.isEmbedded;
 
       let cs = getComputedStyle(subKeys);
-      let oskHeight = keyman.osk.computedHeight;
       let topY = parseFloat(cs.top);
 
       let delta = 0;
       if(topY < 0 && constrainPopup) {
-        delta = -topY - 3;
+        delta = -topY;
         ss.top = '0px';
       }
 
@@ -177,7 +176,7 @@ namespace com.keyman.osk.browser {
 
       delta = delta || 0;
 
-      let calloutHeight = key.offsetHeight - delta;
+      let calloutHeight = key.offsetHeight - delta + 6;
 
       if(calloutHeight > 0) {
         var cc = document.createElement('div'), ccs = cc.style;
@@ -188,16 +187,11 @@ namespace com.keyman.osk.browser {
         let keyRect = key.getBoundingClientRect();
         let _BoxRect = keyman.osk._Box.getBoundingClientRect();
 
-        var xLeft = key.offsetLeft + (<HTMLElement>key.offsetParent).offsetLeft,
-            xTop = key.offsetTop + (key.key as OSKBaseKey).row.element.offsetTop + delta,
-            xWidth = key.offsetWidth + 2,
-            xHeight = calloutHeight;
-
         // Set position and style
         ccs.top = (keyRect.top - _BoxRect.top - 8 + delta) + 'px';
         ccs.left = (keyRect.left - _BoxRect.left) + 'px';
         ccs.width = keyRect.width + 'px';
-        ccs.height = (keyRect.height + 6) + 'px';
+        ccs.height = calloutHeight + 'px';
 
         // Return callout element, to allow removal later
         return cc;

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -300,7 +300,14 @@ namespace com.keyman.osk {
       return metrics;
     }
 
-    getIdealFontSize(vkbd: VisualKeyboard, style: {height?: string, fontFamily?: string, fontSize: string}): string {
+    /**
+     * Calculate the font size required for a key cap, scaling to fit longer text
+     * @param vkbd
+     * @param style     specification for the desired base font size
+     * @param override  if true, don't use the font spec from the button, just use the passed in spec
+     * @returns         font size as a style string
+     */
+    getIdealFontSize(vkbd: VisualKeyboard, style: {height?: string, fontFamily?: string, fontSize: string}, override?: boolean): string {
       let buttonStyle = getComputedStyle(this.btn);
       let keyWidth = parseFloat(buttonStyle.width);
       let emScale = 1;
@@ -316,7 +323,7 @@ namespace com.keyman.osk {
         // Recompute the new width for use in autoscaling calculations below, just in case.
         emScale = vkbd.getKeyEmFontSize();
         keyWidth = this.getKeyWidth(vkbd);
-      } else {
+      } else if(!override) {
         // When available, just use computedStyle instead.
         style = buttonStyle;
       }

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -333,9 +333,10 @@ body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;f
   position: absolute;
   display: block;
   background-color: #fdfdfe;
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 5px 5px;
   z-index: 10002;
   pointer-events:none;
+  border-bottom: solid 1px #8a8d90;
 }
 
 #kmw-keytip {
@@ -459,7 +460,7 @@ div.android div.kmw-keytip-tip {
 
 /* Popup key styles */
 #kmw-popup-keys {
-  position: relative;
+  position: absolute;
   display: block;
   width: auto;
   height: auto;

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -18,6 +18,13 @@
 
 /* Common key-layout properties (all form factor + OS combinations) */
 
+.kmw-osk-frame,
+.kmw-osk-frame * {
+  /* border-box may make more sense here in the future, but for compat reasons we need to
+     ensure we are always consistent, regardless of context of placement of the osk */
+  box-sizing: content-box;
+}
+
 .kmw-key-row {position: relative; width: 100%; height: 20%; margin: 0px; padding: 0px; border: 0px; overflow: hidden}
 .kmw-key-square {
   display: inline-block;

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -362,6 +362,7 @@ div.ios div.kmw-keytip-tip {
   border-radius: 6px 6px 4px 4px;
   border: solid 1px #cccccc;
   border-bottom: solid 1px #8a8d90;
+  box-sizing: border-box;
 }
 
 div.ios div.kmw-keytip-cap {

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -19,8 +19,17 @@
 /* Common key-layout properties (all form factor + OS combinations) */
 
 .kmw-key-row {position: relative; width: 100%; height: 20%; margin: 0px; padding: 0px; border: 0px; overflow: hidden}
-.kmw-key-square {display: inline-block; position: relative; z-index: 10000; margin: 0px; border: 0px;
-  padding: 0px; box-sizing: border-box; -moz-box-sizing: border-box;}
+.kmw-key-square {
+  display: inline-block;
+  position: relative;
+  z-index: 10000;
+  margin: 0px;
+  border: 0px;
+  padding: 0px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  vertical-align: top;
+}
 .kmw-key {display: block; position: relative; margin: 0px; text-align: center; box-sizing: border-box;
   -moz-box-sizing: border-box;}
 

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -382,6 +382,8 @@ span.kmw-keytip-label {
 div.ios div.kmw-keytip-cap,
 div.ios div.kmw-keytip-tip {
   background:white;
+  /* background-clip: required to prevent antialiasing on top edge on hires devices e.g. iPhone 13 pro + iOS 15.4 */
+  background-clip: content-box;
 }
 
 div.android div.kmw-keytip {

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -314,12 +314,16 @@ body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;f
 
 /* Style for callout used on phones */
 #kmw-popup-callout {
-  position:absolute; display:block; background-color: #fdfdfe;
-  border-radius: 0 0 6px 6px; z-index:10001; pointer-events:none;
+  position: absolute;
+  display: block;
+  background-color: #fdfdfe;
+  border-radius: 0 0 6px 6px;
+  z-index: 10002;
+  pointer-events:none;
 }
 
 #kmw-keytip {
-  z-index: 10000
+  z-index: 10002;
 }
 
 /* Key preview styles */
@@ -438,9 +442,20 @@ div.android div.kmw-keytip-tip {
 #kmw-language-menu .current {font-weight:bold;}
 
 /* Popup key styles */
-#kmw-popup-keys {position:relative;display:block;width:auto;height:auto;overflow-y:visible;
-        padding: 4px; border: 1px solid #ddd; border-radius:8px;
-        background-color:#fdfdfe; border:none; z-index:10000;}
+#kmw-popup-keys {
+  position: relative;
+  display: block;
+  width: auto;
+  height: auto;
+  overflow-y: visible;
+  padding: 4px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #fdfdfe;
+  border: none;
+  z-index: 10002;
+  box-sizing: content-box;
+}
 
 .tablet.ios #kmw-popup-keys {padding: 4px 7px 0px 0px;}
 .phone.ios #kmw-popup-keys {padding: 4px 5px 0px 0px;}
@@ -459,9 +474,17 @@ div.android div.kmw-keytip-tip {
 
 /* Filter (shim) to darken screen and highlight popup keys */
 #kmw-popup-shim {
-    position: fixed; width: 100%; height: 100%; bottom: 0; left: 0;
-    display: block; ; opacity: 0.15; background-color: #000; pointer-events: none;
-    }
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  bottom: 0;
+  left: 0;
+  display: block;
+  opacity: 0.15;
+  background-color: #000;
+  pointer-events: none;
+  z-index: 10001;
+}
 
 /* Styles for other KMW elements (keyboard loading wait notification, etc.) */
 .kmw-wait-background{display:none;position:absolute;left:0;top:0;width:100%;height:100%;

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -337,6 +337,7 @@ body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;f
   z-index: 10002;
   pointer-events:none;
   border-bottom: solid 1px #8a8d90;
+  box-sizing: border-box;
 }
 
 #kmw-keytip {


### PR DESCRIPTION
Fixes #5929.
Fixes #6381.

This fixes four separate issues with the longpress popups and key previews:

1. The key preview was offset by a couple of pixels (unreported issue).
2. The background 'shim' did not cover the key caps, which caused them to look startlingly white when the rest of the background greyed down (#5929).
3. The popup menu was incorrectly wrapping to two rows due to sizing model mismatches (#6381).
4. The popup menu would be realigned incorrectly for the in-app keyboard, when moving it to keep it in the keyboard area (#5929).

Longpress iOS (Chrome simulation):

![image](https://user-images.githubusercontent.com/4498365/158493999-c40793b0-3f6f-4357-9004-078d5a02394b.png)

Key preview iOS (Chrome simulation): 

![image](https://user-images.githubusercontent.com/4498365/158494112-8bffab63-30c4-4ace-9c53-cdb98775e411.png)

# User Testing

* We need to verify the behaviour of the longpress menu and the key preview. If possible, capture screenshots of both of these elements when running the tests, so we can compare.

* Suggest using sil_euro_latin keyboard for this test, as it has many big longpress menus.

* Test single-row long presses, such as long-press <kbd>m</kbd>, and multi-row, such as long-press <kbd>g</kbd> or <kbd>e</kbd>.

**TEST_IOS:** Verify that the in-app keyboard and system keyboard both display longpress menus and key previews correctly. Note that the longpress menu will be constrained to fit within the keyboard area on iOS, due to limitations with iOS system keyboards. Please test on iPhone 13 Pro and iPhone SE. Consider other devices also. Please test with 4 and 5 row keyboards.
**TEST_ANDROID:** Verify that the in-app keyboard and system keyboard both display longpress menus and key previews correctly.
**TEST_WEB_IOS:** Verify that the web keyboard in unminified/testing, on an iOS simulator or device, displays longpress menus and key previews correctly. Please test on iPhone 13 Pro and iPhone SE. Consider other devices also. Please test with 4 and 5 row keyboards.
**TEST_WEB_ANDROID:** Verify that the web keyboard in unminified/testing, on an Android emulator or device, displays longpress menus and key previews correctly.