### PR TITLE
chore(windows): convert `wm_keyman_keyevent` and `wm_keyman_modifierevent` to private `WM_USER` messages

### DIFF
--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -208,7 +208,6 @@ void DoChangeWindowMessageFilter()
   }
 
 	DoCWMF(wm_keyman);   // I3594
-  DoCWMF(wm_keyman_keyevent);
   DoCWMF(wm_keymankeydown);
   DoCWMF(wm_keymankeyup);
   DoCWMF(wm_keyman_grabwindowproc);
@@ -219,7 +218,6 @@ void DoChangeWindowMessageFilter()
   DoCWMF(wm_keymanshift);
   DoCWMF(wm_keyman_control);   // I4714
   DoCWMF(wm_keyman_control_internal);   // I4714
-  DoCWMF(wm_keyman_modifierevent);
 
   FreeLibrary(hUser32);
 }
@@ -301,7 +299,6 @@ BOOL InitialiseProcess(HWND hwnd)
   Initialise_Flag_ShouldSerializeInput();
 
 	wm_keyman = RegisterWindowMessage(RWM_KEYMAN);
-  wm_keyman_keyevent = RegisterWindowMessage("WM_KEYMAN_KEYEVENT");
 	wm_keymankeydown = RegisterWindowMessage("WM_KEYMANKEYDOWN");
 	wm_keymankeyup = RegisterWindowMessage("WM_KEYMANKEYUP");
 	wm_keyman_grabwindowproc = RegisterWindowMessage("WM_KEYMAN_GRABWINDOWPROC");
@@ -314,7 +311,6 @@ BOOL InitialiseProcess(HWND hwnd)
 
 	wm_keyman_control = RegisterWindowMessage(RWM_KEYMAN_CONTROL);
 	wm_keyman_control_internal = RegisterWindowMessage("WM_KEYMAN_CONTROL_INTERNAL");
-  wm_keyman_modifierevent = RegisterWindowMessage("WM_KEYMAN_MODIFIEREVENT");
 
 	wm_test_keyman_functioning = RegisterWindowMessage("wm_test_keyman_functioning");
 

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -278,9 +278,7 @@ extern UINT
   wm_keymanshift,
   wm_keymanim_close,
   wm_keymanim_contextchanged,
-  wm_test_keyman_functioning,
-  wm_keyman_keyevent,   // for serialized input
-  wm_keyman_modifierevent;
+  wm_test_keyman_functioning;
 extern BOOL
   flag_ShouldSerializeInput;
 

--- a/windows/src/engine/keyman32/k32_dbg.cpp
+++ b/windows/src/engine/keyman32/k32_dbg.cpp
@@ -44,6 +44,7 @@
                     09 Aug 2015 - mcdurdin - I4843 - Log reported modifier state as well as Keyman current modifier state
 */
 #include "pch.h"
+#include "serialkeyeventcommon.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <evntprov.h>
@@ -206,8 +207,8 @@ void DebugMessage(LPMSG msg, WPARAM wParam)  // I2908
 	else if(msg->message == wm_keymankeyup)
     wsprintf(ds, "DebugMessage(%x, wm_keymankeyup: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
       Debug_VirtualKey((WORD) msg->wParam), (unsigned int) msg->lParam, wParam, (int) msg->time);
