### PR TITLE
fix(developer): crash on exit when checking for updates 🎾

### DIFF
--- a/developer/src/tike/Tike.dpr
+++ b/developer/src/tike/Tike.dpr
@@ -320,6 +320,7 @@ begin
             Application.Run;
           finally
             FreeAndNil(modWebHttpServer);
+            FreeAndNil(frmKeymanDeveloper);
           end;
         end;
       finally

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -477,7 +477,10 @@ begin
     with PCWPSTRUCT(lParam)^ do
       if message = WM_INPUTLANGCHANGE then
         PostMessage(frmKeymanDeveloper.Handle, WM_USER_INPUTLANGCHANGE, wParam, lParam);
-  Result := CallNextHookEx(frmKeymanDeveloper.hInputLangChangeHook, nCode, wParam, lParam);
+  if frmKeymanDeveloper <> nil then
+    Result := CallNextHookEx(frmKeymanDeveloper.hInputLangChangeHook, nCode, wParam, lParam)
+  else
+    Result := 0;
 end;
 
 


### PR DESCRIPTION
Fixes #6928.

This was due to the main form not being destroyed in time during shutdown.

@keymanapp-test-bot skip