### PR TITLE
feat(core): ldml: Use new UTF-16 to UTF-32 function 🙀

### DIFF
--- a/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
+++ b/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+@@keys: [K_BKQUOTE][K_1][K_BKQUOTE][K_2][K_BKSP][K_2][K_BKQUOTE]
+@@expected: \u0127\u1790\u17B6\u0127\uD83D\uDE40\u0127
+
+-->
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <name value="TestKbd-UTF32" />
+  </names>
+
+  <keys>
+    <key id="hmaqtua" to="ħ" />
+    <key id="that" to="ថា" />
+    <key id="screamcat" to="🙀" />
+  </keys>
+
+  <layerMaps form="hardware">
+    <layerMap id="base">
+      <row keys="hmaqtua that screamcat" /> <!-- number row -->
+    </layerMap>
+  </layerMaps>
+</keyboard>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -7,7 +7,8 @@
 tests = [
 # disabling 000 until we have updates to core or to the keyboard so that it passes
 #  'k_000_null_keyboard',
-  'k_001_tiny'
+  'k_001_tiny',
+  'k_002_tinyu32',
 ]
 
 # Setup kmc


### PR DESCRIPTION
- also a test case with a 🙀 key on the tiny keyboard

For #7418

Note this will currently conflict with #7437 and following

@keymanapp-test-bot skip