### PR TITLE
fix(android/engine): Check listview for setting keyboard selection

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -321,8 +321,10 @@ public final class KeyboardPickerActivity extends BaseActivity {
   }
 
   private static void setSelection(int position) {
-    listView.setItemChecked(position, true);
-    listView.setSelection(position);
+    if (listView != null) {
+      listView.setItemChecked(position, true);
+      listView.setSelection(position);
+    }
     selectedIndex = position;
   }
 


### PR DESCRIPTION
Follow-on to #7291

This :cherries: picks commit https://github.com/keymanapp/keyman/pull/7304/commits/0ff9946ff92fd5707a917a07e984877380582a87 to master

When Keyman is launched without entering the Keyboard picker menu, the listview is uninitialized. This adds the check for setting the keyboard selection.

## User Testing
Setup
1. Install the PR build of Keyman for Android
2. On the "Get Started" menu, enable Keyman as a system keyboard and set it as the default system keyboard.

* **TEST_KEYBOARD_PICKER_MENU** - Verifies keyboard switches when deleting current keyboard from Keyboard Picker menu
1. Launch Keyman for Android and verify the current keyboard is sil_euro_latin 
2. Launch another app (e.g. Chrome) and verify the system keyboard is sil_euro_latin
3. In the Keyman app, go to Settings, search for the language `l:id:bkc` and download sil_cameroon_qwerty. Note: make sure the system keyboard used in the keyboard search isn't altering the search query.
4. Install the sil_cameroon_qwerty keyboard package for the Baka language (bkc-Latn)
5. In the Keyman app, verify the current keyboard is now sil_cameroon_qwerty
6. Short-press the globe key to switch to sil_euo_latin keyboard
7. Verify the current keyboard is now sil_euro_latin
8. Long-press the globe key to display the Keyboard Picker menu
9. On the Keyboard Picker menu, long-press on sil_euro_latin and select "Delete"
10. Verify sil_euro_latin does not appear on the Keyboard Picker menu
11. Exit the menu and verify the current keyboard is now sil_cameroon_qwerty

* **TEST_KEYBOARD_SETTINGS_MENU** - Verifies fix to issue #6733 that the current keyboard is no longer active after uninstalling from the keyboard settings menu
**Note**: this test is run after TEST_KEYBOARD_PICKER_MENU so the installed keyboard is sil_cameroon_qwerty(sil_euro_latin was uninstalled during the test). Exit Keyman completely before starting this test.
1. Launch Keyman for Android and verify the current keyboard is sil_cameroon_qwerty
2. Launch another app (e.g. Chrome) and verify the system keyboard is sil_cameroon_qwerty
3. In the Keyman app, go to Settings, search for sil_euro_latin and download it. Note: make sure the system keyboard used in the keyboard search isn't altering the search query.
4. Install the sil_euro_latin keyboard package for the English language
5. In the Keyman app, verify the current keyboard is now sil_euro_latin
6. Short-press the globe key to switch to sil_cameroon_qwerty
7. Verify the current keyboard is now sil_cameroon_qwerty
8. Go to Keyman settings --> Installed Languages -->  Baka --> Cameroon QWERTY settings
9. On the Cameroon QWERTY settings menu, uninstall the keyboard
10. Hit "Back" and return to the "Installed Languages" menu (don't exit completely back to the Keyman app)
11. On the "Installed Languages" menu, click "+" to search for another keyboard
12. In the keyboard search, verify the system keyboard used for the keyboard search is no longer sil_cameroon_qwerty.
13. Verify the system keyboard in the search is now sil_euro_latin
