### PR TITLE
fix(windows): base layout support in Keyman Core

### DIFF
--- a/windows/src/engine/keyman32/CoreEnvironment.cpp
+++ b/windows/src/engine/keyman32/CoreEnvironment.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+
+BOOL SetupCoreEnvironment(km_kbp_option_item **core_environment) {
+  km_kbp_option_item *items = new km_kbp_option_item[5];
+
+  items[0].scope = KM_KBP_OPT_ENVIRONMENT;
+  items[0].key = KM_KBP_KMX_ENV_BASELAYOUT;
+  items[0].value = reinterpret_cast<km_kbp_cp*>(Globals::get_BaseKeyboardName());
+
+  items[1].scope = KM_KBP_OPT_ENVIRONMENT;
+  items[1].key = KM_KBP_KMX_ENV_BASELAYOUTALT;
+  items[1].value = reinterpret_cast<km_kbp_cp*>(Globals::get_BaseKeyboardNameAlt());
+
+  items[2].scope = KM_KBP_OPT_ENVIRONMENT;
+  items[2].key = KM_KBP_KMX_ENV_SIMULATEALTGR;
+  items[2].value = Globals::get_SimulateAltGr() ? u"1" : u"0";
+
+  items[3].scope = KM_KBP_OPT_ENVIRONMENT;
+  items[3].key = KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT;
+  items[3].value = KeyboardGivesCtrlRAltForRAlt() ? u"1" : u"0";
+
+  items[4] = KM_KBP_OPTIONS_END;
+
+  *core_environment = items;
+  return TRUE;
+}
+
+void DeleteCoreEnvironment(km_kbp_option_item *core_environment) {
+  // All keys and values are pointers to owned memory, so only need to delete
+  // the array of options
+  delete [] core_environment;
+}

--- a/windows/src/engine/keyman32/K32_load.cpp
+++ b/windows/src/engine/keyman32/K32_load.cpp
@@ -101,12 +101,17 @@ BOOL LoadlpKeyboardCore(int i)
   }
   delete keyboardPath;
 
-  const km_kbp_option_item test_env_opts[] =
-  {
-    KM_KBP_OPTIONS_END
-  };
+  km_kbp_option_item *core_environment = nullptr;
 
