### PR TITLE
feat(developer): compiler regression support (build kmcomp-$version.zip during release build) 🚦

### DIFF
--- a/common/windows/cpp/src/keymansentry.cpp
+++ b/common/windows/cpp/src/keymansentry.cpp
@@ -222,6 +222,11 @@ void keyman_sentry_report_start() {
 }
 
 int keyman_sentry_main(bool is_keyman_developer, const char *logger, int argc, char *argv[], int (*run)(int, char**)) {
+  if (GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "wine_get_version") != NULL) {
+    // We always disable Sentry when running under WINE, because
+    // Sentry/dbghelp calls are failing on WINE.
+    return run(argc, argv);
+  }
   keyman_sentry_init(is_keyman_developer, logger);
   keyman_sentry_setexceptionfilter();
   keyman_sentry_report_start();

--- a/developer/src/inst/download.in.mak
+++ b/developer/src/inst/download.in.mak
@@ -113,13 +113,17 @@ make-kmcomp-install-zip: copy-schemas
     cd $(DEVELOPER_ROOT)\bin
 
     $(WZZIP) -bd -bb0 $(KMCOMP_ZIP) \
-        kmcomp.exe kmcmpdll.dll kmcomp.x64.exe kmcmpdll.x64.dll \
+        kmcomp.exe kmcmpdll.dll \
+        kmcomp.x64.exe kmcmpdll.x64.dll \
         kmconvert.exe \
+        sentry.dll sentry.x64.dll \
+        kmdecomp.exe \
         keyboard_info.source.json keyboard_info.distribution.json \
         keyman-touch-layout.spec.json keyman-touch-layout.clean.spec.json \
         xml\layoutbuilder\*.keyman-touch-layout \
         projects\* \
         server\*
+
 
 copy-schemas:
     copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.source.json $(DEVELOPER_ROOT)\bin

--- a/developer/src/inst/download.in.mak
+++ b/developer/src/inst/download.in.mak
@@ -19,10 +19,10 @@ KEYMAN_WIX_TEMP_TEMPLATES=$(TEMP)\keyman_wix_build\templates
 KEYMAN_WIX_TEMP_MODELCOMPILER=$(TEMP)\keyman_wix_build\ModelCompiler
 KEYMAN_WIX_TEMP_SERVER=$(TEMP)\keyman_wix_build\Server
 
-KEYMAN_WIX_KMDEV_SERVER=$(DEVELOPER_ROOT)\src\server\build
+KEYMAN_WIX_KMDEV_SERVER=$(DEVELOPER_ROOT)\bin\server
 KEYMAN_DEVELOPER_TEMPLATES_ROOT=$(DEVELOPER_ROOT)\src\kmconvert\data
 
-copykmdev: makeinstaller
+copykmdev: makeinstaller make-kmcomp-install-zip
     -mkdir $(DEVELOPER_ROOT)\release\$Version
     copy /Y $(DEVELOPER_ROOT)\src\inst\keymandeveloper.msi $(DEVELOPER_ROOT)\release\$Version\keymandeveloper.msi
     copy /Y $(DEVELOPER_ROOT)\src\inst\keymandeveloper-$Version.exe $(DEVELOPER_ROOT)\release\$Version\keymandeveloper-$Version.exe
@@ -102,3 +102,28 @@ makeinstaller:
     $(WZZIP) setup.zip keymandeveloper.msi setup.inf
     copy /b $(DEVELOPER_PROGRAM)\setup.exe + setup.zip keymandeveloper-$Version.exe
     $(SIGNCODE) /d "Keyman Developer" keymandeveloper-$Version.exe
+
+#
+# Zip the files we distribute as part of the standalone kmcomp distro into release\$Version\kmcomp-$Version.zip
+#
+
+KMCOMP_ZIP=$(DEVELOPER_ROOT)\release\$Version\kmcomp-$Version.zip
+
+make-kmcomp-install-zip: copy-schemas
+    cd $(DEVELOPER_ROOT)\bin
+
+    $(WZZIP) -bd -bb0 $(KMCOMP_ZIP) \
+        kmcomp.exe kmcmpdll.dll kmcomp.x64.exe kmcmpdll.x64.dll \
+        kmconvert.exe \
+        keyboard_info.source.json keyboard_info.distribution.json \
+        keyman-touch-layout.spec.json keyman-touch-layout.clean.spec.json \
+        xml\layoutbuilder\*.keyman-touch-layout \
+        projects\* \
+        server\*
+
+copy-schemas:
+    copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.source.json $(DEVELOPER_ROOT)\bin
+    copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.distribution.json $(DEVELOPER_ROOT)\bin
+    copy $(KEYMAN_ROOT)\common\schemas\keyman-touch-layout\keyman-touch-layout.spec.json $(DEVELOPER_ROOT)\bin
+    copy $(KEYMAN_ROOT)\common\schemas\keyman-touch-layout\keyman-touch-layout.clean.spec.json $(DEVELOPER_ROOT)\bin
+

--- a/developer/src/kmdecomp/savekeyboard.cpp
+++ b/developer/src/kmdecomp/savekeyboard.cpp
@@ -192,7 +192,7 @@ PWCHAR ifvalue(WCHAR ch)
   return L"=";
 }
 
