### PR TITLE
fix(ios): overzealous error about missing banner image

### DIFF
--- a/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
+++ b/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
@@ -61,6 +61,13 @@ class KeyboardViewController: InputViewController {
   }
 
   func setupTopBarImage(size: CGSize) {
+    // We override the height in getTopBarImage, but not width.
+    // If width is 0, we return null from that function; this'll
+    // trigger the guard below.
+    if size.width == 0 {
+      return
+    }
+
     let imgPath = getTopBarImage(size: size)
     guard let path = imgPath else {
       SentryManager.captureAndLog("No image specified for the image banner!")


### PR DESCRIPTION
Fixes #6806.

So, it turns out that there's a very simple case in which we should _expect_ there not to be a constructable banner image - whenever one of the potential banner-image's dimensions will be zero:

https://github.com/keymanapp/keyman/blob/88e18db690407ae807d0419fa6d5da3d3fb2924b/ios/keyman/Keyman/SWKeyboard/ImageBannerViewController.swift#L45-L48

As width = 0 can occur as a temporary state during view initialization, we should probably filter this case out.  The original log message was only ever meant to capture when the image-banner's rendering outright failed to produce an image.

@keymanapp-test-bot skip

The only functional change is that the Sentry log count will be dramatically reduced, if not eliminated.  If the function returns because of the new condition, it would have returned from the pre-existing `guard` statement.