### PR TITLE
fix(developer): prevent repeated `begin` statements

### DIFF
--- a/developer/src/common/delphi/compiler/CompileErrorCodes.pas
+++ b/developer/src/common/delphi/compiler/CompileErrorCodes.pas
@@ -165,6 +165,7 @@ const
 
   CERR_DuplicateGroup                              = $4071;
   CERR_DuplicateStore                              = $4072;
+  CERR_RepeatedBegin                               = $4073;
 
   CWARN_TooManyWarnings                            = $2080;
   CWARN_OldVersion                                 = $2081;

--- a/developer/src/kmcmpdll/Compiler.rc
+++ b/developer/src/kmcmpdll/Compiler.rc
@@ -254,4 +254,5 @@ BEGIN
     CERR_PostKeystrokeGroupMustBeReadonly              "Group used in begin postKeystroke must be readonly"
     CERR_DuplicateGroup                                "A group with this name has already been defined."
     CERR_DuplicateStore                                "A store with this name has already been defined."
+    CERR_RepeatedBegin                                 "This begin statement has already been defined."
 END

--- a/developer/src/kmcmpdll/comperr.h
+++ b/developer/src/kmcmpdll/comperr.h
@@ -163,6 +163,8 @@
 #define CERR_DuplicateGroup                                0x00004071
 #define CERR_DuplicateStore                                0x00004072
 
+#define CERR_RepeatedBegin                                 0x00004073
+
 #define CWARN_TooManyWarnings                              0x00002080
 #define CWARN_OldVersion                                   0x00002081
 #define CWARN_BitmapNotUsed                                0x00002082


### PR DESCRIPTION
Fixes #3784.

Only one type of each `begin` statement should be allowed in any given keyboard source file.

# User Testing

**TEST_NORMAL:** Try compiling a variety of keyboards to ensure they continue to compile successfully.
**TEST_REPEATED:** Create a keyboard with multiple `begin unicode` statements. Try and compile it; it should report an error.