### PR TITLE
fix(linux): Fix keyboard icon in system tray

### DIFF
--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -104,7 +104,7 @@ gchar * keyman_get_icon_file(const gchar *kmx_file)
 
     p=rindex(kmx_file,'.');
     filename = g_strndup(kmx_file, p-kmx_file);
-    full_path_to_icon_file=g_strdup_printf("%s.ico.png", filename);
+    full_path_to_icon_file=g_strdup_printf("%s.bmp.png", filename);
     g_free(filename);
 
     if (!g_file_test(full_path_to_icon_file, G_FILE_TEST_EXISTS)) {


### PR DESCRIPTION
Show the keyboard specific icon in the system tray on Wasta instead of the generic keyman one.

Fixes #7547.

# User Testing

## Preparations

- The test should be run on Wasta 20.04 with Cinnamon

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Install the Khmer Angkor keyboard

- Reboot

## Tests

**TEST_ICON**: keyboard specific icon shows

- switch to Khmer Angkor keyboard by clicking on the icon in the system tray:

  ![image](https://user-images.githubusercontent.com/181336/201167777-4a68d0b3-1648-4f44-8e33-898e1ba215ab.png)

- verify that the keyboard specific icon shows instead of the generic Keyman icon:

  ![image](https://user-images.githubusercontent.com/181336/201168207-44d7bcf5-9716-499a-8115-8cd1b2ee2473.png)
