### PR TITLE
fix(developer): compiler mismatch on currentLine 🍒

### DIFF
--- a/windows/src/developer/kmcmpdll/DeprecationChecks.cpp
+++ b/windows/src/developer/kmcmpdll/DeprecationChecks.cpp
@@ -26,7 +26,7 @@ BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
       // Keyman 7
       #define TSS_WINDOWSLANGUAGES 29 
   */
-  int currentLineBackup = currentLine;
+  int oldCurrentLine = currentLine;
   DWORD i;
   PFILE_STORE sp;
 
@@ -47,7 +47,7 @@ BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
     }
   }
 
-  currentLine = currentLineBackup;
+  currentLine = oldCurrentLine;
 
   return TRUE;
 }

--- a/windows/src/developer/kmcmpdll/UnreachableRules.cpp
+++ b/windows/src/developer/kmcmpdll/UnreachableRules.cpp
@@ -25,6 +25,8 @@ DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
   PFILE_KEY kp = gp->dpKeyArray;
   DWORD i;
 
+  int oldCurrentLine = currentLine;
+
   std::unordered_map<std::wstring, FILE_KEY> map;
   std::unordered_set<int> reportedLines;
 
@@ -43,6 +45,8 @@ DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
       map.insert({ key, *kp });
     }
   }
+
+  currentLine = oldCurrentLine;
 
   return CERR_None;
 }


### PR DESCRIPTION
Fixes #7122.

Cherry-pick of #7190.

The compiler was updating currentLine when checking for unreachable rules, but not restoring it afterwards. This led to mismatches in the debugger and in compiler warnings.

@keymanapp-test-bot skip