### PR TITLE
fix(developer): prevent crash attempting to compile ansi keyboard 🎾

### DIFF
--- a/developer/src/tike/compile/CompileKeymanWeb.pas
+++ b/developer/src/tike/compile/CompileKeymanWeb.pas
@@ -2200,11 +2200,11 @@ begin
 	{ Write the groups out }
 
   // I853 - begin unicode missing causes crash
-{  if fk.StartGroup[BEGIN_UNICODE] = $FFFFFFFF then
+  if fk.StartGroup[BEGIN_UNICODE] = $FFFFFFFF then
   begin
-    FCallback(fkp.Line, $4005, PChar('A "begin unicode" statement is required to compile a KeymanWeb keyboard'));
+    ReportError(0, CERR_InvalidBegin, 'A "begin unicode" statement is required to compile a KeymanWeb keyboard');
     Exit;
-  end;}
+  end;
 
   Result := Result + WriteBeginStatement('gs', fk.StartGroup[BEGIN_UNICODE]);
   rec := ExpandSentinel(PChar(sBegin_NewContext));


### PR DESCRIPTION
Fixes #7032.

# User Testing

* **TEST_COMPILE:** Make sure compiler no longer crashes when building an ANSI keyboard for web

  1. Create a new keyboard project, targeting 'web' platform
  2. Change the `begin Unicode` line in the .kmn to `begin ANSI > use(main)`
  3. Compile the keyboard: the compiler should give an error message: 'A "begin unicode" statement is required to compile a KeymanWeb keyboard' but should not crash Keyman Developer.