### PR TITLE
chore(android,ios,mac): Update crowdin strings for Spanish (Latin America)

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-b+es+419/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-b+es+419/strings.xml
@@ -18,6 +18,10 @@
   <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">Instalar actualizaciones</string>
   <!-- Context: Title -->
   <string name="title_version" comment="Title of Keyman for Android version">Versión: %1$s</string>
+  <!-- Context: Text label when old Chrome version installed -->
+  <string name="text_require_chrome_57" comment="Banner text when old version of Chrome is installed">    Keyman requiere Chrome versión 57 o posterior.</string>
+  <!-- Context: Button label -->
+  <string name="button_update_chrome" comment="Prompt to upgrade Chrome in the Play Store">Actualizar Chrome</string>
   <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
   <string name="textview_hint" comment="Prompt to start typing">Comienza a escribir aquí&#8230;</string>
   <!-- Context: Splash screen (version/copyright info currently disabled -->
@@ -50,13 +54,33 @@
   <string name="keyman_settings" comment="Settings menu title">Configuración</string>
   <!-- Context: Keyman Settings menu -->
   <plurals name="installed_languages">
-    <item quantity="one">Installed languages (%1$d)</item>
-    <item quantity="other">Installed languages (%1$d)</item>
+    <item quantity="one">Idiomas instalados (%1$d)</item>
+    <item quantity="other">Idiomas instalados (%1$d)</item>
   </plurals>
   <!-- Context: Keyman Settings menu -->
   <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">Instalar teclado o diccionario</string>
   <!-- Context: Keyman Settings menu -->
-  <string name="change_display_language" comment="Menu action to change interface language">Cambiar idioma de interfaz</string>
+  <string name="change_display_language" comment="Menu action to change interface language">Idioma de interfaz</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="adjust_keyboard_height" comment="Menu action to adjust keyboard height">Ajustar la altura del teclado</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">Leyenda de barra espaciadora</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">Teclado</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">Idioma</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">Idioma + Teclado</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">Vacío</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">Mostrar nombre del teclado en la barra espaciadora</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">Mostrar nombre del idioma en la barra espaciadora</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">Idioma y teclado en la barra espaciadora</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">No mostrar leyenda en la barra espaciadora</string>
   <!-- Context: Keyman Settings menu -->
   <string name="show_banner" comment="text suggestions banner">Mostrar siempre el banner</string>
   <!-- Context: Keyman Settings menu -->
@@ -87,6 +111,12 @@
   <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">Se agregó el idioma %1$s a %2$s</string>
   <!-- Context: Select Package and Select Languages menu -->
   <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">Ya están instalados todos los idiomas</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="drag_the_keyboard" comment="First line of adjusting keyboard height">Arrastra el teclado para ajustar la altura</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="rotate_the_device" comment="Second line of adjusting keyboard height">Rota el dispositivo para ajustar el modo vertical y horizontal</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="reset_to_defaults" comment="Button to reset to default heights">Restaurar valores predeterminados</string>
   <!-- Context: Keyman Web Browser -->
   <string name="hint_text" comment="Prompt to type in the browser search bar">Buscar o escribir una dirección web</string>
   <!-- Context: Keyman Web Browser -->
@@ -121,4 +151,6 @@
   <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">El paquete del teclado no tiene idiomas asociados para instalar</string>
   <!-- Context: KMP Package strings -->
   <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">Metadatos inválidos/ausentes en el paquete</string>
+  <!-- Context: KMP Package strings -->
+  <string name="minimum_keyboard_version_not_supported" comment="Notification when keyboard has functionality not supported by current Keyman">    El teclado requiere una versión más reciente de Keyman</string>
 </resources>

--- a/android/KMEA/app/src/main/res/values-b+es+419/strings.xml
+++ b/android/KMEA/app/src/main/res/values-b+es+419/strings.xml
@@ -8,6 +8,11 @@
         <item quantity="other">Teclados</item>
     </plurals>
     <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+        <item quantity="one">Otro método de entrada</item>
+        <item quantity="other">Otros métodos de entrada</item>
+    </plurals>
+    <!-- Context: Title for list -->
     <string name="title_add_keyboard" comment="Add a new keyboard">Agregar teclado nuevo</string>
     <!-- Context: Title for list -->
     <string name="title_languages_settings" comment="List of installed languages">Idiomas instalados</string>
@@ -21,8 +26,12 @@
     <string name="label_cancel" comment="Button to cancel an action">Cancelar</string>
     <!-- Context: Button label -->
     <string name="label_close" comment="Close a dialog">Cerrar</string>
-    <!-- Context: Button label -->
+    <!-- Context: Button label. Removed in Keyman 15 -->
     <string name="label_close_keyman" comment="Close the Keyman application">Cerrar Keyman</string>
+    <!-- Context: Button label -->
+    <string name="label_forward" comment="Button to go forward">Adelante</string>
+    <!-- Context: Button label -->
+    <string name="label_next_input_method" comment="Switch to next input method (replaces label_close_keyman)">Siguiente método de entrada</string>
     <!-- Context: Button label -->
     <string name="label_download" comment="Button to confirm downloading an item">Descargar</string>
     <!-- Context: Button label -->
@@ -35,6 +44,8 @@
     <string name="label_ok" comment="Button to acknowledge a dialog">Aceptar</string>
     <!-- Context: Button label -->
     <string name="label_update" comment="Dialog button to update a resource">Actualizar</string>
+    <!-- Context: No internet for updates -->
+    <string name="no_internet_connection" comment="Internet connection missing">No hay conexión a Internet</string>
     <!-- Context: Keyboard Updates -->
     <string name="cannot_connect" comment="Error message when network connection fails">¡No se puede conectar con el servidor Keyman!</string>
     <!-- Context: Keyboard Updates -->
@@ -69,8 +80,11 @@
     <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">      Se necesita la librería FileProvider para ver el archivo de ayuda: %1$s</string>
     <!-- Context: Fatal keyboard error. Will load default keyboard -->
     <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">      Error fatal del teclado con %1$s:%2$s para el idioma %3$s. Cargando teclado predeterminado.</string>
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">      Error en el teclado %1$s:%2$s para el idioma %3$s.</string>
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Buscando diccionario asociado para descargar</string>
+    <string name="cannot_query_associated_model" comment="Cannot reach server to check if there's an available dictionary to download">      No se pudo conectar al servidor de Keyman para buscar un diccionario asociado para descargar</string>
     <!-- Context: Model Updates -->
     <string name="confirm_download_model" comment="Confirmation to download a dictionary update">¿Quieres descargar la última versión de este diccionario?</string>
     <!-- Context: No associated dictionary found -->
@@ -113,16 +127,25 @@
     <string name="uninstall_model" comment="Label to uninstall a dictionary">Desinstalar diccionario</string>
     <!-- Context: Model Info -->
     <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">¿Quieres eliminar este diccionario?</string>
+    <!-- Context: Model Deleted -->
+    <string name="model_deleted" comment="Notification when a dictionary is deleted">Diccionario borrado</string>
     <!-- Context: Language Settings Keyboard install strings -->
     <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">Teclado %1$s instalado</string>
+    <!-- Context: Language Settings Keyboard uninstall strings -->
+    <string name="keyboard_deleted_toast" comment="Notification when a keyboard is deleted">Teclado borrado</string>
     <!-- Context: Language Settings menu strings -->
     <string name="enable_corrections" comment="Enable corrections from the suggestion banner">Habilitar correcciones</string>
     <!-- Context: Language Settings menu strings -->
     <string name="enable_predictions" comment="Enable predictions from the suggestion banner">Habilitar predicciones</string>
     <!-- Context: Language Settings menu strings -->
     <string name="model_label">Diccionario</string>
+    <plurals name="model_count">
+        <item quantity="one">Diccionario</item>
+        <item quantity="other">Diccionarios</item>
+    </plurals>
     <!-- Context: Language Settings menu substring - Check for available dictionary -->
     <string name="check_available_model" comment="Check for available dictionary">Buscar diccionario disponible</string>
+    <string name="check_model_online" comment="Check for dictionaries online">Buscar diccionarios en línea</string>
     <!-- Context: Language Settings menu strings -->
     <string name="model_info_header" comment="Dictionary name">Diccionario: %1$s</string>
     <!-- Context: Language Settings menu strings -->

--- a/ios/engine/KMEI/KeymanEngine/es-419.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/es-419.lproj/Localizable.strings
@@ -49,6 +49,12 @@
 /* Confirmation text to display before uninstalling a lexical model */
 "command-uninstall-lexical-model-confirm" = "¿Quieres desinstalar este diccionario?";
 
+/* Text for error when a keyboard cannot load properly */
+"error-loading-keyboard" = "No se puede cargar el teclado solicitado";
+
+/* Text for error when a lexical model cannot load properly */
+"error-loading-lexical-model" = "No se puede cargar el diccionario solicitado";
+
 /* Text for error when an installed file is unexpectedly missing */
 "error-missing-file" = "No se pudo encontrar un archivo requerido.";
 
@@ -112,11 +118,20 @@
 /* Error opening a Keyman package - package is not valid */
 "kmp-error-invalid" = "El archivo del paquete está corrupto.";
 
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "El paquete especificado no existe.";
+
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "Este paquete no contiene el teclado o el diccionario solicitado.";
 
+/* Error installing a Keyman package with a version of Keyman that does not support it */
+"kmp-error-unsupported-keyman-version" = "Este paquete requiere una versión más reciente de Keyman.";
+
 /* Error opening a Keyman package - cannot parse contents */
 "kmp-error-no-metadata" = "Este paquete no fue compilado correctamente - contenidos desconocidos.";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "Este paquete no incluye soporte para su dispositivo.";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "Este paquete no contiene el tipo de recurso esperado.";
@@ -180,6 +195,36 @@
 
 /* Title for the main Settings menu */
 "menu-settings-title" = "Configuración de Keyman";
+
+/* Secondary text showing current setting for spacebar caption - blank */
+"menu-settings-spacebar-hint-blank" = "No mostrar leyenda en la barra espaciadora";
+
+/* Secondary text showing current setting for spacebar caption - keyboard */
+"menu-settings-spacebar-hint-keyboard" = "Mostrar nombre del teclado en la barra espaciadora";
+
+/* Secondary text showing current setting for spacebar caption - language */
+"menu-settings-spacebar-hint-language" = "Mostrar nombre del idioma en la barra espaciadora";
+
+/* Secondary text showing current setting for spacebar caption - language + keyboard */
+"menu-settings-spacebar-hint-languageKeyboard" = "Mostrar nombre de idioma y teclado en la barra espaciadora";
+
+/* Label for the "Spacebar Caption" item on the main settings screen */
+"menu-settings-spacebar-text" = "Leyenda de Barra Espaciadora";
+
+/* Title for the "Spacebar Caption" settings screen */
+"menu-settings-spacebar-title" = "Leyenda de Barra Espaciadora";
+
+/* Text showing name of spacebar caption - blank */
+"menu-settings-spacebar-item-blank" = "Vacío";
+
+/* Text showing name of spacebar caption - keyboard */
+"menu-settings-spacebar-item-keyboard" = "Teclado";
+
+/* Text showing name of spacebar caption - language */
+"menu-settings-spacebar-item-language" = "Idioma";
+
+/* Text showing name of spacebar caption - language + keyboard */
+"menu-settings-spacebar-item-languageKeyboard" = "Idioma y teclado";
 
 /* Short text for notification:  download failure for keyboard */
 "notification-download-failure-keyboard" = "Error al descargar el teclado";

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -160,6 +160,12 @@
 		29B5BC0628169A6500B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
 		29B5BC0728169A6600B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		29B5BC0828169A8600B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/Localizable.strings; sourceTree = "<group>"; };
