### PR TITLE
fix(windows): Improve shutdown robustness

### DIFF
--- a/common/windows/delphi/general/Keyman.System.KeymanSentryClient.pas
+++ b/common/windows/delphi/general/Keyman.System.KeymanSentryClient.pas
@@ -34,6 +34,7 @@ type
     class procedure Validate(Force: Boolean = False);
 
     class procedure ReportHandledException(E: Exception; const Message: string = ''; IncludeStack: Boolean = True);
+    class procedure ReportMessage(const Message: string; IncludeStack: Boolean = True);
 
     class procedure Breadcrumb(const BreadcrumbType, Message: string; const Category: string = ''; const Level: string = 'info');
 
@@ -227,6 +228,14 @@ begin
     text := Format('%s: %s%s', [E.ClassName, text, E.Message]);
 
   Client.MessageEvent(TSentryLevel.SENTRY_LEVEL_WARNING, text, IncludeStack);
+end;
+
+class procedure TKeymanSentryClient.ReportMessage(const Message: string; IncludeStack: Boolean);
+begin
+  if not Enabled then
+    Exit;
+
+  Client.MessageEvent(TSentryLevel.SENTRY_LEVEL_WARNING, Message, IncludeStack);
 end;
 
 procedure TKeymanSentryClient.ReportRemoteErrors(const childEventID: string);

--- a/windows/src/engine/keyman/kmint.pas
+++ b/windows/src/engine/keyman/kmint.pas
@@ -54,12 +54,16 @@ const
 
 function KeymanCustomisation: IKeymanCustomisation;
 begin
-  Result := (kmcom.Control as IKeymanCustomisationAccess).KeymanCustomisation;
+  if kmcom = nil
+    then Result := nil
+    else Result := (kmcom.Control as IKeymanCustomisationAccess).KeymanCustomisation;
 end;
 
 function KeymanEngineControl: IKeymanEngineControl;
 begin
-  Result := kmcom.Control as IKeymanEngineControl;
+  if kmcom = nil
+    then Result := nil
+    else Result := kmcom.Control as IKeymanEngineControl;
 end;
 
 function EncodingsAsString(encodings: KeymanKeyboardEncodings): WideString;


### PR DESCRIPTION
Relates to KEYMAN-WINDOWS-B.

While this doesn't address the root cause of the exception, it should prevent this unhandled exception, and adds breadcrumbs to help us see which code path might be triggering the issue.

@keymanapp-test-bot skip