### PR TITLE
test(web): adds artificial keyboard-load delay (DO NOT MERGE)

### DIFF
--- a/web/source/keyboards/kmwkeyboards.ts
+++ b/web/source/keyboards/kmwkeyboards.ts
@@ -800,22 +800,26 @@ namespace com.keyman.keyboards {
         }
       }, false);
 
-      // Some browsers may instantly start loading the file when assigned to an element, so we do this after the rest
-      // of our setup.  This method is not relocated here (yet) b/c it varies based upon 'native' vs 'embedded'.
-      Lscript.src = scriptSrc;
+      // DO NOT MERGE THIS!  ARTIFICIAL REPRO ATTEMPT FOR #6898.
+      window.setTimeout(() => {
+        // Some browsers may instantly start loading the file when assigned to an element, so we do this after the rest
+        // of our setup.  This method is not relocated here (yet) b/c it varies based upon 'native' vs 'embedded'.
+        Lscript.src = scriptSrc;
 
-      try {
-        document.body.appendChild(Lscript);
-      }
-      catch(ex) {
         try {
-          document.getElementsByTagName('head')[0].appendChild(Lscript);
-        } catch(ex2) {
-          reject('Error registering script ' + scriptSrc + ': ' + ex2);
-          return;
+          document.body.appendChild(Lscript);
         }
-      }
-      this.linkedScripts.push(Lscript);
+        catch(ex) {
+          try {
+            document.getElementsByTagName('head')[0].appendChild(Lscript);
+          } catch(ex2) {
+            reject('Error registering script ' + scriptSrc + ': ' + ex2);
+            return;
+          }
+        }
+        this.linkedScripts.push(Lscript);
+      // DO NOT MERGE THIS!  ARTIFICIAL REPRO ATTEMPT FOR #6898.
+      }, 5000);
     }
 
     /* TODO: why not use util.loadCookie and saveCookie?? */


### PR DESCRIPTION
Provides an avenue for 'artificial reproduction' of #6898, delaying all KMW, Keyman for Android, and Keyman for iPhone/iOS first-time loading of keyboards by 5 seconds.  (This affects each keyboard individually.)

To repro #6898 using this, wait for the default keyboard to load, then change keyboards.  While waiting on the swap to complete, simply use any text-outputting key from the OSK.

## User Testing

- TEST_FAIL:  Fail this test regardless of anything else.  (We don't want this merged!)