### PR TITLE
chore(core): emcc off path for linux

### DIFF
--- a/core/wasm.build.linux.in
+++ b/core/wasm.build.linux.in
@@ -1,2 +1,7 @@
+[binaries]
+c = ['$EMSCRIPTEN_BASE/emcc.py', '-s', 'WASM=1', '-O2']
+cpp = ['$EMSCRIPTEN_BASE/em++.py', '-s', 'WASM=1','-O2']
+ar = ['$EMSCRIPTEN_BASE/emar.py']
+
 [properties]
 root = '$EMSCRIPTEN_BASE/system'


### PR DESCRIPTION
This is a cherry-pick of 0057b7d95c23d3314b847e88a5738641ef7ed18d (from #7129) just so we can get WASM tests passing for other PRs before we merge feature-ldml.

@keymanapp-test-bot skip