### PR TITLE
chore(core): `kmc --outFile` to `kmc --out-file` (and `--` rider) 🙀

### DIFF
--- a/core/build.bat
+++ b/core/build.bat
@@ -15,7 +15,7 @@ goto help
 rem ----------------------------------
 
 :help
-echo Usage: %0 x86^|x64^|all debug^|release [configure] [build] [test]
+echo Usage: %0 x86^|x64^|all debug^|release [configure] [build] [test] [additional params for meson/ninja]
 echo   or
 echo Usage: %0 x86^|x64 -c
 echo -c will leave your environment configured for Visual Studio for selected platform.
@@ -30,10 +30,10 @@ rem ----------------------------------
 
 setlocal
 cd %KEYMAN_ROOT%\core
-cmd /c build.bat x86 %2 %3 %4 %5 || exit !errorlevel!
+cmd /c build.bat x86 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
 
 cd %KEYMAN_ROOT%\core
-cmd /c build.bat x64 %2 %3 %4 %5 || exit !errorlevel!
+cmd /c build.bat x64 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
 
 goto :eof
 
@@ -41,9 +41,10 @@ rem ----------------------------------
 
 :build
 
-if "%2"=="-c" goto :setup
-
 set ARCH=%1
+shift
+
+if "%1"=="-c" goto :setup
 
 echo === Locating Visual Studio ===
 
@@ -67,29 +68,33 @@ call !VCVARSALL! !ARCH! || exit !errorlevel!
 
 cd %KEYMAN_ROOT%\core
 
-set BUILDTYPE=%2
+set BUILDTYPE=%1
+shift
 
 set STATIC_LIBRARY=--default-library both
 
