### PR TITLE
fix(android/engine): Use IME package name if query permission denied 🍒

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.VIBRATE" />
 
+  <!-- Ideally we would declare this permission so we can get other installed keyboard names.
+  But would involve a long review process with the Play Store:
+  https://support.google.com/googleplay/android-developer/answer/9214102#
+  <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" /> -->
   <application
     android:allowBackup="true"
     android:hardwareAccelerated="true"

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.inputmethodservice.InputMethodService;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
@@ -543,17 +544,24 @@ public final class KeyboardPickerActivity extends BaseActivity {
         ComponentName componentName = ComponentName.unflattenFromString(id);
         if (componentName != null) {
           String packageName = componentName.getPackageName();
+          String imeName = "";
           try {
-            //PackageInfo info = packageManager.getPackageInfo(packageName, 0);
             ApplicationInfo info = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
-            String imeName = (String)packageManager.getApplicationLabel(info);
+            imeName = (String)packageManager.getApplicationLabel(info);
+          } catch (PackageManager.NameNotFoundException e) {
+            // For Android 11+, this exception is thrown because we don't have QUERY_ALL_PACKAGES permission.
+            // We'll just display the package name instead.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+              KMLog.LogException(TAG, "Name not found", e);
+            }
+            imeName = packageName;
+          }
+
+          if (!imeName.isEmpty()) {
             HashMap<String, String> hashMap = new HashMap<String, String>();
             hashMap.put(titleKey, imeName);
             hashMap.put(subtitleKey, id);
             list.add(hashMap);
-
-          } catch (PackageManager.NameNotFoundException e) {
-            KMLog.LogException(TAG, "Name not found", e);
           }
         }
       }


### PR DESCRIPTION
:cherries: pick of #7664 to stable-15.0

Rather than applying for the QUERY_ALL_PACKAGES permission, we'll handle NameNotFoundExceptions as follows

> Quick fix seems like would be we handle NameNotFoundExceptions and just use the package name in that case?

So we'll fallback to display the packageName (not the descriptive keyboard name) on the keyboard picker.

## User Testing
Setup
1. Install the PR build of Keyman for Android on an Android 11+ device/emulator. You'll need to be signed into the Google Play Store for the other setup step
2. From the Google Play Store, install another IME (e.g "dominicweb african keyboard" is the one from some Sentry logs)
3. Setup the IME as an enabled system keyboard

* **TEST_PACKAGE_NAME_LISTED** - Verifies NameNotFound exception isn't thrown and other IME's appear on the keyboard picker
1. Launch Keyman for Android
2. On the "Get Started" menu,  enable Keyman as a system keyboard and set as the default keyboard
3. Open Chrome browser and click on the search box to display the keybaord
4. If Keyman keyboard doesn't appear, change keyboard to Keyman
5. Long-press on the globe key to display the Keyman keyboard picker
6. Verify the following:
    * Keyboard picker displays other IMEs (Samsung and Gboard should appear fine)
    * No Toast errors displayed about "NameNotFound exceptions"
    * The Dominic African keyboard appears as "eu.dominicweb.africankeyboard"
![keyboard picker](https://user-images.githubusercontent.com/7358010/200973886-ad5d63bd-5cff-4e00-9b5d-1c25b7d41528.jpg)
7. Select "eu.dominicweb.africankeyboard"
8. Verify the Domonic African keyboard appears

