### PR TITLE
fix(web): fixes unintended auto-acceptance of suggestion after reverting

### DIFF
--- a/web/source/osk/banner.ts
+++ b/web/source/osk/banner.ts
@@ -560,13 +560,17 @@ namespace com.keyman.osk {
     private doAccept(suggestion: BannerSuggestion) {
       let _this = this;
 
+      // Selecting a suggestion or a reversion should both clear selection
+      // and clear the reversion-displaying state of the banner.
+      this.selected = null;
+      this.doRevert = false;
+
       this.revertAcceptancePromise = suggestion.apply();
       if(!this.revertAcceptancePromise) {
         // We get here either if suggestion acceptance fails or if it was a reversion.
         if(suggestion.suggestion && suggestion.suggestion.tag == 'revert') {
           // Reversion state management
           this.recentAccept = false;
-          this.doRevert = false;
           this.recentRevert = true;
 
           this.doUpdate();
@@ -581,9 +585,7 @@ namespace com.keyman.osk {
         }
       });
 
-      this.selected = null;
       this.recentAccept = true;
-      this.doRevert = false;
       this.recentRevert = false;
 
       this.swallowPrediction = true;


### PR DESCRIPTION
Fixes #7167.

While we've never really "turned it on", there are parts of the predictive text pathway that were designed to facilitate auto-correct behaviors.  (See #1747)  This one is the most noteworthy:

https://github.com/keymanapp/keyman/blob/52e9a39a8575a88368808dba9b0eb4380d5f275f/common/web/input-processor/src/text/inputProcessor.ts#L121-L127

While we rewired `tryRevertSuggestion` to simply _display_ the reversion rather than automatically doing it (#1851), we never bothered modifying `tryAcceptSuggestion`.  After all, we never automatically 'select' any suggestion, so there's nothing to be auto-applied.

... except for this one little edge case.  Even then, it's not like we auto-selected anything... we just forgot to _clear_ a previous suggestion's selected state.  This is what causes the bug from #7167 - the suggestion in the same position as the reversion will be auto-applied if its selection is not cleared once activated.

## User Testing

**TEST_REPRO**:  Verify that the following reproduction is no longer affected by the bug.

1. In Keyman for Android, type <kbd>P</kbd><kbd>r</kbd><kbd>o</kbd><kbd>b</kbd>.
2. Select `Problem` from banner.
3. Press <kbd>Backspace</kbd>, then select `"Prob"` (undoing the last suggestion).
4. Then press <kbd>Spacebar</kbd>.
5. You should see  `Prob `, as if no suggestion were auto-applied from the spacebar.