### PR TITLE
feat(core): add event_flags to process_event #7046 🙀 

### DIFF
--- a/core/include/keyman/keyboardprocessor.h
+++ b/core/include/keyman/keyboardprocessor.h
@@ -1052,6 +1052,7 @@ enum km_kbp_tech_value {
  * Bit flags to be used with the event_flags parameter of km_kbp_process_event
  */
 enum km_kbp_event_flags {
+  KM_KBP_EVENT_FLAG_DEFAULT = 0, // default value: hardware
   KM_KBP_EVENT_FLAG_TOUCH = 1, // set if the event is touch, otherwise hardware
 };
 

--- a/core/include/keyman/keyboardprocessor.h
+++ b/core/include/keyman/keyboardprocessor.h
@@ -1048,6 +1048,12 @@ enum km_kbp_tech_value {
   KM_KBP_TECH_LDML        = 1 << 2
 };
 
+/**
+ * Bit flags to be used with the event_flags parameter of km_kbp_process_event
+ */
+enum km_kbp_event_flags {
+  KM_KBP_EVENT_FLAG_TOUCH = 1, // set if the event is touch, otherwise hardware
+};
 
 /*
 ```
@@ -1088,6 +1094,7 @@ state is passed.
 - __modifier_state__:
 The combinations of modifier keys set at the time key `vk` was pressed, bitmask
 from the `km_kbp_modifier_state` enum.
+- __event_flags__: Event level flags, see km_kbp_event_flags
 
 ```c
 */
@@ -1096,7 +1103,8 @@ km_kbp_status
 km_kbp_process_event(km_kbp_state *state,
                      km_kbp_virtual_key vk,
                      uint16_t modifier_state,
-                     uint8_t is_key_down);
+                     uint8_t is_key_down,
+                     uint16_t event_flags);
 
 /*
 ```

--- a/core/python/keyman/keyboardprocessor/_api.py
+++ b/core/python/keyman/keyboardprocessor/_api.py
@@ -277,13 +277,20 @@ class Tech(IntFlag):
     KMN = 1
     LDML = 2
 
+class EventFlag(IntFlag):
+    KM_KBP_EVENT_FLAG_DEFAULT = 0
+    """default value: hardware"""
+    KM_KBP_EVENT_FLAG_TOUCH = 1
+    """set if the event is touch, otherwise hardware"""
+
 
 __method(None, 'get_engine_attrs', POINTER(Attributes))
 
 __method(None, 'process_event', Status,
          (State_p, Dir.IN, 'state'),
          (VirtualKey, Dir.IN, 'vkey'),
-         (c_uint16, Dir.IN, 'modifier_state'))
+         (c_uint16, Dir.IN, 'modifier_state'),
+         (c_uint16, Dir.IN, 'event_flags'))
 
 
 class Modifier(IntFlag):

--- a/core/python/keyman/keyboardprocessor/api.py
+++ b/core/python/keyman/keyboardprocessor/api.py
@@ -114,5 +114,6 @@ class State:
 def process_event(vk: VirtualKey,
                   modifier_state,
                   state: State,
-                  acts: ActionList):
+                  acts: ActionList,
+                  event_flags):
     pass

--- a/core/src/km_kbp_processevent_api.cpp
+++ b/core/src/km_kbp_processevent_api.cpp
@@ -16,8 +16,9 @@ km_kbp_status
 km_kbp_process_event(km_kbp_state *state,
                      km_kbp_virtual_key vk,
                      uint16_t modifier_state,
-                     uint8_t is_key_down) {
-  return state->processor().process_event(state, vk, modifier_state, is_key_down);
+                     uint8_t is_key_down,
+                     uint16_t event_flags) {
+  return state->processor().process_event(state, vk, modifier_state, is_key_down, event_flags);
 }
 
 km_kbp_status

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -233,7 +233,8 @@ kmx_processor::process_event(
   km_kbp_state *state,
   km_kbp_virtual_key vk,
   uint16_t modifier_state,
-  uint8_t is_key_down
+  uint8_t is_key_down,
+  uint16_t /* event_flags */
 ) {
   // Construct a context buffer from the items
   std::u16string ctxt;

--- a/core/src/kmx/kmx_processor.hpp
+++ b/core/src/kmx/kmx_processor.hpp
@@ -36,7 +36,8 @@ namespace kbp
       km_kbp_state *state,
       km_kbp_virtual_key vk,
       uint16_t modifier_state,
-      uint8_t is_key_down
+      uint8_t is_key_down,
+      uint16_t event_flags
     ) override;
 
     km_kbp_attr const & attributes() const override;

