### PR TITLE
chore(core): improve xstring macros 🙀

### DIFF
--- a/core/src/kmx/kmx_actions.cpp
+++ b/core/src/kmx/kmx_actions.cpp
@@ -45,11 +45,12 @@ KMX_BOOL KMX_Actions::QueueAction(int ItemType, KMX_DWORD dwData)
     break;
 
   case QIT_CHAR:
-    if(Uni_IsSMP(dwData)) {
-      m_context->Add(Uni_UTF32ToSurrogate1(dwData));
-      m_context->Add(Uni_UTF32ToSurrogate2(dwData));
-    } else {
-      m_context->Add((KMX_WORD) dwData);
+    {
+      char16_single buf;
+      int len = Utf32CharToUtf16(dwData, buf);
+      for(int i=0; i<len; i++) {
+        m_context->Add(buf.ch[i]);
+      }
     }
     break;
 

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -242,11 +242,10 @@ kmx_processor::process_event(
   for (auto c = cp.begin(); c != cp.end(); c++) {
     switch (c->type) {
     case KM_KBP_CT_CHAR:
-      if (Uni_IsSMP(c->character)) {
-        ctxt += Uni_UTF32ToSurrogate1(c->character);
-        ctxt += Uni_UTF32ToSurrogate2(c->character);
-      } else {
-        ctxt += (km_kbp_cp)c->character;
+      {
+        km::kbp::kmx::char16_single buf;
+        const int len = km::kbp::kmx::Utf32CharToUtf16(c->character, buf);
+        ctxt.append(buf.ch, len);
       }
       break;
     case KM_KBP_CT_MARKER:

--- a/core/src/kmx/kmx_xstring.cpp
+++ b/core/src/kmx/kmx_xstring.cpp
@@ -12,22 +12,6 @@
 using namespace km::kbp;
 using namespace kmx;
 
-int
-km::kbp::kmx::Utf32CharToUtf16(const KMX_DWORD ch32, char16_single &ch16) {
-  int len;
-  if (Uni_IsBMP(ch32)) {
-    len        = 1;
-    ch16.ch[0] = Uni_UTF32BMPToUTF16(ch32);
-    ch16.ch[1] = 0;
-  } else {
-    len        = 2;
-    ch16.ch[0] = Uni_UTF32ToSurrogate1(ch32);
-    ch16.ch[1] = Uni_UTF32ToSurrogate2(ch32);
-    ch16.ch[2] = 0;
-  }
-  return len;
-}
-
 const km_kbp_cp *km::kbp::kmx::u16chr(const km_kbp_cp *p, km_kbp_cp ch) {
   while (*p) {
     if (*p == ch) return p;

--- a/core/src/kmx/kmx_xstring.h
+++ b/core/src/kmx/kmx_xstring.h
@@ -18,11 +18,6 @@ namespace kmx {
 #define Uni_IsSurrogate2(ch) ((ch) >= 0xDC00 && (ch) <= 0xDFFF)
 
 /**
- * @brief Misnomer, actually returns true if "not BMP"
- * \def Uni_IsSMP
- */
-#define Uni_IsSMP(ch) ((ch) >= 0x10000)
-/**
  * @brief Returns true if BMP (Plane 0)
  * \def Uni_IsBMP
  */
@@ -84,6 +79,25 @@ km_kbp_cp *u16tok(km_kbp_cp *p, km_kbp_cp ch, km_kbp_cp **ctx);
 km_kbp_cp *u16dup(km_kbp_cp *src);
 
 //KMX_BOOL MapUSCharToVK(KMX_WORD ch, PKMX_WORD puKey, PKMX_DWORD puShiftFlags);
+
+//  --- implementation ---
+
+inline int
+Utf32CharToUtf16(const KMX_DWORD ch32, char16_single &ch16) {
+  int len;
+  if (Uni_IsBMP(ch32)) {
+    len        = 1;
+    ch16.ch[0] = Uni_UTF32BMPToUTF16(ch32);
+    ch16.ch[1] = 0;
+  } else {
+    len        = 2;
+    ch16.ch[0] = Uni_UTF32ToSurrogate1(ch32);
+    ch16.ch[1] = Uni_UTF32ToSurrogate2(ch32);
+    ch16.ch[2] = 0;
+  }
+  return len;
+}
+
 
 } // namespace kmx
 } // namespace kbp

--- a/core/tests/unit/kmx/kmx.cpp
+++ b/core/tests/unit/kmx/kmx.cpp
@@ -78,11 +78,12 @@ apply_action(
             0,
         },
         {act.character}});
-    if (Uni_IsSMP(act.character)) {
-      text_store.push_back(Uni_UTF32ToSurrogate1(act.character));
-      text_store.push_back(Uni_UTF32ToSurrogate2(act.character));
-    } else {
-      text_store.push_back((char16_t)act.character);
+    {
+      km::kbp::kmx::char16_single buf;
+      const int len = km::kbp::kmx::Utf32CharToUtf16(act.character, buf);
+      for(int i=0; i<len; i++) {
+        text_store.push_back(buf.ch[i]);
+      }
     }
     // std::cout << "char(" << act.character << ") size=" << cp->size() << std::endl;
     break;

--- a/core/tests/unit/ldml/ldml.cpp
+++ b/core/tests/unit/ldml/ldml.cpp
@@ -76,11 +76,12 @@ apply_action(
             0,
         },
         {act.character}});
-    if (Uni_IsSMP(act.character)) {
-      text_store.push_back(Uni_UTF32ToSurrogate1(act.character));
-      text_store.push_back(Uni_UTF32ToSurrogate2(act.character));
-    } else {
-      text_store.push_back((char16_t)act.character);
+    {
+      km::kbp::kmx::char16_single buf;
+      const int len = km::kbp::kmx::Utf32CharToUtf16(act.character, buf);
+      for(int i=0; i<len; i++) {
+        text_store.push_back(buf.ch[i]);
+      }
     }
     // std::cout << "char(" << act.character << ") size=" << cp->size() << std::endl;
     break;


### PR DESCRIPTION
- move Utf32CharToUtf16 to inline
- remove Is_SMP and call sites, use Utf32CharToUtf16 instead.

For: #7134

I did not modify call sites that are using the windows unicode.h

@keymanapp-test-bot skip