### PR TITLE
chore(ios): modernizes app-help's internals

### DIFF
--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController.swift
@@ -7,18 +7,18 @@
 //
 
 import KeymanEngine
-import UIKit
+import WebKit
 import Reachability
 
-class InfoViewController: UIViewController, UIWebViewDelegate {
-  @IBOutlet var webView: UIWebView!
+class InfoViewController: UIViewController, WKNavigationDelegate {
+  @IBOutlet var webView: WKWebView!
 
   @IBOutlet var backButton: UIBarButtonItem!
   @IBOutlet var forwardButton: UIBarButtonItem!
 
   private var networkReachable: Reachability?
 
-  private var exitClosure: (() -> Void)? = nil;
+  private var exitClosure: (() -> Void)?
 
   convenience init(exitClosure: @escaping () -> Void) {
     if UIDevice.current.userInterfaceIdiom == .phone {
@@ -33,7 +33,7 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
     extendedLayoutIncludesOpaqueBars = true
-    webView?.delegate = self
+    webView?.navigationDelegate = self
     NotificationCenter.default.addObserver(self, selector: #selector(self.networkStatusChanged),
         name: NSNotification.Name.reachabilityChanged, object: nil)
 
@@ -54,17 +54,17 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
     forwardButton.isEnabled = webView.canGoForward
   }
 
-  func webViewDidStartLoad(_ webView: UIWebView) {
+  func didStartProvisionalNvaigation(_ webView: WKWebView) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = true
     updateButtons()
   }
 
-  func webViewDidFinishLoad(_ webView: UIWebView) {
+  func didFinishNavigation(_ webView: WKWebView) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = false
     updateButtons()
   }
 
-  func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
+  func didFailNavigation(_ webView: WKWebView, didFailLoadWithError error: Error) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = false
     updateButtons()
     log.debug(error)
@@ -91,7 +91,7 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
 
     // Safari won't recognize the contents without the .html ending.
     let filePath = offlineHelpBundle.path(forResource: "index", ofType: "html", inDirectory: nil)
-    webView.loadRequest(URLRequest(url: URL.init(fileURLWithPath: filePath!)))
+    webView.load(URLRequest(url: URL.init(fileURLWithPath: filePath!)))
   }
 
   // Currently unused, as we haven't yet added a toggle to allow users to choose online
@@ -99,7 +99,7 @@ class InfoViewController: UIViewController, UIWebViewDelegate {
   private func loadFromServer() {
     let appVersion = Version.current.majorMinor
     let url =  "\(KeymanHosts.HELP_KEYMAN_COM)/products/iphone-and-ipad/\(appVersion.plainString)/"
-    webView.loadRequest(URLRequest(url: URL(string: url)!))
+    webView.load(URLRequest(url: URL(string: url)!))
     log.debug("Info page URL: \(url)")
   }
 }

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController.swift
@@ -54,17 +54,17 @@ class InfoViewController: UIViewController, WKNavigationDelegate {
     forwardButton.isEnabled = webView.canGoForward
   }
 
-  func didStartProvisionalNvaigation(_ webView: WKWebView) {
+  func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = true
     updateButtons()
   }
 
-  func didFinishNavigation(_ webView: WKWebView) {
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = false
     updateButtons()
   }
 
-  func didFailNavigation(_ webView: WKWebView, didFailLoadWithError error: Error) {
+  func webView(_ webView: WKWebView, didFailNavigation error: Error) {
     UIApplication.shared.isNetworkActivityIndicatorVisible = false
     updateButtons()
     log.debug(error)

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPad.xib
@@ -21,10 +21,14 @@
             <rect key="frame" x="0.0" y="0.0" width="768" height="974"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="46">
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="46">
                     <rect key="frame" x="0.0" y="0.0" width="768" height="924"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </webView>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fsh-gd-wpz">
                     <rect key="frame" x="0.0" y="924" width="768" height="50"/>
                     <items>

--- a/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/InfoViewController/InfoViewController_iPhone.xib
@@ -26,10 +26,14 @@
                     <rect key="frame" x="0.0" y="804" width="428" height="34"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
-                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38">
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="38">
                     <rect key="frame" x="0.0" y="0.0" width="428" height="755"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </webView>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DPl-QD-inD">
                     <rect key="frame" x="0.0" y="755" width="428" height="49"/>
                     <items>

--- a/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.swift
@@ -7,12 +7,12 @@
 //
 
 import KeymanEngine
-import UIKit
+import WebKit
 import Reachability
 
 // TODO: Refactor common functionality from InfoViewController
-class SetUpViewController: UIViewController, UIWebViewDelegate {
-  @IBOutlet var webView: UIWebView!
+class SetUpViewController: UIViewController, WKNavigationDelegate {
+  @IBOutlet var webView: WKWebView!
 
   private var networkReachable: Reachability?
 
@@ -27,7 +27,7 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
     let doneButton = navBar?.topItem?.rightBarButtonItem
     doneButton?.target = self
     doneButton?.action = #selector(self.dismissView)
-    webView?.delegate = self
+    webView?.navigationDelegate = self
     NotificationCenter.default.addObserver(self, selector: #selector(self.networkStatusChanged),
         name: NSNotification.Name.reachabilityChanged, object: nil)
 
@@ -66,14 +66,14 @@ class SetUpViewController: UIViewController, UIWebViewDelegate {
     let filePath = offlineHelpBundle.path(forResource: "installing-system-keyboard",
                                           ofType: "html",
                                           inDirectory: "start")
-    webView.loadRequest(URLRequest(url: URL.init(fileURLWithPath: filePath!)))
+    webView.load(URLRequest(url: URL.init(fileURLWithPath: filePath!)))
   }
 
   private func loadFromServer() {
     let appVersion = Version.current.majorMinor
     let url = "\(KeymanHosts.HELP_KEYMAN_COM)/products/iphone-and-ipad/\(appVersion.plainString)"
       + "/start/installing-system-keyboard?embed=ios"
-    webView.loadRequest(URLRequest(url: URL(string: url)!))
+    webView.load(URLRequest(url: URL(string: url)!))
     log.debug("Set up page URL: \(url)")
   }
 }

--- a/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.xib
@@ -28,10 +28,14 @@
                         </navigationItem>
                     </items>
                 </navigationBar>
-                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hiW-6P-SIQ">
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hiW-6P-SIQ">
                     <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </webView>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>


### PR DESCRIPTION
Apple's official view is that the `UIWebView`, which is used by various parts of the app, is considered deprecated in favor of the `WKWebView`.  We've... been a bit lazy about this in the past, but after a little investigation and effort, it turns out that this use of it, at least, is pretty easy to modernize.

## User Testing

### Test Environments
As this does affect the layout specification used by our in-app help, it'd be best to make sure the help "looks right" across a few different iOS devices.

Feel free to test against any version of an Apple device matching the name of the "groups" listed below; whichever is most convenient for our testers should be 100% fine.

- GROUP_IPHONE_SE
- GROUP_IPHONE_13
- GROUP_IPAD_AIR

### Test Specifications

- TEST_APP_HELP:  simply open the Keyman app's "Info" section and make sure it works intuitively.
    - If it's mispositioned, that's definitely a fail
    - If the links don't operate as expected, or the default page doesn't load, that's definitely a fail
    - If the back and forward buttons don't operate as expected, that's a fail
    - All in all, it shouldn't _feel_ like this PR changed anything.