### PR TITLE
chore: Add #7554 to HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 * fix(developer): handle LControl being set by Windows when AltGr pressed (#7537)
 * fix(android/engine): Dismiss subkeys when hiding keyboard (#7562)
+* fix(android/engine): Dismiss key previews and subkeys on multi-touch (#7554)
 * fix(ios): iPad was not recognised as tablet device (#7576)
 * fix(developer): Use US base layout for debugger (#7538)
 


### PR DESCRIPTION
Due to the order that I merged #7554 and #7562 to stable-15.0, the change from #7554 got missed in HISTORY.md

(both are in the 15.0.272 stable release)

@keymanapp-test-bot skip
