### PR TITLE
fix(ios): ignore CFBundleShortVersionString

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -122,9 +122,7 @@ public enum Util {
 
   /// The version of the Keyman SDK
   public static let sdkVersion: String = {
-    let url = Resources.bundle.url(forResource: "KeymanEngine-Info", withExtension: "plist")!
-    let info = NSDictionary(contentsOf: url)!
-    return info["CFBundleShortVersionString"] as! String
+    return Version.current.plainString
   }()
 }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/Version.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/Version.swift
@@ -25,8 +25,7 @@ public class Version: NSObject, Comparable {
   public static let latestFeature = packageBasedFileReorg
 
   public static var current: Version {
-    let engineInfo = Bundle(for: Manager.self).infoDictionary
-    return Version(engineInfo!["CFBundleShortVersionString"] as! String)!
+    return Version(Version.currentTagged.plainString)!
   }
 
   public static var currentTagged: Version {


### PR DESCRIPTION
Fixes #6932.

Use KeymanVersionWithTag from .plist instead of CFBundleShortVersionString when checking version information, because XCode can rewrite bundle version of frameworks.

@keymanapp-test-bot skip.