### PR TITLE
fix(developer): kmdecomp stability tweaks 🚦

### DIFF
--- a/common/windows/cpp/src/keymansentry.cpp
+++ b/common/windows/cpp/src/keymansentry.cpp
@@ -222,7 +222,7 @@ void keyman_sentry_report_start() {
 }
 
 int keyman_sentry_main(bool is_keyman_developer, const char *logger, int argc, char *argv[], int (*run)(int, char**)) {
-  if (GetProcAddress(GetModuleHandle("ntdll.dll"), "wine_get_version") != NULL) {
+  if (GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "wine_get_version") != NULL) {
     // We always disable Sentry when running under WINE, because
     // Sentry/dbghelp calls are failing on WINE.
     return run(argc, argv);

--- a/common/windows/cpp/src/keymansentry.cpp
+++ b/common/windows/cpp/src/keymansentry.cpp
@@ -222,6 +222,11 @@ void keyman_sentry_report_start() {
 }
 
 int keyman_sentry_main(bool is_keyman_developer, const char *logger, int argc, char *argv[], int (*run)(int, char**)) {
+  if (GetProcAddress(GetModuleHandle("ntdll.dll"), "wine_get_version") != NULL) {
+    // We always disable Sentry when running under WINE, because
+    // Sentry/dbghelp calls are failing on WINE.
+    return run(argc, argv);
+  }
   keyman_sentry_init(is_keyman_developer, logger);
   keyman_sentry_setexceptionfilter();
   keyman_sentry_report_start();

--- a/developer/src/inst/download.in.mak
+++ b/developer/src/inst/download.in.mak
@@ -113,13 +113,17 @@ make-kmcomp-install-zip: copy-schemas
     cd $(DEVELOPER_ROOT)\bin
 
     $(WZZIP) -bd -bb0 $(KMCOMP_ZIP) \
-        kmcomp.exe kmcmpdll.dll kmcomp.x64.exe kmcmpdll.x64.dll \
+        kmcomp.exe kmcmpdll.dll \
+        kmcomp.x64.exe kmcmpdll.x64.dll \
         kmconvert.exe \
+        sentry.dll sentry.x64.dll \
+        kmdecomp.exe \
         keyboard_info.source.json keyboard_info.distribution.json \
         keyman-touch-layout.spec.json keyman-touch-layout.clean.spec.json \
         xml\layoutbuilder\*.keyman-touch-layout \
         projects\* \
         server\*
+
 
 copy-schemas:
     copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.source.json $(DEVELOPER_ROOT)\bin

--- a/developer/src/kmdecomp/savekeyboard.cpp
+++ b/developer/src/kmdecomp/savekeyboard.cpp
@@ -192,7 +192,7 @@ PWCHAR ifvalue(WCHAR ch)
   return L"=";
 }
 
-#define BUFSIZE 512
+#define BUFSIZE 2048
 PWCHAR ExtString(PWCHAR str)
 {
 	static WCHAR buf[2][BUFSIZE], bufpointer = 0;	// allows for multiple strings in one printf
@@ -369,17 +369,18 @@ void wr(FILE *fp, PWSTR buf)
 	fwrite(buf, wcslen(buf) * 2, 1, fp);
 }
 
-int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *filename, char *bmpfile)
+int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char* filename, char* bmpfile)
 {
-	PWCHAR buf;
-	FILE *fp;
-	LPSTORE sp;
-	LPGROUP gp;
-	LPKEY kp;
-	unsigned int i, j;
-  char bmpbuf[256];
+  PWCHAR buf;
+  FILE* fp;
+  LPSTORE sp;
+  LPGROUP gp;
+  LPKEY kp;
+  unsigned int i, j;
+  char bmpbuf[_MAX_PATH];
+  char bmp_drive[_MAX_DRIVE], bmp_dir[_MAX_DIR], bmp_filename[_MAX_FNAME], bmp_ext[_MAX_EXT];
 
-	buf = new WCHAR[1024];
+	buf = new WCHAR[2048];
 
 	g_kbd = kbd;
 
@@ -405,7 +406,10 @@ int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *fi
 
     if(sp->dwSystemID == TSS_BITMAP)
     {
-      WideCharToMultiByte(CP_ACP, 0, sp->dpString, -1, bmpbuf, 256, NULL, NULL);
+      WideCharToMultiByte(CP_ACP, 0, sp->dpString, -1, bmpbuf, _MAX_PATH, NULL, NULL);
+      _splitpath_s(bmpbuf, NULL, NULL, NULL, NULL, bmp_filename, _MAX_FNAME, bmp_ext, _MAX_EXT);
+      _splitpath_s(bmpfile, bmp_drive, _MAX_DRIVE, bmp_dir, _MAX_DIR, NULL, NULL, NULL, NULL);
+      _makepath_s(bmpbuf, _MAX_PATH, bmp_drive, bmp_dir, bmp_filename, bmp_ext);
       bmpfile = bmpbuf;
     }
 		wr(fp, buf);
@@ -452,7 +456,9 @@ int SaveKeyboardSource(LPKEYBOARD kbd, LPBYTE lpBitmap, DWORD cbBitmap, char *fi
 	wsprintfW(buf, L"c EOF\n\n"); wr(fp, buf);
 	fclose(fp);
 
-	SaveBitmapFile(lpBitmap, cbBitmap, bmpfile);
+  if (lpBitmap && cbBitmap && bmpfile && *bmpfile) {
+    SaveBitmapFile(lpBitmap, cbBitmap, bmpfile);
+  }
 
 	return 0;
 }


### PR DESCRIPTION
This is part of a larger set of PRs coming which will automate the build of keyboards during the Keyman Developer build.

See also:

* keymanapp/keyboards#1913
* keymanapp/keyboards#1914

Adds kmdecomp to kmcomp-<version>.zip and fixes a couple of stability issues:

* Increase buffer sizes (this fix very much a hack)
* Ensures that .bmp/.ico files are saved to correct output folder
* Don't create zero byte .bmp if there is no .bmp embedded in the .kmx
* Disable loading sentry.dll when running on WINE

@keymanapp-test-bot skip