### PR TITLE
fix(developer): QR Code for Package Editor had wrong path

### DIFF
--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -2040,7 +2040,7 @@ begin
   begin
     b := TBitmap.Create;
     try
-      DrawQRCode(lbDebugHosts.Items[lbDebugHosts.ItemIndex] + '/packages.html', b);
+      DrawQRCode(lbDebugHosts.Items[lbDebugHosts.ItemIndex], b);
       imgQRCode.Picture.Bitmap := b;
     finally
       b.Free;


### PR DESCRIPTION
Fixes #6922.

Path changed in Keyman Developer 15.0, but was not updated here.

@keymanapp-test-bot skip