### PR TITLE
chore(common): improve PR reporting of changes

### DIFF
--- a/resources/build/version/src/graphql/queries.ts
+++ b/resources/build/version/src/graphql/queries.ts
@@ -22,8 +22,9 @@ export const getAssociatedPR = `
         ... on Commit {
           parents(last: 1) {
             nodes {
-              associatedPullRequests(first: 1) {
+              associatedPullRequests(last: 10) {
                 nodes {
+                  state
                   title
                   number
                 }

--- a/resources/build/version/src/reportHistory.ts
+++ b/resources/build/version/src/reportHistory.ts
@@ -51,8 +51,6 @@ const getAssociatedPRInformation = async (
     return undefined;
   }
 
-  //console.log(JSON.stringify(response));
-
   const {
     repository: {
       commit: {
@@ -60,12 +58,7 @@ const getAssociatedPRInformation = async (
           nodes: [
             {
               associatedPullRequests: {
-                nodes: [
-                  {
-                    title: title,
-                    number: number
-                  }
-                ]
+                nodes: nodes
               }
             }
           ]
@@ -74,7 +67,8 @@ const getAssociatedPRInformation = async (
     }
   } = response;
 
-  return { title, number };
+  const node = nodes.find(node => node.state == 'MERGED');
+  return node ? { title: node.title, number: node.number } : undefined;
 };
 
 /**


### PR DESCRIPTION
Fixes #6391.

The issue here was quite nuanced: where we merged a PR, and then merged the changes into an earlier PR, but left it open, the earlier PR could end up getting the release information comment from keyman-server instead of the later, merged PR. This was because the commit would appear in both PRs, so GitHub would report on both of them.

This is not a 100% fix -- but it should stop the PR tagging on unmerged pull requests. The one situation where this may leave a gap is where we have multiple PRs merged on the same day, where a later PR's changes are merged into an earlier PR; in this case I think it is possible that one of the PRs will not get the informative version comment.

But given the current fix should avoid the more common situation, I am comfortable to leave it as is for now. This is only informative data... and a more complete fix is a distraction.

@keymanapp-test-bot skip