### PR TITLE
chore(android/engine): Don't show Toast errors on stable tier

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/util/KMLog.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.tavultesoft.kmea.BaseActivity;
+import com.tavultesoft.kmea.BuildConfig;
+import com.tavultesoft.kmea.KMManager;
 
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
@@ -39,7 +41,9 @@ public final class KMLog {
     if (msg != null && !msg.isEmpty()) {
       Log.e(tag, msg);
 
-      BaseActivity.makeToast(null, msg, Toast.LENGTH_LONG);
+      if (KMManager.getTier(BuildConfig.KEYMAN_ENGINE_VERSION_NAME) != KMManager.Tier.STABLE) {
+        BaseActivity.makeToast(null, msg, Toast.LENGTH_LONG);
+      }
 
       if (Sentry.isEnabled()) {
         Sentry.captureMessage(msg, SentryLevel.ERROR);
@@ -62,7 +66,9 @@ public final class KMLog {
     }
     Log.e(tag, errorMsg, e);
 
-    BaseActivity.makeToast(null, errorMsg, Toast.LENGTH_LONG);
+    if (KMManager.getTier(BuildConfig.KEYMAN_ENGINE_VERSION_NAME) != KMManager.Tier.STABLE) {
+      BaseActivity.makeToast(null, errorMsg, Toast.LENGTH_LONG);
+    }
 
     if (Sentry.isEnabled()) {
       Sentry.addBreadcrumb(errorMsg);


### PR DESCRIPTION
Follow-on to #7390 which generates Toast notifications on errors and exceptions.

This updates KMLog so the Toast notifications appear only on pre-release builds.

@keymanapp-test-bot skip

I verified locally that the beta build shows a Toast error along with the [Sentry error](https://sentry.io/organizations/keyman/issues/3731201459)