### PR TITLE
fix(web): layer-setting ops should not trigger for hardware keystroke processing 🖇️

### DIFF
--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -102,8 +102,9 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.  `doModifierPress` must always run.
-      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      // of state management.  `doModifierPress` must always run for desktop-mode contexts.
+      // In standard Web integration, `contextDevice` indicates what type of OSK is visible.
+      if(!this.contextDevice.touchable && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
         // If run on a desktop platform, we know that modifier & state key presses may not
         // produce output, so we may make an immediate return safely.
         if(!fromOSK) {

--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -102,9 +102,8 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.  `doModifierPress` must always run for desktop-mode contexts.
-      // In standard Web integration, `contextDevice` indicates what type of OSK is visible.
-      if(!this.contextDevice.touchable && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      // of state management.  `doModifierPress` must always run.
+      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
         // If run on a desktop platform, we know that modifier & state key presses may not
         // produce output, so we may make an immediate return safely.
         if(!fromOSK) {

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -882,7 +882,8 @@ namespace com.keyman.text {
      */
     setStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
       this.resetContextCache();
-      if(systemId == KeyboardInterface.TSS_LAYER) {
+      // Unique case:  we only allow set-store ops from keyboard rules triggered by touch OSKs.
+      if(systemId == KeyboardInterface.TSS_LAYER && this.activeDevice.touchable) {
         // Denote the changed store as part of the matched rule's behavior.
         this.ruleBehavior.setStore[systemId] = strValue;
       } else {

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -882,7 +882,7 @@ namespace com.keyman.text {
      */
     setStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
       this.resetContextCache();
-      // Unique case:  we only allow set-store ops from keyboard rules triggered by touch OSKs.
+      // Unique case:  we only allow set(&layer) ops from keyboard rules triggered by touch OSKs.
       if(systemId == KeyboardInterface.TSS_LAYER && this.activeDevice.touchable) {
         // Denote the changed store as part of the matched rule's behavior.
         this.ruleBehavior.setStore[systemId] = strValue;

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -728,7 +728,7 @@ namespace com.keyman.text {
       } else if(KeyboardProcessor.isModifier(Levent)) {
         this.activeKeyboard.notify(Levent.Lcode, outputTarget, isKeyDown ? 1 : 0);
         // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-        if(!Levent.device.touchable) {
+        if(!this.contextDevice.touchable) {
           return this._UpdateVKShift(Levent); // I2187
         } else {
           return true;
@@ -737,7 +737,9 @@ namespace com.keyman.text {
 
       if(Levent.LmodifierChange) {
         this.activeKeyboard.notify(0, outputTarget, 1);
-        this._UpdateVKShift(Levent);
+        if(!this.contextDevice.touchable) {
+          this._UpdateVKShift(Levent);
+        }
       }
 
       // No modifier keypresses detected.

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -749,7 +749,9 @@ namespace com.keyman.text {
     resetContext() {
       this.layerId = 'default';
       this.keyboardInterface.resetContextCache();
-      this._UpdateVKShift(null);
+      if(this.contextDevice.touchable) {
+        this._UpdateVKShift(null);
+      }
     };
 
     setNumericLayer(device: utils.DeviceSpec) {

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -749,7 +749,7 @@ namespace com.keyman.text {
     resetContext() {
       this.layerId = 'default';
       this.keyboardInterface.resetContextCache();
-      if(this.contextDevice.touchable) {
+      if(!this.contextDevice.touchable) {
         this._UpdateVKShift(null);
       }
     };

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -121,7 +121,7 @@ if(!window['keyman']['initialized']) {
      * Reset context when entering or exiting the active element.
      * Will also trigger OSK shift state / layer reset.
      **/
-    function resetVKShift() {
+    keymanweb.pageFocusHandler = function() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
         keyman.core.resetContext(null);
@@ -129,9 +129,8 @@ if(!window['keyman']['initialized']) {
     }
 
     // We need to track this handler, as it causes... interesting... interactions during testing in certain browsers.
-    keymanweb['pageFocusHandler'] = resetVKShift;
-    util.attachDOMEvent(window, 'focus', keymanweb['pageFocusHandler'], false);  // I775
-    util.attachDOMEvent(window, 'blur', keymanweb['pageFocusHandler'], false);   // I775
+    util.attachDOMEvent(window, 'focus', keymanweb.pageFocusHandler, false);  // I775
+    util.attachDOMEvent(window, 'blur', keymanweb.pageFocusHandler, false);   // I775
 
     // Initialize supplementary plane string extensions
     String.kmwEnableSupplementaryPlane(true);

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -117,17 +117,6 @@ if(!window['keyman']['initialized']) {
 
     util.attachDOMEvent(document, 'keyup', keymanweb.hotkeyManager._Process, false);
 
-    /**
-     * Reset context when entering or exiting the active element.
-     * Will also trigger OSK shift state / layer reset.
-     **/
-    keymanweb.pageFocusHandler = function() {
-      let keyman = com.keyman.singleton;
-      if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
-        keyman.core.resetContext(null);
-      }
-    }
-
     // We need to track this handler, as it causes... interesting... interactions during testing in certain browsers.
     util.attachDOMEvent(window, 'focus', keymanweb.pageFocusHandler, false);  // I775
     util.attachDOMEvent(window, 'blur', keymanweb.pageFocusHandler, false);   // I775

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -118,12 +118,13 @@ if(!window['keyman']['initialized']) {
     util.attachDOMEvent(document, 'keyup', keymanweb.hotkeyManager._Process, false);
 
     /**
-     * Reset OSK shift states when entering or exiting the active element
+     * Reset context when entering or exiting the active element.
+     * Will also trigger OSK shift state / layer reset.
      **/
     function resetVKShift() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
-        keyman.core.keyboardProcessor._UpdateVKShift(null);  //this should be enabled !!!!! TODO
+        keyman.core.resetContext(null);
       }
     }
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -183,8 +183,8 @@ namespace com.keyman {
      */
     ['shutdown']() {
       // Disable page focus/blur events, which can sometimes trigger and cause parallel KMW instances in testing.
-      this.util.detachDOMEvent(window, 'focus', this['pageFocusHandler'], false);
-      this.util.detachDOMEvent(window, 'blur', this['pageFocusHandler'], false);
+      this.util.detachDOMEvent(window, 'focus', (this as any).pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'blur', (this as any).pageFocusHandler, false);
 
       this.domManager.shutdown();
       this.osk.shutdown();

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -180,12 +180,12 @@ namespace com.keyman {
      * Reset context when entering or exiting the active element.
      * Will also trigger OSK shift state / layer reset.
      **/
-    pageFocusHandler: () => boolean = function(this: KeymanBase) {
+    pageFocusHandler = () => {
       if(!this.uiManager.isActivating && this.osk?.vkbd) {
         this.core.resetContext(null);
       }
       return false;
-    }.bind(this);
+    }
 
     /**
      * Triggers a KeymanWeb engine shutdown to facilitate a full system reset.

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -177,14 +177,25 @@ namespace com.keyman {
     }
 
     /**
+     * Reset context when entering or exiting the active element.
+     * Will also trigger OSK shift state / layer reset.
+     **/
+    pageFocusHandler: () => boolean = function(this: KeymanBase) {
+      if(!this.uiManager.isActivating && this.osk?.vkbd) {
+        this.core.resetContext(null);
+      }
+      return false;
+    }.bind(this);
+
+    /**
      * Triggers a KeymanWeb engine shutdown to facilitate a full system reset.
      * This function is designed for use with KMW unit-testing, which reloads KMW
      * multiple times to test the different initialization paths.
      */
     ['shutdown']() {
       // Disable page focus/blur events, which can sometimes trigger and cause parallel KMW instances in testing.
-      this.util.detachDOMEvent(window, 'focus', (this as any).pageFocusHandler, false);
-      this.util.detachDOMEvent(window, 'blur', (this as any).pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'focus', this.pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'blur', this.pageFocusHandler, false);
 
       this.domManager.shutdown();
       this.osk.shutdown();


### PR DESCRIPTION
 Based on #6901.

Fixes two related issues:

1.  On a desktop platform, it's rather odd to have postkeystroke and newcontext rules auto-shifting the layer.  The user's using a physical keyboard; stay matched to that.
2.  Our current design says that hardware keystroke events should not affect the OSK's behavior in any way.
    - Caveat:  _aftereffects_ of that keystroke - namely, postkeystroke and newcontext rules - may still affect the OSK.

For point 2 above, we've been stating this design for a while, but we never actually filtered out such layer-changing effects until now.

## User Testing

Use the standard "Test unminified Keymanweb" test page and the "English > Obolo Chwerty" keyboard for the following tests:

TEST_DESKTOP:  in standard desktop Chrome:

1. Release any pressed keyboard keys before swapping to the Obolo Chwerty keyboard.
2. Verify that the OSK is in the 'default' layer when first shown.
3. Press and hold hardware 'shift'.  Verify that the 'shift' layer is now shown.
4. Type hardware `j`.  Verify that a `J` is produced.
5. Release hardware 'shift'.  Verify that the 'default', lowercase layer is now shown.
6. Press the hardware CAPS key.  Verify that it remains on the 'default' layer.
    - Desktop form-factors do not support a 'caps' OSK layer yet.
7. Type the hardware `h` key.  Verify that `SH` is produced.

TEST_MOBILE:  using Chrome's developer mode, emulate a mobile device, then refresh the page.

1. With no pre-existing text in the textbox, swap to the Obolo Chwerty keyboard.
2. Verify that the OSK is in the 'shift' layer when first shown.
3. Type hardware 'j'.  Verify that a `j` is produced - not a `J`.
4. Press and hold hardware 'shift'.  Verify that the 'default' layer remains visible.
5. Type the hardware `h` key.  Verify that `Sh` is produced.
6. Release hardware 'shift', then toggle hardware caps-lock.
7. Type the hardware `h` key again.  Verify that `SH` is produced.