### PR TITLE
fix(developer): reduce timeouts if server shut down 🎾 🍒

### DIFF
--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -294,7 +294,8 @@ uses
   Keyman.Developer.System.ValidateKpsFile in '..\..\global\delphi\general\Keyman.Developer.System.ValidateKpsFile.pas',
   Keyman.Developer.UI.UfrmServerOptions in 'dialogs\Keyman.Developer.UI.UfrmServerOptions.pas' {frmServerOptions},
   Keyman.Developer.System.ServerAPI in 'http\Keyman.Developer.System.ServerAPI.pas',
-  Keyman.System.FontLoadUtil in 'main\Keyman.System.FontLoadUtil.pas';
+  Keyman.System.FontLoadUtil in 'main\Keyman.System.FontLoadUtil.pas',
+  Keyman.Developer.UI.ServerUI in 'http\Keyman.Developer.UI.ServerUI.pas';
 
 {$R *.RES}
 {$R ICONS.RES}
@@ -326,7 +327,7 @@ begin
           //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-          try
+  try
             Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
             Application.Run;
           finally

--- a/windows/src/developer/TIKE/Tike.dpr
+++ b/windows/src/developer/TIKE/Tike.dpr
@@ -327,7 +327,7 @@ begin
           //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-  try
+          try
             Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
             Application.Run;
           finally

--- a/windows/src/developer/TIKE/Tike.dproj
+++ b/windows/src/developer/TIKE/Tike.dproj
@@ -563,6 +563,7 @@
         </DCCReference>
         <DCCReference Include="http\Keyman.Developer.System.ServerAPI.pas"/>
         <DCCReference Include="main\Keyman.System.FontLoadUtil.pas"/>
+        <DCCReference Include="http\Keyman.Developer.UI.ServerUI.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/windows/src/developer/TIKE/actions/dmActionsMain.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.dfm
@@ -494,6 +494,18 @@ object modActionsMain: TmodActionsMain
       Caption = 'Co&nfigure...'
       OnExecute = actToolsWebConfigureExecute
     end
+    object actToolsWebStartServer: TAction
+      Category = 'Tools'
+      Caption = '&Start server'
+      OnExecute = actToolsWebStartServerExecute
+      OnUpdate = actToolsWebStartServerUpdate
+    end
+    object actToolsWebStopServer: TAction
+      Category = 'Tools'
+      Caption = '&Stop server'
+      OnExecute = actToolsWebStopServerExecute
+      OnUpdate = actToolsWebStopServerUpdate
+    end
   end
   object ActionManager1: TActionManager
     ActionBars = <

--- a/windows/src/developer/TIKE/actions/dmActionsMain.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsMain.pas
@@ -137,6 +137,8 @@ type
     actToolsWebCopyPublicUrl: TAction;
     actToolsWebOpenPublicUrl: TAction;
     actToolsWebConfigure: TAction;
+    actToolsWebStartServer: TAction;
+    actToolsWebStopServer: TAction;
     procedure actFileNewExecute(Sender: TObject);
     procedure DataModuleCreate(Sender: TObject);
     procedure actFileOpenAccept(Sender: TObject);
@@ -237,6 +239,10 @@ type
     procedure actToolsWebConfigureExecute(Sender: TObject);
     procedure actToolsWebCopyPublicUrlUpdate(Sender: TObject);
     procedure actToolsWebOpenPublicUrlUpdate(Sender: TObject);
+    procedure actToolsWebStartServerExecute(Sender: TObject);
+    procedure actToolsWebStartServerUpdate(Sender: TObject);
+    procedure actToolsWebStopServerExecute(Sender: TObject);
+    procedure actToolsWebStopServerUpdate(Sender: TObject);
   private
     function CheckFilenameConventions(FileName: string): Boolean;
     function SaveAndCloseAllFiles: Boolean;
@@ -789,6 +795,26 @@ begin
   if actToolsWebOpenPublicUrl.Enabled
     then actToolsWebOpenPublicUrl.Caption := 'Open '+TServerDebugAPI.ngrokEndpoint+' in browser'
     else actToolsWebOpenPublicUrl.Caption := 'Open in browser';
+end;
+
+procedure TmodActionsMain.actToolsWebStartServerExecute(Sender: TObject);
+begin
+  TServerDebugAPI.StartServer;
+end;
+
+procedure TmodActionsMain.actToolsWebStartServerUpdate(Sender: TObject);
+begin
+  actToolsWebStartServer.Visible := not TServerDebugAPI.Running;
+end;
+
+procedure TmodActionsMain.actToolsWebStopServerExecute(Sender: TObject);
+begin
+  TServerDebugAPI.StopServer;
+end;
+
+procedure TmodActionsMain.actToolsWebStopServerUpdate(Sender: TObject);
+begin
+  actToolsWebStopServer.Visible := TServerDebugAPI.Running;
 end;
 
 procedure TmodActionsMain.actViewCharacterIdentifierExecute(Sender: TObject);   // I4807

