### PR TITLE
fix(android/engine): Add FLAG_ACTIVITY_NEW_TASK flag for resource update

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -603,6 +603,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
     for(OngoingUpdate _up:openUpdates.values())
     {
       Intent intent = new Intent(currentContext, KMKeyboardDownloaderActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       intent.putExtras(_up.bundle);
       currentContext.startActivity(intent);
     }


### PR DESCRIPTION
I know we're limiting the changes before going to Beta.
I was trying to get a repro for issue #7412 with the following setup:

### Configuration
Android 12.0 emulator
Older version of sil_euro_latin (1.9.4) to trigger resource update
Keyman 16.0 92 alpha.local

After setting Keyman as the default system keyboard from the "Get Started" menu, and then going to menu --> "Install Updates"

It triggered a crash
```
Process: com.tavultesoft.kmapro.debug, PID: 16261
    android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:952)
```

This PR just adds the required flag.

@keymanapp-test-bot skip

Since the CI builds include the latest keyboard packages, the steps can't be repro'd.
