### PR TITLE
chore(developer): improve kmc validation and corresponding tests 🙀

### DIFF
--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -37,7 +37,7 @@ labels:
   # note, this does not pick up chained PRs automatically
   - label: 'stable'
     matcher:
-      baseBranch: '^stable-\\d+\\.\\d+'
+      baseBranch: '^stable-.+'
 
   - label: 'cherry-pick'
     matcher:

--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -11,7 +11,9 @@ version: v1
 #
 
 labels:
+  #
   # conventional commit / semantic PR styles
+  #
 
   - label: 'feat'
     matcher:
@@ -32,18 +34,28 @@ labels:
     matcher:
       title: '^auto(\(|:)'
 
+  #
   # additional meta flags
+  #
 
-  # note, this does not pick up chained PRs automatically
+  # stable-targeted patches; note, this does not pick up chained PRs automatically
   - label: 'stable'
     matcher:
       baseBranch: '^stable-.+'
 
+  # PRs marked as cherry-picks by title
   - label: 'cherry-pick'
     matcher:
       title: '(🍒|:cherries:)'
 
+  # long-lived feature branches
+  - label: 'feature-branch'
+    matcher:
+      branch: '^feature-.+'
+
+  #
   # Scopes that we look for in the PR title
+  #
 
   - label: 'android/'
     matcher:
@@ -76,7 +88,9 @@ labels:
     matcher:
       title: '\(.*windows.*\):'
 
+  #
   # epics -- we will add/remove these as we work on new epics each release
+  #
 
   - label: 'epic-ldml'
     matcher:

--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -11,6 +11,8 @@ version: v1
 #
 
 labels:
+  # conventional commit / semantic PR styles
+
   - label: 'feat'
     matcher:
       title: '^feat(\(|:)'
@@ -20,26 +22,38 @@ labels:
   - label: 'chore'
     matcher:
       title: '^chore(\(|:)'
-  # "change",
   - label: 'docs'
     matcher:
       title: '^docs(\(|:)'
-  # "style",
   - label: 'refactor'
     matcher:
       title: '^refactor(\(|:)'
-  # "test",
   - label: 'auto'
     matcher:
       title: '^auto(\(|:)'
 
-  # Below are the scopes that we look for in the PR title
+  # additional meta flags
+
+  # note, this does not pick up chained PRs automatically
+  - label: 'stable'
+    matcher:
+      baseBranch: '^stable-\\d+\\.'
+
+  - label: 'cherry-pick'
+    matcher:
+      title: '(🍒|:cherries:)'
+
+  # Scopes that we look for in the PR title
+
   - label: 'android/'
     matcher:
       title: '\(.*android.*\):'
   - label: 'common/'
     matcher:
       title: '\(.*common.*\):'
+  - label: 'core/'
+    matcher:
+      title: '\(.*core.*\):'
   - label: 'developer/'
     matcher:
       title: '\(.*developer.*\):'
@@ -62,6 +76,8 @@ labels:
     matcher:
       title: '\(.*windows.*\):'
 
-  - label: 'cherry-pick'
+  # epics -- we will add/remove these as we work on new epics each release
+
+  - label: 'epic-ldml'
     matcher:
-      title: '(🍒|:cherries:)'
+      branch: '.*epic-ldml.*' # anywhere in the branch name, e.g. feat/epic-ldml/developer/... or feat/developer/foo-epic-ldml

--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -37,7 +37,7 @@ labels:
   # note, this does not pick up chained PRs automatically
   - label: 'stable'
     matcher:
-      baseBranch: '^stable-\\d+\\.'
+      baseBranch: '^stable-\\d+\\.\\d+'
 
   - label: 'cherry-pick'
     matcher:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@8afa186ed03230c98fe24ebf9fe35093072ad46e # v1.4.0
+      uses: fuxingloh/multi-labeler@fb9bc28b2d65e406ffd208384c5095793c3fd59a # v1.8.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml

