### PR TITLE
fix(web): *Shifted* showed unshifted key cap

### DIFF
--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -82,7 +82,7 @@ namespace com.keyman.osk {
       '*123*':      19,
       '*Symbol*':   21,
       '*Currency*': 20,
-      '*Shifted*':  8, // set SHIFTED->9 for filled arrow icon
+      '*Shifted*':  9,
       '*AltGr*':    2,
       '*TabLeft*':  7,
       '*LAlt*':     0x56,

--- a/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
+++ b/windows/src/developer/TIKE/xml/layoutbuilder/builder.js
@@ -583,7 +583,7 @@ $(function () {
     '*123*':      19,
     '*Symbol*':   21,
     '*Currency*': 20,
-    '*Shifted*':  8, // set SHIFTED->9 for filled arrow icon
+    '*Shifted*':  9,
     '*AltGr*':    2,
     '*TabLeft*':  7,
     '*LAlt*':     0x56,


### PR DESCRIPTION
Changes `*Shifted*` from ![image](https://user-images.githubusercontent.com/4498365/160302858-47196b40-bca9-43c8-a865-f763f7ae5cb5.png) (same as `*Shift*`) to ![image](https://user-images.githubusercontent.com/4498365/160302866-7780fe4c-da93-4d2a-b264-6724872156c6.png).

While this was done in code as a global override, probably following Apple stylistic changes, it is better to leave this to the keyboard developer to decide on.

@keymanapp-test-bot skip