### PR TITLE
fix(web): bulk renderer update

### DIFF
--- a/web/bulk_rendering/README.md
+++ b/web/bulk_rendering/README.md
@@ -6,12 +6,14 @@ This renderer loads all the cloud keyboards from api.keyman.com and renders each
 
 1. `build.sh` to build the renderer (must have already built KeymanWeb in ../source/, `./build.sh -debug`).
 2. Open `index.html` (via http, not via file, as otherwise fonts will not be accessible).
-3. If you want a touch layout, use Developer Tools to select the appropriate emulation and then reload the page.
-4. Choose whether you wish to render all layers or just the default layer for each keyboard.
-5. If desired, filter out keyboards by id (regex).
+3. Choose whether you wish to render all layers or just the default layer for each keyboard.
+4. If desired, filter out keyboards by id (regex).
 5. Run the render.
-    - When prompted to screenshare, be sure to share _the Chrome tab_ if emulating mobile.  The screen capture
-      system will fail to capture the OSK properly otherwise.
+    - Note that it is preferable to run this on an actual device if possible.
+      - If no prompt is given re: screensharing when you click the 'run' button, use Chrome's Developer Tools
+        on a desktop or laptop to run this via emulation instead.
+      - If emulating a mobile device, when prompted to screenshare, be sure to share _the Chrome tab_.  The screen capture
+        system will fail to capture the OSK properly otherwise.
 6. Save the result to a .html file, either before.html or after.html.
 7. When swapping versions, don't forget to rebuild.
 

--- a/web/bulk_rendering/README.md
+++ b/web/bulk_rendering/README.md
@@ -7,9 +7,11 @@ This renderer loads all the cloud keyboards from api.keyman.com and renders each
 1. `build.sh` to build the renderer (must have already built KeymanWeb in ../source/, `./build.sh -debug`).
 2. Open `index.html` (via http, not via file, as otherwise fonts will not be accessible).
 3. If you want a touch layout, use Developer Tools to select the appropriate emulation and then reload the page.
-3. Choose whether you wish to render all layers or just the default layer for each keyboard.
-4. If desired, filter out keyboards by id (regex).
+4. Choose whether you wish to render all layers or just the default layer for each keyboard.
+5. If desired, filter out keyboards by id (regex).
 5. Run the render.
+    - When prompted to screenshare, be sure to share _the Chrome tab_ if emulating mobile.  The screen capture
+      system will fail to capture the OSK properly otherwise.
 6. Save the result to a .html file, either before.html or after.html.
 7. When swapping versions, don't forget to rebuild.
 