--- a/developer/src/kmc/src/keyman/compiler/compiler.ts
+++ b/developer/src/kmc/src/keyman/compiler/compiler.ts
@@ -6,6 +6,7 @@ import CompilerCallbacks from './callbacks';
 import CompilerOptions from './compiler-options';
 import { KeysCompiler } from './keys';
 import { LocaCompiler } from './loca';
+import { CompilerMessages } from './messages';
 import { MetaCompiler } from './meta';
 import { NameCompiler } from './name';
 import { OrdrCompiler } from './ordr';
@@ -92,8 +93,9 @@ export default class Compiler {
 
       /* istanbul ignore if */
       if(!sect) {
-        // This should not really happen -- validate() should be telling us
-        // if something is going to fail to compiler
+        // This should not happen -- validate() should have told us
+        // if something is going to fail to compile
+        this.callbacks.reportMessage(CompilerMessages.Fatal_SectionCompilerFailed({sect:section.id}));
         passed = false;
         continue;
       }

--- a/developer/src/kmc/src/keyman/compiler/loca.ts
+++ b/developer/src/kmc/src/keyman/compiler/loca.ts
@@ -46,7 +46,7 @@ export class LocaCompiler extends SectionCompiler {
     const locales = sourceLocales.map((sourceLocale: string) => {
       const locale = new Intl.Locale(sourceLocale).minimize().toString();
       if(locale != sourceLocale) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_LocaleIsNotMinimalAndClean(sourceLocale, locale));
+        this.callbacks.reportMessage(CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale, locale}));
       }
       return locale;
     });

--- a/developer/src/kmc/src/keyman/compiler/messages.ts
+++ b/developer/src/kmc/src/keyman/compiler/messages.ts
@@ -14,7 +14,7 @@ const SevInfo = CompilerErrorSeverity.Info;
 const SevHint = CompilerErrorSeverity.Hint;
 // const SevWarn = CompilerErrorSeverity.Warn;
 const SevError = CompilerErrorSeverity.Error;
