### PR TITLE
fix(developer): Make Details and Build tabs scrollable

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.dfm
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.dfm
@@ -46,6 +46,7 @@ inherited frmModelEditor: TfrmModelEditor
         Color = 14211288
         ParentColor = False
         TabOrder = 0
+        OnMouseWheel = sbDetailsMouseWheel
         object panWordlists: TPanel
           AlignWithMargins = True
           Left = 4
@@ -82,7 +83,7 @@ inherited frmModelEditor: TfrmModelEditor
             Top = 200
             Width = 415
             Height = 13
-            Caption = 
+            Caption =
               'The editor was unable to parse the source file. Details shown he' +
               're are read-only.'
           end
@@ -313,22 +314,25 @@ inherited frmModelEditor: TfrmModelEditor
     object pageCompile: TTabSheet
       Caption = 'Build'
       ImageIndex = 1
-      object Panel1: TPanel
+      object sbCompile: TScrollBox
         Left = 0
         Top = 0
         Width = 619
         Height = 708
         Align = alClient
+        BevelInner = bvNone
         BevelOuter = bvNone
+        BorderStyle = bsNone
         Color = 14211288
-        ParentBackground = False
+        ParentColor = False
         TabOrder = 0
+        OnMouseWheel = sbDetailsMouseWheel
         object lblCongrats: TLabel
           Left = 10
           Top = 13
           Width = 333
           Height = 13
-          Caption = 
+          Caption =
             'The keyboard must be compiled in order to distribute or install ' +
             'it'
         end
@@ -373,7 +377,7 @@ inherited frmModelEditor: TfrmModelEditor
             Top = 72
             Width = 389
             Height = 26
-            Caption = 
+            Caption =
               'Optionally, select a compiled keyboard with which to test this l' +
               'exical model. Any keyboards already loaded in the web debugger w' +
               'ill also be available.'

--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -37,6 +37,7 @@ type
     pages: TLeftTabbedPageControl;
     pageDetails: TTabSheet;
     sbDetails: TScrollBox;
+    sbCompile: TScrollBox;
     panWordlists: TPanel;
     lblWordlists: TLabel;
     gridWordlists: TStringGrid;
@@ -47,7 +48,6 @@ type
     lblBasicInformation: TLabel;
     pageSource: TTabSheet;
     pageCompile: TTabSheet;
-    Panel1: TPanel;
     lblCongrats: TLabel;
     panBuildLexicalModel: TPanel;
     cbFormat: TComboBox;
@@ -120,6 +120,8 @@ type
     procedure cmdOpenProjectFolderClick(Sender: TObject);
     procedure cmdCopyDebuggerLinkClick(Sender: TObject);
     procedure chkLanguageUsesCasingClick(Sender: TObject);
