### PR TITLE
chore(linux): Fix ibus-keyman.postinst script

### DIFF
--- a/linux/debian/ibus-keyman.postinst
+++ b/linux/debian/ibus-keyman.postinst
@@ -37,8 +37,8 @@ case "$1" in
       fi
 
       # Verify that it's running now
-      if [ ! -z $SUDO_USER ]; then
-        ! ibusdaemon=`ps --user $SUDO_USER -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*"`
+      if [ ! -z $SUDO_USER ] && id $SUDO_USER > /dev/null 2>/dev/null; then
+        ! ibusdaemon=$(ps --user $SUDO_USER -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*")
         if [ "x$ibusdaemon" = "x" ]; then
           # otherwise try to start it for the user installing the package
           if [ "x$is_gnome_shell" = "x1" ]; then


### PR DESCRIPTION
When installing ibus-keyman it could happen that we got an (ignored) error "user name does not exist". This change tries to work around this problem.

@keymanapp-test-bot skip