### PR TITLE
feat(ios): adds back and forward navigation buttons for in-app help

### DIFF
--- a/ios/help/about/welcome.md
+++ b/ios/help/about/welcome.md
@@ -2,10 +2,10 @@
 title: Welcome to Keyman
 ---
 
-Thank you for installing Keyman for iPhone and iPad. Whether you're a new or returning user, 
+Thank you for installing Keyman for iPhone and iPad. Whether you're a new or returning user,
 we believe you will appreciate the significant enhancements in this latest version of Keyman for iPhone and iPad.
 
 ## What is Keyman for iPhone and iPad?
 Keyman for iPhone and iPad lets you type in over 600 languages on Apple iPhones and iPads.
 
-[Click here](../start) to get started
+[Click here](../start/) to get started

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
@@ -1,39 +1,73 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InfoViewController">
             <connections>
+                <outlet property="backButton" destination="TLs-g2-xbM" id="jNT-EB-krs"/>
+                <outlet property="forwardButton" destination="QUu-pQ-ATm" id="hlc-dV-pzs"/>
                 <outlet property="view" destination="1" id="26"/>
                 <outlet property="webView" destination="46" id="47"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="64" width="768" height="960"/>
+            <rect key="frame" x="0.0" y="0.0" width="768" height="974"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="3">
-                    <rect key="frame" x="0.0" y="0.0" width="768" height="960"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <subviews>
-                        <webView contentMode="scaleToFill" id="46">
-                            <rect key="frame" x="0.0" y="0.0" width="768" height="960"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                        </webView>
-                    </subviews>
-                </scrollView>
+                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="46">
+                    <rect key="frame" x="0.0" y="0.0" width="768" height="924"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </webView>
+                <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fsh-gd-wpz">
+                    <rect key="frame" x="0.0" y="924" width="768" height="50"/>
+                    <items>
+                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="rEo-7j-3D9"/>
+                        <barButtonItem image="chevron.left" catalog="system" id="TLs-g2-xbM">
+                            <connections>
+                                <action selector="back:" destination="-1" id="QxZ-wD-p3z"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="aOV-hW-Vog"/>
+                        <barButtonItem image="chevron.right" catalog="system" id="QUu-pQ-ATm">
+                            <connections>
+                                <action selector="forward:" destination="-1" id="nek-4k-IZn"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem systemItem="flexibleSpace" id="5kj-Re-lwh"/>
+                        <barButtonItem image="UIAccessoryButtonX.png" id="tui-2v-Hnv">
+                            <connections>
+                                <action selector="close:" destination="-1" id="Z6P-DT-vrW"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="aR8-Uo-xOo"/>
+                    </items>
+                </toolbar>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <viewLayoutGuide key="safeArea" id="4Nv-Di-iZ0"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="4Nv-Di-iZ0" firstAttribute="bottom" secondItem="fsh-gd-wpz" secondAttribute="bottom" id="DeX-v1-YPt"/>
+                <constraint firstItem="46" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="JKp-EJ-WRW"/>
+                <constraint firstAttribute="trailing" secondItem="46" secondAttribute="trailing" id="S6m-BM-jgq"/>
+                <constraint firstItem="fsh-gd-wpz" firstAttribute="trailing" secondItem="4Nv-Di-iZ0" secondAttribute="trailing" id="Umy-Nq-soY"/>
+                <constraint firstItem="fsh-gd-wpz" firstAttribute="top" secondItem="46" secondAttribute="bottom" id="ask-9d-0a8"/>
+                <constraint firstItem="fsh-gd-wpz" firstAttribute="leading" secondItem="4Nv-Di-iZ0" secondAttribute="leading" id="bQX-03-Vyz"/>
+                <constraint firstItem="46" firstAttribute="top" secondItem="1" secondAttribute="top" id="yQr-5s-ut4"/>
+            </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+            <point key="canvasLocation" x="-166.40625" y="69.7265625"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
+    <resources>
+        <image name="UIAccessoryButtonX.png" width="22" height="22"/>
+        <image name="chevron.left" catalog="system" width="96" height="128"/>
+        <image name="chevron.right" catalog="system" width="96" height="128"/>
+    </resources>
 </document>

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
@@ -28,7 +28,6 @@
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fsh-gd-wpz">
                     <rect key="frame" x="0.0" y="924" width="768" height="50"/>
                     <items>
