### PR TITLE
fix(common/models): fixes reference dropped by git merge

### DIFF
--- a/common/web/lm-worker/src/model-compositor.ts
+++ b/common/web/lm-worker/src/model-compositor.ts
@@ -162,8 +162,9 @@ class ModelCompositor {
 
       // The amount of text to 'replace' depends upon whatever sort of context change occurs
       // from the received input.
-      let postContextLength = postContextState.tokens.length;
-      let contextLengthDelta = postContextState.tokens.length - contextState.tokens.length;
+      const postContextTokens = postContextState.tokens;
+      let postContextLength = postContextTokens.length;
+      let contextLengthDelta = postContextTokens.length - contextState.tokens.length;
       // If the context now has more tokens, the token we'll be 'predicting' didn't originally exist.
       if(postContextLength == 0 || contextLengthDelta > 0) {
         // As the word/token being corrected/predicted didn't originally exist, there's no
@@ -225,7 +226,7 @@ class ModelCompositor {
       //
       // NOTE:  we only want this applied word-initially, when any corrections 'correct'
       // 100% of the word.  Things are generally fine once it's not "all or nothing."
-      let tailToken = contextTokens[contextTokens.length - 1];
+      let tailToken = postContextTokens[postContextTokens.length - 1];
       const isTokenStart = tailToken.transformDistributions.length <= 1;
 
       // TODO:  whitespace, backspace filtering.  Do it here.


### PR DESCRIPTION
Fixes a post-merge issue caused when merging both of the following two PRs:
- #7241 
- #7205

From #7205:

![image](https://user-images.githubusercontent.com/25213402/190938724-91ab7eef-08fe-49c3-843b-a0b0b85ea839.png)

Note the original line 165:

```typescript
let contextTokens = contextState.tokens;
```

This line is referenced by #7241:

![image](https://user-images.githubusercontent.com/25213402/190938812-428561b0-68e1-4518-bc98-68d10d0c0ef1.png)

Due to the way the changes were made, this was not detected as a merge conflict, allowing this to slip through:

![image](https://user-images.githubusercontent.com/25213402/190938847-169f11ad-5b6b-4bed-ace5-239e96816fd6.png)

Fortunately, it's a very easy "conflict" to resolve. 

@keymanapp-test-bot skip