### PR TITLE
fix(developer): rebuilding a model would not refresh it in server 🎾 🍒

### DIFF
--- a/developer/server/package.json
+++ b/developer/server/package.json
@@ -8,7 +8,7 @@
     "postbuild": "npx gosh ./postbuild.sh",
     "prod": "node .",
     "test": "mocha",
-    "watch": "npm run postbuild && tsc-watch --onSuccess \"node .\" --onFailure \"node .\""
+    "watch": "npm run postbuild && tsc-watch --onSuccess \"node --inspect .\" --onFailure \"node --inspect .\""
   },
   "author": "",
   "license": "MIT",

--- a/developer/server/src/handlers/api/debugobject/get.ts
+++ b/developer/server/src/handlers/api/debugobject/get.ts
@@ -1,18 +1,20 @@
 import chalk = require('chalk');
 import express = require('express');
-import { DebugObject, isValidId } from "../../../data";
+import { DebugObject, isValidId, simplifyId } from "../../../data";
 
 export default function apiGet (data: { [id: string]: DebugObject }, req: express.Request, res: express.Response, next: express.NextFunction) {
-  const id = req.query['id'] as string;
+  let id = req.query['id'] as string;
   if(!isValidId(id)) {
     res.sendStatus(400);
     return;
   }
 
+  id = simplifyId(id);
+
   const o: DebugObject = data[id];
   if(!o) {
-    console.error(chalk.red('  not found'));
-    res.status(404).send(JSON.stringify({error: 'not found'}));
+    console.error(chalk.red(id+' not found'));
+    res.status(404).send(JSON.stringify({error: id+' not found'}));
   } else {
     res.send(JSON.stringify(o));
   }

--- a/developer/server/src/handlers/api/debugobject/unregister.ts
+++ b/developer/server/src/handlers/api/debugobject/unregister.ts
@@ -1,14 +1,17 @@
 import express = require('express');
-import { DebugObject, isValidId } from "../../../data";
+import { DebugObject, isValidId, simplifyId } from "../../../data";
 import fs = require('fs');
 import chalk = require('chalk');
 
 export default function apiUnregister<O extends DebugObject> (root:{ [id: string]: O }, req: express.Request, res: express.Response, next: express.NextFunction) {
-  const id = req.body['id'];
+  let id = req.body['id'];
   if(!isValidId(id)) {
     res.sendStatus(400);
     return;
   }
+
+  id = simplifyId(id);
+
   const o = root[id];
 
   if(!o) {


### PR DESCRIPTION
Cherry-pick of #7015.

When rebuilding a model, Keyman Developer would query for the registered model, but a missing simplifyId call meant that it never matched the model name (due to `.` vs `_`).

@keymanapp-test-bot skip