### PR TITLE
fix(android/engine):  Standardize language ID in language picker 🍒

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageFragment.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageFragment.java
@@ -32,6 +32,7 @@ import com.tavultesoft.kmea.util.KMLog;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -190,6 +191,33 @@ public final class SelectLanguageFragment extends Fragment implements BlockingSt
 
     listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
+      /**
+       * Utility to modify keyboardList. Based on BCP47.toggleLanguage
+       * If keyboard's languageID exists in the list, remove the keyboard.
+       * Otherwise, add the keyboard to the list.
+       * @param keyboardList
+       * @param k
+       */
+      private void toggleLanguage(ArrayList<Keyboard> keyboardList, Keyboard k) {
+        if (keyboardList == null) {
+          throw new InvalidParameterException("keyboardList must not be null");
+        }
+        if (k == null) {
+          throw new InvalidParameterException("keyboard must not be null");
+        }
+
+        // See if languageID already exists in the keyboardList
+        for (Keyboard l: keyboardList) {
+          if (BCP47.languageEquals(l.getLanguageID(), k.getLanguageID())) {
+            keyboardList.remove(l);
+            return;
+          }
+        }
+
+        k.setLanguage(k.getLanguageID().toLowerCase(), k.getLanguageName());
+        keyboardList.add(k);
+      }
+
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         Keyboard k = availableKeyboardsList.get(position);
@@ -199,21 +227,13 @@ public final class SelectLanguageFragment extends Fragment implements BlockingSt
             languageList = new ArrayList<String>();
           }
           String selectedLanguageID = k.getLanguageID();
-          if (languageList.contains(selectedLanguageID)) {
-            languageList.remove(selectedLanguageID);
-          } else {
-            languageList.add(selectedLanguageID);
-          }
+          BCP47.toggleLanguage(languageList, selectedLanguageID);
         } else {
           // Otherwise, add the language association
           if (addKeyboardsList == null) {
             addKeyboardsList = new ArrayList<Keyboard>();
           }
-          if (addKeyboardsList.contains(k)) {
-            addKeyboardsList.remove(k);
-          } else {
-            addKeyboardsList.add(k);
-          }
+          toggleLanguage(addKeyboardsList, k);
         }
 
         // Disable install button if no languages selected or all languages already installed

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/BCP47.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/BCP47.java
@@ -4,6 +4,9 @@
 
 package com.tavultesoft.kmea.util;
 
+import java.util.ArrayList;
+import java.security.InvalidParameterException;
+
 public final class BCP47 {
   /**
    * Utility to compare two language ID strings
@@ -17,5 +20,30 @@ public final class BCP47 {
     }
 
     return id1.equalsIgnoreCase(id2);
+  }
+
+  /**
+   * Utility to modify languageList.
+   * If languageID exists in the list, remove it. Otherwise, add languageID to the list.
+   * @param languageList
+   * @param languageID
+   */
+  public static void toggleLanguage(ArrayList<String> languageList, String languageID) {
+    if (languageList == null) {
+      throw new InvalidParameterException("languageList must not be null");
+    }
+    if (languageID == null) {
+      throw new InvalidParameterException("languageID must not be null");
+    }
+
+    // See if languageID already exists in the languageList
+    for (String l: languageList) {
+      if (languageEquals(l, languageID)) {
+        languageList.remove(l);
+        return;
+      }
+    }
+
+    languageList.add(languageID.toLowerCase());
   }
 }


### PR DESCRIPTION
:cherries: pick of #7239 to stable-15.0

Standardize language ID in language picker menu to compare language tags in the lists.


## User Testing
Setup - Use any Android device / emulator of Android SDK >= 21

* **TEST_ASSOCIATED_LANGUAGE_WORKS** - Verifies existing functionality of installing keyboard and associated lexical-model
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In Keyman Settings --> Install Keyboard or Dictionary --> Install from keyman.com --> Search for sil_jarai
4. Install the **sil_jarai** keyboard package
5. Wait a few minutes for the associated dictionary to install (for jra-Latn language)
6. Verify suggestions appear on top of the sil_jarai keyboard

* **TEST_ADD_LANGUAGE** - Verifies existing functionality of adding a language for an already installed keyboard
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In Keyman Settings --> Install Keyboard or Dictionary --> Add languages to installed keyboard
4. Select EuroLatin (SIL) Keyboard
5. In the language picker, scroll down and select "Crimean Tatar" --> Install.  This adds the language tag `crh-latn`
6. Return to Keyman Settings --> Installed languages
7. Verify "Crimean Tatar" appears as an installed language

* **TEST_DEFAULT_LANGUAGE_UNSELECTED** - Verifies the fix to #6732
1. On the Android device, install the PR build of Keyman for Android
2. Dismiss the "Get Started" menu
3. In Keyman Settings --> Install Keyboard or Dictionary --> Install from keyman.com
4. Search for "`l:id:bkc`" which searches for associated language Baka (`bkc-Latn`). Note, beware if Gboard keyboard auto-corrects the query and changes your search string, which could cause the keyboard search to return 0 results.
5. In the search results, select and install "**sil_cameroon_qwerty**"
6. During the sil_cameroon_qwerty keyboard package installation, scroll down and verify the default language "Baka") is selected.
7. De-select "Baka" and attempt to hit "install"
8. Verify a toast notification "no languages selected" appears and the language picker is still visible
9. With Baka unselected, select a different language (e.g. Pinyin) and finish the keyboard installation
10. When the keyboard package installation finishes, go back to Keyman Settings --> Installed languages
11. Verify Baka does not appear