### PR TITLE
feat(linux): Replace deprecated distutils

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import zipfile
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from enum import Enum
 from shutil import rmtree
 
@@ -127,7 +127,7 @@ class InstallKmp():
             fileVersion = secure_lookup(system, 'fileVersion')
             if not fileVersion:
                 fileVersion = '7.0'
-            if StrictVersion(fileVersion) > StrictVersion(__version__):
+            if parse_version(fileVersion) > parse_version(__version__):
                 logging.error("install_kmp.py: error: %s requires a newer version of Keyman (%s)",
                               inputfile, fileVersion)
                 rmtree(self.packageDir)

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -15,7 +15,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit2', '4.0')
 
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 from gi.repository import Gtk, WebKit2
 
@@ -107,8 +107,8 @@ class InstallKmpWindow(Gtk.Dialog):
                     try:
                         logging.info("package version %s", secure_lookup(info, 'version', 'description'))
                         logging.info("installed kmp version %s", installed_kmp_ver)
-                        if StrictVersion(secure_lookup(info, 'version',
-                                                       'description')) <= StrictVersion(installed_kmp_ver):
+                        if parse_version(secure_lookup(info, 'version',
+                                                       'description')) <= parse_version(installed_kmp_ver):
                             dialog = Gtk.MessageDialog(
                               viewkmp, 0, Gtk.MessageType.QUESTION,
                               Gtk.ButtonsType.YES_NO, _("Keyboard is installed already"))

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 import time
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from zipfile import is_zipfile
 
 from keyman_config import KeymanApiUrl, __version__, secure_lookup
@@ -150,8 +150,8 @@ def main():
             sys.exit(3)
         kbdata_v = secure_lookup(kbdata, 'version')
         if installed_kmp_v and kbdata_v:
-            kbdata_version = StrictVersion(kbdata_v)
-            installed_kmp_ver = StrictVersion(installed_kmp_v)
+            kbdata_version = parse_version(kbdata_v)
+            installed_kmp_ver = parse_version(installed_kmp_v)
             if kbdata_version == installed_kmp_ver:
                 print("km-package-install: Version %s of the %s keyboard package is already installed."
                       % (installed_kmp_ver, args.package))

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -25,40 +25,40 @@ class UninstallKmpTests(unittest.TestCase):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('ibus', 'fooDir/foo2.kmx')]
+          ('ibus', 'fooDir/foo2.kmx')]
         # Execute
         uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([
-            ('ibus', 'fooDir/foo2.kmx')])
+          ('ibus', 'fooDir/foo2.kmx')])
 
     def test_UninstallKeyboardsFromGnome_RemoveOneKeyboard(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx')]
+          ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx')]
         # Execute
         uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])
 
     def test_UninstallKeyboardsFromGnome_RemoveMultipleKeyboards(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+          ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
         # Execute
         uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])
 
     def test_UninstallKeyboardsFromGnome_RemoveAllKeyboards(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
+          ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
         # Execute
         uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
         # Verify
@@ -68,45 +68,45 @@ class UninstallKmpTests(unittest.TestCase):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
+          ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
         # Execute
         uninstall_keyboards_from_gnome([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])
 
     def test_UninstallKeyboardsFromGnome_RemoveKeyboard_MultipleLanguages(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')]
+          ('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')]
         # Execute
         uninstall_keyboards_from_gnome(
-            [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
+          [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])
 
     def test_UninstallKeyboardsFromGnome_RemoveKeyboard_OneNotMatchingLanguage(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
+          ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
         # Execute
         uninstall_keyboards_from_gnome(
-            [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])
 
     def test_UninstallKeyboardsFromGnome_RemoveKeyboard_RemovesAllMatching(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
-            ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx'), ('ibus', 'fr:fooDir/foo1.kmx')]
+          ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx'), ('ibus', 'fr:fooDir/foo1.kmx')]
         # Execute
         uninstall_keyboards_from_gnome(
-            [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
-            [('xkb', 'en')])
+          [('xkb', 'en')])


### PR DESCRIPTION
Fixes #6955.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_BIONIC**: Ubuntu 18.04 Bionic with Gnome Shell and X11
  - **GROUP_JAMMY_X11**: Ubuntu 22.04 Jammy with Gnome Shell and X11

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

- **TEST_CLI_INST:** Run `km-package-install`. Verify that you get an error message, but no deprecation warning.
- **TEST_CLI_INST_PKG:** Run `km-package-install -p sil_korda_jamo`. Verify that this adds the "Korean KORDA Jamo (SIL)" keyboard to the keyboard dropdown.
- **TEST_CLI_INST_PKG2:** Run `km-package-install -p sil_korda_jamo` a second time. Verify that it shows the message _"km-package-install: Version 3.0 of the sil_korda_jamo keyboard package is already installed."_