+    procedure sbDetailsMouseWheel(Sender: TObject; Shift: TShiftState;
+      WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
   private
     type
       TWordlist = class
@@ -618,6 +620,14 @@ begin
     AllowChange := MoveSourceToDesign
   else
     AllowChange := MoveDesignToSource
+end;
+
+procedure TfrmModelEditor.sbDetailsMouseWheel(Sender: TObject;
+  Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint;
+  var Handled: Boolean);
+begin
+  (Sender as TScrollBox).VertScrollBar.Position := (Sender as TScrollBox).VertScrollBar.Position - WheelDelta div 2;
+  Handled := True;
 end;
 
 { --------- Details tab --------- }

--- a/developer/src/tike/child/UfrmKeymanWizard.dfm
+++ b/developer/src/tike/child/UfrmKeymanWizard.dfm
@@ -1049,42 +1049,65 @@ inherited frmKeymanWizard: TfrmKeymanWizard
         object pageTouchLayoutDesign: TTabSheet
           Caption = 'Design'
           ImageIndex = -1
+          ExplicitLeft = 0
+          ExplicitTop = 0
+          ExplicitWidth = 0
+          ExplicitHeight = 0
         end
         object pageTouchLayoutCode: TTabSheet
           Caption = 'Code'
           ImageIndex = -1
+          ExplicitLeft = 0
+          ExplicitTop = 0
+          ExplicitWidth = 0
+          ExplicitHeight = 0
         end
       end
     end
     object pageIncludeCodes: TTabSheet
       Caption = 'Char Codes'
       ImageIndex = 9
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
     end
     object pageKMWEmbedJS: TTabSheet
       Caption = 'Embedded JS'
       ImageIndex = 9
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
     end
     object pageKMWEmbedCSS: TTabSheet
       Caption = 'Embedded CSS'
       ImageIndex = 9
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
     end
     object pageKMWHelp: TTabSheet
       Caption = 'Embedded Help'
       ImageIndex = 9
+      ExplicitLeft = 0
+      ExplicitWidth = 0
+      ExplicitHeight = 0
     end
     object pageCompile: TTabSheet
       Caption = 'Build'
       ImageIndex = 1
-      object Panel1: TPanel
+      object sbCompile: TScrollBox
         Left = 0
         Top = 0
         Width = 950
         Height = 645
         Align = alClient
+        BevelInner = bvNone
         BevelOuter = bvNone
+        BorderStyle = bsNone
         Color = 14211288
-        ParentBackground = False
+        ParentColor = False
         TabOrder = 0
+        OnMouseWheel = sbDetailsMouseWheel
         object lblCongrats: TLabel
           Left = 10
           Top = 13

--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -204,6 +204,7 @@ type
     panWindowsLanguages: TPanel;
     panFeatures: TPanel;
     sbDetails: TScrollBox;
+    sbCompile: TScrollBox;
     gridFeatures: TStringGrid;
     cmdAddFeature: TButton;
     cmdRemoveFeature: TButton;
@@ -234,7 +235,6 @@ type
     lblISOLang: TLabel;
     editEthnologueCode: TEdit;
     cmdISOLang_Lookup: TButton;
-    Panel1: TPanel;
     lblCongrats: TLabel;
     panBuildWindows: TPanel;
     lblInstallHint: TLabel;
@@ -3198,8 +3198,7 @@ procedure TfrmKeymanWizard.sbDetailsMouseWheel(Sender: TObject;
   Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint;
   var Handled: Boolean);   // I4082
 begin
-  //inherited;
-  sbDetails.VertScrollBar.Position := sbDetails.VertScrollBar.Position - WheelDelta div 2;
+  (Sender as TScrollBox).VertScrollBar.Position := (Sender as TScrollBox).VertScrollBar.Position - WheelDelta div 2;
   Handled := True;
 end;
 

--- a/developer/src/tike/child/UfrmPackageEditor.dfm
+++ b/developer/src/tike/child/UfrmPackageEditor.dfm
@@ -716,16 +716,19 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageDetails: TTabSheet
       Caption = 'Details'
       ImageIndex = 2
-      object Panel2: TPanel
+      object sbDetails: TScrollBox
         Left = 0
         Top = 0
         Width = 872
         Height = 622
         Align = alClient
+        BevelInner = bvNone
         BevelOuter = bvNone
+        BorderStyle = bsNone
         Color = 14211288
-        ParentBackground = False
+        ParentColor = False
         TabOrder = 0
+        OnMouseWheel = sbDetailsMouseWheel
         DesignSize = (
           872
           622)
@@ -1123,16 +1126,19 @@ inherited frmPackageEditor: TfrmPackageEditor
     object pageCompile: TTabSheet
       Caption = 'Compile'
       ImageIndex = 1
-      object Panel4: TPanel
+      object sbCompile: TScrollBox
         Left = 0
         Top = 0
         Width = 872
         Height = 622
         Align = alClient
+        BevelInner = bvNone
         BevelOuter = bvNone
+        BorderStyle = bsNone
         Color = 14211288
-        ParentBackground = False
+        ParentColor = False
         TabOrder = 0
+        OnMouseWheel = sbDetailsMouseWheel
         object Label13: TLabel
           Left = 15
           Top = 48

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -91,7 +91,6 @@ type
     memoFileDetails: TMemo;
     cmdOpenFile: TButton;
     cmdOpenContainingFolder: TButton;
-    Panel2: TPanel;
     lblKMPImageFile: TLabel;
     lblKMPImageSize: TLabel;
     lblReadme: TLabel;
@@ -104,6 +103,8 @@ type
     lblStep2a: TLabel;
     lblPackageDetails: TLabel;
     lblPackageRequiredInformation: TLabel;
+    sbDetails: TScrollBox;
+    sbCompile: TScrollBox;
     lblVersionHint: TLabel;
     cbReadMe: TComboBox;
     editInfoName: TEdit;
@@ -132,7 +133,6 @@ type
     editStartMenuDescription: TEdit;
     editStartMenuParameters: TEdit;
     cbStartMenuProgram: TComboBox;
-    Panel4: TPanel;
     Label13: TLabel;
     lblCompilePackage: TLabel;
     pageKeyboards: TTabSheet;
@@ -269,6 +269,8 @@ type
     procedure cmdOpenProjectFolderClick(Sender: TObject);
     procedure cmdSendURLsToEmailClick(Sender: TObject);
     procedure cmdCopyDebuggerLinkClick(Sender: TObject);
+    procedure sbDetailsMouseWheel(Sender: TObject; Shift: TShiftState;
+      WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -1752,6 +1754,14 @@ begin
   panBuildDesktop.Visible := FHasDesktopTarget;
   panBuildWindowsInstaller.Visible := FHasDesktopTarget;
   panBuildMobile.Visible := FHasMobileTarget;
+end;
+
+procedure TfrmPackageEditor.sbDetailsMouseWheel(Sender: TObject;
+  Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint;
+  var Handled: Boolean);
+begin
+  (Sender as TScrollBox).VertScrollBar.Position := (Sender as TScrollBox).VertScrollBar.Position - WheelDelta div 2;
+  Handled := True;
 end;
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5238.

The Details and Build tabs have fixed positional content in the Keyboard Editor, Model Editor, and Package Editor. Sizing the window too small can cause content to be outside the bounds of the tab. This patch moves these tabs into scrollboxes (except for Details tabs on Keyboard and Model editors, which were already in scrollboxes). The remaining tabs have resizable content. The tabs will still become fairly unusable if they become too small, but this should be less of a problem than before.

# User Testing

For all these tests, make sure the Keyman Developer window is not maximized, or alternatively, that the Message window is large enough that it causes scrollbars to appear on tabs.

* **TEST_KEYBOARD_DETAILS_TAB:** Verify that the Keyboard Editor Details tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.
* **TEST_KEYBOARD_BUILD_TAB:** Verify that the Keyboard Editor Build tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.
* **TEST_MODEL_DETAILS_TAB:** Verify that the Model Editor Details tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.
* **TEST_MODEL_BUILD_TAB:** Verify that the Model Editor Build tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.
* **TEST_PACKAGE_DETAILS_TAB:** Verify that the Package Editor Details tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.
* **TEST_PACKAGE_BUILD_TAB:** Verify that the Package Editor Build tab gets a vertical scrollbar when its content does not fit in the visible area and is scrollable both with the scrollbar and with the mouse wheel on an empty area of the tab.