### PR TITLE
fix(iOS): check version during package install

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -22,6 +22,7 @@ public enum KMPError : String, Error {
   //        to provide better clarity.
   case wrongPackageType = "kmp-error-wrong-type"
   case resourceNotInPackage = "kmp-error-missing-resource"
+  case unsupportedKeymanVersion = "kmp-error-unsupported-keyman-version"
 
   var localizedDescription: String {
     return engineBundle.localizedString(forKey: self.rawValue, value: nil, table: nil)
@@ -397,6 +398,10 @@ public class KeymanPackage {
         throw KMPError.noMetadata
       }
 
+      let packageName = metadata.info?.name?.description ?? ""
+      let minVersion = metadata.system.fileVersion
+      try validateVersionSupported(packageName: packageName, minSupportedVersion: minVersion)
+
       var package: KeymanPackage
 
       switch metadata.packageType {
@@ -418,6 +423,20 @@ public class KeymanPackage {
     return nil
   }
 
+  /*
+   * Checks whether the version of Keyman being used is greater than or equal to the minimum
+   * Keyman version required by the package, and, if not, throws error.
+   */
+  static private func validateVersionSupported(packageName: String, minSupportedVersion: String) throws {
+    let currentVersion = Version.current
+    let minVersion = Version(minSupportedVersion)
+    
+    if (currentVersion.major < minVersion!.major) {
+      log.error("package '\(packageName)' could not be installed because it requires version \(minSupportedVersion) of Keyman")
+      throw KMPError.unsupportedKeymanVersion
+    }
+  }
+  
   @available(*, deprecated, message: "Use of the completion block is unnecessary; this method now returns synchronously.")
   static public func extract(fileUrl: URL, destination: URL, complete: @escaping (KeymanPackage?) -> Void) throws {
     try unzipFile(fileUrl: fileUrl, destination: destination) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -423,9 +423,13 @@ public class KeymanPackage {
     return nil
   }
 
-  /*
+  /**
    * Checks whether the version of Keyman being used is greater than or equal to the minimum
    * Keyman version required by the package, and, if not, throws error.
+   *
+   * This function only verifies the major component of the version number, not the 
+   * minor or patch versions. This meets the Keyman design requirement that breaking
+   * file format changes can only occur in major version updates.
    */
   static private func validateVersionSupported(packageName: String, minSupportedVersion: String) throws {
     let currentVersion = Version.current

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/Version.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/Version.swift
@@ -52,6 +52,11 @@ public class Version: NSObject, Comparable {
   public let plainString: String
   public let fullString: String
   public let tier: Tier?
+  public var major: Int {
+    get {
+      return components[0]
+    }
+  }
 
   public init?(_ string: String) {
     let tagComponents = string.components(separatedBy: "-")

--- a/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/en.lproj/Localizable.strings
@@ -124,6 +124,9 @@
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "This package does not contain the requested keyboard or dictionary.";
 
+/* Error installing a Keyman package with a version of Keyman that does not support it */
+"kmp-error-unsupported-keyman-version" = "This package requires a newer version of Keyman.";
+
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "This package was not properly built - contents unknown.";
 


### PR DESCRIPTION
Fixes #6255

When a package is being installed, checks the fileVersion field to find the minimum version of Keyman that the package supports. If this minimum version is greater than the version of Keyman , then the package installation fails and an alert is presented to the user.

# User Testing

* **TEST_FUTURE_VERSION:** Try installing package [the_99.kmp](https://downloads.keyman.com/developer/beta/15.0.219/keyboards/the_99.kmp). It should not fail to install and display the following alert:
![image](https://user-images.githubusercontent.com/89134789/161687601-5ca92c6c-e5ff-45d3-b3ef-f4c76a3e9de2.png)

* **TEST_KHMER:** Try installing Khmer Angkor -- it should install successfully
