### PR TITLE
fix(developer): icon editor font color now follows fgcolor

### DIFF
--- a/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.dfm
+++ b/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.dfm
@@ -77,7 +77,7 @@ inherited frmBitmapEditorText: TfrmBitmapEditorText
   object editFont: TEdit
     Left = 64
     Top = 20
-    Width = 233
+    Width = 204
     Height = 21
     TabStop = False
     ParentColor = True
@@ -92,6 +92,14 @@ inherited frmBitmapEditorText: TfrmBitmapEditorText
     Caption = '&Change...'
     TabOrder = 1
     OnClick = cmdFontClick
+  end
+  object cpTextColor: TmbColorPreview
+    Left = 274
+    Top = 20
+    Width = 24
+    Height = 21
+    Hint = 'Text Color'
+    Color = clNone
   end
   object dlgFont: TFontDialog
     Font.Charset = DEFAULT_CHARSET

--- a/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.pas
+++ b/windows/src/developer/TIKE/dialogs/UfrmBitmapEditorText.pas
@@ -25,7 +25,7 @@ interface
 uses
   System.UITypes,
   Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls, Forms,
-  Dialogs, StdCtrls, ClearTypeDrawCharacter, UfrmTike;
+  Dialogs, StdCtrls, ClearTypeDrawCharacter, UfrmTike, mbColorPreview;
 
 type
   TBitmapEditorTextDrawPreviewEvent = procedure(ADisplayQuality: TClearTypeDisplayQuality; AInsertFont: TFont; AInsertText: WideString) of object;
@@ -41,6 +41,7 @@ type
     editFont: TEdit;
     lblQuality: TLabel;
     cmdFont: TButton;
+    cpTextColor: TmbColorPreview;
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
     procedure cbDisplayQualityClick(Sender: TObject);
@@ -186,6 +187,9 @@ begin
   FInsertFont.Assign(Value);
   editText.Font := FInsertFont;
   editFont.Text := FontDetailsToString(Value);
+  if FInsertFont.Color = TframeBitmapEditor.TransparentReplacementColour
+    then cpTextColor.Color := clNone
+    else cpTextColor.Color := FInsertFont.Color;
   DrawPreview;
 end;
 

--- a/windows/src/developer/TIKE/main/UframeBitmapEditor.pas
+++ b/windows/src/developer/TIKE/main/UframeBitmapEditor.pas
@@ -168,6 +168,9 @@ type
     function CanClearSelection: Boolean;
 
   public
+    const
+      TransparentReplacementColour = $100000;  // I2634
+
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
     procedure LoadFromFile(FileName: WideString);
@@ -194,8 +197,6 @@ uses
   JPEG,
   UfrmBitmapEditorText;
 
-const
-  TransparentReplacementColour = $100000;  // I2634
 constructor TframeBitmapEditor.Create(AOwner: TComponent);
 var
   beb: TBitmapEditorBMType;
@@ -431,6 +432,8 @@ begin
 
   if GetDrawMode = dmText then
   begin
+    FLastInsertFont.Color := FEdit.Colour;
+
     r := panEdit.BoundsRect;
     r.TopLeft := ClientToScreen(r.TopLeft);
     r.BottomRight := ClientToScreen(r.BottomRight);


### PR DESCRIPTION
Fixes #2748.

Note that transparent text is not supported for ClearType or antialiased modes.

@keymanapp-test-bot skip