--- a/windows/src/developer/TIKE/http/Keyman.Developer.System.ServerAPI.pas
+++ b/windows/src/developer/TIKE/http/Keyman.Developer.System.ServerAPI.pas
@@ -119,7 +119,7 @@ var
   ss: TStringStream;
 begin
   try
-    fs := TFileStream.Create(TKeymanDeveloperPaths.ServerDataPath + 'pid.json', fmOpenRead);
+    fs := TFileStream.Create(Filename, fmOpenRead);
     try
       ss := TStringStream.Create('', TEncoding.UTF8);
       try

--- a/windows/src/developer/TIKE/http/Keyman.Developer.UI.ServerUI.pas
+++ b/windows/src/developer/TIKE/http/Keyman.Developer.UI.ServerUI.pas
@@ -1,0 +1,57 @@
+unit Keyman.Developer.UI.ServerUI;
+
+interface
+
+type
+  TServerUI = class sealed
+    class function VerifyServerRunning: Boolean; static;
+  end;
+
+implementation
+
+uses
+  Vcl.Controls,
+  Vcl.Dialogs,
+  Winapi.Windows,
+
+  Keyman.Developer.System.ServerAPI;
+
+class function TServerUI.VerifyServerRunning: Boolean;
+var
+  t: UInt64;
+begin
+  if TServerDebugAPI.Running then
+    Exit(True);
+
+  case MessageDlg('Keyman Developer Server does not appear to be running. '+
+     'Try and start Keyman Developer Server now?',
+     mtConfirmation, mbYesNoCancel, 0) of
+    mrYes:
+      // Trying to start Server
+      begin
+        TServerDebugAPI.StartServer;
+        repeat
+          t := GetTickCount64;
+          while GetTickCount64 - t < 3000 do
+          begin
+            Sleep(500);
+            if TServerDebugAPI.Running then Exit(True);
+          end;
+          case MessageDlg('Keyman Developer Server has not yet started successfully. Keep waiting?',
+              mtConfirmation, mbOkCancel, 0) of
+            mrOk: ;
+            mrCancel: Exit(False);
+          end;
+        until False;
+      end;
+    mrNo:
+      // Try and continue even though Server does not appear to be running...
+      Exit(True);
+    mrCancel:
+      ;
+  end;
+
+  Result := False;
+end;
+
+end.

--- a/windows/src/developer/TIKE/main/UfrmMain.dfm
+++ b/windows/src/developer/TIKE/main/UfrmMain.dfm
@@ -3087,6 +3087,15 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
         object mnuToolsWebDebuggerCopyToClipboard: TMenuItem
           Action = modActionsMain.actToolsWebCopyPublicUrl
         end
+        object N11: TMenuItem
+          Caption = '-'
+        end
+        object Startserver1: TMenuItem
+          Action = modActionsMain.actToolsWebStartServer
+        end
+        object Stopserver1: TMenuItem
+          Action = modActionsMain.actToolsWebStopServer
+        end
         object N7: TMenuItem
           Caption = '-'
         end

--- a/windows/src/developer/TIKE/main/UfrmMain.pas
+++ b/windows/src/developer/TIKE/main/UfrmMain.pas
@@ -281,6 +281,9 @@ type
     mnuToolsWebDebuggerCopyToClipboard: TMenuItem;
     N7: TMenuItem;
     mnuToolsWebDebuggerConfigure: TMenuItem;
+    N11: TMenuItem;
+    Startserver1: TMenuItem;
+    Stopserver1: TMenuItem;
     procedure FormCreate(Sender: TObject);
     procedure FormShow(Sender: TObject);
     procedure mnuFileClick(Sender: TObject);

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -69,6 +69,7 @@ uses
   UfrmMDIEditor,
   UmodWebHttpServer,
   Keyman.Developer.System.ServerAPI,
+  Keyman.Developer.UI.ServerUI,
   KeyboardFonts,
   KeymanDeveloperUtils,
   KeymanDeveloperOptions,
@@ -130,7 +131,9 @@ begin
 
   Result := ProjectFile.CompileKeyboard;
 
-  if Result and TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) then
+  if Result and
+      TServerDebugAPI.Running and
+      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) then
     TestKeymanWeb(True);
 end;
 
@@ -218,7 +221,8 @@ var
     begin
       strm := TMemoryStream.Create;
       try
