### PR TITLE
fix(web): clears repeating bksp on keyboard reload ⬅️

### DIFF
--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1786,7 +1786,7 @@ namespace com.keyman.osk {
       this.keyPending = null;
       this.touchPending = null;
 
-      this.keytip.show(null, false, this);
+      this.keytip?.show(null, false, this);
       this.subkeyGesture?.clear();
       this.pendingMultiTap?.cancel();
       this.pendingSubkey?.cancel();

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1778,6 +1778,17 @@ namespace com.keyman.osk {
       if(this.inputEngine) {
         this.inputEngine.unregisterEventHandlers();
       }
+
+      if(this.deleting) {
+        window.clearTimeout(this.deleting);
+      }
+
+      this.keyPending = null;
+      this.touchPending = null;
+
+      this.subkeyGesture?.clear();
+      this.pendingMultiTap?.cancel();
+      this.pendingSubkey?.cancel();
     }
   }
 }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1786,6 +1786,7 @@ namespace com.keyman.osk {
       this.keyPending = null;
       this.touchPending = null;
 
+      this.keytip.show(null, false, this);
       this.subkeyGesture?.clear();
       this.pendingMultiTap?.cancel();
       this.pendingSubkey?.cancel();


### PR DESCRIPTION
Fixes #6735.

May also fix #1930, but I have been unable to repro it on (emulated) Android using #6735's repro.

------

Turns out a very natural assumption for us to make actually isn't valid - for iOS, at least, it is possible for the OSK itself to be reloaded _during_ a backspace event.  (I haven't been able to succesfully reproduce this with emulated Android yet.)  With how KMW is structured, a reload results in the OSK being rebuilt from the ground up.

When this occurs - a backspace at the same time as an OSK reload, with the old OSK's final event being a 'touchstart' on `K_BKSP` - we get a permanently-sticky backspace key, as the new OSK has no reference for the repeating `K_BKSP`'s timer.

Note that we'll want a more comprehensive rework to prevent the event that's causing the full OSK reload, as that could easily interfere with a multitap, something we're considering adding in 16.0.  That, or _prevent_ the full reload itself.  Lots of 15.0 work went into things that should facilitate the latter idea, fortunately... but it's still for another PR, as we need this fix for 15.0 stable.

# User Testing

## Testing environments

Just in case, be sure that your test device's settings do not suppress device rotation events.  There is a chance that such a setting may interfere with the repros. 

GROUP_IOS:  Using the Keyman app on any real iOS device...
GROUP_ANDROID:  Using the Keyman app on any real Android device...

## Tests

Note that for both tests that follow, step 2 represents our best-known reproduction strategies for issues #1930 and #6735.

TEST_PLAIN_STICKY:  Attempt to reproduce the sticky backspace issue and _**FAIL**_ this test if successful.

1. Type enough text for word-wrapping effects to take effect at least once.
2. Then, mash the backspace key as quickly as you can.
    - If using emulation/simulation, try mashing **_both_** the left and right mouse buttons.
3. Before half the text is erased, stop mashing the backspace key.
4. If all text is erased, try typing text.  If newly-typed text is immediately erased, _**FAIL**_ this test.
5. Repeat steps 1-4 at least two additional times.

TEST_ROTATING_STICKY:  Attempt to reproduce the sticky backspace issue and _**FAIL**_ this test if successful.

1. Type enough text for word-wrapping effects to take effect at least once.
2. Then, mash the backspace key as quickly as you can _while rotating the device back and forth_.
3. Before half the text is erased, stop mashing the backspace key and stop rotating the device.
4. If all text is erased, try typing text.  If newly-typed text is immediately erased, _**FAIL**_ this test.
5. Repeat steps 1-4 at least two additional times.