### PR TITLE
fix(linux): Remove wrong `ok_for_single_backspace` method

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -508,16 +508,6 @@ static void forward_backspace(IBusKeymanEngine *keyman, unsigned int state)
     ibus_engine_forward_key_event((IBusEngine *)keyman, KEYMAN_BACKSPACE_KEYSYM, KEYMAN_BACKSPACE, state);
 }
 
-static gboolean ok_for_single_backspace(const km_kbp_action_item *action_items, int i, size_t num_actions)
-{
-    for (int j=i+1; j < num_actions; j++) {
-        if (action_items[i].type == KM_KBP_IT_BACK || action_items[i].type == KM_KBP_IT_CHAR || action_items[i].type == KM_KBP_IT_EMIT_KEYSTROKE) {
-            return FALSE;
-        }
-    }
-    return TRUE;
-}
-
 static gboolean
 process_unicode_char_action(
   IBusKeymanEngine *keyman,
@@ -601,10 +591,6 @@ process_backspace_action(
     }
     g_free(keyman->char_buffer);
     keyman->char_buffer = new_buffer;
-  } else if (ok_for_single_backspace(action_items, i, num_action_items)) {
-    // single backspace can be handled by ibus as normal
-    g_message("no char actions, just single back");
-    return FALSE;
   } else {
     g_message(
         "DAR: process_backspace_action - client_capabilities=%x, %x", engine->client_capabilities, IBUS_CAP_SURROUNDING_TEXT);


### PR DESCRIPTION
The implementation of `ok_for_single_backspace` checked the current action_item multiple times. However, we already know that that item is `KM_KBP_IT_BACK` because the only place this method gets called is from the `process_backspace_action` method. So basically this method always returns `FALSE`. "Fixing" this method to check the next action_items makes things fail.

Removing this method since it doesn't do anything except burn processing cycles...

Fixes #5614.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_BIONIC**: Ubuntu 18.04 Bionic with Gnome Shell and X11
  - **GROUP_JAMMY_X11**: Ubuntu 22.04 Jammy with Gnome Shell and X11

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

- **TEST_IPA_WRITER:** Open LibreOffice Writer. Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_IPA_GEDIT:** Open gedit. Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_KO_WRITER:** Open LibreOffice Writer. Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_KO_GEDIT:** Open gedit. Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_KM_WRITER:** Open LibreOffice Writer. Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_KM_GEDIT:** Open gedit. Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
