### PR TITLE
chore(common): Update Crowding strings for Azerbaijani

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-az-rAZ/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-az-rAZ/strings.xml
@@ -18,6 +18,10 @@
   <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">Yeniləməni quraşdır</string>
   <!-- Context: Title -->
   <string name="title_version" comment="Title of Keyman for Android version">Versiya: %1$s</string>
+  <!-- Context: Text label when old Chrome version installed -->
+  <string name="text_require_chrome_57" comment="Banner text when old version of Chrome is installed">Keyman Chrome 57 və ya daha yeni versiyasını tələb edir.</string>
+  <!-- Context: Button label -->
+  <string name="button_update_chrome" comment="Prompt to upgrade Chrome in the Play Store">Chrome yeniləşdirin</string>
   <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
   <string name="textview_hint" comment="Prompt to start typing">Burada mətn daxil edin&#8230;</string>
   <!-- Context: Splash screen (version/copyright info currently disabled -->
@@ -56,7 +60,27 @@
   <!-- Context: Keyman Settings menu -->
   <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">Klaviatura və ya sözlügü quraşdırmaq</string>
   <!-- Context: Keyman Settings menu -->
-  <string name="change_display_language" comment="Menu action to change interface language">Ekran dili deyişdirmək</string>
+  <string name="change_display_language" comment="Menu action to change interface language">Ekran dili</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="adjust_keyboard_height" comment="Menu action to adjust keyboard height">Klaviaturanın hündürlüyünü tənzimlə</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">Ara düymənin mətni</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">Klaviatura</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">Dil</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">Dil + klaviatura</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">Boş</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">Klaviatura adı ara düyməsində göstərilsin</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">Dil adı ara düyməsində göstərilsin</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">Dil və klaviatura ara düyməsində</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">Ara düyməsində mətni göstərilməsin</string>
   <!-- Context: Keyman Settings menu -->
   <string name="show_banner" comment="text suggestions banner">Həmişə elan göstər</string>
   <!-- Context: Keyman Settings menu -->
@@ -87,6 +111,12 @@
   <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">%1$s dili  %2$s-ya əlavə edildi</string>
   <!-- Context: Select Package and Select Languages menu -->
   <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">Bütün dillər artıq quraşdırılıb</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="drag_the_keyboard" comment="First line of adjusting keyboard height">Hündürlüyünün ölcüsü tənzimləmək üçün klaviaturanı dartın</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="rotate_the_device" comment="Second line of adjusting keyboard height">Portret və landşaft tənzimləmək üçün cihazı çevirin</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="reset_to_defaults" comment="Button to reset to default heights">İlkin vəziyyətinə qaytar</string>
   <!-- Context: Keyman Web Browser -->
   <string name="hint_text" comment="Prompt to type in the browser search bar">URL axtarın və ya yazın</string>
   <!-- Context: Keyman Web Browser -->
@@ -121,4 +151,6 @@
   <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">Klaviatura paketinin qurulacaq əlaqəli dilləri yoxdur</string>
   <!-- Context: KMP Package strings -->
   <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Paketdə yanlış / itkin metaverilənlər</string>
+  <!-- Context: KMP Package strings -->
+  <string name="minimum_keyboard_version_not_supported" comment="Notification when keyboard has functionality not supported by current Keyman">    Keyboard requires a newer version of Keyman</string>
 </resources>

--- a/android/KMEA/app/src/main/res/values-az-rAZ/strings.xml
+++ b/android/KMEA/app/src/main/res/values-az-rAZ/strings.xml
@@ -8,6 +8,11 @@
         <item quantity="other">Klaviatura</item>
     </plurals>
     <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+        <item quantity="one">Digər daxil etmə üsul</item>
+        <item quantity="other">Digər daxil etmə usullar</item>
+    </plurals>
+    <!-- Context: Title for list -->
     <string name="title_add_keyboard" comment="Add a new keyboard">Yeni klaviatura əlavə etmək</string>
     <!-- Context: Title for list -->
     <string name="title_languages_settings" comment="List of installed languages">Quraşdırılmış Dillər</string>
@@ -21,8 +26,12 @@
     <string name="label_cancel" comment="Button to cancel an action">Ləğv etmək</string>
     <!-- Context: Button label -->
     <string name="label_close" comment="Close a dialog">Bağlamaq</string>
-    <!-- Context: Button label -->
+    <!-- Context: Button label. Removed in Keyman 15 -->
     <string name="label_close_keyman" comment="Close the Keyman application">Keyman bağlamaq</string>
+    <!-- Context: Button label -->
+    <string name="label_forward" comment="Button to go forward">İrəli</string>
+    <!-- Context: Button label -->
+    <string name="label_next_input_method" comment="Switch to next input method (replaces label_close_keyman)">Növbəti daxil etmə üsul</string>
     <!-- Context: Button label -->
     <string name="label_download" comment="Button to confirm downloading an item">Yükləyin</string>
     <!-- Context: Button label -->
@@ -69,8 +78,11 @@
     <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">FileProvider (Fayl Təminatçısı) kitabxanasına kömək sənədinə baxmaq lazımdır:%1$s</string>
     <!-- Context: Fatal keyboard error. Will load default keyboard -->
     <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">%3$s dili üçün %1$s ilə ölümcül klaviatura xətası :%3$s dili üçün %2$s. Varsayılan klaviatura yüklənir.</string>
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">%3$s dil üçün %1$s:%2$s klaviaturasında xəta.</string>
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Yükləmək üçün əlaqəli lüğət yoxlanılır</string>
+    <string name="cannot_query_associated_model" comment="Cannot reach server to check if there's an available dictionary to download">      Cannot connect to Keyman server to check for associated dictionary to download</string>
     <!-- Context: Model Updates -->
     <string name="confirm_download_model" comment="Confirmation to download a dictionary update">Bu lüğətin son versiyasını yükləmək istərdinizmi?</string>
     <!-- Context: No associated dictionary found -->
@@ -121,8 +133,13 @@
     <string name="enable_predictions" comment="Enable predictions from the suggestion banner">Proqnozları aktivləşdirmək</string>
     <!-- Context: Language Settings menu strings -->
     <string name="model_label">Lüğət</string>
+    <plurals name="model_count">
+        <item quantity="one">Dictionary</item>
+        <item quantity="other">Dictionaries</item>
+    </plurals>
     <!-- Context: Language Settings menu substring - Check for available dictionary -->
     <string name="check_available_model" comment="Check for available dictionary">Mövcud lüğəti üçün yoxlamaq</string>
+    <string name="check_model_online" comment="Check for dictionaries online">Check for dictionaries online</string>
     <!-- Context: Language Settings menu strings -->
     <string name="model_info_header" comment="Dictionary name">Lüğət:%1$s</string>
     <!-- Context: Language Settings menu strings -->

--- a/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/az.lproj/Localizable.strings
@@ -49,6 +49,12 @@
 /* Confirmation text to display before uninstalling a lexical model */
 "command-uninstall-lexical-model-confirm" = "Bu lüğəti silmək istəyirsiniz?";
 
+/* Text for error when a keyboard cannot load properly */
+"error-loading-keyboard" = "Sorğu edilmiş klaviaturanı yüklənə bilmir";
+
+/* Text for error when a lexical model cannot load properly */
+"error-loading-lexical-model" = "Sorğu edilmiş lüğəti yüklənə bilmir";
+
 /* Text for error when an installed file is unexpectedly missing */
 "error-missing-file" = "Tələb olunan fayl tapıla bilmədi.";
 
@@ -112,11 +118,17 @@
 /* Error opening a Keyman package - package is not valid */
 "kmp-error-invalid" = "Paketin faylı zədəlidir.";
 
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "Müəyyənləşdirilmiş paketi mövcud deyil.";
+
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "Bu paket tələb olunan klaviatura və ya lüğəti ehtiva etmir.";
 
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "Bu paket düzgün qurulmamışdır - məzmunu bilinmir.";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "Bu paket sizin cihazınız üçün dəstəyini daxil etmir.";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "Bu paketdə gözlənilən resurs növü yoxdur.";
@@ -180,6 +192,36 @@
 
 /* Title for the main Settings menu */
 "menu-settings-title" = "Keyman Parametrləri";
+
+/* Secondary text showing current setting for spacebar caption - blank */
+"menu-settings-spacebar-hint-blank" = "Ara düyməsində mətni göstərilməsin";
+
+/* Secondary text showing current setting for spacebar caption - keyboard */
+"menu-settings-spacebar-hint-keyboard" = "Klaviatura adı ara düyməsində göstərilsin";
+
+/* Secondary text showing current setting for spacebar caption - language */
+"menu-settings-spacebar-hint-language" = "Dil adı ara düyməsində göstərilsin";
+
+/* Secondary text showing current setting for spacebar caption - language + keyboard */
+"menu-settings-spacebar-hint-languageKeyboard" = "Dil və klaviatura adı ara düyməsində göstərilsin";
+
+/* Label for the "Spacebar Caption" item on the main settings screen */
+"menu-settings-spacebar-text" = "Ara düymənin mətni";
+
+/* Title for the "Spacebar Caption" settings screen */
+"menu-settings-spacebar-title" = "Ara düymənin mətni";
+
+/* Text showing name of spacebar caption - blank */
+"menu-settings-spacebar-item-blank" = "Boş";
+
+/* Text showing name of spacebar caption - keyboard */
+"menu-settings-spacebar-item-keyboard" = "Klaviatura";
+
+/* Text showing name of spacebar caption - language */
+"menu-settings-spacebar-item-language" = "Dil";
+
+/* Text showing name of spacebar caption - language + keyboard */
+"menu-settings-spacebar-item-languageKeyboard" = "Dil və klaviatura";
 
 /* Short text for notification:  download failure for keyboard */
 "notification-download-failure-keyboard" = "Klaviatura endirilmədi";

--- a/linux/keyman-config/locale/az_AZ.po
+++ b/linux/keyman-config/locale/az_AZ.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: keyman\n"
 "Report-Msgid-Bugs-To: <support@keyman.com>\n"
 "POT-Creation-Date: 2020-08-19 19:17+0200\n"
-"PO-Revision-Date: 2021-04-30 02:05\n"
+"PO-Revision-Date: 2022-04-08 02:57\n"
 "Last-Translator: \n"
 "Language-Team: Azerbaijani\n"
 "Language: az_AZ\n"
@@ -101,7 +101,7 @@ msgstr "Ətraflı məlumat"
 
 #: keyman_config/install_window.py:248
 msgid "README"
-msgstr ""
+msgstr "MƏNİOXYUYUN"
 
 #: keyman_config/install_window.py:256 keyman_config/view_installed.py:200
 msgid "_Install"

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/az.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/az.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "Bağla";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "Lisenziya Razılaşması";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "Konfiqurasiya...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/az.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/az.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "Həmişə ekrandakı klaviaturasını göstər";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "Uzun əmr sətri qeyd etməni istifadə et";
+
+/* Support button text  */
+"93O-x6-RLF.label" = "Dəstək";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "Klaviaturanı endir...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "Keyman konfiqurasiyası";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "Geri";
+
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "Keyboards";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "Uzun qeyd etmə seçimi aktivləşdiriləndə, Keyman destəkiçilərə problemi müəyyənləşdirmək üçün kömək edə bilən hərəkətləri qeyd edəcək. Əmr sətri proqramı Keymandan mesajlarının qeydləri baxmaq üçün istifadə edə bilər. Əmr sətridə süzgəc seçin ki, Keyman prosesindən bütün mesajları göstərilsin. Bu qeydlərinin sirası ixrac edilə bilər, və lazım olanda Keyman dəstəyə göndərilə bilər.";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "İrəli";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "Əsas səhifə";
+
+/* Options button text */
+"frd-No-seV.label" = "Seçimlər";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "Quraşdırılmış klaviaturası";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "Müəyyən bir klaviaturanı və ya ümumiyyətlə Keyman ilə problemlər yarınırsa, bu seçimi aktivləşdirin.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/az.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/az.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "Package Information";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "Ətraflı məlumat";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "Məni oxuyun";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/az.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/az.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "Klaviatura köməyi";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "Oldu";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "Çap et...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/az.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/az.lproj/Localizable.strings
@@ -1,0 +1,62 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "'%@' Klaviaturanı silmək istədiyinizə əminsiniz?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "Bu hərəkət geri qaytara bilməz.";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "Ləğv etmək";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "Sil";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "Keyman klaviaturası quraşdırılsın?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "Keyman '%@' fayldan klaviaturanı quraşdırsınmı?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "Ləğv etmək";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "Quraşdır";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "Keyman faylı '%@' oxuya bilmədi.";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "Oldu";
+
+/* label text to identify Keyman version */
+"version-label-text" = "Versiya %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "Endirilir...";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "Endirmə başa çatdı.";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "Ləğv etmək";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "Hazırdır";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "Keyboards:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "Fonts:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "Package Version:";
+
+/* author label in the Package Information window */
+"author-label" = "Author:";
+
+/* website label in the Package Information window */
+"website-label" = "Website:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "Copyright:";

--- a/mac/Keyman4MacIM/Keyman4MacIM/az.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/az.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "Konfiqurasiya...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "Klaviaturalar";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "Klaviaturalar";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "Haqqında";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "Ekran klaviaturası";

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -19,7 +19,7 @@
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKButtonYes" comment="Yes button in message boxes">&amp; Bəli</string>
+  <string name="SKButtonYes" comment="Yes button in message boxes">&amp;Bəli</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
@@ -47,7 +47,7 @@
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.330.0 -->
-  <string name="SKBalloonClickToSelectKeyboard" comment="Balloon that shows when Keyman icon is first shown during the tutorial">Klaviatura seçmək üçün bu işarəni vurun</string>
+  <string name="SKBalloonClickToSelectKeyboard" comment="Balloon that shows when Keyman icon is first shown during the tutorial">Klaviatura seçmək üçün bu nişana klikləyin</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.330.0 -->
@@ -151,7 +151,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Caption_LayoutType" comment="Keyboard download window, etc. - term for keyboard layout type (keyboard layout types include Fixed and Mnemonic)">Düzüm növü:</string>
+  <string name="S_Caption_LayoutType" comment="Keyboard download window, etc. - term for keyboard layout type (keyboard layout types include Fixed and Mnemonic)">Düzülüş növü:</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -300,7 +300,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koShowWelcome" comment="Startup options - show/hide welcome screen">Salamlama ekranını göstərin</string>
+  <string name="koShowWelcome" comment="Startup options - show/hide welcome screen">Xoş gəldiniz ekranını göstərin</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
@@ -308,7 +308,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.236.0 -->
-  <string name="koTestKeymanFunctioning" comment="Startup options - test for conflicting apps when Product starts">Keyman başlayanda ziddiyyətli tətbiqetmələr üçün test etmək</string>
+  <string name="koTestKeymanFunctioning" comment="Startup options - test for conflicting apps when Product starts">Keyman başlayanda ziddiyyətli tətbiqetmələr üçün test et</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.236.0 -->
@@ -601,7 +601,7 @@
   <!-- Context: Online Update Dialog -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.288.0 -->
-  <string name="SKUpdate_IconMenuText" comment="Update icon - install menu item">Keyman yeniləmələrinə baxın &amp; və quraşdırın</string>
+  <string name="SKUpdate_IconMenuText" comment="Update icon - install menu item">Keyman yeniləmələrinə baxın &amp;və quraşdırın</string>
   <!-- Context: Online Update Dialog -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.288.0 -->
@@ -733,7 +733,7 @@
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">Keyman &amp; söndərmək düyməsini dəyişdirin</string>
+  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">Keyman &amp;söndərmək düyməsini dəyişdirin</string>
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/desktop/setup/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/setup/locale/az-AZ/strings.xml
@@ -21,8 +21,8 @@
   <string name="ssActionDownload">(%0:s endirmə)</string>
   <string name="ssActionInstall">Quraşdırma quraşdıracaq:</string>
   <string name="ssFreeCaption">$APPNAME $VERSION pulsuz və açıq mənbəlidir</string>
-  <string name="ssLicenseLink">&amp; Lisenziyanı oxuyun</string>
-  <string name="ssInstallOptionsLink">Quraşdırma &amp; seçimlər</string>
+  <string name="ssLicenseLink">&amp;Lisenziyanı oxuyun</string>
+  <string name="ssInstallOptionsLink">Quraşdırma &amp;seçimlər</string>
   <string name="ssMessageBoxTitle">$APPNAME Quraşdırma</string>
   <string name="ssOkButton">Oldu</string>
   <string name="ssInstallButton">&amp;Quraşdırmaql</string>


### PR DESCRIPTION
Addresses the English strings in #5531 

All the iOS strings for Azerbaijani should be complete. there's still a few missing macOS.

@keymanapp-test-bot skip