### PR TITLE
fix(android): Add language name when installing default lexical-model

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -165,6 +165,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       HashMap<String, String> lexicalModelInfo = new HashMap<String, String>();
       lexicalModelInfo.put(KMManager.KMKey_PackageID, defaultLexicalModel.getPackageID());
       lexicalModelInfo.put(KMManager.KMKey_LanguageID, defaultLexicalModel.getLanguageID());
+      lexicalModelInfo.put(KMManager.KMKey_LanguageName, defaultLexicalModel.getLanguageName());
       lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, defaultLexicalModel.getLexicalModelID());
       lexicalModelInfo.put(KMManager.KMKey_LexicalModelName, defaultLexicalModel.getLexicalModelName());
       lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, defaultLexicalModel.getVersion());

--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -58,6 +58,7 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     HashMap<String, String>lexicalModelInfo = new HashMap<String, String>();
     lexicalModelInfo.put(KMManager.KMKey_PackageID, "example.ta.wordlist");
     lexicalModelInfo.put(KMManager.KMKey_LanguageID, "ta");
+    lexicalModelInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, "example.ta.wordlist");
     lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, "1.0");
     KMManager.addLexicalModel(context, lexicalModelInfo);

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -62,6 +62,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     HashMap<String, String>lexicalModelInfo = new HashMap<String, String>();
     lexicalModelInfo.put(KMManager.KMKey_PackageID, "example.ta.wordlist");
     lexicalModelInfo.put(KMManager.KMKey_LanguageID, "ta");
+    lexicalModelInfo.put(KMManager.KMKey_LanguageName, "Tamil");
     lexicalModelInfo.put(KMManager.KMKey_LexicalModelID, "example.ta.wordlist");
     lexicalModelInfo.put(KMManager.KMKey_LexicalModelVersion, "1.0");
     KMManager.addLexicalModel(this, lexicalModelInfo);


### PR DESCRIPTION
Fixes #7326 

I don't think this is a recent regression, but a scenario uncovered from the Keyman 15 change #5838 of allowing the default sil_euro_latin keyboard to be uninstalled.

1. The language list in the Languages settings menu is backed by a legacy filtered Dataset structure (introduced a long time ago to generate the  list of installed languages). This dataset is sourced by the list of installed keyboard languages and installed lexical-model languages.
2. Including the language name with the lexical-model data structure was optional since we are only checking language ID's for association. So we haven't had to bother including the language name when installing the default English lexical-model.
3. When the English keyboard for sil_euro_latin is uninstalled,
4. The underlying Dataset now only has the lexical-model info for "English language". Because only the language ID is defined, it's re-used as a fallback for the language name (See https://github.com/keymanapp/keyman/blob/1a7ad09fdb3e14a6d117e8555775745bece555d8/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java#L120)

5. This was causing "en" to display for English.

This PR just sets the language name when installing the default lexical-models.

## User Testing

- **TEST_UNINSTALL_SIL_EUROLATIN**: - Verifies issue #7326 is fixed
1. Install the PR build of Keyman for Android
2. Open Keyman app.
4. Click Settings / Installed Languages. 
5. Verify that the language name 'English' appears on the pane. 
6. Click the plus sign which appears at the bottom right corner of the view. 
7. Enter 'Khmer Angkor' in the language search bar. 
8. Verify that the Khmer Angkor Keyboard available on the list. 
9. Install Khmer Angkor keyboard. 
10. Verify that the Khmer Angkor keyboard appears in the text pane. 
11. Long press the globe key. 
12. Long press on the  [new]English name in the language picker menu.
13. Click Delete. 
14. Verify that the English Keyboard has been removed from the Language picker menu. 
15. Close the Keyman app. 
16. Launch the Keyman app once again. 
17. Install sil_euro_latin keyboard. 
18. Long press the globe key. 
19. Verify that the [new]English name appears in the language picker menu. 
20. Open Installed Languages menu. 
21. Verify the English language name has the name "English" and not "en".
