### PR TITLE
fix(android/engine): Test fileVersion during package install 🍒 

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -100,6 +100,13 @@ public class PackageActivity extends AppCompatActivity implements
       return;
     }
 
+    // Check minimum keyboard version to ensure current version of Keyman supports the features
+    String pkgMinimumKeyboardVersion = kmpProcessor.getPackageMinimumKeyboardVersion(pkgInfo);
+    if (FileUtils.compareVersions(pkgMinimumKeyboardVersion, KMManager.getMajorVersion()) == FileUtils.VERSION_GREATER) {
+      showErrorToast(context, getString(R.string.minimum_keyboard_version_not_supported));
+      return;
+    }
+
     pkgName = kmpProcessor.getPackageName(pkgInfo);
     final int keyboardCount = kmpProcessor.getKeyboardCount(pkgInfo);
 

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -195,4 +195,7 @@
   <!-- Context: KMP Package strings -->
   <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Invalid/Missing metadata in package</string>
 
+  <!-- Context: KMP Package strings -->
+  <string name="minimum_keyboard_version_not_supported" comment="Notification when keyboard has functionality not supported by current Keyman">
+    Keyboard requires a newer version of Keyman</string>
 </resources>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -395,6 +395,22 @@ public class PackageProcessor {
   }
 
   /**
+   * Parse a kmp.json JSON object and return the package's minimum keyboard version (system.fileVersion).
+   * This is to avoid issues with app crashing if keyboard functionality is not supported.
+   * If undefined, return default version "7.0".
+   * @param json kmp.json as a JSON object.
+   * @return String of the package's minimum keyboard version
+   */
+  public static String getPackageMinimumKeyboardVersion(JSONObject json) {
+    try {
+      return json.getJSONObject("system").getString("fileVersion");
+    } catch (Exception e) {
+      KMLog.LogException(TAG, "", e);
+      return "7.0";
+    }
+  }
+
+  /**
    * Parse a kmp.json JSON object and return the package's target (keyboards vs lexical models).
    * Only one can be valid. Otherwise, return "invalid"
    * @param json kmp.json as a JSON object.


### PR DESCRIPTION
Addresses #6254 for stable-14.0. This is a 🍒 -pick of the Keyman Engine for Android portion of #6355.

This updates PackageActivity() to check kmp.json that the minimum keyboard version (system.fileVersion) is supported by the current Keyman version.

### Notes on test keyboards
Since 14.0 doesn't have common/ test keyboards, I didn't include the_99.kmp files on this PR. Test steps modified to reference the_99.kmp from #6355. 

The test keyboard "the_99.kmp" is a standard keyboard created from template where fileVersion is manually edited to "99.0". 
Keyman Developer currently (as of 15.0.210 beta) doesn't allow `store(&VERSION)` to define version greater than '15.0'.

Also updated full_caps_3620_3621 to use `store(&VERSION) '15.0'`

## User Testing

Setup
1. On an Android device/emulator, load the PR build of Keyman for Android
2. Also upload the [test_99.kmp](https://github.com/keymanapp/keyman/raw/b213c3b8291221746d96013769308430d7716f04/common/test/keyboards/the_99/the_99.kmp) keyboard to the device's "Download" folder.


* **TEST_FILEVERSION_CHECKED**
1. Launch Keyman
4. Dismiss the "Get Started" menu
5. From the "Settings" menu --> "Install Keyboard or Dictionary" --> Install from local file 
6. Browse to the Downloads folder where the test_99.kmp file was uploaded.
7. Install the test_99.kmp keyboard and verify the installation fails
Screenshot:
 
![unsupported](https://user-images.githubusercontent.com/7358010/157601788-fbe15db0-9b01-4195-b42f-da9c9ba1a508.png)

8. From the "Settings" menu, install the khmer_angkor keyboard from keyman.com
9. Verify the khmer_angkor keyboard downloads and installs.
