### PR TITLE
chore(ios): updates core internals for the in-app browser

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -654,6 +654,17 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
     return nil
   }
 
+  /// - Returns: The font name for the given keyboard ID and languageID, or returns nil if
+  ///   - The keyboard doesn't have a font
+  ///   - The keyboard info is not available in the user keyboards list
+  public func fontPathForKeyboard(withFullID fullID: FullKeyboardID) -> URL? {
+    if let kb = Storage.active.userDefaults.userKeyboard(withFullID: fullID),
+       let filename = kb.font?.source.first(where: { $0.hasFontExtension }) {
+      return Storage.active.fontURL(forResource: kb, filename: filename)!
+    }
+    return nil
+  }
+
   /// - Returns: the OSK font name for the given keyboard ID and languageID, or returns nil if
   ///   - The keyboard doesn't have an OSK font
   ///   - The keyboard info is not available in the user keyboards list

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/BookmarksViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/BookmarksViewController.swift
@@ -62,7 +62,12 @@ class BookmarksViewController: UIViewController, UITableViewDelegate, UITableVie
         selector: #selector(BookmarksViewController.handleTextFieldTextChangedNotification(notification:)),
         name: UITextField.textDidChangeNotification, object: textField)
       textField.placeholder = "Title"
-      textField.text = self.webBrowser?.webView?.stringByEvaluatingJavaScript(from: "document.title")
+      self.webBrowser?.webView?.evaluateJavaScript("document.title") { val, _ in
+        if let str = val as? String {
+          textField.text = str
+          self.updateAddButtonEnableState()
+        }
+      }
       textField.autocapitalizationType = .sentences
       textField.font = UIFont.systemFont(ofSize: 17)
       textField.keyboardType = .default
@@ -75,7 +80,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate, UITableVie
           selector: #selector(BookmarksViewController.handleTextFieldTextChangedNotification(notification:)),
           name: UITextField.textDidChangeNotification, object: textField)
       textField.placeholder = "URL"
-      textField.text = self.webBrowser?.webView?.request?.mainDocumentURL?.absoluteString
+      textField.text = self.webBrowser?.webView?.url?.absoluteString
       textField.autocapitalizationType = .none
       textField.font = UIFont.systemFont(ofSize: 17)
       textField.keyboardType = UIKeyboardType.URL
@@ -186,7 +191,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate, UITableVie
   private func performAction(for indexPath: IndexPath) {
     let bookmark = bookmarks[indexPath.section]
     if let urlString = bookmark[bookmarkUrlKey], let url = URL(string: urlString) {
-      webBrowser?.webView?.loadRequest(URLRequest(url: url))
+      webBrowser?.webView?.load(URLRequest(url: url))
     }
     dismiss(animated: true, completion: nil)
   }

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
@@ -28,9 +28,7 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
   @IBOutlet var closeButton: UIBarButtonItem!
 
   var navbarBackground: KMNavigationBarBackgroundView!
-  var font: Font?
   var fontKeyboard: InstallableKeyboard?
-  private var newFont: Font?
   private var newFontKeyboard: InstallableKeyboard?
 
   private let webBrowserLastURLKey = "KMWebBrowserLastURL"
