### PR TITLE
fix(web): osk shrinkage from rounding

### DIFF
--- a/web/source/osk/anchoredOskView.ts
+++ b/web/source/osk/anchoredOskView.ts
@@ -62,7 +62,7 @@ namespace com.keyman.osk {
     protected postKeyboardLoad() {
       // Initializes the size of a touch keyboard.
       if(this.vkbd && this.device.touchable) {
-        let targetOSKHeight = this.vkbd.computedAdjustedOskHeight(this.getDefaultKeyboardHeight());
+        let targetOSKHeight = this.getDefaultKeyboardHeight();
         this.setSize(this.getDefaultWidth(), targetOSKHeight + this.banner.height);
       }
 

--- a/web/source/osk/oskLayer.ts
+++ b/web/source/osk/oskLayer.ts
@@ -22,7 +22,7 @@ namespace com.keyman.osk {
                        layout: keyboards.ActiveLayout,
                        layer: keyboards.ActiveLayer) {
       this.spec = layer;
-      
+
       const gDiv = this.element = document.createElement('div');
       const gs=gDiv.style;
       gDiv.className='kmw-key-layer';
@@ -38,7 +38,7 @@ namespace com.keyman.osk {
       this.nextlayer = gDiv['layer'] = layer['id'];
       if(typeof layer['nextlayer'] == 'string') {
         // The gDiv['nextLayer'] is no longer referenced in KMW 15.0+, but is
-        // maintained for partial back-compat in case any site devs actually 
+        // maintained for partial back-compat in case any site devs actually
         // relied on its value from prior versions.
         //
         // We won't pay attention to any mutations to the gDiv copy, though.
@@ -90,10 +90,10 @@ namespace com.keyman.osk {
     public refreshLayout(vkbd: VisualKeyboard, paddedHeight: number, trueHeight: number) {
       // Check the heights of each row, in case different layers have different row counts.
       let nRows = this.rows.length;
-      let rowHeight = Math.floor(trueHeight/(nRows == 0 ? 1 : nRows));
+      let rowHeight = Math.floor(paddedHeight/(nRows == 0 ? 1 : nRows));
 
       if(vkbd.usesFixedHeightScaling) {
-        this.element.style.height=(paddedHeight)+'px';
+        this.element.style.height=(trueHeight)+'px';
       }
 
       for(let nRow=0; nRow<nRows; nRow++) {
@@ -102,8 +102,8 @@ namespace com.keyman.osk {
 
         if(vkbd.usesFixedHeightScaling) {
           // Calculate the exact vertical coordinate of the row's center.
-          this.spec.row[nRow].proportionalY = ((paddedHeight - bottom) - rowHeight/2) / paddedHeight;
-        
+          this.spec.row[nRow].proportionalY = ((trueHeight - bottom) - rowHeight/2) / paddedHeight;
+
           if(nRow == nRows-1) {
             oskRow.element.style.bottom = '1px';
           }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -366,7 +366,7 @@ namespace com.keyman.osk {
      * of alternate keystroke sequences.
      * @param input The input coordinate of the event that led to use of this function
      * @param keySpec The spec of the key directly triggered by the input event.  May be for a subkey.
-     * @returns 
+     * @returns
      */
     getTouchProbabilities(input: InputEventCoordinate, keySpec?: keyboards.ActiveKey): text.KeyDistribution {
       let keyman = com.keyman.singleton;
@@ -1235,9 +1235,9 @@ namespace com.keyman.osk {
       let b = this.layerGroup.element as HTMLElement;
       let gs = this.kbdDiv.style;
       let bs = b.style;
-      if (this.usesFixedHeightScaling) {
+      if (this.usesFixedHeightScaling && this.height) {
         // Sets the layer group to the correct height.
-        gs.height = gs.maxHeight = paddedHeight + 'px';
+        gs.height = gs.maxHeight = this.height + 'px';
       }
 
       // The font-scaling applied on the layer group.


### PR DESCRIPTION
Fixes #5646.

The reason that the black border line was appearing in the iOS keyboard is that before these changes, the OSK may shrink itself slightly during its initialization.  The reason for this?  From `VisualKeyboard.computedAdjustedOskHeight`:

https://github.com/keymanapp/keyman/blob/2d0fed11d37aec94875054413a335d94fdefc69d/web/source/osk/visualKeyboard.ts#L1290-L1300

Note:  that's a `Math.floor`.  As a result, this will never adjust to a greater total height, but may adjust it - rather, shrink it - if it would otherwise result in keyboard rows with fractional height.

The thing is... there's no need to shrink the main container (`_Box`) of the OSK.  We can round the rows to even integer heights and just keep an extra pixel or two at the top, rather than ending the element early... which shows the 1px black border as a result.

## User Testing

* TEST_IPHONE_12_MAX_PRO:  Using the Simulator for the iPhone 12 Pro Max...
    - Load the Keyman app and ensure that no black border bar appears at the top of the keyboard.
    - Confirm for both portrait and landscape orientations.
* TEST_IPHONE_SE:   Using the Simulator for the iPhone SE (2nd gen)...
    - Load the Keyman app and ensure that no black border bar appears at the top of the keyboard.
    - Confirm for both portrait and landscape orientations.
* TEST_DESKTOP_WEB:  Visit the standard "unminified" test page - `web/testing/unminified.html` / "Test unminified Keymanweb"
    - Confirm that the OSK appears as normal, with no glaring visual artifacts or glitches.
        - Basically, report if something looks seriously unintended.
    - Resize the keyboard by clicking and dragging the button that looks like this:
        ![image](https://user-images.githubusercontent.com/25213402/170221943-f9a0ecb6-fae6-40dc-8abe-813530efd89e.png)
        - It should appear to resize fairly smoothly; you should have a reasonable looking OSK no matter where and when you stop dragging that handle.
    - Generally, it should look something like this:

        ![image](https://user-images.githubusercontent.com/25213402/170222473-2b6619a9-b4db-4d53-a02d-51ce2a7a8a65.png)

        It may stretch wider or narrower as you resize it, matching your mouse movements, unless you try to shrink it too much in one or both dimensions.


Note that the first test - for the iPhone 12 Max Pro - would fail on the current `beta` branch.