### PR TITLE
chore(linux): Add Node.js to the docker container

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -21,4 +21,6 @@ ADD debian/control /tmp/control
 # Answer 'yes' to install questions
 RUN (yes | mk-build-deps --install /tmp/control) || true
 # now, switch to build user
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get -q -y install nodejs
 USER build


### PR DESCRIPTION
- used in feature-ldml

Relates to #7102

@keymanapp-test-bot skip