### PR TITLE
chore(oem/fv/android): Update dependencies 🍒 

### DIFF
--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -66,10 +66,10 @@ android {
 // how to configure the sentry android gradle plugin
 sentry {
     // Disables or enables the automatic configuration of Native symbols
-    uploadNativeSymbols true
+    uploadNativeSymbols = true
 
     // Does or doesn't include the source code of native code for Sentry
-    includeNativeSources true
+    includeNativeSources = true
 }
 
 String env_keys_json_file = System.getenv("oem_firstvoices_keys_json_file")
@@ -80,20 +80,22 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
         serviceAccountCredentials = file(String.valueOf(env_keys_json_file))
 
         // Deactivate lower conflicting version APKs
-        resolutionStrategy = "ignore"
+        resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
         switch (System.env.TIER) {
             case 'beta':
-                track = 'beta'
+                track.set("beta")
+                println "TIER set to beta"
                 break
 
             case 'stable':
-                track = 'production'
+                track.set("production")
+                println "TIER set to production"
                 break
 
             default:
-                track = 'alpha'
+                track.set("alpha")
+                println "TIER set to alpha"
         }
-        println "TIER set to $track"
     }
 }
 
@@ -102,6 +104,7 @@ repositories {
         dirs 'libs'
     }
     google()
+    mavenCentral()
 }
 
 dependencies {
@@ -109,7 +112,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'com.google.android.material:material:1.2.1'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'io.sentry:sentry-android:4.3.0'
     implementation 'androidx.preference:preference:1.1.1'
 }
 

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -3,13 +3,12 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath 'com.google.gms:google-services:4.3.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.35'
+        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Fixes failing CI build of stable-14.0 on Android

🍒 -pick of #5127 to stable-14.0
This is a follow-on to #6224 which missed updating build gradle other dependencies for the FV Android build.
The plugin syntax for publishing to the Play Store is also updated.

@keymanapp-test-bot skip
