### PR TITLE
fix(web): Add polyfill for Array.includes()

### DIFF
--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -58,6 +58,7 @@ wrap-worker-code ( ) {
   # short and simple, which is good.
   cat "src/polyfills/array.fill.js" || die # Needed for Android / Chromium browser pre-45.
   cat "src/polyfills/array.from.js" || die # Needed for Android / Chromium browser pre-45.
+  cat "src/polyfills/array.includes.js" || die # Needed for Android / Chromium browser pre-47.
 
   # For Object.values, for iteration over object-based associate arrays.
   cat "src/polyfills/object.values.js" || die # Needed for Android / Chromium browser pre-54.

--- a/common/web/lm-worker/src/polyfills/array.includes.js
+++ b/common/web/lm-worker/src/polyfills/array.includes.js
@@ -1,0 +1,7 @@
+// https://stackoverflow.com/questions/53308396/how-to-polyfill-array-prototype-includes-for-ie8
+if(!Array.prototype.includes){
+  //or use Object.defineProperty
+  Array.prototype.includes = function(search){
+   return !!~this.indexOf(search);
+ }
+}


### PR DESCRIPTION
Fixes #7613

The wordbreaker update in #7279 uses [Array.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#browser_compatibility) (ES2016 and Chrome 47, not included in ES6)
https://github.com/paulmillr/es6-shim/issues/426#issuecomment-252040954

This adds a polyfill so that lexical-models can run on Android 5.0 (Chrome 37)
Alternatively, we could add the npm package
https://github.com/kevlatus/polyfill-array-includes


## User Testing
Setup - Install the PR build of Keyman for Android on Android 5.0 emulator/device (API 21)

* **TEST_ANDROID_5** - Verifies error does not appear on Android 5.0
1. Launch Keyman for Android
2. Verify Toast message "Error in Keyboard...sil_euro_latin.. for language' does **not* appear at the bottom of the keyboard.
3. Dismiss the "Get Started" menu
4. If the context is empty, verify suggestions appear in the suggestion banner


