### PR TITLE
fix(web): fixes OSK-interaction issues in Float, Toolbar UI modules 

### DIFF
--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -56,14 +56,16 @@ if(!window['keyman']['ui']['name']) {
      */
     ui.toggleOSK = function()
     {
+      keymanweb['activatingUI'](true);
       // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
-      keymanweb['focusLastActiveElement']();
       if(osk && osk['show'])
       {
         if(osk['isEnabled']()) osk['hide'](); else osk['show'](true);
       }
       if(window.event) window.event.returnValue=false;
+      keymanweb['focusLastActiveElement']();
+      keymanweb['activatingUI'](false);
       return false;
     }
 
@@ -397,6 +399,7 @@ if(!window['keyman']['ui']['name']) {
      */
     ui.SelectKeyboardChange = function(e)
     {
+      keymanweb['activatingUI'](true);
       if(ui.KeyboardSelector.value != '-')
       {
         var i=ui.KeyboardSelector.selectedIndex;
@@ -408,6 +411,7 @@ if(!window['keyman']['ui']['name']) {
 
       //if(osk['show']) osk['show'](osk['isEnabled']()); handled by keyboard change event???
       keymanweb['focusLastActiveElement']();
+      keymanweb['activatingUI'](false);
       ui.selecting = true;
     }
 

--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -8,7 +8,7 @@
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!window['keyman']['ui']['name']) { 
+if(!window['keyman']['ui']['name']) {
   /********************************/
   /*                              */
   /* Floating User Interface      */
@@ -22,7 +22,7 @@ if(!window['keyman']['ui']['name']) {
    * Instead, use the --output-wrapper command during optimization, which will
    * add the anonymous function to enclose all code, including those optimized
    * variables which would otherwise have global scope.
-   **/  
+   **/
 
   try {
 
@@ -33,112 +33,113 @@ if(!window['keyman']['ui']['name']) {
 
     // Disable UI for touch devices
     if(util['isTouchDevice']()) throw '';
-    
+
     // User interface global and local variables
     keymanweb['ui'] = {};
     var ui=keymanweb['ui'];
     ui['name'] = 'float';
-    
-    ui.KeyboardSelector = null; 
-    
+
+    ui.KeyboardSelector = null;
+
     ui.outerDiv = null;     // replaces DivKeymanWeb
     ui.innerDiv = null;     // replaces Lkdiv
-    ui.oskButton = null;    // toggles OSK on or off  
+    ui.oskButton = null;    // toggles OSK on or off
     ui.kbdIcon = null;      // keyboard icon within OSK button
     ui.selecting = false;   // control focus behaviour during selection
     ui.updateList = true;   // control keyboard list updating
     ui.updateTimer = null;  // prevent unnecessary list refreshing
     ui.floatRight = false;  // align left by default
-    ui.initialized = false; // initialization flag 
+    ui.initialized = false; // initialization flag
 
     /**
      * Display or hide the OSK from the OSK icon link
-     */     
+     */
     ui.toggleOSK = function()
     {
-      let osk = keymanweb.osk;
+      // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
+      let osk = keymanweb['osk'];
       keymanweb['focusLastActiveElement']();
-      if(osk && osk['show']) 
+      if(osk && osk['show'])
       {
         if(osk['isEnabled']()) osk['hide'](); else osk['show'](true);
       }
       if(window.event) window.event.returnValue=false;
       return false;
     }
-    
+
     /**
      * Function     Initialize
-     * Scope        Private   
+     * Scope        Private
      * Description  UI Initialization
      **/
     ui['initialize'] = ui.Initialize = function()
-    { 
+    {
       // Must always initialize after keymanWeb itself, otherwise options are undefined
       if(!keymanweb['initialized'])
       {
         window.setTimeout(ui.Initialize,50); return;
       }
-      
+
       if(ui.initialized || util['isTouchDevice']()) return;
-          
+
       var imgPath=util['getOption']('resources')+"ui/float/";
-      
+
       ui.outerDiv = util['createElement']('DIV');         // Container for UI (visible when KeymanWeb is active)
       ui.innerDiv = util['createElement']('DIV');         // inner div for UI
-      ui.kbdIcon = util['createElement']('IMG');  
+      ui.kbdIcon = util['createElement']('IMG');
       ui.outerDiv.innerHTML = "<a href='http://keyman.com/web/' target='KeymanWebHelp'>"
         + "<img src='"+imgPath+"kmicon.gif' border='0' style='padding: 0px 2px 0 1px; margin:0px;' title='KeymanWeb' alt='KeymanWeb' /></a>"; /* I2081 */
 
-      var s=ui.outerDiv.style;                                                                              
+      var s=ui.outerDiv.style;
       s.backgroundColor='white'; s.border='solid 1px black'; s.position='absolute'; s.height='18px';
-      s.font='bold 8pt sans-serif'; s.display='none'; s.textAlign='left';s.overflow='hidden'; 
-      
+      s.font='bold 8pt sans-serif'; s.display='none'; s.textAlign='left';s.overflow='hidden';
+
       util['attachDOMEvent'](ui.outerDiv,'mousedown',ui._SelectorMouseDown);
       util['attachDOMEvent'](ui.outerDiv,'mouseover',ui._SelectorMouseOver);
       util['attachDOMEvent'](ui.outerDiv,'mouseout',ui._SelectorMouseOut);
-          
+
       // Register keymanweb events
-      ui.registerEvents();        
+      ui.registerEvents();
 
       ui.kbdIcon.src = imgPath+'kbdicon.gif';
       ui.kbdIcon.title = 'Display visual keyboard';
 
       // Set initial OSK button style (off by default)
       ui.oskButtonState(false);
-      
-      var Lhdiv = util['createElement']('DIV'); 
+
+      var Lhdiv = util['createElement']('DIV');
       ui.oskButton = Lhdiv;
-      Lhdiv.onclick = ui.toggleOSK;    
+      Lhdiv.onclick = ui.toggleOSK;
       Lhdiv.appendChild(ui.kbdIcon);
       ui.innerDiv.appendChild(Lhdiv);
       ui.outerDiv.appendChild(ui.innerDiv);
       document.body.appendChild(ui.outerDiv);
 
       ui.KeyboardSelector =  util['createElement']('SELECT'); // ControlSelector - KeymanWeb keyboard selector
-      
+
       s=ui.KeyboardSelector.style;
       s.font='8pt sans-serif'; s.backgroundColor='#f3e5de'; s.border='solid 1px #7B9EBD'; s.height='16px';s.margin='1px 2px 0px 2px';
       s.left='20px'; s.top='0px'; s.position='absolute'; s.maxWidth='150px';
 
       util['attachDOMEvent'](ui.KeyboardSelector,'change',ui.SelectKeyboardChange);
       util['attachDOMEvent'](ui.KeyboardSelector,'blur',ui.SelectBlur);
-      
-      ui.innerDiv.appendChild(ui.KeyboardSelector);  //this may need to be moved up.... 
+
+      ui.innerDiv.appendChild(ui.KeyboardSelector);  //this may need to be moved up....
 
       // Check required interface alignment and default keyboard
       var opt=util['getOption']('ui'),dfltKeyboard='(System keyboard)';
       if(opt && typeof(opt) == 'object')
       {
-        if(typeof(opt['position']) == 'string' && opt['position'] == 'right') 
+        if(typeof(opt['position']) == 'string' && opt['position'] == 'right')
           ui.floatRight = true;
-        if(typeof(opt['default']) == 'string') 
-          dfltKeyboard = opt['default']; 
+        if(typeof(opt['default']) == 'string')
+          dfltKeyboard = opt['default'];
       }
 
       var Lopt = util['createElement']('OPTION');
       Lopt.value = '-';
       Lopt.innerHTML = dfltKeyboard;
-      ui.KeyboardSelector.appendChild(Lopt);  
+      ui.KeyboardSelector.appendChild(Lopt);
       Lopt = null;
 
       // This must be set before updating the keyboard list to prevent recursion!
@@ -146,18 +147,18 @@ if(!window['keyman']['ui']['name']) {
 
       // Update the keyboard list if required
       ui.updateKeyboardList();
-      
+
       //may also want to initialize style sheet here ??
     }
 
     ui._UnloadUserInterface = function() {
-      ui.KeyboardSelector = ui.innerDiv = ui.outerDiv = ui.kbdIcon = null; 
+      ui.KeyboardSelector = ui.innerDiv = ui.outerDiv = ui.kbdIcon = null;
     };
     /**
      * UI removal - resource cleanup
-     */    
+     */
     keymanweb['addEventListener']('unloaduserinterface', ui._UnloadUserInterface);
-        
+
 
     ui.shutdown = function() {
       var root = ui.outerDiv;
@@ -171,53 +172,53 @@ if(!window['keyman']['ui']['name']) {
         window.removeEventListener('resize', ui._Resize, false);
       }
     }
-  
+
     /**
      * Update list of keyboards shown by UI
-     */     
+     */
     ui.updateKeyboardList = function()
     {
       // Do nothing unless list requires updating
-      if(ui.updateList) 
-      { 
+      if(ui.updateList)
+      {
         if(!ui.initialized) ui.Initialize();
-                                                      
+
         // Remove current list (except for default element)
         var i,opts=ui.KeyboardSelector.getElementsByTagName('OPTION');
         for(i=opts.length; i>1; i--)
         {
           ui.KeyboardSelector.removeChild(opts[i-1]);
-        }    
-        
-        // Loop over installed keyboards and add to selection list     
-        var Ln,Lopt,Lkbds=keymanweb['getKeyboards']();  
-            
-        for(Ln=0; Ln<Lkbds.length; Ln++) 
+        }
+
+        // Loop over installed keyboards and add to selection list
+        var Ln,Lopt,Lkbds=keymanweb['getKeyboards']();
+
+        for(Ln=0; Ln<Lkbds.length; Ln++)
         {
           Lopt = util['createElement']('OPTION');
-          Lopt.value = Lkbds[Ln]['InternalName']+':'+Lkbds[Ln]['LanguageCode'];;        
-          Lopt.innerHTML = Lkbds[Ln]['Name'].replace(/\s?keyboard/i,'');      
+          Lopt.value = Lkbds[Ln]['InternalName']+':'+Lkbds[Ln]['LanguageCode'];;
+          Lopt.innerHTML = Lkbds[Ln]['Name'].replace(/\s?keyboard/i,'');
           if(Lkbds[Ln]['LanguageName'])
           {
             var lg=Lkbds[Ln]['LanguageName'];
             // Only show the main language name if variants indicated (this is tentative)
             // e.g. Chinese rather than Chinese, Mandarin, which is in the keyboard name
             lg = lg.split(',')[0];
-            if(Lkbds[Ln]['Name'].search(lg) == -1)        
+            if(Lkbds[Ln]['Name'].search(lg) == -1)
               Lopt.innerHTML = lg+' ('+Lopt.innerHTML+')';  // I1300 - Language support
           }
-          
+
           ui.KeyboardSelector.appendChild(Lopt);
           Lopt = null;
         }
       }
-      ui.updateList = false;    
-      
+      ui.updateList = false;
+
       // Set the menu selector to the currently saved keyboard
       var sk = keymanweb['getSavedKeyboard']().split(':');
-      if(sk.length < 2) sk[1] = ''; 
-      ui.updateMenu(sk[0],sk[1]); 
-      
+      if(sk.length < 2) sk[1] = '';
+      ui.updateMenu(sk[0],sk[1]);
+
       // Redisplay the UI to correct width for any new language entries
       if(keymanweb['getLastActiveElement']())
       {
@@ -228,140 +229,141 @@ if(!window['keyman']['ui']['name']) {
 
     /**
      * Function     updateMenu
-     * Scope        Private   
+     * Scope        Private
      * @param       {string}     kbd
-     * @param       {string}     lg 
+     * @param       {string}     lg
      * Description  Update the UI menu selection
-     *              Separate arguments passed to allow better control of selection when a keyboard 
-     *              is listed more than once for different language codes       
-     */   
+     *              Separate arguments passed to allow better control of selection when a keyboard
+     *              is listed more than once for different language codes
+     */
     ui.updateMenu = function(kbd,lg)
     {
       var i=0;
-      
+
       // This can be called during startup before fully initialized - ignore if so
-      if(!ui.initialized) return;  
-      
+      if(!ui.initialized) return;
+
       var match = kbd;
       if(lg != '') match += ':' + lg;
-      
+
       if(kbd == '')
         ui.KeyboardSelector.selectedIndex=0;
       else
-      {  
+      {
         var opt=ui.KeyboardSelector.getElementsByTagName('OPTION');
         for(i=0; i<opt.length; i++)
         {
-          var t=opt[i].value; 
+          var t=opt[i].value;
           if(lg == '') t = t.split(':')[0];
-          if(t == match) 
+          if(t == match)
           {
             ui.KeyboardSelector.selectedIndex=i;
-            break; 
-          }   
+            break;
+          }
         }
       }
-    }  
+    }
 
     /**
      * Function     oskButtonState
-     * Scope        Private   
+     * Scope        Private
      * @param       {boolean}     oskEnabled
      * Description  Update kbd icon border style to indicate whether OSK is enabled for display or not
-     **/   
+     **/
     ui.oskButtonState = function(oskEnabled)
     {
       var s = ui.kbdIcon.style;
-      s.width='24px'; s.height='13px'; s.top='1px'; 
+      s.width='24px'; s.height='13px'; s.top='1px';
       s.verticalAlign='bottom'; s.padding='2px 2px 1px 2px'; s.position='absolute';
-      s.border=oskEnabled ? 'inset 1px #808080' : 'none'; 
+      s.border=oskEnabled ? 'inset 1px #808080' : 'none';
       s.background=oskEnabled ? '#f7e7de' : 'white';
-      s.display = 'block';     
+      s.display = 'block';
       if(ui.initialized) ui.oskButton.style.display = 'block';
     }
-    
+
     /**
      * Register all keymanweb and OSK events only after keymanweb is fully initialized
-     *    
-     **/      
+     *
+     **/
     ui.registerEvents = function()
     {
       /**
        * Keyboard registration event handler
-       *    
-       * Set a timer to update the UI keyboard list on timeout after each keyboard is registered, 
+       *
+       * Set a timer to update the UI keyboard list on timeout after each keyboard is registered,
        * thus updating only once when only if multiple keyboards are registered together
-       */   
-      keymanweb['addEventListener']('keyboardregistered', 
+       */
+      keymanweb['addEventListener']('keyboardregistered',
         function(p)
-        {  
+        {
             ui.updateList = true;
             if(ui.updateTimer) clearTimeout(ui.updateTimer);
             ui.updateTimer = setTimeout(ui.updateKeyboardList,200);
-        });       
-      
+        });
+
       /**
        * Keyboard load event handler
-       * 
+       *
        * Set the menu selector to the currently saved keyboard when a keyboard is loaded
-       *    
-       * Note: Cannot simply set it to the loaded keyboard, 
+       *
+       * Note: Cannot simply set it to the loaded keyboard,
        *       as more than one language may be supported by that keyboard.
-       */   
+       */
       keymanweb['addEventListener']('keyboardloaded',
         function(p) {
           var sk = keymanweb['getSavedKeyboard']().split(':');
           if(sk.length > 1) ui.updateMenu(sk[0],sk[1]);
         });
-        
+
       /**
        * Keyboard change event handler
-       *        
+       *
        * Update menu selection and control OSK display appropriately
        */
-      keymanweb['addEventListener']('keyboardchange',  
+      keymanweb['addEventListener']('keyboardchange',
         function(p)
         {
-          // Update the keyboard selector whenever a keyboard is loaded  
-          ui.updateMenu(p['internalName'],p['languageCode']);    
-      
-          // (Conditionally) display the OSK button, and set the style 
-          ui.addButtonOSK();        
+          // Update the keyboard selector whenever a keyboard is loaded
+          ui.updateMenu(p['internalName'],p['languageCode']);
+
+          // (Conditionally) display the OSK button, and set the style
+          ui.addButtonOSK();
         });
-      
-      let osk = keymanweb.osk;
+
+      // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
+      let osk = keymanweb['osk'];
       if(!osk) {
         return;
       }
       /**
        * Show OSK event handler: show or hide the OSK button (never display if a CJK keyboard)
-       */                
+       */
       osk['addEventListener']('show',
         function(oskPosition)
-        {          
-          ui.addButtonOSK();    
-          return oskPosition; 
-        }); 
+        {
+          ui.addButtonOSK();
+          return oskPosition;
+        });
 
       /**
        * Hide OSK event handler
-       */ 
-      
+       */
+
       osk['addEventListener']('hide',
         function(hiddenByUser)
         {
           if(ui.initialized) ui.oskButtonState(false);
-        }); 
+        });
     }
-      
+
     /**
      * Function     _SelectorMouseDown
-     * Scope        Private   
+     * Scope        Private
      * @param       {Object}     e      event
      * Description  Set KMW UI activation state on mouse click
-     */    
+     */
     ui._SelectorMouseDown = function(e)
-    { 
+    {
       if(keymanweb['activatingUI']) keymanweb['activatingUI'](1);
     }
 
@@ -370,7 +372,7 @@ if(!window['keyman']['ui']['name']) {
      * Scope        Private
      * @param       {Object}    e       event
      * Description  Set KMW UI activation state on mouse over
-     */    
+     */
     ui._SelectorMouseOver = function(e)
     {
       if(keymanweb['activatingUI']) keymanweb['activatingUI'](1);
@@ -381,7 +383,7 @@ if(!window['keyman']['ui']['name']) {
      * Scope        Private
      * @param       {Object}    e       event
      * Description Clear KMW UI activation state on mouse out
-     */    
+     */
     ui._SelectorMouseOut = function(e)
     {
       if(keymanweb['activatingUI']) keymanweb['activatingUI'](0);
@@ -392,9 +394,9 @@ if(!window['keyman']['ui']['name']) {
      * Scope        Private
      * @param       {Object}    e       event
      * Description  Change active keyboard in response to user selection event
-     */    
+     */
     ui.SelectKeyboardChange = function(e)
-    { 
+    {
       if(ui.KeyboardSelector.value != '-')
       {
         var i=ui.KeyboardSelector.selectedIndex;
@@ -402,8 +404,8 @@ if(!window['keyman']['ui']['name']) {
         keymanweb['setActiveKeyboard'](t[0],t[1]);
       }
       else
-        keymanweb['setActiveKeyboard'](''); 
-      
+        keymanweb['setActiveKeyboard']('');
+
       //if(osk['show']) osk['show'](osk['isEnabled']()); handled by keyboard change event???
       keymanweb['focusLastActiveElement']();
       ui.selecting = true;
@@ -414,50 +416,50 @@ if(!window['keyman']['ui']['name']) {
      * Scope        Private
      * @param       {Object}    e       event
      * Description  Ensure OSK is hidden when moving focus after reselecting a keyboard
-     */    
+     */
     ui.SelectBlur = function(e)
     {
       if(!ui.selecting) keymanweb['focusLastActiveElement']();
-      ui.selecting = false;                                   
+      ui.selecting = false;
     }
-    
+
     /**
      * Function     ShowInterface
      * Scope        Private
      * @param       {number=}    Px    x-position for KMW window
      * @param       {number=}    Py    y-position for KMW window
      * Description  Display KMW window at specified position
-     */    
+     */
     ui.ShowInterface = function(Px, Py)
     {
       if(!ui.initialized) return;
-    
-      var Ls = ui.outerDiv.style;   
+
+      var Ls = ui.outerDiv.style;
 
       if(Px  &&  Py) {
         Ls.left = Px + 'px';
         Ls.top = Py + 'px';
       }
       Ls.display = 'block';
-      
+
       ui.kbdIcon.style.left = ui.KeyboardSelector.offsetWidth + 24 + 'px';
-      
+
       // (Conditionally) display the OSK button
       ui.addButtonOSK();
-          
+
       // Set the language selection to the currently active keyboard, if listed
       ui.updateMenu(keymanweb['getActiveKeyboard'](),keymanweb['getActiveLanguage']());
     }
-      
+
     /**
      * Function     HideInterface
      * Scope        Private
-     * Description  Completely hide KMW window 
-     */    
+     * Description  Completely hide KMW window
+     */
     ui.HideInterface = function()
     {
       if(!ui.initialized) return;
-      
+
       ui.outerDiv.style.display = 'none';
     }
 
@@ -466,29 +468,31 @@ if(!window['keyman']['ui']['name']) {
      * Function     addButtonOSK
      * Scope        Private
      * Description  Display the OSK button unless a CJK keyboard (or English)
-     */            
+     */
     ui.addButtonOSK = function()
     {
       if(ui.oskButton != null)
       {
-        if(keymanweb['isCJK']() || (ui.KeyboardSelector.selectedIndex==0)) 
+        if(keymanweb['isCJK']() || (ui.KeyboardSelector.selectedIndex==0))
         {
           ui.oskButton.style.display = 'none';
-          ui.outerDiv.style.width = ui.KeyboardSelector.offsetWidth+30+'px';    
-        } 
-        else 
+          ui.outerDiv.style.width = ui.KeyboardSelector.offsetWidth+30+'px';
+        }
+        else
         {
           ui.oskButton.style.display = 'block';
-          if(keymanweb.osk) {
-            ui.oskButtonState(keymanweb.osk['isEnabled']());
+          // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
+          let osk = keymanweb['osk'];
+          if(osk) {
+            ui.oskButtonState(osk['isEnabled']());
           } else {
             ui.oskButtonState(false);
           }
           ui.outerDiv.style.width = ui.KeyboardSelector.offsetWidth+56+'px';
-        }      
+        }
       }
     }
-    //TODO:  had to expose properties of params - what does that do? (focus event doesn't normally include these properties?)  
+    //TODO:  had to expose properties of params - what does that do? (focus event doesn't normally include these properties?)
     keymanweb['addEventListener']('controlfocused',
       function(params)
       {
@@ -501,32 +505,32 @@ if(!window['keyman']['ui']['name']) {
           if(ui.floatRight)   // I1296
             ui.ShowInterface(util['getAbsoluteX'](params.target) + params.target.offsetWidth + 1, util['getAbsoluteY'](params.target) + 1);
           else
-            ui.ShowInterface(util['getAbsoluteX'](params.target), util['getAbsoluteY'](params.target) 
+            ui.ShowInterface(util['getAbsoluteX'](params.target), util['getAbsoluteY'](params.target)
               - parseInt(util['getStyleValue'](ui.outerDiv,'height'),10) - 2);
         }
         return true;
-      });               
+      });
 
     keymanweb['addEventListener']('controlblurred',
       function(params)
-      {  
+      {
         if(!params['event']) return true;   // I2404 - Manage IE events in IFRAMEs
-    
+
         if(!params['isActivating']) ui.HideInterface();
 
         return true;
       });
-    
+
     /**
      * Function     _Resize
-     * Scope        Private   
+     * Scope        Private
      * @param       {Object}     e      event object
-     * @return      {boolean}      
-     * Description  Display KMW OSK at specified position (returns nothing) 
-     */    
+     * @return      {boolean}
+     * Description  Display KMW OSK at specified position (returns nothing)
+     */
     ui._Resize = function(e)
     {
-      if(ui.outerDiv.style.display =='block') 
+      if(ui.outerDiv.style.display =='block')
       {
         var elem = keymanweb['getLastActiveElement']();
         if(ui.floatRight)   // I1296
@@ -535,17 +539,17 @@ if(!window['keyman']['ui']['name']) {
           ui.ShowInterface(util['getAbsoluteX'](elem) + 1, util['getAbsoluteY'](elem) + elem.offsetHeight + 1);
       }
       return true;
-    }  
-    
+    }
+
     if(window.addEventListener)
       window.addEventListener('resize', ui._Resize, false);
 
     // Initialize after KMW is fully initialized, if UI already loaded
     keymanweb['addEventListener']('loaduserinterface',ui.Initialize);
-    
+
     // but also call initialization when script loaded, which is after KMW initialization for asynchronous script loading
     ui.Initialize();
-    
+
   } catch(err){}
 
   // Do not wrap in an anonymous function - let the closure compiler do that, but

--- a/web/source/kmwuifloat.ts
+++ b/web/source/kmwuifloat.ts
@@ -57,7 +57,6 @@ if(!window['keyman']['ui']['name']) {
     ui.toggleOSK = function()
     {
       keymanweb['activatingUI'](true);
-      // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
       if(osk && osk['show'])
       {
@@ -332,7 +331,6 @@ if(!window['keyman']['ui']['name']) {
           ui.addButtonOSK();
         });
 
-      // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
       if(!osk) {
         return;
@@ -485,7 +483,6 @@ if(!window['keyman']['ui']['name']) {
         else
         {
           ui.oskButton.style.display = 'block';
-          // As the Float UI uses more advanced minification, we must preserve the 'osk' field name.
           let osk = keymanweb['osk'];
           if(osk) {
             ui.oskButtonState(osk['isEnabled']());

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -253,6 +253,7 @@ if(!window['keyman']['ui']['name']) {
       aNode = ui.createNode('a', null, 'kmw_button_a');
       aNode.href = '#';
       aNode.onclick = ui.showOSK;
+      aNode.onmousedown = function() { keymanweb['activatingUI'](true); };
       aNode.title = ui.ToolBar_Text.ShowOSK;
       aNode.appendChild(ui.createNode('div', 'kmw_img_osk', 'kmw_img'));
       //aNode.appendChild(ui.createNode('div', null, 'kmw_a', 'On Screen Keyboard'));
@@ -505,7 +506,7 @@ if(!window['keyman']['ui']['name']) {
         var p1=ui.ToolBar_Text['SelectKeyboardPre']+kbd['Name'],p2=ui.ToolBar_Text['SelectKeyboardSuf'];
         if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) p1=p1+' '+ p2;
         aNode.title = p1;
-        aNode.onclick = function(event) { return ui.selectLanguage(event, lang) };
+        aNode.onclick = function(event) { return ui.selectLanguage(event, lang) }; // FINDME
         aNode.appendChild(ui.createNode('div', 'kmw_img_kbd', 'kmw_img'));
 
         ui.lgText=ui.truncate(lang.name,28);
@@ -667,6 +668,7 @@ if(!window['keyman']['ui']['name']) {
      * @return      {boolean}
      **/
     ui.selectKeyboard = function(event,lang,kbd,updateKeyman:boolean) {
+      keymanweb['activatingUI'](true);
       if(ui.selectedLanguage) {
         var found = ui.findListedKeyboard(ui.selectedLanguage);
         if(found != null) {
@@ -694,6 +696,7 @@ if(!window['keyman']['ui']['name']) {
       // Always save current state when selecting a keyboard
       ui.saveCookie();
       ui.enableControls();
+      keymanweb['activatingUI'](false);
       return ui.hideKeyboardsPopup(event) || ui.hideKeyboardsForLanguage(event);
     }
 
@@ -751,6 +754,7 @@ if(!window['keyman']['ui']['name']) {
      **/
     ui.showOSK = function(event)
     {
+      keymanweb['activatingUI'](true);
       // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
 
@@ -763,6 +767,7 @@ if(!window['keyman']['ui']['name']) {
         if(osk['isEnabled']()) osk['hide'](); else osk['show'](true);
       }
       ui.setLastFocus();
+      keymanweb['activatingUI'](false);
       return ui.eventCapture(event);
     }
 

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -253,7 +253,9 @@ if(!window['keyman']['ui']['name']) {
       aNode = ui.createNode('a', null, 'kmw_button_a');
       aNode.href = '#';
       aNode.onclick = ui.showOSK;
-      aNode.onmousedown = function() { keymanweb['activatingUI'](true); };
+      aNode.onmousedown = function() {
+        keymanweb['activatingUI'](true);
+      };
       aNode.title = ui.ToolBar_Text.ShowOSK;
       aNode.appendChild(ui.createNode('div', 'kmw_img_osk', 'kmw_img'));
       //aNode.appendChild(ui.createNode('div', null, 'kmw_a', 'On Screen Keyboard'));
@@ -506,7 +508,7 @@ if(!window['keyman']['ui']['name']) {
         var p1=ui.ToolBar_Text['SelectKeyboardPre']+kbd['Name'],p2=ui.ToolBar_Text['SelectKeyboardSuf'];
         if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) p1=p1+' '+ p2;
         aNode.title = p1;
-        aNode.onclick = function(event) { return ui.selectLanguage(event, lang) }; // FINDME
+        aNode.onclick = function(event) { return ui.selectLanguage(event, lang) };
         aNode.appendChild(ui.createNode('div', 'kmw_img_kbd', 'kmw_img'));
 
         ui.lgText=ui.truncate(lang.name,28);
@@ -759,6 +761,7 @@ if(!window['keyman']['ui']['name']) {
       let osk = keymanweb['osk'];
 
       if(!osk) {
+        keymanweb['activatingUI'](false);
         return;
       }
       //Toggle OSK on or off
@@ -920,7 +923,6 @@ if(!window['keyman']['ui']['name']) {
             }
             else
             {
-              // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
               let osk = keymanweb['osk'];
               ui.oskButtonNode.className = (osk && osk['isEnabled']()) ? 'kmw_button_selected' : 'kmw_button';
             }
@@ -1020,7 +1022,6 @@ if(!window['keyman']['ui']['name']) {
 
 
     ui.registerEvents = function() {
-      // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
       if(!osk) {
         return;

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -751,7 +751,8 @@ if(!window['keyman']['ui']['name']) {
      **/
     ui.showOSK = function(event)
     {
-      let osk = keymanweb.osk;
+      // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
+      let osk = keymanweb['osk'];
 
       if(!osk) {
         return;
@@ -914,7 +915,8 @@ if(!window['keyman']['ui']['name']) {
             }
             else
             {
-              let osk = keymanweb.osk;
+              // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
+              let osk = keymanweb['osk'];
               ui.oskButtonNode.className = (osk && osk['isEnabled']()) ? 'kmw_button_selected' : 'kmw_button';
             }
           }
@@ -1013,7 +1015,8 @@ if(!window['keyman']['ui']['name']) {
 
 
     ui.registerEvents = function() {
-      let osk = keymanweb.osk;
+      // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
+      let osk = keymanweb['osk'];
       if(!osk) {
         return;
       }

--- a/web/source/kmwuitoolbar.ts
+++ b/web/source/kmwuitoolbar.ts
@@ -756,14 +756,11 @@ if(!window['keyman']['ui']['name']) {
      **/
     ui.showOSK = function(event)
     {
-      keymanweb['activatingUI'](true);
-      // As the Toolbar UI uses more advanced minification, we must preserve the 'osk' field name.
       let osk = keymanweb['osk'];
-
       if(!osk) {
-        keymanweb['activatingUI'](false);
         return;
       }
+      keymanweb['activatingUI'](true);
       //Toggle OSK on or off
       if(osk && keymanweb['getActiveKeyboard']() != '')
       {

--- a/web/source/osk/floatingOskView.ts
+++ b/web/source/osk/floatingOskView.ts
@@ -555,6 +555,11 @@ namespace com.keyman.osk {
       }
     }
 
+    ['show'](bShow: boolean) {
+      super['show'](bShow);
+      this.saveCookie();
+    }
+
     /**
      * Function     userPositioned
      * Scope        Public


### PR DESCRIPTION
Fixes #6685.

As it turns out, both the Float and Toolbar UI modules were broken by changes made during the `InlinedOSK` work for 15.0.

1. The OSK is no longer initialized immediately, meaning the file-level variable for the `osk` had to be eliminated.  The adjustments were fine with minification disabled, but not when enabled.
    - Refer to #5412.
2. The encapsulated modeling of OSK hide vs show behavior caused the OSK to be hidden (via `Promise`-deferment) on loss of focus when users interacted with certain UI elements, as the two modules didn't make full use of `keyman.activatingUI` to note when the active element should be preserved on temporary loss of focus.
    - As the hiding operation was via `Promise`-deferment, any "show" commands would actually work... and then would instantly be overridden once the deferred operation kicked in.
3.  `osk.show()` is now _only_ an API method, as display state tracking based on page interaction is now tracked by other mannerisms.  While _hiding_ the OSK was set to update cookie state in one of its submethods... someone (`git blame` -> @jahorton) forgot to also update cookie state when setting it visible.  Oops.

For reviews, "hide whitespace" is strongly suggested.

## User Testing

<details>
<summary><strong>Desktop instructions</strong></summary>

The important part:  pay extra attention to in-browser desktop form-factor tests, as those are the most likely to break.  Make sure the UI modules load properly and allow keyboard-swapping as expected.

There is a new set of test pages designed to facilitate testing the UI modules:

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/25213402/126420955-ce885af4-cb3c-44b6-a181-aae7f8589f21.png">

The pages may be found through this link on the testing index page:

<img width="350" alt="image" src="https://user-images.githubusercontent.com/25213402/126421028-6bfbd938-3bcc-4879-93b1-cf2d39632755.png">


In order to test compatibility with the different UI module types, you'll need to mildly edit the unminified test page's source:

Here's the UI you should expect to see for each test:
- Button UI
    ![image](https://user-images.githubusercontent.com/25213402/126131066-fa59a6f1-5365-42f2-9cae-64c02e9e4e2b.png)
    - Note:  the button will likely display above the first input element, rather than beside the current text input receiver.  This is fine.
- Float UI
    ![image](https://user-images.githubusercontent.com/25213402/126131199-ce14429f-5ae4-4316-9f0c-af640fbd0003.png)
- Toggle UI
    ![image](https://user-images.githubusercontent.com/25213402/126131230-9e2409ac-010e-4a2e-9bc3-7afa6d14b80b.png)
- Toolbar UI
    ![image](https://user-images.githubusercontent.com/25213402/126131258-64f6e98c-566a-479c-be0c-6651a41015b8.png)

</details>

<details>
<summary><strong>Mobile instructions</strong></summary>

As the OSK will be loading at a later time than it used to, we need to ensure that this doesn't cause obvious blank-keyboard bugs.

It would be wise to ensure that the keyboard loads correctly and consistently in both portrait and landscape orientations (issue #5252 not withstanding) within the apps and as system keyboard.
</details>


### Explicit test list

Using `web/testing/desktop-ui` ("Desktop UI module testing") and its subpages:

- TEST_FLOAT_LOAD:  Confirm that KMW loads properly and displays the Float UI (`kmwuifloat.ts`) when the OSK is visible.
    ![image](https://user-images.githubusercontent.com/25213402/126131199-ce14429f-5ae4-4316-9f0c-af640fbd0003.png)
- TEST_FLOAT_OSK_TOGGLE: With the Float UI active and an active keyboard (and visible OSK), repeatedly toggle the OSK on and off.
    - Note the 'toggle' button on the right-hand side of this image:  <img width="206" alt="image" src="https://user-images.githubusercontent.com/25213402/171331235-344bb111-51af-41c7-8d21-40eff703297e.png">
- TEST_FLOAT_OSK_LANGUAGE_SWAP:  With the Float UI active and an active keyboard, change the language.
    - (Possibly) after a slight delay, the OSK for the newly-selected keyboard should be displayed and the text area should still be selected.
    - Type any key (with your hardware keyboard) to confirm that the text area is indeed still active.
    - Repeat all previous steps twice, verifying that the OSK displays each time.
    - Now, toggle the OSK off.
    - Repeat the first four steps once (up to the previous "repeat" step), but this time verify that the OSK is not displayed afterward.

- TEST_TOOLBAR_LOAD:
    1. Confirm that KMW loads properly and displays the Toolbar UI (`kmwuitoolbar.ts`).
            ![image](https://user-images.githubusercontent.com/25213402/126131258-64f6e98c-566a-479c-be0c-6651a41015b8.png)
    2. Use the Toolbar UI to select `sil_euro_latin` and confirm the keyboard swaps properly.
        - Most easily done through the "Europe" region, then the "English" language.
- TEST_TOOLBAR_OSK_TOGGLE:  With the Toolbar UI active and an active keyboard (and visible OSK), repeatedly toggle the OSK on and off.
    - Note the 'toggle' button on the right-hand side of this image:  <img width="600" alt="image" src="https://user-images.githubusercontent.com/25213402/171333353-5c887c72-0231-4b25-85ed-3ec0fdd1257c.png">

- TEST_TOOLBAR_OSK_LANGUAGE_SWAP:  With the Toolbar UI active and an active keyboard, change the language to French.
    - (Possibly) after a slight delay, the OSK for the newly-selected keyboard should be displayed and the text area should still be selected.
    - Type any key (with your hardware keyboard) to confirm that the text area is indeed still active.
    - Use the drop-down beside French to select a different keyboard for the same language.
    - Repeat these steps _for the Polish language_ instead, verifying that the OSK displays each time.
    - Now, toggle the OSK off.
    - Repeat all steps, but this time verify that the OSK is not displayed afterward at any point.