### PR TITLE
fix(windows): Delete both code units when deleting surrogate pairs in TSF-aware apps

### DIFF
--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -30,8 +30,17 @@ static BOOL processAlert(AITIP* app) {
 static BOOL processBack(AITIP* app, const km_kbp_action_item* actionItem) {
   if (actionItem->backspace.expected_type == KM_KBP_BT_MARKER) {
     app->QueueAction(QIT_BACK, BK_DEADKEY);
-  } else /* actionItem->backspace.expected_type == KM_KBP_BT_CHAR, KM_KBP_BT_UNKNOWN */ {
-    app->QueueAction(QIT_BACK, 0);
+  } else if(actionItem->backspace.expected_type == KM_KBP_BT_CHAR) {
+    // If this is a TSF-aware app we need to set the BK_SURROGATE flag to delete
+    // both parts of the surrogate pair. Legacy apps receive a BKSP WM_KEYDOWN event
+    // which results in deleting both parts in one action.
+    if (!app->IsLegacy() && Uni_IsSMP(actionItem->backspace.expected_value)) {
+      app->QueueAction(QIT_BACK, BK_DEFAULT | BK_SURROGATE);
+    } else {
+      app->QueueAction(QIT_BACK, BK_DEFAULT);
+    }
+  } else { // KM_KBP_BT_UNKNOWN
+    app->QueueAction(QIT_BACK, BK_DEFAULT);
   }
   return TRUE;
 }


### PR DESCRIPTION
Fixes: #7231
When the windows platform receives the action for a backspace it will check to see if the character being deleted is a surrogate pair. If it is and the app is TSF aware app it will need to set the BK_SURROGATE flag in the platform action queue This will result in two backspaces to remove both parts of the surrogate pair. For legacy apps, this is not required.

Issue: #7251 will add some windows unit tests.
   
Using a public available keyboard.
# USER TESTING 
**Setup Text Services Framework(TSF) testing with Keyman for Windows**

1. Install Keyman Developer version 15 or greater. 
2. Open the Keyman Developers Test page in Firefox. **It must be [`Firefox Browser`](https://www.mozilla.org/en-US/firefox/new/)** 
  a. By default this is at localhost:8008 so you could type in to the firefox address bar
  b. You can also access it by pressing the `Test package on web` button found in the `Compile` tab for any keyboard package.
3. On the `Keymand Developer Keyboard Test Page` use the `Keyboard` dropdown to select `system keyboard`
4. Use the `Status Bar` to select the desired Keyman for the Windows keyboard. 
5. Typing text into the input field will now use the TSF with the keyboard selected in step 4.


* TEST_TSF_BACKSPACE_SURROGATE

1. Install [Hieroglyphic ](url)Keyboard from keyman.com
2. Open the `Keyman Developer Test Page`. Follow the steps from `Setup Text Services Framework(TSF) testing with Keyman for Windows` if needed.
3. Select the Hieroglyphic keyboard from the status bar
4. In the `Keyman Developer Test Page` Type: <kbd>d</kbd><kbd>i</kbd><kbd>spacebar</kbd>
5. Expected Output : 𓏙                 and the character bar just show the one character "0133d9" 
6. Type:<kbd>backspace</kbd>
7. Expected Output: Empty and the character bar above the input text should no have any character just showing `empty`.


* TEST_TSF_RULE_DELETES_SURROGATE

1. Install [Hieroglyphic ](url)Keyboard from keyman.com
2. Open the `Keyman Developer Test Page`. Follow the steps from `Setup Text Services Framework(TSF) testing with Keyman for Windows` if needed.
3. Select the Hieroglyphic keyboard from the status bar
4. In the `Keyman Developer Test Page` Type: <kbd>d</kbd><kbd>i</kbd><kbd>spacebar</kbd><kbd>spacebar</kbd>
5. Expected Output : 𓂞     and the character bar just show the one character "01309e" 
6. Type:<kbd>backspace</kbd>
7. Expected Output: Empty and the character bar above the input text should no have any character just showing `empty`.

* TEST_TSF_BACKSPAE_DELETES_NON_SURROGATE
This is to test that if we have a normal (non-surrogate) we do not delete two characters.

1. Install [Hieroglyphic ](url)Keyboard from keyman.com
2. Open the `Keyman Developer Test Page`. Follow the steps from `Setup Text Services Framework(TSF) testing with Keyman for Windows` if needed.
3. Select the Hieroglyphic keyboard from the status bar
4. In the `Keyman Developer Test Page` Type: <kbd>d</kbd><kbd>i</kbd><kbd>spacebar</kbd><kbd>d</kbd>
5. Expected Output : 𓏙d    and the character bar shows two characters "0133d9"  "0064"
6. Type:<kbd>backspace</kbd>
7. Expected Output: 𓏙                 and the character bar just show the one character "0133d9" 
