### PR TITLE
feat(common): builder dependency support

### DIFF
--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -24,6 +24,11 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 builder_check_color "$@"
 
+# TODO: once these modules are builder-based, reference here too:
+#  "@../models/templates" \
+#  "@../models/types" \
+#  "@../models/wordbreakers"
+
 builder_describe "Builds the lm-layer module" \
   "@../web/keyman-version" \
   "@../web/lm-worker" \

--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# We should work within the script's directory, not the one we were called in.
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
 . "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
@@ -25,38 +26,23 @@ builder_describe "Runs all tests for the language-modeling / predictive-text lay
   "--ci        Uses CI-based test configurations & emits CI-friendly test reports" \
   "--debug,-d  Activates developer-friendly debug mode for unit tests where applicable"
 
+# TODO: consider dependencies? ideally this will be test.inc.sh?
+
 builder_parse "$@"
-
-do_configure() {
-  # Ensure all testing dependencies are in place.
-  verify_npm_setup
-}
-
-CONFIGURED=
 
 if builder_start_action configure :libraries; then
   # Ensure all testing dependencies are in place.
-  do_configure
-  CONFIGURED=configure:libraries
+  verify_npm_setup
   builder_finish_action success configure :libraries
 fi
 
 if builder_start_action configure :headless; then
-  if [ -n "$CONFIGURED" ]; then
-    echo "Configuration already completed in ${BUILDER_TERM_START}${CONFIGURED}${BUILDER_TERM_END}; skipping."
-  else
-    do_configure
-    CONFIGURED=configure:headless
-  fi
+  verify_npm_setup
   builder_finish_action success configure :headless
 fi
 
 if builder_start_action configure :browser; then
-  if [[ -n "$CONFIGURED" ]]; then
-    echo "Configuration already completed in ${BUILDER_TERM_START}${CONFIGURED}${BUILDER_TERM_END}; skipping."
-  else
-    do_configure
-  fi
+  verify_npm_setup
   builder_finish_action success configure :browser
 fi
 

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -23,30 +23,23 @@ builder_check_color "$@"
 
 builder_describe \
   "Compiles the web-oriented utility function module." \
+  "@../recorder  test" \
+  "@../keyman-version" \
+  "@../utils" \
   configure \
   clean \
   build \
   test \
   "--ci    For use with action ${BUILDER_TERM_START}test${BUILDER_TERM_END} - emits CI-friendly test reports"
 
+builder_describe_outputs \
+  configure     /node_modules \
+  build         build/index.js
+
 builder_parse "$@"
-
-# START - Script parameter configuration
-REPORT_STYLE=local  # Default setting.
-
-if builder_has_option --ci; then
-  REPORT_STYLE=ci
-
-  echo "Replacing user-friendly test reports with CI-friendly versions."
-fi
-
-# END - Script parameter configuration
 
 if builder_start_action configure; then
   verify_npm_setup
-
-  "$KEYMAN_ROOT/common/web/keyman-version/build.sh"
-
   builder_finish_action success configure
 fi
 
@@ -61,17 +54,13 @@ if builder_start_action build; then
 fi
 
 if builder_start_action test; then
-  # Build test dependency
-  pushd "$KEYMAN_ROOT/common/web/recorder"
-  ./build.sh
-  popd
-
   npm run tsc -- --build "$THIS_SCRIPT_PATH/src/tsconfig.bundled.json"
 
   echo_heading "Running Keyboard Processor test suite"
 
   FLAGS=
