### PR TITLE
refactor(developer): kmldmlc - rename `CompilerErrors` to `CompilerMessages` 🙀

### DIFF
--- a/developer/src/kmldmlc/src/keyman/compiler/keys.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/keys.ts
@@ -2,7 +2,7 @@ import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { Keys } from '../kmx/kmx-plus';
 import * as LDMLKeyboard from '../ldml-keyboard/ldml-keyboard-xml';
 import { USVirtualKeyMap } from "../ldml-keyboard/us-virtual-keys";
-import { CompilerErrors } from './errors';
+import { CompilerMessages } from './messages';
 
 import { SectionCompiler } from "./section-compiler";
 
@@ -37,7 +37,7 @@ export class KeysCompiler extends SectionCompiler {
     for(let row of layer.row) {
       y++;
       if(y > USVirtualKeyMap.length) {
-        this.callbacks.reportMessage(CompilerErrors.HardwareLayerHasTooManyRows());
+        this.callbacks.reportMessage(CompilerMessages.Error_HardwareLayerHasTooManyRows());
         break;
       }
 
@@ -46,13 +46,13 @@ export class KeysCompiler extends SectionCompiler {
       for(let key of keys) {
         x++;
         if(x > USVirtualKeyMap[y].length) {
-          this.callbacks.reportMessage(CompilerErrors.RowOnHardwareLayerHasTooManyKeys({row: y+1}));
+          this.callbacks.reportMessage(CompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({row: y+1}));
           break;
         }
 
         let keydef = this.keyboard.keys?.key?.find(x => x.id == key);
         if(!keydef) {
-          this.callbacks.reportMessage(CompilerErrors.KeyNotFoundInKeyBag({keyId: key, col: x+1, row: y+1, layer: layer.id, form: 'hardware'}));
+          this.callbacks.reportMessage(CompilerMessages.Error_KeyNotFoundInKeyBag({keyId: key, col: x+1, row: y+1, layer: layer.id, form: 'hardware'}));
         }
 
         result.keys.push({

--- a/developer/src/kmldmlc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/loca.ts
@@ -1,7 +1,7 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { Loca } from "../kmx/kmx-plus";
 import { SectionCompiler } from "./section-compiler";
-import { CompilerErrors } from "./errors";
+import { CompilerMessages } from "./messages";
 import { LKKeyboard } from "../ldml-keyboard/ldml-keyboard-xml";
 
 export class LocaCompiler extends SectionCompiler {
@@ -27,7 +27,7 @@ export class LocaCompiler extends SectionCompiler {
         new Intl.Locale(tag);
       } catch(e) {
         if(e instanceof RangeError) {
-          this.callbacks.reportMessage(CompilerErrors.InvalidLocale({tag}));
+          this.callbacks.reportMessage(CompilerMessages.Error_InvalidLocale({tag}));
           valid = false;
         } else {
           throw e;
@@ -46,7 +46,7 @@ export class LocaCompiler extends SectionCompiler {
     const locales = sourceLocales.map((sourceLocale: string) => {
       const locale = new Intl.Locale(sourceLocale).minimize().toString();
       if(locale != sourceLocale) {
-        this.callbacks.reportMessage(CompilerErrors.LocaleIsNotMinimalAndClean(sourceLocale, locale));
+        this.callbacks.reportMessage(CompilerMessages.Hint_LocaleIsNotMinimalAndClean(sourceLocale, locale));
       }
       return locale;
     });
@@ -57,7 +57,7 @@ export class LocaCompiler extends SectionCompiler {
     result.locales = (Intl as any).getCanonicalLocales(locales);
 
     if(result.locales.length < locales.length) {
-      this.callbacks.reportMessage(CompilerErrors.OneOrMoreRepeatedLocales());
+      this.callbacks.reportMessage(CompilerMessages.Hint_OneOrMoreRepeatedLocales());
     }
 
     return result;

--- a/developer/src/kmldmlc/src/keyman/compiler/messages.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/messages.ts
@@ -16,32 +16,32 @@ const SevHint = CompilerErrorSeverity.Hint;
 const SevError = CompilerErrorSeverity.Error;
 // const SevFatal = CompilerErrorSeverity.Fatal;
 
-export class CompilerErrors {
-  static InvalidNormalization = (o:{form: string}) => m(this.ERROR_InvalidNormalization, `Invalid normalization form '${o.form}`);
+export class CompilerMessages {
+  static Error_InvalidNormalization = (o:{form: string}) => m(this.ERROR_InvalidNormalization, `Invalid normalization form '${o.form}`);
   static ERROR_InvalidNormalization = SevError | 0x0001;
 
-  static InvalidLocale = (o:{tag: string}) => m(this.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${o.tag}`);
+  static Error_InvalidLocale = (o:{tag: string}) => m(this.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${o.tag}`);
   static ERROR_InvalidLocale = SevError | 0x0002;
 
-  static HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
+  static Error_HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
   static ERROR_HardwareLayerHasTooManyRows = SevError | 0x0003;
 
-  static RowOnHardwareLayerHasTooManyKeys = (o:{row: number}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' layer has too many keys`);
+  static Error_RowOnHardwareLayerHasTooManyKeys = (o:{row: number}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' layer has too many keys`);
   static ERROR_RowOnHardwareLayerHasTooManyKeys = SevError | 0x0004;
 
-  static KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
+  static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
      m(this.ERROR_KeyNotFoundInKeyBag, `Key ${o.keyId} in position #${o.col} on row #${o.row} of layer ${o.layer}, form '${o.form}' not found in key bag`);
   static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
 
-  static OneOrMoreRepeatedLocales = () =>
+  static Hint_OneOrMoreRepeatedLocales = () =>
     m(this.HINT_OneOrMoreRepeatedLocales, `After minimization, one or more locales is repeated and has been removed`);
   static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
 
-  static InvalidFile = (errorText: string) =>
+  static Error_InvalidFile = (errorText: string) =>
     m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${errorText}`);
   static ERROR_InvalidFile = SevError | 0x0007;
 
-  static LocaleIsNotMinimalAndClean = (sourceLocale: string, locale: string) =>
+  static Hint_LocaleIsNotMinimalAndClean = (sourceLocale: string, locale: string) =>
     m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${sourceLocale}' is not minimal or correctly formatted and should be '${locale}'`);
   static HINT_LocaleIsNotMinimalAndClean = SevHint | 0x0008;
 

--- a/developer/src/kmldmlc/src/keyman/compiler/meta.ts
+++ b/developer/src/kmldmlc/src/keyman/compiler/meta.ts
@@ -1,7 +1,7 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { KeyboardSettings, Meta, Meta_NormalizationForm } from "../kmx/kmx-plus";
 import { isValidEnumValue } from "../util/util";
-import { CompilerErrors } from "./errors";
+import { CompilerMessages } from "./messages";
 import { SectionCompiler } from "./section-compiler";
 import * as semver from "semver";
 
@@ -34,7 +34,7 @@ export class MetaCompiler extends SectionCompiler {
   private validateNormalization(normalization?: string) {
     if (normalization !== undefined) {
       if (!isValidEnumValue(Meta_NormalizationForm, normalization)) {
-        this.callbacks.reportMessage(CompilerErrors.InvalidNormalization({ form: normalization }));
+        this.callbacks.reportMessage(CompilerMessages.Error_InvalidNormalization({ form: normalization }));
         return false;
       }
     }

--- a/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmldmlc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -2,7 +2,7 @@ import * as xml2js from 'xml2js';
 import LDMLKeyboardXMLSourceFile from './ldml-keyboard-xml';
 import CompilerCallbacks from '../compiler/callbacks';
 import Ajv from 'ajv';
-import { CompilerErrors } from '../compiler/errors';
+import { CompilerMessages } from '../compiler/messages';
 
 export default class LDMLKeyboardXMLSourceFileReader {
   private readonly callbacks: CompilerCallbacks;
@@ -49,7 +49,7 @@ export default class LDMLKeyboardXMLSourceFileReader {
     const schema = JSON.parse(this.callbacks.loadLdmlKeyboardSchema().toString('utf8'));
     const ajv = new Ajv();
     if(!ajv.validate(schema, source)) {
-      this.callbacks.reportMessage(CompilerErrors.InvalidFile(ajv.errorsText()));
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile(ajv.errorsText()));
       return null;
     }
     return source;

--- a/developer/src/kmldmlc/src/kmldmlc.ts
+++ b/developer/src/kmldmlc/src/kmldmlc.ts
@@ -9,7 +9,7 @@ import * as program from 'commander';
 
 import Compiler from './keyman/compiler/compiler';
 import KMXBuilder from './keyman/kmx/kmx-builder';
-import { CompilerErrors } from './keyman/compiler/errors';
+import { CompilerMessages } from './keyman/compiler/messages';
 import { CompilerEvent } from './keyman/compiler/callbacks';
 
 let inputFilename: string;
@@ -44,7 +44,7 @@ class CompilerCallbacks {
     return fs.readFileSync(filename);
   }
   reportMessage(event: CompilerEvent): void {
-    console.log(CompilerErrors.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
+    console.log(CompilerMessages.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
   }
   loadLdmlKeyboardSchema(): Buffer {
     return fs.readFileSync(path.join(__dirname, 'ldml-keyboard.schema.json'));

--- a/developer/src/kmldmlc/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmldmlc/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import {assert} from 'chai';
 import {CompilerCallbacks, makePathToFixture} from '../helpers/index';
 import LDMLKeyboardXMLSourceFileReader from '../../src/keyman/ldml-keyboard/ldml-keyboard-xml-reader';
-import { CompilerErrors } from '../../src/keyman/compiler/errors';
+import { CompilerMessages } from '../../src/keyman/compiler/messages';
 
 describe('ldml keyboard xml reader tests', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
@@ -14,7 +14,7 @@ describe('ldml keyboard xml reader tests', function() {
     const source = reader.loadFile(inputFilename);
     assert.isNull(source);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidFile("data/keyboard must have required property 'names'"));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile("data/keyboard must have required property 'names'"));
   });
 
   it("should fail to load files with an invalid conformsTo", function() {
@@ -24,7 +24,7 @@ describe('ldml keyboard xml reader tests', function() {
     const source = reader.loadFile(inputFilename);
     assert.isNull(source);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidFile("data/keyboard/conformsTo must be equal to one of the allowed values"));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile("data/keyboard/conformsTo must be equal to one of the allowed values"));
   });
 
 });

--- a/developer/src/kmldmlc/test/test-loca.ts
+++ b/developer/src/kmldmlc/test/test-loca.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { LocaCompiler } from '../src/keyman/compiler/loca';
 import { CompilerCallbacks, loadSectionFixture } from './helpers';
 import { Loca } from '../src/keyman/kmx/kmx-plus';
-import { CompilerErrors } from '../src/keyman/compiler/errors';
+import { CompilerMessages } from '../src/keyman/compiler/messages';
 
 describe('loca', function () {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
@@ -23,10 +23,10 @@ describe('loca', function () {
 
     // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
     assert.equal(callbacks.messages.length, 4);
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.LocaleIsNotMinimalAndClean('fr-FR','fr'));
-    assert.deepEqual(callbacks.messages[1], CompilerErrors.LocaleIsNotMinimalAndClean('km-khmr-kh', 'km'));
-    assert.deepEqual(callbacks.messages[2], CompilerErrors.LocaleIsNotMinimalAndClean('fr-fr', 'fr'));
-    assert.deepEqual(callbacks.messages[3], CompilerErrors.OneOrMoreRepeatedLocales());
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('fr-FR','fr'));
+    assert.deepEqual(callbacks.messages[1], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('km-khmr-kh', 'km'));
+    assert.deepEqual(callbacks.messages[2], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('fr-fr', 'fr'));
+    assert.deepEqual(callbacks.messages[3], CompilerMessages.Hint_OneOrMoreRepeatedLocales());
 
     // Original is 6 locales, now five minimized in the results
     assert.equal(loca.locales.length, 5);
@@ -44,7 +44,7 @@ describe('loca', function () {
     assert.equal(callbacks.messages.length, 1);
     // We'll only test one invalid BCP 47 tag to verify that we are properly calling BCP 47 validation routines.
     // Furthermore, we are testing BCP 47 structure, not the validity of each subtag -- we must assume the author knows of new subtags!
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidLocale({tag:'en-*'}));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidLocale({tag:'en-*'}));
   })
 });
 

--- a/developer/src/kmldmlc/test/test-meta.ts
+++ b/developer/src/kmldmlc/test/test-meta.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import { MetaCompiler } from '../src/keyman/compiler/meta';
 import { CompilerCallbacks, loadSectionFixture } from './helpers';
 import { KeyboardSettings, Meta } from '../src/keyman/kmx/kmx-plus';
-import { CompilerErrors } from '../src/keyman/compiler/errors';
+import { CompilerMessages } from '../src/keyman/compiler/messages';
 
 describe('meta', function () {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
@@ -41,7 +41,7 @@ describe('meta', function () {
     let meta = loadSectionFixture(MetaCompiler, 'sections/meta/invalid-normalization.xml', callbacks) as Meta;
     assert.isNull(meta);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerErrors.InvalidNormalization({form:'NFQ'}));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidNormalization({form:'NFQ'}));
   });
 });
 


### PR DESCRIPTION
Just wanted to rename this to make it clearer. Also added a prefix to each message generator to indicate the type of message, as otherwise it is not obvious within the compiler which messages are going to cause the compiler to fail.

Note that the message generator function prefixes are Title Cased whereas the message identifier constant prefixes are CAPS. I guess this could be confusing but I think it works okay in practice.

@keymanapp-test-bot skip