### PR TITLE
fix(web): postkeystroke processing should ignore key-event source🖇️

### DIFF
--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -11,8 +11,9 @@ namespace com.keyman.text {
     }
 
     /**
-     * Indicates the device (platform) to be used for context-only rules,
-     * such as those found in `postkeystroke` and `newcontext` groups.
+     * Indicates the device (platform) to be used for non-keystroke events,
+     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * entry points.
      */
     private contextDevice: utils.DeviceSpec;
     private kbdProcessor: KeyboardProcessor;

--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -10,7 +10,11 @@ namespace com.keyman.text {
       baseLayout: 'us'
     }
 
-    private device: utils.DeviceSpec;
+    /**
+     * Indicates the device (platform) to be used for context-only rules,
+     * such as those found in `postkeystroke` and `newcontext` groups.
+     */
+    private contextDevice: utils.DeviceSpec;
     private kbdProcessor: KeyboardProcessor;
     private lngProcessor: prediction.LanguageProcessor;
 
@@ -23,7 +27,7 @@ namespace com.keyman.text {
         options = InputProcessor.DEFAULT_OPTIONS;
       }
 
-      this.device = device;
+      this.contextDevice = device;
       this.kbdProcessor = new KeyboardProcessor(device, options);
       this.lngProcessor = new prediction.LanguageProcessor();
     }
