### PR TITLE
fix(web): avoid reset for touch system keyboard

### DIFF
--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -94,15 +94,15 @@ namespace com.keyman.text {
 
       try {
         if(kbdMismatch) {
-          // This will force-reset the context per our setter above.
-          this.activeKeyboard = keyEvent.srcKeyboard;
+          // Avoid force-reset of context per our setter above.
+          this.keyboardInterface.activeKeyboard = keyEvent.srcKeyboard;
         }
 
         return this._processKeyEvent(keyEvent, outputTarget);
       } finally {
         if(kbdMismatch) {
           // Restore our "current" activeKeyboard to its setting before the mismatching KeyEvent.
-          this.activeKeyboard = trueActiveKeyboard;
+          this.keyboardInterface.activeKeyboard = trueActiveKeyboard;
         }
       }
     }

--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -49,7 +49,7 @@ namespace com.keyman.text {
 
     /**
      * Indicates the device (platform) to be used for non-keystroke events,
-     * such as those sent to `begin postkeystroke` and `begin newcontext` 
+     * such as those sent to `begin postkeystroke` and `begin newcontext`
      * entry points.
      */
     contextDevice: utils.DeviceSpec;
@@ -731,7 +731,7 @@ namespace com.keyman.text {
       } else if(KeyboardProcessor.isModifier(Levent)) {
         this.activeKeyboard.notify(Levent.Lcode, outputTarget, isKeyDown ? 1 : 0);
         // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-        if(!this.contextDevice.touchable) {
+        if(!Levent.device.touchable) {
           return this._UpdateVKShift(Levent); // I2187
         } else {
           return true;
@@ -740,7 +740,7 @@ namespace com.keyman.text {
 
       if(Levent.LmodifierChange) {
         this.activeKeyboard.notify(0, outputTarget, 1);
-        if(!this.contextDevice.touchable) {
+        if(!Levent.device.touchable) {
           this._UpdateVKShift(Levent);
         }
       }


### PR DESCRIPTION
Fixes #7636.

When using the touch 'system' keyboard, the modifier keys are reset by the kbdMismatch logic introduced in #7543. This is evident in the web debugger of Keyman Developer, where the system keyboard is easily accessible.

This maintains the fix from #7543, but removes the `resetContext()` side-effect. That may have negative consequences for the original fix, but given the original fix is targeted for the rare keyboard switch scenario, it seems manageable.

I am not convinced that this is the most appropriate place to fix the problem. There may be a better fix in terms of when `activeKeyboard=null`, which is what is triggering the `kbdMismatch` flag, because internally there is a implicit synthetic system keyboard that KMW uses in this situation, and that is what is being switched to by `kbdMismatch` logic. But hopefully this gives a good discussion starting point!

Note that layer switch keys on the 'system' keyboard triggered an error in KMW 15 in the web debugger and also did not work.

The second commit may not be necessary, but the code in question seemed wrong:

> The doModifierPress function was testing against the 'actual' device rather than the virtual device, which meant that in the web debugger on a desktop, testing a touch device, it was effectively testing against the desktop device data rather than the simulated touch device data.
>
> I did not observe any significant differences in behaviour between the two modes. So I am not 100% confident that this change is necessary. But it is a little concerning that there was a mismatch here.

# User Testing

* **TEST_DEBUGGER_MOBILE:** Verify that the web debugger still works correctly with layer switch keys when testing a touch keyboard.
* **TEST_DEBUGGER_DESKTOP:** Verify that the web debugger still works correctly with modifier keys when testing a desktop keyboard.