### PR TITLE
 fix(web): key preview styling, positioning issues 🍒 

### DIFF
--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -78,7 +78,7 @@ namespace com.keyman.osk.browser {
         let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
         let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
 
-        kts.top = Math.floor(y - canvasHeight) + 'px';
+        kts.bottom = Math.floor(keyman.osk.computedHeight - y) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';
         kts.fontFamily = util.getStyleValue(kc,'font-family');

--- a/web/source/osk/browser/keytip.ts
+++ b/web/source/osk/browser/keytip.ts
@@ -78,6 +78,7 @@ namespace com.keyman.osk.browser {
         let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
         let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
 
+        kts.top = 'auto';
         kts.bottom = Math.floor(keyman.osk.computedHeight - y) + 'px';
         kts.textAlign = 'center';
         kts.overflow = 'visible';

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -402,6 +402,10 @@ div.android div.kmw-keytip-tip {
   background: #999;
 }
 
+div.android div.kmw-keytip-cap {
+  background: #999;
+}
+
 /* Dark mode - ensure text is colored appropriately for key tips. */
 @media (prefers-color-scheme: dark) {
   div.ios div.kmw-keytip {

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -403,7 +403,10 @@ div.android div.kmw-keytip-tip {
 }
 
 div.android div.kmw-keytip-cap {
+  position: absolute;
   background: #999;
+  border-radius: 0 0 5px 5px;
+  border-bottom: solid 1px #8a8d90
 }
 
 /* Dark mode - ensure text is colored appropriately for key tips. */


### PR DESCRIPTION
A 🍒-pick of #6784.

Fixes two issues:
- When using the iOS version of keyman, key previews for the top row will no longer be cropped.
- When using KeymanWeb in a browser on Android devices, the bottom part of the key preview is no longer missing.

@keymanapp-test-bot skip