### PR TITLE
fix(web): improve `console.error()` reporting 🍒

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -171,8 +171,8 @@ final class KMKeyboard extends WebView {
           sendKMWError(cm.lineNumber(), sourceID, cm.message());
           // This duplicates the sendKMWError message, which itself duplicates the reporting now
           // managed by sentry-manager on the js side in patch in #6890. It does not give us
-          // additional useful information.
-          //sendError(packageID, keyboardID, "");
+          // additional useful information. So we don't re-send to Sentry.
+          sendError(packageID, keyboardID, "", false);
         }
 
         return true;
@@ -443,7 +443,7 @@ final class KMKeyboard extends WebView {
     }
 
     if (!KMManager.shouldAllowSetKeyboard() || kbInfo == null) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       retVal = false;
     } else {
@@ -474,7 +474,7 @@ final class KMKeyboard extends WebView {
 
     if (!KMManager.shouldAllowSetKeyboard() ||
         (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
       keyboardID = kbInfo.getKeyboardID();
@@ -528,7 +528,7 @@ final class KMKeyboard extends WebView {
 
     if (!KMManager.shouldAllowSetKeyboard() ||
         (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
       keyboardID = kbInfo.getKeyboardID();
@@ -613,14 +613,14 @@ final class KMKeyboard extends WebView {
 
   // Display localized Toast notification that keyboard selection failed, so loading default keyboard.
   // Also sends a message to Sentry (not localized)
-  private void sendError(String packageID, String keyboardID, String languageID) {
+  private void sendError(String packageID, String keyboardID, String languageID, boolean reportToSentry) {
     this.currentKeyboardErrorReports++;
 
     if(this.currentKeyboardErrorReports == 1) {
       BaseActivity.makeToast(context, R.string.fatal_keyboard_error_short, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
     }
 
-    if(this.currentKeyboardErrorReports < 5) {
+    if(this.currentKeyboardErrorReports < 5 && reportToSentry) {
       // We'll only report up to 5 errors in a given keyboard to avoid spamming
       // errors and using unnecessary bandwidth doing so
       // Don't use localized string R.string.fatal_keyboard_error msg for Sentry

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -685,7 +685,12 @@ final class KMKeyboard extends WebView {
         breadcrumb.setData("keyboardVersion", this.keyboardVersion);
       }
       Sentry.addBreadcrumb(breadcrumb);
-      Sentry.captureMessage(message, SentryLevel.ERROR);
+      //
+      // We now rely on Sentry within KMW to capture these errors
+      // We'll continue to capture breadcrumbs so we can associate
+      // java-side errors with javascript-side errors.
+      //Sentry.captureMessage(message, SentryLevel.ERROR);
+      //
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -169,7 +169,10 @@ final class KMKeyboard extends WebView {
           String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";
           String sourceID = cm.sourceId().replaceAll(NAVIGATION_PATTERN, "$1$2");
           sendKMWError(cm.lineNumber(), sourceID, cm.message());
-          sendError(packageID, keyboardID, "");
+          // This duplicates the sendKMWError message, which itself duplicates the reporting now
+          // managed by sentry-manager on the js side in patch in #6890. It does not give us
+          // additional useful information.
+          //sendError(packageID, keyboardID, "");
         }
 
         return true;

--- a/common/core/web/tools/sentry-manager/src/index.ts
+++ b/common/core/web/tools/sentry-manager/src/index.ts
@@ -62,7 +62,11 @@ namespace com.keyman {
     pathFilter(event: any) {
       // Get the underlying JS error.
       let exception = event.exception;
-
+      if(!exception) {
+        // events are not required to have an exception property
+        // e.g. console.log-type events
+        return;
+      }
       // Iterate through all wrapped exceptions.
       for(let e of exception.values) {
         // If Sentry was unable to generate a stacktrace, there's no path filtering to
@@ -97,7 +101,7 @@ namespace com.keyman {
     }
 
     // Sanitizes the event object (in-place) to remove sensitive information
-    // from the breadcrumbs and url
+    // from the breadcrumbs and url (for embedded KeymanWeb)
     sanitizeEvent(event: any) {
       if (event && event.breadcrumbs) {
         event.breadcrumbs.forEach((b: any) => {
@@ -109,7 +113,7 @@ namespace com.keyman {
         });
       }
 
-      if (event.request.url) {
+      if (event.request && event.request.url) {
         let URL_PATTERN = /#.*$/;
         event.request.url = event.request.url.replace(URL_PATTERN, '');
       }
@@ -168,6 +172,52 @@ namespace com.keyman {
       }
     }
 
+    /**
+     * Capture errors and warnings logged to Console in order to get
+     * stack traces. We can't use CaptureConsole integration until we
+     * upgrade to a newer version of Sentry, which has a bit of a cascade
+     * of changes required, in particular a change of module type and
+     * transpiling down to ES5.
+     *
+     * https://stackoverflow.com/a/53214615/1836776
+     */
+    initConsole() {
+      // creating function declarations for better stacktraces (otherwise they'd be anonymous function expressions)
+      let oldConsoleError = console.error;
+      console.error = reportingConsoleError; // defined via function hoisting
+      function reportingConsoleError() {
+        let args = Array.prototype.slice.call(arguments);
+        Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        return oldConsoleError.apply(console, args);
+      };
+
+      let oldConsoleWarn = console.warn;
+      console.warn = reportingConsoleWarn; // defined via function hoisting
+      function reportingConsoleWarn() {
+        let args = Array.prototype.slice.call(arguments);
+        Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        return oldConsoleWarn.apply(console, args);
+      }
+
+      function reduceConsoleArgs(args) {
+        let errorMsg = args[0];
+        // Make sure errorMsg is either an error or string.
+        // It's therefore best to pass in new Error('msg') instead of just 'msg' since
+        // that'll give you a stack trace leading up to the creation of that new Error
+        // whereas if you just pass in a plain string 'msg', the stack trace will include
+        // reportingConsoleError and reportingConsoleCall
+        if (!(errorMsg instanceof Error)) {
+          // stringify all args as a new Error (which creates a stack trace)
+          errorMsg = new Error(
+            args.reduce(function(accumulator, currentValue) {
+              return accumulator.toString() + ' ' + currentValue.toString();
+            }, '')
+          );
+        }
+        return errorMsg;
+      }
+    }
+
     init() {
       // Do the actual Sentry initialization.
       //@ts-ignore
@@ -179,6 +229,8 @@ namespace com.keyman {
         release: com.keyman.environment.SENTRY_RELEASE,
         environment: com.keyman.environment.ENVIRONMENT
       });
+
+      this.initConsole();
     }
 
     get enabled(): boolean {

--- a/common/core/web/tools/sentry-manager/src/index.ts
+++ b/common/core/web/tools/sentry-manager/src/index.ts
@@ -190,6 +190,7 @@ namespace com.keyman {
       function reportingConsoleError() {
         let args = Array.prototype.slice.call(arguments);
         if(_this._enabled) {
+          //@ts-ignore
           Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
         }
         return oldConsoleError.apply(console, args);
@@ -200,6 +201,7 @@ namespace com.keyman {
       function reportingConsoleWarn() {
         let args = Array.prototype.slice.call(arguments);
         if(_this._enabled) {
+          //@ts-ignore
           Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
         }
         return oldConsoleWarn.apply(console, args);

--- a/common/core/web/tools/sentry-manager/src/index.ts
+++ b/common/core/web/tools/sentry-manager/src/index.ts
@@ -113,7 +113,7 @@ namespace com.keyman {
         });
       }
 
-      if (event.request && event.request.url) {
+      if (event && event.request && event.request.url) {
         let URL_PATTERN = /#.*$/;
         event.request.url = event.request.url.replace(URL_PATTERN, '');
       }

--- a/common/core/web/tools/sentry-manager/src/index.ts
+++ b/common/core/web/tools/sentry-manager/src/index.ts
@@ -184,10 +184,14 @@ namespace com.keyman {
     initConsole() {
       // creating function declarations for better stacktraces (otherwise they'd be anonymous function expressions)
       let oldConsoleError = console.error;
+      let _this = this;
+      // Note that Sentry may have overridden console.error so we are re-overriding it here post-init.
       console.error = reportingConsoleError; // defined via function hoisting
       function reportingConsoleError() {
         let args = Array.prototype.slice.call(arguments);
-        Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        if(_this._enabled) {
+          Sentry.captureException(reduceConsoleArgs(args), { level: 'error' });
+        }
         return oldConsoleError.apply(console, args);
       };
 
@@ -195,7 +199,9 @@ namespace com.keyman {
       console.warn = reportingConsoleWarn; // defined via function hoisting
       function reportingConsoleWarn() {
         let args = Array.prototype.slice.call(arguments);
-        Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        if(_this._enabled) {
+          Sentry.captureMessage(reduceConsoleArgs(args), { level: 'warning' });
+        }
         return oldConsoleWarn.apply(console, args);
       }
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -1,21 +1,24 @@
+let _debug = false;
 
-console = new Object();
-console.log = function(log) {
-    var iframe = document.createElement("IFRAME");
-    iframe.setAttribute("src", "ios-log:#iOS#" + log);
-    document.documentElement.appendChild(iframe);
-    iframe.parentNode.removeChild(iframe);
-    iframe = null;
-    if (typeof(window.webkit) != 'undefined')
-        window.webkit.messageHandlers.keyman.postMessage("ios-log:#iOS#" + log);
-};
-console.debug = console.log;
-console.info = console.log;
-console.warn = console.log;
-console.error = console.log;
-window.onerror = function(error, url, line) {
-    console.log('ERROR: '+error+' URL:'+url+' L:'+line);
-};
+if(_debug) {
+    console = new Object();
+    console.log = function(log) {
+        var iframe = document.createElement("IFRAME");
+        iframe.setAttribute("src", "ios-log:#iOS#" + log);
+        document.documentElement.appendChild(iframe);
+        iframe.parentNode.removeChild(iframe);
+        iframe = null;
+        if (typeof(window.webkit) != 'undefined')
+            window.webkit.messageHandlers.keyman.postMessage("ios-log:#iOS#" + log);
+    };
+    console.debug = console.log;
+    console.info = console.log;
+    console.warn = console.log;
+    console.error = console.log;
+    window.onerror = function(error, url, line) {
+        console.log('ERROR: '+error+' URL:'+url+' L:'+line);
+    };
+}
 
 var device = 'AppleMobile';
 var oskHeight = 0;

--- a/web/source/dom/domManager.ts
+++ b/web/source/dom/domManager.ts
@@ -1647,9 +1647,7 @@ namespace com.keyman.dom {
 
       // Exit initialization here if we're using an embedded code path.
       if(this.keyman.isEmbedded) {
-        if(!this.keyman.keyboardManager.setDefaultKeyboard()) {
-          console.error("No keyboard stubs exist - cannot initialize keyboard!");
-        }
+        this.keyman.keyboardManager.setDefaultKeyboard();
         return Promise.resolve();
       }
 


### PR DESCRIPTION
Cherry-pick of #6890 and #6905.

Only change is to add `//@ts-ignore` for Sentry calls, required for 15.0 branch, not needed in 16.0.

@keymanapp-test-bot skip