### PR TITLE
feat(developer): unit test framework for kmldmlc 🙀

### DIFF
--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -39,8 +39,8 @@ struct COMP_KMXPLUS_SECT_ENTRY {
 struct COMP_KMXPLUS_SECT {
   COMP_KMXPLUS_HEADER header;
   KMX_DWORD total;                     // 0008 KMXPlus entire length
-  KMX_DWORD count;                     // 000B number of section headers
-  COMP_KMXPLUS_SECT_ENTRY entries[];  // 0010 section entries
+  KMX_DWORD count;                     // 000C number of section headers
+  COMP_KMXPLUS_SECT_ENTRY entries[];   // 0010 section entries
   /**
    * @brief Get the offset of a section, or 0
    *
@@ -63,7 +63,7 @@ struct COMP_KMXPLUS_STRS {
   COMP_KMXPLUS_HEADER header;
   KMX_DWORD count;                    // 0008 count of str entries
   KMX_DWORD reserved;                 // 000C padding
-  COMP_KMXPLUS_STRS_ENTRY entries[]; // 0010+ entries
+  COMP_KMXPLUS_STRS_ENTRY entries[];  // 0010+ entries
 
   /**
    * @brief Get a string entry
@@ -93,7 +93,7 @@ struct COMP_KMXPLUS_META {
 static_assert(sizeof(struct COMP_KMXPLUS_META) == LDML_LENGTH_META, "mismatched size of section meta");
 
 struct COMP_KMXPLUS_LOCA_ENTRY {
-  KMX_DWORD locale; // 000C+ locale string entry
+  KMX_DWORD locale; // 0010+ locale string entry
 };
 
 struct COMP_KMXPLUS_LOCA {

--- a/developer/src/kmldmlc/package.json
+++ b/developer/src/kmldmlc/package.json
@@ -9,14 +9,14 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "test": "cd src/test && tsc -b && cd .. && mocha",
+    "test": "cd test && tsc -b && cd .. && mocha ",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "license": "MIT",
-  "main": "build/kmldmlc.js",
+  "main": "build/src/kmldmlc.js",
   "bin": {
-    "kmldmlc": "build/kmldmlc.js"
+    "kmldmlc": "build/src/kmldmlc.js"
   },
   "dependencies": {
     "commander": "^3.0.0",
@@ -37,7 +37,7 @@
     "ts-node": "^9.1.1"
   },
   "mocha": {
-    "spec": "build-tests/**/test-*.js"
+    "spec": "build/test/test-*.js"
   },
   "repository": {
     "type": "git",

--- a/developer/src/kmldmlc/src/kmldmlc.ts
+++ b/developer/src/kmldmlc/src/kmldmlc.ts
@@ -18,7 +18,7 @@ program
   .description('Compiles Keyman LDML keyboards')
   .version(KEYMAN_VERSION.VERSION_WITH_TAG)
   .arguments('<infile>')
-  .action(infile => inputFilename = infile)
+  .action((infile:any) => inputFilename = infile)
   .option('-o, --outFile <filename>', 'where to save the resulting .kmx file');
 
 program.parse(process.argv);
@@ -69,5 +69,6 @@ let code = compileKeyboard(inputFilename);
 
 if(code) {
   const outFile = program.outFile ?? path.join(path.dirname(inputFilename), path.basename(inputFilename, '.xml') + '.kmx');
+  console.log(`Writing compiled keyboard to ${outFile}`);
   fs.writeFileSync(outFile, code);
 }

--- a/developer/src/kmldmlc/test/README.md
+++ b/developer/src/kmldmlc/test/README.md
@@ -1,0 +1,7 @@
+Keyman LDML Keyboard Compiler Tests
+===================================
+
+Test
+----
+
+    ../build.sh test

--- a/developer/src/kmldmlc/test/fixtures/basic.txt
+++ b/developer/src/kmldmlc/test/fixtures/basic.txt
@@ -1,0 +1,122 @@
+0x0000:            #  struct COMP_KEYBOARD {
+  4b 58 54 53      #    KMX_DWORD dwIdentifier;   // 0000 Keyman compiled keyboard id
+
+  00 10 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
+
+  fc 29 af f8      #    KMX_DWORD dwCheckSum;     // 0008 As stored in keyboard
+  00 00 00 00      #    KMX_DWORD KeyboardID;     // 000C as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
+  01 00 00 00      #    KMX_DWORD IsRegistered;   // 0010
+  00 00 00 00      #    KMX_DWORD version;        // 0014 keyboard version
+
+  00 00 00 00      #    KMX_DWORD cxStoreArray;   // 0018 in array entries
+  00 00 00 00      #    KMX_DWORD cxGroupArray;   // 001C in array entries
+
+  00 00 00 00      #    KMX_DWORD dpStoreArray;   // 0020 [LPSTORE] address of first item in store array
+  00 00 00 00      #    KMX_DWORD dpGroupArray;   // 0024 [LPGROUP] address of first item in group array
+
+  ff ff ff ff      #    KMX_DWORD StartGroup[2];  // 0028 index of starting groups [2 of them]
+  ff ff ff ff      #
+
+  20 00 00 00      #    KMX_DWORD dwFlags;        // 0030 Flags for the keyboard file
+
+  00 00 00 00      #    KMX_DWORD dwHotKey;       // 0034 standard windows hotkey (hiword=shift/ctrl/alt stuff, loword=vkey)
+
+  00 00 00 00      #    KMX_DWORD dpBitmapOffset; // 0038 offset of the bitmaps in the file
+  00 00 00 00      #    KMX_DWORD dwBitmapSize;   // 003C size in bytes of the bitmaps
+                   #  };
+
+
+0x0040:            #  struct COMP_KEYBOARD_KMXPLUSINFO {
+  48 00 00 00      #    KMX_DWORD dpKMXPlus;      // 0040 offset of KMXPlus data, <sect> header is first
+  52 01 00 00      #    KMX_DWORD dwKMXPlusSize;  // 0044 size in bytes of entire KMXPlus data
+                   #  };
+
+0x0048:            #  struct COMP_KMXPLUS_SECT {
+  73 65 63 74      #    KMX_DWORD header.ident;   // 0000 Section name
+  30 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  52 01 00 00      #    KMX_DWORD total;          // 0008 KMXPlus entire length
+  04 00 00 00      #    KMX_DWORD count;          // 000C number of section headers
+
+  73 74 72 73      #    KMX_DWORD sect;    // 0010+ Section identity - strs
+  30 00 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+
+  6d 65 74 61      #    KMX_DWORD sect;    // 0010+ Section identity - meta
+  ea 00 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+
+  6c 6f 63 61      #    KMX_DWORD sect;    // 0010+ Section identity - loca
+  0e 01 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+
+  6b 65 79 73      #    KMX_DWORD sect;    // 0010+ Section identity - keys
+  22 01 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+                   #  };
+
+0x0078:            #  struct COMP_KMXPLUS_STRS {
+  73 74 72 73      #    KMX_DWORD header.ident;   // 0000 Section name - strs
+  ba 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  09 00 00 00      #    KMX_DWORD count;          // 0008 count of str entries
+  00 00 00 00      #    KMX_DWORD reserved;       // 000C padding
+
+  58 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  07 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  68 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  06 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  76 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  0b 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  8e 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  06 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  9c 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  03 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  a4 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  aa 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  b0 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  01 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  b4 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
+  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+                   # };
+
+# String table
+
+  54 00 65 00 73 00 74 00 4b 00 62 00 64 00 00 00 # 0:TestKbd
+  73 00 72 00 6c 00 32 00 39 00 35 00 00 00       # 1:srl295
+  74 00 65 00 63 00 68 00 70 00 72 00 65 00 76 00
+  69 00 65 00 77 00 00 00                         # 2:techpreview
+  71 00 77 00 65 00 72 00 74 00 79 00 00 00       # 3:qwerty
+  4e 00 46 00 43 00 00 00                         # 4:NFC
+  3d d8 40 de 00 00                               # 5:🙀
+  6d 00 74 00 00 00                               # 6:mt
+  27 01 00 00                                     # 7:ħ
+  90 17 b6 17 00 00                               # 8:ថា
+
+0x132:             # struct COMP_KMXPLUS_META {
+  6d 65 74 61      #    KMX_DWORD header.ident;   // 0000 Section name - meta
+  24 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  00 00 00 00      #   KMX_DWORD name;
+  01 00 00 00      #   KMX_DWORD author;
+  02 00 00 00      #   KMX_DWORD conform;
+  03 00 00 00      #   KMX_DWORD layout;
+  04 00 00 00      #   KMX_DWORD normalization;
+  05 00 00 00      #   KMX_DWORD indicator;
+  00 00 00 00      #   KMX_DWORD settings;
+                   # };
+
+0x0156:            # struct COMP_KMXPLUS_LOCA {
+  6c 6f 63 61      #    KMX_DWORD header.ident;   // 0000 Section name - loca
+  14 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  01 00 00 00      #    KMX_DWORD count; // 0008 number of locales
+  00 00 00 00      #    KMX_DWORD reserved;
+  06 00 00 00      #    KMX_DWORD locale; // 0010+ locale string entry = 'mt'
+                   # };
+
+0x016a:            # struct COMP_KMXPLUS_KEYS {
+  6b 65 79 73      #    KMX_DWORD header.ident;   // 0000 Section name - keys
+  30 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  02 00 00 00      #    KMX_DWORD count;    // number of keys
+  00 00 00 00      #    KMX_DWORD reserved; // padding
+                   # };
+
+# Keys data:
+
+  c0 00 00 00  00 00 00 00  07 00 00 00  01 00 00 00   # KMX_DWORD vkey, mod, to, flags;
+  31 00 00 00  00 00 00 00  08 00 00 00  01 00 00 00   # KMX_DWORD vkey, mod, to, flags;

--- a/developer/src/kmldmlc/test/fixtures/basic.xml
+++ b/developer/src/kmldmlc/test/fixtures/basic.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+@@keys: [K_Q][K_W][K_Q]
+@@expected: \u0127\u1790\u17B6\u0127
+-->
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <name value="TestKbd" />
+  </names>
+
+  <keys>
+    <key id="hmaqtua" to="ħ" />
+    <key id="that" to="ថា" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <row keys="hmaqtua that" />
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/developer/src/kmldmlc/test/helpers/index.ts
+++ b/developer/src/kmldmlc/test/helpers/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Helpers and utilities for the Mocha tests.
+ */
+import * as path from 'path';
+
+/**
+ * Builds a path to the fixture with the given path components.
+ *
+ * e.g., makePathToFixture('basic.xml')
+ *
+ * @param components One or more path components.
+ */
+export function makePathToFixture(...components: string[]): string {
+  return path.join(__dirname, '..', '..', '..', 'test', 'fixtures', ...components);
+}
+

--- a/developer/src/kmldmlc/test/test-base.ts
+++ b/developer/src/kmldmlc/test/test-base.ts
@@ -1,0 +1,9 @@
+import 'mocha';
+import {assert} from 'chai';
+
+describe('null-test', function () {
+  it('should-pass-null-test', function() {
+    assert.isTrue(true);
+  });
+});
+

--- a/developer/src/kmldmlc/test/test-compiler-e2e.ts
+++ b/developer/src/kmldmlc/test/test-compiler-e2e.ts
@@ -1,0 +1,52 @@
+import 'mocha';
+import * as fs from 'fs';
+import * as path from 'path';
+import {assert} from 'chai';
+import hextobin from '@keymanapp/hextobin';
+import Compiler from '../src/keyman/compiler/compiler';
+import {makePathToFixture} from './helpers/index';
+
+class CompilerCallbacks {
+  loadFile(baseFilename: string, filename:string): Buffer {
+    // TODO: translate filename based on the baseFilename
+    return fs.readFileSync(filename);
+  }
+  reportMessage(severity: number, message: string): void {
+    console.log(message);
+  }
+}
+
+function compileKeyboard(inputFilename: string): Uint8Array {
+  const c = new CompilerCallbacks();
+  const k = new Compiler(c);
+  let source = k.load(inputFilename);
+  if(!source) {
+    return null;
+  }
+  if(!k.validate(source)) {
+    return null;
+  }
+  let kmx = k.compile(source);
+  if(!kmx) {
+    return null;
+  }
+  return k.write(kmx);
+}
+
+describe('compiler-tests', function() {
+  it('should-build-fixtures', async function() {
+    // Let's build basic.xml
+    // It should match basic.kmx (built from basic.txt)
+
+    const inputFilename = makePathToFixture('basic.xml');
+    const outputFilename = makePathToFixture('basic.txt');
+
+    // Compile:
+    const code = compileKeyboard(inputFilename);
+    assert.isNotNull(code);
+
+    // Compare output
+    let expected = await hextobin(outputFilename, undefined, {silent:true});
+    assert.deepEqual<Uint8Array>(code, expected);
+  });
+});

--- a/developer/src/kmldmlc/test/tsconfig.json
+++ b/developer/src/kmldmlc/test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "extends": "../../../../tsconfig-base.json",
+
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noImplicitAny": true,
+        "sourceMap": true,
+        "rootDir": ".",
+        "rootDirs": ["./", "../src/"],
+        "outDir": "../build/test",
+        "baseUrl": ".",
+    },
+    "include": [
+        "**/test-*.ts",
+        "./helpers/index.ts"
+    ],
+    "references": [
+        { "path": "../" }
+      ]
+}

--- a/developer/src/kmldmlc/tsconfig.json
+++ b/developer/src/kmldmlc/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2017",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "build/",
+    "outDir": "build/src/",
     "rootDir": "src/",
     "declaration": true,
     "alwaysStrict": true,


### PR DESCRIPTION
Establishes a basic set of unit and e2e tests for the LDML keyboard compiler, giving me a place to put additional tests.

I'm using hextobin for the binary generation of .kmx for comparison for test. It's a lot of work to hand-craft. But doing it automatically or including binary fixtures has the downside of probably failing to actually check that the generated file is valid!

@keymanapp-test-bot skip