### PR TITLE
fix(windows): check if permissions for thread to access file

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -162,7 +162,11 @@ begin
       FilenameBCP47 := Filenames[i].Split(['=']);
       Filename := FilenameBCP47[0];
       IsPackage := AnsiSameText(ExtractFileExt(FileName), '.kmp');
-
+      if not FileExists(FileName) then
+      begin
+        ShowMessage('File: ' + Filename + ' location not available to Admin User');
+        Exit;
+      end;
       if IsPackage then
       begin
         FPackage := (kmcom.Packages as IKeymanPackagesInstalled2).Install2(FileName, True);

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.InstallFile.pas
@@ -164,7 +164,8 @@ begin
       IsPackage := AnsiSameText(ExtractFileExt(FileName), '.kmp');
       if not FileExists(FileName) then
       begin
-        ShowMessage('File: ' + Filename + ' location not available to Admin User');
+        if not ASilent then
+          ShowMessage('File: ' + Filename + ' location not available to Admin User');
         Exit;
       end;
       if IsPackage then

--- a/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
+++ b/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
@@ -164,7 +164,7 @@ begin
       FZip := TZipFile.Create;
       try
         FZip.Open(FileName, TZipMode.zmRead);
-        
+
         InfFile := '';
 
         for i := 0 to FZip.FileCount - 1 do

--- a/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
+++ b/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
@@ -161,6 +161,7 @@ begin
       FTempOutPath := buf; FTempOutPath := FTempOutPath + '\';
 
       inf := nil;
+      // #TODO 6570Check we can access the file and display an error if we can't, then exit.
       FZip := TZipFile.Create;
       try
         FZip.Open(FileName, TZipMode.zmRead);

--- a/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
+++ b/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
@@ -143,8 +143,6 @@ begin
   try
     if not IsAdministrator then
       Error(KMN_E_Install_KeyboardMustBeInstalledByAdmin);   // I3612
-    if not TZipFile.IsValid(FileName) then
-      Error(KMN_E_Install_KeyboardMustBeInstalledByAdmin); // #TODO: 6570 a new error message explaining issue
 
     FAutoApply := Context.Control.AutoApply;
     try
@@ -166,13 +164,7 @@ begin
 
       FZip := TZipFile.Create;
       try
-        // #TODO: 6570: Check we can access the file and display an error
-
-        // try
         FZip.Open(FileName, TZipMode.zmRead);
-         // except on EZipExeception do begin
-        //        ErrorFmt(KMN_E_Install_InvalidFile, VarArrayOf([ExtractFileName(FileName), E.Message]));
-        //    end;
         InfFile := '';
 
         for i := 0 to FZip.FileCount - 1 do

--- a/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
+++ b/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
@@ -143,6 +143,8 @@ begin
   try
     if not IsAdministrator then
       Error(KMN_E_Install_KeyboardMustBeInstalledByAdmin);   // I3612
+    if not TZipFile.IsValid(FileName) then
+      Error(KMN_E_Install_KeyboardMustBeInstalledByAdmin); // #TODO: 6570 a new error message explaining issue
 
     FAutoApply := Context.Control.AutoApply;
     try
@@ -161,11 +163,16 @@ begin
       FTempOutPath := buf; FTempOutPath := FTempOutPath + '\';
 
       inf := nil;
-      // #TODO 6570Check we can access the file and display an error if we can't, then exit.
+
       FZip := TZipFile.Create;
       try
-        FZip.Open(FileName, TZipMode.zmRead);
+        // #TODO: 6570: Check we can access the file and display an error
 
+        // try
+        FZip.Open(FileName, TZipMode.zmRead);
+         // except on EZipExeception do begin
+        //        ErrorFmt(KMN_E_Install_InvalidFile, VarArrayOf([ExtractFileName(FileName), E.Message]));
+        //    end;
         InfFile := '';
 
         for i := 0 to FZip.FileCount - 1 do

--- a/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
+++ b/windows/src/engine/kmcomapi/processes/package/kpinstallpackage.pas
@@ -161,10 +161,10 @@ begin
       FTempOutPath := buf; FTempOutPath := FTempOutPath + '\';
 
       inf := nil;
-
       FZip := TZipFile.Create;
       try
         FZip.Open(FileName, TZipMode.zmRead);
+        
         InfFile := '';
 
         for i := 0 to FZip.FileCount - 1 do


### PR DESCRIPTION
Fixes #6412

The fix addresses the crash by testing for file existence before continuing, in the admin account run, it show a message to the user if not in Silent mode. 

# User Testing Under Contsruction
Testing this is quite tricky. The way I was able to test this was to have a mapped network drive that was accessed with a different user than the user of my local machine.  See. [windows troubleshooting note](https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/mapped-drives-not-available-from-elevated-command)

I can run this test if you are not able to replicate it. 

**TEST_INSTALL_KMP_MAPPED_DRIVE**

1. Install the Keyman associated with this PR.
2. Download a Keyboard file `sil_ipa.kmp` and copy it to a folder on a mapped network drive.
3. Double-click the `sil_ipa.kmp` file on the mapped network drive.
4. Follow all the dialogs that appear. 
5. The window do you want to allow this app to make changes to your device? Select Yes
6.  All the windows will close. The keyboard will not be installed
7. No crash dialog appears.

**TEST_INSTALL_KMP_LOCAL_DRIVE**  Insure the normal case still works

1. Install the Keyman associated with this PR.
2. Download a Keyboard file `sil_ipa.kmp`  ensure it is in a location on your local drive.
3. Double-click the `sil_ipa.kmp` file .
4. Follow all the dialogs that appear. 
5. The window do you want to allow this app to make changes to your device? Select Yes
6. The keyboard should install as per normal with the help file for the keyboard being displayed.

