### PR TITLE
fix(core): `save()` should be on internal kmx action queue

### DIFF
--- a/core/src/kmx/kmx_actions.h
+++ b/core/src/kmx/kmx_actions.h
@@ -30,8 +30,9 @@ typedef struct
 #define QIT_BACK    7
 #define QIT_CAPSLOCK  8
 #define QIT_INVALIDATECONTEXT 9
+#define QIT_SAVEOPT 10
 
-#define QIT_MAX     9
+#define QIT_MAX     10
 
 #define QVK_EXTENDED 0x00010000 // Flag for QIT_VKEYDOWN to indicate an extended key
 #define QVK_KEYMASK  0x0000FFFF

--- a/core/src/kmx/kmx_options.cpp
+++ b/core/src/kmx/kmx_options.cpp
@@ -5,7 +5,6 @@
 #include "processor.hpp"
 #include "kmx_processevent.h"
 #include <option.hpp>
-#include <state.hpp>
 
 using namespace km::kbp;
 using namespace kmx;
@@ -204,7 +203,7 @@ void KMX_Options::Reset(abstract_processor & ap, int nStoreToReset)
 }
 
 
-void KMX_Options::Save(state & state, int nStoreToSave)
+void KMX_Options::Save(kmx::KMX_Actions & m_actions, int nStoreToSave)
 {
   assert(_kp != NULL);
   assert(_kp->Keyboard != NULL);
@@ -214,8 +213,5 @@ void KMX_Options::Save(state & state, int nStoreToSave)
 
   auto const & rStoreToSave = _kp->Keyboard->dpStoreArray[nStoreToSave];
   if (rStoreToSave.dpName == nullptr) return;
-
-  state.processor().persisted_store()[rStoreToSave.dpName] = rStoreToSave.dpString;
-  state.actions().push_persist(
-    option{KM_KBP_OPT_KEYBOARD, rStoreToSave.dpName, rStoreToSave.dpString});
+  m_actions.QueueAction(QIT_SAVEOPT, nStoreToSave);
 }

--- a/core/src/kmx/kmx_options.cpp
+++ b/core/src/kmx/kmx_options.cpp
@@ -203,7 +203,7 @@ void KMX_Options::Reset(abstract_processor & ap, int nStoreToReset)
 }
 
 
-void KMX_Options::Save(kmx::KMX_Actions & m_actions, int nStoreToSave)
+void KMX_Options::Save(int nStoreToSave)
 {
   assert(_kp != NULL);
   assert(_kp->Keyboard != NULL);

--- a/core/src/kmx/kmx_options.h
+++ b/core/src/kmx/kmx_options.h
@@ -41,7 +41,7 @@ public:
   void Set(int nStoreToSet, std::u16string const &value);
   void Set(std::u16string const &key, std::u16string const &value);
   void Reset(abstract_processor &, int nStoreToReset);
-  void Save(kmx::KMX_Actions &m_actions, int nStoreToSave);
+  void Save(int nStoreToSave);
 
   void SetInternalDebugItems(KMX_DebugItems *debug_items) {
     m_debug_items = debug_items;

--- a/core/src/kmx/kmx_options.h
+++ b/core/src/kmx/kmx_options.h
@@ -14,7 +14,6 @@ namespace km {
 namespace kbp {
 
 class abstract_processor;
-class state;
 
 namespace kmx {
 
@@ -42,7 +41,7 @@ public:
   void Set(int nStoreToSet, std::u16string const &value);
   void Set(std::u16string const &key, std::u16string const &value);
   void Reset(abstract_processor &, int nStoreToReset);
-  void Save(state & state, int nStoreToSave);
+  void Save(kmx::KMX_Actions &m_actions, int nStoreToSave);
 
   void SetInternalDebugItems(KMX_DebugItems *debug_items) {
     m_debug_items = debug_items;

--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -524,7 +524,7 @@ int KMX_ProcessEvent::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR end
       case CODE_SAVEOPT:
         p++;
         n1 = *p - 1;
-        GetOptions()->Save(*m_kbp_state, n1);
+        GetOptions()->Save(m_actions, n1);
         break;
       case CODE_IFSYSTEMSTORE:
         p+=3;

--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -524,7 +524,7 @@ int KMX_ProcessEvent::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR end
       case CODE_SAVEOPT:
         p++;
         n1 = *p - 1;
-        GetOptions()->Save(m_actions, n1);
+        GetOptions()->Save(n1);
         break;
       case CODE_IFSYSTEMSTORE:
         p+=3;

--- a/core/tests/unit/kmnkbd/debug_api.cpp
+++ b/core/tests/unit/kmnkbd/debug_api.cpp
@@ -375,6 +375,38 @@ void test_set_option() {
   }));
 }
 
+/**
+ * Test 8: save option
+ */
+void test_save_option() {
+  setup("023 - options with save.kmx");
+  DEBUG_GROUP gp = {u"Main"};
+  DEBUG_KEY kp1 = { '2', /*line*/19, };
+  // DEBUG_STORE sp = {0, u"foo", u"0"};
+  km_kbp_option_item opt = {u"foo", u"0", KM_KBP_OPT_KEYBOARD};
+
+  try_status(km_kbp_state_debug_set(test_state, 1));
+
+  // '2' -> save_option
+
+  try_status(km_kbp_process_event(test_state, KM_KBP_VKEY_2, 0, 1));
+  assert(debug_items(test_state, {
+    km_kbp_state_debug_item{KM_KBP_DEBUG_BEGIN, KM_KBP_DEBUG_FLAG_UNICODE, {KM_KBP_VKEY_2, 0, '2'}},
+    km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_ENTER, 0, {}, {u"", &gp}},
+
+      km_kbp_state_debug_item{KM_KBP_DEBUG_RULE_ENTER, 0, {}, {u"", &gp, &kp1, {0xFFFF}}},
+      km_kbp_state_debug_item{KM_KBP_DEBUG_RULE_EXIT, 0, {}, {u"", &gp, &kp1, {0xFFFF}, 1}},
+
+    km_kbp_state_debug_item{KM_KBP_DEBUG_GROUP_EXIT, 0, {}, {u"", &gp, nullptr, {}, 1}},
+    km_kbp_state_debug_item{KM_KBP_DEBUG_END, 0, {}, {u"", nullptr, nullptr, {}, 1}},
+  }));
+
+  assert(action_items(test_state, {
+    {KM_KBP_IT_PERSIST_OPT, {0,}, {uintptr_t(&opt)}},
+    {KM_KBP_IT_END}
+  }));
+}
+
 
 constexpr const auto help_str = "\
 debug_api [--color] <SOURCE_PATH>|--print-sizeof\n\
@@ -436,6 +468,7 @@ int main(int argc, char *argv []) {
   test_multiple_groups();
   test_store_offsets();
   test_set_option();
+  test_save_option();
 
   // Destroy them
   teardown();


### PR DESCRIPTION
Fixes #7643.

The kmn statement `save()` action was being written directly to the state queue, bypassing the internal kmx action queue. This caused two issues:

1. `save()` actions were out-of-order with other actions on the same key event.
2. The number of items in the internal action queue became out of sync with the debug item queue, which would cause the debugger to fail with an assertion.

The new test in debug_api.cpp validates this second issue as the number of items in the action queue now matches the expected count in the corresponding debug item.

# User Testing

* **TEST_SAVE_ACTION:** Using the keyboard in #7643, test it in the Keyman Developer debugger. Press <kbd>s</kbd> and verify that `save` is emitted, and that Developer doesn't crash 🤣