### PR TITLE
feat(core): ldml: improve file reading/validation 🙀

### DIFF
--- a/core/src/kmx/kmx_plus.cpp
+++ b/core/src/kmx/kmx_plus.cpp
@@ -8,11 +8,6 @@
 #include <kmx_file.h>
 #include <kmx/kmx_plus.h>
 
-/**
- * @def KMXPLUS_DEBUG Set to 1 to enable debug output
- */
-#define KMXPLUS_DEBUG 0
-
 #if KMXPLUS_DEBUG
 #include <stdio.h>
 #endif

--- a/core/src/kmx/kmx_plus.cpp
+++ b/core/src/kmx/kmx_plus.cpp
@@ -244,16 +244,6 @@ validate_kmxplus_data(kmx::PCOMP_KEYBOARD keyboard) {
   return validate_kmxplus_data(rawdata + ex->kmxplus.dpKMXPlus);
 }
 
-const kmx::COMP_KMXPLUS_KEYS_ENTRY *COMP_KMXPLUS_KEYS::find(KMX_DWORD vkey, KMX_DWORD mod) const {
-    // TODO-LDML: eventually, assume sorted order & binary search
-    for (KMX_DWORD i=0; i<count; i++) {
-        if(entries[i].vkey == vkey && entries[i].mod == mod) {
-            return &entries[i];
-        }
-    }
-    return nullptr;
-}
-
 KMX_DWORD COMP_KMXPLUS_SECT::find(KMX_DWORD ident) const {
   for (KMX_DWORD i = 0; i < count; i++) {
     if (ident == entries[i].sect) {

--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -125,7 +125,6 @@ struct COMP_KMXPLUS_KEYS {
   KMX_DWORD count;    // number of keys
   KMX_DWORD reserved; // padding
   COMP_KMXPLUS_KEYS_ENTRY entries[];
-  const COMP_KMXPLUS_KEYS_ENTRY *find(KMX_DWORD vkey, KMX_DWORD mod) const;
 };
 
 static_assert(sizeof(struct COMP_KMXPLUS_KEYS) % 0x10 == 0, "Structs prior to entries[] should align to 128-bit boundary");

--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -11,6 +11,13 @@
 #include <kmx_file.h>
 #include <ldml/keyboardprocessor_ldml.h>
 
+/**
+ * @def KMXPLUS_DEBUG Set to 1 to enable debug output
+ */
+#ifndef KMXPLUS_DEBUG
+#define KMXPLUS_DEBUG 0
+#endif
+
 namespace km {
 namespace kbp {
 namespace kmx {
@@ -227,7 +234,7 @@ as_kmxplus_vkey(const uint8_t *data) {
  * @param kmxplusdata data from the beginning of the KMXPlus section
  * @return true if valid
  */
-bool validate_kmxplus_data(void *kmxplusdata);
+bool validate_kmxplus_data(const uint8_t *kmxplusdata);
 
 /**
  * @param keyboard pointer to PCOMP_KEYBOARD with plus data following

--- a/core/src/ldml/C7043_ldml.md
+++ b/core/src/ldml/C7043_ldml.md
@@ -24,6 +24,7 @@ Draft spec PR: <https://github.com/unicode-org/cldr/pull/1847>
 - All variable length sections have the variable part begin on a 128-bit boundary, with zero padding as needed.
 - All sections begin with a 32-bit (four character) section identifier, and a 32-bit section size.
 - Other than the `sect` table itself, the rest of the sections follow in binary order in the file.  In other words, the binary ordering of the section identifiers determines the order of the file layout.
+- All sections other than the `sect` table are optional
 
 ### C7043.2.1 `sect`—Section Table of contents
 
@@ -68,6 +69,8 @@ Then for each string:
 After the string offset table comes the actual UTF-16LE data. There is a null (\u0000) after each string, which is _not_ included in the string length.
 
 The string offset table, and then strings themselves, are sorted according to a binary codepoint sort, not including the null.
+
+A string may be zero length.
 
 ### C7043.2.3 `meta`—Metadata
 
@@ -140,7 +143,7 @@ For each key:
 |--------------|----------|---------------------------------------------|
 |       0      | extend   | 0: `to` is a char, 1: `to` is a string      |
 
-- `to`: If `extend` is 0, `to` is a UTF-32LE codepoint. If `extend` is 1, `to` is a 32 bit index into the `strs` table.
+- `to`: If `extend` is 0, `to` is a UTF-32LE codepoint. If `extend` is 1, `to` is a 32 bit index into the `strs` table. The string may be zero-length.
 
 ### C7043.2.6 `vkey`—VKey Map
 

--- a/core/src/ldml/ldml_processor.hpp
+++ b/core/src/ldml/ldml_processor.hpp
@@ -32,12 +32,6 @@ namespace kbp {
   class ldml_processor : public abstract_processor {
   private:
     bool _valid;
-    std::vector<uint8_t> rawdata; // TODO-LDML: should be 'unpacked' format instead.
-
-    const kmx::COMP_KMXPLUS_SECT *sect;
-    const kmx::COMP_KMXPLUS_STRS *strs;
-    const kmx::COMP_KMXPLUS_KEYS *keys;
-
     std::map<ldml_vkey_id, std::u16string> vkey_to_string;
 
   public:

--- a/core/src/ldml/ldml_processor.hpp
+++ b/core/src/ldml/ldml_processor.hpp
@@ -7,22 +7,39 @@
 
 #pragma once
 
+#include <map>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 #include <keyman/keyboardprocessor.h>
 #include "processor.hpp"
 #include "option.hpp"
+
+// TODO-LDML: May not need this eventually
+#include <kmx/kmx_plus.h>
 
 namespace km {
 namespace kbp {
 
 #define KM_KBP_LMDL_PROCESSOR_VERSION u"1.0"
 
+ /**
+  * identifier for keybag lookup
+  */
+  typedef std::pair<km_kbp_virtual_key, uint16_t> ldml_vkey_id;
+
   class ldml_processor : public abstract_processor {
   private:
     bool _valid;
     std::vector<uint8_t> rawdata; // TODO-LDML: should be 'unpacked' format instead.
+
+    const kmx::COMP_KMXPLUS_SECT *sect;
+    const kmx::COMP_KMXPLUS_STRS *strs;
+    const kmx::COMP_KMXPLUS_KEYS *keys;
+
+    std::map<ldml_vkey_id, std::u16string> vkey_to_string;
+
   public:
     ldml_processor(
       path const & kb_path,


### PR DESCRIPTION
- don't reparse structs on each keydown, read into memory
- improve validation
- move validation into constructor
- validate length of data
- don't retain the raw .kmx data at runtime

#5015 

and of course,
@keymanapp-test-bot skip