@@ -65,7 +69,7 @@ namespace com.keyman.text {
      *                                    all matched keyboard rules
      */
      processNewContextEvent(outputTarget: OutputTarget): RuleBehavior {
-      const ruleBehavior = this.keyboardProcessor.processNewContextEvent(this.device, outputTarget);
+      const ruleBehavior = this.keyboardProcessor.processNewContextEvent(this.contextDevice, outputTarget);
 
       if(ruleBehavior) {
         ruleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
@@ -193,7 +197,7 @@ namespace com.keyman.text {
       this.keyboardProcessor.newLayerStore.set(hasLayerChanged ? this.keyboardProcessor.layerId : '');
       this.keyboardProcessor.oldLayerStore.set(hasLayerChanged ? startingLayerId : '');
 
-      let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(keyEvent.device, outputTarget);
+      let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(this.contextDevice, outputTarget);
       if(postRuleBehavior) {
         postRuleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
       }

--- a/common/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/web/input-processor/tests/cases/inputProcessor.js
@@ -30,7 +30,7 @@ describe('InputProcessor', function() {
       let core = new InputProcessor(device);
 
       assert.isOk(core.keyboardProcessor);
-      assert.isDefined(core.keyboardProcessor.device);
+      assert.isDefined(core.keyboardProcessor.contextDevice);
       assert.isOk(core.languageProcessor);
       assert.isOk(core.keyboardInterface);
       assert.isUndefined(core.activeKeyboard); // No keyboard should be loaded yet.

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -48,8 +48,9 @@ namespace com.keyman.text {
     keyboardInterface: KeyboardInterface;
 
     /**
-     * Indicates the device (platform) to be used for context-only rules,
-     * such as those found in `postkeystroke` and `newcontext` groups.
+     * Indicates the device (platform) to be used for non-keystroke events,
+     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * entry points.
      */
     contextDevice: utils.DeviceSpec;
 

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -46,7 +46,12 @@ namespace com.keyman.text {
     modStateFlags: number = 0;
 
     keyboardInterface: KeyboardInterface;
-    device: utils.DeviceSpec;
+
+    /**
+     * Indicates the device (platform) to be used for context-only rules,
+     * such as those found in `postkeystroke` and `newcontext` groups.
+     */
+    contextDevice: utils.DeviceSpec;
 
     baseLayout: string;
 
@@ -60,7 +65,7 @@ namespace com.keyman.text {
         options = KeyboardProcessor.DEFAULT_OPTIONS;
       }
 
-      this.device = device;
+      this.contextDevice = device;
 
       this.baseLayout = options.baseLayout || KeyboardProcessor.DEFAULT_OPTIONS.baseLayout;
       this.keyboardInterface = new KeyboardInterface(options.variableStoreSerializer);

--- a/common/web/keyboard-processor/src/text/systemStores.ts
+++ b/common/web/keyboard-processor/src/text/systemStores.ts
@@ -42,6 +42,11 @@ namespace com.keyman.text {
     }
 
     set(value: string) {
+      // No need to signal changes when things stay the same.
+      if(this._value == value) {
+        return;
+      }
+
       if(this.handler) {
         if(this.handler(this, value)) {
           return;
@@ -105,7 +110,7 @@ namespace com.keyman.text {
               return false; // web matches anything other than 'native'
             }
             break;
-            
+
           case 'native':
             // This will return true for embedded KeymanWeb
           case 'chrome':
@@ -117,7 +122,7 @@ namespace com.keyman.text {
               return false;
             }
             break;
-            
+
           default:
             return false;
         }

--- a/common/web/keyboard-processor/src/text/systemStores.ts
+++ b/common/web/keyboard-processor/src/text/systemStores.ts
@@ -42,11 +42,9 @@ namespace com.keyman.text {
     }
 
     set(value: string) {
-      // No need to signal changes when things stay the same.
-      if(this._value == value) {
-        return;
-      }
-
+      // Even if things stay the same, we should still signal this.
+      // It's important for tracking if a rule directly set the layer
+      // versus if it passively remained.
       if(this.handler) {
         if(this.handler(this, value)) {
           return;

--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -202,7 +202,10 @@ window.onload = function() {
       keyman.osk = null;
     }
 
+    // Create a new on screen keyboard view and tell KeymanWeb that
+    // we are using the targetDevice for context input.
     newOSK = new com.keyman.osk.InlinedOSKView(targetDevice, keyman.util.device.coreSpec);
+    keyman.core.contextDevice = targetDevice;
 
     if(document.body.offsetWidth < targetDevice.dimensions[0]) {
       newOSK.setSize('320px', '200px');


### PR DESCRIPTION
It turns out that postkeystroke rules weren't being processed correctly if they were following a physical keystroke.  The reason?  Internally, to detect the "context device" the rules should be applied to, the Web engine's keyboard API relies on the device supplied by the attached key event object.  Unfortunately, while we created a separate object for it... we were reusing the triggering event's device setting, not the one actually matching the host device.

Now, postkeystroke rules will consistently apply on touch devices, as they'll always be aware that they're _on_ touch devices for context processing.

----

## User Testing

Note that the text sequences below are very precisely defined.  When told to type something, type _exactly_ what is shown - no more and no less.

TEST_ANDROID_EXTERNAL:  Using an Android device with an external keyboard...

1. Install the KMP within this .zip:  [sil_euro_latin.zip](https://github.com/keymanapp/keyboards/files/9050066/sil_euro_latin.zip)
2. With `sil_euro_latin` active, clear any previously-existing text.
3. Verify that the keyboard is on the 'shift' layer - the key caps should all be capitalized.
4. Using _only the external, hardware keyboard_, type `hello world.`
5. Type the `.` key once more.  Note that no visible text changes should occur; this is not a bug.
6. Type the ` ` (space) key.
7. If the 'shift' layer is not automatically displayed at this time, _**FAIL**_ this test.
    - ONLY if you did BOTH steps 5 and 6.  It will appear to fail if you leave out either step. 

Alternatively, you may use Android Studio's emulator, treating your computer's hardware keyboard as if it were the simulated device's external keyboard.

TEST_ANDROID_OSK:  Using an Android device...

1. Install the KMP within this .zip:  [sil_euro_latin.zip](https://github.com/keymanapp/keyboards/files/9050066/sil_euro_latin.zip)
2. With `sil_euro_latin` active, clear any previously-existing text.
3. Verify that the keyboard is on the 'shift' layer - the key caps should all be capitalized.
4. Using _only the OSK_, type `H`.
5. Verify that the OSK returns to the 'default' layer.
6. Type `ello world.`  (The OSK's layer should remain unshifted.)
7. Type the ` ` (space) key.
8. If the 'shift' layer is not automatically displayed at this time, _**FAIL**_ this test.