### PR TITLE
fix(android/engine): Dismiss key previews and subkeys on multi-touch 🍒

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -302,6 +302,11 @@ final class KMKeyboard extends WebView {
       // if active, allowing for smooth, integrated gesture control.
       subKeysWindow.getContentView().findViewById(R.id.grid).dispatchTouchEvent(event);
     } else {
+      if (event.getPointerCount() > 1) {
+        // Multiple points touch the screen at the same time, so dismiss any pending subkeys
+        dismissKeyPreview(0);
+        dismissSubKeysWindow();
+      }
       gestureDetector.onTouchEvent(event);
     }
 

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2177,6 +2177,15 @@ public final class KMManager {
    * @param keyboardType KeyboardType KEYBOARD_TYPE_INAPP or KEYBOARD_TYPE_SYSTEM
    */
   public static void handleGlobeKeyAction(Context context, boolean globeKeyDown, KeyboardType keyboardType) {
+    // Clear preview and subkeys
+    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+      InAppKeyboard.dismissKeyPreview(0);
+      InAppKeyboard.dismissSubKeysWindow();
+    } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
+      SystemKeyboard.dismissKeyPreview(0);
+      SystemKeyboard.dismissSubKeysWindow();
+    }
+
     // Update globeKeyState
     if (globeKeyState != GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS) {
       globeKeyState = globeKeyDown ? GlobeKeyState.GLOBE_KEY_STATE_DOWN : GlobeKeyState.GLOBE_KEY_STATE_UP;


### PR DESCRIPTION
🍒 pick of #7388 and #7472 to stable-15.0
Fixes #7510 (16.0 master should already contain the fixes)

This PR causes subkeys to get dismissed when a multi-touch is detected (either another key or globe key)

## User Testing
1. Needs a physical Android device for multi-touch typing (two thumbs)
2. Install the PR build of Keyman for Android


* **TEST_MULTI_TOUCH_DISMISSES_LONGPRESS** - Verifies long-press keys aren't generated when multi-touch detected
1. Start Keyman for Android with the default sil_euro_latin keyboard.
2. If the OSK doesn't start on the Shift layer, press the Shift key change to the Shift layer (upper-case)
3. With the right thumb, start long-press on <kbd>G</kbd> and hold. Immediately with the left thumb press and release the shift button to switch to Default layer
4. With the right thumb still held, observe the layer is default layer. Verify long-presses options for uppercase-G do not appear.
5. Observe the base key that was held (G) is output in the text.

* **TEST_GLOBE_KEY_DISMISSES_KEYS** - Verifies key previews and subkeys are dismissed on Globe key action
1. Launch Keyman and dismiss the Get Started menu
2. With the default sil_euro_latin keyboard, long-press and hold a key with one finger
3. While holding the long-press, use another finger to short-press the globe key
4. Verify nothing happens with the globe key and the long-press keys are still visible
5. Release the long-press key
6. With the default sil_euro_latin keyboard, first short-press a key with one finger, and then short-press the globe key with another finger and release both fingers (before a long-press triggers)
7. Verify the key preview briefly appears and disappears when the globe key action is handled:
  * If 1 keyboard installed, the Keyboard picker menu appears
  * If multiple keyboards installed, Keyman switches to the next keyboard







