### PR TITLE
chore(common): build-utils.sh minor tweaks

### DIFF
--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 ################################ Main script ################################
 
-builder_describe "Build the include script for current Keyman version" configure clean build test
+builder_describe "Build the include script for current Keyman version" configure clean build
 builder_parse "$@"
 
 # TODO: build if out-of-date if test is specified
@@ -59,9 +59,4 @@ if builder_has_action build; then
   # Build
   npm run build -- $builder_verbose || die "Could not build worker."
   builder_report success build
-fi
-
-if builder_has_action test; then
-  npm test || fail "Tests failed"
-  builder_report success test
 fi

--- a/core/build.sh
+++ b/core/build.sh
@@ -6,23 +6,12 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
-# NOTE: this is slightly non-standard; see longer discussion below
+. "$(dirname "$THIS_SCRIPT")/../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-# This script does not use our normal shared build-utils.sh because Linux package builds
-# cannot access anything outside of the `core` directory. This means that:
-# 1. `shellHelperFunctions.sh`, `VERSION.md` and `TIER.md` are copied here by the script
-#    `linux/scripts/dist.sh` for inclusion locally in Linux package builds.
-# 2. `getversion.sh` and `gettier.sh` will use current folder if we can't access the
-#    root level `VERSION.md` and `TIER.md`.
-# 3. `$SCRIPTS_DIR` is set to this folder by the package build Makefile
-#    `core/debian/rules`
-SCRIPTS_DIR=${SCRIPTS_DIR:-$(dirname "$THIS_SCRIPT")/../resources}
-. "${SCRIPTS_DIR}/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
-THIS_DIR="$(dirname "$THIS_SCRIPT")"
-
-pushd $THIS_DIR > /dev/null
+pushd "$THIS_SCRIPT_PATH" > /dev/null
 VERSION=$(./getversion.sh)
 TIER=$(./gettier.sh)
 popd > /dev/null
@@ -64,7 +53,7 @@ TESTS_CPP=false
 INSTALL_CPP=false
 UNINSTALL_CPP=false
 QUIET=false
-TARGET_PATH="$THIS_DIR/build"
+TARGET_PATH="$THIS_SCRIPT_PATH/build"
 ADDITIONAL_ARGS=
 PLATFORM=native
 
@@ -224,7 +213,7 @@ build_standard() {
   # Build meson targets
   if $CONFIGURE; then
     echo_heading "======= Configuring C++ library for $BUILD_PLATFORM ======="
-    pushd "$THIS_DIR" > /dev/null
+    pushd "$THIS_SCRIPT_PATH" > /dev/null
     meson setup "$MESON_PATH" --werror --buildtype $MESON_TARGET $STANDARD_MESON_ARGS $ADDITIONAL_ARGS
     popd > /dev/null
   fi

--- a/core/build.sh
+++ b/core/build.sh
@@ -11,11 +11,6 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
-pushd "$THIS_SCRIPT_PATH" > /dev/null
-VERSION=$(./getversion.sh)
-TIER=$(./gettier.sh)
-popd > /dev/null
-
 display_usage() {
   echo "usage: build.sh [build options] [targets] [-- options to pass to c++ configure]"
   echo

--- a/core/gettier.sh
+++ b/core/gettier.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Get the tier from TIER.md
-# When building from a Linux source package, `TIER.md` is in the
-# same directory as this script.
-TIERFILE=TIER.md
-[ -f ../TIER.md ] && TIERFILE=../TIER.md
-cat $TIERFILE

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -3,8 +3,14 @@
 set -e
 set -u
 
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
 # Include our resource functions; they're pretty useful!
-. ../../resources/shellHelperFunctions.sh
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
 # Please note that this build script (understandably) assumes that it is running on Mac OS X.
 verify_on_mac

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -6,7 +6,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
-. "$(dirname "$THIS_SCRIPT")/../resources/build/build-utils.sh"
+. "$(dirname "$THIS_SCRIPT")/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 # Include our resource functions; they're pretty useful!

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -270,21 +270,31 @@ replaceVersionStrings_Mkver() {
 # Standard build script functions for managing command line, actions and targets
 ################################################################################
 
-# TODO: colors are defined here and in shellHelperFunctions.sh
 # The following allows coloring of warning and error lines, but only works if there's a
 # terminal attached, so not on the build machine.
-if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]]; then
+builder_use_color() {
+  if $1; then
     COLOR_RED=$(tput setaf 1)
     COLOR_GREEN=$(tput setaf 2)
     COLOR_BLUE=$(tput setaf 4)
     COLOR_YELLOW=$(tput setaf 3)
     COLOR_RESET=$(tput sgr0)
-else
+    # e.g. VSCode https://code.visualstudio.com/updates/v1_69#_setmark-sequence-support
+    HEADING_SETMARK='\x1b]1337;SetMark\x07'
+  else
     COLOR_RED=
     COLOR_GREEN=
     COLOR_BLUE=
     COLOR_YELLOW=
     COLOR_RESET=
+    HEADING_SETMARK=
+  fi
+}
+
+if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]]; then
+  builder_use_color true
+else
+  builder_use_color false
 fi
 
 ####################################################################################
