### PR TITLE
chore(web): reintroduce sourceRoot and revert types 🎡

### DIFF
--- a/common/web/input-processor/src/tsconfig.json
+++ b/common/web/input-processor/src/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "inlineSources": true,
     "sourceMap": true,
+    "sourceRoot": "keyman/",
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],

--- a/common/web/keyboard-processor/src/tsconfig.json
+++ b/common/web/keyboard-processor/src/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "inlineSources": true,
     "sourceMap": true,
+    "sourceRoot": "keyman/",
     "target": "es5",
     "types": ["node"],
     "lib": ["es6"],

--- a/common/web/lm-worker/src/correction/distance-modeler.ts
+++ b/common/web/lm-worker/src/correction/distance-modeler.ts
@@ -8,7 +8,7 @@ namespace correction {
     traversal: LexiconTraversal
   }
 
-  export const QUEUE_NODE_COMPARATOR: any /*models.Comparator<SearchNode>*/ = function(arg1, arg2) { // @ts-ignore
+  export const QUEUE_NODE_COMPARATOR: models.Comparator<SearchNode> = function(arg1, arg2) {
     return arg1.currentCost - arg2.currentCost;
   }
 

--- a/common/web/lm-worker/src/index.ts
+++ b/common/web/lm-worker/src/index.ts
@@ -383,7 +383,7 @@ class LMLayerWorker {
    *
    * @param scope A global scope to install upon.
    */
-  static install(scope: any /* DedicatedWorkerGlobalScope */): LMLayerWorker {  // @ts-ignore
+  static install(scope: DedicatedWorkerGlobalScope): LMLayerWorker {
     let worker = new LMLayerWorker({ postMessage: scope.postMessage, importScripts: scope.importScripts.bind(scope) });
     scope.onmessage = worker.onMessage.bind(worker);
     worker.self = scope;

--- a/common/web/lm-worker/src/worker-interfaces.ts
+++ b/common/web/lm-worker/src/worker-interfaces.ts
@@ -31,8 +31,8 @@
 /**
  * The signature of self.postMessage(), so that unit tests can mock it.
  */
-type PostMessage = any; //typeof DedicatedWorkerGlobalScope.prototype.postMessage; // @ts-ignore
-type ImportScripts = any; //typeof DedicatedWorkerGlobalScope.prototype.importScripts; // @ts-ignore
+type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
+type ImportScripts = typeof DedicatedWorkerGlobalScope.prototype.importScripts;
 
 
 /**

--- a/web/source/tsconfig.base.json
+++ b/web/source/tsconfig.base.json
@@ -6,7 +6,7 @@
     "outDir": "../intermediate/",
     "inlineSources": true,
     "sourceMap": true,
-    // "sourceRoot": "/keyman/",
+    "sourceRoot": "/keyman/",
     "target": "es5",
     "types": ["node"],
     "lib": ["es6", "dom"]


### PR DESCRIPTION
Addresses review comments in #6525:

* There were a few temporary type patches I had made earlier in the refactor chain in order to get a build to pass. After completing the refactor, I was able to return them to their more proper types.
* revert PostMessage and ImportScripts types
* reintroduce sourceRoot in tsconfig files

@keymanapp-test-bot skip