### PR TITLE
chore(web): add 'index.html' to parent links in test pages

### DIFF
--- a/web/samples/index.html
+++ b/web/samples/index.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match iOS device widths -->                         
+
+    <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Samples</title>
-    <style type='text/css'>   
+    <style type='text/css'>
       body {padding-left:20px;margin-left:12px; font-family:Tahoma,Helvetica}
       h1 {color: #800;margin-left:10px;}
       h2 {color: #008;margin-left:20px;}
@@ -23,6 +23,6 @@
   <h2><a href="./unminified.html">Test unminified Keymanweb</a></h2>
   <h2><a href="./minified.html">Test fully compiled Keymanweb</a></h2>
   <h2><a href="./multilingual.html">Full multilingual (compiled) Keymanweb</a></h2>
-  <p><a href="../">Return to main index.</a>
+  <p><a href="../index.html">Return to main index.</a>
   </body>
 </html>

--- a/web/testing/index.html
+++ b/web/testing/index.html
@@ -66,6 +66,6 @@
   <h2><a href="./start-of-sentence-3621/">Test start of sentence keyboard rules (#5963)</a></h2>
   <h2><a href="./issue6005/">Tests predictive text & other handling of rule matching when the final rule group does not match (#6005)</a></h2>
   <h2><a href="./issue5312-touch-alias-optimization/">Tests performance of touch-alias elements with large amounts of text (#5312)</a></h2>
-  <p><a href="../">Return to main index.</a>
+  <p><a href="../index.html">Return to main index.</a>
   </body>
 </html>

--- a/web/tools/index.html
+++ b/web/tools/index.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match iOS device widths -->                         
+
+    <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Resources and Tools</title>
-    <style type='text/css'>   
+    <style type='text/css'>
       body {padding-left:20px;margin-left:12px; font-family:Tahoma,Helvetica}
       h1 {color: #800;margin-left:10px;}
       h2 {color: #008;margin-left:20px;}
@@ -22,6 +22,6 @@
     <h1>KeymanWeb Resources and Tools</h1>
   <h2><a href="./recorder/">Test Sequence Recorder</a></h2>
   <hr>
-  <p><a href="../">Return to main index.</a>
+  <p><a href="../index.html">Return to main index.</a>
   </body>
 </html>


### PR DESCRIPTION
We need a '../index.html' link rather than '../' on the three second-level KeymanWeb test pages, in order to get to the index page for artifacts when the test pages are hosted on build.palaso.org -- otherwise TeamCity returns a 404. (This is probably also good for file-system-based navigation.)

We don't need the same reference on other directories, just for the top-level index.html.

Identified at https://github.com/keymanapp/keyman/pull/6557#issuecomment-1157526326

@keymanapp-test-bot skip I think we can skip testing on this...