### PR TITLE
fix(ios): iPad was not recognised as tablet device

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -254,20 +254,6 @@ extension KeymanWebViewController {
     webView!.evaluateJavaScript("doResetContext();", completionHandler: nil)
   }
 
-  func setDeviceType(_ idiom: UIUserInterfaceIdiom) {
-    let type: String
-    switch idiom {
-    case .phone:
-      type = "AppleMobile"
-    case .pad:
-      type = "AppleTablet"
-    default:
-      SentryManager.captureAndLog("Unexpected interface idiom: \(idiom)", logLevel: .severe)
-      return
-    }
-    webView!.evaluateJavaScript("setDeviceType('\(type)');", completionHandler: nil)
-  }
-
   private func fontObject(from font: Font?, keyboard: InstallableKeyboard, isOsk: Bool) -> [String: Any]? {
     guard let font = font else {
       return nil
@@ -660,8 +646,6 @@ extension KeymanWebViewController: KeymanWebDelegate {
     if let cursorRange = self.currentCursorRange {
       self.setCursorRange(cursorRange)
     }
-
-    setDeviceType(UIDevice.current.userInterfaceIdiom)
 
     var newKb = Manager.shared.currentKeyboard
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -20,7 +20,6 @@ if(_debug) {
     };
 }
 
-var device = 'AppleMobile';
 var oskHeight = 0;
 var oskWidth = 0;
 
@@ -32,6 +31,8 @@ sentryManager.init();
 window.addEventListener('load', init, false);
 
 function init() {
+    const device = navigator.userAgent.indexOf('iPad') >= 0 ? 'AppleTablet' : 'AppleMobile';
+
     // As of iOS 15, Safari WebViews will try to avoid letting us use the "safe area"
     // at the bottom of iPhone X style devices.  While `-webkit-fill-available` will partly
     // counteract this... it's only a "partly".  Fortunately, we can manually force the
@@ -90,12 +91,6 @@ function setBannerHeight(h) {
     // Refresh KMW's OSK
     kmw.correctOSKTextSize();
     doResetContext();
-}
-
-function setDeviceType(deviceType) {
-    // Set device type: AppleMobile|AppleTablet
-    device = deviceType;
-    init();
 }
 
 function setOskHeight(height) {

--- a/web/source/kmwembedded.ts
+++ b/web/source/kmwembedded.ts
@@ -136,10 +136,7 @@ namespace com.keyman.text {
     opt['attachType'] = 'manual';
     device.app=opt['app'];
     device.touchable=true;
-    device.formFactor='phone';
-    if(navigator && navigator.userAgent && navigator.userAgent.indexOf('iPad') >= 0) device.formFactor='tablet';
-    if(device.app.indexOf('Mobile') >= 0) device.formFactor='phone';
-    if(device.app.indexOf('Tablet') >= 0) device.formFactor='tablet';
+    device.formFactor = device.app.indexOf('Tablet') >= 0 ? 'tablet' : 'phone';
     device.browser='native';
   };
 


### PR DESCRIPTION
Fixes #7517.

Cleans up the setDeviceType code which was attempting to set the device type far too late in the init sequence, and moves responsibility for detection from kmwembedded.ts to ios-host.ts, as this device test is iOS-specific.

# User Testing

Issue #7517 shows screenshots of what the gff_amharic keyboard should look like on phone and tablet devices (styling may vary, but layout is what we are looking at here).

* **TEST_KEYBOARD_ANDROID_PHONE:** Using gff_amharic 3.0, test that the 'phone' keyboard is shown on Android phone device. Emulator ok.
* **TEST_KEYBOARD_IPHONE:** Using gff_amharic 3.0, test that the 'phone' keyboard is shown on iPhone device. Simulator ok.
* **TEST_KEYBOARD_ANDROID_TABLET:** Using gff_amharic 3.0, test that the 'tablet' keyboard is shown on Android tablet device. Emulator ok.
* **TEST_KEYBOARD_IPAD:** Using gff_amharic 3.0, test that the 'tablet' keyboard is shown on iPad device. Simulator ok.