### PR TITLE
fix(windows) Update unit tests for tsf bkspace

### DIFF
--- a/windows/src/engine/keyman32/keyman-engine.vcxproj
+++ b/windows/src/engine/keyman32/keyman-engine.vcxproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\common\include;$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\core\include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LibraryPath>$(ProjectDir)..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\core\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -30,8 +30,17 @@ static BOOL processAlert(AITIP* app) {
 static BOOL processBack(AITIP* app, const km_kbp_action_item* actionItem) {
   if (actionItem->backspace.expected_type == KM_KBP_BT_MARKER) {
     app->QueueAction(QIT_BACK, BK_DEADKEY);
-  } else /* actionItem->backspace.expected_type == KM_KBP_BT_CHAR, KM_KBP_BT_UNKNOWN */ {
-    app->QueueAction(QIT_BACK, 0);
+  } else if(actionItem->backspace.expected_type == KM_KBP_BT_CHAR) {
+    // If this is a TSF-aware app we need to set the BK_SURROGATE flag to delete
+    // both parts of the surrogate pair. Legacy apps receive a BKSP WM_KEYDOWN event
+    // which results in deleting both parts in one action.
+    if (!app->IsLegacy() && Uni_IsSMP(actionItem->backspace.expected_value)) {
+      app->QueueAction(QIT_BACK, BK_DEFAULT | BK_SURROGATE);
+    } else {
+      app->QueueAction(QIT_BACK, BK_DEFAULT);
+    }
+  } else { // KM_KBP_BT_UNKNOWN
+    app->QueueAction(QIT_BACK, BK_DEFAULT);
   }
   return TRUE;
 }

--- a/windows/src/engine/keyman32/kmprocessactions.h
+++ b/windows/src/engine/keyman32/kmprocessactions.h
@@ -6,7 +6,7 @@
  *              Keyman for Windows engine.
  */
 #ifndef _KMPROCESSACTIONS_H
-#define _KMPROCESSACTIONS_h
+#define _KMPROCESSACTIONS_H
 
 /**
  * Process the actions queued in the core processor

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/keyman-engine-tests.vcxproj
@@ -34,10 +34,10 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(ProjectDir)..\..\..\..\..\..\core\include;$(ProjectDir)..\..\..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\global\inc;$(ProjectDir)..\..;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\..\..\common\include;$(ProjectDir)..\..\..\..\..\..\core\include;$(ProjectDir)..\..\..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\global\inc;$(ProjectDir)..\..;$(IncludePath)</IncludePath>
     <OutDir>$(ProjectDir)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
-    <LibraryPath>$(ProjectDir)..\..\..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\..\..\core\build\rust\x86\$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(ProjectDir)..\..\..\..\..\..\core\build\x86\$(Configuration)\src;$(ProjectDir)..\..\..\..\..\..\core\build\rust\x86\$(Configuration);$(ProjectDir)..\..\..\kmtip\bin\Win32\$(Configuration);$(LibraryPath)</LibraryPath>
     <Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static-Disable-gtest_main>true</Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static-Disable-gtest_main>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -46,7 +46,7 @@
     <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(ProjectDir)..\..\..\..\global\inc;$(ProjectDir)..\..;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\..\..\..\..\common\include;$(ProjectDir)..\..\..\..\..\..\core\build\x86\$(Configuration)\include;$(ProjectDir)..\..\..\..\..\..\core\include;$(ProjectDir)..\..\..\..\global\inc;$(ProjectDir)..\..;$(IncludePath)</IncludePath>
     <OutDir>$(ProjectDir)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -59,6 +59,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\..\global\cpp\kmtip_guids.cpp" />
     <ClCompile Include="appinttests.cpp" />
     <ClCompile Include="gtest_main.cpp" />
     <ClCompile Include="keyboardoptionstests.cpp" />
@@ -99,6 +100,9 @@
       <SubSystem>Console</SubSystem>
       <AdditionalDependencies>version.lib;psapi.lib;imm32.lib;libkmnkbp0.a;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <ProjectReference>
+      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
+    </ProjectReference>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
@@ -114,11 +114,11 @@ TEST_F(KMPROCESSACTIONS, processBackCharactertest) {
 TEST_F(KMPROCESSACTIONS, processBackSurrogateTSFtest) {
   WCHAR callbuf[MAXCONTEXT];
   AITIP testApp;
-  WCHAR expectedContext[]        = { 0 };
+  WCHAR expectedContext[]         = { 0 };
   WCHAR expectedStringSurrogate[] = {0xD801, 0xDC37, 0};
 
   km_kbp_usv testSurrogateChar    = Uni_SurrogateToUTF32(0xD801, 0xDC37);  //𐐷';
-  km_kbp_action_item itemAddChar = {KM_KBP_IT_CHAR, {0,}, {testSurrogateChar}};
+  km_kbp_action_item itemAddChar  = {KM_KBP_IT_CHAR, {0,}, {testSurrogateChar}};
   processUnicodeChar(&testApp, &itemAddChar);
 
   km_kbp_action_item itemBackSpace       = {KM_KBP_IT_BACK};

--- a/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
+++ b/windows/src/engine/keyman32/tests/keyman-engine-tests/kmprocessactionstests.cpp
@@ -106,6 +106,32 @@ TEST_F(KMPROCESSACTIONS, processBackCharactertest) {
   EXPECT_STREQ(contextBuf, expectedContextFinal);
 }
 
+
+// KM_KBP_IT_BACK - processBack
+// Press Backspace for a surrogate character.
+// TODO: This test doesn't test for the PostKey handling
+// of TSF and two backspaces being sent to the App. 
+TEST_F(KMPROCESSACTIONS, processBackSurrogateTSFtest) {
+  WCHAR callbuf[MAXCONTEXT];
+  AITIP testApp;
+  WCHAR expectedContext[]        = { 0 };
+  WCHAR expectedStringSurrogate[] = {0xD801, 0xDC37, 0};
+
+  km_kbp_usv testSurrogateChar    = Uni_SurrogateToUTF32(0xD801, 0xDC37);  //𐐷';
+  km_kbp_action_item itemAddChar = {KM_KBP_IT_CHAR, {0,}, {testSurrogateChar}};
+  processUnicodeChar(&testApp, &itemAddChar);
+
+  km_kbp_action_item itemBackSpace       = {KM_KBP_IT_BACK};
+  itemBackSpace.backspace.expected_type  = KM_KBP_IT_CHAR;
+  itemBackSpace.backspace.expected_value = testSurrogateChar;
+  WCHAR *contextBuf                      = testApp.ContextBufMax(MAXCONTEXT);
+  EXPECT_STREQ(contextBuf, expectedStringSurrogate);
+  // backspace
+  processBack(&testApp, &itemBackSpace);
+  contextBuf = testApp.ContextBufMax(MAXCONTEXT);
+  EXPECT_STREQ(contextBuf, expectedContext);
+}
+
 // KM_KBP_IT_BACK - processBack
 // Press Backspace for a character doesn't match expected character
 // Note currently we don't check for a character match this should be updated


### PR DESCRIPTION
Fixes: #7251
This is just updating the Visual Studio Code project properties to have the correct include paths. Adding `kmtip_guids.cpp` to the test project. 
A unit test was added for testing backspace on a surrogate pair in `processactions`. However, this would not test issue #7231. For that, we need to be able to test the output of  `PostKeys()`.

@keymanapp-test-bot skip