-// const SevFatal = CompilerErrorSeverity.Fatal;
+const SevFatal = CompilerErrorSeverity.Fatal;
 
 export class CompilerMessages {
   static Error_InvalidNormalization = (o:{form: string}) => m(this.ERROR_InvalidNormalization, `Invalid normalization form '${o.form}`);
@@ -30,36 +30,48 @@ export class CompilerMessages {
   static ERROR_RowOnHardwareLayerHasTooManyKeys = SevError | 0x0004;
 
   static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
-     m(this.ERROR_KeyNotFoundInKeyBag, `Key ${o.keyId} in position #${o.col} on row #${o.row} of layer ${o.layer}, form '${o.form}' not found in key bag`);
+     m(this.ERROR_KeyNotFoundInKeyBag, `Key '${o.keyId}' in position #${o.col} on row #${o.row} of layer ${o.layer}, form '${o.form}' not found in key bag`);
   static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
 
   static Hint_OneOrMoreRepeatedLocales = () =>
     m(this.HINT_OneOrMoreRepeatedLocales, `After minimization, one or more locales is repeated and has been removed`);
   static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
 
-  static Error_InvalidFile = (errorText: string) =>
-    m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${errorText}`);
+  static Error_InvalidFile = (o:{errorText: string}) =>
+    m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${o.errorText}`);
   static ERROR_InvalidFile = SevError | 0x0007;
 
-  static Hint_LocaleIsNotMinimalAndClean = (sourceLocale: string, locale: string) =>
-    m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${sourceLocale}' is not minimal or correctly formatted and should be '${locale}'`);
+  static Hint_LocaleIsNotMinimalAndClean = (o:{sourceLocale: string, locale: string}) =>
+    m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${o.sourceLocale}' is not minimal or correctly formatted and should be '${o.locale}'`);
   static HINT_LocaleIsNotMinimalAndClean = SevHint | 0x0008;
 
-  static Error_VkeyIsNotValid = (vkey: string) =>
-    m(this.ERROR_VkeyIsNotValid, `Virtual key '${vkey}' is not found in the CLDR VKey Enum table.`);
+  static Error_VkeyIsNotValid = (o:{vkey: string}) =>
+    m(this.ERROR_VkeyIsNotValid, `Virtual key '${o.vkey}' is not found in the CLDR VKey Enum table.`);
   static ERROR_VkeyIsNotValid = SevError | 0x0009;
 
-  static Hint_VkeyMapIsRedundant = (vkey: string) =>
-    m(this.HINT_VkeyMapIsRedundant, `Virtual key '${vkey}' is mapped to itself, which is redundant.`);
+  static Hint_VkeyMapIsRedundant = (o:{vkey: string}) =>
+    m(this.HINT_VkeyMapIsRedundant, `Virtual key '${o.vkey}' is mapped to itself, which is redundant.`);
   static HINT_VkeyMapIsRedundant = SevHint | 0x000A;
 
-  static Error_VkeyMapIsRepeated = (vkey: string) =>
-    m(this.ERROR_VkeyMapIsRepeated, `Virtual key '${vkey}' has more than one VkeyMap entry.`);
+  static Error_VkeyMapIsRepeated = (o:{vkey: string}) =>
+    m(this.ERROR_VkeyMapIsRepeated, `Virtual key '${o.vkey}' has more than one VkeyMap entry.`);
   static ERROR_VkeyMapIsRepeated = SevError | 0x000B;
 
-  static Info_MultipleVkeyMapsHaveSameTarget = (vkey: string) =>
-    m(this.INFO_MultipleVkeyMapsHaveSameTarget, `Target virtual key '${vkey}' has multiple source mappings, which may be an error.`);
+  static Info_MultipleVkeyMapsHaveSameTarget = (o:{vkey: string}) =>
+    m(this.INFO_MultipleVkeyMapsHaveSameTarget, `Target virtual key '${o.vkey}' has multiple source mappings, which may be an error.`);
   static INFO_MultipleVkeyMapsHaveSameTarget = SevInfo | 0x000C;
+
+  static Error_InvalidVersion = (o:{version: string}) =>
+    m(this.ERROR_InvalidVersion, `Version number '${o.version}' must be a semantic version format string.`);
+  static ERROR_InvalidVersion = SevError | 0x000D;
+
+  static Error_MustBeAtLeastOneLayerElement = () =>
+    m(this.ERROR_MustBeAtLeastOneLayerElement, `The source file must contain at least one layer element.`);
+  static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;
+
+  static Fatal_SectionCompilerFailed = (o:{sect: string}) =>
+    m(this.FATAL_SectionCompilerFailed, `The compiler for '${o.sect}' failed unexpectedly.`);
+  static FATAL_SectionCompilerFailed = SevFatal | 0x000F;
 
   static severityName(code: number): string {
     let severity = code & CompilerErrorSeverity.Severity_Mask;
@@ -69,6 +81,7 @@ export class CompilerMessages {
       case CompilerErrorSeverity.Warn: return 'WARN';
       case CompilerErrorSeverity.Error: return 'ERROR';
       case CompilerErrorSeverity.Fatal: return 'FATAL';
+      /* istanbul ignore next */
       default: return 'UNKNOWN';
     }
   }

--- a/developer/src/kmc/src/keyman/compiler/meta.ts
+++ b/developer/src/kmc/src/keyman/compiler/meta.ts
@@ -24,9 +24,13 @@ export class MetaCompiler extends SectionCompiler {
     if(versionNumber !== undefined) {
       if(versionNumber.match(/^[=v]/i)) {
         // semver ignores a preceding '=' or 'v'
+        this.callbacks.reportMessage(CompilerMessages.Error_InvalidVersion({ version: versionNumber }));
         return false;
       }
-      return !!semver.parse(versionNumber, {loose: false, includePrerelease: true});
+      if(!semver.parse(versionNumber, {loose: false, includePrerelease: true})) {
+        this.callbacks.reportMessage(CompilerMessages.Error_InvalidVersion({ version: versionNumber }));
+        return false;
+      }
     }
     return true;
   }
@@ -48,7 +52,7 @@ export class MetaCompiler extends SectionCompiler {
     result.layout        = sections.strs.allocString(this.keyboard.info?.layout);
     result.normalization = sections.strs.allocString(this.keyboard.info?.normalization);
     result.indicator     = sections.strs.allocString(this.keyboard.info?.indicator);
-    result.version       = sections.strs.allocString(this.keyboard.version?.number ?? "0");
+    result.version       = sections.strs.allocString(this.keyboard.version?.number ?? "0.0.0");
     result.settings =
       (this.keyboard.settings?.fallback == "omit" ? KeyboardSettings.fallback : 0) |
       (this.keyboard.settings?.transformFailure == "omit" ? KeyboardSettings.transformFailure : 0) |

--- a/developer/src/kmc/src/keyman/compiler/section-compiler.ts
+++ b/developer/src/kmc/src/keyman/compiler/section-compiler.ts
@@ -3,6 +3,7 @@ import LDMLKeyboardXMLSourceFile, { LKKeyboard } from "../ldml-keyboard/ldml-key
 import CompilerCallbacks from "./callbacks";
 import { SectionIdent } from '@keymanapp/ldml-keyboard-constants';
 
+/* istanbul ignore next */
 export class SectionCompiler {
   protected readonly keyboard: LKKeyboard;
   protected readonly callbacks: CompilerCallbacks;
@@ -12,17 +13,14 @@ export class SectionCompiler {
     this.callbacks = callbacks;
   }
 
-  /* istanbul ignore next */
   public get id(): SectionIdent {
     return null;
   }
 
-  /* istanbul ignore next */
   public get required(): boolean {
     return true;
   }
 
-  /* istanbul ignore next */
   public compile(sections: GlobalSections): Section {
     return null;
   }

--- a/developer/src/kmc/src/keyman/compiler/vkey.ts
+++ b/developer/src/kmc/src/keyman/compiler/vkey.ts
@@ -21,27 +21,27 @@ export class VkeyCompiler extends SectionCompiler {
 
       this.keyboard.vkeyMaps.vkeyMap.forEach(vk => {
         if(LdmlVkeyNames[vk.from] === undefined) {
-          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid(vk.from));
+          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid({vkey: vk.from}));
           valid = false;
         }
 
         if(LdmlVkeyNames[vk.to] === undefined) {
-          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid(vk.to));
+          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid({vkey: vk.to}));
           valid = false;
         }
 
         if(vk.from == vk.to) {
-          this.callbacks.reportMessage(CompilerMessages.Hint_VkeyMapIsRedundant(vk.from));
+          this.callbacks.reportMessage(CompilerMessages.Hint_VkeyMapIsRedundant({vkey: vk.from}));
         }
 
         if(from.find(svk => svk == vk.from)) {
-          this.callbacks.reportMessage(CompilerMessages.Error_VkeyMapIsRepeated(vk.from));
+          this.callbacks.reportMessage(CompilerMessages.Error_VkeyMapIsRepeated({vkey: vk.from}));
           valid = false;
         }
         from.push(vk.from);
 
         if(to.find(svk => svk == vk.to)) {
-          this.callbacks.reportMessage(CompilerMessages.Info_MultipleVkeyMapsHaveSameTarget(vk.to));
+          this.callbacks.reportMessage(CompilerMessages.Info_MultipleVkeyMapsHaveSameTarget({vkey: vk.to}));
         }
         to.push(vk.to);
       });

