### PR TITLE
feat(web): touchpath segment objects 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/constructingSegment.ts
+++ b/common/web/gesture-recognizer/src/constructingSegment.ts
@@ -1,0 +1,116 @@
+namespace com.keyman.osk {
+  /**
+   * This class is responsible for managing the construction of public-facing Segments while keeping
+   * all the internal parts... internal.  As such, it includes state management for parts of
+   * PathSegmenter's operations.
+   */
+  export class ConstructingSegment {
+    /**
+     * Marks the accumulated stats on the touchpath that precede the in-construction Segment.
+     */
+    private readonly preIntervalAccumulation: CumulativePathStats;
+
+    /**
+     * Notes all subsegments identified as part of the overall segment being constructed.
+     */
+    subsegmentations: Subsegmentation[] = [];  // TODO:  `private`?
+
+    /**
+     * Marks a potential follow-up subsegment.  This portion is not automatically
+     * committed during finalization.
+     */
+    private pendingSubsegmentation: Subsegmentation = null;
+
+    constructor(preIntervalAccumulation: CumulativePathStats,) {
+      this.preIntervalAccumulation = preIntervalAccumulation;
+
+      this.subsegmentations = [];
+    }
+
+    /**
+     * Constructs a stats object for the interval ending with the specified accumulation
+     * state and beginning at the start of the in-construction Segment.
+     * @param accumulation
+     * @returns
+     */
+    public buildIntervalFromBase(accumulation: CumulativePathStats) {
+      return accumulation.deaccumulate(this.preIntervalAccumulation);
+    }
+
+    /**
+     * Returns the stats accumulation covering all currently-committed subsegments.
+     */
+    public get committedInterval(): CumulativePathStats {
+      return this.committedIntervalAsSubsegmentation.stats;
+    }
+
+    /**
+     * Returns a merged form of all currently-committed subsegments in
+     * Subsegmentation form.
+     */
+    public get committedIntervalAsSubsegmentation(): Subsegmentation {
+      if(this.subsegmentations.length == 0) {
+        return {
+          stats: null,
+          endingAccumulation: null
+        };
+      } else {
+        const tailSub = this.subsegmentations[this.subsegmentations.length - 1];
+        const tail = tailSub.endingAccumulation;
+
+        return {
+          stats: this.buildIntervalFromBase(tail),
+          endingAccumulation: tail
+        };
+      }
+    }
+
+    public clearPendingPortion() {
+      this.pendingSubsegmentation = null;
+    }
+
+    /**
+     * Denotes the currently in-construction subsegment that **may** be included in the
+     * Segment.
+     *
+     * If the pending subsegment appears to belong to the current Segment, it contains valuable info
+     * about the state of the as-of-yet unresolved Segment, including the most recent location
+     * of the corresponding touchpoint.
+     * @param subsegmentation
+     */
+    public updatePendingPortion(subsegmentation: Subsegmentation) {
+      // Would be awfully convenient if setting the value here auto-triggered an update of the
+      // public-facing Segment.
+      //
+      // But, CURRENTLY, it's set here first, then a check for compatibility is run.
+      this.pendingSubsegmentation = subsegmentation;
+    }
+
+    public commitPendingPortion() {
+      if(this.pendingSubsegmentation) {
+        this.subsegmentations.push(this.pendingSubsegmentation);
+        this.clearPendingPortion();
+      } else {
+        throw "Illegal state - `commitPendingPortion` should never be called with nothing pending.";
+      }
+    }
+
+    public finalize() {
+      // does NOT include an uncommited pending portion!
+      this.pendingSubsegmentation = null;
+    }
+
+    // Obviously, needs better specification.  'hold' / 'move' / 'unknown'?
+    public type(): string {
+      return undefined;
+    }
+
+    public get isEmpty(): boolean {
+      if(this.subsegmentations.length != 0) {
+        return false;
+      } else {
+        return this.pendingSubsegmentation == null
+      }
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/constructingSegment.ts
+++ b/common/web/gesture-recognizer/src/constructingSegment.ts
@@ -126,7 +126,7 @@ namespace com.keyman.osk {
         return true;
       }
 
-      const segmentationSplit = new SegmentationSplit(committed, subsegment, this.buildIntervalFromBase(subsegment.endingAccumulation));
+      const segmentationSplit = new SegmentationSplit(committed, subsegment, this.baseAccumulation);
 
       // TODO:  where to move logging, if preserving it?
       console.log("Desegmentation under consideration: ");

--- a/common/web/gesture-recognizer/src/constructingSegment.ts
+++ b/common/web/gesture-recognizer/src/constructingSegment.ts
@@ -41,6 +41,7 @@ namespace com.keyman.osk {
 
     /**
      * Returns the stats accumulation covering all currently-committed subsegments.
+     * May be `null` if there are no committed subsegments.
      */
     public get committedInterval(): CumulativePathStats {
       return this.committedIntervalAsSubsegmentation.stats;
@@ -54,7 +55,8 @@ namespace com.keyman.osk {
       if(this.subsegmentations.length == 0) {
         return {
           stats: null,
-          endingAccumulation: null
+          endingAccumulation: null,
+          baseAccumulation: this.baseAccumulation
         };
       } else {
         const tailSub = this.subsegmentations[this.subsegmentations.length - 1];
@@ -62,7 +64,8 @@ namespace com.keyman.osk {
 
         return {
           stats: this.buildIntervalFromBase(tail),
-          endingAccumulation: tail
+          endingAccumulation: tail,
+          baseAccumulation: this.baseAccumulation
         };
       }
     }
@@ -126,18 +129,10 @@ namespace com.keyman.osk {
         return true;
       }
 
-      const segmentationSplit = new SegmentationSplit(committed, subsegment, this.baseAccumulation);
+      const segmentationSplit = new SegmentationSplit(committed, subsegment);
 
-      // TODO:  where to move logging, if preserving it?
-      console.log("Desegmentation under consideration: ");
-      console.log(segmentationSplit);
-
-      const xF = segmentationSplit.segReg('x', 'y');
-      const yF = segmentationSplit.segReg('y', 'x');
-      console.log(`merger F-test (xy): F_(${xF.fDoF1}, ${xF.fDoF2}) = ${xF.fStat} @ ${xF.certaintyThreshold}`);
-      console.log(`merger F-test (yx): F_(${yF.fDoF1}, ${yF.fDoF2}) = ${yF.fStat} @ ${yF.certaintyThreshold}`);
-      console.log(`will remerge: ${segmentationSplit.mergeMerited}`);
-      // TODO:  end of "where to move"
+      // TODO:  remove for production / feature-branch merge
+      segmentationSplit._debugLogAlignmentReport();
 
       return segmentationSplit.mergeMerited;
     }
@@ -183,19 +178,6 @@ namespace com.keyman.osk {
       }
 
       // TODO: fully 'recognize' the Segment.
-    }
-
-    // Obviously, needs better specification.  'hold' / 'move' / 'unknown'?
-    public type(): string {
-      return undefined;
-    }
-
-    public get isEmpty(): boolean {
-      if(this.subsegmentations.length != 0) {
-        return false;
-      } else {
-        return this.pendingSubsegmentation == null
-      }
     }
   }
 }

--- a/common/web/gesture-recognizer/src/constructingSegment.ts
+++ b/common/web/gesture-recognizer/src/constructingSegment.ts
@@ -197,9 +197,10 @@ namespace com.keyman.osk {
       // it's time to commit to classifying the in-construction Segment.
       const alreadyElapsed = fullStatsWithIncoming.duration;
       const recognitionWaitTime = this.classifier.config.holdMinimumDuration - alreadyElapsed;
+      const recognitionFromMove = (this.pathSegment.distance > this.classifier.config.holdMoveTolerance);
 
       // `undefined` if and only if still unrecognized.
-      if(recognitionWaitTime <= 0 && !this._pathSegment.isRecognized) {
+      if((recognitionFromMove || recognitionWaitTime <= 0) && !this._pathSegment.isRecognized) {
         const classification = this.classifier.classifySegment(fullStatsWithIncoming);
 
         // Based on the specification for segment classification, there WILL be a classification

--- a/common/web/gesture-recognizer/src/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/cumulativePathStats.ts
@@ -64,7 +64,7 @@ namespace com.keyman.osk {
        */
       constructor(mainStats: CumulativePathStats, dependentAxis: PathCoordAxis, independentAxis: PathCoordAxis) {
         if(dependentAxis == independentAxis) {
-          throw "Two different axes must be specified for the regression object.";
+          throw new Error("Two different axes must be specified for the regression object.");
         }
 
         this.accumulator = mainStats;
@@ -223,7 +223,7 @@ namespace com.keyman.osk {
       } else if(isAnInputSample(obj)) {
         Object.assign(this, this.extend(obj));
       } else {
-        throw "A constructor for this input pattern has not yet been implemented";
+        throw new Error("A constructor for this input pattern has not yet been implemented");
       }
     }
 

--- a/common/web/gesture-recognizer/src/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/cumulativePathStats.ts
@@ -199,7 +199,7 @@ namespace com.keyman.osk {
      * The initial sample included by this instance's computed stats.  Needed for
      * the 'directness' properties.
      */
-    private initialSample?: InputSample;
+    private _initialSample?: InputSample;
 
     private _lastSample?: InputSample;
     private followingSample?: InputSample;
@@ -235,8 +235,8 @@ namespace com.keyman.osk {
      *          newly-sampled point.
      */
     public extend(sample: InputSample): CumulativePathStats {
-      if(!this.initialSample) {
-        this.initialSample = sample;
+      if(!this._initialSample) {
+        this._initialSample = sample;
         this.baseSample = sample;
       }
       const result = new CumulativePathStats(this);
@@ -376,7 +376,7 @@ namespace com.keyman.osk {
       // ANY case except the timestamp (.t) - and even then, not far from the baseSample's timestamp value.
 
       // initialSample, though, we need to update b/c of the 'directness' properties.
-      result.initialSample = subsetStats.followingSample;
+      result._initialSample = subsetStats.followingSample;
 
       return result;
     }
@@ -395,6 +395,10 @@ namespace com.keyman.osk {
 
     private set sampleCount(value: number) {
       this._sampleCount = value;
+    }
+
+    public get initialSample() {
+      return this._initialSample;
     }
 
     /**
@@ -705,7 +709,7 @@ namespace com.keyman.osk {
     }
 
     // Convert to a `toJSON` method for use during investigative debugging.
-    private toDebuggingJSON() {
+    public get summaryObject() {
       // This `likelyState` value is extremely prototyped & just here for reviewer/tester convenience.
       // It'll need to be developed a bit more fully, but follows my intuitions from development &
       // testing.
@@ -726,20 +730,14 @@ namespace com.keyman.osk {
         cardinal: this.cardinalDirection,
         likelyType: likelyType,
         speedMean: this.mean('v'),
-        rawDistance: this.rawDistance,
+        netDistance: this.netDistance,
         duration: this.duration,
         sampleCount: this.sampleCount,
         angleMeanDegrees: this.angleMean * 180 / Math.PI,
         angleDeviation: this.angleDeviation,
+        rawDistance: this.rawDistance,
         speedVariance: this.variance('v')
       }
-    }
-
-    public toJSON() {
-      // We're not actually saving the JSON out to anything yet or loading/parsing it
-      // for any use beyond direct human interpretation, so... it's "okay" to
-      // leave like this for now.
-      return this.toDebuggingJSON();
     }
   }
 

--- a/common/web/gesture-recognizer/src/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/cumulativePathStats.ts
@@ -584,10 +584,10 @@ namespace com.keyman.osk {
      */
     public get angle() {
       if(this.sampleCount == 1 || !this.lastSample || !this.initialSample) {
-        return Number.NaN;
+        return undefined;
       } else if(this.netDistance < 1) {
         // < 1 px, thus sub-pixel, means we have nothing relevant enough to base an angle on.
-        return Number.NaN;
+        return undefined;
       }
 
       const xDelta = this.lastSample.targetX - this.initialSample.targetX;
@@ -615,6 +615,10 @@ namespace com.keyman.osk {
      */
     public get cardinalDirection() {
       if(this.sampleCount == 1 || !this.lastSample || !this.initialSample) {
+        return undefined;
+      }
+
+      if(isNaN(this.angle) || this.angle === null || this.angle === undefined) {
         return undefined;
       }
 

--- a/common/web/gesture-recognizer/src/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/cumulativePathStats.ts
@@ -628,10 +628,11 @@ namespace com.keyman.osk {
 
     /**
      * Measured in pixels per second.
-     * @return a speed in pixels per millisecond, or `Number.NaN` if no data
+     * @return a speed in pixels per millisecond.  May be 0 if no movement was observed
+     * among the samples.
      */
     public get speed() {
-      return this.duration ? this.netDistance / this.duration : Number.NaN;
+      return this.duration ? this.netDistance / this.duration : 0;
     }
 
     /**

--- a/common/web/gesture-recognizer/src/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/cumulativePathStats.ts
@@ -709,27 +709,14 @@ namespace com.keyman.osk {
       return this.coordArcSum;
     }
 
-    // Convert to a `toJSON` method for use during investigative debugging.
+    /**
+     * Provides a JSON.stringify()-friendly object with the properties most useful for
+     * debugger-based inspection and/or console-logging statements.
+     */
     public get summaryObject() {
-      // This `likelyState` value is extremely prototyped & just here for reviewer/tester convenience.
-      // It'll need to be developed a bit more fully, but follows my intuitions from development &
-      // testing.
-      let likelyType = 'unknown';
-
-      if(this.mean('v') < 0.08 && this.rawDistance < 12 && this.duration > 100) {
-        likelyType = 'hold';
-      } else if(this.mean('v') < 0.08 && this.rawDistance < 6) {
-        likelyType = 'hold';
-      }
-
-      if(this.mean('v') > 0.4 || (this.mean('v') > 0.2 && this.duration > 80) || this.netDistance > 20) {
-        likelyType = 'move';
-      }
-
       return {
         angle: this.angle,
         cardinal: this.cardinalDirection,
-        likelyType: likelyType,
         speedMean: this.mean('v'),
         netDistance: this.netDistance,
         duration: this.duration,

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -650,7 +650,9 @@ namespace com.keyman.osk {
        * Note that they won't quite be the _same_ answers you'd get while in-process, but it should give useful
        * info nonetheless.
        */
+
       console.log(this.segmentConstructors);
+      console.log(this.segmentConstructors.map((obj) => obj.pathSegment));
     }
 
     /**
@@ -873,7 +875,7 @@ namespace com.keyman.osk {
 
     private finalizeSegment() {
       if(this.constructingSegment) {
-        if(this.constructingSegment.subsegmentations.length == 0) {
+        if(this.constructingSegment.subsegmentCount == 0) {
           throw "Implementation error!";
         }
         this.constructingSegment.finalize();

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -650,8 +650,9 @@ namespace com.keyman.osk {
       }
 
       // Needed for a very quick, simple tap - it may not last long enough to start subsegmentation!
+      let lateSegment: ConstructingSegment = null;
       if(!this.constructingSegment) {
-        this.constructingSegment = new ConstructingSegment(finalSubsegment, new SegmentClassifier(this.segmentationConfig));
+        lateSegment = this.constructingSegment = new ConstructingSegment(finalSubsegment, new SegmentClassifier(this.segmentationConfig));
       }
       // No need to check if this matches any predecessor subsegments; that already happened during
       // the last `performSubsegmentation` call.  There's no new data since then.
@@ -659,7 +660,11 @@ namespace com.keyman.osk {
       this.constructingSegment.updatePendingSubsegment(finalSubsegment);
       // As we're finalizing, we do NOT need to recall maintainRecentSegment.
       this.constructingSegment.commitPendingSubsegment();
-      this.finalizeSegment();
+      this.finalizeSegment(); // clears `this.constructingSegment`!
+
+      if(lateSegment) {
+        this.segmentForwarder(lateSegment.pathSegment);
+      }
 
       // Using the last-received sample, generate & publish an "end" segment.
       // As ConstructingSegment is designed to work with -sequences- of samples, it's less

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -1,12 +1,5 @@
 /// <reference path="cumulativePathStats.ts" />
 
-/* FIXME:  There exists code emitting to the `console` at present.
- * Do not release before fixing this.
- *
- * Developer's note:  for debugging the algorithm seen in this file,
- * CTRL+F `_debugLogPath` and its notes.
- */
-
 namespace com.keyman.osk {
   // Mostly used here to compare the sum-squared error components of segmented regressions
   // to the sum-squared "modeled" components of their overall variance.  Those are the two
@@ -530,14 +523,6 @@ namespace com.keyman.osk {
     private constructingSegment: ConstructingSegment;
 
     /**
-     * TODO: These Segment-construction objects directly represent path segments
-     * produced by the prototype algorithm.  This field should be decommissioned
-     * once implementation of this class is complete; the produced Segments
-     * are retrievable from TrackedPath.segments.
-     */
-    private segmentConstructors: ConstructingSegment[] = [];
-
-    /**
      * Used to 'repeat' the most-recently observed incoming sample if no
      * other replaces it before it triggers.
      *
@@ -655,32 +640,6 @@ namespace com.keyman.osk {
       endSegment.resolve();
 
       this.segmentForwarder(endSegment);
-
-      // TODO:  this is a temporary statement to facilitate exploration, experimentation, & debugging.
-      //        The true goal is to provide output to the touchpath object (`.path.segments`).
-      //        So, once implementation is complete, we should probably eliminate this method.
-      this._debugLogPath();
-    }
-
-    // TODO:  alt goal - support a 'debug event' or some-such that emits the constructors for
-    // debugging analysis without directly needing to `console.log`.
-    private _debugLogPath() {
-      /*
-       * Debugging assistance notes:  in many modern browsers, you can right-click a logged object
-       * and say to "Store object as global variable", giving you console access to the array logged
-       * below.
-       *
-       * From there, you can use this line to examine the debug-log reports for any contiguous
-       * Subsegment pair like this, where `temp1` is the name auto-assigned by the "store object" command:
-       *
-       * `new com.keyman.osk.SegmentationSplit(temp1[1].subsegmentations[0], temp1[1].subsegmentations[1])`
-       *
-       * Note that they won't quite be the _same_ answers you'd get while in-process, but it should give useful
-       * info nonetheless.
-       */
-
-      console.log(this.segmentConstructors);
-      console.log(this.segmentConstructors.map((obj) => obj.pathSegment));
     }
 
     /**
@@ -880,6 +839,10 @@ namespace com.keyman.osk {
       // First phase of segmentation:  complete!
       // Step 4:  basic bookkeeping.
 
+      /*
+       * NOTE:  this marks a very good location to call _debugLogSplitReport() if a deep-dive
+       * inspection of the subsegmentation algorithm and its decisions is needed.
+       */
       if(!candidateSplit.segmentationMerited) {
         return;
       }
@@ -907,7 +870,20 @@ namespace com.keyman.osk {
           throw "Implementation error!";
         }
         this.constructingSegment.finalize();
-        this.segmentConstructors.push(this.constructingSegment);
+
+        /*
+         * NOTE:  if a deep-dive investigation is needed, it may prove helpful to emit each finalized
+         * `constructingSegment` instance to the console here.  Like, _**precisely**_ here, immediately
+         * after this multiline comment.
+         *
+         * From there, note that in many modern browsers, you can right-click a logged object and say
+         * to "Store object as global variable", giving you console access to any such logged instances.
+         *
+         * `SubsegmentCompatibilityAnalyzer` is designed for ease-of-use with the members of
+         * `ConstructingSegment.subsegmentations` via `SegmentationSplit`, facilitating interactive
+         * inspection of which subsegments are and are not recombined into `Segment`s and why.
+         */
+
         this.constructingSegment = null;
       }
     }

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -573,7 +573,7 @@ namespace com.keyman.osk {
     // within this module / package.
     private segmentationConfig: SegmentationConfiguration;
 
-    public static readonly DEFAULT_CONFIG = {
+    public static readonly DEFAULT_CONFIG: SegmentationConfiguration = {
       holdMinimumDuration: 100,
       holdMoveTolerance: 5
     }
@@ -649,6 +649,10 @@ namespace com.keyman.osk {
         baseAccumulation:   this.choppedStats
       }
 
+      // Needed for a very quick, simple tap - it may not last long enough to start subsegmentation!
+      if(!this.constructingSegment) {
+        this.constructingSegment = new ConstructingSegment(finalSubsegment, new SegmentClassifier(this.segmentationConfig));
+      }
       // No need to check if this matches any predecessor subsegments; that already happened during
       // the last `performSubsegmentation` call.  There's no new data since then.
       // (Actually... this should already be in place now, after recent changes!)

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -563,8 +563,11 @@ namespace com.keyman.osk {
      */
     private choppedStats: CumulativePathStats = null;
 
-    constructor() {
+    private readonly segmentForwarder: (segment: Segment) => void;
+
+    constructor(segmentStartClosure: (segment: Segment) => void) {
       this.steppedCumulativeStats = [];
+      this.segmentForwarder = segmentStartClosure;
     }
 
     /**
@@ -910,9 +913,9 @@ namespace com.keyman.osk {
 
       this.constructingSegment?.clearPendingSubsegment();
       this.finalizeSegment();
-      this.constructingSegment = new ConstructingSegment(subsegment, new SegmentClassifier());
 
-      // TODO:  trigger publishing of the newly-constructing Segment!
+      this.constructingSegment = new ConstructingSegment(subsegment, new SegmentClassifier());
+      this.segmentForwarder(this.constructingSegment.pathSegment);
 
       return true;
     }

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -492,17 +492,15 @@ namespace com.keyman.osk {
   }
 
   /**
-   * The core logic, algorithm, and manager for touchpath segmentation.
+   * The core logic, algorithm, and manager for touchpath segmentation and
+   * subsegmentation.
+   *
+   * This class itself directly handles 'subsegmentation', as the first pass of
+   * our algorithm errs on the side of segmenting too much in order to never
+   * 'undersegment'.  It then delegates to other classes to recombine the
+   * results as appropriate before producing completed `Segment`s.
    */
   export class PathSegmenter {
-    /*
-     * NOTE:  internally, this class only directly handles _subsegmentation_;
-     * the real workload for synthesizing Segments is found in ConstructingSegment.
-     *
-     * That said, this class does help marshall the constructed Segments to the
-     * TrackedPath.
-     */
-
     /**
      * The minimum amount of time (in ms) to wait between sample repetitions
      * once inputs stop arriving, so long as the path is still active.

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -577,6 +577,7 @@ namespace com.keyman.osk {
      */
     public add(sample: InputSample) {
       // TODO:  if this is the first received input sample, generate & publish a "start" segment.
+      // Bypass ConstructingSegment for this?  (So, directly instantiate SegmentImplementation)
 
       // Set up the input-repeater (in case we don't get further feedback but remain active)
       const repeater = (timeDelta: number) => {
@@ -627,6 +628,7 @@ namespace com.keyman.osk {
       this.finalizeSegment();
 
       // TODO:  create + publish an "end" segment.
+      // Bypass ConstructingSegment for this?  (So, directly instantiate SegmentImplementation)
 
       // TODO:  this is a temporary statement to facilitate exploration, experimentation, & debugging.
       //        We should be providing output to the touchpath object (`.path.segments`).

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -573,6 +573,8 @@ namespace com.keyman.osk {
      * @param sample
      */
     public add(sample: InputSample) {
+      // TODO:  if this is the first received input sample, generate & publish a "start" segment.
+
       // Set up the input-repeater (in case we don't get further feedback but remain active)
       const repeater = (timeDelta: number) => {
         this.observe(sample, timeDelta);
@@ -619,7 +621,9 @@ namespace com.keyman.osk {
       this.constructingSegment.updatePendingSubsegment(finalSubsegment);
       // As we're finalizing, we do NOT need to recall maintainRecentSegment.
       this.constructingSegment.commitPendingSubsegment();
-      this.finalizeSubsegment();
+      this.finalizeSegment();
+
+      // TODO:  create + publish an "end" segment.
 
       // TODO:  this is a temporary statement to facilitate exploration, experimentation, & debugging.
       //        We should be providing output to the touchpath object (`.path.segments`).
@@ -837,10 +841,11 @@ namespace com.keyman.osk {
       this.updateSegmentConstruction(candidateSplit.post);
     }
 
-    private finalizeSubsegment() {
+    private finalizeSegment() {
       if(this.constructingSegment) {
         this.constructingSegment.finalize();
         this.segmentConstructors.push(this.constructingSegment);
+        this.constructingSegment = null;
       }
     }
 
@@ -848,8 +853,8 @@ namespace com.keyman.osk {
       if(this.constructingSegment && this.constructingSegment.isCompatible(subsegment)) {
         this.constructingSegment.updatePendingSubsegment(subsegment);
       } else {
-        this.finalizeSubsegment();
-        this.constructingSegment = new ConstructingSegment(this.choppedStats, subsegment);
+        this.finalizeSegment();
+        this.constructingSegment = new ConstructingSegment(subsegment);
         // TODO:  trigger publishing of the newly-constructing Segment!
       }
     }

--- a/common/web/gesture-recognizer/src/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/pathSegmenter.ts
@@ -704,15 +704,16 @@ namespace com.keyman.osk {
     private performSubsegmentation() {
       const cumulativeStats = this.steppedCumulativeStats[this.steppedCumulativeStats.length - 1];
       const unsegmentedDuration = cumulativeStats.lastTimestamp - this.steppedCumulativeStats[0].lastTimestamp;
+      const unsegmentedForm: Subsegmentation = {
+        stats: cumulativeStats.deaccumulate(this.choppedStats),
+        endingAccumulation: cumulativeStats,
+        baseAccumulation: this.choppedStats
+      }
 
       // STEP 1:  Determine the range of the initial sliding time window for the most recent samples.
 
       if(unsegmentedDuration < this.SLIDING_WINDOW_INTERVAL * 2) {
-        this.updateSegmentConstruction({
-          stats: cumulativeStats.deaccumulate(this.choppedStats),
-          endingAccumulation: cumulativeStats,
-          baseAccumulation: this.choppedStats
-        });
+        this.updateSegmentConstruction(unsegmentedForm);
         return;
       }
 
@@ -873,6 +874,7 @@ namespace com.keyman.osk {
        * inspection of the subsegmentation algorithm and its decisions is needed.
        */
       if(!candidateSplit.segmentationMerited) {
+        this.updateSegmentConstruction(unsegmentedForm);
         return;
       }
 

--- a/common/web/gesture-recognizer/src/segment.ts
+++ b/common/web/gesture-recognizer/src/segment.ts
@@ -94,7 +94,7 @@ namespace com.keyman.osk {
 
     protected classifyType(type: SegmentClass) {
       if(!this._stats) {
-        throw "Cannot recognize the segment - lacking critical metadata";
+        throw new Error("Cannot recognize the segment - lacking critical metadata");
       }
 
       if(this._type === undefined) {
@@ -102,7 +102,7 @@ namespace com.keyman.osk {
 
         this._recognitionPromiseResolver(type);
       } else if(this._type != type) {
-        throw "May not change segment type once set!";
+        throw new Error("May not change segment type once set!");
       }
     }
 
@@ -180,6 +180,10 @@ namespace com.keyman.osk {
       return this._type || null;
     }
 
+    protected _isRecognized(): boolean {
+      return this._type !== undefined;
+    }
+
     /**
      * A `Promise` that resolves when the segment's classification is determined
      * - when we "recognize" its role in the touchpath.
@@ -200,7 +204,7 @@ namespace com.keyman.osk {
 
     protected resolve() {
       if(!this._stats) {
-        throw "Cannot resolve the segment - illegal state!";
+        throw new Error("Cannot resolve the segment - illegal state!");
       }
       this._resolutionPromiseResolver();
     }
@@ -257,6 +261,10 @@ namespace com.keyman.osk {
 
     public resolve() {
       super.resolve();
+    }
+
+    public get isRecognized() {
+      return super._isRecognized();
     }
   }
 }

--- a/common/web/gesture-recognizer/src/segment.ts
+++ b/common/web/gesture-recognizer/src/segment.ts
@@ -38,6 +38,7 @@ namespace com.keyman.osk {
       if(serializedObj) {
         // We'll use the loaded object as our core reference.
         this._stats = serializedObj;
+        this._peakSpeed = serializedObj.peakSpeed; // Is retrieved from `this`, not `this._stats`.
 
         // Ensure that the two promises are properly initialized for this construction type.
         this._recognitionPromise = Promise.resolve(serializedObj.type);

--- a/common/web/gesture-recognizer/src/segment.ts
+++ b/common/web/gesture-recognizer/src/segment.ts
@@ -12,6 +12,14 @@ namespace com.keyman.osk {
     lastCoord: InputSample
   }
 
+  /**
+   * Denotes one "segment" of the ongoing touchpath.  These segments are then utilized as the basis
+   * for detecting and synthesizing gestures.
+   *
+   * By first breaking the touchpath into gestures, we gain the ability to define something of a
+   * finite-state-machine (FSM) model for each type of gesture we wish to support.  While technically
+   * possible to do even without this step... we find that this makes such a goal far less complex.
+   */
   export class Segment {
     /**
      * Denotes the highest (mean + 1-sigma) speed seen among all subsegments comprising
@@ -34,6 +42,16 @@ namespace com.keyman.osk {
     private _resolutionPromise: Promise<void>;
     private _resolutionPromiseResolver: () => void;
 
+    /**
+     * Intended for internal-use only; this is utilized during the segmentation process.
+     */
+    public constructor();
+    /**
+     * Reconstructs an instance based upon a previously-serialized `.toJSON()` call on this
+     * object.
+     * @param serializedObj
+     */
+    public constructor(serializedObj: JSONSegment);
     public constructor(serializedObj?: JSONSegment) {
       if(serializedObj) {
         // We'll use the loaded object as our core reference.
@@ -56,6 +74,12 @@ namespace com.keyman.osk {
       }
     }
 
+    /**
+     * Indicates the likely "highest sustained" speed observed within the `Segment`'s path.
+     *
+     * To be more precise, the mean + 1-sigma (average + one standard deviation) of the speed
+     * for the fastest component of the `Segment`.
+     */
     get peakSpeed(): number {
       return this._peakSpeed;
     }
@@ -70,7 +94,7 @@ namespace com.keyman.osk {
 
     protected classifyType(type: SegmentClass) {
       if(!this._stats) {
-        throw "Implementation error";
+        throw "Cannot recognize the segment - lacking critical metadata";
       }
 
       if(this._type === undefined) {
@@ -82,6 +106,9 @@ namespace com.keyman.osk {
       }
     }
 
+    /**
+     * The starting point of this touchpath segment.
+     */
     get initialCoord(): InputSample {
       if(this._stats instanceof CumulativePathStats) {
         return this._stats.initialSample;
@@ -90,6 +117,9 @@ namespace com.keyman.osk {
       }
     };
 
+    /**
+     * The ending point of this touchpath segment.
+     */
     get lastCoord(): InputSample {
       if(this._stats instanceof CumulativePathStats) {
         return this._stats.lastSample;
@@ -98,10 +128,17 @@ namespace com.keyman.osk {
       }
     };
 
+    /**
+     * The duration of this touchpath segment, measured in ms.
+     */
     get duration(): number {
       return this._stats.duration;
     }
 
+    /**
+     * The net distance traveled by this touchpath segment.  In other words,
+     * the distance between `initialCoord` and `lastCoord` (ignoring time).
+     */
     get distance(): number {
       if(this._stats instanceof CumulativePathStats) {
         return this._stats.netDistance;
@@ -110,37 +147,68 @@ namespace com.keyman.osk {
       }
     }
 
+    /**
+     * The average speed of this touchpath segment - distance / duration.
+     */
     get speed(): number {
       return this._stats.speed;
     };
 
+    /**
+     * The angle traveled by this touchpath segment.  Measured in radians.
+     */
     get angle(): number {
       return this._stats.angle;
     };
 
+    /**
+     * The 'directional bucket' for the detected angle.  This will
+     * correspond to a cardinal or an intercardinal ('n', 'ne', etc.)
+     */
     get direction(): string {
       return this._stats.cardinalDirection;
     };
 
+    /**
+     * The classification of this Segment:  'start', 'hold', 'move', or 'end'.
+     *
+     * May be null if the Segment has not yet been `recognized`.
+     *
+     * @see `SegmentClass`
+     */
     get type(): SegmentClass {
-      return this._type;
+      return this._type || null;
     }
 
-    get recognitionPromise(): Promise<SegmentClass> {
+    /**
+     * A `Promise` that resolves when the segment's classification is determined
+     * - when we "recognize" its role in the touchpath.
+     */
+    get whenRecognized(): Promise<SegmentClass> {
       return this._recognitionPromise;
     }
 
-    get resolutionPromise(): Promise<void> {
+    /**
+     * A `Promise` that resolves when the segment and its role within the touchpath
+     * are fully determined, as segmentation has noted the need for a new boundary -
+     * and thus, distinct and different behavior after the endpoint of this segment
+     * of the touchpath.
+     */
+    get whenResolved(): Promise<void> {
       return this._resolutionPromise;
     }
 
     protected resolve() {
       if(!this._stats) {
-        throw "Implementation error";
+        throw "Cannot resolve the segment - illegal state!";
       }
       this._resolutionPromiseResolver();
     }
 
+    /**
+     * Provides a human-readable yet serialization-friendly version of this instance.
+     * @returns
+     */
     public toJSON(): JSONSegment {
       const cleanSample: (sample: InputSample) => InputSample = (sample) => {
         const clone = {... sample};
@@ -165,8 +233,10 @@ namespace com.keyman.osk {
   }
 
   /**
-   * Provides an editable typing for Segment; casting to the superclass provides an
-   * uneditable version instead.
+   * Provides an editable typing for Segment utilized during the segmentation process;
+   * casting to the superclass provides an uneditable view into the Segment instead.
+   *
+   * This is intended for internal use only.
    */
   export class SegmentImplementation extends Segment {
     constructor() {

--- a/common/web/gesture-recognizer/src/segment.ts
+++ b/common/web/gesture-recognizer/src/segment.ts
@@ -1,5 +1,56 @@
 namespace com.keyman.osk {
   export class Segment {
-    // TODO: stuff.
+    /**
+     * Gets the accumulated stats across the full represented interval.
+     *
+     * This should be referenced for most statistical values that may be requested of the interval.
+     */
+    private stats: CumulativePathStats;
+
+    // Does NOT track the subsegment stats.  That said, will maintain internal fields
+    // with values sourced FROM subsegment stats as needed.
+
+    /**
+     * Denotes the highest (mean + 1-sigma) speed seen among all subsegments comprising
+     * this segment.
+     *
+     * This is likely not the maximum speed observed, as that observation is likely an outlier
+     * and is not internally recorded.  We rebuild this from stats observations.
+     *
+     * Think of it as acting like a "smoothed peak speed".
+     */
+    private _peakSpeed: number;
+
+    get peakSpeed(): number {
+      return this._peakSpeed;
+    }
+
+    // get initialCoord(): InputSample;
+    // get lastCoord(): InputSample;
+
+    // get meanSpeed(): number;
+
+    // get angle();
+    // get direction(): string; // (n, nw, ...)
+
+    // In-dev notes:
+
+    // can get speed from best entry in subsegment stats
+    // subsegments should have consistent direction:  get direction from cumulative stats
+
+    // interface to update subsegments?
+    // as this'll be a public object, we prob don't want to public-expose the related method(s).
+    // but we want a consistent object for the user / 'library consumer'.  How to?
+    // Idea:  public interface
+    // - private implementation
+    // - (possible) safety wrapper for the private implementation
+    //   - but, as far as Web (TS) goes, private-implementation parts won't be accessible.
+
+    // segment 'type' / 'classification'
+
+    // events?  or Promises?
+    // - 'recognized' - from 'unknown' to something specific.
+    // - 'resolved'   - when the segment is definitively finished.
+    // Promises might actually be simpler to work with externally - a segment could, in theory, be auto-recognized.
   }
 }

--- a/common/web/gesture-recognizer/src/segment.ts
+++ b/common/web/gesture-recognizer/src/segment.ts
@@ -14,6 +14,8 @@ namespace com.keyman.osk {
 
     private _type?: SegmentClass;
 
+    private _stats: CumulativePathStats;
+
     private _recognitionPromise: Promise<SegmentClass>;
     private _recognitionPromiseResolver: (type: SegmentClass | PromiseLike<SegmentClass>) => void;
 
@@ -40,13 +42,15 @@ namespace com.keyman.osk {
       this._peakSpeed = speed;
     }
 
-    private _stats: CumulativePathStats;
-
     protected updateStats(totalStats: CumulativePathStats) {
       this._stats = totalStats;
     }
 
     protected classifyType(type: SegmentClass) {
+      if(!this._stats) {
+        throw "Implementation error";
+      }
+
       if(this._type === undefined) {
         this._type = type;
 
@@ -63,6 +67,10 @@ namespace com.keyman.osk {
     get lastCoord(): InputSample {
       return this._stats.lastSample;
     };
+
+    get duration(): number {
+      return this._stats.duration;
+    }
 
     get speed(): number {
       return this._stats.speed;
@@ -89,6 +97,9 @@ namespace com.keyman.osk {
     }
 
     protected resolve() {
+      if(!this._stats) {
+        throw "Implementation error";
+      }
       this._resolutionPromiseResolver();
     }
   }

--- a/common/web/gesture-recognizer/src/segmentClassifier.ts
+++ b/common/web/gesture-recognizer/src/segmentClassifier.ts
@@ -1,0 +1,80 @@
+namespace com.keyman.osk {
+  /**
+   * Nomenclature pending.
+   *
+   * This object defines the configured values to be used for classification of Segments.
+   */
+  export interface SegmentClassifierConfig {
+    /** The minimum duration required to classify a segment as a 'hold', in milliseconds. */
+    holdMinimumDuration: number;
+
+    /** The minimum number of "CSS pixels" the touchpoint must travel to break a 'hold'. */
+    holdMoveTolerance: number;
+  }
+
+  export type SegmentClass = 'move' | 'hold';
+
+  export class SegmentClassifier {
+    // TODO:  This should be defined somewhere that can be configured by
+    // the library consumer and passed along until it reaches this class's
+    // constructor.  But... tomorrow's troubles are their own, for now.
+    static readonly DEFAULT_CONFIG: SegmentClassifierConfig = {
+      holdMinimumDuration: 100,
+      holdMoveTolerance: 5
+    };
+
+    private readonly config: SegmentClassifierConfig;
+
+    constructor(config?: SegmentClassifierConfig) {
+      this.config = config || SegmentClassifier.DEFAULT_CONFIG;
+    }
+
+    /**
+     * The speed that must be traversed during the timespan allocated to a
+     * minimum-duration 'wait' segment in order to match the maximum-allowed
+     * 'wait' distance threshold.
+     */
+    private get breakevenSpeed(): number {
+      return this.config.holdMoveTolerance / this.config.holdMinimumDuration;
+    }
+
+    public classifySubsegment(stats: CumulativePathStats): SegmentClass {
+      const segmentClass = this.classifySegment(stats);
+
+      if(segmentClass || segmentClass === null) {
+        return segmentClass;
+      }
+
+      // For subsegment compatibility classification, we allow early 'hold' declaration if
+      // the subsegment is "on pace" to become a 'hold' if the status quo is maintained.
+      // If following a 'move', this is probably the first part of a 'hold', and that's nice
+      // to capture.  (Or, if preceding a 'move', the last part of a 'hold'.)
+      if(stats.speed <= this.breakevenSpeed) {
+        return 'hold';
+        // Otherwise, there's a strong chance - but not a guarantee - of transitioning into a
+        // 'move' classification.  It's best to blend with whichever neighboring subsegment
+        // will take it, if any.
+      } else {
+        return null;
+      }
+    }
+
+    public classifySegment(stats: CumulativePathStats): SegmentClass {
+      if(!stats) {
+        return null;
+      }
+      // If the segment's net traveled distance exceeds the configured 'wait' distance
+      // threshold, it must be classified as a 'move'.
+      if(stats.netDistance > this.config.holdMoveTolerance) {
+        return 'move';
+        // If it does not, and the duration of the segment exceeds the configured minimum
+        // 'hold' time threshold, it's therefore a 'hold'.
+      } else if(stats.duration >= this.config.holdMinimumDuration) {
+        return 'hold';
+        // Otherwise, it cannot be 'recognized' as a formal segment.
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/segmentClassifier.ts
+++ b/common/web/gesture-recognizer/src/segmentClassifier.ts
@@ -20,18 +20,10 @@ namespace com.keyman.osk {
   }
 
   export class SegmentClassifier {
-    // TODO:  This should be defined somewhere that can be configured by
-    // the library consumer and passed along until it reaches this class's
-    // constructor.  But... tomorrow's troubles are their own, for now.
-    static readonly DEFAULT_CONFIG: SegmentClassifierConfig = {
-      holdMinimumDuration: 100,
-      holdMoveTolerance: 5
-    };
-
     readonly config: SegmentClassifierConfig;
 
-    constructor(config?: SegmentClassifierConfig) {
-      this.config = config || SegmentClassifier.DEFAULT_CONFIG;
+    constructor(config: SegmentClassifierConfig) {
+      this.config = config;
     }
 
     /**
@@ -43,6 +35,13 @@ namespace com.keyman.osk {
       return this.config.holdMoveTolerance / this.config.holdMinimumDuration;
     }
 
+    /**
+     * Given the cumulative stats for an observed Subsegment, determines its
+     * segment-level classification - but only if we would commit to said
+     * classification.
+     * @param stats
+     * @returns
+     */
     public classifySubsegment(stats: CumulativePathStats): SegmentClass {
       const segmentClass = this.classifySegment(stats);
 
@@ -64,6 +63,13 @@ namespace com.keyman.osk {
       }
     }
 
+    /**
+     *
+     * @param stats Given the cumulative stats for a potential Segment, determines
+     * the classification it would be assigned.  Will return `null` if it is not
+     * yet possible to commit to a classification.
+     * @returns
+     */
     public classifySegment(stats: CumulativePathStats): SegmentClass {
       if(!stats) {
         return null;

--- a/common/web/gesture-recognizer/src/segmentClassifier.ts
+++ b/common/web/gesture-recognizer/src/segmentClassifier.ts
@@ -12,7 +12,12 @@ namespace com.keyman.osk {
     holdMoveTolerance: number;
   }
 
-  export type SegmentClass = 'move' | 'hold';
+  export enum SegmentClass {
+    START = 'start',
+    END   = 'end',
+    HOLD  = 'hold',
+    MOVE  = 'move'
+  }
 
   export class SegmentClassifier {
     // TODO:  This should be defined somewhere that can be configured by
@@ -23,7 +28,7 @@ namespace com.keyman.osk {
       holdMoveTolerance: 5
     };
 
-    private readonly config: SegmentClassifierConfig;
+    readonly config: SegmentClassifierConfig;
 
     constructor(config?: SegmentClassifierConfig) {
       this.config = config || SegmentClassifier.DEFAULT_CONFIG;
@@ -50,7 +55,7 @@ namespace com.keyman.osk {
       // If following a 'move', this is probably the first part of a 'hold', and that's nice
       // to capture.  (Or, if preceding a 'move', the last part of a 'hold'.)
       if(stats.speed <= this.breakevenSpeed) {
-        return 'hold';
+        return SegmentClass.HOLD;
         // Otherwise, there's a strong chance - but not a guarantee - of transitioning into a
         // 'move' classification.  It's best to blend with whichever neighboring subsegment
         // will take it, if any.
@@ -66,11 +71,11 @@ namespace com.keyman.osk {
       // If the segment's net traveled distance exceeds the configured 'wait' distance
       // threshold, it must be classified as a 'move'.
       if(stats.netDistance > this.config.holdMoveTolerance) {
-        return 'move';
+        return SegmentClass.MOVE;
         // If it does not, and the duration of the segment exceeds the configured minimum
         // 'hold' time threshold, it's therefore a 'hold'.
       } else if(stats.duration >= this.config.holdMinimumDuration) {
-        return 'hold';
+        return SegmentClass.HOLD;
         // Otherwise, it cannot be 'recognized' as a formal segment.
       } else {
         return null;

--- a/common/web/gesture-recognizer/src/subsegmentCompatibilityAnalyzer.ts
+++ b/common/web/gesture-recognizer/src/subsegmentCompatibilityAnalyzer.ts
@@ -1,0 +1,158 @@
+namespace com.keyman.osk {
+  /**
+   * This class fulfills two roles:
+   *
+   * 1.  The `.isCompatible()` function provides the core definition used by
+   * `ConstructingSegment` to re-merge compatible subsegments, 'correcting' any
+   * 'oversegmentation' that may have resulted from `PathSegmenter`'s algorithm.
+   *
+   * 2. This class's other properties and methods facilitate inspection of
+   * the algorithm and its decision-making process during interactive debugging
+   * sessions.
+   *
+   * `SegmentationSplit` objects are constructed from Subsegmentation objects,
+   * which are made in abundance throughout the segmentation algorithms.  So, it
+   * shouldn't be difficult to construct the necessary parameters to dynamically
+   * construct instances of this class during an interactive debugging session.
+   */
+  export class SubsegmentCompatibilityAnalyzer {
+    readonly classifier: SegmentClassifier;
+    private split: SegmentationSplit;
+
+    constructor(subsegmentationSplit: SegmentationSplit, classifier: SegmentClassifier) {
+      this.split = subsegmentationSplit;
+
+      this.classifier = classifier;
+    }
+
+    private get preStats() {
+      return this.split.pre.stats;
+    }
+
+    private get postStats() {
+      return this.split.post.stats;
+    }
+
+    private get unionStats() {
+      return this.split.union;
+    }
+
+    /**
+     * This property summarizes subsegment compatibility on the basis of direction.
+     *
+     * 1. If both subsegments are compatible as determined by geometry-based regression, we consider
+     * them compatible.  (The first phase considers both geometry _and time_; we leave the "time"
+     * part out here.)
+     *
+     * 2. If regression upholds the segmentation, but both subsegments are classified as
+     * 'move'-compatible and their directions both fall within the same "direction bucket", we
+     * consider them compatible.
+     *
+     * 3. If both subsegments are classified as 'hold's, angle doesn't matter - the user's intent
+     * is "no motion".
+     */
+    get directionCompatible(): boolean {
+      if(!this.preStats || this.regressionDirectionCompatible) {
+        return true;
+      }
+
+      let preMatchesMove  = this.classifier.classifySubsegment(this.preStats)  != SegmentClass.HOLD;
+      let postMatchesMove = this.classifier.classifySubsegment(this.postStats) != SegmentClass.HOLD;
+
+      if(preMatchesMove != postMatchesMove) {
+        // If one subsegment appears to be a 'hold' while the other does not, well... holds
+        // don't (practically) have a direction, which mismatches with the 'move' that does
+        // have a direction.
+        return false;
+      } else if(!preMatchesMove) {
+        // If both are 'hold' subsegments, both should be treated as directionless.
+        return true;
+      } else {
+        // If both are 'move' / 'move'-like subsegments, only merge if their directional
+        // classification falls into the same 'direction bucket'.
+        return this.cardinalDirectionCompatible;
+      }
+    }
+
+    /**
+     * Indicates whether or not the two halves of the represented segmentation fall within
+     * the same cardinal-direction "bucket".
+     */
+    get cardinalDirectionCompatible(): boolean {
+      return !this.preStats || this.preStats.cardinalDirection == this.postStats.cardinalDirection;
+    }
+
+    /**
+     * Indicates whether or not geometry-based regression of the two subsegments (without
+     * respect to speed and/or time) provides sufficient evidence to uphold the segmentation.
+     */
+    get regressionDirectionCompatible(): boolean {
+      return !this.preStats || this.split.mergeMerited;
+    }
+
+    /**
+     * Indicates whether or not the classifications of the two subsegments is compatible;
+     * if so, it returns the corresponding `SegmentClass` (or `null`, if no classification
+     * may be committed yet).
+     *
+     * If the classifications are incompatible, ths function will return `undefined`
+     * instead.
+     */
+    get classificationIfCompatible(): SegmentClass {
+      // Get the baseline subsegment classification for each subsegment.
+      let leftClass  = this.classifier.classifySubsegment(this.preStats);
+      let rightClass = this.classifier.classifySubsegment(this.postStats);
+      let unionClass = this.classifier.classifySubsegment(this.unionStats);
+
+      // Choose the first non-null one as a fallback, then apply it.
+      let fallbackClass = leftClass || rightClass || unionClass;
+
+      leftClass  = leftClass || fallbackClass;
+      rightClass = rightClass || fallbackClass;
+      unionClass = unionClass || fallbackClass;
+
+      // If all classes (post-fallback) match, that's the class if compatible.
+      if(leftClass == rightClass && leftClass == unionClass) {
+        return fallbackClass;  // can technically still be null.
+      } else {
+        return undefined;
+      }
+    }
+
+    /**
+     * The full, complete test for subsegment 'compatibility'.  If `true`, our
+     * criteria indicate no merit in upholding the segmentation under review.
+     * `false` indicates that the segmentation should be upheld instead.
+     */
+    get isCompatible(): boolean {
+      const commonClass = this.classificationIfCompatible;
+
+      // If two adjacent hold subsegments also make a hold when combined...
+      // just merge the two holds & call 'em compatible.
+      if(!this.preStats || commonClass == 'hold') {
+        return true;
+      } else if(commonClass === undefined) { // `null`: pending; `undefined`: incompatible
+        return false;
+      }
+
+      // if(null || "move"):  as `null` "looks like" a not-quite-there-yet "move",
+      // we treat it as such here.  Such subsegments are only compatible if
+      // their directions are compatible.
+      return this.directionCompatible;
+    }
+
+    /**
+     * Intended only for use during interactive debugging sessions; prints useful logging
+     * information to the developer console.
+     */
+    public debugLogCompabilityReport() {
+      if(!this.preStats) {
+        console.log("No prior subsegments - thus, no compatibility conflicts are possible.");
+        return;
+      }
+
+      console.log("Regression-based compatibility check:")
+      this.split._debugLogAlignmentReport();
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/trackedPath.ts
@@ -31,13 +31,17 @@ namespace com.keyman.osk {
    *   - Provides no parameters.
    *   - Will be the last event raised by its instance, after any final 'segmentation'
    *     events.
+   *   - Still precedes resolution Promise fulfillment on the `Segment` provided by
+   *     the most recently-preceding 'segmentation' event.
+   *     - And possibly recognition Promise fulfillment.
    *
    * `'invalidated'`: the touchpoint is no longer active; the path has crossed
    * gesture-recognition boundaries and is no longer considered valid.
    *   - Provides no parameters.
-   *   - Will precede recognition Promise fulfillment on the `Segment` provided by
-   *     the most recently-preceding 'segmentation' event.
    *   - Will precede the final 'segmentation' event for the 'end' segment
+   *   - Will precede resolution Promise fulfillment on the `Segment` provided by
+   *     the most recently-preceding 'segmentation' event.
+   *     - And possibly recognition Promise fulfillment.
    *
    * `'segmentation'`:  a new segmentation boundary has been identified for the
    * ongoing touchpath.

--- a/common/web/gesture-recognizer/src/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/trackedPath.ts
@@ -76,7 +76,7 @@ namespace com.keyman.osk {
         this.emit('segmentation', segment);
       }
 
-      this.segmenter = new PathSegmenter(segmentStartClosure);
+      this.segmenter = new PathSegmenter(PathSegmenter.DEFAULT_CONFIG, segmentStartClosure);
     }
 
     /**

--- a/common/web/gesture-recognizer/src/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/trackedPath.ts
@@ -96,9 +96,12 @@ namespace com.keyman.osk {
         throw "Invalid state:  this TrackedPath has already terminated.";
       }
 
+      // The tracked path should emit InputSample events before Segment events and
+      // resolution of Segment Promises.
       this.samples.push(sample);
-      this.segmenter.add(sample);
       this.emit('step', sample);
+
+      this.segmenter.add(sample);
     }
 
     /**
@@ -111,13 +114,16 @@ namespace com.keyman.osk {
       }
       this.wasCancelled = cancel;
       this._isComplete = true;
-      this.segmenter.close();
 
+      // The tracked path should emit InputSample events before Segment events and
+      // resolution of Segment Promises.
       if(cancel) {
         this.emit('invalidated');
       } else {
         this.emit('complete');
       }
+
+      this.segmenter.close();
       this.removeAllListeners();
     }
 

--- a/common/web/gesture-recognizer/src/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/trackedPath.ts
@@ -135,6 +135,34 @@ namespace com.keyman.osk {
       return this.samples;
     }
 
+    /**
+     * Returns the segmented form of the touchpath over its lifetime thus far.  It is
+     * possible for certain parts of the path to go unrepresented if they are detected as
+     * insignificant.
+     *
+     * Also of note:  for the common case, the final coordinate of one Segment will usually
+     * be the initial point of the following Segment.  Usually, but not always.  This is
+     * the only overlap that may occur.
+     *
+     * Note:  segment events and updates will always occur in the following order:
+     *
+     * 1. A segment's role is 'recognized' - its classification becomes known.
+     * 2. The segment is 'resolved' - the segment is marked as completed.
+     * 3. The next segment is added to this field, with on('segmentation') is raised
+     *    for it.
+     *
+     * Note that it is possible for a segment to be 'recognized' and even 'resolved'
+     * before its event is raised (thus, before it is added here) under some scenarios.
+     * In particular, 'start' and 'end'-type segments are always 'recognized' and
+     * 'resolved'.
+     *
+     * While the touchpath is active, there is a very high chance that the final
+     * segment listed will not be resolved.  There will also be a distinct chance
+     * that it is not yet recognized.
+     *
+     * The first Segment should always be a 'start', while the final Segment - once
+     * _all_ input for the ongoing touchpath is complete - will be an 'end'.
+     */
     public get segments(): readonly Segment[] {
       return this._segments;
     }

--- a/common/web/gesture-recognizer/src/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/trackedPath.ts
@@ -7,14 +7,14 @@ namespace com.keyman.osk {
   export type JSONTrackedPath = {
     coords: InputSample[]; // ensures type match with public class property.
     wasCancelled?: boolean;
-    //segments: Segment[];
+    segments: Segment[];
   }
 
   interface EventMap {
     'step': (sample: InputSample) => void,
     'complete': () => void,
     'invalidated': () => void
-    // 'segmentation': (endingSegment: Segment, openingSegment: Segment) => void
+    'segmentation': (segment: Segment) => void
   }
 
   /**
@@ -69,7 +69,14 @@ namespace com.keyman.osk {
       // Keep this as the _final_ statement in the constructor.  `PathSegmenter` will
       // need a reference to this instance, even if only via closure.
       // (Most likely; not yet done.) Kinda awkward, but it's useful for compartmentalization.
-      this.segmenter = new PathSegmenter();
+      // - DO use 'via closure.'  That allows us to have the segment passing done via
+      // `private` method.
+      const segmentStartClosure = (segment: Segment) => {
+        this._segments.push(segment);
+        this.emit('segmentation', segment);
+      }
+
+      this.segmenter = new PathSegmenter(segmentStartClosure);
     }
 
     /**
@@ -139,6 +146,7 @@ namespace com.keyman.osk {
           targetY: obj.targetY,
           t:       obj.t
         }))],
+        segments: [...this.segments],
         wasCancelled: this.wasCancelled
       }
 


### PR DESCRIPTION
Continuing from #7058, this PR seeks to construct & publish "proper" Segment objects to the `TrackedPath` object that may be used for later stages of gesture recognition.  These are synthesized by examining the sequence of "subsegments" produced by the segmentation algorithm and recombining them as appropriate based on a few common patterns and rules.

This implements "stage one" from [our "Gesture Recognition" design doc](https://docs.google.com/document/d/1i7WI7iGD0FI2nGx7T65Yu32LgLCaGfIaZN3EPMhlTog/edit?usp=sharing).

Additionally, this PR's changes seek to provide a better, more long-term-maintenance-friendly set of debugging functions, logging methods, etc - rather than maintaining the slew of raw `console.log()` statements its predecessor had.  Accordingly, any debug-logging statements are no longer accessible except through user interaction via the developer console.

------

While I could see there being a desire to split this one into pieces... I'm a little stumped at the moment on how to approach that well - the most-easily separable changes are required by those most directly connected to already-completed work.  Apologies that it grew to this point before being submitted for review, though I'm still glad it wasn't as large as I feared.

------

While user tests are _technically_ possible to write, they'd require parsing the output logs to verify success - and that's not the simplest thing to ask of our user testers.  (I actually started to write a user test or two and then realized just how complex the "verify" instructions were going to be.)

As I plan to follow this up a PR or two for unit-testing, and as this part of the module is meant to be quite "internal" in the grand scheme of things...

@keymanapp-test-bot skip

See #7157 for tests.