### PR TITLE
fix(web): ncaps rules not matching on touch 🔥

### DIFF
--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -386,6 +386,8 @@ namespace com.keyman.text {
 
       if(layerId.indexOf('caps') >= 0) {
         modifier |= Codes.modifierCodes['CAPS'];
+      } else {
+        modifier |= Codes.modifierCodes['NO_CAPS'];
       }
 
       return modifier;


### PR DESCRIPTION
Fixes #6910.

Regression introduced in #6874 / #6849 (which themselves were improving the Caps Lock situation).

Ensures that either `NO_CAPS` or `CAPS` is always set in the modifier flags.

# User Testing

* **TEST_DEGA:** Test that typing <kbd>a</kbd><kbd>a</kbd> on the Dega keyboard on mobile web, iOS or Android, on the touch keyboard, gives the expected `â`.
* **TEST_KHMER:** Test that typing on the Khmer Angkor keyboard on mobile web, iOS or Android, on the touch keyboard, gives expected results (e.g. type xEjmr gives the right result).