### PR TITLE
fix(android/engine): Check temporary kmp file is valid

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -767,6 +767,9 @@ public class PackageProcessor {
       return specs;
     }
     JSONObject newInfoJSON = loadPackageInfo(tempPath);
+    if (newInfoJSON == null) {
+      return specs;
+    }
     String packageId = getPackageID(path);
 
     // For lexical model packages, lexical model version is determined by the package version


### PR DESCRIPTION
Fixes some of the Sentry crashes in #6862 where the temporary kmp file during a package installation suddenly isn't available.

We still haven't found what can cause the temporary kmp file to be removed...

@keymanapp-test-bot skip
