### PR TITLE
fix(windows): put correct HK_ALT flag for modifier

### DIFF
--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -161,7 +161,7 @@ LRESULT _kmnLowLevelKeyboardProc(
     FHotkeyShiftState = 0;
     if (GetKeyState(VK_LCONTROL) < 0) FHotkeyShiftState |= HK_CTRL;
     if (GetKeyState(VK_RCONTROL) < 0) FHotkeyShiftState |= HK_RCTRL_INVALID;
-    if (GetKeyState(VK_LMENU) < 0) FHotkeyShiftState |= HK_CTRL;
+    if (GetKeyState(VK_LMENU) < 0) FHotkeyShiftState |= HK_ALT;
     if (GetKeyState(VK_RMENU) < 0) FHotkeyShiftState |= HK_RALT_INVALID;
     if (GetKeyState(VK_LSHIFT) < 0) FHotkeyShiftState |= HK_SHIFT;
     if (GetKeyState(VK_RSHIFT) < 0) FHotkeyShiftState |= HK_RSHIFT_INVALID;


### PR DESCRIPTION
Fixes: #6422

#5190 removed using cache for the hotkeys but had a cut and paste bug for the VK_LMENU key.  This meant that hotkeys with ALT didn't work.  It also meant the alt key could match and ctrl hot key combo.  eg. `shift` + `ctrl` + `y` could also be activated by `shift` + `alt` + `y`

