### PR TITLE
fix(developer): structure sizes for kmcomp x64

### DIFF
--- a/windows/src/developer/kmcmpdll/kcframe/kcframe.cpp
+++ b/windows/src/developer/kmcmpdll/kcframe/kcframe.cpp
@@ -34,11 +34,11 @@ int WINAPI msgproc(int line, DWORD dwMsgCode, LPSTR szText)
 int main(int argc, char *argv[])
 {
   if (argc == 2 && strcmp(argv[1], "--sizeof") == 0) {
-    printf("FILE_KEYBOARD_SIZE = %d\n", sizeof(FILE_KEYBOARD));
-    printf("FILE_GROUP_SIZE = %d\n", sizeof(FILE_GROUP));
-    printf("FILE_STORE_SIZE = %d\n", sizeof(FILE_STORE));
-    printf("FILE_KEY_SIZE = %d\n", sizeof(FILE_KEY));
-    printf("FILE_DEADKEY_SIZE = %d\n", sizeof(FILE_DEADKEY));
+    printf("FILE_KEYBOARD_SIZE = %zu\n", sizeof(FILE_KEYBOARD));
+    printf("FILE_GROUP_SIZE = %zu\n", sizeof(FILE_GROUP));
+    printf("FILE_STORE_SIZE = %zu\n", sizeof(FILE_STORE));
+    printf("FILE_KEY_SIZE = %zu\n", sizeof(FILE_KEY));
+    printf("FILE_DEADKEY_SIZE = %zu\n", sizeof(FILE_DEADKEY));
     return 0;
   }
 	if(argc < 3)


### PR DESCRIPTION
~~I am not sure how this was ever working.~~ Okay, looked at history, and this was broken by #5963 (commit e24b7561c6a69b9cdd5f16b2c1858f1a5ce159be), of all things, which added structure size sanity checks... but neglected to remember that struct sizes may differ between 32-bit and 64-bit code.

This just adds the specific structure sizes for x64 and verifies that the Delphi sizes are the same as the reported sizes from C++ (as reported by `kcframe.exe --sizeof`)

Minor tweak to printf format args for kcframe to assist in this, sorting a compiler warning.

@keymanapp-test-bot skip