### PR TITLE
feat(developer): visual keyboard compiler for LDML 🙀

### DIFF
--- a/developer/src/kmc-keyboard/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/visual-keyboard-compiler.ts
@@ -1,0 +1,64 @@
+import { Constants, VisualKeyboard, LDMLKeyboard } from "@keymanapp/common-types";
+
+export default class VisualKeyboardCompiler {
+  public compile(source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): VisualKeyboard.VisualKeyboard {
+    let result = new VisualKeyboard.VisualKeyboard();
+
+    /* TODO-LDML: consider VisualKeyboardHeaderFlags.kvkhUseUnderlying kvkhDisplayUnderlying kvkhAltGr kvkh102 */
+    result.header.flags = 0;
+    result.header.version = 0x0600;
+
+    /* TODO-LDML: consider font, associatedKeyboard */
+    result.header.associatedKeyboard = '';
+    result.header.ansiFont.name = 'Arial';
+    result.header.ansiFont.size = 10;
+    result.header.ansiFont.color = 0;
+    result.header.unicodeFont.name = 'Arial';
+    result.header.unicodeFont.size = 10;
+    result.header.unicodeFont.color = 0;
+
+    for(let layerMap of source.keyboard.layerMaps) {
+      for(let layer of layerMap.layerMap) {
+        this.compileHardwareLayer(source, result, layer);
+      }
+    }
+    return result;
+  }
+
+  private compileHardwareLayer(
+    source: LDMLKeyboard.LDMLKeyboardXMLSourceFile,
+    vk: VisualKeyboard.VisualKeyboard,
+    layer: LDMLKeyboard.LKLayerMap
+  ) {
+    // TODO: consider consolidation with keys.ts?
+    const shift = this.translateLayerIdToVisualKeyboardShift(layer.id);
+
+    let y = -1;
+    for(let row of layer.row) {
+      y++;
+
+      const keys = row.keys.split(' ');
+      let x = -1;
+      for(let key of keys) {
+        x++;
+
+        let keydef = source.keyboard.keys?.key?.find(x => x.id == key);
+
+        vk.keys.push({
+          flags: VisualKeyboard.VisualKeyboardKeyFlags.kvkkUnicode,
+          shift: shift,
+          text: keydef.to, // TODO-LDML: displays
+          vkey: Constants.USVirtualKeyMap[y][x]
+        });
+      }
+    }
+  }
+
+  private translateLayerIdToVisualKeyboardShift(id: string) {
+    if(id == 'base') {
+      return 0;
+    }
+    // TODO: other modifiers
+    return 0;
+  }
+}

--- a/developer/src/kmc-keyboard/src/main.ts
+++ b/developer/src/kmc-keyboard/src/main.ts
@@ -1,5 +1,6 @@
 
 export { default as Compiler } from './compiler/compiler.js';
+export { default as VisualKeyboardCompiler } from './compiler/visual-keyboard-compiler.js';
 export { CompilerEvent, default as CompilerCallbacks } from './compiler/callbacks.js';
 export { default as CompilerOptions } from './compiler/compiler-options.js';
 export { CompilerMessages, CompilerErrorSeverity } from './compiler/messages.js';

--- a/developer/src/kmc-keyboard/test/fixtures/basic-kvk.txt
+++ b/developer/src/kmc-keyboard/test/fixtures/basic-kvk.txt
@@ -1,0 +1,53 @@
+#
+# basic-kvk.txt describes the expected output of running kmc against basic.xml to generate
+# a .kvk file. It is used in the end-to-end test test-visual-keyboard-compiler-e2e.ts.
+#
+# Any changes to the compiler or basic.xml will likely result in changes to the compiled file.
+#
+
+block(kvkheader)
+  4b 56 4b 46      # identifier 'KVKF'
+  00 06 00 00      # version 0x0600
+  00               # flags
+block(associated_keyboard)
+  01 00            # string len in UTF-16 code units incl zterm
+  00 00            # '\0'
+
+block(ansi_font)
+  06 00            # string len in UTF-16 code units incl zterm
+  41 00 72 00 69 00 61 00 6c 00 00 00           # 'Arial\0'
+
+block(ansi_font_extra)
+  0a 00 00 00      # size
+  00 00 00 00      # color
+
+block(unicode_font)
+  06 00            # string len in UTF-16 code units incl zterm
+  41 00 72 00 69 00 61 00 6c 00 00 00           # 'Arial\0'
+
+block(unicode_font_extra)
+  0a 00 00 00      # size
+  00 00 00 00      # color
+
+block(keys_header)
+  02 00 00 00      # number of keys
+
+block(keys)
+
+block(key0)
+  02            # flags = unicode
+  00 00         # shift
+  c0 00         # vkey
+  02 00         # string len in UTF-16 code units incl zterm
+  27 01 00 00   # "ħ"
+  00 00 00 00   # bitmap
+
+block(key1)
+  02                  # flags = unicode
+  00 00               # shift
+  31 00               # vkey
+  03 00               # string len in UTF-16 code units incl zterm
+  90 17 b6 17 00 00   # "ថា"
+  00 00 00 00         # bitmap
+
+block(eof)   # end of file

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -5,12 +5,13 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';
 import { SectionCompiler } from '../../src/compiler/section-compiler.js';
