### PR TITLE
modify(android/engine): Stop logging if keyboard index not found

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -234,7 +234,7 @@ public class KeyboardController {
     synchronized (list) {
       for (int i=0; i<list.size(); i++) {
         Keyboard k = list.get(i);
-        if (k.getPackageID().equals(packageID) && k.getKeyboardID().equals(keyboardID)) {
+        if (k.getPackageID().equalsIgnoreCase(packageID) && k.getKeyboardID().equalsIgnoreCase(keyboardID)) {
           if ( (matchLanguage && BCP47.languageEquals(k.getLanguageID(), languageID)) ||
               !matchLanguage ) {
             return i;
@@ -243,8 +243,9 @@ public class KeyboardController {
       }
     }
 
-    Log.w(TAG, "getKeyboardIndex failed for packageID: " + packageID +
-      ", keyboardID: " + keyboardID + ", languageID: " + languageID);
+    // Sometimes it's expected that languageID isn't found in the keyboard list
+    // (e.g. rendering the list of additional languages to install for an existing keyboard package)
+    // See keyboardExists()
     return index;
   }
 


### PR DESCRIPTION
To my chagrin, I've found the valid use case of KeyboardController not finding a language in the keyboard list
In displaying  some language lists, it's expected for a languageID not to be found. (e.g. "Add languages to installed keyboard" menu where it's filtering for languages not already installed)

So this PR also takes @jahorton's suggestion about checking equalsIgnoresCase, along with disabling the Sentry warning.

## User Testing
Setup - Load the PR build of Keyman for Android

* **TEST_LANGUAGE_NOT_FOUND**
1.  Launch the PR build of Keyman for Android
2. Using the Keyman Settings menu, search keyman.com and install sil_cameroon_qwerty keyboard for any language.
3. When the keyboard 
4. package finishes installing, observe the OSK is switched to sil_cameroon_qwerty
5. In Keyman Settings --> Install Keyboard or Dictionary --> Add languages to installed keyboard --> sil_cameroon_qwerty 
6. Select another language and click "INSTALL"
7. Verify the language is added