--- a/developer/src/kmc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmc/src/keyman/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -58,7 +58,7 @@ export default class LDMLKeyboardXMLSourceFileReader {
     const schema = JSON.parse(this.callbacks.loadLdmlKeyboardSchema().toString('utf8'));
     const ajv = new Ajv();
     if(!ajv.validate(schema, source)) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile(ajv.errorsText()));
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: ajv.errorsText()}));
       return null;
     }
     return source;

--- a/developer/src/kmc/test/fixtures/sections/keys/hardware.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/hardware.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="hardware-minimal" />
+  </names>
+
+  <keys>
+    <key id="Q" to="qqq" />
+    <key id="W" to="www" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <!-- beware: this is mapping ` and 1! -->
+      <row keys="Q W" />
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/developer/src/kmc/test/fixtures/sections/keys/invalid-hardware-too-many-keys.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/invalid-hardware-too-many-keys.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="keys-minimal" />
+  </names>
+
+  <keys>
+    <key id="grave" to="`" />
+    <key id="one" to="1" />
+    <key id="two" to="2" />
+    <key id="three" to="3" />
+    <key id="four" to="4" />
+    <key id="five" to="5" />
+    <key id="six" to="6" />
+    <key id="seven" to="7" />
+    <key id="eight" to="8" />
+    <key id="nine" to="9" />
+    <key id="zero" to="0" />
+    <key id="ten" to="10" />
+    <key id="eleven" to="11" />
+    <key id="minus" to="-" />
+    <key id="equal" to="=" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <!-- beware: this is mapping ` and 1! -->
+      <row keys="grave one two three four five six seven eight nine ten eleven minus equal" />
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/developer/src/kmc/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="keys-minimal" />
+  </names>
+
+  <keys>
+    <key id="Q" to="qqq" />
+    <key id="W" to="www" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <!-- beware: this is mapping ` and 1! -->
+      <row keys="Q W" />
+      <row keys="Q W" />
+      <row keys="Q W" />
+      <row keys="Q W" />
+      <row keys="Q W" />
+      <row keys="Q W" />
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/developer/src/kmc/test/fixtures/sections/keys/invalid-missing-layer.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/invalid-missing-layer.xml
@@ -2,15 +2,9 @@
 
 <!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
 <keyboard locale="mt" conformsTo="techpreview">
