### PR TITLE
fix(windows): Don't reset defaults on Keyman upgrade

### DIFF
--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -543,8 +543,6 @@ begin
         InstallDefaults := True;
     end;
 
-
-
     { Log the install to the diag folder }
 
     FLogFileName := TKeymanPaths.ErrorLogPath(ChangeFileExt(ExtractFileName(msiLocation.Path), ''));  // I1610 // I2755 // I2792
@@ -690,8 +688,6 @@ begin
     if StartWithWindows then s := s + 'StartWithWindows,';
     if CheckForUpdates then s := s + 'CheckForUpdates,';
     if AutomaticallyReportUsage then s := s + 'AutomaticallyReportUsage,';
-
-
 
     if InstallDefaults then
     begin

--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -683,9 +683,7 @@ begin
     if AutomaticallyReportUsage then s := s + 'AutomaticallyReportUsage,';
 
     msiLocation := FInstallInfo.MsiInstallLocation;
-    if Assigned(msiLocation) and (
-        (FInstallInfo.InstalledVersion.Version = '') or (FInstallInfo.InstalledVersion.ProductCode <> msiLocation.ProductCode)
-      ) then
+    if Assigned(msiLocation) and (FInstallInfo.InstalledVersion.Version = '') then
     begin
       s := s + 'InstallDefaults,';  // I2651
       s := s + ' -defaultuilanguage='+TSetupUILanguageManager.ActiveLocale;

--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -535,16 +535,14 @@ begin
       end;
     end;
 
-    //  Need to update the InstallDefaults flag based on current installed version information
+    //  InstallDefaults may have already been set True from the command line if not then
+    //  update the InstallDefaults flag based on current installed version information.
     if not(InstallDefaults) and not (ContinueSetup) then
     begin
       if Assigned(FInstallInfo.MsiInstallLocation) and (FInstallInfo.InstalledVersion.Version = '') then
         InstallDefaults := True;
     end;
-    if(InstallDefaults) then
-      GetRunTools.LogInfo('InstallDefaults value IMSI True', True)
-    else
-      GetRunTools.LogInfo('InstallDefaults value IMSI False', True);
+
 
 
     { Log the install to the diag folder }
@@ -693,15 +691,7 @@ begin
     if CheckForUpdates then s := s + 'CheckForUpdates,';
     if AutomaticallyReportUsage then s := s + 'AutomaticallyReportUsage,';
 
-    if(InstallDefaults) then
-      GetRunTools.LogInfo('FInstallDefaults value CFR True')
-    else
-      GetRunTools.LogInfo('FInstallDefaults value CFR False');
 
-    if (Assigned(FInstallInfo.MsiInstallLocation))
-          then GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation not nil', True)
-          else GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation is nil', True);
-    GetRunTools.LogInfo('InstalledVersion.Version'+FInstallInfo.InstalledVersion.Version, True);
 
     if InstallDefaults then
     begin
@@ -776,7 +766,6 @@ begin
       if InstallDefaults then
         s := s + ' -d';
       WriteString(SRegValue_WindowsRunOnce_Setup, s);
-      LogInfo('reboot command line '+s);
     end;
   finally
     Free;

--- a/windows/src/desktop/setup/RunTools.pas
+++ b/windows/src/desktop/setup/RunTools.pas
@@ -80,11 +80,11 @@ type
     function CacheMSIFile(msiLocation: TInstallInfoFileLocation): WideString;
     procedure FinishCacheMSIFile(msiLocation: TInstallInfoFileLocation;
       InstallSuccess: Boolean);
-    function InstallMSI(msiLocation: TInstallInfoFileLocation): Boolean;
+    function InstallMSI(msiLocation: TInstallInfoFileLocation; InstallDefaults: Boolean): Boolean;
     procedure ConfigFirstRun(StartKeyman,StartWithWindows,
-      CheckForUpdates,StartDisabled,StartWithConfiguration,
+      CheckForUpdates,StartDisabled,StartWithConfiguration,InstallDefaults,
       AutomaticallyReportUsage: Boolean);
