### PR TITLE
chore(web): fixup languageProcessor text unit tests 🎡

### DIFF
--- a/common/core/web/input-processor/test.sh
+++ b/common/core/web/input-processor/test.sh
@@ -64,7 +64,8 @@ test-headless ( ) {
     FLAGS="$FLAGS --reporter mocha-teamcity-reporter"
   fi
 
-  # Poor Man's Modules until we support ES6 throughout
+  # TODO: Poor Man's Modules until we support ES6 throughout
+
   PREPEND=./tests/cases/prepend.js
   (cat ../../../web/web-environment/build/index.js; echo) > $PREPEND
   (cat ../utils/build/index.js; echo) >> $PREPEND
@@ -72,9 +73,16 @@ test-headless ( ) {
   (cat ../input-processor/build/index.js; echo) >> $PREPEND
   (cat tests/cases/inputProcessor.js; echo) >> $PREPEND
 
-  # TODO: We will re-enable languageProcessor tests when we have sorted out
-  #       paths and modules for lmc
-  #(cat tests/cases/languageProcessor.js; echo) >> $PREPEND
+  npm run mocha -- --recursive $FLAGS ./tests/cases/prepend.js
+
+  PREPEND=./tests/cases/prepend.js
+  (cat ../../../web/web-environment/build/index.js; echo) > $PREPEND
+  (cat ../../../predictive-text/build/headless.js; echo) >> $PREPEND
+  (cat ../utils/build/index.js; echo) >> $PREPEND
+  (cat ../keyboard-processor/build/index.js; echo) >> $PREPEND
+  (cat ../input-processor/build/index.js; echo) >> $PREPEND
+  (cat ../../../web/lm-worker/build/index.js; echo) >> $PREPEND
+  (cat tests/cases/languageProcessor.js; echo) >> $PREPEND
 
   npm run mocha -- --recursive $FLAGS ./tests/cases/prepend.js
 

--- a/common/core/web/input-processor/tests/cases/languageProcessor.js
+++ b/common/core/web/input-processor/tests/cases/languageProcessor.js
@@ -6,18 +6,15 @@ var vm = require("vm");
  * Unit tests for the Dummy prediction model.
  */
 
-var LexicalModelCompiler = require('@keymanapp/lexical-model-compiler/dist/lexical-model-compiler/lexical-model-compiler').default;
+var LexicalModelCompiler = require('../../../../../../developer/js/dist/lexical-model-compiler/lexical-model-compiler').default;
 var path = require('path');
 
-let InputProcessor = require('../../dist');
-
 // Required initialization setup.
-global.com = InputProcessor.com; // exports all keyboard-processor namespacing.
 global.keyman = {}; // So that keyboard-based checks against the global `keyman` succeed.
                     // 10.0+ dependent keyboards, like khmer_angkor, will otherwise fail to load.
 
 // Initialize supplementary plane string extensions
-String.kmwEnableSupplementaryPlane(false); 
+String.kmwEnableSupplementaryPlane(false);
 
 let LanguageProcessor = com.keyman.text.prediction.LanguageProcessor;
 
@@ -49,8 +46,8 @@ describe('LanguageProcessor', function() {
   describe('.predict', function() {
     let compiler = new LexicalModelCompiler();
     const MODEL_ID = 'example.qaa.trivial';
-    const PATH = path.join(__dirname, '../../node_modules/@keymanapp/lexical-model-compiler/tests/fixtures', MODEL_ID);
-  
+    const PATH = path.join(__dirname, '../../../../../../developer/js/tests/fixtures', MODEL_ID);
+
     describe('using angle brackets for quotes', function() {
       let modelCode = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
@@ -108,21 +105,21 @@ describe('LanguageProcessor', function() {
           languageUsesCasing: true,
           //applyCasing // we rely on the compiler's default implementation here.
         }, PATH);
-  
+
         let modelSpec = {
           id: MODEL_ID,
           languages: ['en'],
           code: modelCode
         };
-  
+
         describe("does not alter casing when input is lowercased", function() {
           it("when input is fully lowercased", function(done) {
             let languageProcessor = new LanguageProcessor();
             languageProcessor.init();
-    
+
             let contextSource = new com.keyman.text.Mock("li", 2);
             let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-    
+
             languageProcessor.loadModel(modelSpec).then(function() {
               languageProcessor.predict(transcription).then(function(suggestions) {
                 assert.isOk(suggestions);
@@ -139,10 +136,10 @@ describe('LanguageProcessor', function() {
           it("when input has non-initial uppercased letters", function(done) {
             let languageProcessor = new LanguageProcessor();
             languageProcessor.init();
-    
+
             let contextSource = new com.keyman.text.Mock("lI", 2);
             let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-    
+
             languageProcessor.loadModel(modelSpec).then(function() {
               languageProcessor.predict(transcription).then(function(suggestions) {
                 // The source suggestion is simply 'like'.
@@ -160,10 +157,10 @@ describe('LanguageProcessor', function() {
           it("unless the suggestion has uppercased letters", function(done) {
             let languageProcessor = new LanguageProcessor();
             languageProcessor.init();
-    
+
             let contextSource = new com.keyman.text.Mock("i", 1);
             let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-    
+
             languageProcessor.loadModel(modelSpec).then(function() {
               languageProcessor.predict(transcription).then(function(suggestions) {
                 assert.isOk(suggestions);
@@ -182,10 +179,10 @@ describe('LanguageProcessor', function() {
           it("for suggestions with default casing  (== 'lower')", function(done) {
             let languageProcessor = new LanguageProcessor();
             languageProcessor.init();
-    
+
             let contextSource = new com.keyman.text.Mock("LI", 2);
             let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-    
+
             languageProcessor.loadModel(modelSpec).then(function() {
               languageProcessor.predict(transcription).then(function(suggestions) {
                 // The source suggestion is simply 'like'.
@@ -203,7 +200,7 @@ describe('LanguageProcessor', function() {
           it("for precapitalized suggestions", function(done) {
             let languageProcessor = new LanguageProcessor();
             languageProcessor.init();
-    
+
             let contextSource = new com.keyman.text.Mock("I", 1);
             let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
 
@@ -226,10 +223,10 @@ describe('LanguageProcessor', function() {
             it("for suggestions with default casing (== 'lower')", function(done) {
               let languageProcessor = new LanguageProcessor();
               languageProcessor.init();
-      
+
               let contextSource = new com.keyman.text.Mock("L", 1);
               let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-      
+
               languageProcessor.loadModel(modelSpec).then(function() {
                 languageProcessor.predict(transcription).then(function(suggestions) {
                   // The source suggestion is simply 'like'.
@@ -249,10 +246,10 @@ describe('LanguageProcessor', function() {
             it("for suggestions with default casing (== 'lower')", function(done) {
               let languageProcessor = new LanguageProcessor();
               languageProcessor.init();
-      
+
               let contextSource = new com.keyman.text.Mock("Li", 2);
               let transcription = contextSource.buildTranscriptionFrom(contextSource, null, null);
-      
+
               languageProcessor.loadModel(modelSpec).then(function() {
                 languageProcessor.predict(transcription).then(function(suggestions) {
                   // The source suggestion is simply 'like'.

--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -108,7 +108,6 @@ mv kmtypes.tgz "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 cd "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 # package-lock.json wasn't bundled; this is needed to keep dependency versions
 # consistent.
-# cp "$KEYMAN_MODELCOMPILER_TEMP/package-lock.json" "$KEYMAN_WIX_TEMP_MODELCOMPILER/"
 
 # as of npm v8.x, even though we are only working with `dependencies`,
 # `devDependencies` is still checked, and as these modules are present in

--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -108,7 +108,7 @@ mv kmtypes.tgz "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 cd "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 # package-lock.json wasn't bundled; this is needed to keep dependency versions
 # consistent.
-cp "$KEYMAN_MODELCOMPILER_TEMP/package-lock.json" "$KEYMAN_WIX_TEMP_MODELCOMPILER/"
+# cp "$KEYMAN_MODELCOMPILER_TEMP/package-lock.json" "$KEYMAN_WIX_TEMP_MODELCOMPILER/"
 
 # as of npm v8.x, even though we are only working with `dependencies`,
 # `devDependencies` is still checked, and as these modules are present in


### PR DESCRIPTION
Uses "Poor Man's Modules" until we have ES6, just so we can get passing
tests.

@keymanapp-test-bot skip