-                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="rEo-7j-3D9"/>
                         <barButtonItem image="chevron.left" catalog="system" id="TLs-g2-xbM">
                             <connections>
                                 <action selector="back:" destination="-1" id="QxZ-wD-p3z"/>
@@ -46,7 +45,6 @@
                                 <action selector="close:" destination="-1" id="Z6P-DT-vrW"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="aR8-Uo-xOo"/>
                     </items>
                 </toolbar>
             </subviews>

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
@@ -1,40 +1,89 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InfoViewController">
             <connections>
+                <outlet property="backButton" destination="ptS-kA-9Tw" id="55r-w8-dlm"/>
+                <outlet property="forwardButton" destination="OvI-rz-OW9" id="WmO-fp-gXG"/>
                 <outlet property="view" destination="1" id="40"/>
                 <outlet property="webView" destination="38" id="41"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="64" width="320" height="416"/>
+            <rect key="frame" x="0.0" y="0.0" width="428" height="838"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="4">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q0q-mp-JYD">
+                    <rect key="frame" x="0.0" y="0.0" width="428" height="818"/>
                     <subviews>
-                        <webView contentMode="scaleToFill" id="38">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38">
+                            <rect key="frame" x="0.0" y="0.0" width="428" height="769"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </webView>
+                        <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DPl-QD-inD">
+                            <rect key="frame" x="0.0" y="769" width="428" height="49"/>
+                            <items>
+                                <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="PE1-7X-Amq"/>
+                                <barButtonItem image="chevron.left" catalog="system" id="ptS-kA-9Tw">
+                                    <connections>
+                                        <action selector="back:" destination="-1" id="2rM-Md-H8q"/>
+                                    </connections>
+                                </barButtonItem>
+                                <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="fLB-0C-ctw"/>
+                                <barButtonItem image="chevron.right" catalog="system" id="OvI-rz-OW9">
+                                    <connections>
+                                        <action selector="forward:" destination="-1" id="bYZ-fr-4LT"/>
+                                    </connections>
+                                </barButtonItem>
+                                <barButtonItem systemItem="flexibleSpace" id="pdo-sP-gkn"/>
+                                <barButtonItem image="UIAccessoryButtonX.png" id="Etw-CW-3uh">
+                                    <connections>
+                                        <action selector="close:" destination="-1" id="Or7-qh-Vf6"/>
+                                    </connections>
+                                </barButtonItem>
+                                <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="hfW-UQ-U3N"/>
+                            </items>
+                        </toolbar>
                     </subviews>
