### PR TITLE
feat(common/models): extra Unicode-based wordbreaker unit tests

### DIFF
--- a/common/models/wordbreakers/src/default/index.ts
+++ b/common/models/wordbreakers/src/default/index.ts
@@ -14,7 +14,7 @@ namespace wordBreakers {
       return [];
     }
 
-    // All non-empty strings have at least TWO boundaries at the start and end of
+    // All non-empty strings have at least TWO boundaries: at the start and at the end of
     // the string.
     let spans = [];
     for (let i = 0; i < boundaries.length - 1; i++) {

--- a/common/models/wordbreakers/test/test-default-word-breaker.js
+++ b/common/models/wordbreakers/test/test-default-word-breaker.js
@@ -178,9 +178,14 @@ describe('The default word breaker', function () {
   });
 
   it('handles emoji flag sequences properly (WB15-16)', function() {
-    let breaks = breakWords(`🇨🇦🇰🇭🇽🇽`); // May not render well within VSCode.
+    // For clarity on what's being tested...
+    let CA_FLAG =      '\u{1f1e8}\u{1f1e6}' // '🇨🇦' (canadian flag emoji); should not be broken.
+    let KH_FLAG =      '\u{1f1f0}\u{1f1ed}' // '🇰🇭' (khmer flag emoji); same
+    let X_FLAG_PIECE = '\u{1f1fd}'          // '🇽'  (half of a flag emoji; '🇽🇽' doesn't match a flag)
+    let breaks = breakWords(`${CA_FLAG}${KH_FLAG}${X_FLAG_PIECE}${X_FLAG_PIECE}`);
     let words = breaks.map(span => span.text);
 
-    assert.deepEqual(words, ['🇨🇦', '🇰🇭', '🇽🇽']); // the last is two emoji in a row.
+    // Note that the emoji may not render well within VSCode, but they show up nicely on GitHub.
+    assert.deepEqual(words, ['🇨🇦', '🇰🇭', '🇽🇽']);
   });
 });

--- a/common/models/wordbreakers/test/test-default-word-breaker.js
+++ b/common/models/wordbreakers/test/test-default-word-breaker.js
@@ -32,4 +32,155 @@ describe('The default word breaker', function () {
       'jump', '32.3', 'feet', ',', 'right', '?'
     ]);
   });
