### PR TITLE
chore(web): remove invalid warning msg

### DIFF
--- a/common/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -157,9 +157,6 @@ namespace com.keyman.text.prediction {
       } else if(outputTarget) {
         let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
         this.predict_internal(transcription, true, layerId);
-      } else {
-        // Shouldn't be possible, and we'll want to know if and when it is.
-        console.warn("OutputTarget missing during an invalidateContext call");
       }
     }
 


### PR DESCRIPTION
Addresses a number of Sentry events (now merged into [KEYMAN-WEB-42](https://sentry.io/organizations/keyman/issues/3410147810/)) that started appearing after #6904 was merged.

Upon inspection of several events, it appears that we'll generally have an unset `OutputTarget` within that method during any keyboard swap.  The culprit: 

https://github.com/keymanapp/keyman/blob/04b8ae1ed1001680fdb177594616276a77ce2e57/common/web/input-processor/src/text/inputProcessor.ts#L47-L53

As you can't exactly pass two parameters into a property setter, there's not really any way around this... and it's not like this scenario is causing users any issues.  May as well just nix it, as it's not worth the Sentry noise.

Fixes KEYMAN-WEB-42.

@keymanapp-test-bot skip