--- a/core/src/ldml/ldml_processor.cpp
+++ b/core/src/ldml/ldml_processor.cpp
@@ -99,7 +99,8 @@ ldml_processor::process_event(
   km_kbp_state *state,
   km_kbp_virtual_key vk,
   uint16_t _kmn_unused(modifier_state),
-  uint8_t is_key_down
+  uint8_t is_key_down,
+  uint16_t /*event_flags*/ // TODO-LDML: unused... for now...
 ) {
   assert(state);
   if (!state)

--- a/core/src/ldml/ldml_processor.hpp
+++ b/core/src/ldml/ldml_processor.hpp
@@ -40,7 +40,8 @@ namespace kbp {
       km_kbp_state *state,
       km_kbp_virtual_key vk,
       uint16_t modifier_state,
-      uint8_t is_key_down
+      uint8_t is_key_down,
+      uint16_t event_flags
     ) override;
 
     virtual km_kbp_attr const & attributes() const override;

--- a/core/src/mock/mock_processor.cpp
+++ b/core/src/mock/mock_processor.cpp
@@ -131,7 +131,8 @@ namespace km {
       km_kbp_state *state,
       km_kbp_virtual_key vk,
       uint16_t modifier_state,
-      uint8_t is_key_down
+      uint8_t is_key_down,
+      uint16_t /* event_flags */
     ) {
       assert(state);
       if (!state)

--- a/core/src/mock/mock_processor.hpp
+++ b/core/src/mock/mock_processor.hpp
@@ -31,7 +31,8 @@ namespace kbp
       km_kbp_state *state,
       km_kbp_virtual_key vk,
       uint16_t modifier_state,
-      uint8_t is_key_down
+      uint8_t is_key_down,
+      uint16_t event_flags
     ) override;
 
     virtual km_kbp_attr const & attributes() const override;

--- a/core/src/processor.hpp
+++ b/core/src/processor.hpp
@@ -41,7 +41,8 @@ namespace kbp
       km_kbp_state *,
       km_kbp_virtual_key,
       uint16_t modifier_state,
-      uint8_t is_key_down
+      uint8_t is_key_down,
+      uint16_t event_flags
     ) = 0;
 
     virtual km_kbp_attr const & attributes() const = 0;

--- a/core/tests/unit/kmnkbd/debug_api.cpp
+++ b/core/tests/unit/kmnkbd/debug_api.cpp
@@ -73,7 +73,7 @@ void setup(const char *keyboard) {
 void test_debugging_disabled() {
   setup("000 - null keyboard.kmx");
   try_status(km_kbp_state_debug_set(test_state, 0));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_END}
   }));
