### PR TITLE
fix(web): Maintain separate Caps Lock states for touch and physical

### DIFF
--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -190,10 +190,14 @@ namespace com.keyman.text {
     }
 
     setSyntheticEventDefaults(Lkc: text.KeyEvent) {
-      // Set the flags for the state keys.
-      Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
-      Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
-      Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
+      // Set the flags for the state keys - for desktop devices. For touch
+      // devices, the only state key in use currently is Caps Lock, which is set
+      // when the 'caps' layer is active in ActiveKey::constructBaseKeyEvent.
+      if(!Lkc.device.touchable) {
+        Lkc.Lstates |= this.stateKeys['K_CAPS']    ? Codes.modifierCodes['CAPS'] : Codes.modifierCodes['NO_CAPS'];
+        Lkc.Lstates |= this.stateKeys['K_NUMLOCK'] ? Codes.modifierCodes['NUM_LOCK'] : Codes.modifierCodes['NO_NUM_LOCK'];
+        Lkc.Lstates |= this.stateKeys['K_SCROLL']  ? Codes.modifierCodes['SCROLL_LOCK'] : Codes.modifierCodes['NO_SCROLL_LOCK'];
+      }
 
       // Set LisVirtualKey to false to ensure that nomatch rule does fire for U_xxxx keys
       if(Lkc.kName && Lkc.kName.substr(0,2) == 'U_') {
@@ -272,7 +276,7 @@ namespace com.keyman.text {
             matchBehavior.mergeInDefaults(defaultBehavior);
           }
           matchBehavior.triggerKeyDefault = false; // We've triggered it successfully.
-        } // If null, we must rely on something else (like the browser, in DOM-aware code) to fulfill the default. 
+        } // If null, we must rely on something else (like the browser, in DOM-aware code) to fulfill the default.
 
         this.keyboardInterface.activeTargetOutput = null;
       }
@@ -688,19 +692,8 @@ namespace com.keyman.text {
         this.layerId = 'default';
       }
 
-      this.updateStateKeysFromLayer();
-
       let baseModifierState = text.KeyboardProcessor.getModifierState(this.layerId);
       this.modStateFlags = baseModifierState | keyEvent.Lstates;
