### PR TITLE
fix(mac): invalid keyboard breaks configuration 🍒

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -137,15 +137,29 @@
                 [_tableContents addObject:[NSDictionary dictionaryWithObjectsAndKeys:packageName, @"HeaderTitle", nil]];
                 for (NSString *path in pArray) {
                     NSDictionary *info = [KMXFile keyboardInfoFromKmxFile:path];
-                    if (info)
-                        [_tableContents addObject:info];
+                    if (!info) {
+                        info = [[NSDictionary alloc] initWithObjectsAndKeys:
+                            NSLocalizedString(@"message-error-loading-keyboard", nil), kKMKeyboardNameKey,
+                            NSLocalizedString(@"message-error-unknown-metadata", nil), kKMKeyboardVersionKey,
+                            NSLocalizedString(@"message-error-unknown-metadata", nil), kKMKeyboardCopyrightKey,
+                            NSLocalizedString(@"message-error-unknown-metadata", nil), kKMVisualKeyboardKey,
+                            nil];
+                    }
+                    [_tableContents addObject:info];
                 }
             }
             else {
                 NSString *path = (NSString *)obj;
                 NSDictionary *info = [KMXFile keyboardInfoFromKmxFile:path];
-                if (info)
-                    [_tableContents addObject:info];
+                if (!info) {
+                    info = [[NSDictionary alloc] initWithObjectsAndKeys:
+                        NSLocalizedString(@"message-error-loading-keyboard", nil), kKMKeyboardNameKey,
+                        NSLocalizedString(@"message-error-unknown-metadata", nil), kKMKeyboardVersionKey,
+                        NSLocalizedString(@"message-error-unknown-metadata", nil), kKMKeyboardCopyrightKey,
+                        NSLocalizedString(@"message-error-unknown-metadata", nil), kKMVisualKeyboardKey,
+                        nil];
+                }
+                [_tableContents addObject:info];
             }
         }
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
@@ -26,6 +26,12 @@
 /* Message displayed to inform user that .kmp file could not be read/unzipped  */
 "message-keyboard-file-unreadable" = "Could not read the Keyman file '%@'.";
 
+/* Message displayed in Configuration window when keyboard cannot be loaded */
+"message-error-loading-keyboard" = "(error loading keyboard)";
+
+/* Message displayed in Configuration window when keyboard metadata cannot be loaded */
+"message-error-unknown-metadata" = "unknown";
+
 /* Button text to acknowledge that .kmp file could not be read  */
 "button-keyboard-file-unreadable" = "OK";
 


### PR DESCRIPTION
Fixes #4877.

If a keyboard is invalid for any reason (missing, wrong version), then it would not appear in Configuration, which would break the row indexing, causing crashes.

Cherry-picked from stable-14.0 branch.

# User Testing

TEST_BROKEN_KEYBOARD: Verify that a broken keyboard is still listed, shown as "(error loading keyboard)" and UI functions as expected.

1. Start a Terminal and run `cd ~/Documents/Keyman-Keyboards`.
2. Type `ls` and press Enter. Choose one of the keyboards listed there, e.g. "khmer_angkor" (replace the name as needed below).
3. Type `cd khmer_angkor` and press Enter.
4. Type `rm khmer_angkor.kmx` and press Enter.
5. Type `cp kmp.json khmer_angkor.kmx` and press Enter.
6. Ensure Keyman is not running by typing `killall Keyman` and pressing Enter.
7. Start Keyman, open Keyman Configuration, and verify that Khmer Angkor is now shown as "(error loading keyboard)"
8. If there are keyboards lower in the list, try checking/unchecking the checkbox next to them -- the app should no longer crash.

Cleanup: uninstall the khmer_angkor keyboard and reinstall it!