-#define BUFSIZE 512
+#define BUFSIZE 2048
 PWCHAR ExtString(PWCHAR str)
 {
 	static WCHAR buf[2][BUFSIZE], bufpointer = 0;	// allows for multiple strings in one printf
@@ -369,17 +369,18 @@ void wr(FILE *fp, PWSTR buf)
 	fwrite(buf, wcslen(buf) * 2, 1, fp);
 }
 
-int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *filename, char *bmpfile)
+int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char* filename, char* bmpfile)
 {
-	PWCHAR buf;
-	FILE *fp;
-	LPSTORE sp;
-	LPGROUP gp;
-	LPKEY kp;
-	unsigned int i, j;
-  char bmpbuf[256];
+  PWCHAR buf;
+  FILE* fp;
+  LPSTORE sp;
+  LPGROUP gp;
+  LPKEY kp;
+  unsigned int i, j;
+  char bmpbuf[_MAX_PATH];
+  char bmp_drive[_MAX_DRIVE], bmp_dir[_MAX_DIR], bmp_filename[_MAX_FNAME], bmp_ext[_MAX_EXT];
 
-	buf = new WCHAR[1024];
+	buf = new WCHAR[2048];
 
 	g_kbd = kbd;
 
@@ -405,7 +406,10 @@ int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *fi
 
     if(sp->dwSystemID == TSS_BITMAP)
     {
-      WideCharToMultiByte(CP_ACP, 0, sp->dpString, -1, bmpbuf, 256, NULL, NULL);
+      WideCharToMultiByte(CP_ACP, 0, sp->dpString, -1, bmpbuf, _MAX_PATH, NULL, NULL);
+      _splitpath_s(bmpbuf, NULL, NULL, NULL, NULL, bmp_filename, _MAX_FNAME, bmp_ext, _MAX_EXT);
+      _splitpath_s(bmpfile, bmp_drive, _MAX_DRIVE, bmp_dir, _MAX_DIR, NULL, NULL, NULL, NULL);
+      _makepath_s(bmpbuf, _MAX_PATH, bmp_drive, bmp_dir, bmp_filename, bmp_ext);
       bmpfile = bmpbuf;
     }
 		wr(fp, buf);
@@ -452,7 +456,9 @@ int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *fi
 	wsprintfW(buf, L"c EOF\n\n"); wr(fp, buf);
 	fclose(fp);
 
-	SaveBitmapFile(lpBitmap, cbBitmap, bmpfile);
+  if (lpBitmap && cbBitmap && bmpfile && *bmpfile) {
+    SaveBitmapFile(lpBitmap, cbBitmap, bmpfile);
+  }
 
 	return 0;
 }

--- a/developer/src/server/build.sh
+++ b/developer/src/server/build.sh
@@ -28,7 +28,7 @@ display_usage ( ) {
   echo "       $0 --help"
   echo
   echo "  --help                      displays this screen and exits"
-  echo "  --production, -p            builds production release in build/"
+  echo "  --production, -p            builds production release in /developer/bin/server/"
   echo "  --skip-package-install, -S  don't run npm install (not valid with --production)"
   echo "  --test, -t                  runs unit tests after building"
   #echo "  --watch, -w                 builds dev server in watch mode"
@@ -184,10 +184,10 @@ if (( production )) ; then
   mkdir -p "$PRODBUILDTEMP/node_modules/@keymanapp/"
   cp -R "$KEYMAN_ROOT/node_modules/@keymanapp/keyman-version/" "$PRODBUILDTEMP/node_modules/@keymanapp/"
 
-  # We'll build in the build/ folder
-  rm -rf build/
-  mkdir -p build/dist/
-  cp -R dist/* build/dist/
-  cp -R "$PRODBUILDTEMP"/* build/
+  # We'll build in the $KEYMAN_ROOT/developer/bin/server/ folder
+  rm -rf "$KEYMAN_ROOT/developer/bin/server/"
+  mkdir -p "$KEYMAN_ROOT/developer/bin/server/dist/"
+  cp -R dist/* "$KEYMAN_ROOT/developer/bin/server/dist/"
+  cp -R "$PRODBUILDTEMP"/* "$KEYMAN_ROOT/developer/bin/server/"
   rm -rf "$PRODBUILDTEMP"
 fi

--- a/developer/src/tools/sentry-upload-difs.sh
+++ b/developer/src/tools/sentry-upload-difs.sh
@@ -41,4 +41,4 @@ cd "$KEYMAN_ROOT/developer/src"
 
 echo "Uploading symbols for developer/"
 sentry-cli upload-dif -p keyman-developer -t breakpad -t pdb . --include-sources
-sentry-cli releases -p keyman-developer files "release-$VERSION_WITH_TAG" upload-sourcemaps ./TIKE/xml ./server/build ./kmlmc/dist
+sentry-cli releases -p keyman-developer files "release-$VERSION_WITH_TAG" upload-sourcemaps ./TIKE/xml ../bin/server ./kmlmc/dist


### PR DESCRIPTION
Replaces the script building kmcomp-$version.zip in TeamCity. Will be used for more automated keyboard testing shortly.

Means kmcomp-$version.zip will be available as an artifact in all test builds.

I have adjusted the TeamCity release build configuration for Developer to only build kmcomp-$version.zip if it needs to. Once this merges, I will cleanup the old code in that build configuration as it is 16.0+ (the older build is part of Keyman for Windows 14.0 build and that won't change for now).

Note: also moves the distribution point for Keyman Developer Server from src/server/build to bin/server (where it really belongs and can be included in the archives more easily).

@keymanapp-test-bot skip