### PR TITLE
fix(android/engine): Fix sticky long-press keys

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -290,12 +290,16 @@ final class KMKeyboard extends WebView {
       //handleTouchEvent(event);
       gestureDetector.onTouchEvent(event);
       if (event.getAction() == MotionEvent.ACTION_UP) {
-        subKeysList = null;
+        dismissKeyPreview(0);
+        dismissSubKeysWindow();
+        //subKeysList = null;
       } else if (event.getAction() == MotionEvent.ACTION_MOVE) {
         if (subKeysList != null && subKeysWindow == null) {
           // Display subkeys during move
           showSubKeys(context);
         }
+      } else if (event.getAction() != MotionEvent.ACTION_DOWN) {
+        Log.d(TAG, "action");
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -187,7 +187,7 @@ final class KMKeyboard extends WebView {
       @Override
       public void onLongPress(MotionEvent event) {
         // This is also called for banner longpresses!  Need a way to differentiate the sources.
-        if (subKeysList != null) {
+        if (subKeysList != null && subKeysWindow != null && !subKeysWindow.isShowing()) {
           showSubKeys(context);
           return;
         } else if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
@@ -276,6 +276,7 @@ final class KMKeyboard extends WebView {
   @SuppressLint("ClickableViewAccessibility")
   @Override
   public boolean onTouchEvent(MotionEvent event) {
+    int action = event.getAction();
     // JH:  I'm not sure if we even USE the suggestionMenuWindow construct anywhere, but either way,
     // this if block is designed explicitly for handling the subKeysWindow.
     //
@@ -289,24 +290,16 @@ final class KMKeyboard extends WebView {
     } else {
       //handleTouchEvent(event);
       gestureDetector.onTouchEvent(event);
-      switch(event.getAction()) {
-        case MotionEvent.ACTION_UP :
-          dismissKeyPreview(0);
-          dismissSubKeysWindow();
-          //subKeysList = null;
-          break;
-        case MotionEvent.ACTION_MOVE :
-          if (subKeysList != null && subKeysWindow == null) {
-            // Display subkeys during move
-            showSubKeys(context);
-          }
-          break;
-        default :
-          if (event.getAction() != MotionEvent.ACTION_DOWN) {
-            Log.d(TAG, "action");
-          }
-          return false;
+      if (action == MotionEvent.ACTION_MOVE && subKeysList != null && subKeysWindow == null) {
+        // Display subkeys during move
+        showSubKeys(context);
       }
+    }
+
+    if (action == MotionEvent.ACTION_UP) {
+      // Cleanup popups. #6636
+      dismissKeyPreview(0);
+      dismissSubKeysWindow();
     }
 
     return super.onTouchEvent(event);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -289,17 +289,23 @@ final class KMKeyboard extends WebView {
     } else {
       //handleTouchEvent(event);
       gestureDetector.onTouchEvent(event);
-      if (event.getAction() == MotionEvent.ACTION_UP) {
-        dismissKeyPreview(0);
-        dismissSubKeysWindow();
-        //subKeysList = null;
-      } else if (event.getAction() == MotionEvent.ACTION_MOVE) {
-        if (subKeysList != null && subKeysWindow == null) {
-          // Display subkeys during move
-          showSubKeys(context);
-        }
-      } else if (event.getAction() != MotionEvent.ACTION_DOWN) {
-        Log.d(TAG, "action");
+      switch(event.getAction()) {
+        case MotionEvent.ACTION_UP :
+          dismissKeyPreview(0);
+          dismissSubKeysWindow();
+          //subKeysList = null;
+          break;
+        case MotionEvent.ACTION_MOVE :
+          if (subKeysList != null && subKeysWindow == null) {
+            // Display subkeys during move
+            showSubKeys(context);
+          }
+          break;
+        default :
+          if (event.getAction() != MotionEvent.ACTION_DOWN) {
+            Log.d(TAG, "action");
+          }
+          return false;
       }
     }
 


### PR DESCRIPTION
Fixes #6636

The logic to clear popup keys depends on GestureDetector triggering `MotionEvent.ACTION_UP`. This PR pulls the handling out of the if/else because sometimes, the `ACTION_UP` event goes through the if() block.

https://github.com/keymanapp/keyman/blob/1747722ebdd264587a876b73a2c253801ef0fdcc/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java#L285-L289

## User Testing
Setup - A physical Android device. Don't use emulator because the scenario involves typing fast on the OSK (e.g. two thumbs)

* **TEST_BETA_STICKY_KEYS** - Verify beta build can have long-press keys stuck
1. On the Android device, install 15.0.249 beta of Keyman for Android
https://downloads.keyman.com/android/beta/15.0.249/keyman-15.0.249.apk
2. Dismiss the "Get Started" menu 
3. In the Keyman app, quickly type with the default sil_euro_latin keyboard on the OSK.
4. After typing a long paragraph, observe if a long-press keys become stuck (displayed while not holding down on a key)
5. Verify at some point, the long-press key is stuck. If you see this bug, this test is PASS
6. Uninstall the beta build of Keyman for Android.  

* **TEST_POPUPS** - Verify popup keys don't get stuck on
1. On the Android device, install the PR build of Keyman for Android 
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Type on the OSK using the following scenarios and verify expected output:
    * Clicking a suggestion on the suggestion banner - should insert the suggestion
    * short-press a key and release - should insert the base key
    * long-press a key, select a long-press key, and release - should insert the long-press key
    * long-press a key, while keeping the finger down, move off the long-press options, and release - should **not** output
    * long-press a key, while keeping the finger down, move off the long-press options, then move back on a long-press option so it's highlighted, and release - should output the long-press key
    * quickly type a long paragraph (e.g. repeat the word "reply") - verify long-press keys don't get stuck (displayed when not touching a key)
