### PR TITLE
fix(android): rework longpress movement trigger 🎁

### DIFF
--- a/android/KMEA/.idea/.gitignore
+++ b/android/KMEA/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -188,9 +188,20 @@ final class KMKeyboard extends WebView {
       }
 
       @Override
+      public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
+        if(e2.getY() - e1.getY() < -5) { // TODO: get better threshold value from KMW
+          if (subKeysList != null && (subKeysWindow == null || !subKeysWindow.isShowing())) {
+            showSubKeys(context);
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
       public void onLongPress(MotionEvent event) {
         // This is also called for banner longpresses!  Need a way to differentiate the sources.
-        if (subKeysList != null && subKeysWindow != null && !subKeysWindow.isShowing()) {
+        if (subKeysList != null && (subKeysWindow == null || !subKeysWindow.isShowing())) {
           showSubKeys(context);
           return;
         } else if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
@@ -286,17 +297,12 @@ final class KMKeyboard extends WebView {
     // Come to think of it, I wonder if suggestionMenuWindow was work being done to link with
     // suggestion banner longpresses - if so, it's not yet ready for proper integration...
     // and would need its own rung in this if-else ladder.
-    if (subKeysWindow != null && suggestionMenuWindow == null) {
+    if (subKeysWindow != null && suggestionMenuWindow == null && subKeysWindow.isShowing()) {
       // Passes KMKeyboard (subclass of WebView)'s touch events off to our subkey window
       // if active, allowing for smooth, integrated gesture control.
       subKeysWindow.getContentView().findViewById(R.id.grid).dispatchTouchEvent(event);
     } else {
-      //handleTouchEvent(event);
       gestureDetector.onTouchEvent(event);
-      if (action == MotionEvent.ACTION_MOVE && subKeysList != null && subKeysWindow == null) {
-        // Display subkeys during move
-        showSubKeys(context);
-      }
     }
 
     if (action == MotionEvent.ACTION_UP) {


### PR DESCRIPTION
Fixes #6981.

Longpress menus were being triggered on any detected movement on keys on Android. This would cause rapid typing to periodically fail as the user would make a single-pixel movement while typing, which would then block subsequent key events.

This issue was introduced in #6637, which resolved a somewhat related problem with sticky longpress menus.

The fix is in three parts:

1. Remove the touch movement detection which caused the primary problem
2. Address some logic issues around visibility of `subkeysWindow` which meant that the longpress delay trigger was never fired.
3. Introduce a new 'scroll' gesture handler which detects a negative-y movement above a 5px threshold, to open the longpress menu.

The 5px threshold is the minimum default used by Keyman Engine for Web. However, it may not be ideal, and we should consider moving to using the 0.25 x row height value that Keyman Engine for Web uses in a future update. However, I do not consider this to be a reason to block this fix, as it would require significant extra engineering.

# User Testing

We need to re-run the main test from #6637, first, to verify that this does not re-introduce any of the behaviours that that PR was intended to fix.

Setup - A physical Android device. Don't use emulator because the scenario involves typing fast on the OSK (e.g. two thumbs)

* **TEST_POPUPS** - Verify popup keys don't get stuck on
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Type on the OSK using the following scenarios and verify expected output:
    * Clicking a suggestion on the suggestion banner - should insert the suggestion
    * short-press a key and release - should insert the base key
    * long-press a key, select a long-press key, and release - should insert the long-press key (**note:** there should be a 0.5 second delay before the menu appears)
    * long-press a key, while keeping the finger down, move off the long-press options, and release - should **not** output
    * long-press a key, while keeping the finger down, move off the long-press options, then move back on a long-press option so it's highlighted, and release - should output the long-press key
    * quickly type a long paragraph (e.g. repeat the word "reply") - verify long-press keys don't get stuck (displayed when not touching a key)

* **TEST_UP_FLICK** - Verify that the up-flick gesture reliably opens the longpress menu
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Touch a key such as `e` and immediately swipe upwards to access the long-press menu, keeping your finger down. This should show long-press options without the 0.5 second delay.
   * You should be able to select an option from the long-press menu.
   * You should be able to move back onto the base key to select the base key letter again.
   * You should also be able to move your finger away from the menu to cancel the input.
5. Please run this test a number of times to verify that the behaviour remains consistent.