### PR TITLE
fix(mac): load default privacy alert string

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyWindowController.m
@@ -25,13 +25,31 @@
   NSString *bundleDisplayName = [[[NSBundle mainBundle] localizedInfoDictionary]
                            objectForKey:@"CFBundleDisplayName"];
   [self.window setTitle:bundleDisplayName];
-  [_alertText setStringValue:NSLocalizedString(@"privacy-alert-text", nil)];
+  
+  // need to provide a defaultValue for the possibility that:
+  // 1. the app is localized for a given language x
+  // 2. the string with the specified key is not found in Localizable.strings for language x
+  // if not, then UI will display the key instead of the string with that language selected
+
+  NSString *defaultValue = [self defaultLocalizableString: @"privacy-alert-text"];
+  [_alertText setStringValue:NSLocalizedStringWithDefaultValue(@"privacy-alert-text", nil, NSBundle.mainBundle, defaultValue, nil)];
   
   NSImage *keymanLogo = [NSImage imageNamed:NSImageNameApplicationIcon];
   if (keymanLogo) {
     [_appLogo setImage:keymanLogo];
   }
   [_okButton setEnabled:YES];
+}
+
+/**
+ * utility method to get the English string for the localizable key
+ * move to some generic place if it will be widely used
+ */
+- (NSString*) defaultLocalizableString:(NSString*) key {
+  NSBundle *main = [NSBundle mainBundle];
+  NSString *resourcePath = [main pathForResource:@"en" ofType:@"lproj"];
+  NSBundle *bundle = [NSBundle bundleWithPath:resourcePath];
+  return NSLocalizedStringFromTableInBundle(key, nil, bundle, nil);
 }
 
 - (IBAction)closeAction:(id)sender {


### PR DESCRIPTION
Fixes #7475 

This fix loads the English string for privacy-alert-text and uses it as a default in case the string cannot be found for a localization. The problem occurred when:
1. Keyman was localized for a given language x
2. the string with the key privacy-alert-text was not found in Localizable.strings for language x
In that case, the key name, "privacy-alert-text", would be displayed instead of a localized string

It is best if we actually have an alert in the localized language, but when we don't, English is much better than an incomprehensible key name.

# User Testing

* **TEST_LOCALIZED_PRIVACY_ALERT:** - Confirm that a readable alert displays in English when Hausa is set as the preferred language.

1. Remove old version of Keyman **after** first removing its permissions from Security & Privacy > Privacy > Accessibility
2. Install the Keyman build for this PR. 
3. Go to Apple > System Preferences...
4. Choose Language and Region and select + to add Hausa, then drag Hausa to the top to be the primary preferred language
5. Restart the system
6. Select Keyman from the System Input Source menu
7. Confirm that the following dialog is displayed:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/89134789/196115410-9d892d08-4843-4edc-8c39-6862426a1c5d.png">

Note that after the Hausa localization is eventually updated, this test will not result in an alert in English.