### PR TITLE
fix(core): remove `KMN_API` from callback spec

### DIFF
--- a/core/include/keyman/keyboardprocessor.h
+++ b/core/include/keyman/keyboardprocessor.h
@@ -127,7 +127,7 @@ typedef struct km_kbp_option_item  km_kbp_option_item;
 // Callback function used to to access Input Method eXtension library functions
 // from Keyman Core
 //
-typedef KMN_API uint8_t (*km_kbp_keyboard_imx_platform)(km_kbp_state*, uint32_t, void*);
+typedef uint8_t (*km_kbp_keyboard_imx_platform)(km_kbp_state*, uint32_t, void*);
 
 /*```
 ### Error Handling


### PR DESCRIPTION
Fixes #7487.

`KMN_API` defines only import/export/static modifiers for functions, so it makes no sense to apply it to a typedef. (Previously, I thought it also included a calling convention, but it doesn't.)

@keymanapp-test-bot skip