+		29B70A23283CB6680086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/KMAboutWindowController.strings"; sourceTree = "<group>"; };
+		29B70A24283CB6690086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/preferences.strings"; sourceTree = "<group>"; };
+		29B70A25283CB66A0086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/KMInfoWindowController.strings"; sourceTree = "<group>"; };
+		29B70A26283CB66B0086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/KMKeyboardHelpWindowController.strings"; sourceTree = "<group>"; };
+		29B70A27283CB66C0086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/MainMenu.strings"; sourceTree = "<group>"; };
+		29B70A28283CB6900086B580 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		29BFA761282936D4009FCCC3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/KMAboutWindowController.strings; sourceTree = "<group>"; };
 		29BFA762282936D5009FCCC3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/preferences.strings; sourceTree = "<group>"; };
 		29BFA763282936D5009FCCC3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/KMInfoWindowController.strings; sourceTree = "<group>"; };
@@ -692,7 +698,8 @@
 				"pt-PT",
 				ff,
 				it,
-				pl
+				pl,
+				"es-419",
 			);
 			mainGroup = 989C9BFF1A7876DE00A20425;
 			productRefGroup = 989C9C091A7876DE00A20425 /* Products */;
@@ -930,7 +937,8 @@
 				29C1E1742800227500759EDE /* pt-PT */,
 				29B5BC0328169A6300B86A17 /* ff */,
 				29BFA761282936D4009FCCC3 /* it */,
