### PR TITLE
feat(developer): add loca tests 🙀

### DIFF
--- a/developer/src/kmldmlc/src/keyman/compiler/errors.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/errors.ts
@@ -10,7 +10,8 @@ export enum CompilerErrorSeverity {
 };
 
 export enum CompilerErrors {
-  ERROR_InvalidNormalization = CompilerErrorSeverity.Error | 0x0001 // `Invalid normalization form '${}'`
+  ERROR_InvalidNormalization = CompilerErrorSeverity.Error | 0x0001, // `Invalid normalization form '${}'`
+  ERROR_InvalidLocale        = CompilerErrorSeverity.Error | 0x0002, // `Invalid BCP 47 locale form '${}'`
 };
 
 export function getErrorSeverityName(code: number): string {

--- a/developer/src/kmldmlc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/loca.ts
@@ -1,6 +1,9 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { Loca } from "../kmx/kmx-plus";
 import { SectionCompiler } from "./section-compiler";
+//import tags = require('language-tags');
+import { CompilerErrors } from "./errors";
+import { LKKeyboard } from "../ldml-keyboard/ldml-keyboard-xml";
 
 export class LocaCompiler extends SectionCompiler {
 
@@ -8,9 +11,43 @@ export class LocaCompiler extends SectionCompiler {
     return constants.section.loca;
   }
 
+  private getLocales =
+    (keyboard: LKKeyboard) =>
+    [keyboard.locale].concat(Array.isArray(keyboard.locales?.locale) ? keyboard.locales.locale.map(v => v.id) : [])
+
+  public validate(): boolean {
+    let valid = true;
+    const locales = this.getLocales(this.keyboard);
+    for(let tag of locales) {
+      try {
+        new Intl.Locale(tag);
+      } catch(e) {
+        if(e instanceof RangeError) {
+          this.callbacks.reportMessage(CompilerErrors.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${tag}'`);
+          valid = false;
+        } else {
+          throw e;
+        }
+      }
+    }
+    return valid;
+  }
+
   public compile(): Loca {
     let result = new Loca();
-    result.locales.push(this.keyboard.locale);
+
+    let locales = this.getLocales(this.keyboard);
+    // TODO: remove `as any` cast: (Intl as any): ts lib version we have doesn't
+    // yet include `getCanonicalLocales` but node 16 does include it so we can
+    // safely use it. Also well supported in modern browsers.
+    result.locales = (Intl as any).getCanonicalLocales(locales);
+
+    if(result.locales.length < locales.length) {
+      // TODO-LDML: hint on repeated locales
+    }
+
+    // TODO-LDML: do we do any locale normalization (e.g. en-Latn-US => en-US)
+
     return result;
   }
 }

--- a/developer/src/kmldmlc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/loca.ts
@@ -1,7 +1,6 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { Loca } from "../kmx/kmx-plus";
 import { SectionCompiler } from "./section-compiler";
-//import tags = require('language-tags');
 import { CompilerErrors } from "./errors";
 import { LKKeyboard } from "../ldml-keyboard/ldml-keyboard-xml";
 

--- a/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -22,6 +22,7 @@ export default class LDMLKeyboardXMLSourceFileReader {
     box(source?.keyboard, 'layerMaps');
     box(source?.keyboard?.names, 'name');
     box(source?.keyboard?.keys, 'key');
+    box(source?.keyboard?.locales, 'locale');
     if(source?.keyboard?.layerMaps) {
       for(let layerMaps of source?.keyboard?.layerMaps) {
         box(layerMaps, 'layerMap');

--- a/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml.ts
+++ b/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml.ts
@@ -18,11 +18,20 @@ export interface LKKeyboard {
   locale?: string;
   conformsTo?: string;
 
+  locales?: LKLocales;
   info?: LKInfo;
   names?: LKNames;
   settings?: LKSettings;
   keys?: LKKeys;
   layerMaps?: LKLayerMaps[];
+};
+
+export interface LKLocales {
+  locale: LKLocale[];
+};
+
+export interface LKLocale {
+  id?: string;
 };
 
 export interface LKInfo {
@@ -36,14 +45,14 @@ export interface LKNames {
   name: LKName[];
 };
 
+export interface LKName {
+  value?: string;
+};
+
 export interface LKSettings {
   fallback: "omit";
   transformFailure: "omit";
   transformPartial: "hide";
-};
-
-export interface LKName {
-  value?: string;
 };
 
 export interface LKKeys {

--- a/developer/src/kmldmlc/test/fixtures/sections/loca/invalid-locale.xml
+++ b/developer/src/kmldmlc/test/fixtures/sections/loca/invalid-locale.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="en-*" conformsTo="techpreview">
+  <names>
+    <name value="invalid-loca" />
+  </names>
+  <keys />
+</keyboard>

--- a/developer/src/kmldmlc/test/fixtures/sections/loca/minimal.xml
+++ b/developer/src/kmldmlc/test/fixtures/sections/loca/minimal.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="loca-minimal" />
+  </names>
+
+  <keys />
+</keyboard>

--- a/developer/src/kmldmlc/test/fixtures/sections/loca/multiple.xml
+++ b/developer/src/kmldmlc/test/fixtures/sections/loca/multiple.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <locales>
+    <locale id="fr-FR" />
+    <locale id="km-khmr-kh" />
+    <locale id="fr-fr" />
+    <locale id="qq-Abcd-ZZ-x-foobar" />
+    <locale id="en-fonipa" />
+  </locales>
+
+  <names>
+    <name value="loca-multiple" />
+  </names>
+
+  <keys />
+</keyboard>

--- a/developer/src/kmldmlc/test/test-loca.ts
+++ b/developer/src/kmldmlc/test/test-loca.ts
@@ -1,0 +1,42 @@
+import 'mocha';
+import { assert } from 'chai';
+import { LocaCompiler } from '../src/keyman/compiler/loca';
+import { CompilerCallbacks, loadSectionFixture } from './helpers';
+import { Loca } from '../src/keyman/kmx/kmx-plus';
+import { CompilerErrors } from '../src/keyman/compiler/errors';
+
+describe('loca', function () {
+  it('should compile minimal loca data', function() {
+    const callbacks = new CompilerCallbacks();
+    let loca = loadSectionFixture(LocaCompiler, 'sections/loca/minimal.xml', callbacks) as Loca;
+    assert.equal(callbacks.messages.length, 0);
+
+    assert.equal(loca.locales.length, 1);
+    assert.equal(loca.locales[0].toLowerCase(), 'mt');
+  });
+
+  it('should compile multiple locales', function() {
+    const callbacks = new CompilerCallbacks();
+    let loca = loadSectionFixture(LocaCompiler, 'sections/loca/multiple.xml', callbacks) as Loca;
+    assert.equal(callbacks.messages.length, 0);
+
+    // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
+    assert.equal(loca.locales.length, 5);
+    assert.equal(loca.locales[0], 'mt');
+    assert.equal(loca.locales[1], 'fr-FR');
+    assert.equal(loca.locales[2], 'km-Khmr-KH');
+    assert.equal(loca.locales[3], 'qq-Abcd-ZZ-x-foobar');
+    assert.equal(loca.locales[4], 'en-fonipa');
+  });
+
+  it('should reject structurally invalid invalid locales', function() {
+    const callbacks = new CompilerCallbacks();
+    let meta = loadSectionFixture(LocaCompiler, 'sections/loca/invalid-locale.xml', callbacks) as Loca;
+    assert.isNull(meta);
+    assert.equal(callbacks.messages.length, 1);
+    // We'll only test one invalid BCP 47 tag to verify that we are properly calling BCP 47 validation routines.
+    // Furthermore, we are testing BCP 47 structure, not the validity of each subtag -- we must assume the author knows of new subtags!
+    assert.deepEqual(callbacks.messages[0], {code: CompilerErrors.ERROR_InvalidLocale, message: "Invalid BCP 47 locale form 'en-*'"});
+  })
+});
+

--- a/developer/src/kmldmlc/tsconfig.json
+++ b/developer/src/kmldmlc/tsconfig.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2020",
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "build/src/",


### PR DESCRIPTION
Note: bumps target to es2020 for better Intl.* support. Verified as supported by Node 16+ and modern browsers.

Adds support for multiple locales and basic canonicalization. Does not support normalization of locales.

@keymanapp-test-bot skip