### PR TITLE
feat(web): adds .getKeyboard().IsRTL, .HasLoaded

### DIFF
--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -258,9 +258,7 @@ namespace com.keyman.keyboards {
       Lr['OskFont'] = Lstub['KOskFont'];
       Lr['HasLoaded'] = !!Lkbd;
 
-      if(Lkbd) {
-        Lr['IsRTL'] = !!Lkbd['KRTL'];
-      }
+      Lr['IsRTL'] = Lkbd ? !!Lkbd['KRTL'] : null;
       return Lr;
     }
 

--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -238,23 +238,29 @@ namespace com.keyman.keyboards {
      *   This was defined as an array, so is kept that way, but
      *   Javascript treats it as an object anyway
      *
-     * @param       {Object}    Lkbd       Keyboard object
+     * @param       {Object}    Lstub      Keyboard stub object
+     * @param       {Object}    Lkbd       Keyboard script object
      * @return      {Object}               Copy of keyboard identification strings
      *
      */
-    private _GetKeyboardDetail = function(Lkbd) { // I2078 - Full keyboard detail
+    private _GetKeyboardDetail = function(Lstub: KeyboardStub, Lkbd: any /* KeyboardScriptObject */) { // I2078 - Full keyboard detail
       var Lr={};
-      Lr['Name'] = Lkbd['KN'];
-      Lr['InternalName'] =  Lkbd['KI'];
-      Lr['LanguageName'] = Lkbd['KL'];  // I1300 - Add support for language names
-      Lr['LanguageCode'] = Lkbd['KLC']; // I1702 - Add support for language codes, region names, region codes, country names and country codes
-      Lr['RegionName'] = Lkbd['KR'];
-      Lr['RegionCode'] = Lkbd['KRC'];
-      Lr['CountryName'] = Lkbd['KC'];
-      Lr['CountryCode'] = Lkbd['KCC'];
-      Lr['KeyboardID'] = Lkbd['KD'];
-      Lr['Font'] = Lkbd['KFont'];
-      Lr['OskFont'] = Lkbd['KOskFont'];
+      Lr['Name'] = Lstub['KN'];
+      Lr['InternalName'] =  Lstub['KI'];
+      Lr['LanguageName'] = Lstub['KL'];  // I1300 - Add support for language names
+      Lr['LanguageCode'] = Lstub['KLC']; // I1702 - Add support for language codes, region names, region codes, country names and country codes
+      Lr['RegionName'] = Lstub['KR'];
+      Lr['RegionCode'] = Lstub['KRC'];
+      Lr['CountryName'] = Lstub['KC'];
+      Lr['CountryCode'] = Lstub['KCC'];
+      Lr['KeyboardID'] = Lstub['KD'];
+      Lr['Font'] = Lstub['KFont'];
+      Lr['OskFont'] = Lstub['KOskFont'];
+      Lr['HasLoaded'] = !!Lkbd;
+
+      if(Lkbd) {
+        Lr['IsRTL'] = !!Lkbd['KRTL'];
+      }
       return Lr;
     }
 
@@ -267,10 +273,16 @@ namespace com.keyman.keyboards {
     getDetailedKeyboards() {
       var Lr = [], Ln, Lstub, Lrn;
 
-      for(Ln=0; Ln < this.keyboardStubs.length; Ln++)  // I1511 - array prototype extended
-      {
+      for(Ln=0; Ln < this.keyboardStubs.length; Ln++) { // I1511 - array prototype extended
         Lstub = this.keyboardStubs[Ln];
-        Lrn = this._GetKeyboardDetail(Lstub);  // I2078 - Full keyboard detail
+        let Lkbd;
+        for(let kbdIndex=0; kbdIndex < this.keyboards.length; kbdIndex++) {
+          if(this.keyboards[kbdIndex]['KI'] == Lstub['KI']) {
+            Lkbd = this.keyboards[kbdIndex];
+            break;
+          }
+        }
+        Lrn = this._GetKeyboardDetail(Lstub, Lkbd);  // I2078 - Full keyboard detail
         Lr=this.keymanweb._push(Lr,Lrn); // TODO:  Resolve without need for the cast.
       }
       return Lr;


### PR DESCRIPTION
Fixes #2238.

Adds two new properties to the return values of [`keyman.getKeyboard()`](https://help.keyman.com/DEVELOPER/ENGINE/WEB/14.0/reference/core/getKeyboard) and `keyman.getKeyboards()`:
- `HasLoaded`:  a boolean indicating whether or not KMW has actually loaded the keyboard.
    - necessary for the following property to be set
    - thus, is surfaced to the site developer so that they can condition upon this if necessary.
    - doesn't matter whether or not the keyboard is _active_ - only that it has been fully _loaded_ by KMW, usually by having been active at one point in the past.
- `IsRTL`:  a 'boolean' indicating whether or not the keyboard is used for a language written right-to-left.
    - Is `.HasLoaded` is `false`, this will be ~`undefined`~ `null` instead.  Hence the quotes on 'boolean'.

The only way forward I can see to alleviate that caveat would require a very interesting use of `_SetActiveKeyboard`, with its `Promise`s.  While theoretically reasonable for one keyboard, it gets problematic because of the batch-request `.getKeyboards` - we'd need to `Promise`-wait on ALL the `Promise`s.  Yes, even for a single request, as the same backing function is used for both.  (Unless we add extra refactoring.)

Even then... this would near-force calls to both `.getKeyboard` and `.getKeyboards` to be deceptively desynchronous, and I don't think we wish to force that wait on API functions that previously had no such wait.  It'd be especially problematic if a keyboard outright failed to load, and still somewhat problematic if the site user had a problematic connection in general.

Instead, by surfacing `.HasLoaded`, a site developer can choose to use other API functions to set the keyboard to active and use its `Promise`s to know when the value is available.  This allows site-devs to take a "lazy" approach and only care once a corresponding keyboard has loaded... which is probably the more likely use-case, anyway.  (KMW has generated an event that a new keyboard has loaded?  _Now_ is when we'd want to make page adjustments if the language is RTL.)