### PR TITLE
fix(developer): stack overflow when compiling non-web keyboard 🎾 

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -67,6 +67,7 @@ uses
   UfrmKeymanWizard,
   UfrmKeyboardFonts,
   UfrmMDIEditor,
+  UKeymanTargets,
   UmodWebHttpServer,
   Keyman.Developer.System.ServerAPI,
   Keyman.Developer.UI.ServerUI,
@@ -133,7 +134,8 @@ begin
 
   if Result and
       TServerDebugAPI.Running and
-      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) then
+      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) and
+      (ProjectFile.Targets * KMWKeymanTargets <> []) then
     TestKeymanWeb(True);
 end;
 
@@ -235,7 +237,13 @@ begin
     Exit(False);
   wizard := editor as TfrmKeymanWizard;
 
+  if ProjectFile.Targets * KMWKeymanTargets = [] then
+    Exit(False);
+
   FCompiledName := ProjectFile.JSTargetFilename;
+  if FCompiledName = '' then
+    Exit(False);
+
   if not TestKeyboardState(FCompiledName, FSilent) then
     Exit(False);
 


### PR DESCRIPTION
Fixes #7030.

Prevents a stack overflow / loop when the web target is removed from a keyboard and it has already been tested on web, and the user presses the Compile button.

# User Testing

* **TEST_COMPILE:** Make sure the compiler no longer goes into a loop and crashes.

  1. Create a new keyboard project, targeting 'all'
  2. Compile the keyboard, and start a web test on it.
  3. Change the `store(&targets)` line to `store(&targets) 'windows'`
  4. Press Compile again.
  5. The compiler should only compile once!

  (Note: you may want to test this procedure in 15.0.267 to observe it going wrong!)