### PR TITLE
fix(developer): update monaco editor to 0.15.6

### DIFF
--- a/developer/src/tike/xml/app/editor/editor.js
+++ b/developer/src/tike/xml/app/editor/editor.js
@@ -149,15 +149,15 @@ async function loadSettings() {
   //
 
   context.editUndo = function() {
-    editor.model.undo();
+    editor.getModel().undo();
   };
 
   context.editRedo = function() {
-    editor.model.redo();
+    editor.getModel().redo();
   };
 
   context.editSelectAll = function() {
-    editor.setSelection(editor.model.getFullModelRange());
+    editor.setSelection(editor.getModel().getFullModelRange());
   };
 
   //
@@ -345,7 +345,7 @@ async function loadSettings() {
 
       monaco.editor.setTheme(themeName);
 
-      editor.model.updateOptions({
+      editor.getModel().updateOptions({
         insertSpaces:
           !_settings.useTabChar && // user pref
           !isWordlistTsv, // We always use tabs for TSV files
@@ -418,10 +418,10 @@ async function loadSettings() {
   var updateState = function () {
     let s = editor.getSelection();
     command(s.isEmpty() ? 'no-selection' : 'has-selection');
-    command(editor.model.canUndo() ? 'undo-enable' : 'undo-disable');
-    command(editor.model.canRedo() ? 'redo-enable' : 'redo-disable');
+    command(editor.getModel().canUndo() ? 'undo-enable' : 'undo-disable');
+    command(editor.getModel().canRedo() ? 'redo-enable' : 'redo-disable');
 
-    var n = editor.model.getValueInRange(s).length;
+    var n = editor.getModel().getValueInRange(s).length;
     if (editor.getSelection().getDirection() == monaco.SelectionDirection.LTR) n = -n;
     command('location,' + (s.startLineNumber-1) + ',' + (s.startColumn-1) + ',' + (s.endLineNumber-1) + ',' + (s.endColumn-1) + ',' + n);
     var token = getTokenAtCursor();
@@ -431,7 +431,7 @@ async function loadSettings() {
   };
 
   var getTokenAtCursor = function () {
-    var txt = editor.model.getValueInRange(editor.getSelection());
+    var txt = editor.getModel().getValueInRange(editor.getSelection());
     if (txt != '') {
       // We'll always return the first 100 characters of the selection and not
       // do any manipulation here.
@@ -442,7 +442,7 @@ async function loadSettings() {
       // Get the token under the cursor
       var c = editor.getSelection();
       try {
-        var line = editor.model.getLineContent(c.positionLineNumber);
+        var line = editor.getModel().getLineContent(c.positionLineNumber);
       } catch(e) {
         // In some situations, e.g. deleting a selection at the end of the document,
         // the selected line may be past the end of the document for a moment

--- a/developer/src/tike/xml/app/package-lock.json
+++ b/developer/src/tike/xml/app/package-lock.json
@@ -6,20 +6,20 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "monaco-editor": "0.14.3"
+        "monaco-editor": "0.15.6"
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.14.3.tgz",
-      "integrity": "sha512-RhaO4xXmWn/p0WrkEOXe4PoZj6xOcvDYjoAh0e1kGUrQnP1IOpc0m86Ceuaa2CLEMDINqKijBSmqhvBQnsPLHQ=="
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.15.6.tgz",
+      "integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
     }
   },
   "dependencies": {
     "monaco-editor": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.14.3.tgz",
-      "integrity": "sha512-RhaO4xXmWn/p0WrkEOXe4PoZj6xOcvDYjoAh0e1kGUrQnP1IOpc0m86Ceuaa2CLEMDINqKijBSmqhvBQnsPLHQ=="
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.15.6.tgz",
+      "integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
     }
   }
 }

--- a/developer/src/tike/xml/app/package.json
+++ b/developer/src/tike/xml/app/package.json
@@ -7,6 +7,6 @@
   },
   "homepage": "https://keyman.com/",
   "dependencies": {
-    "monaco-editor": "0.14.3"
+    "monaco-editor": "0.15.6"
   }
 }


### PR DESCRIPTION
Updates Monaco editor from 0.14.3 to 0.15.6, incorporating microsoft/vscode#57617 to fix #7625.

The changes to editor.js are required because `editor.model` was not a public property and we should have been using `editor.getModel()` all along.

I have not updated to the latest version of monaco (0.35.1 at time of writing this), as I wish to minimize the changeset during beta.

While I prefer not to update dependencies in beta, this seems to be a fairly clean update. Will monitor and can roll back if it leads to instability.

# User Testing

* **TEST_FIXES_7625:** In a .kmn source file for a new basic keyboard project, press F12 to open the Developer console. Return to the editor and type `V` on a new line. A popup should appear with, e.g. `VERSION`, `VISUALKEYBOARD`. Select the second item in the list with the mouse. No errors should be raised in the Developer console. (In previous versions, an error would be shown in the Developer console.)
* **TEST_EDITOR_REGRESSION:** Test various aspects of the text editor integration into Keyman Developer.

  Notes:
  * Press F12 when opening the editor in each case to display the Developer console so you can capture any errors that arise.
  * Test all the Edit menu items, to verify that they continue to work correctly.
  * Compare any issues found with previous beta release to verify that they are new to this version.
  * Try using various text editor views:
    * the keyboard source editor
    * visual keyboard source view
    * touch layout source view
    * package source editor
    * model source editor
    * model wordlist source editor
    * Markdown source editor (open README.md in the Distribution tab).