-  else if (msg->message == wm_keyman_keyevent)
-    wsprintf(ds, "DebugMessage(%x, wm_keyman_keyevent: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
+  else if (msg->message == WM_KEYMAN_KEY_EVENT)
+    wsprintf(ds, "DebugMessage(%x, WM_KEYMAN_KEYEVENT: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
       Debug_VirtualKey((WORD)msg->wParam), (unsigned int) msg->lParam, wParam, (int) msg->time);
   else if(msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_SYSKEYDOWN || msg->message == WM_SYSKEYUP)
     wsprintf(ds, "DebugMessage(%x, %s, wParam: %s, lParam: %X) [message flags: %x time: %d extra: %x]",

--- a/windows/src/engine/keyman32/k32_dbg.cpp
+++ b/windows/src/engine/keyman32/k32_dbg.cpp
@@ -208,7 +208,7 @@ void DebugMessage(LPMSG msg, WPARAM wParam)  // I2908
     wsprintf(ds, "DebugMessage(%x, wm_keymankeyup: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
       Debug_VirtualKey((WORD) msg->wParam), (unsigned int) msg->lParam, wParam, (int) msg->time);
   else if (msg->message == WM_KEYMAN_KEY_EVENT)
-    wsprintf(ds, "DebugMessage(%x, WM_KEYMAN_KEYEVENT: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
+    wsprintf(ds, "DebugMessage(%x, WM_KEYMAN_KEY_EVENT: %s lParam: %X) [message flags: %x time: %d]", PtrToInt(msg->hwnd),
       Debug_VirtualKey((WORD)msg->wParam), (unsigned int) msg->lParam, wParam, (int) msg->time);
   else if(msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_SYSKEYDOWN || msg->message == WM_SYSKEYUP)
     wsprintf(ds, "DebugMessage(%x, %s, wParam: %s, lParam: %X) [message flags: %x time: %d extra: %x]",

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -72,8 +72,6 @@
 UINT
   //TODO: consolidate these messages -- they are probably not all required now
   wm_keyman = 0,						// user message - ignore msg   // I3594
-  wm_keyman_keyevent = 0,      // for serialized input
-  wm_keyman_modifierevent = 0, // for serialized input
 	wm_kmdebug = 0,						//  " "  "  "   - debugging
 
 	wm_keymankeydown = 0,

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -202,7 +202,7 @@ LRESULT _kmnLowLevelKeyboardProc(
     if(isUp) FHotkeyShiftState &= ~Flag;
     else FHotkeyShiftState |= Flag;
     // #7337 Post the modifier state ensuring the serialized queue is in sync
-    // Note that the modifier key may be posted again with WM_KEYMAN_KEYEVENT,
+    // Note that the modifier key may be posted again with WM_KEYMAN_KEY_EVENT,
     // later in this function. This is intentional, as the WM_KEYMAN_MODIFIER_EVENT 
     // message only updates our internal modifier state, and does not do 
     // any additional processing or other serialization of the input queue.

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -202,12 +202,12 @@ LRESULT _kmnLowLevelKeyboardProc(
     if(isUp) FHotkeyShiftState &= ~Flag;
     else FHotkeyShiftState |= Flag;
     // #7337 Post the modifier state ensuring the serialized queue is in sync
-    // Note that the modifier key may be posted again with wm_keyman_keyevent,
-    // later in this function. This is intentional, as the wm_keyman_modifierevent 
+    // Note that the modifier key may be posted again with WM_KEYMAN_KEYEVENT,
+    // later in this function. This is intentional, as the WM_KEYMAN_MODIFIER_EVENT 
     // message only updates our internal modifier state, and does not do 
     // any additional processing or other serialization of the input queue.
     if (flag_ShouldSerializeInput) {
-      PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), wm_keyman_modifierevent, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
+      PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), WM_KEYMAN_MODIFIER_EVENT, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
     }
   }
 
@@ -258,7 +258,7 @@ LRESULT _kmnLowLevelKeyboardProc(
 
       HWND hwnd = gui.hwndFocus ? gui.hwndFocus : gui.hwndActive;
       if (!IsConsoleWindow(hwnd)) {
-        PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), wm_keyman_keyevent, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
+        PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), WM_KEYMAN_KEY_EVENT, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
         return 1;
       }
       //else SendDebugMessageFormat(0, sdmGlobal, 0, "LowLevelHook: console window, not serializing"); // too noisy

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -63,6 +63,7 @@
 */
    // I3583   // I4287
 #include "pch.h"
+#include "serialkeyeventcommon.h"
 
 void ProcessWMKeymanControlInternal(HWND hwnd, WPARAM wParam, LPARAM lParam);
 void ProcessWMKeymanControl(WPARAM wParam, LPARAM lParam);
@@ -141,7 +142,7 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
   }
 
   if (((mp->message >= WM_KEYFIRST && mp->message <= WM_KEYLAST) || mp->message == wm_keymankeydown || mp->message == wm_keymankeyup ||
-    mp->message == wm_keyman_keyevent)
+    mp->message == WM_KEYMAN_KEY_EVENT)
     && ShouldDebug(sdmMessage)) {
     DebugMessage(mp, wParam);
   }

--- a/windows/src/engine/keyman32/serialkeyeventcommon.h
+++ b/windows/src/engine/keyman32/serialkeyeventcommon.h
@@ -17,6 +17,11 @@
 #define GLOBAL_KEY_MUTEX_NAME "KeymanEngine_KeyMutex"
 
 /**
+WM_USER private messages
+*/
+#define WM_KEYMAN_KEY_EVENT (WM_USER + 1)
+#define WM_KEYMAN_MODIFIER_EVENT (WM_USER + 2)
+/**
   The INPUT structure and the KEYBDINPUT structure both vary in size between x86 and x64
   because of the presence of the ULONG_PTR member dwExtraInfo. Thus we need to maintain an
   equal sized structure between the two platforms for shared memory, and copy into INPUT
@@ -34,3 +39,5 @@ struct SerialKeyEventSharedData {
   DWORD nInputs;
   CSDINPUT inputs[MAX_KEYEVENT_INPUTS];
 };
+
+

--- a/windows/src/engine/keyman32/serialkeyeventcommon.h
+++ b/windows/src/engine/keyman32/serialkeyeventcommon.h
@@ -17,7 +17,8 @@
 #define GLOBAL_KEY_MUTEX_NAME "KeymanEngine_KeyMutex"
 
 /**
-WM_USER private messages
+WM_USER private messages -- used only for communication 
+between low level keyboard hook and serial key event server
 */
 #define WM_KEYMAN_KEY_EVENT (WM_USER + 1)
 #define WM_KEYMAN_MODIFIER_EVENT (WM_USER + 2)

