### PR TITLE
change(web): better fat-finger key weighting ✏️

### DIFF
--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -12,7 +12,7 @@ namespace com.keyman.text {
 
     /**
      * Indicates the device (platform) to be used for non-keystroke events,
-     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * such as those sent to `begin postkeystroke` and `begin newcontext`
      * entry points.
      */
     private contextDevice: utils.DeviceSpec;
@@ -273,6 +273,7 @@ namespace com.keyman.text {
           let totalMass = 0; // Tracks sum of non-error probabilities.
           for(let pair of keyDistribution) {
             if(pair.p < KEYSTROKE_EPSILON) {
+              totalMass += pair.p;
               break;
             } else if(timer && timer() >= TIMEOUT_THRESHOLD) {
               // Note:  it's always possible that the thread _executing_ our JS

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -512,8 +512,7 @@ namespace com.keyman.keyboards {
       // Should we wish to allow multiple different transforms for distance -> probability, use a function parameter in place
       // of the formula in the loop below.
       for(let key in keyDists) {
-        keyProbs[key] = 1 / (Math.pow(keyDists[key], 2) + 1e-6); // Prevent div-by-0 errors.
-        totalMass += keyProbs[key];
+        totalMass += keyProbs[key] = 1 / (Math.pow(keyDists[key], 2) + 1e-6); // Prevent div-by-0 errors.
       }
 
       for(let key in keyProbs) {

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -37,6 +37,7 @@ namespace com.keyman.keyboards {
     layer: string;
     displayLayer: string;
     nextlayer: string;
+    sp?: ButtonClass;
 
     private baseKeyEvent: text.KeyEvent;
     isMnemonic: boolean = false;
@@ -71,6 +72,12 @@ namespace com.keyman.keyboards {
       }
 
       return this.id;
+    }
+
+    public get isPadding(): boolean {
+      // Does not include 9 (class:  blank) as that may be an intentional 'catch' for misplaced
+      // keystrokes.
+      return this['sp'] == 10; // Button class: hidden.
     }
 
     /**
@@ -546,6 +553,8 @@ namespace com.keyman.keyboards {
             // Attempt to filter out known non-output keys.
             // Results in a more optimized distribution.
             if(text.Codes.isKnownOSKModifierKey(key.baseKeyID)) {
+              return;
+            } else if(key.isPadding) { // to the user, blank / padding keys do not exist.
               return;
             }
           }

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -337,14 +337,12 @@ namespace com.keyman.keyboards {
 
       // Allow for right OSK margin (15 layout units)
       let rightMargin = ActiveKey.DEFAULT_RIGHT_MARGIN/totalWidth;
-      totalPercent += rightMargin;
 
       // If a single key, and padding is negative, add padding to right align the key
       if(keys.length == 1 && parseInt(keys[0]['pad'],10) < 0) {
         keyPercent=parseInt(keys[0]['width'],10)/totalWidth;
         keys[0]['widthpc']=keyPercent;
-        totalPercent += keyPercent;
-        keys[0]['padpc']=1-totalPercent;
+        keys[0]['padpc']=1-(totalPercent + keyPercent + rightMargin);
 
         // compute center's default x-coord (used in headless modes)
         setProportions(keys[0] as ActiveKey, padPercent, keyPercent, totalPercent);
@@ -352,8 +350,7 @@ namespace com.keyman.keyboards {
         let j=keys.length-1;
         padPercent=parseInt(keys[j]['pad'],10)/totalWidth;
         keys[j]['padpc']=padPercent;
-        totalPercent += padPercent;
-        keys[j]['widthpc'] = keyPercent = 1-totalPercent;
+        keys[j]['widthpc'] = keyPercent = 1-(totalPercent + padPercent + rightMargin);
 
         // compute center's default x-coord (used in headless modes)
         setProportions(keys[j] as ActiveKey, padPercent, keyPercent, totalPercent);
@@ -511,39 +508,16 @@ namespace com.keyman.keyboards {
       let keyProbs: {[keyId: string]: number} = {};
 
       let totalMass = 0;
-      let bestKey = null;
-      let bestProb = Number.MIN_VALUE;
 
       // Should we wish to allow multiple different transforms for distance -> probability, use a function parameter in place
       // of the formula in the loop below.
       for(let key in keyDists) {
         keyProbs[key] = 1 / (Math.pow(keyDists[key], 2) + 1e-6); // Prevent div-by-0 errors.
         totalMass += keyProbs[key];
-
-        if(keyProbs[key] > bestProb) {
-          bestProb = keyProbs[key];
-          bestKey = key;
-        }
       }
 
       for(let key in keyProbs) {
         keyProbs[key] /= totalMass;
-      }
-
-      // To help ensure the highest probability key gets priority, we'll square-root its probability,
-      // then renormalize.  (p <= 1)  Has the largest effect when near the edge of the best key.
-      const originalBestProb = keyProbs[bestKey];
-      const finalBestProb = Math.sqrt(keyProbs[bestKey]);
-
-      const normDelta = finalBestProb - originalBestProb; // will be positive.
-      const renormalizer = 1 / (1 + normDelta); // as we're increasing the sum-total probability mass.
-
-      for(let key in keyProbs) {
-        if(key == bestKey) {
-          keyProbs[key] = finalBestProb * renormalizer;  // override with the adjusted value, renorm'd.
-        } else {
-          keyProbs[key] *= renormalizer;
-        }
       }
 
       return keyProbs;

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -74,6 +74,7 @@ namespace com.keyman.keyboards {
       return this.id;
     }
 
+    @Enumerable
     public get isPadding(): boolean {
       // Does not include 9 (class:  blank) as that may be an intentional 'catch' for misplaced
       // keystrokes.

--- a/common/web/keyboard-processor/src/text/codes.ts
+++ b/common/web/keyboard-processor/src/text/codes.ts
@@ -81,10 +81,13 @@ namespace com.keyman.text {
         case 'K_SHIFT':
         case 'K_LOPT':
         case 'K_ROPT':
-        case 'K_NUMLOCK': // Often used for numeric layers.
+        case 'K_NUMLOCK':  // Often used for numeric layers.
         case 'K_CAPS':
           return true;
         default:
+          if(Codes.keyCodes[keyID] >= 50000) { // A few are used by `sil_euro_latin`.
+            return true; // is a 'K_' key defined for layer shifting or 'control' use.
+          }
           // Refer to text/codes.ts - these are Keyman-custom "keycodes" used for
           // layer shifting keys.  To be safe, we currently let K_TABBACK and
           // K_TABFWD through, though we might be able to drop them too.


### PR DESCRIPTION
Mitigates #7240 by more strongly weighting keys close to the touch point.

**Also** fixes interference that was being caused from 'hidden'-property keys, which resemble padding areas on the OSK.  If one of these was 'most likely', default suggestions would be displayed instead of suggestions for the most likely actual key.

**Additionally**, this fixes a bug with determining how far a touchpoint is from the center of the right-most key of each row of the on-screen-keyboard - this bug was causing overcorrections in favor of the key immediately to the left in most cases.

Previously, we were using an inverse-linear relationship for a key's probability based on its distance from the touchpoint; I now believe inverse-quadratic to be more appropriate.  In relation to #7201 (and [this comment](https://github.com/keymanapp/keyman/pull/7241/files#r967960102)), this helps make boundaries between keys "sharper" without interfering much with our ability to correct further down the line once more characters are added.

## User Testing

Run all user tests specified below on an Android device (or simulator).  I'm not picky about which.

**TEST_S_Q**:  Using the default (`sil_euro_latin`) keyboard, press the bottom edge of the 'q' (or 'Q') key.
- All suggestions should begin with the corresponding letter and case.  (So, 'question' for 'q' or 'Question' for 'Q'.)

**TEST_E_Q**:  Using the default (`sil_euro_latin`) keyboard, press the right edge of the 'q' (or 'Q') key.
- All suggestions should begin with the corresponding letter and case.  (So, 'question' for 'q' or 'Question' for 'Q'.)
- If you manage to land perfectly in the middle, you may see 'w' suggestions, but not 'a' suggestions.

**TEST_W_P**:  Using the default (`sil_euro_latin`) keyboard, press the far left edge of the 'p' (or 'P') key.
- All suggestions should begin with either an 'o' or a 'p'.
    - If you manage to land right near the edge, you may get a mix!
    - If you land a bit further right than that, you should get all 'p' suggestions.

(Note:  the precision required to land these near-key corrections may be better served with the "predictive text: robust testing" Web test page.  It's a good thing if they don't happen for you when testing via touch!)

**TEST_SW_Z**:  Using the default (`sil_euro_latin`) keyboard, press the far bottom-left edge of the 'z' (or 'Z') key.
- All suggestions should begin with with the corresponding letter and case.

**TEST_E_L_BLANK**:  Using the default (`sil_euro_latin`) keyboard, press past the right edge of the 'l' (or 'L') key.
- All suggestions should begin with with 'l' / 'L' if it is the closest key to your touchpoint.

**TEST_S_P_BLANK**:  Using the default (`sil_euro_latin`) keyboard, press past the bottom edge of the 'p' (or 'P') key.
- All suggestions should begin with with 'p' / 'P' if it is the closest key to your touchpoint, regardless of the text actually produced.

For the next test, you may wish to make note of the following resource:
- https://keyman.com/keyboards/sil_jarai?bcp47=jra-khmr
- In order to properly set things up for the test, please use the _**in-app keyboard search**_ to find and install this keyboard.
    - If you're missing predictive text after installing it, it's likely because you ignored the bolded part above.

**TEST_JARAI_SE_SHIFT_Q**:  Using the `sil_jarai` keyboard's shift layer, touch the far, far bottom-right corner of the first key in the second row.  (ឈ)
- All predictions should start with the corresponding letter.

### Other notes

Note that the fat-finger distribution is currently _not_ used by the web engine to determine the actually selected key.  As a few of the tests above highlight... it may be wise to actually 'fix' that, as there are some cases where the distance-measuring functionality definitely performs better.  That "S_P_BLANK" one is a particular standout in this regard.