### PR TITLE
chore(mac): update build env for monterey

### DIFF
--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -48,11 +48,15 @@ These dependencies are also listed below if you'd prefer to install manually.
 
 ## Shared Dependencies
 
-* Shared: HomeBrew, Bash 5.0+, jq, Python 3, Meson, Ninja, coreutils, Pandoc
+* Shared: HomeBrew, Bash 5.0+, jq, Python 2.7, Python 3, Meson, Ninja, coreutils, Pandoc
 
   ```shell
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  brew install bash jq python3 meson ninja coreutils pandoc
+  brew install bash jq python3 meson ninja coreutils pandoc pyenv
+  # Python 2.7 required for DeviceKit (among others?) at present
+  pyenv install 2.7.18
+  pyenv global 2.7.18
+  echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile
   ```
 
   On M1 only (as greadlink is not on the path otherwise in XCode):

--- a/resources/devbox/macos/keyman.macos.env.sh
+++ b/resources/devbox/macos/keyman.macos.env.sh
@@ -17,3 +17,6 @@ export PATH=$ANDROID_HOME/build-tools/30.0.3:$PATH
 export PATH="/usr/local/opt/openjdk@8/bin:$PATH"
 
 export JAVA_HOME=/usr/local/opt/openjdk@8
+
+# Python 2.7
+eval "$(pyenv init --path)"

--- a/resources/devbox/macos/macos.sh
+++ b/resources/devbox/macos/macos.sh
@@ -144,7 +144,7 @@ which brew || (
 
 ## Install devchain components
 
-BREW_ALL="bash jq python3 meson ninja coreutils"
+BREW_ALL="bash jq python3 meson ninja coreutils pyenv"
 BREW_WEB="node emscripten openjdk@8"
 BREW_IOS="swiftlint carthage"
 BREW_MACOS="carthage cocoapods"
@@ -161,6 +161,10 @@ $REQUIRE_MACOS && brew install $BREW_MACOS
 
 $REQUIRE_PANDOC && brew install pandoc
 $REQUIRE_SENTRYCLI && brew install getsentry/tools/sentry-cli
+
+# Add python 2.7.18 from pyenv
+pyenv install 2.7.18
+pyenv global 2.7.18
 
 # Install WINE
 $REQUIRE_KMCOMP && (


### PR DESCRIPTION
Python2.7 is excluded from macOS Monterey, and is not available directly via brew any longer. We still need it for now. pyenv does the job...

@keymanapp-test-bot skip