### PR TITLE
fix(web): Update spacebar caption when refreshing layout

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -143,8 +143,7 @@ function setSpacebarText(mode) {
   keyman.osk.show(true);
 
   // Refresh KMW OSK
-  var kmw = window['keyman'];
-  kmw.correctOSKTextSize();
+  keyman.correctOSKTextSize();
 }
 
 // #6665: we need to know when the user has pressed a hardware key so we don't

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -143,7 +143,8 @@ function setSpacebarText(mode) {
   keyman.osk.show(true);
 
   // Refresh KMW OSK
-  keyman.correctOSKTextSize();
+  var kmw = window['keyman'];
+  kmw.correctOSKTextSize();
 }
 
 // #6665: we need to know when the user has pressed a hardware key so we don't

--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -499,6 +499,8 @@ namespace com.keyman.osk {
         bs.width  = bs.maxWidth  = this.computedWidth + 'px';
         bs.height = bs.maxHeight = this.computedHeight + 'px';
 
+        // Ensure that the layer's spacebar is properly captioned.
+        this.vkbd.showLanguage();
       } else {
         const bs = this._Box.style;
         bs.width  = 'auto';


### PR DESCRIPTION
Fixes #6603 and ~possibly addresses #7228~ (edit - fails to fix #7228)

(The original PR description explored changing the Android namespace call from `keyman` to `kmw` `.correctOSKTextSize()`; which turned out to have no impact on the issue. The description has now been edited after further investigating the cause in KeyamnWeb)

It seems the KeymanWeb call to refresh the layout was missing a call to ensure the spacebar caption was updated as well.

I don't understand why the issue doesn't happen when only the default sil_euro_latin keyboard is installed...

## User Testing

* **TEST_SPACEBAR_CAPTION_ANDROID** - Verifies issue #6603 on Android is fixed

![Android spacebar caption menu](https://user-images.githubusercontent.com/7358010/191900421-2940f1dd-9439-41e8-8e99-d07a1f3bb922.png)
*Spacebar caption menu*

1. Load the PR build of Keyman for Android
2. From Keyman Settings, search for and install another keyboard (e.g. sil_cameroon_qwerty keyboard for the "Basa" language)
3. Verify the default OSK spacebar caption shows **Language + Keyboard** (e.g. Basa - Cameroon QWERTY)
4. Go to Keyman settings --> change Spacebar caption to **Language** --> exit the Settings menu
5. Verify the OSK spacebar caption shows **Language** (e.g. Basa)
6. Go to Keyman settings --> change Spacebar caption to **Keyboard** --> exit the Settings menu
7. Verify the OSK spacebar caption shows **Keyboard** (e.g. Cameroon QWERTY)
8. Go to Keyman settings --> change Spacebar caption to **Language + Keyboard** --> exit the Settings menu
9. Verify the OSK spacebar caption shows **Language + Keyboard** (e.g. Basa - Cameroon QWERTY)
10. Go to Keyman settings --> change Spacebar caption to **Blank** --> exit the Settings menu
11. Verify the OSK spacebar caption shows **Blank** (e.g. no caption)

