### PR TITLE
fix(developer): handle edge cases for app sources

### DIFF
--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -75,7 +75,11 @@ var
 begin
   T := FSources.LockList;
   try
-    Assert(T.Count = 0, 'TAppSourceHttpResponder.Sources should be empty at destruction');
+    // Note: Unlike regular functions, Assert has short-circuit evaluation
+    // intrinsics on the first param which makes it safe to dereference T[0] in
+    // the second parameter.
+    Assert(T.Count = 0, 'TAppSourceHttpResponder.Sources should be empty at destruction '+
+      '(T.Count='+IntToStr(T.Count)+', T[0].Filename='+T[0].Filename+')');
   finally
     FSources.UnlockList;
   end;

--- a/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -87,7 +87,7 @@ type
     procedure UpdateCharacterMap(code: string);  // I4046
     function GetFontInfo(Index: TKeyboardFont): TKeyboardFontInfo;   // I4057
     procedure SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);   // I4057
-    
+
     procedure cefCommand(Sender: TObject; const command: string; params: TStringList);
     procedure cefLoadEnd(Sender: TObject);
     procedure RegisterSource;
@@ -393,7 +393,7 @@ begin
 
   finally
     RegisterSource;
-    if FState <> '' then
+    if (FFileName <> '') and (FState <> '') then
       modWebHttpServer.AppSource.RegisterSource(FFilename + '#state', FState, True);
   end;
 


### PR DESCRIPTION
Relates to #6928 and KEYMAN-DEVELOPER-74.

Fixes one more potential pathway for assertions being raised, and adds some extra debugging in case there are additional pathways we are not capturing.

@keymanapp-test-bot skip