### PR TITLE
fix(android/engine): Lower the max height for landscape orientation

### DIFF
--- a/android/KMEA/app/src/main/res/values-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land/dimens.xml
@@ -2,7 +2,7 @@
 <!-- Dimens for Landscape (Phone) -->
 <resources>
     <dimen name="banner_height">40dp</dimen>
-    <dimen name="keyboard_height">150dp</dimen>
+    <dimen name="keyboard_height">100dp</dimen>
     <dimen name="key_width">49.25dp</dimen>
     <dimen name="key_height">49.25dp</dimen>
     <dimen name="popup_arrow_width">21dp</dimen>

--- a/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -2,7 +2,7 @@
 <!-- Dimens for Landscape (Tablet 7") -->
 <resources>
     <dimen name="banner_height">50dp</dimen>
-    <dimen name="keyboard_height">200dp</dimen>
+    <dimen name="keyboard_height">140dp</dimen>
     <dimen name="key_width">73.5dp</dimen>
     <dimen name="key_height">58.5dp</dimen>
     <dimen name="popup_arrow_width">32dp</dimen>

--- a/android/KMEA/app/src/main/res/values-sw720dp-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw720dp-land/dimens.xml
@@ -2,7 +2,7 @@
 <!-- Dimens for Landscape (Tablet 10") -->
 <resources>
     <dimen name="banner_height">60dp</dimen>
-    <dimen name="keyboard_height">300dp</dimen>
+    <dimen name="keyboard_height">200dp</dimen>
     <dimen name="key_width">98.5dp</dimen>
     <dimen name="key_height">98.5dp</dimen>
     <dimen name="popup_arrow_width">42dp</dimen>


### PR DESCRIPTION
Fixes #7085

The maximum keyboard heights in landscape orientation from #5606 are too high, making the in-app keyboard unusable at max height. If the suggestion banner is enabled, the in-app keyboard even fails to display.

This PR lowers the maximum heights so that keyboards with suggestion banners can be used.


## Emulator Screenshots of Updated Maximum Heights (Landscape Orientation)

### Default
![max landscape](https://user-images.githubusercontent.com/7358010/186553769-a138cfab-24f4-4d57-9c40-4abe5036abf2.png)

### 600dp
![max landscape 600](https://user-images.githubusercontent.com/7358010/186550000-355cb70a-845f-458e-8fe5-8bae74f3b71b.png)


### 720 dp
![max landscape 720](https://user-images.githubusercontent.com/7358010/186549936-eb3260cd-fbbb-4e30-8070-7b5e8ee239d8.png)

## User Testing
**Setup for each test** - Have Android Emulator for the following devices (SDK can be any version between 21 <= 30

TEST_PIXEL2_DEFAULT - Tests landscape orientation on phones
1. On Pixel 2 emulator, install the PR build of Keyman for Android
2. Rotate the device to landscape orientation and launch the Keyman app (you may need to hit the system icon on the bottom taskbar for the screen to rotate to landscape)
3. In the Keyman app, go to Settings --> Adjust Keyboard Height
4. In the keyboard height menu, drag the OSK to the maximum height and then back out of the Settings menus
5. In the Keyman app, verify the OSK is visible and at the maximum height
6. In the Keyman app, verify the text field is visible and that you can type into it

TEST_NEXUS7_600 - Tests landscape orientation for 600dp devices
1. On a Nexus 7 emulator, install the PR build of Keyman for Android
2. Rotate the device to landscape orientation and launch the Keyman app (you may need to hit the system icon on the bottom taskbar for the screen to rotate to landscape)
3. In the Keyman app, go to Settings --> Adjust Keyboard Height
4. In the keyboard height menu, drag the OSK to the maximum height and then back out of the Settings menus
5. In the Keyman app, verify the OSK is visible and at the maximum height
6. In the Keyman app, verify the text field is visible and that you can type into it

TEST_NEXUS10_720 - Tests landscape orientation for 720dp devices
1. On a Nexus 10 emulator, install the PR build of Keyman for Android
2. Rotate the device to landscape orientation and launch the Keyman app (you may need to hit the system icon on the bottom taskbar for the screen to rotate to landscape)
3. In the Keyman app, go to Settings --> Adjust Keyboard Height
4. In the keyboard height menu, drag the OSK to the maximum height and then back out of the Settings menus
5. In the Keyman app, verify the OSK is visible and at the maximum height
6. In the Keyman app, verify the text field is visible and that you can type into it
