### PR TITLE
feat(windows): Change "None" to "No Hotkey" matching new config

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmChangeHotkey.dfm
+++ b/windows/src/desktop/kmshell/main/UfrmChangeHotkey.dfm
@@ -66,7 +66,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
     Top = 61
     Width = 113
     Height = 17
-    Caption = 'None'
+    Caption = 'No Hotkey'
     TabOrder = 0
     OnClick = rbNoneClick
   end


### PR DESCRIPTION
Fixes: #7536
Change the label on the radio button for the "Change Hotkey" dialogue to "No Hotkey" to match the change to the windows configuration.

@keymanapp-test-bot skip
