### PR TITLE
feat(common/models): wordbreaker customization

### DIFF
--- a/common/models/templates/test/test-tokenization.js
+++ b/common/models/templates/test/test-tokenization.js
@@ -289,6 +289,82 @@ describe('Tokenization functions', function() {
 
       assert.deepEqual(tokenization, expectedResult);
     });
+
+    let midLetterNonbreaker = (text) => {
+      let customization = {
+        rules: [{
+          match: (context) => {
+            if(context.propertyMatch(null, ["ALetter"], ["MidLetter"], ["eot"])) {
+              return true;
+            } else {
+              return false;
+            }
+          },
+          breakIfMatch: false
+        }],
+        propertyMapping: (char) => {
+          let hyphens = ['\u002d', '\u2010', '\u058a', '\u30a0'];
+          if(hyphens.includes(char)) {
+              return "MidLetter";
+          } else {
+            return null;
+          }
+        }
+      };
+
+      return wordBreakers.default(text, customization);
+    }
+
+    it('treats caret as `eot` for pre-caret text', function() {
+      let context = {
+        left: "don-",  // We use a hyphen here b/c single-quote is hardcoded.
+        right: " worry",
+        endOfBuffer: true,
+        startOfBuffer: true
+      };
+
+      let tokenization = models.tokenize(wordBreakers.default, context);
+
+      assert.deepEqual(tokenization, {
+        left: ["don", "-"],
+        right: ["worry"],
+        caretSplitsToken: false
+      });
+
+      tokenization = models.tokenize(midLetterNonbreaker, context);
+
+      assert.deepEqual(tokenization, {
+        left: ["don-"],
+        right: ["worry"],
+        caretSplitsToken: false
+      });
+    });
+
+    it('handles mid-contraction tokenization', function() {
+      let context = {
+        left: "don:",
+        right: "t worry",
+        endOfBuffer: true,
+        startOfBuffer: true
+      };
+
+      let tokenization = models.tokenize(wordBreakers.default, context);
+
+      assert.deepEqual(tokenization, {
+        left: ["don", ":"],    // This particular case feels like a possible issue.
+        right: ["t", "worry"], // It'd be a three-way split token, as "don:t" would
+                               // be a single token were it not for the caret in the middle.
+        caretSplitsToken: false
+      })
+
+      tokenization = models.tokenize(midLetterNonbreaker, context);
+
+      assert.deepEqual(tokenization, {
+        left: ["don:"],
+        right: ["t", "worry"],
+        caretSplitsToken: true
+      });
+    });
   });
 
   describe('getLastPreCaretToken', function() {

--- a/common/models/wordbreakers/src/default/data.ts
+++ b/common/models/wordbreakers/src/default/data.ts
@@ -28,6 +28,32 @@ export const enum WordBreakProperty { // Scary bit:  this does not exist as an o
   eot
 };
 
+// Not currently built by the auto-generator tool, but it easily could be.
+// If and when we import the data.ts rebuilder, we can add this in.
+export const propertyMap = [
+  "Other",
+  "LF",
+  "Newline",
+  "CR",
+  "WSegSpace",
+  "Double_Quote",
+  "Single_Quote",
+  "MidNum",
+  "MidNumLet",
+  "Numeric",
+  "MidLetter",
+  "ALetter",
+  "ExtendNumLet",
+  "Format",
+  "Extend",
+  "Hebrew_Letter",
+  "ZWJ",
+  "Katakana",
+  "Regional_Indicator",
+  "sot",
+  "eot"
+];
+
 /**
  * Constants for indexing values in WORD_BREAK_PROPERTY.
  */

--- a/common/models/wordbreakers/src/default/data.ts
+++ b/common/models/wordbreakers/src/default/data.ts
@@ -4,7 +4,7 @@ export namespace data {
 /**
  * Valid values for a word break property.
  */
-export const enum WordBreakProperty {
+export const enum WordBreakProperty { // Scary bit:  this does not exist as an object at run-time!
   Other,
   LF,
   Newline,

--- a/common/models/wordbreakers/src/default/index.ts
+++ b/common/models/wordbreakers/src/default/index.ts
@@ -26,7 +26,7 @@ namespace wordBreakers {
      * Allows definition of extra word-breaking properties for use with custom
      * rules.
      */
-    customProperties?: [string];
+    customProperties?: string[];
   }
 
   /**

--- a/common/models/wordbreakers/src/default/index.ts
+++ b/common/models/wordbreakers/src/default/index.ts
@@ -254,6 +254,9 @@ namespace wordBreakers {
      *
      * Names should match those found at https://unicode.org/reports/tr29/#Word_Boundary_Rules
      * or defined in the word-breaker customization options; matching is case-insensitive.
+     * Also includes two extra properties:
+     * - `sot` - start of text
+     * - `eot` - end of text
      * @param lookbehindSet
      * @param leftSet
      * @param rightSet

--- a/common/models/wordbreakers/src/default/index.ts
+++ b/common/models/wordbreakers/src/default/index.ts
@@ -584,20 +584,6 @@ namespace wordBreakers {
     return customIndex != -1 ? -customIndex - 1 : data.propertyMap.findIndex(matcher);
   }
 
-  // /**
-  //  * Provides the word-breaking property name for the specified character based on the property
-  //  * values used by https://unicode.org/reports/tr29/#Word_Boundary_Rules.
-  //  * @param character
-  //  * @returns
-  //  */
-  // export function unicodeProperty(character: string): string {
-  //   // Since we use a const enum for property names, the TS compiler optimizes it away
-  //   // and does not provide a reverse lookup for us.  So, we do that here.
-  //   const enumVal = property(character);
-
-  //   return data.propertyMap[enumVal];
-  // }
-
   /**
    * Binary search for the word break property of a given CODE POINT.
    *
@@ -634,7 +620,6 @@ namespace wordBreakers {
 // implementing a namespace, BUT we can manually make the
 // assignment and **declare** it as part of the namespace.
 wordBreakers['default'] = wordBreakers.default_;
-// wordBreakers['unicodeProperty'] = wordBreakers.unicodeProperty;
 declare namespace wordBreakers {
   export { default_ as default };
 }

--- a/common/models/wordbreakers/test/test-default-word-breaker.js
+++ b/common/models/wordbreakers/test/test-default-word-breaker.js
@@ -8,184 +8,334 @@ const breakWords = require('../build').wordBreakers['default'];
 const SHY = '\u00AD'; // Other, Format.  The "Soft HYphen" - usually invisible unless needed for word-wrapping.
 
 describe('The default word breaker', function () {
-  it('should break multilingual text', function () {
-    let breaks = breakWords(
-      `Добрый день! ᑕᐻ᙮ — after working on ka${SHY}wen${SHY}non:${SHY}nis,
-       let's eat phở! 🥣`
-    );
-    let words = breaks.map(span => span.text);
-    assert.deepEqual(words, [
-      'Добрый', 'день', '!', 'ᑕᐻ', '᙮', '—', 'after',
-      'working', 'on', `ka${SHY}wen${SHY}non:${SHY}nis`, ',',
-      "let's", 'eat', 'phở', '!', '🥣'
-    ]);
+  describe('default configuration', function() {
+    it('should break multilingual text', function () {
+      let breaks = breakWords(
+        `Добрый день! ᑕᐻ᙮ — after working on ka${SHY}wen${SHY}non:${SHY}nis,
+         let's eat phở! 🥣`
+      );
+      let words = breaks.map(span => span.text);
+      assert.deepEqual(words, [
+        'Добрый', 'день', '!', 'ᑕᐻ', '᙮', '—', 'after',
+        'working', 'on', `ka${SHY}wen${SHY}non:${SHY}nis`, ',',
+        "let's", 'eat', 'phở', '!', '🥣'
+      ]);
+    });
+
+    it('handles heavily-punctuated English text', function() {
+      // This test case brought to you by http://unicode.org/reports/tr29/#Word_Boundaries, Figure 1.
+      let breaks = breakWords(
+        `The quick ("brown") fox can't jump 32.3 feet, right?`
+      );
+      let words = breaks.map(span => span.text);
+      assert.deepEqual(words, [
+        'The', 'quick', '(', '"', 'brown', '"', ')', 'fox', "can't",
+        'jump', '32.3', 'feet', ',', 'right', '?'
+      ]);
+    });
+
+    // The way these two tests are written is a bit much on the "white-box" style,
+    // but they do decently cover the boundary rules mentioned.
+    it('Does not split empty contexts (WB1 + WB2)', function() {
+      let breaks = breakWords('');
+      let words = breaks.map(span => span.text);
+      assert.deepEqual(words, []);
+    });
+
+    it('Does split at context boundaries (WB1 + WB2)', function() {
+      let breaks = breakWords('a');
+      let words = breaks.map(span => span.text);
+      assert.deepEqual(words, ['a']);
+    });
+
+    // WB3, WB3a, WB3b are all handled internally, within the top-level function.
+
+    // iff, as in "if and only if"
+    it('ignores the zero-width joiner iff appropriate (WB4)', function() {
+      const zwj = '\u200d';
+
+      let breaks = breakWords(`a${zwj}b\n${zwj}c${zwj}\nd`);
+      let words = breaks.map(span => span.text);
+
+      // Does NOT ignore the zwj immediately after a newline - the notable exception
+      // (the reason for "iff", not "if").
+      assert.deepEqual(words, [`a${zwj}b`, `${zwj}`, `c${zwj}`, `d`]);
+    })
+
+    it('ignores extend characters iff appropriate (WB4)', function() {
+      const comboGrave = '\u0300'; // The 'combining grave accent', as used in NFD.
+
+      let breaks = breakWords(`a${comboGrave}e\n${comboGrave}i${comboGrave}\no`);
+      let words = breaks.map(span => span.text);
+
+      // Does NOT ignore the zwj immediately after a newline - the notable exception
+      // (the reason for "iff", not "if").
+      assert.deepEqual(words, [`a${comboGrave}e`, `${comboGrave}`, `i${comboGrave}`, `o`]);
+    });
+
+    it('ignores format characters iff appropriate (WB4)', function() {
+      // Re-uses `const SHY` from above.
+      let breaks = breakWords(`a${SHY}e\n${SHY}i${SHY}\no`);
+      let words = breaks.map(span => span.text);
+
+      // Does NOT ignore the zwj immediately after a newline - the notable exception
+      // (the reason for "iff", not "if").
+      assert.deepEqual(words, [`a${SHY}e`, `${SHY}`, `i${SHY}`, `o`]);
+    });
+
+    it('does not break between most alphabetic characters (WB5)', function() {
+      let breaks = breakWords(`aəσאБ лאʈγX`); // a mix of latin, hebrew, greek, cyrillic, and IPA chars
+                                              // for both "words".
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, [`aəσאБ`, `лאʈγX`]);
+    });
+
+    it('does not break letters across specific punctuation patterns (WB6, WB7)', function() {
+      // `'`:  MidNumLetQ (from Single_Quote)
+      // '.':  MidNumLet
+      // ':':  MidLetter
+      let breaks = breakWords(`don't b.r.e.a.k t:h:e:s:e`);
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, [`don't`, `b.r.e.a.k`, `t:h:e:s:e`]);
+
+      let breaks2 = breakWords(`.drop: :the' 'extras.`);
+      let words2 = breaks2.map(span => span.text);
+
+      assert.deepEqual(words2, [`.`, `drop`, `:`, `:`, `the`, `'`, `'`, `extras`, `.`]);
+
+      // ',': MidNum (is NOT included by rule!)
+      let breaks3 = breakWords('do br,eak that');
+      let words3 = breaks3.map(span => span.text);
+
+      assert.deepEqual(words3, ['do', 'br', ',', 'eak', 'that']);
+    });
+
+    it('treats Hebrew properly (WB7a-c)', function() {
+      const aleph = 'א';
+      const bet = 'ב';
+
+      // As Hebrew is RTL... this is probably the clearest way for us LTR people to
+      // clearly see what's going on without ordering mechanics messing up the render.
+      let breaks = breakWords(`${aleph}' ${aleph}" ${aleph}"${bet}`);
+      let words = breaks.map(span => span.text);
+
+      // A lingering double-quote isn't cool, but one in the middle's fine.
+      // Lingering single-quote is fine regardless.
+      assert.deepEqual(words, [`${aleph}'`, `${aleph}`, `"`, `${aleph}"${bet}`]);
+    });
+
+    it(`doesn't break within digit + digit/letter sequences (WB8-10)`, function() {
+      let breaks = breakWords('a1b2c3 hunter2 ab12cd34 1234567890');
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, ['a1b2c3', 'hunter2', 'ab12cd34', '1234567890']);
+    });
+
+    it('does not break within formatted number sequences (WB11-12)', function() {
+      // Note:  `'` fits "MidNumLetQ", part of the two rules!
+      let breaks = breakWords(`1.2.3 3,458.01 3.45'8,01`);
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, [`1.2.3`, `3,458.01`, `3.45'8,01`]);
+
+      let breaks2 = breakWords(`.1' ,3.`);
+      let words2 = breaks2.map(span => span.text);
+
+      assert.deepEqual(words2, [`.`, `1`, `'`, `,`, `3`, `.`]);
+    });
+
+    it('does not break between Katakana (WB13)', function() {
+      const kataSmA = '\u30a2'; //ァ
+      const kataA = '\u30a2'; //ア
+      const kataSound = '\u309b'; // ゛
+
+      let breaks = breakWords(`${kataSound}${kataA} ${kataSmA}${kataSound}b ${kataA}${kataSound}${kataSmA}`);
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, [
+        `${kataSound}${kataA}`,
+        `${kataSmA}${kataSound}`,
+        'b',
+        `${kataA}${kataSound}${kataSmA}`
+      ]);
+    });
+
+    it('does not break form extenders (WB13a-b)', function() {
+      // The `_` (underscore) fits the ExtendNumLet class this rule focuses on.
+      const kataA = '\u30a2'; //ア
+
+      let breaks = breakWords(`${kataA}_a__0_b_${kataA} _${kataA} 1_ _c_ ____`);
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, [
+        `${kataA}_a__0_b_${kataA}`,
+        `_${kataA}`,
+        `1_`,
+        `_c_`,
+        `____`
+      ]);
+    });
+
+    it('handles emoji flag sequences properly (WB15-16)', function() {
+      // For clarity on what's being tested...
+      let CA_FLAG =      '\u{1f1e8}\u{1f1e6}' // '🇨🇦' (canadian flag emoji); should not be broken.
+      let KH_FLAG =      '\u{1f1f0}\u{1f1ed}' // '🇰🇭' (khmer flag emoji); same
+      let X_FLAG_PIECE = '\u{1f1fd}'          // '🇽'  (half of a flag emoji; '🇽🇽' doesn't match a flag)
+      let breaks = breakWords(`${CA_FLAG}${KH_FLAG}${X_FLAG_PIECE}${X_FLAG_PIECE}`);
+      let words = breaks.map(span => span.text);
+
+      // Note that the emoji may not render well within VSCode, but they show up nicely on GitHub.
+      assert.deepEqual(words, ['🇨🇦', '🇰🇭', '🇽🇽']);
+    });
+
+    it('breaks hyphenated words by default', function() {
+      let breaks = breakWords('Smith-Jones');
+      let words = breaks.map(span => span.text);
+
+      assert.deepEqual(words, ['Smith', '-', 'Jones']);
+    });
   });
 
-  it('handles heavily-punctuated English text', function() {
-    // This test case brought to you by http://unicode.org/reports/tr29/#Word_Boundaries, Figure 1.
-    let breaks = breakWords(
-      `The quick ("brown") fox can't jump 32.3 feet, right?`
-    );
-    let words = breaks.map(span => span.text);
-    assert.deepEqual(words, [
-      'The', 'quick', '(', '"', 'brown', '"', ')', 'fox', "can't",
-      'jump', '32.3', 'feet', ',', 'right', '?'
-    ]);
-  });
+  describe('customization', function() {
+    // Refer to https://unicode.org/reports/tr29/#Word_Boundary_Rules, third bullet point.
+    it('custom prop, rule:  do not break on letter-adjacent hyphens', function() {
+      let customization = {
+        rules: [{
+          match: (context) => {
+            if(context.propertyMatch(null, ["ALetter"], ["Hyphen"], ["ALetter"])) {
+              return true;
+            } else if(context.propertyMatch(["ALetter"], ["Hyphen"], ["ALetter"], null)) {
+              return true;
+            } else {
+              return false;
+            }
+          },
+          breakIfMatch: false
+        }],
+        propertyMapping: (char) => {
+          const validHyphenCodes = [
+            '\u002d', '\u2010', '\u058a', '\u30a0'
+          ];
+          if(validHyphenCodes.includes(char)) {
+            return "Hyphen";
+          }
 
-  // The way these two tests are written is a bit much on the "white-box" style,
-  // but they do decently cover the boundary rules mentioned.
-  it('Does not split empty contexts (WB1 + WB2)', function() {
-    let breaks = breakWords('');
-    let words = breaks.map(span => span.text);
-    assert.deepEqual(words, []);
-  });
+          return null;
+        },
+        customProperties: ["Hyphen"]
+      }
 
-  it('Does split at context boundaries (WB1 + WB2)', function() {
-    let breaks = breakWords('a');
-    let words = breaks.map(span => span.text);
-    assert.deepEqual(words, ['a']);
-  });
+      let breaks = breakWords('Smith-Jones', customization);
+      let words = breaks.map(span => span.text);
 
-  // WB3, WB3a, WB3b are all handled internally, within the top-level function.
+      assert.deepEqual(words, ['Smith-Jones']);
+    });
 
-  // iff, as in "if and only if"
-  it('ignores the zero-width joiner iff appropriate (WB4)', function() {
-    const zwj = '\u200d';
+    it('mid-word hyphen via reassignment to MidLetter', function() {
+      let customization = {
+        propertyMapping: (char) => {
+          const validHyphenCodes = [
+            '\u002d', '\u2010', '\u058a', '\u30a0'
+          ];
+          if(validHyphenCodes.includes(char)) {
+            return "MidLetter";
+          }
 
-    let breaks = breakWords(`a${zwj}b\n${zwj}c${zwj}\nd`);
-    let words = breaks.map(span => span.text);
+          return null;
+        }
+      }
 
-    // Does NOT ignore the zwj immediately after a newline - the notable exception
-    // (the reason for "iff", not "if").
-    assert.deepEqual(words, [`a${zwj}b`, `${zwj}`, `c${zwj}`, `d`]);
-  })
+      let breaks = breakWords('Smith-Jones', customization);
+      let words = breaks.map(span => span.text);
 
-  it('ignores extend characters iff appropriate (WB4)', function() {
-    const comboGrave = '\u0300'; // The 'combining grave accent', as used in NFD.
+      assert.deepEqual(words, ['Smith-Jones']);
+    });
 
-    let breaks = breakWords(`a${comboGrave}e\n${comboGrave}i${comboGrave}\no`);
-    let words = breaks.map(span => span.text);
+    // Useful for some regional minority languages that prefer word-breaking spaces.
+    it('character reassignment:  Khmer letters as ALetter', function() {
+      let customization = {
+        propertyMapping: (char) => {
+          if(char >= '\u1780' && char <= '\u17b3') {
+            return "ALetter";
+          } else {
+            // The other Khmer characters already have useful word-breaking
+            // property assignments.
+            return null;
+          }
+        }
+      }
 
-    // Does NOT ignore the zwj immediately after a newline - the notable exception
-    // (the reason for "iff", not "if").
-    assert.deepEqual(words, [`a${comboGrave}e`, `${comboGrave}`, `i${comboGrave}`, `o`]);
-  });
+      let breaks = breakWords('ស្រុក ខ្មែរ', customization);
+      let words = breaks.map(span => span.text);
 
-  it('ignores format characters iff appropriate (WB4)', function() {
-    // Re-uses `const SHY` from above.
-    let breaks = breakWords(`a${SHY}e\n${SHY}i${SHY}\no`);
-    let words = breaks.map(span => span.text);
+      assert.deepEqual(words, ['ស្រុក', 'ខ្មែរ']);
+    });
 
-    // Does NOT ignore the zwj immediately after a newline - the notable exception
-    // (the reason for "iff", not "if").
-    assert.deepEqual(words, [`a${SHY}e`, `${SHY}`, `i${SHY}`, `o`]);
-  });
+    // See:  suggested language-specific WB5a from the spec's notes.
+    it("french/italian apostrophe / vowel boundaries", function() {
+      let customization = {
+        rules: [
+          // WB5, but with differentiated consonants (ALetter) and vowels (AVowel)
+          {
+            match: (context) => {
+              if(context.propertyMatch(null, ["ALetter", "AVowel"], ["ALetter", "AVowel"], null)) {
+                return true;
+              } else {
+                return false;
+              }
+            },
+            breakIfMatch: false
+          },
+          // Proposed WB5a
+          {
+            match: (context) => {
+              if(context.propertyMatch(null, ["Single_Quote"], ["AVowel"], null)) {
+                return true;
+              } else {
+                return false;
+              }
+            },
+            breakIfMatch: true
+          },
+          // WB6, 7
+          {
+            match: (context) => {
+              if(context.propertyMatch(null,
+                                       ["ALetter", "AVowel"],
+                                       ["MidLetter", "MidNumLet", "Single_Quote"],
+                                       ["ALetter", "AVowel"])) {
+                return true;
+              } else if(context.propertyMatch(["ALetter", "AVowel"],
+                                              ["MidLetter", "MidNumLet", "Single_Quote"],
+                                              ["ALetter", "AVowel"],
+                                              null)) {
+                return true;
+              } else {
+                return false;
+              }
+            },
+            breakIfMatch: false
+          }
+          // Similar extensions to WB9, 10, 13a, and 13b would also be needed for robustness.
+          // And I kind of left the Hebrew_Letter out of the WB5, 6, and 7 rewrites.
+        ],
+        propertyMapping: (char) => {
+          const vowels = ['a', 'e', 'i', 'o', 'u'];
+          if(vowels.includes(char)) {
+            return "AVowel";
+          }
 
-  it('does not break between most alphabetic characters (WB5)', function() {
-    let breaks = breakWords(`aəσאБ лאʈγX`); // a mix of latin, hebrew, greek, cyrillic, and IPA chars
-                                            // for both "words".
-    let words = breaks.map(span => span.text);
+          return null;
+        },
+        customProperties: ["AVowel"]
+      }
 
-    assert.deepEqual(words, [`aəσאБ`, `лאʈγX`]);
-  });
+      let breaks = breakWords("l'objectif aujourd'hui", customization);
+      let words = breaks.map(span => span.text);
 
-  it('does not break letters across specific punctuation patterns (WB6, WB7)', function() {
-    // `'`:  MidNumLetQ (from Single_Quote)
-    // '.':  MidNumLet
-    // ':':  MidLetter
-    let breaks = breakWords(`don't b.r.e.a.k t:h:e:s:e`);
-    let words = breaks.map(span => span.text);
-
-    assert.deepEqual(words, [`don't`, `b.r.e.a.k`, `t:h:e:s:e`]);
-
-    let breaks2 = breakWords(`.drop: :the' 'extras.`);
-    let words2 = breaks2.map(span => span.text);
-
-    assert.deepEqual(words2, [`.`, `drop`, `:`, `:`, `the`, `'`, `'`, `extras`, `.`]);
-
-    // ',': MidNum (is NOT included by rule!)
-    let breaks3 = breakWords('do br,eak that');
-    let words3 = breaks3.map(span => span.text);
-
-    assert.deepEqual(words3, ['do', 'br', ',', 'eak', 'that']);
-  });
-
-  it('treats Hebrew properly (WB7a-c)', function() {
-    const aleph = 'א';
-    const bet = 'ב';
-
-    // As Hebrew is RTL... this is probably the clearest way for us LTR people to
-    // clearly see what's going on without ordering mechanics messing up the render.
-    let breaks = breakWords(`${aleph}' ${aleph}" ${aleph}"${bet}`);
-    let words = breaks.map(span => span.text);
-
-    // A lingering double-quote isn't cool, but one in the middle's fine.
-    // Lingering single-quote is fine regardless.
-    assert.deepEqual(words, [`${aleph}'`, `${aleph}`, `"`, `${aleph}"${bet}`]);
-  });
-
-  it(`doesn't break within digit + digit/letter sequences (WB8-10)`, function() {
-    let breaks = breakWords('a1b2c3 hunter2 ab12cd34 1234567890');
-    let words = breaks.map(span => span.text);
-
-    assert.deepEqual(words, ['a1b2c3', 'hunter2', 'ab12cd34', '1234567890']);
-  });
-
-  it('does not break within formatted number sequences (WB11-12)', function() {
-    // Note:  `'` fits "MidNumLetQ", part of the two rules!
-    let breaks = breakWords(`1.2.3 3,458.01 3.45'8,01`);
-    let words = breaks.map(span => span.text);
-
-    assert.deepEqual(words, [`1.2.3`, `3,458.01`, `3.45'8,01`]);
-
-    let breaks2 = breakWords(`.1' ,3.`);
-    let words2 = breaks2.map(span => span.text);
-
-    assert.deepEqual(words2, [`.`, `1`, `'`, `,`, `3`, `.`]);
-  });
-
-  it('does not break between Katakana (WB13)', function() {
-    const kataSmA = '\u30a2'; //ァ
-    const kataA = '\u30a2'; //ア
-    const kataSound = '\u309b'; // ゛
-
-    let breaks = breakWords(`${kataSound}${kataA} ${kataSmA}${kataSound}b ${kataA}${kataSound}${kataSmA}`);
-    let words = breaks.map(span => span.text);
-
-    assert.deepEqual(words, [
-      `${kataSound}${kataA}`,
-      `${kataSmA}${kataSound}`,
-      'b',
-      `${kataA}${kataSound}${kataSmA}`
-    ]);
-  });
-
-  it('does not break form extenders (WB13a-b)', function() {
-    // The `_` (underscore) fits the ExtendNumLet class this rule focuses on.
-    const kataA = '\u30a2'; //ア
-
-    let breaks = breakWords(`${kataA}_a__0_b_${kataA} _${kataA} 1_ _c_ ____`);
-    let words = breaks.map(span => span.text);
-
-    assert.deepEqual(words, [
-      `${kataA}_a__0_b_${kataA}`,
-      `_${kataA}`,
-      `1_`,
-      `_c_`,
-      `____`
-    ]);
-  });
-
-  it('handles emoji flag sequences properly (WB15-16)', function() {
-    // For clarity on what's being tested...
-    let CA_FLAG =      '\u{1f1e8}\u{1f1e6}' // '🇨🇦' (canadian flag emoji); should not be broken.
-    let KH_FLAG =      '\u{1f1f0}\u{1f1ed}' // '🇰🇭' (khmer flag emoji); same
-    let X_FLAG_PIECE = '\u{1f1fd}'          // '🇽'  (half of a flag emoji; '🇽🇽' doesn't match a flag)
-    let breaks = breakWords(`${CA_FLAG}${KH_FLAG}${X_FLAG_PIECE}${X_FLAG_PIECE}`);
-    let words = breaks.map(span => span.text);
-
-    // Note that the emoji may not render well within VSCode, but they show up nicely on GitHub.
-    assert.deepEqual(words, ['🇨🇦', '🇰🇭', '🇽🇽']);
+      assert.deepEqual(words, ["l'", "objectif", "aujourd'hui"]);
+    });
   });
 });


### PR DESCRIPTION
Addresses #3347.  If nothing else, this should help prompt some nice discussion toward a better solution.

Note the addition of unit tests to cover almost every base case of the standard Unicode word-breaking implementation, then extra ones to verify that customization can work for a few decent sample cases.

To be clear, any custom rules will have priority over all rules after WB4 from the wordbreaker spec.  Furthermore, reclassifying any character is absolute - each character may only match a single word-breaking property value.

These changes don't make any direct changes to the lexical model compiler, so testing may be needed to be sure there are no issues with specifying the customizations to the word-breaking function.  (That said, it appears to be 100% fine when using command-line compilation!)  Alternatively, the model.ts file could provide a more friendly format (syntactic sugar) that compiles down to the actual customization function closure format shown below.

I _have_ tested this with KeymanWeb via an edited lexical model (for a minority language with Khmer-based script):

Before:

```javascript
wordBreaker: wordBreakers['default']
```

After:

```javascript
wordBreaker: (text) => {
    let customization = {
      rules: [{
        match: (context) => {
          if(context.propertyMatch(null, ["ALetter"], ["Hyphen"], ["ALetter"])) {
            return true;
          } else if(context.propertyMatch(null, ["ALetter"], ["Hyphen"], ["eot"])) {
            return true;
          } else if(context.propertyMatch(["ALetter"], ["Hyphen"], ["ALetter"], null)) {
            return true;
          } else {
            return false;
          }
        },
        breakIfMatch: false
      }],
      propertyMapping: (char) => {
        let hyphens = ['\u002d', '\u2010', '\u058a', '\u30a0'];
        if(char >= '\u1780' && char <= '\u17b3') {  // treats Khmer consonants & independent vowels as English chars
            return "ALetter";
        } else if(hyphens.includes(char)) {
            return "Hyphen";
        } else {
          // The other Khmer characters already have useful word-breaking
          // property assignments.
          return null;
        }
      },
      customProperties: ["Hyphen"]
    }
    return wordBreakers['default'](text, customization);
  },
```

Resulting package:  [sil.jra-khmr.jarai.model.kmp.zip](https://github.com/keymanapp/keyman/files/9553911/sil.jra-khmr.jarai.model.kmp.zip)

The experiment was done by making these edits in https://github.com/keymanapp/lexical-models/tree/master/release/sil/sil.jra-khmr.jarai.  Note that the unit tests contain a few other nifty examples for possible customization, though I'll admit the solution for French & Italian article conjunctions isn't the most elegant.

Again, the actual model.ts file compiles well via command-line with the lexical-model compiler - no editing needed!  That said, when editing (granted, in VSCode), I did see a minor issue on the final line of the closure - it doesn't know what `wordBreakers['default']` is referencing there.  I don't know if this will also be an issue in Developer yet.

@keymanapp-test-bot skip

I believe the sizable array of new unit tests are sufficient to cover us here.

Though, if we did want _some_ form of user test, installation of the model from the zipped KMP could be used with one of the build artifacts for a test.