### PR TITLE
fix(developer): Ctrl key to select key was conflicting with shortcuts

### DIFF
--- a/developer/src/tike/child/UfrmKeymanWizard.dfm
+++ b/developer/src/tike/child/UfrmKeymanWizard.dfm
@@ -157,7 +157,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
     FFFFFFFFFFFF}
   KeyPreview = True
   Position = poDefaultSizeOnly
-  OnKeyUp = FormKeyUp
   ExplicitWidth = 1043
   ExplicitHeight = 831
   PixelsPerInch = 96
@@ -920,7 +919,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
               Text = 'editKeyOutputText'
               OnChange = editKeyOutputTextChange
               OnClick = editKeyOutputTextClick
-              OnKeyDown = editKeyOutputTextKeyDown
               OnKeyUp = editKeyOutputTextKeyUp
             end
             object editKeyOutputCode: TEdit
@@ -932,7 +930,6 @@ inherited frmKeymanWizard: TfrmKeymanWizard
               Text = 'editKeyOutputCode'
               OnChange = editKeyOutputCodeChange
               OnClick = editKeyOutputCodeClick
-              OnKeyDown = editKeyOutputTextKeyDown
               OnKeyUp = editKeyOutputTextKeyUp
             end
             object chkSplitCtrlAlt: TCheckBox

--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -281,8 +281,6 @@ type
     procedure editNameChange(Sender: TObject);
     procedure editCopyrightChange(Sender: TObject);
     procedure editMessageChange(Sender: TObject);
-    procedure FormKeyUp(Sender: TObject; var Key: Word;
-      Shift: TShiftState);
     procedure FormDestroy(Sender: TObject);
     procedure cmdRunTutorialClick(Sender: TObject);
     procedure mnuViewUnderlyingLayoutClick(Sender: TObject);
@@ -298,8 +296,6 @@ type
     procedure kbdLayoutDragOver(Sender, Source: TObject; X, Y: Integer;
       State: TDragState; var Accept: Boolean);
     procedure kbdLayoutDragDrop(Sender, Source: TObject; X, Y: Integer);
-    procedure editKeyOutputTextKeyDown(Sender: TObject; var Key: Word;
-      Shift: TShiftState);
     procedure editKeyOutputTextKeyUp(Sender: TObject; var Key: Word;
       Shift: TShiftState);
     procedure chkLayoutDisplay102KeyClick(Sender: TObject);
@@ -353,11 +349,6 @@ type
 
     FKeyboardParser: TKeyboardParser;
     FCurrentRule: TKeyboardParser_LayoutRule;
-
-    FControlDown: Boolean;  // True when Ctrl has been held down.
-
-    //FCurrentShiftState: TExtShiftState;
-    //FCurrentVKey: Integer;
 
     frameOSK: TframeOnScreenKeyboardEditor;
 
@@ -513,6 +504,8 @@ type
     procedure DebugUpdateExecutionPoint(Sender: TObject; ALine: Integer);
 
     function HasSubfilename(const Filename: string): Boolean; override;   // I4081
+
+    procedure ControlKeyPressedAndReleased; override;
 
     procedure FindError(const Filename: string; s1: string; line: Integer); override;   // I4081
     procedure RefreshOptions; override;
@@ -689,31 +682,6 @@ begin
   FreeAndNil(FDebugForm);
   FreeAndNil(FCheckboxGridHelper);
   UninitSystemKeyboard;
-end;
-
-procedure TfrmKeymanWizard.FormKeyUp(Sender: TObject; var Key: Word;
-  Shift: TShiftState);
-begin
-  inherited;
-
-  if FControlDown and (Key = VK_CONTROL) and (Pages.ActivePage = pageLayout) and (pagesLayout.ActivePage = pageLayoutDesign) then
-  begin
-    Key := 0;
-    with TfrmSelectKey.Create(Application.MainForm) do
-    try
-      DistinguishLeftRight := chkSplitCtrlAlt.Checked;
-      if ShowModal = mrOk then
-      begin
-        kbdLayout.ShiftState := ShiftState;
-        Layout_SetAllKeyDetails;
-        SelectVKey(VKey);
-      end;
-    finally
-      Free;
-    end;
-  end;
-
-  FControlDown := False;
 end;
 
 {-----------------------------------------------------------------------------}
@@ -1453,32 +1421,8 @@ begin
   DoUpdateCharacterMap;
 end;
 
-procedure TfrmKeymanWizard.editKeyOutputTextKeyDown(Sender: TObject;
-  var Key: Word; Shift: TShiftState);
-begin
-  FControlDown := (Key = VK_CONTROL) and (Pages.ActivePage = pageLayout) and (pagesLayout.ActivePage = pageLayoutDesign) and (Shift = [ssCtrl]);
-end;
-
 procedure TfrmKeymanWizard.editKeyOutputTextKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
 begin
