### PR TITLE
fix(web): Only unhighlight suggestion if there's a pending one

### DIFF
--- a/web/source/osk/uiTouchHandlerBase.ts
+++ b/web/source/osk/uiTouchHandlerBase.ts
@@ -275,7 +275,9 @@ namespace com.keyman.osk {
 
         // Cancel (but do not execute) pending key if neither a popup key or the base key
         if(t == null || t.id.indexOf('popup') < 0) {
-          this.highlight(this.pendingTarget,false);
+          if (this.pendingTarget) {
+            this.highlight(this.pendingTarget,false);
+          }
           this.clearHolds();
           this.pendingTarget = null;
         }


### PR DESCRIPTION
Fixes #7382 

In certain instances, KeymanWeb is attempting to un-highlight a suggestion when `this.pendingTarget` is null.
This causes the suggestion banner to crash (t = this.pendingTarget = null => t.className is undefined)
https://github.com/keymanapp/keyman/blob/a3dde68d52c9f84c5181b54da7eba6a054810c46/web/source/osk/banner.ts#L460-L461

## User Testing

* **TEST_SUGGESTION_NO_CRASH** - Verifies issue #7382 is fixed
Setup: Install the PR build of Keyman for Android on a physical device. (The test involves multi-touch typing)

1. In the Keyman app with the default sil_euro_latin keyboard and nrc.en.mtnt lexical-model
2. Type enough characters until all 3 suggestions in the banner are blank (e.g. the text "Jjjjnnn")
3. Restart Keyman and observe all 3 suggestions are still blank
4. With one thumb, hold on a long-press key (e.g <kbd>j</kbd>)
5. With the other thumb, touch on a blank suggestion, then simultaneously release both thumbs
6. Verify the keyboard does not crash