### PR TITLE
fix(developer): crash when switching back a tab 🎾

### DIFF
--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -1021,6 +1021,8 @@ procedure TmodActionsMain.actWindowPrevExecute(Sender: TObject);
 begin
   with frmKeymanDeveloper do
   begin
+    if ChildWindows.Count = 0 then
+      Exit;
     if ActiveChildIndex = 0
       then ActiveChildIndex := ChildWindows.Count - 1
       else ActiveChildIndex := ActiveChildIndex - 1;


### PR DESCRIPTION
In rare circumstances, Keyman Developer can crash during startup if you try and switch back to a tab which is not yet available (Ctrl+Shift+Tab).

@keymanapp-test-bot skip