@@ -290,16 +288,14 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
   }
 
   private func appendCSSFontFamily() {
-    guard let font = font else {
+    guard let fontKeyboard = fontKeyboard, let font = fontKeyboard.font else {
       return
     }
 
-    guard let fontKeyboard = fontKeyboard else {
-      return
-    }
+    let styleFontFamily = font.family
 
-    let fontCSS = "*{font-family:\"\(font.family)\" !important;}"
-    guard let fontFaceStyle = buildFontSheet(from: font, keyboard: fontKeyboard) else {
+    let fontCSS = "*{font-family:\"\(styleFontFamily)\" !important;}"
+    guard let fontFaceStyle = buildFontSheet(keyboard: fontKeyboard, styleName: styleFontFamily) else {
       return
     }
 
@@ -319,7 +315,7 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
 
   }
 
-  private func buildFontSheet(from font: Font, keyboard: InstallableKeyboard) -> String? {
+  private func buildFontSheet(keyboard: InstallableKeyboard, styleName: String) -> String? {
     guard let fontKeyboard = fontKeyboard,
           let fontURL = Manager.shared.fontPathForKeyboard(withFullID: fontKeyboard.fullID) else {
       return nil
@@ -356,7 +352,7 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
 
     let styleString = """
     @font-face {
-      font-family: "\(font.family)";
+      font-family: "\( styleName )";
       src: url(data:\(dataType);charset=utf-8;base64,\(fontData.base64EncodedString())); format('\(fontFormat)')
     }
     """
@@ -365,18 +361,15 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
   }
 
   private func keyboardChanged(_ kb: InstallableKeyboard) {
-    if let font = kb.font {
-      newFont = font
+    if kb.font != nil {
       newFontKeyboard = kb
     } else {
-      newFont = nil
       newFontKeyboard = nil
     }
   }
 
   private func keyboardPickerDismissed() {
-    if newFont?.family != font?.family {
-      font = newFont
+    if newFontKeyboard?.font?.family != fontKeyboard?.font?.family {
       fontKeyboard = newFontKeyboard
       webView?.reload()
     }

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
@@ -288,13 +288,12 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
   }
 
   private func appendCSSFontFamily() {
-    guard let fontKeyboard = fontKeyboard, let font = fontKeyboard.font else {
+    guard let fontKeyboard = fontKeyboard else {
       return
     }
 
-    let styleFontFamily = font.family
+    let styleFontFamily = "KeymanEmbeddedBrowserFont"
 
-    let fontCSS = "*{font-family:\"\(styleFontFamily)\" !important;}"
     guard let fontFaceStyle = buildFontSheet(keyboard: fontKeyboard, styleName: styleFontFamily) else {
       return
     }
@@ -303,7 +302,9 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
     var style = document.createElement('style');
     style.type = 'text/css';
     style.innerHTML = `
-    \(fontCSS)
+    * {
+      font-family:\"\(styleFontFamily)\" !important;
+    }
 
     \(fontFaceStyle)
     `;
@@ -340,12 +341,6 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
       case "otf":
         dataType = "font/opentype"
         fontFormat = "opentype"
-      case "eot":
-        fontFormat = "application/vnd.ms-fontobject"
-        fontFormat = "embedded-opentype"
-      case "svg":
-        dataType = "image/svg+xml"
-        fontFormat = "svg"
       default:
         return nil
     }

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
@@ -332,15 +332,18 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
       case "ttf":
         dataType = "font/truetype"
         fontFormat = "truetype"
+      case "otf":
+        dataType = "font/opentype"
+        fontFormat = "opentype"
+      // The following two entries are here for completeness.  At present, we do not
+      // actually distribute these in .kmp packages; we only include one font within them,
+      // and these two are web-oriented, not main-OS oriented.
       case "woff":
         dataType = "font/woff"
         fontFormat = "woff"
       case "woff2":
         dataType = "font/woff2"
         fontFormat = "woff2"
-      case "otf":
-        dataType = "font/opentype"
-        fontFormat = "opentype"
       default:
         return nil
     }

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.swift
@@ -52,7 +52,6 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
       function: WebBrowserViewController.keyboardPickerDismissed)
 
     webView.navigationDelegate = self
-    webView.scalesPageToFit = true
 
     if #available(iOS 13.0, *) {
       // Dark mode settings must be applied through this new property,
@@ -203,7 +202,7 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
 
   func webView(_ webView: WKWebView,
                decidePolicyFor navigationAction: WKNavigationAction,
-               decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) -> Void {
+               decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     let request = navigationAction.request
     if request.url?.lastPathComponent.hasSuffix(".kmp") ?? false {
       // Can't have the browser auto-download with no way to select a different page.
@@ -292,7 +291,7 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate, UIAlertV
       "style.type = 'text/css';" +
       "style.innerHTML = '*{font-family:\"\(fontFamily)\" !important;}';" +
     "document.getElementsByTagName('head')[0].appendChild(style);"
-    webView?.stringByEvaluatingJavaScript(from: jsStr)
+    webView.evaluateJavaScript(jsStr)
   }
 
   private func keyboardChanged(_ kb: InstallableKeyboard) {

--- a/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.xib
+++ b/ios/keyman/Keyman/Keyman/Classes/KMWebBrowser/WebBrowserViewController.xib
@@ -32,10 +32,14 @@
                         <constraint firstAttribute="height" constant="44" id="qmb-kf-rzZ"/>
                     </constraints>
                 </navigationBar>
-                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b82-37-gRv">
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b82-37-gRv">
                     <rect key="frame" x="0.0" y="44" width="320" height="480"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </webView>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e8W-i1-0tJ">
                     <rect key="frame" x="0.0" y="524" width="320" height="44"/>
                     <items>

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -1009,8 +1009,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
     let webBrowserVC = WebBrowserViewController()
-    if let fontFamily = textView.font?.fontName {
-      webBrowserVC.fontFamily = fontFamily
+    if let kbFont = Manager.shared.currentKeyboard?.font {
+      webBrowserVC.font = kbFont
+      webBrowserVC.fontKeyboard = Manager.shared.currentKeyboard
     }
     present(webBrowserVC, animated: true, completion: nil)
   }

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -1009,8 +1009,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     popover?.dismiss(animated: false)
     _ = dismissDropDownMenu()
     let webBrowserVC = WebBrowserViewController()
-    if let kbFont = Manager.shared.currentKeyboard?.font {
-      webBrowserVC.font = kbFont
+    if Manager.shared.currentKeyboard?.font != nil {
       webBrowserVC.fontKeyboard = Manager.shared.currentKeyboard
     }
     present(webBrowserVC, animated: true, completion: nil)


### PR DESCRIPTION
This fulfills a similar role to #6836, just for the in-app browser instead of the in-app help.  To quote part of its description:

> Apple's official view is that the UIWebView, which is used by various parts of the app, is considered deprecated in favor of the WKWebView.

There was a bit more involved here, as this section is meant for general-purpose web-browsing, but it wasn't too rough to handle.

Fortunately, as these are two completely separate parts of the app... there's no need for us to actually _base_ this PR on #6836.  They can be merged separately and in either order without issue.

## User Testing

Feel free to test with _any_ iOS device.

TEST_6836_SUCCESS:  This test passes when - and only when - #6836 has passed all of its tests.
- The main layout changes are similar enough that I believe those tests will cover many aspects of these changes, too.

TEST_NAVIGATION:  the in-app browser should provide a rudimentary web browser experience...

- Note:  you'll be looking for this icon to open the in-app browser:  ![image](https://user-images.githubusercontent.com/25213402/175452736-09f4894c-ee0a-4fa5-9067-d31ef4b5e2e4.png)

1. If you are not presented with the Google main page, go to the navigation / URL bar at the top and enter `google.com`, then hit ENTER.
    - If you are still not presented with the Google main page, _**FAIL**_ this test.
2. In the search bar, enter `github keymanapp`, then hit ENTER to search.
    - If the URL does not update when the search results appear, _**FAIL**_ this test.
3. Find the search result corresponding to this repo (which is likely the first one) and follow it.
    - Once you've triggered the link, if the URL does not update to match the repo's URL, _**FAIL**_ this test.
4. At the bottom-left, use the back button once.
    - Both the page and the current URL should revert to that of the previous page.
5. At the bottom-left, use the forward button once.
    - Same note as step 4.
6. Close the browser view (the 'x' at the bottom-right).
7. Re-open the browser view.
    - The browser should display the last page you were viewing - this repo's main page.

TEST_BOOKMARKS:  continuing from the previous test...
1.  If not continuing from the previous test... well, follow its steps again before continuing.
2. Click the "book" icon at the bottom-center.  (This corresponds to the bookmark menu.)
3. Click the "plus" icon at the bottom-left of the new view.
    - If the "Add" button on the modal popup is not automatically enabled, _**FAIL**_ this test.
4. Clear the top line of the modal (where the page title is).
    - If the "Add" button is enabled once the text is cleared, _**FAIL**_ this test.
5. Hit cancel.  No bookmark should be added.
6. Hit the "plus" icon again, then choose "add" to create a bookmark.
7. Click "done" at the top-right.
8. Use the URL / navigation bar and go to `google.com`.
9. Re-open the bookmark menu (via that book icon).
10. Use the "plus" icon to create a bookmark for Google.
11. Click the bookmark created during step 6.
12. If you are not presented with this repo's main page, _**FAIL**_ this test.
13. Use the bookmarks menu to return to Google.

TEST_KMP_DOWNLOAD:  navigate to keyman.com, search for a keyboard, and attempt to install it through the app's browser.
1. In the navigation bar, enter the URL `keyman.com`.
2. Use the menu at the top left to search for any keyboard.  (E.g: `khmer`, for `khmer_angkor`.)
3. When the results are displayed, click the page for the appropriate package.
4. Click the big green button.
5. Click the _**new**_ big green button.
6. After a small delay, the browser should auto-dismiss, after which the package installer should open automatically.
    - Ensure that the package being installed matches the one you selected within the browser.

TEST_CHAKMA:  verify that the browser's font-linking functionality is still working properly; use an iOS 12.4 Simulator for this.
1. Install the "Easy Chakma" keyboard.
2. Using the in-app browser, navigate to https://en.wikipedia.org/wiki/Chakma_script.
3. Expand the "Unicode" section.
4. Verify that the last four non-blank entries in the table render properly, as seen in this screenshot:

    ![image](https://user-images.githubusercontent.com/25213402/177675567-5360d6ef-fa25-4bd6-b95e-91ee76469fc5.png)

TEST_ARABIC_TTF: similar to the "Chakma" test, but using the `urdu_phonetic_crulp` keyboard.
1.  Install the `urdu_phonetic_crulp` keyboard.
2. Using the in-app browser, navigate to https://en.m.wikipedia.org/wiki/List_of_Arabic_letter_components.
3. Expand the "Table of Letter Components" section and scroll down to the table.
4. Verify that multiple entries of the table appear notably different than in this screenshot:

    ![image](https://user-images.githubusercontent.com/25213402/177902108-7c04f5b3-bdfb-4971-956a-09e232289e5c.png)

TEST_ARABIC_OTF: similar to the "Chakma" test, but using the `syriac_arabic` keyboard.
1.  Install the Syriac/Aramaic package with its default language selection.  (This is a multi-keyboard package!)
2. Select the "Syriac (Arabic layout)" keyboard.
3. Using the in-app browser, navigate to https://en.m.wikipedia.org/wiki/List_of_Arabic_letter_components.
4. Expand the "Table of Letter Components" section and scroll down to the table.
5. Verify that multiple entries of the table appear notably different than in this screenshot:

    ![image](https://user-images.githubusercontent.com/25213402/177902108-7c04f5b3-bdfb-4971-956a-09e232289e5c.png)
