### PR TITLE
fix(developer): handle crash reports without Keyman Engine installed

### DIFF
--- a/common/windows/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/common/windows/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -131,6 +131,7 @@ var
   AppID, ProjectName: string;
 {$IF NOT DEFINED(CONSOLE)}
   ApplicationTitle, CommandLine: string;
+  tsysinfopath, enginepath: string;
 {$ENDIF}
 begin
   if EventType = scetException then
@@ -181,12 +182,20 @@ begin
         StringReplace(Message, '"', '""', [rfReplaceAll])
       ]);
 
-      if not TUtilExecute.Shell(0, TKeymanPaths.KeymanEngineInstallPath('tsysinfo.exe'),  // I3349
-          TKeymanPaths.KeymanEngineInstallPath(''), CommandLine) then
+      try
+        tsysinfopath := TKeymanPaths.KeymanEngineInstallPath('tsysinfo.exe');
+        enginepath := TKeymanPaths.KeymanEngineInstallPath('');
+      except
+        on E:EKeymanPath do
+        begin
+          tsysinfopath := '';
+          enginepath := '';
+        end;
+      end;
+      if (tsysinfopath = '') or not TUtilExecute.Shell(0, tsysinfopath, enginepath, CommandLine) then
       begin
 {$IF NOT DEFINED(SENTRY_NOVCL)}
-        MessageDlg(Application.Title+' has had a fatal error.  An additional error was encountered '+
-          'starting the exception manager ('+SysErrorMessage(GetLastError)+'). '+
+        MessageDlg(Application.Title+' has had a fatal error '+EventID+'. '+
           'This error has been automatically reported to the Keyman team.', mtError, [mbOK], 0);
 {$ENDIF}
       end;


### PR DESCRIPTION
Fixes #7656.

If Keyman Developer is installed, but not Keyman for Windows, then tsysinfo.exe is not present. If a crash occurs, this causes a secondary crash when trying to display the error handler dialog. In this situation, we now just show a dialog box with a short message rather than the more friendly dialog available via tsysinfo.exe.

We could consider adding tsysinfo.exe into Keyman Developer for a future release.

@keymanapp-test-bot skip