### PR TITLE
fix(developer): improves More Help link for icon tool

### DIFF
--- a/windows/src/developer/TIKE/xml/help/contexthelp.xml
+++ b/windows/src/developer/TIKE/xml/help/contexthelp.xml
@@ -99,17 +99,17 @@
 
     <!-- Layout tab -->
     <!-- Icon tab -->
-    <Control Name="cmdbitmapChange" Title="Change">
+    <Control Name="cmdbitmapChange" Title="Change" TopicName="context/keyboard-editor#toc-icon-tab">
       <p>The Change option allows the editing of the icon filename.</p>
     </Control>
-    <Control Name="cmdExport" Title="Export">
+    <Control Name="cmdExport" Title="Export" TopicName="context/keyboard-editor#toc-icon-tab">
       <p>The Export option allows the exporting of the new image to a selected location.</p>
     </Control>
-    <Control Name="cmdImport" Title="Import">
+    <Control Name="cmdImport" Title="Import" TopicName="context/keyboard-editor#toc-icon-tab">
       <p>The import option allows for the loading of an existing icon from a selected location.</p>
     </Control>
-    <Control Name="panEdit" Title="Icon Editor">
-      <p>The toolbox allows for the changing of the colours, addition of text and shapes.  It also allows for the moving of the icon around the button and also a preview of the button is displayed.</p>
+    <Control Name="panEdit" Title="Icon Editor" TopicName="context/keyboard-editor#toc-icon-tab">
+      <p>The toolbox allows for the changing of the colours, addition of text and shapes.  It also allows for the moving of the icon around the canvas and also a preview of the icon is displayed.</p>
     </Control>
 
     <!-- On-Screen tab: see context/keyboard-editor#toc-on-screen-tab -->

--- a/windows/src/developer/TIKE/xml/help/help.xsl
+++ b/windows/src/developer/TIKE/xml/help/help.xsl
@@ -71,7 +71,10 @@
       <xsl:attribute name="id"><xsl:value-of select="../@Name"/>-<xsl:value-of select="@Name"/></xsl:attribute>
       <div class="title"><xsl:value-of select="@Title"/></div>
       <xsl:copy-of select="." />
-      <div class="morehelp"><a><xsl:attribute name='href'>help:<xsl:value-of select='../@Name'/></xsl:attribute>More help...</a></div>
+      <div class="morehelp"><a><xsl:attribute name='href'>help:<xsl:choose>
+          <xsl:when test="@TopicName"><xsl:value-of select="@TopicName"></xsl:value-of></xsl:when>
+          <xsl:otherwise><xsl:value-of select='../@Name'/></xsl:otherwise>
+        </xsl:choose></xsl:attribute>More help...</a></div>
     </div>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Fixes #2750.

This tweaks the More Help link to open the correct part of the Keyboard Editor help page.

Goes together with keymanapp/help.keyman.com#526.

The context help data needs a consolidated rewrite. This does not attempt to touch that, nor does it attempt to add more contextual help links for any other part of the Developer IDE. That is work for another day...

@keymanapp-test-bot skip