### PR TITLE
chore(developer): remove crc generation from kmc-keyboard

### DIFF
--- a/common/tools/hextobin/index.ts
+++ b/common/tools/hextobin/index.ts
@@ -44,7 +44,7 @@ export default async function hextobin(inputFilename: string, outputFilename?: s
 
   return save();
 
-  function reportError(message) {
+  function reportError(message: string) {
     if(!options.silent) {
       console.error(`Invalid input file: ${message} on line #${currentLineNumber}: "${currentLine}"`);
     }

--- a/common/tools/hextobin/tsconfig.json
+++ b/common/tools/hextobin/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
+        "target": "ES2020",
         "module": "CommonJS",
         "moduleResolution": "node",
         "rootDir": ".",

--- a/developer/src/kmc-keyboard/package.json
+++ b/developer/src/kmc-keyboard/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@keymanapp/keyman-version": "*",
     "ajv": "^8.11.0",
-    "crc-32": "^1.2.2",
     "restructure": "^3.0.0",
     "semver": "^7.3.7",
     "xml2js": "^0.4.19"

--- a/developer/src/kmc-keyboard/src/kmx/kmx-builder.ts
+++ b/developer/src/kmc-keyboard/src/kmx/kmx-builder.ts
@@ -1,5 +1,4 @@
 import * as r from 'restructure';
-import crc32 from 'crc-32';
 import KMXFile, { GROUP, KEY, STORE } from './kmx.js';
 import KMXPlusFile from './kmx-plus.js';
 import KMXPlusBuilder from './kmx-plus-builder/kmx-plus-builder.js';
@@ -98,7 +97,7 @@ export default class KMXBuilder {
     this.comp_header = {
       dwIdentifier: KMXFile.FILEID_COMPILED,
       dwFileVersion: KMXFile.VERSION_160,
-      dwCheckSum: 0,
+      dwCheckSum: 0,  // Deprecated in Keyman 16.0
       KeyboardID: 0,
       IsRegistered: 1,
       version: 0,
@@ -234,10 +233,6 @@ export default class KMXBuilder {
     }
   }
 
-  calculateCRC32(file: Uint8Array): number {
-    return ~crc32.buf(file, 0);
-  }
-
   compile(): Uint8Array {
     const fileSize = this.build();
 
@@ -286,11 +281,6 @@ export default class KMXBuilder {
     if(this.file instanceof KMXPlusFile) {
       file.set(this.comp_kmxplus_data, this.comp_kmxplus.dpKMXPlus);
     }
-
-    // Finally, calculate and write the checksum
-
-    this.comp_header.dwCheckSum = this.calculateCRC32(file);
-    file.set(this.file.COMP_KEYBOARD.toBuffer(this.comp_header), this.base_keyboard);
 
     return file;
   }

--- a/developer/src/kmc-keyboard/test/fixtures/basic.txt
+++ b/developer/src/kmc-keyboard/test/fixtures/basic.txt
@@ -21,7 +21,7 @@ block(kmxheader)  #  struct COMP_KEYBOARD {
 
   00 10 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
 
-  c1 79 c0 dd      #    KMX_DWORD dwCheckSum;     // 0008 As stored in keyboard
+  00 00 00 00      #    KMX_DWORD dwCheckSum;     // 0008 deprecated in 16.0, always 0
   00 00 00 00      #    KMX_DWORD KeyboardID;     // 000C as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
   01 00 00 00      #    KMX_DWORD IsRegistered;   // 0010
   00 00 00 00      #    KMX_DWORD version;        // 0014 keyboard version

--- a/package-lock.json
+++ b/package-lock.json
@@ -498,7 +498,6 @@
       "dependencies": {
         "@keymanapp/keyman-version": "*",
         "ajv": "^8.11.0",
-        "crc-32": "^1.2.2",
         "restructure": "^3.0.0",
         "semver": "^7.3.7",
         "xml2js": "^0.4.19"
@@ -3449,17 +3448,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-require": {
@@ -9045,7 +9033,7 @@
         "chai": "^4.3.4",
         "chalk": "^2.4.2",
         "commander": "^3.0.0",
-        "esbuild": "*",
+        "esbuild": "^0.15.8",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
         "typescript": "^4.5.4"
@@ -9127,7 +9115,6 @@
         "c8": "^7.12.0",
         "chai": "^4.3.4",
         "chalk": "^2.4.2",
-        "crc-32": "^1.2.2",
         "mocha": "^8.4.0",
         "restructure": "^3.0.0",
         "semver": "^7.3.7",
@@ -11256,11 +11243,6 @@
         "object-assign": "^4",
         "vary": "^1"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-require": {
       "version": "1.1.1",


### PR DESCRIPTION
Fixes #7301.

(Note: hextobin changes are due to es2020 asynciterable feature in `load` function: `for await (const l of reader) {`. Generally it builds fine separately but trouble can arise with project builds.)

@keymanapp-test-bot skip