### PR TITLE
fix(android/engine): Show keyboard after rotating

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -225,7 +225,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public void onKeyboardChanged(String newKeyboard) {
-    // Do nothing
+    KMManager.showSystemKeyboard();
   }
 
   @Override

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -309,9 +309,8 @@ function hideKeyboard() {
 }
 
 function showKeyboard() {
-  var kmw=window['keyman'];
   // Refresh KMW OSK
-  kmw.correctOSKTextSize();
+  keyman.correctOSKTextSize();
 }
 
 function showHelpBubble() {

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -308,6 +308,12 @@ function hideKeyboard() {
   window.location.hash = 'hideKeyboard' + fragmentToggle;
 }
 
+function showKeyboard() {
+  var kmw=window['keyman'];
+  // Refresh KMW OSK
+  kmw.correctOSKTextSize();
+}
+
 function showHelpBubble() {
   fragmentToggle = (fragmentToggle + 1) % 100;
   var kmw = window['keyman'];

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -262,6 +262,11 @@ final class KMKeyboard extends WebView {
     loadJavascript(jsString);
   }
 
+  public void showKeyboard() {
+    String jsString = "showKeyboard()";
+    loadJavascript(jsString);
+  }
+
   public void executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
     String jsFormat = "executeHardwareKeystroke(%d,%d, %d, %d)";
     String jsString = KMString.format(jsFormat, code, shift, lstates, eventModifiers);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -647,6 +647,12 @@ public final class KMManager {
     }
   }
 
+  public static void showSystemKeyboard() {
+    if (SystemKeyboard != null) {
+      SystemKeyboard.showKeyboard();
+    }
+  }
+
   public static boolean isKeyboardLoaded(KeyboardType type) {
     if (type == KeyboardType.KEYBOARD_TYPE_INAPP) {
       return InAppKeyboardLoaded;


### PR DESCRIPTION
Fixes #5277 and possibly fixes #5965

Update SystemKeyboard to show the keyboard after a keyboard change.

## User Testing
Setup
1. Install the the PR build of Keyman for Android
2. Dismiss the "Getting Started" menu and enable Keyman as the default system keyboard

* **TEST_ROTATION** - Verifies the Keyman keyboard is visible after rotating device and the layer can change
1. Launch a separate app (e.g. Twitter or Chrome)
2. With the Keyman keyboard, start typing. Note, any stuck popup keys are addressed separately by #6494
3. Select the "Shift" layer and continue typing
4. Rotate the device
5. Verify after rotation, the Keyman keyboard refreshes and is visible. Note, the layer reverts to Default layer.
6. Continue typing
7. Verify the keyboard continues to output text in the current field and it's lower-case (default layer of SIL EuroLatin).
8. Select the "Shift" layer
9. Verify the keyboard displays the Shift layer
10. Type a character
11. Verify the keyboard outputs a capital letter and stays on the Shift layer (with SIL Euro Latin keyboard)