### PR TITLE
fix(common): Fix `delete` :cherries: 

### DIFF
--- a/common/core/desktop/src/kmx/kmx_file.cpp
+++ b/common/core/desktop/src/kmx/kmx_file.cpp
@@ -183,7 +183,7 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboard(km_kbp_path_name fileName, LPKEYBOARD *l
 
   if(*PKMX_DWORD(filebase) != KMX_DWORD(FILEID_COMPILED))
   {
-    delete buf;
+    delete [] buf;
     DebugLog("Invalid file - signature is invalid");
     return FALSE;
   }
@@ -198,7 +198,11 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboard(km_kbp_path_name fileName, LPKEYBOARD *l
 
   if(!kbp) return FALSE;
 
-  if(kbp->dwIdentifier != FILEID_COMPILED) { delete buf; DebugLog("errNotFileID"); return FALSE; }
+  if(kbp->dwIdentifier != FILEID_COMPILED) {
+    delete [] buf;
+    DebugLog("errNotFileID");
+    return FALSE;
+  }
 
   *lpKeyboard = kbp;
 

--- a/common/core/desktop/src/kmx/kmx_options.cpp
+++ b/common/core/desktop/src/kmx/kmx_options.cpp
@@ -118,7 +118,7 @@ KMX_Options::~KMX_Options()
     if(_kp->KeyboardOptions[i].Value)
     {
       _kp->Keyboard->dpStoreArray[i].dpString = _kp->KeyboardOptions[i].OriginalStore;
-      delete _kp->KeyboardOptions[i].Value;
+      delete [] _kp->KeyboardOptions[i].Value;
     }
   delete _kp->KeyboardOptions;
   _kp->KeyboardOptions = NULL;
@@ -147,7 +147,7 @@ void KMX_Options::Set(int nStoreToSet, std::u16string const & rValueToSet)
   auto & rStoreToSetValue = _kp->KeyboardOptions[nStoreToSet].Value;
   if(rStoreToSetValue)
   {
-    delete rStoreToSetValue;
+    delete [] rStoreToSetValue;
   }
 
   if(m_debug_items) {
@@ -187,7 +187,7 @@ void KMX_Options::Reset(abstract_processor & ap, int nStoreToReset)
   if (rOptionToReset.Value)
   {
     rStoreToReset.dpString = rOptionToReset.OriginalStore;
-    delete rOptionToReset.Value;
+    delete [] rOptionToReset.Value;
     rOptionToReset.Value = nullptr;
   }
 


### PR DESCRIPTION
GCC 12 will output an error if the wrong `delete` is used.

Fixes #6930

(:cherries: picked from #6965)

@keymanapp-test-bot skip