-                </scrollView>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="DPl-QD-inD" firstAttribute="top" secondItem="38" secondAttribute="bottom" id="Ejj-Y4-pzk"/>
+                        <constraint firstItem="38" firstAttribute="top" secondItem="q0q-mp-JYD" secondAttribute="top" id="LRX-hu-nAg"/>
+                        <constraint firstAttribute="trailing" secondItem="DPl-QD-inD" secondAttribute="trailing" id="TYo-px-TFZ"/>
+                        <constraint firstItem="38" firstAttribute="leading" secondItem="q0q-mp-JYD" secondAttribute="leading" id="Vdj-pf-UAE"/>
+                        <constraint firstAttribute="bottom" secondItem="DPl-QD-inD" secondAttribute="bottom" id="n3a-Am-nFt"/>
+                        <constraint firstAttribute="trailing" secondItem="38" secondAttribute="trailing" id="nwI-JB-3nD"/>
+                        <constraint firstItem="DPl-QD-inD" firstAttribute="leading" secondItem="q0q-mp-JYD" secondAttribute="leading" id="ogP-zo-V31"/>
+                    </constraints>
+                </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <viewLayoutGuide key="safeArea" id="TI6-wh-wgp"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="TI6-wh-wgp" firstAttribute="bottom" secondItem="q0q-mp-JYD" secondAttribute="bottom" constant="-14" id="0Hb-ri-MP5"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="leading" secondItem="TI6-wh-wgp" secondAttribute="leading" id="2Di-cj-RDH"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="top" secondItem="TI6-wh-wgp" secondAttribute="top" id="Pxf-g6-xoM"/>
+                <constraint firstItem="TI6-wh-wgp" firstAttribute="trailing" secondItem="q0q-mp-JYD" secondAttribute="trailing" id="k0p-fB-jZG"/>
+            </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-            <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-72.89719626168224" y="79.049676025917933"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
+    <resources>
+        <image name="UIAccessoryButtonX.png" width="22" height="22"/>
+        <image name="chevron.left" catalog="system" width="96" height="128"/>
+        <image name="chevron.right" catalog="system" width="96" height="128"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
@@ -23,56 +23,52 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q0q-mp-JYD">
-                    <rect key="frame" x="0.0" y="0.0" width="428" height="818"/>
-                    <subviews>
-                        <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38">
-                            <rect key="frame" x="0.0" y="0.0" width="428" height="769"/>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </webView>
-                        <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DPl-QD-inD">
-                            <rect key="frame" x="0.0" y="769" width="428" height="49"/>
-                            <items>
-                                <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="PE1-7X-Amq"/>
-                                <barButtonItem image="chevron.left" catalog="system" id="ptS-kA-9Tw">
-                                    <connections>
-                                        <action selector="back:" destination="-1" id="2rM-Md-H8q"/>
-                                    </connections>
-                                </barButtonItem>
-                                <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="fLB-0C-ctw"/>
-                                <barButtonItem image="chevron.right" catalog="system" id="OvI-rz-OW9">
-                                    <connections>
-                                        <action selector="forward:" destination="-1" id="bYZ-fr-4LT"/>
-                                    </connections>
-                                </barButtonItem>
-                                <barButtonItem systemItem="flexibleSpace" id="pdo-sP-gkn"/>
-                                <barButtonItem image="UIAccessoryButtonX.png" id="Etw-CW-3uh">
-                                    <connections>
-                                        <action selector="close:" destination="-1" id="Or7-qh-Vf6"/>
-                                    </connections>
-                                </barButtonItem>
-                                <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="hfW-UQ-U3N"/>
-                            </items>
-                        </toolbar>
-                    </subviews>
+                    <rect key="frame" x="0.0" y="804" width="428" height="34"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstItem="DPl-QD-inD" firstAttribute="top" secondItem="38" secondAttribute="bottom" id="Ejj-Y4-pzk"/>
-                        <constraint firstItem="38" firstAttribute="top" secondItem="q0q-mp-JYD" secondAttribute="top" id="LRX-hu-nAg"/>
-                        <constraint firstAttribute="trailing" secondItem="DPl-QD-inD" secondAttribute="trailing" id="TYo-px-TFZ"/>
-                        <constraint firstItem="38" firstAttribute="leading" secondItem="q0q-mp-JYD" secondAttribute="leading" id="Vdj-pf-UAE"/>
-                        <constraint firstAttribute="bottom" secondItem="DPl-QD-inD" secondAttribute="bottom" id="n3a-Am-nFt"/>
-                        <constraint firstAttribute="trailing" secondItem="38" secondAttribute="trailing" id="nwI-JB-3nD"/>
-                        <constraint firstItem="DPl-QD-inD" firstAttribute="leading" secondItem="q0q-mp-JYD" secondAttribute="leading" id="ogP-zo-V31"/>
-                    </constraints>
                 </view>
