### PR TITLE
fix(android/engine): Reload keyboard after switchToNextKeyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -2132,7 +2132,7 @@ public final class KMManager {
     globeKeyState = state;
   }
 
-  public static void updateSuggestionBanner(String languageID, boolean inAppKeyboardChanged, boolean systemKeyboardChanged) {
+  private static void updateSuggestionBanner(String languageID, boolean inAppKeyboardChanged, boolean systemKeyboardChanged) {
     toggleSuggestionBanner(languageID, inAppKeyboardChanged, systemKeyboardChanged);
     registerAssociatedLexicalModel(languageID);
   }

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java
@@ -1541,9 +1541,7 @@ public final class KMManager {
       result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
     }
 
-    //toggleSuggestionBanner(languageID, result1, result2);
-    //registerAssociatedLexicalModel(languageID);
-    //updateSuggestionBanner(languageID, result1, result2);
+    updateSuggestionBanner(languageID, result1, result2);
     return (result1 || result2);
   }
 
@@ -1558,7 +1556,6 @@ public final class KMManager {
       result2 = SystemKeyboard.setKeyboard(packageID, keyboardID, languageID, keyboardName, languageName, kFont, kOskFont);
 
     updateSuggestionBanner(languageID, result1, result2);
-
     return (result1 || result2);
   }
 
@@ -1583,10 +1580,9 @@ public final class KMManager {
     }
 
     if (kbInfo != null) {
-      prepareKeyboardSwitch(kbInfo.getPackageID(), kbInfo.getKeyboardID(), kbInfo.getLanguageID(), kbInfo.getKeyboardName());
-      //setKeyboard(kbInfo);
+      setKeyboard(kbInfo);
+      updateSuggestionBanner(kbInfo.getLanguageID(), true, true);
     }
-    KMManager.updateSuggestionBanner(kbInfo.getLanguageID(), true, true);
 
     if (KMManager.InAppKeyboard != null) {
       KMManager.InAppKeyboard.loadKeyboard();

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -342,10 +342,13 @@ public final class KeyboardPickerActivity extends BaseActivity {
     String kbId = kbInfo.getKeyboardID();
     String langId = kbInfo.getLanguageID();
     String kbName = kbInfo.getKeyboardName();
-    if(aPrepareOnly)
+    if(aPrepareOnly) {
       KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName);
-    else
+    } else {
       KMManager.setKeyboard(kbInfo);
+    }
+
+    KMManager.updateSuggestionBanner(langId, true, true);
   }
 
   protected static boolean addKeyboard(Context context, Keyboard keyboardInfo) {

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -342,13 +342,10 @@ public final class KeyboardPickerActivity extends BaseActivity {
     String kbId = kbInfo.getKeyboardID();
     String langId = kbInfo.getLanguageID();
     String kbName = kbInfo.getKeyboardName();
-    if(aPrepareOnly) {
+    if(aPrepareOnly)
       KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName);
-    } else {
+    else
       KMManager.setKeyboard(kbInfo);
-    }
-
-    KMManager.updateSuggestionBanner(langId, true, true);
   }
 
   protected static boolean addKeyboard(Context context, Keyboard keyboardInfo) {


### PR DESCRIPTION
Fixes #7086
In the reported issue, the OSK has inconsistent sizes when switching from the Keyboard Picker menu vs the globe key (switchToNextKeyboard), which can result in visual artifacts of black lines.

This PR tidies up the two methods of switching keyboards. (Note, when Keyboard picker menu exits, it reloads the keyboard with onPause())

https://github.com/keymanapp/keyman/blob/bfc87d0ea1903002af79062bd43157180e8c6c7e/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java#L265-L274

* Add that block to switchToNextKeyboard(). Though it results in a "busier" keyboard switch, the OSK is correct
* Add utility method updateSuggestionBanner() so that the suggestion banner is consistently handled (needs to toggle and register associated model)

## User Testing
* **Setup**
1. Install the PR build of Keyman for Android on an Android device/emulator
2. From the settings menu, install a keyboard that has a dictionary (e.g. khmer_angkor). Allow sufficient time for the dictionary to download in the background.
3. From the settings menu, install a keyboard that doesn't have a dictionary (e.g. basic_kbdfr)

* **TEST_BANNER_TOGGLES** - Verifies suggestion banner appears only when keyboard has dictionary
1. Launch the Keyman app and dismiss the "Get Started" menu
2. Short-press the globe key to switch keyboard and verify:
  * keyboards that have a dictionary show the suggestion banner (sil_euro_latin, khmer_angkor)
  * keyboards that don't have a dictionary don't show the suggestion banner (basic_kbdfr)
3. Long-press the globe key to switch keyboard with the Keyboard Picker menu and and exit the picker to verify:
  *  keyboards that have a dictionary show the suggestion banner (sil_euro_l;atin, khmer_angkor)
  *  keyboards that don't have a dictionary don't show the suggestion banner (basic_kbdfr) 

* **TEST_BANNER_AND_ROTATE** - Verifies black lines from the report issue don't appear
1. Launch the Keyman app in Portrait orientation
2. Short-press the globe key to switch keyboards a few times
3. Rotate the device to Landscape orientation (You may need to ensure the device can auto-rotate, and may need to press the icon on the status bar to rotate the screen)
4. Long-press the globe key to switch keyboard with the Keyboard Picker menu
5. Rotate the device back to Portrait orientation  
6. Short-press the globe key to switch keyboards a few times
7. Verify black lines do not appear on the suggestion banner