@@ -324,16 +334,21 @@ _builder_item_is_target() {
 # Returns 0 if the user has asked to perform action on target on the command line
 #
 # Usage:
-#   if build_has_action action :target; then ...; fi
+#   if build_has_action action[:target]; then ...; fi
 # Parameters:
 #   1: action    name of action
-#   2: target    name of target, :-prefixed
+#   2: :target    name of target, :-prefixed, as part of first param or space separated ok
 # Example:
 #   if build_has_action build :app; then
+#   if build_has_action build:app; then
 #
 builder_has_action() {
   local action="$1" target
-  if [[ -z ${2+x} ]]; then
+
+  if [[ $action =~ : ]]; then
+    IFS=: read -r action target <<< $action
+    target=:$target
+  elif [[ -z ${2+x} ]]; then
     target=:project
   else
     target="$2"
@@ -481,14 +496,15 @@ _builder_get_default_description() {
   echo "$description"
 }
 
-# Overrides default colorization of logging; can be used in command-line with
-# --color or --no-color, or overridden as necessary on a per-script basis.
-#
-# Parameters
-#  1: use_color       true or false
-builder_use_color() {
-  local use_color=$1
-  shell_helper_color $use_color
+_builder_parameter_error() {
+  local program="$1"
+  local type="$2"
+  local param="$3"
+  echo "$COLOR_RED$program: invalid $type: $param$COLOR_RESET"
+  echo
+  builder_display_usage
+  exit 64
+
 }
 
 # Initializes a build.sh script, parses command line. Will abort the script if
@@ -533,11 +549,22 @@ builder_parse() {
       _builder_chosen_action_targets+=("$key")
     elif (( has_action )); then
       # apply the selected action to all targets
+      if [[ ! -z $target ]]; then
+        # A target was specified but is not valid
+        _builder_parameter_error "$0" target "$target"
+      fi
+
       for e in "${_builder_targets[@]}"; do
         _builder_chosen_action_targets+=("$action$e")
       done
     elif (( has_target )); then
       # apply the default action to the selected target
+
+      if [[ ! -z $action ]]; then
+        # An action was specified but is not valid
+        _builder_parameter_error "$0" action "$action"
+      fi
+
       _builder_chosen_action_targets+=("$_builder_default_action$target")
     elif (( has_option )); then
       _builder_chosen_options+=("$key")
@@ -558,9 +585,7 @@ builder_parse() {
           builder_verbose=--verbose
           ;;
         *)
-          echo "$0: invalid option: $key"
-          builder_display_usage
-          exit 64
+          _builder_parameter_error "$0" parameter "$key"
       esac
     fi
     shift # past the processed argument
@@ -646,10 +671,10 @@ builder_display_usage() {
     fi
   done
 
-  _builder_pad $width "  --verbose, -v" "Verbose logging"
-  _builder_pad $width "  --color" "Force colorized output"
-  _builder_pad $width "  --no-color" "Never use colorized output"
-  _builder_pad $width "  --help, -h" "Show this help"
+  _builder_pad $width "  --verbose, -v"  "Verbose logging"
+  _builder_pad $width "  --color"        "Force colorized output"
+  _builder_pad $width "  --no-color"     "Never use colorized output"
+  _builder_pad $width "  --help, -h"     "Show this help"
   local c1="${COLOR_BLUE:=<}"
   local c0="${COLOR_RESET:=>}"
   echo
@@ -664,7 +689,10 @@ builder_report() {
   local result="$1"
   local action="$2" target
 
-  if [[ -z ${3+x} ]]; then
+  if [[ $action =~ : ]]; then
+    IFS=: read -r action target <<< $action
+    target=:$target
+  elif [[ -z ${3+x} ]]; then
     target=:project
   else
     target="$3"

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -272,6 +272,12 @@ replaceVersionStrings_Mkver() {
 
 # The following allows coloring of warning and error lines, but only works if there's a
 # terminal attached, so not on the build machine.
+
+# Overrides default colorization of logging; can be used in command-line with
+# --color or --no-color, or overridden as necessary on a per-script basis.
+#
+# Parameters
+#  1: use_color       true or false
 builder_use_color() {
   if $1; then
     COLOR_RED=$(tput setaf 1)

--- a/resources/build/build-utils.test.sh
+++ b/resources/build/build-utils.test.sh
@@ -62,8 +62,15 @@ else
 fi
 
 if builder_has_action clean :app; then
-  echo "Cleaning app"
+  echo "Cleaning <clean :app>"
   builder_report success clean :app
+else
+  fail "FAIL: should have matched action clean for :app"
+fi
+
+if builder_has_action clean:app; then
+  echo "Cleaning <clean:app>"
+  builder_report success clean:app
 else
   fail "FAIL: should have matched action clean for :app"
 fi

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -82,32 +82,9 @@ get_platform_folder() {
   fi
 }
 
-# The following allows coloring of warning and error lines, but only works if there's a
-# terminal attached, so not on the build machine.
-shell_helper_color() {
-  if $1; then
-    COLOR_RED=$(tput setaf 1)
-    COLOR_GREEN=$(tput setaf 2)
-    COLOR_BLUE=$(tput setaf 4)
-    COLOR_YELLOW=$(tput setaf 3)
-    COLOR_RESET=$(tput sgr0)
-    # e.g. VSCode https://code.visualstudio.com/updates/v1_69#_setmark-sequence-support
-    HEADING_SETMARK='\x1b]1337;SetMark\x07'
-  else
-    COLOR_RED=
-    COLOR_GREEN=
-    COLOR_BLUE=
-    COLOR_YELLOW=
-    COLOR_RESET=
-    HEADING_SETMARK=
-  fi
-}
-
-if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]]; then
-  shell_helper_color true
-else
-  shell_helper_color false
-fi
+# Note: COLOR_ and HEADING_ variables are defined in build-utils.sh
+# which is already required for scripts so these should be safe.
+# (part of TODO: consolidate these two scripts)
 
 echo_heading() {
   echo -e "${HEADING_SETMARK}${COLOR_BLUE}$*${COLOR_RESET}"


### PR DESCRIPTION
Fixing up a number of minor bits and pieces identified during demo:

* invalid action or :target would not be picked up if paired with a valid one (e.g.: build:foo should not have worked)
* colors defined in both shellHelperFunctions and build-utils were problematic; able to remove them from shellHelperFunctions because all references included both scripts
* builder_has_action and builder_report now allow both `action:target` and `action :target`
* keyman-version/build.sh did not have working test action...

@keymanapp-test-bot skip