### PR TITLE
fix(web): properly binds 'suggestionApplied' event handler

### DIFF
--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -399,7 +399,7 @@ namespace com.keyman.osk {
      * @param    outputTarget
      * @returns  true
      */
-    suggestionApplied(outputTarget: text.OutputTarget): boolean {
+    suggestionApplied: (outputTarget: text.OutputTarget) => boolean = function(this: SuggestionBanner, outputTarget: text.OutputTarget) {
       const keyman = com.keyman.singleton;
       // Tell the keyboard that the current layer has not changed
       keyman.core.keyboardProcessor.newLayerStore.set('');
@@ -411,7 +411,7 @@ namespace com.keyman.osk {
         ?.finalize(keyman.core.keyboardProcessor, outputTarget, true);
 
       return true;
-    };
+    }.bind(this);
 
     postConfigure() {
       let keyman = com.keyman.singleton;
@@ -427,6 +427,7 @@ namespace com.keyman.osk {
       keyman.core.languageProcessor.removeListener('suggestionsready', manager.updateSuggestions);
       keyman.core.languageProcessor.removeListener('tryaccept', manager.tryAccept);
       keyman.core.languageProcessor.removeListener('tryrevert', manager.tryRevert);
+      keyman.core.languageProcessor.removeListener('suggestionapplied', this.suggestionApplied);
     }
   }
 


### PR DESCRIPTION
Ooh, a rare inverse-🍒 - and to an active PR at that!

This fixes an issue noted in PR #6849 that was detected when its 🍒 to stable-15.0 got merged in first and started generating Sentry events.

## User Testing

TEST_PRED_TEXT:  On a desktop device, using Chrome's developer mode on the "Prediction - robust testing" Web test page...

1. Use the "Toggle device toolbar" button to _emulate_ a mobile device.
2. Refresh the page.
3. Click one of the textboxes.
4. Click any default suggestion.
    - If the selected suggestion is not applied properly, _**FAIL**_ this test.
5. Check the developer-mode "Console" tab (it's usually visible by default).  If there are _any_ errors (with red text!) in the console log, report them and _**FAIL**_ this test.
    - Unless they were already in the console before step 4.
6. Type a few letters and click another suggestion.
    - If the selected suggestion is not applied properly, _**FAIL**_ this test.
7. Repeat step 5.
8. Repeat steps 6 and 7 at least 4 more times.