### PR TITLE
fix(developer): URL parameters should be UTF-8

### DIFF
--- a/common/windows/delphi/web/Keyman.System.HttpServer.Base.pas
+++ b/common/windows/delphi/web/Keyman.System.HttpServer.Base.pas
@@ -23,12 +23,33 @@ type
       AResponseInfo: TIdHTTPResponseInfo);
   end;
 
+function CrackUTF8ZeroExtendedString(const p: string): string;
+
 implementation
 
 uses
   IdGlobalProtocols,
 
   System.SysUtils;
+
+function CrackUTF8ZeroExtendedString(const p: string): string;
+var
+  s: RawByteString;
+  i: Integer;
+begin
+  // Indy's UTF8 handling of URLs is *completely* broken.
+  // We may need to check this with updated versions of Delphi
+{$IFNDEF VER330}
+  ERROR! Check if this is still needed with Delphi update
+{$ENDIF}
+
+  SetLength(s, p.Length);
+  for i := 1 to p.Length do
+  begin
+    s[i] := AnsiChar(Ord(p[i]));
+  end;
+  Result := UTF8ToString(s);
+end;
 
 { TBaseHttpResponder }
 

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
@@ -102,7 +102,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := ARequestInfo.Params.Values['path'];
+    path := UTF8ToString(AnsiString(ARequestInfo.Params.Values['path']));
 
     if (Path <> '') and (not FileExists(path) or not SameText(ExtractFileExt(path), Ext_ProjectSource)) then
     begin
@@ -132,7 +132,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := ARequestInfo.Params.Values['path'];
+    path := UTF8ToString(AnsiString(ARequestInfo.Params.Values['path']));
 
     if not FileExists(path) or (
       not SameText(ExtractFileExt(path), '.ico') and

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
@@ -102,7 +102,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := UTF8ToString(AnsiString(ARequestInfo.Params.Values['path']));
+    path := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['path']);
 
     if (Path <> '') and (not FileExists(path) or not SameText(ExtractFileExt(path), Ext_ProjectSource)) then
     begin
@@ -132,7 +132,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := UTF8ToString(AnsiString(ARequestInfo.Params.Values['path']));
+    path := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['path']);
 
     if not FileExists(path) or (
       not SameText(ExtractFileExt(path), '.ico') and

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -96,7 +96,7 @@ begin
   if ARequestInfo.Document = '/app/source/file' then
   begin
     // TODO: We should be passing a token to the browser for future POST security
-    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
 
     if ARequestInfo.CommandType = hcGET then
     begin
@@ -112,12 +112,12 @@ begin
   else if ARequestInfo.Document = '/app/source/toucheditor' then
   begin
     // Respond files?
-    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
     RespondTouchEditor(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document = '/app/source/toucheditor/state' then
   begin
-    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
     RespondTouchEditorState(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document.StartsWith('/app/source/toucheditor/lib/') then
@@ -147,7 +147,7 @@ begin
   end
   else if ARequestInfo.CommandType = hcPOST then
   begin
-    FData := UTF8ToString(AnsiString(ARequestInfo.Params.Values['State']));
+    FData := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['State']);
     RegisterSource(AFilename + '#state', FData, True);
   end;
 end;

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -96,7 +96,7 @@ begin
   if ARequestInfo.Document = '/app/source/file' then
   begin
     // TODO: We should be passing a token to the browser for future POST security
-    Filename := ARequestInfo.Params.Values['Filename'];
+    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
 
     if ARequestInfo.CommandType = hcGET then
     begin
@@ -112,12 +112,12 @@ begin
   else if ARequestInfo.Document = '/app/source/toucheditor' then
   begin
     // Respond files?
-    Filename := ARequestInfo.Params.Values['Filename'];
+    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
     RespondTouchEditor(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document = '/app/source/toucheditor/state' then
   begin
-    Filename := ARequestInfo.Params.Values['Filename'];
+    Filename := UTF8ToString(AnsiString(ARequestInfo.Params.Values['Filename']));
     RespondTouchEditorState(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document.StartsWith('/app/source/toucheditor/lib/') then
@@ -147,7 +147,7 @@ begin
   end
   else if ARequestInfo.CommandType = hcPOST then
   begin
-    FData := ARequestInfo.Params.Values['State'];
+    FData := UTF8ToString(AnsiString(ARequestInfo.Params.Values['State']));
     RegisterSource(AFilename + '#state', FData, True);
   end;
 end;


### PR DESCRIPTION
Fixes #7628.

Indy components do not treat URLs as UTF-8. Our legacy `URLEncode()` function (sourced from Indy components) was the same. Discovered we needed to fixup the parsing of URLs as well as the construction of them; there may be other places we need to fix, although I did do a search for the relevant types in TIKE source.

# User Testing

* **TEST_NON_ASCII_PATHS:** Create a folder that contains non-ASCII letters, e.g. Khmer, Tamil or European diacritics. Create a new keyboard project within that folder. In the Project view, press F12 to verify that no errors are raised in the Developer console. Do a basic regression test on working with the keyboard project, including editing, compiling.