### PR TITLE
fix(android/app): Append tier to app name

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -73,6 +73,8 @@ android {
     applicationVariants.all { variant ->
         // Append tier and environment to app name
         // Beware: Gradle sync will nullify these values
+        executeBuildUtils()
+
         String appSuffix = ''
         String environment = VERSION_ENVIRONMENT
         String tag = VERSION_TAG
@@ -152,6 +154,25 @@ dependencies {
     // we "lose" it in the dependency management)
     implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
         transitive = true
+    }
+}
+
+// Use build-utils.sh to get common build version info.
+// Beware: Android Studio IDE Gradle sync will invalidate these values
+def executeBuildUtils() {
+    try {
+        exec {
+            commandLine 'bash', '-c', 'pwd; THIS_SCRIPT=build.gradle; . ../../../resources/build/build-utils.sh'
+        }
+    }
+    catch(Exception e) {
+        GradleException("Exception: $e")
+    }
+    // Debugging
+    println "version.gradle TAG: " + System.getenv("VERSION_TAG") + ", ENVIRONMENT: " + System.getenv("VERSION_ENVIRONMENT");
+    ext {
+        VERSION_TAG=System.getenv("VERSION_TAG")
+        VERSION_ENVIRONMENT=System.getenv("VERSION_ENVIRONMENT")
     }
 }
 

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -71,17 +71,21 @@ android {
     }
 
     applicationVariants.all { variant ->
-        String tier = ''
-        switch (VERSION_TIER) {
-            case 'beta':
-                tier = ' Beta'
-                break
-            case 'stable':
-                break
-            default:
-                tier = ' Alpha'
+        // Append tier and environment to app name
+        // Beware: Gradle sync will nullify these values
+        String appSuffix = ''
+        String environment = VERSION_ENVIRONMENT
+        String tag = VERSION_TAG
+        println "variant: " + variant + "tag: " + tag + ", environment: " + environment;
+        if (environment != null && environment.endsWith("-test-\\d+")) {
+            // -test-PR_NUMBER
+            appSuffix = environment;
+        } else if (tag != null && tag.startsWith("-beta")) {
+            appSuffix = ' Beta';
+        } else if (tag != null && tag.startsWith("-alpha")) {
+            appSuffix = ' Alpha';
         }
-        variant.resValue "string", "app_name", 'Keyman' + tier
+        variant.resValue "string", "app_name", 'Keyman' + appSuffix;
     }
     lintOptions {
         disable 'MissingQuantity', 'MissingTranslation'

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -70,6 +70,20 @@ android {
     productFlavors {
     }
 
+    applicationVariants.all { variant ->
+        switch (System.env.TIER) {
+            case 'beta':
+                variant.resValue "string", "app_name", 'Keyman Beta'
+                break
+
+            case 'stable':
+                variant.resValue "string", "app_name", 'Keyman'
+                break
+
+            default:
+                variant.resValue "string", "app_name", 'Keyman Alpha'
+        }
+    }
     lintOptions {
         disable 'MissingQuantity', 'MissingTranslation'
         lintConfig file("lint.xml")

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -71,18 +71,17 @@ android {
     }
 
     applicationVariants.all { variant ->
-        switch (System.env.TIER) {
+        String tier = ''
+        switch (VERSION_TIER) {
             case 'beta':
-                variant.resValue "string", "app_name", 'Keyman Beta'
+                tier = ' Beta'
                 break
-
             case 'stable':
-                variant.resValue "string", "app_name", 'Keyman'
                 break
-
             default:
-                variant.resValue "string", "app_name", 'Keyman Alpha'
+                tier = ' Alpha'
         }
+        variant.resValue "string", "app_name", 'Keyman' + tier
     }
     lintOptions {
         disable 'MissingQuantity', 'MissingTranslation'

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -75,19 +75,22 @@ android {
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
         String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');
-        if (tag != null && tag ==~ /.*-test-\d+$/) {
-            // -test-PR_NUMBER
-            appSuffix = tag;
-        } else if (tag != null && tag.startsWith("-beta")) {
+        if (tag.startsWith("-beta")) {
             appSuffix = ' Beta';
-        } else if (tag != null && tag.startsWith("-alpha")) {
+        } else if (tag.startsWith("-alpha")) {
             appSuffix = ' Alpha';
         }
-        String environment = VERSION_ENVIRONMENT ? VERSION_ENVIRONMENT : 'local';
-        if (environment.matches("local")) {
-            appSuffix = appSuffix + '-' + environment;
+        def match = (tag =~ /.*(-test-\d+)$/);
+        if (match.find()) {
+            // -test-PR_NUMBER
+            appSuffix = appSuffix + match.group(1)
+        } else {
+            String environment = VERSION_ENVIRONMENT ? VERSION_ENVIRONMENT : 'local';
+            if (environment.matches("local")) {
+                appSuffix = appSuffix + '-' + environment;
+            }
         }
-        println "variant: " + variant + "tag: " + tag + ", environment: " + environment;
+        println "tag: " + tag + ", appSuffix: " + appSuffix;
         variant.resValue "string", "app_name", 'Keyman' + appSuffix;
     }
     lintOptions {

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -77,7 +77,7 @@ android {
         String environment = VERSION_ENVIRONMENT
         String tag = VERSION_TAG
         println "variant: " + variant + "tag: " + tag + ", environment: " + environment;
-        if (environment != null && environment.endsWith("-test-\\d+")) {
+        if (environment != null && environment ==~ /.*-test-\d+$/) {
             // -test-PR_NUMBER
             appSuffix = environment;
         } else if (tag != null && tag.startsWith("-beta")) {

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -71,20 +71,23 @@ android {
     }
 
     applicationVariants.all { variant ->
-        // Append tier and environment to app name
-        // Beware: Gradle sync will nullify these values
+        // Append tag to app name
+        // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
-        String environment = VERSION_ENVIRONMENT
-        String tag = VERSION_TAG
-        println "variant: " + variant + "tag: " + tag + ", environment: " + environment;
-        if (environment != null && environment ==~ /.*-test-\d+$/) {
+        String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');
+        if (tag != null && tag ==~ /.*-test-\d+$/) {
             // -test-PR_NUMBER
-            appSuffix = environment;
+            appSuffix = tag;
         } else if (tag != null && tag.startsWith("-beta")) {
             appSuffix = ' Beta';
         } else if (tag != null && tag.startsWith("-alpha")) {
             appSuffix = ' Alpha';
         }
+        String environment = VERSION_ENVIRONMENT ? VERSION_ENVIRONMENT : 'local';
+        if (environment.matches("local")) {
+            appSuffix = appSuffix + '-' + environment;
+        }
+        println "variant: " + variant + "tag: " + tag + ", environment: " + environment;
         variant.resValue "string", "app_name", 'Keyman' + appSuffix;
     }
     lintOptions {

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -71,7 +71,11 @@ android {
     }
 
     applicationVariants.all { variant ->
-        // Append tag to app name
+        // Append tag to app name to help differentiate versions for app testers:
+        //  - stable builds have no suffix
+        //  - beta and alpha release builds have "Beta" and "Alpha" suffixes
+        //  - local builds (incl. from IDE) also have "-local" suffix
+        //  - PR builds also have "-test-1234" suffix (where 1234 is PR#)
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
         String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -75,9 +75,9 @@ android {
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
         String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');
-        if (tag.startsWith("-beta")) {
+        if (tag.startsWithAny("-beta", "beta")) {
             appSuffix = ' Beta';
-        } else if (tag.startsWith("-alpha")) {
+        } else if (tag.startsWithAny("-alpha", "alpha")) {
             appSuffix = ' Alpha';
         }
         def match = (tag =~ /.*(-test-\d+)$/);

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -73,8 +73,6 @@ android {
     applicationVariants.all { variant ->
         // Append tier and environment to app name
         // Beware: Gradle sync will nullify these values
-        executeBuildUtils()
-
         String appSuffix = ''
         String environment = VERSION_ENVIRONMENT
         String tag = VERSION_TAG
@@ -154,25 +152,6 @@ dependencies {
     // we "lose" it in the dependency management)
     implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
         transitive = true
-    }
-}
-
-// Use build-utils.sh to get common build version info.
-// Beware: Android Studio IDE Gradle sync will invalidate these values
-def executeBuildUtils() {
-    try {
-        exec {
-            commandLine 'bash', '-c', 'pwd; THIS_SCRIPT=build.gradle; . ../../../resources/build/build-utils.sh'
-        }
-    }
-    catch(Exception e) {
-        GradleException("Exception: $e")
-    }
-    // Debugging
-    println "version.gradle TAG: " + System.getenv("VERSION_TAG") + ", ENVIRONMENT: " + System.getenv("VERSION_ENVIRONMENT");
-    ext {
-        VERSION_TAG=System.getenv("VERSION_TAG")
-        VERSION_ENVIRONMENT=System.getenv("VERSION_ENVIRONMENT")
     }
 }
 

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <string name="app_name" translatable="false">Keyman</string>
+  <!-- app_name removed in 16.0 beta. Set in build.gradle -->
 
   <!-- Context: Menu Action -->
   <string name="action_share" comment="Menu action to send text content to another app">Share</string>

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -61,4 +61,7 @@ ext {
     VERSION_CODE=getVersionCode()
     VERSION_NAME=getVersionName()
     VERSION_ENVIRONMENT=getVersionEnvironment()
+    VERSION_TAG=System.getenv("VERSION_TAG")
 }
+
+println "version.gradle: VERSION_TAG: " + VERSION_TAG

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -57,26 +57,8 @@ def getVersionEnvironment = { ->
     }
 }
 
-// Use build-utils.sh to get common build version info.
-// Beware: Android Studio IDE Gradle sync will invalidate these values
-def executeBuildUtils() {
-    try {
-        exec {
-            commandLine 'bash', '-c', 'pwd; THIS_SCRIPT=build.gradle; . ../../../resources/build/build-utils.sh'
-        }
-    }
-    catch(Exception e) {
-        GradleException("Exception: $e")
-    }
-    // Debugging
-    println "version.gradle TAG: " + System.getenv("VERSION_TAG") + ", ENVIRONMENT: " + System.getenv("VERSION_ENVIRONMENT");
-}
-
-executeBuildUtils()
-
 ext {
     VERSION_CODE=getVersionCode()
     VERSION_NAME=getVersionName()
-    VERSION_ENVIRONMENT=System.getenv("VERSION_ENVIRONMENT")
-    VERSION_TAG=System.getenv("VERSION_TAG")
+    VERSION_ENVIRONMENT=getVersionEnvironment()
 }

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -66,7 +66,7 @@ def executeBuildUtils() {
         }
     }
     catch(Exception e) {
-        println("Exception: $e")
+        GradleException("Exception: $e")
     }
     // Debugging
     println "version.gradle TAG: " + System.getenv("VERSION_TAG") + ", ENVIRONMENT: " + System.getenv("VERSION_ENVIRONMENT");

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -57,23 +57,26 @@ def getVersionEnvironment = { ->
     }
 }
 
-def getVersionTier = { ->
-    String env_tier = System.getenv("TIER")
-    if (env_tier != null) {
-        // If building from script, we have build tier
-        println "Using $env_tier from TIER"
-        return "$env_tier"
-    } else {
-        // Building probably from IDE, so let's use TIER.md directly
-        String tier_md = file("$rootPath/../TIER.md").text.trim()
-        println "Using tier $tier_md from TIER.md"
-        return "$tier_md"
+// Use build-utils.sh to get common build version info.
+// Beware: Android Studio IDE Gradle sync will invalidate these values
+def executeBuildUtils() {
+    try {
+        exec {
+            commandLine 'bash', '-c', 'pwd; THIS_SCRIPT=build.gradle; . ../../../resources/build/build-utils.sh'
+        }
     }
+    catch(Exception e) {
+        println("Exception: $e")
+    }
+    // Debugging
+    println "version.gradle TAG: " + System.getenv("VERSION_TAG") + ", ENVIRONMENT: " + System.getenv("VERSION_ENVIRONMENT");
 }
+
+executeBuildUtils()
 
 ext {
     VERSION_CODE=getVersionCode()
     VERSION_NAME=getVersionName()
-    VERSION_ENVIRONMENT=getVersionEnvironment()
-    VERSION_TIER=getVersionTier()
+    VERSION_ENVIRONMENT=System.getenv("VERSION_ENVIRONMENT")
+    VERSION_TAG=System.getenv("VERSION_TAG")
 }

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -64,4 +64,4 @@ ext {
     VERSION_TAG=System.getenv("VERSION_TAG")
 }
 
-println "version.gradle: VERSION_TAG: " + VERSION_TAG
+//println "version.gradle: VERSION_TAG: " + VERSION_TAG

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -57,8 +57,23 @@ def getVersionEnvironment = { ->
     }
 }
 
+def getVersionTier = { ->
+    String env_tier = System.getenv("TIER")
+    if (env_tier != null) {
+        // If building from script, we have build tier
+        println "Using $env_tier from TIER"
+        return "$env_tier"
+    } else {
+        // Building probably from IDE, so let's use TIER.md directly
+        String tier_md = file("$rootPath/../TIER.md").text.trim()
+        println "Using tier $tier_md from TIER.md"
+        return "$tier_md"
+    }
+}
+
 ext {
     VERSION_CODE=getVersionCode()
     VERSION_NAME=getVersionName()
     VERSION_ENVIRONMENT=getVersionEnvironment()
+    VERSION_TIER=getVersionTier()
 }


### PR DESCRIPTION
Addresses #7364 by appending the tier to the app name. For stable, we'll keep the default 'Keyman'.

Developers likely aren't going to have `TIER` defined as an environment variable though so I'm updating version.gradle to include VERSION_TIER. (CI only sets it for Release- and not Test- builds anyway)

## User Testing
Setup - Install the PR build of Keyman for Android 

* **TEST_APP_NAME** - Verifies the app name shows the tier
1. From the device launcher, show all apps
2. Browse to Keyman and verify the name is "Keyman Beta-test-7674"
3. Launch Keyman 
4. On the "Get Started" menu, enable Keyman as a system keyboard
5. Verify the Android system keyboard list has "Keyman Beta-test-7674"
6. On the Keyman "Get Started" menu, set Keyman as default keyboard
7. Verify the Android "Choose input method" list shows "Keyman Beta-test-7674"

 