### PR TITLE
fix(ios): disables transparent nav bar for ios 15

### DIFF
--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -63,6 +63,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ = log
     _ = KeymanEngine.log
 
+    // In iOS 15, navigation bars become transparent by default when the edge
+    // of the scrollable content aligns with the edge of the navigation bar.
+    // Force the appearance back to the pre-iOS 15 default behavior.
+    if #available(iOS 15, *) {
+        UINavigationBar.appearance().scrollEdgeAppearance = UINavigationBarAppearance()
+    }
     UniversalLinks.externalLinkLauncher = { url in
       UIApplication.shared.open(url)
     }


### PR DESCRIPTION
Fixes #6413.
 
In iOS 15 Apple introduced a new default behavior for navigation bars where they become transparent when the edge of the scrollable content aligns with the edge of the navigation bar. This would cause the background view to bleed through and interfere with presentation of the view in the foreground. 

This was most noticeable when installing a new keyboard and could also be seen in the info window.

This fix changes the appearance back to the pre-iOS 15 default behavior so that the navigation bar is translucent white as originally designed.

## User Testing

- **TEST_MAIN_SCREEN**:  Open Keyman and confirm that the navigation bar is white and not yellow.

- **TEST_INSTALL_KEYBOARD**:  Install a keyboard from within the Keyman and see that the navigation bar of the install dialog looks correct with the Cancel and Next button text in blue on a white background.

- **TEST_VIEW_INFO**:  Press the Info menu item and see that the info screen navigation bar is white rather than yellow.

