### PR TITLE
chore(ios): Document minimum iOS version 12.1

### DIFF
--- a/ios/help/about/system-requirements.md
+++ b/ios/help/about/system-requirements.md
@@ -6,4 +6,4 @@ title: System Requirements - Keyman for iPhone and iPad Help
 
 ### Minimum iOS Version
 Keyman for iPhone and iPad will run on Apple iPhones and iPads that have a minimum version of
-iOS 9.
+iOS 12.1.

--- a/ios/help/about/whatsnew.md
+++ b/ios/help/about/whatsnew.md
@@ -4,14 +4,9 @@ title: What's New
 
 Here are some of the new features we have added to Keyman for iPhone and iPad 15.0:
 
-* Simpler and smoother keyboard search
-* Localizable UI through [translate.keyman.com](https://translate.keyman.com)
-  * Translations for French, German, and Khmer have already been added
-* Consolidated crash reporting to [sentry.keyman.com](https://sentry.keyman.com)
-* Choose associated language(s) when keyboard is installed (#3437)
-* Improved batching of keyboard and dictionary downloads (#3458)
-* Improved corrections and predictions (#3555)
-* Match user input capital letters when offering suggestions (#3845)
+* Verify Keyman supports a keyboard package before installing
+* Fix positioning and style of popup keys
+* Update minimum iOS version to 12.1
 
 [![](../ios_images/video.png) Watch a video](https://youtu.be/Tm-7Rvs-6Ig)
 that highlights some of these new features.


### PR DESCRIPTION
Documents the change from #5168 of the minimum iOS version to 12.1

@keymanapp-test-bot skip