-if "%3" == "configure" (
+set COMMAND=%1
+shift
+
+if "!COMMAND!" == "configure" (
   echo === Configuring Keyman Core for Windows !ARCH! !BUILDTYPE! ===
   if exist build\!ARCH!\!BUILDTYPE! rd /s/q build\!ARCH!\!BUILDTYPE!
-  meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror || exit !errorlevel!
+  meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
   shift
 )
 
-if "%3" == "build" (
+if "!COMMAND!" == "build" (
   echo === Building Keyman Core for Windows !ARCH! !BUILDTYPE! ===
   cd build\!ARCH!\!BUILDTYPE! || exit !errorlevel!
-  ninja || exit !errorlevel!
+  ninja %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
   cd ..\..\..
   shift
 )
 
-if "%3" == "test" (
+if "!COMMAND!" == "test" (
   echo === Testing Keyman Core for Windows !ARCH! !BUILDTYPE! ===
-  cd build\!ARCH!/!BUILDTYPE! || exit !errorlevel!
-  meson test --print-errorlogs || exit !errorlevel!
+  cd build\!ARCH!\!BUILDTYPE! || exit !errorlevel!
+  meson test --print-errorlogs %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
   cd ..\..\..
   shift
 )
@@ -107,7 +112,7 @@ endlocal
 for /f "usebackq tokens=*" %%i in (`..\resources\build\vswhere -version [15^,17^) -latest -requires Microsoft.Component.MSBuild -find **\vcvarsall.bat`) do (
   set VCVARSALL="%%i"
 )
-%VCVARSALL% %1
+%VCVARSALL% !ARCH!
 goto :eof
 
 rem ----------------------------------

--- a/core/build.sh
+++ b/core/build.sh
@@ -45,18 +45,18 @@ builder_describe \
 
 Libraries will be built in 'build/<target>/<configuration>/src'.
   * <configuration>: 'debug' or 'release' (see --debug flag)
+  * All parameters after '--' are passed to meson or ninja
 " \
   "clean" \
   "configure" \
   "build" \
   "test" \
-  "install         Install libraries to current system" \
-  "uninstall       Uninstall libraries from current system" \
+  "install         install libraries to current system" \
+  "uninstall       uninstall libraries from current system" \
   "${archtargets[@]}" \
-  "--debug,d                       Configuration is 'debug', not 'release'" \
-  "--target-path=opt_target_path   Override for build/ target path" \
-  "--configure=opt_configure       Options to pass to C++ configure" \
-  "--test=opt_tests,-t             Test[s] to run (space separated)"
+  "--debug,d                       configuration is 'debug', not 'release'" \
+  "--target-path=opt_target_path   override for build/ target path" \
+  "--test=opt_tests,-t             test[s] to run (space separated)"
 builder_parse "$@"
 
 if builder_has_option --debug; then

--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -131,7 +131,7 @@ do_command() {
   echo_heading "======= Installing $target ======="
 
   pushd "$MESON_PATH" > /dev/null
-  ninja $2
+  ninja $command
   popd > /dev/null
 }
 

--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -22,8 +22,6 @@ do_configure() {
   builder_has_action configure:$target || return 0
 
   local STANDARD_MESON_ARGS=
-  # Additional arguments are used by Linux build, e.g. -Dprefix=${INSTALLDIR}
-  local ADDITIONAL_ARGS=${opt_configure-}
 
   echo_heading "======= Configuring $target ======="
 
@@ -37,10 +35,11 @@ do_configure() {
   fi
 
   if [[ $target =~ ^(x86|x64)$ ]]; then
-    cmd //C build.bat $target $CONFIGURATION configure
+    cmd //C build.bat $target $CONFIGURATION configure "${builder_extra_params[@]}"
   else
     pushd "$THIS_SCRIPT_PATH" > /dev/null
-    meson setup "$MESON_PATH" --werror --buildtype $CONFIGURATION $STANDARD_MESON_ARGS $ADDITIONAL_ARGS
+    # Additional arguments are used by Linux build, e.g. -Dprefix=${INSTALLDIR}
+    meson setup "$MESON_PATH" --werror --buildtype $CONFIGURATION $STANDARD_MESON_ARGS "${builder_extra_params[@]}"
     popd > /dev/null
   fi
 }
@@ -85,7 +84,7 @@ do_build() {
     # the Visual Studio build environment with vcvarsall.bat
     # TODO: if PATH is the only variable required, let's try and
     #       eliminate this difference in the build process
-    cmd //C build.bat $target $CONFIGURATION build
+    cmd //C build.bat $target $CONFIGURATION build "${builder_extra_params[@]}"
   else
     pushd "$MESON_PATH" > /dev/null
     ninja
@@ -104,10 +103,10 @@ do_test() {
   echo_heading "======= Testing $target ======="
 
   if [[ $target =~ ^(x86|x64)$ ]]; then
-    cmd //C build.bat $target $CONFIGURATION test
+    cmd //C build.bat $target $CONFIGURATION test "${builder_extra_params[@]}"
   else
     pushd "$MESON_PATH" > /dev/null
-    meson test --print-errorlogs
+    meson test "${builder_extra_params[@]}"
     popd > /dev/null
   fi
 }

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -25,7 +25,7 @@ foreach kbd : tests
   )
 
   configure_file(
-    command: kmc_cmd + ['@INPUT@', '--outFile', '@OUTPUT@'],
+    command: kmc_cmd + ['@INPUT@', '--out-file', '@OUTPUT@'],
     output: kbd + '.kmx',
     input: kbd + '.xml'
   )

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	# keymankeyboardprocessor
-	cd core && ./build.sh build
+	cd core && ./build.sh build:arch
 	# ibus-keyman
 	cd linux/ibus-keyman && make
 	# keyman-config
@@ -48,7 +48,7 @@ override_dh_auto_build:
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# keymankeyboardprocessor
-	cd core && ./build.sh tests
+	cd core && ./build.sh test:arch
 	# ibus-keyman
 	cd linux/ibus-keyman && make check VERBOSE=1
 	# keyman-config
@@ -58,7 +58,7 @@ endif
 override_dh_auto_install:
 	# keymankeyboardprocessor
 	install -d $(CURDIR)/debian/tmp
-	cd core && DESTDIR=$(CURDIR)/debian/tmp ./build.sh install
+	cd core && DESTDIR=$(CURDIR)/debian/tmp ./build.sh install:arch
 	# ibus-keyman
 	cd linux/ibus-keyman && make install DESTDIR=$(CURDIR)/debian/tmp
 	# keyman-config

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -20,9 +20,9 @@ export LC_ALL=C.UTF-8
 override_dh_auto_configure:
 	# keymankeyboardprocessor
 	cd core && \
-		./build.sh configure -- --wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc \
+		./build.sh configure --configure="--wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc \
 			--localstatedir=/var --libdir=lib/$(DEB_TARGET_MULTIARCH) \
-			--libexecdir=lib/$(DEB_TARGET_MULTIARCH)
+			--libexecdir=lib/$(DEB_TARGET_MULTIARCH)"
 	# ibus-keyman
 	cd linux/ibus-keyman && \
 		cp -f ../../VERSION.md VERSION && \

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -20,9 +20,9 @@ export LC_ALL=C.UTF-8
 override_dh_auto_configure:
 	# keymankeyboardprocessor
 	cd core && \
-		./build.sh configure --configure="--wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc \
+		./build.sh configure:arch -- --wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc \
 			--localstatedir=/var --libdir=lib/$(DEB_TARGET_MULTIARCH) \
-			--libexecdir=lib/$(DEB_TARGET_MULTIARCH)"
+			--libexecdir=lib/$(DEB_TARGET_MULTIARCH)
 	# ibus-keyman
 	cd linux/ibus-keyman && \
 		cp -f ../../VERSION.md VERSION && \

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -328,6 +328,11 @@ fi
 #
 _builder_debug=false
 
+#
+# builder_extra_params: string containing all parameters after '--'
+#
+builder_extra_params=()
+
 # returns 0 if first parameter is in the array passed as second parameter
 #
 # Usage:
@@ -557,6 +562,7 @@ _builder_parameter_error() {
 #   1: $@         command-line arguments
 builder_parse() {
   builder_verbose=
+  builder_extra_params=()
   _builder_chosen_action_targets=()
   _builder_chosen_options=()
 
@@ -566,6 +572,12 @@ builder_parse() {
     local action=
     local target=
     local e has_action has_target has_option longhand_option
+
+    if [[ $key == "--" ]]; then
+      shift
+      builder_extra_params=("$@")
+      break
+    fi
 
     if [[ $key =~ : ]]; then
       IFS=: read -r action target <<< $key

--- a/resources/build/build-utils.test.sh
+++ b/resources/build/build-utils.test.sh
@@ -142,10 +142,21 @@ if builder_has_option --feature; then
   if [[ $FOO == xyzzy ]]; then
     echo "PASS: --feature option variable \$FOO has expected value 'xyzzy'"
   else
-    echo "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
+    fail "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
   fi
 else
   echo "FAIL: --feature option not found"
+fi
+
+builder_parse -- one two "three four five"
+if [[ ${builder_extra_params[0]} != "one" ]]; then
+  fail "FAIL: -- extra parameter 'one' not found"
+fi
+if [[ ${builder_extra_params[1]} != "two" ]]; then
+  fail "FAIL: -- extra parameter 'two' not found"
+fi
+if [[ ${builder_extra_params[2]} != "three four five" ]]; then
+  fail "FAIL: -- extra parameter 'three four five' not found"
 fi
 
 # Finally, run with --help so we can see what it looks like


### PR DESCRIPTION
This fixes the failing Core tests in #7054 -- broke in #7286, but wasn't picked up
there because Core build didn't run on that PR.

## All about `./build.sh --`

This update also allows use of `./build.sh configure -- --param-one=foo ...`.

Updates Core build to support `--` (including build.bat wrapper for Windows builds). Fixes Linux debian rules to pass additional parameters in with this format again, and adds `:arch` to only build current architecture, not wasm as well...

Note that when using `--` you should typically avoid multiple actions in a single command, as each action may interpret the additional parameters differently!

@keymanapp-test-bot skip