### PR TITLE
fix(android/engine): Refresh OSK when changing spacebar text

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -141,6 +141,9 @@ function setKeymanLanguage(k) {
 function setSpacebarText(mode) {
   keyman.options['spacebarText'] = mode;
   keyman.osk.show(true);
+
+  // Refresh KMW OSK
+  keyman.correctOSKTextSize();
 }
 
 /**


### PR DESCRIPTION
Fixes #6603
This update refreshes the OSK when changing the spacebar caption text.

## User Testing
Setup - Install the PR build of "Keyman for Android"

* **TEST_SPACEBAR_TEXT** - Verifies the spacebar caption refreshes on user selection
1. Launch Keyman for Android
2. Observe the default spacebar caption on sil_euro_latin is "Language + Keyboard" (e.g. **English - EuroLatin (SIL)**)
3. From Keyman Settings --> Spacebar caption --> Select an option and verify the keyboard caption updates accordingly:
    * Language
    * Keyboard
    * Language + Keyboard
    * Blank
 
