### PR TITLE
fix(web): crash in highlightKey

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1921,7 +1921,7 @@ namespace com.keyman.osk {
      **/
     highlightKey(key: KeyElement, on: boolean) {
       // Do not change element class unless a key
-      if(!key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
+      if(!key || (key.className == '') || (typeof key.className != 'string') || (key.className.indexOf('kmw-key-row') >= 0)) return;
 
       var classes=key.className, cs = ' kmw-key-touched';
 


### PR DESCRIPTION
Fixes [KEYMAN-WEB-X](https://sentry.io/organizations/keyman/issues/2846706970/?project=5983524&query=is%3Aunresolved).

Relates to #6541.

`TypeError: Cannot read properties of undefined (reading 'indexOf')`

@jahorton I have not identified a root cause for this. There may be something deeper going on? But this mitigates the crash report I think.

~~Once this is approved I will cherry-pick to beta (which will then flow through to alpha eventually).~~

@keymanapp-test-bot skip (I cannot think of any applicable tests)