--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -139,7 +139,7 @@ namespace com.keyman.renderer {
 
         // Appromixate handling for non-fullscreen mode runs.
         // Adjusts for the browser window's title bars, address bars, etc.
-        let screenOffsetY = window.outerHeight - window.innerHeight;
+        const screenOffsetY = window.outerHeight - window.innerHeight;
         BatchRenderer.boundingRect.y += screenOffsetY;
 
         divSummary.appendChild(renderer.createKeyboardHeader(kbd, true));
@@ -150,7 +150,7 @@ namespace com.keyman.renderer {
         // Uses 'private' APIs that may be subject to change in the future.  Keep it updated!
         var layers;
         if(isMobile) {
-          layers = keyman.osk.vkbd.layerGroup.layers;  // It's not there anymore!
+          layers = keyman.osk.vkbd.layerGroup.layers;
         } else {
           // The desktop OSK will be overpopulated, with a number of blank layers to display in most cases.
           // We instead rely upon the KLS definition to ensure we keep the renders sparse.
@@ -161,11 +161,7 @@ namespace com.keyman.renderer {
           return new Promise(function(resolve) {
             // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
             if(keyman.osk.vkbd) {
-              if(isMobile) {
-                keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
-              } else {
-                keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
-              }
+              keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
             } else {
               console.error("Error - keyman.osk.vkbd is undefined!");
             }

--- a/web/bulk_rendering/renderer_core.ts
+++ b/web/bulk_rendering/renderer_core.ts
@@ -134,7 +134,13 @@ namespace com.keyman.renderer {
       // Once the keyboard's loaded, we can really get started.
       return p.then(function() {
         let box: HTMLDivElement = keyman.osk._Box;
+
         BatchRenderer.boundingRect = box.getBoundingClientRect();
+
+        // Appromixate handling for non-fullscreen mode runs.
+        // Adjusts for the browser window's title bars, address bars, etc.
+        let screenOffsetY = window.outerHeight - window.innerHeight;
+        BatchRenderer.boundingRect.y += screenOffsetY;
 
         divSummary.appendChild(renderer.createKeyboardHeader(kbd, true));
 
@@ -144,21 +150,19 @@ namespace com.keyman.renderer {
         // Uses 'private' APIs that may be subject to change in the future.  Keep it updated!
         var layers;
         if(isMobile) {
-          layers = keyman.osk.vkbd.layers;
+          layers = keyman.osk.vkbd.layerGroup.layers;  // It's not there anymore!
         } else {
           // The desktop OSK will be overpopulated, with a number of blank layers to display in most cases.
           // We instead rely upon the KLS definition to ensure we keep the renders sparse.
           layers = keyman.core.activeKeyboard._legacyLayoutSpec.KLS;
         }
 
-        if(!BatchRenderer.allLayers && layers.length) layers = [layers[0]];
-
         let renderLayer = function(i: number) {
           return new Promise(function(resolve) {
             // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
             if(keyman.osk.vkbd) {
               if(isMobile) {
-                keyman.core.keyboardProcessor.layerId = layers[i].id;
+                keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
               } else {
                 keyman.core.keyboardProcessor.layerId = Object.keys(layers)[i];
               }
@@ -174,7 +178,7 @@ namespace com.keyman.renderer {
                 renderer.render(box, isMobile).then(function(imgEle: HTMLImageElement) {
                   let eleLayer = document.createElement('div');
                   let eleLayerId = document.createElement('p');
-                  eleLayerId.textContent = 'Layer ID:  ' + (isMobile ? layers[i].id : Object.keys(layers)[i]);
+                  eleLayerId.textContent = 'Layer ID:  ' + Object.keys(layers)[i];
 
                   eleLayer.appendChild(eleLayerId);
                   eleLayer.appendChild(imgEle);
@@ -189,7 +193,7 @@ namespace com.keyman.renderer {
         };
 
         // The resulting Promise will only call it's `.then()` once all of this keyboard's renders have been completed.
-        return renderer.arrayPromiseIteration(renderLayer, isMobile ? layers.length : Object.keys(layers).length);
+        return renderer.arrayPromiseIteration(renderLayer, Object.keys(layers).length);
       }).catch(function() {
         console.log("Failed to load the \"" + kbd['InternalName'] + "\" keyboard for rendering!");
         divSummary.appendChild(renderer.createKeyboardHeader(kbd, false));
@@ -231,7 +235,7 @@ namespace com.keyman.renderer {
     }
 
     setActiveDummy() {
-      com.keyman['dom']['DOMEventHandlers'].states._activeElement = BatchRenderer.dummy;
+      window['keyman'].domManager.activeElement = BatchRenderer.dummy;
     }
 
     async run(allLayers, filter) {
@@ -246,6 +250,7 @@ namespace com.keyman.renderer {
 
         // Establish a 'dummy' element to bypass the 'nothing's active' check KMW usually uses.
         BatchRenderer.dummy = document.createElement('input');
+        window['keyman'].attachToControl(BatchRenderer.dummy);
         this.setActiveDummy();
 
         BatchRenderer.divMaster = <HTMLDivElement> document.getElementById('renderList');


### PR DESCRIPTION
The old bulk-renderer subproject for OSK regression testing doesn't seem to have been updated in a while.  It _definitely_ seems to rely on patterns from before the big OSK refactor that resulted in the "inlined" OSK mode used by Developer.

So far, I've gotten the desktop-OSK mode working pretty flawlessly, but mobile's an entirely different matter.  The screen-capturing system it's utilizing doesn't seem to play nice with mobile device emulation.  I can get it close, but any zoom factor to the emulation will break the OSK scaling used for its snapshots.  Things will be a bit off even with 99% scaling (Chrome defaults to 99% for iPhone SE emulation with 125% OS UI scaling @ 1080p).

To highlight the previous point, here's a screenshot of the bulk-renderer running in that scenario:

![image](https://user-images.githubusercontent.com/25213402/197488766-494064f6-78d2-4dec-97c4-cf9871f64bf7.png)

Note how the bottom gets chopped off - that's likely due to the "Sharing this tab..." banner that occurs as part of the screen recording.  I pretty much have to use that mode to actually capture the keyboard though; I couldn't find any good JS strategies to discern the keyboard's screen placement when under emulation without focusing down on the tab being emulated.

@keymanapp-test-bot skip