### PR TITLE
fix(web): better element inputmode management 📴

### DIFF
--- a/web/source/kmwtypedefs.ts
+++ b/web/source/kmwtypedefs.ts
@@ -17,11 +17,16 @@ namespace com.keyman {
 
     /**
      * Tracks if the control has an aliased control for touch functionality.
-     * 
+     *
      * Future note - could be changed to track the DOMEventHandler instance used by this control;
      *               this may be useful for an eventual hybrid touch/non-touch implementation.
      */
     touchEnabled:   boolean;
+
+    /**
+     * Tracks the inputmode originally set by the webpage.
+     */
+    inputMode?: string;
 
     constructor(eleInterface: dom.targets.OutputTarget, kbd: string, touch?: boolean) {
       this.interface = eleInterface;


### PR DESCRIPTION
Refer to https://github.com/keymanapp/keyman/pull/7343#discussion_r985318712.

If a website designer would normally be specifying input mode for elements that KMW will be managing, we should put forth a good-faith effort to remember what the page's original settings were.  At some point, we might even go so far as to support 'intent' behavior in KMW... but not this release cycle.
- In this regard, refer to #1221.  It's the main example of a pre-existing feature request I've found in-repo.