-    procedure PrepareForReboot(res: Cardinal);
+    procedure PrepareForReboot(res: Cardinal; InstallDefaults: Boolean);
     function RestartWindows: Boolean;
     procedure RunVersion6Upgrade(const kmshellpath: WideString);
     procedure RunVersion7Upgrade(const KMShellPath: WideString);
@@ -102,7 +102,7 @@ type
     procedure CheckInternetConnectedState;
     function DoInstall(Handle: THandle;
       StartAfterInstall, StartWithWindows, CheckForUpdates, StartDisabled,
-      StartWithConfiguration, AutomaticallyReportUsage: Boolean): Boolean;
+      StartWithConfiguration, InstallDefaults, AutomaticallyReportUsage: Boolean): Boolean;
     procedure LogError(const msg: WideString; ShowDialogIfNotSilent: Boolean = True);
     procedure LogInfo(const msg: string; ShowDialogIfNotSilent: Boolean = False);
 
@@ -196,7 +196,7 @@ end;
 
 function TRunTools.DoInstall(Handle: THandle;
   StartAfterInstall, StartWithWindows, CheckForUpdates, StartDisabled,
-  StartWithConfiguration, AutomaticallyReportUsage: Boolean): Boolean;
+  StartWithConfiguration, InstallDefaults, AutomaticallyReportUsage: Boolean): Boolean;
 var
   msiLocation: TInstallInfoFileLocation;
 begin
@@ -221,12 +221,12 @@ begin
 
     CloseKeymanApplications;  // I2740
 
-    if not InstallMSI(msiLocation) then
+    if not InstallMSI(msiLocation, InstallDefaults) then
       Exit(False);
   end;
 
   ConfigFirstRun(StartAfterInstall,StartWithWindows,CheckForUpdates,
-    StartDisabled,StartWithConfiguration,AutomaticallyReportUsage);
+    StartDisabled,StartWithConfiguration,InstallDefaults,AutomaticallyReportUsage);
 
   Result := True;
 end;
@@ -500,7 +500,7 @@ begin
   end;
 end;
 
-function TRunTools.InstallMSI(msiLocation: TInstallInfoFileLocation): Boolean;
+function TRunTools.InstallMSI(msiLocation: TInstallInfoFileLocation;InstallDefaults: Boolean): Boolean;
 var
   pcode: array[0..39] of Char;
   res: Cardinal;
@@ -557,7 +557,7 @@ begin
       ERROR_SUCCESS: ;
       ERROR_SUCCESS_REBOOT_REQUIRED, ERROR_SUCCESS_REBOOT_INITIATED:
         begin
-          PrepareForReboot(res); // We need to continue this install after reboot
+          PrepareForReboot(res, InstallDefaults); // We need to continue this install after reboot
           Result := False;
           Exit;
         end;
@@ -582,13 +582,12 @@ begin
 end;
 
 procedure TRunTools.ConfigFirstRun(StartKeyman,StartWithWindows,CheckForUpdates,
-  StartDisabled,StartWithConfiguration,AutomaticallyReportUsage: Boolean);
+  StartDisabled,StartWithConfiguration,InstallDefaults,AutomaticallyReportUsage: Boolean);
 var
   i: Integer;
   s: WideString;
   FKMShellPath: WideString;
   FExitCode: Cardinal;
-  msiLocation: TInstallInfoFileLocation;
   FKMShellVersion: string;
 
   procedure DoInstallPackages;
@@ -682,8 +681,7 @@ begin
     if CheckForUpdates then s := s + 'CheckForUpdates,';
     if AutomaticallyReportUsage then s := s + 'AutomaticallyReportUsage,';
 
-    msiLocation := FInstallInfo.MsiInstallLocation;
-    if Assigned(msiLocation) and (FInstallInfo.InstalledVersion.Version = '') then
+    if InstallDefaults then
     begin
       s := s + 'InstallDefaults,';  // I2651
       s := s + ' -defaultuilanguage='+TSetupUILanguageManager.ActiveLocale;
