### PR TITLE
chore(common): adds .gitignore to prevent noise from 16.0 changes

### DIFF
--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,0 +1,3 @@
+# Helps prevent git-noise when swapping from 15.0 stable to 16.0, given the latter's repo filesystem restructure.
+**/build
+**/*.inc.ts


### PR DESCRIPTION
#6525's 🎡 chain made a _lot_ of file system changes, and those are only going to be increasing with the 🎢 PRs.  When swapping from `master` to `stable-15.0`, without this in place...

<img width="407" alt="image" src="https://user-images.githubusercontent.com/25213402/173976529-8dc1b2b1-6139-44bd-a0d8-0c914f84975a.png">

And that's _before_ all the package-lock.json changes (for Web builds) kick in that need to be manually ignored during development!

Fortunately, one small `.gitignore` later, and we can mask all the 16.0+ tidbits with relative ease.

@keymanapp-test-bot skip