-  <version number="1.2.3" />
-
-  <info author="The Keyman Team" indicator="QW" layout="QWIRKY" normalization="NFC" />
-
   <names>
-    <name value="meta-maximal" />
+    <name value="keys-minimal" />
   </names>
-
-  <settings fallback="omit" transformFailure="omit" transformPartial="hide" />
 
   <keys />
 </keyboard>

--- a/developer/src/kmc/test/fixtures/sections/keys/invalid-undefined-key.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/invalid-undefined-key.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="keys-minimal" />
+  </names>
+
+  <keys>
+    <key id="grave" to="🪦" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <row keys="foo" />
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/developer/src/kmc/test/fixtures/sections/keys/minimal.xml
+++ b/developer/src/kmc/test/fixtures/sections/keys/minimal.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="keys-minimal" />
+  </names>
+
+  <keys>
+    <key id="grave" to="🪦" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <row keys="grave" />
+    </layerMap>
+  </layerMaps>
+
+</keyboard>

--- a/developer/src/kmc/test/fixtures/sections/meta/invalid-version-1.0.xml
+++ b/developer/src/kmc/test/fixtures/sections/meta/invalid-version-1.0.xml
@@ -2,15 +2,11 @@
 
 <!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
 <keyboard locale="mt" conformsTo="techpreview">
-  <version number="1.2.3" />
-
-  <info author="The Keyman Team" indicator="QW" layout="QWIRKY" normalization="NFC" />
+  <version number="1.0" />
 
   <names>
-    <name value="meta-maximal" />
+    <name value="meta-minimal" />
   </names>
-
-  <settings fallback="omit" transformFailure="omit" transformPartial="hide" />
 
   <keys />
 </keyboard>

--- a/developer/src/kmc/test/fixtures/sections/meta/invalid-version-1.0.xml
+++ b/developer/src/kmc/test/fixtures/sections/meta/invalid-version-1.0.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
 <keyboard locale="mt" conformsTo="techpreview">