-        if TFontLoadUtil.LoadFontData(fontname, strm) then
+        if TFontLoadUtil.LoadFontData(fontname, strm) and
+            TServerDebugAPI.Running then
           TServerDebugAPI.RegisterFont(strm, fontname);
       finally
         strm.Free;
@@ -250,16 +254,19 @@ begin
       RegisterFont(Wizard.FontInfo[i].Name);
   end;
 
-  TServerDebugAPI.RegisterKeyboard(
-    FCompiledName,
-    ProjectFile.FileVersion,
-    // We only need to specify the char + osk fonts here
-    // as the others are referenced in the touch layout definition directly
-    Wizard.FontInfo[kfontChar].Name,
-    Wizard.FontInfo[kfontOSK].Name
-  );
+  if TServerUI.VerifyServerRunning then
+  begin
+    TServerDebugAPI.RegisterKeyboard(
+      FCompiledName,
+      ProjectFile.FileVersion,
+      // We only need to specify the char + osk fonts here
+      // as the others are referenced in the touch layout definition directly
+      Wizard.FontInfo[kfontChar].Name,
+      Wizard.FontInfo[kfontOSK].Name
+    );
 
-  wizard.NotifyStartedWebDebug;   // I4021
+    wizard.NotifyStartedWebDebug;   // I4021
+  end;
 
   Result := True;
 end;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kpsProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kpsProjectFileUI.pas
@@ -57,6 +57,7 @@ uses
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.ServerAPI,
   Keyman.Developer.UI.Project.ProjectUIFileType,
+  Keyman.Developer.UI.ServerUI,
   UfrmMain,
   UfrmMessages,
   UfrmMDIEditor,
@@ -76,7 +77,9 @@ begin
 
   Result := ProjectFile.CompilePackage(GetPack, FSilent);
 
-  if Result and TServerDebugAPI.IsPackageRegistered(ProjectFile.TargetFileName) then
+  if Result and
+      TServerDebugAPI.Running and
+      TServerDebugAPI.IsPackageRegistered(ProjectFile.TargetFileName) then
     TestPackageOnline;
 end;
 
@@ -141,9 +144,11 @@ begin
   if not FileExists(FCompiledName) then
     Exit(False);
 
-  TServerDebugAPI.RegisterPackage(FCompiledName, ProjectFile.Header_Name);
-
-  packageEditor.NotifyStartedWebDebug;   // I4021
+  if TServerUI.VerifyServerRunning then
+  begin
+    TServerDebugAPI.RegisterPackage(FCompiledName, ProjectFile.Header_Name);
+    packageEditor.NotifyStartedWebDebug;   // I4021
+  end;
 
   Result := True;
 end;

--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.modelTsProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.modelTsProjectFileUI.pas
@@ -60,6 +60,7 @@ uses
   UfrmMain,
   UfrmMDIEditor,
   Keyman.Developer.System.ServerAPI,
+  Keyman.Developer.UI.ServerUI,
   Keyman.Developer.UI.UfrmModelEditor,
   KeymanDeveloperUtils,
   KeymanDeveloperOptions,
@@ -99,8 +100,9 @@ begin
 
   Result := ProjectFile.CompileModel;
 
-
-  if Result and TServerDebugAPI.IsModelRegistered(ProjectFile.TargetFileName) then
+  if Result and
+      TServerDebugAPI.Running and
+      TServerDebugAPI.IsModelRegistered(ProjectFile.TargetFileName) then
     TestKeymanWeb(True);
 end;
 
@@ -134,11 +136,14 @@ begin
   if not TestModelState(FCompiledName, FSilent) then
     Exit(False);
 
-  if FileExists(ProjectFile.TestKeyboard) then
-    TServerDebugAPI.RegisterKeyboard(ProjectFile.TestKeyboard, '1.0', '', '');
-  TServerDebugAPI.RegisterModel(FCompiledName);
+  if TServerUI.VerifyServerRunning then
+  begin
+    if FileExists(ProjectFile.TestKeyboard) then
+      TServerDebugAPI.RegisterKeyboard(ProjectFile.TestKeyboard, '1.0', '', '');
+    TServerDebugAPI.RegisterModel(FCompiledName);
 
-  wizard.NotifyStartedWebDebug;   // I4021
+    wizard.NotifyStartedWebDebug;   // I4021
+  end;
 
   Result := True;
 end;


### PR DESCRIPTION
Cherry-pick of #6943.

Fixes #6897.

If Server is shut down, Keyman Developer now handles this better and offers to restart it in UI interactions, and backs out quietly in non-UI processes.

@keymanapp-test-bot skip