### PR TITLE
change(web): updates mobile screen dimension detection code ⬅️

### DIFF
--- a/web/source/kmwutils.ts
+++ b/web/source/kmwutils.ts
@@ -452,7 +452,7 @@ namespace com.keyman {
           }
         }
         // Calculate viewport scale
-        return Math.round(100*screenWidth / window.innerWidth)/100;
+        return Math.round(100*screenWidth / viewportWidth)/100;
       } catch(ex) {
         return 1;
       }

--- a/web/source/osk/anchoredOskView.ts
+++ b/web/source/osk/anchoredOskView.ts
@@ -150,9 +150,25 @@ namespace com.keyman.osk {
         return keymanweb['getOskHeight']();
       }
 
+      /*
+       * We've noticed some fairly inconsistent behavior in the past when attempting to base
+       * this logic on window.innerWidth/Height, as there can be very unexpected behavior
+       * on mobile devices during and after rotation.
+       *
+       * Online forums (such as https://stackoverflow.com/a/54812656) seem to indicate that
+       * document.documentElement.clientWidth/Height seem to be the most stable analogues
+       * to a window's size in the situations where it matters for Keyman Engine for Web.
+       *
+       * That said, an important note:  this gets the dimensions of the _document element_,
+       * not the screen or even the window.
+       */
       let baseWidth  = document?.documentElement?.clientWidth;
       let baseHeight = document?.documentElement?.clientHeight;
       if(typeof baseWidth == 'undefined') {
+        /*
+         * Fallback logic.  We _shouldn't_ need this, but it's best to have _something_
+         * for the sake of robustness.
+         */
         baseWidth  = Math.min(screen.height, screen.width);
         baseHeight = Math.max(screen.height, screen.width);
 
@@ -167,6 +183,15 @@ namespace com.keyman.osk {
           height=oskHeightLandscapeView;
 
       if(device.formFactor == 'phone') {
+        /**
+         * Assuming the first-pass detection of width and height work correctly, note
+         * that these calculations are based on the document's size, not the device's
+         * resolution.  This _particularly_ matters for height.
+         *
+         * - Is the mobile-device browser showing a URL bar?  That's not included.
+         * - The standard signal-strength, battery-strength, etc device status bar?
+         *   Also not included.
+         */
         if(keymanweb.util.portraitView())
           height=Math.floor(baseHeight/2.4);
         else
@@ -200,8 +225,6 @@ namespace com.keyman.osk {
       width = document?.documentElement?.clientWidth;
       if(typeof width == 'undefined') {
         if(device.OS == 'iOS') {
-          // iOS does not interchange these values when the orientation changes!
-          //width = util.portraitView() ? screen.width : screen.height;
           width = window.innerWidth;
         } else if(device.OS == 'Android') {
           width=screen.availWidth;

--- a/web/source/osk/anchoredOskView.ts
+++ b/web/source/osk/anchoredOskView.ts
@@ -150,17 +150,27 @@ namespace com.keyman.osk {
         return keymanweb['getOskHeight']();
       }
 
-      var oskHeightLandscapeView=Math.floor(Math.min(screen.availHeight,screen.availWidth)/2),
+      let baseWidth  = document?.documentElement?.clientWidth;
+      let baseHeight = document?.documentElement?.clientHeight;
+      if(typeof baseWidth == 'undefined') {
+        baseWidth  = Math.min(screen.height, screen.width);
+        baseHeight = Math.max(screen.height, screen.width);
+
+        if(!keymanweb.util.portraitView()) {
+          let temp = baseWidth;
+          baseWidth = baseHeight;
+          baseHeight = temp;
+        }
+      }
+
+      var oskHeightLandscapeView=Math.floor(Math.min(baseHeight, baseWidth)/2),
           height=oskHeightLandscapeView;
 
       if(device.formFactor == 'phone') {
-        var sx=Math.min(screen.height,screen.width),
-            sy=Math.max(screen.height,screen.width);
-
         if(keymanweb.util.portraitView())
-          height=Math.floor(Math.max(screen.availHeight,screen.availWidth)/3);
+          height=Math.floor(baseHeight/2.4);
         else
-          height=height*(sy/sx)/1.6;  //adjust for aspect ratio, increase slightly for iPhone 5
+          height=Math.floor(baseHeight/1.6);  //adjust for aspect ratio, increase slightly for iPhone 5
       }
 
       // Correct for viewport scaling (iOS - Android 4.2 does not want this, at least on Galaxy Tab 3))
@@ -186,18 +196,18 @@ namespace com.keyman.osk {
       }
 
       var width: number;
-      if(device.OS == 'iOS') {
-        // iOS does not interchange these values when the orientation changes!
-        //width = util.portraitView() ? screen.width : screen.height;
-        width = window.innerWidth;
-      } else if(device.OS == 'Android') {
-        try {
-          width=document.documentElement.clientWidth;
-        } catch(ex) {
+
+      width = document?.documentElement?.clientWidth;
+      if(typeof width == 'undefined') {
+        if(device.OS == 'iOS') {
+          // iOS does not interchange these values when the orientation changes!
+          //width = util.portraitView() ? screen.width : screen.height;
+          width = window.innerWidth;
+        } else if(device.OS == 'Android') {
           width=screen.availWidth;
+        } else {
+          width=screen.width;
         }
-      } else {
-        width=screen.width;
       }
 
       return width;


### PR DESCRIPTION
Based on #6787, as its user test issues motivated development of this PR.

So, it turns out there there are some very strange issues with how `window.innerWidth` updates on mobile devices, and these issues were behind the failed user tests.  It appears that the best approach for detecting screen width (what the mobile-form OSK uses) is actually `document.documentElement.clientWidth`.  (Minor reference: https://stackoverflow.com/a/54812656)

Relying upon that, along with some other shifts to how the mobile-form OSK computes its preferred height, appear to stabilize the base PR's issues.  That said, these are some notable shifts to how the calculations are done, and there may be noteworthy history behind why things were the way that they were, so I expect some scrunity in the review & in the user-test suite.

----

Alternatively, adding a 50ms timeout halfway during the rotation adjustments _seems_ to be enough to remedy the issue.  There's some very odd behavior that I noticed when stepping through this function via debugger:

https://github.com/keymanapp/keyman/blob/16643d7479b2dc751b4e8ccaa3f5627bc2570bda/web/source/kmwrotation.ts#L44-L67

Before `keyman.alignInputs()` is called, `window.innerWidth` is consistently "wrong" - it's notably larger than the value we'd expect it to hold.  _After_ it's called, when stepping through, `window.innerWidth` changes.  Unfortunately, that appears to be asynchronous, and a very short timeout isn't enough to alleviate the issue.  And there's nothing in that function that should directly affect the browser's management of `window.innerWidth`.

So, that "halfway during" note seen above would involve setting a 50ms timeout to run lines 47-60.  Possible to do, but that feels more "hacky" than the approach I decided to run with.  That _may_ just be my perception, though.

By the way, setting the rotation "resolve" timer to a longer period (i.e. further delaying the whole function shown above)  does _not_ remedy the issue.  Somehow, it's about that line - `keyman.alignInputs` - so far as I can tell.

# User Testing

SUITE_ROTATION

## Test environments

- GROUP_IOS_PHONE - any modern iOS phone should suffice
- GROUP_IOS_TABLET - any modern iOS tablet should suffice
- GROUP_OLD_IOS - try to find an iOS 12 or iOS 13 device to test with
- GROUP_ANDROID_PHONE - any modern Android phone should suffice
- GROUP_ANDROID_TABLET - any modern Android tablet should suffice
- GROUP_ANDROID_7 - run tests against early Android if possible (Android 7.0)

## Tests


- **TEST_OSK_PORTRAIT_LOAD**:

  1. Before loading the test page, have the device in a portrait orientation.
  2. Load the KeymanWeb testing page "Test unminified Keymanweb".
  3. Select the top text area in order to display the OSK.
  4. Report on the appearance of the OSK.  Does it seem reasonably positioned and sized?  No cropping issues?

- **TEST_OSK_LANDSCAPE_LOAD**:

  1. Before loading the test page, have the device in a landscape orientation.
  2. Load the KeymanWeb testing page "Test unminified Keymanweb".
  3. Select the top text area in order to display the OSK.
  4. Report on the appearance of the OSK.  Does it seem reasonably positioned and sized?  No cropping issues?

- **TEST_BROWSER_ROTATE_P-TO-L**:

  1. Before loading the test page, have the device in a portrait orientation.
  2. Load the KeymanWeb testing page "Test unminified Keymanweb".
  3. Select the top text area in order to display the OSK.
  4. Open the language menu, but do not change keyboards.
  5. Once loaded, rotate the device to a landscape orientation.
      - The test "passes" if the OSK rotates properly.
      - The test "fails" if the OSK is not visible after rotation.

- **TEST_BROWSER_ROTATE_L-TO-P**:

  1. Before loading the test page, have the device in a landscape orientation.
  2. Load the KeymanWeb testing page "Test unminified Keymanweb".
  3. Select the top text area in order to display the OSK.
  4. Open the language menu, but do not change keyboards.
  6. Once loaded, rotate the device to a portrait orientation.
      - The test "passes" if the OSK rotates properly.
      - The test "fails" if the OSK is not visible after rotation.
