### PR TITLE
chore(android/engine): Remove help bubble tool tip

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -337,13 +337,6 @@ function showKeyboard() {
   keyman.correctOSKTextSize();
 }
 
-function showHelpBubble() {
-  fragmentToggle = (fragmentToggle + 1) % 100;
-  var kmw = window['keyman'];
-  var pos = kmw['touchMenuPos']();
-  window.location.hash = 'showHelpBubble-' + fragmentToggle + '+keyPos=' + pos;
-}
-
 function executePopupKey(keyID, keyText) {
   var kmw=window['keyman'];
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -80,18 +80,15 @@ final class KMKeyboard extends WebView {
   private final String fontUndefined = "undefined";
   private GestureDetector gestureDetector;
   private static ArrayList<OnKeyboardEventListener> kbEventListeners = null;
-  private boolean ShouldShowHelpBubble = false;
   private boolean isChiral = false;
 
   private int currentKeyboardErrorReports = 0;
 
   protected boolean keyboardSet = false;
   protected boolean keyboardPickerEnabled = true;
-  protected boolean isHelpBubbleEnabled = true;
 
   public PopupWindow subKeysWindow = null;
   public PopupWindow keyPreviewWindow = null;
-  public PopupWindow helpBubbleWindow = null;
 
   public ArrayList<HashMap<String, String>> subKeysList = null;
   public String[] subKeysWindowPos = {"0", "0"};
@@ -326,28 +323,16 @@ final class KMKeyboard extends WebView {
     loadJavascript(KMString.format(
       "window.onload = function(){ setOskWidth(\"%d\");"+
       "setOskHeight(\"0\"); };", kbWidth));
-    if (ShouldShowHelpBubble) {
-      ShouldShowHelpBubble = false;
-      Handler handler = new Handler();
-      handler.postDelayed(new Runnable() {
-        @Override
-        public void run() {
-          loadJavascript("showHelpBubble()");
-        }
-      }, 2000);
-    }
   }
 
   public void onPause() {
     dismissKeyPreview(0);
     dismissSubKeysWindow();
-    ShouldShowHelpBubble = dismissHelpBubble();
   }
 
   public void onDestroy() {
     dismissKeyPreview(0);
     dismissSubKeysWindow();
-    dismissHelpBubble();
   }
 
   public void onConfigurationChanged(Configuration newConfig) {
@@ -363,16 +348,6 @@ final class KMKeyboard extends WebView {
     loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));
     loadJavascript(KMString.format("setOskWidth(%d)", newConfig.screenWidthDp));
     loadJavascript(KMString.format("setOskHeight(%d)", oskHeight));
-
-    if (dismissHelpBubble()) {
-      Handler handler = new Handler();
-      handler.postDelayed(new Runnable() {
-        @Override
-        public void run() {
-          loadJavascript("showHelpBubble()");
-        }
-      }, 2000);
-    }
   }
 
   public void dismissSubKeysWindow() {
@@ -599,15 +574,6 @@ final class KMKeyboard extends WebView {
     currentKeyboard = kbKey;
     keyboardSet = true;
     saveCurrentKeyboardIndex();
-    if (dismissHelpBubble()) {
-      Handler handler = new Handler();
-      handler.postDelayed(new Runnable() {
-        @Override
-        public void run() {
-          loadJavascript("showHelpBubble()");
-        }
-      }, 2000);
-    }
 
     KeyboardEventHandler.notifyListeners(kbEventListeners, keyboardType, EventType.KEYBOARD_CHANGED, currentKeyboard);
 
@@ -1082,7 +1048,6 @@ final class KMKeyboard extends WebView {
       posY = kbPos[1] + (int) py;
     }
 
-    dismissHelpBubble();
     dismissKeyPreview(0);
     //subKeysWindow.setAnimationStyle(R.style.PopupAnim);
 
@@ -1246,7 +1211,6 @@ final class KMKeyboard extends WebView {
       posY = kbPos[1] + (int) (py * density - frame.height() + offset_y);
     }
 
-    dismissHelpBubble();
     //keyPreviewWindow.setAnimationStyle(R.style.KeyPreviewAnim);
     if (keyPreviewWindow != null) {
       keyPreviewWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX, posY);
@@ -1267,118 +1231,6 @@ final class KMKeyboard extends WebView {
         }
       }
     }, delay);
