### PR TITLE
chore(web): bulk renderer tsc cleanup 🎡

### DIFF
--- a/developer/js/tests/helpers/index.ts
+++ b/developer/js/tests/helpers/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../../common/web/lm-message-types/message.d.ts" />
+/// <reference types="@keymanapp/models-types" />
 
 /**
  * Helpers and utilities for the Mocha tests.

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -27,6 +27,9 @@
 # Note: keep changes to version, tier and tag determination in sync with mkver (windows/src/buildutils/mkver)
 #
 
+# Setup variable for calling script's path
+THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+readonly THIS_SCRIPT_PATH
 
 function die () {
     # TODO: consolidate this with fail() from shellHelperFunctions.sh
@@ -365,4 +368,8 @@ builder_report() {
   else
     echo "${COLOR_RED}Action '$1' Result: $2${COLOR_RESET}"
   fi
+}
+
+set_keyman_standard_build_path() {
+  PATH="$KEYMAN_ROOT/node_modules/.bin:$PATH"
 }

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -28,8 +28,10 @@
 #
 
 # Setup variable for calling script's path
-THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
-readonly THIS_SCRIPT_PATH
+if [ ! -z ${THIS_SCRIPT+x} ]; then
+  THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+  readonly THIS_SCRIPT_PATH
+fi
 
 function die () {
     # TODO: consolidate this with fail() from shellHelperFunctions.sh

--- a/web/bulk_rendering/build.sh
+++ b/web/bulk_rendering/build.sh
@@ -2,6 +2,8 @@
 #
 # Compile the KeymanWeb bulk-renderer module for use with developing/running engine tests.
 
+set -eu
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
@@ -9,30 +11,30 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-# Ensure the dependencies are downloaded.  --no-optional should help block fsevents warnings.
-verify_npm_setup
+set_keyman_standard_build_path
 
-# Definition of global compile constants
-COMPILED_FILE="bulk_render.js"
-OUTPUT="../release/renderer"
-NODE_SOURCE="bulk_rendering"
-#ENGINE_TEST_OUTPUT="../unit_tests/"
+display_usage ( ) {
+  echo "Usage: build.sh [flags...] [commands...]"
+  echo
+  echo "Commands:"
+  echo "  configure              runs 'npm ci' on root folder"
+  echo "  build                  (default) builds bulk_renderer to ../release/renderer"
+  echo
+  echo "Flags:"
+  echo "  -v, --verbose          Use verbose logging"
+  echo "  -h, --help             Print this help"
+}
 
-readonly OUTPUT
-readonly NODE_SOURCE
-#readonly ENGINE_TEST_OUTPUT
+################################ Main script ################################
 
-# Ensures that we rely first upon the local npm-based install of Typescript.
-# (Facilitates automated setup for build agents.)
-PATH="../../node_modules/.bin:$PATH"
+builder_init "configure build" "$@"
 
-compiler="npm run tsc --"
-compilecmd="$compiler"
-
-$compilecmd -p $NODE_SOURCE/tsconfig.json
-if [ $? -ne 0 ]; then
-    fail "Typescript compilation failed."
+if builder_has_action configure; then
+  verify_npm_setup
+  builder_report configure success
 fi
 
-#cp $OUTPUT/$COMPILED_FILE $ENGINE_TEST_OUTPUT
-#cp $OUTPUT/$COMPILED_FILE.map $ENGINE_TEST_OUTPUT
+if builder_has_action build; then
+  tsc --build "$THIS_SCRIPT_PATH/tsconfig.json" $builder_verbose
+  builder_report build success
+fi

--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -1,7 +1,5 @@
 // Includes KeymanWeb's Device class, as it's quite a useful resource for KMW-related projects.
 /// <reference path="../source/kmwdevice.ts" />
-// Ensure that Promises are within scope.
-/// <reference path="@keymanapp/es6-shim/build/index.d.ts" />
 
 type KeyboardMap = {[id: string]: any};
 

--- a/web/bulk_rendering/tsconfig.json
+++ b/web/bulk_rendering/tsconfig.json
@@ -1,16 +1,25 @@
 {
+  "extends": "../../tsconfig-base.json",
+
   "compilerOptions": {
-	"allowJs": true,
-	"inlineSources": true,
-	"module": "none",
-	"outFile": "../release/renderer/bulk_render.js",
-	"sourceMap": true,
-	"target": "es5"
-	},
+    "allowJs": true,
+    "inlineSources": true,
+    "module": "none",
+    "outFile": "../release/renderer/bulk_render.js",
+    "sourceMap": true,
+    "target": "es5"
+  },
+
   "files": [
-		"../node_modules/@keymanapp/web-utils/src/index.ts",
-    "../node_modules/@keymanapp/web-environment/environment.inc.ts",
-		"../node_modules/@keymanapp/lexical-model-layer/message.d.ts",
-		"renderer_core.ts"
-  ]
+    "renderer_core.ts",
+		"../source/kmwdevice.ts",
+		"../source/utils/styleConstants.ts",
+  ],
+
+	"references": [
+    { "path": "../../common/core/web/utils", "prepend": true },
+    { "path": "../../resources/web-environment", "prepend": true },
+		{ "path": "../../common/web/es6-shim", "prepend": true },
+    { "path": "../../common/web/lm-message-types" },
+	]
 }


### PR DESCRIPTION
Changes the bulk renderer build script to the new standard build script format and updates to use `tsc -b`. Cleans up final external `<reference>`s.

@keymanapp-test-bot skip