### PR TITLE
chore(web): disable browserstack on non-web-specific builds

### DIFF
--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# This script gets CI / pull request details for builds, part of the build-utils
+# builder_ suite of functions. All functions and variables in this file have the
+# prefix builder_pull_.
+#
+
+. "$KEYMAN_ROOT/resources/build/jq.inc.sh"
+
+#
+# Returns 0 if current build is in CI and triggered from a pull request. If it
+# returns 0, then a call is made to GitHub to get pull request details, and the
+# PR details are added to $builder_pull_title, $builder_pull_number, and
+# the $builder_pull_labels array.
+#
+# Note that the GitHub REST call is made with credentials if $GITHUB_TOKEN is
+# available; without credentials it will be subject to IP-based rate limits.
+#
+builder_pull_get_details() {
+  builder_pull_title=
+  builder_pull_number=
+  builder_pull_labels=()
+  if [[ ! ${TEAMCITY_PR_NUMBER-} =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+
+  if [ -z "${GITHUB_TOKEN-}" ]; then
+    local pull_data=`curl -s https://api.github.com/repos/keymanapp/keyman/pulls/$TEAMCITY_PR_NUMBER`
+  else
+    local pull_data=`curl -H "Authorization: Bearer $GITHUB_TOKEN" -s https://api.github.com/repos/keymanapp/keyman/pulls/$TEAMCITY_PR_NUMBER`
+  fi
+
+  builder_pull_title=`echo $pull_data | $JQ .title`
+
+  # Simple poor bash test if data returned from API is valid
+  if [[ -z builder_pull_title ]]; then
+    return 1
+  fi
+
+  builder_pull_number=$TEAMCITY_PR_NUMBER
+  builder_pull_labels=(`echo $pull_data | $JQ -jr '.labels[].name|.," "'`)
+
+  return 0
+}
+
+
+#
+# Returns 0 if the current PR has a particular label. Requires
+# builder_pull_get_details to have successfully run first
+#
+# Usage:
+#   builder_pull_has_label "label-name"
+# Parameters
+#   1: $label       label to test
+#
+function builder_pull_has_label() {
+  local label="$1"
+  if [[ " ${builder_pull_labels[*]} " =~ " $label " ]]; then
+    return 0
+  fi
+  return 1
+}

--- a/resources/build/build-utils-ci.test.sh
+++ b/resources/build/build-utils-ci.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# This script tests build-utils-ci.sh
+#
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+# Tests
+
+echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER not set${COLOR_RESET}"
+if ! builder_pull_get_details; then
+  echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
+else
+  fail "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
+fi
+
+
+echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=master${COLOR_RESET}"
+TEAMCITY_PR_NUMBER=master
+if ! builder_pull_get_details; then
+  echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
+else
+  fail "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
+fi
+
+
+echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER${COLOR_RESET}"
+TEAMCITY_PR_NUMBER=7248
+if ! builder_pull_get_details; then
+  fail "FAIL: builder_pull_get_details was unable to read and parse PR details for #$TEAMCITY_PR_NUMBER from GitHub"
+fi
+
+# print metadata from PR
+echo "  pull number: $builder_pull_number"
+echo "  title:       $builder_pull_title"
+echo "  labels:      ${builder_pull_labels[*]}"
+
+echo "PASS: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER"
+
+
+echo "${COLOR_BLUE}## Testing: builder_pull_has_label epic-ldml${COLOR_RESET}"
+if ! builder_pull_has_label epic-ldml; then
+  fail "FAIL: builder_pull_has_label epic-ldml"
+fi
+
+echo "PASS: builder_pull_has_label epic-ldml"
+
+echo "All tests passed."


### PR DESCRIPTION
Because BrowserStack tests are unreliable, I am disabling them for any builds that are not specifically targeting web. Two ways that the tests can be enabled:

1. Include '(web)' in the PR title
2. Include the label test-browserstack

This only impacts builds in the CI test environment, not anything else.

See build-utils-ci.inc.sh for helper functions for accessing PR metadata, and build-utils-ci.test.sh for unit tests for this functionality.

@keymanapp-test-bot skip