### PR TITLE
chore(common): add KF_KMXPLUS dwFlag value 🙀

### DIFF
--- a/common/windows/cpp/include/legacy_kmx_file.h
+++ b/common/windows/cpp/include/legacy_kmx_file.h
@@ -1,3 +1,5 @@
+// TODO: merge and replace with kmx_file.h from core
+
 /*
   Name:             legacy_kmx_file
   Copyright:        Copyright (C) SIL International.
@@ -282,6 +284,9 @@
 #define KF_CAPSALWAYSOFF	0x0004
 #define KF_LOGICALLAYOUT	0x0008
 #define KF_AUTOMATICVERSION 0x0010
+
+// 16.0: Support for LDML Keyboards in KMXPlus file format
+#define KF_KMXPLUS  0x0020
 
 #define HK_ALT			0x00010000
 #define HK_CTRL			0x00020000

--- a/common/windows/delphi/keyboards/kmxfile.pas
+++ b/common/windows/delphi/keyboards/kmxfile.pas
@@ -195,8 +195,10 @@ const
     KF_CAPSONONLY =     $0002;
     KF_CAPSALWAYSOFF =  $0004;
     KF_LOGICALLAYOUT =  $0008;
+    KF_AUTOMATICVERSION = $0010;
 
-
+    // 16.0: Support for LDML Keyboards in KMXPlus file format
+    KF_KMXPLUS =        $0020;
 
 function GetSystemStore(Memory: PByte; SystemID: DWord; var Buffer: WideString): Boolean;  // I3310
 var

--- a/core/src/kmx/kmx_file.h
+++ b/core/src/kmx/kmx_file.h
@@ -260,6 +260,9 @@ namespace kmx {
 #define KF_LOGICALLAYOUT  0x0008
 #define KF_AUTOMATICVERSION 0x0010
 
+// 16.0: Support for LDML Keyboards in KMXPlus file format
+#define KF_KMXPLUS  0x0020
+
 #define HK_ALT      0x00010000
 #define HK_CTRL     0x00020000
 #define HK_SHIFT    0x00040000


### PR DESCRIPTION
Part of #7045.

Indicates that the .kmx file has additional header structure immediately following the COMP_KEYBOARD header. Used by KMXPlus file format for supporting LDML keyboards. Requires VERSION_160 or higher in keyboard file.

@keymanapp-test-bot skip