### PR TITLE
chore(core): refactor kmx_file.h to common 🚑

### DIFF
--- a/common/include/km_types.h
+++ b/common/include/km_types.h
@@ -1,0 +1,65 @@
+#pragma once
+
+/*
+#if defined(_WIN32) || defined(_WIN64)
+#define snprintf _snprintf
+#define vsnprintf _vsnprintf
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+*/
+
+#if defined(__LP64__) || defined(_LP64)
+/* 64-bit, g++ */
+#define KMX_64BIT
+#endif
+
+#if defined(_WIN64) && !defined(USE_64)
+/* 64-bit, Windows */
+#define KMX_64BIT
+#endif
+
+typedef uint32_t            KMX_DWORD;
+typedef int32_t             KMX_BOOL;
+typedef uint8_t             KMX_BYTE;
+typedef uint16_t            KMX_WORD;
+
+#if defined(__cplusplus)
+typedef char16_t   km_kbp_cp;
+typedef char32_t   km_kbp_usv;
+#else
+typedef uint16_t    km_kbp_cp;          // code point
+typedef uint32_t    km_kbp_usv;         // Unicode Scalar Value
+#endif
+
+typedef km_kbp_cp KMX_WCHAR;    // wc,   16-bit UNICODE character
+typedef KMX_WCHAR *PKMX_WCHAR;
+
+typedef char KMX_CHAR;
+typedef KMX_CHAR *PKMX_CHAR;
+
+typedef uint32_t             KMX_UINT;
+
+typedef KMX_BYTE *PKMX_BYTE;
+typedef KMX_WORD *PKMX_WORD;
+typedef KMX_DWORD *PKMX_DWORD;
+
+#ifndef FALSE
+#define FALSE               0
+#endif
+
+#ifndef TRUE
+#define TRUE                1
+#endif
+
+// Macros and types to support char16_t vs wchar_t depending on project
+
+#ifdef USE_CHAR16_T
+#define lpuch(x) u ## x
+typedef  char16_t KMX_UCHAR;
+#else
+#define lpuch(x) L ## x
+typedef  wchar_t KMX_UCHAR;
+#endif
+
+typedef KMX_UCHAR* KMX_PUCHAR;

--- a/common/include/km_types.h
+++ b/common/include/km_types.h
@@ -56,7 +56,7 @@ typedef KMX_DWORD *PKMX_DWORD;
 
 #ifdef USE_CHAR16_T
 #define lpuch(x) u ## x
-typedef  char16_t KMX_UCHAR;
+typedef  km_kbp_cp KMX_UCHAR;
 #else
 #define lpuch(x) L ## x
 typedef  wchar_t KMX_UCHAR;

--- a/common/include/kmx_file.h
+++ b/common/include/kmx_file.h
@@ -5,11 +5,14 @@
 
 #pragma once
 
-#include "kmx_base.h"
+#include <km_types.h>
 
