### PR TITLE
fix(ios): fixes OSK mispositioning bug in iOS 15

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -29,6 +29,12 @@ sentryManager.init();
 window.addEventListener('load', init, false);
 
 function init() {
+    // As of iOS 15, Safari WebViews will try to avoid letting us use the "safe area"
+    // at the bottom of iPhone X style devices.  While `-webkit-fill-available` will partly
+    // counteract this... it's only a "partly".  Fortunately, we can manually force the
+    // page to our desired size.
+    document.body.style.height = window.outerHeight;
+
     var kmw=window['keyman'];
     // We could convert to relying on the promise, but the underlying input element
     // tends to show a bit due to the delay when we do so.

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -10,7 +10,7 @@
             body {background-color: rgb(210,214,220);}
         </style>
     </head>
-    <body class="kmw-embedded keyman-app">
+    <body class="kmw-embedded keyman-app" style="height: -webkit-fill-available">
         <textarea id="ta" cols="1" rows="1" style="visibility:hidden;" disabled></textarea>
     </body>
 </html>


### PR DESCRIPTION
Fixes #6595.

It turns out that with iOS 15, Apple decided that the page content of WebViews should always respect the "safe area guidelines".  (A reference with a similar issue: https://developer.apple.com/forums/thread/685727)  This, in combination with an interesting bug, appears to force our host page's allotted area to be smaller than its viewport... even when it's not actually disrespecting that safe area.

This has the net effect of the host page's viewport being bumped vertically up the page.  Web's mobile OSK uses `fixed` positioning, which is viewport-relative.  It's also directly told a target size from the Swift side, meaning that the OSK still expected to use the full page... causing the top part of the 'oversized' OSK up and out of the viewport.

Fortunately, JavaScript has this lovely little thing called `window.outerHeight`, allowing the JS side to know the intended size of the WebView, disregarding any safe area shenanigans, unintended or no.  Forcing the body element's size to match puts the viewport's bottom boundary back where it belongs, allowing the OSK to display correctly again.

Written in collaboration with @sgschantz.

------

One interesting detail of note is that we aren't actually changing the body element size after OSK rotations.  While a bit odd... so long as landscape keyboards are always shorter than portrait keyboards, we'll be fine - Web's OSK is locked to viewport-relative positioning, and so the OSK will remain fully within the viewport.  The assumption should be a safe one given the inherent meanings of "portrait" vs "landscape".

------

## User Testing

### Devices / environments for testing

- **GROUP_SE_14**:  Run the tests on a simulated iPhone SE (2nd gen) with an iOS 14.x runtime.
- **GROUP_SE_15**:  Run the tests on a simulated iPhone SE (2nd gen) with an iOS 15.x runtime.
- **GROUP_X_14**:  Run the tests on a simulated iPhone X with an iOS 14.x runtime.
- **GROUP_X_15**:  Run the tests on a simulated iPhone X with an iOS 15.x runtime.

### Actual tests

- **TEST_SETUP**:  Install Keyman on the device and disable the Get Started menu.

  This is just setup, as the "Get Started" menu actually interferes with one important test.

- **TEST_LAUNCH**:  On a fresh launch of Keyman, ensure the OSK is properly aligned.

  1. If Keyman has recently been active, make sure to force-quit it before starting this test.  Use this iOS mode and swipe up to force-quit the app:  <details><summary>Helpful screenshot</summary>
  
      <img width="440" alt="image" src="https://user-images.githubusercontent.com/25213402/168948452-9fcdbe8f-76f4-454b-acb2-59076037df75.png">

      </details>

  2. Launch Keyman and wait for it to load.  Do _nothing else_.

- **TEST_ROTATE**:  Ensure that the OSK continues to display properly after device rotations.

  1. Rotate your test device clockwise and report on the results.
  2. Rotate your test device back to its original orientation and report on the results.
      - If using Simulator, Cmd+Right will rotate clockwise and Cmd+Left will rotate counter-clockwise.