### PR TITLE
fix(windows): TSF apps delete all of smp 🍒

### DIFF
--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -30,8 +30,17 @@ static BOOL processAlert(AITIP* app) {
 static BOOL processBack(AITIP* app, const km_kbp_action_item* actionItem) {
   if (actionItem->backspace.expected_type == KM_KBP_BT_MARKER) {
     app->QueueAction(QIT_BACK, BK_DEADKEY);
-  } else /* actionItem->backspace.expected_type == KM_KBP_BT_CHAR, KM_KBP_BT_UNKNOWN */ {
-    app->QueueAction(QIT_BACK, 0);
+  } else if(actionItem->backspace.expected_type == KM_KBP_BT_CHAR) {
+    // If this is a TSF-aware app we need to set the BK_SURROGATE flag to delete
+    // both parts of the surrogate pair. Legacy apps receive a BKSP WM_KEYDOWN event
+    // which results in deleting both parts in one action.
+    if (!app->IsLegacy() && Uni_IsSMP(actionItem->backspace.expected_value)) {
+      app->QueueAction(QIT_BACK, BK_DEFAULT | BK_SURROGATE);
+    } else {
+      app->QueueAction(QIT_BACK, BK_DEFAULT);
+    }
+  } else { // KM_KBP_BT_UNKNOWN
+    app->QueueAction(QIT_BACK, BK_DEFAULT);
   }
   return TRUE;
 }


### PR DESCRIPTION
Fixes: #7231 

This a cherry-pick of the fix made in PR #7243. Fixing the deletion of half a surrogate pair in an application using the TSF.

@keymanapp-test-bot skip
 