### PR TITLE
fix(web): touch-platform language menu initial scrolling + index scrolling

### DIFF
--- a/web/source/osk/languageMenu.ts
+++ b/web/source/osk/languageMenu.ts
@@ -270,16 +270,21 @@ namespace com.keyman.osk {
         }
       } catch(ex){}
 
+      // Will leave this much portion of the last pre-index item visible.
+      // 0.5 => 50%.
+      const SCROLL_ITEM_BUFFER = 0.5;
       try {
-        top=(<HTMLElement>menu.firstChild).offsetHeight*i+1;
+        top=(<HTMLElement>menu.firstChild).getBoundingClientRect().height*(i-SCROLL_ITEM_BUFFER)+1;
         m2.scrollTop=top;
       } catch(ex) {
         top=0;
       }
 
       try {
-        if(m2.scrollTop < top) {
-          m2.scrollTop=m2.scrollHeight-m2.offsetHeight;
+        // Clamp the language menu scroll within boundaries - do not leave "whitespace" either
+        // before or after all menu items due to scroll positioning near list borders.
+        if(m2.scrollTop < 0) {
+          m2.scrollTop = 0;
         }
         if(m2.scrollTop > m2.scrollHeight-m2.offsetHeight-1) {
           m2.scrollTop=m2.scrollHeight-m2.offsetHeight-1;
@@ -506,7 +511,7 @@ namespace com.keyman.osk {
         this.lgList.style.visibility='hidden';
 
         window.setTimeout(function(){
-          // In case of extremely rapid keyboard swaps, this event may trigger more than once - 
+          // In case of extremely rapid keyboard swaps, this event may trigger more than once -
           // the shim's on-touch event can trigger after a keyboard has been selected!
           if(languageMenu.shim.parentElement) {
             document.body.removeChild(languageMenu.shim);

--- a/web/source/osk/languageMenu.ts
+++ b/web/source/osk/languageMenu.ts
@@ -59,7 +59,6 @@ namespace com.keyman.osk {
       // Insert a transparent overlay to prevent anything else happening during keyboard selection,
       // but allow the menu to be closed if anywhere else on screen is touched
 
-      let osk = this.keyman.osk;
       let languageMenu = this;
 
       document.body.appendChild(this.shim);
@@ -185,18 +184,7 @@ namespace com.keyman.osk {
       // Now display the menu
       this.lgList.style.visibility='';
 
-      // Set initial scroll to show current language (but never less than 1, to avoid dragging body)
-      var top=(<HTMLElement>m3.firstChild).offsetHeight*this.activeLgNo+1;
-      m2.scrollTop=top;
-
-      // The scrollTop value is limited by the device, and must be limited to avoid dragging the document body
-      if(m2.scrollTop < top) {
-        m2.scrollTop=m2.scrollHeight-m2.offsetHeight;
-      }
-
-      if(m2.scrollTop > m2.scrollHeight-m2.offsetHeight-1) {
-        m2.scrollTop=m2.scrollHeight-m2.offsetHeight-1;
-      }
+      this.scrollToIndex(this.activeLgNo, m2, m3);
     }
 
     /**
@@ -260,7 +248,7 @@ namespace com.keyman.osk {
         return;
       }
 
-      var i,t,top=0,initial=target.innerHTML.charCodeAt(0),nn=menu.childNodes;
+      var i,t,initial=target.innerHTML.charCodeAt(0),nn=menu.childNodes;
       try {
         for(i=0; i<nn.length-1; i++) {
           t=(<HTMLElement>nn[i].firstChild).innerHTML.toUpperCase().charCodeAt(0);
@@ -270,11 +258,17 @@ namespace com.keyman.osk {
         }
       } catch(ex){}
 
+      this.scrollToIndex(i, m2, menu);
+    }
+
+    scrollToIndex(index: number, m2: HTMLDivElement, menu: HTMLDivElement) {
+      let top: number;
+
       // Will leave this much portion of the last pre-index item visible.
       // 0.5 => 50%.
       const SCROLL_ITEM_BUFFER = 0.5;
       try {
-        top=(<HTMLElement>menu.firstChild).getBoundingClientRect().height*(i-SCROLL_ITEM_BUFFER)+1;
+        top=(<HTMLElement>menu.firstChild).getBoundingClientRect().height*(index-SCROLL_ITEM_BUFFER)+1;
         m2.scrollTop=top;
       } catch(ex) {
         top=0;


### PR DESCRIPTION
Fixes #6638.

## User Testing

### Common test setup

For _**all**_ user tests below, perform the following test setup:

1. On a mobile device (real or emulated), go to the "Test unminified Keymanweb" test page found under "KeymanWeb Test Home" below.
2.  Under "Add a keyboard by keyboard name", type `sil_cameroon_azerty` and then press the "Add" button beside it.
3. Touch either of the first two text areas ("Type here", "or here") to display the OSK.

### Test definitions

**TEST_DEFAULT_POSITION**: Verify that the language menu displays an entry for the active keyboard when first launched.

4. Press the globe key to launch the language menu.
5. Verify that "English" is visible near the top of the language menu, without any need for scrolling.
    - There may be one half-visible entry before it; this is expected and not a test failure.

**TEST_INDEX_A**:

4. Press the globe key to launch the language menu.
5. Touch the "A" at the top of the menu's right-hand side.
6. Verify that the language menu displays languages beginning with the letter A, starting from the top of the visible area.
7. Verify that the language menu does not scroll past the first displayed entry ("Afade").

**TEST_INDEX_R**:

4. Press the globe key to launch the language menu.
5. Touch the "R" within the menu's right-hand side.
6. Verify that the language menu displays languages beginning with the letter S.
    - The half-visible entry before the first "S" entry - "Samba Leko" - should start with a "P" - this is expected and not a test failure.

**TEST_INDEX_Z**:

4. Press the globe key to launch the language menu.
5. Touch the "Z" at the bottom of the menu's right-hand side.
6. Verify that the language menu displays all languages beginning with the letter Z, which will be visible near the menu's bottom.
7. Verify that the language menu does not scroll past the final entry ("cug-latn").