### PR TITLE
fix(windows): show full version number

### DIFF
--- a/windows/src/desktop/kmshell/render/SupportXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/SupportXMLRenderer.pas
@@ -1,18 +1,18 @@
 (*
   Name:             SupportXMLRenderer
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    28 Aug 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Initial version
                     04 Dec 2006 - mcdurdin - Add product name to support information
                     04 Jan 2007 - mcdurdin - Encode entities in XML render
@@ -40,6 +40,7 @@ uses
   SysUtils,
   VersionInfo,
   kmint,
+  KeymanVersion,
   keymanapi_TLB,
   MessageIdentifierConsts,
   MessageIdentifiers,
@@ -52,7 +53,7 @@ begin
   //kmcom.SystemInfo.EngineVersion
   Result := '<support>'+
     '<productname>'+XMLEncode(MsgFromId(SKApplicationTitle))+'</productname>'+
-    '<version>'+XMLEncode(GetVersionString)+'</version>'+
+    '<version>'+XMLEncode(CKeymanVersionInfo.VersionWithTag)+'</version>'+
     '<engineversion>'+XMLEncode(kmcom.SystemInfo.EngineVersion)+'</engineversion>'+
     '<engineinstallpath>'+XMLEncode(kmcom.SystemInfo.EngineInstallPath) +'</engineinstallpath>'+
     '</support>';

--- a/windows/src/engine/tsysinfo/sysinfo_main.pas
+++ b/windows/src/engine/tsysinfo/sysinfo_main.pas
@@ -115,6 +115,7 @@ uses
   ErrorControlledRegistry,
   Keyman.System.KeymanSentryClient,
   KeymanPaths,
+  KeymanVersion,
   RegistryKeys,
   sysinfo_Util,
   UframeAttachedFiles,
@@ -233,7 +234,7 @@ end;
 
 procedure TfrmDiagnostics.mnuHelpAboutClick(Sender: TObject);
 begin
-  ShowMessage(SCaption + ' Version ' + GetVersionString);
+  ShowMessage(SCaption + ' Version ' + CKeymanVersionInfo.VersionWithTag);
 end;
 
 procedure TfrmDiagnostics.mnuExitClick(Sender: TObject);


### PR DESCRIPTION
Updated various places in Keyman for Windows to show the full VersionWithTag rather than the short version number we had been previously showing:

- Support tab
- System Information, About dialog

# User Testing

* TEST_SUPPORT_TAB: Verify the version number shows correctly in the Support tab.
* TEST_DIAGNOSTICS: Verify the version number shows correctly in the Diagnostics, About dialog.