### PR TITLE
fix(common): trigger builds correctly for stable builds

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -44,7 +44,7 @@ function triggerTeamCityBuild() {
   local GIT_OID=`git rev-parse HEAD`
   local TEAMCITY_SERVER=https://build.palaso.org
 
-  local command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID,buildType:(id:$TEAMCITY_BUILDTYPE)'/></lastChanges></build>"
+  local command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID'/></lastChanges></build>"
   echo "TeamCity Build Command: $command"
 
   # adjust indentation for output of curl


### PR DESCRIPTION
@keymanapp-test-bot skip

stable-15.0 builds were not triggering for test PRs. I think this is because a test build had never run on that branch in TeamCity, and so its locator didn't match. Removing the buildType appears to have resolved this.