### PR TITLE
chore(web): unit test polishing pass

### DIFF
--- a/web/unit_tests/cases/engine_chirality.js
+++ b/web/unit_tests/cases/engine_chirality.js
@@ -24,23 +24,24 @@ describe('Engine - Chirality', function() {
     fixture.cleanup();
   });
 
-  it('Keyboard + OSK simulation', function(done) {
+  it('Keyboard + OSK simulation', function() {
     this.timeout(testconfig.timeouts.scriptLoad * (testconfig.mobile ? 1 : 2));
     /* Interestingly, this still works on iOS, probably because we're able to force-set
      * the 'location' property in the simulated event on mobile devices, even when iOS neglects to
      * set it for real events.
      */
-    runKeyboardTestFromJSON('/engine_tests/chirality.json', {usingOSK: false}, function() {
-        /* We only really care to test the 'desktop' OSK because of how it directly models the modifier keys.
-         *
-         * The 'phone' and 'layout' versions take shortcuts that bypass any tricky chiral logic;
-         * a better test for those would be to ensure the touch OSK is constructed properly.
-         */
-        if(!testconfig.mobile) {
-          runKeyboardTestFromJSON('/engine_tests/chirality.json', {usingOSK: true}, done, assert.equal, testconfig.timeouts.scriptLoad);
-        } else {
-          done();
-        }
-      }, assert.equal, testconfig.timeouts.scriptLoad);
+    return runKeyboardTestFromJSON('/engine_tests/chirality.json',
+                            {usingOSK: false},
+                            assert.equal,
+                            testconfig.timeouts.scriptLoad).then(() => {
+      /* We only really care to test the 'desktop' OSK because of how it directly models the modifier keys.
+        *
+        * The 'phone' and 'layout' versions take shortcuts that bypass any tricky chiral logic;
+        * a better test for those would be to ensure the touch OSK is constructed properly.
+        */
+      if(!testconfig.mobile) {
+        return runKeyboardTestFromJSON('/engine_tests/chirality.json', {usingOSK: true}, assert.equal, testconfig.timeouts.scriptLoad);
+      }
+    });
   });
 });

--- a/web/unit_tests/cases/events.js
+++ b/web/unit_tests/cases/events.js
@@ -19,7 +19,7 @@ describe('Event Management', function() {
     teardownKMW();
   });
 
