### PR TITLE
fix(developer): kmdecomp virtual character key output 🎾 🍒

### DIFF
--- a/windows/src/developer/kmdecomp/savekeyboard.cpp
+++ b/windows/src/developer/kmdecomp/savekeyboard.cpp
@@ -253,7 +253,7 @@ PWCHAR ExtString(PWCHAR str)
 				str++;
 				if(*str & VIRTUALCHARKEY)
 					wsprintfW(p, L"[%s%c%c%c] ", flagstr(*str), *(str+1) == L'"' ? L'\'' : L'"',
-						str+1, *(str+1) == L'"' ? L'\'' : L'"');
+						*(str+1), *(str+1) == L'"' ? L'\'' : L'"');
 				else
         {
           if(*(str+1) > VK__MAX)  // I3438


### PR DESCRIPTION
Cherry-pick of #6940.

Virtual character keys were being written as garbage, for example:

```
store(store17) [RALT ""] [RALT SHIFT ""] [RALT ""] [RALT SHIFT ''] [RALT SHIFT ""] [RALT SHIFT ""] [RALT SHIFT ""] [RALT SHIFT ""] [RALT SHIFT ""] [RALT ""] [RALT SHIFT ""] [RALT SHIFT ""] [RALT SHIFT ""] [RALT ""] [RALT SHIFT ""] [RALT ""] [RALT ""] [RALT ""] [RALT SHIFT ""]
store(store18) [RCTRL ""] [RCTRL SHIFT ""] [RCTRL ""] [RCTRL SHIFT ''] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL ""] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL SHIFT ""] [RCTRL ""] [RCTRL SHIFT ""] [RCTRL ""] [RCTRL ""] [RCTRL ""] [RCTRL SHIFT ""]
```

Picked up in regression testing the compiler.

@keymanapp-test-bot skip