### PR TITLE
fix(common/models): max prediction wait check

### DIFF
--- a/common/web/lm-worker/src/correction/distance-modeler.ts
+++ b/common/web/lm-worker/src/correction/distance-modeler.ts
@@ -710,7 +710,7 @@ namespace correction {
 
       let batcher = new BatchingAssistant();
 
-      const timer = new ExecutionTimer(maxTime*3, maxTime);
+      const timer = new ExecutionTimer(maxTime*1.5, maxTime);
 
       // Stage 1 - if we already have extracted results, build a queue just for them and iterate over it first.
       let returnedValues = Object.values(this.returnedValues);

--- a/common/web/lm-worker/src/correction/distance-modeler.ts
+++ b/common/web/lm-worker/src/correction/distance-modeler.ts
@@ -653,7 +653,7 @@ namespace correction {
 
         shouldTimeout(): boolean {
           const now = Date.now();
-          if(this.start - now > this.maxTrueTime) {
+          if(now - this.start > this.maxTrueTime) {
             return true;
           }
 


### PR DESCRIPTION
Fixes #7283.

When checking how long something has waited... it usually helps when you subtract the smaller value from the larger value.  🤦   The "enhanced prediction timer"'s maximum wait threshold wasn't triggering because of this.

That said, the fact that predictions would lag that much without it says something about how much context-switching the worker thread is having to contend with...

Revisiting this, I've noticed that each prediction queues up and cannot be interrupted.  Since there's a forced wait there... allowing too much extra wait time can really start to add up when there's a significant amount of context switching.  There's no 'interrupt' system to cancel the current predictive-text ops when receiving a new prediction request within the worker itself.  Addressing _that_, and doing so well, may take significant effort.

The implication of the prior paragraph:  if each keystroke is forced to wait the maximum wait time, setting it even moderately high can cause a 'lag' effect that will add up.  We can't say "actually, stop waiting and do _this_ instead" to old prediction requests, which would mitigate said "lag" effect.

## User Testing

- TEST_HANGING:  Follow the following steps to attempt a repro of the base issue:
    1. In Keyman, type 'Aqua' and we may notice that the related text appears on the suggestion bar. 
    2. Enter some random letters on the text pane. 
    3. Enter a spacebar key. 
    4. Type a word 'testing'
    5. Predictive text should appear on the suggestion bar.   (There may be a _slight_ wait if you have a high typing/key-mash speed and amount, but nothing egregious.)
    6. Clear text
    7. Type 'testing'.  Predictive text should appear on the suggestion bar.