### PR TITLE
feat(common): add parameter variable support to `builder_` functions

### DIFF
--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -27,6 +27,11 @@
 # Note: keep changes to version, tier and tag determination in sync with mkver (windows/src/buildutils/mkver)
 #
 
+#
+# Prevents 'clear' on exit of mingw64 bash shell
+#
+SHLVL=0
+
 # Setup variable for calling script's path and name
 if [ ! -z ${THIS_SCRIPT+x} ]; then
   THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
@@ -597,7 +602,10 @@ builder_parse() {
           _builder_parameter_error "$0" parameter "$key"
         fi
         # Set the variable associated with this option to the next parameter value
-        eval ${_builder_options_var[$key]}="$1"
+        # A little bit of hoop jumping here to avoid issues with cygwin paths being
+        # corrupted too early in the game
+        local varname=${_builder_options_var[$key]}
+        declare -g $varname="$1"
       fi
 
     else

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -667,7 +667,6 @@ builder_display_usage() {
 
   for e in "${!_builder_params[@]}"; do
     if (( ${#e} > $width )); then
-      echo ${#e}
       width=${#e}
     fi
   done

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -470,11 +470,15 @@ builder_describe() {
         local option_short="$(echo "$value" | cut -d, -f 2 -)"
         _builder_options+=($option_long)
         _builder_options_short[$option_short]="$option_long"
-        _builder_options_var[$option_long]="$option_var"
+        if [[ ! -z "$option_var" ]]; then
+          _builder_options_var[$option_long]="$option_var"
+        fi
         value="$option_long, $option_short"
       else
         _builder_options+=($value)
-        _builder_options_var[$value]="$option_var"
+        if [[ ! -z "$option_var" ]]; then
+          _builder_options_var[$value]="$option_var"
+        fi
       fi
 
       if [[ ! -z $option_var ]]; then

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -410,11 +410,15 @@ _builder_trim() {
 #
 # There are three types of parameters that may be specified:
 #
-# * Option, param_desc format: "--option[,-o]   [One line description]"
+# * Option, param_desc format: "--option[,-o][=var]   [One line description]"
 #   All options must have a longhand form with two prefix hyphens,
 #   e.g. --option. The ",-o" shorthand form is optional. When testing if
 #   the option is set with `builder_has_option``, always use the longhand
 #   form.
+#
+#   if =var is specified, then the next parameter will be a variable stored
+#   in $var for that option. e.g. --option=opt means $opt will have the value
+#   'foo' when the script is called for --option foo.
 #
 # * Action, param_desc format: "action   [One line description]"
 #   Actions must be a single word, lower case. To specify an action
@@ -433,6 +437,7 @@ builder_describe() {
   _builder_default_action=build
   declare -A -g _builder_params
   declare -A -g _builder_options_short
+  declare -A -g _builder_options_var
   shift
   # describe each target, action, and option possibility
   while [[ $# -gt 0 ]]; do
@@ -449,14 +454,26 @@ builder_describe() {
     elif [[ $value =~ ^-- ]]; then
       # Parameter is an option
       # Look for a shorthand version of the option
+      local option_var=
+      if [[ $value =~ = ]]; then
+        option_var="$(echo "$value" | cut -d= -f 2 -)"
+        value="$(echo "$value" | cut -d= -f 1 -)"
+      fi
+
       if [[ $value =~ , ]]; then
         local option_long="$(echo "$value" | cut -d, -f 1 -)"
         local option_short="$(echo "$value" | cut -d, -f 2 -)"
         _builder_options+=($option_long)
         _builder_options_short[$option_short]="$option_long"
+        _builder_options_var[$option_long]="$option_var"
         value="$option_long, $option_short"
       else
         _builder_options+=($value)
+        _builder_options_var[$value]="$option_var"
+      fi
+
+      if [[ ! -z $option_var ]]; then
+        value="$value $option_var"
       fi
     else
       # Parameter is an action
@@ -574,6 +591,15 @@ builder_parse() {
       _builder_chosen_action_targets+=("$_builder_default_action$target")
     elif (( has_option )); then
       _builder_chosen_options+=("$key")
+      if [[ ! -z ${_builder_options_var[$key]+x} ]]; then
+        shift
+        if [[ $# -eq 0 ]]; then
+          _builder_parameter_error "$0" parameter "$key"
+        fi
+        # Set the variable associated with this option to the next parameter value
+        eval ${_builder_options_var[$key]}="$1"
+      fi
+
     else
       case "$key" in
         --help|-h)
@@ -632,7 +658,10 @@ builder_display_usage() {
   local width=12
 
   for e in "${!_builder_params[@]}"; do
-    if (( ${#e} > $width )); then width = ${#e}; fi
+    if (( ${#e} > $width )); then
+      echo ${#e}
+      width=${#e}
+    fi
   done
 
   width=$((width + 6))

--- a/resources/build/build-utils.test.sh
+++ b/resources/build/build-utils.test.sh
@@ -94,7 +94,7 @@ builder_parse_test() {
   shift
   shift
   local parameters="$@"
-  echo "Testing: builder_parse $parameters"
+  echo "${COLOR_BLUE}## Testing: builder_parse $parameters${COLOR_RESET}"
   builder_parse $parameters || fail "builder_parse died under curious circumstances"
   if [[ "$expected" != "${_builder_chosen_action_targets[@]}" ]]; then
     fail "  Test: builder_parse $parameters action:target != \"$expected\""
@@ -112,7 +112,8 @@ builder_describe \
   ":app" \
   ":engine      Thomas, y'know" \
   "--power,-p   Use powerful mode" \
-  "--zoom,-z    Use zoom mode"
+  "--zoom,-z    Use zoom mode" \
+  "--feature=FOO Enable feature foo"
 
 # Test --options
 
@@ -130,6 +131,21 @@ if builder_has_option --zoom; then
   echo "PASS: --zoom option found"
 else
   fail "FAIL: --zoom option not found"
+fi
+
+# Test --feature <foo>
+
+echo "${COLOR_BLUE}## Testing: builder_parse --feature xyzzy${COLOR_RESET}"
+builder_parse --feature xyzzy
+
+if builder_has_option --feature; then
+  if [[ $FOO == xyzzy ]]; then
+    echo "PASS: --feature option variable \$FOO has expected value 'xyzzy'"
+  else
+    echo "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
+  fi
+else
+  echo "FAIL: --feature option not found"
 fi
 
 # Finally, run with --help so we can see what it looks like


### PR DESCRIPTION
This PR is cherry-picked from #7101, to bring new build-utils.sh functionality into alpha outside of the feature-ldml branch timeline.

The changes here allows you to define variables for parameters, where you need to pass additional data on the command line.

First, use `builder_describe` to add an option, with a variable name, for example (cut down example here from the original PR):

```
builder_describe "Build Keyman LDML Keyboard Compiler kmldmlc" \
  "bundle                   Creates a bundled version of kmldmlc" \
  "--build-path=BUILD_PATH  Build directory for bundle"
```

Adding `=VAR` to the option definition means that the builder_ utils will expect a second parameter after the option, for example:

```
./build.sh bundle --build-path /tmp/foo
```

This new option will be made available in the environment variable `$VAR`, so in the above example, it would be `$BUILD_PATH`. The environment variable will only be defined if the option is passed on the command line (so use normal bash semantics to avoid errors, or test the option with `builder_has_option`).

You can also mix with short form of options, for example:

```
builder_describe "Build Keyman LDML Keyboard Compiler kmldmlc" \
  "bundle                      Creates a bundled version of kmldmlc" \
  "--build-path,-b=BUILD_PATH  Build directory for bundle"
```

@keymanapp-test-bot skip