### PR TITLE
fix(developer): detect changes in dropdowns in builder

### DIFF
--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -1446,11 +1446,18 @@ $(function () {
     builder.updateKeyId(builder.selectedKey());
   }, {saveOnce: true});
 
+  const wrapInstant = function(f) {
+    return function() {
+      window.setTimeout(f.bind(this), 0);
+    }
+  }
+
   $('#inpKeyName')
     .change(inpKeyNameChange)
     .autocomplete({
       source: builder.lookupKeyNames,
-      change: inpKeyNameChange
+      change: inpKeyNameChange,
+      select: wrapInstant(inpKeyNameChange)
     })
     .on('input', inpKeyNameChange)
     .blur(function () {
@@ -1494,7 +1501,8 @@ $(function () {
     .change(inpKeyCapChange)
     .autocomplete({
       source: builder.specialKeyNames,
-      change: inpKeyCapChange
+      change: inpKeyCapChange,
+      select: wrapInstant(inpKeyCapChange)
     })
     .mouseup(function () {
       builder.updateCharacterMap($(this).val(), false);
@@ -1721,7 +1729,8 @@ $(function () {
     .on('input', subKeyNameChange)
     .autocomplete({
       source: builder.lookupKeyNames,
-      change: subKeyNameChange
+      change: subKeyNameChange,
+      select: wrapInstant(subKeyNameChange)
     }).blur(function () {
       builder.hasSavedKeyUndo = false;
     });
@@ -1744,7 +1753,8 @@ $(function () {
     .change(inpSubKeyCapChange)
     .autocomplete({
       source: builder.specialKeyNames,
-      change: inpSubKeyCapChange
+      change: inpSubKeyCapChange,
+      select: wrapInstant(inpSubKeyCapChange)
     })
     .on('input', inpSubKeyCapChange)
     .mouseup(function () {


### PR DESCRIPTION
Fixes #6386.

The touch layout editor would not reliably detect changes if using the mouse to select an item in a dropdown 'autocomplete'.

# User Testing

**TEST_SELECTOR:** Verify that selecting an item in a dropdown works correctly.

1. In the Touch Layout Editor, select a key, select the ID edit control.
2. Type `K_S`. Use the mouse to choose an item from the dropdown that is presented.
3. Verify that the selected item is shown in small letters at the bottom of the selected on the key cap.

See the video in #6386 for comparison with the original issue.