### PR TITLE
chore(web): make build paths consistent 🎡

### DIFF
--- a/common/core/web/input-processor/src/tsconfig.json
+++ b/common/core/web/input-processor/src/tsconfig.json
@@ -3,14 +3,14 @@
   "compilerOptions": {
     "allowJs": true,
     "module": "none",
-    "outDir": "../dist/",
+    "outDir": "../build/",
     "declaration": true,
     "inlineSources": true,
     "sourceMap": true,
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],
-    "outFile": "../dist/index.js"
+    "outFile": "../build/index.js"
   },
   "references": [
     { "path": "../../../../../resources/web-environment" },

--- a/common/core/web/keyboard-processor/src/tsconfig.json
+++ b/common/core/web/keyboard-processor/src/tsconfig.json
@@ -3,14 +3,14 @@
   "compilerOptions": {
     "allowJs": true,
     "module": "none",
-    "outDir": "../dist/",
+    "outDir": "../build/",
     "declaration": true,
     "inlineSources": true,
     "sourceMap": true,
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],
-    "outFile": "../dist/index.js"
+    "outFile": "../build/index.js"
   },
   "references": [
     { "path": "../../../../../common/models/types" },

--- a/common/core/web/tools/recorder/src/build.sh
+++ b/common/core/web/tools/recorder/src/build.sh
@@ -47,7 +47,7 @@ if [ $FETCH_DEPS = true ]; then
 fi
 
 # Definition of global compile constants
-OUTPUT_DIR="dist"
+OUTPUT_DIR="build"
 OUTPUT="index.js"
 
 # Ensures that we rely first upon the local npm-based install of Typescript.

--- a/common/core/web/tools/recorder/src/tsconfig.json
+++ b/common/core/web/tools/recorder/src/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
 	"allowJs": true,
 	"module": "none",
-	"outDir": "../dist/",
+	"outDir": "../build/",
 	"inlineSources": true,
   "inlineSourceMap": true,
   "target": "es5",
   "types": ["node"],
   "lib": ["es6"],
-  "outFile": "../dist/index.js"
+  "outFile": "../build/index.js"
   },
   "files": [
     "../node_modules/@keymanapp/models-types/index.d.ts",

--- a/common/core/web/tools/sentry-manager/src/build.sh
+++ b/common/core/web/tools/sentry-manager/src/build.sh
@@ -47,7 +47,7 @@ if [ $FETCH_DEPS = true ]; then
 fi
 
 # Definition of global compile constants
-OUTPUT_DIR="dist"
+OUTPUT_DIR="build"
 OUTPUT="index.js"
 
 # Ensures that we rely first upon the local npm-based install of Typescript.

--- a/common/core/web/tools/sentry-manager/src/tsconfig.json
+++ b/common/core/web/tools/sentry-manager/src/tsconfig.json
@@ -3,12 +3,12 @@
   "compilerOptions": {
     "allowJs": true,
     "module": "none",
-    "outDir": "../dist/",
+    "outDir": "../build/",
     "inlineSources": true,
     "sourceMap": true,
     "target": "es5",
     "lib": ["es6", "dom"],
-    "outFile": "../dist/index.js"
+    "outFile": "../build/index.js"
   },
   "references": [
     { "path": "../../../../../../resources/web-environment" }

--- a/common/core/web/utils/build.sh
+++ b/common/core/web/utils/build.sh
@@ -45,7 +45,7 @@ if [ "$FETCH_DEPS" = true ]; then
 fi
 
 # Definition of global compile constants
-OUTPUT_DIR="dist"
+OUTPUT_DIR="build"
 OUTPUT="index.js"
 
 # Ensures that we rely first upon the local npm-based install of Typescript.

--- a/common/core/web/utils/tsconfig.json
+++ b/common/core/web/utils/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],
-    "outFile": "dist/index.js"
+    "outFile": "build/index.js"
   },
   "references": [
     { "path": "../../../../resources/web-environment"}

--- a/common/models/templates/tsconfig.json
+++ b/common/models/templates/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "module": "none",
-    "outFile": "build/index.js",
+    "outFile": "./build/index.js",
     "sourceMap": true,
     "lib": ["es6"],
     "target": "es5",

--- a/common/models/wordbreakers/.gitignore
+++ b/common/models/wordbreakers/.gitignore
@@ -1,3 +1,1 @@
-*.js
-*.js.map
-*.d.ts
+build/

--- a/common/models/wordbreakers/tsconfig.json
+++ b/common/models/wordbreakers/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "declaration": true,
     "sourceMap": true,
-    "outFile": "index.js",
+    "outFile": "./build/index.js",
     "strict": true,
     "allowJs": false,
   },

