### PR TITLE
fix(web): ncaps rules not matching on touch 🔥 🍒

### DIFF
--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -386,6 +386,8 @@ namespace com.keyman.text {
 
       if(layerId.indexOf('caps') >= 0) {
         modifier |= Codes.modifierCodes['CAPS'];
+      } else {
+        modifier |= Codes.modifierCodes['NO_CAPS'];
       }
 
       return modifier;


### PR DESCRIPTION
Fixes #6910.

Cherry-pick of #6911.

Regression introduced in #6874 / #6849 (which themselves were improving the Caps Lock situation).

Ensures that either `NO_CAPS` or `CAPS` is always set in the modifier flags.

@keymanapp-test-bot skip.