### PR TITLE
feat(developer): add kmlmc and kmldmlc to `make test` 🙀

### DIFF
--- a/developer/src/kmlmc/Makefile
+++ b/developer/src/kmlmc/Makefile
@@ -5,13 +5,16 @@
 !include ..\Defines.mak
 
 build: .virtual
-    $(GIT_BASH_FOR_KEYMAN) build.sh -test
+    $(GIT_BASH_FOR_KEYMAN) build.sh
 
 clean: .virtual
 #TODO: move to build.sh `clean` target
     -rd /s/q dist
     -rd /s/q dist-tests
     -del tsconfig.tsbuildinfo
+
+test: .virtual
+    $(GIT_BASH_FOR_KEYMAN) build.sh -tdd
 
 signcode:
     @rem nothing to do

--- a/developer/src/test/auto/Makefile
+++ b/developer/src/test/auto/Makefile
@@ -25,7 +25,9 @@ developer-tests: \
   kmx-file-languages \
   lexical-model-compiler \
   model-ts-parser \
-  package-info
+  package-info \
+  kmlmc \
+  kmldmlc
 
 # ----------------------------------------------------------------------
 
@@ -78,6 +80,18 @@ model-ts-parser: .virtual
 
 package-info: .virtual
   cd $(DEVELOPER_ROOT)\src\test\auto\package-info
+  $(MAKE) $(TARGET)
+
+# ----------------------------------------------------------------------
+# Tests outside the test/auto folder
+# ----------------------------------------------------------------------
+
+kmldmlc: .virtual
+  cd $(DEVELOPER_ROOT)\src\kmldmlc
+  $(MAKE) $(TARGET)
+
+kmlmc: .virtual
+  cd $(DEVELOPER_ROOT)\src\kmlmc
   $(MAKE) $(TARGET)
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #7180.

Also removes `-test` from normal `make build` for kmlmc, moving that responsibility to `make test` (but uses `-tdd` to avoid rebuild).

@keymanapp-test-bot skip