+                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38">
+                    <rect key="frame" x="0.0" y="0.0" width="428" height="755"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </webView>
+                <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DPl-QD-inD">
+                    <rect key="frame" x="0.0" y="755" width="428" height="49"/>
+                    <items>
+                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="PE1-7X-Amq"/>
+                        <barButtonItem image="chevron.left" catalog="system" id="ptS-kA-9Tw">
+                            <connections>
+                                <action selector="back:" destination="-1" id="2rM-Md-H8q"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="fLB-0C-ctw"/>
+                        <barButtonItem image="chevron.right" catalog="system" id="OvI-rz-OW9">
+                            <connections>
+                                <action selector="forward:" destination="-1" id="bYZ-fr-4LT"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem systemItem="flexibleSpace" id="pdo-sP-gkn"/>
+                        <barButtonItem image="UIAccessoryButtonX.png" id="Etw-CW-3uh">
+                            <connections>
+                                <action selector="close:" destination="-1" id="Or7-qh-Vf6"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="hfW-UQ-U3N"/>
+                    </items>
+                </toolbar>
             </subviews>
             <viewLayoutGuide key="safeArea" id="TI6-wh-wgp"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="TI6-wh-wgp" firstAttribute="bottom" secondItem="q0q-mp-JYD" secondAttribute="bottom" constant="-14" id="0Hb-ri-MP5"/>
-                <constraint firstItem="q0q-mp-JYD" firstAttribute="leading" secondItem="TI6-wh-wgp" secondAttribute="leading" id="2Di-cj-RDH"/>
-                <constraint firstItem="q0q-mp-JYD" firstAttribute="top" secondItem="TI6-wh-wgp" secondAttribute="top" id="Pxf-g6-xoM"/>
-                <constraint firstItem="TI6-wh-wgp" firstAttribute="trailing" secondItem="q0q-mp-JYD" secondAttribute="trailing" id="k0p-fB-jZG"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="DuX-dg-5mP"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="top" secondItem="TI6-wh-wgp" secondAttribute="bottom" id="EGB-3c-vKb"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="bottom" secondItem="1" secondAttribute="bottom" id="L2a-LF-e0z"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="trailing" secondItem="1" secondAttribute="trailing" id="MR2-Kw-FFc"/>
+                <constraint firstItem="DPl-QD-inD" firstAttribute="top" secondItem="38" secondAttribute="bottom" id="N05-AY-Vks"/>
+                <constraint firstItem="DPl-QD-inD" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="Uyx-jL-nrb"/>
+                <constraint firstItem="38" firstAttribute="top" secondItem="TI6-wh-wgp" secondAttribute="top" id="a6J-fg-ykX"/>
+                <constraint firstItem="38" firstAttribute="leading" secondItem="TI6-wh-wgp" secondAttribute="leading" id="k6F-H4-Dgi"/>
+                <constraint firstItem="38" firstAttribute="trailing" secondItem="TI6-wh-wgp" secondAttribute="trailing" id="udC-CP-YSS"/>
+                <constraint firstItem="DPl-QD-inD" firstAttribute="trailing" secondItem="1" secondAttribute="trailing" id="wiY-98-IhB"/>
+                <constraint firstItem="q0q-mp-JYD" firstAttribute="top" secondItem="DPl-QD-inD" secondAttribute="bottom" id="y3E-wq-FHx"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
             <point key="canvasLocation" x="-72.89719626168224" y="79.049676025917933"/>
@@ -80,7 +76,7 @@
     </objects>
     <resources>
         <image name="UIAccessoryButtonX.png" width="22" height="22"/>
-        <image name="chevron.left" catalog="system" width="96" height="128"/>
+        <image name="chevron.left" catalog="system" width="32" height="32"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
@@ -33,7 +33,6 @@
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DPl-QD-inD">
                     <rect key="frame" x="0.0" y="755" width="428" height="49"/>
                     <items>
