### PR TITLE
fix(mac): invalid keyboard breaks configuration

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -137,15 +137,25 @@
                 [_tableContents addObject:[NSDictionary dictionaryWithObjectsAndKeys:packageName, @"HeaderTitle", nil]];
                 for (NSString *path in pArray) {
                     NSDictionary *info = [KMXFile infoDictionaryFromFilePath:path];
-                    if (info)
-                        [_tableContents addObject:info];
+                    if (!info) {
+                        info = [[NSDictionary alloc] initWithObjectsAndKeys:@"(Error loading keyboard)", kKMKeyboardNameKey,
+                            @"unknown", kKMKeyboardVersionKey,
+                            @"unknown", kKMKeyboardCopyrightKey,
+                            @"unknown", kKMVisualKeyboardKey, nil];
+                    }
+                    [_tableContents addObject:info];
                 }
             }
             else {
                 NSString *path = (NSString *)obj;
                 NSDictionary *info = [KMXFile infoDictionaryFromFilePath:path];
-                if (info)
-                    [_tableContents addObject:info];
+                if (!info) {
+                  info = [[NSDictionary alloc] initWithObjectsAndKeys:@"(Error loading keyboard)", kKMKeyboardNameKey,
+                      @"unknown", kKMKeyboardVersionKey,
+                      @"unknown", kKMKeyboardCopyrightKey,
+                      @"unknown", kKMVisualKeyboardKey, nil];
+                }
+                [_tableContents addObject:info];
             }
         }
     }


### PR DESCRIPTION
Fixes #4877.

If a keyboard is invalid for any reason (missing, wrong version), then it would not appear in Configuration, which would break the row indexing, causing crashes.

@keymanapp-test-bot skip (We'll test on beta)