### PR TITLE
chore(web): update npm version refs for publishing packages 🎡

### DIFF
--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -88,8 +88,6 @@ if (( install_dependencies )) ; then
   npm install || fail "Could not download dependencies."
 fi
 
-set_npm_version || fail "Setting version failed."
-
 if (( run_tests )); then
   npm test || fail "Tests failed"
 fi
@@ -100,6 +98,8 @@ if (( should_publish )); then
   else
     npm_dist_tag=$TIER
   fi
+
+  set_npm_version
 
   # Note: In either case, npm publish MUST be given --access public to publish
   # a package in the @keymanapp scope on the public npm package index.

--- a/developer/js/build.sh
+++ b/developer/js/build.sh
@@ -106,13 +106,13 @@ if (( run_tests )); then
 fi
 
 if (( should_publish )); then
-  set_npm_version || fail "Setting version failed."
-
   if [[ $TIER == stable ]]; then
     npm_dist_tag=latest
   else
     npm_dist_tag=$TIER
   fi
+
+  set_npm_version
 
   # Note: In either case, npm publish MUST be given --access public to publish
   # a package in the @keymanapp scope on the public npm package index.

--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -7,6 +7,7 @@ set -eu
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
 . "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 display_usage() {
@@ -73,7 +74,7 @@ rm -rf "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 
 # Step 1 - npm-pack the model compiler package, then unpack it in our bundling
 # directory. This automatically strips the package to its barebones.
-npm version --allow-same-version --no-git-tag-version --no-commit-hooks "$VERSION_WITH_TAG"
+set_npm_version
 npm pack
 mv keymanapp-lexical-model-compiler*.tgz kmlmc.tgz
 mv kmlmc.tgz "$KEYMAN_WIX_TEMP_BASE"
@@ -97,7 +98,7 @@ mkdir -p "$KEYMAN_MODELCOMPILER_TEMP/node_modules/@keymanapp/"
 cp -R "$KEYMAN_ROOT/node_modules/@keymanapp/models-types" "$KEYMAN_MODELCOMPILER_TEMP/node_modules/@keymanapp/"
 
 cd "$KEYMAN_MODELCOMPILER_TEMP/node_modules/@keymanapp/models-types"
-npm version --allow-same-version --no-git-tag-version --no-commit-hooks "$VERSION_WITH_TAG"
+set_npm_version
 npm pack
 mv keymanapp-models-types*.tgz kmtypes.tgz
 mv kmtypes.tgz "$KEYMAN_WIX_TEMP_MODELCOMPILER"

--- a/developer/server/build.sh
+++ b/developer/server/build.sh
@@ -102,8 +102,6 @@ if (( install_dependencies )) ; then
   rm -f "$KEYMAN_ROOT"/node_modules/ngrok/bin/ngrok.exe
 fi
 
-# set_npm_version || fail "Setting version failed."
-
 # ----------------------------------------
 # Rebuild and bundle addins
 # ----------------------------------------

--- a/docs/npm-packages.md
+++ b/docs/npm-packages.md
@@ -75,7 +75,7 @@ This helper function sets the version in the `package.json` for the
 given package, according to the VERSION_WITH_TAG variable.
 
 ```bash
-. $KEYMAN_REPOSITORY_ROOT/resources/shellHelperFunctions.sh
+. $KEYMAN_ROOT/resources/shellHelperFunctions.sh
 
 set_npm_version
 ```

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -257,16 +257,12 @@ set_version ( ) {
 #   set_npm_version
 #
 set_npm_version () {
-  local version="$VERSION_WITH_TAG"
   # We use --no-git-tag-version because our CI system controls version numbering and
   # already tags releases. We also want to have the version of this match the
   # release of Keyman Developer -- these two versions should be in sync. Because this
   # is a large repo with multiple projects and build systems, it's better for us that
   # individual build systems don't take too much ownership of git tagging. :)
-  pushd . > /dev/null
-  cd "${KEYMAN_ROOT}"
-  npm run version "$version"  || fail "Could not set package versions to $version."
-  popd > /dev/null
+  npm version --allow-same-version --no-git-tag-version --no-commit-hooks "$VERSION_WITH_TAG"
 }
 
 # Initializes use of the npm packages within the repo.


### PR DESCRIPTION
Note that the version entry will be added to the local package.json which will then be dirty. This version entry should not be committed.

@keymanapp-test-bot skip