--- a/common/web/es6-shim/tsconfig.json
+++ b/common/web/es6-shim/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
-    "outFile": "build/index.js",
+    "outFile": "./build/index.js",
     "module": "none",
     "inlineSources": true,
     "sourceMap": true,

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -12,6 +12,8 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 . "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
 # This script runs from its own folder
 cd "$(dirname "$THIS_SCRIPT")"
 

--- a/common/web/keyman-version/tsconfig.json
+++ b/common/web/keyman-version/tsconfig.json
@@ -5,7 +5,7 @@
     "allowJs": false,
     "declaration": true,
     "module": "none",
-    "outFile": "build/index.js",
+    "outFile": "./build/index.js",
     "sourceMap": true,
     "lib": ["es6"],
     "target": "es5",

--- a/common/web/lm-worker/tsconfig.json
+++ b/common/web/lm-worker/tsconfig.json
@@ -5,7 +5,7 @@
     "allowJs": false,
     "declaration": true,
     "module": "none",
-    "outFile": "build/index.js",
+    "outFile": "./build/index.js",
     "sourceMap": true,
     "lib": ["webworker", "es6"],
     "target": "es5",

--- a/developer/js/tsconfig.json
+++ b/developer/js/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2017",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": "dist/",
     "declaration": true,
     "alwaysStrict": true,
     "noImplicitThis": true,

--- a/developer/server/build.sh
+++ b/developer/server/build.sh
@@ -95,9 +95,6 @@ type npm >/dev/null ||\
 
 if (( install_dependencies )) ; then
   verify_npm_setup
-  pushd "$KEYMAN_ROOT" > /dev/null
-  npm ci --production=false
-  popd > /dev/null
   # See https://github.com/bubenshchykov/ngrok/issues/254, https://github.com/bubenshchykov/ngrok/pull/255
   # TODO: this is horrible; is there a way we can avoid this?
   rm -f "$KEYMAN_ROOT"/node_modules/ngrok/bin/ngrok.exe

--- a/developer/server/src/win32-tray.ts
+++ b/developer/server/src/win32-tray.ts
@@ -9,7 +9,6 @@ const WindowsConsole = require("./win32/console");
 const open = require("open");
 
 module.exports = class Win32Tray {
-  private readonly signals = ['exit']; //, 'SIGINT', 'uncaughtException'];
   private myTrayApp: any;
 
   public restart(localPort: number, ngrokAddress: string) {
@@ -81,7 +80,7 @@ module.exports = class Win32Tray {
     });
 
     //console.log('starting tray icon');
-    this.signals.forEach(signal => process.on(signal, this.shutdown.bind(this)));
+    process.on('exit', this.shutdown.bind(this));
   }
 
   public shutdown() {

--- a/developer/server/tsconfig.json
+++ b/developer/server/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2017",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": "dist/",
     "declaration": true,
     "alwaysStrict": true,
     "noImplicitThis": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,16 +231,8 @@
       "license": "MIT",
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^14.0.4",
-        "ts-node": "^9.1.1",
         "typescript": "^4.5.4"
       }
-    },
-    "common/web/keyman-version/node_modules/@types/node": {
-      "version": "14.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-      "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
-      "dev": true
     },
     "common/web/lm-message-types": {
       "name": "@keymanapp/lm-message-types",
@@ -6503,17 +6495,7 @@
       "version": "file:common/web/keyman-version",
       "requires": {
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^14.0.4",
-        "ts-node": "^9.1.1",
         "typescript": "^4.5.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-          "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
-          "dev": true
-        }
       }
     },
     "@keymanapp/lexical-model-compiler": {

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -275,7 +275,7 @@ init_npm() {
     fail "KEYMAN_ROOT not defined; cannot install repo's dependencies"
   fi
   pushd "$KEYMAN_ROOT" > /dev/null
-  npm install --no-optional
+  npm ci
   popd > /dev/null
 }
 

--- a/resources/web-environment/.gitignore
+++ b/resources/web-environment/.gitignore
@@ -1,3 +1,3 @@
 environment.inc.ts
 node_modules
-dist/
+build/

--- a/resources/web-environment/tsconfig.json
+++ b/resources/web-environment/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig-base.json",
 
   "compilerOptions": {
-    "outFile": "dist/index.js"
+    "outFile": "./build/index.js"
   },
 
   "files": [

--- a/web/source/build.sh
+++ b/web/source/build.sh
@@ -218,7 +218,7 @@ readonly SOURCE
 
 # Ensures that we rely first upon the local npm-based install of Typescript.
 # (Facilitates automated setup for build agents.)
-PATH="../node_modules/.bin:$PATH"
+PATH="../../node_modules/.bin:$PATH"
 
 compiler="npm run tsc --"
 compilecmd="$compiler"


### PR DESCRIPTION
Update all web component build paths to use ./build/ instead of current variety of ./, ./dist/, ./build/

Does not touch build paths for server components yet (that'll come much later).

@keymanapp-test-bot skip