### PR TITLE
fix(web): post-keystroke processing after use of pred. text selection

### DIFF
--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -393,13 +393,15 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.addListener('suggestionapplied', this.suggestionApplied);
     }
 
+    // tryRevert: () => boolean = function(this: SuggestionManager, returnObj: {shouldSwallow: boolean}) {
+
     /**
      * Handler for post-processing once a suggestion has been applied: calls
      * into the active keyboard's `begin postKeystroke` entry point.
      * @param    outputTarget
      * @returns  true
      */
-    suggestionApplied(outputTarget: text.OutputTarget): boolean {
+    suggestionApplied: (outputTarget: text.OutputTarget) => boolean = function(this: SuggestionBanner, outputTarget: text.OutputTarget) {
       const keyman = com.keyman.singleton;
       // Tell the keyboard that the current layer has not changed
       keyman.core.keyboardProcessor.newLayerStore.set('');
@@ -411,7 +413,7 @@ namespace com.keyman.osk {
         ?.finalize(keyman.core.keyboardProcessor, outputTarget, true);
 
       return true;
-    };
+    }.bind(this);
 
     postConfigure() {
       let keyman = com.keyman.singleton;
@@ -427,6 +429,7 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.removeListener('suggestionsready', manager.updateSuggestions);
       keyman.core.languageProcessor.removeListener('tryaccept', manager.tryAccept);
       keyman.core.languageProcessor.removeListener('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.removeListener('suggestionapplied', this.suggestionApplied);
     }
   }
 

--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -393,8 +393,6 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.addListener('suggestionapplied', this.suggestionApplied);
     }
 
-    // tryRevert: () => boolean = function(this: SuggestionManager, returnObj: {shouldSwallow: boolean}) {
-
     /**
      * Handler for post-processing once a suggestion has been applied: calls
      * into the active keyboard's `begin postKeystroke` entry point.


### PR DESCRIPTION
Fixes #6885 for `stable-15.0`.  We'll likely want equivalent changes in #6849 before it merges as well.

## User Testing

TEST_PRED_TEXT:  On a desktop device, using Chrome's developer mode on the "Prediction - robust testing" Web test page...

1. Use the "Toggle device toolbar" button to _emulate_ a mobile device.
2. Refresh the page.
3. Click one of the textboxes.
4. Click any default suggestion.
    - If the selected suggestion is not applied properly, _**FAIL**_ this test.
5. Check the developer-mode "Console" tab (it's usually visible by default).  If there are _any_ errors (with red text!) in the console log, report them and _**FAIL**_ this test.
    - Unless they were already in the console before step 4.
6. Type a few letters and click another suggestion.
    - If the selected suggestion is not applied properly, _**FAIL**_ this test.
7. Repeat step 5.
8. Repeat steps 6 and 7 at least 4 more times.

It would be nice if we had a pre-existing resource set where we could selectively trigger a postKeyboard rule in a meaningful, visual way without resorting to the console... but I don't believe that we do.  And it is a simple enough and highly directed fix, so... this may be fine as-is?