### PR TITLE
fix(android): check index validity in getCurrentKeyboardInfo

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -148,6 +148,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         boolean mayPredict = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(langId), true);
         KMManager.setBannerOptions(mayPredict);
+      } else {
+        KMManager.setBannerOptions(false);
       }
     }
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
@@ -87,11 +87,14 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
         return;
       }
 
-      // If the active keyboard is for this language, immediately enact the new pref setting.
-      String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-      if (kbdLgCode.equals(lgCode)) {
-        // Not only registers the model but also applies our modeling preferences.
-        KMManager.registerAssociatedLexicalModel(lgCode);
+      Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(context);
+      if(kbInfo != null) {
+        // If the active keyboard is for this language, immediately enact the new pref setting.
+        String kbdLgCode = kbInfo.getLanguageID();
+        if (kbdLgCode.equals(lgCode)) {
+          // Not only registers the model but also applies our modeling preferences.
+          KMManager.registerAssociatedLexicalModel(lgCode);
+        }
       }
     }
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2000,6 +2000,13 @@ public final class KMManager {
   public static Keyboard getCurrentKeyboardInfo(Context context) {
     int index = getCurrentKeyboardIndex(context);
     if(index < 0) {
+      // As of 15.0-beta and 15.0-stable, this only appears to occur when
+      // #6703 would trigger.  This logging may help us better identify the
+      // root cause.
+      String key = KMKeyboard.currentKeyboard();
+      // Even if it's null, it's still a notable error.  This function shouldn't
+      // be reachable in execution (15.0) at a time this variable would be set to `null`.
+      KMLog.LogError(TAG, "Failed getCurrentKeyboardIndex check for keyboard: " + key);
       return null;
     }
     return KeyboardController.getInstance().getKeyboardInfo(index);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1999,6 +1999,9 @@ public final class KMManager {
 
   public static Keyboard getCurrentKeyboardInfo(Context context) {
     int index = getCurrentKeyboardIndex(context);
+    if(index < 0) {
+      return null;
+    }
     return KeyboardController.getInstance().getKeyboardInfo(index);
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/ModelPickerActivity.java
@@ -209,9 +209,12 @@ public final class ModelPickerActivity extends BaseActivity {
         if(immediateRegister) {
           // Register associated lexical model if it matches the active keyboard's language code;
           // it's safe since we're on the same thread.  Needs to be called AFTER deinstalling the old one.
-          String kbdLgCode = KMManager.getCurrentKeyboardInfo(context).getLanguageID();
-          if(BCP47.languageEquals(kbdLgCode, languageID)) {
-            KMManager.registerAssociatedLexicalModel(languageID);
+          com.tavultesoft.kmea.data.Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(context);
+          if(kbInfo != null) {
+            String kbdLgCode = kbInfo.getLanguageID();
+            if(BCP47.languageEquals(kbdLgCode, languageID)) {
+              KMManager.registerAssociatedLexicalModel(languageID);
+            }
           }
         }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -207,7 +207,7 @@ public class KeyboardController {
       }
     }
 
-    Log.w(TAG, "getKeyboardIndex failed for key " + key);
+    KMLog.LogError(TAG, "getKeyboardIndex failed for key " + key);
     return index;
   }
 


### PR DESCRIPTION
Fixes #6703.

This issue was first reported in 14.0.282-stable. I have done a careful review of changes in 14.0.282 (and 14.0.281) but have been unable to find any changes that could have bearing on this.

The basic issue is that there appears to be some circumstances where `KMManager` thinks that it has a keyboard loaded (ref `SystemKeyboardLoaded` variable), but `KMKeyboard.currentKeyboard` is still `null`.

The crash has been reported for only a very small set of users, 119 at time of fix, but average reports per user is over 100. As is usual with this type of thing, a small fraction of those users are reporting the majority of crashes. I have not found any real commonality across the error reports -- they are geographically dispersed, across multiple device types and Android versions.

Note that this addresses the error at hand but as I am unable to reproduce the issue, does not necessarily address the root problem, so there may still be other issues reported even after this is fixed.

A longer-term refactor would eliminate `SystemKeyboardLoaded` because from what I can tell, we should always be able to determine that from the state of `KMKeyboard.currentKeyboard`. However, the state entanglement is a lot deeper than just those two variables, with cross references to keyboard indexes between `KMManager` and `KMKeyboard` which need to be resolved (`KMKeyboard` should *never* refer to `KMManager`).

# User Testing

* TEST_BASIC: Run through a basic usage test of Keyman for Android, both in-app and system keyboards, verifying that you can switch keyboards, lock and unlock your device, switch between Keyman and other input methods, and install and use Keyman keyboards without errors.