### PR TITLE
chore(web): updates error-reporting lib uploader (pseudo-🍒)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "keyman",
-			"version": "15.0.104",
+			"version": "15.0.262",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^11.9.4",
@@ -14,7 +14,7 @@
 				"eventemitter3": "^4.0.0"
 			},
 			"devDependencies": {
-				"@sentry/cli": "^1.52.3",
+				"@sentry/cli": "2.2.0",
 				"google-closure-compiler-java": "^20200224.0.0",
 				"karma": "^6.3.4",
 				"karma-browserstack-launcher": "^1.6.0",
@@ -34,22 +34,24 @@
 			}
 		},
 		"node_modules/@sentry/cli": {
-			"version": "1.52.3",
-			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.52.3.tgz",
-			"integrity": "sha512-QOSIg5hxAEa6v6H7oEeF6A/Rpa0wloMhbu0Qed6zHv3lyoqf0Z34Kq2jCXdqGsOE3IzkO+3CNy81F6361j5TKg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.2.0.tgz",
+			"integrity": "sha512-ywFtB8VHyWN248LuM67fsRtdMLif/SOHYY3zyef5WybvnAmRLDmGTWK//hSUCebsHBpehRIkmt4iMiyUXwgd5w==",
 			"dev": true,
+			"hasInstallScript": true,
 			"dependencies": {
 				"https-proxy-agent": "^5.0.0",
-				"mkdirp": "^0.5.5",
-				"node-fetch": "^2.6.0",
+				"node-fetch": "^2.6.7",
+				"npmlog": "^6.0.1",
 				"progress": "^2.0.3",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^1.1.0",
+				"which": "^2.0.2"
 			},
 			"bin": {
 				"sentry-cli": "bin/sentry-cli"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/@sentry/cli/node_modules/agent-base": {
@@ -64,6 +66,49 @@
 				"node": ">= 6.0.0"
 			}
 		},
+		"node_modules/@sentry/cli/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/aproba": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/are-we-there-yet": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+			"integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+			"dev": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true,
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"dev": true
+		},
 		"node_modules/@sentry/cli/node_modules/debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -72,6 +117,43 @@
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
+		},
+		"node_modules/@sentry/cli/node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/gauge": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"dev": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"dev": true
 		},
 		"node_modules/@sentry/cli/node_modules/https-proxy-agent": {
 			"version": "5.0.0",
@@ -86,22 +168,13 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@sentry/cli/node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
-		"node_modules/@sentry/cli/node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+		"node_modules/@sentry/cli/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/cli/node_modules/ms": {
@@ -109,6 +182,174 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/npmlog": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"dev": true,
+			"dependencies": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/@sentry/cli/node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"node_modules/@sentry/cli/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
 		},
 		"node_modules/@types/node": {
 			"version": "11.9.4",
@@ -2191,15 +2432,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"node_modules/node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-			"dev": true,
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			}
-		},
 		"node_modules/null-check": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
@@ -2567,16 +2799,17 @@
 	},
 	"dependencies": {
 		"@sentry/cli": {
-			"version": "1.52.3",
-			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.52.3.tgz",
-			"integrity": "sha512-QOSIg5hxAEa6v6H7oEeF6A/Rpa0wloMhbu0Qed6zHv3lyoqf0Z34Kq2jCXdqGsOE3IzkO+3CNy81F6361j5TKg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.2.0.tgz",
+			"integrity": "sha512-ywFtB8VHyWN248LuM67fsRtdMLif/SOHYY3zyef5WybvnAmRLDmGTWK//hSUCebsHBpehRIkmt4iMiyUXwgd5w==",
 			"dev": true,
 			"requires": {
 				"https-proxy-agent": "^5.0.0",
-				"mkdirp": "^0.5.5",
-				"node-fetch": "^2.6.0",
+				"node-fetch": "^2.6.7",
+				"npmlog": "^6.0.1",
 				"progress": "^2.0.3",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^1.1.0",
+				"which": "^2.0.2"
 			},
 			"dependencies": {
 				"agent-base": {
@@ -2588,6 +2821,40 @@
 						"debug": "4"
 					}
 				},
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"dev": true
+				},
+				"are-we-there-yet": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+					"integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+					"dev": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					}
+				},
+				"color-support": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+					"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+					"dev": true
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2596,6 +2863,40 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"gauge": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+					"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+					"dev": true,
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.3",
+						"console-control-strings": "^1.1.0",
+						"has-unicode": "^2.0.1",
+						"signal-exit": "^3.0.7",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wide-align": "^1.1.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+					"dev": true
 				},
 				"https-proxy-agent": {
 					"version": "5.0.0",
@@ -2607,26 +2908,142 @@
 						"debug": "4"
 					}
 				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
 				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
+				"npmlog": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+					"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+					"dev": true,
+					"requires": {
+						"are-we-there-yet": "^3.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^4.0.3",
+						"set-blocking": "^2.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+					"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+					"dev": true
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+					"dev": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+					"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2 || 3 || 4"
+					}
 				}
 			}
 		},
@@ -4285,12 +4702,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
 			"dev": true
 		},
 		"null-check": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@keymanapp/resources-gosh": "^15.0.262",
     "@keymanapp/web-sentry-manager": "^15.0.262",
-    "@sentry/cli": "^1.52.3",
+    "@sentry/cli": "2.2.0",
     "chai": "^4.3.4",
     "google-closure-compiler-java": "^20200224.0.0",
     "karma": "^6.3.4",


### PR DESCRIPTION
Fixes #5616.

This parallels #6818 for 15.0.

It's not exactly a 🍒-pick because of all the changes to our dependency infrastructure brought about by the big 🎡 PR-chain (see #6525, et al).  Instead, I just re-implemented the changes directly in 15.0's package.json and used the results from that.

@keymanapp-test-bot skip

But do make sure that Web's CI build log indicates that no errors occurred with the upload to Sentry... on the following stable build.  Because the Sentry upload doesn't run on PR builds.