### PR TITLE
chore: update core/ label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,7 +18,6 @@ android/samples/: android/Samples/**
 
 common/:
   - common/**
-  - core/**
   - resources/**
 
 common/models/: common/models/**
@@ -29,7 +28,7 @@ common/models/wordbreakers/: common/models/wordbreakers/**
 common/resources/: resources/**
 common/web/: common/web/**
 
-common/core/:
+core/:
   - core/**
 
 developer/:


### PR DESCRIPTION
Move core/ to its own top-level label (not common/core/ any more.)

@keymanapp-test-bot skip