+#ifdef KMN_KBP
+// TODO: move this to a common namespace keyman::common::kmx_file or similar in the future
 namespace km {
 namespace kbp {
 namespace kmx {
+#endif
 
 /* */
 
@@ -352,6 +355,8 @@ static_assert(sizeof(COMP_KEY) == KEYBOARDFILEKEY_SIZE, "COMP_KEY must be KEYBOA
 static_assert(sizeof(COMP_GROUP) == KEYBOARDFILEGROUP_SIZE, "COMP_GROUP must be KEYBOARDFILEGROUP_SIZE bytes");
 static_assert(sizeof(COMP_KEYBOARD) == KEYBOARDFILEHEADER_SIZE, "COMP_KEYBOARD must be KEYBOARDFILEHEADER_SIZE bytes");
 
+#ifdef KMN_KBP
 } // namespace kmx
 } // namespace kbp
 } // namespace km
+#endif

--- a/common/web/keyboard-processor/src/text/codes.ts
+++ b/common/web/keyboard-processor/src/text/codes.ts
@@ -1,7 +1,7 @@
 namespace com.keyman.text {
   export var Codes = {
     // Define Keyman Developer modifier bit-flags (exposed for use by other modules)
-    // Compare against /core/src/kmx/kmx_file.h.  CTRL+F "#define LCTRLFLAG" to find the secton.
+    // Compare against /common/include/kmx_file.h.  CTRL+F "#define LCTRLFLAG" to find the secton.
     modifierCodes: {
       "LCTRL":0x0001,           // LCTRLFLAG
       "RCTRL":0x0002,           // RCTRLFLAG

--- a/common/windows/cpp/include/legacy_kmx_file.h
+++ b/common/windows/cpp/include/legacy_kmx_file.h
@@ -2,7 +2,7 @@
   Name:             legacy_kmx_file
   Copyright:        Copyright (C) SIL International.
   Documentation:
-  Description:      Describes .kmx binary format. To be replaced with Core's kmx_file.h
+  Description:      Describes .kmx binary format. To be replaced with common/include/kmx_file.h
   Create Date:      4 Jan 2007
 
   Modified Date:    24 Aug 2015

--- a/core/include/keyman/keyboardprocessor.h
+++ b/core/include/keyman/keyboardprocessor.h
@@ -110,13 +110,6 @@ extern "C"
 #endif
 // Basic types
 //
-#if defined(__cplusplus)
-typedef char16_t   km_kbp_cp;
-typedef char32_t   km_kbp_usv;
-#else
-typedef uint16_t    km_kbp_cp;          // code point
-typedef uint32_t    km_kbp_usv;         // Unicode Scalar Value
-#endif
 typedef uint16_t    km_kbp_virtual_key; // A virtual key code.
 typedef uint32_t    km_kbp_status;      // Status return code.
 

--- a/core/include/keyman/keyboardprocessor_bits.h
+++ b/core/include/keyman/keyboardprocessor_bits.h
@@ -59,4 +59,6 @@
   #define KMN_DEPRECATED_API  _kmn_tag_fn(_kmn_deprecated_flag _kmn_and _kmn_import_flag)
 #endif
 
+#define KMN_KBP
+#define USE_CHAR16_T
 #include <km_types.h>

--- a/core/include/keyman/keyboardprocessor_bits.h
+++ b/core/include/keyman/keyboardprocessor_bits.h
@@ -59,6 +59,11 @@
   #define KMN_DEPRECATED_API  _kmn_tag_fn(_kmn_deprecated_flag _kmn_and _kmn_import_flag)
 #endif
 
+#ifndef KMN_KBP
 #define KMN_KBP
+#endif
+#ifndef USE_CHAR16_T
 #define USE_CHAR16_T
+#endif
+
 #include <km_types.h>

--- a/core/include/keyman/keyboardprocessor_bits.h
+++ b/core/include/keyman/keyboardprocessor_bits.h
@@ -58,3 +58,5 @@
   #define KMN_API             _kmn_tag_fn(_kmn_import_flag)
   #define KMN_DEPRECATED_API  _kmn_tag_fn(_kmn_deprecated_flag _kmn_and _kmn_import_flag)
 #endif
+
+#include <km_types.h>

--- a/core/include/meson.build
+++ b/core/include/meson.build
@@ -6,5 +6,5 @@
 # History:     6 Oct 2018 - TSE - Move into keyman folder.
 #
 
-inc = include_directories('.', is_system: true)
+inc = include_directories('.', '../../common/include', is_system: true)
 subdir('keyman')

--- a/core/meson.build
+++ b/core/meson.build
@@ -37,6 +37,10 @@ message('compiler.get_id(): ' + compiler.get_id())
 
 cc = meson.get_compiler('c')
 
+# TODO: Shared includes may use namespaces, etc which need future tidyup.
+# For now, we use KMN_KBP to inject the km::kbp::kmx namespace
+defns = ['-DKMN_KBP']
+
 subdir('doc')
 subdir('include')
 subdir('src')

--- a/core/src/kmx/kmx_base.h
+++ b/core/src/kmx/kmx_base.h
@@ -10,41 +10,6 @@
 #define strncasecmp _strnicmp
 #endif
 
-#if defined(__LP64__) || defined(_LP64)
-/* 64-bit, g++ */
-#define KMX_64BIT
-#endif
-
-#if defined(_WIN64) && !defined(USE_64)
-/* 64-bit, Windows */
-#define KMX_64BIT
-#endif
-
-typedef uint32_t            KMX_DWORD;
-typedef int32_t             KMX_BOOL;
-typedef uint8_t             KMX_BYTE;
-typedef uint16_t            KMX_WORD;
-
-typedef km_kbp_cp KMX_WCHAR;    // wc,   16-bit UNICODE character
-typedef KMX_WCHAR *PKMX_WCHAR;
-
-typedef char KMX_CHAR;
-typedef KMX_CHAR *PKMX_CHAR;
-
-typedef uint32_t             KMX_UINT;
-
-typedef KMX_BYTE *PKMX_BYTE;
-typedef KMX_WORD *PKMX_WORD;
-typedef KMX_DWORD *PKMX_DWORD;
-
-#ifndef FALSE
-#define FALSE               0
-#endif
-
-#ifndef TRUE
-#define TRUE                1
-#endif
-
 namespace km {
 namespace kbp {
 namespace kmx {

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -1,8 +1,12 @@
 
 #pragma once
 
+#ifndef KMN_KBP
 #define KMN_KBP
+#endif
+#ifndef USE_CHAR16_T
 #define USE_CHAR16_T
+#endif
 
 #include <assert.h>
 #include <string>

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -1,6 +1,9 @@
 
 #pragma once
 
+#define KMN_KBP
+#define USE_CHAR16_T
+
 #include <assert.h>
 #include <string>
 #include <string.h>

--- a/core/src/meson.build
+++ b/core/src/meson.build
@@ -4,7 +4,7 @@
 # Authors:      Tim Eves (TSE)
 #
 
-defns = ['-DKMN_KBP_EXPORTING']
+defns += ['-DKMN_KBP_EXPORTING']
 version_res = []
 
 if compiler.get_id() == 'gcc' or compiler.get_id() == 'clang'
@@ -54,7 +54,7 @@ endif
 if compiler.get_id() == 'emscripten'
   warns = []
   flags = []
-  defns = []
+  defns = ['-DKMN_KBP']
   links = []
 endif
 

--- a/core/tests/unit/kmnkbd/meson.build
+++ b/core/tests/unit/kmnkbd/meson.build
@@ -13,7 +13,7 @@ else
   warns = []
 endif
 
-defns=['-DKMN_KBP_STATIC']
+defns+=['-DKMN_KBP_STATIC']
 tests = [
   ['context-api', 'context_api.cpp'],
   ['keyboard-api', 'keyboard_api.cpp'],

--- a/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -4,6 +4,9 @@
  * Keyman Core - KMX Extended String unit tests
  */
 
+#define KMN_KBP
+#define USE_CHAR16_T
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -11,7 +11,7 @@
 #include <iterator>
 #include <string>
 #include "../../../src/kmx/kmx_xstring.h"
-#include "../../../src/kmx/kmx_file.h"
+#include <kmx_file.h>
 #include "../test_assert.h"
 
 using namespace km::kbp::kmx;

--- a/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -4,8 +4,12 @@
  * Keyman Core - KMX Extended String unit tests
  */
 
+#ifndef KMN_KBP
 #define KMN_KBP
+#endif
+#ifndef USE_CHAR16_T
 #define USE_CHAR16_T
+#endif
 
 #include <cstdlib>
 #include <cstring>

--- a/docs/settings/linux/c_cpp_properties.json
+++ b/docs/settings/linux/c_cpp_properties.json
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "name": "linux",
-      "includePath": ["${workspaceFolder}/core/include/**", "${workspaceFolder}/common/include/**"],
+      "includePath": ["${workspaceFolder}/common/include/","${workspaceFolder}/core/include/**"],
       "defines": [],
       "compilerPath": "/usr/lib/ccache/clang",
       "cStandard": "c11",

--- a/docs/settings/linux/c_cpp_properties.json
+++ b/docs/settings/linux/c_cpp_properties.json
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "name": "linux",
-      "includePath": ["${workspaceFolder}/core/include/**"],
+      "includePath": ["${workspaceFolder}/core/include/**", "${workspaceFolder}/common/include/**"],
       "defines": [],
       "compilerPath": "/usr/lib/ccache/clang",
       "cStandard": "c11",

--- a/docs/settings/linux/tasks.json
+++ b/docs/settings/linux/tasks.json
@@ -66,7 +66,7 @@
       "label": "ibus-keyman: configure",
       "command": "./configure",
       "args": [
-        "CPPFLAGS=\"-DG_MESSAGES_DEBUG -I${workspaceFolder}/core/build/arch/debug/include/ -I${workspaceFolder}/core/include/\"",
+        "CPPFLAGS=\"-DG_MESSAGES_DEBUG -I${workspaceFolder}/core/build/arch/debug/include/ -I${workspaceFolder}/common/include/ -I${workspaceFolder}/core/include/\"",
         "CFLAGS=\"-g -O0\"",
         "CXXFLAGS=\"-g -O0\"",
         "KEYMAN_PROC_LIBS=\"-L${workspaceFolder}/common/core/desktop/build/arch/debug/src -lkmnkbp0\"",

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -26,7 +26,7 @@ override_dh_auto_configure:
 	# ibus-keyman
 	cd linux/ibus-keyman && \
 		cp -f ../../VERSION.md VERSION && \
-		export KEYMAN_PROC_CFLAGS="-I$(CURDIR)/core/build/arch/release/include -I$(CURDIR)/core/include" && \
+		export KEYMAN_PROC_CFLAGS="-I$(CURDIR)/core/build/arch/release/include -I$(CURDIR)/common/include -I$(CURDIR)/core/include" && \
 		export KEYMAN_PROC_LIBS="-L$(CURDIR)/core/build/arch/release/src -lkmnkbp0" && \
 		export PKG_CONFIG_PATH=$(CURDIR)/core/build/arch/release/meson-private && \
 		./autogen.sh && \

--- a/linux/ibus-keyman/README.md
+++ b/linux/ibus-keyman/README.md
@@ -24,6 +24,6 @@ For a debug build:
 To use the header files from the source repo, you need to specify paths to the include files in core:
 
 ```bash
-./configure CPPFLAGS="-DG_MESSAGES_DEBUG -I../../core/build/arch/debug/include/ -I../../core/include/" \
+./configure CPPFLAGS="-DG_MESSAGES_DEBUG -I../../core/build/arch/debug/include/ -I../../common/include/ -I../../core/include/" \
   CFLAGS="-g -O0" CXXFLAGS="-g -O0"
 ```

--- a/linux/ibus-keyman/tests/Makefile.am
+++ b/linux/ibus-keyman/tests/Makefile.am
@@ -70,7 +70,7 @@ ibus_keyman_tests_SOURCES = \
   ../../../core/src/kmx/kmx_environment.cpp \
   ../../../core/src/kmx/kmx_environment.h \
   ../../../core/src/kmx/kmx_file.cpp \
-  ../../../core/src/kmx/kmx_file.h \
+  ../../../common/include/kmx_file.h \
   ../../../core/src/kmx/kmx_modifiers.cpp \
   ../../../core/src/kmx/kmx_options.cpp \
   ../../../core/src/kmx/kmx_options.h \

--- a/linux/scripts/build.sh
+++ b/linux/scripts/build.sh
@@ -60,12 +60,12 @@ function buildproject() {
 	if [[ "${BUILDONLY}" == "no" ]]; then
 		echo "Configuring $proj"
 		if [[ "${INSTALLDIR}" == "/tmp/kmfl" ]]; then # don't install ibus-kmfl or ibus-keyman into ibus
-			../${subdir}$proj/configure KEYMAN_PROC_CFLAGS="-I\$(top_builddir)/../keyboardprocessor/arch/release/include -I\$(top_builddir)/../../core/include" \
+			../${subdir}$proj/configure KEYMAN_PROC_CFLAGS="-I\$(top_builddir)/../keyboardprocessor/arch/release/include -I\$(top_builddir)/../../common/include -I\$(top_builddir)/../../core/include" \
 				CPPFLAGS="-I\$(top_builddir)/../build-kmflcomp -I\$(top_builddir)/../build-libkmfl" \
 				KEYMAN_PROC_LIBS="-L`pwd`/../build-libkmfl/src -L`pwd`/../keyboardprocessor/arch/release/src -lkmnkbp0" \
 				LDFLAGS="-L`pwd`/../build-kmflcomp/src -L`pwd`/../build-libkmfl/src" --prefix=${INSTALLDIR} --libexecdir=${INSTALLDIR}/lib/ibus
 		else	# install ibus-kmfl and ibus-keyman into ibus
-			../${subdir}$proj/configure KEYMAN_PROC_CFLAGS="-I\$(top_builddir)/../keyboardprocessor/arch/release/include -I\$(top_builddir)/../../core/include" \
+			../${subdir}$proj/configure KEYMAN_PROC_CFLAGS="-I\$(top_builddir)/../keyboardprocessor/arch/release/include -I\$(top_builddir)/../../common/include -I\$(top_builddir)/../../core/include" \
 				CPPFLAGS="-I\$(top_builddir)/../build-kmflcomp -I\$(top_builddir)/../build-libkmfl" \
 				LDFLAGS="-L`pwd`/../build-kmflcomp/src -L`pwd`/../build-libkmfl/src" \
 				KEYMAN_PROC_LIBS="-L`pwd`/../build-libkmfl/src -L`pwd`/../keyboardprocessor/arch/release/src -lkmnkbp0" \

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -68,14 +68,17 @@ for proj in ${extra_projects}; do
     dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
         --tar-ignore=.gitignore --tar-ignore=experiments --tar-ignore=debian \
         --tar-ignore=.github --tar-ignore=.vscode --tar-ignore=android \
-        --tar-ignore=common --tar-ignore=developer --tar-ignore=docs --tar-ignore=ios \
+        --tar-ignore=common/models --tar-ignore=common/predictive-text \
+        --tar-ignore=common/resources --tar-ignore=common/schemas \
+        --tar-ignore=common/test --tar-ignore=common/web --tar-ignore=common/windows \
+        --tar-ignore=developer --tar-ignore=docs --tar-ignore=ios \
         --tar-ignore=linux/keyman-config/buildtools/build-langtags.py --tar-ignore=__pycache__ \
         --tar-ignore=linux/help --tar-ignore=linux/Jenkinsfile \
         --tar-ignore=linux/keyboardprocessor --tar-ignore=linux/legacy \
         --tar-ignore=mac --tar-ignore=node_modules --tar-ignore=oem \
         --tar-ignore=linux/build* --tar-ignore=core/build \
         --tar-ignore=resources/devbox --tar-ignore=resources/git-hooks \
-        --tar-ignore=resources/scopes --tar-ignore=common/web \
+        --tar-ignore=resources/scopes \
         --tar-ignore=resources/build/*.lua --tar-ignore=resources/build/jq* \
         --tar-ignore=resources/build/vswhere* --tar-ignore=results \
         --tar-ignore=web --tar-ignore=windows --tar-ignore=keyman_1* \

--- a/windows/src/engine/keyman32/Keyman32.vcxproj
+++ b/windows/src/engine/keyman32/Keyman32.vcxproj
@@ -55,11 +55,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(ProjectDir)..\..\..\..\core\include;$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\common\include;$(ProjectDir)..\..\..\..\core\include;$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\common\include;$(ProjectDir)..\..\..\..\core\include;$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>

--- a/windows/src/engine/keyman64/keyman64.vcxproj
+++ b/windows/src/engine/keyman64/keyman64.vcxproj
@@ -55,11 +55,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x64\$(Configuration);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\common\include;$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x64\$(Configuration);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
-    <IncludePath>$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\common\include;$(ProjectDir)..\..\..\..\core\build\x64\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>


### PR DESCRIPTION
Part of the kmcompx refactor. We want the definitions in kmx_file.h rather than continuing to use legacy_kmx_file.h.

@keymanapp-test-bot skip