### PR TITLE
chore(android): disable sendError for js errors

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -171,8 +171,8 @@ final class KMKeyboard extends WebView {
           sendKMWError(cm.lineNumber(), sourceID, cm.message());
           // This duplicates the sendKMWError message, which itself duplicates the reporting now
           // managed by sentry-manager on the js side in patch in #6890. It does not give us
-          // additional useful information.
-          //sendError(packageID, keyboardID, "");
+          // additional useful information. So we don't re-send to Sentry.
+          sendError(packageID, keyboardID, "", false);
         }
 
         return true;
@@ -443,7 +443,7 @@ final class KMKeyboard extends WebView {
     }
 
     if (!KMManager.shouldAllowSetKeyboard() || kbInfo == null) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       retVal = false;
     } else {
@@ -474,7 +474,7 @@ final class KMKeyboard extends WebView {
 
     if (!KMManager.shouldAllowSetKeyboard() ||
         (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
       keyboardID = kbInfo.getKeyboardID();
@@ -528,7 +528,7 @@ final class KMKeyboard extends WebView {
 
     if (!KMManager.shouldAllowSetKeyboard() ||
         (packageID.equals(KMManager.KMDefault_UndefinedPackageID) && keyboardVersion == null)) {
-      sendError(packageID, keyboardID, languageID);
+      sendError(packageID, keyboardID, languageID, true);
       Keyboard kbInfo = KeyboardController.getInstance().getKeyboardInfo(0);
       packageID = kbInfo.getPackageID();
       keyboardID = kbInfo.getKeyboardID();
@@ -613,14 +613,14 @@ final class KMKeyboard extends WebView {
 
   // Display localized Toast notification that keyboard selection failed, so loading default keyboard.
   // Also sends a message to Sentry (not localized)
-  private void sendError(String packageID, String keyboardID, String languageID) {
+  private void sendError(String packageID, String keyboardID, String languageID, boolean reportToSentry) {
     this.currentKeyboardErrorReports++;
 
     if(this.currentKeyboardErrorReports == 1) {
       BaseActivity.makeToast(context, R.string.fatal_keyboard_error_short, Toast.LENGTH_LONG, packageID, keyboardID, languageID);
     }
 
-    if(this.currentKeyboardErrorReports < 5) {
+    if(this.currentKeyboardErrorReports < 5 && reportToSentry) {
       // We'll only report up to 5 errors in a given keyboard to avoid spamming
       // errors and using unnecessary bandwidth doing so
       // Don't use localized string R.string.fatal_keyboard_error msg for Sentry

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -169,7 +169,10 @@ final class KMKeyboard extends WebView {
           String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";
           String sourceID = cm.sourceId().replaceAll(NAVIGATION_PATTERN, "$1$2");
           sendKMWError(cm.lineNumber(), sourceID, cm.message());
-          sendError(packageID, keyboardID, "");
+          // This duplicates the sendKMWError message, which itself duplicates the reporting now
+          // managed by sentry-manager on the js side in patch in #6890. It does not give us
+          // additional useful information.
+          //sendError(packageID, keyboardID, "");
         }
 
         return true;


### PR DESCRIPTION
@keymanapp-test-bot skip

This is a follow-up to #6890 and already cherry-picked to #6904.

Turns out that we were getting *three* reports of JS errors on Android. These are also pretty useless for the same reason as for `sendKMWError`, and in fact conflated the JS errors with other kinds of errors. This makes it very hard to pick out the non-JS errors from the noise.