### PR TITLE
fix(web): enhanced timer for prediction algorithm

### DIFF
--- a/common/web/lm-worker/src/correction/distance-modeler.ts
+++ b/common/web/lm-worker/src/correction/distance-modeler.ts
@@ -535,9 +535,25 @@ namespace correction {
         maxTime = waitMillis;
       }
 
+      /**
+       * This inner class is designed to help the algorithm detect its active execution time.
+       * While there's no official JS way to do this, we can approximate it by polling the
+       * current system time (in ms) after each iteration of a short-duration loop.  Unusual
+       * spikes in system time for a single iteration is likely to indicate that an OS
+       * context switch occurred at some point during the iteration's execution.
+       */
       class ExecutionTimer {
+        /**
+         * The system time when this instance was created.
+         */
         private start: number;
+
+        /**
+         * Marks the system time at the start of the currently-running loop, as noted
+         * by a call to the `startLoop` function.
+         */
         private loopStart: number;
+
         private maxExecutionTime: number;
         private maxTrueTime: number;
 
@@ -545,10 +561,14 @@ namespace correction {
 
         /**
          * Used to track intervals in which potential context swaps by the OS may
-         * have occurred.
+         * have occurred.  Context switches generally seem to pause threads for
+         * at least 16 ms, while we expect each loop iteration to complete
+         * within just 1 ms.  So, any possible context switch should have the
+         * longest observed change in system time.
+         *
+         * See `updateOutliers` for more details.
          */
         private largestIntervals: number[] = [0];
-        private iterationCount: number = 0;
 
         constructor(maxExecutionTime: number, maxTrueTime: number) {
           // JS measures time by the number of milliseconds since Jan 1, 1970.
@@ -565,15 +585,69 @@ namespace correction {
           const now = Date.now();
           const delta = now - this.loopStart;
           this.executionTime += delta;
-          this.iterationCount++;
 
+          /**
+           * Update the list of the three longest system-time intervals observed
+           * for execution of a single loop iteration.
+           *
+           * Ignore any zero-ms length intervals; they'd make the logic much
+           * messier than necessary otherwise.
+           */
           if(delta) {
+            // If the currently-observed interval is longer than the shortest of the 3
+            // previously-observed longest intervals, replace it.
             if(this.largestIntervals.length > 2 && delta > this.largestIntervals[0]) {
               this.largestIntervals[0] = delta;
             } else {
               this.largestIntervals.push(delta);
             }
+            // Puts the list in ascending order.  Shortest of the list becomes the head,
+            // longest one the tail.
             this.largestIntervals.sort();
+
+            // Then, determine if we need to update our outlier-based tweaks.
+            this.updateOutliers();
+          }
+        }
+
+        updateOutliers() {
+          /* Base assumption:  since each loop of the search should evaluate within ~1ms,
+           *                   notably longer execution times are probably context switches.
+           *
+           * Base assumption:  OS context switches generally last at least 16ms.  (Based on
+           *                   a window.setTimeout() usually not evaluating for at least
+           *                   that long, even if set to 1ms.)
+           *
+           * To mitigate these assumptions:  we'll track the execution time of every loop
+           * iteration.  If the longest observation somehow matches or exceeds the length of
+           * the next two almost-longest observations twice over... we have a very strong
+           * 'context switch' candidate.
+           *
+           * Or, in near-formal math/stats:  we expect a very low variance in execution
+           * time among the iterations of the search's loops.  With a very low variance,
+           * ANY significant proportional spikes in execution time are outliers - outliers
+           * likely caused by an OS context switch.
+           *
+           * Rather than do intensive math, we use a somewhat lazy approach below that
+           * achieves the same net results given our assumptions, even when relaxed somewhat.
+           *
+           * The logic below relaxes the base assumptions a bit to be safe:
+           * - [2ms, 2ms, 8ms]  will cause 8ms to be seen as an outlier.
+           * - [2ms, 3ms, 10ms] will cause 10ms to be seen as an outlier.
+           *
+           * Ideally:
+           * - [1ms, 1ms, 4ms] will view 4ms as an outlier.
+           *
+           * So we can safely handle slightly longer average intervals and slightly shorter
+           * OS context-switch time intervals.
+           */
+          if(this.largestIntervals.length > 2) {
+            // Precondition:  the `largestIntervals` array is sorted in ascending order.
+            // Shortest entry is at the head, longest at the tail.
+            if(this.largestIntervals[2] >= 2 * (this.largestIntervals[0] + this.largestIntervals[1])) {
+              this.executionTime -= this.largestIntervals[2];
+              this.largestIntervals.pop();
+            }
           }
         }
 
@@ -581,14 +655,6 @@ namespace correction {
           const now = Date.now();
           if(this.start - now > this.maxTrueTime) {
             return true;
-          }
-
-          // Look at the 'intervals' for a possible over-large outliers.
-          if(this.largestIntervals.length > 2) {
-            if(this.largestIntervals[2] > 2 * (this.largestIntervals[0] + this.largestIntervals[1])) {
-              this.executionTime -= this.largestIntervals[2];
-              this.largestIntervals.pop();
-            }
           }
 
           return this.executionTime > this.maxExecutionTime;
@@ -674,6 +740,7 @@ namespace correction {
       }
 
       // Stage 2:  the fun part; actually searching!
+      timer.resetOutlierCheck();
       timer.startLoop();
       let timedOut = false;
       do {


### PR DESCRIPTION
Hopefully addresses some aspects of #6985.

This PR is primarily designed to address some CI unit testing stability issues.  Since our browser-based unit testing is handled via an external service, it's quite possible that our unit tests may be run alongside others in a manner that causes context-switching.  Noting that we've had issues arise from context switching before - see #5467 / #5479 - it's quite possible that some of our prediction instability is arising from the same underlying problem - a user often _does_ have background threads and processes running on their mobile device, after all.

Noting the similarity between this and intermittent failures for predictive text to produce no results when it often otherwise produces _something_ with identical text, if my suspicions are correct, this may actually help mitigate some of the aspects of #6985.

The inner class `ExecutionTimer` here is an attempt to determine the predictive-text search's active execution time (that is, "actual time on the processor") by detecting possible context-switching time intervals and ignoring them.  If the longest-interval observed at any point is at least twice as long as the next two longest-intervals observed, we'll call that an outlier.  "Zero-length intervals" will also be ignored, since otherwise even a 1ms interval would automatically be an outlier.

- [1, 1, 4]:  the '4' is considered an outlier
- [1, 2, 4]:  the '4' isn't - 3*2 > 4, after all.

Note that excluded outliers aren't considered for any future outliers.  The expectation/assumption is that each measured loop iteration should take a consistent amount of time... unless affected by context switching.  To facilitate this, I've set things up for the timer (as used) to avoid tracking time in the search's `yield` state.

@keymanapp-test-bot skip

I think we should be fine without user testing... though I could see an argument for a mild bit of user testing for predictive text in the mobile apps if someone wanted to push for it.