### PR TITLE
fix(common): always define dry_run variable

### DIFF
--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -77,7 +77,7 @@ function builder_pull_has_label() {
 # ```
 #
 function builder_publish_to_npm() {
-  local dist_tag=$TIER dry_run
+  local dist_tag=$TIER dry_run=
 
   if [[ $TIER == stable ]]; then
     dist_tag=latest


### PR DESCRIPTION
Follow-up for #7595 after build failed with:

```
[17:44:32][Step 8/8] ## [common/web/keyman-version] publish starting...
[17:44:34][Step 8/8] v16.0.95-beta
[17:44:34][Step 8/8] /c/BuildAgent/work/deb663ed6681f452/keyman/resources/build/build-utils-ci.inc.sh: line 101: dry_run: unbound variable
[17:44:34][Step 8/8] ## [common/web/keyman-version] publish failed
```

Relates to #7582.

@keymanapp-test-bot skip