### PR TITLE
chore(web): switch on additional BrowserStack reporting

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -74,7 +74,7 @@ module.exports = function(config) {
 
   var CURRENT_WIN_LAUNCHERS = {
     // Currently, Firefox launcher is unstable; see https://github.com/karma-runner/karma-firefox-launcher/issues/93
-    // (in particular "not maintained" commentary). 
+    // (in particular "not maintained" commentary).
     //bs_firefox_win: {
     //  os: 'Windows',
     //  os_version: '10',
@@ -133,7 +133,7 @@ module.exports = function(config) {
   var specifics = {
     // BrowserStack configuration options
     browserStack: {
-      video: false,
+      video: true,
       browserDisconnectTimeout: 3e5,
       retryLimit: 1, // 0 is ignored.
       startTunnel: true,
@@ -153,7 +153,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['teamcity'],
+    reporters: ['teamcity', 'BrowserStack'],
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG

--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -39,14 +39,14 @@ test-headless ( ) {
 test-browsers ( ) {
   _FLAGS=$FLAGS
   if (( CI_REPORTING )); then
-    _FLAGS="$_FLAGS -CI -reporter teamcity"
+    _FLAGS="$_FLAGS -CI -reporter teamcity,BrowserStack"
   fi
 
   $SCRIPT_ROOT/in_browser/browser-test.sh $os_id $_FLAGS
 }
 
 # Defaults
-get_builder_OS  # return:  os_id="linux"|"mac"|"win" 
+get_builder_OS  # return:  os_id="linux"|"mac"|"win"
 
 FLAGS="--require ./unit_tests/helpers"
 CI_REPORTING=0

--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -124,7 +124,7 @@ module.exports = function(config) {
   var specifics = {
     // BrowserStack configuration options
     browserStack: {
-      video: false,
+      video: true,
       browserDisconnectTimeout: 3e5,
       retryLimit: 1, // 0 is ignored.
       startTunnel: true,
@@ -144,7 +144,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['teamcity'],
+    reporters: ['teamcity', 'BrowserStack'],
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG


### PR DESCRIPTION
Per support case with BrowserStack, am turning on deeper reporting for BrowserStack-based testing in karma.

@keymanapp-test-bot skip