### PR TITLE
fix(windows): Cleanup CEF more correctly in shutdown

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
+++ b/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
@@ -55,12 +55,18 @@ type
   TfrmWebContainer = class(TfrmKeymanBase)
     procedure TntFormCreate(Sender: TObject);
   private
+    class var WebContainerDepth: Integer;
+  private
     FDialogName: WideString;
+    FCanClose: Boolean;
+    FIsClosing: Boolean;
     procedure WMUser_FormShown(var Message: TMessage); message WM_USER_FormShown;
     procedure WMUser_ContentRender(var Message: TMessage); message WM_USER_ContentRender;
     procedure WMSysCommand(var Message: TWMSysCommand); message WM_SYSCOMMAND;
 
     procedure ContributeUILanguages;
+    procedure CEFShutdownComplete(Sender: TObject);
+    function IsTopLevel: Boolean;
   protected
     cef: TframeCEFHost;
     FRenderPage: string;
@@ -88,6 +94,8 @@ type
     procedure DoOpenHelp;
   public
     constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    function CloseQuery: Boolean; override;
     procedure SetFocus; override;  // I2720
     property DialogName: WideString read FDialogName;
 
@@ -109,6 +117,7 @@ uses
   custinterfaces,
   ErrorControlledRegistry,
   Keyman.Configuration.System.UmodWebHttpServer,
+  Keyman.System.CEFManager,
   Keyman.System.KeymanSentryClient,
   kmint,
   UILanguages,
@@ -154,6 +163,7 @@ end;
 
 constructor TfrmWebContainer.Create(AOwner: TComponent);
 begin
+  Inc(WebContainerDepth);
   inherited Create(AOwner);
 end;
 
@@ -165,10 +175,44 @@ begin
   else ShowMessage(command + '?' + params.Text);
 end;
 
+function TfrmWebContainer.IsTopLevel: Boolean;
+begin
+  Result := WebContainerDepth = 1;
+end;
+
+function TfrmWebContainer.CloseQuery: Boolean;
+begin
+  Result := inherited;
+  if Result and IsTopLevel then
+  begin
+    if not FIsClosing then
+    begin
+      FIsClosing := True;
+      Result := FInitializeCEF.StartShutdown(CEFShutdownComplete);
+    end
+    else
+      Result := FCanClose;
+  end;
+end;
+
+procedure TfrmWebContainer.CEFShutdownComplete(Sender: TObject);
+begin
+//  OutputDebugString(PChar('TfrmKeymanDeveloper.CEFShutdownComplete'));
+  FCanClose := True;
+  Close;
+end;
+
+
 /// <summary>Returns true if url is from the local render server</summary>
 function TfrmWebContainer.IsLocalUrl(const url: string): Boolean;
 begin
   Result := url.StartsWith(modWebHttpServer.Host, True);
+end;
+
+destructor TfrmWebContainer.Destroy;
+begin
+  Dec(WebContainerDepth);
+  inherited Destroy;
 end;
 
 procedure TfrmWebContainer.DoOpenHelp;


### PR DESCRIPTION
Hopefully fixes KEYMAN-WINDOWS-1MR, and probably many related crash reports. Will monitor on alpha before porting to stable/beta.

This changes the form destruction sequence to make sure that it doesn't close the form until CEF has been shutdown correctly.

@keymanapp-test-bot skip

We are going to need to do a full regression on this, but that can wait until we exit beta.