### PR TITLE
fix(android/engine): Check suggestion banner after setting keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2116,17 +2116,17 @@ public final class KMManager {
     globeKeyState = state;
   }
 
-  private static void toggleSuggestionBanner(String languageID, boolean result1, boolean result2) {
+  private static void toggleSuggestionBanner(String languageID, boolean inappKeyboardChanged, boolean systemKeyboardChanged) {
     //reset banner state if new language has no lexical model
     if (currentBanner.equals(KMManager.KM_BANNER_STATE_SUGGESTION)
       && getAssociatedLexicalModel(languageID)==null) {
       currentBanner = KMManager.KM_BANNER_STATE_BLANK;
     }
 
-    if(result1) {
+    if(inappKeyboardChanged) {
       InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
-    if(result2) {
+    if(systemKeyboardChanged) {
       SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1492,7 +1492,9 @@ public final class KMManager {
       result2 = SystemKeyboard.setKeyboard(keyboardInfo);
 
     if (keyboardInfo != null) {
-      registerAssociatedLexicalModel(keyboardInfo.getLanguageID());
+      String languageID = keyboardInfo.getLanguageID();
+      toggleSuggestionBanner(languageID, result1, result2);
+      registerAssociatedLexicalModel(languageID);
     }
 
     return (result1 || result2);
@@ -1521,19 +1523,7 @@ public final class KMManager {
       result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
     }
 
-    if(result1 || result2)
-    {
-      //reset banner state if new language has no lexical model
-      if(currentBanner.equals(KMManager.KM_BANNER_STATE_SUGGESTION)
-        && getAssociatedLexicalModel(languageID)==null)
-        currentBanner = KMManager.KM_BANNER_STATE_BLANK;
-
-      if(result1)
-        InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
-      if(result2)
-        SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
-    }
-
+    toggleSuggestionBanner(languageID, result1, result2);
     registerAssociatedLexicalModel(languageID);
 
     return (result1 || result2);
@@ -2124,6 +2114,21 @@ public final class KMManager {
 
   public static void setGlobeKeyState(GlobeKeyState state) {
     globeKeyState = state;
+  }
+
+  private static void toggleSuggestionBanner(String languageID, boolean result1, boolean result2) {
+    //reset banner state if new language has no lexical model
+    if (currentBanner.equals(KMManager.KM_BANNER_STATE_SUGGESTION)
+      && getAssociatedLexicalModel(languageID)==null) {
+      currentBanner = KMManager.KM_BANNER_STATE_BLANK;
+    }
+
+    if(result1) {
+      InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
+    }
+    if(result2) {
+      SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #6554

The keyboard picker contains logic in `prepareKeyboardSwitch` to determine if the suggestion banner needs to be enabled/disabled. We need to do the same after installing a keyboard / setting new keyboard to determine if the suggestion banner needs to be enabled/disabled.

## User Testing
Setup
1. Load the PR build of "Keyman for Android"

* **TEST_BANNER_TOGGLE** - Tests suggestion banner is enabled/disabled
1. Start Keyman and dismiss the "Get Started" menu
2. Verify the default sil_euro_latin keyboard has suggestions visible
3. From Keyman Settings, search for and install a keyboard that doesn't have a dictionary (e.g. khmer_angkor)
4. Finish the keyboard package installation and verify the keyboard changes to the installed keyboard
5. Verify the suggestion banner is no longer visible
6. Longpress on the globe button to bring up the keyboard picker menu
7. Select sil_euro_latin
8. Verify the suggestion banner is visible 