### PR TITLE
fix(web): null-guard for refreshLayout

### DIFF
--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -449,14 +449,9 @@ namespace com.keyman.osk {
         return;
       }
 
-      // Proper layout cannot occur if the OSKView's dimensions have not yet
-      // been properly specified in some fashion.
-      if(!this.width || !this.height) {
-        return;
-      }
-
       // Step 1:  have the necessary conditions been met?
-      const fixedSize = this.width && this.height && this.width.absolute && this.height.absolute;
+      const hasDimensions = this.width && this.height;
+      const fixedSize = hasDimensions && this.width.absolute && this.height.absolute;
       const computedStyle = getComputedStyle(this._Box);
       const isInDOM = computedStyle.height != '' && computedStyle.height != 'auto';
 
@@ -464,7 +459,7 @@ namespace com.keyman.osk {
       if(fixedSize) {
         this._computedWidth  = this.width.val;
         this._computedHeight = this.height.val;
-      } else if(isInDOM) {
+      } else if(isInDOM && hasDimensions) {
         const parent = this._Box.offsetParent as HTMLElement;
         this._computedWidth  = this.width.val  * (this.width.absolute  ? 1 : parent.offsetWidth);
         this._computedHeight = this.height.val * (this.height.absolute ? 1 : parent.offsetHeight);

--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -449,6 +449,12 @@ namespace com.keyman.osk {
         return;
       }
 
+      // Proper layout cannot occur if the OSKView's dimensions have not yet
+      // been properly specified in some fashion.
+      if(!this.width || !this.height) {
+        return;
+      }
+
       // Step 1:  have the necessary conditions been met?
       const fixedSize = this.width && this.height && this.width.absolute && this.height.absolute;
       const computedStyle = getComputedStyle(this._Box);


### PR DESCRIPTION
Fixes #6853.

Looks like someone (probably me) over-optimized a check here, causing the second rung of the affected `if`-`else` ladder to be active in a scenario that was intended for the final rung.  Oops!

## User Testing

We could probably skip here, but...

- TEST_ANDROID_LOAD:  Make sure the Android app loads smoothly and that its keyboard rotates normally.

- TEST_IOS_LOAD:  Make sure that the iOS app loads smoothly and that its keyboard rotates normally.

- TEST_BASE_WEB:  In Chrome, use the "Test unminified Keymanweb" test page _in desktop mode_ and ensure that the OSK displays normally when each text area is clicked, moving underneath the current input element.