### PR TITLE
fix(linux): Fix post-install script

### DIFF
--- a/linux/debian/ibus-keyman.postinst
+++ b/linux/debian/ibus-keyman.postinst
@@ -37,7 +37,7 @@ case "$1" in
       fi
 
       # Verify that it's running now
-      ! ibusdaemon=`ps --user ${SUDO_USER} -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*"`
+      ! ibusdaemon=`ps --user ${SUDO_USER:=$USER} -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*"`
       if [ "x$ibusdaemon" = "x" ]; then
         # otherwise try to start it for the user installing the package
         if [ "x$is_gnome_shell" = "x1" ]; then


### PR DESCRIPTION
This change fixes the ibus-keyman post install script which previously failed if for whatever reason `SUDO_USER` is not set.

Fixes #6893

@keymanapp-test-bot skip