### PR TITLE
fix(windows): use GlobalGetAtomName to access global list

### DIFF
--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -430,7 +430,7 @@ ProcessWMKeymanControl(WPARAM wParam, LPARAM lParam) {
       }
       WORD wAtom = HIWORD(lParam);
       char atomStr[128];
-      if (GetAtomName(wAtom, atomStr, 128)) {
+      if (GlobalGetAtomName(wAtom, atomStr, 128)) {
         isKeymanKeyboardActive = strstr(atomStr, cs_clsidKMTipTextService) != nullptr;
       }
       break;


### PR DESCRIPTION
Fixes #6571
Fixes #6576 

The check to see if the active keyboard was a Keyman keyboard was using the wrong API call `GetAtomName` instead of `GlobalGetAtomName`. So it was never going to find the str associated with the atom.

This had the effect of turning off the pipeline. It also it broke IMX, [ Ctl Alt ] key combinations in some applications as well as the 
right ALT combinations in Khmer Angkor

