### PR TITLE
fix(web): crash on focus before init

### DIFF
--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -122,7 +122,7 @@ if(!window['keyman']['initialized']) {
      **/
     function resetVKShift() {
       let keyman = com.keyman.singleton;
-      if(!keyman.uiManager.isActivating && keyman.osk.vkbd) {
+      if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
         keyman.core.keyboardProcessor._UpdateVKShift(null);  //this should be enabled !!!!! TODO
       }
     }


### PR DESCRIPTION
Fixes the following crash noted when testing on keymanweb.com, focusing during the load process on a slow network.

Fixes KEYMANWEB-COM-5M.

```
helpers.ts:111 Uncaught TypeError: Cannot read properties of null (reading 'vkbd')
    at g.pageFocusHandler (keymanweb.ts:125:44)
    at sentryWrapped (helpers.ts:87:17)
```

@keymanapp-test-bot skip