-                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="PE1-7X-Amq"/>
                         <barButtonItem image="chevron.left" catalog="system" id="ptS-kA-9Tw">
                             <connections>
                                 <action selector="back:" destination="-1" id="2rM-Md-H8q"/>
@@ -51,7 +50,6 @@
                                 <action selector="close:" destination="-1" id="Or7-qh-Vf6"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem width="14" style="plain" systemItem="fixedSpace" id="hfW-UQ-U3N"/>
                     </items>
                 </toolbar>
             </subviews>
@@ -76,7 +74,7 @@
     </objects>
     <resources>
         <image name="UIAccessoryButtonX.png" width="22" height="22"/>
-        <image name="chevron.left" catalog="system" width="32" height="32"/>
+        <image name="chevron.left" catalog="system" width="96" height="128"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -384,9 +384,8 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // But, in the interest of a quick pre-release fix...
     let window = UIApplication.shared.windows.first
     let topPadding = window?.safeAreaInsets.top ?? 0
-    let bottomPadding = window?.safeAreaInsets.bottom ?? 0
     let barHeights: CGFloat = (topPadding == 0 ? AppDelegate.statusBarHeight() : topPadding) + navBarHeight()
-    let height: CGFloat = mainScreen.height - barHeights /*- bottomPadding*/ - kbHeight
+    let height: CGFloat = mainScreen.height - barHeights - kbHeight
 
     // Like really, this REALLY should be done with constraints.
     textView.frame = CGRect(x: margin, y: barHeights + margin,

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -373,14 +373,28 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // Resize textView and infoView
     let mainScreen: CGRect = UIScreen.main.bounds
     let margin: CGFloat = 2.0
-    let barHeights: CGFloat = AppDelegate.statusBarHeight() + navBarHeight()
     let kbHeight: CGFloat = keyboardVisible ? textView.inputView?.frame.height ?? 0 : 0
     let width: CGFloat = mainScreen.size.width
-    let height: CGFloat = mainScreen.size.height - barHeights - kbHeight
 
+    // This sort of thing really should be handled by the iOS layout engine, not programatically
+    // as it has been.  The original code was written pre-iOS 11 & safe areas!
+    // But, in the interest of a quick pre-release fix...
+    let window = UIApplication.shared.windows.first
+    let topPadding = window?.safeAreaInsets.top ?? 0
+    let bottomPadding = window?.safeAreaInsets.bottom ?? 0
+    let barHeights: CGFloat = (topPadding == 0 ? AppDelegate.statusBarHeight() : topPadding) + navBarHeight()
+    let height: CGFloat = mainScreen.height - barHeights /*- bottomPadding*/ - kbHeight
+
+    // Like really, this REALLY should be done with constraints.
     textView.frame = CGRect(x: margin, y: barHeights + margin,
                              width: width - 2 * margin, height: height - 2 * margin)
     infoView?.view?.frame = CGRect(x: 0, y: barHeights, width: width, height: height + kbHeight)
+
+    // Partly because it breaks the InfoView's safe area insets!
+    // This is programmatic correction for a bug our approach has caused.
+    var fixedSafeArea = UIEdgeInsets()
+    fixedSafeArea.bottom += bottomPadding
+    infoView?.additionalSafeAreaInsets = fixedSafeArea
   }
 
   private func navBarWidth() -> CGFloat {

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -192,7 +192,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     view?.addSubview(textView!)
 
     // Setup Info View
-    infoView = InfoViewController()
+    infoView = InfoViewController {
+      self.infoButtonClick(nil)
+    }
     if UIDevice.current.userInterfaceIdiom != .phone {
       textSize *= 2
       textView.font = textView?.font?.withSize(textSize)

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -203,6 +203,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     infoView.view?.isHidden = true
     infoView.view?.backgroundColor = UIColor(named: "InputBackground")!
     view?.addSubview(infoView!.view)
+    // Don't forget to add the child view's controller, too!
+    // Its safe area layout guide won't work correctly without this!
+    self.addChild(infoView)
 
     resizeViews(withKeyboardVisible: textView.isFirstResponder)
 
@@ -389,12 +392,6 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     textView.frame = CGRect(x: margin, y: barHeights + margin,
                              width: width - 2 * margin, height: height - 2 * margin)
     infoView?.view?.frame = CGRect(x: 0, y: barHeights, width: width, height: height + kbHeight)
-
-    // Partly because it breaks the InfoView's safe area insets!
-    // This is programmatic correction for a bug our approach has caused.
-    var fixedSafeArea = UIEdgeInsets()
-    fixedSafeArea.bottom += bottomPadding
-    infoView?.additionalSafeAreaInsets = fixedSafeArea
   }
 
   private func navBarWidth() -> CGFloat {


### PR DESCRIPTION
Fixes #6599.
Fixes #6653.  (The bug was discovered during testing and is a one-liner to fix.)

In a couple of screenshots...

![image](https://user-images.githubusercontent.com/25213402/170409857-eafe40be-bae4-4d52-af9d-fc0b336c1149.png)

![image](https://user-images.githubusercontent.com/25213402/170409985-1a6526b3-954a-43ff-b86d-8ff2363a262d.png)

Note the new bar at the bottom.  Since we've long had the bar at the top where it is, how it is... I felt it better to add something simple at the bottom.  This also mimics the in-app browser a bit, though with fewer toolbar options.  While the final, right-most option is redundant... the bar feels much better with that option, rather than having a whole bar _just_ for "back" and "forward".  I did consider a "top" / return-to-TOC... but then there's the matter of finding a reasonable icon / image for that.

### Other notes

I may have been a touch lazy and not implemented the safe-area buffer seen on phones for tablets, as there are not currently any notched iPads.  There's no guarantee that this won't happen in the future, though, so perhaps I should go ahead and implement that just in case?

Alternatively... having looked at the difference between the `InfoViewController`'s iPhone and iPad layout specs... I'm not sure why they're differentiated.  (Without the safe-area buffer differentiation, they may as well be identical!)  Perhaps we should just unify 'em and call it a day.  But... that's a big enough change to affect the scale of this review, so I felt it best to present as-is for now.

## User Testing

### Environments:

- GROUP_IPHONE_SE:  Test on the (notchless) iPhone SE (2nd gen) through Simulator
- GROUP_IPHONE_12:  Test on the (notched) iPhone 12 Pro Max through Simulator
- GROUP_IPAD_PRO: Test on any IPad Pro target available through Simulator.  Any **one** will suffice.
    - Basically, make sure things look fine on tablets, too.

### Tests

- TEST_HELP_NAVIGATION:  Make sure that the in-app help functions as expected...
    1.  Launch the Keyman app
    2. Open the help section / "info view".  You should see something like this:

        ![image](https://user-images.githubusercontent.com/25213402/170409857-eafe40be-bae4-4d52-af9d-fc0b336c1149.png)
        
        This is the "top level page".
    3. Fail the test if any of the buttons on the new toolbar at the bottom are obscured by edges or curves of the test device.
    4. Follow the "Welcome to Keyman" link (under "About Keyman")
    5. Verify that the back button on the toolbar lights up.
    6. Follow the "Click here" (to get started) link.
    7. The first line in the new page should read "Getting Started".
    8. Use the new back button one time - you should return to the previous page.
    9. Verify that the forward button on the toolbar lights up.
    10. Use the forward button one time - you should return to the "Getting Started" page.
    11. Verify that the forward button has greyed.
    12. Use the back button twice - you should return to the original, top-level page.
    13. Verify that the forward button has lit up and that the back button has greyed.