### PR TITLE
feat(developer): add compiler hint for non-minimal loca 🙀

### DIFF
--- a/developer/src/kmldmlc/src/keyman/compiler/errors.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/errors.ts
@@ -41,6 +41,10 @@ export class CompilerErrors {
     m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${errorText}`);
   static ERROR_InvalidFile = SevError | 0x0007;
 
+  static LocaleIsNotMinimalAndClean = (sourceLocale: string, locale: string) =>
+    m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${sourceLocale}' is not minimal or correctly formatted and should be '${locale}'`);
+  static HINT_LocaleIsNotMinimalAndClean = SevHint | 0x0008;
+
   static severityName(code: number): string {
     let severity = code & CompilerErrorSeverity.Severity_Mask;
     switch(severity) {

--- a/developer/src/kmldmlc/test/test-loca.ts
+++ b/developer/src/kmldmlc/test/test-loca.ts
@@ -22,8 +22,11 @@ describe('loca', function () {
     let loca = loadSectionFixture(LocaCompiler, 'sections/loca/multiple.xml', callbacks) as Loca;
 
     // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
-    assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.OneOrMoreRepeatedLocales());
+    assert.equal(callbacks.messages.length, 4);
+    assert.deepEqual(callbacks.messages[0], CompilerErrors.LocaleIsNotMinimalAndClean('fr-FR','fr'));
+    assert.deepEqual(callbacks.messages[1], CompilerErrors.LocaleIsNotMinimalAndClean('km-khmr-kh', 'km'));
+    assert.deepEqual(callbacks.messages[2], CompilerErrors.LocaleIsNotMinimalAndClean('fr-fr', 'fr'));
+    assert.deepEqual(callbacks.messages[3], CompilerErrors.OneOrMoreRepeatedLocales());
 
     // Original is 6 locales, now five minimized in the results
     assert.equal(loca.locales.length, 5);


### PR DESCRIPTION
If a loca entry is either formatted wrongly (e.g. wrong case), or is not minimal, then the compiler will now report a hint.

@keymanapp-test-bot skip