### PR TITLE
fix(ios): stops leaking memory on system keyboard rotation

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -38,6 +38,8 @@ class KeymanWebViewController: UIViewController {
   let storage: Storage
   weak var delegate: KeymanWebDelegate?
   private var useSpecialFont = false
+  private var userContentController = WKUserContentController()
+  private let keymanWebViewName: String = "keyman"
 
   // Views
   var webView: KeymanWebView?
@@ -120,11 +122,8 @@ class KeymanWebViewController: UIViewController {
     prefs.javaScriptEnabled = true
     config.preferences = prefs
     config.suppressesIncrementalRendering = false
-
-    let userContentController = WKUserContentController()
-    userContentController.add(self, name: "keyman")
-    config.userContentController = userContentController
-
+    config.userContentController = self.userContentController
+    
     webView = KeymanWebView(frame: CGRect(origin: .zero, size: keyboardSize), configuration: config)
     webView!.isOpaque = false
     webView!.translatesAutoresizingMaskIntoConstraints = false
@@ -150,6 +149,7 @@ class KeymanWebViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    self.userContentController.add(self, name: keymanWebViewName)
   }
   
   // Very useful for immediately adjusting the WebView's properties upon loading.
@@ -159,6 +159,10 @@ class KeymanWebViewController: UIViewController {
     // Initialize the keyboard's size/scale.  In iOS 13 (at least), the system
     // keyboard's width will be set at this stage, but not in viewWillAppear.
     keyboardSize = view.bounds.size
+  }
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    self.userContentController.removeScriptMessageHandler(forName: keymanWebViewName)
   }
 }
 


### PR DESCRIPTION
fixes #6547 

Rotation of the Keyman system in iOS was causing the app to leak memory as the old web view instances used to implement the system keyboard were not being deallocated. This would cause the Keyman keyboard extension to consume more memory and potentially become unstable.

Before this fix, memory consumption increases with each rotation and is not released:
 
![image](https://user-images.githubusercontent.com/89134789/164428391-08d822e9-7d3d-4d4e-8511-74a6a2e9c224.png)

After this fix, memory is quickly reclaimed after many rotations as shown in Xcode:

![image](https://user-images.githubusercontent.com/89134789/164428341-0654cdcf-f943-41b1-b162-9e205f9bb691.png)