-  if [ $REPORT_STYLE == ci ]; then
+  if builder_has_option --ci; then
+    echo "Replacing user-friendly test reports with CI-friendly versions."
     FLAGS="$FLAGS --reporter mocha-teamcity-reporter"
   fi
 

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -76,7 +76,12 @@ wrap-worker-code ( ) {
 
 builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
+  "@../keyman-version" \
   configure clean build test
+
+builder_describe_outputs \
+  configure     /node_modules \
+  build         build/index.js
 
 builder_parse "$@"
 
@@ -104,9 +109,6 @@ if builder_start_action build; then
   if ! builder_has_action clean; then
     npm run clean
   fi
-
-  # Ensure keyman-version is properly build (requires build script)
-  "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || fail "Could not build keyman-version"
 
   # Build worker with tsc first
   npm run build -- $builder_verbose || fail "Could not build worker."

--- a/common/web/recorder/build.sh
+++ b/common/web/recorder/build.sh
@@ -19,32 +19,23 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 builder_describe \
   "Compiles the web-oriented utility function module." \
+  "@../keyman-version" \
   configure \
   clean \
   build \
   ":module      Builds recorder-core module" \
   ":proctor     Builds headless-testing, node-oriented 'proctor' component"
 
+builder_describe_outputs \
+  configure:module   "/node_modules" \
+  configure:proctor  "/node_modules" \
+  build:module    "build/index.js" \
+  build:proctor   "build/nodeProctor/index.js"
+
 builder_parse "$@"
 
-# START - Script parameter configuration
-REPORT_STYLE="local"  # Default setting.
-
-if builder_has_option --ci; then
-  REPORT_STYLE="ci"
-
-  echo "Replacing user-friendly test reports with CI-friendly versions."
-fi
-
-# END - Script parameter configuration
-
-function do_configure() {
-  verify_npm_setup
-  "$KEYMAN_ROOT/common/web/keyman-version/build.sh"
-}
-
 if builder_start_action configure :module; then
-  do_configure
+  verify_npm_setup
   builder_finish_action success configure :module
 fi
 
@@ -52,7 +43,7 @@ if builder_start_action configure :proctor; then
   if builder_has_action configure :module; then
     echo "Configuration already completed in configure:module; skipping."
   else
-    do_configure
+    verify_npm_setup
   fi
   builder_finish_action success configure :proctor
 fi

--- a/resources/build/tests/builder-deps.test.sh
+++ b/resources/build/tests/builder-deps.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
+. "$(dirname "$THIS_SCRIPT")/../build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+builder_describe \
+  "Tests dependency builds" \
+  "@./dep1" \
+  "@./dep2 test" \
+  "@./dep3 test:*" \
+  "@./dep4 *:project" \
+  "@./dep5 build:bar test:*" \
+  "@./dep6 build:bar test" \
+  configure \
+  build \
+  test \
+  :project \
+  :bar
+
+builder_describe_outputs \
+  configure  builder.inc.test.sh \
+  build      non-existing-file \
+  test       non-existing-file
+
+builder_parse configure build test
+
+function test_dep_should_build() {
+  local at="$1"
+  local dep="$2"
+
+  if ! _builder_should_build_dep "$at" "resources/build/tests/$dep"; then
+    fail "FAIL: expecting to build dependency $dep for $at"
+  else
+    echo "PASS: will build dependency $dep for $at"
+  fi
+}
+
+function test_dep_should_not_build() {
+  local at="$1"
+  local dep="$2"
+
+  if _builder_should_build_dep "$at" "resources/build/tests/$dep"; then
+    fail "FAIL: not expecting to build dependency $dep for $at"
+  else
+    echo "PASS: will not build dependency $dep for $at"
+  fi
+}
+
+test_dep_should_build configure:project dep1
+test_dep_should_build build:project dep1
+test_dep_should_build test:project dep1
+test_dep_should_build configure:bar dep1
+test_dep_should_build build:bar dep1
+test_dep_should_build test:bar dep1
+
+test_dep_should_not_build configure:project dep2
+test_dep_should_not_build build:project dep2
+test_dep_should_build test:project dep2
+test_dep_should_not_build configure:bar dep2
+test_dep_should_not_build build:bar dep2
+test_dep_should_build test:bar dep2
+
+test_dep_should_not_build configure:project dep3
+test_dep_should_not_build build:project dep3
+test_dep_should_build test:project dep3
+test_dep_should_not_build configure:bar dep3
+test_dep_should_not_build build:bar dep3
+test_dep_should_build test:bar dep3
+
+test_dep_should_build configure:project dep4
+test_dep_should_build build:project dep4
+test_dep_should_build test:project dep4
+test_dep_should_not_build configure:bar dep4
+test_dep_should_not_build build:bar dep4
+test_dep_should_not_build test:bar dep4
+
+test_dep_should_not_build configure:project dep5
+test_dep_should_not_build build:project dep5
+test_dep_should_build test:project dep5
+test_dep_should_not_build configure:bar dep5
+test_dep_should_build build:bar dep5
+test_dep_should_build test:bar dep5
+
+test_dep_should_not_build configure:project dep6
+test_dep_should_not_build build:project dep6
+test_dep_should_build test:project dep6
+test_dep_should_not_build configure:bar dep6
+test_dep_should_build build:bar dep6
+test_dep_should_build test:bar dep6

--- a/resources/build/tests/builder.inc.test.sh
+++ b/resources/build/tests/builder.inc.test.sh
@@ -163,11 +163,14 @@ fi
 
 # Due to the nature of the build-utils-traps tests, only one may be
 # specified at a time; each ends with an `exit`.
-echo "Running separate tests"
+echo "${COLOR_BLUE}## Running trap tests{$COLOR_RESET}"
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh error
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh error-in-function
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh incomplete
-echo "Fin"
+echo "${COLOR_BLUE}## Running dependency tests{$COLOR_RESET}"
+$THIS_SCRIPT_PATH/builder-deps.test.sh
+echo "${COLOR_BLUE}## End external tests${COLOR_RESET}"
+echo
 
 # Finally, run with --help so we can see what it looks like
 # Note:  calls `exit`, so no further tests may be defined.

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -369,7 +369,7 @@ _builder_expand_relative_path() {
   if [[ "$path" =~ ^/ ]]; then
     echo "${path:1}"
   else
-    realpath --relative-to="$KEYMAN_ROOT" "$THIS_SCRIPT_PATH/$path"
+    realpath --canonicalize-missing --relative-to="$KEYMAN_ROOT" "$THIS_SCRIPT_PATH/$path"
   fi
 }
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -145,6 +145,31 @@ _builder_item_in_array() {
   return 1
 }
 
+#
+# Returns `0` if first parameter is in the array passed as second parameter,
+# where the array may contain globs.
+#
+# ### Parameters
+#
+# * 1: `item`       item to search for in array
+# * 2: `array`      bash array, e.g. `array=(one two three)`
+#
+# ### Example
+#
+# ```bash
+#   array=(foo bar it*)
+#   if _builder_item_in_glob_array "item" "${array[@]}"; then ...; fi
+# ```
+#
+_builder_item_in_glob_array() {
+  local e match="$1"
+  shift
+  [[ -z "$match" ]] && return 1
+  for e; do [[ "$match" == $e ]] && return 0; done
+  return 1
+}
+
+
 _builder_item_is_target() {
   local item="$1"
   [[ $item =~ ^: ]] && return 1
@@ -167,6 +192,8 @@ function _builder_warn_if_incomplete() {
 _builder_failure_trap() {
   local trappedExitCode=$?
   local action target
+
+  _builder_cleanup_deps
 
   # Since 'exit' is also trapped, we can also handle end-of-script incomplete actions.
   if [[ $trappedExitCode == 0 ]]; then
@@ -193,6 +220,21 @@ _builder_failure_trap() {
     # Without this, nested scripts have failed to chain errors from npm calls past the script
     # that directly executed the failed npm command.
     exit $trappedExitCode
+  fi
+}
+
+#
+# Removes temporary `_builder_deps_built` file when top-level build script
+# finishes.
+#
+_builder_cleanup_deps() {
+  if ! builder_is_dep_build && [[ ! -z ${_builder_deps_built+x} ]]; then
+    if $_builder_debug; then
+      echo "[DEBUG] Dependencies that were built:"
+      cat "$_builder_deps_built"
+    fi
+    rm -f "$_builder_deps_built"
+    _builder_deps_built=
   fi
 }
 
@@ -235,27 +277,52 @@ builder_has_action() {
 }
 
 #
-# Returns 0 if the user has asked to perform action on target on the command line, and
-# then starts the action. Should be paired with builder_finish_action
+# Returns `0` if the user has asked to perform action on target on the command
+# line, and then starts the action. Should be paired with
+# `builder_finish_action`.
 #
-# Usage:
+# ### Usage
+#
+# ```bash
 #   if builder_start_action action[:target]; then ...; fi
-# Parameters:
-#   1: action    name of action
-#   2: :target    name of target, :-prefixed, as part of first param or space separated ok
-# Example:
-#   if builder_start_action build :app; then
-#   if builder_start_action build:app; then
+# ```
+#
+# ### Parameters
+#
+# * 1: `action[:target]`   name of action, and optionally also target, if
+#                          target excluded starts for all defined targets
+#
+# ### Example
+#
+# ```bash
+#   if builder_start_action build:app; then ...
+# ```
 #
 builder_start_action() {
   local scope="[$THIS_SCRIPT_IDENTIFIER] "
 
   if builder_has_action $@; then
+    # In a dependency quick build (the default), determine whether we actually
+    # need to run this step. Uses data passed to builder_describe_outputs to
+    # verify whether a target output is present.
+    if builder_is_dep_build &&
+        ! builder_is_full_dep_build &&
+        [[ ! -z ${_builder_dep_path[$_builder_matched_action]+x} ]] &&
+        [[ -e "$KEYMAN_ROOT/${_builder_dep_path[$_builder_matched_action]}" ]]; then
+      if builder_verbose; then
+        echo "[$THIS_SCRIPT_IDENTIFIER] skipping $_builder_matched_action, up-to-date"
+      fi
+      return 1
+    fi
+
     echo "${COLOR_BLUE}## $scope$_builder_matched_action starting...${COLOR_RESET}"
     if [ -n "${_builder_current_action}" ]; then
       _builder_warn_if_incomplete
     fi
     _builder_current_action="$_builder_matched_action"
+
+    # Build dependencies as required
+    _builder_do_build_deps "$_builder_matched_action"
     return 0
   else
     return 1
@@ -291,47 +358,130 @@ _builder_trim() {
 }
 
 #
+# Expands an in-repo-relative path to a repo-relative path. A path starting with
+# `/` is expected to be relative to repo root, not filesystem root. Otherwise,
+# it's relative to current script path, not current working directory. The
+# returned path will not have a prefix `/`, and will be relative to
+# `$KEYMAN_ROOT`. Assumes realpath is installed (brew coreutils on macOS).
+#
+_builder_expand_relative_path() {
+  local path="$1"
+  if [[ "$path" =~ ^/ ]]; then
+    echo "${path:1}"
+  else
+    realpath --relative-to="$KEYMAN_ROOT" "$THIS_SCRIPT_PATH/$path"
+  fi
+}
+
+#
+# Expands an `[action][:target]` string, replacing missing values with `*`,
+# for example:
+#
+# * `build` --> `build:*`
+# * `build:app` --> `build:app`
+# * `:app` --> `*:app`
+#
+# Supports multiple action:targets in the string
+#
+_builder_expand_action_target() {
+  local input="$1" target= action=
+  if [[ "$input" =~ : ]]; then
+    action=$(echo "$input" | cut -d: -f 1 -)
+    target=$(echo "$input" | cut -d: -f 2 -)
+  else
+    action=$input
+  fi
+
+  if [[ -z "$action" ]]; then
+    action='*'
+  fi
+  if [[ -z "$target" ]]; then
+    target='*'
+  fi
+
+  echo "$action:$target"
+}
+
+_builder_expand_action_targets() {
+  local input=($1) e output=()
+  for e in "${input[@]}"; do
+    e=`_builder_expand_action_target "$e"`
+    output+=($e)
+  done
+  if [[ ${#output[@]} == 0 ]]; then
+    echo "*:*"
+  else
+    echo "${output[@]}"
+  fi
+}
+
+#
 # Describes a build script, defines available parameters and their meanings. Use
 # together with `builder_parse` to process input parameters.
 #
-# Usage:
+# ### Usage
+#
+# ```bash
 #    builder_describe description param_desc...
-# Parameters:
-#    description   A short description of what the script does
-#    param_desc    Space separated name and description of parameter, e.g.
-#                  "build   Builds the target"
-#                  May be repeated to describe all parameters
+# ```
 #
-# There are three types of parameters that may be specified:
+# ### Parameters
 #
-# * Option, param_desc format: "--option[,-o][=var]   [One line description]"
+#  * `description`  A short description of what the script does.
+#  * `param_desc`   Space separated name and description of parameter, e.g.
+#                   `"build   Builds the target"`
+#                   This parameter may be repeated to describe all parameters.
+#
+# There are four types of parameters that may be specified:
+#
+# * **Option:** `"--option[,-o][=var]   [One line description]"`
+#
 #   All options must have a longhand form with two prefix hyphens,
-#   e.g. --option. The ",-o" shorthand form is optional. When testing if
-#   the option is set with `builder_has_option``, always use the longhand
+#   e.g. `--option`. The `,-o` shorthand form is optional. When testing if
+#   the option is set with `builder_has_option`, always use the longhand
 #   form.
 #
-#   if =var is specified, then the next parameter will be a variable stored
-#   in $var for that option. e.g. --option=opt means $opt will have the value
-#   'foo' when the script is called for --option foo.
+#   if `=var` is specified, then the next parameter will be a variable stored in
+#   `$var` for that option. e.g. `--option=opt` means `$opt` will have the value
+#   `"foo"` when the script is called for `--option foo`.
 #
-# * Action, param_desc format: "action   [One line description]"
-#   Actions must be a single word, lower case. To specify an action
-#   as the default, append a '+' to the action name, e.g.
-#   "test+   Test the project". If there is no default specified, then
-#   it will be 'build'
+# * **Action**: `"action   [One line description]"`
 #
-# * Target, param_desc format: ":target   [One line description]"
-#   A target always starts with colon, e.g. :project.
+#   Actions must be a single word, lower case. To specify an action as the
+#   default, append a `+` to the action name, e.g. `"test+   Test the project"`.
+#   If there is no default specified, then it will be `build`.
+#
+# * **Target:** `":target   [One line description]"`
+#
+#   A target always starts with colon, e.g. `:project`.
+#
+# * **Dependency:** "@/path/to/dependency [action][:target] ..."
+#
+#   A dependency always starts with `@`. The path to the dependency will be
+#   relative to the build script folder, or to the root of the repository, if
+#   the path starts with `/`, not to the root of the file system. It is an error
+#   to specify a dependency outside the repo root.
+#
+#   Relative paths will be expanded to full paths, again, relative to the root
+#   of the repository.
+#
+#   Dependencies may be limited to specific `action:target`. If not specified,
+#   dependencies will be built for all actions on all targets. Either `action`
+#   or `:target` may be omitted, and multiple actions and targets may be
+#   specified, space separated.
 #
 builder_describe() {
   _builder_description="$1"
   _builder_actions=()
   _builder_targets=()
   _builder_options=()
+  _builder_deps=()                    # array of all dependencies for this script
   _builder_default_action=build
   declare -A -g _builder_params
   declare -A -g _builder_options_short
   declare -A -g _builder_options_var
+  declare -A -g _builder_dep_path     # array of output files for action:target pairs
+  declare -A -g _builder_dep_related_actions  # array of action:targets associated with a given dependency
   shift
   # describe each target, action, and option possibility
   while [[ $# -gt 0 ]]; do
@@ -339,12 +489,20 @@ builder_describe() {
     local value="$(echo "$key" | cut -d" " -f 1 -)"
     local description=
     if [[ $key =~ [[:space:]] ]]; then
-      description=$(_builder_trim "$(echo "$key" | cut -d" " -f 2- -)")
+      description="$(_builder_trim "$(echo "$key" | cut -d" " -f 2- -)")"
     fi
 
     if [[ $value =~ ^: ]]; then
       # Parameter is a target
       _builder_targets+=($value)
+    elif [[ $value =~ ^@ ]]; then
+      # Parameter is a dependency
+      local dependency="${value:1}"
+      dependency="`_builder_expand_relative_path "$dependency"`"
+      _builder_deps+=($dependency)
+      # echo "$description"
+      _builder_dep_related_actions[$dependency]="`_builder_expand_action_targets "$description"`"
+      # echo "${_builder_dep_related_actions[$dependency]}"
     elif [[ $value =~ ^-- ]]; then
       # Parameter is an option
       # Look for a shorthand version of the option
@@ -396,6 +554,50 @@ builder_describe() {
     _builder_targets+=(:project)
     _builder_params[\:project]=$(_builder_get_default_description ":project")
   fi
+}
+
+#
+# Defines an output file or folder expected to be present after successful
+# completion of an action for a target. Used to skip actions for dependency
+# builds. If `:target` is not provided, assumes `:project`.
+#
+# Relative paths are relative to script folder; absolute paths are relative
+# to repository root, not filesystem root.
+#
+# ### Usage
+#
+# ```bash
+#   builder_describe_outputs action:target filename [...]
+# ```
+#
+# ### Parameters
+#
+# * 1: `action[:target]`   action and/or target associated with file
+# * 2: `filename`          name of file or folder to check
+# * 3+: ... repeat previous arguments for additional outputs
+#
+# ### Example
+#
+# ```bash
+#   builder_describe_outputs \
+#     configure /node_modules \
+#     build     build/index.js
+# ```
+#
+function builder_describe_outputs() {
+  while [[ $# -gt 0 ]]; do
+    local key="$1" path="$2" action target
+    if [[ $key =~ : ]]; then
+      action=$(echo "$key" | cut -d: -f 1 -)
+      target=$(echo "$key" | cut -d: -f 2 -)
+    else
+      action=$key
+      target=project
+    fi
+    path="`_builder_expand_relative_path "$path"`"
+    _builder_dep_path[$action:$target]="$path"
+    shift 2
+  done
 }
 
 _builder_get_default_description() {
@@ -463,6 +665,7 @@ builder_check_color() {
 # Parameters
 #   1: $@         command-line arguments
 builder_parse() {
+  _builder_build_deps=--deps
   builder_verbose=
   builder_extra_params=()
   _builder_chosen_action_targets=()
@@ -551,6 +754,19 @@ builder_parse() {
           _builder_chosen_options+=(--verbose)
           builder_verbose=--verbose
           ;;
+        --deps|--no-deps|--force-deps)
+          _builder_build_deps=$key
+          ;;
+        --builder-dep-parent)
+          # internal use parameter for dependency builds - identifier of parent script
+          shift
+          builder_dep_parent="$1"
+          ;;
+        --builder-deps-built)
+          # internal use parameter for dependency builds - path to dependency tracking file
+          shift
+          _builder_deps_built="$1"
+          ;;
         *)
           _builder_parameter_error "$0" parameter "$key"
       esac
@@ -574,6 +790,19 @@ builder_parse() {
     for e in "${_builder_chosen_options[@]}"; do
       echo "* $e"
     done
+  fi
+
+  if builder_is_dep_build; then
+    echo "[$THIS_SCRIPT_IDENTIFIER] dependency build, started by $builder_dep_parent"
+    if [[ -z ${_builder_deps_built+x} ]]; then
+      echo "FATAL ERROR: Expected --builder-deps-built parameter"
+      exit 1
+    fi
+  else
+    # This is a top-level invocation, not a dependency build, so we want to
+    # track which dependencies have been built, so they don't get built multiple
+    # times.
+    _builder_deps_built=`mktemp`
   fi
 
   # Now that we've successfully parsed options adhering to the _builder spec, we may activate our
@@ -611,11 +840,16 @@ builder_display_usage() {
 
   program="$(basename "$0")"
   if [[ ! -z ${_builder_description+x} ]]; then
-    echo "$program: $_builder_description"
+    echo "Summary:"
+    echo "  $_builder_description"
     echo
   fi
+  echo "Script Identifier:"
+  echo "  $THIS_SCRIPT_IDENTIFIER"
+  echo
 
-  echo "Usage: $program [options...] [action][:target]..."
+  echo "Usage:"
+  echo "  $program [options...] [action][:target]..."
   echo
   echo "Actions: "
 
@@ -652,7 +886,23 @@ builder_display_usage() {
   _builder_pad $width "  --verbose, -v"  "Verbose logging"
   _builder_pad $width "  --color"        "Force colorized output"
   _builder_pad $width "  --no-color"     "Never use colorized output"
+  if builder_has_dependencies; then
+    _builder_pad $width "  --deps"         "Build dependencies if required (default)"
+    _builder_pad $width "  --no-deps"      "Skip build of dependencies"
+    _builder_pad $width "  --force-deps"   "Reconfigure and rebuild all dependencies"
+  fi
   _builder_pad $width "  --help, -h"     "Show this help"
+
+  echo
+  echo "Dependencies: "
+
+  if builder_has_dependencies; then
+    for d in "${_builder_deps[@]}"; do
+      echo "  $d"
+    done
+  else
+    echo "  This module has no dependencies"
+  fi
 
   # Defined in `builder_use_color`; this assumes that said func has been called.
   local c1=$BUILDER_TERM_START
@@ -694,6 +944,183 @@ builder_finish_action() {
   else
     echo "${COLOR_YELLOW}## Warning: reporting result of $action$target but the action was never started!${COLOR_RESET}"
   fi
+}
+
+#
+# Returns `0` if the dependency should be built for the given action:target
+#
+_builder_should_build_dep() {
+  local action_target="$1"
+  local dep="$2"
+  local related_actions=(${_builder_dep_related_actions[$dep]})
+  # echo "bdra: ${_builder_dep_related_actions[@]}"
+  # echo "target: $action_target"
+  # echo "dep: $2"
+  # echo "ra: ${related_actions[@]}"
+  if ! _builder_item_in_glob_array "$action_target" "${related_actions[@]}"; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# Configure and build all dependencies
+# Later, may restrict by either action or target
+#
+_builder_do_build_deps() {
+  local action_target="$1"
+
+  if [[ $_builder_build_deps == --no-deps ]]; then
+    # we've been asked to skip dependencies
+    return 0
+  fi
+
+  for dep in "${_builder_deps[@]}"; do
+    # Don't attempt to build dependencies that don't match the current
+    # action:target (wildcards supported for matches here)
+    if ! _builder_should_build_dep "$action_target" "$dep"; then
+      echo "[$THIS_SCRIPT_IDENTIFIER] Skipping dependency build $dep for $action_target"
+      continue
+    fi
+
+    # Only configure and build the dependency once per invocation
+    if builder_has_module_been_built "$dep"; then
+      continue
+    fi
+
+    # TODO: add --debug as a standard builder parameter
+    builder_set_module_has_been_built "$dep"
+    "$KEYMAN_ROOT/$dep/build.sh" configure build \
+      $builder_verbose \
+      $_builder_build_deps \
+      --builder-deps-built "$_builder_deps_built" \
+      --builder-dep-parent "$THIS_SCRIPT_IDENTIFIER"
+  done
+}
+
+#
+# returns `0` if we are in a dependency doing a build.
+#
+builder_is_dep_build() {
+  if [[ ! -z ${builder_dep_parent+x} ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# returns `0` if we should attempt to do quick builds in a dependency build, for
+# example skipping `tsc -b` where a parent may also do it; corresponds to the
+# `--deps` parameter (which is the default).
+#
+builder_is_quick_dep_build() {
+  if builder_is_dep_build && [[ $_builder_build_deps == --deps ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# returns `0` if we should do a full configure and build in a dependency build;
+# corresponds to the `--force-deps`` parameter.
+#
+builder_is_full_dep_build() {
+  if builder_is_dep_build && [[ $_builder_build_deps == --force-deps ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# returns `0` if the current build script has at least one dependency.
+#
+builder_has_dependencies() {
+  if [[ ${#_builder_deps[@]} -eq 0 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# Tests if a dependency module has been built already in the current script
+# invocation; if not running in a builder context, always returns `1` (i.e.
+# "false").
+#
+# ### Usage
+#
+# ```bash
+# builder_has_module_been_built dependency-name
+# ```
+#
+# ### Parameters
+#
+# * 1: `dependency-name`   the `$SCRIPT_IDENTIFIER` of the dependency
+#                          (repo-relative path without leading `/`); or for
+#                          external dependencies, a path-like starting with
+#                          `/external/`.
+#
+# ### Examples
+#
+# ```bash
+#   if builder_has_module_been_built common/web/keyman-version; then ...
+#   if builder_has_module_been_built /external/npm-ci; then ...
+# ```
+#
+builder_has_module_been_built() {
+  local module="$1"
+
+  if [[ -z ${_builder_deps_built+x} ]]; then
+    # not in a builder context, so we assume a build is needed
+    return 1
+  fi
+
+  if [[ -f $_builder_deps_built ]] && grep -qx "$module" $_builder_deps_built; then
+    # dependency history file contains the dependency module
+    return 0
+  fi
+  return 1
+}
+
+#
+# Updates the dependency module build state for the current script invocation;
+# if not running in a builder context, a no-op.
+#
+# ### Usage
+#
+# ```bash
+#   builder_set_module_has_been_built dependency-name
+# ```
+#
+# ### Parameters
+#
+# * 1: `dependency-name`   the `$SCRIPT_IDENTIFIER` of the dependency
+#                          (repo-relative path without leading `/`); or for
+#                          external dependencies, a path-like starting with
+#                          `/external/`.
+#
+# ### Examples
+#
+# ```bash
+#   builder_set_module_has_been_built common/web/keyman-version
+#   builder_set_module_has_been_built /external/npm-ci
+# ```
+#
+builder_set_module_has_been_built() {
+  local module="$1"
+
+  if [[ ! -z ${_builder_deps_built+x} ]]; then
+    echo "$module" >> $_builder_deps_built
+  fi
+}
+
+#
+# returns `0` if we should be verbose in output
+#
+builder_verbose() {
+  if [[ $builder_verbose == --verbose ]]; then
+    return 0
+  fi
+  return 1
 }
 
 #

--- a/web/unit_tests/test.sh
+++ b/web/unit_tests/test.sh
@@ -131,6 +131,11 @@ cd ../tools/recorder
 # Run our headless tests first.
 
 # First:  Web-core tests.
+pushd "$KEYMAN_ROOT/common/web/keyboard-processor"
+./build.sh test $HEADLESS_FLAGS || fail "Tests failed by dependencies; aborting integration tests."
+# Once done, now we run the integrated (KeymanWeb) tests.
+popd
+
 pushd "$KEYMAN_ROOT/common/web/input-processor"
 ./build.sh build:tools test $HEADLESS_FLAGS || fail "Tests failed by dependencies; aborting integration tests."
 # Once done, now we run the integrated (KeymanWeb) tests.


### PR DESCRIPTION
# Managing Internal Dependencies

Internal dependencies are other projects within the keyman repo. External dependencies are not really a part of this discussion.

[Original design document](https://docs.google.com/document/d/1xoQaO7ZcICNm2q_C35Cm7Z9TgYq8d2XErSJblVPXM28/edit#heading=h.f0emrhxutzki)

## Problem statement

We have a complex web of internal dependencies, but we want to be able to have our build scripts manage them without us having to figure out what needs building. At the same time, we don't want unnecessary builds.

We want to:



1. Simply and cleanly define dependencies in build.sh and continue to avoid boilerplate in these scripts **Maintenance**
2. Define dependencies in just one place in each project **Maintenance**
    * Sadly, it is recognised that we _will_ need to define them both in build.sh and in the build system e.g. tsconfig.json.

3. Keep knowledge of each dependency's build requirements internal to its own build **Separation of Concerns**
    * e.g. we don't want to know that common/web/keyman-version has a pre-build step in its build.sh
    * e.g. we don't want to have to figure out if a dependency needs building – it should do that itself

4. Only build or configure dependencies if they actually need building **Performance**
5. Keep the command line clean, straightforward, and consistent across scripts **Usability**


## Environment

We have a number of build systems in use, some of which also manage dependencies:

Build System | Where used | Dependency Management | Notes
-------------|------------|-----------------------|--------
tsc --build | common/ web/ developer/ | Automatically builds all referenced projects in `tsconfig.json`	| Still need build.sh for any pre-build and post-build steps
`npm` (plus utilities) | common/ web/ developer/ | - | Not really a build system, but defines build scripts
meson / ninja | core/ | `meson.build` defines dependencies | Meson has some complexities with paths on Windows and running in a bash environment there
nmake | windows/ developer/ | `Makefile` defines dependencies | We may replace with build.sh in future
msbuild | windows/ developer/ | - | Builds a single project, at least in the way we use it
gradle | android/ | - | Builds a single project, at least in the way we use it
xcodebuild | ios/ mac/ | - | Builds a single project, at least in the way we use it
Legacy bash scripts | * | - | Various legacy build scripts, slowly moving over to builder scripts. Some named build.sh, other names in use also.
Configure / Makefiles | linux/ | `Makefile` defines dependencies | This has various script interactions as well.
## Design

Any actions may call on internal dependencies. The dependencies will be built if the action:target pair defines a relationship with that dependency.

Dependencies are by default for all actions and targets. You can however add an action and/or target to a dependency; this will be used most commonly for tests. But if you have a complex web of differing dependencies for each target, then that probably indicates that you need to refactor into multiple build scripts and folders.


### Define dependencies

We define additional dependencies in `builder_describe`. In the same way as we have separated declaration of build targets and actions from the actual process with `builder_describe`, we always define dependencies but don't actually build them here.


```
    builder_describe \
      "common/web/keyman-version"  \
      "developer/src/kmc     test" \
      "common/tools/hextobin test"
```


Additional space separated strings define the action:target pairs that depend on the module.

There is no specified order to the list of dependencies; you should not assume that one dependency will be built before another, unless the first one is itself a dependency of the second module. The builder scripts will make sure that common dependencies are only ever called once in a given invocation (by use of a global _builder_ variable tracking which dependencies have been built).


### Configuring and building dependencies

Dependencies will automatically be configured and built in `builder_start_action` when the action starts. Of course, we don't always want to reconfigure a dependency, so the default build mode for dependencies is a "quick build" (`--deps` parameter can be used to make this explicit).


### Dependency script awareness

When a dependency build.sh is started, it will be passed an additional command-line parameter `--builder-dep-parent <parent_folder>`, which will be made available in the variable `builder_dep_parent`, for example `builder_dep_parent=web` (always relative to repo root).

The `builder_describe_outputs` function allows a module to define specific files, which, if present, will cause the build to skip the step. A common call to this function will reference the repo-root-level `node_modules` folder, which will be present if `npm ci` or `npm install` has ever been run:


```
builder_describe_outputs \
	  configure  /node_modules \
	  build      build/index.js
```


A build script may also opt to short-circuit certain build steps during a quick build. For example, `tsc --build` already automatically builds dependencies, so there is no point calling it in each dependent script. Here's how you can do this:


```
      if builder_is_dep_build; then
        echo "[$THIS_SCRIPT_IDENTIFIER] skipping tsc -b; will be completed by $builder_dep_parent"
      else
        npm run build -- $builder_verbose
      fi
```


The `$builder_dep_parent` variable is the Script Identifier for the calling script.

While we could assume that `verify_npm_setup` is run in the `keyman-version/build.sh` `configure` call, we don't do that, because that violates the rule of separation of concerns (think black-box). `verify_npm_setup` will instead ensure that it only runs once in a given script invocation – see below.

However, we should not attempt to replicate internal build consistency or out-of-date checks. Leave that up to the build tools such as tsc.


### Rebuilding dependencies

If you change code in a dependency, you should be building that module directly. It is important to work in the context of the module that you are modifying, so that tests etc are run. This is just good development practice! We will not attempt to support any other work practices, such as testing modules from their dependents.


### Forcing / avoiding dependency actions

Several possible command-line parameters:



1. `--deps` runs a quick-mode configure or build of dependencies
2. `--no-deps` skips configure or build of dependencies (may cause a build failure if there are things out-of-date or missing, but that's up to you). tsc and other build systems may also continue to build dependencies as well – this only controls build.sh calling into dependency build.sh scripts.
3. `--force-deps` does a full configure and build. This will typically be the safest way to rebuild for a platform, for example, when switching branches.


### Checking if a dependency has been built

It may be useful to be able to check if a dependency has already been built in a given script invocation. Two functions are provided that assist here, which reference the Script Identifier for the module. This is also usable for external dependencies, where we may need to do the external dependency call from multiple modules. For external dependencies, the reference should be prefixed with `/external/`, and then a path-like string unique for that external dependency.

For example, for our `npm ci` call, we do something like this:


```
      if builder_has_module_been_built /external/npm-ci; then
        return 0
      fi
      builder_set_module_has_been_built /external/npm-ci
      …
      npm ci
```


You could check if keyman-version is built with:


```
    if builder_has_module_been_built common/web/keyman-version; then
```


@keymanapp-test-bot skip