### PR TITLE
feat(developer): add hint support to Touch Layout Editor and schema 🙊

### DIFF
--- a/common/schemas/keyman-touch-layout/README.md
+++ b/common/schemas/keyman-touch-layout/README.md
@@ -84,16 +84,26 @@ optionally contain three additional properties: `font`, `fontsize`, and
 : A boolean value, if `true`, then the base layout's key cap will be displayed
   in the top left of the key cap. Defaults to `false`.
 
-* `displayHint`
+* `defaultHint`
 
-: A string value, one of `"none"`, `"dot"`, or `"text"`. Defaults to `"dot"`.
-  Controls the display of the hint on the key cap:
+: A string value. Default is `"dot"`.  Controls the display of the hint text on
+  the key cap, which is shown at the top right of the key cap.
 
   * `"none"`: show no hint on the key cap.
-  * `"dot"`: show a dot on top-right of key cap if a longpress menu
-    is available, default and only option for Keyman 15.0 and earlier.
-  * `"text"`: show the text `hint` property if present, often on
-    top-right of key cap.
+  * `"dot"`: show a dot on top-right of key cap if a longpress menu is
+    available, default. Matches behavior for Keyman 15.0 and earlier.
+  * `"longpress"`: show the default longpress key cap, if it exists.
+  * `"multitap"`: show the first multitap key cap, if it exists.
+  * `"flick"`: show the first flick key cap, selected in clockwise order,
+    starting from North.
+  * `"flick-n"`: show the key cap from the North flick, if it exists.
+  * `"flick-ne"`: show the key cap from the North-East flick, if it exists.
+  * `"flick-e"`: show the key cap from the East flick, if it exists.
+  * `"flick-se"`: show the key cap from the South-East flick, if it exists.
+  * `"flick-s"`: show the key cap from the South flick, if it exists.
+  * `"flick-sw"`: show the key cap from the South-West flick, if it exists.
+  * `"flick-w"`: show the key cap from the West flick, if it exists.
+  * `"flick-nw"`: show the key cap from the North-West flick, if it exists.
 
   Introduced in Keyman 16.0.
 
@@ -219,6 +229,9 @@ object](#sk-object). A `key` object must include either an `id` or `sp` property
 
 : String. If present, a small hint, often shown at top right of key cap.
 
+  Introduced in Keyman 16.0.
+
+
 * `layer`
 
 : String. If specified, overrides the modifier associated with the layer (this
@@ -309,7 +322,9 @@ object](#sk-object). A `key` object must include either an `id` or `sp` property
 
 : If present, defines additional keys that may be selected when using a
   flick gesture on the key, with a [`flick` object](#flick-object). Flicks
-  should not be used on modifier keys, special keys, or the Spacebar. Keyman 16+.
+  should not be used on modifier keys, special keys, or the Spacebar.
+
+  Introduced in Keyman 16.0.
 
 * `multitap`
 
@@ -317,11 +332,14 @@ object](#sk-object). A `key` object must include either an `id` or `sp` property
   tapping multiple times on the key, an array of [`sk` objects](#sk-object).
   Multitaps generally should not be used on modifier keys, special keys, or the
   Spacebar. Beware of mixing multitaps with layer switching, as this can lead to
-  a confusing user experience. Keyman 16+.
+  a confusing user experience.
 
   Keyman 15+: the Shift key has a predefined multitap sequence to access the
   `caps` layer, which is available if the `caps` layer is present. This is the
-  only multitap sequence supported in Keyman 15.
+  only multitap sequence supported in Keyman 15. This multitap sequence cannot
+  be overridden.
+
+  Introduced in Keyman 16.0.
 
 ## `sk` object
 
@@ -428,7 +446,7 @@ string") into the appropriate spec format.
 # .keyman-touch-layout version history
 
 ## 2022-06-30 2.0 stable
-* Add support for flick and multitap. Aligns with Keyman 16.0.
+* Add support for flick, multitap, hint, defaultHint. Aligns with Keyman 16.0.
 
 ## 2022-06-27 1.0 stable
 * Initial schema version and full documentation

--- a/common/schemas/keyman-touch-layout/README.md
+++ b/common/schemas/keyman-touch-layout/README.md
@@ -84,6 +84,19 @@ optionally contain three additional properties: `font`, `fontsize`, and
 : A boolean value, if `true`, then the base layout's key cap will be displayed
   in the top left of the key cap. Defaults to `false`.
 
+* `displayHint`
+
+: A string value, one of `"none"`, `"dot"`, or `"text"`. Defaults to `"dot"`.
+  Controls the display of the hint on the key cap:
+
+  * `"none"`: show no hint on the key cap.
+  * `"dot"`: show a dot on top-right of key cap if a longpress menu
+    is available, default and only option for Keyman 15.0 and earlier.
+  * `"text"`: show the text `hint` property if present, often on
+    top-right of key cap.
+
+  Introduced in Keyman 16.0.
+
 ## `layer` object
 
 The `layer` object describes one visible layer on a touch keyboard. It has two
@@ -201,6 +214,10 @@ object](#sk-object). A `key` object must include either an `id` or `sp` property
 * `text`
 
 : String. The string displayed on the key cap.
+
+* `hint`
+
+: String. If present, a small hint, often shown at top right of key cap.
 
 * `layer`
 

--- a/common/schemas/keyman-touch-layout/README.md
+++ b/common/schemas/keyman-touch-layout/README.md
@@ -330,14 +330,14 @@ object](#sk-object). A `key` object must include either an `id` or `sp` property
 
 : If present, defines an array of keys that may be selected sequentially when
   tapping multiple times on the key, an array of [`sk` objects](#sk-object).
-  Multitaps generally should not be used on modifier keys, special keys, or the
+  Multitaps may not be used on layer switch keys, special keys such as the globe key, or the
   Spacebar. Beware of mixing multitaps with layer switching, as this can lead to
   a confusing user experience.
 
   Keyman 15+: the Shift key has a predefined multitap sequence to access the
   `caps` layer, which is available if the `caps` layer is present. This is the
   only multitap sequence supported in Keyman 15. This multitap sequence cannot
-  be overridden.
+  be overridden, and is the sole case where multitap input may cause a layer switch.
 
   Introduced in Keyman 16.0.
 

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
@@ -23,7 +23,7 @@
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
         "layer": { "$ref": "#/definitions/layers" },
         "displayUnderlying": { "type": "boolean" },
-        "displayHint": { "type": "string", "enum": ["none","dot","text"] }
+        "defaultHint": { "type": "string", "enum": ["none","dot","longpress","multitap","flick","flick-n","flick-ne","flick-e","flick-se","flick-s","flick-sw","flick-w","flick-nw"] }
       },
       "required": ["layer"],
       "additionalProperties": false

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
@@ -22,7 +22,8 @@
         "font": { "$ref": "#/definitions/font-spec" },
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
         "layer": { "$ref": "#/definitions/layers" },
-        "displayUnderlying": { "type": "boolean" }
+        "displayUnderlying": { "type": "boolean" },
+        "displayHint": { "type": "string", "enum": ["none","dot","text"] }
       },
       "required": ["layer"],
       "additionalProperties": false
@@ -91,7 +92,8 @@
         "width": { "$ref" : "#/definitions/key-width" },
         "sk": { "$ref": "#/definitions/subkeys" },
         "flick": { "$ref": "#/definitions/flick" },
-        "multitap": { "$ref": "#/definitions/subkeys" }
+        "multitap": { "$ref": "#/definitions/subkeys" },
+        "hint": { "type": "string" }
       },
       "anyOf": [
         {"required": ["id"]},

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
@@ -20,7 +20,8 @@
         "font": { "$ref": "#/definitions/font-spec" },
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
         "layer": { "$ref": "#/definitions/layers" },
-        "displayUnderlying": { "type": "boolean" }
+        "displayUnderlying": { "type": "boolean" },
+        "displayHint": { "type": "string", "enum": ["none","dot","text"] }
       },
       "required": ["layer"],
       "additionalProperties": false
@@ -95,7 +96,8 @@
         "width": { "$ref" : "#/definitions/numeric" },
         "sk": { "$ref": "#/definitions/subkeys" },
         "flick": { "$ref": "#/definitions/flick" },
-        "multitap": { "$ref": "#/definitions/subkeys" }
+        "multitap": { "$ref": "#/definitions/subkeys" },
+        "hint": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
@@ -21,7 +21,7 @@
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
         "layer": { "$ref": "#/definitions/layers" },
         "displayUnderlying": { "type": "boolean" },
-        "displayHint": { "type": "string", "enum": ["none","dot","text"] }
+        "defaultHint": { "type": "string", "enum": ["none","dot","longpress","multitap","flick","flick-n","flick-ne","flick-e","flick-se","flick-s","flick-sw","flick-w","flick-nw"] }
       },
       "required": ["layer"],
       "additionalProperties": false

--- a/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
+++ b/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
@@ -60,9 +60,10 @@ const
     (Name: 'se'; ClassType: TJSONObject; Value: @SKDef; ValueSize: Length(SkDef))
   );
 
