### PR TITLE
fix(web): improve `console.error()` reporting

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -685,7 +685,12 @@ final class KMKeyboard extends WebView {
         breadcrumb.setData("keyboardVersion", this.keyboardVersion);
       }
       Sentry.addBreadcrumb(breadcrumb);
-      Sentry.captureMessage(message, SentryLevel.ERROR);
+      //
+      // We now rely on Sentry within KMW to capture these errors
+      // We'll continue to capture breadcrumbs so we can associate
+      // java-side errors with javascript-side errors.
+      //Sentry.captureMessage(message, SentryLevel.ERROR);
+      //
     }
   }
 

--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -62,7 +62,11 @@ namespace com.keyman {
     pathFilter(event: any) {
       // Get the underlying JS error.
       let exception = event.exception;
-
+      if(!exception) {
+        // events are not required to have an exception property
+        // e.g. console.log-type events
+        return;
+      }
       // Iterate through all wrapped exceptions.
       for(let e of exception.values) {
         // If Sentry was unable to generate a stacktrace, there's no path filtering to
@@ -97,7 +101,7 @@ namespace com.keyman {
     }
 
     // Sanitizes the event object (in-place) to remove sensitive information
-    // from the breadcrumbs and url
+    // from the breadcrumbs and url (for embedded KeymanWeb)
     sanitizeEvent(event: any) {
       if (event && event.breadcrumbs) {
         event.breadcrumbs.forEach((b: any) => {
@@ -109,7 +113,7 @@ namespace com.keyman {
         });
       }
 
-      if (event.request.url) {
+      if (event.request && event.request.url) {
         let URL_PATTERN = /#.*$/;
         event.request.url = event.request.url.replace(URL_PATTERN, '');
       }
@@ -168,6 +172,52 @@ namespace com.keyman {
       }
     }
 
+    /**
+     * Capture errors and warnings logged to Console in order to get
+     * stack traces. We can't use CaptureConsole integration until we
+     * upgrade to a newer version of Sentry, which has a bit of a cascade
+     * of changes required, in particular a change of module type and
+     * transpiling down to ES5.
+     *
+     * https://stackoverflow.com/a/53214615/1836776
+     */
+    initConsole() {
+      // creating function declarations for better stacktraces (otherwise they'd be anonymous function expressions)
+      let oldConsoleError = console.error;
+      console.error = reportingConsoleError; // defined via function hoisting
+      function reportingConsoleError() {
+        let args = Array.prototype.slice.call(arguments);
+        Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        return oldConsoleError.apply(console, args);
+      };
+
+      let oldConsoleWarn = console.warn;
+      console.warn = reportingConsoleWarn; // defined via function hoisting
+      function reportingConsoleWarn() {
+        let args = Array.prototype.slice.call(arguments);
+        Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        return oldConsoleWarn.apply(console, args);
+      }
+
+      function reduceConsoleArgs(args) {
+        let errorMsg = args[0];
+        // Make sure errorMsg is either an error or string.
+        // It's therefore best to pass in new Error('msg') instead of just 'msg' since
+        // that'll give you a stack trace leading up to the creation of that new Error
+        // whereas if you just pass in a plain string 'msg', the stack trace will include
+        // reportingConsoleError and reportingConsoleCall
+        if (!(errorMsg instanceof Error)) {
+          // stringify all args as a new Error (which creates a stack trace)
+          errorMsg = new Error(
+            args.reduce(function(accumulator, currentValue) {
+              return accumulator.toString() + ' ' + currentValue.toString();
+            }, '')
+          );
+        }
+        return errorMsg;
+      }
+    }
+
     init() {
       // Do the actual Sentry initialization.
       //@ts-ignore
@@ -177,8 +227,10 @@ namespace com.keyman {
         debug: DEBUG,
         dsn: 'https://cf96f32d107c4286ab2fd82af49c4d3b@o1005580.ingest.sentry.io/5983524', // keyman-web DSN
         release: com.keyman.KEYMAN_VERSION.SENTRY_RELEASE,
-        environment: com.keyman.KEYMAN_VERSION.VERSION_ENVIRONMENT
+        environment: com.keyman.KEYMAN_VERSION.VERSION_ENVIRONMENT,
       });
+
+      this.initConsole();
     }
 
     get enabled(): boolean {

--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -113,7 +113,7 @@ namespace com.keyman {
         });
       }
 
-      if (event.request && event.request.url) {
+      if (event && event.request && event.request.url) {
         let URL_PATTERN = /#.*$/;
         event.request.url = event.request.url.replace(URL_PATTERN, '');
       }

--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -184,10 +184,14 @@ namespace com.keyman {
     initConsole() {
       // creating function declarations for better stacktraces (otherwise they'd be anonymous function expressions)
       let oldConsoleError = console.error;
+      let _this = this;
+      // Note that Sentry may have overridden console.error so we are re-overriding it here post-init.
       console.error = reportingConsoleError; // defined via function hoisting
       function reportingConsoleError() {
         let args = Array.prototype.slice.call(arguments);
-        Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        if(_this._enabled) {
+          Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        }
         return oldConsoleError.apply(console, args);
       };
 
@@ -195,7 +199,9 @@ namespace com.keyman {
       console.warn = reportingConsoleWarn; // defined via function hoisting
       function reportingConsoleWarn() {
         let args = Array.prototype.slice.call(arguments);
-        Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        if(_this._enabled) {
+          Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        }
         return oldConsoleWarn.apply(console, args);
       }
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -1,21 +1,24 @@
+let _debug = false;
 
-console = new Object();
-console.log = function(log) {
-    var iframe = document.createElement("IFRAME");
-    iframe.setAttribute("src", "ios-log:#iOS#" + log);
-    document.documentElement.appendChild(iframe);
-    iframe.parentNode.removeChild(iframe);
-    iframe = null;
-    if (typeof(window.webkit) != 'undefined')
-        window.webkit.messageHandlers.keyman.postMessage("ios-log:#iOS#" + log);
-};
-console.debug = console.log;
-console.info = console.log;
-console.warn = console.log;
-console.error = console.log;
-window.onerror = function(error, url, line) {
-    console.log('ERROR: '+error+' URL:'+url+' L:'+line);
-};
+if(_debug) {
+    console = new Object();
+    console.log = function(log) {
+        var iframe = document.createElement("IFRAME");
+        iframe.setAttribute("src", "ios-log:#iOS#" + log);
+        document.documentElement.appendChild(iframe);
+        iframe.parentNode.removeChild(iframe);
+        iframe = null;
+        if (typeof(window.webkit) != 'undefined')
+            window.webkit.messageHandlers.keyman.postMessage("ios-log:#iOS#" + log);
+    };
+    console.debug = console.log;
+    console.info = console.log;
+    console.warn = console.log;
+    console.error = console.log;
+    window.onerror = function(error, url, line) {
+        console.log('ERROR: '+error+' URL:'+url+' L:'+line);
+    };
+}
 
 var device = 'AppleMobile';
 var oskHeight = 0;

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1623,9 +1623,7 @@ namespace com.keyman.dom {
 
       // Exit initialization here if we're using an embedded code path.
       if(this.keyman.isEmbedded) {
-        if(!this.keyman.keyboardManager.setDefaultKeyboard()) {
-          console.error("No keyboard stubs exist - cannot initialize keyboard!");
-        }
+        this.keyman.keyboardManager.setDefaultKeyboard();
         return Promise.resolve();
       }
 


### PR DESCRIPTION
## The back story

Currently Keyman for Android reports errors sent to the console via `console.error()` into Sentry but sentry-manager itself does not. This means that Keyman for iPhone and iPad and other users of sentry-manager do not report these errors. Many of these errors are important.

What's worse is that Keyman for Android's error reporting here (via the `sendKMWError()` function in Keyman Engine for Android) does not capture stack traces, and so many of the errors we get do not have enough information to resolve them.

Furthermore, by having `sendKMWError()` in Keyman for Android, we capture exceptions and other program errors twice -- once on the web side, and once on the Java side -- this adds noise to our error reporting. Sentry also tends to lump many unrelated `sendKMWError()` events together, so tracking resolution to the errors is painful.

## The fix

This adds a patch to sentry-manager to capture `console.error()` and `console.warning()` events and report them through Sentry's normal error reporting, and disables the `sendKMWError()` report (although we leave the breadcrumb in place for when there are later, related Java errors). There is a Sentry integration called CaptureConsole, but it does not support capturing stack traces until v6.14 (https://github.com/getsentry/sentry-javascript/pull/4034). Updating Sentry to 6.14 or newer is a bigger job (due to ES6 baseline req. etc.)

## Keyman for iOS

I note that Keyman for iOS currently has some other stubs in place overriding the `console.*` functions. I have disabled these for release builds, so that we can use this new pattern instead.

## Sample 

* A sample Keyman for Android error report captured with this mechanism (no sourcemaps here because this is a -local build):   https://sentry.io/organizations/keyman/issues/3401287467/events/c40fd2cebb7743cc8dfe72e0dd34bf65/?project=5983524

* A sample Keyman for iPhone and iPad error report captured with this mechanism (no sourcemaps here because this is a -local build): https://sentry.io/organizations/keyman/issues/3401477935/events/a64b3dda3bb948bc965dced118b26df5/?project=5983524

I know that the error shown in the above samples ("No keyboard stubs exist") is reported on every launch of Keyman, so I have gone ahead and removed it -- nothing bad ever happens in the 'failure' path, so it's completely spurious at this point.

## Back-port

I am proposing we back-port this to 15.0-stable as we are missing a lot of data in many of our error reports on Android and missing many error reports on iOS.

@keymanapp-test-bot skip