### PR TITLE
fix(web): maps touch-layout chiral alt, ctrl to non-chiral when non-chiral keyboard is active

### DIFF
--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -537,7 +537,7 @@ namespace com.keyman.text {
      * @param e The source KeyEvent
      * @returns
      */
-    private static getEventRuleModifiers(eventModifiers: number, targetModifierMask: number): number {
+    private static matchModifiersToRuleChirality(eventModifiers: number, targetModifierMask: number): number {
       const CHIRAL_ALT  = Codes.modifierCodes["LALT"]  | Codes.modifierCodes["RALT"];
       const CHIRAL_CTRL = Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["RCTRL"];
 
@@ -584,7 +584,7 @@ namespace com.keyman.text {
       var modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
       var stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
-      const eventModifiers = KeyboardInterface.getEventRuleModifiers(e.Lmodifiers, Lruleshift);
+      const eventModifiers = KeyboardInterface.matchModifiersToRuleChirality(e.Lmodifiers, Lruleshift);
 
       if(e.vkCode > 255) {
         keyCode = e.vkCode; // added to support extended (touch-hold) keys for mnemonic layouts

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -530,20 +530,21 @@ namespace com.keyman.text {
     }
 
     /**
-     * Maps a KeyEvent's modifiers to their appropriate value for key-rule evaluation.
-     * Mostly used to correct for chiral OSK-keys used on non-chiral keyboards.
+     * Maps a KeyEvent's modifiers to their appropriate value for key-rule evaluation
+     * based on the rule's specified target modifier set.
+     *
+     * Mostly used to correct chiral OSK-keys targeting non-chiral rules.
      * @param e The source KeyEvent
      * @returns
      */
-    private getEventModifiers(e: KeyEvent): number {
+    private static getEventRuleModifiers(e: KeyEvent, targetModifierMask: number): number {
       const CHIRAL_ALT  = Codes.modifierCodes["LALT"]  | Codes.modifierCodes["RALT"];
       const CHIRAL_CTRL = Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["RCTRL"];
 
       let modifiers = e.Lmodifiers;
-      const keyboard_bitmask = this.activeKeyboard.modifierBitmask;
 
-      // If this keyboard does not use chiral alt...
-      if(!(keyboard_bitmask & CHIRAL_ALT)) {
+      // If the target rule does not use chiral alt...
+      if(!(targetModifierMask & CHIRAL_ALT)) {
         const alt_intersection  = modifiers & CHIRAL_ALT;
 
         if(alt_intersection) {
@@ -552,8 +553,8 @@ namespace com.keyman.text {
         }
       }
 
-      // If this keyboard does not use chiral ctrl...
-      if(!(keyboard_bitmask & CHIRAL_CTRL)) {
+      // If the target rule does not use chiral ctrl...
+      if(!(targetModifierMask & CHIRAL_CTRL)) {
         const ctrl_intersection = modifiers & CHIRAL_CTRL;
 
         if(ctrl_intersection) {
@@ -583,7 +584,7 @@ namespace com.keyman.text {
       var modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
       var stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
-      const eventModifiers = this.getEventModifiers(e);
+      const eventModifiers = KeyboardInterface.getEventRuleModifiers(e, Lruleshift);
 
       if(e.vkCode > 255) {
         keyCode = e.vkCode; // added to support extended (touch-hold) keys for mnemonic layouts

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -536,21 +536,25 @@ namespace com.keyman.text {
      * @returns
      */
     private getEventModifiers(e: KeyEvent): number {
+      const CHIRAL_ALT  = Codes.modifierCodes["LALT"]  | Codes.modifierCodes["RALT"];
+      const CHIRAL_CTRL = Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["RCTRL"];
+
       let modifiers = e.Lmodifiers;
       const keyboard_bitmask = this.activeKeyboard.modifierBitmask;
 
-      // If this keyboard is explicitly non-chiral...
-      const kbd_chiral_intersection = keyboard_bitmask & Codes.modifierBitmasks["CHIRAL"];
-      if(kbd_chiral_intersection == Codes.modifierCodes["SHIFT"] || !kbd_chiral_intersection) {
-        const CHIRAL_ALT  = Codes.modifierCodes["LALT"]  | Codes.modifierCodes["RALT"];
-        const CHIRAL_CTRL = Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["RCTRL"];
+      // If this keyboard does not use chiral alt...
+      if(!(keyboard_bitmask & CHIRAL_ALT)) {
         const alt_intersection  = modifiers & CHIRAL_ALT;
-        const ctrl_intersection = modifiers & CHIRAL_CTRL;
 
         if(alt_intersection) {
           // Undo the chiral part          and replace with non-chiral.
           modifiers ^= alt_intersection  | Codes.modifierCodes["ALT"];
         }
+      }
+
+      // If this keyboard does not use chiral ctrl...
+      if(!(keyboard_bitmask & CHIRAL_CTRL)) {
+        const ctrl_intersection = modifiers & CHIRAL_CTRL;
 
         if(ctrl_intersection) {
           // Undo the chiral part          and replace with non-chiral.

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -537,29 +537,29 @@ namespace com.keyman.text {
      * @param e The source KeyEvent
      * @returns
      */
-    private static getEventRuleModifiers(e: KeyEvent, targetModifierMask: number): number {
+    private static getEventRuleModifiers(eventModifiers: number, targetModifierMask: number): number {
       const CHIRAL_ALT  = Codes.modifierCodes["LALT"]  | Codes.modifierCodes["RALT"];
       const CHIRAL_CTRL = Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["RCTRL"];
 
-      let modifiers = e.Lmodifiers;
+      let modifiers = eventModifiers;
 
       // If the target rule does not use chiral alt...
       if(!(targetModifierMask & CHIRAL_ALT)) {
-        const alt_intersection  = modifiers & CHIRAL_ALT;
+        const altIntersection  = modifiers & CHIRAL_ALT;
 
-        if(alt_intersection) {
-          // Undo the chiral part          and replace with non-chiral.
-          modifiers ^= alt_intersection  | Codes.modifierCodes["ALT"];
+        if(altIntersection) {
+          // Undo the chiral part         and replace with non-chiral.
+          modifiers ^= altIntersection  | Codes.modifierCodes["ALT"];
         }
       }
 
       // If the target rule does not use chiral ctrl...
       if(!(targetModifierMask & CHIRAL_CTRL)) {
-        const ctrl_intersection = modifiers & CHIRAL_CTRL;
+        const ctrlIntersection = modifiers & CHIRAL_CTRL;
 
-        if(ctrl_intersection) {
-          // Undo the chiral part          and replace with non-chiral.
-          modifiers ^= ctrl_intersection | Codes.modifierCodes["CTRL"];
+        if(ctrlIntersection) {
+          // Undo the chiral part         and replace with non-chiral.
+          modifiers ^= ctrlIntersection | Codes.modifierCodes["CTRL"];
         }
       }
 
@@ -584,7 +584,7 @@ namespace com.keyman.text {
       var modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
       var stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
-      const eventModifiers = KeyboardInterface.getEventRuleModifiers(e, Lruleshift);
+      const eventModifiers = KeyboardInterface.getEventRuleModifiers(e.Lmodifiers, Lruleshift);
 
       if(e.vkCode > 255) {
         keyCode = e.vkCode; // added to support extended (touch-hold) keys for mnemonic layouts

--- a/common/web/keyboard-processor/tests/cases/chirality.js
+++ b/common/web/keyboard-processor/tests/cases/chirality.js
@@ -59,219 +59,198 @@ describe('Engine - Chirality', function() {
 
   describe("Chiral modifier mapping", function() {
     let VIRTUAL_KEY_CODE = Codes.modifierCodes["VIRTUAL_KEY"];
-
-    // An incomplete instance of text.KeyEvent; we only **_really_** need the one field,
-    // `Lmodifiers`, though.
-    let BASE_KEY_EVENT = {
-      Lcode: 64,
-      Lstates: 0,
-      Lmodifiers: VIRTUAL_KEY_CODE, // The one we'll modify for this set of tests.
-      LisVirtualKey: true
-    };
+    let CTRL_CODE  = Codes.modifierCodes["CTRL"];
+    let LCTRL_CODE = Codes.modifierCodes["LCTRL"];
+    let RCTRL_CODE = Codes.modifierCodes["RCTRL"];
+    let ALT_CODE   = Codes.modifierCodes["ALT"];
+    let LALT_CODE  = Codes.modifierCodes["LALT"];
+    let RALT_CODE  = Codes.modifierCodes["RALT"];
+    let SHIFT_CODE = Codes.modifierCodes["SHIFT"];
 
     it("does not affect non-chiral KeyEvents - CTRL only", function() {
-      let key = Object.assign({}, BASE_KEY_EVENT);
-      key.Lmodifiers |= Codes.modifierCodes["CTRL"];
-
-      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | CTRL_CODE;
+      let targetModifiers  = VIRTUAL_KEY_CODE | CTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | CTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["LCTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["RCTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | RCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
     });
 
     it("does not affect non-chiral KeyEvents - ALT only", function() {
-      let key = Object.assign({}, BASE_KEY_EVENT);
-      key.Lmodifiers |= Codes.modifierCodes["ALT"];
-
-      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+      let initialModifiers = VIRTUAL_KEY_CODE | ALT_CODE;
+      let targetModifiers  = VIRTUAL_KEY_CODE | ALT_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | ALT_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LALT_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | RALT_CODE);
       assert.equal(targetModifiers, mappedModifiers);
     });
 
     it("does not affect non-chiral KeyEvents - ALT + CTRL", function() {
-      let key = Object.assign({}, BASE_KEY_EVENT);
-      key.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
-
-      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | ALT_CODE | CTRL_CODE;
+      let targetModifiers  = VIRTUAL_KEY_CODE | ALT_CODE | CTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      let ctrlPlusAlt = Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | ctrlPlusAlt);
+      let ctrlPlusAlt = ALT_CODE | CTRL_CODE;
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | ctrlPlusAlt);
       assert.equal(targetModifiers, mappedModifiers);
 
-      let leftVariant = Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | leftVariant);
+      let leftVariant = LALT_CODE | LCTRL_CODE;
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | leftVariant);
       assert.equal(targetModifiers, mappedModifiers);
 
-      let rightVariant = Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"];
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | rightVariant);
+      let rightVariant = RALT_CODE | RCTRL_CODE;
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | rightVariant);
       assert.equal(targetModifiers, mappedModifiers);
 
-      let mixedVariant1 = Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"];
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | mixedVariant1);
+      let mixedVariant1 = LALT_CODE | CTRL_CODE;
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | mixedVariant1);
       assert.equal(targetModifiers, mappedModifiers);
 
-      let mixedVariant2 = Codes.modifierCodes["ALT"] | Codes.modifierCodes["RCTRL"];
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | mixedVariant2);
+      let mixedVariant2 = ALT_CODE | RCTRL_CODE;
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | mixedVariant2);
       assert.equal(targetModifiers, mappedModifiers);
     });
 
     it("maps chiral modifiers when the rule does not expect a matching modifier", function() {
-      let ctrlTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+      let ctrlTargetModifiers = VIRTUAL_KEY_CODE | CTRL_CODE;
 
-      let ctrlKey1 = Object.assign({}, BASE_KEY_EVENT);
-      ctrlKey1.Lmodifiers |= Codes.modifierCodes["LCTRL"];
+      let initialCtrlModifiers1   = VIRTUAL_KEY_CODE | LCTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey1, VIRTUAL_KEY_CODE);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialCtrlModifiers1, VIRTUAL_KEY_CODE);
       assert.equal(ctrlTargetModifiers, mappedModifiers);
 
-      let ctrlKey2 = Object.assign({}, BASE_KEY_EVENT);
-      ctrlKey2.Lmodifiers |= Codes.modifierCodes["RCTRL"];
+      let initialCtrlModifiers2   =  VIRTUAL_KEY_CODE | RCTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey2, VIRTUAL_KEY_CODE);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialCtrlModifiers2, VIRTUAL_KEY_CODE);
       assert.equal(ctrlTargetModifiers, mappedModifiers);
 
-      let altTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+      let altTargetModifiers   = VIRTUAL_KEY_CODE | ALT_CODE;
 
-      let altKey1 = Object.assign({}, BASE_KEY_EVENT);
-      altKey1.Lmodifiers |= Codes.modifierCodes["LALT"];
+      let initialAltModifiers1 = VIRTUAL_KEY_CODE | LALT_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey1, VIRTUAL_KEY_CODE);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialAltModifiers1, VIRTUAL_KEY_CODE);
       assert.equal(altTargetModifiers, mappedModifiers);
 
-      let altKey2 = Object.assign({}, BASE_KEY_EVENT);
-      altKey2.Lmodifiers |= Codes.modifierCodes["RALT"];
+      let initialAltModifiers2 = VIRTUAL_KEY_CODE | RALT_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey2, VIRTUAL_KEY_CODE);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialAltModifiers2, VIRTUAL_KEY_CODE);
       assert.equal(altTargetModifiers, mappedModifiers);
     });
 
     it("maps chiral modifiers when the rule expects the non-chiral version", function() {
-      let ctrlTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+      let ctrlTargetModifiers   = VIRTUAL_KEY_CODE | CTRL_CODE;
 
-      let ctrlKey1 = Object.assign({}, BASE_KEY_EVENT);
-      ctrlKey1.Lmodifiers |= Codes.modifierCodes["LCTRL"];
+      let initialCtrlModifiers1 = VIRTUAL_KEY_CODE | LCTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey1, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialCtrlModifiers1, VIRTUAL_KEY_CODE | CTRL_CODE);
       assert.equal(ctrlTargetModifiers, mappedModifiers);
 
-      let ctrlKey2 = Object.assign({}, BASE_KEY_EVENT);
-      ctrlKey2.Lmodifiers |= Codes.modifierCodes["RCTRL"];
+      let initialCtrlModifiers2 = VIRTUAL_KEY_CODE | RCTRL_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey2, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialCtrlModifiers2, VIRTUAL_KEY_CODE | CTRL_CODE);
       assert.equal(ctrlTargetModifiers, mappedModifiers);
 
-      let altTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+      let altTargetModifiers   = VIRTUAL_KEY_CODE | ALT_CODE;
 
-      let altKey1 = Object.assign({}, BASE_KEY_EVENT);
-      altKey1.Lmodifiers |= Codes.modifierCodes["LALT"];
+      let initialAltModifiers1 = VIRTUAL_KEY_CODE | LALT_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey1, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialAltModifiers1, VIRTUAL_KEY_CODE | ALT_CODE);
       assert.equal(altTargetModifiers, mappedModifiers);
 
-      let altKey2 = Object.assign({}, BASE_KEY_EVENT);
-      altKey2.Lmodifiers |= Codes.modifierCodes["RALT"];
+      let initialAltModifiers2 = VIRTUAL_KEY_CODE | RALT_CODE;
 
       // We should get the same results whether or not there actually is a corresponding modifier
       // expected by the rule we're examining.
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey2, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialAltModifiers2, VIRTUAL_KEY_CODE | ALT_CODE);
       assert.equal(altTargetModifiers, mappedModifiers);
     });
 
     it("does not map nonchiral modifiers", function() {
-      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
-      keyEvent.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | ALT_CODE | CTRL_CODE;
 
-      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+      let targetModifiers  = VIRTUAL_KEY_CODE | ALT_CODE | CTRL_CODE;
 
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"]);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | RALT_CODE | RCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
     });
 
     it("does not map chirals when a chiral version is expected", function() {
-      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
-      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE;
 
-      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+      let targetModifiers  = VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE;
 
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"]);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | RALT_CODE | RCTRL_CODE);
       assert.equal(targetModifiers, mappedModifiers);
     });
 
     it("handles mixed chiral/nonchiral rules - case 1", function() {
-      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
-      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE;
 
-      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"];
+      let modifierTarget   = VIRTUAL_KEY_CODE | LALT_CODE |  CTRL_CODE;
 
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"]);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LALT_CODE | CTRL_CODE);
       assert.equal(modifierTarget, mappedModifiers);
     });
 
     it("handles mixed chiral/nonchiral rules - case 2", function() {
-      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
-      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+      let initialModifiers = VIRTUAL_KEY_CODE | LALT_CODE | LCTRL_CODE;
 
-      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"];
+      let modifierTarget   = VIRTUAL_KEY_CODE |  ALT_CODE | LCTRL_CODE;
 
-      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["RCTRL"]);
+      let mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | ALT_CODE | RCTRL_CODE);
       assert.equal(modifierTarget, mappedModifiers);
     });
 
     it("handles mixed chiral/nonchiral rules - case 3", function() {
-      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
-      keyEvent.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["SHIFT"];
+      let initialModifiers = VIRTUAL_KEY_CODE | ALT_CODE | LCTRL_CODE | SHIFT_CODE;
 
-      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["SHIFT"];
+      let modifierTarget   = VIRTUAL_KEY_CODE | ALT_CODE | LCTRL_CODE | SHIFT_CODE;
 
-      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["RCTRL"]);
+      mappedModifiers = KeyboardInterface.matchModifiersToRuleChirality(initialModifiers, VIRTUAL_KEY_CODE | LALT_CODE | RCTRL_CODE);
       assert.equal(modifierTarget, mappedModifiers);
     });
   });

--- a/common/web/keyboard-processor/tests/cases/chirality.js
+++ b/common/web/keyboard-processor/tests/cases/chirality.js
@@ -7,6 +7,8 @@ let KMWRecorder = require('../../../recorder/build/nodeProctor');
 
 // Required initialization setup.
 global.com = KeyboardProcessor.com; // exports all keyboard-processor namespacing.
+let KeyboardInterface = com.keyman.text.KeyboardInterface;
+let Codes = com.keyman.text.Codes;
 
 describe('Engine - Chirality', function() {
   let testJSONtext = fs.readFileSync('../../test/resources/json/engine_tests/chirality.json');
@@ -54,4 +56,223 @@ describe('Engine - Chirality', function() {
       it.skip(set.toTestName() + " - modifier state simulation for OSK not yet supported in headless KeyboardProcessor");
     }
   }
+
+  describe("Chiral modifier mapping", function() {
+    let VIRTUAL_KEY_CODE = Codes.modifierCodes["VIRTUAL_KEY"];
+
+    // An incomplete instance of text.KeyEvent; we only **_really_** need the one field,
+    // `Lmodifiers`, though.
+    let BASE_KEY_EVENT = {
+      Lcode: 64,
+      Lstates: 0,
+      Lmodifiers: VIRTUAL_KEY_CODE, // The one we'll modify for this set of tests.
+      LisVirtualKey: true
+    };
+
+    it("does not affect non-chiral KeyEvents - CTRL only", function() {
+      let key = Object.assign({}, BASE_KEY_EVENT);
+      key.Lmodifiers |= Codes.modifierCodes["CTRL"];
+
+      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["LCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["RCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+    });
+
+    it("does not affect non-chiral KeyEvents - ALT only", function() {
+      let key = Object.assign({}, BASE_KEY_EVENT);
+      key.Lmodifiers |= Codes.modifierCodes["ALT"];
+
+      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"]);
+      assert.equal(targetModifiers, mappedModifiers);
+    });
+
+    it("does not affect non-chiral KeyEvents - ALT + CTRL", function() {
+      let key = Object.assign({}, BASE_KEY_EVENT);
+      key.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+
+      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      let ctrlPlusAlt = Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | ctrlPlusAlt);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      let leftVariant = Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | leftVariant);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      let rightVariant = Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"];
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | rightVariant);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      let mixedVariant1 = Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"];
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | mixedVariant1);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      let mixedVariant2 = Codes.modifierCodes["ALT"] | Codes.modifierCodes["RCTRL"];
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(key, VIRTUAL_KEY_CODE | mixedVariant2);
+      assert.equal(targetModifiers, mappedModifiers);
+    });
+
+    it("maps chiral modifiers when the rule does not expect a matching modifier", function() {
+      let ctrlTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+
+      let ctrlKey1 = Object.assign({}, BASE_KEY_EVENT);
+      ctrlKey1.Lmodifiers |= Codes.modifierCodes["LCTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey1, VIRTUAL_KEY_CODE);
+      assert.equal(ctrlTargetModifiers, mappedModifiers);
+
+      let ctrlKey2 = Object.assign({}, BASE_KEY_EVENT);
+      ctrlKey2.Lmodifiers |= Codes.modifierCodes["RCTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey2, VIRTUAL_KEY_CODE);
+      assert.equal(ctrlTargetModifiers, mappedModifiers);
+
+      let altTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+
+      let altKey1 = Object.assign({}, BASE_KEY_EVENT);
+      altKey1.Lmodifiers |= Codes.modifierCodes["LALT"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey1, VIRTUAL_KEY_CODE);
+      assert.equal(altTargetModifiers, mappedModifiers);
+
+      let altKey2 = Object.assign({}, BASE_KEY_EVENT);
+      altKey2.Lmodifiers |= Codes.modifierCodes["RALT"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey2, VIRTUAL_KEY_CODE);
+      assert.equal(altTargetModifiers, mappedModifiers);
+    });
+
+    it("maps chiral modifiers when the rule expects the non-chiral version", function() {
+      let ctrlTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"];
+
+      let ctrlKey1 = Object.assign({}, BASE_KEY_EVENT);
+      ctrlKey1.Lmodifiers |= Codes.modifierCodes["LCTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey1, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      assert.equal(ctrlTargetModifiers, mappedModifiers);
+
+      let ctrlKey2 = Object.assign({}, BASE_KEY_EVENT);
+      ctrlKey2.Lmodifiers |= Codes.modifierCodes["RCTRL"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(ctrlKey2, VIRTUAL_KEY_CODE | Codes.modifierCodes["CTRL"]);
+      assert.equal(ctrlTargetModifiers, mappedModifiers);
+
+      let altTargetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"];
+
+      let altKey1 = Object.assign({}, BASE_KEY_EVENT);
+      altKey1.Lmodifiers |= Codes.modifierCodes["LALT"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey1, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      assert.equal(altTargetModifiers, mappedModifiers);
+
+      let altKey2 = Object.assign({}, BASE_KEY_EVENT);
+      altKey2.Lmodifiers |= Codes.modifierCodes["RALT"];
+
+      // We should get the same results whether or not there actually is a corresponding modifier
+      // expected by the rule we're examining.
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(altKey2, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"]);
+      assert.equal(altTargetModifiers, mappedModifiers);
+    });
+
+    it("does not map nonchiral modifiers", function() {
+      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
+      keyEvent.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+
+      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["CTRL"];
+
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+    });
+
+    it("does not map chirals when a chiral version is expected", function() {
+      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
+      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+
+      let targetModifiers = VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["RALT"] | Codes.modifierCodes["RCTRL"]);
+      assert.equal(targetModifiers, mappedModifiers);
+    });
+
+    it("handles mixed chiral/nonchiral rules - case 1", function() {
+      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
+      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+
+      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"];
+
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["CTRL"]);
+      assert.equal(modifierTarget, mappedModifiers);
+    });
+
+    it("handles mixed chiral/nonchiral rules - case 2", function() {
+      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
+      keyEvent.Lmodifiers |= Codes.modifierCodes["LALT"] | Codes.modifierCodes["LCTRL"];
+
+      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"];
+
+      let mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["RCTRL"]);
+      assert.equal(modifierTarget, mappedModifiers);
+    });
+
+    it("handles mixed chiral/nonchiral rules - case 3", function() {
+      let keyEvent = Object.assign({}, BASE_KEY_EVENT);
+      keyEvent.Lmodifiers |= Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["SHIFT"];
+
+      let modifierTarget = VIRTUAL_KEY_CODE | Codes.modifierCodes["ALT"] | Codes.modifierCodes["LCTRL"] | Codes.modifierCodes["SHIFT"];
+
+      mappedModifiers = KeyboardInterface.getEventRuleModifiers(keyEvent, VIRTUAL_KEY_CODE | Codes.modifierCodes["LALT"] | Codes.modifierCodes["RCTRL"]);
+      assert.equal(modifierTarget, mappedModifiers);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #6792.

Up until now, KeymanWeb hasn't bothered comparing a keyboard's chirality with the corresponding OSK's key "layer" property - it's simply assumed consistency between the two.  Should a keyboard developer specify a chiral "layer" property when the keyboard itself isn't actually chiral, that unchecked assumption would cause the key not to match in the expected way.  For the price of a little extra overhead, we can remove that assumption.

Note that there is no matching keyboard for the user test; instead, I've added numerous unit tests to handle the important part of the changes for the original issue.  However, it's still best to test other keyboards to make sure that others aren't affected.

## User Testing

### Tests

- TEST_NORMAL_CHIRALITY:  Using the "Chirality testing/bootstrapping" test page...
    - Test by using Chrome's remote-device emulation.
    - Use a longpress-shift and select the "LAlt" layer, then type at least 3 keys with the OSK.
    - Resulting text should perfectly match the keycaps for the keys you typed.
    - Then, tap shift and then longpress-shift again to select the "Shift + RAlt" layer, then type at least 3 keys with the OSK.
    - Resulting text should, again, perfectly match the keycaps for the keys you typed.

- TEST_CHIRALITY_HARDWARE:  Using the "Chirality testing/bootstrapping" test page...
    - Without remote-device emulation in Chrome, but with a hardware keyboard that has two Alt keys...
    - Hold LAlt.  The desktop OSK should change layer and show new keycaps.
    - Type at least three keys while holding LAlt.  The resulting text should perfectly match the keycaps for the keys you typed.
    - Then, hold Shift + RAlt.  The desktop OSK should change layer and show new keycaps. 
    - Again, type at least 3 keys with the OSK.  The resulting text should perfectly match the keycaps for the keys you typed.
    - Now, hold Shift + LAlt + LCtrl.  The desktop OSK should show the same keycaps that it did for Shift + RAlt.

- TEST_NORMAL_KEYBOARD_OSK:  Using the "Test unminified Keymanweb" test page...
    - Test by using Chrome's remote-device emulation.
    - Select the "French" keyboard.
    - Type at least two keys on the base layer and confirm they act as expected.
    - Then, use a longpress-shift to select the Alt+Ctrl layer, then type `[` and `]`, confirming they act as expected.
    - Then, type the `~` key.  Nothing should emit.
    - Then, drop to the base layer, then type an `a`.  An `ã` should result.

- TEST_NORMAL_KEYBOARD_HARDWARE:  Using the "Test unminified Keymanweb" test page...
    - Without remote-device emulation in Chrome, but with a hardware keyboard that has two Alt keys...
    - Select the "French" keyboard.
    - Type at least two unmodified (no Shift, Ctrl, Alt...) _with your hardware keyboard_ and confirm they act as expected.
    - Then, hold Alt + Ctrl and type your hardware `5` and `-` keys - they should produce `[` and `]` respectively, regardless of which Alt and Ctrl key you use.
    - Then, type Alt + Ctrl + `2` key.  Nothing should emit.
    - Then, release Alt + Ctrl, then type an `a`.  An `ã` should result.