-  if FControlDown and (Key = VK_CONTROL) and (Pages.ActivePage = pageLayout) and (pagesLayout.ActivePage = pageLayoutDesign) then
-  begin
-    Key := 0;
-    with TfrmSelectKey.Create(Application.MainForm) do
-    try
-      DistinguishLeftRight := chkSplitCtrlAlt.Checked;
-      if ShowModal = mrOk then
-      begin
-        kbdLayout.ShiftState := ShiftState;
-        Layout_SetAllKeyDetails;
-        SelectVKey(VKey);
-      end;
-    finally
-      Free;
-    end;
-  end;
-
-  FControlDown := False;
   DoUpdateCharacterMap;
 end;
 
@@ -2111,8 +2055,6 @@ var
 begin
   Result := False;
 
-  FControlDown := False;   // I4680
-
   if not IsInParserMode then   // I4557
     MoveSourceToParser(True);
 
@@ -2378,6 +2320,31 @@ begin
       );
 
   // TODO: other file types
+end;
+
+procedure TfrmKeymanWizard.ControlKeyPressedAndReleased;
+var
+  frmSelectKey: TfrmSelectKey;
+begin
+  if (Pages.ActivePage = pageLayout) and (pagesLayout.ActivePage = pageLayoutDesign) then
+  begin
+    frmSelectKey := TfrmSelectKey.Create(Application.MainForm);
+    try
+      frmSelectKey.DistinguishLeftRight := chkSplitCtrlAlt.Checked;
+      if frmSelectKey.ShowModal = mrOk then
+      begin
+        kbdLayout.ShiftState := frmSelectKey.ShiftState;
+        Layout_SetAllKeyDetails;
+        SelectVKey(frmSelectKey.VKey);
+      end;
+    finally
+      frmSelectKey.Free;
+    end;
+  end
+  else if Pages.ActivePage = pageOnScreenKeyboard then
+  begin
+    frameOSK.ControlKeyPressedAndReleased;
+  end;
 end;
 
 procedure TfrmKeymanWizard.UpdateControls(UpdateLRShift: Boolean);   // I4137

--- a/developer/src/tike/child/UfrmMDIEditor.pas
+++ b/developer/src/tike/child/UfrmMDIEditor.pas
@@ -109,6 +109,8 @@ type
 
     function Revert: Boolean;
 
+    procedure ControlKeyPressedAndReleased; virtual;
+
     procedure SetFocus; override;   // I4679
 
     property Untitled: Boolean read GetUntitled;
@@ -159,6 +161,11 @@ end;
 
 procedure TfrmTikeEditor.CodeFontChanged;
 begin
+end;
+
+procedure TfrmTikeEditor.ControlKeyPressedAndReleased;
+begin
+  // Do nothing
 end;
 
 constructor TfrmTikeEditor.Create(AOwner: TComponent);

--- a/developer/src/tike/child/UfrmOSKEditor.pas
+++ b/developer/src/tike/child/UfrmOSKEditor.pas
@@ -41,6 +41,7 @@ type
     function DoOpenFile: Boolean; override;
   public
     procedure FindError(const Filename: string; s: string; line: Integer); override;   // I4081
+    procedure ControlKeyPressedAndReleased; override;
   end;
 
 implementation
@@ -51,6 +52,11 @@ uses
 {$R *.dfm}
 
 { TfrmOSKEditor }
+
+procedure TfrmOSKEditor.ControlKeyPressedAndReleased;
+begin
+  frameOSK.ControlKeyPressedAndReleased;
+end;
 
 function TfrmOSKEditor.DoOpenFile: Boolean;
 begin

--- a/developer/src/tike/main/UframeOnScreenKeyboardEditor.pas
+++ b/developer/src/tike/main/UframeOnScreenKeyboardEditor.pas
@@ -192,6 +192,7 @@ type
     procedure Load;
     procedure Save;
     procedure UpdateControls;
+    procedure ControlKeyPressedAndReleased;
     procedure SetFocus; override;
     property UnderlyingLayout: HKL read GetUnderlyingLayout write SetUnderlyingLayout;
     property CodeFont: TFont read GetCodeFont write SetCodeFont;
@@ -217,6 +218,7 @@ uses
   ExtShiftState,
   KeymanDeveloperOptions,
   kmxfile,
+  UfrmSelectKey,
   UfrmVisualKeyboardExportBMPParams,
   UfrmVisualKeyboardExportHTMLParams,
   UfrmVisualKeyboardImportKMX,
@@ -767,6 +769,28 @@ begin
     FVK.Header.UnderlyingLayout := FSystemKeyboardName;
     VK_UpdateUnderlyingLayoutCaption;
   end; *)
+end;
+
+procedure TframeOnScreenKeyboardEditor.ControlKeyPressedAndReleased;
+var
+  frmSelectKey: TfrmSelectKey;
+begin
+  frmSelectKey := TfrmSelectKey.Create(Application.MainForm);
+  try
+    frmSelectKey.DistinguishLeftRight := chkVKSplitCtrlAlt.Checked;
+    if frmSelectKey.ShowModal = mrOk then
+    begin
+      kbdOnScreen.ShiftState := frmSelectKey.ShiftState;
+      kbdOnScreen.SelectedKey := kbdOnScreen.Keys.ItemsByUSVK[frmSelectKey.VKey];
+      if kbdOnScreen.SelectedKey = nil then kbdOnScreen.SelectedKey := kbdOnScreen.Keys[0]; // I2584
+      FVKCurrentKey := nil;
+      VK_SetAllKeyDetails;
+      VK_SelectVKey;
+      VK_FocusKey;
+    end;
+  finally
+    frmSelectKey.Free;
+  end;
 end;
 
 procedure TframeOnScreenKeyboardEditor.editVKKeyTextChange(Sender: TObject);

