### PR TITLE
fix(android): globe key tip repositioning on keyboard height change

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1271,6 +1271,14 @@ final class KMKeyboard extends WebView {
       }
     }
 
+    // We can't properly display the help bubble if this token is null.  Abort and try again
+    // next time.
+    if (getWindowToken() == null) {
+      helpBubbleWindow = null;
+      ShouldShowHelpBubble = true;
+      return;
+    }
+
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     DisplayMetrics metrics = new DisplayMetrics();
     wm.getDefaultDisplay().getMetrics(metrics);
@@ -1329,12 +1337,7 @@ final class KMKeyboard extends WebView {
     helpBubblePos = new float[]{px, py};
 
     helpBubbleWindow.setAnimationStyle(R.style.PopupAnim);
-    if (getWindowToken() != null) {
-      this.repositionHelpBubble();
-    } else {
-      helpBubbleWindow = null;
-      ShouldShowHelpBubble = true;
-    }
+    this.repositionHelpBubble();
   }
 
   protected void repositionHelpBubble() {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1366,16 +1366,14 @@ final class KMKeyboard extends WebView {
   // cause the new position of the help bubble to be wrong.
   @Override public void setLayoutParams(ViewGroup.LayoutParams params) {
     super.setLayoutParams(params);
-    Log.i("HELLO", "World");
 
     Handler handler = new Handler();
     handler.postDelayed(new Runnable() {
       @Override
       public void run() {
-        if(helpBubbleWindow != null) {
-          // Update positioning!  Addresses #6734.
-          repositionHelpBubble();
-        }
+        // #6734 - help bubble position may need update after keyboard relayout
+        // This (`protected`) function does/should do any needed null checks on our behalf.
+        repositionHelpBubble();
       }
     }, 10);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1251,6 +1251,11 @@ final class KMKeyboard extends WebView {
 
   @SuppressLint("InflateParams")
   protected void showHelpBubble(Context context, float fx, float fy) {
+    // Remove any leftover artifacts from previous help-bubbles.  If we've made it this far,
+    // we're building the new one (should it be shown) from scratch anyway.
+    dismissHelpBubble();
+    helpBubbleWindow = null;
+
     if (!isHelpBubbleEnabled || keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       return; // Help bubble is disabled for System-wide keyboard
     }
@@ -1274,7 +1279,6 @@ final class KMKeyboard extends WebView {
     // We can't properly display the help bubble if this token is null.  Abort and try again
     // next time.
     if (getWindowToken() == null) {
-      helpBubbleWindow = null;
       ShouldShowHelpBubble = true;
       return;
     }
@@ -1323,7 +1327,6 @@ final class KMKeyboard extends WebView {
 
     popoverView.redraw();
 
-    dismissHelpBubble();
     helpBubbleWindow = new PopupWindow(contentView, (int) pvWidth, (int) pvHeight, false);
     helpBubbleWindow.setTouchable(true);
     helpBubbleWindow.setOnDismissListener(new OnDismissListener() {


### PR DESCRIPTION
Fixes #6734.

An important aspect of #6734 was that the known reproduction involved swapping from a keyboard with predictive text to one without it.  This causes an adjustment for the total amount of height 'reserved' for the keyboard, as the predictive text banner is treated as part of the keyboard's area.  So, the core of the issue: if the help tip is positioned before the keyboard's height is adjusted, there was no logic to reposition it based on the keyboard's new height.

## User Testing

TEST_HELP_TIP_POSITION:  on a fresh install of the Keyman app, install a keyboard without predictive text.

1. Perform a fresh install of the Keyman app.  (Delete any previously-installed version first!)
2. When the "Get Started" menu shows up, select the first option and add a keyboard using the keyboard search.
    - A couple of good options:
        - Tamil99 (`ekwtamil99uni`)
        - Plains, Cree Syllabics (`nrc_crk_cans`)
    - The important part:  only pick keyboards that don't have any matching lexical models.
3. Follow the standard package installation process from there, clicking "Install" and "Done" as soon as the options are available.
4. Rotate the device and ensure the help tip is properly displayed for the new layout.

- This test _**PASSES**_ if and only if the globe key's help tip is properly aligned over the globe key in both steps 3 and 4.  For example,

<img width="161" alt="image" src="https://user-images.githubusercontent.com/25213402/176379433-bbb5fcc3-9f89-44db-ad6b-e4634e9be179.png">
