### PR TITLE
chore(common): Update in-app help versions to 15.0

### DIFF
--- a/ios/help/about/whatsnew.md
+++ b/ios/help/about/whatsnew.md
@@ -2,7 +2,7 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman for iPhone and iPad 14.0:
+Here are some of the new features we have added to Keyman for iPhone and iPad 15.0:
 
 * Simpler and smoother keyboard search
 * Localizable UI through [translate.keyman.com](https://translate.keyman.com)

--- a/linux/help/about/whatsnew.md
+++ b/linux/help/about/whatsnew.md
@@ -2,7 +2,7 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman for Linux 14.0:
+Here are some of the new features we have added to Keyman for Linux 15.0:
 
 * Open a .kmp file with Keyman Config (#3183)
 * Now supports Ubuntu 20.10 (Groovy) (#3876)

--- a/mac/help/about/requirements.md
+++ b/mac/help/about/requirements.md
@@ -4,7 +4,7 @@ title: System Requirements
 
 ## Supported Mac Operating Systems
 
-Keyman 14.0 supports the following Mac operating systems:
+Keyman 15.0 supports the following Mac operating systems:
 
 * Mac OS X Yosemite (10.10)
 * Mac OS X El Capitan (10.11)

--- a/mac/help/common/keyboards.md
+++ b/mac/help/common/keyboards.md
@@ -3,7 +3,7 @@ title: Which keyboards work on Mac?
 ---
 
 Most Keyman keyboards work on Mac. A small subset of keyboards require features which
-are not yet available in version 14.0. These features will be progressively implemented.
+are not yet available in version 15.0. These features will be progressively implemented.
 Keyman for macOS will inform you when you attempt to install a keyboard if it is using
 a currently unsupported feature.
 

--- a/mac/help/common/os.md
+++ b/mac/help/common/os.md
@@ -4,7 +4,7 @@ title: Which versions does Keyman for macOS work with?
 
 ## Supported Mac Operating Systems
 
-Keyman 14.0 supports the following Mac operating systems:
+Keyman 15.0 supports the following Mac operating systems:
 
 * Mac OS X Yosemite (10.10)
 * Mac OS X El Capitan (10.11)
@@ -12,3 +12,4 @@ Keyman 14.0 supports the following Mac operating systems:
 * macOS High Sierra (10.13)
 * macOS Mojave (10.14)
 * macOS Catalina (10.15)
+* macOS Big Sur (11.0)

--- a/mac/help/index.md
+++ b/mac/help/index.md
@@ -1,8 +1,8 @@
 ---
-title: Keyman 14.0 for macOS Help
+title: Keyman 15.0 for macOS Help
 ---
 
-Need help using Keyman 14.0 for macOS?  You'll find everything you need here, including product documentation,
+Need help using Keyman 15.0 for macOS?  You'll find everything you need here, including product documentation,
 frequently asked questions, tutorials and videos.
 
 ## [About Keyman](about/)

--- a/windows/src/desktop/help/basic/config/options.md
+++ b/windows/src/desktop/help/basic/config/options.md
@@ -92,7 +92,7 @@ To open the Options tab of Keyman Configuration:
     or any personally identifying data. If you would prefer not to
     share these statistics, uncheck this box.
 
-    **Note:** In Keyman 14.0, no statistics are currently sent,
+    **Note:** In Keyman 15.0, no statistics are currently sent,
     although the infrastructure is in place.
 
 ## Using Startup Options

--- a/windows/src/desktop/help/index.md
+++ b/windows/src/desktop/help/index.md
@@ -1,5 +1,5 @@
 ---
-title: Keyman 14.0 Help
+title: Keyman 15.0 Help
 ---
 
 Need help using Keyman for Windows? You'll find everything you need here, including product documentation,


### PR DESCRIPTION
This updates some of the in-app help to Keyman 15.0.

Also updates the supported macOS to include Big Sur

@keymanapp-test-bot skip