### PR TITLE
fix(common): ignore deps when formatting help

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -512,9 +512,11 @@ builder_describe() {
       local dependency="${value:1}"
       dependency="`_builder_expand_relative_path "$dependency"`"
       _builder_deps+=($dependency)
-      # echo "$description"
       _builder_dep_related_actions[$dependency]="`_builder_expand_action_targets "$description"`"
-      # echo "${_builder_dep_related_actions[$dependency]}"
+
+      # We don't want to add deps to params, so shift+continue
+      shift
+      continue
     elif [[ $value =~ ^-- ]]; then
       # Parameter is an option
       # Look for a shorthand version of the option


### PR DESCRIPTION
Fixes #7512.

Dependencies were being added to list of parameters, which caused the help formatting to be overly spaced out. Given deps are not parameters, we should never have been adding them anyway.

@keymanapp-test-bot skip