### PR TITLE
fix(developer): kmlmc has runtime dependency on keyman-version

### DIFF
--- a/developer/src/kmlmc/package.json
+++ b/developer/src/kmlmc/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@keymanapp/models-types": "*",
+    "@keymanapp/keyman-version": "*",
     "commander": "^3.0.0",
     "typescript": "^4.5.4",
     "xml2js": "^0.4.19"
@@ -44,7 +45,6 @@
   "devDependencies": {
     "@keymanapp/models-templates": "*",
     "@keymanapp/models-wordbreakers": "*",
-    "@keymanapp/keyman-version": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.6",


### PR DESCRIPTION
@keymanapp-test-bot skip

This is blocking usage via npm. To test next version:

```
  npm init
  npm install @keymanapp/lexical-model-compiler
  ./node_modules/.bin/kmlmc
```