### PR TITLE
fix(web): allow `isChiral()` to accept string name parameter of keyboard

### DIFF
--- a/web/source/kmwbase.ts
+++ b/web/source/kmwbase.ts
@@ -412,6 +412,15 @@ namespace com.keyman {
     ['isChiral'](k0?) {
       var kbd: keyboards.Keyboard;
       if(k0) {
+        if(typeof k0 == 'string') {
+          const kbdObj = this.keyboardManager.keyboards.find((kbd) => kbd['KI'] == k0);
+          if(!kbdObj) {
+            throw new Error(`Keyboard '${k0}' has not been loaded.`);
+          } else {
+            k0 = kbdObj;
+          }
+        }
+
         kbd = new keyboards.Keyboard(k0);
       } else {
         kbd = this.core.activeKeyboard;


### PR DESCRIPTION
Fixes #7467.

Since we've documented it as taking a string, but it was expecting the keyboard script object.

https://help.keyman.com/developer/engine/web/15.0/reference/core/isChiral

@keymanapp-test-bot skip