### PR TITLE
fix(web): Add polyfill for Array.findIndex()

### DIFF
--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -57,6 +57,7 @@ wrap-worker-code ( ) {
   # use the node `require` statement for the second.  They're also relatively
   # short and simple, which is good.
   cat "src/polyfills/array.fill.js" || die # Needed for Android / Chromium browser pre-45.
+  cat "src/polyfills/array.findIndex.js" || die # Needed for Android / Chromium browser pre-45.
   cat "src/polyfills/array.from.js" || die # Needed for Android / Chromium browser pre-45.
   cat "src/polyfills/array.includes.js" || die # Needed for Android / Chromium browser pre-47.
 

--- a/common/web/lm-worker/src/polyfills/array.findIndex.js
+++ b/common/web/lm-worker/src/polyfills/array.findIndex.js
@@ -1,0 +1,51 @@
+/**
+ * Array.prototype.findIndex() polyfill
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+ * @license MIT
+ */
+ if (!Array.prototype.findIndex) {
+  Object.defineProperty(Array.prototype, 'findIndex', {
+    value: function(predicate) {
+
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      // 1. Let O be ? ToObject(this value).
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return k.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return k;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return -1.
+      return -1;
+    },
+    configurable: true,
+    writable: true
+  });
+}


### PR DESCRIPTION
Follow-on to #7646 - this adds a polyfill for Array.findIndex() needed for the wordbreaker update in #7279 

The user test involves installing a modified sil.jra-khmr.jarai,model dictionary with custom word breaking based on
https://github.com/keymanapp/keyman/files/9553911/sil.jra-khmr.jarai.model.kmp.zip from PR #7279.

with the following modifications in the model.js file for Android 5.0 compatibility:
* Change `let` to `var`
* Change array functions


## User Testing
**Setup**
1. Install the PR build of Keyman for Android on an Android 5.0 (API 21) emulator/device.
2. Launch a browser and download the modified copy of [sil.jra-khmr.jarai.model](https://darcywong00.github.io/examples/jra/sil.jra-khmr.jarai.model.kmp) (Should save to the Downloads folder)
3. Return to Keyman, from the Keyman Settings menu --> Install Keyboard or Dictionary --> Install from keyman.com -->  search for and install the sil_jarai keyboard package.
4. This will also install the sil.jra-khmr.jarai.model dictionary package in the background

* **TEST_MODIFIED_DICTIONARY** - Verify suggestions appear with custom word breaking
1. Launch Keyman for Android
2. Go to Keyman Settings --> Install Keyboard or Dictionary --> Install from local file --> browse to the Downloads folder and select "sil.jra-khmr.jarai.model.kmp" and install the dictionary package that uses custom word breaking
3. Restart Keyman for Android
4. Use the globe key to toggle between sil_euro_latin and sil_jarai keyboards
5. Verify for each keyboard
    * if context clear, that suggestions appear  
    * no Toast notifications appear about keyboard error