### PR TITLE
fix(web): row height layout calcs now consider layer-group padding

### DIFF
--- a/web/source/osk/oskBaseKey.ts
+++ b/web/source/osk/oskBaseKey.ts
@@ -131,7 +131,7 @@ namespace com.keyman.osk {
 
       if(vkbd.usesFixedHeightScaling) {
         // Matches its row's height.
-        this.square.style.height = vkbd.layoutHeight.scaledBy(this.row.heightFraction).styleString;
+        this.square.style.height = vkbd.internalHeight.scaledBy(this.row.heightFraction).styleString;
       } else {
         this.square.style.height = '100%'; // use the full row height
       }

--- a/web/source/osk/oskLayer.ts
+++ b/web/source/osk/oskLayer.ts
@@ -93,13 +93,13 @@ namespace com.keyman.osk {
       return null;
     }
 
-    public refreshLayout(vkbd: VisualKeyboard, paddedHeight: number, trueHeight: number) {
+    public refreshLayout(vkbd: VisualKeyboard, layerHeight: number) {
       // Check the heights of each row, in case different layers have different row counts.
       const nRows = this.rows.length;
-      const rowHeight = this._rowHeight = Math.floor(paddedHeight/(nRows == 0 ? 1 : nRows));
+      const rowHeight = this._rowHeight = Math.floor(layerHeight/(nRows == 0 ? 1 : nRows));
 
       if(vkbd.usesFixedHeightScaling) {
-        this.element.style.height=(trueHeight)+'px';
+        this.element.style.height=(layerHeight)+'px';
       }
 
       for(let nRow=0; nRow<nRows; nRow++) {
@@ -108,7 +108,7 @@ namespace com.keyman.osk {
 
         if(vkbd.usesFixedHeightScaling) {
           // Calculate the exact vertical coordinate of the row's center.
-          this.spec.row[nRow].proportionalY = ((trueHeight - bottom) - rowHeight/2) / paddedHeight;
+          this.spec.row[nRow].proportionalY = ((layerHeight - bottom) - rowHeight/2) / layerHeight;
 
           if(nRow == nRows-1) {
             oskRow.element.style.bottom = '1px';

--- a/web/source/osk/oskRow.ts
+++ b/web/source/osk/oskRow.ts
@@ -9,7 +9,7 @@ namespace com.keyman.osk {
     public readonly keys: OSKBaseKey[];
     public readonly heightFraction: number;
 
-    public constructor(vkbd: VisualKeyboard, 
+    public constructor(vkbd: VisualKeyboard,
                        layerSpec: keyboards.ActiveLayer,
                        rowSpec: keyboards.ActiveRow) {
       const rDiv = this.element = document.createElement('div');
@@ -30,7 +30,7 @@ namespace com.keyman.osk {
       for(let j=0; j<keys.length; j++) {
         const key = keys[j];
         var keyObj = new OSKBaseKey(key as OSKKeySpec, layerSpec.id, this);
-        
+
         var element = keyObj.construct(vkbd);
         this.keys.push(keyObj);
 
@@ -55,7 +55,7 @@ namespace com.keyman.osk {
     public refreshLayout(vkbd: VisualKeyboard) {
       const rs = this.element.style;
 
-      const rowHeight = vkbd.layoutHeight.scaledBy(this.heightFraction);
+      const rowHeight = vkbd.internalHeight.scaledBy(this.heightFraction);
       if(vkbd.usesFixedHeightScaling) {
         rs.maxHeight=rs.lineHeight=rs.height=rowHeight.styleString;
       }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -257,6 +257,15 @@ namespace com.keyman.osk {
       }
     }
 
+    get internalHeight(): ParsedLengthStyle {
+      if (this.usesFixedHeightScaling) {
+        // Touch OSKs may apply internal padding to prevent row cropping at the edges.
+        return ParsedLengthStyle.inPixels(this.layoutHeight.val - this.getVerticalLayerGroupPadding());
+      } else {
+        return ParsedLengthStyle.forScalar(1);
+      }
+    }
+
     get fontSize(): ParsedLengthStyle {
       if (!this._fontSize) {
         this._fontSize = new ParsedLengthStyle('1em');
@@ -1275,8 +1284,14 @@ namespace com.keyman.osk {
 
       // Needs the refreshed layout info to work correctly.
       if(this.currentLayer) {
-        this.currentLayer.refreshLayout(this, paddedHeight, this._computedHeight);
+        this.currentLayer.refreshLayout(this, this._computedHeight - this.getVerticalLayerGroupPadding());
       }
+    }
+
+    private getVerticalLayerGroupPadding(): number {
+      // For touch-based OSK layouts, kmwosk.css may include top & bottom padding on the layer-group element.
+      const computedGroupStyle = getComputedStyle(this.layerGroup.element);
+      return parseInt(computedGroupStyle.paddingTop) + parseInt(computedGroupStyle.paddingBottom);
     }
 
     /*private*/ computedAdjustedOskHeight(allottedHeight: number): number {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1291,7 +1291,7 @@ namespace com.keyman.osk {
     private getVerticalLayerGroupPadding(): number {
       // For touch-based OSK layouts, kmwosk.css may include top & bottom padding on the layer-group element.
       const computedGroupStyle = getComputedStyle(this.layerGroup.element);
-      return parseInt(computedGroupStyle.paddingTop) + parseInt(computedGroupStyle.paddingBottom);
+      return parseInt(computedGroupStyle.paddingTop, 10) + parseInt(computedGroupStyle.paddingBottom, 10);
     }
 
     /*private*/ computedAdjustedOskHeight(allottedHeight: number): number {


### PR DESCRIPTION
Fixes #6699.

It looks like I may have missed something small and subtle related to row-height layout calculations in the big OSK refactoring batch last year.  For touch OSKs, our CSS applies light top and bottom padding... but this wasn't being considered in layout calculations.  This resulted in it being applied twice-over at the top, with very-slightly oversized keys to boot - the net effect of which caused the bottom row's keys to appear lightly cropped.

## User Testing

### Testing environments

- GROUP_ANDROID:  test on an Android device.  Emulated should be fine.
- GROUP_IOS:  test on an iOS device.  Emulated should be fine.
    - It may be best to use an un-notched device - something like the iPhone SE.  One aspect of the test may be trickier to confirm otherwise.

### Tests:

- TEST_OSK_PADDING:  load the keyboard and verify that the bottom row's keys are uncropped.
    - There should also be a pixel or two of space underneath them - only a small amount.
        - Note that this space may be used for a drop-shadow effect.
    - If there is an uneven gap between the last key's bottom and the bottom of the keyboard, FAIL this test.
        - Any such gap should evenly match a corresponding gap above the top row.
        - **On notched iOS devices**, note that the "bottom of the keyboard" is where there is a slight transition between two different gray colors:

            ![image](https://user-images.githubusercontent.com/25213402/173293981-86ac36ca-86e9-42b6-a608-690de8158b23.png)

            This screenshot PASSES; note how the keyboard's background gray is slightly darker than the gray for the iOS's "safe area" beneath it.  It _is_ subtle, but detectable - you may need to bring your eyes close to the screen to discern the difference.  (Also, note how the bottom of the keys is just above the part of the device that would otherwise crop them.)

- TEST_NO_BLACK_BAR:  verify that there is no "black border bar" at the top of the keyboard.  (We don't want #6604 to re-emerge.)