### PR TITLE
chore: use keyman.com instead of keyman-staging.com

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/CloudRepository.java
@@ -39,7 +39,7 @@ public class CloudRepository {
   public static final String DOWNLOAD_IDENTIFIER_CATALOGUE = "catalogue";
 
   public static final String API_PRODUCTION_HOST = "api.keyman.com";
-  public static final String API_STAGING_HOST = "api.keyman-staging.com";
+  public static final String API_STAGING_HOST = "api.keyman.com"; // #7227 disabling: "api.keyman-staging.com";
 
   public static final String API_MODEL_LANGUAGE_FORMATSTR = "https://%s/model?q=bcp47:%s";
   public static final String API_PACKAGE_VERSION_FORMATSTR = "https://%s/package-version?platform=android%s%s";

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMPLink.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 public final class KMPLink {
 
   public static final String KMP_PRODUCTION_HOST = "keyman.com";
-  public static final String KMP_STAGING_HOST = "keyman-staging.com";
+  public static final String KMP_STAGING_HOST =  "keyman.com"; // #7227 disabling: "keyman-staging.com";
 
   private static final String KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR = "^http(s)?://(%s|%s)/keyboards/install/([^\\?/]+)(\\?(.+))?$";
   private static final String installPatternFormatStr = KMString.format(KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR,

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/KMPLinkTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/KMPLinkTest.java
@@ -18,9 +18,9 @@ public class KMPLinkTest {
     Assert.assertFalse(KMPLink.isKeymanInstallLink(""));
 
     // Valid Keyman keyboard install links
-    Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/malar_malayalam"));
-    Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/malar_malayalam?bcp47=ml"));
-    Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/fv_sencoten?bcp47=str-Latn"));
+    // Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/malar_malayalam"));
+    // Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/malar_malayalam?bcp47=ml"));
+    // Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/fv_sencoten?bcp47=str-Latn"));
     Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman.com/keyboards/install/lao%20unicode"));  // legacy keyboard within download dialog
     Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman.com/keyboards/install/khmer_angkor?_gid=112233&bcp47=lo")); // other query params appearing
 
@@ -28,11 +28,11 @@ public class KMPLinkTest {
     Assert.assertTrue(KMPLink.isKeymanInstallLink("https://keyman.com/keyboards/install/malar_malayalam?bcp47=ml"));
 
     // Keyboard link is wrong
-    Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboard/install/malar_malayalam"));
+    // Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboard/install/malar_malayalam"));
 
     // link missing packageID
-    Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install"));
-    Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/"));
+    // Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install"));
+    // Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman-staging.com/keyboards/install/"));
     Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman.com/keyboards/install"));
     Assert.assertFalse(KMPLink.isKeymanInstallLink("https://keyman.com/keyboards/install/"));
   }
@@ -43,14 +43,14 @@ public class KMPLinkTest {
     Assert.assertFalse(KMPLink.isKeymanDownloadLink(""));
 
     // Valid Keyman keyboard download links
-    Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/malar_malayalam?platform=android&tier=alpha"));
-    Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/malar_malayalam?platform=android&tier=alpha&bcp47=ml"));
+    // Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/malar_malayalam?platform=android&tier=alpha"));
+    // Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/malar_malayalam?platform=android&tier=alpha&bcp47=ml"));
     Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman.com/go/package/download/malar_malayalam?platform=android&tier=alpha"));
     Assert.assertTrue(KMPLink.isKeymanDownloadLink("https://keyman.com/go/package/download/malar_malayalam?platform=android&tier=alpha&bcp47=ml"));
 
     // link missing packageID
-    Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download"));
-    Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/"));
+    // Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download"));
+    // Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman-staging.com/go/package/download/"));
     Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman.com/go/package/download"));
     Assert.assertFalse(KMPLink.isKeymanDownloadLink("https://keyman.com/go/package/download/"));
   }

--- a/common/windows/delphi/general/Upload_Settings.pas
+++ b/common/windows/delphi/general/Upload_Settings.pas
@@ -108,8 +108,8 @@ const
   // Alpha versions will work against the staging server so that they
   // can access new APIs etc that will only be available there. The staging
   // servers have resource constraints but should be okay for limited use.
-  S_KeymanCom_Staging = 'https://keyman-staging.com';
-  S_APIServer_Staging = 'api.keyman-staging.com';
+  S_KeymanCom_Staging = 'https://keyman.com';  // #7227 disabling: 'https://keyman-staging.com';
+  S_APIServer_Staging = 'api.keyman.com';  // #7227 disabling: 'api.keyman-staging.com';
 
 const
   URLPath_PackageDownload_Format = '/go/package/download/%0:s?platform=windows&tier=%1:s&bcp47=%2:s&update=%3:d';

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanHosts.swift
@@ -30,7 +30,7 @@ public enum KeymanHosts {
         case .alpha:
           fallthrough
         case .beta:
-          return URL.init(string: "https://api.keyman-staging.com")!
+          return URL.init(string: "https://api.keyman.com")! // #7227 disabling: "https://api.keyman-staging.com")!
         case .stable:
           return URL.init(string: "https://api.keyman.com")!
       }
@@ -54,7 +54,7 @@ public enum KeymanHosts {
         case .alpha:
           fallthrough
         case .beta:
-          return URL.init(string: "https://help.keyman-staging.com")!
+          return URL.init(string: "https://help.keyman.com")! // #7227 disabling: "https://help.keyman-staging.com")!
         case .stable:
           return URL.init(string: "https://help.keyman.com")!
       }
@@ -78,7 +78,7 @@ public enum KeymanHosts {
         case .alpha:
           fallthrough
         case .beta:
-          return URL.init(string: "https://keyman-staging.com")!
+          return URL.init(string: "https://keyman.com")! // #7227 disabling: "https://keyman-staging.com")!
         case .stable:
           return URL.init(string: "https://keyman.com")!
       }

--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -40,15 +40,15 @@ def secure_lookup(data, key1, key2 = None):
 gettext.bindtextdomain('keyman-config', '/usr/share/locale')
 gettext.textdomain('keyman-config')
 
-if __tier__ == 'alpha' or __tier__ == 'beta':
+#if __tier__ == 'alpha' or __tier__ == 'beta':  // #7227 disabling:
     # Alpha and beta versions will work against the staging server so that they
     # can access new APIs etc that will only be available there. The staging
     # servers have resource constraints but should be okay for limited use.
-    KeymanComUrl = 'https://keyman-staging.com'
-    KeymanApiUrl = 'https://api.keyman-staging.com'
-else:
-    KeymanComUrl = 'https://keyman.com'
-    KeymanApiUrl = 'https://api.keyman.com'
+#    KeymanComUrl = 'https://keyman-staging.com'
+#    KeymanApiUrl = 'https://api.keyman-staging.com'
+#else:
+KeymanComUrl = 'https://keyman.com'
+KeymanApiUrl = 'https://api.keyman.com'
 
 # There's no staging site for downloads
 KeymanDownloadsUrl = 'https://downloads.keyman.com'

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -130,16 +130,16 @@ NSString* _keymanDataPath = nil;
     result.tier = [keymanInfo objectForKey:@"Tier"];
     result.versionRelease = [keymanInfo objectForKey:@"VersionRelease"];
     result.versionWithTag = [keymanInfo objectForKey:@"VersionWithTag"];
-    if([result.tier isEqualToString:@"stable"]) {
-        result.keymanCom = @"keyman.com";
-        result.helpKeymanCom = @"help.keyman.com";
-        result.apiKeymanCom = @"api.keyman.com";
-    }
+    // if([result.tier isEqualToString:@"stable"]) {  // #7227 disabling:
+    result.keymanCom = @"keyman.com";
+    result.helpKeymanCom = @"help.keyman.com";
+    result.apiKeymanCom = @"api.keyman.com";
+    /*}
     else {
         result.keymanCom = @"keyman-staging.com";
         result.helpKeymanCom = @"help.keyman-staging.com";
         result.apiKeymanCom = @"api.keyman-staging.com";
-    }
+    }*/
     return result;
 }
 
@@ -632,11 +632,11 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 
     NSString *path = [[self keymanDataPath] stringByAppendingPathComponent:packageFolder];
     KMPackageInfo *packageInfo = [self.packageReader loadPackageInfo:path];
-  
+
     if (packageInfo) {
         packageName = packageInfo.packageName;
     }
-  
+
     return packageName;
 }
 
@@ -1149,7 +1149,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     [self.receivedData writeToFile:filePath atomically:YES];
     [self unzipFile:filePath];
     [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
-    
+
     [_downloadInfoView setMessageText:NSLocalizedString(@"message-keyboard-download-complete", nil)];
     NSButton *button = (NSButton *)[_downloadInfoView.buttons objectAtIndex:0];
     [button setTitle:NSLocalizedString(@"button-download-complete", nil)];


### PR DESCRIPTION
Fixes #7227.

We want to use keyman.com for now even for alpha builds, as keyman-staging.com is going to be used for transition to Docker-based hosting, and it will be problematic to try and share that process with alpha builds.

# User Testing

* **TEST_LINK_WINDOWS:** Verify that you can install a keyboard from the "Download Keyboard..." button in Keyman Configuration.
* **TEST_LINK_MACOS:**  Verify that you can install a keyboard from the "Download Keyboard..." button in Keyman.
* **TEST_LINK_LINUX:**  Verify that you can install a keyboard from the "Download Keyboard..." button in Keyman.
* **TEST_LINK_ANDROID:**  Verify that you can install a keyboard from the cloud in Keyman.
* **TEST_LINK_IOS:**  Verify that you can install a keyboard from the cloud in Keyman.