-  }
-
-  @SuppressLint("InflateParams")
-  protected void showHelpBubble(Context context, float fx, float fy) {
-    if (!isHelpBubbleEnabled || keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      return; // Help bubble is disabled for System-wide keyboard
-    }
-
-    if (KMManager.getGlobeKeyAction(keyboardType) == KMManager.GlobeKeyAction.GLOBE_KEY_ACTION_DO_NOTHING) {
-      return; // Help bubble is disabled if globe key has no action
-    }
-
-    if (KMManager.getGlobeKeyAction(keyboardType) == KMManager.GlobeKeyAction.GLOBE_KEY_ACTION_SWITCH_TO_NEXT_KEYBOARD) {
-      // Help bubble is disabled if next keyboard is not available for this action
-      List<Keyboard> keyboardsList = KMManager.getKeyboardsList(context);
-      if (keyboardsList == null) {
-        return;
-      }
-
-      if (keyboardsList.size() < 2) {
-        return;
-      }
-    }
-
-    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-    DisplayMetrics metrics = new DisplayMetrics();
-    wm.getDefaultDisplay().getMetrics(metrics);
-    float density = metrics.density;
-
-    int x = (int) (fx * density);
-    int y = (int) (fy * density);
-
-    int kbWidth = getWidth();
-    float pvWidth = getResources().getDimension(R.dimen.help_bubble_width);
-    float pvHeight = getResources().getDimension(R.dimen.help_bubble_height);
-
-    float arrowWidth = getResources().getDimension(R.dimen.popup_arrow_width);
-    float arrowHeight = getResources().getDimension(R.dimen.popup_arrow_height);
-    float offset_x = getResources().getDimension(R.dimen.help_bubble_offset_x);
-    float offset_y = getResources().getDimension(R.dimen.help_bubble_offset_y);
-
-    LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-    View contentView = inflater.inflate(R.layout.help_bubble_layout, null, false);
-    KMPopoverView popoverView = (KMPopoverView) contentView.findViewById(R.id.kmPopoverView);
-    popoverView.setBackgroundColor(Color.rgb(253, 244, 196));
-    popoverView.setBackgroundColor2(Color.rgb(233, 224, 176));
-    popoverView.setBorderColor(Color.rgb(128, 64, 64));
-    popoverView.setSize((int) pvWidth, (int) pvHeight);
-    popoverView.setArrowSize(arrowWidth, arrowHeight);
-
-    float px = x + offset_x - pvWidth / 2.0f;
-    float py = y + offset_y - pvHeight;
-    if (px < 0) {
-      px = 0;
-    } else if ((px + pvWidth) > kbWidth) {
-      px = kbWidth - pvWidth;
-    }
-
-    if (px == 0) {
-      popoverView.setArrowPosX(x);
-    } else if (px == (kbWidth - pvWidth)) {
-      popoverView.setArrowPosX(x - px);
-    } else {
-      popoverView.setArrowPosX(pvWidth / 2.0f);
-    }
-
-    popoverView.redraw();
-
-    dismissHelpBubble();
-    helpBubbleWindow = new PopupWindow(contentView, (int) pvWidth, (int) pvHeight, false);
-    helpBubbleWindow.setTouchable(true);
-    helpBubbleWindow.setOnDismissListener(new OnDismissListener() {
-      @Override
-      public void onDismiss() {
-        helpBubbleWindow = null;
-      }
-    });
-
-    int posX, posY;
-    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      int[] kbPos = new int[2];
-      getLocationOnScreen(kbPos);
-      posX = (int) px;
-      posY = kbPos[1] + (int) py;
-    } else {
-      int[] kbPos = new int[2];
-      getLocationInWindow(kbPos);
-      posX = (int) px;
-      posY = kbPos[1] + (int) py;
-    }
-
-    helpBubbleWindow.setAnimationStyle(R.style.PopupAnim);
-    if (getWindowToken() != null) {
-      helpBubbleWindow.showAtLocation(KMKeyboard.this, Gravity.TOP | Gravity.LEFT, posX, posY);
-    } else {
-      helpBubbleWindow = null;
-      ShouldShowHelpBubble = true;
-    }
-  }
-
-  protected boolean dismissHelpBubble() {
-    try {
-      if (helpBubbleWindow != null && helpBubbleWindow.isShowing()) {
-        helpBubbleWindow.dismiss();
-        return true;
-      } else {
-        return false;
-      }
-    } catch (Exception e) {
-      KMLog.LogException(TAG, "", e);
-      return true;
-    }
   }
 
   public static void addOnKeyboardEventListener(OnKeyboardEventListener listener) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -261,8 +261,7 @@ public final class KMManager {
   public static final String KMKey_CustomModel = "CustomModel";
   public static final String KMKey_HelpLink = "helpLink";
 
-  // Keyman internal keys
-  protected static final String KMKey_ShouldShowHelpBubble = "ShouldShowHelpBubble";
+  // Help Bubble removed in 16.0
 
   // Default Legacy Asset Paths
   // Previous keyboards installed from the cloud  went to /languages/ and /fonts/
@@ -2057,26 +2056,14 @@ public final class KMManager {
     return result;
   }
 
+  // This API is deprecated in Keyman 16.0
   public static boolean isHelpBubbleEnabled() {
-    boolean retVal = true;
-
-    if (InAppKeyboard != null) {
-      retVal = InAppKeyboard.isHelpBubbleEnabled;
-    } else if (SystemKeyboard != null) {
-      retVal = SystemKeyboard.isHelpBubbleEnabled;
-    }
-
-    return retVal;
+    return false;
   }
 
+  // This API is deprecated in Keyman 16.0
   public static void setHelpBubbleEnabled(boolean newValue) {
-    if (InAppKeyboard != null) {
-      InAppKeyboard.isHelpBubbleEnabled = newValue;
-    }
-
-    if (SystemKeyboard != null) {
-      SystemKeyboard.isHelpBubbleEnabled = newValue;
-    }
+    return;
   }
 
   public static SpacebarText getSpacebarText() {
@@ -2268,17 +2255,6 @@ public final class KMManager {
 
         registerAssociatedLexicalModel(langId);
 
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-          @Override
-          public void run() {
-            SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-            if (prefs.getBoolean(KMManager.KMKey_ShouldShowHelpBubble, true)) {
-              InAppKeyboard.loadJavascript("showHelpBubble()");
-            }
-          }
-        }, 2000);
-
         InAppKeyboard.callJavascriptAfterLoad();
         InAppKeyboard.setSpacebarText(spacebarText);
 
@@ -2309,33 +2285,12 @@ public final class KMManager {
         pageLoaded(view, url);
       } else if (url.indexOf("hideKeyboard") >= 0) {
         if (KMTextView.activeView != null && KMTextView.activeView.getClass() == KMTextView.class) {
-          InAppKeyboard.dismissHelpBubble();
           KMTextView textView = (KMTextView) KMTextView.activeView;
           textView.dismissKeyboard();
         }
       } else if (urlCommand.getQueryParameter("globeKeyAction") != null) {
-        InAppKeyboard.dismissHelpBubble();
-        if (!InAppKeyboard.isHelpBubbleEnabled) {
-          return false;
-        }
-
-        SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(KMManager.KMKey_ShouldShowHelpBubble, false);
-        editor.commit();
-
         handleGlobeKeyAction(context, urlCommand.getBooleanQueryParameter("keydown", false),
           KeyboardType.KEYBOARD_TYPE_INAPP);
-      } else if (url.indexOf("showHelpBubble") >= 0) {
-        int start = url.indexOf("keyPos=") + 7;
-        String value = url.substring(start);
-        if (!value.isEmpty()) {
-          String[] globeKeyPos = value.split("\\,");
-          float fx = Float.valueOf(globeKeyPos[0]);
-          float fy = Float.valueOf(globeKeyPos[1]);
-          if (InAppKeyboard.getVisibility() == View.VISIBLE)
-            InAppKeyboard.showHelpBubble(context, fx, fy);
-        }
       } else if (url.indexOf("showKeyPreview") >= 0) {
         String deviceType = context.getResources().getString(R.string.device_type);
         if (deviceType.equals("AndroidTablet")) {
@@ -2506,17 +2461,6 @@ public final class KMManager {
 
         registerAssociatedLexicalModel(langId);
 
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-          @Override
-          public void run() {
-            SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-            if (prefs.getBoolean(KMManager.KMKey_ShouldShowHelpBubble, true)) {
-              SystemKeyboard.loadJavascript("showHelpBubble()");
-            }
-          }
-        }, 2000);
-
         KeyboardEventHandler.notifyListeners(KMTextView.kbEventListeners, KeyboardType.KEYBOARD_TYPE_SYSTEM, EventType.KEYBOARD_LOADED, null);
 
         SystemKeyboard.callJavascriptAfterLoad();
@@ -2541,30 +2485,10 @@ public final class KMManager {
       if(url.indexOf("pageLoaded") >= 0) {
         pageLoaded(view, url);
       } else if (url.indexOf("hideKeyboard") >= 0) {
-        SystemKeyboard.dismissHelpBubble();
         IMService.requestHideSelf(0);
       } else if (urlCommand.getQueryParameter("globeKeyAction") != null) {
-        SystemKeyboard.dismissHelpBubble();
-        if (!SystemKeyboard.isHelpBubbleEnabled) {
-          return false;
-        }
-
-        SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(KMManager.KMKey_ShouldShowHelpBubble, false);
-        editor.commit();
-
         handleGlobeKeyAction(context, urlCommand.getBooleanQueryParameter("keydown", false),
           KeyboardType.KEYBOARD_TYPE_SYSTEM);
-      } else if (url.indexOf("showHelpBubble") >= 0) {
-        int start = url.indexOf("keyPos=") + 7;
-        String value = url.substring(start);
-        if (!value.isEmpty()) {
-          String[] globeKeyPos = value.split("\\,");
-          float fx = Float.valueOf(globeKeyPos[0]);
-          float fy = Float.valueOf(globeKeyPos[1]);
-          SystemKeyboard.showHelpBubble(context, fx, fy);
-        }
       } else if (url.indexOf("showKeyPreview") >= 0) {
         String deviceType = context.getString(R.string.device_type);
         if (deviceType.equals("AndroidTablet")) {
@@ -2740,8 +2664,6 @@ public final class KMManager {
             return;
           }
 
-          InAppKeyboard.dismissHelpBubble();
-
           KMTextView textView = (KMTextView) KMTextView.activeView;
           textView.beginBatchEdit();
 
@@ -2864,8 +2786,6 @@ public final class KMManager {
             return;
           }
 
-          SystemKeyboard.dismissHelpBubble();
-
           // Handle tab or enter since KMW didn't process it
           Log.d(HANDLER_TAG, "dispatchKey called with code: " + code + ", eventModifiers: " + eventModifiers);
           if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_TAB]) {
@@ -2903,8 +2823,6 @@ public final class KMManager {
             }
             return;
           }
-
-          SystemKeyboard.dismissHelpBubble();
 
           ic.beginBatchEdit();
 


### PR DESCRIPTION
Fixes #6734 
Rather than fixing the display of the help bubble, we'll remove it for 16.0 and re-implement it in a future release.

This does deprecate the two KMManager calls:
```
isHelpBubbleEnabled()
setHelpBubbleEnabled()
```

TODO: 
- [ ] Update deprecated calls on help.keyman.com

### User Testing
Setup - Install the PR build of Keyman for Android

* **TEST_BASIC** - Verifies app still works
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. Verify no help bubble tooltip is displayed on the globe key
3. Short-press the globe key
4. When 1 keyboard is installed, verify the keyboard picker menu is displayed
5. Dismiss the menu