-				29BFA76D282948BD009FCCC3 /* pl */
+				29BFA76D282948BD009FCCC3 /* pl */,
+				29B70A23283CB6680086B580 /* es-419 */,
 			);
 			name = KMAboutWindowController.xib;
 			sourceTree = "<group>";
@@ -946,7 +954,8 @@
 				29C1E1752800227600759EDE /* pt-PT */,
 				29B5BC0428169A6400B86A17 /* ff */,
 				29BFA762282936D5009FCCC3 /* it */,
-				29BFA76E282948BE009FCCC3 /* pl */
+				29BFA76E282948BE009FCCC3 /* pl */,
+				29B70A24283CB6690086B580 /* es-419 */,
 			);
 			name = preferences.xib;
 			path = Keyman4MacIM/KMConfiguration;
@@ -962,7 +971,8 @@
 				29C1E179280025A900759EDE /* pt-PT */,
 				29B5BC0828169A8600B86A17 /* ff */,
 				29BFA76628293760009FCCC3 /* it */,
-				29BFA7722829490A009FCCC3 /* pl */
+				29BFA7722829490A009FCCC3 /* pl */,
+				29B70A28283CB6900086B580 /* es-419 */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -978,7 +988,8 @@
 				29C1E1762800227700759EDE /* pt-PT */,
 				29B5BC0528169A6400B86A17 /* ff */,
 				29BFA763282936D5009FCCC3 /* it */,
