### PR TITLE
chore(android/engine): Display Toast notifications on Sentry errors

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
@@ -36,6 +36,19 @@ public class BaseActivity extends AppCompatActivity {
     Toast.makeText(context, String.format(msg, args), duration).show();
   }
 
+  /**
+   * Some classes aren't an AppCompatActivity and need this helper to send Toast notifications
+   * @param defaultContext - the context to fallback if localeUpdatedContext is null
+   * @param msg - Toast notification string
+   * @param duration - length of the Toast notification (Toast.LENGTH_LONG or Toast.LENGTH_SHORT)
+   */
+  public static void makeToast(Context defaultContext, String msg, int duration) {
+    Context context = (localeUpdatedContext != null) ? localeUpdatedContext : defaultContext;
+    if (context != null) {
+      Toast.makeText(context, msg, duration).show();
+    }
+  }
+
   @Override
   protected void attachBaseContext(Context newBase) {
     // Override the app locale using the BCP 47 tag from shared preferences

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -148,7 +148,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
   private void processCloudResultForModel(Context aContext, MetaDataResult _r) {
     JSONArray lmData = _r.returnjson.jsonArray;
     if (lmData == null || lmData.length() == 0) {
-      KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - zero or null");
+      // Not an error if api.keyman.com returns empty array of associated lexical models
       return;
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/FileUtils.java
@@ -135,7 +135,7 @@ public final class FileUtils {
         if (tmpFile != null && tmpFile.exists()) {
           tmpFile.delete();
         }
-        KMLog.LogError(TAG, "Could not download filename " + filename);
+        KMLog.LogError(TAG, "Could not download filename " + destinationFilename);
       }
 
       Connection.disconnect();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -5,6 +5,10 @@
 package com.tavultesoft.kmea.util;
 
 import android.util.Log;
+import android.widget.Toast;
+
+import com.tavultesoft.kmea.BaseActivity;
+
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 
@@ -34,6 +38,8 @@ public final class KMLog {
   public static void LogError(String tag, String msg) {
     if (msg != null && !msg.isEmpty()) {
       Log.e(tag, msg);
+
+      BaseActivity.makeToast(null, msg, Toast.LENGTH_SHORT);
 
       if (Sentry.isEnabled()) {
         Sentry.captureMessage(msg, SentryLevel.ERROR);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -39,7 +39,7 @@ public final class KMLog {
     if (msg != null && !msg.isEmpty()) {
       Log.e(tag, msg);
 
-      BaseActivity.makeToast(null, msg, Toast.LENGTH_SHORT);
+      BaseActivity.makeToast(null, msg, Toast.LENGTH_LONG);
 
       if (Sentry.isEnabled()) {
         Sentry.captureMessage(msg, SentryLevel.ERROR);
@@ -50,20 +50,22 @@ public final class KMLog {
   /**
    * Utility to log exceptions and send to Sentry
    * @param tag String of the caller
-   * @param msg String of the exception message
+   * @param msg String of the exception message (maybe localized)
    * @param e Throwable exception
    */
   public static void LogException(String tag, String msg, Throwable e) {
+    String errorMsg = "";
     if (msg != null && !msg.isEmpty()) {
-      Log.e(tag, msg + "\n" + e);
+      errorMsg = msg + "\n" + e;
     } else if (e != null) {
-      Log.e(tag, e.getMessage(), e);
+      errorMsg = e.getMessage();
     }
+    Log.e(tag, errorMsg, e);
+
+    BaseActivity.makeToast(null, errorMsg, Toast.LENGTH_LONG);
 
     if (Sentry.isEnabled()) {
-      if (msg != null && !msg.isEmpty()) {
-        Sentry.addBreadcrumb(msg);
-      }
+      Sentry.addBreadcrumb(errorMsg);
       Sentry.captureException(e);
     }
   }


### PR DESCRIPTION
Fixes #7189
This updates the KMLog error handling to also display a Toast notification of the error message (provides user additional info about errors)

* Some classes aren't an AppCompatActivity, so they'll need BaseActivity.makeToast() to display the notification.
* Also updated the error string when downloads fail to use the destinationFilename, since filename could be blank.
* Found that api.keyman returns a valid empty array if no matching lexcal-model for a language is found. So I've removed that LogError.

Note: with this change, the localized strings used for Toast notifications are passed on to Sentry logging...

## User Testing
**Setup**
Install the PR build of Keyman for Android, and start the test with the device having network access

* **TEST_LOG_ERROR** - Verifies KMLog.LogError displays Toast notifications
1. Start Keyman for Android
2. In the Keyman app, go to Settings --> search for a Keyman keyboard (e.g. sil_cameroon_qwerty), but **do not** click the green button to install
3. Swipe down on the system notifications panel and set the device in airplane mode (disabling network access)
4. Back in the Keyman app, click on the green button to install the keyboard
5. Observe the keyboard fails to download
6. Verify several Toast notifications appear, one of which is "Could not download filename sil_cameroon_qwerty.kmp"

* **TEST_LOG_EXCEPTION** - Verifies KMLog.LogException displays Toast notifications
1. Start Keyman for Android
2. Launch a separate browser and download this invalid kmp package (the kmp.json file doesn't contain a valid keyboard version)
https://darcywong00.github.io/examples/invalid/khmer10/khmer10_noKbVer.kmp
3. When the kmp file downloads, click to open it (the file association should be handled in Keyman)
4. In the keyboard installation process, click "INSTALL"
5. Verify a Toast notification appears "No keyboards or predictive text to install"

* **TEST_KMP_INSTALL** - Verifies valid kmp package installs
1. Start Keyman for Android
2. Go to Keyman settings --> Install a keyboard from keyman.com (e.g. sil_cameroon_qwerty)
3. Continue with the keyboard package installation, picking "Akum" language, and install
4. Verify keyboard package installs and no Toast errors are displayed.
