### PR TITLE
fix(linux): Allow downgrades for installing build deps

### DIFF
--- a/linux/scripts/jenkins.sh
+++ b/linux/scripts/jenkins.sh
@@ -55,7 +55,7 @@ checkAndInstallRequirements()
 	fi
 
 	sudo mk-build-deps debian/control
-	sudo apt-get -qy install ./keyman-build-deps_*.deb
+	sudo apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
 	sudo rm -f keyman-buid-deps_*
 }
 


### PR DESCRIPTION
When install the keyman-build-deps_*.deb file it can happen that we end up with a lower version number than what we previously
built. This change allows downgrades so that the build dependencies can be installed.

@keymanapp-test-bot skip