### PR TITLE
chore(linux): Update changelog

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -5,7 +5,7 @@
 @Library('lsdev-pipeline-library') _
 
 keymanPackaging {
-  distributionsToPackage = 'bionic focal impish jammy'
+  distributionsToPackage = 'bionic focal jammy kinetic'
   arches = 'amd64 i386'
   packagesToBuild = ['keyman']
 }

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,11 @@
+keyman (15.0.266-2) unstable; urgency=high
+
+  * Team upload.
+  * debian/patches/0001-fix-common-Fix-delete.patch: Apply upstream
+    trunk patch to fix FTBFS with GCC 12. (Closes: #1012958)
+
+ -- Boyuan Yang <byang@debian.org>  Sun, 24 Jul 2022 01:07:36 -0400
+
 keyman (15.0.266-1) unstable; urgency=medium
 
   * New upstream release.


### PR DESCRIPTION
This change updates the changelog to keep it in sync with Debian where PR #6966 got applied to the current stable version.

Also remove outdated impish and add kinetic.

@keymanapp-test-bot skip