### PR TITLE
fix(linux): Deal with non-existing files

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -201,6 +201,9 @@ class InstallKmp():
         return dir
 
     def _safeLinkFile(self, source, target):
+        if not os.path.isfile(source):
+            logging.error("Can't link file %s - source file doesn't exist", source)
+            return
         if os.path.isfile(target):
             return
         if os.path.exists(target):


### PR DESCRIPTION
This change deals with files that are referenced in the keyboard package but don't actually exist.

Fixes #6811.

@keymanapp-test-bot skip