### PR TITLE
feat(developer): improve err msg from Ajv 🙀

### DIFF
--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -62,7 +62,16 @@ export default class LDMLKeyboardXMLSourceFileReader {
     const schema = JSON.parse(schemaSource.toString('utf8'));
     const ajv = new Ajv();
     if(!ajv.validate(schema, source)) {
-      throw new Error(ajv.errorsText());
+      // Try to improve the message
+      if (ajv.errors?.length === 1) {
+        // Only one error. Try to improve the message.
+        const err = ajv.errors[0];
+        const { instancePath, keyword, params, message } = err;
+        throw new Error(`${instancePath}: ${keyword}: ${message} ${JSON.stringify(params||{})}`);
+      } else {
+        // Not a single error, so fall through to errorsText()
+        throw new Error(ajv.errorsText());
+      }
     }
   }
 


### PR DESCRIPTION
- make it clearer what the exact issue is by extracting params from the Ajv error

Old message: 

> ERROR 300007: The source file has an invalid structure: Error: data/keyboard must NOT have additional properties

New message: 

> ERROR 300007: The source file has an invalid structure: Error: /keyboard: additionalProperties: must NOT have additional properties {"additionalProperty":"layerMaps"}

err objects are documented https://ajv.js.org/api.html#error-objects so this is depending on stable API


@keymanapp-test-bot skip