@@ -739,9 +737,10 @@ begin
   Status(FInstallInfo.Text(ssStatusComplete));
 end;
 
-procedure TRunTools.PrepareForReboot(res: Cardinal);
+procedure TRunTools.PrepareForReboot(res: Cardinal; InstallDefaults: Boolean);
 var
   FTempFilename: string;
+  s: string;
 begin
   FMustReboot := True;
 
@@ -751,7 +750,10 @@ begin
     begin
       FTempFilename := KGetTempFilename;
       FInstallInfo.SaveToJSONFile(FTempFilename);
-      WriteString(SRegValue_WindowsRunOnce_Setup, '"'+ParamStr(0)+'" -c "'+FTempFilename+'"');
+      s := '"'+ParamStr(0)+'" -c "'+FTempFilename+'"';
+      if InstallDefaults then
+        s := s + ' -d';
+      WriteString(SRegValue_WindowsRunOnce_Setup, s);
     end;
   finally
     Free;

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -524,7 +524,8 @@ begin
     SetupMSI; // I2644
 
     if GetRunTools.DoInstall(Handle, FStartAfterInstall, FStartWithWindows, FCheckForUpdates,
-      FInstallInfo.StartDisabled, FInstallInfo.StartWithConfiguration, FInstallDefaults, FAutomaticallyReportUsage) then
+      FInstallInfo.StartDisabled, FInstallInfo.StartWithConfiguration, FInstallDefaults,
+      FAutomaticallyReportUsage, FContinueSetup) then
     begin
       if not Silent and not FStartAfterInstall then   // I2610
         ShowMessage(FInstallInfo.Text(ssInstallSuccess));

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -117,6 +117,7 @@ type
     FStartWithWindows: Boolean;
     FAutomaticallyReportUsage: Boolean;
     FDisableUpgradeFrom6Or7Or8: Boolean;  // I2847   // I4293
+    FInstallDefaults: Boolean;
     procedure CheckVersion6Upgrade;
     procedure CheckVersion7Upgrade;
     procedure CheckVersion8Upgrade;   // I4293
@@ -136,6 +137,7 @@ type
     property ContinueSetup: Boolean read FContinueSetup write FContinueSetup;
     property StartAfterInstall: Boolean read FStartAfterInstall write FStartAfterInstall;  // I2738
     property DisableUpgradeFrom6Or7Or8: Boolean read FDisableUpgradeFrom6Or7Or8 write FDisableUpgradeFrom6Or7Or8; // I2847   // I4293
+    property InstallDefaults: Boolean read FInstallDefaults write FInstallDefaults;
   end;
 
 implementation
@@ -522,7 +524,7 @@ begin
     SetupMSI; // I2644
 
     if GetRunTools.DoInstall(Handle, FStartAfterInstall, FStartWithWindows, FCheckForUpdates,
-      FInstallInfo.StartDisabled, FInstallInfo.StartWithConfiguration, FAutomaticallyReportUsage) then
+      FInstallInfo.StartDisabled, FInstallInfo.StartWithConfiguration, FInstallDefaults, FAutomaticallyReportUsage) then
     begin
       if not Silent and not FStartAfterInstall then   // I2610
         ShowMessage(FInstallInfo.Text(ssInstallSuccess));

--- a/windows/src/desktop/setup/bootstrapmain.pas
+++ b/windows/src/desktop/setup/bootstrapmain.pas
@@ -168,22 +168,6 @@ BEGIN
             FPromptForReboot, FSilent, FForceOffline, FExtractOnly,
             FContinueSetupFilename, FStartAfterInstall,
             FDisableUpgradeFrom6Or7Or8, FInstallDefaults, FPackages, FExtractOnly_Path, FTier);  // I2738, I2847  // I3355   // I3500   // I4293
