### PR TITLE
fix(developer): hide key-sizes when in desktop layout in touch layout editor

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.css
+++ b/developer/src/tike/xml/layoutbuilder/builder.css
@@ -613,6 +613,11 @@ body:not(.text-controls-in-toolbar) input#inpSubKeyCap {
   color: white;
 }
 
+#kbd.desktop .key-size {
+  /* the layout is fixed on desktop so key size is not useful */
+  display: none;
+}
+
 /* Position flick keys relative to the flick grid, by hand */
 
 #flick .key {

--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -12,10 +12,7 @@ $(function() {
 
 
   this.getPresentation = function () {
-    var platform = $('#selPlatformPresentation').val();
-    //if(platform == 'tablet') return 'tablet-ipad';
-    //if(platform == 'phone') return 'phone-iphone5';
-    return platform;
+    return $('#selPlatformPresentation').val();
   }
 
   this.saveSelection = function() {

--- a/developer/src/tike/xml/layoutbuilder/constants.js
+++ b/developer/src/tike/xml/layoutbuilder/constants.js
@@ -604,7 +604,8 @@ $(function() {
     "tablet-ipad-landscape": { "x": 829, "y": 299, "name": "iPad (landscape)" }, // 829x622 = iPad tablet box size; (97,101)-(926,723)
     "tablet-ipad-portrait": { "x": 605, "y": 300, "name": "iPad (portrait)" }, // 605x806 = iPad tablet box size; (98,94)-(703,900)
     "phone-iphone5-landscape": { "x": 731, "y": 196, "name": "iPhone 5 (landscape)" }, // 731x412 = iPhone box size; (144,39)-(875,451)
-    "phone-iphone5-portrait": { "x": 526, "y": 266, "name": "iPhone 5 (portrait)"}  // 528x936 = iPhone box size; (90,204)-(618,1040)
+    "phone-iphone5-portrait": { "x": 526, "y": 266, "name": "iPhone 5 (portrait)"}, // 528x936 = iPhone box size; (90,204)-(618,1040)
+    "desktop": { "x": 640, "y": 300, "name": "Desktop" },
   };
 
   this.keyMargin = 15;


### PR DESCRIPTION
Fixes #7028.

Note that the desktop layout is not currently used by KeymanWeb. The designer has a number of additional issues, as the .keyman-touch-layout format is not well suited to describing a fixed hardware layout, but fixing this is outside the scope of this issue.

Key Size information is not relevant for desktop view, so I have chosen to hide it.

# User Testing

Test according to #7028 problem description:

**TEST_DESKTOP_LAYOUT:** Verify that the key size information is no longer visible in desktop view.

1. Open .kpj project using Keyman Developer. (eg., cameroon qwerty.kpj)
2. Click on Touch Layout view.
3. Verify that the 'tablet' option appears under the Platform field.
4. Click the '+' plus button.
5. Verify that the desktop option appears against the Platform dropdown list.
6. Click the OK button.
7. Verify that the Key Size Information no longer is visible.