### PR TITLE
fix(developer): Handle hints and warnings cleanly

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
@@ -211,7 +211,15 @@ end;
 
 procedure TframeWordlistEditor.FindError(const Filename: string; s: string; line: Integer);
 begin
-  //
+  if pages.ActivePage <> pageCode then
+  begin
+    if MoveDesignToWordlist then
+      pages.ActivePage := pageCode;
+  end;
+
+  if line > 0 then
+    Dec(line);
+  frameSource.FindError(line);
 end;
 
 function TframeWordlistEditor.GetHelpTopic: string;

--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -131,6 +131,7 @@ type
       TWordlists = class(TObjectList<TWordlist>)
       public
         function IndexOfFilename(const Filename: string): Integer;
+        function FindByFullPath(const Filename: string): TWordlist;
       end;
   private
     parser: TLexicalModelParser;
@@ -169,6 +170,8 @@ type
 
     function CanChangeView(FView: TCodeDesignView): Boolean; override;
     procedure ChangeView(FView: TCodeDesignView); override;
+
+    function HasSubfilename(const Filename: string): Boolean; override;
 
     procedure FindError(const Filename: string; s: string; line: Integer); override;   // I4081
     procedure NotifyStartedWebDebug;
@@ -432,11 +435,31 @@ begin
   EnableControls;
 end;
 
+function TfrmModelEditor.HasSubfilename(const Filename: string): Boolean;
+begin
+  Result := wordlists.FindByFullPath(Filename) <> nil;
+end;
+
 procedure TfrmModelEditor.FindError(const Filename: string; s: string;
   line: Integer);
+var
+  wordlist: TWordlist;
 begin
-  inherited;
-  // TODO
+  if SameText(Filename, Self.FileName) then
+  begin
+    // Switch to code view, highlight line
+    pages.ActivePage := pageSource;
+    frameSource.FindError(line);
+    Exit;
+  end;
+
+  wordlist := wordlists.FindByFullPath(Filename);
+  if Assigned(wordlist) then
+  begin
+    pages.ActivePage := wordlist.Tab;
+    wordlist.Frame.FindError(Filename, s, line);
+    Exit;
+  end;
 end;
 
 procedure TfrmModelEditor.FormCreate(Sender: TObject);
@@ -699,6 +722,19 @@ begin
 end;
 
 { TfrmModelEditor.TWordlists }
+
+function TfrmModelEditor.TWordlists.FindByFullPath(
+  const Filename: string): TWordlist;
+begin
+  for Result in Self do
+  begin
+    if SameText(Result.Frame.Filename, Filename) then
+    begin
+      Exit;
+    end;
+  end;
+  Result := nil;
+end;
 
 function TfrmModelEditor.TWordlists.IndexOfFilename(
   const Filename: string): Integer;

--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmWordlistEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmWordlistEditor.pas
@@ -54,6 +54,7 @@ begin
   frame.Align := alClient;
   frame.Parent := Self;
   frame.OnChanged := FrameModified;
+  frame.Visible := True;
 end;
 
 procedure TfrmWordlistEditor.FormDestroy(Sender: TObject);

--- a/developer/src/tike/kmlmc.cmd
+++ b/developer/src/tike/kmlmc.cmd
@@ -2,14 +2,14 @@
 setlocal
 rem This script is a rough duplicate of /developer/src/node/inst/kmlmc.cmd. It is stored here
 rem in order to allow TIKE to call out to the compiler while debugging.