-  err_status = km_kbp_state_create(_td->lpKeyboards[i].lpCoreKeyboard, test_env_opts, &_td->lpKeyboards[i].lpCoreKeyboardState);
+  if(!SetupCoreEnvironment(&core_environment)) {
+    SendDebugMessageFormat(0, sdmLoad, 0, "LoadlpKeyboardCore: Unable to set environment options for keyboard %ls", keyboardPath);
+    return FALSE;
+  }
+
+  err_status = km_kbp_state_create(_td->lpKeyboards[i].lpCoreKeyboard, core_environment, &_td->lpKeyboards[i].lpCoreKeyboardState);
+
+  DeleteCoreEnvironment(core_environment);
+
   if (err_status != KM_KBP_STATUS_OK) {
     SendDebugMessageFormat(
         0, sdmLoad, 0, "LoadlpKeyboardCore: km_kbp_state_create failed with error status [%d]", err_status);

--- a/windows/src/engine/keyman32/Keyman32.cpp
+++ b/windows/src/engine/keyman32/Keyman32.cpp
@@ -575,9 +575,18 @@ extern "C" BOOL  _declspec(dllexport) WINAPI Keyman_ForceKeyboard(PCSTR FileName
     delete keyboardPath;
     SendDebugMessageFormat(0, sdmGlobal, 0, "Keyman_ForceKeyboard Core: %s OK", FileName); // TODO: 5442 - remove word Core
 
-    const km_kbp_option_item test_env_opts[] = {KM_KBP_OPTIONS_END};
+    km_kbp_option_item *core_environment = nullptr;
+
+    if(!SetupCoreEnvironment(&core_environment)) {
+      SendDebugMessageFormat(0, sdmLoad, 0, "Keyman_ForceKeyboard Core: Unable to set environment options for keyboard %s", FileName); // TODO: 5442 - remove word Core
+      return FALSE;
+    }
+
     err_status =
-        km_kbp_state_create(_td->lpActiveKeyboard->lpCoreKeyboard, test_env_opts, &_td->lpActiveKeyboard->lpCoreKeyboardState);
+        km_kbp_state_create(_td->lpActiveKeyboard->lpCoreKeyboard, core_environment, &_td->lpActiveKeyboard->lpCoreKeyboardState);
+
+    DeleteCoreEnvironment(core_environment);
+
     if (err_status != KM_KBP_STATUS_OK) {
       SendDebugMessageFormat(
           0, sdmGlobal, 0, "Keyman_ForceKeyboard Core: km_kbp_state_create failed with error status [%d]", err_status);

--- a/windows/src/engine/keyman32/Keyman32.vcxproj
+++ b/windows/src/engine/keyman32/Keyman32.vcxproj
@@ -211,6 +211,7 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="CoreEnvironment.cpp" />
     <ClCompile Include="DebugEventTrace.cpp" />
     <ClCompile Include="glossary.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/windows/src/engine/keyman32/Keyman32.vcxproj.filters
+++ b/windows/src/engine/keyman32/Keyman32.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="..\..\global\cpp\kmtip_guids.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CoreEnvironment.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="KEYMAN32.DEF">

--- a/windows/src/engine/keyman32/keymanengine.h
+++ b/windows/src/engine/keyman32/keymanengine.h
@@ -40,6 +40,7 @@
 #include <msctf.h>
 #include "../../../../common/windows/cpp/include/legacy_kmx_file.h"
 #include <keyman/keyboardprocessor.h>
+#include <keyman/keyboardprocessor_consts.h>
 
 /***************************************************************************/
 
@@ -274,5 +275,8 @@ void SelectKeyboardHKL(DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4
 BOOL SelectKeyboardTSF(DWORD KeymanID, BOOL foreground);   // I3933   // I3949   // I4271
 BOOL ReportKeyboardChanged(WORD wCommand, DWORD dwProfileType, UINT langid, HKL hkl, GUID clsid, GUID guidProfile);
 void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
+
+BOOL SetupCoreEnvironment(km_kbp_option_item **test_env_opts);
+void DeleteCoreEnvironment(km_kbp_option_item *test_env_opts);
 
 #endif  // _KEYMANENGINE_H

--- a/windows/src/engine/keyman64/keyman64.vcxproj
+++ b/windows/src/engine/keyman64/keyman64.vcxproj
@@ -193,6 +193,7 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
     </ClCompile>
+    <ClCompile Include="..\keyman32\CoreEnvironment.cpp" />
     <ClCompile Include="..\keyman32\DebugEventTrace.cpp" />
     <ClCompile Include="..\keyman32\glossary.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename)1.obj</ObjectFileName>

--- a/windows/src/engine/keyman64/keyman64.vcxproj.filters
+++ b/windows/src/engine/keyman64/keyman64.vcxproj.filters
@@ -38,6 +38,7 @@
     <ClCompile Include="..\keyman32\DebugEventTrace.cpp" />
     <ClCompile Include="..\keyman32\kmprocessactions.cpp" />
     <ClCompile Include="..\..\global\cpp\kmtip_guids.cpp" />
+    <ClCompile Include="..\keyman32\CoreEnvironment.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\keyman32\addins.h" />


### PR DESCRIPTION
While Keyman Core already supported the base layout flags, they were not being passed in from Keyman Engine for Windows. This meant that any rules that used `baselayout` would fail, such as in sil_ipa with <kbd>AltGr</kbd>+<kbd>0</kbd> for `}`: https://github.com/keymanapp/keyboards/blob/0bf72bed74f563f823b1af002f6a8ccef8510ebf/release/sil/sil_ipa/source/sil_ipa.kmn#L348-L350

This patch adds support for the following properties:

* `KM_KBP_KMX_ENV_BASELAYOUT`: the legacy base layout name, e.g. kbdus.dll
* `KM_KBP_KMX_ENV_BASELAYOUTALT`: the BCP 47 base layout name, e.g. en-US
* `KM_KBP_KMX_ENV_SIMULATEALTGR`: whether the user has selected to emulate AltGr with Ctrl+Alt, for example on laptops without a right alt key.
* `KM_KBP_KMX_ENV_BASELAYOUTGIVESCTRLRALTFORRALT`: whether the system base layout in use generates Ctrl+RAlt when RAlt is pressed, which can be true for many European system layouts. This is necessary when associating the keyboard with a European language because the base keyboard becomes the language's default keyboard, rather than kbdus.

# User Testing

**TEST_BASELINE:** We need to verify that SIL IPA continues to work correctly on US English base keyboard. Verify that key sequences from the SIL IPA keyboard documentation work correctly in Word and Notepad.

**TEST_GERMAN:** Switch the 'Base Keyboard' in Keyman Configuration / Options tab to German. With the SIL IPA keyboard, type <kbd>a</kbd> <kbd>AltGr</kbd>+<kbd>0</kbd>. The output should be `aˈ`.

**TEST_SIMULATE_ALTGR_OFF:** We need to test the Simulate AltGr with Ctrl+Alt option in Keyman Configuration. First, turn the option off. Then with Khmer Angkor, press <kbd>AltGr</kbd>+<kbd>B</kbd>, and verify that it emits `ឞ` (U+179E). Then, press<kbd>LCtrl</kbd>+<kbd>LAlt</kbd>+<kbd>B</kbd>. You should get no output.

**TEST_SIMULATE_ALTGR_ON:** We need to test the Simulate AltGr with Ctrl+Alt option in Keyman Configuration. Now, turn the option on. Then with Khmer Angkor, press <kbd>AltGr</kbd>+<kbd>B</kbd>, and verify that it emits `ឞ` (U+179E). Then, press<kbd>LCtrl</kbd>+<kbd>LAlt</kbd>+<kbd>B</kbd>. It should also emit `ឞ` (U+179E).

---

Ref: https://community.software.sil.org/t/bug-report-on-keyman-ipa-sil-for-windows/4811