### PR TITLE
fix(web): crash on custom modifier keys

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -141,27 +141,29 @@ namespace com.keyman.text {
 
       // If it's a key that we 'optimize out' of our fat-finger correction algorithm,
       // we MUST NOT trigger it for this keystroke.
-      let isOnlyLayerShift = text.Codes.isKnownOSKModifierKey(keyEvent.kName);
+      let isOnlyLayerSwitchKey = text.Codes.isKnownOSKModifierKey(keyEvent.kName);
 
       // Best-guess stopgap for possible custom modifier keys.
       // If a key (1) does not affect the context and (2) shifts the active layer,
       // we assume it's a modifier key.  (Touch keyboards may define custom modifier keys.)
       //
-      // Note:  this could cause an issue in the niche scenario where:
+      // Note:  this will mean we won't generate alternates in the niche scenario where:
       // 1.  Keypress does not alter the actual context
       // 2.  It DOES emit a deadkey with an earlier processing rule.
       // 3.  The FINAL processing rule does not match.
       // 4.  The key ALSO signals a layer shift.
       // If any of the four above conditions aren't met - no problem!
       // So it's a pretty niche scenario.
-      if((ruleBehavior.transcription?.transform as TextTransform).isNoOp() && keyEvent.kNextLayer) {
-        isOnlyLayerShift = true;
+      if((ruleBehavior?.transcription?.transform as TextTransform)?.isNoOp() && keyEvent.kNextLayer) {
+        isOnlyLayerSwitchKey = true;
       }
 
       const keepRuleBehavior = ruleBehavior != null;
       // Should we swallow any further processing of keystroke events for this keydown-keypress sequence?
-      if(keepRuleBehavior && !isOnlyLayerShift) {
-        let alternates = this.buildAlternates(ruleBehavior, keyEvent, preInputMock);
+      if(keepRuleBehavior) {
+        // alternates are our fat-finger alternate outputs. We don't build these for keys we detect as
+        // layer switch keys
+        let alternates = isOnlyLayerSwitchKey ? null : this.buildAlternates(ruleBehavior, keyEvent, preInputMock);
 
         // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
         // by the actual keystroke occur.
@@ -173,7 +175,7 @@ namespace com.keyman.text {
         if(alternates && alternates.length > 0) {
           ruleBehavior.transcription.alternates = alternates;
         }
-      } else if(ruleBehavior == null) {
+      } else {
         // We need a dummy RuleBehavior for keys which have no output (e.g. Shift)
         ruleBehavior = new RuleBehavior();
         ruleBehavior.transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);


### PR DESCRIPTION
Fixes #6788.
Fixes KEYMAN-WEB-22.
Fixes KEYMAN-DEVELOPER-BQ.
Fixes KEYMAN-ANDROID-160.

Fixes a crash introduced in #6473 which was trying to prevent modifier keys from triggering "fat finger" alternate lookups, due to incomplete nullish coalescing.

Related to this, from what I can see, a secondary side-effect of the fix in #6473 was that some key events may have never had their ruleBehaviors finalized if they matched the `isOnlyLayerSwitchKey` heuristic, leading to potential issues with edge case 'deadkey+layer switch' keys or keys that set store values, for example. So this fix also makes the `isOnlyLayerSwitchKey` test more targeted.

Identified this when adding a Caps Lock layer to sil_euro_latin and testing the layer switching. At time of fix, the error had been raised in KeymanWeb, Keyman Developer and Keyman for Android, but not yet Keyman for iPhone and iPad.

# User Testing

Re-run the user tests run in #6473.

All tests should be done on the new, dedicated test page at `web/testing/issue6005/index.html`.  The keyboards and lexical models for testing are all preconfigured on that page.

## SUITE_DESKTOP:  desktop-only user tests.  Chrome browser advised.

- **TEST_HEBREW**:  Using the "Hebrew, Galaxie Hebrew" keyboard, type the following:

  - `m`:  You should see `מ`.
  - Follow that with ` ` (a space):  you should now see `ם`, with the newly-typed space on the left (as it's an RTL language)

- **TEST_ANTIVOWEL**:  Using the "Unmatched Vowel Rule" keyboard, type the keystrokes for the following:
  - `tried`: the word should be output as expected
  - `queue`:  only `que` should be output
  - `try`:  should output `tryy`.

- **TEST_ARROWS**:  Using any keyboard, do the following:
  1. type `attempt`
  2. hit ENTER
  3. type `try`
  4. use the left, then up arrow key of your keyboard.
      - the text caret should move intuitively.

## SUITE_PREDICTION:  Use either Firefox's or Chrome's mobile device emulation.

Note:  predictive text should activate for all keyboards but the Hebrew one.
Also note:  the predictive text for the "Pinyin" language is a total hack - it's just the English MTNT model.

- **TEST_HEBREW**:  Using the "Hebrew" (Galaxie Hebrew) keyboard, type the following:

  - `m`:  You should see `מ`.
  - Follow that with ` ` (a space):  you should now see `ם`, with the newly-typed space on the left (as it's an RTL language)

**NOTE**:  Please refresh the page after the previous test.

- **TEST_ANTIVOWEL_TRIED**:  Using the "English" > "Unmatched Vowel Rule" keyboard...
  1. Type the keystrokes for `tried`.
      - The final output should be `tried`.  Predictive text should operate normally, presenting reasonable predictions at all steps.
  2.  Select a suggestion.  The resulting text should match the selected suggestion.

- **TEST_ANTIVOWEL_QUEUE**:  Using the "English" > "Unmatched Vowel Rule" keyboard...
  1. Type the keystrokes for `queue`.
      - The final output should be `que`.  Predictive text should operate normally, presenting reasonable predictions based on the current state of the output.  Predictions should not change after the first `e`.
  2.  Select a suggestion.  The resulting text should match the selected suggestion.

- **TEST_ANTIVOWEL_TRY**:  Using the "English" > "Unmatched Vowel Rule" keyboard, type the keystrokes for `try`.  Be precise for 'y' keystroke, aiming for the key's center.

  The final output should be `tryy`.  Predictive text should operate normally, presenting reasonable predictions based on the current state of the output.  Predictions should be based on `try`, since `tryy` doesn't start any English words.

- **TEST_TRICOLOR**:  Using the "Pinyin" (Cameroon QWERTY) keyboard...

  1. Type `th`.  Suggestions based on `th` for English should appear.
  2. Press the keyboard's tri-color key - the final one in the third row.  The suggestions should not change, no matter how many times it is pressed.
  3. Type `e`.  Suggestions based on `the` should appear, no matter how many times the tri-color key was pressed on the previous step.
  4. Select a suggestion.  The text should change to match the suggestion's text.

- **TEST_NUMERIC**:  Using the "English" > "EuroLatin (SIL)" keyboard...

  1. Type `th`.  Suggestions based on `th` for English should appear.
  2. Press the keyboard's numeric key - the first one in the final row.  The suggestions should not change, no matter how many times it is pressed.
  3. Return to the base layer and type `e`.  Suggestions based on `the` should appear, no matter how many times the numeric-layer key was pressed on the previous step.
  4. Select a suggestion.  The text should change to match the suggestion's text.

- **TEST_ARROWS**:  Using the "English" > "EuroLatin (SIL)" keyboard, do the following:
  1. type `attempt`
  2. hit ENTER
  3. type `try`
  5. use the left, then up arrow key **of your physical keyboard**.
      - the text caret should not move (a limitation of how we handle input on touch)
      - the predictions should be unchanged whenever an arrow key is pressed (the *important* part of this test)

- **TEST_CAPS**:  Using the "English" > "EuroLatin (SIL)" keyboard, do the following:
  1. type `attempt`
  2. press SHIFT.
      - the second and third suggestion should become capitalized.
  3. press SHIFT again, returning to the base layer.
      - the second and third suggestions should no longer be capitalized.