### PR TITLE
fix(developer): stack overflow when compiling non-web keyboard 🎾 🍒

### DIFF
--- a/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/windows/src/developer/TIKE/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -67,6 +67,7 @@ uses
   UfrmKeymanWizard,
   UfrmKeyboardFonts,
   UfrmMDIEditor,
+  UKeymanTargets,
   UmodWebHttpServer,
   Keyman.Developer.System.ServerAPI,
   Keyman.Developer.UI.ServerUI,
@@ -133,7 +134,8 @@ begin
 
   if Result and
       TServerDebugAPI.Running and
-      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) then
+      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) and
+      (ProjectFile.Targets * KMWKeymanTargets <> []) then
     TestKeymanWeb(True);
 end;
 
@@ -235,7 +237,13 @@ begin
     Exit(False);
   wizard := editor as TfrmKeymanWizard;
 
+  if ProjectFile.Targets * KMWKeymanTargets = [] then
+    Exit(False);
+
   FCompiledName := ProjectFile.JSTargetFilename;
+  if FCompiledName = '' then
+    Exit(False);
+
   if not TestKeyboardState(FCompiledName, FSilent) then
     Exit(False);
 


### PR DESCRIPTION
Cherry-pick of #7031.

Fixes #7030.

Prevents a stack overflow / loop when the web target is removed from a keyboard and it has already been tested on web, and the user presses the Compile button.

@keymanapp-test-bot skip