### PR TITLE
fix(ios): reset context when osk is resized

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -80,6 +80,7 @@ function setBannerHeight(h) {
 
     // Refresh KMW's OSK
     kmw.correctOSKTextSize();
+    doResetContext();
 }
 
 function setDeviceType(deviceType) {
@@ -95,7 +96,8 @@ function setOskHeight(height) {
         kmw.core.activeKeyboard.refreshLayouts();
     }
     kmw.osk.show(true);
-    kmw['correctOSKTextSize']();
+    kmw.correctOSKTextSize();
+    doResetContext();
 }
 
 function setOskWidth(width) {
@@ -123,11 +125,13 @@ function getOskHeight() {
 var keyboardOffset = 0;
 function setKeymanLanguage(stub) {
     var kmw = window.keyman;
-
+    
     KeymanWeb.registerStub(stub);
-
-    kmw.setActiveKeyboard(stub.KP + '::' + stub.KI, stub.KLC);
-    kmw.osk.show(true);
+    
+    kmw.setActiveKeyboard(stub.KP + '::' + stub.KI, stub.KLC).then(function() {
+        kmw.osk.show(true);
+        doResetContext();
+    });
 }
 
 var fragmentToggle = 0;


### PR DESCRIPTION
Fixes #6416.

The OSK is being rebuilt when we change size in some cases, which causes the default layer to be incorrectly set.

# User Testing

* **TEST_DEFAULT_LAYER:** With the obolo_chwerty_3151 keyboard, test that the default layer is set correctly when selecting the keyboard, and in as many circumstances as you can find, both in-app and system. Be sure to test the scenario described in #6416.