### PR TITLE
fix(developer): handle shutdown cleanup more cleanly

### DIFF
--- a/developer/src/tike/Tike.dpr
+++ b/developer/src/tike/Tike.dpr
@@ -312,17 +312,15 @@ begin
           SetThemeAppProperties(STAP_ALLOW_NONCLIENT or STAP_ALLOW_CONTROLS or STAP_ALLOW_WEBCONTENT);
           Application.MainFormOnTaskBar := True;
           Application.Initialize;
-        //  TStyleManager.TrySetStyle(FKeymanDeveloperOptions.DisplayTheme);
           Application.Title := 'Keyman Developer';
-          //TBX.TBXSetTheme('OfficeXP2');
           if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-  try
+          try
             Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
             Application.Run;
           finally
-            FreeAndNil(modWebHttpServer);
             FreeAndNil(frmKeymanDeveloper);
+            FreeAndNil(modWebHttpServer);
           end;
         end;
       finally

--- a/developer/src/tike/update/Keyman.Developer.UI.TikeOnlineUpdateCheck.pas
+++ b/developer/src/tike/update/Keyman.Developer.UI.TikeOnlineUpdateCheck.pas
@@ -1,18 +1,18 @@
 (*
   Name:             OnlineUpdateCheck
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      4 Dec 2006
 
   Modified Date:    8 Jun 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          04 Dec 2006 - mcdurdin - Support download progress
                     12 Dec 2006 - mcdurdin - Don't shutdown if update is cancelled
                     14 Dec 2006 - mcdurdin - Only test for patches, not downloads
@@ -285,7 +285,10 @@ end;
 procedure TOnlineUpdateCheck.SyncShutDown;
 begin
   if Assigned(Application) then
-    Application.Terminate;
+  begin
+    if Assigned(Application.MainForm) then
+      Application.MainForm.Close;
+  end;
 end;
 
 function TOnlineUpdateCheck.DoRun: TOnlineUpdateCheckResult;


### PR DESCRIPTION
Fixes #4757.
Fixes #6928.

This may also fix some other Developer crashes relating to CEF, as some of those are probably due to unclean shutdown.

Three separate ways shutdown is more robust:

1. Destroy main form before web server -- this ensures that all main form routines have deregistered app sources from web server.
2. In some situations, `FormClose` can be skipped by shutdown routines, for example, if you call `Application.Terminate`. This change ensures that we get a second chance to cleanup in the form destructor with `DoCloseCleanup`.
3. In the Online Update Check, instead of `Application.Terminate`, we now use `Application.MainForm.Close`, which is much more polite, as it ensures that changed files are saved, etc, and does proper cleanup. This particular change may make the other two somewhat irrelevant but they are still sensible as they will cover us for other potential form destruction sequences.

@keymanapp-test-bot skip

Note: when the regression test for Keyman Developer is run for Beta, we'll be checking most of these code pathways. Some of these are hard to reproduce in beta testing in any case, so we'll monitor Sentry for other possible crash reports.