### PR TITLE
fix(developer): crash when switching back a tab 🎾 🍒

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsMain.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.pas
@@ -1022,6 +1022,8 @@ procedure TmodActionsMain.actWindowPrevExecute(Sender: TObject);
 begin
   with frmKeymanDeveloper do
   begin
+    if ChildWindows.Count = 0 then
+      Exit;
     if ActiveChildIndex = 0
       then ActiveChildIndex := ChildWindows.Count - 1
       else ActiveChildIndex := ActiveChildIndex - 1;


### PR DESCRIPTION
Cherry-pick of #6942.

In rare circumstances, Keyman Developer can crash during startup if you try and switch back to a tab which is not yet available (Ctrl+Shift+Tab).

@keymanapp-test-bot skip