### PR TITLE
fix(windows): make sure IdStackWindows finalizes after Vcl.Forms

### DIFF
--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -1,6 +1,7 @@
 program kmshell;
 
 uses
+  IdStackWindows,
   Winapi.Windows,
   comobj,
   Forms,
@@ -198,7 +199,7 @@ begin
         Application.Initialize;
         Application.Title := 'Keyman Configuration';
         Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-  try
+        try
           Run;
         finally
           FreeAndNil(modWebHttpServer);


### PR DESCRIPTION
Fixes #7690.

When kmshell.dpr is being shut down by Windows via `WM_ENDSESSION`, the order of termination of units through `finalization` sections means that `IdStackWindows` was finalizing while components were still depending on it, causing a cascade of exceptions resulting eventually in the crash visible in #7690.

We saw this when there were message loops before `Application.Run` had ever been called. For example, message box/dialog, ShellExecute (yep... this can do a `PeekMessage`), `THttpUploader` (which calls `Application.ProcessMessages`) and probably others.

Ideally, it would be better to always call `Application.Run`, but it is not safe to call `Application.Run` more than once, because it ends up adding multiple `DoneApplication` exit procs, which would likely cause other crashes.

I landed on the somewhat heavy-handed solution of adding `IdStackWindows` to the start of the project `uses` list, ensuring it is the last unit to be finalized -- importantly, before `Vcl.Forms`. A better solution would be to find a way of ensuring that `Application.Run` is called, just once, in all situations, but this is likely to be hard to achieve. The shutdown sequence for Delphi apps is so very, very fragile.

# User Testing

For all these tests, there should be no crashes. Please run each test a few times.

* **TEST_CONFIGURATION:** Open Keyman Configuration, then close it again.
* **TEST_START:** Start and shutdown Keyman.
* **TEST_UPDATES:** Run `"C:\Program Files (x86)\Keyman\Keyman Desktop\kmshell.exe" -ouc` from a command prompt.