### PR TITLE
fix(developer): kmcomp package compiler race condition

### DIFF
--- a/common/core/desktop/tests/unit/kmx/028 - smp.kmn
+++ b/common/core/desktop/tests/unit/kmx/028 - smp.kmn
@@ -4,7 +4,6 @@ c expected: \U0001F601yx
 c context:
 
 store(&version) '10.0'
-store(&name) '028smp'
 
 begin Unicode > use(Main)
 

--- a/common/core/desktop/tests/unit/kmx/meson.build
+++ b/common/core/desktop/tests/unit/kmx/meson.build
@@ -77,7 +77,7 @@ tests = [
 ]
 
 if build_machine.system() == 'windows'
-  kmcomp = find_program('kmcomp.exe', required: false)
+  kmcomp = find_program(join_paths(meson.source_root(),'..','..','..','windows','bin','developer','kmcomp.exe'), 'kmcomp.exe', required: false)
   kmcomp_cmd = [kmcomp]
   copy_cmd = [find_program('cmd.exe', required: true), '/c', 'copy']
   cat_cmd = [find_program('cmd.exe', required: true), '/c', 'type']

--- a/windows/src/global/delphi/general/CompilePackage.pas
+++ b/windows/src/global/delphi/general/CompilePackage.pas
@@ -159,6 +159,7 @@ function TCompilePackage.Compile: Boolean;
 var
   buf: array[0..260] of Char;
   n: Integer;
+  b: Boolean;
   f: TSearchRec;
 begin
   Result := False;
@@ -187,10 +188,15 @@ begin
   FTempPath := buf;
 
   GetTempFileName(PChar(FTempPath), 'kmn', 0, buf);
-  FTempPath := buf;
-  if FileExists(FTempPath) then DeleteFile(FTempPath);
+  FTempPath := buf + '.dir';
+  b := CreateDir(FTempPath);
+  if not b then
+  begin
+    FatalMessage('Unable to create temp folder '+FTempPath);
+    if FileExists(buf) then DeleteFile(buf);
+    Exit;
+  end;
 
-  CreateDir(FTempPath);
   try
     Result := BuildKMP;
   finally
@@ -205,6 +211,7 @@ begin
       FindClose(f);
     end;
     RemoveDirectory(PChar(FTempPath));
+    if FileExists(buf) then DeleteFile(buf);
   end;
 end;
 


### PR DESCRIPTION
Fixes a race condition when compiling multiple packages, where the temp path may be re-used before the compiler has finished with it.

To take advantage of this fix, I wanted to make sure I was using the right kmcomp.exe when building unit tests for Keyman Core. This uncovered a couple of other things:

* Updates Keyman Core build infrastructure to use the current kmcomp.exe rather than a system-installed one.
* Corrects a bug that was identified by the 15.0 version of kmcomp in one unit test (duplicate `&NAME` stores -- the meson test script prepends a `&NAME` store to each source file during build).

@keymanapp-test-bot skip