### PR TITLE
change(web): adjusts minimum distance needed for quick-display of subkeys

### DIFF
--- a/web/source/osk/oskLayer.ts
+++ b/web/source/osk/oskLayer.ts
@@ -14,6 +14,12 @@ namespace com.keyman.osk {
     public readonly numKey:      OSKBaseKey;
     public readonly scrollKey:   OSKBaseKey;
 
+    private _rowHeight: number;
+
+    public get rowHeight(): number {
+      return this._rowHeight;
+    }
+
     public get id(): string {
       return this.spec.id;
     }
@@ -89,8 +95,8 @@ namespace com.keyman.osk {
 
     public refreshLayout(vkbd: VisualKeyboard, paddedHeight: number, trueHeight: number) {
       // Check the heights of each row, in case different layers have different row counts.
-      let nRows = this.rows.length;
-      let rowHeight = Math.floor(paddedHeight/(nRows == 0 ? 1 : nRows));
+      const nRows = this.rows.length;
+      const rowHeight = this._rowHeight = Math.floor(paddedHeight/(nRows == 0 ? 1 : nRows));
 
       if(vkbd.usesFixedHeightScaling) {
         this.element.style.height=(trueHeight)+'px';
@@ -98,7 +104,7 @@ namespace com.keyman.osk {
 
       for(let nRow=0; nRow<nRows; nRow++) {
         const oskRow = this.rows[nRow];
-        let bottom = (nRows-nRow-1)*rowHeight+1;
+        const bottom = (nRows-nRow-1)*rowHeight+1;
 
         if(vkbd.usesFixedHeightScaling) {
           // Calculate the exact vertical coordinate of the row's center.

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1620,9 +1620,11 @@ namespace com.keyman.osk {
       // If popup is visible, need to move over popup, not over main keyboard
       // Could be turned into a browser-longpress specific implementation within browser.PendingLongpress?
       if (key1 && key1['subKeys'] != null && this.initTouchCoord) {
-        // Show popup keys immediately if touch moved up towards key array (KMEW-100, Build 353)
-        if ((this.initTouchCoord.y - input.y > 5) && this.pendingSubkey && this.pendingSubkey instanceof browser.PendingLongpress) {
-          this.pendingSubkey.resolve();
+        if(this.pendingSubkey && this.pendingSubkey instanceof browser.PendingLongpress) {
+          // Show popup keys immediately if touch moved up towards key array (KMEW-100, Build 353)
+          if (this.initTouchCoord.y - input.y > this.getLongpressFlickThreshold()) {
+            this.pendingSubkey.resolve();
+          }
         }
       }
 
@@ -1633,6 +1635,16 @@ namespace com.keyman.osk {
       }
 
       return false;
+    }
+
+    private getLongpressFlickThreshold(): number {
+      const rowHeight = this.currentLayer.rowHeight;
+
+      // If larger than 5 (and it likely is), new threshold = 1/4 the std. key height.
+      const proportionalThreshold = rowHeight / 4;
+
+      // 5 - the longpress-flick triggering threshold before 15.0.
+      return Math.max(proportionalThreshold, 5);
     }
 
     optionKey(e: KeyElement, keyName: string, keyDown: boolean) {


### PR DESCRIPTION
Fixes #6646.

## User Testing

GROUP_IN_APP:  Test using the main Keyman app on a physical iPhone or iPad.
GROUP_IN_MOBILE_BROWSER:  Using a physical iPhone or iPad, use Safari and navigate to the "Prediction - robust testing" manual test page through the "KeymanWeb Test Home" link below.

For both, select the "EuroLatin" keyboard.  (It has lots of subkeys.)  In app, this is the default keyboard.

TEST_QUICK_YOU_TYPING:  Rapidly type `you ` at least 10 times in a row.  Fail if a subkey is emitted more than once for every ten tries.
- Do try to be a bit precise, but the focus _is_ on rapidly typing.

TEST_LONGPRESS_FLICK: 

1. Press and hold the `i` key and _quickly_ move your finger in an upward motion.  Select a subkey.
2. Press and hold the `i` key, keeping your finger still.
    - The subkey menu should display earlier for step 1 than for step 2.