--- a/windows/src/engine/keyman32/serialkeyeventserver.cpp
+++ b/windows/src/engine/keyman32/serialkeyeventserver.cpp
@@ -436,7 +436,7 @@ private:
       You can disable this flag with flag_ShouldSerializeInput.
     */
 
-    if ((msg == wm_keyman_keyevent || msg == wm_keyman_modifierevent) && flag_ShouldSerializeInput  /*&& _td->lpActiveKeyboard*/) {
+    if ((msg == WM_KEYMAN_KEY_EVENT || msg == WM_KEYMAN_MODIFIER_EVENT) && flag_ShouldSerializeInput  /*&& _td->lpActiveKeyboard*/) {
 
       if (wParam == VK_RMENU && (lParam & (KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP)) == (KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP) && GetKeyState(VK_LCONTROL) < 0) {
         /*
@@ -485,9 +485,9 @@ private:
         input[1].ki.dwExtraInfo = EXTRAINFO_FLAG_SERIALIZED_USER_KEY_EVENT;
         input[1].ki.dwFlags = lParam & 0xFFFF;
 
-        if (msg == wm_keyman_keyevent) {
-          // We track changes to modifiers with wm_keyman_modifierevent, but only ever
-          // pass them on to the app when we receive them with the wm_keyman_keyevent 
+        if (msg == WM_KEYMAN_KEY_EVENT) {
+          // We track changes to modifiers with WM_KEYMAN_MODIFIER_EVENT, but only ever
+          // pass them on to the app when we receive them with the WM_KEYMAN_KEYEVENT 
           // message.
           if (!SendInput(2, input, sizeof(INPUT))) {
             DebugLastError("SendInput");
@@ -516,7 +516,7 @@ private:
         input.ki.dwExtraInfo = EXTRAINFO_FLAG_SERIALIZED_USER_KEY_EVENT;
         input.ki.dwFlags = lParam & 0xFFFF;
 
-        if (msg == wm_keyman_keyevent){
+        if (msg == WM_KEYMAN_KEY_EVENT){
           if (!SendInput(1, &input, sizeof(INPUT))) {
             DebugLastError("SendInput");
           }

--- a/windows/src/engine/keyman32/serialkeyeventserver.cpp
+++ b/windows/src/engine/keyman32/serialkeyeventserver.cpp
@@ -487,7 +487,7 @@ private:
 
         if (msg == WM_KEYMAN_KEY_EVENT) {
           // We track changes to modifiers with WM_KEYMAN_MODIFIER_EVENT, but only ever
-          // pass them on to the app when we receive them with the WM_KEYMAN_KEYEVENT 
+          // pass them on to the app when we receive them with the WM_KEYMAN_KEY_EVENT 
           // message.
           if (!SendInput(2, input, sizeof(INPUT))) {
             DebugLastError("SendInput");


### PR DESCRIPTION
Fixes #7458 
`wm_keyman_keyevent` and `wm_keyman_modifierevent` have been converted to use the `WM_USER` message range and no longer globally registered messages.

# USER TESTING :

**GROUP_WIN10**  - Run the tests in a Windows 10 OS
**GROUP_WIN11** - Run the tests in Windows 11 OS


**TEST_ALTGR_IN_RULES** 
This is to test the key rules which contain <kbd>AltGr</kbd> or <kbd>Shift</kbd> + <kbd>AltGr</kbd> still work correctly.

* Load a keyboard `khmer_angkor` 
* Open LibreOffice or Notepad 
* Type a <kbd>AltGr</kbd> + <kbd>o</kbd> 
* Observe output of  ឱ​

* Type a <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>o</kbd> 
* Observe output of ᧨


**TEST_HOTKEYS**
This is to test switching between non-keyman and keyman keyboards using hotkeys. To make sure this PR has not broken Hotkeys that use modifiers 
* Install two different keyman keyboards in addition to the default for the Windows installation.
* Use the Keyman Configuration to assign hotkeys to the default Keyboard as well as the two Keyman Keyboards that use modifiers for the hotkey for example <kbd>Ctrl</kbd> + <kbd>1</kbd>  or <kbd>Alt</kbd> + <kbd>K</kbd>
* Open Notepad 
* Use the hotkeys to switch between keyboards
* Verify that switching between the keyboards is working