### PR TITLE
fix(oem/fv/android): Check current keyboard before registering model

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -106,11 +106,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
       }
 
       // If the active keyboard is for this language, immediately enact the new pref setting.
-      Keyboard currentKeyboard = KMManager.getCurrentKeyboardInfo(context);
-      if (currentKeyboard != null && BCP47.languageEquals(currentKeyboard.getLanguageID(), lgCode)) {
-        // Not only registers the model but also applies our modeling preferences.
-        KMManager.registerAssociatedLexicalModel(lgCode);
-      }
+      registerMatchingLexicalModel(lgCode);
     }
   }
 
@@ -307,10 +303,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
         if(immediateRegister) {
           // Register associated lexical model if it matches the active keyboard's language code;
           // it's safe since we're on the same thread.  Needs to be called AFTER deinstalling the old one.
-          String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-          if(BCP47.languageEquals(kbdLgCode, languageID)) {
-            KMManager.registerAssociatedLexicalModel(languageID);
-          }
+          registerMatchingLexicalModel(languageID);
         }
 
         // Force a display refresh.
@@ -366,6 +359,16 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
     CloudDownloadMgr.getInstance().executeAsDownload(
       context, _downloadid, null, _callback,
       aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+  }
+
+  // Register associated lexical model if it matches the active keyboard's language code
+  private void registerMatchingLexicalModel(String languageID) {
+    if (context != null) {
+      Keyboard currentKeyboard = KMManager.getCurrentKeyboardInfo(context);
+      if (currentKeyboard != null && BCP47.languageEquals(currentKeyboard.getLanguageID(), languageID)) {
+        KMManager.registerAssociatedLexicalModel(languageID);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes crash from FirstVoices pre-launch report in version 1500245 
```
Process: com.firstvoices.keyboards, PID: 20671
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.tavultesoft.kmea.data.Keyboard.getLanguageID()' on a null object reference
	at com.firstvoices.keyboards.FVKeyboardSettingsActivity$4.onItemClick(FVKeyboardSettingsActivity.java:310)
	at android.widget.AdapterView.performItemClick(AdapterView.java:318)
	at android.widget.AbsListView.performItemClick(AbsListView.java:1333)
```

Refactors the repeated block of code into `registerMatchingLexicalModel()` which has null checks on the current keyboard.

## User Testing
Setup - Load the PR build of "FirstVoices for Android"

* **TEST_DICTIONARY**
1. Launch the FirstVoices app
2. On the Setup menu, click **Select keyboards**
3. From the "Regions" page, select **Western Subarctic** --> **Dane-Z̲aa Z̲áágéʔ** --> Enable keyboard
4. Wait for the app to install the keyboard, query for associated dictionary, download and install dictionary
5. Verify the **Dane-Z̲aa Z̲áágéʔ Settings** page refreshes with the dictionary info for **bea**
6. Click on **bea** --> Uninstall dictionary --> Click "Delete" on the confirmation dialog
7. Verify toast notification briefly appears about dictionary being uninstalled
8. On the **Dane-Z̲aa Z̲áágéʔ Settings** page, click on **bea** again
9. Verify toast notification briefly appears about dictionary being installed
 
