### PR TITLE
fix(developer): handle unpaired surrogate

### DIFF
--- a/developer/src/tike/xml/app/editor/editor.js
+++ b/developer/src/tike/xml/app/editor/editor.js
@@ -426,7 +426,19 @@ async function loadSettings() {
     command('location,' + (s.startLineNumber-1) + ',' + (s.startColumn-1) + ',' + (s.endLineNumber-1) + ',' + (s.endColumn-1) + ',' + n);
     var token = getTokenAtCursor();
     if (token) {
-      command('token,' + token.column + ',' + encodeURIComponent(token.text));
+      let text;
+      try {
+        text = encodeURIComponent(token.text);
+      } catch(e) {
+        if(e instanceof URIError) {
+          // if token.text contains an unpaired surrogate, encodeURIComponent
+          // fails with a URIError, in which case we will just avoid
+          // sending the token command.
+          return;
+        }
+        throw e;
+      }
+      command('token,' + token.column + ',' + text);
     }
   };
 


### PR DESCRIPTION
Fixes #7658.

When manipulating text that contains an unpaired surrogate, the text editor could throw an exception trying to encode the text to send through to the token command. This simply masks that error.

@keymanapp-test-bot skip