### PR TITLE
feat(web): Custom layer targets for Shift double-tap

### DIFF
--- a/web/source/osk/browser/pendingMultiTap.ts
+++ b/web/source/osk/browser/pendingMultiTap.ts
@@ -18,6 +18,7 @@ namespace com.keyman.osk {
     private _state: PendingMultiTapState = PendingMultiTapState.Waiting;
     private _timeout: Promise<void>;
     private cancelDelayFactor = 125; // 125msec * count
+    private _destinationLayerId;
 
     public get timeout() {
       return this._timeout;
@@ -39,6 +40,12 @@ namespace com.keyman.osk {
       this.vkbd = vkbd;
       this.count = count;
       this.baseKey = baseKey;
+
+      this._destinationLayerId = 'caps';
+      let multitap = baseKey?.key?.spec?.['multitap'];
+      if(multitap?.length && multitap[0]?.['nextlayer']) {
+        this._destinationLayerId = multitap[0]['nextlayer'];
+      }
 
       const _this = this;
       this._timeout = new Promise<void>(function(resolve) {
@@ -112,7 +119,7 @@ namespace com.keyman.osk {
       // TODO: generalize this with double-tap key properties in touch layout
       //       description.
       let e = text.KeyEvent.constructNullKeyEvent(this.vkbd.device);
-      e.kNextLayer = 'caps';
+      e.kNextLayer = this._destinationLayerId;
       e.Lstates = text.Codes.stateBitmasks.CAPS;
       e.LmodifierChange = true;
       PreProcessor.raiseKeyEvent(e);


### PR DESCRIPTION
Applies proposed feature https://community.software.sil.org/t/testing-caps-on-touch/6849/5:

1. A `caps` layer must still exist in the keyboard.
2. If there is at least one multitap subkey defined on the Shift key on the active layer, then the `nextlayer` property of the first multitap subkey for the Shift key will be used instead of the default `caps`.
3. This does not change the behavior of the Shift key otherwise.

For example, the following defines a valid multitap key on Shift on the `rightalt` layer to switch to a custom extended `rightalt-shift-caps` layer.

```
  {
    "id": "K_SHIFT",
    "text": "*Shift*",
    "width": 150,
    "sp": 1,
    "nextlayer": "rightalt-shift",
    "layer": "default",
    "multitap": [
      {
        "text": "",
        "id": "T_new_694",
        "sp": "1",
        "nextlayer": "rightalt-shift-caps"
      }
    ]
  },
```

This does not implement any other multitap functionality. It just allows the keyboard developer to specify a target layer for a given double-tap.

This change should be forward-compatible with the multitap gesture support.

@keymanapp-test-bot skip

We'll do some testing on this with @MattGyverLee once this hits beta.