### PR TITLE
fix(developer): avoid reformatting unchanged system stores

### DIFF
--- a/developer/src/tike/main/KeyboardParser.pas
+++ b/developer/src/tike/main/KeyboardParser.pas
@@ -962,8 +962,11 @@ end;
 
 procedure TKeyboardParser_SystemStore.SetValue(Value: WideString);
 begin
-  FValue := Value;
-  Line := 'store(&'+SystemStoreNames[FSystemStoreType]+') '+StrToXStr(FValue);
+  if (FValue <> Value) or (Line = '') then
+  begin
+    FValue := Value;
+    Line := 'store(&'+SystemStoreNames[FSystemStoreType]+') '+StrToXStr(FValue);
+  end;
 end;
 
 { TKeyboardParser_LayoutRule }


### PR DESCRIPTION
Fixes #298.

# User Testing

**TEST_SAVE:** Create a keyboard source file, with `store(&visualkeyboard)` indented. Make a change to the file and save it. The indent should remain.
**TEST_CHANGE:** With the same keyboard source file, remove the visual keyboard feature from the Details page, then re-add it. The `store(&visualkeyboard)` line should be reformatted, and may change its position in the file. The primary thing we want to ensure is that it is added correctly to the file in this situation.