### PR TITLE
fix(developer): compiler mismatch on currentLine

### DIFF
--- a/developer/src/kmcmpdll/DeprecationChecks.cpp
+++ b/developer/src/kmcmpdll/DeprecationChecks.cpp
@@ -25,7 +25,7 @@ BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
       // Keyman 7
       #define TSS_WINDOWSLANGUAGES 29
   */
-  int currentLineBackup = currentLine;
+  int oldCurrentLine = currentLine;
   DWORD i;
   PFILE_STORE sp;
 
@@ -46,7 +46,7 @@ BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
     }
   }
 
-  currentLine = currentLineBackup;
+  currentLine = oldCurrentLine;
 
   return TRUE;
 }

--- a/developer/src/kmcmpdll/UnreachableRules.cpp
+++ b/developer/src/kmcmpdll/UnreachableRules.cpp
@@ -24,6 +24,8 @@ DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
   PFILE_KEY kp = gp->dpKeyArray;
   DWORD i;
 
+  int oldCurrentLine = currentLine;
+
   std::unordered_map<std::wstring, FILE_KEY> map;
   std::unordered_set<int> reportedLines;
 
@@ -42,6 +44,8 @@ DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
       map.insert({ key, *kp });
     }
   }
+
+  currentLine = oldCurrentLine;
 
   return CERR_None;
 }


### PR DESCRIPTION
Fixes #7122.

The compiler was updating currentLine when checking for unreachable rules, but not restoring it afterwards. This led to mismatches in the debugger and in compiler warnings.

# User Testing

TEST_SINGLE_STEP: Verify that single step in the debugger no longer ends up on the wrong line

1. Load khmer_angkor.kmn in Keyman Developer, and start debugging (<kbd>F5</kbd>).
2. Type <kbd>x</kbd><kbd>E</kbd><kbd>j</kbd>
3. Turn on the Single Step mode from Debug menu.
4. Type <kbd>m</kbd>, and step through with Debug/Step Forward.
5. Step forward through to the `normalise` group, and then verify that the next step shows the correct rule that is applied, not a blank line.