### PR TITLE
change(web): removes unused config, help buttons from OSK

### DIFF
--- a/web/source/osk/layouts/targetedFloatLayout.ts
+++ b/web/source/osk/layouts/targetedFloatLayout.ts
@@ -161,7 +161,7 @@ namespace com.keyman.osk.layouts {
 
           let newWidth  = this.startWidth  + cumulativeX;
           let newHeight = this.startHeight + cumulativeY;
-          
+
           // Set the smallest and largest OSK size
           if(newWidth < 0.2*screen.width) {
             newWidth = 0.2*screen.width;

--- a/web/source/osk/layouts/titleBar.ts
+++ b/web/source/osk/layouts/titleBar.ts
@@ -6,8 +6,6 @@ namespace com.keyman.osk.layouts {
     private _element: HTMLDivElement;
     private _unpinButton: HTMLDivElement;
     private _closeButton: HTMLDivElement;
-    private _helpButton: HTMLDivElement;
-    private _configButton: HTMLDivElement;
     private _caption: HTMLSpanElement;
 
     private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(20); // As set in kmwosk.css
@@ -52,26 +50,6 @@ namespace com.keyman.osk.layouts {
     }
 
     public attachHandlers(osk: OSKView) {
-      let util = com.keyman.singleton.util;
-
-      this._helpButton.onclick = function() {
-        var p={};
-        util.callEvent('osk.helpclick',p);
-        if(window.event) {
-          window.event.returnValue=false;
-        }
-        return false;
-      }
-
-      this._configButton.onclick = function() {
-        var p={};
-        util.callEvent('osk.configclick',p);
-        if(window.event) {
-          window.event.returnValue=false;
-        }
-        return false;
-      }
-
       this._closeButton.onclick = function () {
         osk.startHide(true);
         return false;
@@ -104,12 +82,6 @@ namespace com.keyman.osk.layouts {
       var Limg = this._closeButton = this.buildCloseButton();
       bar.appendChild(Limg);
 
-      Limg = this._helpButton = this.buildHelpButton()
-      bar.appendChild(Limg);
-
-      Limg = this._configButton = this.buildConfigButton();
-      bar.appendChild(Limg);
-
       Limg = this._unpinButton = this.buildUnpinButton();
       bar.appendChild(Limg);
 
@@ -129,28 +101,6 @@ namespace com.keyman.osk.layouts {
 
       Limg.id='kmw-close-button';
       Limg.className='kmw-title-bar-image';
-      Limg.onmousedown = this.mouseCancellingHandler;
-
-      return Limg;
-    }
-
-    private buildHelpButton(): HTMLDivElement {
-      let Limg = document.createElement('div');
-      this.markUnselectable(Limg);
-      Limg.id='kmw-help-image';
-      Limg.className='kmw-title-bar-image';
-      Limg.title='KeymanWeb Help';
-      Limg.onmousedown = this.mouseCancellingHandler;
-      return Limg;
-    }
-
-    private buildConfigButton(): HTMLDivElement {
-      let Limg = document.createElement('div');
-      this.markUnselectable(Limg);
-
-      Limg.id='kmw-config-image';
-      Limg.className='kmw-title-bar-image';
-      Limg.title='KeymanWeb Configuration Options';
       Limg.onmousedown = this.mouseCancellingHandler;
 
       return Limg;

--- a/web/source/osk/layouts/titleBar.ts
+++ b/web/source/osk/layouts/titleBar.ts
@@ -20,7 +20,7 @@ namespace com.keyman.osk.layouts {
     public set helpEnabled(val) {
       this._helpEnabled = val;
 
-      this._helpButton.style.visibility = val ? 'visible' : 'hidden';
+      this._helpButton.style.display = val ? 'inline' : 'none';
     }
 
     public get configEnabled(): boolean {
@@ -30,7 +30,7 @@ namespace com.keyman.osk.layouts {
     public set configEnabled(val) {
       this._configEnabled = val;
 
-      this._configButton.style.visibility = val ? 'visible' : 'hidden';
+      this._configButton.style.display = val ? 'inline' : 'none';
     }
 
     private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(20); // As set in kmwosk.css

--- a/web/source/osk/layouts/titleBar.ts
+++ b/web/source/osk/layouts/titleBar.ts
@@ -10,10 +10,36 @@ namespace com.keyman.osk.layouts {
     private _configButton: HTMLDivElement;
     private _caption: HTMLSpanElement;
 
+    private _helpEnabled:   boolean;
+    private _configEnabled: boolean;
+
+    public get helpEnabled(): boolean {
+      return this._helpEnabled;
+    }
+
+    public set helpEnabled(val) {
+      this._helpEnabled = val;
+
+      this._helpButton.style.visibility = val ? 'visible' : 'hidden';
+    }
+
+    public get configEnabled(): boolean {
+      return this._configEnabled;
+    }
+
+    public set configEnabled(val) {
+      this._configEnabled = val;
+
+      this._configButton.style.visibility = val ? 'visible' : 'hidden';
+    }
+
     private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(20); // As set in kmwosk.css
 
     public constructor(dragHandler?: MouseDragOperation) {
       this._element = this.buildTitleBar();
+
+      this.helpEnabled   = false;
+      this.configEnabled = false;
 
       if(dragHandler) {
         this.element.onmousedown = dragHandler.mouseDownHandler;

--- a/web/source/osk/layouts/titleBar.ts
+++ b/web/source/osk/layouts/titleBar.ts
@@ -6,6 +6,8 @@ namespace com.keyman.osk.layouts {
     private _element: HTMLDivElement;
     private _unpinButton: HTMLDivElement;
     private _closeButton: HTMLDivElement;
+    private _helpButton: HTMLDivElement;
+    private _configButton: HTMLDivElement;
     private _caption: HTMLSpanElement;
 
     private static readonly DISPLAY_HEIGHT = ParsedLengthStyle.inPixels(20); // As set in kmwosk.css
@@ -50,6 +52,26 @@ namespace com.keyman.osk.layouts {
     }
 
     public attachHandlers(osk: OSKView) {
+      let util = com.keyman.singleton.util;
+
+      this._helpButton.onclick = function() {
+        var p={};
+        util.callEvent('osk.helpclick',p);
+        if(window.event) {
+          window.event.returnValue=false;
+        }
+        return false;
+      }
+
+      this._configButton.onclick = function() {
+        var p={};
+        util.callEvent('osk.configclick',p);
+        if(window.event) {
+          window.event.returnValue=false;
+        }
+        return false;
+      }
+
       this._closeButton.onclick = function () {
         osk.startHide(true);
         return false;
@@ -82,6 +104,12 @@ namespace com.keyman.osk.layouts {
       var Limg = this._closeButton = this.buildCloseButton();
       bar.appendChild(Limg);
 
+      Limg = this._helpButton = this.buildHelpButton()
+      bar.appendChild(Limg);
+
+      Limg = this._configButton = this.buildConfigButton();
+      bar.appendChild(Limg);
+
       Limg = this._unpinButton = this.buildUnpinButton();
       bar.appendChild(Limg);
 
@@ -101,6 +129,28 @@ namespace com.keyman.osk.layouts {
 
       Limg.id='kmw-close-button';
       Limg.className='kmw-title-bar-image';
+      Limg.onmousedown = this.mouseCancellingHandler;
+
+      return Limg;
+    }
+
+    private buildHelpButton(): HTMLDivElement {
+      let Limg = document.createElement('div');
+      this.markUnselectable(Limg);
+      Limg.id='kmw-help-image';
+      Limg.className='kmw-title-bar-image';
+      Limg.title='KeymanWeb Help';
+      Limg.onmousedown = this.mouseCancellingHandler;
+      return Limg;
+    }
+
+    private buildConfigButton(): HTMLDivElement {
+      let Limg = document.createElement('div');
+      this.markUnselectable(Limg);
+
+      Limg.id='kmw-config-image';
+      Limg.className='kmw-title-bar-image';
+      Limg.title='KeymanWeb Configuration Options';
       Limg.onmousedown = this.mouseCancellingHandler;
 
       return Limg;

--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -1078,6 +1078,20 @@ namespace com.keyman.osk {
      * Description  Wrapper function to add and identify OSK-specific event handlers
      */
     ['addEventListener'](event: string, func: (obj) => boolean) {
+      // As the following title bar buttons (for desktop / FloatingOSKView) do nothing unless
+      // a site designer uses these events, we disable / hide them until an event is attached.
+      let titleBar = this.headerView;
+      if(titleBar && titleBar instanceof layouts.TitleBar) {
+        switch(event) {
+          case 'configclick':
+            titleBar.configEnabled = true;
+            break;
+          case 'helpclick':
+            titleBar.helpEnabled = true;
+            break;
+        }
+      }
+
       return com.keyman.singleton.util.addEventListener('osk.'+event, func);
     }
   }

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -305,8 +305,6 @@
           font-family:SpecialOSK; color:white;}
 .kmw-title-bar-image:hover{font-weight:bold;}
 #kmw-pin-image:before{content:'\e024';}
-#kmw-config-image:before{content:'\e030';}
-#kmw-help-image:before{content:'\e042';}
 #kmw-close-button:before {content:'\e025';}
 
 /* Common key appearance styles (can override with form-factor styles if necessary) */

--- a/web/source/resources/osk/kmwosk.css
+++ b/web/source/resources/osk/kmwosk.css
@@ -305,6 +305,8 @@
           font-family:SpecialOSK; color:white;}
 .kmw-title-bar-image:hover{font-weight:bold;}
 #kmw-pin-image:before{content:'\e024';}
+#kmw-config-image:before{content:'\e030';}
+#kmw-help-image:before{content:'\e042';}
 #kmw-close-button:before {content:'\e025';}
 
 /* Common key appearance styles (can override with form-factor styles if necessary) */

--- a/web/testing/index.html
+++ b/web/testing/index.html
@@ -36,6 +36,7 @@
   <h2><a href="./sentry-integration/">Tests Sentry error-reporting functionality</a></h2>
   <h2><a href="./osk-movement/">Test page for osk setRect() and restorePosition() interaction</a></h2>
   <h2><a href="./ckeditor/">Integration with CKEditor</a></h2>
+  <h2><a href="./osk-event-buttons/">Tests toggling & use of desktop OSK config & help buttons</a></h2>
   <h1>Auto-attachment mode tests</h1>
   <h2><a href="./issue29">Test desktop MutationObserver functionality</a></h2>
   <h2><a href="./issue62">Light test for touch-based MutationObserver functionality</a></h2>

--- a/web/testing/osk-event-buttons/index.html
+++ b/web/testing/osk-event-buttons/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <title>KeymanWeb Sample Page - Uncompiled Source</title>
+
+    <!-- Your page CSS -->
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../release/unminified/web/keymanweb.js" type="application/javascript"></script>
+
+    <!--
+      For desktop browsers, a script for the user interface must be inserted here.
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
+      a large number of languages.
+    -->
+    <script src="../../release/unminified/web/kmwuitoggle.js"></script>
+
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      var kmw=window.keyman;
+      kmw.init({
+        attachType:'auto'
+      }).then(() => {
+        loadKeyboards(1);
+      });
+    </script>
+
+    <!-- Add keyboard management script for local selection of keyboards to use -->
+    <script src="../commonHeader.js"></script>
+    <script src="./oskButtonSrc.js"></script>
+
+  </head>
+
+<!-- Sample page HTML -->
+  <body>
+    <h2>KeymanWeb Sample Page - OSK title-bar button test page</h2>
+    <div>
+    <!--
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>
+
+    <p>Click to add an event & enable OSK title-bar buttons to the OSK:</p>
+    <input type="button" id="addConfig" value="Add Config Button" onclick='addButton("config");'/>
+    <input type="button" id="addHelp" value="Add Help Button" onclick='addButton("help");'/>
+
+    <h3>Type in your language in this text area:</h3>
+    <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <h3>or in this input field:</h3>
+    <input class='test' value='' placeholder='or here'/>
+
+    <hr>
+
+    <p>Events clicked, in order:</p>
+
+    <textarea id="log" style="width: 40%; min-height:80px;" disabled="true"></textarea>
+
+    <h3><a href="../index.html">Return to testing home page</a></h3>
+  </div>
+
+  </body>
+
+  <!--
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *
+    ***
+  -->
+</html>

--- a/web/testing/osk-event-buttons/oskButtonSrc.js
+++ b/web/testing/osk-event-buttons/oskButtonSrc.js
@@ -1,0 +1,21 @@
+function addButton(name) {
+  let enablerButton;
+  let message;
+  let eventName;
+
+  if(name == "config") {
+    enablerButton = document.getElementById("addConfig");
+    message = "Config clicked";
+    eventName = "configclick";
+  } else {
+    enablerButton = document.getElementById("addHelp");
+    message = "Help clicked";
+    eventName = "helpclick";
+  }
+
+  enablerButton.disabled = true;
+  let logElement = document.getElementById("log");
+  keyman.osk.addEventListener(eventName, () => {
+    logElement.value += message + '\n';
+  });
+}


### PR DESCRIPTION
Fixes #7226.

Disables the two buttons highlighted by the green square in the following image unless a related event has (or has had) a listener:

![image](https://user-images.githubusercontent.com/25213402/196576285-457cd67b-ccd2-4d02-a2f9-48dd3d4c6e84.png)

Their only use in KMW at this point:

https://github.com/keymanapp/keyman/blob/1f573231c0fd54b117e40f5b90bea00b2f9db298/web/source/osk/layouts/titleBar.ts#L57-L73

So, they only exist to trigger events that a site designer has decided to handle; KMW itself does not use the two buttons in any way.

## User Testing

- TEST_REMOVED_BUTTONS: On any desktop or laptop computer, verify that the two buttons above no longer appear.
    1. Pick and launch a browser (say, Chrome).
    2. Use the standard "Test unminified Keymanweb" test page found under the "KeymanWeb Test Home" link below.
    3. Click one of the two main text areas at the top ("Type here", "or here").
    4. Verify that the two buttons are missing at the top-right of the OSK.

    Expected result:
    
    ![image](https://user-images.githubusercontent.com/25213402/196576806-2cc003d0-f228-4cbb-a5aa-99d54c5963da.png)

- TEST_ENABLE_BUTTONS:  On any desktop or laptop computer, verify that the two buttons appear when requested on the corresponding test page.
    1. Pick and launch a browser (say, Chrome).
    2. Use the new "Tests toggling & use of desktop OSK config & help buttons" test page found under the "KeymanWeb Test Home" link below.
    3. Click one of the two main text areas at the top ("Type here", "or here").
    4. Verify that the two buttons are missing at the top-right of the OSK.
    5. Drag the OSK to a new position on the page; verify that the 'pin' button appears.
    6. Click the page's "Add Config Button" button.
    7. Click one of the two main text areas at the top again.
    8. Verify that the config button (the gear-shaped button in the first screenshot) appears.
        - Click it, and verify that corresponding text is added to the log below the text areas.
        - Verify that the buttons are evenly spaced and right-aligned, with no overlap or uneven gaps.
        - Verify that the 'pin' button has been shifted left as a result.
    9. Click the page's "Add Help Button" button.
    10. Verify that the help button (the button with a circled `?` in the first screenshot) appears.
        - Click it, and verify that corresponding text is added to the log below the text areas.
        - Verify that the buttons are evenly spaced and right-aligned, with no overlap or uneven gaps.
        - Verify that the 'pin' and 'config' buttons have been shifted left as a result.