-          // always honour the command line -d from ProcessCommandLine
-
-          msiLocation := FInstallInfo.MsiInstallLocation;
-          if Assigned(msiLocation) then
-            GetRunTools.LogInfo('msiLocation set in Run', False);
-
-          if(FInstallDefaults) then
-            GetRunTools.LogInfo('FInstallDefaults value PC True', True)
-          else
-            GetRunTools.LogInfo('FInstallDefaults value PC False', True);
-
-          GetRunTools.LogInfo('FContinueSetupFilename'+FContinueSetupFilename, True);
-          if (Assigned(FInstallInfo.MsiInstallLocation))
-          then GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation not nil', True)
-          else GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation is nil', True);
-          GetRunTools.LogInfo('FContinueSetupFilename'+FInstallInfo.InstalledVersion.Version, True);
 
           GetRunTools.Silent := FSilent;
 

--- a/windows/src/desktop/setup/bootstrapmain.pas
+++ b/windows/src/desktop/setup/bootstrapmain.pas
@@ -147,6 +147,7 @@ procedure TSetupBootstrap.Run;
 var
   FTempPath: string;
   frmDownloadProgress: TfrmDownloadProgress;
+  msiLocation: TInstallInfoFileLocation;
   FResult: Boolean;
 BEGIN
   CoInitializeEx(nil, COINIT_APARTMENTTHREADED);
@@ -168,11 +169,21 @@ BEGIN
             FContinueSetupFilename, FStartAfterInstall,
             FDisableUpgradeFrom6Or7Or8, FInstallDefaults, FPackages, FExtractOnly_Path, FTier);  // I2738, I2847  // I3355   // I3500   // I4293
           // always honour the command line -d from ProcessCommandLine
-          if not(FInstallDefaults) and (FContinueSetupFilename = '') then
-          begin
-            if (Assigned(FInstallInfo.MsiInstallLocation) and (FInstallInfo.InstalledVersion.Version = '')) then
-              FInstallDefaults := True;
-          end;
+
+          msiLocation := FInstallInfo.MsiInstallLocation;
+          if Assigned(msiLocation) then
+            GetRunTools.LogInfo('msiLocation set in Run', False);
+
+          if(FInstallDefaults) then
+            GetRunTools.LogInfo('FInstallDefaults value PC True', True)
+          else
+            GetRunTools.LogInfo('FInstallDefaults value PC False', True);
+
+          GetRunTools.LogInfo('FContinueSetupFilename'+FContinueSetupFilename, True);
+          if (Assigned(FInstallInfo.MsiInstallLocation))
+          then GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation not nil', True)
+          else GetRunTools.LogInfo('FInstallInfo.MsiInstallLocation is nil', True);
+          GetRunTools.LogInfo('FContinueSetupFilename'+FInstallInfo.InstalledVersion.Version, True);
 
           GetRunTools.Silent := FSilent;
 
@@ -233,6 +244,7 @@ BEGIN
             ContinueSetup := FContinueSetupFilename <> '';
             StartAfterInstall := FStartAfterInstall; // I2738
             DisableUpgradeFrom6Or7Or8 := FDisableUpgradeFrom6Or7Or8;  // I2847   // I4293
+            InstallDefaults := FInstallDefaults;
             if FSilent
               then DoInstall(True, FPromptForReboot)  // I3355   // I3500
               else ShowModal;

--- a/windows/src/desktop/setup/bootstrapmain.pas
+++ b/windows/src/desktop/setup/bootstrapmain.pas
@@ -99,6 +99,7 @@ type
     FPromptForReboot: Boolean;  // I3355   // I3500
     FSilent: Boolean;
     FForceOffline: Boolean;
+    FInstallDefaults: Boolean;
     FTier, FPackages, FExtractOnly_Path: string;
 
     function CheckForOldVersionScenario: Boolean;
