### PR TITLE
fix(developer): Use US base layout for debugger

### DIFF
--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -219,6 +219,7 @@ uses
   RegistryKeys,
   KeymanDeveloperOptions,
   KeymanDeveloperUtils,
+  ScanCodeMap,
   TextFileFormat,
   UfrmEditor,
   UfrmKeymanWizard,
@@ -448,18 +449,22 @@ function TfrmDebug.ProcessKeyEvent(var Message: TMessage): Boolean;
     end;
   end;
 var
-  modifier: uint16_t;
+  vkey, modifier: uint16_t;
 begin
   Assert(Assigned(FDebugCore));
+
+  // We always use the US virtual key code as a basis for our keystroke
+  // mapping; the best way to do this is to extract the scan code from
+  // the message data and work from that
+  vkey := MapScanCodeToUSVK((Message.LParam and $FF0000) shr 16);
   modifier := 0;
+
   if GetKeyState(VK_LCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_LCTRL;
   if GetKeyState(VK_RCONTROL) < 0 then modifier := modifier or KM_KBP_MODIFIER_RCTRL;
   if GetKeyState(VK_LMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_LALT;
   if GetKeyState(VK_RMENU) < 0 then modifier := modifier or KM_KBP_MODIFIER_RALT;
   if GetKeyState(VK_SHIFT) < 0 then modifier := modifier or KM_KBP_MODIFIER_SHIFT;
   if (GetKeyState(VK_CAPITAL) and 1) = 1 then modifier := modifier or KM_KBP_MODIFIER_CAPS;
-
-  // TODO: #7529 support translation of base layout to KBDUS layout
 
   if (modifier and (KM_KBP_MODIFIER_LCTRL or KM_KBP_MODIFIER_RALT)) = (KM_KBP_MODIFIER_LCTRL or KM_KBP_MODIFIER_RALT) then
   begin
@@ -471,19 +476,19 @@ begin
   if not SetKeyEventContext then
     Exit(False);
 
-  if km_kbp_process_event(FDebugCore.State, Message.WParam, modifier, 1) = KM_KBP_STATUS_OK then
+  if km_kbp_process_event(FDebugCore.State, vkey, modifier, 1) = KM_KBP_STATUS_OK then
   begin
     // Process keystroke -- true = swallow keystroke
     Result := True;
 
-    if IsModifierKey(Message.WParam) then
+    if IsModifierKey(vkey) then
     begin
       // We don't want to trigger the debugger on modifier keys
       Exit(True);
     end;
 
     FEvents.Clear;
-    FEvents.AddStateItems(FDebugCore.State, Message.WParam, modifier, debugkeyboard);
+    FEvents.AddStateItems(FDebugCore.State, vkey, modifier, debugkeyboard);
 
     if FSingleStepMode then
     begin


### PR DESCRIPTION
Fixes #7529.

We must always use the US base layout for the debugger, as positional keyboards are not affected by the active Windows system keyboard. This fix ensures that the behaviour in the debugger matches what the user experiences in Keyman for Windows.

Note that this does not address support for mnemonic layouts, tracked in issue #1074.

# User Testing

For these tests, we want to ensure that every key emits the expected US English key, no matter what the underlying keyboard is. To do this:

1. Create a brand new basic keyboard with no rules.
2. Compile the keyboard (F7), and start the debugger (F5).
3. Press each key in turn on the keyboard: the character emitted should match the character for the US English hardware keyboard.

**TEST_US:** Select the English (US) keyboard in the Windows language picker. Verify each key on the keyboard matches US English.
**TEST_FRENCH:** Select the French (AZERTY) keyboard in the Windows language picker. Verify each key on the keyboard matches US English.