### PR TITLE
fix(linux): Fix ignored error

### DIFF
--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -55,8 +55,10 @@ deb: dist
 man:
 	./build-help.sh --man --no-reconf
 
-version:
+version_reconf:
 	cd .. && ./scripts/reconf.sh keyman-config
+
+version: version_reconf
 	$(eval VERSION := $(shell python3 -c "from keyman_config import __releaseversion__; print(__releaseversion__)"))
 
 # i18n


### PR DESCRIPTION
Previously we ignored an error that showed in the build logs because the eval line got executed before calling reconf.sh which created the version file. I think despite this error things worked, but it didn't look nice to have and ignore a build error in the build log.

Fixes #7275.

@keymanapp-test-bot skip