### PR TITLE
fix(ios): remove busy 100ms waitForFonts timer on iOS

### DIFF
--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -34,7 +34,7 @@ namespace com.keyman.osk {
       }
     } else if(keyName.indexOf('K_ROPT') >= 0) {
       if(keyDown) {
-        this.highlightKey(e,false);            
+        this.highlightKey(e,false);
         if(typeof keyman['hideKeyboard'] == 'function') {
           keyman['hideKeyboard']();
         }
@@ -49,10 +49,10 @@ namespace com.keyman.osk {
   if(device.OS == 'Android') { // assumption - if this file is being loaded, keyman.isEmbedded == true.
     // Send the subkey array to iOS, with centre,top of base key position
     /**
-     * Create a popup key array natively 
-     * 
+     * Create a popup key array natively
+     *
      * @param {Object}  key   base key element
-     */            
+     */
     VisualKeyboard.prototype.startLongpress = function(this: VisualKeyboard, key: KeyElement): PendingGesture {
       if(typeof(window['oskCreatePopup']) == 'function') {
         var xBase = dom.Utils.getAbsoluteX(key) - dom.Utils.getAbsoluteX(this.kbdDiv) + key.offsetWidth/2,
@@ -78,11 +78,11 @@ namespace com.keyman.osk {
         this.keytip = new osk.embedded.KeyTip(window['oskCreateKeyPreview'], window['oskClearKeyPreview']);
       }
     };
+  }
 
-    VisualKeyboard.prototype.waitForFonts = function(this: VisualKeyboard, kfd, ofd) {
-      // a dummy function; it's only really used for 'native' KMW.
-      return true;
-    }
+  VisualKeyboard.prototype.waitForFonts = function(this: VisualKeyboard, kfd, ofd) {
+    // a dummy function; it's only really used for 'native' KMW.
+    return true;
   }
 
   SuggestionManager.prototype.platformHold = function(this: SuggestionManager, suggestionObj: BannerSuggestion, isCustom: boolean) {
@@ -129,10 +129,10 @@ namespace com.keyman.text {
 
   // Allow definition of application name
   keymanweb.options['app']='';
-  
+
   // Flag to control refreshing of a keyboard that is already loaded
   keymanweb.mustReloadKeyboard = true;
-  
+
   // Skip full page initialization - skips native-mode only code
   keymanweb.isEmbedded = true;
 
@@ -140,14 +140,14 @@ namespace com.keyman.text {
   keymanweb.setDefaultDeviceOptions = function(opt: com.keyman.OptionType) {
     opt['attachType'] = 'manual';
     device.app=opt['app'];
-    device.touchable=true; 
-    device.formFactor='phone'; 
+    device.touchable=true;
+    device.formFactor='phone';
     if(navigator && navigator.userAgent && navigator.userAgent.indexOf('iPad') >= 0) device.formFactor='tablet';
     if(device.app.indexOf('Mobile') >= 0) device.formFactor='phone';
     if(device.app.indexOf('Tablet') >= 0) device.formFactor='tablet';
     device.browser='native';
   };
-  
+
   // Get default style sheet path
   keymanweb.getStyleSheetPath = function(ssName) {
     return keymanweb.rootPath+ssName;
@@ -191,7 +191,7 @@ namespace com.keyman.text {
 
     /**
    * Force reload of resource
-   * 
+   *
    *  @param  {string}  s unmodified URL
    *  @return {string}    modified URL
    */
@@ -200,7 +200,7 @@ namespace com.keyman.text {
     s = s + '?v=' + t;
     return s;
   };
-  
+
   util.wait = function() {
     // Empty stub - this function should not be implemented or used within embedded code routes.
     console.warn("util.wait() call attempted in embedded mode!");  // Sends log message to embedding app.
@@ -213,39 +213,39 @@ namespace com.keyman.text {
 
   /**
    * Refresh element content after change of text (if required)
-   * 
+   *
    *  @param  {Object}  Pelem   input element
-   */         
-  keymanweb.refreshElementContent = function(Pelem) 
+   */
+  keymanweb.refreshElementContent = function(Pelem)
   {
     if('ontextchange' in keymanweb) keymanweb['ontextchange'](Pelem);
   };
 
   /**
    * Set target element text direction (LTR or RTL): not functional for KMEI, KMEA
-   *    
+   *
    * @param       {Object}      Ptarg      Target element
-   */    
+   */
   keymanweb.domManager._SetTargDir = function(Ptarg){};
-  
+
   /**
    * Align input fields (should not be needed with KMEI, KMEA)
-   * 
+   *
    *  @param  {object}   eleList    A list of specific elements to align.  If nil, selects all elements.
-   * 
+   *
    **/
   keymanweb.alignInputs = function(eleList: HTMLElement[]) {};
 
   /**
    * Use rotation events to adjust OSK element positions and scaling if necessary
-   */     
+   */
   keymanweb.handleRotationEvents = function() {};
-  
+
   /**
    * Caret position always determined from the active (but hidden) element
-   * 
+   *
    * @return  {boolean}
-   **/          
+   **/
   keymanweb.isPositionSynthesized = function()
   {
     return false;
@@ -264,7 +264,7 @@ namespace com.keyman.text {
 
   /**
    * Register a lexical model
-   * 
+   *
    * @param {com.keyman.text.prediction.ModelSpec} model  Spec of the lexical model
    */
   keymanweb['registerModel']=function(model: com.keyman.text.prediction.ModelSpec) {
@@ -272,12 +272,12 @@ namespace com.keyman.text {
   };
 
   /**
-   * Function called by Android and iOS when a device-implemented keyboard popup 
+   * Function called by Android and iOS when a device-implemented keyboard popup
    * is displayed or hidden.  As this is controlled by the app, we use it as a
    * trigger for 'embedded'-mode gesture state management.
-   * 
+   *
    *  @param  {boolean}  isVisible
-   *     
+   *
    **/
   keymanweb['popupVisible'] = function(isVisible) {
     let osk = keymanweb.osk;
@@ -287,7 +287,7 @@ namespace com.keyman.text {
     /*
      * If a longpress popup was visible, but is no longer, this means that the
      * associated longpress gesture was cancelled.  It is possible for the base
-     * key to emit if selected at this time; detecton of this is managed by 
+     * key to emit if selected at this time; detecton of this is managed by
      * the `SubkeyDelegator` class.
      */
     if(!isVisible) {
@@ -302,9 +302,9 @@ namespace com.keyman.text {
 
     /*
      * If the popup was not visible, but now is, that means our previously-pending
-     * longpress is now 'realized' (complete).  The OSK relies upon this state 
+     * longpress is now 'realized' (complete).  The OSK relies upon this state
      * information, which will be properly updated by `resolve`.
-     * 
+     *
      * Prominent uses of such state info helps prevent change of base key, key
      * previews, and key output from occurring while a subkey popup remains active.
      */
@@ -316,9 +316,9 @@ namespace com.keyman.text {
 
   /**
    *  Return position of language menu key to KeymanTouch
-   *  
+   *
    *  @return  {string}      comma-separated x,y,w,h of language menu key
-   *  
+   *
    **/
   keymanweb['touchMenuPos'] = function() {
     let osk = keymanweb.osk;
@@ -329,14 +329,14 @@ namespace com.keyman.text {
     var key: HTMLElement = osk.vkbd.lgKey;
     // A CSS change of kmd-key-square from position:fixed to position:static was needed
     // for Android 4.3 to display the OSK correctly, but resulted in the position of
-    // the menu key not being returned correctly.  The following line gets the 
-    // key element, instead of the key-square element, fixes this.  It should be 
+    // the menu key not being returned correctly.  The following line gets the
+    // key element, instead of the key-square element, fixes this.  It should be
     // removed again when the key-square elements are all removed as planned.
     if(typeof key.firstChild != 'undefined' && key.firstChild != null && util.hasClass(key.firstChild,'kmw-key')) {
       key = <HTMLElement> key.firstChild;
     }
 
-    var w=key.offsetWidth, 
+    var w=key.offsetWidth,
         h=key.offsetHeight,
         // Since the full OSKManager '_Box' is displayed within the keyboards' WebViews,
         // these calculations should be performed with respect to that, rather than osk.vkbd.kbdDiv.
@@ -345,13 +345,13 @@ namespace com.keyman.text {
 
     return x+','+y+','+w+','+h;
   };
-  
+
  /**
    *  Accept an external key ID (from KeymanTouch) and pass to the keyboard mapping
-   *  
+   *
    *  @param  {string}  keyName   key identifier which could contain a display layer and a "functional" layer
    *                              e.g: 'shift-K_E+rightalt-shift'
-   **/            
+   **/
   keymanweb['executePopupKey'] = function(keyName: string) {
       let osk = keymanweb.osk;
       var origArg = keyName;
@@ -376,7 +376,7 @@ namespace com.keyman.text {
         return false;
       }
       keyName = matches[2] + (matches[3] ? '+' + matches[3] : '');
- 
+
       // Note:  this assumes Lelem is properly attached and has an element interface.
       // Currently true in the Android and iOS apps.
       var Lelem=keymanweb.domManager.lastActiveElement;
@@ -394,13 +394,13 @@ namespace com.keyman.text {
 
   /**
    *  API endpoint for hardware keystroke events from Android external keyboards
-   *  
+   *
    *  @param  {number}  code   key identifier
    *  @param  {number}  shift  shift state (0x01=left ctrl 0x02=right ctrl 0x04=left alt 0x08=right alt
    *                                        0x10=shift 0x20=ctrl 0x40=alt)
    *  @param  {number}  lstates lock state (0x0200=no caps 0x0400=num 0x0800=no num 0x1000=scroll 0x2000=no scroll locks)
    *  @return {boolean} false when KMW _has_ fully handled the event and true when not.
-   **/            
+   **/
   keymanweb['executeHardwareKeystroke'] = function(code, shift, lstates = 0): boolean {
     if(!keymanweb.core.activeKeyboard || code == 0) {
       return false;
@@ -408,14 +408,14 @@ namespace com.keyman.text {
 
     // Clear any pending (non-popup) key
     keymanweb.osk.vkbd.keyPending = null;
-    
+
     // Note:  this assumes Lelem is properly attached and has an element interface.
     // Currently true in the Android and iOS apps.
     var Lelem = keymanweb.domManager.lastActiveElement;
-    
+
     keymanweb.domManager.initActiveElement(Lelem);
 
-    // Check the virtual key 
+    // Check the virtual key
     var Lkc: com.keyman.text.KeyEvent = {
       Lmodifiers: shift,
       vkCode: code,
@@ -425,7 +425,7 @@ namespace com.keyman.text {
       kName: '',
       device: keymanweb.util.physicalDevice.coreSpec, // As we're executing a hardware keystroke.
       isSynthetic: false
-    }; 
+    };
 
     try {
       // Now that we've manually constructed a proper keystroke-sourced KeyEvent, pass control


### PR DESCRIPTION
Observed while debugging another issue on iOS. The VisualKeyboard.waitForFonts function sets up a busy timer to wait for font loading. This functionality is not even needed on the iOS app, because it's really only used for the touch alias elements.

However, it was being called, potentially multiple times, leading to the timer never being removed. On Android, the timer was correctly removed.

This aligns the iOS code path with the Android code path.

@keymanapp-test-bot skip