### PR TITLE
feat(developer): loca minimization + cleanup kmldmlc error list 🙀

### DIFF
--- a/developer/src/kmldmlc/src/keyman/compiler/callbacks.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/callbacks.ts
@@ -1,4 +1,9 @@
+export interface CompilerEvent {
+  code: number;
+  message: string;
+};
+
 export default interface CompilerCallbacks {
   loadFile(baseFilename: string, filename: string): Buffer;
-  reportMessage(code: number, message: string): void;
+  reportMessage(event: CompilerEvent): void;
 };

--- a/developer/src/kmldmlc/src/keyman/compiler/errors.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/errors.ts
@@ -9,19 +9,44 @@ export enum CompilerErrorSeverity {
   Error_Mask =    0x0FFFFF,
 };
 
-export enum CompilerErrors {
-  ERROR_InvalidNormalization = CompilerErrorSeverity.Error | 0x0001, // `Invalid normalization form '${}'`
-  ERROR_InvalidLocale        = CompilerErrorSeverity.Error | 0x0002, // `Invalid BCP 47 locale form '${}'`
-};
+const m = (code: number, message: string) => { return { code, message } };
+// const SevInfo = CompilerErrorSeverity.Info;
+const SevHint = CompilerErrorSeverity.Hint;
+// const SevWarn = CompilerErrorSeverity.Warn;
+const SevError = CompilerErrorSeverity.Error;
+// const SevFatal = CompilerErrorSeverity.Fatal;
 
