### PR TITLE
fix(common/core/web): Fix forEach loop in SentryManager

### DIFF
--- a/common/core/web/tools/sentry-manager/src/index.ts
+++ b/common/core/web/tools/sentry-manager/src/index.ts
@@ -99,13 +99,15 @@ namespace com.keyman {
     // Sanitizes the event object (in-place) to remove sensitive information
     // from the breadcrumbs and url
     sanitizeEvent(event: any) {
-      event.breadcrumbs.forEach((b: any) => {
-        if (b.category == 'navigation') {
-          let NAVIGATION_PATTERN = /(.*)?(keyboard\.html#[^-]+)-.*/;
-          b.data.from = b.data.from.replace(NAVIGATION_PATTERN, '$1$2');
-          b.data.to = b.data.to.replace(NAVIGATION_PATTERN, '$1$2');
-        }
-      });
+      if (event && event.breadcrumbs) {
+        event.breadcrumbs.forEach((b: any) => {
+          if (b.category == 'navigation') {
+            let NAVIGATION_PATTERN = /(.*)?(keyboard\.html#[^-]+)-.*/;
+            b.data.from = b.data.from.replace(NAVIGATION_PATTERN, '$1$2');
+            b.data.to = b.data.to.replace(NAVIGATION_PATTERN, '$1$2');
+          }
+        });
+      }
 
       if (event.request.url) {
         let URL_PATTERN = /#.*$/;


### PR DESCRIPTION
Fixes Sentry [report](https://sentry.io/organizations/keyman/issues/2798359833/?project=5983524&query=is%3Aunresolved) of `Cannot read properties of undefined (reading 'forEach')`

@keymanapp-test-bot skip