-  KeyDef: array[0..12] of TJSONDef = (
+  KeyDef: array[0..13] of TJSONDef = (
     (Name: 'id'; ClassType: TJSONString),
     (Name: 'text'; ClassType: TJSONString),
+    (Name: 'hint'; ClassType: TJSONString),
     (Name: 'sp'; ClassType: TJSONValue),
     (Name: 'width'; ClassType: TJSONValue),
     (Name: 'pad'; ClassType: TJSONValue),
@@ -86,10 +87,11 @@ const
     (Name: 'row'; ClassType: TJSONArray; Required: True; Value: @RowDef[0]; ValueSize: Length(RowDef))
   );
 
-  PlatformDef: array[0..3] of TJSONDef = (
+  PlatformDef: array[0..4] of TJSONDef = (
     (Name: 'font'; ClassType: TJSONString),
     (Name: 'fontsize'; ClassType: TJSONString),   // I4062
     (Name: 'displayUnderlying'; ClassType: TJSONBool),
+    (Name: 'displayHint'; ClassType: TJSONString),
     (Name: 'layer'; ClassType: TJSONArray; Required: True; Value: @LayerDef[0]; ValueSize: Length(LayerDef))
   );
 

--- a/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
+++ b/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
@@ -91,7 +91,7 @@ const
     (Name: 'font'; ClassType: TJSONString),
     (Name: 'fontsize'; ClassType: TJSONString),   // I4062
     (Name: 'displayUnderlying'; ClassType: TJSONBool),
-    (Name: 'displayHint'; ClassType: TJSONString),
+    (Name: 'defaultHint'; ClassType: TJSONString),
     (Name: 'layer'; ClassType: TJSONArray; Required: True; Value: @LayerDef[0]; ValueSize: Length(LayerDef))
   );
 

--- a/developer/src/tike/xml/layoutbuilder/builder.css
+++ b/developer/src/tike/xml/layoutbuilder/builder.css
@@ -1,9 +1,12 @@
-
 @font-face {
   font-family: KeymanwebOsk;
   font-style:  normal;
   font-weight: normal;
   src: url('keymanweb-osk.ttf')  format('truetype');
+}
+
+* {
+  box-sizing: border-box;
 }
 
 #selKeyCapType,
@@ -17,6 +20,8 @@ body {
   font-size: 18pt;
   padding: 0;
   margin: 0;
+  display: grid;
+  grid-template-columns: 152px 1fr;
 }
 
 .ui-dialog {
@@ -82,6 +87,15 @@ body {
   padding-bottom: 2px;
 }
 
+.toolbar-item.toolbar-single-column {
+  grid-template-columns: 1fr;
+}
+
+.toolbar-item.toolbar-2-small-buttons {
+  grid-template-columns: 1fr 24px 24px;
+  column-gap: 4px;
+}
+
 .toolbar-item label {
   padding: 0.75em 0;
 }
@@ -90,8 +104,11 @@ body {
 .toolbar-item input,
 .toolbar-item button {
   padding: 6px;
-  width: 140px;
-  box-sizing: border-box;
+  width: 100%;
+}
+
+.toolbar-item button.emoji-button {
+  padding: 6px 0;
 }
 
 .key-droppable
@@ -203,6 +220,18 @@ body {
   top: 1px;
   width: 10px;
   height: 10px;
+}
+
+.display-hint-none .has-longpress,
+.display-hint-text .has-longpress {
+  /* Fade out the has-longpress icon if displayHint is none or text */
+  opacity: 0.5;
+}
+
+.display-hint-dot .hint,
+.display-hint-none .hint {
+  /* Fade out the hint text if displayHint is dot or none */
+  color: #cccccc;
 }
 
 /* If we have both flick-n and longpress, we need to move the longpress icon down */
@@ -414,7 +443,6 @@ br.clear {
   clear: both;
 }
 
-#toolbar,
 #kbd-container,
 #sub-key-container {
   min-width: 1020px;
@@ -422,21 +450,29 @@ br.clear {
 
 #toolbar div {
   background: #DCDCDD;
-  margin: -1px -1px -1px 0;
-  padding: 8px;
-  float: left;
+}
+
+#toolbar h3 {
+  margin: 0;
+  padding: 0 0 4px 0;
+  font-size: 10pt;
+}
+
+#toolbar #controlToolbar > div {
+  margin: 4px 0;
+  padding: 4px;
+  line-height: 1.4em;
 }
 
 #toolbar #layoutToolbar > div {
-  margin: 0;
-  padding: 0 8px;
-  border-left: 1px solid #444444;
-  line-height: 24px;
+  margin: 4px 0;
+  padding: 4px;
+  border-top: 1px solid #444444;
+  line-height: 1.4em;
 }
 
 button, input, select {
   font: 9pt Tahoma;
-  margin: 1px 2px;
 }
 
 button {

--- a/developer/src/tike/xml/layoutbuilder/builder.css
+++ b/developer/src/tike/xml/layoutbuilder/builder.css
@@ -174,6 +174,14 @@ body {
   text-align: left;
 }
 
+.key .hint {
+  font-size: 12px;
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  text-align: right;
+}
+
 .key.key-modifier .id {
   color: #808080;
 }

--- a/developer/src/tike/xml/layoutbuilder/builder.css
+++ b/developer/src/tike/xml/layoutbuilder/builder.css
@@ -199,6 +199,10 @@ body {
   text-align: right;
 }
 
+.key .hint.custom-hint {
+  color: #0cb901;
+}
+
 .key.key-modifier .id {
   color: #808080;
 }
@@ -220,18 +224,6 @@ body {
   top: 1px;
   width: 10px;
   height: 10px;
-}
-
-.display-hint-none .has-longpress,
-.display-hint-text .has-longpress {
-  /* Fade out the has-longpress icon if displayHint is none or text */
-  opacity: 0.5;
-}
-
-.display-hint-dot .hint,
-.display-hint-none .hint {
-  /* Fade out the hint text if displayHint is dot or none */
-  color: #cccccc;
 }
 
 /* If we have both flick-n and longpress, we need to move the longpress icon down */
@@ -559,11 +551,11 @@ div#btnDelKey, div#btnDelSubKey {
     color: #FFFFFF;
     font-family: Tahoma;
     font-size: 10px;
-    height: 9px;
-    line-height: 6px;
+    height: 13px;
+    line-height: 8px;
     position: absolute;
     text-align: center;
-    width: 9px;
+    width: 13px;
 }
 
 div#btnDelKey:hover, div#btnDelSubKey:hover {

