### PR TITLE
fix(developer): Add Wordlist button now copies into source folder

### DIFF
--- a/windows/src/developer/TIKE/child/Keyman.Developer.UI.UframeWordlistEditor.pas
+++ b/windows/src/developer/TIKE/child/Keyman.Developer.UI.UframeWordlistEditor.pas
@@ -187,6 +187,7 @@ begin
   if FileExists(FileName) then
   begin
     FWordlist.LoadFromFile(FileName);
+    FModified := False;
   end;
   UpdateData;
   Result := True;
@@ -285,8 +286,6 @@ begin
     end;
 
     Modified := True;
-    if Assigned(FOnChanged) then
-      FOnChanged(Self);
   finally
     Dec(FSetup);
   end;
@@ -351,6 +350,8 @@ end;
 procedure TframeWordlistEditor.SetModified(const Value: Boolean);
 begin
   FModified := Value;
+  if Value and Assigned(FOnChanged) then
+    FOnChanged(Self);
 end;
 
 procedure TframeWordlistEditor.SourceChanged(Sender: TObject);
@@ -358,8 +359,6 @@ begin
   if FSetup = 0 then
   begin
     Modified := True;
-    if Assigned(FOnChanged) then
-      FOnChanged(Self);
   end;
 end;
 

--- a/windows/src/developer/TIKE/main/Keyman.Developer.System.LexicalModelParser.pas
+++ b/windows/src/developer/TIKE/main/Keyman.Developer.System.LexicalModelParser.pas
@@ -78,7 +78,7 @@ const
   SComment = '^\s*\/\*(.+?)\*\/';
   SFormat = 'format\s*:\s*([''"])(.+?)(\1)';
   SWordBreaker = 'wordBreaker\s*:\s*([''"])(.+?)(\1)';
-  SSources = 'sources\s*:\s*\[(.+?)\]';
+  SSources = 'sources\s*:\s*\[(.*?)\]';
   SSource = '\s*([''"])(.+?)(\1)\s*(,?)';
 
   SEndOfObject = '\s*};';


### PR DESCRIPTION
Fixes #2185.

If a wordlist file is not in the same folder as the .model.ts file, Keyman Developer will now ask the user if they want it copied into the folder.

Also minor fix: if the user deletes a row in a wordlist, it marks the file as modified.

Also very minor: the initial folder for the Add Wordlist dialog is now the same as the .model.ts file.

# User Testing

**TEST_COPY_WORDLIST:** Verify that Keyman Developer correctly copies a wordlist into the right folder.

1. Create a new model project and open the .model.ts file in Keyman Developer.
2. Click Add button in the Wordlists section to add a wordlist to the project, and select a wordlist that is in another folder.
3. You should be prompted to copy the wordlist into the .model.ts folder. Accept the prompt by clicking Yes.
4. The wordlist should be copied in to the correct source/ folder and loaded in the editor.