--- a/developer/src/tike/main/UfrmMain.dfm
+++ b/developer/src/tike/main/UfrmMain.dfm
@@ -2699,6 +2699,7 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
   end
   object ApplicationEvents1: TApplicationEvents
     OnHelp = ApplicationEvents1Help
+    OnMessage = ApplicationEvents1Message
     Left = 484
     Top = 176
   end

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -304,9 +304,12 @@ type
     procedure mnuToolsClick(Sender: TObject);
     procedure mnuToolsDebugTestsCompilerExceptionTestClick(Sender: TObject);
     procedure mnuToolsDebugTestsShowDebuggerEventsPanelClick(Sender: TObject);
+    procedure ApplicationEvents1Message(var Msg: tagMSG; var Handled: Boolean);
 
   private
     AppStorage: TJvAppRegistryStorage;
+
+    FControlDown: Boolean;
 
     FCharMapSettings: TCharMapSettings;
     FDropTarget: TDropTarget;
@@ -824,6 +827,25 @@ begin
       mHHelp.HelpTopic(s);
   end;
   Result := True;
+end;
+
+procedure TfrmKeymanDeveloper.ApplicationEvents1Message(var Msg: tagMSG;
+  var Handled: Boolean);
+var
+  state: Boolean;
+begin
+  Handled := False;
+  if (Msg.message = WM_KEYDOWN) or (Msg.message = WM_SYSKEYDOWN) or
+    (Msg.message = WM_KEYUP) or (Msg.message = WM_SYSKEYUP) then
+  begin
+    state := (Msg.message = WM_KEYDOWN) and (Msg.wParam = VK_CONTROL) and
+      (GetKeyState(VK_SHIFT) >= 0) and (GetKeyState(VK_MENU) >= 0);
+    if not state and FControlDown and Assigned(ActiveEditor) and (Msg.wParam = VK_CONTROL) then
+    begin
+      ActiveEditor.ControlKeyPressedAndReleased;
+    end;
+    FControlDown := state;
+  end;
 end;
 
 procedure TfrmKeymanDeveloper.AppOnActivate(Sender: TObject);


### PR DESCRIPTION
Fixes #7425.

In the layout editor, the "Select Key" dialog was being shown sometimes when using shortcuts such as Ctrl+V. The reason this happened was that the shortcut handler in Delphi was capturing the keydown of the V key, so the Ctrl event handler never saw it. Then, if you pressed Ctrl+V, and released the Ctrl key before releasing the V key (which often happens when you press a shortcut rapidly), the Ctrl event handler would receive notification of the Ctrl key release and trigger the "Select Key" dialog.

This fix shifts the Ctrl key event handler out of the keyboard editor and into the top-level application events handler -- this is the best place where we can preview key events before they are passed to the shortcut handler and controls for processing.

This necessitated adding a general `ControlKeyPressedAndReleased` event function to the TIKE editor base class. This is currently only used by `UfrmKeymanWizard` and `UfrmOSKEditor`.

I noted that the OSK editor did not currently support the Ctrl key event to select a new key. As a part of this fix, I added support for this, to bring it into line with the Layout Editor and the Touch Layout Editor.

# User Testing

All tests are done in Keyman Developer.

**GROUP_LAYOUT_EDITOR:** Test in the Keyboard editor, Layout tab, Design view.
**GROUP_OSK_EDITOR:** Test in the Keyboard editor, On-Screen tab, Design view.
**GROUP_OSK_STANDALONE_EDITOR:** Open a .kvks file from File/Open, and test in the standalone OSK editor.

* **TEST_SELECT_KEY:** Verify that the Select Key dialog works. Press and release <kbd>Ctrl</kbd> to activate the Select Key Dialog. Press any character key on the keyboard and verify that the correct key is selected, and that you can edit it. Do this with several different keys, including keys with a modifier combination such as <kbd>Alt</kbd>+<kbd>M</kbd>.

* **TEST_CTRL_V:** Copy a single letter to the clipboard. With the key's "Output Character"/"Text" text field focused, press <kbd>Ctrl</kbd>+<kbd>V</kbd> to paste it. Try this several times, with special attention to the order in which you release the two keys -- try releasing <kbd>Ctrl</kbd> first, and try releasing <kbd>V</kbd> first (this can be a little tricky because you want to avoid the key repeating if you hold it too long!)

* **TEST_PASTE_INTO_CODE:** Switch to the Code view for the current editor. Ensure that <kbd>Ctrl</kbd>+<kbd>V</kbd> works. Make sure that pressing and releasing <kbd>Ctrl</kbd> has no effect here.