### PR TITLE
fix(web): Add additional checks on className.indexOf

### DIFF
--- a/web/source/dom/domEventHandlers.ts
+++ b/web/source/dom/domEventHandlers.ts
@@ -352,7 +352,7 @@ namespace com.keyman.dom {
         if(el && typeof el.kmwInput != 'undefined' && el.kmwInput == false) {
           return true;
         }
-      } else if(el && el.className.indexOf('kmw-disabled') >= 0) {
+      } else if(el?.className?.indexOf('kmw-disabled') >= 0) {
         return true;
       }
 


### PR DESCRIPTION
Fixes Sentry [report](https://sentry.io/organizations/keyman/issues/3728694505/?project=5983520&query=is%3Aunresolved&referrer=issue-stream) which goes back at least to 14.0.287

> Uncaught TypeError: Cannot read property 'indexOf' of undefined

@keymanapp-test-bot skip

