### PR TITLE
chore(web): update `got` dependency for regression tests

### DIFF
--- a/web/testing/regression-tests/README.md
+++ b/web/testing/regression-tests/README.md
@@ -1,6 +1,6 @@
 # Regression Tests
 
-This folder contains tools to run automated regression tests on Keyman Engine for Web 
+This folder contains tools to run automated regression tests on Keyman Engine for Web
 and Keyman Developer. The intent is to validate changes to the compiler and the engine
 against the set of available keyboards in the Keyman keyboards repository from
 https://github.com/keymanapp/keyboards.
@@ -10,7 +10,7 @@ the `kmanalyze` program which is not yet available outside the keyman source rep
 is the only Windows dependency (the `kmcomp` compiler is also used, but this runs under
 WINE and is available in binary form outside the source repo).
 
-The test suite runs in Node.js and launches Chrome for the tests. In the future, the 
+The test suite runs in Node.js and launches Chrome for the tests. In the future, the
 tests may be able to be run in native Node.js.
 
 ## Configuration
@@ -35,7 +35,7 @@ the keyman repository, for example:
           - regression-tests
 
 Keyman Engine for Web, Keyman Developer (kmcomp, kmcmpdll, kmanalyze) must be built
-prior to running the tests. (If not testing source versions, only kmanalyze is 
+prior to running the tests. (If not testing source versions, only kmanalyze is
 required). See the build documentation for each project for details; summary below:
 
 To build KeymanWeb (bash):
@@ -45,12 +45,12 @@ To build KeymanWeb (bash):
 
 To build just the Keyman Developer tools required from the Windows source (cmd):
 
-    cd windows\src
-    make -DNOUI ext global buildtools developer
+    cd developer\src
+    nmake
 
 ### Known Failures
 
-As there are some known failures, these are listed in `src/known-failures.js`. 
+As there are some known failures, these are listed in `src/known-failures.js`.
 As the bugs that impact these keyboards are addressed, they should be progressively
 removed from the file. Keyboards listed in this file will still be tested and
 report errors, but they will not fail the test suite overall.
@@ -62,7 +62,7 @@ tests that run with node + Karma + Mocha + Chai.
 
 ### Manual Tests
 
-`node interactive.js` will start a web server listening on http://localhost:1337/. 
+`node interactive.js` will start a web server listening on http://localhost:1337/.
 Navigating to this address will allow you to load and test a given keyboard from the
 keyboards repository. This assumes that the keyboards are already available and that
 the .tests have already been built.
@@ -72,7 +72,7 @@ tools than for intensive testing.
 
 ### Automated Tests
 
-`node test.js` runs the entire test suite. There are a number of command line 
+`node test.js` runs the entire test suite. There are a number of command line
 parameters available:
 
     $ node test.js -h
@@ -89,15 +89,15 @@ parameters available:
       -l, --log-all-failures              Log all test failures to console, not just the first failure for each keyboard
       -h, --help                          output usage information
 
-When the entire test suite is run, the regression test compares the latest version of 
+When the entire test suite is run, the regression test compares the latest version of
 the compiler from the source repository, together with the latest version of Keyman
-Engine for Web from the source repository, against the latest stable releases of 
+Engine for Web from the source repository, against the latest stable releases of
 each, downloaded from https://downloads.keyman.com/
 
 These two versions are referenced as `source` and `stable` respectively. You can
 also specify exact stable, beta or alpha versions for download by specifying a
 version number in the `-c` and `-e` parameters. You can test as many versions as
-you like at a time, but beware: the number of permutations tested increases as 
+you like at a time, but beware: the number of permutations tested increases as
 the square of tested versions.
 
 The continuous integration configuration currently uses `node test.js -l`.
@@ -126,14 +126,14 @@ The test builder generates a `tests-generated.js` file for running Karma and the
 ## Background
 
 `kmanalyze` generates a .tests file for a given keyboard, from analysis of a
-corresponding .kmx file (a future update will use the intermediate in-memory 
+corresponding .kmx file (a future update will use the intermediate in-memory
 .kmx file used by the compiler to ensure we access only the web rules). It
 does not currently support deadkeys, recursive groups, or web-specific rules
 (lines prefixed with `$keymanweb:`). Nor does it support keyboard or system
 options. It will generate a single test for each store referenced in an `any`
 statement, rather than a test for each character in the store.
 
-.tests files and .results files are stored in a `tests/` folder for each 
+.tests files and .results files are stored in a `tests/` folder for each
 keyboard in the repository.
 
 The test suite runs tests against the physical keyboard ruleset for keyboards.

--- a/web/testing/regression-tests/package.json
+++ b/web/testing/regression-tests/package.json
@@ -13,7 +13,7 @@
     "commander": "^2.19.0",
     "express": "^4.16.4",
     "fs-extra": "^7.0.1",
-    "got": "^9.6.0",
+    "got": "^11.8.5",
     "jasmine-core": "^3.3.0",
     "karma": "^6.3.16",
     "karma-chai": "^0.1.0",

--- a/web/testing/regression-tests/src/test-runner.js
+++ b/web/testing/regression-tests/src/test-runner.js
@@ -1,6 +1,6 @@
 // test-runner
 
-const KEYBOARDS_RELATIVE_PATH = "/keyboards/"; 
+const KEYBOARDS_RELATIVE_PATH = "/keyboards/";
 const TEST_BATCH_SIZE = 100; // or Infinity
 
 var receiver;
@@ -17,7 +17,7 @@ var windowLoad = new Promise(function(resolve, reject) {
     receiver = document.getElementById('receiver');
     if(!receiver) {
       // When running tests, we dynamically create the receiver
-      receiver = document.createElement('input'); 
+      receiver = document.createElement('input');
       document.body.appendChild(receiver);
       let d0 = document.createElement('div');
       d0.id = 'progressWindow';
@@ -51,15 +51,15 @@ function chunk(arr, chunkSize) {
 }
 
 var testRunner = {
-  modCodes: keyman.osk.modifierCodes,
-  keyCodes: keyman.osk.keyCodes,
+  modCodes: com.keyman.text.Codes.modifierCodes,
+  keyCodes: com.keyman.text.Codes.keyCodes,
   keyboards: {},
   max: 0,
 
   /**
-   * Loads a .tests file for the given keyboard, and the corresponding keyboard. Both the 
+   * Loads a .tests file for the given keyboard, and the corresponding keyboard. Both the
    * keyboard and the tests file are injected via script into the document.
-   * 
+   *
    * @param {string} locator  a string in the form of shortname/id, e.g. k/kayan, sil/sil_ipa
    * @returns {Promise} A promise fulfilled when the keyboard and the tests file are ready
    */
@@ -102,7 +102,7 @@ var testRunner = {
 
   /**
    * Load a tests file and a keyboard from the keyboards repository
-   * @param {string} locator 
+   * @param {string} locator
    */
   loadTests: function(locator) {
     console.log('Loading tests + keyboard for '+locator);
@@ -130,7 +130,7 @@ var testRunner = {
         };
         // The KeymanWeb global will always exist, even when we otherwise change API.
         KeymanWeb.registerStub(stub);
-        let k = testRunner.keyboards[id]; 
+        let k = testRunner.keyboards[id];
         keyman.setKeyboardForControl(receiver, id, k.keyboard.languages[0].id);
         document.body.focus();
         receiver.focus();
@@ -185,7 +185,7 @@ var testRunner = {
       };
       http.open('POST', '/save-results');
       http.setRequestHeader('Content-Type', 'application/json');
-      http.send(JSON.stringify(json)); 
+      http.send(JSON.stringify(json));
     });
   },
 
@@ -203,7 +203,7 @@ var testRunner = {
 
   /**
    * Called by a .tests file to register a set of input tests
-   * @param {object} data  
+   * @param {object} data
    */
   register: function(data) {
     let keys = Object.keys(data.inputTests);
@@ -240,7 +240,7 @@ var testRunner = {
   runTests: function(keyboardId) {
     return new Promise(function(resolve, reject) {
       this.keyboards[keyboardId].results = {};
-      
+
       console.log('-- Running '+this.keyboards[keyboardId].inputTests.length+' tests for '+keyboardId+'.');
       var chunkSize = TEST_BATCH_SIZE;
 
@@ -291,7 +291,7 @@ var testRunner = {
         e.LisVirtualKeyCode = true;
         e.LisVirtualKey = true;
         e.vkCode = test.key;
-        
+
         // Keyman 14 changes the processKeystroke interface
         e.device = keyman.util.device.coreSpec;
         if(keyman.core) {
@@ -319,7 +319,7 @@ var testRunner = {
   initProgress: function(max) {
     this.max = max;
     this.progressPosition = document.getElementById('progressPosition');
-    if(this.progressPosition) this.progressPosition.style.width = '0px'; 
+    if(this.progressPosition) this.progressPosition.style.width = '0px';
   },
 
   /**
@@ -327,7 +327,7 @@ var testRunner = {
    * @param {number} len Current position of progress bar
    */
   updateProgress: function(len) {
-    if(this.progressPosition) this.progressPosition.style.width = Math.round(len / this.max * 100).toString() + '%'; 
+    if(this.progressPosition) this.progressPosition.style.width = Math.round(len / this.max * 100).toString() + '%';
   }
 };
 


### PR DESCRIPTION
* Updates `got` from ^9.6.0 to ^11.8.5. (10.0.0 had [significant breaking changes](https://github.com/sindresorhus/got/releases/tag/v10.0.0), 11.0.0 [less problematic](https://github.com/sindresorhus/got/releases/tag/v11.0.0))
* Also fixes paths referencing developer, and tweaks command line help.

@keymanapp-test-bot skip