-  <version number="1.0" />
+  <version number="1.0" /> <!-- invalid because it's not "1.0.0" as required by semver -->
 
   <names>
     <name value="meta-minimal" />

--- a/developer/src/kmc/test/fixtures/sections/meta/invalid-version-v1.0.3.xml
+++ b/developer/src/kmc/test/fixtures/sections/meta/invalid-version-v1.0.3.xml
@@ -2,15 +2,11 @@
 
 <!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
 <keyboard locale="mt" conformsTo="techpreview">
-  <version number="1.2.3" />
-
-  <info author="The Keyman Team" indicator="QW" layout="QWIRKY" normalization="NFC" />
+  <version number="v1.0.3" />
 
   <names>
-    <name value="meta-maximal" />
+    <name value="meta-minimal" />
   </names>
-
-  <settings fallback="omit" transformFailure="omit" transformPartial="hide" />
 
   <keys />
 </keyboard>

--- a/developer/src/kmc/test/helpers/index.ts
+++ b/developer/src/kmc/test/helpers/index.ts
@@ -39,6 +39,7 @@ export class CompilerCallbacks {
 }
 
 export function loadSectionFixture(compilerClass: typeof SectionCompiler, filename: string, callbacks: CompilerCallbacks): Section {
+  callbacks.messages = [];
   const inputFilename = makePathToFixture(filename);
   const source = (new LDMLKeyboardXMLSourceFileReader(callbacks)).loadFile(inputFilename);
   const compiler = new compilerClass(source, callbacks);

--- a/developer/src/kmc/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmc/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -14,7 +14,7 @@ describe('ldml keyboard xml reader tests', function() {
     const source = reader.loadFile(inputFilename);
     assert.isNull(source);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile("data/keyboard must have required property 'names'"));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile({errorText: "data/keyboard must have required property 'names'"}));
   });
 
   it("should fail to load files with an invalid conformsTo", function() {
@@ -24,7 +24,7 @@ describe('ldml keyboard xml reader tests', function() {
     const source = reader.loadFile(inputFilename);
     assert.isNull(source);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile("data/keyboard/conformsTo must be equal to one of the allowed values"));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidFile({errorText: "data/keyboard/conformsTo must be equal to one of the allowed values"}));
   });
 
 });

--- a/developer/src/kmc/test/test-keys.ts
+++ b/developer/src/kmc/test/test-keys.ts
@@ -1,0 +1,62 @@
+import 'mocha';
+import { assert } from 'chai';
+import { KeysCompiler } from '../src/keyman/compiler/keys';
+import { CompilerCallbacks, loadSectionFixture } from './helpers';
+import { Keys } from '../src/keyman/kmx/kmx-plus';
+import { CompilerMessages } from '../src/keyman/compiler/messages';
+
+describe('keys', function () {
+  this.slow(500); // 0.5 sec -- json schema validation takes a while
+
+  it('should compile minimal keys data', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/minimal.xml', callbacks) as Keys;
+    assert.isNotNull(keys);
+    assert.equal(callbacks.messages.length, 0);
+    assert.equal(keys.keys.length, 1);
+  });
+
+  it('should compile a hardware layer', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/hardware.xml', callbacks) as Keys;
+    assert.isNotNull(keys);
+    assert.equal(callbacks.messages.length, 0);
+    assert.equal(keys.keys.length, 2);
+  });
+
+  it('should reject structurally invalid layers', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/invalid-missing-layer.xml', callbacks) as Keys;
+    assert.isNull(keys);
+    assert.equal(callbacks.messages.length, 1);
+
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_MustBeAtLeastOneLayerElement());
+  });
+
+  it('should reject layouts with too many hardware rows', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/invalid-hardware-too-many-rows.xml', callbacks) as Keys;
+    assert.isNull(keys);
+    assert.equal(callbacks.messages.length, 1);
+
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_HardwareLayerHasTooManyRows());
+  });
+
+  it('should reject layouts with too many hardware keys', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/invalid-hardware-too-many-keys.xml', callbacks) as Keys;
+    assert.isNull(keys);
+    assert.equal(callbacks.messages.length, 1);
+
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({row: 1}));
+  });
+
+  it('should reject layouts with undefined keys', function() {
+    const callbacks = new CompilerCallbacks();
+    let keys = loadSectionFixture(KeysCompiler, 'sections/keys/invalid-undefined-key.xml', callbacks) as Keys;
+    assert.isNull(keys);
+    assert.equal(callbacks.messages.length, 1);
+
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_KeyNotFoundInKeyBag({col: 1, form: 'hardware', keyId: 'foo', layer: 'base', row: 1}));
+  });
+});

