### PR TITLE
fix(web): track stateKeys changes with layer changes

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -15,6 +15,10 @@ namespace com.keyman.text {
     private lngProcessor: prediction.LanguageProcessor;
 
     constructor(device: utils.DeviceSpec, options?: ProcessorInitOptions) {
+      if(!device) {
+        throw new Error('device must be defined');
+      }
+
       if(!options) {
         options = InputProcessor.DEFAULT_OPTIONS;
       }

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -20,7 +20,7 @@ namespace com.keyman.text {
       }
 
       this.device = device;
-      this.kbdProcessor = new KeyboardProcessor(options);
+      this.kbdProcessor = new KeyboardProcessor(device, options);
       this.lngProcessor = new prediction.LanguageProcessor();
     }
 

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -46,6 +46,7 @@ namespace com.keyman.text {
     modStateFlags: number = 0;
 
     keyboardInterface: KeyboardInterface;
+    device: utils.DeviceSpec;
 
     baseLayout: string;
 
@@ -54,10 +55,12 @@ namespace com.keyman.text {
     warningLogger?: LogMessageHandler;
     errorLogger?: LogMessageHandler;
 
-    constructor(options?: ProcessorInitOptions) {
+    constructor(device: utils.DeviceSpec, options?: ProcessorInitOptions) {
       if(!options) {
         options = KeyboardProcessor.DEFAULT_OPTIONS;
       }
+
+      this.device = device;
 
       this.baseLayout = options.baseLayout || KeyboardProcessor.DEFAULT_OPTIONS.baseLayout;
       this.keyboardInterface = new KeyboardInterface(options.variableStoreSerializer);
@@ -685,15 +688,19 @@ namespace com.keyman.text {
         this.layerId = 'default';
       }
 
-      if(keyEvent.device.formFactor != utils.FormFactor.Desktop) {
+      this.updateStateKeysFromLayer();
+
+      let baseModifierState = text.KeyboardProcessor.getModifierState(this.layerId);
+      this.modStateFlags = baseModifierState | keyEvent.Lstates;
+    }
+
+    public updateStateKeysFromLayer() {
+      if(this.device.formFactor != utils.FormFactor.Desktop) {
         // The caps layer works slightly differently on touch than on desktop.
         // It's a single layer with no ability to mix with other modifiers
         // We need to make sure that the state is kept in sync with the layer.
         this.stateKeys['K_CAPS'] = this.layerId == 'caps';
       }
-
-      let baseModifierState = text.KeyboardProcessor.getModifierState(this.layerId);
-      this.modStateFlags = baseModifierState | keyEvent.Lstates;
     }
 
     static isModifier(Levent: KeyEvent): boolean {
@@ -741,7 +748,7 @@ namespace com.keyman.text {
 
     resetContext() {
       this.layerId = 'default';
-
+      this.updateStateKeysFromLayer();
       this.keyboardInterface.resetContextCache();
       this._UpdateVKShift(null);
     };
@@ -751,6 +758,7 @@ namespace com.keyman.text {
         let layout = this.activeKeyboard.layout(device.formFactor);
         if(layout.getLayer('numeric')) {
           this.layerId = 'numeric';
+          this.updateStateKeysFromLayer();
         }
       }
     };

--- a/common/core/web/tools/recorder/src/nodeProctor.ts
+++ b/common/core/web/tools/recorder/src/nodeProctor.ts
@@ -4,13 +4,11 @@
 namespace KMWRecorder {
   export class NodeProctor extends Proctor {
     private keyboard: com.keyman.keyboards.Keyboard;
-    private device: com.keyman.utils.DeviceSpec;
     public __debug = false;
 
     constructor(keyboard: com.keyman.keyboards.Keyboard, device: com.keyman.utils.DeviceSpec, assert: AssertCallback) {
       super(device, assert);
 
-      this.device = device;
       this.keyboard = keyboard;
     }
 

--- a/common/core/web/tools/recorder/src/nodeProctor.ts
+++ b/common/core/web/tools/recorder/src/nodeProctor.ts
@@ -4,11 +4,13 @@
 namespace KMWRecorder {
   export class NodeProctor extends Proctor {
     private keyboard: com.keyman.keyboards.Keyboard;
+    private device: com.keyman.utils.DeviceSpec;
     public __debug = false;
 
     constructor(keyboard: com.keyman.keyboards.Keyboard, device: com.keyman.utils.DeviceSpec, assert: AssertCallback) {
       super(device, assert);
 
+      this.device = device;
       this.keyboard = keyboard;
     }
 
@@ -45,7 +47,7 @@ namespace KMWRecorder {
       }
 
       // Establish a fresh processor, setting its keyboard appropriately for the test.
-      let processor = new com.keyman.text.KeyboardProcessor();
+      let processor = new com.keyman.text.KeyboardProcessor(this.device);
       processor.activeKeyboard = this.keyboard;
 
       if(sequence instanceof RecordedKeystrokeSequence) {
@@ -74,7 +76,7 @@ namespace KMWRecorder {
 
           // And now, execute the keystroke!
           // We don't care too much about particularities of per-keystroke behavior yet.
-          // ... we _could_ if we wanted to, though.  The framework is mostly in place; 
+          // ... we _could_ if we wanted to, though.  The framework is mostly in place;
           // it's a matter of actually adding the feature.
           let ruleBehavior = processor.processKeystroke(keyEvent, target);
 


### PR DESCRIPTION
Fixes #6405.

If the layer is reset to default, e.g. by switching fields, then the state key bitmask was not always kept in sync with the layer change.

This does not attempt to keep Caps Lock on when switching tabs.

@keymanapp-test-bot skip