### PR TITLE
fix(web): keyboardchange event should defer until successful

### DIFF
--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -477,7 +477,12 @@ namespace com.keyman.keyboards {
       // if(!PLgCode && (<KeymanBase>keymanweb).keyboardManager.activeStub) {
       //   PLgCode = (<KeymanBase>keymanweb).keyboardManager.activeStub['KLC'];
       // }
-      this.doKeyboardChange(PInternalName, PLgCode);
+      let _this = this;
+      p.then(function() {
+        // Only mark the keyboard as having changed once the setActiveKeyboard op
+        // is successful.
+        _this.doKeyboardChange(PInternalName, PLgCode);
+      })
 
       p.catch(error => {
         // Rejection indicates a failure of the keyboard to load.

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -477,12 +477,12 @@ namespace com.keyman.keyboards {
       // if(!PLgCode && (<KeymanBase>keymanweb).keyboardManager.activeStub) {
       //   PLgCode = (<KeymanBase>keymanweb).keyboardManager.activeStub['KLC'];
       // }
-      let _this = this;
+      const _this = this;
       p.then(function() {
         // Only mark the keyboard as having changed once the setActiveKeyboard op
         // is successful.
         _this.doKeyboardChange(PInternalName, PLgCode);
-      })
+      });
 
       p.catch(error => {
         // Rejection indicates a failure of the keyboard to load.

--- a/web/testing/promise-api/eventLogging.js
+++ b/web/testing/promise-api/eventLogging.js
@@ -1,0 +1,45 @@
+function attachLoggingEvents() {
+
+  keyman.addEventListener('beforekeyboardchange', beforeChange);
+  keyman.addEventListener('keyboardchange', change);
+  keyman.addEventListener('keyboardloaded', loaded);
+  keyman.addEventListener('keyboardregistered', registered);
+}
+
+function appendLog(logText) {
+  if(this.loggingElement === undefined) {
+    this.loggingElement = document.getElementById('eventLogging');
+  }
+  if(this.loggingElement.value) {
+    logText = '\n' + logText;
+  }
+  this.loggingElement.value += logText;
+}
+
+function beforeChange(props) {
+  if(!loggingActive) {
+    return;
+  }
+  appendLog('beforekeyboardchange: ' + JSON.stringify(props));
+}
+
+function change(props) {
+  if(!loggingActive) {
+    return;
+  }
+  appendLog('keyboardchange: ' + JSON.stringify(props));
+}
+
+function loaded(props) {
+  if(!loggingActive) {
+    return;
+  }
+  appendLog('keyboardloaded: ' + JSON.stringify(props));
+}
+
+function registered(props) {
+  if(!loggingActive) {
+    return;
+  }
+  appendLog('keyboardregistered: ' + JSON.stringify(props));
+}

--- a/web/testing/promise-api/eventLogging.js
+++ b/web/testing/promise-api/eventLogging.js
@@ -21,6 +21,7 @@ function beforeChange(props) {
     return;
   }
   appendLog('beforekeyboardchange: ' + JSON.stringify(props));
+  appendLog('- active keyboard: ' + keyman.getActiveKeyboard());
 }
 
 function change(props) {
@@ -28,6 +29,7 @@ function change(props) {
     return;
   }
   appendLog('keyboardchange: ' + JSON.stringify(props));
+  appendLog('- active keyboard: ' + keyman.getActiveKeyboard());
 }
 
 function loaded(props) {
@@ -35,6 +37,7 @@ function loaded(props) {
     return;
   }
   appendLog('keyboardloaded: ' + JSON.stringify(props));
+  appendLog('- active keyboard: ' + keyman.getActiveKeyboard());
 }
 
 function registered(props) {
@@ -42,4 +45,5 @@ function registered(props) {
     return;
   }
   appendLog('keyboardregistered: ' + JSON.stringify(props));
+  appendLog('- active keyboard: ' + keyman.getActiveKeyboard());
 }

--- a/web/testing/promise-api/eventLogging.js
+++ b/web/testing/promise-api/eventLogging.js
@@ -1,21 +1,66 @@
-function attachLoggingEvents() {
+var loggingActive = false;
+var loggingElement = null;
 
+// ------- UI aspects -------
+
+// Handles activation/deactivation of logging (via radio buttons)
+function eventLogChange() {
+  const logActiveRadio = document.getElementById('eventLog-on');
+  const offLabel = document.getElementById('event-label-off');
+  const onLabel = document.getElementById('event-label-on');
+
+  const loggingDiv = document.getElementById('logZone');
+  const hasLoggingText = !!loggingElement.value;
+
+  const active = logActiveRadio.checked;
+  loggingActive = active;
+
+  offLabel.className = active ? '' : 'active';
+  onLabel.className  = active ? 'active' : '';
+
+  loggingDiv.style.display = active || hasLoggingText ? 'block' : 'none';
+}
+
+// Exactly what it says - flushes / clears the logged-events textbox.
+function flushLogs() {
+  loggingElement.value = '';
+
+  eventLogChange();
+}
+
+// UI + initialization
+window.addEventListener('load', function() {
+  let alertLink = null;
+  if(alertType) {
+    alertLink = document.getElementById('alert_default');
+  } else {
+    alertLink = document.getElementById('alert_disabled');
+  }
+
+  alertLink.className += 'active';
+  loggingElement = document.getElementById('eventLogging');
+
+  attachLoggingEvents();
+});
+
+// ------- Logging aspects -------
+
+function attachLoggingEvents() {
   keyman.addEventListener('beforekeyboardchange', beforeChange);
   keyman.addEventListener('keyboardchange', change);
   keyman.addEventListener('keyboardloaded', loaded);
   keyman.addEventListener('keyboardregistered', registered);
 }
 
+// Gives us a nice, console.log-ish way to output to the textbox.
 function appendLog(logText) {
-  if(this.loggingElement === undefined) {
-    this.loggingElement = document.getElementById('eventLogging');
-  }
-  if(this.loggingElement.value) {
+  if(loggingElement.value) {
     logText = '\n' + logText;
   }
-  this.loggingElement.value += logText;
+  loggingElement.value += logText;
 }
 
+// The handlers attached within attachLoggingEvents().
 function beforeChange(props) {
   if(!loggingActive) {
     return;

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -20,6 +20,7 @@
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
       #KeymanWebControl {width:50%;min-width:600px;}
+      .active {font-weight:bold}
     </style>
 
     <!-- Insert uncompiled KeymanWeb source scripts -->
@@ -41,7 +42,6 @@
     <script>
       // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
       const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
-      var alertText = alertType ? 'enabled(default)' : 'disabled';
 
       var kmw=window.keyman;
 
@@ -53,12 +53,24 @@
       }).then(function() {
         loadKeyboards();
       });
+
+      function onLoad() {
+        let alertLink = null;
+        if(alertType) {
+          alertLink = document.getElementById('alert_default');
+        } else {
+          alertLink = document.getElementById('alert_disabled');
+        }
+
+        var alertText = alertType ? 'enabled(default)' : 'disabled';
+        alertLink.className += 'active';
+      }
     </script>
 
   </head>
 
 <!-- Sample page HTML -->
-  <body>
+  <body onload='onLoad();'>
     <h2>KeymanWeb Sample Page - Promise API</h2>
     <p>This page is for testing the Promises returned from adding keyboards.
       See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044.</a>
@@ -71,18 +83,13 @@
       for any of the three keyboard-adding options at the bottom of the page.
     </p>
 
-    <p id="modeSelect">You are currently testing under the internal alerts <em id="mode"> </em> mode.
-    Two alert modes are available:
+    <p id="modeSelect">Two internal-alert testing modes are available:
     <a id="alert_disabled" href="./index.html?useAlerts=false">Disabled</a> or
     <a id="alert_default" href="./index.html">Enabled (Default)</a></p>
     <p>This will only affect whether or not KeymanWeb's alert modal is displayed.
       A native browser alert and dev-console error log will occur regardless of this
       setting when stub fetch errors occur.
     </p>
-
-<script>
-      document.getElementById("mode").textContent = alertText;
-    </script>
 
     <div>
     <!--

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -19,6 +19,7 @@
       body {font-family: Tahoma,helvetica;}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      .log  {font-size: 1em; width:80%; min-height:80px; max-height: 80px; border: 1px solid gray;}
       #KeymanWebControl {width:50%;min-width:600px;}
       .active {font-weight:bold}
     </style>
@@ -37,6 +38,7 @@
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <script src="promisehdr.js"></script>
+    <script src="eventLogging.js"></script>
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
@@ -44,6 +46,32 @@
       const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
 
       var kmw=window.keyman;
+
+      var loggingActive = false;
+
+      function eventLogChange() {
+        const logActiveRadio = document.getElementById('eventLog-on');
+        const offLabel = document.getElementById('event-label-off');
+        const onLabel = document.getElementById('event-label-on');
+
+        const loggingDiv = document.getElementById('logZone');
+        const hasLoggingText = !!document.getElementById('eventLogging').value;
+
+        const active = logActiveRadio.checked;
+        loggingActive = active;
+
+        offLabel.className = active ? '' : 'active';
+        onLabel.className  = active ? 'active' : '';
+
+        loggingDiv.style.display = active || hasLoggingText ? 'block' : 'none';
+      }
+
+      function flushLogs() {
+        const loggingElement = document.getElementById('eventLogging');
+        loggingElement.value = '';
+
+        eventLogChange();
+      }
 
       // Test adding keyboards before kmw.init get deferred
       addKeyboards('french','@he');
@@ -64,6 +92,8 @@
 
         var alertText = alertType ? 'enabled(default)' : 'disabled';
         alertLink.className += 'active';
+
+        attachLoggingEvents();
       }
     </script>
 
@@ -90,6 +120,22 @@
       A native browser alert and dev-console error log will occur regardless of this
       setting when stub fetch errors occur.
     </p>
+
+    <hr>
+    <p>Two keyboard-change related event-logging modes are available:
+      <div>
+        <input type='radio' id='eventLog-off' name='eventLog' value='off' onchange='eventLogChange()' checked>
+        <label id='event-label-off' for='eventLog-off' class='active'>No logging</label>
+
+        <input type='radio' id='eventLog-on' name='eventLog' value='on' onchange='eventLogChange()'>
+        <label id='event-label-on' for='eventLog-on'>Logging</label>
+      </div>
+    </p>
+    <div id='logZone' style='display:none'>
+      <textarea id='eventLogging' class='log' disabled></textarea>
+      <input type='button' id='logFlusher' style='display: block' onclick='flushLogs();' value='Clear event logs' />
+    </div>
+    <hr>
 
     <div>
     <!--

--- a/web/testing/promise-api/index.html
+++ b/web/testing/promise-api/index.html
@@ -47,32 +47,6 @@
 
       var kmw=window.keyman;
 
-      var loggingActive = false;
-
-      function eventLogChange() {
-        const logActiveRadio = document.getElementById('eventLog-on');
-        const offLabel = document.getElementById('event-label-off');
-        const onLabel = document.getElementById('event-label-on');
-
-        const loggingDiv = document.getElementById('logZone');
-        const hasLoggingText = !!document.getElementById('eventLogging').value;
-
-        const active = logActiveRadio.checked;
-        loggingActive = active;
-
-        offLabel.className = active ? '' : 'active';
-        onLabel.className  = active ? 'active' : '';
-
-        loggingDiv.style.display = active || hasLoggingText ? 'block' : 'none';
-      }
-
-      function flushLogs() {
-        const loggingElement = document.getElementById('eventLogging');
-        loggingElement.value = '';
-
-        eventLogChange();
-      }
-
       // Test adding keyboards before kmw.init get deferred
       addKeyboards('french','@he');
 
@@ -81,26 +55,12 @@
       }).then(function() {
         loadKeyboards();
       });
-
-      function onLoad() {
-        let alertLink = null;
-        if(alertType) {
-          alertLink = document.getElementById('alert_default');
-        } else {
-          alertLink = document.getElementById('alert_disabled');
-        }
-
-        var alertText = alertType ? 'enabled(default)' : 'disabled';
-        alertLink.className += 'active';
-
-        attachLoggingEvents();
-      }
     </script>
 
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='onLoad();'>
+  <body>
     <h2>KeymanWeb Sample Page - Promise API</h2>
     <p>This page is for testing the Promises returned from adding keyboards.
       See <a href="https://github.com/keymanapp/keyman/issues/5044">Specification #5044.</a>


### PR DESCRIPTION
Fixes #5730.

A `kmw.keyboardchange` event should only occur once the keyboard has been successfully changed.  For initial loads of a keyboard, this is an asynchronous process - so it must interact with the `Promise` system.  Fortunately, `Promise`s (and our `setActiveKeyboard()` implementations of them) make this fairly simple.

Note that it _is_ currently expected that on a keyboard's first load, `beforekeyboardchange` will be called twice - once for the initial change attempt, then another once the keyboard's script has actually been loaded:

https://github.com/keymanapp/keyman/blob/bb4887387729a2ea5761e4e0d7d19c118eac6d9f/web/source/keyboards/kmwkeyboards.ts#L753-L757

(More context may prove useful, but I didn't want it to overwhelm this description.)

------

To facilitate testing these changes, I've made modifications to the old Promise API test page for Web.  In particular, check out this new zone of the page:

<img width="762" alt="Screen Shot 2022-04-18 at 10 22 44 AM" src="https://user-images.githubusercontent.com/25213402/163830946-3a10152b-1ea4-4a79-813d-080de9504324.png">

The text box and button will only display under two conditions:
- Logging has been enabled
- Existing log text (once disabled) has not been cleared.

------

# User Testing

First, please note the details above regarding the "Promise API testing" page.  We'll be using that for these tests.
- Also known as `web/testing/promise-api`.

Feel free to use your preferred desktop browser for these tests.  Any one of the following should do:
- Edge
- Firefox
- Chrome
- Safari

## Actual Tests

- TEST_FIRST_LOAD:  Tests the initial load of a keyboard, which is performed asynchronously.

  1.  Enable event logging.  Be sure the logging text area and "Clear Event Logs" button appear.
  2. Click the text area beneath the text "Type in your language in this text area".
      - Do not fail this test if log entries appear at this step.
  3. Use the keyboard selection menu to swap to "French - French".
  
  Expected result:
  
  ```
  beforekeyboardchange: {"internalName":"Keyboard_french","languageCode":"fr"}
  - active keyboard: Keyboard_us
  keyboardloaded: {"keyboardName":"Keyboard_french"}
  - active keyboard: 
  beforekeyboardchange: {"internalName":"Keyboard_french","languageCode":"fr"}
  - active keyboard: 
  keyboardchange: {"internalName":"Keyboard_french","languageCode":"fr","indirect":false}
  - active keyboard: Keyboard_french
  ```

  Again, do not fail the test if there are extra lines before these as a result of step 2.  Simply ensure that the final lines of the log match the lines shown above, in this order.

- TEST_SECOND_LOAD:  Tests subsequent loads of a keyboard, which should occur synchronously.

  1.  If enabled, **disable** event logging.  "Clear" the logs if the logging text area does not disappear.
  2. Click the text area beneath the text "Type in your language in this text area".
  3. Use the keyboard selection menu to swap to "French - French".
  5. Use the keyboard selection menu to swap to "English - English".
  6. **Now** enable event logging.  Be sure the logging text area and "Clear Event Logs" button appear.
  7. Click the text area beneath the text "Type in your language in this text area".
      - Do not fail this test if log entries appear at this step.
  8. Use the keyboard selection menu to swap to "French - French".
  
  Expected result:
  
  ```
  beforekeyboardchange: {"internalName":"Keyboard_french","languageCode":"fr"}
  - active keyboard: Keyboard_us
  keyboardchange: {"internalName":"Keyboard_french","languageCode":"fr","indirect":false}
  - active keyboard: Keyboard_french
  ```
  
  Again, do not fail the test if there are extra lines before these as a result of step 7.  Simply ensure that the final lines of the log match the lines shown above, in this order.