### PR TITLE
chore(android/app): Add description for referrer response error

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -79,6 +79,9 @@ public class CheckInstallReferrer {
             // Connection couldn't be established; log to Sentry
             KMLog.LogError(TAG, "onInstallReferrerSetupFinished:SERVICE_UNAVAILABLE");
             break;
+          case InstallReferrerClient.InstallReferrerResponse.PERMISSION_ERROR:
+            KMLog.LogError(TAG, "onInstallReferrerSetupFinished.PERMISSION_ERROR");
+            break;
           default:
             // There are some other error codes; log to Sentry
             KMLog.LogError(TAG, "onInstallReferrerSetupFinished: Unexpected code: " +


### PR DESCRIPTION
For investigating [Sentry report](https://sentry.io/organizations/keyman/issues/2700298447/?project=5983520&query=is%3Aunresolved&statsPeriod=14d)

```
onInstallReferrerSetupFinished: Unexpected code: 4
```
This was added in [Play Install Referrer API Library 2.2](https://developer.android.com/google/play/installreferrer/release-notes#2_2) which added the response `PERMISSION_ERROR`

Unfortunately the documentation is sparse on how to fix non-OK responses (the Android [sample code](https://developer.android.com/google/play/installreferrer/library#connecting) isn't even updated to include the new response).

All the non-OK responses seem to get lumped in the same Sentry issue.

@keymanapp-test-bot skip