### PR TITLE
fix(windows): make long menus scroll in Configuration

### DIFF
--- a/windows/src/desktop/kmshell/Makefile
+++ b/windows/src/desktop/kmshell/Makefile
@@ -42,7 +42,7 @@ test-manifest:
     # test that (a) linked manifest exists and correct, and (b) has uiAccess=true
     $(MT) -nologo -inputresource:$(PROGRAM)\desktop\kmshell.exe -validate_manifest
 
-install:
+install: .virtual
     copy $(ROOT)\bin\desktop\kmshell.exe "$(INSTALLPATH_KEYMANDESKTOP)"
     copy $(ROOT)\bin\desktop\xml\* "$(INSTALLPATH_KEYMANDESKTOP)\xml\"
 

--- a/windows/src/desktop/kmshell/xml/keyman.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman.xsl
@@ -78,6 +78,7 @@
   <xsl:template name="popupmenu_uilanguage">
     <div class="menu" id="menu_uilanguage">
       <xsl:for-each select="/Keyman/uilanguages/uilanguage">
+        <xsl:sort select="@name" />
         <xsl:call-template name="menuitem">
           <xsl:with-param name="id">menu_uilanguage_<xsl:value-of select="@code" /></xsl:with-param>
           <xsl:with-param name="caption"><xsl:value-of select="@name" /></xsl:with-param>

--- a/windows/src/desktop/kmshell/xml/menu.css
+++ b/windows/src/desktop/kmshell/xml/menu.css
@@ -14,6 +14,7 @@
   background-position: 0 0;
   width: 220px;
   z-index: 100;
+  box-sizing: border-box;
 }
 
 .menuitem

--- a/windows/src/desktop/kmshell/xml/menu.js
+++ b/windows/src/desktop/kmshell/xml/menu.js
@@ -27,6 +27,8 @@ var menudiv = null, global_menu_elem_name = null;
 
     menudiv.innerHTML = menu.innerHTML;
     menudiv.style.width = menu.offsetWidth + 'px';
+    menudiv.style.overflowY = 'auto';
+    menudiv.style.overflowX = 'hidden';
 
     (function(m) {
       for(var i = 0; i < m.children.length; i++) {
@@ -40,18 +42,21 @@ var menudiv = null, global_menu_elem_name = null;
     menudiv.style.zIndex=100;
     menudiv.style.visibility='visible';
 
+    let top = 0;
+
     if( xpos && ypos ) {
       if(align=='right')
         menudiv.style.left = (xpos-menudiv.offsetWidth) + 'px';
       else
         menudiv.style.left = xpos + 'px';
-      menudiv.style.top = ypos + 'px';
+      top = ypos;
     } else {
       if(align=='right') menudiv.style.left = (pb.x+button.offsetWidth-menudiv.offsetWidth) + 'px';
-        else menudiv.style.left = pb.x + 'px';
-      menudiv.style.top = (pb.y+button.offsetHeight) + 'px';
+      else menudiv.style.left = pb.x + 'px';
+      top = pb.y+button.offsetHeight;
     }
-
+    menudiv.style.top = top + 'px';
+    menudiv.style.maxHeight = (document.body.clientHeight - top) + 'px';
 
     q = menudiv.children[0];
     q.focus();


### PR DESCRIPTION
Fixes #6098.

If the list of languages is too long to fit, the menu now dynamically adds a scroll bar.

As a bonus:
* The language names are sorted (non-Latin scripts at bottom for now)
* `nmake install` works again (in kmshell, presence of `install` folder was confusing it)

Side note: the JS/CSS/HTML/XSL in Keyman Configuration is somewhat archaic and filled with anachronisms. Fun project for an intern to rewrite it?

# User Testing

TEST_MENU: Verify that the User Interface Language menu scrolls when it is too long, in Keyman Configuration.

![image](https://user-images.githubusercontent.com/4498365/160018901-522f88b3-2d56-480a-a556-b31acc372998.png)