@@ -91,7 +91,7 @@ void test_debugging_no_rule_match() {
   setup("000 - null keyboard.kmx");
   DEBUG_GROUP gp = {u"Main"};
   try_status(km_kbp_state_debug_set(test_state, 1));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 'S'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -112,7 +112,7 @@ void test_debugging_function_key() {
   setup("000 - null keyboard.kmx");
   DEBUG_GROUP gp = {u"Main"};
   try_status(km_kbp_state_debug_set(test_state, 1));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F1, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F1, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_F1, 0, 0}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -138,7 +138,7 @@ void test_basic_rule_matches() {
 
   // 'DE' + 'F' > U+0E04 U+0E05 U+0E06
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 'D'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -151,7 +151,7 @@ void test_basic_rule_matches() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 'E'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -164,7 +164,7 @@ void test_basic_rule_matches() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 'F'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -208,7 +208,7 @@ void test_multiple_groups() {
 
   // '12' -> 'abc'
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_1, 0, '1'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -238,7 +238,7 @@ void test_multiple_groups() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_2, 0, '2'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -287,7 +287,7 @@ void test_store_offsets() {
 
   // 'ab' -> 'ex'
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_A, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_A, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_A, 0, 'a'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -307,7 +307,7 @@ void test_store_offsets() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_B, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_B, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_B, 0, 'b'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -361,7 +361,7 @@ void test_set_option() {
 
   // '1' -> set_option
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_1, 0, '1'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},

--- a/core/tests/unit/kmnkbd/debug_api.cpp
+++ b/core/tests/unit/kmnkbd/debug_api.cpp
@@ -73,7 +73,7 @@ void setup(const char *keyboard) {
 void test_debugging_disabled() {
   setup("000 - null keyboard.kmx");
   try_status(km_kbp_state_debug_set(test_state, 0));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_END}
   }));
@@ -91,7 +91,7 @@ void test_debugging_no_rule_match() {
   setup("000 - null keyboard.kmx");
   DEBUG_GROUP gp = {u"Main"};
   try_status(km_kbp_state_debug_set(test_state, 1));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_S, KM_KBP_MODIFIER_SHIFT, 'S'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -112,7 +112,7 @@ void test_debugging_function_key() {
   setup("000 - null keyboard.kmx");
   DEBUG_GROUP gp = {u"Main"};
   try_status(km_kbp_state_debug_set(test_state, 1));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F1, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F1, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_F1, 0, 0}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -138,7 +138,7 @@ void test_basic_rule_matches() {
 
   // 'DE' + 'F' > U+0E04 U+0E05 U+0E06
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_D, KM_KBP_MODIFIER_SHIFT, 'D'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -151,7 +151,7 @@ void test_basic_rule_matches() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_E, KM_KBP_MODIFIER_SHIFT, 'E'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -164,7 +164,7 @@ void test_basic_rule_matches() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_F, KM_KBP_MODIFIER_SHIFT, 'F'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -208,7 +208,7 @@ void test_multiple_groups() {
 
   // '12' -> 'abc'
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_1, 0, '1'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -238,7 +238,7 @@ void test_multiple_groups() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_2, 0, '2'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -287,7 +287,7 @@ void test_store_offsets() {
 
   // 'ab' -> 'ex'
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_A, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_A, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_A, 0, 'a'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -307,7 +307,7 @@ void test_store_offsets() {
     {KM_KBP_IT_END}
   }));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_B, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_B, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_B, 0, 'b'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
@@ -361,7 +361,7 @@ void test_set_option() {
 
   // '1' -> set_option
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(debug_items(test_state, {
     km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_1, 0, '1'}},
     km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},

--- a/core/tests/unit/kmnkbd/state_api.cpp
+++ b/core/tests/unit/kmnkbd/state_api.cpp
@@ -156,20 +156,20 @@ int main(int argc, char * argv[])
   DISABLE_WARNING_POP
 
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,
-                                  KM_KBP_MODIFIER_SHIFT, 1));
+                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('S')}}, {KM_KBP_IT_END}}));
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_I,
-                                  KM_KBP_MODIFIER_SHIFT, 1));
+                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('I')}}, {KM_KBP_IT_END}}));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L, 0, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('l')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_BACK, {0,}, {0}}, {KM_KBP_IT_END}}));
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L,
-                                  KM_KBP_MODIFIER_SHIFT, 1));
+                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('L')}}, {KM_KBP_IT_END}}));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F2, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F2, 0, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_PERSIST_OPT, {0,},
                       {uintptr_t(&expected_persist_opt)}}, {KM_KBP_IT_END}}));
 

--- a/core/tests/unit/kmnkbd/state_api.cpp
+++ b/core/tests/unit/kmnkbd/state_api.cpp
@@ -156,20 +156,20 @@ int main(int argc, char * argv[])
   DISABLE_WARNING_POP
 
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,
-                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
+                                  KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('S')}}, {KM_KBP_IT_END}}));
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_I,
-                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
+                                  KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('I')}}, {KM_KBP_IT_END}}));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('l')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_BACK, {0,}, {0}}, {KM_KBP_IT_END}}));
   try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_L,
-                                  KM_KBP_MODIFIER_SHIFT, 1, 0));
+                                  KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('L')}}, {KM_KBP_IT_END}}));
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F2, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_F2, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_PERSIST_OPT, {0,},
                       {uintptr_t(&expected_persist_opt)}}, {KM_KBP_IT_END}}));
 

