### PR TITLE
fix(android/engine): Dismiss subkeys on multi-touch

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -302,6 +302,11 @@ final class KMKeyboard extends WebView {
       // if active, allowing for smooth, integrated gesture control.
       subKeysWindow.getContentView().findViewById(R.id.grid).dispatchTouchEvent(event);
     } else {
+      if (event.getPointerCount() > 1) {
+        // Multiple points touch the screen at the same time, so dismiss any pending subkeys
+        dismissKeyPreview(0);
+        dismissSubKeysWindow();
+      }
       gestureDetector.onTouchEvent(event);
     }
 


### PR DESCRIPTION
Possibly addresses #6978

Keyman Engine for Android currently isn't set up to robustly handle multi-touch. If the user starts a long-press with one finger and switches layer with a second finger, it can cause KeymanWeb to process a subkey that doesn't match the base key anymore.

This PR causes subkeys to get dismissed when a multi-touch is detected.

## User Testing
**Setup**
1. Needs a physical Android device for multi-touch typing (two thumbs)
2. Install the PR build of Keyman for Android


* **TEST_MULTI_TOUCH_DISMISSES_LONGPRESS** - Verifies long-press keys aren't generated when multi-touch detected
1. Start Keyman for Android with the default sil_euro_latin keyboard.
2. Observe the OSK is on the Shift layer (upper-case)
3. With the right thumb, start long-press on G and hold. Immediately with the left thumb press and release the shift button to switch to Default layer
4. With the right thumb still held, observe the layer is default layer. Verify long-presses for uppercase-G **do not** appear.
5. Observe the base key that was held is output in the text.
