### PR TITLE
chore(web): adapts keyman-version bundling in Developer products 🎡

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -85,7 +85,7 @@ module.exports = function(config) {
       os: 'Windows',
       os_version: '10',
       browser: 'chrome',
-      browser_version: '90.0'
+      browser_version: '70.0'
     },
     // On recent versions of Edge, launcher fails to start and/or stop Edge successfully
     //bs_edge_win: {

--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -74,7 +74,7 @@ module.exports = function(config) {
 
   var CURRENT_WIN_LAUNCHERS = {
     // Currently, Firefox launcher is unstable; see https://github.com/karma-runner/karma-firefox-launcher/issues/93
-    // (in particular "not maintained" commentary). 
+    // (in particular "not maintained" commentary).
     //bs_firefox_win: {
     //  os: 'Windows',
     //  os_version: '10',
@@ -85,7 +85,7 @@ module.exports = function(config) {
       os: 'Windows',
       os_version: '10',
       browser: 'chrome',
-      browser_version: '70.0'
+      browser_version: '90.0'
     },
     // On recent versions of Edge, launcher fails to start and/or stop Edge successfully
     //bs_edge_win: {

--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -5,13 +5,10 @@
   "exports": "./build/index.js",
   "scripts": {
     "build": "echo 'Building @keymanapp/keyman-version' && tsc -b",
-    "clean": "tsc -b --clean",
-    "postinstall": "gosh ./build.sh build",
-    "postci": "gosh ./build.sh build"
+    "clean": "tsc -b --clean"
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.5.4",
-    "@keymanapp/resources-gosh": "*"
+    "typescript": "^4.5.4"
   }
 }

--- a/developer/js/bundle.sh
+++ b/developer/js/bundle.sh
@@ -103,6 +103,15 @@ npm pack
 mv keymanapp-models-types*.tgz kmtypes.tgz
 mv kmtypes.tgz "$KEYMAN_WIX_TEMP_MODELCOMPILER"
 
+
+cp -R "$KEYMAN_ROOT/node_modules/@keymanapp/keyman-version" "$KEYMAN_MODELCOMPILER_TEMP/node_modules/@keymanapp/"
+
+cd "$KEYMAN_MODELCOMPILER_TEMP/node_modules/@keymanapp/keyman-version"
+set_npm_version
+npm pack
+mv keymanapp-keyman-version*.tgz kmver.tgz
+mv kmver.tgz "$KEYMAN_WIX_TEMP_MODELCOMPILER"
+
 # Step 3 - install just the bare essentials by using our packed local
 # dependency, followed by all external production dependencies.
 cd "$KEYMAN_WIX_TEMP_MODELCOMPILER"
@@ -123,10 +132,12 @@ cat "$KEYMAN_MODELCOMPILER_TEMP/package.json" | "$JQ" \
   > "package.json"
 
 npm install kmtypes.tgz --production --no-optional
+npm install kmver.tgz --production --no-optional
 npm install --production --no-optional
 
 # Clean up the npm pack artifacts for the dependencies.
 rm kmtypes.tgz
+rm kmver.tgz
 
 # We don't need the unit tests
 rm -rf "$KEYMAN_WIX_TEMP_MODELCOMPILER/tests"

--- a/developer/js/source/kmlmc.ts
+++ b/developer/js/source/kmlmc.ts
@@ -12,7 +12,7 @@ import { SysExits } from './util/sysexits';
 
 let inputFilename: string;
 
-/// <reference types="@keymanapp/keyman-version" />
+const KEYMAN_VERSION = require("@keymanapp/keyman-version").KEYMAN_VERSION;
 
 /* Arguments */
 program

--- a/developer/js/source/kmlmi.ts
+++ b/developer/js/source/kmlmi.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import KmpCompiler from './package-compiler/kmp-compiler';
 import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from './model-info-compiler/model-info-compiler';
 import { SysExits } from './util/sysexits';
+const KEYMAN_VERSION = require("@keymanapp/keyman-version").KEYMAN_VERSION;
 
 let inputFilename: string;
 

--- a/developer/js/source/kmlmp.ts
+++ b/developer/js/source/kmlmp.ts
@@ -7,6 +7,7 @@ import * as program from 'commander';
 import * as fs from 'fs';
 import KmpCompiler from './package-compiler/kmp-compiler';
 import { SysExits } from './util/sysexits';
+const KEYMAN_VERSION = require("@keymanapp/keyman-version").KEYMAN_VERSION;
 
 let inputFilename: string;
 

--- a/developer/js/source/lexical-model-compiler/model-definitions.ts
+++ b/developer/js/source/lexical-model-compiler/model-definitions.ts
@@ -3,7 +3,7 @@ import { defaultApplyCasing,
          defaultSearchTermToKey
        } from "./model-defaults";
 
-const KEYMAN_VERSION = require("@keymanapp/keyman-version");
+const KEYMAN_VERSION = require("@keymanapp/keyman-version").KEYMAN_VERSION;
 
 /**
  * Processes certain defined model behaviors in such a way that the needed closures

--- a/developer/server/build.sh
+++ b/developer/server/build.sh
@@ -180,6 +180,10 @@ if (( production )) ; then
   rm -f node_modules/ngrok/bin/ngrok.exe
   popd
 
+  # @keymanapp/keyman-version is required in dist now but we need to copy it in manually
+  mkdir -p "$PRODBUILDTEMP/node_modules/@keymanapp/"
+  cp -R "$KEYMAN_ROOT/node_modules/@keymanapp/keyman-version/" "$PRODBUILDTEMP/node_modules/@keymanapp/"
+
   # We'll build in the build/ folder
   rm -rf build/
   mkdir build/

--- a/developer/server/src/environment.ts
+++ b/developer/server/src/environment.ts
@@ -1,3 +1,5 @@
 import { extractVersionData } from './version-data';
 // TODO: environment should be just KEYMAN_VERSION
+
+const KEYMAN_VERSION = require("@keymanapp/keyman-version").KEYMAN_VERSION;
 export const environment = extractVersionData(KEYMAN_VERSION.VERSION_WITH_TAG);

--- a/oem/firstvoices/ios/exportAppStore.plist
+++ b/oem/firstvoices/ios/exportAppStore.plist
@@ -7,9 +7,9 @@
     <key>teamID</key>
     <string>D7TR486TEH</string>
     <key>signingCertificate</key>
-    <string>B165C9678B6CB2CA34C397482DF2EF32A28B8CD0</string>
+    <string>EFA9DE793B2A25F38270468AE62060CFF55CD634</string>
     <key>installerSigningCertificate</key>
-    <string>B165C9678B6CB2CA34C397482DF2EF32A28B8CD0</string>
+    <string>EFA9DE793B2A25F38270468AE62060CFF55CD634</string>
     <key>provisioningProfiles</key>
     <dict>
         <key>com.firstvoices.keyboards</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,12 +219,13 @@
       "devDependencies": {}
     },
     "common/web/input-processor": {
+      "name": "@keymanapp/input-processor",
       "license": "MIT",
       "dependencies": {
         "@keymanapp/keyboard-processor": "*",
+        "@keymanapp/keyman-version": "*",
         "@keymanapp/lexical-model-layer": "*",
         "@keymanapp/models-types": "*",
-        "@keymanapp/web-environment": "*",
         "@keymanapp/web-utils": "*",
         "eventemitter3": "^4.0.0"
       },
@@ -240,10 +241,11 @@
       }
     },
     "common/web/keyboard-processor": {
+      "name": "@keymanapp/keyboard-processor",
       "license": "MIT",
       "dependencies": {
+        "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "@keymanapp/web-environment": "*",
         "@keymanapp/web-utils": "*",
         "@types/node": "^11.9.4"
       },
@@ -258,7 +260,22 @@
     },
     "common/web/keyman-version": {
       "name": "@keymanapp/keyman-version",
-      "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.5.4"
+      }
+    },
+    "common/web/keyman-version-node": {
+      "name": "@keymanapp/keyman-version-node",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.5.4"
+      }
+    },
+    "common/web/keyman-version/node": {
+      "name": "@keymanapp/keyman-version-node",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
@@ -317,11 +334,12 @@
       "dev": true
     },
     "common/web/recorder": {
+      "name": "@keymanapp/recorder-core",
       "license": "MIT",
       "dependencies": {
         "@keymanapp/keyboard-processor": "*",
+        "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "@keymanapp/web-environment": "*",
         "@keymanapp/web-utils": "*",
         "@types/node": "^11.9.4"
       },
@@ -330,9 +348,10 @@
       }
     },
     "common/web/sentry-manager": {
+      "name": "@keymanapp/web-sentry-manager",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/web-environment": "*",
+        "@keymanapp/keyman-version": "*",
         "@sentry/browser": "^5.27.4"
       },
       "devDependencies": {
@@ -340,10 +359,11 @@
       }
     },
     "common/web/utils": {
+      "name": "@keymanapp/web-utils",
       "license": "MIT",
       "devDependencies": {
+        "@keymanapp/keyman-version": "*",
         "@keymanapp/resources-gosh": "*",
-        "@keymanapp/web-environment": "*",
         "@types/node": "^14.0.5",
         "typescript": "^4.5.4"
       }
@@ -6552,7 +6572,6 @@
     "@keymanapp/keyman-version": {
       "version": "file:common/web/keyman-version",
       "requires": {
-        "@keymanapp/resources-gosh": "*",
         "typescript": "^4.5.4"
       }
     },

--- a/web/source/build_dev_resources.sh
+++ b/web/source/build_dev_resources.sh
@@ -25,4 +25,5 @@ if [ $? -ne 0 ]; then
     fail "Typescript compilation failed for 'dev_resources'."
 fi
 
-cp ../release/dev_resources/dev_resources.js "$ENGINE_TEST_OUTPUT/dev_resources.js.map"
+cp ../release/dev_resources/dev_resources.js "$ENGINE_TEST_OUTPUT/dev_resources.js"
+cp ../release/dev_resources/dev_resources.js.map "$ENGINE_TEST_OUTPUT/dev_resources.js.map"


### PR DESCRIPTION
As KEYMAN-VERSION changed from being a type to a class, this broke the bundling and referencing strategies in Developer/Server and Developer/kmlmc. This updates the bundling process and fixes the references in both projects.

Note that keyman-version no longer depends on gosh. Given we are currently manually calling the build for this in all projects (or should be!), it's better that we keep the build of this explicit for now.

If we want to restore the postinstall/postci steps in the future, the gosh dependency would need to be manually removed from package.json in order for the bundling builds to work for Developer/Server and Developer/kmlmc.

@keymanapp-test-bot skip