### PR TITLE
fix(developer): generate a default icon for basic keyboard projects

### DIFF
--- a/common/windows/delphi/ui/Keyman.System.Util.RenderLanguageIcon.pas
+++ b/common/windows/delphi/ui/Keyman.System.Util.RenderLanguageIcon.pas
@@ -7,11 +7,19 @@ uses
   System.UITypes,
   Vcl.Graphics;
 
-procedure DrawLanguageIcon(ACanvas: TCanvas; x, y: Integer; code: string);   // I3933
+{
+  Renders a two or three character language icon into the canvas
+
+  Parameters:
+    x, y: top left of icon graphic on canvas
+    code: the language code to render
+    size: 0=default size (-10), MaxInt=scale to fit, otherwise font.size as given
+}
+procedure DrawLanguageIcon(ACanvas: TCanvas; x, y: Integer; code: string; size: integer = 0);   // I3933
 
 implementation
 
-procedure DrawLanguageIcon(ACanvas: TCanvas; x, y: Integer; code: string);   // I3933
+procedure DrawLanguageIcon(ACanvas: TCanvas; x, y: Integer; code: string; size: integer);   // I3933
 var
   FIconRect: TRect;
   sz: TSize;
@@ -27,11 +35,29 @@ begin
   FFontName := ACanvas.Font.Name;
   FFontSize := ACanvas.Font.Size;
 
+  if Size = 0 then
+    Size := -10;
+
   ACanvas.Brush.Color := $C0C2C6;
   ACanvas.FillRect(Rect(x, y, x+16, y+16));
   ACanvas.Font.Color := $404143;
   ACanvas.Font.Name := 'Tahoma';
-  ACanvas.Font.Size := -10;
+
+  if Size = MaxInt then
+  begin
+    sz.cx := MaxInt;
+    Size := -12;
+    while (sz.cx > 16) and (Size < -4) do
+    begin
+      ACanvas.Font.Size := Size;
+      sz := ACanvas.TextExtent(code);
+      Inc(Size);
+    end;
+  end
+  else
+  begin
+    ACanvas.Font.Size := Size;
+  end;
 
   sz := ACanvas.TextExtent(code);
 

--- a/developer/src/kmconvert/Keyman.Developer.System.GenerateKeyboardIcon.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.GenerateKeyboardIcon.pas
@@ -1,0 +1,67 @@
+unit Keyman.Developer.System.GenerateKeyboardIcon;
+
+interface
+
+type
+  TKeyboardIconGenerator = class sealed
+    class function GenerateIcon(const BCP47Tags, IconFilename: string; size: Integer): Boolean;
+  end;
+
+implementation
+
+uses
+  System.Math,
+  System.SysUtils,
+  System.Types,
+  Vcl.Graphics,
+  Winapi.Windows,
+
+  Keyman.System.Util.RenderLanguageIcon;
+
+class function TKeyboardIconGenerator.GenerateIcon(
+  const BCP47Tags, IconFilename: string; size: Integer): Boolean;
+var
+  FTag: string;
+  n: Integer;
+  ico: TIcon;
+  b: array[0..1] of Vcl.Graphics.TBitmap;
+  iconInfo: TIconInfo;
+begin
+  // We need to use the BCP47 tag that we have received and render that, for now
+
+  n := Min(Pos(' ', BCP47Tags), Pos('-', BCP47Tags));
+  if n > 0
+    then FTag := Copy(BCP47Tags, 1, n-1)
+    else FTag := BCP47Tags;
+
+  b[0] := Vcl.Graphics.TBitmap.Create;
+  b[1] := Vcl.Graphics.TBitmap.Create;
+  try
+    b[0].SetSize(16, 16);
+    b[0].PixelFormat := pf32bit;
+
+    b[1].SetSize(16, 16);
+    b[1].PixelFormat := pf1bit;
+    b[1].Canvas.Brush.Color := clBlack;
+    b[1].Canvas.FillRect(Rect(0,0,16,16));
+
+    DrawLanguageIcon(b[0].Canvas, 0, 0, UpperCase(FTag), size);
+    ico := TIcon.Create;
+    try
+      FillChar(iconInfo, sizeof(iconInfo), 0);
+      iconInfo.fIcon := True;
+      iconInfo.hbmMask := b[1].Handle;
+      iconInfo.hbmColor := b[0].Handle;
+      ico.Handle := CreateIconIndirect(iconInfo);
+      ico.SaveToFile(IconFilename);
+    finally
+      ico.Free;
+    end;
+    Result := True;
+  finally
+    b[0].Free;
+    b[1].Free;
+  end;
+end;
+
+end.