-import { KMXPlus, LDMLKeyboardXMLSourceFileReader } from '@keymanapp/common-types';
+import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard } from '@keymanapp/common-types';
 import { CompilerEvent } from '../../src/compiler/callbacks.js';
 import Compiler from '../../src/compiler/compiler.js';
 import { assert } from 'chai';
 import KMXPlusMetadataCompiler from '../../src/compiler/metadata-compiler.js';
 import CompilerOptions from '../../src/compiler/compiler-options.js';
+import VisualKeyboardCompiler from '../../src/compiler/visual-keyboard-compiler.js';
 
 import KMXPlusFile = KMXPlus.KMXPlusFile;
 import Elem = KMXPlus.Elem;
@@ -107,6 +108,23 @@ export function compileKeyboard(inputFilename: string, options: CompilerOptions)
   KMXPlusMetadataCompiler.addKmxMetadata(kmx.kmxplus, kmx.keyboard, options);
 
   return kmx;
+}
+
+export function compileVisualKeyboard(inputFilename: string, options: CompilerOptions): VisualKeyboard.VisualKeyboard {
+  const k = new Compiler(compilerTestCallbacks, options);
+  const source = k.load(inputFilename);
+  checkMessages();
+  assert.isNotNull(source, 'k.load should not have returned null');
+
+  const valid = k.validate(source);
+  checkMessages();
+  assert.isTrue(valid, 'k.validate should not have failed');
+
+  const vk = (new VisualKeyboardCompiler()).compile(source);
+  checkMessages();
+  assert.isNotNull(vk, 'VisualKeyboardCompiler.compile should not have returned null');
+
+  return vk;
 }
 
 export function checkMessages() {

--- a/developer/src/kmc-keyboard/test/test-visual-keyboard-compiler-e2e.ts
+++ b/developer/src/kmc-keyboard/test/test-visual-keyboard-compiler-e2e.ts
@@ -1,5 +1,4 @@
 import 'mocha';
-import * as fs from 'fs';
 import {assert} from 'chai';
 import x_hextobin from '@keymanapp/hextobin';
 import { KvkFileWriter } from '@keymanapp/common-types';

--- a/developer/src/kmc-keyboard/test/test-visual-keyboard-compiler-e2e.ts
+++ b/developer/src/kmc-keyboard/test/test-visual-keyboard-compiler-e2e.ts
@@ -1,0 +1,34 @@
+import 'mocha';
+import * as fs from 'fs';
+import {assert} from 'chai';
+import x_hextobin from '@keymanapp/hextobin';
+import { KvkFileWriter } from '@keymanapp/common-types';
+import {checkMessages,  compileVisualKeyboard, makePathToFixture} from './helpers/index.js';
+
+const hextobin = (x_hextobin as any).default;
+
+describe('visual-keyboard-compiler', function() {
+  this.slow(500); // 0.5 sec -- json schema validation takes a while
+
+  it('should build fixtures', async function() {
+    // Let's build basic.xml
+    // It should match basic.kvk (built from basic-kvk.txt)
+
+    const inputFilename = makePathToFixture('basic.xml');
+    const binaryFilename = makePathToFixture('basic-kvk.txt');
+
+    // Compile the visual keyboard
+    const vk = compileVisualKeyboard(inputFilename, {debug: true, addCompilerVersion: false});
+    assert.isNotNull(vk);
+
+    // Use the builder to generate the binary output file
+    const writer = new KvkFileWriter();
+    const code = writer.write(vk);
+    checkMessages();
+    assert.isNotNull(code);
+
+    // Compare output
+    let expected = await hextobin(binaryFilename, undefined, {silent:true});
+    assert.deepEqual<Uint8Array>(code, expected);
+  });
+});

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@keymanapp/keyman-version": "*",
+    "@keymanapp/common-types": "*",
     "@keymanapp/kmc-keyboard": "*",
     "@keymanapp/kmc-model": "*",
     "@keymanapp/kmc-model-info": "*",

--- a/developer/src/kmc/tsconfig.json
+++ b/developer/src/kmc/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src/",
     "baseUrl": ".",
     "paths": {
+      "@keymanapp/common-types": [ "../../../common/web/types/src/main" ],
       "@keymanapp/kmc-keyboard": [ "../kmc-keyboard/src/main" ],
       "@keymanapp/kmc-model": [ "../kmc-model/src/main" ],
       "@keymanapp/kmc-model-info": [ "../kmc-model-info/src/model-info-compiler" ],
@@ -17,6 +18,7 @@
   ],
   "references": [
     { "path": "../../../common/web/keyman-version/tsconfig.esm.json" },
+    { "path": "../../../common/web/types" },
     { "path": "../kmc-keyboard" },
     { "path": "../kmc-model" },
     { "path": "../kmc-model-info" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,6 +423,7 @@
       "name": "@keymanapp/kmc",
       "license": "MIT",
       "dependencies": {
+        "@keymanapp/common-types": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/kmc-keyboard": "*",
         "@keymanapp/kmc-model": "*",
@@ -8838,6 +8839,7 @@
     "@keymanapp/kmc": {
       "version": "file:developer/src/kmc",
       "requires": {
+        "@keymanapp/common-types": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/kmc-keyboard": "*",
         "@keymanapp/kmc-model": "*",


### PR DESCRIPTION
Adds support for building .kvk files to kmc. At present, .kvk will always be generated, even if the .xml does not have a hardware layer.

Adds visual-keyboard-compiler and corresponding e2e test.

@keymanapp-test-bot skip