--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -52,12 +52,6 @@ $(function() {
     builder.saveState();
   });
 
-  $('#chkShowAllModifierOptions').click(function () {
-    builder.showAllModifierCombinations = $('#chkShowAllModifierOptions')[0].checked;
-    builder.fillModifierSelect();
-    builder.prepareKey();
-  });
-
   builder.removeAllSubKeys = function() {
     $('#sub-key-groups .key').remove();
   }
@@ -362,6 +356,8 @@ $(function() {
       var calcWidth = calcKeyWidth + calcGapWidth;
 
       $('#kbd').attr('class', builder.getPresentation());
+      $('#kbd').addClass('display-hint-'+(KVKL[builder.lastPlatform].displayHint ?? 'dot'));
+
     }
 
     builder.updateKeySizeInfo();
@@ -409,8 +405,6 @@ $(function() {
       option.attr('value', i).text(this.presentations[i].name);
       listContainer.append(option);
     }
-
-    $('#chkDisplayUnderlying')[0].checked = KVKL[builder.lastPlatform].displayUnderlying;
 
     builder.prepareLayers();
     builder.selectLayer(0);
@@ -822,11 +816,6 @@ $(function() {
   this.generate = function (display, force) {
     var json = JSON.stringify(KVKL, null, '  ');
 
-    if(!display) {
-      // Save changed settings -- only when not saving undo
-      KVKL[builder.lastPlatform].displayUnderlying = $('#chkDisplayUnderlying')[0].checked;
-    }
-
     var layer = KVKL[builder.lastPlatform].layer[builder.lastLayerIndex];
     layer.row = [];
 
@@ -896,14 +885,6 @@ $(function() {
   }, {rescale: true}));
 
   $('#btnGenerate').click(function () { builder.generate(false,false); });
-
-  $('#chkDisplayUnderlying').click(function () {
-    let selection = builder.saveSelection();
-    builder.saveUndo();
-    builder.generate();
-    builder.prepareLayer();
-    builder.restoreSelection(selection);
-  });
 
   $('input').focus(function () {
     builder.lastFocus = this;

--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -333,6 +333,7 @@ $(function() {
           .data('nextlayer', key.nextlayer)
           .data('layer', key.layer)
           .data('text', text)
+          .data('hint', key.hint)
           .data('longpress', key.sk)
           .data('flick', builder.translateFlickObjectToArray(key.flick))
           .data('multitap', key.multitap)
@@ -351,7 +352,9 @@ $(function() {
         builder.addKeyAnnotations(nkey);
 
         $('.text', nkey).text(this.renameSpecialKey(text));
+        $('.hint', nkey).text(key.hint);
         if(KVKL[builder.lastPlatform].displayUnderlying) $('.underlying', nkey).text(this.getStandardKeyCap(key.id, key.layer ? builder.isLayerIdShifted(key.layer) : isLayerShifted));
+
 
         builder.updateKeyId(nkey);
       }
@@ -668,6 +671,26 @@ $(function() {
     keyCapChange(val);
   }, {saveOnce: true});
 
+  const keyHintChange = function(val) {
+    const k = builder.selectedKey();
+    $('.hint', k).text(val);
+    k.data('hint', val);
+    builder.updateCharacterMap(val, false);
+  }
+
+  const inpKeyHintChange = builder.wrapChange(function (e) {
+    const val = $(this).val();
+    $('#inpKeyHintUnicode').val(builder.toUnicodeString(val));
+    keyHintChange(val);
+  }, {saveOnce: true});
+
+  const inpKeyHintUnicodeChange = builder.wrapChange(function (e) {
+    const val = builder.fromUnicodeString($(this).val());
+    $('#inpKeyHint').val(val);
+    keyHintChange(val);
+  }, {saveOnce: true});
+
+
   const selKeyCapTypeChange = builder.wrapChange(function () {
     var val = $(this).val();
     $('#inpKeyCap').val(val);
@@ -694,6 +717,28 @@ $(function() {
   $('#inpKeyCapUnicode')
     .on('input', inpKeyCapUnicodeChange)
     .change(inpKeyCapUnicodeChange)
+    .mouseup(function () {
+      builder.updateCharacterMap(builder.fromUnicodeString($(this).val()), false);
+    }).focus(function () {
+      builder.updateCharacterMap(builder.fromUnicodeString($(this).val()), false);
+    }).blur(function () {
+      builder.hasSavedKeyUndo = false;
+    });
+
+  $('#inpKeyHint')
+    .on('input', inpKeyHintChange)
+    .change(inpKeyHintChange)
+    .mouseup(function () {
+      builder.updateCharacterMap($(this).val(), false);
+    }).focus(function () {
+      builder.updateCharacterMap($(this).val(), false);
+    }).blur(function () {
+      builder.hasSavedKeyUndo = false;
+    });
+
+  $('#inpKeyHintUnicode')
+    .on('input', inpKeyHintUnicodeChange)
+    .change(inpKeyHintUnicodeChange)
     .mouseup(function () {
       builder.updateCharacterMap(builder.fromUnicodeString($(this).val()), false);
     }).focus(function () {
@@ -798,6 +843,7 @@ $(function() {
         key.fontsize = $(this).data('fontsize');
         key.nextlayer = $(this).data('nextlayer');
         key.layer = $(this).data('layer');
+        key.hint = $(this).data('hint');
         let longpress = $(this).data('longpress');
         if(longpress && longpress.length) key.sk = longpress;
         let flick = $(this).data('flick');

--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -890,10 +890,6 @@ $(function() {
     builder.lastFocus = this;
   });
 
-  $('input').click(function (event) {
-    event.stopImmediatePropagation();
-  });
-
   $('#btnTemplate').click(function () {
     builder.command('template');
   });

--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -304,15 +304,25 @@
         <label for='chkDisplayUnderlying'>Display underlying key label</label>
       </fieldset>
       <fieldset>
-        <div>Control display of text hints on the key. Note that when in "dot" mode,
-          the dot is not shown in the Touch Layout Editor, but will be visible when
-          using the compiled keyboard.<br/><br/>
+        <div>Default hint source for keys for this platform. These can be
+          overridden on a key-by-key basis. "Show a dot if a longpress is present"
+          is the behavior in Keyman 15 and earlier versions and is the default option.<br/><br/>
         </div>
-        <label for='selDisplayHint'>Display hint:</label>
-        <select id='selDisplayHint'>
-          <option value='none'>None</option>
-          <option value='dot'>Dot for longpress</option>
-          <option value='text'>Text hints</option>
+        <label for='selDefaultHint'>Default hint source:</label>
+        <select id='selDefaultHint'>
+          <option value='none'>No default hint</option>
+          <option value='dot'>Show a dot if a longpress is present</option>
+          <option value='longpress'>Use first longpress key cap</option>
+          <option value='multitap'>Use first multitap key cap</option>
+          <option value='flick'>Use first flick key cap (priority: n,ne,e,se,s,sw,w,nw)</option>
+          <option value='flick-n'>Use flick north key cap</option>
+          <option value='flick-ne'>Use flick north-east key cap</option>
+          <option value='flick-e'>Use flick east key cap</option>
+          <option value='flick-se'>Use flick south-east key cap</option>
+          <option value='flick-s'>Use flick south key cap</option>
+          <option value='flick-sw'>Use flick south-west key cap</option>
+          <option value='flick-w'>Use flick west key cap</option>
+          <option value='flick-nw'>Use flick north-west key cap</option>
         </select>
       </fieldset>
     </form>

--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -26,6 +26,7 @@
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>undo.js</xsl:attribute></script>
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>prepare-key.js</xsl:attribute></script>
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>subkeys.js</xsl:attribute></script>
+  <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>view-controls.js</xsl:attribute></script>
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>platform-controls.js</xsl:attribute></script>
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>layer-controls.js</xsl:attribute></script>
   <script><xsl:attribute name="src"><xsl:value-of select="/TouchLayoutBuilder/LibPath"/>builder-charmap.js</xsl:attribute></script>
@@ -34,203 +35,227 @@
   <script>initBuilder();</script>
 </head>
 <body class='text-controls-in-toolbar'>
-
   <div id='toolbar'>
     <div id='controlToolbar'>
-      <button id='btnTemplate'>Template...</button>
-      <button id='btnImport'>Import from On Screen</button>
+      <div>
+        <div class='toolbar-item toolbar-single-column'>
+          <button id='btnTemplate'>Template...</button>
+        </div>
+        <div class='toolbar-item toolbar-single-column'>
+          <button id='btnImport'>Import from On Screen</button>
+        </div>
+      </div>
     </div>
     <div id='layoutToolbar'>
       <div>
-        Platform: <select id='selPlatform'></select>
-        <button id='btnAddPlatform'>Add</button>
-        <button id='btnDelPlatform'>Del</button>
-        <input type='checkbox' id='chkDisplayUnderlying'/> <label for='chkDisplayUnderlying'>Display underlying</label>
+        <h3>View Controls</h3>
+        <div class='toolbar-item toolbar-single-column'>
+          <select id='selPlatformPresentation'></select>
+        </div>
+        <div class='toolbar-item toolbar-single-column'>
+          <button id='btnViewOptions'>View options...</button>
+        </div>
       </div>
       <div>
-        Layer: <select id='selLayer'></select>
-        <button id='btnAddLayer'>Add</button>
-        <button id='btnDelLayer'>Del</button>
-        <button id='btnEditLayer'>Edit</button>
+        <h3>Platform</h3>
+        <div class='toolbar-item toolbar-2-small-buttons'>
+          <select id='selPlatform'></select>
+          <button id='btnAddPlatform' class='emoji-button'>➕</button>
+          <button id='btnDelPlatform' class='emoji-button'>➖</button>
+        </div>
+        <div class='toolbar-item toolbar-single-column'>
+          <button id='btnEditPlatform'>Edit...</button>
+        </div>
       </div>
       <div>
-        Presentation: <select id='selPlatformPresentation'></select>
-        <input type='checkbox' id='chkShowAllModifierOptions'/> <label for='chkShowAllModifierOptions'>Show all modifier options</label>
+        <h3>Layer</h3>
+        <div class='toolbar-item toolbar-2-small-buttons'>
+          <select id='selLayer'></select>
+          <button id='btnAddLayer' class='emoji-button'>➕</button>
+          <button id='btnDelLayer' class='emoji-button'>➖</button>
+        </div>
+        <div class='toolbar-item toolbar-single-column'>
+          <button id='btnEditLayer'>Edit...</button>
+        </div>
       </div>
     </div>
     <br class='clear' />
   </div>
 
-  <!-- Keyboard Container -->
+  <div id='container'>
 
-  <div id='kbd-container'>
-    <div id='kbd-scroll-container'>
-      <div id='kbd'></div>
-    </div>
+    <!-- Keyboard Container -->
 
-    <!-- Keyboard Toolbar -->
-
-    <div id='keyToolbar'>
-
-      <div class='toolbar-item'>
-        <label for='selKeyCapType'>Keycap Value:</label>
-        <select id='selKeyCapType'>
-          <option value=''>Text</option>
-        </select>
+    <div id='kbd-container'>
+      <div id='kbd-scroll-container'>
+        <div id='kbd'></div>
       </div>
 
-      <div class='toolbar-item' id='key-cap-toolbar-item'>
-        <label for='inpKeyCap'>Text:</label>
-        <input id='inpKeyCap' type='text' size='16' />
-      </div>
+      <!-- Keyboard Toolbar -->
 
-      <div class='toolbar-item' id='key-cap-unicode-toolbar-item'>
-        <label for='inpKeyCapUnicode'>Unicode:</label>
-        <input id='inpKeyCapUnicode' type='text' size='16' />
-      </div>
+      <div id='keyToolbar'>
 
-      <div class='toolbar-item' id='key-hint-toolbar-item'>
-        <label for='inpKeyHint'>Hint:</label>
-        <input id='inpKeyHint' type='text' size='16' />
-      </div>
+        <div class='toolbar-item'>
+          <label for='selKeyCapType'>Keycap Value:</label>
+          <select id='selKeyCapType'>
+            <option value=''>Text</option>
+          </select>
+        </div>
 
-      <div class='toolbar-item' id='key-hint-unicode-toolbar-item'>
-        <label for='inpKeyHintUnicode'>Unicode:</label>
-        <input id='inpKeyHintUnicode' type='text' size='16' />
-      </div>
+        <div class='toolbar-item' id='key-cap-toolbar-item'>
+          <label for='inpKeyCap'>Text:</label>
+          <input id='inpKeyCap' type='text' size='16' />
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='selKeyType'>Key Type:</label>
-        <select id='selKeyType'>
-          <option value='0'>Default</option>
-          <option value='1'>Special</option>
-          <option value='2'>Special (active)</option>
-          <option value='8'>Deadkey</option>
-          <option value='9'>Blank</option>
-          <option value='10'>Spacer</option>
-        </select>
-      </div>
+        <div class='toolbar-item' id='key-cap-unicode-toolbar-item'>
+          <label for='inpKeyCapUnicode'>Unicode:</label>
+          <input id='inpKeyCapUnicode' type='text' size='16' />
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='selKeyLayerOverride'>Modifier:</label>
-        <select id='selKeyLayerOverride'></select>
-      </div>
+        <div class='toolbar-item' id='key-hint-toolbar-item'>
+          <label for='inpKeyHint'>Hint:</label>
+          <input id='inpKeyHint' type='text' size='16' />
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='inpKeyName'>ID:</label>
-        <input id='inpKeyName' type='text' size='16' maxlength='64' />
-      </div>
+        <div class='toolbar-item' id='key-hint-unicode-toolbar-item'>
+          <label for='inpKeyHintUnicode'>Unicode:</label>
+          <input id='inpKeyHintUnicode' type='text' size='16' />
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='inpKeyPadding'>Padding Left:</label>
-        <input id='inpKeyPadding' size='5' maxlength='5' />
-      </div>
+        <div class='toolbar-item'>
+          <label for='selKeyType'>Key Type:</label>
+          <select id='selKeyType'>
+            <option value='0'>Default</option>
+            <option value='1'>Special</option>
+            <option value='2'>Special (active)</option>
+            <option value='8'>Deadkey</option>
+            <option value='9'>Blank</option>
+            <option value='10'>Spacer</option>
+          </select>
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='inpKeyWidth'>Width:</label>
-        <input id='inpKeyWidth' size='5' maxlength='5' />
-      </div>
+        <div class='toolbar-item'>
+          <label for='selKeyLayerOverride'>Modifier:</label>
+          <select id='selKeyLayerOverride'></select>
+        </div>
 
-      <div class='toolbar-item'>
-        <label for='selKeyNextLayer'>Next Layer:</label>
-        <select id='selKeyNextLayer'></select>
-      </div>
-    </div>
+        <div class='toolbar-item'>
+          <label for='inpKeyName'>ID:</label>
+          <input id='inpKeyName' type='text' size='16' maxlength='64' />
+        </div>
 
-    <!-- Keyboard Controls -->
+        <div class='toolbar-item'>
+          <label for='inpKeyPadding'>Padding Left:</label>
+          <input id='inpKeyPadding' size='5' maxlength='5' />
+        </div>
 
-    <div id="wedgeAddRowAbove" class="kcontrol wedge-horz"><span>+</span></div>
-    <div id="wedgeAddRowBelow" class="kcontrol wedge-horz"><span>+</span></div>
-    <div id="wedgeAddKeyLeft" class="kcontrol wedge-vert"><span>+</span></div>
-    <div id="wedgeAddKeyRight" class="kcontrol wedge-vert"><span>+</span></div>
-    <div id="btnDelKey">x</div>
-  </div>
+        <div class='toolbar-item'>
+          <label for='inpKeyWidth'>Width:</label>
+          <input id='inpKeyWidth' size='5' maxlength='5' />
+        </div>
 
-
-  <!-- Longpress Container -->
-
-  <div id='sub-key-container'>
-    <div id='sub-key-groups'>
-      <div>
-        <span class='tab' id='tab-longpress'>Longpress Keys</span>
-
-        <div id='longpress'>
-          <div class='key-placeholder' id='btnAddLongpress'>+</div>
+        <div class='toolbar-item'>
+          <label for='selKeyNextLayer'>Next Layer:</label>
+          <select id='selKeyNextLayer'></select>
         </div>
       </div>
 
-      <div>
-        <span class='tab' id='tab-flick'>Flicks</span>
-        <div id='flick'>
-          <div class='key-placeholder btn-add-flick' id='flick-nw'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-n'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-ne'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-w'>+</div>
-          <div class='key-placeholder' id='flick-center'></div>
-          <div class='key-placeholder btn-add-flick' id='flick-e'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-sw'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-s'>+</div>
-          <div class='key-placeholder btn-add-flick' id='flick-se'>+</div>
+      <!-- Keyboard Controls -->
+
+      <div id="wedgeAddRowAbove" class="kcontrol wedge-horz"><span>+</span></div>
+      <div id="wedgeAddRowBelow" class="kcontrol wedge-horz"><span>+</span></div>
+      <div id="wedgeAddKeyLeft" class="kcontrol wedge-vert"><span>+</span></div>
+      <div id="wedgeAddKeyRight" class="kcontrol wedge-vert"><span>+</span></div>
+      <div id="btnDelKey">x</div>
+    </div>
+
+
+    <!-- Longpress Container -->
+
+    <div id='sub-key-container'>
+      <div id='sub-key-groups'>
+        <div>
+          <span class='tab' id='tab-longpress'>Longpress Keys</span>
+
+          <div id='longpress'>
+            <div class='key-placeholder' id='btnAddLongpress'>+</div>
+          </div>
+        </div>
+
+        <div>
+          <span class='tab' id='tab-flick'>Flicks</span>
+          <div id='flick'>
+            <div class='key-placeholder btn-add-flick' id='flick-nw'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-n'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-ne'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-w'>+</div>
+            <div class='key-placeholder' id='flick-center'></div>
+            <div class='key-placeholder btn-add-flick' id='flick-e'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-sw'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-s'>+</div>
+            <div class='key-placeholder btn-add-flick' id='flick-se'>+</div>
+          </div>
+        </div>
+
+        <div>
+          <span class='tab' id='tab-multitap'>Multitaps</span>
+          <div id='multitap'>
+            <div class='key-placeholder' id='btnAddMultitap'>+</div>
+          </div>
         </div>
       </div>
 
-      <div>
-        <span class='tab' id='tab-multitap'>Multitaps</span>
-        <div id='multitap'>
-          <div class='key-placeholder' id='btnAddMultitap'>+</div>
+      <div id='subKeyToolbar'>
+        <div class='toolbar-item'>
+          <label for='inpSubKeyGestureType'>Gesture Type:</label>
+          <input id='inpSubKeyGestureType' type='text' size='16' disabled='disabled' />
+        </div>
+        <div class='toolbar-item'>
+          <label for='selSubKeyCapType'>Keycap Value:</label>
+          <select id='selSubKeyCapType'>
+            <option value=''>Text</option>
+          </select>
+        </div>
+        <div class='toolbar-item' id='sub-key-cap-toolbar-item'>
+          <label>Text:</label>
+          <input id='inpSubKeyCap' type='text' size='8' />
+        </div>
+        <div class='toolbar-item' id='sub-key-cap-unicode-toolbar-item'>
+          <label>Unicode:</label>
+          <input id='inpSubKeyCapUnicode' type='text' size='16' />
+        </div>
+        <div class='toolbar-item'>
+          <label for='selSubKeyType'>Key Type:</label>
+          <select id='selSubKeyType'>
+            <option value='0'>Default</option>
+            <option value='1'>Special</option>
+            <option value='2'>Special (active)</option>
+            <option value='8'>Deadkey</option>
+            <option value='9'>Blank</option>
+            <option value='10'>Spacer</option>
+          </select>
+        </div>
+        <div class='toolbar-item'>
+          <label for='selSubKeyLayerOverride'>Modifier:</label>
+          <select id='selSubKeyLayerOverride'></select>
+        </div>
+        <div class='toolbar-item'>
+          <label for='inpSubKeyName'>ID:</label>
+          <input id='inpSubKeyName' type='text' size='16' maxlength='64' />
+        </div>
+        <div class='toolbar-item'>
+          <label for='selSubKeyNextLayer'>Next Layer:</label>
+          <select id='selSubKeyNextLayer'></select>
         </div>
       </div>
+
+      <!-- Subkey Controls -->
+
+      <div id="wedgeAddSubKeyLeft" class="skcontrol wedge-vert"><span>+</span></div>
+      <div id="wedgeAddSubKeyRight" class="skcontrol wedge-vert"><span>+</span></div>
+      <div id="btnDelSubKey">x</div>
+
     </div>
-
-    <div id='subKeyToolbar'>
-      <div class='toolbar-item'>
-        <label for='inpSubKeyGestureType'>Gesture Type:</label>
-        <input id='inpSubKeyGestureType' type='text' size='16' disabled='disabled' />
-      </div>
-      <div class='toolbar-item'>
-        <label for='selSubKeyCapType'>Keycap Value:</label>
-        <select id='selSubKeyCapType'>
-          <option value=''>Text</option>
-        </select>
-      </div>
-      <div class='toolbar-item' id='sub-key-cap-toolbar-item'>
-        <label>Text:</label>
-        <input id='inpSubKeyCap' type='text' size='8' />
-      </div>
-      <div class='toolbar-item' id='sub-key-cap-unicode-toolbar-item'>
-        <label>Unicode:</label>
-        <input id='inpSubKeyCapUnicode' type='text' size='16' />
-      </div>
-      <div class='toolbar-item'>
-        <label for='selSubKeyType'>Key Type:</label>
-        <select id='selSubKeyType'>
-          <option value='0'>Default</option>
-          <option value='1'>Special</option>
-          <option value='2'>Special (active)</option>
-          <option value='8'>Deadkey</option>
-          <option value='9'>Blank</option>
-          <option value='10'>Spacer</option>
-        </select>
-      </div>
-      <div class='toolbar-item'>
-        <label for='selSubKeyLayerOverride'>Modifier:</label>
-        <select id='selSubKeyLayerOverride'></select>
-      </div>
-      <div class='toolbar-item'>
-        <label for='inpSubKeyName'>ID:</label>
-        <input id='inpSubKeyName' type='text' size='16' maxlength='64' />
-      </div>
-      <div class='toolbar-item'>
-        <label for='selSubKeyNextLayer'>Next Layer:</label>
-        <select id='selSubKeyNextLayer'></select>
-      </div>
-    </div>
-
-    <!-- Subkey Controls -->
-
-    <div id="wedgeAddSubKeyLeft" class="skcontrol wedge-vert"><span>+</span></div>
-    <div id="wedgeAddSubKeyRight" class="skcontrol wedge-vert"><span>+</span></div>
-    <div id="btnDelSubKey">x</div>
 
   </div>
 
@@ -256,6 +281,41 @@
 
   <div id='selectKeyDialog' title='Select key'>
     Press any key to select it on the keyboard
+  </div>
+
+  <div id='viewOptionsDialog' title='View options'>
+    <form>
+      <fieldset>
+        <div>By default, only common modifiers are shown in the modifier lists. If
+          access to more unusual modifier combinations are required, check this option.<br/><br/>
+          This option only affects the controls within the Touch Layout Editor; it has no impact on the layout itself.<br/><br/>
+        </div>
+        <input type='checkbox' id='chkShowAllModifierOptions'/>
+        <label for='chkShowAllModifierOptions'>Show all modifier options</label>
+      </fieldset>
+    </form>
+  </div>
+
+  <div id='platformPropertiesDialog' title='Platform properties'>
+    <form>
+      <fieldset>
+        <div>Displays the underlying keyboard label on top-left of the key<br/><br/></div>
+        <input type='checkbox' id='chkDisplayUnderlying'/>
+        <label for='chkDisplayUnderlying'>Display underlying key label</label>
+      </fieldset>
+      <fieldset>
+        <div>Control display of text hints on the key. Note that when in "dot" mode,
+          the dot is not shown in the Touch Layout Editor, but will be visible when
+          using the compiled keyboard.<br/><br/>
+        </div>
+        <label for='selDisplayHint'>Display hint:</label>
+        <select id='selDisplayHint'>
+          <option value='none'>None</option>
+          <option value='dot'>Dot for longpress</option>
+          <option value='text'>Text hints</option>
+        </select>
+      </fieldset>
+    </form>
   </div>
 
   <div id='layerPropertiesDialog' title='Layer properties'>

--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -89,6 +89,16 @@
         <input id='inpKeyCapUnicode' type='text' size='16' />
       </div>
 
+      <div class='toolbar-item' id='key-hint-toolbar-item'>
+        <label for='inpKeyHint'>Hint:</label>
+        <input id='inpKeyHint' type='text' size='16' />
+      </div>
+
+      <div class='toolbar-item' id='key-hint-unicode-toolbar-item'>
+        <label for='inpKeyHintUnicode'>Unicode:</label>
+        <input id='inpKeyHintUnicode' type='text' size='16' />
+      </div>
+
       <div class='toolbar-item'>
         <label for='selKeyType'>Key Type:</label>
         <select id='selKeyType'>

--- a/developer/src/tike/xml/layoutbuilder/platform-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/platform-controls.js
@@ -35,7 +35,7 @@ $(function() {
 
   $('#btnEditPlatform').click(function () {
     $('#chkDisplayUnderlying')[0].checked = KVKL[builder.lastPlatform].displayUnderlying;
-    $('#selDisplayHint').val(KVKL[builder.lastPlatform].displayHint ?? 'dot');
+    $('#selDefaultHint').val(KVKL[builder.lastPlatform].defaultHint ?? 'dot');
     $('#platformPropertiesDialog').dialog('open');
   });
 
@@ -83,12 +83,12 @@ $(function() {
     builder.restoreSelection(selection);
   });
 
-  $('#selDisplayHint').change(function () {
+  $('#selDefaultHint').change(function () {
     let selection = builder.saveSelection();
     builder.saveUndo();
-    KVKL[builder.lastPlatform].displayHint = $('#selDisplayHint').val();
-    if(KVKL[builder.lastPlatform].displayHint == 'dot') {
-      delete KVKL[builder.lastPlatform].displayHint;
+    KVKL[builder.lastPlatform].defaultHint = $('#selDefaultHint').val();
+    if(KVKL[builder.lastPlatform].defaultHint == 'dot') {
+      delete KVKL[builder.lastPlatform].defaultHint;
     }
     builder.generate();
     builder.prepareLayer();
@@ -97,8 +97,8 @@ $(function() {
 
   $('#platformPropertiesDialog').dialog({
     autoOpen: false,
-    height: 300,
-    width: 350,
+    height: 400,
+    width: 450,
     modal: true,
     buttons: {
       "Close": function () {

--- a/developer/src/tike/xml/layoutbuilder/platform-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/platform-controls.js
@@ -69,29 +69,39 @@ $(function() {
     }
   });
 
+  //
+  // Platform Properties Dialog
+  //
+
+  $('#chkDisplayUnderlying').click(function (event) {
+    event.stopImmediatePropagation();
+    let selection = builder.saveSelection();
+    builder.saveUndo();
+    KVKL[builder.lastPlatform].displayUnderlying = $('#chkDisplayUnderlying')[0].checked;
+    builder.generate();
+    builder.prepareLayer();
+    builder.restoreSelection(selection);
+  });
+
+  $('#selDisplayHint').change(function () {
+    let selection = builder.saveSelection();
+    builder.saveUndo();
+    KVKL[builder.lastPlatform].displayHint = $('#selDisplayHint').val();
+    if(KVKL[builder.lastPlatform].displayHint == 'dot') {
+      delete KVKL[builder.lastPlatform].displayHint;
+    }
+    builder.generate();
+    builder.prepareLayer();
+    builder.restoreSelection(selection);
+  });
+
   $('#platformPropertiesDialog').dialog({
     autoOpen: false,
     height: 300,
     width: 350,
     modal: true,
     buttons: {
-      "OK": function () {
-
-        KVKL[builder.lastPlatform].displayUnderlying = $('#chkDisplayUnderlying')[0].checked;
-        KVKL[builder.lastPlatform].displayHint = $('#selDisplayHint').val();
-        if(KVKL[builder.lastPlatform].displayHint == 'dot') {
-          delete KVKL[builder.lastPlatform].displayHint;
-        }
-
-        let selection = builder.saveSelection();
-        builder.saveUndo();
-        builder.generate();
-        builder.prepareLayer();
-        builder.restoreSelection(selection);
-
-        $(this).dialog('close');
-      },
-      "Cancel": function () {
+      "Close": function () {
         $(this).dialog('close');
       }
     }

--- a/developer/src/tike/xml/layoutbuilder/platform-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/platform-controls.js
@@ -33,6 +33,12 @@ $(function() {
     builder.saveState();
   });
 
+  $('#btnEditPlatform').click(function () {
+    $('#chkDisplayUnderlying')[0].checked = KVKL[builder.lastPlatform].displayUnderlying;
+    $('#selDisplayHint').val(KVKL[builder.lastPlatform].displayHint ?? 'dot');
+    $('#platformPropertiesDialog').dialog('open');
+  });
+
   //
   // Platform dialogs
   //
@@ -62,4 +68,33 @@ $(function() {
       }
     }
   });
+
+  $('#platformPropertiesDialog').dialog({
+    autoOpen: false,
+    height: 300,
+    width: 350,
+    modal: true,
+    buttons: {
+      "OK": function () {
+
+        KVKL[builder.lastPlatform].displayUnderlying = $('#chkDisplayUnderlying')[0].checked;
+        KVKL[builder.lastPlatform].displayHint = $('#selDisplayHint').val();
+        if(KVKL[builder.lastPlatform].displayHint == 'dot') {
+          delete KVKL[builder.lastPlatform].displayHint;
+        }
+
+        let selection = builder.saveSelection();
+        builder.saveUndo();
+        builder.generate();
+        builder.prepareLayer();
+        builder.restoreSelection(selection);
+
+        $(this).dialog('close');
+      },
+      "Cancel": function () {
+        $(this).dialog('close');
+      }
+    }
+  });
+
 }.bind(builder));

--- a/developer/src/tike/xml/layoutbuilder/prepare-key.js
+++ b/developer/src/tike/xml/layoutbuilder/prepare-key.js
@@ -98,8 +98,10 @@ $(function() {
     $('#inpKeyCapUnicode').val(builder.toUnicodeString(val));
 
     val = $(key).data('hint');
+    $('#inpKeyHint')[0].placeholder = builder.inferKeyHintText(null, $(key).data('longpress'), $(key).data('flick'), $(key).data('multitap'));
     $('#inpKeyHint').val(val);
     $('#inpKeyHintUnicode').val(builder.toUnicodeString(val));
+    $('#inpKeyHintUnicode')[0].placeholder = builder.toUnicodeString($('#inpKeyHint')[0].placeholder);
 
     $('#inpKeyName').val($(key).data('id'));
     $('#inpKeyWidth').val($(key).data('width'));
@@ -123,8 +125,7 @@ $(function() {
     function addSubKeys(keys, type) {
       for(let key of keys) {
         let nkey = builder.addKey(type, '#'+type);
-        let code = key.id ? String.fromCharCode(parseInt(key.id.substring(2), 16)) : 0;
-        let text = typeof key.text == 'string' ? key.text : (code.charCodeAt(0) < 32 ? '' : code);
+        let text = builder.inferKeyText(key);
 
         if(key.direction) $(nkey).addClass('flick-'+key.direction);
 

--- a/developer/src/tike/xml/layoutbuilder/prepare-key.js
+++ b/developer/src/tike/xml/layoutbuilder/prepare-key.js
@@ -3,13 +3,16 @@ $(function() {
   this.addKey = function (type, position, sp) {
     var key = document.createElement('div');
     var ktext = document.createElement('div');
+    var khint = document.createElement('div');
     var kid = document.createElement('div');
     var kunderlying = document.createElement('div');
     $(kid).addClass('id');
     $(ktext).addClass('text');
+    $(khint).addClass('hint');
     $(kunderlying).addClass('underlying');
     $(key).append(kid);
     $(key).append(ktext);
+    $(key).append(khint);
     $(key).append(kunderlying);
     $(key).addClass('key');
     $(key).data('id', 'T_new_' + this.uniqId);
@@ -93,6 +96,11 @@ $(function() {
     $('#selKeyCapType').val(builder.specialCharacters[val] ? val : '');
     $('#inpKeyCap').val(val);
     $('#inpKeyCapUnicode').val(builder.toUnicodeString(val));
+
+    val = $(key).data('hint');
+    $('#inpKeyHint').val(val);
+    $('#inpKeyHintUnicode').val(builder.toUnicodeString(val));
+
     $('#inpKeyName').val($(key).data('id'));
     $('#inpKeyWidth').val($(key).data('width'));
     $('#inpKeyPadding').val($(key).data('pad'));

--- a/developer/src/tike/xml/layoutbuilder/view-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/view-controls.js
@@ -1,0 +1,27 @@
+$(function() {
+
+  $('#btnViewOptions').click(function () {
+    $('#chkShowAllModifierOptions')[0].checked = builder.showAllModifierCombinations;
+    $('#viewOptionsDialog').dialog('open');
+  });
+
+  $('#viewOptionsDialog').dialog({
+    autoOpen: false,
+    height: 300,
+    width: 350,
+    modal: true,
+    buttons: {
+      "OK": function () {
+        builder.showAllModifierCombinations = $('#chkShowAllModifierOptions')[0].checked;
+        builder.fillModifierSelect();
+        builder.prepareKey();
+        $(this).dialog('close');
+      },
+      "Cancel": function () {
+        $(this).dialog('close');
+      }
+    }
+
+  });
+
+}.bind(builder));

--- a/developer/src/tike/xml/layoutbuilder/view-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/view-controls.js
@@ -5,19 +5,20 @@ $(function() {
     $('#viewOptionsDialog').dialog('open');
   });
 
+  $('#chkShowAllModifierOptions').click(function (event) {
+    event.stopImmediatePropagation();
+    builder.showAllModifierCombinations = $('#chkShowAllModifierOptions')[0].checked;
+    builder.fillModifierSelect();
+    builder.prepareKey();
+  });
+
   $('#viewOptionsDialog').dialog({
     autoOpen: false,
     height: 300,
     width: 350,
     modal: true,
     buttons: {
-      "OK": function () {
-        builder.showAllModifierCombinations = $('#chkShowAllModifierOptions')[0].checked;
-        builder.fillModifierSelect();
-        builder.prepareKey();
-        $(this).dialog('close');
-      },
-      "Cancel": function () {
+      "Close": function () {
         $(this).dialog('close');
       }
     }


### PR DESCRIPTION
@keymanapp-test-bot skip

I ended up with all the changes in one PR to support hints in Keyman Developer and the schema.

I reworked the touch layout editor to support hints, including moving the main control toolbar so that additional properties could be neatly fit into the design.

![image](https://user-images.githubusercontent.com/4498365/178850874-d76694a5-55fb-4184-afff-2623cca5e800.png)

Green coloured hint text indicates that the hint has been customised:
![image](https://user-images.githubusercontent.com/4498365/178850978-1086dec0-58f7-439c-bc68-fcf1317ecba2.png)

I moved the delete button off the key cap itself so that it doesn't overlap the hint text:
![image](https://user-images.githubusercontent.com/4498365/178851033-03d0c0ca-87cc-48a8-a7ac-d61e99068600.png)

I moved the controls off the top and into a left-hand-side toolbar, moving some functions into Edit dialogs so we have more flexibility for future functionality:
![image](https://user-images.githubusercontent.com/4498365/178851615-05073c00-447f-4466-8c7a-7b127112f9b8.png)

Hint text shows a placeholder of the default hint (in this case from the longpress) if no custom hint has been applied:
![image](https://user-images.githubusercontent.com/4498365/178851766-b9ccdb2b-8a5c-48ee-bae2-84fd3fa46653.png)

Platform properties dialog:
![image](https://user-images.githubusercontent.com/4498365/178851846-435eee17-3d5b-4b11-957c-cd1fa6793e8a.png)

View options dialog:
![image](https://user-images.githubusercontent.com/4498365/178851881-6ef3327e-826d-4c57-9052-c87acb93349e.png)

Note that the "Show all modifier options" check box would be rarely used so it's good to get it out of the main UI.