### PR TITLE
fix(developer): readonly groups should never emit output

### DIFF
--- a/developer/src/tike/compile/CompileKeymanWeb.pas
+++ b/developer/src/tike/compile/CompileKeymanWeb.pas
@@ -1024,7 +1024,10 @@ begin
 
   if IsKeyboardVersion10OrLater() and (pwsz^ <> #0) then
   begin
-    Result := Result + nlt+Format('k.KDC(%d,t);', [ len ] );   // I3681
+    if not fgp.fReadOnly then
+    begin
+      Result := Result + nlt+Format('k.KDC(%d,t);', [ len ] );   // I3681
+    end;
     len := -1;
   end;
 
@@ -1048,7 +1051,10 @@ begin
               n := 1;
               while pwszContext^ <> '' do   // I4611
               begin
-                Result := Result + ContextChar(n, pwszContext);
+                if not fgp.fReadOnly then
+                begin
+                  Result := Result + ContextChar(n, pwszContext);
+                end;
                 Inc(n);
                 pwszContext := incxstr(pwszContext);
               end;
@@ -1060,20 +1066,33 @@ begin
           end;
         CODE_CONTEXTEX:
           begin
-            pwszContext := fkp.dpContext; for i := 1 to rec.ContextEx.Index - 1 do pwszContext := incxstr(pwszContext);
-            Result := Result + ContextChar(rec.ContextEx.Index, pwszContext);   // I4611
+            pwszContext := fkp.dpContext;
+            for i := 1 to rec.ContextEx.Index - 1 do
+            begin
+              pwszContext := incxstr(pwszContext);
+            end;
 
+            if not fgp.fReadOnly then
+            begin
+              Result := Result + ContextChar(rec.ContextEx.Index, pwszContext);   // I4611
+            end;
             len := -1;
           end;
         CODE_BEEP:
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
-            Result := Result + nlt+'k.KB(t);';   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+              Result := Result + nlt+'k.KB(t);';   // I3681
+            end;
             len := -1;
           end;
         CODE_NUL:
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
             len := -1;
           end;
         CODE_INDEX:
@@ -1088,31 +1107,45 @@ begin
 
             Index := AdjustIndex(fkp.dpContext, rec.Index.Index);   // I3910
 
-            Result := Result + nlt+Format('k.KIO(%d,this.s%s,%d,t);', [len, JavaScript_Name(rec.Index.StoreIndex, rec.Index.Store.szName),
-              // I783 - was: rec.Index.Index [2007-06-04]
-              // I783 again.  Returned to rec.Index.Index.  Was previously: [2008-08-15]
-              //              xstrlen(fkp.dpContext) + 1 - rec.Index.Index]);
-              //      this was wrong.  Can't find any reason why this change was made
-              //      which suggests it was in response to another bug and poorly traced (bad Marc)
-              //      and not properly tested (bad, bad Marc).  Anyway, now tested with test_i783
-              Index]);   // I3681   // I3910
+            if not fgp.fReadOnly then
+            begin
+              Result := Result + nlt+Format('k.KIO(%d,this.s%s,%d,t);', [len, JavaScript_Name(rec.Index.StoreIndex, rec.Index.Store.szName),
+                // I783 - was: rec.Index.Index [2007-06-04]
+                // I783 again.  Returned to rec.Index.Index.  Was previously: [2008-08-15]
+                //              xstrlen(fkp.dpContext) + 1 - rec.Index.Index]);
+                //      this was wrong.  Can't find any reason why this change was made
+                //      which suggests it was in response to another bug and poorly traced (bad Marc)
+                //      and not properly tested (bad, bad Marc).  Anyway, now tested with test_i783
+                Index]);   // I3681   // I3910
+            end;
             len := -1;
           end;
         CODE_DEADKEY:
           begin
-            Result := Result + nlt+Format('k.KDO(%d,t,%d);', [len, rec.Deadkey.Deadkey]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              Result := Result + nlt+Format('k.KDO(%d,t,%d);', [len, rec.Deadkey.Deadkey]);   // I3681
+            end;
             len := -1;
           end;
         CODE_USE:
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
             Result := Result + nlt+Format('r=this.g%s(t,e);', [JavaScript_Name(rec.Use.GroupIndex, rec.Use.Group.szName)]);    // I1959   // I3681
             Result := Result + nlt+'m=2;';  // #5440 - match desktop behavior
             len := -1;
           end;
         CODE_CALL:
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
             n := FCallFunctions.IndexOf(CallFunctionName(rec.Call.Store.dpString));
             if n = -1 then
               n := FCallFunctions.Add(CallFunctionName(rec.Call.Store.dpString));
@@ -1122,7 +1155,11 @@ begin
           end;
         CODE_SETOPT:    // I3429
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
             Result := Result + nlt+Format('this.s%s=this.s%s;',
               [JavaScript_Name(rec.SetOpt.StoreIndex1,rec.SetOpt.Store1.szName),
               JavaScript_Name(rec.SetOpt.StoreIndex2,rec.SetOpt.Store2.szName)]);  // I3429   // I3681
@@ -1130,7 +1167,11 @@ begin
           end;
         CODE_RESETOPT:  // I3429
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
 
             Result := Result + nlt+Format('this.s%s=k.KLOAD(this.KI,"%s",%s);',
               [JavaScript_Name(rec.ResetOpt.StoreIndex,rec.ResetOpt.Store.szName),
@@ -1140,7 +1181,11 @@ begin
           end;
         CODE_SAVEOPT:  // I3429
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);
+            end;
             Result := Result + nlt+Format('k.KSAVE("%s",this.s%s);',
               [JavaScript_Name(rec.SaveOpt.StoreIndex,rec.SaveOpt.Store.szName,True),   // I3690
               JavaScript_Name(rec.SaveOpt.StoreIndex,rec.SaveOpt.Store.szName)]); // I3429   // I3659   // I3681
@@ -1148,7 +1193,11 @@ begin
           end;
         CODE_SETSYSTEMSTORE:  // I3437
           begin
-            if len > 0 then Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            if not fgp.fReadOnly then
+            begin
+              if len > 0 then
+                Result := Result + nlt+Format('k.KO(%d,t,"");', [len]);   // I3681
+            end;
             Result := Result + nlt+Format('k.KSETS(%d,this.s%s,t);',   // I3681
               [rec.SetSystemStore.dwSystemID,
               JavaScript_Name(rec.SetSystemStore.StoreIndex, rec.SetSystemStore.Store.szName)]);
@@ -1167,12 +1216,18 @@ begin
     begin
 			if not InQuotes then
       begin
-        Result := Result + nlt+Format('k.KO(%d,t,"', [len]);   // I3681
+        if not fgp.fReadOnly then
+        begin
+          Result := Result + nlt+Format('k.KO(%d,t,"', [len]);   // I3681
+        end;
         InQuotes := True; len := -1;
       end;
 
       if rec.ChrVal in [Ord('"'), Ord('\')] then Result := Result + '\';
-      Result := Result + Javascript_String(rec.ChrVal);  // I2242
+      if not fgp.fReadOnly then
+      begin
+        Result := Result + Javascript_String(rec.ChrVal);  // I2242
+      end;
     end;
 
     pwsz := incxstr(pwsz);


### PR DESCRIPTION
Retrying #6848.

Fixes #6846. (Note #6799 is related but fixed by subsequent PR.)

Note: this fix and the following PR will be cherry-picked to stable-15.0 once testing and review is complete.

For KeymanWeb compiled keyboards, readonly groups should never emit any output. Rules in these groups permitted only to:
  * `use` other readonly groups
  * `call` external functions (which MUST NOT emit output)
  * `set`, `reset` or `save` store values

The problem solved here is that the compiler would generate a `k.KO()` the first time any statement such as `set()` was encountered when emitting the rule output, which is just wrong for a `readonly` group. For safety, we make sure that all other output is omitted here also for readonly groups.

The base kmx compiler can emit output for rules in readonly groups (e.g. when it encounters a 'context' statement). Thus, the KeymanWeb compiler, when it transpiles from the generated .kmx, needs to omit output for any readonly group, while avoiding any other potential change in behaviour.

Before this PR, we were relying on KeymanWeb ignoring output when running a readonly entry-point. KeymanWeb should probably do this as well. But this should have the same outcome and has the additional benefit of not performing no-op actions in NewContext and PostKeystroke groups.

# User Testing

Use the keyboard [sil_euro_latin.zip](https://github.com/keymanapp/keyman/files/8985670/sil_euro_latin.zip) for testing. All tests should be performed in the Keyman Developer web debugger:

1. Install Keyman Developer from the artifacts in this PR.
2. Unzip and load this .kpj into Keyman Developer.
3. Open sil_euro_latin.kmn
4. In the **Build** tab, click **Compile Keyboard**, then click **Test Keyboard on web**.
5. Select 'http://localhost:8008' from the list of web addresses and click **Open in browser**.
6. In the web debugger, select sil_euro_latin from the list of keyboards.

* **TEST_DELETE_SELECTION_DESKTOP:** Using the web debugger, select 'Windows' from the **Device** menu. Click in the text area, and type a few words using the hardware keyboard. Select one of the words you just typed using the mouse. For this test to pass, the selected word should not be deleted as soon as you select it!

* **TEST_DELETE_SELECTION_IPHONE:** Using the web debugger, select 'iPhone 5S' from the **Device** menu. Click in the text area, and type a few words using the iPhone keyboard. Select one of the words you just typed using the mouse.  For this test to pass, the selected word should not be deleted as soon as you select it!

If you want to compare with the previous (wrong) behaviour, you can run the same tests using [version 15.0.263](https://keyman.com/go/download/keyman-developer?version=15.0.263).