### PR TITLE
fix(android/engine): Disable haptic feedback on hardware keystrokes

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboardJSHandler.java
@@ -82,5 +82,5 @@ public abstract class KMKeyboardJSHandler {
    * @param dr  Number of post-caret code points to delete.
    */
   @JavascriptInterface
-  public abstract void insertText(final int dn, final String s, final int dr);
+  public abstract void insertText(final int dn, final String s, final int dr, final boolean executingHardwareKeystroke);
 }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -207,8 +207,10 @@ public final class KMManager {
   protected static String currentBanner = KM_BANNER_STATE_BLANK;
 
 
-  // Special override for when the keyboard may have haptic feedback when typing
+  // Special override for when the keyboard may have haptic feedback when typing.
+  // haptic feedback disabled for hardware keystrokes
   private static boolean mayHaveHapticFeedback = false;
+  private static boolean executingHardwareKeystroke = false;
 
   // Special override for when keyboard is entering a password text field.
   // When mayPredictOverride is true, the option {'mayPredict' = false} is set in the lm-layer
@@ -459,6 +461,7 @@ public final class KMManager {
   public static InputMethodService getInputMethodService() { return IMService; }
 
   public static boolean executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
+    executingHardwareKeystroke = true;
     if (SystemKeyboard != null) {
       return executeHardwareKeystroke(code, shift, KeyboardType.KEYBOARD_TYPE_SYSTEM, lstates, eventModifiers);
     } else if (InAppKeyboard != null) {
@@ -470,6 +473,7 @@ public final class KMManager {
 
   public static boolean executeHardwareKeystroke(
     int code, int shift, KeyboardType keyboard, int lstates, int eventModifiers) {
+    executingHardwareKeystroke = true;
     if (keyboard == KeyboardType.KEYBOARD_TYPE_INAPP && InAppKeyboard != null) {
       InAppKeyboard.executeHardwareKeystroke(code, shift, lstates, eventModifiers);
       return true;
@@ -2815,9 +2819,10 @@ public final class KMManager {
           // Collapse the selection
           textView.setSelection(start + s.length());
           textView.endBatchEdit();
-          if (mayHaveHapticFeedback) {
+          if (mayHaveHapticFeedback && !executingHardwareKeystroke) {
             textView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
           }
+          executingHardwareKeystroke = false;
         }
       });
     }
@@ -2960,9 +2965,10 @@ public final class KMManager {
 
           ic.endBatchEdit();
           ViewGroup parent = (ViewGroup) SystemKeyboard.getParent();
-          if (parent != null && mayHaveHapticFeedback) {
+          if (parent != null && mayHaveHapticFeedback && !executingHardwareKeystroke) {
             parent.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
           }
+          executingHardwareKeystroke = false;
         }
       });
     }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -210,7 +210,6 @@ public final class KMManager {
   // Special override for when the keyboard may have haptic feedback when typing.
   // haptic feedback disabled for hardware keystrokes
   private static boolean mayHaveHapticFeedback = false;
-  private static boolean executingHardwareKeystroke = false;
 
   // Special override for when keyboard is entering a password text field.
   // When mayPredictOverride is true, the option {'mayPredict' = false} is set in the lm-layer
@@ -461,7 +460,6 @@ public final class KMManager {
   public static InputMethodService getInputMethodService() { return IMService; }
 
   public static boolean executeHardwareKeystroke(int code, int shift, int lstates, int eventModifiers) {
-    executingHardwareKeystroke = true;
     if (SystemKeyboard != null) {
       return executeHardwareKeystroke(code, shift, KeyboardType.KEYBOARD_TYPE_SYSTEM, lstates, eventModifiers);
     } else if (InAppKeyboard != null) {
@@ -473,7 +471,6 @@ public final class KMManager {
 
   public static boolean executeHardwareKeystroke(
     int code, int shift, KeyboardType keyboard, int lstates, int eventModifiers) {
-    executingHardwareKeystroke = true;
     if (keyboard == KeyboardType.KEYBOARD_TYPE_INAPP && InAppKeyboard != null) {
       InAppKeyboard.executeHardwareKeystroke(code, shift, lstates, eventModifiers);
       return true;
@@ -2711,7 +2708,7 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s, final int dr) {
+    public void insertText(final int dn, final String s, final int dr, final boolean executingHardwareKeystroke) {
       if(dr != 0) {
         Log.d(TAG, "Right deletions requested but are not presently supported by the in-app keyboard.");
       }
@@ -2822,7 +2819,6 @@ public final class KMManager {
           if (mayHaveHapticFeedback && !executingHardwareKeystroke) {
             textView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
           }
-          executingHardwareKeystroke = false;
         }
       });
     }
@@ -2874,7 +2870,7 @@ public final class KMManager {
 
     // This annotation is required in Jelly Bean and later:
     @JavascriptInterface
-    public void insertText(final int dn, final String s, final int dr) {
+    public void insertText(final int dn, final String s, final int dr, final boolean executingHardwareKeystroke) {
       // TODO: Unify in-app and system insertText
       Handler mainLoop = new Handler(Looper.getMainLooper());
       mainLoop.post(new Runnable() {
@@ -2968,7 +2964,6 @@ public final class KMManager {
           if (parent != null && mayHaveHapticFeedback && !executingHardwareKeystroke) {
             parent.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY, HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
           }
-          executingHardwareKeystroke = false;
         }
       });
     }


### PR DESCRIPTION
Follow-on to #6626 and fixes #6665

This updates KMManager to not vibrate the device when processing hardware keystrokes.

## User Testing
**Setup**
1. Pair a physical Android device with an external keyboard
2. Install the PR build of "Keyman for Android"
3. Start Keyman 
4. On the "Get Started" menu, enable Keyman as a system-wide keyboard and set Keyman as default keyboard
5. Clear the checkbox for **Show "Get Started" on startup** and dismiss the "Get Started" menu

* **TEST_INAPP_KEYBOARD** - Verifies haptic feedback with the in-app keyboard
1. Start Keyman
2. In the Keyman app, type with the OSK a mixture of base keys, longpress keys, and suggestions
6. Verify the device **does not** vibrate when outputting text (haptic feedback defaults to off)
7. In the Keyman app, type with the external keyboard
8. Verify the device **does not** vibrate when outputting text
9. In the Keyman app, go to "Settings" and enable the toggle for "Vibrate when typing"
10. Dismiss the "Settings" menu
11. In the Keyman app, type with the OSK a mixture of base keys, longpress keys, and suggestions
12. Verify the device **does** vibrate when outputting text
13. In the Keyman app, type with the external keyboard
14. Verify the device **does not** vibrate when outputting text (haptic feedback disabled for hardware keystrokes)
15. In the Keyman app, go to "Settings" and disable the toggle for "Vibrate when typing" (returns to default for next text)

* **TEST_SYSTEM_KEYBOARD** - Verifies haptic feedback with the system keyboard
1. Launch an external app (like Google Chrome) and click in a text field
2. With Keyman selected as the keyboard, type with the OSK a mixture of base keys, longpress keys, and suggestions
3. Verify the device **does not** vibrate when outputting text (haptic feedback defaults to off)
4. In the external app, type with the external keyboard
5. Verify the device **does not** vibrate when outputting text
6. In the Keyman app, go to "Settings" and enable the toggle for "Vibrate when typing"
7. Dismiss the "Settings" menu
8. In the external app, type with the OSK a mixture of base keys, longpress keys, and suggestions
9. Verify the device **does** vibrate when outputting text
10. In the external app, type with the external keyboard
11. Verify the device **does not** vibrate when outputting text (haptic feedback disabled for hardware keystrokes)