@@ -109,7 +110,7 @@ type
     procedure ProcessCommandLine(
       var FPromptForReboot, FSilent, FForceOffline, FExtractOnly: Boolean;
       var FContinueSetupFilename: string;
-      var FStartAfterInstall, FDisableUpgradeFrom6Or7Or8: Boolean;
+      var FStartAfterInstall, FDisableUpgradeFrom6Or7Or8, FInstallDefaults: Boolean;
       var FPackages, FExtractPath, FTier: string);
     procedure SetExitVal(c: Integer);
     function IsKeymanDesktop7Installed: string;
@@ -165,7 +166,13 @@ BEGIN
           ProcessCommandLine(
             FPromptForReboot, FSilent, FForceOffline, FExtractOnly,
             FContinueSetupFilename, FStartAfterInstall,
-            FDisableUpgradeFrom6Or7Or8, FPackages, FExtractOnly_Path, FTier);  // I2738, I2847  // I3355   // I3500   // I4293
+            FDisableUpgradeFrom6Or7Or8, FInstallDefaults, FPackages, FExtractOnly_Path, FTier);  // I2738, I2847  // I3355   // I3500   // I4293
+          // always honour the command line -d from ProcessCommandLine
+          if not(FInstallDefaults) and (FContinueSetupFilename = '') then
+          begin
+            if (Assigned(FInstallInfo.MsiInstallLocation) and (FInstallInfo.InstalledVersion.Version = '')) then
+              FInstallDefaults := True;
+          end;
 
           GetRunTools.Silent := FSilent;
 
@@ -542,7 +549,7 @@ end;
 procedure TSetupBootstrap.ProcessCommandLine(
   var FPromptForReboot, FSilent, FForceOffline, FExtractOnly: Boolean;
   var FContinueSetupFilename: string;
-  var FStartAfterInstall, FDisableUpgradeFrom6Or7Or8: Boolean;
+  var FStartAfterInstall, FDisableUpgradeFrom6Or7Or8, FInstallDefaults: Boolean;
   var FPackages, FExtractPath, FTier: string
 );
 var
@@ -555,6 +562,7 @@ begin
   FContinueSetupFilename := '';
   FDisableUpgradeFrom6Or7Or8 := False; // I2847   // I4293
   FStartAfterInstall := True;  // I2738
+  FInstallDefaults := False;
   i := 1;
   while i <= ParamCount do
   begin
@@ -577,6 +585,8 @@ begin
       FStartAfterInstall := True;
       FDisableUpgradeFrom6Or7Or8 := True;  // I2847   // I4293
     end
+    else if WideSameText(ParamStr(i), '-d') then
+      FInstallDefaults := True
     else if WideSameText(ParamStr(i), '-o') then
       FForceOffline := True
     else if WideSameText(ParamStr(i), '-r') then

--- a/windows/src/desktop/setup/setup.dproj
+++ b/windows/src/desktop/setup/setup.dproj
@@ -1031,7 +1031,6 @@
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
             </Deployment>
-            <ModelSupport>False</ModelSupport>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>
     </ProjectExtensions>

--- a/windows/src/desktop/setup/setup.dproj
+++ b/windows/src/desktop/setup/setup.dproj
@@ -1031,6 +1031,7 @@
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
             </Deployment>
+            <ModelSupport>False</ModelSupport>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>
     </ProjectExtensions>


### PR DESCRIPTION
Fixes #1864
There was a time,  up to version 11 when the Product version GUID was the same between versions. That is no longer the case.
Now we only set defaults if no previous installed version exists.

There were a few snags along the way if the MSI installer requests a reboot after installing a previous version of Keyman, then on reboot the `FInstallInfo.InstalledVersion.Version` will be empty. 
Added switch of `-d` to the command line which if it is set the defaults will be set. 
When msi installer requests a reboot the command to run after reboot can be set to include `-d`.

It would be good to move the checking of the `FInstallInfo.InstalledVersion.Version` into `bootstrapmain.pas`  however the version is not available at this point. So it needs to be checked in the `RunTool.pas` however whether it is a first run or continuing install after a reboot needs to passed through with the flag `ContineSetup`. 