### PR TITLE
refactor(developer): each section compiler is a pure function 🙀

### DIFF
--- a/core/include/ldml/keyboardprocessor_ldml.ts
+++ b/core/include/ldml/keyboardprocessor_ldml.ts
@@ -5,6 +5,29 @@
   to be shared between TypeScript and C++ via the generator (below)
 */
 
+// This defines the section identifiers and ensures that we include each and
+// every one of them in the `sections` block and gives us a type which we can
+// iterate through
+
+export type SectionIdent =
+  'keys' |
+  'loca' |
+  'meta' |
+  'sect' |
+  'strs' |
+  'vkey';
+
+type SectionMap = {
+  [id in SectionIdent]: SectionIdent;
+}
+
+interface Constants_Section {
+  // For now, only defining one property as other types
+  // can be inferred
+  section: SectionMap;
+}
+
+type Constants = Constants_Section & {[id:string]:any};
 
 // Notice!
 //
@@ -24,7 +47,7 @@
  * values that are designed to appear as text when written in little endian
  * format, so 0x7379656b = 'keys'
  */
-export const constants = {
+export const constants: Constants = {
     /**
      * The version of the LDML processor
      */

--- a/developer/src/kmldmlc/src/keyman/compiler/keys.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/keys.ts
@@ -1,3 +1,5 @@
+import { constants } from '@keymanapp/ldml-keyboard-constants';
+import { Keys } from '../kmx/kmx-plus';
 import * as LDMLKeyboard from '../ldml-keyboard/ldml-keyboard-xml';
 import { USVirtualKeyMap } from "../ldml-keyboard/us-virtual-keys";
 
@@ -5,19 +7,29 @@ import { SectionCompiler } from "./section-compiler";
 
 export class KeysCompiler extends SectionCompiler {
 
-  public execute() {
+  public get id() {
+    return constants.section.keys;
+  }
+
+  public compile(): Keys {
     // Use LayerMap + keys to generate compiled keys for hardware
 
     if(this.source.keyboard.layerMaps?.[0]?.form == 'hardware') {
       for(let layer of this.source.keyboard.layerMaps[0].layerMap) {
-        this.compileHardwareLayer(layer);
+        let sect = this.compileHardwareLayer(layer);
+        return sect;
       }
     }
+
+    // TODO: generate vkey mapping for touch-only keys
+
+    return null;
   }
 
   private compileHardwareLayer(
     layer: LDMLKeyboard.LKLayerMap
-  ) {
+  ): Keys {
+    let result = new Keys();
     const mod = this.translateLayerIdToModifier(layer.id);
 
     let y = -1;
@@ -44,7 +56,7 @@ export class KeysCompiler extends SectionCompiler {
           continue;
         }
 
-        this.kmx.kmxplus.keys.keys.push({
+        result.keys.push({
           vkey: USVirtualKeyMap[y][x],
           mod: mod,
           to: keydef.to,
@@ -52,6 +64,8 @@ export class KeysCompiler extends SectionCompiler {
         });
       }
     }
+
+    return result;
   }
 
   private translateLayerIdToModifier(id: string) {

--- a/developer/src/kmldmlc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/loca.ts
@@ -1,8 +1,16 @@
+import { constants } from "@keymanapp/ldml-keyboard-constants";
+import { Loca } from "../kmx/kmx-plus";
 import { SectionCompiler } from "./section-compiler";
 
 export class LocaCompiler extends SectionCompiler {
 
-  public execute() {
-    this.kmx.kmxplus.loca.locales.push(this.source.keyboard.locale);
+  public get id() {
+    return constants.section.loca;
+  }
+
+  public compile(): Loca {
+    let result = new Loca();
+    result.locales.push(this.source.keyboard.locale);
+    return result;
   }
 }

--- a/developer/src/kmldmlc/src/keyman/compiler/meta.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/meta.ts
@@ -1,13 +1,27 @@
+import { constants } from "@keymanapp/ldml-keyboard-constants";
+import { Meta } from "../kmx/kmx-plus";
 import { SectionCompiler } from "./section-compiler";
 
 export class MetaCompiler extends SectionCompiler {
 
-  public execute() {
-    this.kmx.kmxplus.meta.name = this.source.keyboard.names?.name?.[0]?.value;
-    this.kmx.kmxplus.meta.author = this.source.keyboard.info?.author;
-    this.kmx.kmxplus.meta.conform = this.source.keyboard.conformsTo;
-    this.kmx.kmxplus.meta.layout = this.source.keyboard.info?.layout;
-    this.kmx.kmxplus.meta.normalization = this.source.keyboard.info?.normalization;
-    this.kmx.kmxplus.meta.indicator = this.source.keyboard.info?.indicator;
+  public get id() {
+    return constants.section.meta;
+  }
+
+  public validate(): boolean {
+    //
+    return true;
+  }
+
+  public compile(): Meta {
+    let result = new Meta();
+    result.name = this.source.keyboard.names?.name?.[0]?.value;
+    result.author = this.source.keyboard.info?.author;
+    result.conform = this.source.keyboard.conformsTo;
+    result.layout = this.source.keyboard.info?.layout;
+    result.normalization = this.source.keyboard.info?.normalization;
+    result.indicator = this.source.keyboard.info?.indicator;
+    result.settings = 0;
+    return result;
   }
 }

--- a/developer/src/kmldmlc/src/keyman/compiler/section-compiler.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/section-compiler.ts
@@ -1,18 +1,26 @@
-import KMXPlusFile from "../kmx/kmx-plus";
+import { Section } from "../kmx/kmx-plus";
 import LDMLKeyboardXMLSourceFile from "../ldml-keyboard/ldml-keyboard-xml";
 import CompilerCallbacks from "./callbacks";
+import { SectionIdent } from '@keymanapp/ldml-keyboard-constants';
 
 export class SectionCompiler {
-  private _kmx: KMXPlusFile;
-  private _source: LDMLKeyboardXMLSourceFile;
-  private _callbacks: CompilerCallbacks;
+  protected readonly source: LDMLKeyboardXMLSourceFile;
+  protected readonly callbacks: CompilerCallbacks;
 
-  constructor(kmx: KMXPlusFile, source: LDMLKeyboardXMLSourceFile, callbacks: CompilerCallbacks) {
-    this._kmx = kmx;
-    this._source = source;
+  constructor(source: LDMLKeyboardXMLSourceFile, callbacks: CompilerCallbacks) {
+    this.source = source;
+    this.callbacks = callbacks;
   }
 
-  get kmx() { return this._kmx; }
-  get source() { return this._source; }
-  get callbacks() { return this._callbacks; }
+  public get id(): SectionIdent {
+    return null;
+  }
+
+  public compile(): Section {
+    return null;
+  }
+
+  public validate(): boolean {
+    return true;
+  }
 }

--- a/developer/src/kmldmlc/src/keyman/kmx/kmx-plus.ts
+++ b/developer/src/kmldmlc/src/keyman/kmx/kmx-plus.ts
@@ -79,19 +79,14 @@ export default class KMXPlusFile extends KMXFile {
 
   /* File in-memory data */
 
-  // strs and sect are not kept in-memory
-
   public kmxplus: {
-    loca: Loca;
-    meta: Meta;
-    keys: Keys;
-    vkey: Vkey;
-  } = {
-    loca: new Loca(),
-    meta: new Meta(),
-    keys: new Keys(),
-    vkey: new Vkey()
-  };
+    sect?: Section; // sect is ignored here for writing
+    strs?: Section; // strs is ignored here for writing
+    loca?: Loca;
+    meta?: Meta;
+    keys?: Keys;
+    vkey?: Vkey;
+  } = { };
 
   constructor() {
     super();

--- a/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -3,10 +3,10 @@ import LDMLKeyboardXMLSourceFile from './ldml-keyboard-xml';
 import CompilerCallbacks from '../compiler/callbacks';
 
 export default class LDMLKeyboardXMLSourceFileReader {
+  private readonly callbacks: CompilerCallbacks;
 
-  //private callbacks: CompilerCallbacks;
   constructor (callbacks: CompilerCallbacks) {
-    //this.callbacks = callbacks;
+    this.callbacks = callbacks;
   }
 
   /**
@@ -33,6 +33,11 @@ export default class LDMLKeyboardXMLSourceFileReader {
       }
     }
     return source;
+  }
+
+  public loadFile(filename: string) {
+    const buf = this.callbacks.loadFile(filename, filename);
+    return this.load(buf);
   }
 
   public load(file: Uint8Array): LDMLKeyboardXMLSourceFile {

--- a/developer/src/kmldmlc/src/kmldmlc.ts
+++ b/developer/src/kmldmlc/src/kmldmlc.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as program from 'commander';
 
 import Compiler from './keyman/compiler/compiler';
+import KMXBuilder from './keyman/kmx/kmx-builder';
 
 let inputFilename: string;
 
@@ -59,7 +60,10 @@ function compileKeyboard(inputFilename: string): Uint8Array {
   if(!kmx) {
     return null;
   }
-  return k.write(kmx);
+
+  // Use the builder to generate the binary output file
+  let builder = new KMXBuilder(kmx, true);
+  return builder.compile();
 }
 
 // Compile:

--- a/developer/src/kmldmlc/test/test-compiler-e2e.ts
+++ b/developer/src/kmldmlc/test/test-compiler-e2e.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {assert} from 'chai';
 import hextobin from '@keymanapp/hextobin';
 import Compiler from '../src/keyman/compiler/compiler';
+import KMXBuilder from '../src/keyman/kmx/kmx-builder';
 import {makePathToFixture} from './helpers/index';
 
 class CompilerCallbacks {
@@ -30,7 +31,10 @@ function compileKeyboard(inputFilename: string): Uint8Array {
   if(!kmx) {
     return null;
   }
-  return k.write(kmx);
+
+  // Use the builder to generate the binary output file
+  let builder = new KMXBuilder(kmx, true);
+  return builder.compile();
 }
 
 describe('compiler-tests', function() {


### PR DESCRIPTION
Makes each section compiler a pure function. Good for testing in the future.

Well, almost. There are still callback side-effects for messages. These may in future be returned as an array as well, eliminating the need for a message callback.

But restructures each section compiler so that it is self-contained and responsible only for writing its own section. Also tightens up the types for the sections constants.

Last, but not least, moves responsibility for writing the output .kmx out of compiler.ts and into its callers -- removing one dependency from the compiler. Reading input files still needs to be done in the compiler, as there may be multiple input files with `<import>` that we cannot know about until we start parsing xml.

@keymanapp-test-bot skip