### PR TITLE
feat(developer): add Clear All button to icon editor

### DIFF
--- a/windows/src/developer/TIKE/main/UframeBitmapEditor.dfm
+++ b/windows/src/developer/TIKE/main/UframeBitmapEditor.dfm
@@ -6,8 +6,8 @@ object frameBitmapEditor: TframeBitmapEditor
   TabOrder = 0
   TabStop = True
   object imgTransparent: TImage
-    Left = 280
-    Top = 252
+    Left = 494
+    Top = 251
     Width = 23
     Height = 23
     AutoSize = True
@@ -28,7 +28,7 @@ object frameBitmapEditor: TframeBitmapEditor
     Visible = False
   end
   object lblPixel: TLabel
-    Left = 232
+    Left = 302
     Top = 256
     Width = 3
     Height = 13
@@ -316,7 +316,7 @@ object frameBitmapEditor: TframeBitmapEditor
         '$00999999'
         '$00666666'
         '$00333333')
-      HintFormat = 
+      HintFormat =
         'RGB(%r, %g, %b) '#13'Hex: %hex Click for foreground Shift+Click for ' +
         'background'
       AutoHeight = True
@@ -848,7 +848,6 @@ object frameBitmapEditor: TframeBitmapEditor
     Align = alClient
     BevelOuter = bvNone
     TabOrder = 7
-    ExplicitTop = 7
     object ppReadOnlyIcons: TPaintPanel
       Left = 0
       Top = 154
@@ -857,10 +856,8 @@ object frameBitmapEditor: TframeBitmapEditor
       OnPaint = ppReadOnlyIconsPaint
       Align = alClient
       TabOrder = 0
-      ExplicitLeft = 10
-      ExplicitTop = 146
-      ExplicitWidth = 519
-      ExplicitHeight = 101
+      ExplicitLeft = -85
+      ExplicitTop = 249
     end
     object panReadOnlyIconsTop: TPanel
       Left = 0
@@ -879,7 +876,7 @@ object frameBitmapEditor: TframeBitmapEditor
         Width = 492
         Height = 41
         AutoSize = False
-        Caption = 
+        Caption =
           'This icon file is read only because it either contains multiple ' +
           'image resources, has a size other than 16x16 pixels, or a colour' +
           ' depth > 256 pixels'
@@ -894,6 +891,15 @@ object frameBitmapEditor: TframeBitmapEditor
         TabOrder = 0
       end
     end
+  end
+  object cmdClearAll: TButton
+    Left = 224
+    Top = 252
+    Width = 73
+    Height = 25
+    Caption = '&Clear all'
+    TabOrder = 8
+    OnClick = cmdClearAllClick
   end
   object ilCmds: TImageList
     Left = 84

--- a/windows/src/developer/TIKE/main/UframeBitmapEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeBitmapEditor.pas
@@ -95,6 +95,7 @@ type
     memoReadOnlyIcons: TMemo;
     ppReadOnlyIcons: TPaintPanel;
     panReadOnlyIconsTop: TPanel;
+    cmdClearAll: TButton;
     procedure panEditMouseDown(Sender: TObject; Button: TMouseButton;
       Shift: TShiftState; X, Y: Integer);
     procedure panEditMouseMove(Sender: TObject; Shift: TShiftState; X,
@@ -120,6 +121,7 @@ type
     procedure cmdExportClick(Sender: TObject);
     procedure cmdImportClick(Sender: TObject);
     procedure ppReadOnlyIconsPaint(Sender: TObject);
+    procedure cmdClearAllClick(Sender: TObject);
   private
     FReadOnlyIcons: array of TGraphic;
     FRSP21318IsPngIcon: Boolean;
@@ -540,6 +542,11 @@ begin
   finally
     bmp.Free;
   end;
+end;
+
+procedure TframeBitmapEditor.cmdClearAllClick(Sender: TObject);
+begin
+  ClearSelection;
 end;
 
 procedure TframeBitmapEditor.cmdClick(Sender: TObject);
@@ -1156,7 +1163,7 @@ begin
       except
         on E:Exception do   // I3147 - I don't want to use E:Exception but see http://marc.durdin.net/2012/01/how-not-to-do-exception-classes-in.html   // I3508
         begin
-          ShowMessage('The image file could not be imported because it is not a valid PNG file.');
+          ShowMessage('The image file could not be imported because it is not a valid PNG file: '+E.Message);
           Exit;
         end;
       end;
@@ -1238,21 +1245,27 @@ end;
 
 procedure TframeBitmapEditor.Clear;
 begin
-  Modified := False;
-  FBitmaps[bebEdit].Canvas.Brush.Color := BGColour;
-  FBitmaps[bebEdit].Canvas.FillRect(Rect(0,0,16,16));
+  ClearSelection;
   FEdit.IsTemp := False;
-  panEdit.RePaint;
-  panPreview.RePaint;
   SaveUndoBitmap;
 end;
 
 procedure TframeBitmapEditor.ClearSelection;
+var
+  hObject: THandle;
+  FColor: DWord;
 begin
   Modified := True;
   SaveUndoBitmap;
-  FBitmaps[bebEdit].Canvas.Brush.Color := BGColour;
-  FBitmaps[bebEdit].Canvas.FillRect(Rect(0,0,16,16));
+
+  if BGColour = clTransparent
+    then FColor := TransparentReplacementColour
+    else FColor := BGColour;
+
+  hObject := CreateSolidBrush(FColor);
+  Windows.FillRect(FBitmaps[bebEdit].Canvas.Handle, Rect(0,0,16,16), hObject);
+  DeleteObject(hObject);
+
   panEdit.RePaint;
   panPreview.RePaint;
 end;


### PR DESCRIPTION
Fixes #2749.

Adds a Clear All button which does the same as Edit/Clear Selection.

At the same time, fixes the Clear code for transparent background colours; previously, clear all with transparent background gave a black fill.

@keymanapp-test-bot skip