### PR TITLE
chore(common): `--debug` standard flag for builder

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -680,6 +680,7 @@ builder_check_color() {
 builder_parse() {
   _builder_build_deps=--deps
   builder_verbose=
+  builder_debug=
   builder_extra_params=()
   _builder_chosen_action_targets=()
   _builder_chosen_options=()
@@ -767,6 +768,10 @@ builder_parse() {
           _builder_chosen_options+=(--verbose)
           builder_verbose=--verbose
           ;;
+        --debug|-d)
+          _builder_chosen_options+=(--debug)
+          builder_debug=--debug
+          ;;
         --deps|--no-deps|--force-deps)
           _builder_build_deps=$key
           ;;
@@ -844,7 +849,7 @@ builder_display_usage() {
   local e program description
 
   # Minimum padding is 12 characters, increase this if necessary
-  # if you add other, longer, global options (like --verbose)
+  # if you add other, longer, global options (like --verbose, --debug)
   local width=12
 
   for e in "${!_builder_params[@]}"; do
@@ -901,6 +906,7 @@ builder_display_usage() {
   done
 
   _builder_pad $width "  --verbose, -v"  "Verbose logging"
+  _builder_pad $width "  --debug, -d"    "Debug build"
   _builder_pad $width "  --color"        "Force colorized output"
   _builder_pad $width "  --no-color"     "Never use colorized output"
   if builder_has_dependencies; then
@@ -1013,6 +1019,7 @@ _builder_do_build_deps() {
     builder_set_module_has_been_built "$dep"
     "$KEYMAN_ROOT/$dep/build.sh" configure build \
       $builder_verbose \
+      $builder_debug \
       $_builder_build_deps \
       --builder-deps-built "$_builder_deps_built" \
       --builder-dep-parent "$THIS_SCRIPT_IDENTIFIER"
@@ -1139,6 +1146,16 @@ builder_set_module_has_been_built() {
 #
 builder_verbose() {
   if [[ $builder_verbose == --verbose ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# returns `0` if we are doing a debug build
+#
+builder_debug() {
+  if [[ $builder_debug == --debug ]]; then
     return 0
   fi
   return 1


### PR DESCRIPTION
Part of #7455. It seems that there are not yet any builder scripts that use `--debug` on `master` branch (there are some on `feature-ldml` branch, which I'll update once I merge this into that branch.)

@keymanapp-test-bot skip