### PR TITLE
fix(android/engine): Dismiss subkeys when hiding keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -269,6 +269,9 @@ final class KMKeyboard extends WebView {
   }
 
   public void hideKeyboard() {
+    dismissKeyPreview(0);
+    dismissSubKeysWindow();
+
     String jsString = "hideKeyboard()";
     loadJavascript(jsString);
   }


### PR DESCRIPTION
Similar to #7388 and #7472
While trying to get a repro of #7412, I noticed subkeys can get stuck when dismissing/hiding the Keyman system keyboard

## User Testing
1. Install PR build of Keyman for Android on a physical device

* **TEST_LONGPRESS_DISAPPEARS_ON_HIDE** - Verifies longpress keys aren't stuck after hiding system keyboard
1. Launch Keyman for Android
2. On the "Get Started" menu, enable Keyman as the default system keyboard
3. Launch a separate app (e.g. Chrome) and touch the search bar
4. Switch system keyboard so Keyman is visible
5. With the right thumb, long-press and hold a key, select a long-press option, and continue holding
6. With the left thumb, press the down arrow on the system taskbar  to dismiss/hide the system keyboard
7. Verify the OSK disappears
8. Release all keyboard presses
9. Touch the Chrome search bar so the OSK reappears
10. Verify long-press keys are not visible
