### PR TITLE
fix(ios): eliminates conditional height for banner image

### DIFF
--- a/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
+++ b/ios/keyman/Keyman/SWKeyboard/KeyboardViewController.swift
@@ -57,7 +57,7 @@ class KeyboardViewController: InputViewController {
   }
 
   func getTopBarImage(size: CGSize) -> String? {
-    return topBarImageSource.renderAsBase64(size: CGSize(width: size.width, height: self.activeTopBarHeight))
+    return topBarImageSource.renderAsBase64(size: CGSize(width: size.width, height: InputViewController.topBarHeight))
   }
 
   func setupTopBarImage(size: CGSize) {


### PR DESCRIPTION
Fixes #6807, for real this time.

There's no reason to condition the height for the banner's image when building it.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/25213402/175856384-9838ebeb-191d-49d3-a2ba-46c58cf0526c.png">

So, let's just use the non-conditional version.

@keymanapp-test-bot skip