### PR TITLE
fix(developer): support CLDR sample keyboards 🙀

### DIFF
--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -11,6 +11,8 @@ export default class LDMLKeyboardXMLSourceFileReader {
    */
   private boxArrays(source: any) {
     boxXmlArray(source?.keyboard, 'layers');
+    boxXmlArray(source?.keyboard?.displays, 'display');
+    boxXmlArray(source?.keyboard?.displays, 'displayOptions');
     boxXmlArray(source?.keyboard?.names, 'name');
     boxXmlArray(source?.keyboard?.vkeys, 'vkey');
     boxXmlArray(source?.keyboard?.keys, 'key');
@@ -32,7 +34,29 @@ export default class LDMLKeyboardXMLSourceFileReader {
       }
     }
     boxXmlArray(source?.keyboard?.reorders, 'reorder');
+    this.boxImportsAndSpecials(source);
     return source;
+  }
+
+  /**
+   * Recurse over object, boxing up any specials or imports
+   * @param obj any object to be traversed
+   */
+  private boxImportsAndSpecials(obj: any) {
+    if (!obj) return;
+    if (Array.isArray(obj)) {
+      for (const sub of obj) {
+        this.boxImportsAndSpecials(sub);
+      }
+    } else if(typeof obj === 'object') {
+      for (const key of Object.keys(obj)) {
+        if (key === 'special' || key === 'import') {
+          boxXmlArray(obj, key);
+        } else {
+          this.boxImportsAndSpecials(obj[key]);
+        }
+      }
+    }
   }
 
   public validate(source: LDMLKeyboardXMLSourceFile, schemaSource: Buffer): void {

--- a/resources/standards-data/ldml-keyboards/techpreview/3.0/fr-t-k0-azerty.xml
+++ b/resources/standards-data/ldml-keyboards/techpreview/3.0/fr-t-k0-azerty.xml
@@ -7,6 +7,7 @@
 	<!-- 'conformsTo' gives CLDR spec conformance. Distinguishes from prior
 		keyboard formats -->
 	<!-- 'version' element is now optional -->
+	<version number="1.0.0" />
 	<info author="Team Keyboard" normalization="NFC" layout="AZERTY" indicator="FR" />
 	<names>
 		<name value="French" />

--- a/resources/standards-data/ldml-keyboards/techpreview/cldr_info.json
+++ b/resources/standards-data/ldml-keyboards/techpreview/cldr_info.json
@@ -1,5 +1,5 @@
 {
-  "sha": "b3c0702a837c4e11193483b85253b11e148fb06b",
-  "description": "release-42-m1-56-gb3c0702a83",
-  "date": "Mon, 17 Oct 2022 22:44:33 +0000"
+  "sha": "759bcf66b17d4082e2ef6dee46822a19620d66aa",
+  "description": "release-42-m1-58-g759bcf66b1",
+  "date": "Tue, 18 Oct 2022 16:59:09 +0000"
 }

--- a/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd
+++ b/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd
@@ -13,7 +13,7 @@ This DTD is a work in progress.
 
 Please see CLDR-15034 for the latest information. -->
 
-<!ELEMENT keyboard ( import*, locales?, version?, info?, names, settings?, vkeys*, displays*, keys?, layers*, transforms*, reorders?, special* ) >
+<!ELEMENT keyboard ( import*, locales?, version?, info?, names, settings?, vkeys*, displays?, keys?, layers*, transforms*, reorders?, special* ) >
 <!ATTLIST keyboard locale CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-->
 <!ATTLIST keyboard conformsTo (techpreview) #REQUIRED >
@@ -36,9 +36,11 @@ Please see CLDR-15034 for the latest information. -->
 
 <!ELEMENT version EMPTY >
 <!ATTLIST version number CDATA #IMPLIED >
+    <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
+    <!--@MATCH:semver-->
     <!--@VALUE-->
 <!ATTLIST version cldrVersion CDATA #FIXED "techpreview" >
-    <!--@MATCH:version-->
+    <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT info EMPTY >

--- a/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.xsd
+++ b/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.xsd
@@ -26,7 +26,7 @@
         <xs:element ref="names"/>
         <xs:element minOccurs="0" ref="settings"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="vkeys"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="displays"/>
+        <xs:element minOccurs="0" ref="displays"/>
         <xs:element minOccurs="0" ref="keys"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="layers"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="transforms"/>
@@ -87,8 +87,10 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
+  <!-- @MATCH:semver -->
   <!-- @VALUE -->
-  <!-- @MATCH:version -->
+  <!-- @MATCH:any -->
   <!-- @METADATA -->
   <xs:element name="info">
     <xs:complexType>
@@ -120,6 +122,7 @@
       <xs:attribute name="value" use="required"/>
     </xs:complexType>
   </xs:element>
+  <!-- @ORDERED -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <xs:element name="special" type="any"/>
@@ -265,7 +268,7 @@
       <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:any -->
+  <!-- @MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))* -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <xs:element name="layers">

--- a/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd
+++ b/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd
@@ -44,12 +44,6 @@ Please see CLDR-15034 for the latest information. -->
     <!--@MATCH:any-->
     <!--@VALUE-->
 
-<!ELEMENT emit EMPTY >
-    <!--@ORDERED-->
-<!ATTLIST emit to CDATA #REQUIRED >
-    <!--@MATCH:any-->
-    <!--@VALUE-->
-
 <!ELEMENT keystroke EMPTY >
     <!--@ORDERED-->
 <!ATTLIST keystroke key NMTOKEN #REQUIRED >
@@ -65,13 +59,19 @@ Please see CLDR-15034 for the latest information. -->
     <!--@MATCH:range/2~999-->
     <!--@VALUE-->
 
