### PR TITLE
chore(core): changes ldml tsconfig to es2020 🙀

### DIFF
--- a/core/include/ldml/package.json
+++ b/core/include/ldml/package.json
@@ -8,6 +8,7 @@
     "unicode"
   ],
   "license": "MIT",
+  "type": "module",
   "main": "build/keyboardprocessor_ldml.js",
   "repository": {
     "type": "git",

--- a/core/include/ldml/tsconfig.json
+++ b/core/include/ldml/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "module": "CommonJS",
+        "module": "es2020",
         "moduleResolution": "node",
         "rootDir": ".",
         "outDir": "build/",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,4 +1,7 @@
 {
+  // Lists only CommonJS or 'none' modules; as we move modules from cjs/none to
+  // esm, we should move them from here into tsconfig.esm.json. Eventually, when
+  // we have only ES modules, we'll delete this file.
   "files": [],
   "include": [],
   "references": [
@@ -19,18 +22,6 @@
     { "path": "./common/predictive-text/testing/two-stage-embedded-webworker/worker/tsconfig.json" },
     { "path": "./common/predictive-text/tsconfig.json" },
 
-    //{ "path": "./developer/src/kmc/test/tsconfig.json" },
-    { "path": "./developer/src/kmc/tsconfig.json" },
-
-    { "path": "./developer/src/kmc-keyboard/test/tsconfig.json" },
-    { "path": "./developer/src/kmc-keyboard/tsconfig.json" },
-    { "path": "./developer/src/kmc-model/test/tsconfig.json" },
-    { "path": "./developer/src/kmc-model/tsconfig.json" },
-    //{ "path": "./developer/src/kmc-model-info/test/tsconfig.json" },
-    { "path": "./developer/src/kmc-model-info/tsconfig.json" },
-    { "path": "./developer/src/kmc-package/test/tsconfig.json" },
-    { "path": "./developer/src/kmc-package/tsconfig.json" },
-
     { "path": "./developer/src/server/tsconfig.json" },
 
     { "path": "./resources/build/version/tsconfig.json" },
@@ -44,6 +35,5 @@
     { "path": "./common/web/lm-message-types/" },
     { "path": "./common/web/lm-worker/" },
     { "path": "./common/web/keyman-version/" },
-    { "path": "./common/web/keyman-version/tsconfig.esm.json" },
   ]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,24 @@
+{
+  // Lists only ES modules; as we move modules from cjs/none to esm, we should
+  // move them from tsconfig.cjs.json to here. Eventually, when we have only ES
+  // modules, we can rename this to tsconfig.json.
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./core/include/ldml/tsconfig.json" },
+
+    //{ "path": "./developer/src/kmc/test/tsconfig.json" },
+    { "path": "./developer/src/kmc/tsconfig.json" },
+
+    { "path": "./developer/src/kmc-keyboard/test/tsconfig.json" },
+    { "path": "./developer/src/kmc-keyboard/tsconfig.json" },
+    { "path": "./developer/src/kmc-model/test/tsconfig.json" },
+    { "path": "./developer/src/kmc-model/tsconfig.json" },
+    //{ "path": "./developer/src/kmc-model-info/test/tsconfig.json" },
+    { "path": "./developer/src/kmc-model-info/tsconfig.json" },
+    { "path": "./developer/src/kmc-package/test/tsconfig.json" },
+    { "path": "./developer/src/kmc-package/tsconfig.json" },
+
+    { "path": "./common/web/keyman-version/tsconfig.esm.json" },
+  ]
+}


### PR DESCRIPTION
Also splits the root tsconfig.json into tsconfig.cjs.json and tsconfig.esm.json. These are not typically used at present but in theory you could do a `tsc -b <tsconfig.x.json>` and build all modules. In practice, we still have some prebuild steps that make that a bit of a pain.

I have noted some inconsistency with `tsc -b` when referenced modules have different module modes, so splitting them seems wise. Also helpful for a simple index of which modules are in which format...

@keymanapp-test-bot skip