### PR TITLE
chore(linux): call `reset_context` instead of `...focus_in`

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -984,7 +984,7 @@ ibus_keyman_engine_reset (IBusEngine *engine)
 {
     g_message("ibus_keyman_engine_reset");
     parent_class->reset (engine);
-    ibus_keyman_engine_focus_in (engine);
+    reset_context(engine);
 }
 
 


### PR DESCRIPTION
Both `ibus_keyman_engine_reset` and `ibus_keyman_engine_focus_in` are methods that get called by ibus. Having `ibus_keyman_engine_reset` call `ibus_keyman_engine_focus_in` makes it much harder to see in log files which methods get really called by ibus.

This change replaces the call of `...focus_in` with `reset_context`, which is what `...focus_in` does as well. The only other thing that `ibus_keyman_engine_focus_in` does in addition to that is calling `ibus_engine_register_properties` - which shouldn't be necessary on a reset (besides that we don't seem to do anything with the one status property we register).

@keymanapp-test-bot skip