### PR TITLE
docs(windows): add steps for using testhost debugging

### DIFF
--- a/windows/src/engine/testhost/README.md
+++ b/windows/src/engine/testhost/README.md
@@ -5,3 +5,13 @@ This project is a debug host for keyman32 (and keyman64). It is setup to run a s
 The primary use of testhost is in interactive debugging of Keyman Core, and intermediate Engine code around Core. The final stage of characters reaching the document  will not be identical to Keyman Engine in normal use, and there may be other interactive limitations as well.
 
 Before trying to run, make sure you have built keyman32 in Debug configuration. Testhost will attempt to load keyman32.dll from ../keyman32/bin/Win32/Debug/keyman32.dll, and if that is not present, from ../keyman32/bin/Win32/Release/keyman32.dll, and finally, from a hardcoded "C:\\Program Files (x86)\\Common Files\\Keyman\\Keyman Engine\\keyman32.dll" (which is hacky but probably suffices for now).
+
+The work flow that works well using testhost.
+With Visual Studio(VS)
+1. Build Keyman32 with Debug Configuration.
+2. Build testhost with Debug Configuration.
+3. Insure Keyman is not running and that language associated with keyboard you want to test is not selected in the language bar.
+4. Press F5 to start debugging.
+5. Now use the language bar to select the language associated with a keyman keyboard.
+6. You should now be able to debug both the platform and keyman core code.
+7. Once you stop the debug session you will need to got back to step 3 start a new session. [ or step 1 if you are making code changes you should not need to reboot windows]

--- a/windows/src/engine/testhost/README.md
+++ b/windows/src/engine/testhost/README.md
@@ -10,8 +10,8 @@ The work flow that works well using testhost.
 With Visual Studio(VS)
 1. Build Keyman32 with Debug Configuration.
 2. Build testhost with Debug Configuration.
-3. Insure Keyman is not running and that language associated with keyboard you want to test is not selected in the language bar.
+3. Ensure Keyman is not running and that language associated with keyboard you want to test is not selected in the language bar.
 4. Press F5 to start debugging.
 5. Now use the language bar to select the language associated with a keyman keyboard.
 6. You should now be able to debug both the platform and keyman core code.
-7. Once you stop the debug session you will need to got back to step 3 start a new session. [ or step 1 if you are making code changes you should not need to reboot windows]
+7. Once you stop the debug session you will need to go back to step 3 to start a new session. (or step 1 if you are making code changes; you should not need to reboot windows.)


### PR DESCRIPTION
This just adds some workflow steps to testhost/README.md. These are the steps that I have found work consistently and very quickly (no windows restarts or rebuilds) to debug Keyman for windows and Keyman core.