### PR TITLE
fix(linux): Remove tab completion warning

### DIFF
--- a/linux/keyman-config/km-package-get.bash-completion
+++ b/linux/keyman-config/km-package-get.bash-completion
@@ -17,10 +17,13 @@ _km-package-get_completions()
 
     words=""
     if [[ ! -e $cache ]] ; then
+        # NOTE: identical code in `km-package-install.bash-completion`.
+        # Unfortunately with bash completion scripts it's not possible to factor out
+        # common code.
         if [[ -e ./km-package-install ]]; then
-            python3 -c "from imp import load_source;load_source('km_package_install', './km-package-install');from km_package_install import list_keyboards;list_keyboards()"
+            python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', './km-package-install');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
         else
-            python3 -c "from imp import load_source;load_source('km_package_install', '/usr/bin/km-package-install');from km_package_install import list_keyboards;list_keyboards()"
+            python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', '/usr/bin/km-package-install');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
         fi
     fi
 

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -33,7 +33,7 @@ def get_languages():
         response = requests.get(api_url)
         logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
         os.chdir(current_dir)
-        requests_cache.core.uninstall_cache()
+        requests_cache.uninstall_cache()
         if response.status_code == 200:
             return response.json()
         else:

--- a/linux/keyman-config/km-package-install.bash-completion
+++ b/linux/keyman-config/km-package-install.bash-completion
@@ -19,10 +19,13 @@ _km-package-install_completions()
         "-p"|"--package")
             words=""
             if [[ ! -s $cache ]] ; then
+                # NOTE: identical code in `km-package-get.bash-completion`.
+                # Unfortunately with bash completion scripts it's not possible to factor out
+                # common code.
                 if [[ -e ./km-package-install ]]; then
-                    python3 -c "from imp import load_source;load_source('km_package_install', './km-package-install');from km_package_install import list_keyboards;list_keyboards()"
+                    python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', './km-package-install');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
                 else
-                    python3 -c "from imp import load_source;load_source('km_package_install', '/usr/bin/km-package-install');from km_package_install import list_keyboards;list_keyboards()"
+                    python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', '/usr/bin/km-package-install');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
                 fi
             fi
 


### PR DESCRIPTION
This is done by replacing the deprecated `imp` module. Also extract common code into a separate method.

Fixes #6227.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_BIONIC**: Ubuntu 18.04 Bionic with Gnome Shell and X11
  - **GROUP_FOCAL**: Ubuntu 20.04 Focal with Gnome Shell and X11
  - **GROUP_IMPISH_X11**: Ubuntu 21.10 Impish with Gnome Shell and X11

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_PKG_GET**: Tab completion works in `km-package-get` without warning

- open a terminal window
- type `km-package-get a` and then press the `<tab>` key twice
- expected result: this should display a list of Keyman packages starting with _a_, without displaying a warning first:

  ![Screenshot from 2022-04-05 17-10-06](https://user-images.githubusercontent.com/181336/161786030-19874956-7251-4453-8714-855cb8d26ec9.png)

**TEST_PKG_INST**: Tab completion works in `km-package-install` without warning

- open a terminal window
- type `km-package-install -p sil` and then press the `<tab>` key twice
- expected result: this should display a list of Keyman packages starting with _sil_, without displaying a warning first.
