### PR TITLE
fix(developer): generate valid js when using unquoted digits in stores

### DIFF
--- a/developer/src/tike/compile/CompileKeymanWeb.pas
+++ b/developer/src/tike/compile/CompileKeymanWeb.pas
@@ -1467,7 +1467,7 @@ begin
       9:  Result := '\t';
       10: Result := '\n';
       13: Result := '\r';
-      else Result := '\x'+IntToHex(ch,1);
+      else Result := '\x'+IntToHex(ch,2);
     end;
   end
   else


### PR DESCRIPTION
Fixes #7005.

If a developer used single digit values in stores, unquoted (which is not really the usual approach, but should work just fine for non-zero values), the KMW compiler would emit invalid single-digit hexadecimal escapes for them, e.g. `"\x1"` instead of `"\x01"`.

Sample code:

```
store(option) 1

if(option = 1) + 'a' > 'one'
if(option = 2) + 'a' > 'two'
+ '1' > set(option = 1)
+ '2' > set(option = 2)
```

It is not immediately obvious from this code, but the value `1` is actually a character with value `'\x01'` or `U+0001`!

The more usual approach will not encounter this problem:

```
store(option) '1'

if(option = '1') + 'a' > 'one'
if(option = '2') + 'a' > 'two'
+ '1' > set(option = '1')
+ '2' > set(option = '2')
```

Note that the following is a compile error (due to internal use of null terminated strings).

```
store(option) 0
```

@keymanapp-test-bot skip