### PR TITLE
fix(android/engine): Dismiss key preview and subkeys on globe action

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2179,6 +2179,15 @@ public final class KMManager {
    * @param keyboardType KeyboardType KEYBOARD_TYPE_INAPP or KEYBOARD_TYPE_SYSTEM
    */
   public static void handleGlobeKeyAction(Context context, boolean globeKeyDown, KeyboardType keyboardType) {
+    // Clear preview and subkeys
+    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+      InAppKeyboard.dismissKeyPreview(0);
+      InAppKeyboard.dismissSubKeysWindow();
+    } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
+      SystemKeyboard.dismissKeyPreview(0);
+      SystemKeyboard.dismissSubKeysWindow();
+    }
+
     // Update globeKeyState
     if (globeKeyState != GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS) {
       globeKeyState = globeKeyDown ? GlobeKeyState.GLOBE_KEY_STATE_DOWN : GlobeKeyState.GLOBE_KEY_STATE_UP;


### PR DESCRIPTION
Fixes #7424 

similar to #  , this dismisses key previews and subkeys when the Globe key is handled.

## User Testing
Setup - Install PR build of Keyman for Android on physical Android device. (Not an emulator because test involves multi-touches on the OSK)

**TEST_GLOBE_KEY_DISMISSES_KEYS** - Verifies key previews and subkeys are dismissed on Globe key action
1. Launch Keyman and dismiss the Get Started menu
2. With the default sil_euro_latin keyboard, long-press and hold a key with one finger 
3. While holding the long-press, use another finger to short-press the globe key
4. Verify nothing happens with th eglobe key and the long-press keys are still visible
5. Release the long-press key
6. With the default sil_euro_latin keyboard, first short-press a key with one finger, and then short-press the globe key with another finger and release both fingers (before a long-press triggers)
7. Verify the key preview briefly appears and disappears when the globe key action is handled:
  * If 1 keyboard installed, the Keyboard picker menu appears
  * If multiple keyboards installed, Keyman switches to the next keyboard
 