### PR TITLE
fix(windows): Add invalidate context action to non-updatable parse 🍒

### DIFF
--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -190,7 +190,7 @@ BOOL ProcessHook()
     }
 
     if (!_td->TIPFUpdateable) {
-      ProcessActionsTestParse(&fOutputKeystroke);
+      ProcessActionsNonUpdatableParse(&fOutputKeystroke);
     } else {
       ProcessActions(&fOutputKeystroke);
     }

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -167,7 +167,7 @@ BOOL ProcessActions(BOOL* emitKeyStroke)
 }
 
 BOOL
-ProcessActionsTestParse(BOOL* emitKeyStroke) {
+ProcessActionsNonUpdatableParse(BOOL* emitKeyStroke) {
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if (!_td) {
     return FALSE;
@@ -184,12 +184,15 @@ ProcessActionsTestParse(BOOL* emitKeyStroke) {
     switch (act->type) {
     case KM_KBP_IT_EMIT_KEYSTROKE:
       *emitKeyStroke = TRUE;
-      SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessActionsTestParse EMIT_KEYSTROKE: act->type=%d", act->type);
+      SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessActionsNonUpdatableParse EMIT_KEYSTROKE: act->type=[%d]", act->type);
       continueProcessingActions = TRUE;
       _td->CoreProcessEventRun = FALSE; // If we emit the key stroke on this parse we don't need the second parse
       break;
     case KM_KBP_IT_CAPSLOCK:
       continueProcessingActions = processCapsLock(act, !_td->state.isDown, _td->TIPFUpdateable);
+      break;
+    case KM_KBP_IT_INVALIDATE_CONTEXT:
+      continueProcessingActions = processInvalidateContext(_td->app, _td->lpActiveKeyboard->lpCoreKeyboardState);
       break;
     }
     if (!continueProcessingActions) {

--- a/windows/src/engine/keyman32/kmprocessactions.h
+++ b/windows/src/engine/keyman32/kmprocessactions.h
@@ -18,12 +18,12 @@ BOOL ProcessActions(BOOL* emitKeyStroke);
 
 /**
  * This function process the actions queued in the core processor in
- * the non updateable parse of a keystroke.
- * Emit keystroke and capslock are required to be processed in this phase.
+ * the non-updateable parse of a keystroke.
+ * Emit keystroke , capslock, and possibly invalidate key stroke are required to be processed in this phase.
  *
  * @param  [in, out] emitKeyStroke  is set to true if requested by the core action queue
  * @return BOOL  True if actions were successfully processed
  */
-BOOL ProcessActionsTestParse(BOOL* emitKeyStroke);
+BOOL ProcessActionsNonUpdatableParse(BOOL* emitKeyStroke);
 
 #endif

--- a/windows/src/engine/keyman32/kmprocessactions.h
+++ b/windows/src/engine/keyman32/kmprocessactions.h
@@ -19,7 +19,7 @@ BOOL ProcessActions(BOOL* emitKeyStroke);
 /**
  * This function process the actions queued in the core processor in
  * the non-updateable parse of a keystroke.
- * Emit keystroke , capslock, and possibly invalidate key stroke are required to be processed in this phase.
+ * Emit keystroke, capslock and possibly invalidate key stroke are required to be processed in this parse.
  *
  * @param  [in, out] emitKeyStroke  is set to true if requested by the core action queue
  * @return BOOL  True if actions were successfully processed


### PR DESCRIPTION
Cherry Pick from #7089 
Rename ProcessActionsTestParse to NonUpdatable parse as it does more than just test. Add handling for the invalidate context action to this parse. In the case when an emit keystroke is in the action list it will be emitted and the Updateable round will never occur so we need to invalidate the context now in the non-updatable parse.
@keymanapp-test-bot skip