-if exist "%~dp0..\..\..\..\developer\src\inst\node\dist\node.exe" (
+if exist "%~dp0..\inst\node\dist\node.exe" (
   rem If running in windows/src/developer/x/:
-  set nodeexe="%~dp0..\..\..\..\developer\src\inst\node\dist\node.exe"
-  set nodecli="%~dp0..\..\..\..\developer\src\kmlmc\dist\kmlmc.js"
-) else if exist "%~dp0..\..\..\developersrc\inst\node\dist\node.exe" (
+  set nodeexe="%~dp0..\inst\node\dist\node.exe"
+  set nodecli="%~dp0..\kmlmc\dist\kmlmc.js"
+) else if exist "%~dp0..\src\inst\node\dist\node.exe" (
   rem If running in windows/bin/developer/:
-  set nodeexe="%~dp0..\..\..\developer\src\inst\node\dist\node.exe"
-  set nodecli="%~dp0..\..\..\developer\src\kmlmc\dist\kmlmc.js"
+  set nodeexe="%~dp0..\src\inst\node\dist\node.exe"
+  set nodecli="%~dp0..\src\kmlmc\dist\kmlmc.js"
 ) else (
   rem Cannot find node or kmlmc.js relative to execution path
   echo Error: node.exe or kmlmc.js not found.

--- a/developer/src/tike/main/UframeTextEditor.pas
+++ b/developer/src/tike/main/UframeTextEditor.pas
@@ -101,6 +101,7 @@ type
     procedure CharMapDragDrop(Sender, Source: TObject; X, Y: Integer);
     procedure CharMapDragOver(Sender, Source: TObject; X, Y: Integer;
       State: TDragState; var Accept: Boolean);
+    procedure DelayedFindError;
 
   protected
     function GetHelpTopic: string; override;
@@ -331,6 +332,7 @@ procedure TframeTextEditor.cefLoadEnd(Sender: TObject);
 begin
   FHasBeenLoaded := True;
   SetupCharMapDrop;
+  DelayedFindError;
 end;
 
 type
@@ -931,11 +933,20 @@ begin
   end;
 end;
 
+procedure TframeTextEditor.DelayedFindError;
+begin
+  if FErrorLine > 0 then
+    FindError(FErrorLine);
+end;
+
 procedure TframeTextEditor.FindError(ln: Integer);
 begin
   ClearError;
 
   FErrorLine := ln;
+
+  if not FHasBeenLoaded then
+    Exit;
 
   if (ln <= 0) then Exit;
 

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -1171,13 +1171,11 @@ end;
 function TfrmKeymanDeveloper.OpenKMNEditor(FFileName: string): TfrmTikeEditor;
 begin
   Result := OpenEditor(FFileName, TfrmKeymanWizard);
-    //else Result := OpenEditor(FFileName, TfrmEditor);
 end;
 
 function TfrmKeymanDeveloper.OpenTSVEditor(FFileName: string): TfrmTikeEditor;
 begin
   Result := OpenEditor(FFileName, TfrmWordlistEditor);
-    //else Result := OpenEditor(FFileName, TfrmEditor);
 end;
 
 function TfrmKeymanDeveloper.OpenModelEditor(FFileName: string): TfrmTikeEditor;
@@ -1213,7 +1211,7 @@ begin
   for i := 0 to FChildWindows.Count - 1 do
     if FChildWindows[i] is TfrmTikeEditor then
       with FChildWindows[i] as TfrmTikeEditor do
-        if SameFileName(FileName, FFileName) then   // I4749
+        if SameFileName(FileName, FFileName) or HasSubFilename(FFileName) then   // I4749
         begin
           Result := Self.FChildWindows[i] as TfrmTikeEditor;
           ShowChild(Result);


### PR DESCRIPTION
Relates to #4324 (but slightly orthogonal.)

We wanted some message classes to be handled in the lexical model editor more cleanly, including drill-down to line of error. A few changes required to make this work well:

1. Parse error messages from kmlmc. This is not perfect but works while the two projects are kept in sync, which they always are for Keyman Developer. Note that at this stage, .ts warnings are not captured in this parser, as they are generated by tsc.
2. Drill-down in Wordlist Editor Frame to find line of error
3. Model editor reports ownership of .tsv files so they can be loaded
4. In case of model editor not open (e.g. building from project view), the TSV standalone editor was not displaying the frame, so it never actually worked.
5. If the text editor had never loaded, then FindError was effectively a no-op; adds code to seek to error line after page load finishes.
6. Ensures that if we attempt to seek an error in a sub-file owned by an editor (e.g. .tsv owned by .model.ts, .kvks owned by .kmn), that the parent editor will be focused first. Does not verify all paths here, just the tsv one.

# User Testing

* **TEST_MODEL_COMPILER:** Load a model of your choice and verify that it compiles in the model editor.
* **TEST_MODEL_WARNING:** Add a duplicate word into a model wordlist, and compile it from the model editor. Verify that it emits a warning (and if project options are set accordingly, fails the build).
* **TEST_LOCATE_WARNING:** Using the model above, open it in the model editor, compile, and double-click on the warning line. It should open the wordlist view of the model editor, and highlight the relevant line.