### PR TITLE
chore(android/engine): Update Keyman references in android-host.js

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -25,18 +25,17 @@ function init() {
   //document.body.style.backgroundColor="transparent";
   //window.console.log('Device type = '+device);
   //window.console.log('Keyboard height = '+oskHeight);
-  var kmw=com.keyman.singleton;
-  kmw.init({'app':device,'fonts':'packages/',root:'./'});
-  kmw['util']['setOption']('attachType','manual');
-  kmw['oninserttext'] = insertText;
-  kmw['showKeyboardList'] = showMenu;
-  kmw['menuKeyUp'] = menuKeyUp;
-  kmw['hideKeyboard'] = hideKeyboard;
-  kmw['getOskHeight'] = getOskHeight;
-  kmw['getOskWidth'] = getOskWidth;
-  kmw['beepKeyboard'] = beepKeyboard;
+  keyman.init({'app':device,'fonts':'packages/',root:'./'});
+  keyman['util']['setOption']('attachType','manual');
+  keyman['oninserttext'] = insertText;
+  keyman['showKeyboardList'] = showMenu;
+  keyman['menuKeyUp'] = menuKeyUp;
+  keyman['hideKeyboard'] = hideKeyboard;
+  keyman['getOskHeight'] = getOskHeight;
+  keyman['getOskWidth'] = getOskWidth;
+  keyman['beepKeyboard'] = beepKeyboard;
   var ta = document.getElementById('ta');
-  kmw['setActiveElement'](ta);
+  keyman['setActiveElement'](ta);
 
   ta.readOnly = false;
   checkTextArea();
@@ -45,9 +44,9 @@ function init() {
   com.keyman.osk.Banner.DEFAULT_HEIGHT =
     Math.ceil(window.jsInterface.getDefaultBannerHeight() / window.devicePixelRatio);
 
-  kmw.addEventListener('keyboardloaded', setIsChiral);
-  kmw.addEventListener('keyboardchange', setIsChiral);
-  kmw.core.languageProcessor.on('statechange', onStateChange);
+  keyman.addEventListener('keyboardloaded', setIsChiral);
+  keyman.addEventListener('keyboardchange', setIsChiral);
+  keyman.core.languageProcessor.on('statechange', onStateChange);
 
   document.body.addEventListener('touchend', loadDefaultKeyboard);
 
@@ -67,13 +66,12 @@ function notifyHost(event, params) {
 
 // Update the KMW banner height
 function setBannerHeight(h) {
-  var kmw=com.keyman.singleton;
   if (h > 0) {
-    var osk = kmw.osk;
+    var osk = keyman.osk;
     osk.banner.height = Math.ceil(h / window.devicePixelRatio);
   }
   // Refresh KMW OSK
-  kmw.correctOSKTextSize();
+  keyman.correctOSKTextSize();
 }
 
 function setOskHeight(h) {
@@ -346,7 +344,7 @@ function executeHardwareKeystroke(code, shift, lstates, eventModifiers) {
   console_debug('executeHardwareKeystroke(code='+code+',shift='+shift+',lstates='+lstates+',eventModifiers='+eventModifiers+')');
   try {
     executingHardwareKeystroke = true;
-    if (window.keyman.executeHardwareKeystroke(code, shift, lstates)) { // false if matched, true if not
+    if (keyman.executeHardwareKeystroke(code, shift, lstates)) { // false if matched, true if not
       // KMW didn't process the key, so have the Android app dispatch the key with the original event modifiers
       window.jsInterface.dispatchKey(code, eventModifiers);
     }

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -80,11 +80,10 @@ function setOskHeight(h) {
   if(h > 0) {
     oskHeight = Math.ceil(h / window.devicePixelRatio);
   }
-  var kmw=window['keyman'];
-  if(kmw && kmw.core && kmw.core.activeKeyboard) {
-    kmw.core.activeKeyboard.refreshLayouts();
+  if(keyman && keyman.core && keyman.core.activeKeyboard) {
+    keyman.core.activeKeyboard.refreshLayouts();
   }
-  kmw['correctOSKTextSize']();
+  keyman.correctOSKTextSize();
 }
 
 function setOskWidth(w) {
@@ -125,9 +124,7 @@ function onStateChange(change) {
 // Query KMW if a given keyboard uses chiral modifiers.
 function setIsChiral(keyboardProperties) {
   var name = typeof(keyboardProperties.internalName) == 'undefined' ? keyboardProperties.keyboardName : keyboardProperties.internalName;
-  var kmw=window['keyman'];
-  var isChiral = kmw.isChiral(name);
-
+  var isChiral = keyman.isChiral(name);
   window.jsInterface.setIsChiral(isChiral);
   return true;
 }
@@ -169,8 +166,7 @@ function insertText(dn, s, dr) {
 }
 
 function deregisterModel(modelID) {
-  var kmw=window['keyman'];
-  kmw.modelManager.deregister(modelID);
+  keyman.modelManager.deregister(modelID);
 }
 
 function enableSuggestions(model, mayPredict, mayCorrect) {
@@ -191,21 +187,18 @@ function setBannerOptions(mayPredict) {
 }
 
 function registerModel(model) {
-  var kmw=window['keyman'];
   //window.console.log('registerModel: ' + model);
-  kmw.registerModel(model);
+  keyman.registerModel(model);
 }
 
 function resetContext() {
-  var kmw=window['keyman'];
-  kmw.resetContext();
+  keyman.resetContext();
 }
 
 // Tell KMW to switch to "numeric" layer
 function setNumericLayer() {
-  var kmw=window['keyman'];
-  if (kmw && kmw.core && kmw.core.activeKeyboard) {
-    kmw.setNumericLayer();
+  if (keyman && keyman.core && keyman.core.activeKeyboard) {
+    keyman.setNumericLayer();
   }
 }
 
@@ -339,17 +332,14 @@ function showKeyboard() {
 
 function showHelpBubble() {
   fragmentToggle = (fragmentToggle + 1) % 100;
-  var kmw = window['keyman'];
-  var pos = kmw['touchMenuPos']();
+  var pos = keyman.touchMenuPos();
   window.location.hash = 'showHelpBubble-' + fragmentToggle + '+keyPos=' + pos;
 }
 
 function executePopupKey(keyID, keyText) {
-  var kmw=window['keyman'];
-
   // KMW only needs keyID to process the popup key. keyText merely logged to console
   //window.console.log('executePopupKey('+keyID+'); keyText: ' + keyText);
-  kmw['executePopupKey'](keyID);
+  keyman.executePopupKey(keyID);
 }
 
 function executeHardwareKeystroke(code, shift, lstates, eventModifiers) {
@@ -368,8 +358,7 @@ function executeHardwareKeystroke(code, shift, lstates, eventModifiers) {
 }
 
 function popupVisible(value) {
-  var kmw=window['keyman'];
-  kmw['popupVisible'](value);
+  keyman['popupVisible'](value);
 }
 
 function toHex(theString) {

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -26,16 +26,16 @@ function init() {
   //window.console.log('Device type = '+device);
   //window.console.log('Keyboard height = '+oskHeight);
   keyman.init({'app':device,'fonts':'packages/',root:'./'});
-  keyman['util']['setOption']('attachType','manual');
-  keyman['oninserttext'] = insertText;
-  keyman['showKeyboardList'] = showMenu;
-  keyman['menuKeyUp'] = menuKeyUp;
-  keyman['hideKeyboard'] = hideKeyboard;
-  keyman['getOskHeight'] = getOskHeight;
-  keyman['getOskWidth'] = getOskWidth;
-  keyman['beepKeyboard'] = beepKeyboard;
+  keyman.util.setOption('attachType','manual');
+  keyman.oninserttext = insertText;
+  keyman.showKeyboardList = showMenu;
+  keyman.menuKeyUp = menuKeyUp;
+  keyman.hideKeyboard = hideKeyboard;
+  keyman.getOskHeight = getOskHeight;
+  keyman.getOskWidth = getOskWidth;
+  keyman.beepKeyboard = beepKeyboard;
   var ta = document.getElementById('ta');
-  keyman['setActiveElement'](ta);
+  keyman.setActiveElement(ta);
 
   ta.readOnly = false;
   checkTextArea();

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -358,7 +358,7 @@ function executeHardwareKeystroke(code, shift, lstates, eventModifiers) {
 }
 
 function popupVisible(value) {
-  keyman['popupVisible'](value);
+  keyman.popupVisible(value);
 }
 
 function toHex(theString) {


### PR DESCRIPTION
Fixes #6568 updating the Keyman references in android-host.js

## User Testing
**Setup** - Install the PR build of Keyman for Android onto Android device/emulator

**TEST_KMEA** - Verifies Keyman Engine functions still work
1. Launch Keyman for Android
2. In the Keyman app with the default sil_euro_latin keyboard, short-press on key and release
3. Verify the key popup appears, disappears, and the key is output
4. Long-press on key and select one of the long-press options and release
5. Verify the long-press key is output
6. Go to Keyman Settings --> Adjust keyboard height
7. Change the OSK height and exit all the Settings menus
8. In the Keyman app, verify the OSK height is changed the adjusted height.
9. Go to Keyman Settings --> Installed Languages --> English --> English Settings --> Dictionary --> English dictionary (MTNT) --> Uninstall dictionary
10. Exit out of the Settings menus
11. Verify suggestions no longer appear 
12. Go to "Get Started" and enable Keyman as a default system keyboard
13. Launch the Contacts app and create a new contact
14. With Keyman keyboard, type a first name
15. Observe the current OSK layer (should be default)
16. In the Contacts app, select the phone number field
17. Verify the OSK switches to the numeric layer
