### PR TITLE
feat(web): keyboard layout spec now allows numeric width, pad, sp

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -143,18 +143,20 @@ namespace com.keyman.keyboards {
 
     static sanitize(rawKey: LayoutKey) {
       if(typeof rawKey.width == 'string') {
-        rawKey.width = parseInt(rawKey.width, 10); // '' => NaN.
+        rawKey.width = parseInt(rawKey.width, 10);
       }
-      rawKey.width = (isNaN(rawKey.width as number) ? 0 : rawKey.width) || ActiveKey.DEFAULT_KEY_WIDTH;
+      // Handles NaN cases as well as 'set to 0' cases; both are intentional here.
+      rawKey.width ||= ActiveKey.DEFAULT_KEY_WIDTH;
 
       if(typeof rawKey.pad == 'string') {
         rawKey.pad = parseInt(rawKey.pad, 10);
       }
-      rawKey.pad = (isNaN(rawKey.pad as number) ? 0 : rawKey.pad) || ActiveKey.DEFAULT_PAD;
+      rawKey.pad ||= ActiveKey.DEFAULT_PAD;
 
       if(typeof rawKey.sp == 'string') {
         rawKey.sp = Number.parseInt(rawKey.sp, 10) as ButtonClass;
       }
+      rawKey.sp ||= 0; // The default button class.
     }
 
     static polyfill(key: LayoutKey, layout: ActiveLayout, displayLayer: string) {

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -337,17 +337,16 @@ namespace com.keyman.keyboards {
 
       // Calculate percentage-based scalings by summing defined widths and scaling each key to %.
       // Save each percentage key width as a separate member (do *not* overwrite layout specified width!)
-      var keyPercent: number, padPercent: number, totalPercent=0;
+      let totalPercent=0;
       for(let j=0; j<keys.length-1; j++) {
         const key = keys[j] as ActiveKey; // already 'polyfilled' in prior loop
-        keyPercent = key.width/totalWidth;
-        keys[j]['widthpc']=keyPercent;
-        padPercent = key.pad/totalWidth;
-        keys[j]['padpc']=padPercent;
 
-        // compute center's default x-coord (used in headless modes)
-        setProportions(keys[j] as ActiveKey, padPercent, keyPercent, totalPercent);
-        totalPercent += padPercent+keyPercent;
+        // compute center's default x-coord (used in headless modes), assign 'proportional' props
+        setProportions(key, key.pad/totalWidth, key.width/totalWidth, totalPercent);
+
+        // These values are set on the key as part of the prior call.
+        totalPercent += key.proportionalPad;
+        totalPercent += key.proportionalWidth;
       }
 
       // Allow for right OSK margin (15 layout units)
@@ -358,16 +357,14 @@ namespace com.keyman.keyboards {
 
         // If a single key, and padding is negative, add padding to right align the key
         if(keys.length == 1 && finalKey.pad < 0) {
-          keyPercent = finalKey.width/totalWidth;
-          finalKey['widthpc']=keyPercent;
-          finalKey['padpc']=1-(totalPercent + keyPercent + rightMargin);
+          const keyPercent = finalKey.width/totalWidth;
+          const padPercent = 1-(totalPercent + keyPercent + rightMargin);
 
           // compute center's default x-coord (used in headless modes)
           setProportions(finalKey, padPercent, keyPercent, totalPercent);
         } else {
-          padPercent = finalKey.pad/totalWidth;
-          finalKey['padpc']=padPercent;
-          finalKey['widthpc'] = keyPercent = 1-(totalPercent + padPercent + rightMargin);
+          const padPercent = finalKey.pad/totalWidth;
+          const keyPercent = 1-(totalPercent + padPercent + rightMargin);
 
           // compute center's default x-coord (used in headless modes)
           setProportions(finalKey, padPercent, keyPercent, totalPercent);

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -280,7 +280,7 @@ namespace com.keyman.keyboards {
     // Identify key labels (e.g. *Shift*) that require the special OSK font
     static readonly SPECIAL_LABEL=/\*\w+\*/;
 
-    id: string;
+    id: number;
     key: ActiveKey[];
 
     /**
@@ -381,6 +381,9 @@ namespace com.keyman.keyboards {
 
       let aRow = row as ActiveRow;
       aRow.proportionalY = proportionalY;
+      if(typeof row.id == 'string') {
+        row.id = Number.parseInt(row.id, 10);
+      }
     }
 
     populateKeyMap(map: {[keyId: string]: ActiveKey}) {

--- a/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -11,16 +11,17 @@ namespace com.keyman.keyboards {
   export type KLS = {[layerName: string]: string[]};
 
   // The following types provide type definitions for the full JSON format we use for visual keyboard definitions.
-  export type ButtonClass = number|"0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"10"
+  export type ButtonClass       =  0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  export type ButtonClassString = "0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"10";
 
   export type LayoutKey = {
     "id"?: string,
     "text"?: string,
-    "sp"?: ButtonClass,
-    "width"?: string,
+    "sp"?: ButtonClass | ButtonClassString,
+    "width"?: string | number,
     "layer"?: string, // Key derives any modifiers from the value set here if specified, not the actual display layer.
     "nextlayer"?: string,
-    "pad"?: string,
+    "pad"?: string | number,
     "sk"?: LayoutKey[]
   }
 
@@ -73,14 +74,14 @@ namespace com.keyman.keyboards {
 
     // Cross-reference with the ids in osk.setButtonClass.
     static buttonClasses: {[name: string]: ButtonClass} = {
-      'DEFAULT':'0',
-      'SHIFT':'1',
-      'SHIFT-ON':'2',
-      'SPECIAL':'3',
-      'SPECIAL-ON':'4',
-      'DEADKEY':'8',
-      'BLANK':'9',
-      'HIDDEN':'10'
+      'DEFAULT':0,
+      'SHIFT':1,
+      'SHIFT-ON':2,
+      'SPECIAL':3,
+      'SPECIAL-ON':4,
+      'DEADKEY':8,
+      'BLANK':9,
+      'HIDDEN':10
     };
 
     static modifierSpecials = {

--- a/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -26,7 +26,7 @@ namespace com.keyman.keyboards {
   }
 
   export type LayoutRow = {
-    "id": string, // represents a number, though...
+    "id": string | number,
     "key": LayoutKey[]
   };
 

--- a/web/source/osk/browser/oskSubKey.ts
+++ b/web/source/osk/browser/oskSubKey.ts
@@ -34,7 +34,7 @@ namespace com.keyman.osk.browser {
       }
 
       if(typeof spec['width'] != 'undefined') {
-        ks.width=(parseInt(spec['width'],10)*baseKey.offsetWidth/100)+'px';
+        ks.width=(spec['width']*baseKey.offsetWidth/100)+'px';
       } else {
         ks.width=baseKey.offsetWidth+'px';
       }

--- a/web/source/osk/oskBaseKey.ts
+++ b/web/source/osk/oskBaseKey.ts
@@ -67,7 +67,7 @@ namespace com.keyman.osk {
       var bsn: number, bsk=btn['subKeys'] = this.spec['sk'];
       // Transform any special keys into their PUA representations.
       for(bsn=0; bsn<bsk.length; bsn++) {
-        if(bsk[bsn]['sp'] == '1' || bsk[bsn]['sp'] == '2') {
+        if(bsk[bsn]['sp'] == 1 || bsk[bsn]['sp'] == 2) {
           var oldText=bsk[bsn]['text'];
           bsk[bsn]['text']=this.renameSpecialKey(oldText, vkbd);
         }

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -47,17 +47,17 @@ namespace com.keyman.osk {
     elementID?: string;
 
     text?: string;
-    sp?: number | keyboards.ButtonClass;
-    width: string;
+    sp?: keyboards.ButtonClass;
+    width: number;
     layer?: string; // The key will derive its base modifiers from this property - may not equal the layer on which it is displayed.
     nextlayer?: string;
-    pad?: string;
+    pad?: number;
     sk?: OSKKeySpec[];
 
-    constructor(id: string, text?: string, width?: string, sp?: number | keyboards.ButtonClass, nextlayer?: string, pad?: string) {
+    constructor(id: string, text?: string, width?: number, sp?: keyboards.ButtonClass, nextlayer?: string, pad?: number) {
       this.id = id;
       this.text = text;
-      this.width = width ? width : "50";
+      this.width = width ? width : 50;
       this.sp = sp;
       this.nextlayer = nextlayer;
       this.pad = pad;
@@ -159,9 +159,7 @@ namespace com.keyman.osk {
         n=8;
       }
 
-      if(typeof key['sp'] == 'string') {
-        n=parseInt(key['sp'],10);
-      }
+      n = key['sp'] !== undefined ? key['sp'] : n;
 
       if(n < 0 || n > 10) {
         n=0;
@@ -179,13 +177,8 @@ namespace com.keyman.osk {
      */
     public setToggleState(flag?: boolean) {
       let btnClassId: number;
-      let classAsString: boolean;
 
-      if(classAsString = typeof this.spec['sp'] == 'string') {
-        btnClassId = parseInt(this.spec['sp'], 10);
-      } else {
-        btnClassId = this.spec['sp'];
-      }
+      btnClassId = this.spec['sp'];
 
       // 1 + 2:   shift  +  shift-on
       // 3 + 4:  special + special-on
@@ -196,7 +189,7 @@ namespace com.keyman.osk {
             flag = OSKKey.BUTTON_CLASSES[btnClassId] == 'shift';
           }
 
-          this.spec['sp'] = 1 + (flag ? 1 : 0);
+          this.spec['sp'] = 1 + (flag ? 1 : 0) as keyboards.ButtonClass;
           break;
         // Added in 15.0:  special key highlight toggling.
         // Was _intended_ in earlier versions, but not actually implemented.
@@ -206,15 +199,10 @@ namespace com.keyman.osk {
             flag = OSKKey.BUTTON_CLASSES[btnClassId] == 'special';
           }
 
-          this.spec['sp'] = 3 + (flag ? 1 : 0);
+          this.spec['sp'] = 3 + (flag ? 1 : 0) as keyboards.ButtonClass;
           break;
         default:
           return;
-      }
-
-      if(classAsString) {
-        // KMW currently doesn't handle raw numbers for 'sp' properly.
-        this.spec['sp'] = ('' + this.spec['sp']) as keyboards.ButtonClass;
       }
 
       this.setButtonClass();

--- a/web/source/osk/oskKey.ts
+++ b/web/source/osk/oskKey.ts
@@ -159,7 +159,7 @@ namespace com.keyman.osk {
         n=8;
       }
 
-      n = key['sp'] !== undefined ? key['sp'] : n;
+      n = key['sp'] ?? n;
 
       if(n < 0 || n > 10) {
         n=0;


### PR DESCRIPTION
Fixes #119.

## User Testing

**TEST_BASIC_LOAD_DESKTOP**:  With a desktop or laptop running Chrome, use the "Test unminified Keymanweb" test page and verify that the OSK displays correctly.

- The default keyboard displayed - "English - English" in the keyboard menu - should look like this:

    ![image](https://user-images.githubusercontent.com/25213402/196600406-3e61e0e5-3b5a-42ce-a459-3cf1ca7fd2ca.png)

**TEST_BASIC_LOAD_MOBILE**:  With an Android phone (real or emulated), use the "Test unminified Keymanweb" test page and verify that the OSK displays correctly.

- The default keyboard displayed - marked simply as "English" on the space bar - should look like this:

    ![image](https://user-images.githubusercontent.com/25213402/196601346-1eefcdcd-9f5f-46e6-9541-b67d9a2f2c29.png)

**TEST_MOBILE_FOUR_ROW**:  With an Android phone (real or emulated) running Chrome...

1. Use the "Test unminified Keymanweb" test page.
2. Change keyboard to Norwegian.
3. Verify that the layout looks correct.  It should have a layout similar to this:

    ![image](https://user-images.githubusercontent.com/25213402/196838117-2c038553-e0d0-418a-b1e5-bb440a391463.png)

**TEST_KEYBOARD_WITH_DEADKEYS**:  With an Android phone (real or emulated) running Chrome...

1. Use the "Test unminified Keymanweb" test page.
2. Under "Add a keyboard by keyboard name", enter `basic_kbdfr` and then press the "Add" button next to it.
3. Change keyboard:  "French..." => "French Basic".
5. Verify that the second-to-last key on the second row - the `^` key - has green text.
6. Verify the same for the shift layer - for the umlaut key (`¨`).

**TEST_KHMER**:  With an Android phone (real or emulated) running Chrome...

1. Use the "Test unminified Keymanweb" test page.
2. Change keyboard to Khmer.
3. Verify that first key on the last row displays correctly:  `១២៣`
4. Use that key to shift to the keyboard's numeric/symbol layer.  Verify that the key is highlighted while in that layer.
5. Use the key again to return to the base layer.  Verify that the key is no longer highlighted.

**TEST_BASIC_SWAP_DESKTOP**:  With a desktop or laptop running Chrome...

1. Use the "Test unminified Keymanweb" test page and verify that the OSK displays correctly.
2. The default keyboard displayed - "English - English" in the keyboard menu - should look like this:

    ![image](https://user-images.githubusercontent.com/25213402/196600406-3e61e0e5-3b5a-42ce-a459-3cf1ca7fd2ca.png)

3. Swap to _any_ other keyboard.
4. Swap back to original keyboard.
5. Verify that the keyboard looks the same as before.

**TEST_MOBILE_ROTATION**:  With an Android phone (real or emulated) running Chrome...

1. Use the "Test unminified Keymanweb" test page and verify that the OSK displays correctly.
2. Click either text box at the top ("Type here", "or here") to display the OSK.
3. Rotate the device.
4. Verify that the keyboard's layout looks correct.  The layout should match aside from "stretching" or "squashing" all keys proportionally.
    - The space bar should "begin" underneath the same spot under the same key in both portrait and landscape mode.
    - The space bar should "end" underneath the same spot under the same key in both portrait and landscape mode.
    - Example comparison:

        ![image](https://user-images.githubusercontent.com/25213402/196605108-8aed3a48-ab17-4303-954d-5e73a1597210.png)
        vs
        ![image](https://user-images.githubusercontent.com/25213402/196605185-18df4a92-d80b-4cde-8e9a-0aac66278aa6.png)

    - While the keys are far more "square" in the second image, note how the space bar starts halfway under one key (`ច`) in both images and ends halfway under a different key (`ុំ`) in both images.

## Other notes

Note that at this time, the default layout specification _includes_ string-based versions of the affected properties.  This helps to ensure that we continue to process older-format layout specifications correctly.