### PR TITLE
feat(core): turn @keymanapp/ldml-keyboard-constants into a module 🙀

### DIFF
--- a/core/include/ldml/.gitignore
+++ b/core/include/ldml/.gitignore
@@ -1,0 +1,1 @@
+ldml-const-builder/

--- a/core/include/ldml/package.json
+++ b/core/include/ldml/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@keymanapp/ldml-keyboard-constants",
+  "description": "Keyman LDML keyboard constants",
+  "keywords": [
+    "keyboard",
+    "keyman",
+    "ldml",
+    "unicode"
+  ],
+  "license": "MIT",
+  "main": "build/keyboardprocessor_ldml.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keymanapp/keyman.git"
+  }
+}

--- a/core/include/ldml/tsconfig.build.json
+++ b/core/include/ldml/tsconfig.build.json
@@ -6,12 +6,13 @@
         "module": "CommonJS",
         "moduleResolution": "node",
         "rootDir": ".",
-        "outDir": "build/",
+        "outDir": "ldml-const-builder/",
     },
     "exclude": [
         "node_modules"
     ],
     "files": [
-        "keyboardprocessor_ldml.ts"
+        "keyboardprocessor_ldml.ts",
+        "ldml-const-builder.ts"
     ]
 }

--- a/core/tools/ldml-const-builder/build.sh
+++ b/core/tools/ldml-const-builder/build.sh
@@ -36,13 +36,13 @@ fi
 
 if builder_has_action build; then
   # Generate index.ts
-  npx tsc -b ../../include/ldml/
+  npx tsc -b ../../include/ldml/tsconfig.build.json
 
   builder_report success build
 fi
 
 if builder_has_action run; then
-  node ../../include/ldml/build/core/include/ldml/ldml-const-builder.js > ${KBP_LDML_H_FILE}
+  node ../../include/ldml/ldml-const-builder/ldml-const-builder.js > ${KBP_LDML_H_FILE}
   echo "Updated ${KBP_LDML_H_FILE}"
 
   builder_report success run

--- a/developer/src/kmldmlc/src/keyman/kmx/kmx-plus.ts
+++ b/developer/src/kmldmlc/src/keyman/kmx/kmx-plus.ts
@@ -1,0 +1,11 @@
+// import * as r from 'restructure';
+
+import { constants } from '@keymanapp/ldml-keyboard-constants';
+
+// Uses defns from ...
+
+export default class KMXPlusFile {
+  constructor() {
+    console.log(constants);
+  }
+}

--- a/developer/src/kmldmlc/tsconfig.json
+++ b/developer/src/kmldmlc/tsconfig.json
@@ -22,5 +22,6 @@
   ],
   "references": [
     { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../core/include/ldml/"}
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "resources/gosh",
         "resources/build/version",
+        "core/include/ldml",
         "developer/src/kmlmc",
         "developer/src/kmldmlc",
         "developer/src/server",
@@ -375,6 +376,10 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
       "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
       "dev": true
+    },
+    "core/include/ldml": {
+      "name": "@keymanapp/ldml-keyboard-constants",
+      "license": "MIT"
     },
     "developer/js": {
       "name": "@keymanapp/lexical-model-compiler",
@@ -1055,6 +1060,10 @@
     },
     "node_modules/@keymanapp/ldml-keyboard-compiler": {
       "resolved": "developer/src/kmldmlc",
+      "link": true
+    },
+    "node_modules/@keymanapp/ldml-keyboard-constants": {
+      "resolved": "core/include/ldml",
       "link": true
     },
     "node_modules/@keymanapp/lexical-model-compiler": {
@@ -7735,7 +7744,7 @@
         "chai": "^4.3.4",
         "chalk": "^2.4.2",
         "commander": "^3.0.0",
-        "crc-32": "*",
+        "crc-32": "^1.2.2",
         "mocha": "^8.4.0",
         "restructure": "^3.0.0",
         "ts-node": "^9.1.1",
@@ -7806,6 +7815,9 @@
           }
         }
       }
+    },
+    "@keymanapp/ldml-keyboard-constants": {
+      "version": "file:core/include/ldml"
     },
     "@keymanapp/lexical-model-compiler": {
       "version": "file:developer/src/kmlmc",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "workspaces": [
     "resources/gosh",
     "resources/build/version",
+    "core/include/ldml",
     "developer/src/kmlmc",
     "developer/src/kmldmlc",
     "developer/src/server",


### PR DESCRIPTION
Splits the building of keyboardprocessor_ldml.h into a separate tsconfig.build.json, and designates keyboardprocessor_ldml.ts as a new Typescript/Node module @keymanapp/ldml-keyboard-constants.

Includes an example usage in the (currently unused) kmx-plus.ts.

@keymanapp-test-bot skip