### PR TITLE
fix(core): ldml: improve utf-32 handling 🙀

### DIFF
--- a/core/src/kmx/kmx_plus.cpp
+++ b/core/src/kmx/kmx_plus.cpp
@@ -7,6 +7,7 @@
 #include <km_types.h>
 #include <kmx_file.h>
 #include <kmx/kmx_plus.h>
+#include <kmx/kmx_xstring.h>
 
 #if KMXPLUS_DEBUG
 #include <iostream>
@@ -158,6 +159,24 @@ COMP_KMXPLUS_KEYS::valid(KMX_DWORD _kmn_unused(length)) const {
   return true;
 }
 
+std::u16string
+COMP_KMXPLUS_KEYS_ENTRY::get_string() const {
+  if (flags & LDML_KEYS_FLAGS_EXTEND) {
+    return std::u16string();  // error, extended
+  }
+  char16_t buf[2];
+  std::size_t len;
+  if (Uni_IsBMP(to)) {
+    buf[0] = (to & 0xFFFF);
+    len    = 1;
+  } else {
+    buf[0] = Uni_UTF32ToSurrogate1(to);
+    buf[1] = Uni_UTF32ToSurrogate2(to);
+    len    = 2;
+  }
+  return std::u16string(buf, len);
+}
+
 bool
 COMP_KMXPLUS_LOCA::valid(KMX_DWORD _kmn_unused(length)) const {
   if (header.size < sizeof(*this)+(sizeof(entries[0])*count)) {
@@ -207,22 +226,36 @@ COMP_KMXPLUS_STRS::valid(KMX_DWORD _kmn_unused(length)) const {
     return false;
   }
   for (KMX_DWORD i=0; i<this->count; i++) {
-    const size_t MYBUFSIZ = 256;
-    KMX_WCHAR buf[MYBUFSIZ];
     KMXPLUS_PRINTF(("#0x%X: ", i));
-    PKMX_WCHAR str = this->get(i, buf, MYBUFSIZ);
-    if (!str) {
-        KMXPLUS_PRINTF(("NULL/ERR\n"));
-        return false;
+    KMX_DWORD offset = entries[i].offset;
+    KMX_DWORD length = entries[i].length;
+    if(offset+((length+1)*2) > header.size) {
+      debug_println("expected end of string past header.size");
+      return false;
     }
-    for(int j=0; str[j] && j<0x30; j++) {
-        if (str[j] < 0x7F && str[j] > 0x20) {
-            KMXPLUS_PRINTF(("%c", str[j]));
+    const uint8_t* thisptr = reinterpret_cast<const uint8_t*>(this);
+    const KMX_WCHAR* start = reinterpret_cast<const KMX_WCHAR*>(thisptr+offset);
+    if(start[length] != 0) {
+      debug_println("String not null terminated");
+      return false;
+    }
+    // TODO-LDML: validate valid UTF-16LE?
+#if KMXPLUS_DEBUG
+    // first print it escaped
+    for(KMX_DWORD j=0; start[j] && j<length; j++) {
+        if (start[j] < 0x7F && start[j] > 0x20) {
+            KMXPLUS_PRINTF(("%c", start[j]));
         } else {
-            KMXPLUS_PRINTF((" U+%04X ", str[j]));
+            KMXPLUS_PRINTF((" U+%04X ", start[j]));
         }
     }
     KMXPLUS_PRINTF(("\n"));
+
+    // // now print it as a string
+    // TODO-LDML
+    // std::u16string str = get(i);
+    // std::cerr << str << std::endl;
+#endif
   }
   return true;
 }
@@ -314,23 +347,19 @@ KMX_DWORD COMP_KMXPLUS_SECT::find(KMX_DWORD ident) const {
   return 0;
 }
 
-PKMX_WCHAR
-COMP_KMXPLUS_STRS::get(KMX_DWORD entry, PKMX_WCHAR buf, KMX_DWORD bufsiz) const {
+std::u16string
+COMP_KMXPLUS_STRS::get(KMX_DWORD entry) const {
     assert(entry < count);
     if (entry >= count) {
-        return nullptr;
+        return std::u16string(); // Fallback: empty string
     }
-    // TODO-LDML: will be improved in https://github.com/keymanapp/keyman/issues/7134
     KMX_DWORD offset = entries[entry].offset;
     KMX_DWORD length = entries[entry].length;
-    assert(bufsiz > (length+1)); // assert bufsiz big enough
     assert(offset+((length+1)*2) <= header.size); // assert not out of bounds
     const uint8_t* thisptr = reinterpret_cast<const uint8_t*>(this);
     const KMX_WCHAR* start = reinterpret_cast<const KMX_WCHAR*>(thisptr+offset);
-    for(KMX_DWORD i=0;i<=length;i++) {
-        buf[i] = start[i];
-    }
-    return buf;
+    assert(start[length] == 0); // assert null terminated
+    return std::u16string(start, length);
 }
 
 }  // namespace kmx

--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -144,7 +144,7 @@ struct COMP_KMXPLUS_KEYS_ENTRY {
     KMX_DWORD to;     // to may be KMXPLUS_STR or UTF32 char
     KMX_DWORD flags;
     /**
-     * @brief Get the 'to' as a string, if not EXTEND
+     * @brief Get the 'to' as a string, if flags&LDML_KEYS_FLAGS_EXTEND is not set
      *
      * @return std::u16string
      */

--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <string>
 #include <km_types.h>
 #include <kmx/kmx_base.h>
 #include <kmx_file.h>
@@ -142,6 +143,12 @@ struct COMP_KMXPLUS_KEYS_ENTRY {
     KMX_DWORD mod;
     KMX_DWORD to;     // to may be KMXPLUS_STR or UTF32 char
     KMX_DWORD flags;
+    /**
+     * @brief Get the 'to' as a string, if not EXTEND
+     *
+     * @return std::u16string
+     */
+    std::u16string get_string() const;
 };
 
 struct COMP_KMXPLUS_KEYS {
@@ -276,7 +283,7 @@ struct COMP_KMXPLUS_STRS {
    * @param bufsiz buffer size in bytes
    * @return nullptr or a pointer to the output buffer
    */
-  PKMX_WCHAR get(KMX_DWORD entry, PKMX_WCHAR buf, KMX_DWORD bufsiz) const;
+  std::u16string get(KMX_DWORD entry) const;
   /**
    * @brief True if section is valid.
    */

--- a/core/src/kmx/kmx_xstring.cpp
+++ b/core/src/kmx/kmx_xstring.cpp
@@ -12,6 +12,22 @@
 using namespace km::kbp;
 using namespace kmx;
 
+int
+km::kbp::kmx::Utf32CharToUtf16(const KMX_DWORD ch32, char16_single &ch16) {
+  int len;
+  if (Uni_IsBMP(ch32)) {
+    len        = 1;
+    ch16.ch[0] = Uni_UTF32BMPToUTF16(ch32);
+    ch16.ch[1] = 0;
+  } else {
+    len        = 2;
+    ch16.ch[0] = Uni_UTF32ToSurrogate1(ch32);
+    ch16.ch[1] = Uni_UTF32ToSurrogate2(ch32);
+    ch16.ch[2] = 0;
+  }
+  return len;
+}
+
 const km_kbp_cp *km::kbp::kmx::u16chr(const km_kbp_cp *p, km_kbp_cp ch) {
   while (*p) {
     if (*p == ch) return p;

--- a/core/src/kmx/kmx_xstring.h
+++ b/core/src/kmx/kmx_xstring.h
@@ -8,7 +8,9 @@ namespace kmx {
 
 #define Uni_IsSurrogate1(ch) ((ch) >= 0xD800 && (ch) <= 0xDBFF)
 #define Uni_IsSurrogate2(ch) ((ch) >= 0xDC00 && (ch) <= 0xDFFF)
+
 #define Uni_IsSMP(ch) ((ch) >= 0x10000)
+#define Uni_IsBMP(ch) ((ch) < 0x10000)
 
 #define Uni_SurrogateToUTF32(ch, cl) (((ch) - 0xD800) * 0x400 + ((cl) - 0xDC00) + 0x10000)
 

--- a/core/src/kmx/kmx_xstring.h
+++ b/core/src/kmx/kmx_xstring.h
@@ -6,16 +6,61 @@ namespace km {
 namespace kbp {
 namespace kmx {
 
+/**
+ * @brief True if a lead surrogate
+ * \def Uni_IsSurrogate1
+ */
 #define Uni_IsSurrogate1(ch) ((ch) >= 0xD800 && (ch) <= 0xDBFF)
+/**
+ * @brief True if a trail surrogate
+ * \def Uni_IsSurrogate2
+ */
 #define Uni_IsSurrogate2(ch) ((ch) >= 0xDC00 && (ch) <= 0xDFFF)
 
+/**
+ * @brief Misnomer, actually returns true if "not BMP"
+ * \def Uni_IsSMP
+ */
 #define Uni_IsSMP(ch) ((ch) >= 0x10000)
+/**
+ * @brief Returns true if BMP (Plane 0)
+ * \def Uni_IsBMP
+ */
 #define Uni_IsBMP(ch) ((ch) < 0x10000)
 
+/**
+ * @brief Convert two UTF-16 surrogates into one UTF-32 codepoint
+ * @param ch lead surrogate - Uni_IsSurrogate1(ch) must == true
+ * @param cl trail surrogate - Uni_IsSurrogate2(cl) must == true
+ * \def Uni_SurrogateToUTF
+ */
 #define Uni_SurrogateToUTF32(ch, cl) (((ch) - 0xD800) * 0x400 + ((cl) - 0xDC00) + 0x10000)
+
+/**
+ * @brief Convert UTF-32 BMP to UTF-16 BMP
+ * @param ch codepoint - Uni_IsBMP(ch) must == true
+ * \def Uni_UTF32BMPToUTF16
+ */
+#define Uni_UTF32BMPToUTF16(ch) (ch & 0xFFFF)
 
 #define Uni_UTF32ToSurrogate1(ch) (char16_t)(((ch) - 0x10000) / 0x400 + 0xD800)
 #define Uni_UTF32ToSurrogate2(ch) (char16_t)(((ch) - 0x10000) % 0x400 + 0xDC00)
+
+/**
+ * char16_t array big enough to hold a single Unicode codepoint,
+ * including trailing null.
+ */
+typedef struct {
+  char16_t ch[3];
+} char16_single;
+
+/**
+ * Convert a UTF-32 codepoint to UTF-16 code unit(s).
+ * @param ch32 input codepoint
+ * @param ch16 output buffer
+ * @return int length returned (not including null). Will return 1 (BMP) or 2
+ */
+int Utf32CharToUtf16(const KMX_DWORD ch32, char16_single& ch16);
 
 PKMX_WCHAR incxstr(PKMX_WCHAR p);
 PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart);

--- a/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -1236,6 +1236,38 @@ test_xstrlen_ignoreifopt() {
   assert_equal(xstrlen_ignoreifopt((PKMX_WCHAR) U_1F609_WINKING_FACE u"a"), 2);
 }
 
+void
+test_utf32() {
+  const KMX_DWORD u295 =     0x0127; // ħ
+
+  assert(Uni_IsBMP(u295));
+
+  const char16_t hmaqtua = Uni_UTF32BMPToUTF16(u295);
+  assert(hmaqtua == 0x0127);
+
+  char16_single c0;
+  int l0 = Utf32CharToUtf16(u295, c0);
+  assert(l0 == 1);
+  assert(c0.ch[0] == 0x0127);
+  assert(c0.ch[1] == 0);
+  std::u16string s0 = std::u16string(c0.ch, l0);
+  assert(s0 == std::u16string(u"ħ"));
+  assert_equal(s0.at(0), 0x0127);
+
+  const KMX_DWORD scat = 0x0001F640; // 🙀
+  assert(!Uni_IsBMP(scat));
+  char16_single c1;
+  int l1 = Utf32CharToUtf16(scat, c1);
+  assert(l1 == 2);
+  assert_equal(c1.ch[0], 0xD83D);
+  assert_equal(c1.ch[1], 0xDE40);
+  assert_equal(c1.ch[2], 0);
+  std::u16string s1 = std::u16string(c1.ch, l1);
+  assert_equal(s1.at(0), 0xD83D);
+  assert_equal(s1.at(1), 0xDE40);
+  assert(s1 == std::u16string(u"🙀"));
+}
+
 constexpr const auto help_str = u"\
 test_kmx_xstring [--color]\n\
 \n\
@@ -1256,6 +1288,7 @@ int main(int argc, char *argv []) {
   test_decxstr();
   test_xstrlen();
   test_xstrlen_ignoreifopt();
+  test_utf32();
 
   return 0;
 }

--- a/core/tests/unit/ldml/test_kmx_plus.cpp
+++ b/core/tests/unit/ldml/test_kmx_plus.cpp
@@ -6,7 +6,7 @@ using namespace km::kbp::kmx;
 
 int main(int argc, const char *argv[]) {
     // COMP_KMXPLUS_KEYS_ENTRY test
-    COMP_KMXPLUS_KEYS_ENTRY e[3] = {
+    COMP_KMXPLUS_KEYS_ENTRY e[2] = {
         {
             KM_KBP_VKEY__AB,
             0,
@@ -18,12 +18,6 @@ int main(int argc, const char *argv[]) {
             0,
             0x0001F640, // to
             0x00000000  // flags: !EXTEND
-        },
-        {
-            KM_KBP_VKEY__A3,
-            0,
-            0x00000001, // to
-            LDML_KEYS_FLAGS_EXTEND
         }
     };
     std::u16string s0 = e[0].get_string();
@@ -36,10 +30,6 @@ int main(int argc, const char *argv[]) {
     assert_equal(s1.at(0), 0xD83D);
     assert_equal(s1.at(1), 0xDE40);
     assert(s1 == std::u16string(u"🙀"));
-
-    std::u16string s2 = e[2].get_string();
-    assert_equal(s2.length(), 0); // error, EXTEND
-    assert(s2 == std::u16string(u""));
 
     return 0;
 }

--- a/core/tests/unit/ldml/test_kmx_plus.cpp
+++ b/core/tests/unit/ldml/test_kmx_plus.cpp
@@ -1,10 +1,45 @@
 #include <stdio.h>
-#include <assert.h>
 #include "kmx/kmx_plus.h"
+#include "../test_assert.h"
 
 using namespace km::kbp::kmx;
 
 int main(int argc, const char *argv[]) {
-    printf("OKAY\n");
+    // COMP_KMXPLUS_KEYS_ENTRY test
+    COMP_KMXPLUS_KEYS_ENTRY e[3] = {
+        {
+            KM_KBP_VKEY__AB,
+            0,
+            0x00000127, // to = U+0127 = 295
+            0x00000000  // flags: !EXTEND
+        },
+        {
+            KM_KBP_VKEY__A1,
+            0,
+            0x0001F640, // to
+            0x00000000  // flags: !EXTEND
+        },
+        {
+            KM_KBP_VKEY__A3,
+            0,
+            0x00000001, // to
+            LDML_KEYS_FLAGS_EXTEND
+        }
+    };
+    std::u16string s0 = e[0].get_string();
+    assert_equal(s0.length(), 1);
+    assert_equal(s0.at(0), 0x0127);
+    assert(s0 == std::u16string(u"ħ"));
+
+    std::u16string s1 = e[1].get_string();
+    assert_equal(s1.length(), 2);
+    assert_equal(s1.at(0), 0xD83D);
+    assert_equal(s1.at(1), 0xDE40);
+    assert(s1 == std::u16string(u"🙀"));
+
+    std::u16string s2 = e[2].get_string();
+    assert_equal(s2.length(), 0); // error, EXTEND
+    assert(s2 == std::u16string(u""));
+
     return 0;
 }


### PR DESCRIPTION
- remove hacky utf-32 processing
- add utf-32 test case to test_kmx_plus.cpp
- change kmx_plus to return std::u16string
- kmx_xstring: add Uni_IsBMP() macro

Fixes: #7134

@keymanapp-test-bot skip