-    }
-
-    public updateStateKeysFromLayer() {
-      if(this.device.formFactor != utils.FormFactor.Desktop) {
-        // The caps layer works slightly differently on touch than on desktop.
-        // It's a single layer with no ability to mix with other modifiers
-        // We need to make sure that the state is kept in sync with the layer.
-        this.stateKeys['K_CAPS'] = this.layerId == 'caps';
-      }
     }
 
     static isModifier(Levent: KeyEvent): boolean {
@@ -748,7 +741,6 @@ namespace com.keyman.text {
 
     resetContext() {
       this.layerId = 'default';
-      this.updateStateKeysFromLayer();
       this.keyboardInterface.resetContextCache();
       this._UpdateVKShift(null);
     };
@@ -758,7 +750,6 @@ namespace com.keyman.text {
         let layout = this.activeKeyboard.layout(device.formFactor);
         if(layout.getLayer('numeric')) {
           this.layerId = 'numeric';
-          this.updateStateKeysFromLayer();
         }
       }
     };

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -399,7 +399,7 @@ namespace com.keyman.osk {
      * @param    outputTarget
      * @returns  true
      */
-    suggestionApplied(outputTarget: text.OutputTarget): boolean {
+    suggestionApplied: (outputTarget: text.OutputTarget) => boolean = function(this: SuggestionBanner, outputTarget: text.OutputTarget) {
       const keyman = com.keyman.singleton;
       // Tell the keyboard that the current layer has not changed
       keyman.core.keyboardProcessor.newLayerStore.set('');
@@ -411,7 +411,7 @@ namespace com.keyman.osk {
         ?.finalize(keyman.core.keyboardProcessor, outputTarget, true);
 
       return true;
-    };
+    }.bind(this);
 
     postConfigure() {
       let keyman = com.keyman.singleton;
@@ -427,6 +427,7 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.removeListener('suggestionsready', manager.updateSuggestions);
       keyman.core.languageProcessor.removeListener('tryaccept', manager.tryAccept);
       keyman.core.languageProcessor.removeListener('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.removeListener('suggestionapplied', this.suggestionApplied);
     }
   }
 


### PR DESCRIPTION
Fixes #6799.

Caps Lock state management for touch layouts was not quite right -- it touched the base Caps state variables rather than just the event Lstates property. This meant that it was impossible to track the physical Caps Lock key separately to the touch layout layer, and that the two states would interfere with each other.

This PR changes that behaviour and separates the physical caps lock and touch caps lock states. The physical caps lock state is tracked in the `this.stateKeys['K_CAPS']` variable, but is completely ignored for touch layouts. Rules use the Caps Lock state replicated in the `Levent.Lstates` property, which was already being set correctly for the touch layout in the `ActiveKey.constructBaseKeyEvent` function:

https://github.com/keymanapp/keyman/blob/4f36c3c2df0b14ec2d5fac36714c4e8bda54961c/common/web/keyboard-processor/src/keyboards/activeLayout.ts#L177-L182

https://github.com/keymanapp/keyman/blob/aa905e1c61c9743e54ce8c7c0c5a4fae0734fcff/common/web/keyboard-processor/src/text/keyboardProcessor.ts#L378-L392

## Unanswered Questions/Issues

- [ ] There is still a question in my mind around the `NCAPS` state which is never set. Do we need to be tracking this also? The compiler avoids ambiguity now around unspecified Caps Lock state but I am not clear if we are covering all the bases here and if behaviour is consistent -- should we be setting `NCAPS` if not on the `caps` layer? Note that on touch we don't combine Caps Lock with other modifiers, unlike on physical keyboards or desktop OSK.
- [ ] On a desktop device, clicking the Caps Lock key on the OSK results in desync between hardware and OSK. This is unavoidable, as we cannot set the physical Caps Lock state. The current behaviour *seems* okay -- the Caps Lock state is in effect for OSK keys until the user touches the physical keyboard, and physical Caps Lock is reflected in the OSK. Nonetheless, there is a difference in physical Caps Lock state and OSK-initiated Caps Lock state, and I wonder if we need to be able to tell the difference?
- [ ] The desktop OSK does not show a 'Caps Lock' layer. This is definitely not ideal but matches the current Windows behaviour. This is something we need to improve on -- but does require changes to .kvk in order to work properly.

# User Testing

## SUITE_CAPS_ON_TOUCH - Test using the new sil_euro_latin keyboard with Caps Lock support

Use the keyboard ~~[sil_euro_latin.zip](https://github.com/keymanapp/keyman/files/8985670/sil_euro_latin.zip)~~ [sil_euro_latin.zip](https://github.com/keymanapp/keyman/files/9018791/sil_euro_latin.zip) for testing.

### GROUP_WEB_DEBUGGER: Perform tests in the Keyman Developer web debugger:

1. Install Keyman Developer from the artifacts in this PR.
2. Unzip and load this .kpj into Keyman Developer.
3. Open sil_euro_latin.kmn
4. In the Build tab, click Compile Keyboard, then click Test Keyboard on web.
5. Select 'http://localhost:8008/' from the list of web addresses and click Open in browser.
6. In the web debugger, select sil_euro_latin from the list of keyboards.
7. Select 'iPhone 5S' from the list of devices.

### GROUP_IPHONE: Perform these tests in the iPhone simulator, in-app or system keyboard, after installing the compiled sil_euro_latin.kmp from the above link.

### GROUP_ANDROID: Perform these tests in the Android emulator, in-app or system keyboard, after installing the compiled sil_euro_latin.kmp from the above link.

* **TEST_CAPS_LAYER**: on the touch keyboard on screen, double-click on the Shift key to activate the `caps` layer. Verify that:
  1. the `caps` layer is activated
  2. clicking keys on the `caps` layer generate capital letters, including long-presses.
  3. clicking letter keys does not drop back to the default layer.
 
* **TEST_CAPS_LAYER_RESET**: on the touch keyboard on screen, double-click on the Shift key to activate the `caps` layer. Click a few letter keys. Then click the Shift key again. Verify that:
  1. the `default` layer is activated
  2. clicking keys on the `default` layer generates lower case letters, including long-presses.
  3. typing a few letters generates lower case letters.

* **TEST_CAPS_ON_HARDWARE**: verify that Caps Lock is working correctly on hardware keyboard and that hardware caps does not affect the touch keyboard.
  1. On the hardware keyboard (your computer keyboard if using emulator/simulator), ensure Caps Lock is off, and type a few letters on the hardware keyboard. Verify that they are lower case.
  2. Press Caps Lock on your hardware keyboard. Type a few letters on the hardware keyboard. Verify that they are UPPER CASE.
  3. Type a few letters on the touch keyboard. Verify that they are lower case

## SUITE_DESKTOP

For these tests, use the KeymanWeb unminified test page, without any mobile emulation, on a desktop computer.

### GROUP_BASIC_KBDUS: Add the `basic_kbdus` keyboard in the "Add a keyboard by keyboard name" box, then select English - US Basic from keyboard menu.
### GROUP_OBOLO_CHWERTY: Use the `obolo_chwerty_6351` keyboard that is in the keyboard menu. Ensure that you press the Q (ch/Ch/CH key) in the tests to confirm the Caps vs NCaps vs Shift state.

* **TEST_PHYSICAL_CAPS**: Verify that the Caps Lock key on the hardware keyboard affects both hardware keystrokes and OSK keystrokes:
  1. Verify that Caps Lock is off, type a few letters on the hardware keyboard and then a few on the OSK to verify that letters are lower case.
  4. Press Caps Lock on the hardware keyboard. Type a few letters on the hardware keyboard, and then a few on the OSK to verify that letters are now upper case. Verify that the Caps Lock key is highlighted on the OSK (note that the letters will not show upper case on the OSK, this is not a failure.)
  5. Press Caps Lock again. Type a few letters on the hardware keyboard and then a few on the OSK to verify that letters are again lower case.

* **TEST_OSK_CAPS**: Verify that the Caps Lock key on the OSK affects only OSK keystrokes:
  1. Verify that Caps Lock is off, type a few letters on the hardware keyboard and then a few on the OSK to verify that letters are lower case.
  2. Press Caps Lock on the OSK. Type a few letters on the OSK to verify that letters are now upper case. Verify that the Caps Lock key is highlighted on the OSK (note that the letters will not show upper case on the OSK, this is not a failure.)
  3. Press Caps Lock on the OSK again. Type a few letters on the OSK to verify that letters are again lower case.

* **TEST_OSK_CAPS_INTERACTIONS**: Verify that pressing any key on the hardware keyboard cancels the OSK Caps Lock key:
  1. Verify that Caps Lock is off, type a few letters on the hardware keyboard and then a few on the OSK to verify that letters are lower case.
  2. Press Caps Lock on the OSK. Type a few letters on the OSK to verify that letters are now upper case. Verify that the Caps Lock key is highlighted on the OSK (note that the letters will not show upper case on the OSK, this is not a failure.)
  3. Press a letter key on the _hardware keyboard_. Type a few letters on the OSK to verify that letters are again lower case. Type a few letters on the hardware keyboard to verify that they are lower case.