### PR TITLE
fix(developer): prevent crash attempting to compile ansi keyboard 🎾 🍒

### DIFF
--- a/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
+++ b/windows/src/developer/TIKE/compile/CompileKeymanWeb.pas
@@ -2194,11 +2194,11 @@ begin
 	{ Write the groups out }
 
   // I853 - begin unicode missing causes crash
-{  if fk.StartGroup[BEGIN_UNICODE] = $FFFFFFFF then
+  if fk.StartGroup[BEGIN_UNICODE] = $FFFFFFFF then
   begin
-    FCallback(fkp.Line, $4005, PChar('A "begin unicode" statement is required to compile a KeymanWeb keyboard'));
+    ReportError(0, CERR_InvalidBegin, 'A "begin unicode" statement is required to compile a KeymanWeb keyboard');
     Exit;
-  end;}
+  end;
 
   Result := Result + WriteBeginStatement('gs', fk.StartGroup[BEGIN_UNICODE]);
   rec := ExpandSentinel(PChar(sBegin_NewContext));


### PR DESCRIPTION
Cherry-pick of #7033.

Fixes #7032.

@keymanapp-test-bot skip