### PR TITLE
fix(android/engine): Verify keyboard file exists before switching

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -572,6 +572,13 @@ final class KMKeyboard extends WebView {
 
     String keyboardPath = makeKeyboardPath(packageID, keyboardID, keyboardVersion);
 
+    // Verify keyboard file still exists
+    File kbFile = new File(keyboardPath);
+    if (kbFile != null && !kbFile.exists()) {
+      KMLog.LogError(TAG, keyboardID + " no longer installed.");
+      return false;
+    }
+
     JSONObject reg = new JSONObject();
     try {
       reg.put("KN", keyboardName);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -417,6 +417,12 @@ public final class KeyboardPickerActivity extends BaseActivity {
   protected static boolean removeKeyboard(Context context, int position) {
     boolean result = false;
 
+    Keyboard info = KeyboardController.getInstance().getKeyboardInfo(position);
+    if (info != null) {
+      // Log keyboard uninstall to troubleshoot #7412
+      String msg = KMString.format("Uninstalling %s::%s, version: %s.", info.getPackageID(), info.getKeyboardID(), info.getVersion());
+      KMLog.LogInfo(TAG, msg);
+    }
     KeyboardController.getInstance().remove(position);
     result = KeyboardController.getInstance().save(context);
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/impl/CloudKeyboardPackageDownloadCallback.java
@@ -16,6 +16,7 @@ import com.tavultesoft.kmea.packages.LexicalModelPackageProcessor;
 import com.tavultesoft.kmea.packages.PackageProcessor;
 import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
+import com.tavultesoft.kmea.util.KMString;
 
 import org.json.JSONException;
 
@@ -75,6 +76,11 @@ public class CloudKeyboardPackageDownloadCallback implements ICloudDownloadCallb
             if (packageID == null || packageID.isEmpty()) {
               KMLog.LogError(TAG, "Cloud URL " + _d.getCloudParams().url + " has null packageID");
             }
+
+            // Log keyboard package update to troubleshoot #7412 (languageID may be null)
+            String msg = KMString.format("Cloud keyboard package updated for: %s, language: %s.", packageID, languageID);
+            KMLog.LogInfo(TAG, msg);
+
             String kmpFilename = String.format("%s%s", packageID, FileUtils.KEYMANPACKAGE);
 
             // Extract the kmp.


### PR DESCRIPTION
Fixes #7412

This change to Keyman Engine for Android verifies a Javascript keyboard file exists before having KeymanWeb switch to the keyboard.

For my testing, I installed sil_cameroon_qwerty package, then manually deleted the .js file before trying to switch to a second keyboard and verified the Toast notification of the [Sentry LogError](https://sentry.io/organizations/keyman/issues/3682438055/?alert_rule_id=8817330&alert_timestamp=1666168780714&alert_type=email&environment=local&project=5983520&referrer=alert_email) appeared.

@keymanapp-test-bot skip
