### PR TITLE
fix(developer): handle LControl being set by Windows when AltGr pressed 🍒

### DIFF
--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.dfm
@@ -108,6 +108,7 @@ object modActionsKeyboardEditor: TmodActionsKeyboardEditor
       Category = 'Debug Control'
       Caption = 'Select System &Keyboard...'
       ImageIndex = 49
+      Visible = False
       OnExecute = actDebugSelectSystemKeyboardExecute
       OnUpdate = actDebugSelectSystemKeyboardUpdate
     end

--- a/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
+++ b/windows/src/developer/TIKE/actions/dmActionsKeyboardEditor.pas
@@ -556,6 +556,7 @@ end;
 
 procedure TmodActionsKeyboardEditor.SelectDebugSystemKeyboard(k: TSystemKeyboardItem);
 begin
+//TODO: #1225, #1074 (note both menu item and toolbar combo are hidden while this is not working)
 //  if IsDebuggerVisible then   // I3655
 //    ActiveEditor.DebugForm.SetSystemKeyboardID(k.KeyboardID);
 end;

--- a/windows/src/developer/TIKE/child/UfrmDebug.pas
+++ b/windows/src/developer/TIKE/child/UfrmDebug.pas
@@ -461,12 +461,21 @@ begin
   if GetKeyState(VK_SHIFT) < 0 then modifier := modifier or KM_KBP_MODIFIER_SHIFT;
   if (GetKeyState(VK_CAPITAL) and 1) = 1 then modifier := modifier or KM_KBP_MODIFIER_CAPS;
 
+  // TODO: #7529 support translation of base layout to KBDUS layout
+
+  if (modifier and (KM_KBP_MODIFIER_LCTRL or KM_KBP_MODIFIER_RALT)) = (KM_KBP_MODIFIER_LCTRL or KM_KBP_MODIFIER_RALT) then
+  begin
+    // #7506: Windows emits LCtrl+RAlt for AltGr for European keyboards; we want
+    // to ignore this combination
+    modifier := modifier and not KM_KBP_MODIFIER_LCTRL;
+  end;
+
   if not SetKeyEventContext then
     Exit(False);
 
   if km_kbp_process_event(FDebugCore.State, Message.WParam, modifier, 1) = KM_KBP_STATUS_OK then
   begin
-    // Process keystroke
+    // Process keystroke -- true = swallow keystroke
     Result := True;
 
     if IsModifierKey(Message.WParam) then

--- a/windows/src/developer/TIKE/main/UfrmMain.dfm
+++ b/windows/src/developer/TIKE/main/UfrmMain.dfm
@@ -65,7 +65,7 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
     object panDebugToolbar: TPanel
       Left = 481
       Top = 2
-      Width = 504
+      Width = 512
       Height = 23
       AutoSize = True
       BevelOuter = bvNone
@@ -89,12 +89,13 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
         GroupIndex = 2
       end
       object cbDebugSystemKeyboard: TComboBox
-        Left = 359
+        Left = 367
         Top = 1
         Width = 145
         Height = 21
         Style = csDropDownList
         TabOrder = 0
+        Visible = False
         OnClick = cbDebugSystemKeyboardItemClick
         OnDropDown = cbDebugSystemKeyboard_DropDown
       end


### PR DESCRIPTION
Fixes #7506.

Cherry-pick of #7530.

In the keyboard debugger, we need to mask out LControl when AltGr is pressed by the user, because Windows will generate LControl + AltGr for European layouts.

Note: have also hidden the System Keyboard debug setting in this commit, given it is not currently implemented; see #1225.

A follow-up issue is #7529.

@keymanapp-test-bot skip