### PR TITLE
fix(android/engine): Localize some Toast notifications

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ConfirmDialogFragment.java
@@ -106,7 +106,7 @@ public class ConfirmDialogFragment extends DialogFragment {
                 KMKeyboardDownloaderActivity.downloadKeyboard(
                   getActivity(), _langId, _kbId,_preparedCloudApiParams);
               } else {
-                Toast.makeText(getActivity(), "No internet connection", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), getActivity().getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show();
               }
               break;
             case DIALOG_TYPE_DELETE_KEYBOARD :
@@ -121,7 +121,7 @@ public class ConfirmDialogFragment extends DialogFragment {
                 KMKeyboardDownloaderActivity.downloadLexicalModel(getActivity(),
                   _modelId, _preparedCloudApiParams);
               } else {
-                Toast.makeText(getActivity(), "No internet connection", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), getActivity().getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show();
               }
               break;
             case DIALOG_TYPE_DELETE_MODEL :

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -428,7 +428,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     boolean result = removeKeyboard(context, position);
 
     if (result) {
-      Toast.makeText(context, "Keyboard deleted", Toast.LENGTH_SHORT).show();
+      Toast.makeText(context, context.getString(R.string.keyboard_deleted_toast), Toast.LENGTH_SHORT).show();
       BaseAdapter adapter = (BaseAdapter) listAdapter;
       if(adapter != null) {
         adapter.notifyDataSetChanged();
@@ -500,7 +500,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
 
     if (result) {
       if(!silenceNotification) {
-        Toast.makeText(context, "" + "Model deleted", Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, context.getString(R.string.model_deleted), Toast.LENGTH_SHORT).show();
       }
       KMManager.deregisterLexicalModel(modelID);
     }

--- a/android/KMEA/app/src/main/res/values-km-rKH/strings.xml
+++ b/android/KMEA/app/src/main/res/values-km-rKH/strings.xml
@@ -125,6 +125,8 @@
     <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">តើ​អ្នក​ចង់​លុប​បញ្ជី​ពាក្យនេះ​ឬ?</string>
     <!-- Context: Language Settings Keyboard install strings -->
     <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">បានដំឡើង​ក្ដារចុច %1$s</string>
+    <!-- Context: Language Settings Keyboard uninstall strings -->
+    <string name="keyboard_deleted_toast" comment="Notification when a keyboard is deleted">ក្ដារចុចត្រូវបានលុបចេញ</string>
     <!-- Context: Language Settings menu strings -->
     <string name="enable_corrections" comment="Enable corrections from the suggestion banner">បើក​ការកែពាក្យ</string>
     <!-- Context: Language Settings menu strings -->

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@
     <!-- Context: Button label -->
     <string name="label_update" comment="Dialog button to update a resource">Update</string>
 
+    <!-- Context: No internet for updates -->
+    <string name="no_internet_connection" comment="Internet connection missing">No internet connection</string>
 
     <!-- Context: Keyboard Updates -->
     <string name="cannot_connect" comment="Error message when network connection fails">Cannot connect to Keyman server!</string>
@@ -200,9 +202,14 @@
     <!-- Context: Model Info -->
     <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">Would you like to delete this dictionary?</string>
 
+    <!-- Context: Model Deleted -->
+    <string name="model_deleted" comment="Notification when a dictionary is deleted">Dictionary deleted</string>
 
     <!-- Context: Language Settings Keyboard install strings -->
     <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">%1$s keyboard installed</string>
+
+    <!-- Context: Language Settings Keyboard uninstall strings -->
+    <string name="keyboard_deleted_toast" comment="Notification when a keyboard is deleted">Keyboard deleted</string>
 
     <!-- Context: Language Settings menu strings -->
     <string name="enable_corrections" comment="Enable corrections from the suggestion banner">Enable corrections</string>


### PR DESCRIPTION
Fixes #4875

Turns out some of the Toast notifications were using English-only strings. This updates some of them to be localizable.

I've manually edited `values-km-rKH` to include the Khmer string @MakaraSok provided for "Keyboard deleted".

## User Testing
Setup
1. Load the PR build of Keyman for Android

* **TEST_KEYBOARD_DELETED** - Tests the Toast notification is localized when keyboard deleted
1. Start Keyman and dismiss the "Get Started" menu 
2. From the Keyman Settings --> Search for and install a keyboard package (e.g. khmer_angkor)
3. When the keyboard finishes installing, go to Keyman Settings --> Display language --> Set the UI to Khmer
4. Return to Keyman text area and verify the menu UI is in Khmer (may need to click the overflow icon)
5. From Keyman Settings --> Installed languages --> Select the language installed from step 2 --> Select keyboard settings (e.g. Khmer Angkor)
6. On the Keyboard settings page, select "Uninstall keyboard" (above the red line with the QR code)
7. On the Confirmation dialog, click OK (on the right)
8. Verify the Toast notification for "Keyboard deleted" is localized

![keyboard deleted](https://user-images.githubusercontent.com/7358010/165034437-2d2ae950-2108-4264-b292-89a209e76d87.png)

