### PR TITLE
change(web): browser test timeout tweaks

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/CI.conf.js
+++ b/common/predictive-text/unit_tests/in_browser/CI.conf.js
@@ -74,7 +74,7 @@ module.exports = function(config) {
 
   var CURRENT_WIN_LAUNCHERS = {
     // Currently, Firefox launcher is unstable; see https://github.com/karma-runner/karma-firefox-launcher/issues/93
-    // (in particular "not maintained" commentary). 
+    // (in particular "not maintained" commentary).
     //bs_firefox_win: {
     //  os: 'Windows',
     //  os_version: '10',
@@ -134,17 +134,17 @@ module.exports = function(config) {
     // BrowserStack configuration options
     browserStack: {
       video: false,
-      browserDisconnectTimeout: 3e5,
-      retryLimit: 1, // 0 is ignored.
+      browserDisconnectTimeout: 6e4, // 1 minute (60s => 60,000ms)
+      retryLimit: 3, // 0 is ignored.
       startTunnel: true,
     },
 
     // Attempts to avoid generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.
     failOnEmptyTestSuite: false,
 
-    captureTimeout: 6e5, // in milliseconds
-    browserNoActivityTimeout: 3e5,
-    browserDisconnectTimeout: 3e5,
+    captureTimeout: 1.2e5, // in milliseconds
+    browserNoActivityTimeout: 6e4,
+    browserDisconnectTimeout: 6e4,
     browserDisconnectTolerance: 3,
 
     // Avoids generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.

--- a/web/unit_tests/CI.conf.js
+++ b/web/unit_tests/CI.conf.js
@@ -125,17 +125,17 @@ module.exports = function(config) {
     // BrowserStack configuration options
     browserStack: {
       video: false,
-      browserDisconnectTimeout: 3e5,
-      retryLimit: 1, // 0 is ignored.
+      browserDisconnectTimeout: 6e4, // 1 minute (60s => 60,000ms)
+      retryLimit: 3, // 0 is ignored.
       startTunnel: true,
     },
 
     // Attempts to avoid generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.
     failOnEmptyTestSuite: false,
 
-    captureTimeout: 6e5, // in milliseconds
-    browserNoActivityTimeout: 3e5,
-    browserDisconnectTimeout: 3e5,
+    captureTimeout: 1.2e5, // in milliseconds
+    browserNoActivityTimeout: 6e4,
+    browserDisconnectTimeout: 6e4,
     browserDisconnectTolerance: 3,
 
     // Avoids generating a 'fail' exit code if one of our selected browsers on BrowserStack goes poof.


### PR DESCRIPTION
Since we've been occasionally seeing flakiness during browser-based testing due to occasional failure-to-'capture' (BrowserStack term), this PR seems to alleviate that somewhat by upping the allowed number of retries per test suite.  To ensure this doesn't cause a build to run too far over... and also because things don't tend to recover after a minute or so on connection failures, this decreases the timeout allowances.

A follow-up to #6707.

@keymanapp-test-bot skip