### PR TITLE
refactor(linux): Use consts instead of strings

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -38,6 +38,7 @@
 #endif
 
 #include <keyman/keyboardprocessor.h>
+#include <keyman/keyboardprocessor_consts.h>
 
 #include "keymanutil.h"
 #include "keyman-service.h"
@@ -396,21 +397,17 @@ ibus_keyman_engine_constructor(
     km_kbp_option_item *keyboard_opts = g_new0(km_kbp_option_item, KEYMAN_ENVIRONMENT_OPTIONS + num_options + 1);
 
     keyboard_opts[0].scope = KM_KBP_OPT_ENVIRONMENT;
-    km_kbp_cp *cp = g_utf8_to_utf16 ("platform", -1, NULL, NULL, NULL);
-    keyboard_opts[0].key = cp;
-    cp = g_utf8_to_utf16 ("linux desktop hardware native", -1, NULL, NULL, NULL);
-    keyboard_opts[0].value = cp;
+    keyboard_opts[0].key   = KM_KBP_KMX_ENV_PLATFORM;
+    keyboard_opts[0].value = u"linux desktop hardware native";
 
     keyboard_opts[1].scope = KM_KBP_OPT_ENVIRONMENT;
-    cp = g_utf8_to_utf16 ("baseLayout", -1, NULL, NULL, NULL);
-    keyboard_opts[1].key = cp;
-    cp = g_utf8_to_utf16 ("kbdus.dll", -1, NULL, NULL, NULL);
-    keyboard_opts[1].value = cp;
+    keyboard_opts[1].key   = KM_KBP_KMX_ENV_BASELAYOUT;
+    keyboard_opts[1].value = u"kbdus.dll";
 
     keyboard_opts[2].scope = KM_KBP_OPT_ENVIRONMENT;
-    cp = g_utf8_to_utf16 ("baseLayoutAlt", -1, NULL, NULL, NULL);
-    keyboard_opts[2].key = cp;
-    #if 0 // in the future when mnemonic layouts are to be supported
+    keyboard_opts[2].key   = KM_KBP_KMX_ENV_BASELAYOUTALT;
+    keyboard_opts[2].value = u"en-US";
+#if 0  // in the future when mnemonic layouts are to be supported
     const gchar *lang_env = g_getenv("LANG");
     gchar *lang;
     if (lang_env != NULL) {
@@ -434,10 +431,10 @@ ibus_keyman_engine_constructor(
         lang = strdup("en-US");
     }
     g_message("lang is %s", lang);
-    #endif
-    cp = g_utf8_to_utf16 ("en-US", -1, NULL, NULL, NULL);
-    // g_free(lang);
+    km_kbp_cp *cp = g_utf8_to_utf16(lang, -1, NULL, NULL, NULL);
     keyboard_opts[2].value = cp;
+    // g_free(lang);
+#endif
 
     // If queue_options contains keyboard options, pop them into keyboard_opts[3] onward
     for(int i=0; i<num_options; i++)

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -432,7 +432,7 @@ ibus_keyman_engine_constructor(
     }
     g_message("lang is %s", lang);
     km_kbp_cp *cp = g_utf8_to_utf16(lang, -1, NULL, NULL, NULL);
-    keyboard_opts[2].value = cp;
+    keyboard_opts[2].value = cp; // TODO: free this value
     // g_free(lang);
 #endif
 
@@ -459,9 +459,9 @@ ibus_keyman_engine_constructor(
     {
         g_warning("%s: problem creating km_kbp_state", __FUNCTION__);
     }
-    for (int i=0; i < KEYMAN_ENVIRONMENT_OPTIONS + num_options + 1; i++) {
-        g_free((km_kbp_cp *)keyboard_opts[i].key);
-        g_free((km_kbp_cp *)keyboard_opts[i].value);
+    for (int i = KEYMAN_ENVIRONMENT_OPTIONS; i < KEYMAN_ENVIRONMENT_OPTIONS + num_options + 1; i++) {
+      g_free((km_kbp_cp *)keyboard_opts[i].key);
+      g_free((km_kbp_cp *)keyboard_opts[i].value);
     }
     g_queue_free_full(queue_options, NULL);
     g_free(keyboard_opts);


### PR DESCRIPTION
This refactoring makes use of the already defined strings. It also simplifies setting the values by directly specifying an UTF-16 string.

Motivated by the changes in PR #7667.

@keymanapp-test-bot skip