### PR TITLE
chore(core): get wasm core building again

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -258,10 +258,32 @@ build_standard() {
   fi
 }
 
+#
+# We don't want to rely on emcc being on the path, because Emscripten puts far
+# too many things onto the path (in particular for us, node).
+#
+# The following comment suggests that we don't need emcc on the path.
+# https://github.com/emscripten-core/emscripten/issues/4848#issuecomment-1097357775
+#
+# So we try and locate emcc in common locations ourselves. The search pattern
+# is:
+#
+# 1. Look for $EMSCRIPTEN_BASE (our primary emscripten variable), which should
+#    point to the folder that emcc is located in
+# 2. Look for $EMCC which should point to the emcc executable
+# 3. Look for emcc on the path
+#
 locate_emscripten() {
-  local EMCC=`which emcc`
-  [ -z "$EMCC" ] && fail "Could not locate emscripten (emcc)"
-  EMSCRIPTEN_BASE="$(dirname "$EMCC")"
+  if [[ -z ${EMSCRIPTEN_BASE+x} ]]; then
+    if [[ -z ${EMCC+x} ]]; then
+      local EMCC=`which emcc`
+      [[ -z $EMCC ]] && fail "locate_emscripten: Could not locate emscripten (emcc) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
+    fi
+    [[ -x $EMCC ]] || fail "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc"
+    EMSCRIPTEN_BASE="$(dirname "$EMCC")"
+  fi
+
+  [[ -x ${EMSCRIPTEN_BASE}/emcc ]] || fail "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to emcc's folder"
 }
 
 build_meson_cross_file_for_wasm() {

--- a/core/src/kmx/kmx_debugger.cpp
+++ b/core/src/kmx/kmx_debugger.cpp
@@ -21,7 +21,7 @@ void KMX_DebugItems::push_item(
   PKMX_WORD index_stack
 ) {
   _items->assert_push_entry();
-  km_kbp_state_debug_item item = {type, flags};
+  km_kbp_state_debug_item item = {type, flags, {}, {}};
   item.kmx_info.rule = key;
   if(item.kmx_info.rule && index_stack) {
     this->fill_store_offsets(&item.kmx_info, index_stack);
@@ -43,7 +43,7 @@ void KMX_DebugItems::push_set_option(
   KMX_WCHAR const * value
 ) {
   _items->assert_push_entry();
-  km_kbp_state_debug_item item = {KM_KBP_DEBUG_SET_OPTION, 0};
+  km_kbp_state_debug_item item = {KM_KBP_DEBUG_SET_OPTION, 0, {}, {}};
   item.kmx_info.first_action = first_action;
   item.kmx_info.rule = nullptr;
   item.kmx_info.group = nullptr;

--- a/core/tests/unit/kmnkbd/debug_api.cpp
+++ b/core/tests/unit/kmnkbd/debug_api.cpp
@@ -50,7 +50,7 @@ void teardown() {
 void setup(const char *keyboard) {
   teardown();
 
-  km::kbp::path path = km::kbp::path::join(arg_path, "..", "kmx", keyboard);
+  km::kbp::path path = km::kbp::path::join(arg_path, keyboard);
 
   try_status(km_kbp_keyboard_load(path.native().c_str(), &test_kb));
   try_status(km_kbp_state_create(test_kb, test_env_opts, &test_state));

--- a/core/tests/unit/kmnkbd/meson.build
+++ b/core/tests/unit/kmnkbd/meson.build
@@ -4,7 +4,7 @@
 # Authors:      Tim Eves (TSE)
 #
 
-if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
+if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang' or compiler.get_id() == 'emscripten'
   warns = [
      '-Wno-missing-field-initializers',
      '-Wno-unused-parameter'
@@ -24,12 +24,22 @@ tests = [
   ['kmx_context', 'test_kmx_context.cpp'],
 ]
 
+if compiler.get_id() == 'emscripten'
+  tests_flags = ['--embed-file', join_paths(meson.current_source_dir(),'..','kmx','@/')]
+  source_path = '/'
+  test_path = '/'
+else
+  tests_flags = []
+  source_path = meson.current_source_dir()
+  test_path = join_paths(meson.current_source_dir(), '..', 'kmx')
+endif
+
 foreach t : tests
   bin = executable(t[0], t[1],
     cpp_args: defns + warns,
     include_directories: [inc, libsrc],
-    link_args: links,
+    link_args: links + tests_flags,
     objects: lib.extract_all_objects())
 
-  test(t[0], bin, args: ['--color', meson.current_source_dir()])
+  test(t[0], bin, args: ['--color', test_path])
 endforeach

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -219,6 +219,11 @@ endif
 
 # test for km_kbp_keyboard_get_key_list
 
+# For following tests, we need to be copying from source_path,
+# not build_path, so we'll just update test_path accordingly. This
+# should work for Linux, macOS, and WASM.
+test_path = source_path
+
 key_e = executable('key_list', 'kmx_key_list.cpp',
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -5,7 +5,7 @@
 # History:      19  Oct 2018 - TSE - Added test for context API functions.
 #
 
-if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
+if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang' or compiler.get_id() == 'emscripten'
   warns = [
      '-Wno-missing-field-initializers',
      '-Wno-unused-parameter'
@@ -204,6 +204,11 @@ if kmcomp.found()
   endforeach
 else
   foreach kbd : tests
+    if compiler.get_id() == 'emscripten'
+      kbd_basename = kbd
+    else
+      kbd_basename = 'k_' + kbd.underscorify().to_lower()
+    endif
     kbd_src = join_paths(test_path, kbd_basename) + '.kmn'
     kbd_obj = join_paths(test_path, kbd_basename) + '.kmx'
 
@@ -217,7 +222,7 @@ endif
 key_e = executable('key_list', 'kmx_key_list.cpp',
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],
-                link_args: links,
+                link_args: links + tests_flags,
                 objects: lib.extract_all_objects())
 test_kbd = 'kmx_key_list'
 if kmcomp.found()
@@ -230,7 +235,7 @@ if kmcomp.found()
   )
   test('key_list', key_e,  depends: kbd_log, args: [kbd_obj] )
 else
-  kbd_obj = join_paths(meson.current_source_dir(), test_kbd) + '.kmx'
+  kbd_obj = join_paths(test_path, test_kbd) + '.kmx'
   test('key_list', key_e, args: [kbd_obj] )
 endif
 
@@ -239,7 +244,7 @@ endif
 imx_e = executable('imx_list', 'kmx_imx.cpp',
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],
-                link_args: links,
+                link_args: links + tests_flags,
                 objects: lib.extract_all_objects())
 
 test_kbd = 'kmx_imsample'
@@ -253,7 +258,7 @@ if kmcomp.found()
   )
     test('imx_list', imx_e,  depends: kbd_log, args: [kbd_obj] )
 else
-  kbd_obj = join_paths(meson.current_source_dir(), test_kbd) + '.kmx'
+  kbd_obj = join_paths(test_path, test_kbd) + '.kmx'
   test('imx_list', imx_e, args: [kbd_obj] )
 endif
 

--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -71,6 +71,11 @@ These dependencies are also listed below if you'd prefer to install manually.
   brew install node emscripten openjdk@8
   ```
 
+  Note: if you install emscripten with brew on macOS, only emscripten binaries
+  are added to the path via symlinks. This makes it reasonably safe to have
+  emscripten on the path, unlike on other platforms where emscripten also ends
+  up adding its versions of node, python, and other binaries to the path.
+
 * iOS: swiftlint, carthage
 
   ```shell

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -175,21 +175,41 @@ You can use Windows Settings to add these environment variables permanently:
 * KeymanWeb
 
 **Requirements**:
-* node.js 14+
 * emscripten 2.0.23+
+* node.js 14+
 * openjdk 8+
 
 ```ps1
 # Elevated PowerShell
-choco install nodejs emscripten
-choco install openjdk
 
 # for *much* faster download, hide progress bar (PowerShell/PowerShell#2138)
 $ProgressPreference = 'SilentlyContinue'
 
+choco install emscripten
+```
+
+Note: emscripten very unhelpfully overwrites JAVA_HOME, and adds its own
+versions of Python, Node and Java to the PATH. For best results, go ahead
+and remove those paths from your PATH variable before continuing.
+
+There is no need to add emscripten to the path in order to build Keyman.
+However, you should set the EMSCRIPTEN_BASE variable to the path where `emcc`
+can be found, but always in the upstream\emscripten subdirectory where you
+installed emsdk (most likely %LocalAppData%\emsdk\upstream\emscripten)
+
 **Environment variables**:
-* `PATH`:
-  * Add emscripten to path, most likely %LocalAppData%\emsdk\upstream\emscripten
+* `EMSCRIPTEN_BASE`: `<your-emsdk-path>\upstream\emscripten`
+
+After installing emscripten, you'll need to install node.js and openjdk:
+
+```ps1
+# Elevated PowerShell
+
+# for *much* faster download, hide progress bar (PowerShell/PowerShell#2138)
+$ProgressPreference = 'SilentlyContinue'
+choco install nodejs
+choco install openjdk
+```
 
 ### Windows Platform Dependencies
 

--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -13,7 +13,7 @@ watch_android='web|common/models|common/predictive-text|common/web'
 watch_ios='web|common/models|common/predictive-text|common/web'
 watch_linux='core'
 watch_mac='core'
-watch_web='common/models|common/predictive-text|common/web'
+watch_web='common/models|common/predictive-text|common/web|core'
 watch_windows='common|core|web'
 watch_developer='common|core|web'
 
@@ -38,7 +38,7 @@ bc_test_ios=(Keyman_iOS_TestPullRequests Keyman_iOS_TestSamplesAndTestProjects)
 bc_test_linux=(KeymanLinux_TestPullRequests Keyman_Common_KPAPI_TestPullRequests_Linux pipeline-keyman-packaging_Jenkins)
 bc_test_mac=(Keyman_KeymanMac_PullRequests Keyman_Common_KPAPI_TestPullRequests_macOS)
 bc_test_windows=(KeymanDesktop_TestPullRequests KeymanDesktop_TestPrRenderOnScreenKeyboards Keyman_Common_KPAPI_TestPullRequests_Windows)
-bc_test_web=(Keymanweb_TestPullRequests Keyman_Common_LMLayer_TestPullRequests)
+bc_test_web=(Keymanweb_TestPullRequests Keyman_Common_LMLayer_TestPullRequests Keyman_Common_KPAPI_TestPullRequests_WASM)
 bc_test_developer=(Keyman_Developer_Test)
 # Keymanweb_TestPullRequestRegressions : currently this is timing out so disabled until we have
 #                                        time to investigate further


### PR DESCRIPTION
Updates search for emscripten if not on path, and fixes up unit test infrastructure for wasm builds for new tests.

Note that Linux config instructions do not currently list details on how to configure dependencies such as emscripten. This is a separate project!

@keymanapp-test-bot skip