### PR TITLE
chore(ios): log script actions and fixup export settings to avoid version being clobbered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ resources/environment.sh
 
 **/node_modules/
 
+# Temporary file for logging scripts in xcode runs, see build-utils.sh for
+# details
+/xcodebuild-scripts.log

--- a/ios/exportAppStore.plist
+++ b/ios/exportAppStore.plist
@@ -19,5 +19,7 @@
     </dict>
     <key>signingStyle</key>
     <string>manual</string>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
 </dict>
 </plist>

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -23,6 +23,18 @@ cd "$(dirname "$THIS_SCRIPT")"
 # Please note that this build script (understandably) assumes that it is running on Mac OS X.
 verify_on_mac
 
+function printScriptLogs() {
+  echo "printScriptLogs: reporting script results from previous xcode build"
+  if [ -f "$KEYMAN_ROOT/ios/scripts.log" ]; then
+    cat "$KEYMAN_ROOT/ios/scripts.log"
+    rm "$KEYMAN_ROOT/ios/scripts.log"
+  else
+    echo "printScriptLogs: $KEYMAN_ROOT/ios/scripts.log not found"
+  fi
+  echo "printScriptLogs: done"
+  echo
+}
+
 display_usage ( ) {
     echo "build.sh [-clean] [-no-kmw] [-only-framework] [-no-codesign] [-no-archive] [-add-sim-artifact] [-no-build] [-upload-sentry]"
     echo
@@ -253,10 +265,13 @@ xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme KME-universal \
            UPLOAD_SENTRY=$UPLOAD_SENTRY
 
 if [ $? -ne 0 ]; then
+  printScriptLogs
   fail "KMEI build failed."
 fi
 
 assertDirExists "$KEYMAN_XCFRAMEWORK"
+
+printScriptLogs
 
 echo "KMEI build complete."
 
@@ -283,9 +298,11 @@ if [ $DO_KEYMANAPP = true ]; then
                 UPLOAD_SENTRY=$UPLOAD_SENTRY
 
     if [ $? -ne 0 ]; then
+      printScriptLogs
       fail "Keyman app build failed."
     fi
 
+    printScriptLogs
   else
     # Time to prepare the deployment archive data.
     echo ""
@@ -298,6 +315,7 @@ if [ $DO_KEYMANAPP = true ]; then
                 VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
                 UPLOAD_SENTRY=$UPLOAD_SENTRY
 
+    printScriptLogs
     assertDirExists "$ARCHIVE_PATH"
 
     if [ $DO_CODE_SIGN == true ]; then
@@ -307,6 +325,7 @@ if [ $DO_KEYMANAPP = true ]; then
       xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
                   -exportOptionsPlist exportAppStore.plist \
                   -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates
+      printScriptLogs
     fi
   fi
 
@@ -322,8 +341,10 @@ if [ $DO_KEYMANAPP = true ]; then
 
   echo ""
   if [ $? = 0 ]; then
+      printScriptLogs
       echo "Build succeeded."
   else
+      printScriptLogs
       fail "Build failed - please see the log above for details."
   fi
 fi

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -246,7 +246,7 @@ if [ -d "$BUILD_PATH/$CONFIG-universal" ]; then
   rm -r $BUILD_PATH/$CONFIG-universal
 fi
 
-run-xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme KME-universal \
+run_xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme KME-universal \
            VERSION=$VERSION \
            VERSION_WITH_TAG=$VERSION_WITH_TAG \
            VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
@@ -272,7 +272,7 @@ if [ $DO_KEYMANAPP = true ]; then
   fi
 
   if [ $DO_ARCHIVE = false ]; then
-    run-xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
+    run_xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
                 VERSION=$VERSION \
                 VERSION_WITH_TAG=$VERSION_WITH_TAG \
                 VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
@@ -281,7 +281,7 @@ if [ $DO_KEYMANAPP = true ]; then
     # Time to prepare the deployment archive data.
     echo ""
     echo "Preparing .xcarchive for real devices."
-    run-xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
+    run_xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
                 -archivePath $ARCHIVE_PATH \
                 archive -allowProvisioningUpdates \
                 VERSION=$VERSION \
@@ -295,7 +295,7 @@ if [ $DO_KEYMANAPP = true ]; then
       echo "Preparing .ipa file for deployment to real devices"
       # Do NOT use the _EXT variant here; there's no scheme to ref, which will lead
       # Xcode to generate a build error.
-      run-xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
+      run_xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH \
                   -exportOptionsPlist exportAppStore.plist \
                   -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates
     fi
@@ -303,7 +303,7 @@ if [ $DO_KEYMANAPP = true ]; then
 
   if [ $DO_SIMULATOR_TARGET == true ]; then
     echo "Preparing .app file for simulator-targeted artifact for testing"
-    run-xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
+    run_xcodebuild $XCODEFLAGS_EXT $CODE_SIGN -scheme Keyman \
                 -sdk iphonesimulator \
                 VERSION=$VERSION \
                 VERSION_WITH_TAG=$VERSION_WITH_TAG \

--- a/ios/samples/build_common.sh
+++ b/ios/samples/build_common.sh
@@ -7,6 +7,12 @@ set -u
 # set -x: Debugging use, print each statement
 # set -x
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 # Please note that this build script (understandably) assumes that it is running on Mac OS X.
 if [[ "${OSTYPE}" == *"darwin" ]]; then
   echo "This build script will only run in a Mac environment."

--- a/ios/samples/build_common.sh
+++ b/ios/samples/build_common.sh
@@ -133,9 +133,9 @@ if [ $DO_UPDATE = true ]; then
 fi
 
 if [ $CODE_SIGN = true ]; then
-  run-xcodebuild -quiet -target "$TARGET" -config "$CONFIG"
+  run_xcodebuild -quiet -target "$TARGET" -config "$CONFIG"
 else
-  run-xcodebuild -quiet CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_ENTITLEMENTS="" -target "$TARGET" -config "$CONFIG"
+  run_xcodebuild -quiet CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_ENTITLEMENTS="" -target "$TARGET" -config "$CONFIG"
 fi
 
 if [ $? = 0 ]; then

--- a/ios/samples/build_common.sh
+++ b/ios/samples/build_common.sh
@@ -127,9 +127,9 @@ if [ $DO_UPDATE = true ]; then
 fi
 
 if [ $CODE_SIGN = true ]; then
-  xcodebuild -quiet -target "$TARGET" -config "$CONFIG"
+  run-xcodebuild -quiet -target "$TARGET" -config "$CONFIG"
 else
-  xcodebuild -quiet CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_ENTITLEMENTS="" -target "$TARGET" -config "$CONFIG"
+  run-xcodebuild -quiet CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_ENTITLEMENTS="" -target "$TARGET" -config "$CONFIG"
 fi
 
 if [ $? = 0 ]; then

--- a/ios/scripts/kme-universal.sh
+++ b/ios/scripts/kme-universal.sh
@@ -31,7 +31,7 @@ build_archive ( ) {
   #        our build processes.
   #        (It nukes the base .framework file used to build the archive with a
   #        broken alias that subsequent builds [like the main app's!] can't process.)
-  run-xcodebuild build \
+  run_xcodebuild build \
              -scheme "${SCHEME_NAME}" \
              -configuration ${CONFIGURATION} \
              -sdk "$1" \
@@ -68,7 +68,7 @@ echo ""
 # -allow-internal-distribution:  preserves the .swiftmodule files, greatly
 #                                simplifying integration in consuming apps.
 #                                - Carthage uses this for its XCFramework support.
-run-xcodebuild -create-xcframework \
+run_xcodebuild -create-xcframework \
   -allow-internal-distribution \
   -framework ${IPHONE_FRAMEWORK} \
   -framework ${SIMULATOR_FRAMEWORK} \

--- a/ios/scripts/kme-universal.sh
+++ b/ios/scripts/kme-universal.sh
@@ -28,10 +28,10 @@ echo ""
 build_archive ( ) {
   # Note:  while official docs say we should use `xcodebuild archive ...`, that
   #        is not only markedly slower, it also adds undesired side-effects to
-  #        our build processes.  
+  #        our build processes.
   #        (It nukes the base .framework file used to build the archive with a
   #        broken alias that subsequent builds [like the main app's!] can't process.)
-  xcodebuild build \
+  run-xcodebuild build \
              -scheme "${SCHEME_NAME}" \
              -configuration ${CONFIGURATION} \
              -sdk "$1" \
@@ -68,7 +68,7 @@ echo ""
 # -allow-internal-distribution:  preserves the .swiftmodule files, greatly
 #                                simplifying integration in consuming apps.
 #                                - Carthage uses this for its XCFramework support.
-xcodebuild -create-xcframework \
+run-xcodebuild -create-xcframework \
   -allow-internal-distribution \
   -framework ${IPHONE_FRAMEWORK} \
   -framework ${SIMULATOR_FRAMEWORK} \

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -306,6 +306,8 @@ execBuildCommand() {
     ret_code=$?
     set -e
 
+    printXCodeBuildScriptLogs
+
     if [ $ret_code != 0 ]; then
         fail "Build of $component failed! Error: [$ret_code] when executing command: '$cmnd'"
     fi

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -170,7 +170,7 @@ if [ $DO_CARTHAGE = true ]; then
 
   # Deleted workspace - a test for proper deployment to CocoaPods.  Doesn't matter here.
   rm -r ./Carthage/Checkouts/DeviceKit/CocoaPodsVerification/ || fail "Carthage dependency loading failed"
-  
+
   # --no-use-binaries: due to https://github.com/Carthage/Carthage/issues/3134,
   # which affects the sentry-cocoa dependency.
   carthage build --use-xcframeworks --no-use-binaries --platform iOS || fail "Carthage dependency loading failed"
@@ -192,7 +192,7 @@ if [ $CODE_SIGN = true ]; then
     # Time to prepare the deployment archive data.
     echo ""
     echo "Preparing .ipa file for deployment to real devices."
-    xcodebuild $XCODEFLAGS_EXT -scheme $TARGET -archivePath $ARCHIVE_PATH archive -allowProvisioningUpdates \
+    run-xcodebuild $XCODEFLAGS_EXT -scheme $TARGET -archivePath $ARCHIVE_PATH archive -allowProvisioningUpdates \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
 
@@ -201,17 +201,17 @@ if [ $CODE_SIGN = true ]; then
 
     # Do NOT use the _EXT variant here; there's no scheme to ref, which will lead
     # Xcode to generate a build error.
-    xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
+    run-xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
                -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
   else
-    xcodebuild $XCODEFLAGS_EXT -scheme "$TARGET" \
+    run-xcodebuild $XCODEFLAGS_EXT -scheme "$TARGET" \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
   fi
 else
-  xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+  run-xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
              $XCODEFLAGS_EXT -scheme "$TARGET" \
              VERSION=$VERSION \
              VERSION_WITH_TAG=$VERSION_WITH_TAG
@@ -219,7 +219,7 @@ fi
 
 if [ $DO_SIMULATOR_TARGET == true ]; then
   echo "Preparing .app file as Simulator-targeted build artifact."
-  xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+  run-xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
              $XCODEFLAGS_EXT -scheme "$TARGET" \
              -sdk iphonesimulator \
              VERSION=$VERSION \

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -192,7 +192,7 @@ if [ $CODE_SIGN = true ]; then
     # Time to prepare the deployment archive data.
     echo ""
     echo "Preparing .ipa file for deployment to real devices."
-    run-xcodebuild $XCODEFLAGS_EXT -scheme $TARGET -archivePath $ARCHIVE_PATH archive -allowProvisioningUpdates \
+    run_xcodebuild $XCODEFLAGS_EXT -scheme $TARGET -archivePath $ARCHIVE_PATH archive -allowProvisioningUpdates \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
 
@@ -201,17 +201,17 @@ if [ $CODE_SIGN = true ]; then
 
     # Do NOT use the _EXT variant here; there's no scheme to ref, which will lead
     # Xcode to generate a build error.
-    run-xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
+    run_xcodebuild $XCODEFLAGS -exportArchive -archivePath $ARCHIVE_PATH -exportOptionsPlist exportAppStore.plist \
                -exportPath $BUILD_PATH/${CONFIG}-iphoneos -allowProvisioningUpdates \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
   else
-    run-xcodebuild $XCODEFLAGS_EXT -scheme "$TARGET" \
+    run_xcodebuild $XCODEFLAGS_EXT -scheme "$TARGET" \
                VERSION=$VERSION \
                VERSION_WITH_TAG=$VERSION_WITH_TAG
   fi
 else
-  run-xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+  run_xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
              $XCODEFLAGS_EXT -scheme "$TARGET" \
              VERSION=$VERSION \
              VERSION_WITH_TAG=$VERSION_WITH_TAG
@@ -219,7 +219,7 @@ fi
 
 if [ $DO_SIMULATOR_TARGET == true ]; then
   echo "Preparing .app file as Simulator-targeted build artifact."
-  run-xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+  run_xcodebuild CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
              $XCODEFLAGS_EXT -scheme "$TARGET" \
              -sdk iphonesimulator \
              VERSION=$VERSION \

--- a/oem/firstvoices/ios/exportAppStore.plist
+++ b/oem/firstvoices/ios/exportAppStore.plist
@@ -19,6 +19,7 @@
     </dict>
     <key>signingStyle</key>
     <string>manual</string>
-
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
 </dict>
 </plist>

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -406,7 +406,7 @@ printXCodeBuildScriptLogs() {
 #
 # Wraps xcodebuild with error handling and log printing
 #
-run-xcodebuild() {
+run_xcodebuild() {
   typeset cmnd="$*"
   typeset ret_code
   local hasSetErrExit=false

--- a/resources/build/xcode-utils.sh
+++ b/resources/build/xcode-utils.sh
@@ -151,3 +151,9 @@ function phaseSentryDsymUpload() {
     buildWarning "sentry-cli not installed; please run \"brew install getsentry/tools/sentry-cli\" to remedy"
   fi
 }
+
+function logScriptsToFile() {
+  exec >> $KEYMAN_ROOT/ios/scripts.log 2>&1
+}
+
+logScriptsToFile

--- a/resources/build/xcode-utils.sh
+++ b/resources/build/xcode-utils.sh
@@ -46,12 +46,12 @@ function phaseSetBundleVersions() {
     # Note that this script's process will not have access to TC environment variables, but that's fine for
     # local builds triggered through Xcode's UI, which aren't part of our CI processes.
     . "$KEYMAN_ROOT/resources/build/build-utils.sh"
-    echo "UI build - fetching version from repository:"
+    echo "phaseSetBundleVersions: UI build - fetching version from repository:"
     echo "  Plain:  $VERSION"
     echo "  Tagged: $VERSION_WITH_TAG"
     echo "  Environment: $VERSION_ENVIRONMENT"
   else
-    echo "Command-line build - using provided version parameters"
+    echo "phaseSetBundleVersions: Command-line build - using provided version parameters"
   fi
 
   # Now, to set the build number (CFBundleVersion)
@@ -68,22 +68,26 @@ function phaseSetBundleVersions() {
   fi
 
   APP_PLIST="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
-  echo "Setting $VERSION for $TARGET_BUILD_DIR/$INFOPLIST_PATH"
+  echo "phaseSetBundleVersions: Setting CFBundleVersion to $BUILD_NUMBER for $APP_PLIST"
   /usr/libexec/Plistbuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$APP_PLIST"
+  echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $VERSION for $APP_PLIST"
   /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_PLIST"
+
+  /usr/libexec/Plistbuddy -c "Print" "$APP_PLIST"
 
   # Only attempt to write this when directly specified (otherwise, generates minor warning)
   if [ $TAGGED == true ]; then
-    echo "Setting $VERSION_WITH_TAG for tagged version"
+    echo "phaseSetBundleVersions: Setting KeymanVersionWithTag to $VERSION_WITH_TAG for tagged version for $APP_PLIST"
     /usr/libexec/Plistbuddy -c "Set :KeymanVersionWithTag $VERSION_WITH_TAG" "$APP_PLIST"
-    echo "Setting $VERSION_ENVIRONMENT"
+    echo "phaseSetBundleVersions: Setting KeymanVersionEnvironment to $VERSION_ENVIRONMENT for $APP_PLIST"
     /usr/libexec/Plistbuddy -c "Set :KeymanVersionEnvironment $VERSION_ENVIRONMENT" "$APP_PLIST"
   fi
 
   if [ -f "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist" ]; then
     DSYM_PLIST="${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist"
-    echo "Setting $VERSION for $DSYM_PLIST"
+    echo "phaseSetBundleVersions: Setting CFBundleVersion to $BUILD_NUMBER for $DSYM_PLIST"
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$DSYM_PLIST"
+    echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $VERSION for $DSYM_PLIST"
     /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$DSYM_PLIST"
   fi
 }
@@ -96,16 +100,16 @@ function setSettingsBundleVersion() {
     # Note that this script's process will not have access to TC environment variables, but that's fine for
     # local builds triggered through Xcode's UI, which aren't part of our CI processes.
     . "$KEYMAN_ROOT/resources/build/build-utils.sh"
-    echo "UI build - fetching version from repository:"
+    echo "setSettingsBundleVersion: UI build - fetching version from repository:"
     echo "  Plain:  $VERSION"
     echo "  Tagged: $VERSION_WITH_TAG"
     echo "  Environment: (not setting, assume 'local')"
   else
-    echo "Command-line build - using provided version parameters"
+    echo "setSettingsBundleVersion: Command-line build - using provided version parameters"
   fi
 
   SETTINGS_PLIST="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Settings.bundle/Root.plist"
-  echo "Setting $VERSION_WITH_TAG for $SETTINGS_PLIST"
+  echo "setSettingsBundleVersion: Setting $VERSION_WITH_TAG for $SETTINGS_PLIST"
   # We assume that entry 0 = the version "preference" entry.
   /usr/libexec/PlistBuddy -c "Set :PreferenceSpecifiers:0:DefaultValue $VERSION_WITH_TAG" "$SETTINGS_PLIST"
 }

--- a/resources/build/xcode-utils.sh
+++ b/resources/build/xcode-utils.sh
@@ -156,8 +156,17 @@ function phaseSentryDsymUpload() {
   fi
 }
 
+#
+# All calls to xcode-utils.sh scripts will have their output redirected to
+# $KEYMAN_ROOT/xcodebuild-scripts.log. This will redirect both stdout and stderr
+# to this log file. See the corresponding printXCodeBuildScriptLogs function in
+# build-utils.sh to print the log after xcodebuild returns.
+#
+# More information in the build-utils.sh.
+#
 function logScriptsToFile() {
-  exec >> $KEYMAN_ROOT/ios/scripts.log 2>&1
+  local SCRIPT_LOG="$KEYMAN_ROOT/xcodebuild-scripts.log"
+  exec >> "$SCRIPT_LOG" 2>&1
 }
 
 logScriptsToFile


### PR DESCRIPTION
@keymanapp-test-bot skip

Fixes the clobbering of build_version values. For some reason, this was only happening on ba-macos-ext-hba-01 and not on ba-macos-ext-hba-03, despite there being little difference between the two agents. However, writing `manageAppVersionAndBuildNumber` to the export plist makes the behaviour consistent between the two agents. `manageAppVersionAndBuildNumber` does not appear to be documented anywhere that I can find on apple.com -- only discussion in forums and [StackOverflow](https://stackoverflow.com/questions/68237292/xcode-manage-version-and-build-number-option#comment122517504_68237292).

Thank you yet again Apple for introducing a yet another new undocumented build behaviour with the most recent forced xcode update...

This also rewrites some of the scripts for iOS (and a little bit for macOS) so that we can capture output from script phases in xcodebuild.

I will cherry-pick the export plist options to stable-15.0, but propose not back-porting the script changes.