### PR TITLE
fix(web): key tip constraint logic requires .bottom CSS 

### DIFF
--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -78,7 +78,7 @@ namespace com.keyman.osk.browser {
         let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
         let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
 
-        kts.top = Math.floor(y - canvasHeight) + 'px';
+        kts.bottom = Math.floor(keyman.osk.computedHeight - y) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';
         kts.fontFamily = util.getStyleValue(kc,'font-family');

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -78,6 +78,7 @@ namespace com.keyman.osk.browser {
         let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
         let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
 
+        kts.top = 'auto';
         kts.bottom = Math.floor(keyman.osk.computedHeight - y) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -402,6 +402,10 @@ div.android div.kmw-keytip-tip {
   background: #999;
 }
 
+div.android div.kmw-keytip-cap {
+  background: #999;
+}
+
 /* Dark mode - ensure text is colored appropriately for key tips. */
 @media (prefers-color-scheme: dark) {
   div.ios div.kmw-keytip {

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -403,7 +403,10 @@ div.android div.kmw-keytip-tip {
 }
 
 div.android div.kmw-keytip-cap {
+  position: absolute;
   background: #999;
+  border-radius: 0 0 5px 5px;
+  border-bottom: solid 1px #8a8d90
 }
 
 /* Dark mode - ensure text is colored appropriately for key tips. */


### PR DESCRIPTION
Fixes #6783.

Key tips should properly remain within the OSK's bounds again after this fix.

![Screen Shot 2022-06-16 at 10 50 57 AM](https://user-images.githubusercontent.com/25213402/173987415-28947f40-43d4-4f8c-a011-4c75127a94aa.png)

As this is a top-row key preview, note that its base key is completely obscured by the preview.

This fixes a regression introduced in #6383.  (Gotta test the top row _without_ predictive-text!)

# User Testing

These tests are derived from those of #6383, but they're a bit more precise and targeted than before.

## SUITE_1:  no predictive text

### Test environments

In-app groups:
- GROUP_IPHONE_13_APP - use the Keyman app with a (simulated or real) iPhone 13.
- GROUP_IPHONE_SE_2_APP - use the Keyman app with a (simulated or real) iPhone SE 2nd gen.
- GROUP_ANDROID_APP - use the Keyman app with a (simulated or real) Android device - your pick.

In-browser groups:
- GROUP_IPHONE_13_BROWSER - use Safari on a (simulated or real) iPhone 13.
- GROUP_IPHONE_SE_2_BROWSER - use Safari on a (simulated or real) iPhone SE 2nd gen.
- GROUP_ANDROID_BROWSER - use Chrome on a (simulated or real) Android device - your pick.
    - Use the "Test unminified Keymanweb" Web test page.

### Tests

- TEST_TAMIL_TOP_PREVIEW:  Using the Tamil99 keyboard (`ekwtamil99uni`), verify that top row keypresses do not result in a cropped key preview.
    - The result may not be super-pretty, but the key thing is that it's uncropped.
    - There may be a little "stub" at the bottom of the preview; that's okay.
- TEST_TAMIL_NORMAL_PREVIEW:  Using the Tamil99 keyboard (`ekwtamil99uni`), verify that keypresses in the second to last row display nicely.
    - If there is a noticeable gap between the key preview's bottom and the bottom of its corresponding key, **_FAIL_** this test.
    - If the bottom border appears a bit large, but there is no _gap_, do not fail this test.  (Yay for subpixel-precision effects...)

- TEST_CHEROKEE_TOP_PREVIEW:  Using the Cherokee Nation (SIL) keyboard (`sil_cherokee_nation`), verify that top row keypresses do not result in a cropped key preview.
- TEST_CHEROKEE_NORMAL_PREVIEW:  Using the Cherokee Nation (SIL) keyboard (`sil_cherokee_nation`), verify that keypresses in the second to last row display nicely.


## SUITE_2:  predictive text active

This is only written as a separate suite because the predictive-text test can't be done with the (same) in-browser Web test page.

### Test environments

- GROUP_IPHONE_13_APP - use the Keyman app with a (simulated or real) iPhone 13.
- GROUP_IPHONE_SE_2_APP - use the Keyman app with a (simulated or real) iPhone SE 2nd gen.
- GROUP_ANDROID_APP - use the Keyman app with a (simulated or real) Android device - your pick.

### Test

- TEST_EUROLATIN_TOP_PREVIEW:  Using the default SIL EuroLatin keyboard, with predictive text active, verify that top row keypresses result in a _normal_ key preview.
    - If there is a noticeable gap between the key preview's bottom and the bottom of its corresponding key, **_FAIL_** this test.
    - If the bottom border appears a bit large, but there is no _gap_, do not fail this test.  (Yay for subpixel-precision effects...)