### PR TITLE
chore(linux): Fix failure in Debian reproducibility testing 🐧

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -7,6 +7,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export PYBUILD_NAME=keyman-config
 export PYBUILD_INSTALL_ARGS=--install-scripts=/usr/share/keyman-config/
 
+export KEYMAN_PKG_BUILD=1
+
 # xenial needs this to be explicit
 export LC_ALL=C.UTF-8
 

--- a/linux/ibus-keyman/tests/run-tests.sh
+++ b/linux/ibus-keyman/tests/run-tests.sh
@@ -5,7 +5,7 @@ BASEDIR=$(realpath $(dirname $0))
 TESTDIR=${XDG_DATA_HOME:-$HOME/.local/share}/keyman/test_kmx
 PID_FILE=/tmp/ibus-keyman-test-pids
 
-if [ -v DEB_BUILD_MULTIARCH ]; then
+if [ -v KEYMAN_PKG_BUILD ]; then
   # During package builds we skip these tests that require to start ibus because
   # ibus requires to find /var/lib/dbus/machine-id or /etc/machine-id, otherwise it fails with:
   # "Bail out! IBUS-FATAL-WARNING: Unable to load /var/lib/dbus/machine-id: Failed to open file


### PR DESCRIPTION
Debian reproducibility testing runs a slightly different package build that seemingly doesn't set the `DEB_BUILD_MULTIARCH` variable. 
This change introduces our own environment variable to detect package builds so that we can skip the ibus-keyman integration tests that require running an X server.

@keymanapp-test-bot skip