### PR TITLE
chore(android): adds diagnostic logging to assist a fix for #6703

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2000,6 +2000,13 @@ public final class KMManager {
   public static Keyboard getCurrentKeyboardInfo(Context context) {
     int index = getCurrentKeyboardIndex(context);
     if(index < 0) {
+      // As of 15.0-beta and 15.0-stable, this only appears to occur when
+      // #6703 would trigger.  This logging may help us better identify the
+      // root cause.
+      String key = KMKeyboard.currentKeyboard();
+      // Even if it's null, it's still a notable error.  This function shouldn't
+      // be reachable in execution (15.0) at a time this variable would be set to `null`.
+      KMLog.LogError(TAG, "Failed getCurrentKeyboardIndex check for keyboard: " + key);
       return null;
     }
     return KeyboardController.getInstance().getKeyboardInfo(index);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -207,7 +207,7 @@ public class KeyboardController {
       }
     }
 
-    Log.w(TAG, "getKeyboardIndex failed for key " + key);
+    KMLog.LogError(TAG, "getKeyboardIndex failed for key " + key);
     return index;
   }
 


### PR DESCRIPTION
Since the root cause behind #6703 remains pretty elusive, rather than continue to endlessly chase it, perhaps some additional logging may be in order.  I'm basing this on #6704, adding onto its changes.

For one of the logs:  I found it quite interesting how all of the call stacks I randomly checked (>10, for at least 7 affected users) matched; the error for each of them always happened with `SystemKeyboard.onStartInput` on the call stack.  It doesn't seem to be occurring in any other circumstance.  Therefore, I feel it's safe to add (well-documented) log messages to `getCurrentKeyboardInfo` under the assumption that the corresponding `-1` always corresponds to an erroneous internal state... and to #6703's underlying issue.

For the other one - we kinda forgot to Sentry-log something that may have been able to provide us with fairly critical information - the case where a keyboard key is provided, is not null, and yet no corresponding index can be found for it in the keyboards array.  This is a case in which we can get a `-1` in return, and is my current control-flow suspect.

As odd as it would be for this assumption to be invalidated... is it possible that a keyboard's "key" isn't being matched properly in this section?

https://github.com/keymanapp/keyman/blob/47da7685f20c03d4ae15ad78686d78b22f9342ee/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java#L201-L209

Our keys should always use characters in the standard ASCII range, so `equalsIgnoreCase` shouldn't be a vector for issues to arise.  But, at this point it's worth ignoring "should" to double-check if something's being provided that invalidates one or more of these assumptions.  I'm starting to strongly suspect this to be happening... though exactly which is being invalidated and how is still a little open-ended.

Either one or both of the new log messages should be triggered about as frequently as the one for #6703... but this time, with somewhat more revealing information that should help us better resolve the underlying issue.

@keymanapp-test-bot skip