--- a/developer/src/kmc/test/test-loca.ts
+++ b/developer/src/kmc/test/test-loca.ts
@@ -11,6 +11,8 @@ describe('loca', function () {
   it('should compile minimal loca data', function() {
     const callbacks = new CompilerCallbacks();
     let loca = loadSectionFixture(LocaCompiler, 'sections/loca/minimal.xml', callbacks) as Loca;
+    assert.isObject(loca);
+
     assert.equal(callbacks.messages.length, 0);
 
     assert.equal(loca.locales.length, 1);
@@ -20,12 +22,13 @@ describe('loca', function () {
   it('should compile multiple locales', function() {
     const callbacks = new CompilerCallbacks();
     let loca = loadSectionFixture(LocaCompiler, 'sections/loca/multiple.xml', callbacks) as Loca;
+    assert.isObject(loca);
 
     // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
     assert.equal(callbacks.messages.length, 4);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('fr-FR','fr'));
-    assert.deepEqual(callbacks.messages[1], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('km-khmr-kh', 'km'));
-    assert.deepEqual(callbacks.messages[2], CompilerMessages.Hint_LocaleIsNotMinimalAndClean('fr-fr', 'fr'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-FR', locale: 'fr'}));
+    assert.deepEqual(callbacks.messages[1], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'km-khmr-kh', locale: 'km'}));
+    assert.deepEqual(callbacks.messages[2], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-fr', locale: 'fr'}));
     assert.deepEqual(callbacks.messages[3], CompilerMessages.Hint_OneOrMoreRepeatedLocales());
 
     // Original is 6 locales, now five minimized in the results
@@ -37,14 +40,13 @@ describe('loca', function () {
     assert.equal(loca.locales[4].value, 'en-fonipa');
   });
 
-  it('should reject structurally invalid invalid locales', function() {
+  it('should reject structurally invalid locales', function() {
     const callbacks = new CompilerCallbacks();
-    let meta = loadSectionFixture(LocaCompiler, 'sections/loca/invalid-locale.xml', callbacks) as Loca;
-    assert.isNull(meta);
+    let loca = loadSectionFixture(LocaCompiler, 'sections/loca/invalid-locale.xml', callbacks) as Loca;
+    assert.isNull(loca);
     assert.equal(callbacks.messages.length, 1);
     // We'll only test one invalid BCP 47 tag to verify that we are properly calling BCP 47 validation routines.
     // Furthermore, we are testing BCP 47 structure, not the validity of each subtag -- we must assume the author knows of new subtags!
     assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidLocale({tag:'en-*'}));
   })
 });
-

--- a/developer/src/kmc/test/test-meta.ts
+++ b/developer/src/kmc/test/test-meta.ts
@@ -31,6 +31,7 @@ describe('meta', function () {
     assert.equal(meta.layout.value, 'QWIRKY');
     assert.equal(meta.normalization.value, 'NFC');
     assert.equal(meta.indicator.value, 'QW');
+    assert.equal(meta.version.value, "1.2.3");
     assert.equal(meta.settings, KeyboardSettings.fallback | KeyboardSettings.transformFailure | KeyboardSettings.transformPartial);
   });
 
@@ -40,6 +41,19 @@ describe('meta', function () {
     assert.isNull(meta);
     assert.equal(callbacks.messages.length, 1);
     assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidNormalization({form:'NFQ'}));
+  });
+
+  it('should reject invalid version', function() {
+    const callbacks = new CompilerCallbacks();
+    let meta = loadSectionFixture(MetaCompiler, 'sections/meta/invalid-version-1.0.xml', callbacks) as Meta;
+    assert.isNull(meta);
+    assert.equal(callbacks.messages.length, 1);
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidVersion({version:'1.0'}));
+
+    meta = loadSectionFixture(MetaCompiler, 'sections/meta/invalid-version-v1.0.3.xml', callbacks) as Meta;
+    assert.isNull(meta);
+    assert.equal(callbacks.messages.length, 1);
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_InvalidVersion({version:'v1.0.3'}));
   });
 });
 

--- a/developer/src/kmc/test/test-vkey.ts
+++ b/developer/src/kmc/test/test-vkey.ts
@@ -27,7 +27,7 @@ describe('vkey compiler', function () {
     let vkey = loadSectionFixture(VkeyCompiler, 'sections/vkey/redundant.xml', callbacks) as Vkey;
     assert.isNotNull(vkey);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Hint_VkeyMapIsRedundant('A'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Hint_VkeyMapIsRedundant({vkey: 'A'}));
   });
 
   it('should report an info message if same target found', function() {
@@ -35,7 +35,7 @@ describe('vkey compiler', function () {
     let vkey = loadSectionFixture(VkeyCompiler, 'sections/vkey/same-target.xml', callbacks) as Vkey;
     assert.isNotNull(vkey);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Info_MultipleVkeyMapsHaveSameTarget('Q'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Info_MultipleVkeyMapsHaveSameTarget({vkey: 'Q'}));
   });
 
   it('should error on invalid "from" vkey', function() {
@@ -43,8 +43,8 @@ describe('vkey compiler', function () {
     let vkey = loadSectionFixture(VkeyCompiler, 'sections/vkey/invalid-from-vkey.xml', callbacks) as Vkey;
     assert.isNull(vkey);
     assert.equal(callbacks.messages.length, 2);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid('q'));
-    assert.deepEqual(callbacks.messages[1], CompilerMessages.Error_VkeyIsNotValid('HYFEN'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid({vkey: 'q'}));
+    assert.deepEqual(callbacks.messages[1], CompilerMessages.Error_VkeyIsNotValid({vkey: 'HYFEN'}));
   });
 
   it('should error on invalid "to" vkey', function() {
@@ -52,7 +52,7 @@ describe('vkey compiler', function () {
     let vkey = loadSectionFixture(VkeyCompiler, 'sections/vkey/invalid-to-vkey.xml', callbacks) as Vkey;
     assert.isNull(vkey);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid('A-ACUTE'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid({vkey: 'A-ACUTE'}));
   });
 
   it('should error on repeated vkeys', function() {
@@ -60,7 +60,7 @@ describe('vkey compiler', function () {
     let vkey = loadSectionFixture(VkeyCompiler, 'sections/vkey/invalid-repeated-vkey.xml', callbacks) as Vkey;
     assert.isNull(vkey);
     assert.equal(callbacks.messages.length, 1);
-    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyMapIsRepeated('A'));
+    assert.deepEqual(callbacks.messages[0], CompilerMessages.Error_VkeyMapIsRepeated({vkey: 'A'}));
   });
 });
 


### PR DESCRIPTION
* Add a bunch of tests for keys
* Add tests for version. (improves meta test coverage to 100%)
* A bit more consistency cleanup also of error message functions.
* Adds a compiler failure (FATAL) if compile fails after validate passes.
* Overall test coverage now 93.5% lines. Biggest gap still kmx-builder. All compiler units are >90%.

Finally, throws in a tweak to the auto labelling: if 'epic-ldml' is in the branch name, we'll get that label automatically.

@keymanapp-test-bot skip