### PR TITLE
fix(developer): publish `@keymanapp/keyman-version` to npm

### DIFF
--- a/common/web/keyman-version/.npmignore
+++ b/common/web/keyman-version/.npmignore
@@ -1,0 +1,5 @@
+build/index.tsbuildinfo
+build/tsconfig.esm.tsbuildinfo
+build.sh
+index.ts
+tsconfig.json

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -19,7 +19,12 @@ cd "$THIS_SCRIPT_PATH"
 
 ################################ Main script ################################
 
-builder_describe "Build the include script for current Keyman version" configure clean build
+builder_describe "Build the include script for current Keyman version" \
+  configure \
+  clean \
+  build \
+  publish \
+  --dry-run
 
 builder_describe_outputs \
   configure "/node_modules" \
@@ -67,4 +72,10 @@ if builder_start_action build; then
   fi
 
   builder_finish_action success build
+fi
+
+if builder_start_action publish; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_npm
+  builder_finish_action success publish
 fi

--- a/developer/src/kmlmc/.npmignore
+++ b/developer/src/kmlmc/.npmignore
@@ -1,6 +1,9 @@
 # Ignore files required only in development.
-build.sh
-bundle.sh
+dist-tests/*
 source/*
 tests/*
+build.sh
+bundle.sh
+Makefile
 tsconfig.json
+tsconfig.tsbuildinfo

--- a/developer/src/kmlmc/build.sh
+++ b/developer/src/kmlmc/build.sh
@@ -120,4 +120,9 @@ if (( should_publish )); then
   # See `npm help publish` for more details.
   echo "Publishing $DRY_RUN npm package with tag $npm_dist_tag"
   npm publish $DRY_RUN --access public --tag $npm_dist_tag || fail "Could not publish $npm_dist_tag release."
+
+  # For now, kmlmc will have responsibility for publishing keyman-version. In
+  # the future, we should probably have a top-level npm publish script that
+  # publishes all modules for a given release version
+  "$KEYMAN_ROOT/common/web/keyman-version/build.sh" publish $DRY_RUN
 fi


### PR DESCRIPTION
Fixes #7582.

Because of https://github.com/npm/cli/issues/3466, we must publish our internal dependency `@keymanapp/keyman-version`. This change adds a common builder function builder_publish_to_npm in build-utils-ci.inc.sh to help with that task, which should be adopted by other scripts that need to publish to npm, in the future.

For now, responsibility for publishing keyman-version is delegated to kmlmc. In the future, we will move this to a single top-level build action that publishes all npm modules across the entire repo for the given version.

We will need to verify whether this is working correctl when we publish the next beta release post-merge. The change will percolate down to alpha with our normal beta-to-alpha merge process.

@keymanapp-test-bot skip