-<!ELEMENT check EMPTY >
+<!ELEMENT emit EMPTY >
     <!--@ORDERED-->
-<!ATTLIST check result CDATA #REQUIRED >
+<!ATTLIST emit to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
 
 <!ELEMENT backspace EMPTY >
     <!--@ORDERED-->
+
+<!ELEMENT check EMPTY >
+    <!--@ORDERED-->
+<!ATTLIST check result CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
 
 <!ELEMENT special ANY >

--- a/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.xsd
+++ b/resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.xsd
@@ -47,7 +47,7 @@
   <xs:element name="repertoire">
     <xs:complexType>
       <xs:attribute name="chars" use="required"/>
-      <xs:attribute name="type" use="required">
+      <xs:attribute name="type">
         <xs:simpleType>
           <xs:restriction base="xs:token">
             <xs:enumeration value="default"/>
@@ -80,10 +80,10 @@
       <xs:sequence>
         <xs:element minOccurs="0" ref="startContext"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element ref="emit"/>
           <xs:element ref="keystroke"/>
-          <xs:element ref="check"/>
+          <xs:element ref="emit"/>
           <xs:element ref="backspace"/>
+          <xs:element ref="check"/>
         </xs:choice>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="special"/>
       </xs:sequence>
@@ -95,14 +95,6 @@
       <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
-  <!-- @MATCH:any -->
-  <!-- @VALUE -->
-  <xs:element name="emit">
-    <xs:complexType>
-      <xs:attribute name="to" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <!-- @ORDERED -->
   <!-- @MATCH:any -->
   <!-- @VALUE -->
   <xs:element name="keystroke">
@@ -120,11 +112,11 @@
   <!-- @VALUE -->
   <!-- @MATCH:range/1~999 -->
   <!-- @VALUE -->
-  <!-- @MATCH:range/1~999 -->
+  <!-- @MATCH:range/2~999 -->
   <!-- @VALUE -->
-  <xs:element name="check">
+  <xs:element name="emit">
     <xs:complexType>
-      <xs:attribute name="result" use="required"/>
+      <xs:attribute name="to" use="required"/>
     </xs:complexType>
   </xs:element>
   <!-- @ORDERED -->
@@ -134,6 +126,14 @@
     <xs:complexType/>
   </xs:element>
   <!-- @ORDERED -->
+  <xs:element name="check">
+    <xs:complexType>
+      <xs:attribute name="result" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- @ORDERED -->
+  <!-- @MATCH:any -->
+  <!-- @VALUE -->
   <xs:element name="special" type="any"/>
   <xs:complexType name="any" mixed="true">
     <xs:sequence>

--- a/resources/standards-data/ldml-keyboards/techpreview/fixup-schema.js
+++ b/resources/standards-data/ldml-keyboards/techpreview/fixup-schema.js
@@ -22,22 +22,40 @@ if (!data['$id'] && data['id']) {
     delete data['id'];
 }
 
+/**
+ * Turn a schema node from an array into a singleton of the specified type
+ * @param {Object} o
+ */
+function arrayToSingle(o) {
+    if (!o) return;
+    if (o.type === 'array') {
+        o["$ref"] = o.items["$ref"];
+        delete o.items;
+        delete o.type;
+    }
+}
+
+/**
+ * Turn a schema node from a singleton of some type into an array of that type
+ * @param {Object} o
+ */
+function singleToArray(o) {
+    if (!o) return;
+    if (!o.type) {
+        o.items = { "$ref": o["$ref"] };
+        o.type = "array";
+        delete o["$ref"];
+    }
+}
+
 if (data.title.endsWith('ldmlKeyboard.xsd')) {
     if (data?.properties?.keyboard) {
         data.properties.keyboard.type = 'object';
     }
 
-    if (data?.properties?.keyboard?.properties?.vkeys?.type === 'array') {
-        data.properties.keyboard.properties.vkeys["$ref"] = data.properties.keyboard.properties.vkeys.items["$ref"];
-        delete data.properties.keyboard.properties.vkeys.items;
-        delete data.properties.keyboard.properties.vkeys.type;
-    }
-
-    if (!data?.definitions?.keys?.properties?.key?.type) {
-        data.definitions.keys.properties.key.items = { "$ref":  data.definitions.keys.properties.key["$ref"] };
-        data.definitions.keys.properties.key.type = "array";
-        delete data.definitions.keys.properties.key["$ref"];
-    }
+    arrayToSingle(data?.properties?.keyboard?.properties?.vkeys);
+    singleToArray(data?.definitions?.keys?.properties?.key);
+    singleToArray(data?.definitions?.keys?.properties?.flicks);
 }
 
 // Write stuff

--- a/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json
+++ b/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json
@@ -187,7 +187,10 @@
       "additionalProperties": false,
       "properties": {
         "flicks": {
-          "$ref": "#/definitions/flicks"
+          "items": {
+            "$ref": "#/definitions/flicks"
+          },
+          "type": "array"
         },
         "import": {
           "items": {

--- a/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json
+++ b/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json
@@ -558,10 +558,7 @@
           "type": "string"
         },
         "displays": {
-          "items": {
-            "$ref": "#/definitions/displays"
-          },
-          "type": "array"
+          "$ref": "#/definitions/displays"
         },
         "import": {
           "items": {

--- a/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json
+++ b/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json
@@ -96,7 +96,6 @@
       },
       "required": [
         "chars",
-        "type",
         "name"
       ],
       "type": "object"


### PR DESCRIPTION
With this, kmc is at least able to load mt.xml and fr-t-k0-azerty.xml but runs into issues from #7402  and also lack of import support.

for #7411 

includes an update to CLDR data from PR https://github.com/unicode-org/cldr/pull/2469

@keymanapp-test-bot skip