### PR TITLE
feat(common): add size and offset calculators to hextobin 🙀

### DIFF
--- a/common/tools/hextobin/hextobin.ts
+++ b/common/tools/hextobin/hextobin.ts
@@ -9,11 +9,19 @@ let outputFilename: string = "";
 program
   .description(
 `Will convert the input file which is a hex dump to the output file. Hex dump can contain
-blank lines, offsets and comments. File writing will start at zero if no offset given;
-any blank spaces in the file will be filled with nul bytes.
+blank lines, offsets, commands and comments. File writing will start at zero, padding is
+not currently supported.
 
-0x1234: 11 22 33 44 55 aa bb     # This is a comment
-# offset(0xhex|dec): hex bytes            # comment`
+Format:
+
+  # This is a comment
+  block(name)              # each part of file must be defined as a block
+  11 22 33 44 55 aa bb     # inserts hex bytes
+  offset(block)            # inserts 4 byte offset of block from BOF
+  sizeof(block[,divisor])  # inserts 4 byte size of block, optionally divided by divisor
+  diff(block1,block2)      # inserts 4 byte offset diff between start of block1 and block2
+  # block names are required, but if not referenced can be reused (e.g. block(x))
+`
   )
   .arguments('<infile>')
   .arguments('<outfile>')
@@ -34,4 +42,4 @@ function exitDueToUsageError(message: string): never  {
 
 import hextobin from './index';
 
-hextobin(inputFilename, outputFilename, {silent: true});
+hextobin(inputFilename, outputFilename, {silent: false});

--- a/common/tools/hextobin/package.json
+++ b/common/tools/hextobin/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "commander": "^3.0.0"
   },
-  "main": "build/index.js",
+  "main": "build/hextobin.js",
   "bin": {
     "hextobin": "build/hextobin.js"
   },

--- a/common/tools/hextobin/package.json
+++ b/common/tools/hextobin/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "commander": "^3.0.0"
   },
-  "main": "build/hextobin.js",
+  "main": "build/index.js",
   "bin": {
     "hextobin": "build/hextobin.js"
   },

--- a/core/tests/unit/ldml/invalid-keyboards/ik_000_null_invalid.txt
+++ b/core/tests/unit/ldml/invalid-keyboards/ik_000_null_invalid.txt
@@ -1,5 +1,5 @@
 
-0x0000:            #  struct COMP_KEYBOARD {
+block(kmx)         #  struct COMP_KEYBOARD {
   4b 58 54 53      #    KMX_DWORD dwIdentifier;   // 0000 Keyman compiled keyboard id
 
   00 10 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
@@ -27,14 +27,15 @@
                    #  };
 
 
-0x0040:            #  struct COMP_KEYBOARD_KMXPLUSINFO {
+block(kmxplus)     #  struct COMP_KEYBOARD_KMXPLUSINFO {
   00 00 00 00      #  KMX_DWORD dpKMXPlus;      // 0040 offset of KMXPlus data, <sect> header is first
   00 00 00 00      #  KMX_DWORD dwKMXPlusSize;  // 0044 size in bytes of entire KMXPlus data
                    #};
 
-0x0050: 23 20 54 68 69 73 20 69 73 20 6e 6f 74 20 79 65  #  # This is not ye
-0x0060: 74 20 61 20 76 61 6c 69 64 20 2e 6b 6d 78 20 66  #  t a valid .kmx f
-0x0070: 69 6c 65 2e 20 48 61 6e 64 20 67 65 6e 65 72 61  #  ile. Hand genera
-0x0080: 74 65 64 20 74 6f 20 73 65 74 20 74 68 65 20 30  #  ted to set the 0
-0x0090: 78 32 30 20 76 61 6c 75 65 20 69 6e 20 64 77 46  #  x20 value in dwF
-0x00a0: 6c 61 67 73                                      #  lags
+block(kmxplusdata)
+  23 20 54 68 69 73 20 69 73 20 6e 6f 74 20 79 65  #  # This is not ye
+  74 20 61 20 76 61 6c 69 64 20 2e 6b 6d 78 20 66  #  t a valid .kmx f
+  69 6c 65 2e 20 48 61 6e 64 20 67 65 6e 65 72 61  #  ile. Hand genera
+  74 65 64 20 74 6f 20 73 65 74 20 74 68 65 20 30  #  ted to set the 0
+  78 32 30 20 76 61 6c 75 65 20 69 6e 20 64 77 46  #  x20 value in dwF
+  6c 61 67 73                                      #  lags

--- a/developer/src/kmldmlc/test/fixtures/basic.txt
+++ b/developer/src/kmldmlc/test/fixtures/basic.txt
@@ -1,4 +1,4 @@
-0x0000:            #  struct COMP_KEYBOARD {
+block(kmxheader)  #  struct COMP_KEYBOARD {
   4b 58 54 53      #    KMX_DWORD dwIdentifier;   // 0000 Keyman compiled keyboard id
 
   00 10 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
@@ -26,72 +26,70 @@
                    #  };
 
 
-0x0040:            #  struct COMP_KEYBOARD_KMXPLUSINFO {
-  48 00 00 00      #    KMX_DWORD dpKMXPlus;      // 0040 offset of KMXPlus data, <sect> header is first
-  52 01 00 00      #    KMX_DWORD dwKMXPlusSize;  // 0044 size in bytes of entire KMXPlus data
-                   #  };
+block(kmxplusinfo)                  #  struct COMP_KEYBOARD_KMXPLUSINFO {
+  offset(sect)                      #    KMX_DWORD dpKMXPlus;      // 0040 offset of KMXPlus data from BOF, <sect> header is first
+  diff(sect,eof)                    #    KMX_DWORD dwKMXPlusSize;  // 0044 size in bytes of entire KMXPlus data
+                                    #  };
 
-0x0048:            #  struct COMP_KMXPLUS_SECT {
+block(sect)        #  struct COMP_KMXPLUS_SECT {
   73 65 63 74      #    KMX_DWORD header.ident;   // 0000 Section name
-  30 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
-  52 01 00 00      #    KMX_DWORD total;          // 0008 KMXPlus entire length
+  sizeof(sect)     #    KMX_DWORD header.size;    // 0004 Section length
+  diff(sect,eof)   #    KMX_DWORD total;          // 0008 KMXPlus entire length
   04 00 00 00      #    KMX_DWORD count;          // 000C number of section headers
 
   73 74 72 73      #    KMX_DWORD sect;    // 0010+ Section identity - strs
-  30 00 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+  diff(sect,strs)  #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
 
   6d 65 74 61      #    KMX_DWORD sect;    // 0010+ Section identity - meta
-  ea 00 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+  diff(sect,meta)  #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
 
   6c 6f 63 61      #    KMX_DWORD sect;    // 0010+ Section identity - loca
-  0e 01 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+  diff(sect,loca)  #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
 
   6b 65 79 73      #    KMX_DWORD sect;    // 0010+ Section identity - keys
-  22 01 00 00      #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
+  diff(sect,keys)  #    KMX_DWORD offset;  // 0014+ Section offset relative to dpKMXPlus of section
                    #  };
 
-0x0078:            #  struct COMP_KMXPLUS_STRS {
-  73 74 72 73      #    KMX_DWORD header.ident;   // 0000 Section name - strs
-  ba 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
-  09 00 00 00      #    KMX_DWORD count;          // 0008 count of str entries
-  00 00 00 00      #    KMX_DWORD reserved;       // 000C padding
+block(strs)          #  struct COMP_KMXPLUS_STRS {
+  73 74 72 73        #    KMX_DWORD header.ident;   // 0000 Section name - strs
+  diff(strs,endstrs) #    KMX_DWORD header.size;    // 0004 Section length
+  09 00 00 00        #    KMX_DWORD count;          // 0008 count of str entries
+  00 00 00 00        #    KMX_DWORD reserved;       // 000C padding
 
-  58 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  07 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  68 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  06 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  76 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  0b 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  8e 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  06 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  9c 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  03 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  a4 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  aa 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  b0 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  01 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
-  b4 00 00 00      #    KMX_DWORD offset;         // 0010+ offset from this blob
-  02 00 00 00      #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+  # Next sections are string entries
+  #    KMX_DWORD offset;         // 0010+ offset from this blob
+  #    KMX_DWORD length;         // 0014+ str length (UTF-16LE units)
+
+  diff(strs,strName)       sizeof(strName,2)
+  diff(strs,strAuthor)     sizeof(strAuthor,2)
+  diff(strs,strConformsTo) sizeof(strConformsTo,2)
+  diff(strs,strLayout)     sizeof(strLayout,2)
+  diff(strs,strNorm)       sizeof(strNorm,2)
+  diff(strs,strIndicator)  sizeof(strIndicator,2)
+  diff(strs,strLocale)     sizeof(strLocale,2)
+  diff(strs,strKey1)       sizeof(strKey1,2)
+  diff(strs,strKey2)       sizeof(strKey2,2)
                    # };
 
-# String table
+# String table -- block(x) is used to store the null u16char at end of each string
+#                 without interfering with sizeof() calculation above
 
-  54 00 65 00 73 00 74 00 4b 00 62 00 64 00 00 00 # 0:TestKbd
-  73 00 72 00 6c 00 32 00 39 00 35 00 00 00       # 1:srl295
-  74 00 65 00 63 00 68 00 70 00 72 00 65 00 76 00
-  69 00 65 00 77 00 00 00                         # 2:techpreview
-  71 00 77 00 65 00 72 00 74 00 79 00 00 00       # 3:qwerty
-  4e 00 46 00 43 00 00 00                         # 4:NFC
-  3d d8 40 de 00 00                               # 5:🙀
-  6d 00 74 00 00 00                               # 6:mt
-  27 01 00 00                                     # 7:ħ
-  90 17 b6 17 00 00                               # 8:ថា
+block(strName)             54 00 65 00 73 00 74 00 4b 00 62 00 64 00   block(x) 00 00 # 0:TestKbd
+block(strAuthor)           73 00 72 00 6c 00 32 00 39 00 35 00   block(x) 00 00       # 1:srl295
+block(strConformsTo)       74 00 65 00 63 00 68 00 70 00 72 00 65 00 76 00
+                           69 00 65 00 77 00   block(x) 00 00                         # 2:techpreview
+block(strLayout)           71 00 77 00 65 00 72 00 74 00 79 00   block(x) 00 00       # 3:qwerty
+block(strNorm)             4e 00 46 00 43 00   block(x) 00 00                         # 4:NFC
+block(strIndicator)        3d d8 40 de   block(x) 00 00                               # 5:🙀
+block(strLocale)           6d 00 74 00   block(x) 00 00                               # 7:mt
+block(strKey1)             27 01   block(x) 00 00                                     # 8:ħ
+block(strKey2)             90 17 b6 17   block(x) 00 00                               # 9:ថា
 
-0x132:             # struct COMP_KMXPLUS_META {
-  6d 65 74 61      #    KMX_DWORD header.ident;   // 0000 Section name - meta
-  24 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+block(endstrs)    # end of strs block
+
+block(meta)        # struct COMP_KMXPLUS_META {
+  6d 65 74 61      #   KMX_DWORD header.ident;   // 0000 Section name - meta
+  sizeof(meta)     #   KMX_DWORD header.size;    // 0004 Section length
   00 00 00 00      #   KMX_DWORD name;
   01 00 00 00      #   KMX_DWORD author;
   02 00 00 00      #   KMX_DWORD conform;
@@ -101,17 +99,17 @@
   00 00 00 00      #   KMX_DWORD settings;
                    # };
 
-0x0156:            # struct COMP_KMXPLUS_LOCA {
+block(loca)        # struct COMP_KMXPLUS_LOCA {
   6c 6f 63 61      #    KMX_DWORD header.ident;   // 0000 Section name - loca
-  14 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  sizeof(loca)     #    KMX_DWORD header.size;    // 0004 Section length
   01 00 00 00      #    KMX_DWORD count; // 0008 number of locales
   00 00 00 00      #    KMX_DWORD reserved;
   06 00 00 00      #    KMX_DWORD locale; // 0010+ locale string entry = 'mt'
                    # };
 
-0x016a:            # struct COMP_KMXPLUS_KEYS {
+block(keys)        # struct COMP_KMXPLUS_KEYS {
   6b 65 79 73      #    KMX_DWORD header.ident;   // 0000 Section name - keys
-  30 00 00 00      #    KMX_DWORD header.size;    // 0004 Section length
+  sizeof(keys)     #    KMX_DWORD header.size;    // 0004 Section length
   02 00 00 00      #    KMX_DWORD count;    // number of keys
   00 00 00 00      #    KMX_DWORD reserved; // padding
                    # };
@@ -120,3 +118,5 @@
 
   c0 00 00 00  00 00 00 00  07 00 00 00  01 00 00 00   # KMX_DWORD vkey, mod, to, flags;
   31 00 00 00  00 00 00 00  08 00 00 00  01 00 00 00   # KMX_DWORD vkey, mod, to, flags;
+
+block(eof)   # end of file


### PR DESCRIPTION
This makes it easier to write a binary file which contains offsets and size values. Using this for unit tests for the LDML keyboard compiler.

Example kmldmlc basic.txt is updated and included.

Future enhancement suggestion: include count() for repeated blocks and index() for block indices within these repeated blocks. Would be very useful for string tables in the example ref.

The real benefit can be seen in the follow-up PR #7187 with far fewer changes required to basic.txt fixture for an additional field.

@keymanapp-test-bot skip