### PR TITLE
fix(android/engine): Clear WebView cache on package install

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -282,6 +282,8 @@ public class PackageActivity extends AppCompatActivity implements
             notifyPackageInstallListeners(KeyboardEventHandler.EventType.PACKAGE_INSTALLED,
               installedPackageKeyboards, 1);
           }
+          KMManager.clearKeyboardCache();
+
           if(_cleanup)
             cleanup();
         } else {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1579,6 +1579,17 @@ public final class KMManager {
     registerAssociatedLexicalModel(kbInfo.getLanguageID());
   }
 
+  public static void clearKeyboardCache() {
+    if (InAppKeyboard != null && InAppKeyboardLoaded) {
+      InAppKeyboard.clearCache(true);
+      InAppKeyboard.loadKeyboard();
+    }
+    if (SystemKeyboard != null && SystemKeyboardLoaded) {
+      SystemKeyboard.clearCache(true);
+      SystemKeyboard.loadKeyboard();
+    }
+  }
+
   protected static IBinder getToken() {
     if (IMService == null) {
       return null;


### PR DESCRIPTION
Fixes #6292 

When overwriting an existing keyboard package with the same version, we need to clear the webView cache and reload for the updated keyboard to show.

## User Testing
**Setup**
On the Android emulator/device, save this modified keyboard package file [sil_cameroon_qwerty.kmp](https://darcywong00.github.io/examples/sil_cam_qwerty_azerty/sil_cameroon_qwerty.kmp) to the device's "Downloads" folder. This matches the current (at the time of creating this PR) version of [sil_cameroon_qwerty](https://downloads.keyman.com/keyboards/sil_cameroon_qwerty/6.0.6/sil_cameroon_qwerty.kmp) (version 6.0.6), but the keyboard file is replaced with a modified copy of sil_cameroon_azerty. The ID was also modified to remain `sil_cameroon_qwerty`, but the OSK will display *azerty* on the default layer.

* **TEST_CLEAR_CACHE_RELOAD**
1. Install and load the PR build of Keyman for Android
2. Close the "Getting Started" menu
3. From Keyman Settings --> Install Keyboard or Dictionary --> Install from keyman.com
4. Search for "sil_cameroon_qwerty" and install the keyboard package. (If the keyboard version is > 6.0.6, stop testing and comment on the keyboard version)
5. After the sil_cameroon_qwerty keyboard is installed, exit the menus and look at the sil_cameroon_qwerty OSK
6. Verify the top row of letters on the default layer is "qwerty" (below the top row of diacritics)
![qwerty](https://user-images.githubusercontent.com/7358010/160343665-feef0570-5b26-4dd9-8dc2-172dcd7e3301.png)
7. From Keyman Settings --> Install Keyboard or Dictionary --> Install from local file 
8. Browse to the "Downloads" folder and install the modified "sail_cameroon_qwerty.kmp" file from "Setup"
9. After the modified sil_cameroon_qwerty keyboard is installed, exit the menus and look at the OSK
10. Verify the top row of letters on the default row is now "azerty" instead of "qwerty".
![azerty](https://user-images.githubusercontent.com/7358010/160343765-eaf538a4-2ece-44d3-b78c-6c052436f872.png)

