### PR TITLE
chore(common): remove unused ncc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -564,8 +564,8 @@
         "typescript": "^4.5.4"
       },
       "optionalDependencies": {
-        "hetrodo-node-hide-console-window-napi": "git+ssh://git@github.com/keymanapp/hetrodo-node-hide-console-window-napi.git#858b23036a9963b40ad6ff3c5bacd421e5839b92",
-        "node-windows-trayicon": "git+ssh://git@github.com/keymanapp/node-windows-trayicon.git#1e46786082213f3edcddd5953e33f5abdc7ea05f"
+        "hetrodo-node-hide-console-window-napi": "keymanapp/hetrodo-node-hide-console-window-napi#keyman-15.0",
+        "node-windows-trayicon": "keymanapp/node-windows-trayicon#keyman-15.0"
       }
     },
     "developer/src/server/node_modules/@cspotcode/source-map-support": {
@@ -1722,16 +1722,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
-    },
-    "node_modules/@zeit/ncc": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.21.1.tgz",
-      "integrity": "sha512-M9WzgquSOt2nsjRkYM9LRylBLmmlwNCwYbm3Up3PDEshfvdmIfqpFNSK8EJvR18NwZjGHE5z2avlDtYQx2JQnw==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
-      "dev": true,
-      "bin": {
-        "ncc": "dist/ncc/cli.js"
-      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -6863,7 +6853,6 @@
       "devDependencies": {
         "@types/node": "^13.7.0",
         "@types/semver": "^7.1.0",
-        "@zeit/ncc": "^0.21.0",
         "semver": "^7.1.2",
         "ts-node": "^8.6.2"
       },
@@ -7181,7 +7170,6 @@
         "@actions/github": "^2.1.0",
         "@types/node": "^13.7.0",
         "@types/semver": "^7.1.0",
-        "@zeit/ncc": "^0.21.0",
         "semver": "^7.1.2",
         "ts-node": "^8.6.2",
         "typescript": "^4.5.4",
@@ -7344,11 +7332,11 @@
         "chalk": "^4.1.2",
         "copyfiles": "^2.4.1",
         "express": "^4.17.2",
-        "hetrodo-node-hide-console-window-napi": "git+ssh://git@github.com/keymanapp/hetrodo-node-hide-console-window-napi.git#858b23036a9963b40ad6ff3c5bacd421e5839b92",
+        "hetrodo-node-hide-console-window-napi": "keymanapp/hetrodo-node-hide-console-window-napi#keyman-15.0",
         "mocha": "^9.1.4",
         "multer": "^1.4.4",
         "ngrok": "^4.2.2",
-        "node-windows-trayicon": "git+ssh://git@github.com/keymanapp/node-windows-trayicon.git#1e46786082213f3edcddd5953e33f5abdc7ea05f",
+        "node-windows-trayicon": "keymanapp/node-windows-trayicon#keyman-15.0",
         "open": "^8.4.0",
         "ts-node": "^10.4.0",
         "tsc-watch": "^4.5.0",
@@ -8520,12 +8508,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
-    "@zeit/ncc": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.21.1.tgz",
-      "integrity": "sha512-M9WzgquSOt2nsjRkYM9LRylBLmmlwNCwYbm3Up3PDEshfvdmIfqpFNSK8EJvR18NwZjGHE5z2avlDtYQx2JQnw==",
       "dev": true
     },
     "abbrev": {

--- a/resources/build/version/package.json
+++ b/resources/build/version/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@types/node": "^13.7.0",
     "@types/semver": "^7.1.0",
-    "@zeit/ncc": "^0.21.0",
     "semver": "^7.1.2",
     "ts-node": "^8.6.2"
   },
@@ -17,20 +16,16 @@
     "node": "16"
   },
   "files": [
-    "dist",
     "src"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "name": "@keymanapp/auto-history-action",
   "private": true,
   "scripts": {
-    "build": "npm run clean:dist; npm run build:dist",
-    "build:dist": "ncc build src/index.ts --minify --source-map --v8-cache",
     "build:ts": "tsc --project tsconfig.production.json",
     "build:ts:watch": "tsc --project tsconfig.production.json --watch",
     "clean": "run-p clean:*",
-    "clean:dist": "rm -rf dist",
     "clean:lib": "rm -rf lib",
     "types": "tsc --noEmit"
   }


### PR DESCRIPTION
The `build:dist` script was never used; increment-version.sh uses only
`build:ts`.