### PR TITLE
fix(developer): Handle invalid graphics in icon editor

### DIFF
--- a/developer/src/tike/main/UframeBitmapEditor.dfm
+++ b/developer/src/tike/main/UframeBitmapEditor.dfm
@@ -840,6 +840,15 @@ object frameBitmapEditor: TframeBitmapEditor
     TabOrder = 6
     OnClick = cmdExportClick
   end
+  object cmdClearAll: TButton
+    Left = 224
+    Top = 252
+    Width = 73
+    Height = 25
+    Caption = '&Clear all'
+    TabOrder = 8
+    OnClick = cmdClearAllClick
+  end
   object panReadOnlyIcons: TPanel
     Left = 0
     Top = 0
@@ -891,15 +900,6 @@ object frameBitmapEditor: TframeBitmapEditor
         TabOrder = 0
       end
     end
-  end
-  object cmdClearAll: TButton
-    Left = 201
-    Top = 44
-    Width = 73
-    Height = 25
-    Caption = '&Clear all'
-    TabOrder = 8
-    OnClick = cmdClearAllClick
   end
   object ilCmds: TImageList
     Left = 84

--- a/developer/src/tike/main/UframeBitmapEditor.dfm
+++ b/developer/src/tike/main/UframeBitmapEditor.dfm
@@ -893,8 +893,8 @@ object frameBitmapEditor: TframeBitmapEditor
     end
   end
   object cmdClearAll: TButton
-    Left = 224
-    Top = 252
+    Left = 201
+    Top = 44
     Width = 73
     Height = 25
     Caption = '&Clear all'

--- a/developer/src/tike/main/UframeBitmapEditor.pas
+++ b/developer/src/tike/main/UframeBitmapEditor.pas
@@ -888,10 +888,10 @@ begin
           FIcon.LoadFromStream(Stream);
           DrawIconEx(FBitmaps[bebEdit].Canvas.Handle, 0, 0, FIcon.Handle, 16, 16, 0, 0, DI_NORMAL);
         except
-          on E:EOutOfResources do
-            ShowMessage(E.Message);
-          on E:EInvalidGraphic do
-            ShowMessage(E.Message);
+          // We won't complain here because LoadReadOnlyIcon will also be
+          // reporting on this, less obtrusively
+          on E:EOutOfResources do ;
+          on E:EInvalidGraphic do ;
         end;
       finally
         FIcon.Free;

--- a/developer/src/tike/main/UframeBitmapEditor.pas
+++ b/developer/src/tike/main/UframeBitmapEditor.pas
@@ -205,6 +205,9 @@ begin
 
   FIconCanBeEdited := True;
   panReadOnlyIcons.Visible := not FIconCanBeEdited;
+  cmdImport.Visible := FIconCanBeEdited;
+  cmdExport.Visible := FIconCanBeEdited;
+  cmdClearAll.Visible := FIconCanBeEdited;
 
   TPicture.RegisterClipboardFormat(cf_Bitmap, TBitmap);
 
@@ -1148,6 +1151,7 @@ begin
     try
       try
         ico.LoadFromFile(dlgImport.FileName);
+        IconToBitmap(FBitmaps[bebEdit], ico);
       except
         on E:EInvalidGraphic do  // I3147   // I3508
         begin
@@ -1155,7 +1159,6 @@ begin
           Exit;
         end;
       end;
-      IconToBitmap(FBitmaps[bebEdit], ico);
     finally
       ico.Free;
     end;
@@ -1167,6 +1170,7 @@ begin
     try
       try
         LoadFromFile(dlgImport.FileName);
+        FBitmaps[bebEdit].Assign(ji);
       except
         on E:EInvalidGraphic do  // I3147   // I3508
         begin
@@ -1174,7 +1178,6 @@ begin
           Exit;
         end;
       end;
-      FBitmaps[bebEdit].Assign(ji);
     finally
       Free;
     end;
@@ -1194,6 +1197,7 @@ begin
     try
       try
         LoadFromFile(dlgImport.FileName);
+        AssignTo(FBitmaps[bebEdit]);
       except
         on E:Exception do   // I3147 - I don't want to use E:Exception but see http://marc.durdin.net/2012/01/how-not-to-do-exception-classes-in.html   // I3508
         begin
@@ -1201,7 +1205,6 @@ begin
           Exit;
         end;
       end;
-      AssignTo(FBitmaps[bebEdit]);
     finally
       Free;
     end


### PR DESCRIPTION
Fixes #7419.

If the user attempts to add an invalid graphic (e.g. a .png file saved with a .ico extension), Keyman Developer will no longer crash when trying to load the file.

Note that while the keyboard will still compile with an invalid graphic, Keyman for Windows will refuse to install it. I have not tested other platform handling of such a situation.

# User Testing

All tests in the Keyboard Editor. To complete these tests, add a new, blank icon in the keyboard editor, save the keyboard, close the editor, replace the saved icon file with another one via Windows Explorer, and then reopen the keyboard editor.

**TEST_VALID_ICON:** Verify that adding a normal, 16x16 valid icon file to a keyboard causes no problems, and that the icon editor is displayed.
**TEST_VALID_ICON_MULTI:** Verify that adding a valid icon file with multiple resources to a keyboard shows the set of images included in the icon, in a read-only view, without crashing Keyman Developer. [Here's one icon file](https://raw.githubusercontent.com/keymanapp/keyman/master/common/resources/icons/filetypes/kmn.ico).
**TEST_INVALID_ICON:** Verify that adding a file that is not an icon to the keyboard shows an error message but does not crash Keyman Developer. [Here's one invalid icon file](https://raw.githubusercontent.com/JGearySSBand/keyboards/defedf4effefbcc92be38e5cb03ae5bf30ac7241/release/n/nisenan/source/nisenan.ico).