### PR TITLE
fix(developer): compiler emitting garbage for readonly groups 🎾

### DIFF
--- a/developer/src/tike/compile/CompileKeymanWeb.pas
+++ b/developer/src/tike/compile/CompileKeymanWeb.pas
@@ -1038,7 +1038,8 @@ begin
     begin
 			if InQuotes then
       begin
-        Result := Result + '");';
+        if not fgp.fReadOnly then
+          Result := Result + '");';
         InQuotes := False;
       end;
 
@@ -1223,9 +1224,9 @@ begin
         InQuotes := True; len := -1;
       end;
 
-      if rec.ChrVal in [Ord('"'), Ord('\')] then Result := Result + '\';
       if not fgp.fReadOnly then
       begin
+        if rec.ChrVal in [Ord('"'), Ord('\')] then Result := Result + '\';
         Result := Result + Javascript_String(rec.ChrVal);  // I2242
       end;
     end;
@@ -1233,7 +1234,13 @@ begin
     pwsz := incxstr(pwsz);
 	end;
 
-	if InQuotes then Result := Result + '");';
+	if InQuotes then
+  begin
+    if not fgp.fReadOnly then
+    begin
+      Result := Result + '");';
+    end;
+  end;
 end;
 
 function TCompileKeymanWeb.JavaScript_Shift(fkp: PFILE_KEY; FMnemonic: Boolean): Integer;


### PR DESCRIPTION
Picked up while reviewing code for conversion to C++. The compiler could, in some circumstances emit garbage code for readonly groups because we weren't testing all scenarios correctly. In practice, this would have been rare as readonly groups don't emit characters, but it should be fixed!

@keymanapp-test-bot skip