--- a/core/tests/unit/kmx/kmx.cpp
+++ b/core/tests/unit/kmx/kmx.cpp
@@ -218,7 +218,7 @@ run_test(const km::kbp::path &source, const km::kbp::path &compiled) {
     }
 
     for (auto key_down = 1; key_down >= 0; key_down--) {
-      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down));
+      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, 0));
 
       for (auto act = km_kbp_state_action_items(test_state, nullptr); act->type != KM_KBP_IT_END; act++) {
         apply_action(test_state, *act, text_store, test_context, options, test_source);

--- a/core/tests/unit/kmx/kmx.cpp
+++ b/core/tests/unit/kmx/kmx.cpp
@@ -218,7 +218,7 @@ run_test(const km::kbp::path &source, const km::kbp::path &compiled) {
     }
 
     for (auto key_down = 1; key_down >= 0; key_down--) {
-      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, 0));
+      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, KM_KBP_EVENT_FLAG_DEFAULT));
 
       for (auto act = km_kbp_state_action_items(test_state, nullptr); act->type != KM_KBP_IT_END; act++) {
         apply_action(test_state, *act, text_store, test_context, options, test_source);

--- a/core/tests/unit/kmx/kmx_imx.cpp
+++ b/core/tests/unit/kmx/kmx_imx.cpp
@@ -214,26 +214,26 @@ void test_queue_actions (const km::kbp::path &source_keyboard) {
   km_kbp_state_imx_register_callback(test_state, test_imx_callback, (void*)&g_extract_imx_map);
 
   // Key Press that doesn't trigger a call back
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,KM_KBP_MODIFIER_SHIFT, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,KM_KBP_MODIFIER_SHIFT, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('S')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('X')}}, {KM_KBP_IT_ALERT, {0,}, {0}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_ESC, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_ESC, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, { {KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('Y')}},
                                     {KM_KBP_IT_MARKER, {0,}, {1}},
                                     {KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('A')}},
                                     {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
 
   km_kbp_action_item bksp_a = {KM_KBP_IT_BACK};
   bksp_a.backspace.expected_type = KM_KBP_BT_CHAR;
   bksp_a.backspace.expected_value = 'A';
   assert(action_items(test_state, {bksp_a,{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('Z')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, 0));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, KM_KBP_EVENT_FLAG_DEFAULT));
   assert(action_items(test_state, {{KM_KBP_IT_INVALIDATE_CONTEXT, {0,}, {0}}, {KM_KBP_IT_END}}));
 
   km_kbp_state_imx_deregister_callback(test_state);

--- a/core/tests/unit/kmx/kmx_imx.cpp
+++ b/core/tests/unit/kmx/kmx_imx.cpp
@@ -214,26 +214,26 @@ void test_queue_actions (const km::kbp::path &source_keyboard) {
   km_kbp_state_imx_register_callback(test_state, test_imx_callback, (void*)&g_extract_imx_map);
 
   // Key Press that doesn't trigger a call back
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,KM_KBP_MODIFIER_SHIFT, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_S,KM_KBP_MODIFIER_SHIFT, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('S')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_BKSP, 0, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('X')}}, {KM_KBP_IT_ALERT, {0,}, {0}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_ESC, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_ESC, 0, 1, 0));
   assert(action_items(test_state, { {KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('Y')}},
                                     {KM_KBP_IT_MARKER, {0,}, {1}},
                                     {KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('A')}},
                                     {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_1, 0, 1, 0));
 
   km_kbp_action_item bksp_a = {KM_KBP_IT_BACK};
   bksp_a.backspace.expected_type = KM_KBP_BT_CHAR;
   bksp_a.backspace.expected_value = 'A';
   assert(action_items(test_state, {bksp_a,{KM_KBP_IT_CHAR, {0,}, {km_kbp_usv('Z')}}, {KM_KBP_IT_END}}));
 
-  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1));
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1, 0));
   assert(action_items(test_state, {{KM_KBP_IT_INVALIDATE_CONTEXT, {0,}, {0}}, {KM_KBP_IT_END}}));
 
   km_kbp_state_imx_deregister_callback(test_state);

