### PR TITLE
chore(developer): enable source maps for kmc commands 🙀

### DIFF
--- a/developer/src/inst/node/kmc.cmd
+++ b/developer/src/inst/node/kmc.cmd
@@ -1,4 +1,4 @@
 @rem This script avoids path dependencies for node for distribution
 @rem with Keyman Developer. When used on platforms other than Windows,
 @rem node can be used directly with the compiler (`npm link` will setup).
-@"%~dp0\node.js\node.exe" "%~dp0\kmc\kmc.cjs" %*
+@"%~dp0\node.js\node.exe" --enable-source-maps "%~dp0\kmc\kmc.cjs" %*

--- a/developer/src/inst/node/kmlmc.cmd
+++ b/developer/src/inst/node/kmlmc.cmd
@@ -1,4 +1,4 @@
 @rem This script avoids path dependencies for node for distribution
 @rem with Keyman Developer. When used on platforms other than Windows,
 @rem node can be used directly with the compiler (`npm link` will setup).
-@"%~dp0\node.js\node.exe" "%~dp0\kmc\kmlmc.cjs" %*
+@"%~dp0\node.js\node.exe" --enable-source-maps "%~dp0\kmc\kmlmc.cjs" %*

--- a/developer/src/inst/node/kmlmi.cmd
+++ b/developer/src/inst/node/kmlmi.cmd
@@ -1,4 +1,4 @@
 @rem This script avoids path dependencies for node for distribution
 @rem with Keyman Developer. When used on platforms other than Windows,
 @rem node can be used directly with the compiler (`npm link` will setup).
-@"%~dp0\node.js\node.exe" "%~dp0\kmc\kmlmi.cjs" %*
+@"%~dp0\node.js\node.exe" --enable-source-maps "%~dp0\kmc\kmlmi.cjs" %*

--- a/developer/src/inst/node/kmlmp.cmd
+++ b/developer/src/inst/node/kmlmp.cmd
@@ -1,4 +1,4 @@
 @rem This script avoids path dependencies for node for distribution
 @rem with Keyman Developer. When used on platforms other than Windows,
 @rem node can be used directly with the compiler (`npm link` will setup).
-@"%~dp0\node.js\node.exe" "%~dp0\kmc\kmlmp.cjs" %*
+@"%~dp0\node.js\node.exe" --enable-source-maps "%~dp0\kmc\kmlmp.cjs" %*

--- a/developer/src/tike/kmlmc.cmd
+++ b/developer/src/tike/kmlmc.cmd
@@ -16,5 +16,5 @@ if exist "%~dp0..\inst\node\dist\node.exe" (
   exit /b 1
 )
 
-%nodeexe% %nodecli% %*
+%nodeexe% --enable-source-maps %nodecli% %*
 exit /b %errorlevel%

--- a/developer/src/tike/kmlmi.cmd
+++ b/developer/src/tike/kmlmi.cmd
@@ -16,5 +16,5 @@ if exist "%~dp0..\inst\node\dist\node.exe" (
   exit /b 1
 )
 
-%nodeexe% %nodecli% %*
+%nodeexe% --enable-source-maps %nodecli% %*
 exit /b %errorlevel%

--- a/developer/src/tike/kmlmp.cmd
+++ b/developer/src/tike/kmlmp.cmd
@@ -16,5 +16,5 @@ if exist "%~dp0..\inst\node\dist\node.exe" (
   exit /b 1
 )
 
-%nodeexe% %nodecli% %*
+%nodeexe% --enable-source-maps %nodecli% %*
 exit /b %errorlevel%


### PR DESCRIPTION
Fixes #7408.

For kmc*.cmd, enables source maps. If you are running kmc from node on your own system, you may need to enable source maps in other ways.

Note that error reports should be going through to Sentry, and source maps should already be used for those.

@keymanapp-test-bot skip