### PR TITLE
chore(linux): Adjust Linux specific files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,11 +176,9 @@ Thumbs.db
 
 # Linux packaging related
 /debian/
-results/
-*.deb
-*.ddeb
-*.dsc
-*.build
-*.buildinfo
-*.changes
-*.tar.?z
+/results/
+/keyman*.deb
+/keyman*.ddeb
+/keyman*.buildinfo
+/keyman*.changes
+/keyman*.tar.?z


### PR DESCRIPTION
During Linux packaging some files get put in the root of the source directory. This change limits these files in `.gitignore` to the root directory. It would be better to not generate these files in the root directory in the first place, but that's not trivial and a separate task.

@keymanapp-test-bot skip