### PR TITLE
fix(android/engine): :cherries: Cleanup list of subkeys when dismissing window

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -372,8 +372,10 @@ final class KMKeyboard extends WebView {
 
   public void dismissSubKeysWindow() {
     try {
-      if (subKeysWindow != null && subKeysWindow.isShowing())
+      if (subKeysWindow != null && subKeysWindow.isShowing()) {
         subKeysWindow.dismiss();
+      }
+      subKeysList = null;
     } catch (Exception e) {
       KMLog.LogException(TAG, "", e);
     }


### PR DESCRIPTION
:cherries: pick of #7156 to stable-15.0

When the subkeys window is dismissed, the subKeysList isn't cleared, so holding backspace key or globe key would end up displaying the previous longpress menu.

# User Testing

We need to re-run the main test from #6984, first, to verify that this does not re-introduce new bugs.

Setup - A physical Android device. Don't use emulator because the scenario involves typing fast on the OSK (e.g. two thumbs)

* **TEST_POPUPS** - Verify popup keys don't get stuck on
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Type on the OSK using the following scenarios and verify expected output:
    * Clicking a suggestion on the suggestion banner - should insert the suggestion
    * short-press a key and release - should insert the base key
    * long-press a key, select a long-press key, and release - should insert the long-press key (**note:** there should be a 0.5 second delay before the menu appears)
    * long-press a key, while keeping the finger down, move off the long-press options, and release - should **not** output
    * long-press a key, while keeping the finger down, move off the long-press options, then move back on a long-press option so it's highlighted, and release - should output the long-press key
    * quickly type a long paragraph (e.g. repeat the word "reply") - verify long-press keys don't get stuck (displayed when not touching a key)

* **TEST_UP_FLICK** - Verify that the up-flick gesture reliably opens the longpress menu
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Touch a key such as `e` and immediately swipe upwards to access the long-press menu, keeping your finger down. This should show long-press options without the 0.5 second delay.
   * You should be able to select an option from the long-press menu.
   * You should be able to move back onto the base key to select the base key letter again.
   * You should also be able to move your finger away from the menu to cancel the input.
5. Please run this test a number of times to verify that the behaviour remains consistent.

* **TEST_HELD_BACKSPACE** - Verify spurious longpress menu doesn't appear while holding backspace key
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Accept a suggestion
5. Type another letter
6. Touch and hold the backspace key
7. Verify the previous letter is deleted
8. Verify longpress menus for that letter do **not** appear
Note, if the backspace key fails to delete, that's a separate issue #7069 not fixed on this PR

* **TEST_HELD_GLOBE** - Verify spurious longpress menu doesn't appear while holding globe key
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing with the default sil_euro_latin.
4. Touch and hold the globe key
5. Verify longpress menus for other letters do **not** appear
6. Release the globe key and verify the Keyboard menu appears (default globe key action when only 1 Keyman keyboard is installed)


