### PR TITLE
refactor(developer): move compiler callbacks out of readers 🙀

### DIFF
--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -51,9 +51,21 @@ export default class Compiler {
    * @returns
    */
   public load(filename: string): LDMLKeyboardXMLSourceFile {
-    const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
-    const source = reader.loadFile(filename);
-    return source ?? null;
+    const reader = new LDMLKeyboardXMLSourceFileReader();
+    const data = this.callbacks.loadFile(filename, filename);
+    const source = reader.load(data);
+    if(!source) {
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
+      return null;
+    }
+    try {
+      reader.validate(source, this.callbacks.loadLdmlKeyboardSchema());
+    } catch(e) {
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
+      return null;
+    }
+
+    return source;
   }
 
   /**

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -58,8 +58,18 @@ afterEach(function() {
 export function loadSectionFixture(compilerClass: typeof SectionCompiler, filename: string, callbacks: CompilerCallbacks): Section {
   callbacks.messages = [];
   const inputFilename = makePathToFixture(filename);
-  const source = (new LDMLKeyboardXMLSourceFileReader(callbacks)).loadFile(inputFilename);
+  const data = callbacks.loadFile(inputFilename, inputFilename);
+  assert.isNotNull(data);
+
+  const reader = new LDMLKeyboardXMLSourceFileReader();
+  const source = reader.load(data);
+  assert.isNotNull(source);
+  assert.doesNotThrow(() => {
+    reader.validate(source, callbacks.loadLdmlKeyboardSchema());
+  });
+
   const compiler = new compilerClass(source, callbacks);
+
   if(!compiler.validate()) {
     return null;
   }

--- a/developer/src/kmc-keyboard/test/kvk/test-kvk-round-trip.ts
+++ b/developer/src/kmc-keyboard/test/kvk/test-kvk-round-trip.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import 'mocha';
 import {assert} from 'chai';
 import { compilerTestCallbacks, makePathToFixture } from '../helpers/index.js';
-import KvksFileReader from "../../src/kvk/kvks-file-reader.js";
+import KvksFileReader, { KVKSParseError } from "../../src/kvk/kvks-file-reader.js";
 import KvkFileReader from "../../src/kvk/kvk-file-reader.js";
 import KvkFileWriter from "../../src/kvk/kvk-file-writer.js";
 
@@ -24,8 +24,14 @@ describe('kvks-file-reader', function () {
     const compiledPath = makePathToFixture('kvk', 'khmer_angkor.kvk');
     const input = fs.readFileSync(inputPath);
     const compiled = fs.readFileSync(compiledPath);
-    const reader = new KvksFileReader(compilerTestCallbacks);
-    const vk = reader.read(input);
+    const reader = new KvksFileReader();
+    const kvks = reader.read(input);
+    assert.doesNotThrow(() => {
+      reader.validate(kvks, compilerTestCallbacks.loadKvksJsonSchema());
+    });
+    const errors: KVKSParseError[] = [];
+    const vk = reader.transform(kvks, errors);
+    assert.isEmpty(errors);
     const writer = new KvkFileWriter();
     const output = writer.write(vk);
     assert.deepEqual(output, compiled);

--- a/developer/src/kmc-keyboard/test/kvk/test-kvks-file.ts
+++ b/developer/src/kmc-keyboard/test/kvk/test-kvks-file.ts
@@ -1,15 +1,23 @@
 import * as fs from 'fs';
 import 'mocha';
 import { compilerTestCallbacks, makePathToFixture } from '../helpers/index.js';
-import KvksFileReader from "../../src/kvk/kvks-file-reader.js";
+import KvksFileReader, { KVKSParseError } from "../../src/kvk/kvks-file-reader.js";
 import { verify_khmer_angkor } from './test-kvk-utils.js';
+import { assert } from 'chai';
 
 describe('kvks-file-reader', function() {
   it('kvks-file-reader should read a valid file', function() {
     const path = makePathToFixture('kvk', 'khmer_angkor.kvks');
     const input = fs.readFileSync(path);
-    const reader = new KvksFileReader(compilerTestCallbacks);
-    const vk = reader.read(input);
+
+    const reader = new KvksFileReader();
+    const kvks = reader.read(input);
+    assert.doesNotThrow(() => {
+      reader.validate(kvks, compilerTestCallbacks.loadKvksJsonSchema());
+    });
+    const errors: KVKSParseError[] = [];
+    const vk = reader.transform(kvks, errors);
+    assert.isEmpty(errors);
     verify_khmer_angkor(vk);
   });
 });

--- a/developer/src/kmc-keyboard/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/developer/src/kmc-keyboard/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -2,27 +2,30 @@ import 'mocha';
 import {assert} from 'chai';
 import {compilerTestCallbacks, makePathToFixture} from '../helpers/index.js';
 import LDMLKeyboardXMLSourceFileReader from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
-import { CompilerMessages } from '../../src/compiler/messages.js';
 
 describe('ldml keyboard xml reader tests', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
 
   it("should fail to load files that don't conform to DTD", function() {
     const inputFilename = makePathToFixture('invalid-structure-per-dtd.xml');
-    let reader = new LDMLKeyboardXMLSourceFileReader(compilerTestCallbacks);
-    const source = reader.loadFile(inputFilename);
-    assert.isNull(source);
-    assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_InvalidFile({errorText: "data/keyboard must have required property 'names'"}));
+    let reader = new LDMLKeyboardXMLSourceFileReader();
+    const data = compilerTestCallbacks.loadFile(inputFilename, inputFilename);
+    const source = reader.load(data);
+    assert.isNotNull(source);
+    assert.throws(() => {
+      reader.validate(source, compilerTestCallbacks.loadLdmlKeyboardSchema());
+    }, "data/keyboard must have required property 'names'");
   });
 
   it("should fail to load files with an invalid conformsTo", function() {
     const inputFilename = makePathToFixture('invalid-conforms-to.xml');
-    let reader = new LDMLKeyboardXMLSourceFileReader(compilerTestCallbacks);
-    const source = reader.loadFile(inputFilename);
-    assert.isNull(source);
-    assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_InvalidFile({errorText: "data/keyboard/conformsTo must be equal to one of the allowed values"}));
+    let reader = new LDMLKeyboardXMLSourceFileReader();
+    const data = compilerTestCallbacks.loadFile(inputFilename, inputFilename);
+    const source = reader.load(data);
+    assert.isNotNull(source);
+    assert.throws(() => {
+      reader.validate(source, compilerTestCallbacks.loadLdmlKeyboardSchema());
+    }, "data/keyboard/conformsTo must be equal to one of the allowed values");
   });
 
 });


### PR DESCRIPTION
This is a minor refactor to prepare for moving the file readers into common/web/types, rather than keeping them as part of the compiler.

@keymanapp-test-bot skip