### PR TITLE
fix(developer): suppress repeated warnings about unreachable code

### DIFF
--- a/developer/src/common/delphi/compiler/CompileErrorCodes.pas
+++ b/developer/src/common/delphi/compiler/CompileErrorCodes.pas
@@ -194,7 +194,7 @@ const
   CWARN_VisualKeyboardFileMissing                   = $2097;
   CWARN_ExtendedShiftFlagsNotSupportedInKeymanWeb   = $2098;   // I4118
   CWARN_TouchLayoutUnidentifiedKey                  = $2099;   // I4142
-  CWARN_UnreachableKeyCode                          = $209A;   // I4141
+  CHINT_UnreachableKeyCode                          = $109A;   // I4141
 
   CWARN_CouldNotCopyJsonFile                        = $209B;   // I4688
   CWARN_PlatformNotInTargets                        = $209C;

--- a/developer/src/kmcmpdll/comperr.h
+++ b/developer/src/kmcmpdll/comperr.h
@@ -191,7 +191,7 @@
 #define CWARN_VisualKeyboardFileMissing                    0x00002097
 #define CWARN_ExtendedShiftFlagsNotSupportedInKeymanWeb    0x00002098   // I4118
 #define CWARN_TouchLayoutUnidentifiedKey                   0x00002099
-#define CWARN_UnreachableKeyCode                           0x0000209A
+#define CHINT_UnreachableKeyCode                           0x0000109A
 
 #define CWARN_CouldNotCopyJsonFile                         0x0000209B
 #define CWARN_PlatformNotInTargets                         0x0000209C

--- a/developer/src/tike/compile/CompileKeymanWeb.pas
+++ b/developer/src/tike/compile/CompileKeymanWeb.pas
@@ -102,6 +102,7 @@ uses
   Winapi.Windows,
   System.Character,
   System.Classes,
+  System.Generics.Collections,
   System.UITypes,
 
   compile,
@@ -214,6 +215,7 @@ type
     FTouchLayoutFont: string;
     FFix183_LadderLength: Integer;
     FCloseBrace: Boolean;   // I4872
+    FUnreachableKeys: TList<PFILE_KEY>;
 
     function JavaScript_String(ch: DWord): string;  // I2242
 
@@ -254,6 +256,8 @@ type
     function IsKeyboardVersion15OrLater: Boolean;
     function WriteBeginStatement(const name: string;
       groupIndex: Integer): string;
+    function FormatKeyForErrorMessage(fkp: PFILE_KEY;
+      FMnemonic: Boolean): string;
   public
     function Compile(AOwnerProject: TProject; const InFile: string; const OutFile: string; Debug: Boolean; Callback: TCompilerCallbackW): Boolean;   // I3681   // I4140   // I4688   // I4866
     constructor Create;
@@ -300,6 +304,8 @@ var
   WarnDeprecatedCode: Boolean;
   Data: string;
 begin
+  FUnreachableKeys.Clear;
+
   FCallback := Callback;
   FInFile := InFile;
   FOutFile := OutFile;   // I4140   // I4155   // I4154
@@ -372,6 +378,7 @@ end;
 
 constructor TCompileKeymanWeb.Create;
 begin
+  FUnreachableKeys := TList<PFILE_KEY>.Create;
   FillChar(fk, sizeof(fk), 0);
   FFix183_LadderLength := FKeymanDeveloperOptions.Fix183_LadderLength; // How frequently to break ladders
 end;
@@ -379,6 +386,7 @@ end;
 destructor TCompileKeymanWeb.Destroy;
 begin
   // TODO: Free FK values
+  FUnreachableKeys.Free;
   inherited;
 end;
 
@@ -797,6 +805,63 @@ const // I1585 - add space to conversion
     VK_NUMLOCK,			// &H90
     VK_SCROLL);			// &H91
 