--- a/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -71,15 +71,13 @@ implementation
 
 uses
   System.Classes,
-  System.Math,
   System.Win.Registry,
-  Vcl.Graphics,
   Winapi.Windows,
 
   BCP47Tag,
   Keyman.Developer.System.ImportKeyboardDLL,
+  Keyman.Developer.System.GenerateKeyboardIcon,
   Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter,
-  Keyman.System.Util.RenderLanguageIcon,
   Keyman.System.KeyboardUtils,
   KeymanVersion,
   KeyboardParser,
@@ -370,48 +368,8 @@ end;
 
 function TImportWindowsKeyboard.GenerateIcon(
   const IconFilename: string): Boolean;
-var
-  FTag: string;
-  n: Integer;
-  ico: TIcon;
-  b: array[0..1] of Vcl.Graphics.TBitmap;
-  iconInfo: TIconInfo;
 begin
-  // We need to use the BCP47 tag that we have received and render that, for now
-
-  n := Min(Pos(' ', FBCP47Tags), Pos('-', FBCP47Tags));
-  if n > 0
-    then FTag := Copy(FBCP47Tags, 1, n-1)
-    else FTag := FBCP47Tags;
-
-  b[0] := Vcl.Graphics.TBitmap.Create;
-  b[1] := Vcl.Graphics.TBitmap.Create;
-  try
-    b[0].SetSize(16, 16);
-    b[0].PixelFormat := pf32bit;
-
-    b[1].SetSize(16, 16);
-    b[1].PixelFormat := pf1bit;
-    b[1].Canvas.Brush.Color := clBlack;
-    b[1].Canvas.FillRect(Rect(0,0,16,16));
-
-    DrawLanguageIcon(b[0].Canvas, 0, 0, UpperCase(FTag));
-    ico := TIcon.Create;
-    try
-      FillChar(iconInfo, sizeof(iconInfo), 0);
-      iconInfo.fIcon := True;
-      iconInfo.hbmMask := b[1].Handle;
-      iconInfo.hbmColor := b[0].Handle;
-      ico.Handle := CreateIconIndirect(iconInfo);
-      ico.SaveToFile(IconFilename);
-    finally
-      ico.Free;
-    end;
-    Result := True;
-  finally
-    b[0].Free;
-    b[1].Free;
-  end;
+  Result := TKeyboardIconGenerator.GenerateIcon(FBCP47Tags, IconFilename, 0);
 end;
 
 function TImportWindowsKeyboard.ConvertOSKToTouchLayout(const OSKFilename, TouchLayoutFilename: string): Boolean;

--- a/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -36,6 +36,7 @@ type
     procedure WriteKVKS;
     procedure WriteTouchLayout;
     procedure WriteKeyboardInfo;
+    procedure WriteIcon;
   protected
     const
       SFileTemplate_KeyboardInfo = '%s.keyboard_info'; // in root
@@ -65,6 +66,7 @@ uses
   KeyboardParser,
   KeymanVersion,
   kmxfileconsts,
+  Keyman.Developer.System.GenerateKeyboardIcon,
   Keyman.Developer.System.Project.kmnProjectFile,
   Keyman.Developer.System.Project.kpsProjectFile,
   Keyman.Developer.System.Project.ProjectFile,
@@ -96,6 +98,8 @@ begin
     WriteKVKS;
   if HasTouchLayout then
     WriteTouchLayout;
+  if HasIcon then
+    WriteIcon;
 
   WriteKPJ;
 
@@ -345,6 +349,31 @@ begin
   finally
     tl.Free;
   end;
