### PR TITLE
fix(core): emit keystroke was writing to wrong queue

### DIFF
--- a/core/src/kmx/kmx_actions.h
+++ b/core/src/kmx/kmx_actions.h
@@ -31,8 +31,9 @@ typedef struct
 #define QIT_CAPSLOCK  8
 #define QIT_INVALIDATECONTEXT 9
 #define QIT_SAVEOPT 10
+#define QIT_EMIT_KEYSTROKE 11
 
-#define QIT_MAX     10
+#define QIT_MAX     11
 
 #define QVK_EXTENDED 0x00010000 // Flag for QIT_VKEYDOWN to indicate an extended key
 #define QVK_KEYMASK  0x0000FFFF

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -178,6 +178,9 @@ kmx_processor::internal_process_queued_actions(km_kbp_state *state) {
           option{KM_KBP_OPT_KEYBOARD, rStoreToSave.dpName, rStoreToSave.dpString});
       }
       break;
+    case QIT_EMIT_KEYSTROKE:
+      state->actions().push_emit_keystroke();
+      break;
     case QIT_VKEYDOWN:
     case QIT_VKEYUP:
     case QIT_VSHIFTDOWN:
@@ -276,7 +279,7 @@ kmx_processor::process_event(
 
   if (!_kmx.ProcessEvent(state, vk, modifier_state, is_key_down)) {
     // We need to output the default keystroke
-    state->actions().push_emit_keystroke();
+    _kmx.GetActions()->QueueAction(QIT_EMIT_KEYSTROKE, 0);
   }
 
   return internal_process_queued_actions(state);

--- a/core/tests/unit/kmnkbd/action_items.hpp
+++ b/core/tests/unit/kmnkbd/action_items.hpp
@@ -27,7 +27,7 @@ const char *action_item_types[] = {
 
 void print_action_item(const char *title, km_kbp_action_item const & item) {
   std::cout
-    << "debug_item " << title << std::endl
+    << "action_item " << title << std::endl
     << "  type:    " << action_item_types[item.type] << std::endl;
 
   switch(item.type) {

--- a/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
@@ -144,6 +144,7 @@ begin
     KM_KBP_IT_PERSIST_OPT:    ; // TODO: The indicated option needs to be stored.
     KM_KBP_IT_EMIT_KEYSTROKE: Action_EmitKeystroke(key);
     KM_KBP_IT_CAPSLOCK:       ; // TODO: Caps lock state needs to be updated
+    KM_KBP_IT_INVALIDATE_CONTEXT: ;
     else Assert(False, 'Action type '+IntToStr(Ord(action._type))+' is unexpected.');
   end;
 end;
@@ -359,9 +360,10 @@ begin
 
   AddDebugItem(debug, debugkeyboard, vk, modifier_state);
 
-  if action._type = KM_KBP_IT_INVALIDATE_CONTEXT then
+  if action._type = KM_KBP_IT_EMIT_KEYSTROKE then
   begin
-    // We may receive a context invalidation but we can ignore it
+    // The EMIT_KEYSTROKE action comes after all rules have completed processing
+    Result := Result and AddActionItem(vk, action);
     Inc(action);
   end;
 

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -201,6 +201,11 @@ type
 
   pkm_kbp_action_item = ^km_kbp_action_item;
 
+// These types are used only for debugging convenience
+type
+  km_kbp_action_item_array = array[0..100] of km_kbp_action_item;
+  pkm_kbp_action_item_array = ^km_kbp_action_item_array;
+
 function km_kbp_options_list_size(
   opts: pkm_kbp_option_item
 ): Integer; cdecl; external kmnkbp0 delayed;

--- a/developer/src/tike/main/Keyman.System.KeymanCoreDebug.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCoreDebug.pas
@@ -106,6 +106,11 @@ pkm_kbp_state_debug_item = ^km_kbp_state_debug_item;
 
 km_kbp_debug_type = type uint32_t;
 
+// These types are used only for debugging convenience
+type
+  km_kbp_state_debug_item_array = array[0..100] of km_kbp_state_debug_item;
+  pkm_kbp_state_debug_item_array = ^km_kbp_state_debug_item_array;
+
 const
   KM_KBP_DEBUG_BEGIN = 0;
   //KM_KBP_DEBUG_BEGIN_ANSI: km_kbp_debug_type = 1, // not supported; instead rewrite ansi keyboards to Unicode with mcompile


### PR DESCRIPTION
Fixes #7649.

emit_keystroke code path in kmx processor was writing directly to the core queue instead of to the internal kmx processor queue. This caused it to be out-of-order in the actions sent to the engine/debugger.

Engines didn't really care but it broke the debugger, for example if only a deadkey was in the buffer and backspace was pressed, Developer would assert as it would get unexpected context for the deletions.

# User Testing

**TEST_REGRESSION:** I would like to ensure that this is covered in the Linux, Developer, and Windows regression tests in Beta. I don't know if it needs a separate test.

The test we should aim for is to ensure that backspace is working correctly in all contexts, including with rule processing, particularly when deadkeys/markers are involved.
