### PR TITLE
fix(linux): Catch KeyboardInterrupt 🍒

### DIFF
--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -50,5 +50,8 @@ if __name__ == '__main__':
     else:
         from keyman_config.view_installed import ViewInstalledWindow
         w = ViewInstalledWindow()
-        w.run()
+        try:
+            w.run()
+        except KeyboardInterrupt:
+            logging.debug('User cancelled the app')
         w.destroy()


### PR DESCRIPTION
When the user cancels km-config by pressing Ctrl-C we don't want this to be reported on Sentry.

Fixes #6813.

(🍒-picked from #6814)

@keymanapp-test-bot skip