+end;
+
+procedure TKeyboardProjectTemplate.WriteIcon;
+var
+  FTags: string;
+begin
+  Assert(HasIcon);
+  // We'll generate an icon, based first on BCP47 tag,
+  // then if that is not present, on first two letters
+  // of filename. Not going to go silly here!
+
+  if FileExists(IconFilename) then
+  begin
+    // Some tools may already generate an icon,
+    // for example import windows keyboard
+    Exit;
+  end;
+
+  if BCP47Tags <> ''
+    then FTags := BCP47Tags
+    else FTags := ChangeFileExt(ExtractFileName(IconFilename), '');
+
+  FTags := Copy(FTags, 1, 3);
+
+  TKeyboardIconGenerator.GenerateIcon(FTags, IconFilename, MaxInt);
 end;
 
 function TKeyboardProjectTemplate.DataPath: string;

--- a/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -84,6 +84,7 @@ begin
     kpt.Version := FParameters.Version;
     kpt.BCP47Tags := FParameters.BCP47Tags;
     kpt.Author := FParameters.Author;
+    kpt.IncludeIcon := True;
 
     FTargetFolder := ExtractFileDir(kpt.ProjectFilename);
     if DirectoryExists(FTargetFolder) then

--- a/developer/src/tike/Tike.dpr
+++ b/developer/src/tike/Tike.dpr
@@ -284,7 +284,8 @@ uses
   Keyman.Developer.UI.UfrmServerOptions in 'dialogs\Keyman.Developer.UI.UfrmServerOptions.pas' {frmServerOptions},
   Keyman.Developer.System.ServerAPI in 'http\Keyman.Developer.System.ServerAPI.pas',
   Keyman.System.FontLoadUtil in 'main\Keyman.System.FontLoadUtil.pas',
-  Keyman.Developer.UI.ServerUI in 'http\Keyman.Developer.UI.ServerUI.pas';
+  Keyman.Developer.UI.ServerUI in 'http\Keyman.Developer.UI.ServerUI.pas',
+  Keyman.Developer.System.GenerateKeyboardIcon in '..\kmconvert\Keyman.Developer.System.GenerateKeyboardIcon.pas';
 
 {$R *.RES}
 {$R ICONS.RES}
@@ -316,7 +317,7 @@ begin
           //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-          try
+  try
             Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
             Application.Run;
           finally

--- a/developer/src/tike/Tike.dproj
+++ b/developer/src/tike/Tike.dproj
@@ -553,6 +553,7 @@
         <DCCReference Include="http\Keyman.Developer.System.ServerAPI.pas"/>
         <DCCReference Include="main\Keyman.System.FontLoadUtil.pas"/>
         <DCCReference Include="http\Keyman.Developer.UI.ServerUI.pas"/>
+        <DCCReference Include="..\kmconvert\Keyman.Developer.System.GenerateKeyboardIcon.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -138,7 +138,7 @@ uses
 function ShowNewProjectParameters(Owner: TComponent): Boolean;
 var
   f: TfrmNewProjectParameters;
-  pt: TProjectTemplate;
+  pt: TKeyboardProjectTemplate;
 begin
   f := TfrmNewProjectParameters.Create(Owner);
   try
@@ -154,6 +154,7 @@ begin
       pt.Author := f.Author;
       pt.Version := f.Version;
       pt.BCP47Tags := f.BCP47Tags;
+      pt.IncludeIcon := True;
 
       try
         pt.Generate;


### PR DESCRIPTION
Fixes #2803.

The new basic project template will now include a default icon, generated either from the first BCP 47 tag, or else from the first 3 letters of the filename of the keyboard.

The icon will not be included if the keyboard does not target desktop platforms, as web/touch do not currently support the icon.

# User Testing

**TEST_BASIC:** Test that creating a new basic keyboard project includes an icon by default, with the first 3 letters of the BCP 47 tag or the filename. Once the keyboard is created, you can verify the icon in the keyboard editor, Icon tab. The text should usually fit within the icon square (`WWW` may be
difficult!)

**TEST_NO_ICON:** Test that creating a new basic keyboard project that targets only 'web' does not include an icon.