### PR TITLE
fix(web): possible error on change of context to a contextEditable

### DIFF
--- a/web/source/dom/targets/contentEditable.ts
+++ b/web/source/dom/targets/contentEditable.ts
@@ -121,7 +121,7 @@ namespace com.keyman.dom.targets {
 
     getTextAfterCaret(): string {
       if(!this.hasSelection()) {
-        return;
+        return '';
       }
 
       let caret = this.getCarets().end;

--- a/web/source/dom/targets/designIFrame.ts
+++ b/web/source/dom/targets/designIFrame.ts
@@ -143,7 +143,7 @@ namespace com.keyman.dom.targets {
 
     getTextAfterCaret(): string {
       if(!this.hasSelection()) {
-        return;
+        return '';
       }
 
       let caret = this.getCarets().end;


### PR DESCRIPTION
I happened to notice this one while dev-testing #7345; on occasion I'd see the following:

![image](https://user-images.githubusercontent.com/25213402/192426591-cbe429a5-009a-44ab-9eee-a79a52dafc9c.png)

This happened there while preparing a `Mock` for use with predictive-text based on a content-editable element type.  Now, that precise tidbit isn't allowed before #7345 is implemented, _but_ the fact remains that it's a bug.  (Content-editables don't interact with KMW in current builds b/c we don't support touch-aliasing for them.)  It's possible this may arise in other scenarios as well, though.

It could conceivably occur for design-mode iframes, though I haven't managed to reproduce that case yet.

@keymanapp-test-bot skip