-				29BFA76F282948BE009FCCC3 /* pl */
+				29BFA76F282948BE009FCCC3 /* pl */,
+				29B70A25283CB66A0086B580 /* es-419 */,
 			);
 			name = KMInfoWindowController.xib;
 			path = Keyman4MacIM/KMInfoWindow;
@@ -995,7 +1006,8 @@
 				29C1E1772800227700759EDE /* pt-PT */,
 				29B5BC0628169A6500B86A17 /* ff */,
 				29BFA764282936D6009FCCC3 /* it */,
-				29BFA770282948BF009FCCC3 /* pl */
+				29BFA770282948BF009FCCC3 /* pl */,
+				29B70A26283CB66B0086B580 /* es-419 */,
 			);
 			name = KMKeyboardHelpWindowController.xib;
 			path = Keyman4MacIM/KMKeyboardHelpWindow;
@@ -1012,7 +1024,8 @@
 				29C1E1782800227800759EDE /* pt-PT */,
 				29B5BC0728169A6600B86A17 /* ff */,
 				29BFA765282936D7009FCCC3 /* it */,
-				29BFA771282948C0009FCCC3 /* pl */
+				29BFA771282948C0009FCCC3 /* pl */,
+				29B70A27283CB66C0086B580 /* es-419 */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/es-419.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/es-419.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "Cerrar";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "Acuerdo de Licencia";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "Configuración...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/es-419.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/es-419.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "Mostrar siempre el teclado en pantalla";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "Usar registro detallado";
+
+/* Support button text  */
+"93O-x6-RLF.label" = "Soporte";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "Descargar teclado...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "Configuración de Keyman";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "Atrás";
+
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "Teclados";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "Cuando la opción de registro detallado está activada, Keyman registrará acciones que podrían ayudar a Keyman Support diagnosticar un problema. La aplicación de consola puede ser usada para ver un registro de mensajes de Keyman. En la aplicación de consola, puede filtrar para mostrar todos los mensajes del proceso \"Keyman\". Este registro puede ser exportado y enviado al soporte de Keyman si es necesario.";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "Siguiente";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "Inicio";
+
+/* Options button text */
+"frd-No-seV.label" = "Opciones";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "Teclado instalado";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "Active esta opción si tiene problemas con un teclado específico o con Keyman en general.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/es-419.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/es-419.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "Información del paquete";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "Detalles";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "Léame";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/es-419.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/es-419.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "Ayuda para teclado";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "Aceptar";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "Imprimir...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/es-419.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/es-419.lproj/Localizable.strings
@@ -1,0 +1,68 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "¿Estás seguro de que deseas eliminar el teclado '%@'?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "No puedes deshacer esta acción.";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "Cancelar";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "Eliminar";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "¿Instalar teclado de Keyman?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "¿Desea que Keyman instale el teclado desde el archivo '%@'?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "Cancelar";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "Instalar";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "No se pudo leer el archivo de Keyman '%@'.";
+
+/* Message displayed in Configuration window when keyboard cannot be loaded */
+"message-error-loading-keyboard" = "(error al cargar el teclado)";
+
+/* Message displayed in Configuration window when keyboard metadata cannot be loaded */
+"message-error-unknown-metadata" = "desconocido";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "Aceptar";
+
+/* label text to identify Keyman version */
+"version-label-text" = "Versión: %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "Descargando...";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "Descarga finalizada.";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "Cancelar";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "Hecho";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "Teclados:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "Fuentes:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "Versión del paquete:";
+
+/* author label in the Package Information window */
+"author-label" = "Autor:";
+
+/* website label in the Package Information window */
+"website-label" = "Página web:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "Derechos de autor:";

--- a/mac/Keyman4MacIM/Keyman4MacIM/es-419.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/es-419.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "Configuración...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "Teclados";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "Teclados";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "Acerca de";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "Teclado en pantalla";


### PR DESCRIPTION
This updates the crowdin strings for Spanish (Latin America) for Android, iOS, and macOS.
macOS strings are new, so 
TODO
- [x] @sgschantz will need to add the es-419 locale.

These strings will then be used as a "pivot translation" in translate.keyman.com for Qom.

## User Testing
Setup
Install PR build of Keyman for macOS

* **TEST_MACOS_STRINGS** - Verifies macOS localized for Spanish (Latin America)
1. Set the system locale to Spanish (Latin America). (`es-419`)
2. Restart the device
3. Launch Keyman for macOS
4. Verify UI is in Spanish (Latin America)