-export function getErrorSeverityName(code: number): string {
-  let severity = code & CompilerErrorSeverity.Severity_Mask;
-  switch(severity) {
-    case CompilerErrorSeverity.Info: return 'INFO';
-    case CompilerErrorSeverity.Hint: return 'HINT';
-    case CompilerErrorSeverity.Warn: return 'WARN';
-    case CompilerErrorSeverity.Error: return 'ERROR';
-    case CompilerErrorSeverity.Fatal: return 'FATAL';
-    default: return 'UNKNOWN';
+export class CompilerErrors {
+  static InvalidNormalization = (o:{form: string}) => m(this.ERROR_InvalidNormalization, `Invalid normalization form '${o.form}`);
+  static ERROR_InvalidNormalization = SevError | 0x0001;
+
+  static InvalidLocale = (o:{tag: string}) => m(this.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${o.tag}`);
+  static ERROR_InvalidLocale = SevError | 0x0002;
+
+  static HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
+  static ERROR_HardwareLayerHasTooManyRows = SevError | 0x0003;
+
+  static RowOnHardwareLayerHasTooManyKeys = (o:{row: number}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' layer has too many keys`);
+  static ERROR_RowOnHardwareLayerHasTooManyKeys = SevError | 0x0004;
+
+  static KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
+     m(this.ERROR_KeyNotFoundInKeyBag, `Key ${o.keyId} in position #${o.col} on row #${o.row} of layer ${o.layer}, form '${o.form}' not found in key bag`);
+  static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
+
+  static OneOrMoreRepeatedLocales = () =>
+    m(this.HINT_OneOrMoreRepeatedLocales, `After minimization, one or more locales is repeated and has been removed`);
+  static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
+
+  static severityName(code: number): string {
+    let severity = code & CompilerErrorSeverity.Severity_Mask;
+    switch(severity) {
+      case CompilerErrorSeverity.Info: return 'INFO';
+      case CompilerErrorSeverity.Hint: return 'HINT';
+      case CompilerErrorSeverity.Warn: return 'WARN';
+      case CompilerErrorSeverity.Error: return 'ERROR';
+      case CompilerErrorSeverity.Fatal: return 'FATAL';
+      default: return 'UNKNOWN';
+    }
   }
 }
+

--- a/developer/src/kmldmlc/src/keyman/compiler/keys.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/keys.ts
@@ -2,6 +2,7 @@ import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { Keys } from '../kmx/kmx-plus';
 import * as LDMLKeyboard from '../ldml-keyboard/ldml-keyboard-xml';
 import { USVirtualKeyMap } from "../ldml-keyboard/us-virtual-keys";
+import { CompilerErrors } from './errors';
 
 import { SectionCompiler } from "./section-compiler";
 
@@ -36,7 +37,7 @@ export class KeysCompiler extends SectionCompiler {
     for(let row of layer.row) {
       y++;
       if(y > USVirtualKeyMap.length) {
-        this.callbacks.reportMessage(0, `'hardware' layer has too many rows`);
+        this.callbacks.reportMessage(CompilerErrors.HardwareLayerHasTooManyRows());
         break;
       }
 
@@ -45,15 +46,13 @@ export class KeysCompiler extends SectionCompiler {
       for(let key of keys) {
         x++;
         if(x > USVirtualKeyMap[y].length) {
-          this.callbacks.reportMessage(0, `Row #${y+1} on 'hardware' layer has too many keys`);
+          this.callbacks.reportMessage(CompilerErrors.RowOnHardwareLayerHasTooManyKeys({row: y+1}));
           break;
         }
 
         let keydef = this.keyboard.keys?.key?.find(x => x.id == key);
         if(!keydef) {
-          this.callbacks.reportMessage(0,
-            `Key ${key} in position #${x+1} on row #${y+1} of layer ${layer.id}, form 'hardware' not found in key bag`);
-          continue;
+          this.callbacks.reportMessage(CompilerErrors.KeyNotFoundInKeyBag({keyId: key, col: x+1, row: y+1, layer: layer.id, form: 'hardware'}));
         }
 
         result.keys.push({

--- a/developer/src/kmldmlc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/loca.ts
@@ -47,11 +47,11 @@ export class LocaCompiler extends SectionCompiler {
     // TODO: remove `as any` cast: (Intl as any): ts lib version we have doesn't
     // yet include `getCanonicalLocales` but node 16 does include it so we can
     // safely use it. Also well supported in modern browsers.
-    result.locales = ((Intl as any).getCanonicalLocales(locales));
+    result.locales = (Intl as any).getCanonicalLocales(locales);
 
     if(result.locales.length < locales.length) {
       // TODO-LDML: hint on repeated locales
-      this.callbacks.reportMessage(CompilerErrors.OneOrMoreRepeatedLocales())
+      this.callbacks.reportMessage(CompilerErrors.OneOrMoreRepeatedLocales());
     }
 
     return result;

--- a/developer/src/kmldmlc/src/keyman/compiler/meta.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/meta.ts
@@ -16,7 +16,7 @@ export class MetaCompiler extends SectionCompiler {
     const normalization = this.keyboard.info?.normalization;
     if(normalization !== undefined) {
       if(!isValidEnumValue(Meta_NormalizationForm, normalization)) {
-        this.callbacks.reportMessage(CompilerErrors.ERROR_InvalidNormalization, `Invalid normalization form '${normalization}'`);
+        this.callbacks.reportMessage(CompilerErrors.InvalidNormalization({form: normalization}));
         valid = false;
       }
     }

--- a/developer/src/kmldmlc/src/kmldmlc.ts
+++ b/developer/src/kmldmlc/src/kmldmlc.ts
@@ -9,7 +9,8 @@ import * as program from 'commander';
 
 import Compiler from './keyman/compiler/compiler';
 import KMXBuilder from './keyman/kmx/kmx-builder';
-import { getErrorSeverityName } from './keyman/compiler/errors';
+import { CompilerErrors } from './keyman/compiler/errors';
+import { CompilerEvent } from './keyman/compiler/callbacks';
 
 let inputFilename: string;
 
@@ -42,8 +43,8 @@ class CompilerCallbacks {
     // TODO: translate filename based on the baseFilename
     return fs.readFileSync(filename);
   }
-  reportMessage(code: number, message: string): void {
-    console.log(getErrorSeverityName(code) + ' ' + code.toString(16) + ': ' + message);
+  reportMessage(event: CompilerEvent): void {
+    console.log(CompilerErrors.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
   }
 }
 

--- a/developer/src/kmldmlc/test/helpers/index.ts
+++ b/developer/src/kmldmlc/test/helpers/index.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import { SectionCompiler } from '../../src/keyman/compiler/section-compiler';
 import { Section } from '../../src/keyman/kmx/kmx-plus';
 import LDMLKeyboardXMLSourceFileReader from '../../src/keyman/ldml-keyboard/ldml-keyboard-xml-reader';
+import { CompilerEvent } from '../keyman/compiler/callbacks';
 
 /**
  * Builds a path to the fixture with the given path components.
@@ -20,13 +21,13 @@ export function makePathToFixture(...components: string[]): string {
 
 
 export class CompilerCallbacks {
-  messages: { code: number, message: string}[] = [];
+  messages: CompilerEvent[] = [];
   loadFile(baseFilename: string, filename:string): Buffer {
     // TODO: translate filename based on the baseFilename
     return fs.readFileSync(filename);
   }
-  reportMessage(code: number, message: string): void {
-    this.messages.push({code, message});
+  reportMessage(event: CompilerEvent): void {
+    this.messages.push(event);
   }
 }
 

--- a/developer/src/kmldmlc/test/test-loca.ts
+++ b/developer/src/kmldmlc/test/test-loca.ts
@@ -18,13 +18,16 @@ describe('loca', function () {
   it('should compile multiple locales', function() {
     const callbacks = new CompilerCallbacks();
     let loca = loadSectionFixture(LocaCompiler, 'sections/loca/multiple.xml', callbacks) as Loca;
-    assert.equal(callbacks.messages.length, 0);
 
     // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
+    assert.equal(callbacks.messages.length, 1);
+    assert.deepEqual(callbacks.messages[0], CompilerErrors.OneOrMoreRepeatedLocales());
+
+    // Original is 6 locales, now five minimized in the results
     assert.equal(loca.locales.length, 5);
     assert.equal(loca.locales[0], 'mt');
-    assert.equal(loca.locales[1], 'fr-FR');
-    assert.equal(loca.locales[2], 'km-Khmr-KH');
+    assert.equal(loca.locales[1], 'fr');  // Original fr-FR
+    assert.equal(loca.locales[2], 'km');  // Original km-Khmr-kh
     assert.equal(loca.locales[3], 'qq-Abcd-ZZ-x-foobar');
     assert.equal(loca.locales[4], 'en-fonipa');
   });
@@ -36,7 +39,7 @@ describe('loca', function () {
     assert.equal(callbacks.messages.length, 1);
     // We'll only test one invalid BCP 47 tag to verify that we are properly calling BCP 47 validation routines.
     // Furthermore, we are testing BCP 47 structure, not the validity of each subtag -- we must assume the author knows of new subtags!
-    assert.deepEqual(callbacks.messages[0], {code: CompilerErrors.ERROR_InvalidLocale, message: "Invalid BCP 47 locale form 'en-*'"});
+    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidLocale({tag:'en-*'}));
   })
 });
 

--- a/developer/src/kmldmlc/test/test-meta.ts
+++ b/developer/src/kmldmlc/test/test-meta.ts
@@ -39,7 +39,7 @@ describe('meta', function () {
     let meta = loadSectionFixture(MetaCompiler, 'sections/meta/invalid-normalization.xml', callbacks) as Meta;
     assert.isNull(meta);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], {code: CompilerErrors.ERROR_InvalidNormalization, message: "Invalid normalization form 'NFQ'"});
-  })
+    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidNormalization({form:'NFQ'}));
+  });
 });
 


### PR DESCRIPTION
Yeah two for the price of one:

- minimize locales at compile time
- cleans up the list of errors to make it easier to maintain and use

TODO -- on follow-up PRs:

- Add kmldmlc test to developer test build -> see #7180
- Ensure that DTD is used when verifying XML files -> see #7181

@keymanapp-test-bot skip