### PR TITLE
fix(android/app): Don't show "Get Started" after setting Keyman as default system keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -64,6 +64,7 @@ public class GetStartedActivity extends BaseActivity {
     checkBox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        // Save user preference on showing "Get Started"
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean(showGetStartedKey, isChecked);
         editor.commit();
@@ -135,8 +136,9 @@ public class GetStartedActivity extends BaseActivity {
   }
 
   /**
-   * Uncheck show "Get Started" on startup if
-   * Keyman enabled as a system-wide keyboard and
+   * Uncheck show "Get Started" on startup if:
+   * User hasn't set a preference on showing "Get Started",
+   * Keyman enabled as a system-wide keyboard, and
    * Keyman set as default keyboard
    */
   private void uncheckGetStartedIfComplete() {
@@ -144,15 +146,16 @@ public class GetStartedActivity extends BaseActivity {
         SystemIMESettings.isDefaultKB(this)) {
 
       final SharedPreferences prefs = getSharedPreferences(getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-      boolean showGetStarted = prefs.getBoolean(showGetStartedKey, true);
-      if (showGetStarted) {
-        // Everything is completed, so un-check "Get Started" on startup
+      if (!prefs.contains(showGetStartedKey)) {
+        // Everything is completed, so un-check "Get Started" on startup.
+        // onCheckedChanged() will save the preference
         final CheckBox checkBox = (CheckBox) findViewById(R.id.checkBox);
         checkBox.setChecked(false);
 
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(showGetStartedKey, false);
-        editor.commit();
+        // Save preference
+        //SharedPreferences.Editor editor = prefs.edit();
+        //editor.putBoolean(showGetStartedKey, false);
+        //editor.commit();
       }
     }
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -152,10 +152,6 @@ public class GetStartedActivity extends BaseActivity {
         final CheckBox checkBox = (CheckBox) findViewById(R.id.checkBox);
         checkBox.setChecked(false);
 
-        // Save preference
-        //SharedPreferences.Editor editor = prefs.edit();
-        //editor.putBoolean(showGetStartedKey, false);
-        //editor.commit();
       }
     }
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/GetStartedActivity.java
@@ -128,8 +128,33 @@ public class GetStartedActivity extends BaseActivity {
           startActivity(i);
           overridePendingTransition(android.R.anim.fade_in, R.anim.hold);
         }
+
+        uncheckGetStartedIfComplete();
       }
     });
+  }
+
+  /**
+   * Uncheck show "Get Started" on startup if
+   * Keyman enabled as a system-wide keyboard and
+   * Keyman set as default keyboard
+   */
+  private void uncheckGetStartedIfComplete() {
+    if (SystemIMESettings.isEnabledAsSystemKB(this) &&
+        SystemIMESettings.isDefaultKB(this)) {
+
+      final SharedPreferences prefs = getSharedPreferences(getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+      boolean showGetStarted = prefs.getBoolean(showGetStartedKey, true);
+      if (showGetStarted) {
+        // Everything is completed, so un-check "Get Started" on startup
+        final CheckBox checkBox = (CheckBox) findViewById(R.id.checkBox);
+        checkBox.setChecked(false);
+
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putBoolean(showGetStartedKey, false);
+        editor.commit();
+      }
+    }
   }
 
   @Override
@@ -180,6 +205,8 @@ public class GetStartedActivity extends BaseActivity {
       int[] to = new int[]{R.id.left_icon, R.id.text};
       listAdapter = new KMListAdapter(this, list, R.layout.get_started_row_layout, from, to);
       listView.setAdapter(listAdapter);
+
+      uncheckGetStartedIfComplete();
     }
   }
 }


### PR DESCRIPTION
Fixes #5229 and will impact Acceptance testing of Keyman for Android

Currently on a clean installation, the "Get Started" menu will appear until the user unchecks the last box (onCheckedChanged() saves the state as a user preference)
![clean install](https://user-images.githubusercontent.com/7358010/199188715-1383551a-41e9-46f9-bafb-629fe91dd05c.png)

This PR changes it so if the user preference doesn't exist and the user completes steps 2-3
* Enable Keyman as a system-wide keyboard
* Set Keyman as default keyboard

the checkbox will automatically get unchecked and gets saved as a user preference.

Note, if the user has actively set the checkbox (which saves the user preference), this override won't happen.

## User Testing
* **Setup** - Clean installation of the PR build of Keyman for Android on emulator or device on English locale

* **TEST_CLEAN_INSTALL** - Verifies the "Get Started" menu defaults to appear on startup
1. Launch Keyman for Android
2. Verify the "Get Started" menu appears
3. Verify the checkbox *Show "Get Started" on startup* is checked
4. Exit the Keyman app
5. Re-launch Keyman for Android
6. Verify the "Get Started" menu appears

* **TEST_COMPLETED_UNCHECKS_GET_STARTED** - Verifies completing "Get Started" steps 2-3 automatically unchecks *Show "Get Started" on startup*
1. Launch Keyman for Android
2. On the "Get Started" menu, click **Enable Keyman as a system-wide keyboard**
3. Follow the Android system menu for enabling Keyman as a system-wide keyboard, then return to the Keyman app
4. On the "Get Started" menu, click **Set Keyman as default keyboard**
5. Follow the Android system menu for enabling Keyman as default keyboard, then return to the Keyman app
6. Verify the checkbox *Show "Get Started" on startup* is now unchecked
![completed steps 2-3](https://user-images.githubusercontent.com/7358010/199190495-ad5ea583-c268-4195-9fc2-f6480fcd616d.png)
7. Exit the app (the Android device automatically selects another keyboard as default keyboard)
8. Relaunch Keyman for Android
9. Verify the "Get Started" menu does not appear
10. From the menu, select "Get Started"
11. Verify the checkbox *Show "Get Started" on startup* is still un-checked (Step 3 is not checked because Android selected another keyboard as default keyboard)
![completed - restart](https://user-images.githubusercontent.com/7358010/199191038-6af15445-9c0d-4fa8-9dc0-d3f896a87f6a.png)

* **TEST_USER_PREFERENCE_SAVED** - Verifies user clicks on *Show "Get Started" on startup* persist and aren't overridden
1. Do a clean installation of Keyman for Android
2. Verify the "Get Started" menu appears
3. Verify the checkbox *Show "Get Started" on startup* is checked
4. Uncheck the *Show "Get Started" on startup* checkbox
5. Exit the app
6. Relaunch Keyman for Android
7. Verify the "Get Started" menu does not appear
8. From the menu, select "Get Started"
9. Select/tick the *Show "Get Started" on startup* checkbox
10. Exit the app
11. Relaunch Keyman for Android
12. Verify the "Get Started" menu does appear
13. On the "Get Started" menu, click **Enable Keyman as a system-wide keyboard**
14. Follow the Android system menu for enabling Keyman as a system-wide keyboard, then return to the Keyman app
15. On the "Get Started" menu, click **Set Keyman as default keyboard**
16. Follow the Android system menu for enabling Keyman as default keyboard, then return to the Keyman app
17. Verify the checkbox *Show "Get Started" on startup* remains checked (does not override to unchecked)
![no override](https://user-images.githubusercontent.com/7358010/199193003-128e8b49-7318-433e-adf9-29c39b24d7f4.png)


