### PR TITLE
chore(android): Reduce Toast notification noise

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -993,10 +993,6 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           String _downloadid = CloudLexicalModelMetaDataDownloadCallback.createDownloadId(languageID);
           CloudLexicalModelMetaDataDownloadCallback _callback = new CloudLexicalModelMetaDataDownloadCallback();
 
-          Toast.makeText(context,
-            context.getString(R.string.query_associated_model),
-            Toast.LENGTH_SHORT).show();
-
           ArrayList<CloudApiTypes.CloudApiParam> aPreparedCloudApiParams = new ArrayList<>();
           String url = CloudRepository.prepareLexicalModelQuery(languageID);
           aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -148,7 +148,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
             KMLog.LogException(TAG, "Error parsing lexical model from api.keyman.com. ", e);
           }
         } else {
-          BaseActivity.makeToast(aContext, R.string.no_associated_model, Toast.LENGTH_SHORT);
+          // Don't make a Toast notification about nothing to download
         }
       }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -125,31 +125,12 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
    * @param aMetaDataResult the meta data results
    */
   private void processCloudResults(Context aContext, List<MetaDataResult> aMetaDataResult) {
-    for(MetaDataResult _r:aMetaDataResult) {
-      if (_r.returnjson.target== CloudApiTypes.ApiTarget.Keyboard) {
+    for (MetaDataResult _r : aMetaDataResult) {
+      if (_r.returnjson.target == CloudApiTypes.ApiTarget.Keyboard) {
         //handleKeyboardMetaData(_r);
       }
-      if(_r.returnjson.target== CloudApiTypes.ApiTarget.KeyboardLexicalModels) {
-        JSONArray lmData = _r.returnjson.jsonArray;
-        if (lmData != null && lmData.length() > 0) {
-          try {
-            JSONObject modelInfo = lmData.getJSONObject(0);
-
-            if (modelInfo.has("packageFilename") && modelInfo.has("id")) {
-              String _modelID = modelInfo.getString("id");
-              ArrayList<CloudApiTypes.CloudApiParam> urls = new ArrayList<>();
-              urls.add(new CloudApiTypes.CloudApiParam(
-                CloudApiTypes.ApiTarget.LexicalModelPackage,
-                modelInfo.getString("packageFilename")));
-              _r.additionalDownloadid = CloudLexicalPackageDownloadCallback.createDownloadId(_modelID);
-              _r.additionalDownloads= urls;
-            }
-          } catch (JSONException e) {
-            KMLog.LogException(TAG, "Error parsing lexical model from api.keyman.com. ", e);
-          }
-        } else {
-          // Don't make a Toast notification about nothing to download
-        }
+      if (_r.returnjson.target == CloudApiTypes.ApiTarget.KeyboardLexicalModels) {
+        processCloudResultForModel(aContext, _r);
       }
 
       if (_r.returnjson.target == CloudApiTypes.ApiTarget.PackageVersion) {
@@ -161,6 +142,32 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
           CloudDataJsonUtil.processLexicalModelPackageUpdateJSON(aContext, pkgData, updateBundles);
         }
       }
+    }
+  }
+
+  private void processCloudResultForModel(Context aContext, MetaDataResult _r) {
+    JSONArray lmData = _r.returnjson.jsonArray;
+    if (lmData == null || lmData.length() == 0) {
+      KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - zero or null");
+      return;
+    }
+
+    try {
+      JSONObject modelInfo = lmData.getJSONObject(0);
+      if (!modelInfo.has("packageFilename") || !modelInfo.has("id")) {
+        KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - missing metadata");
+        return;
+      }
+
+      String _modelID = modelInfo.getString("id");
+      ArrayList<CloudApiTypes.CloudApiParam> urls = new ArrayList<>();
+      urls.add(new CloudApiTypes.CloudApiParam(
+        CloudApiTypes.ApiTarget.LexicalModelPackage,
+        modelInfo.getString("packageFilename")));
+      _r.additionalDownloadid = CloudLexicalPackageDownloadCallback.createDownloadId(_modelID);
+      _r.additionalDownloads= urls;
+    } catch (JSONException e) {
+      KMLog.LogException(TAG, "Error in lexical model metadata from api.keyman.com. ", e);
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -400,7 +400,6 @@ public class CloudRepository {
         BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
       } else {
         updateIsRunning = true;
-        // Don't make a Toast notification about cloud update
         CloudDownloadMgr.getInstance().executeAsDownload(
           context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -400,7 +400,7 @@ public class CloudRepository {
         BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
       } else {
         updateIsRunning = true;
-        BaseActivity.makeToast(context, R.string.catalog_download_start_in_background, Toast.LENGTH_SHORT);
+        // Don't make a Toast notification about cloud update
         CloudDownloadMgr.getInstance().executeAsDownload(
           context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
       }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -106,7 +106,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           return;
         }
 
-        BaseActivity.makeToast(currentContext, R.string.update_check_current, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();


### PR DESCRIPTION
Fixes #7170

To minimize UX distractions, this PR removes Toast notifications when nothing new is happening (installed/updated).

The dictionary query on the Language Settings menu will still notify the app is "Checking for associated dictionary to download" to give the user feedback on the menu.

## User Testing
* **TEST_REDUCED_TOAST_NOISE** - Verifies the number of Toast notifications are reduced
1. Install the PR build of Keyman for Android
2. Launch the app and observe the "Get Started" menu is displayed
3. Verify there's no Toast notification about checking the cloud catalog for updates
4. Dismiss the "Get Started" menu and  go to Keyman settings --> Installed Languages
5. Click on "+" and search for "afade" language keyboard to install (install a keyboard that has no associated dictionary)
6. Install sil_cameroon_azerty and install the keyboard for the "Afade" language"
7. After the keyboard package is installed, verify no Toast notifications appear about checking for associated dictionary
8. Go to Keyman Settings --> Installed Languages --> Afade
9. On the Afade language settings menu, click the bottom "Dictionary - Check for available dictionary"
10. Verify a Toast notification appears about checking for associated dictionary to download
11. Wait a few minutes and verify no additional toast notifications appear
12. Go to Keyman settings --> Installed Languages
13. Click on "+" and search for khmer_angkor (install a keyboard that has an associated dictionary)
14. Install khmer_angkor
15. After the keyboard package is installed, verify:
  * no Toast notifications appear about "checking for associated dictionary"
  * two Toast notifications do appear about a "dictionary being installed in the background" and eventually "Resources successfully updated" (this may take a while depending on network lag)
  