### PR TITLE
fix(ios): Allow Full Access enabled to fix ios 16 invisible keyboard 🍒 

### DIFF
--- a/oem/firstvoices/ios/SWKeyboard/Info.plist
+++ b/oem/firstvoices/ios/SWKeyboard/Info.plist
@@ -38,7 +38,7 @@
 			<key>PrimaryLanguage</key>
 			<string>mul</string>
 			<key>RequestsOpenAccess</key>
-			<false/>
+			<true/>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.keyboard-service</string>


### PR DESCRIPTION
🍒 -pick of #7459 to stable-15.0

relates to #7391 

Due to an undocumented change in iOS 16, the FirstVoices Keyboard was blank and unusable. This change adds the ability to set Allow Full Access under Settings > General > Keyboard > Keyboards > First Voices:

![image](https://user-images.githubusercontent.com/89134789/195787671-50d9dbcf-9ca7-4dda-9c72-72559e5a6ff3.png)

After tapping Allow Full Access, an alert will be displayed:

![image](https://user-images.githubusercontent.com/89134789/195787849-7eb404cc-3ef2-4ce0-ace4-ba65de5489fc.png)

Select the Allow button to proceed.

# User Testing

* **TEST_ALLOW_FULL_ACCESS_IOS_16:**

1. On an iPhone running iOS 16, enable 'Allow Full Access' under Settings > General > Keyboard > Keyboards > First Voices
2. Switch to Safari and tap on the URL editor field to bring up the virtual keyboard
3. Tap the globe key on the keyboard and then tap FirstVoices from the keyboard list.
4. Verify that the keyboard is displayed as normal rather than being blank
