### PR TITLE
fix(developer): ensure backslash in paths passed to kmcomp

### DIFF
--- a/developer/src/kmcomp/main.pas
+++ b/developer/src/kmcomp/main.pas
@@ -64,6 +64,7 @@ uses
 function CompileKeyboard(FInFile, FOutFile: string; FDebug, FWarnAsError: Boolean): Boolean; forward;   // I4706
 function KCSetCompilerOptions(const FInFile: string; FShouldAddCompilerVersion: Boolean): Boolean; forward;
 //function CompilerMessage(line: Integer; msgcode: LongWord; text: PAnsiChar): Integer; stdcall; forward;
+procedure FixupPathSlashes(var path: string); forward;
 
 procedure Run;
 var
@@ -269,6 +270,14 @@ begin
   try
     if not FSilent then writeln('');
 
+    FixupPathSlashes(FParamDebugFile);
+    FixupPathSlashes(FParamTarget);
+    FixupPathSlashes(FParamInfile);
+    FixupPathSlashes(FParamOutfile);
+    FixupPathSlashes(FParamInfile2);
+    FixupPathSlashes(FInstallerMSI);
+    FixupPathSlashes(FJsonSchemaPath);
+
     if FParamDebugfile <> '' then
     begin
       hOutfile := CreateFile(PChar(FParamDebugfile), GENERIC_WRITE, 0, nil, CREATE_ALWAYS, 0, 0);
@@ -347,6 +356,10 @@ begin
   	else TProjectLogConsole.Instance.Log(plsFailure, FInFile, 'Keyboard '+FInFile+' could not be compiled.', 0, 0);
 end;
 
+procedure FixupPathSlashes(var path: string);
+begin
+  path := path.Replace('/', '\', [rfReplaceAll]);
+end;
 
 
 end.


### PR DESCRIPTION
Fixes #7090.
Fixes #7091.

While kmcomp loads most files just fine when paths with forward slashes are passed in, it fails to parse target path correctly when building one file out of a project.

For example, if the user runs:

```
kmcomp.exe -t khmer_angkor.kmn release/k/khmer_angkor/khmer_angkor.kpj
```

Then the following error arises:

```
khmer_angkor.kps: Error: 0001 Validation error: The system cannot find the path specified.
khmer_angkor.kps: Failure: Package C:\Projects\keyman\keyboards\source\khmer_angkor.kps had validation errors.
```

This patch ensures all paths passed in as command-line parameters are converted to backslashes, matching the expected Windows format. While I only needed to fix the `FParamTarget` parameter in order to address the reported issues, for consistency I applied the same fix to all input paths.

@keymanapp-test-bot skip