--- a/core/tests/unit/ldml/ldml.cpp
+++ b/core/tests/unit/ldml/ldml.cpp
@@ -190,7 +190,7 @@ run_test(const km::kbp::path &source, const km::kbp::path &compiled) {
     }
 
     for (auto key_down = 1; key_down >= 0; key_down--) {
-      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down));
+      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, 0)); // TODO-LDML: for now. Should send touch and hardware events.
 
       for (auto act = km_kbp_state_action_items(test_state, nullptr); act->type != KM_KBP_IT_END; act++) {
         apply_action(test_state, *act, text_store, test_context, test_source);

--- a/core/tests/unit/ldml/ldml.cpp
+++ b/core/tests/unit/ldml/ldml.cpp
@@ -190,7 +190,7 @@ run_test(const km::kbp::path &source, const km::kbp::path &compiled) {
     }
 
     for (auto key_down = 1; key_down >= 0; key_down--) {
-      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, 0)); // TODO-LDML: for now. Should send touch and hardware events.
+      try_status(km_kbp_process_event(test_state, p.vk, p.modifier_state | test_source.caps_lock_state(), key_down, KM_KBP_EVENT_FLAG_DEFAULT)); // TODO-LDML: for now. Should send touch and hardware events.
 
       for (auto act = km_kbp_state_action_items(test_state, nullptr); act->type != KM_KBP_IT_END; act++) {
         apply_action(test_state, *act, text_store, test_context, test_source);

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -462,7 +462,7 @@ begin
   if not SetKeyEventContext then
     Exit(False);
 
-  if km_kbp_process_event(FDebugCore.State, Message.WParam, modifier, 1) = KM_KBP_STATUS_OK then
+  if km_kbp_process_event(FDebugCore.State, Message.WParam, modifier, 1, KM_KBP_EVENT_FLAG_DEFAULT) = KM_KBP_STATUS_OK then
   begin
     // Process keystroke
     Result := True;

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -308,7 +308,7 @@ km_kbp_process_event(
   vk: km_kbp_virtual_key;
   modifier_state: uint16_t;
   is_key_down: uint8_t;
-  event_flags: uint16_t;
+  event_flags: uint16_t
 ): km_kbp_status; cdecl; external kmnkbp0 delayed;
 
 const

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -307,8 +307,13 @@ km_kbp_process_event(
   state: pkm_kbp_state;
   vk: km_kbp_virtual_key;
   modifier_state: uint16_t;
-  is_key_down: uint8_t
+  is_key_down: uint8_t;
+  event_flags: uint16_t;
 ): km_kbp_status; cdecl; external kmnkbp0 delayed;
+
+const
+  KM_KBP_EVENT_FLAG_DEFAULT = 0; // default value: hardware
+  KM_KBP_EVENT_FLAG_TOUCH = 1; // set if the event is touch, otherwise hardware
 
 
 // keyboardprocessor_vkeys.h

--- a/developer/src/tike/main/Keyman.System.VisualKeyboardImportKMX.pas
+++ b/developer/src/tike/main/Keyman.System.VisualKeyboardImportKMX.pas
@@ -110,7 +110,7 @@ var
 begin
   context := km_kbp_state_context(FCore.State);
   km_kbp_context_clear(context);
-  if km_kbp_process_event(FCore.State, vk.vkey, vk.kmshift, 1) = KM_KBP_STATUS_OK then
+  if km_kbp_process_event(FCore.State, vk.vkey, vk.kmshift, 1, KM_KBP_EVENT_FLAG_DEFAULT) = KM_KBP_STATUS_OK then
   begin
     FEvents.Clear;
     FEvents.AddStateItems(FCore.State, vk.vkey, vk.kmshift);

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -838,7 +838,7 @@ ibus_keyman_engine_process_key_event(
   km_kbp_context *context = km_kbp_state_context(keyman->state);
   g_free(get_current_context_text(context));
   g_message("DAR: ibus_keyman_engine_process_key_event - km_mod_state=0x%x", km_mod_state);
-  km_kbp_status event_status = km_kbp_process_event(keyman->state, keycode_to_vk[keycode], km_mod_state, isKeyDown);
+  km_kbp_status event_status = km_kbp_process_event(keyman->state, keycode_to_vk[keycode], km_mod_state, isKeyDown, KM_KBP_EVENT_FLAG_DEFAULT);
   context                    = km_kbp_state_context(keyman->state);
   g_message("after process key event");
   g_free(get_current_context_text(context));

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -112,7 +112,7 @@ Process_Event_Core(PKEYMAN64THREADDATA _td) {
   //  Mask the bits supported according to `km_kbp_modifier_state` enum, update the mask if this enum is expanded.
   if (KM_KBP_STATUS_OK != km_kbp_process_event(
     _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
-    static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown), KM_KBP_EVENT_FLAG_DEFAULT) {
+    static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown, KM_KBP_EVENT_FLAG_DEFAULT)) {
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ", FALSE);
     return FALSE;
   }

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -112,7 +112,7 @@ Process_Event_Core(PKEYMAN64THREADDATA _td) {
   //  Mask the bits supported according to `km_kbp_modifier_state` enum, update the mask if this enum is expanded.
   if (KM_KBP_STATUS_OK != km_kbp_process_event(
     _td->lpActiveKeyboard->lpCoreKeyboardState, _td->state.vkey,
-    static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown)) {
+    static_cast<uint16_t>(Globals::get_ShiftState() & (KM_KBP_MODIFIER_MASK_ALL | KM_KBP_MODIFIER_MASK_CAPS)), (uint8_t)_td->state.isDown), KM_KBP_EVENT_FLAG_DEFAULT) {
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessEvent CoreProcessEvent Result:False %d ", FALSE);
     return FALSE;
   }


### PR DESCRIPTION
- Width: uint16_t
- defined `km_kbp_event_flags` to define the bitfield
- bitfield has value `KM_KBP_EVENT_FLAG_TOUCH` for touch events
- ignored everywhere, currently

Fixes: #7046 

@keymanapp-test-bot skip