+function TCompileKeymanWeb.FormatKeyForErrorMessage(fkp: PFILE_KEY; FMnemonic: Boolean): string;
+  function FormatShift(ShiftFlags: DWord): string;
+  const
+    mask: array[0..13] of string = (
+      'LCTRL',             // 0X0001
+      'RCTRL',             // 0X0002
+      'LALT',              // 0X0004
+      'RALT',              // 0X0008
+
+      'SHIFT',             // 0X0010
+      'CTRL',              // 0X0020
+      'ALT',               // 0X0040
+
+      '???',               // Reserved
+
+      'CAPS',              // 0X0100
+      'NCAPS',             // 0X0200
+
+      'NUMLOCK',           // 0X0400
+      'NNUMLOCK',          // 0X0800
+
+      'SCROLLLOCK',        // 0X1000
+      'NSCROLLLOCK'        // 0X2000
+    );
+  var
+    i: Integer;
+  begin
+    Result := '';
+    for i := 0 to High(mask) do
+    begin
+      if ShiftFlags and (1 shl i) <> 0 then
+      begin
+        Result := Result + mask[i] + ' ';
+      end;
+    end;
+  end;
+begin
+  if not FMnemonic then
+  begin
+    if (fkp.ShiftFlags and KMX_ISVIRTUALKEY) = KMX_ISVIRTUALKEY then
+    begin
+      if Ord(fkp.Key) < 256
+        then Result := Format('[%s%s]', [FormatShift(fkp.ShiftFlags), VKeyNames[Ord(fkp.Key)]])
+        else Result := Format('[%sK_%x]', [FormatShift(fkp.ShiftFlags), Ord(fkp.Key)]);
+    end
+    else
+    begin
+      Result := Format('''%s''', [fkp.Key]);
+    end;
+  end
+  else
+  begin
+    if (fkp.ShiftFlags and KMX_VIRTUALCHARKEY) = KMX_VIRTUALCHARKEY
+      then Result := Format('[%s''%s'']', [FormatShift(fkp.ShiftFlags), fkp.Key])
+      else Result := Format('''%s''', [fkp.Key]);
+  end;
+end;
 
 function TCompileKeymanWeb.JavaScript_Key(fkp: PFILE_KEY; FMnemonic: Boolean): Integer;
 var
@@ -832,7 +897,13 @@ begin
 
   if (Result = 0) or (Result >= Ord(Low(TKeymanWebTouchStandardKey))) then   // I4141
   begin
-    ReportError(fkp.Line, CWARN_UnreachableKeyCode, 'The rule will never be matched because its key code is never fired.');
+    if not FUnreachableKeys.Contains(fkp) then
+    begin
+      ReportError(fkp.Line, CHINT_UnreachableKeyCode,
+        'The rule will never be matched for key '+
+        FormatKeyForErrorMessage(fkp,FMnemonic)+' because its key code is never fired.');
+      FUnreachableKeys.Add(fkp);
+    end;
   end;
 end;
 


### PR DESCRIPTION
Fixes #7216.

The warning message 0x209A 'The rule will never be matched because its key code is never fired.' was being generated multiple times for a single line because the `JavaScript_Key` function it is generated by is used for various purposes.

This PR keeps a cache of reported key rules to ensure that the message is reported only once for a given key rule, and also improves the reporting to clarify which specific key is unreachable, which makes it easier to diagnose when using `any(k)` style messages, for example:

```
lao_phonetic.kmn (237): Hint: 109A The rule will never be matched for key 'ñ' because its key code is never fired.
```

This also reduces the warning to a hint, as this should not be a blocking issue for a keyboard, rather just a place the keyboard author can tidy up.

# User Testing

**TEST_LAO_PHONETIC:** Load the lao_phonetic keyboard from the keyboards repo, and verify that the message `109A` is generated at most once per line/key when compiling. 

1. you will need to edit the line `store(&TARGETS) 'windows macosx'` and change it to `store(&TARGETS) 'any'` in the keyboard before compiling in order to reproduce this and test it.

2. You may wish to contrast to the current alpha release of Keyman Developer, where hundreds of warnings would be generated.