+
+  // The way these two tests are written is a bit much on the "white-box" style,
+  // but they do decently cover the boundary rules mentioned.
+  it('Does not split empty contexts (WB1 + WB2)', function() {
+    let breaks = breakWords('');
+    let words = breaks.map(span => span.text);
+    assert.deepEqual(words, []);
+  });
+
+  it('Does split at context boundaries (WB1 + WB2)', function() {
+    let breaks = breakWords('a');
+    let words = breaks.map(span => span.text);
+    assert.deepEqual(words, ['a']);
+  });
+
+  // WB3, WB3a, WB3b are all handled internally, within the top-level function.
+
+  // iff, as in "if and only if"
+  it('ignores the zero-width joiner iff appropriate (WB4)', function() {
+    const zwj = '\u200d';
+
+    let breaks = breakWords(`a${zwj}b\n${zwj}c${zwj}\nd`);
+    let words = breaks.map(span => span.text);
+
+    // Does NOT ignore the zwj immediately after a newline - the notable exception
+    // (the reason for "iff", not "if").
+    assert.deepEqual(words, [`a${zwj}b`, `${zwj}`, `c${zwj}`, `d`]);
+  })
+
+  it('ignores extend characters iff appropriate (WB4)', function() {
+    const comboGrave = '\u0300'; // The 'combining grave accent', as used in NFD.
+
+    let breaks = breakWords(`a${comboGrave}e\n${comboGrave}i${comboGrave}\no`);
+    let words = breaks.map(span => span.text);
+
+    // Does NOT ignore the zwj immediately after a newline - the notable exception
+    // (the reason for "iff", not "if").
+    assert.deepEqual(words, [`a${comboGrave}e`, `${comboGrave}`, `i${comboGrave}`, `o`]);
+  });
+
+  it('ignores format characters iff appropriate (WB4)', function() {
+    // Re-uses `const SHY` from above.
+    let breaks = breakWords(`a${SHY}e\n${SHY}i${SHY}\no`);
+    let words = breaks.map(span => span.text);
+
+    // Does NOT ignore the zwj immediately after a newline - the notable exception
+    // (the reason for "iff", not "if").
+    assert.deepEqual(words, [`a${SHY}e`, `${SHY}`, `i${SHY}`, `o`]);
+  });
+
+  it('does not break between most alphabetic characters (WB5)', function() {
+    let breaks = breakWords(`aəσאБ лאʈγX`); // a mix of latin, hebrew, greek, cyrillic, and IPA chars
+                                            // for both "words".
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, [`aəσאБ`, `лאʈγX`]);
+  });
+
+  it('does not break letters across specific punctuation patterns (WB6, WB7)', function() {
+    // `'`:  MidNumLetQ (from Single_Quote)
+    // '.':  MidNumLet
+    // ':':  MidLetter
+    let breaks = breakWords(`don't b.r.e.a.k t:h:e:s:e`);
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, [`don't`, `b.r.e.a.k`, `t:h:e:s:e`]);
+
+    let breaks2 = breakWords(`.drop: :the' 'extras.`);
+    let words2 = breaks2.map(span => span.text);
+
+    assert.deepEqual(words2, [`.`, `drop`, `:`, `:`, `the`, `'`, `'`, `extras`, `.`]);
+
+    // ',': MidNum (is NOT included by rule!)
+    let breaks3 = breakWords('do br,eak that');
+    let words3 = breaks3.map(span => span.text);
+
+    assert.deepEqual(words3, ['do', 'br', ',', 'eak', 'that']);
+  });
+
+  it('treats Hebrew properly (WB7a-c)', function() {
+    const aleph = 'א';
+    const bet = 'ב';
+
+    // As Hebrew is RTL... this is probably the clearest way for us LTR people to
+    // clearly see what's going on without ordering mechanics messing up the render.
+    let breaks = breakWords(`${aleph}' ${aleph}" ${aleph}"${bet}`);
+    let words = breaks.map(span => span.text);
+
+    // A lingering double-quote isn't cool, but one in the middle's fine.
+    // Lingering single-quote is fine regardless.
+    assert.deepEqual(words, [`${aleph}'`, `${aleph}`, `"`, `${aleph}"${bet}`]);
+  });
+
+  it(`doesn't break within digit + digit/letter sequences (WB8-10)`, function() {
+    let breaks = breakWords('a1b2c3 hunter2 ab12cd34 1234567890');
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, ['a1b2c3', 'hunter2', 'ab12cd34', '1234567890']);
+  });
+
+  it('does not break within formatted number sequences (WB11-12)', function() {
+    // Note:  `'` fits "MidNumLetQ", part of the two rules!
+    let breaks = breakWords(`1.2.3 3,458.01 3.45'8,01`);
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, [`1.2.3`, `3,458.01`, `3.45'8,01`]);
+
+    let breaks2 = breakWords(`.1' ,3.`);
+    let words2 = breaks2.map(span => span.text);
+
+    assert.deepEqual(words2, [`.`, `1`, `'`, `,`, `3`, `.`]);
+  });
+
+  it('does not break between Katakana (WB13)', function() {
+    const kataSmA = '\u30a2'; //ァ
+    const kataA = '\u30a2'; //ア
+    const kataSound = '\u309b'; // ゛
+
+    let breaks = breakWords(`${kataSound}${kataA} ${kataSmA}${kataSound}b ${kataA}${kataSound}${kataSmA}`);
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, [
+      `${kataSound}${kataA}`,
+      `${kataSmA}${kataSound}`,
+      'b',
+      `${kataA}${kataSound}${kataSmA}`
+    ]);
+  });
+
+  it('does not break form extenders (WB13a-b)', function() {
+    // The `_` (underscore) fits the ExtendNumLet class this rule focuses on.
+    const kataA = '\u30a2'; //ア
+
+    let breaks = breakWords(`${kataA}_a__0_b_${kataA} _${kataA} 1_ _c_ ____`);
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, [
+      `${kataA}_a__0_b_${kataA}`,
+      `_${kataA}`,
+      `1_`,
+      `_c_`,
+      `____`
+    ]);
+  });
+
+  it('handles emoji flag sequences properly (WB15-16)', function() {
+    let breaks = breakWords(`🇨🇦🇰🇭🇽🇽`); // May not render well within VSCode.
+    let words = breaks.map(span => span.text);
+
+    assert.deepEqual(words, ['🇨🇦', '🇰🇭', '🇽🇽']); // the last is two emoji in a row.
+  });
 });


### PR DESCRIPTION
As I'm looking at predictive text issues for non-Roman script languages this sprint, and this may lead me to add features to the wordbreaker... I felt we should probably get some more explicit and directed unit tests in place for our main wordbreaker.  This will help verify that any to-be-done modifications don't break things by mistake.

I did crib a test or two from https://github.com/eddieantonio/unicode-default-word-boundary/blob/master/test/test-split-words.ts, but I tried to go more robust where possible, aside from the emoji-flag case.  Those tests are MIT-licensed, so no worries there.

@keymanapp-test-bot skip