### PR TITLE
fix(developer): set contextDevice in web debugger 🖇️

### DIFF
--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -202,7 +202,10 @@ window.onload = function() {
       keyman.osk = null;
     }
 
+    // Create a new on screen keyboard view and tell KeymanWeb that
+    // we are using the targetDevice for context input.
     newOSK = new com.keyman.osk.InlinedOSKView(targetDevice, keyman.util.device.coreSpec);
+    keyman.core.contextDevice = targetDevice;
 
     if(document.body.offsetWidth < targetDevice.dimensions[0]) {
       newOSK.setSize('320px', '200px');


### PR DESCRIPTION
With the fix in fix/web/context-only-device, we need to ensure that the debugger correctly tells KeymanWeb which device is active.

@keymanapp-test-bot skip