### PR TITLE
fix(web): context-only rule effects, set(&layer) from physical keystrokes 🖇️ 🍒

### DIFF
--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -11,8 +11,9 @@ namespace com.keyman.text {
     }
 
     /**
-     * Indicates the device (platform) to be used for context-only rules,
-     * such as those found in `postkeystroke` and `newcontext` groups.
+     * Indicates the device (platform) to be used for non-keystroke events,
+     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * entry points.
      */
     private contextDevice: utils.DeviceSpec;
     private kbdProcessor: KeyboardProcessor;

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -103,8 +103,9 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.  `doModifierPress` must always run.
-      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      // of state management.  `doModifierPress` must always run for desktop-mode contexts.
+      // In standard Web integration, `contextDevice` indicates what type of OSK is visible.
+      if(!this.contextDevice.touchable && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
         // If run on a desktop platform, we know that modifier & state key presses may not
         // produce output, so we may make an immediate return safely.
         if(!fromOSK) {

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -103,9 +103,8 @@ namespace com.keyman.text {
       }
 
       // Will handle keystroke-based non-layer change modifier & state keys, mapping them through the physical keyboard's version
-      // of state management.  `doModifierPress` must always run for desktop-mode contexts.
-      // In standard Web integration, `contextDevice` indicates what type of OSK is visible.
-      if(!this.contextDevice.touchable && this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
+      // of state management.  `doModifierPress` must always run.
+      if(this.keyboardProcessor.doModifierPress(keyEvent, outputTarget, !fromOSK)) {
         // If run on a desktop platform, we know that modifier & state key presses may not
         // produce output, so we may make an immediate return safely.
         if(!fromOSK) {

--- a/common/core/web/input-processor/src/text/inputProcessor.ts
+++ b/common/core/web/input-processor/src/text/inputProcessor.ts
@@ -10,7 +10,11 @@ namespace com.keyman.text {
       baseLayout: 'us'
     }
 
-    private device: utils.DeviceSpec;
+    /**
+     * Indicates the device (platform) to be used for context-only rules,
+     * such as those found in `postkeystroke` and `newcontext` groups.
+     */
+    private contextDevice: utils.DeviceSpec;
     private kbdProcessor: KeyboardProcessor;
     private lngProcessor: prediction.LanguageProcessor;
 
@@ -23,7 +27,7 @@ namespace com.keyman.text {
         options = InputProcessor.DEFAULT_OPTIONS;
       }
 
-      this.device = device;
+      this.contextDevice = device;
       this.kbdProcessor = new KeyboardProcessor(device, options);
       this.lngProcessor = new prediction.LanguageProcessor();
     }
@@ -65,7 +69,7 @@ namespace com.keyman.text {
      *                                    all matched keyboard rules
      */
      processNewContextEvent(outputTarget: OutputTarget): RuleBehavior {
-      const ruleBehavior = this.keyboardProcessor.processNewContextEvent(this.device, outputTarget);
+      const ruleBehavior = this.keyboardProcessor.processNewContextEvent(this.contextDevice, outputTarget);
 
       if(ruleBehavior) {
         ruleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
@@ -193,7 +197,7 @@ namespace com.keyman.text {
       this.keyboardProcessor.newLayerStore.set(hasLayerChanged ? this.keyboardProcessor.layerId : '');
       this.keyboardProcessor.oldLayerStore.set(hasLayerChanged ? startingLayerId : '');
 
-      let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(keyEvent.device, outputTarget);
+      let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(this.contextDevice, outputTarget);
       if(postRuleBehavior) {
         postRuleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
       }

--- a/common/core/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/core/web/input-processor/tests/cases/inputProcessor.js
@@ -30,7 +30,7 @@ describe('InputProcessor', function() {
       let core = new InputProcessor(device);
 
       assert.isOk(core.keyboardProcessor);
-      assert.isDefined(core.keyboardProcessor.device);
+      assert.isDefined(core.keyboardProcessor.contextDevice);
       assert.isOk(core.languageProcessor);
       assert.isOk(core.keyboardInterface);
       assert.isUndefined(core.activeKeyboard); // No keyboard should be loaded yet.

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -882,7 +882,8 @@ namespace com.keyman.text {
      */
     setStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
       this.resetContextCache();
-      if(systemId == KeyboardInterface.TSS_LAYER) {
+      // Unique case:  we only allow set-store ops from keyboard rules triggered by touch OSKs.
+      if(systemId == KeyboardInterface.TSS_LAYER && this.activeDevice.touchable) {
         // Denote the changed store as part of the matched rule's behavior.
         this.ruleBehavior.setStore[systemId] = strValue;
       } else {

--- a/common/core/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/core/web/keyboard-processor/src/text/kbdInterface.ts
@@ -882,7 +882,7 @@ namespace com.keyman.text {
      */
     setStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
       this.resetContextCache();
-      // Unique case:  we only allow set-store ops from keyboard rules triggered by touch OSKs.
+      // Unique case:  we only allow set(&layer) ops from keyboard rules triggered by touch OSKs.
       if(systemId == KeyboardInterface.TSS_LAYER && this.activeDevice.touchable) {
         // Denote the changed store as part of the matched rule's behavior.
         this.ruleBehavior.setStore[systemId] = strValue;

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -48,8 +48,9 @@ namespace com.keyman.text {
     keyboardInterface: KeyboardInterface;
 
     /**
-     * Indicates the device (platform) to be used for context-only rules,
-     * such as those found in `postkeystroke` and `newcontext` groups.
+     * Indicates the device (platform) to be used for non-keystroke events,
+     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * entry points.
      */
     contextDevice: utils.DeviceSpec;
 

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -46,7 +46,12 @@ namespace com.keyman.text {
     modStateFlags: number = 0;
 
     keyboardInterface: KeyboardInterface;
-    device: utils.DeviceSpec;
+
+    /**
+     * Indicates the device (platform) to be used for context-only rules,
+     * such as those found in `postkeystroke` and `newcontext` groups.
+     */
+    contextDevice: utils.DeviceSpec;
 
     baseLayout: string;
 
@@ -60,7 +65,7 @@ namespace com.keyman.text {
         options = KeyboardProcessor.DEFAULT_OPTIONS;
       }
 
-      this.device = device;
+      this.contextDevice = device;
 
       this.baseLayout = options.baseLayout || KeyboardProcessor.DEFAULT_OPTIONS.baseLayout;
       this.keyboardInterface = new KeyboardInterface(options.variableStoreSerializer);

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -752,7 +752,7 @@ namespace com.keyman.text {
     resetContext() {
       this.layerId = 'default';
       this.keyboardInterface.resetContextCache();
-      if(this.contextDevice.touchable) {
+      if(!this.contextDevice.touchable) {
         this._UpdateVKShift(null);
       }
     };

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -731,7 +731,7 @@ namespace com.keyman.text {
       } else if(KeyboardProcessor.isModifier(Levent)) {
         this.activeKeyboard.notify(Levent.Lcode, outputTarget, isKeyDown ? 1 : 0);
         // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-        if(!Levent.device.touchable) {
+        if(!this.contextDevice.touchable) {
           return this._UpdateVKShift(Levent); // I2187
         } else {
           return true;
@@ -740,7 +740,9 @@ namespace com.keyman.text {
 
       if(Levent.LmodifierChange) {
         this.activeKeyboard.notify(0, outputTarget, 1);
-        this._UpdateVKShift(Levent);
+        if(!this.contextDevice.touchable) {
+          this._UpdateVKShift(Levent);
+        }
       }
 
       // No modifier keypresses detected.

--- a/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/core/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -752,7 +752,9 @@ namespace com.keyman.text {
     resetContext() {
       this.layerId = 'default';
       this.keyboardInterface.resetContextCache();
-      this._UpdateVKShift(null);
+      if(this.contextDevice.touchable) {
+        this._UpdateVKShift(null);
+      }
     };
 
     setNumericLayer(device: utils.DeviceSpec) {

--- a/common/core/web/keyboard-processor/src/text/systemStores.ts
+++ b/common/core/web/keyboard-processor/src/text/systemStores.ts
@@ -42,6 +42,11 @@ namespace com.keyman.text {
     }
 
     set(value: string) {
+      // No need to signal changes when things stay the same.
+      if(this._value == value) {
+        return;
+      }
+
       if(this.handler) {
         if(this.handler(this, value)) {
           return;
@@ -105,7 +110,7 @@ namespace com.keyman.text {
               return false; // web matches anything other than 'native'
             }
             break;
-            
+
           case 'native':
             // This will return true for embedded KeymanWeb
           case 'ie':
@@ -118,7 +123,7 @@ namespace com.keyman.text {
               return false;
             }
             break;
-            
+
           default:
             return false;
         }

--- a/common/core/web/keyboard-processor/src/text/systemStores.ts
+++ b/common/core/web/keyboard-processor/src/text/systemStores.ts
@@ -42,11 +42,9 @@ namespace com.keyman.text {
     }
 
     set(value: string) {
-      // No need to signal changes when things stay the same.
-      if(this._value == value) {
-        return;
-      }
-
+      // Even if things stay the same, we should still signal this.
+      // It's important for tracking if a rule directly set the layer
+      // versus if it passively remained.
       if(this.handler) {
         if(this.handler(this, value)) {
           return;

--- a/developer/server/src/site/test.js
+++ b/developer/server/src/site/test.js
@@ -202,7 +202,10 @@ window.onload = function() {
       keyman.osk = null;
     }
 
+    // Create a new on screen keyboard view and tell KeymanWeb that
+    // we are using the targetDevice for context input.
     newOSK = new com.keyman.osk.InlinedOSKView(targetDevice, keyman.util.device.coreSpec);
+    keyman.core.contextDevice = targetDevice;
 
     if(document.body.offsetWidth < targetDevice.dimensions[0]) {
       newOSK.setSize('320px', '200px');

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -121,7 +121,7 @@ if(!window['keyman']['initialized']) {
      * Reset context when entering or exiting the active element.
      * Will also trigger OSK shift state / layer reset.
      **/
-    function resetVKShift() {
+    keymanweb.pageFocusHandler = function() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
         keyman.core.resetContext(null);
@@ -129,9 +129,8 @@ if(!window['keyman']['initialized']) {
     }
 
     // We need to track this handler, as it causes... interesting... interactions during testing in certain browsers.
-    keymanweb['pageFocusHandler'] = resetVKShift;
-    util.attachDOMEvent(window, 'focus', keymanweb['pageFocusHandler'], false);  // I775
-    util.attachDOMEvent(window, 'blur', keymanweb['pageFocusHandler'], false);   // I775
+    util.attachDOMEvent(window, 'focus', keymanweb.pageFocusHandler, false);  // I775
+    util.attachDOMEvent(window, 'blur', keymanweb.pageFocusHandler, false);   // I775
 
     // Initialize supplementary plane string extensions
     String.kmwEnableSupplementaryPlane(true);

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -117,17 +117,6 @@ if(!window['keyman']['initialized']) {
 
     util.attachDOMEvent(document, 'keyup', keymanweb.hotkeyManager._Process, false);
 
-    /**
-     * Reset context when entering or exiting the active element.
-     * Will also trigger OSK shift state / layer reset.
-     **/
-    keymanweb.pageFocusHandler = function() {
-      let keyman = com.keyman.singleton;
-      if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
-        keyman.core.resetContext(null);
-      }
-    }
-
     // We need to track this handler, as it causes... interesting... interactions during testing in certain browsers.
     util.attachDOMEvent(window, 'focus', keymanweb.pageFocusHandler, false);  // I775
     util.attachDOMEvent(window, 'blur', keymanweb.pageFocusHandler, false);   // I775

--- a/web/source/keymanweb.ts
+++ b/web/source/keymanweb.ts
@@ -118,12 +118,13 @@ if(!window['keyman']['initialized']) {
     util.attachDOMEvent(document, 'keyup', keymanweb.hotkeyManager._Process, false);
 
     /**
-     * Reset OSK shift states when entering or exiting the active element
+     * Reset context when entering or exiting the active element.
+     * Will also trigger OSK shift state / layer reset.
      **/
     function resetVKShift() {
       let keyman = com.keyman.singleton;
       if(!keyman.uiManager.isActivating && keyman.osk?.vkbd) {
-        keyman.core.keyboardProcessor._UpdateVKShift(null);  //this should be enabled !!!!! TODO
+        keyman.core.resetContext(null);
       }
     }
 

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -185,12 +185,12 @@ namespace com.keyman {
      * Reset context when entering or exiting the active element.
      * Will also trigger OSK shift state / layer reset.
      **/
-    pageFocusHandler: () => boolean = function(this: KeymanBase) {
+    pageFocusHandler = () => {
       if(!this.uiManager.isActivating && this.osk?.vkbd) {
         this.core.resetContext(null);
       }
       return false;
-    }.bind(this);
+    }
 
     /**
      * Triggers a KeymanWeb engine shutdown to facilitate a full system reset.

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -186,8 +186,8 @@ namespace com.keyman {
      * Will also trigger OSK shift state / layer reset.
      **/
     pageFocusHandler = () => {
-      if(!this.uiManager.isActivating && this.osk?.vkbd) {
-        this.core.resetContext(null);
+      if(!this.uiManager.isActivating && this.osk?.vkbd && this.core.contextDevice.touchable) {
+        this.core.keyboardProcessor._UpdateVKShift(null);
       }
       return false;
     }

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -186,7 +186,7 @@ namespace com.keyman {
      * Will also trigger OSK shift state / layer reset.
      **/
     pageFocusHandler = () => {
-      if(!this.uiManager.isActivating && this.osk?.vkbd && this.core.contextDevice.touchable) {
+      if(!this.uiManager.isActivating && this.osk?.vkbd && this.util.device.touchable) {
         this.core.keyboardProcessor._UpdateVKShift(null);
       }
       return false;

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -182,14 +182,25 @@ namespace com.keyman {
     }
 
     /**
+     * Reset context when entering or exiting the active element.
+     * Will also trigger OSK shift state / layer reset.
+     **/
+    pageFocusHandler: () => boolean = function(this: KeymanBase) {
+      if(!this.uiManager.isActivating && this.osk?.vkbd) {
+        this.core.resetContext(null);
+      }
+      return false;
+    }.bind(this);
+
+    /**
      * Triggers a KeymanWeb engine shutdown to facilitate a full system reset.
      * This function is designed for use with KMW unit-testing, which reloads KMW
      * multiple times to test the different initialization paths.
      */
     ['shutdown']() {
       // Disable page focus/blur events, which can sometimes trigger and cause parallel KMW instances in testing.
-      this.util.detachDOMEvent(window, 'focus', (this as any).pageFocusHandler, false);
-      this.util.detachDOMEvent(window, 'blur', (this as any).pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'focus', this.pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'blur', this.pageFocusHandler, false);
 
       this.domManager.shutdown();
       this.osk.shutdown();

--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -188,8 +188,8 @@ namespace com.keyman {
      */
     ['shutdown']() {
       // Disable page focus/blur events, which can sometimes trigger and cause parallel KMW instances in testing.
-      this.util.detachDOMEvent(window, 'focus', this['pageFocusHandler'], false);
-      this.util.detachDOMEvent(window, 'blur', this['pageFocusHandler'], false);
+      this.util.detachDOMEvent(window, 'focus', (this as any).pageFocusHandler, false);
+      this.util.detachDOMEvent(window, 'blur', (this as any).pageFocusHandler, false);
 
       this.domManager.shutdown();
       this.osk.shutdown();


### PR DESCRIPTION
A combo-🍒 for both #6901 and #6902 - so, the full 🖇️ set.

There is one notable change from #6902, based on this comment: https://github.com/keymanapp/keyman/pull/6902#discussion_r916426897

Just in case we'd rather split this into two separate 🍒s, commit https://github.com/keymanapp/keyman/pull/6949/commits/9ffca15f643ead60efc810d454d2335c343d14ea is the final one from the first PR.

@keymanapp-test-bot skip