-  it('Keystroke-based onChange event generation', function(done) {
+  it('Keystroke-based onChange event generation', function() {
     var simple_A = {"type":"key","key":"a","code":"KeyA","keyCode":65,"modifierSet":0,"location":0};
     var event = new KMWRecorder.PhysicalInputEventSpec(simple_A);
 
@@ -28,7 +28,6 @@ describe('Event Management', function() {
 
     ele.onchange = function() {
       ele.onchange = null;
-      done();
     }
 
     if(ele['kmw_ip']) {
@@ -48,9 +47,11 @@ describe('Event Management', function() {
     if(focusEvent) {
       ele.dispatchEvent(focusEvent);
     }
+
+    assert.isNull(ele.onchange);
   });
 
-  it('OSK-based onChange event generation', function(done) {
+  it('OSK-based onChange event generation', function() {
     var simple_A = {"type":"osk","keyID":"default-K_A"};
     var event = new KMWRecorder.OSKInputEventSpec(simple_A);
 
@@ -59,7 +60,6 @@ describe('Event Management', function() {
 
     ele.onchange = function() {
       ele.onchange = null;
-      done();
     }
 
     if(ele['kmw_ip']) {
@@ -83,18 +83,14 @@ describe('Event Management', function() {
       focusEvent.initFocusEvent("blur", true, false, ele.ownerDocument.defaultView, 0, ele);
     }
 
-    if(focusEvent)
+    if(focusEvent) {
       ele.dispatchEvent(focusEvent);
-  });
-
-  it('Keystroke-based onInput event generation', function(done) {
-    // Not all browsers support InputEvent.  Bypass the test for these.
-    if(typeof InputEvent != 'function') {
-      console.log("InputEvent not supported.");
-      done();
-      return;
     }
 
+    assert.isNull(ele.onchange);
+  });
+
+  it('Keystroke-based onInput event generation', function() {
     var simple_A = {"type":"key","key":"a","code":"KeyA","keyCode":65,"modifierSet":0,"location":0};
     var event = new KMWRecorder.PhysicalInputEventSpec(simple_A);
 
@@ -106,9 +102,6 @@ describe('Event Management', function() {
 
     ele.addEventListener("input", function() {
       counterObj.i++;
-      if(counterObj.i == fin) {
-        done();
-      }
     });
 
     if(ele['kmw_ip']) {
@@ -120,16 +113,11 @@ describe('Event Management', function() {
     eventDriver.simulateEvent(event);
     eventDriver.simulateEvent(event);
     eventDriver.simulateEvent(event);
+
+    assert.equal(counterObj.i, fin, "Event handler not called the expected number of times");
   });
 
-  it('OSK-based onInput event generation', function(done) {
-    // Not all browsers support InputEvent.  Bypass the test for these.
-    if(typeof InputEvent != 'function') {
-      console.log("InputEvent not supported.");
-      done();
-      return;
-    }
-
+  it('OSK-based onInput event generation', function() {
     var simple_A = {"type":"osk","keyID":"default-K_A"};
     var event = new KMWRecorder.OSKInputEventSpec(simple_A);
 
@@ -141,9 +129,6 @@ describe('Event Management', function() {
 
     ele.addEventListener("input", function() {
       counterObj.i++;
-      if(counterObj.i == fin) {
-        done();
-      }
     });
 
     if(ele['kmw_ip']) {
@@ -155,5 +140,7 @@ describe('Event Management', function() {
     eventDriver.simulateEvent(event);
     eventDriver.simulateEvent(event);
     eventDriver.simulateEvent(event);
+
+    assert.equal(counterObj.i, fin, "Event handler not called the expected number of times");
   });
 });

--- a/web/unit_tests/cases/events.js
+++ b/web/unit_tests/cases/events.js
@@ -24,7 +24,6 @@ describe('Event Management', function() {
     var event = new KMWRecorder.PhysicalInputEventSpec(simple_A);
 
     var ele = document.getElementById("input");
-    var aliasing = false;
 
     ele.onchange = function() {
       ele.onchange = null;
@@ -42,13 +41,12 @@ describe('Event Management', function() {
     let eventDriver = new KMWRecorder.BrowserDriver(ele);
     eventDriver.simulateEvent(event);
 
-    var focusEvent = new FocusEvent('blur', {relatedTarget: ele});
+    let focusEvent = new FocusEvent('blur', {relatedTarget: ele});
+    ele.dispatchEvent(focusEvent);
 
-    if(focusEvent) {
-      ele.dispatchEvent(focusEvent);
-    }
-
-    assert.isNull(ele.onchange);
+    // Asserts that the handler is called.  As the handler clears itself, it will only
+    // remain set if it hasn't been called.
+    assert.isNull(ele.onchange, '`onchange` handler was not called');
   });
 
   it('OSK-based onChange event generation', function() {
@@ -74,20 +72,12 @@ describe('Event Management', function() {
     let eventDriver = new KMWRecorder.BrowserDriver(ele);
     eventDriver.simulateEvent(event);
 
-    var focusEvent;
+    let focusEvent = new FocusEvent('blur', {relatedTarget: ele});
+    ele.dispatchEvent(focusEvent);
 
-    if(typeof FocusEvent == 'function') {
-      focusEvent = new FocusEvent('blur', {relatedTarget: ele});
-    } else {
-      focusEvent = document.createEvent("FocusEvent");
-      focusEvent.initFocusEvent("blur", true, false, ele.ownerDocument.defaultView, 0, ele);
-    }
-
-    if(focusEvent) {
-      ele.dispatchEvent(focusEvent);
-    }
-
-    assert.isNull(ele.onchange);
+    // Asserts that the handler is called.  As the handler clears itself, it will only
+    // remain set if it hasn't been called.
+    assert.isNull(ele.onchange, '`onchange` handler was not called');
   });
 
   it('Keystroke-based onInput event generation', function() {

--- a/web/unit_tests/cases/text_selection.js
+++ b/web/unit_tests/cases/text_selection.js
@@ -5,15 +5,6 @@ describe('Text Selection', function() {
 
   /* Utility functions */
 
-  function supportsInputEvent(done) {
-    if(typeof InputEvent != 'function') {
-      console.log("InputEvent not supported.");
-      done();
-      return false;
-    }
-    return true;
-  }
-
   function setupElement(ele) {
     if(ele['kmw_ip']) {
       ele = ele['kmw_ip'];
@@ -44,12 +35,6 @@ describe('Text Selection', function() {
 
   function instantiateBrowserDriver(ele) {
     return new KMWRecorder.BrowserDriver(setupElement(ele));
-  }
-
-
-  if(!supportsInputEvent()) {
-    console.log('Don\'t run Text Selection tests on browsers that don\'t support Input event');
-    return;
   }
 
   var device = new com.keyman.Device();

--- a/web/unit_tests/test_utils.js
+++ b/web/unit_tests/test_utils.js
@@ -170,15 +170,15 @@ function runLoadedKeyboardTest(testDef, device, usingOSK, assertCallback) {
   testDef.test(proctor);
 }
 
-function runKeyboardTestFromJSON(jsonPath, params, callback, assertCallback, timeout) {
+function runKeyboardTestFromJSON(jsonPath, params, assertCallback, timeout) {
   var testSpec = new KMWRecorder.KeyboardTest(fixture.load(jsonPath, true));
   let device = new com.keyman.Device();
   device.detect();
 
-  loadKeyboardStub(testSpec.keyboard, timeout).then(() => {
+  return loadKeyboardStub(testSpec.keyboard, timeout).then(() => {
     runLoadedKeyboardTest(testSpec, device.coreSpec, params.usingOSK, assertCallback);
+  }).finally(() => {
     keyman.removeKeyboards(testSpec.keyboard.id);
-    callback();
   });
 }
 


### PR DESCRIPTION
This should help make Web's unit testing a little 'snappier', especially when things fail.

Changes made:

1. Keyboard sequence reproduction has been retooled to operate based on `Promise`s, allowing unhandled `Promise`-internal errors to be caught by the test framework.
    - I noticed that when a test dependent on reproducing a keystroke sequence failed, sometimes the test's full timeout would be enforced- likely because we weren't triggering the test-function's callback.  In particular, if the error was raised within a `Promise`'s operation, and not within the synchronous test-setup process.
    - I have seen a few occasions where KMW builds have timed out; this may help mitigate such cases.  No guarantees though, as those builds didn't actually report _any_ failed tests.
        - Like this one:  https://build.palaso.org/viewLog.html?buildId=337434&buildTypeId=Keymanweb_TestPullRequests&tab=buildResultsDiv
    - That said, with the length of wait I had locally before the test fully timed out, and the magnified timeout timer we've got set up for BrowserStack remote testing, I wouldn't be surprised if the cause is related.

2. Now that such tests can fully utilize `Promise`s, I reordered related tests to be more "linear" in their specifications, thus easier to maintain.
3. A similar issue existed for some of the event-oriented tests, so I retooled them to be fully synchronous.
    - They'd complete quickly when successful, but the way they were written, the full timeout would be required should the test fail.  And, upon further inspection, those particular tests should've been synchronous to begin with.
    - Example build: https://build.palaso.org/viewLog.html?buildId=340612&buildTypeId=Keymanweb_TestPullRequests
4. Removed any conditioning upon the existence of `InputEvent` - that was an IE-testing holdover.

@keymanapp-test-bot skip