### PR TITLE
fix(web): documentation keyboard style application + layout

### DIFF
--- a/web/source/osk/oskRow.ts
+++ b/web/source/osk/oskRow.ts
@@ -56,9 +56,7 @@ namespace com.keyman.osk {
       const rs = this.element.style;
 
       const rowHeight = vkbd.internalHeight.scaledBy(this.heightFraction);
-      if(vkbd.usesFixedHeightScaling) {
-        rs.maxHeight=rs.lineHeight=rs.height=rowHeight.styleString;
-      }
+      rs.maxHeight=rs.lineHeight=rs.height=rowHeight.styleString;
 
       // Only used for fixed-height scales at present.
       const padRatio = 0.15;

--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -564,18 +564,6 @@ namespace com.keyman.osk {
       }
       // END:  construction of the actual internal layout for the overall OSK
 
-      // Correct the classname for the (inner) OSK frame (Build 360)
-      var kbdID: string = (this.activeKeyboard ? this.activeKeyboard.id.replace('Keyboard_','') : '');
-
-      if(kbdID.indexOf('::') != -1) { // We used to also test if we were in embedded mode, but... whatever.
-        // De-namespaces the ID for use with CSS classes.
-        // Assumes that keyboard IDs may not contain the ':' symbol.
-        kbdID = kbdID.substring(kbdID.indexOf('::') + 2);
-      }
-
-      const kbdClassSuffix = ' kmw-keyboard-' + kbdID;
-      kbdView.element.className = kbdView.element.className + kbdClassSuffix;
-
       this.banner.appendStyles();
 
       if(this.vkbd) {

--- a/web/source/osk/oskView.ts
+++ b/web/source/osk/oskView.ts
@@ -367,20 +367,20 @@ namespace com.keyman.osk {
     protected get parsedBaseFontSize(): ParsedLengthStyle {
       if(!this._baseFontSize) {
         let keymanweb = com.keyman.singleton;
-        this._baseFontSize = this.defaultFontSize(this.device, keymanweb.isEmbedded);
+        this._baseFontSize = OSKView.defaultFontSize(this.device, this.computedHeight, keymanweb.isEmbedded);
       }
 
       return this._baseFontSize;
     }
 
-    public defaultFontSize(device: utils.DeviceSpec, isEmbedded: boolean): ParsedLengthStyle {
+    public static defaultFontSize(device: utils.DeviceSpec, computedHeight: number, isEmbedded: boolean): ParsedLengthStyle {
       if(device.touchable) {
         const fontScale = device.formFactor == 'phone'
           ? 1.6 * (isEmbedded ? 0.65 : 0.6) * 1.2  // Combines original scaling factor with one previously applied to the layer group.
           : 2; // iPad or Android tablet
         return ParsedLengthStyle.special(fontScale, 'em');
       } else {
-        return this.computedHeight ? ParsedLengthStyle.inPixels(this.computedHeight / 8) : undefined;
+        return computedHeight ? ParsedLengthStyle.inPixels(computedHeight / 8) : undefined;
       }
     }
 

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -110,7 +110,16 @@ namespace com.keyman.osk {
     }
 
     set layerId(value: string) {
-      this._layerId = value;
+      const changedLayer = value != this._layerId;
+      if(this.layerGroup.layers[value]) {
+        this._layerId = value;
+      } else {
+        throw new Error(`Keyboard ${this.layoutKeyboard.id} does not have a layer with id ${value}`);
+      }
+
+      if(changedLayer) {
+        this.updateState();
+      }
     }
 
     get currentLayer(): OSKLayer {
@@ -1491,7 +1500,7 @@ namespace com.keyman.osk {
       // Select the layer to display, and adjust sizes
       if (layout != null) {
         kbdObj.layerId = layerId;
-        kbdObj.updateState();
+
         // This still feels fairly hacky... but something IS needed to constrain the height.
         // There are plans to address related concerns through some of the later aspects of
         // the Web OSK-Core design.

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1317,7 +1317,12 @@ namespace com.keyman.osk {
     private getVerticalLayerGroupPadding(): number {
       // For touch-based OSK layouts, kmwosk.css may include top & bottom padding on the layer-group element.
       const computedGroupStyle = getComputedStyle(this.layerGroup.element);
-      return parseInt(computedGroupStyle.paddingTop, 10) + parseInt(computedGroupStyle.paddingBottom, 10);
+      let pt = parseInt(computedGroupStyle.paddingTop, 10);
+      let pb = parseInt(computedGroupStyle.paddingBottom, 10);
+
+      pt = isNaN(pt) ? 0 : pt; // parseInt('') == NaN; handle such cases!
+      pb = isNaN(pb) ? 0 : pb;
+      return pt + pb;
     }
 
     /*private*/ computedAdjustedOskHeight(allottedHeight: number): number {

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1540,17 +1540,17 @@ namespace com.keyman.osk {
 
             // Grab a reference to the stylesheet.
             const stylesheet = kbdObj.styleSheet;
+            const stylesheetHead = stylesheet.parentElement;
 
             // Don't reset top-level stuff; just the visible layer.
             kbdObj.currentLayer.refreshLayout(kbdObj, kbdObj.height);
 
             // We no longer need a reference to the constructing VisualKeyboard, so we should let
-            // it clean up its <head> stylesheet links.
+            // it clean up its <head> stylesheet links.  This detaches the stylesheet, though.
             kbdObj.shutdown();
 
-            // Now that shutdown is done (and thus won't detach the stylesheet), attach the stylesheet
-            // under the class wrapper.
-            classWrapper.appendChild(stylesheet);
+            // Now that shutdown is done, re-attach the stylesheet.
+            stylesheetHead.appendChild(stylesheet);
           } finally {
             insertionObserver.disconnect();
           }

--- a/web/source/osk/visualKeyboard.ts
+++ b/web/source/osk/visualKeyboard.ts
@@ -1508,6 +1508,8 @@ namespace com.keyman.osk {
         // There are plans to address related concerns through some of the later aspects of
         // the Web OSK-Core design.
         kbdObj.setSize(800, height); // Probably need something for width, too, rather than
+        kbdObj.fontSize = OSKView.defaultFontSize(device.coreSpec, height, false);
+
         // assuming 100%.
         kbdObj.refreshLayout(); // Necessary for the row heights to be properly set!
         // Relocates the font size definition from the main VisualKeyboard wrapper, since we don't return the whole thing.
@@ -1541,7 +1543,12 @@ namespace com.keyman.osk {
             const stylesheetParentElement = stylesheet.parentElement;
 
             // Don't reset top-level stuff; just the visible layer.
-            kbdObj.currentLayer.refreshLayout(kbdObj, kbdObj.height);
+            // kbdObj.currentLayer.refreshLayout(kbdObj, kbdObj.height);
+
+            // We refresh the full layout so that font-size is properly detected & stored
+            // on the documentation keyboard.
+            kbdObj.refreshLayout();
+            kbd.style.fontSize = kbdObj.kbdDiv.style.fontSize;
 
             // We no longer need a reference to the constructing VisualKeyboard, so we should let
             // it clean up its <head> stylesheet links.  This detaches the stylesheet, though.

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -50,23 +50,56 @@
                 platform == 'phone' ? 240 : 360;
       };
 
+      let shadowfy = function(container) {
+        const docBase = container.children[0];
+        container.removeChild(docBase);
+
+        const style = docBase.children[1];
+        docBase.removeChild(style);
+
+        const shadow = container.attachShadow({ mode: "open" });
+        shadow.appendChild(docBase);
+
+        const baseOSKStyle = document.createElement('link');
+        baseOSKStyle.href = "../../release/unminified/web/osk/kmwosk.css";
+        baseOSKStyle.rel="stylesheet";
+        baseOSKStyle.type="text/css";
+        shadow.appendChild(baseOSKStyle);
+
+        shadow.appendChild(style);
+      }
+
+      let documentKeyboard = async function(kbdid, langid, formFactor, layer) {
+        let docTarget = document.getElementById("docTarget");
+        label = document.createElement('h3');
+        docTarget.appendChild(label);
+
+        const container = document.createElement('div');
+
+        await kmw.addKeyboards(`${kbdid}@${langid}`);
+        await kmw.setActiveKeyboard(kbdid, langid);
+        docBase = keyman.BuildVisualKeyboard(kbdid, 1, formFactor, layer);
+
+        label.textContent = `${keyman.getKeyboard(kbdid).Name} - ${formFactor} - ${layer} layer`;
+        container.appendChild(docBase);
+
+        docTarget.appendChild(container);
+
+        await Promise.resolve(); // Trigger message queue:  let the mutation observer do its thing.
+        shadowfy(container);
+      }
+
       kmw.init({
         }).then(async function() {
-          var docTarget = document.getElementById("docTarget");
 
-          await kmw.addKeyboards('gff_amharic');
-          await kmw.setActiveKeyboard("gff_amharic", "am");
-          var kbdDiv = keyman.BuildVisualKeyboard("gff_amharic", 1, "phone", "default");
-
-          // await kmw.addKeyboards('sil_euro_latin@no');
-          // await kmw.setActiveKeyboard("sil_euro_latin", "no");
-          // var kbdDiv = keyman.BuildVisualKeyboard("sil_euro_latin", 1, "phone", "default");
-
-          // await kmw.addKeyboards('lao_2008_basic');
-          // await kmw.setActiveKeyboard("lao_2008_basic", "lo");
-          // var kbdDiv = keyman.BuildVisualKeyboard("lao_2008_basic", 1, "phone", "default");
-
-          docTarget.appendChild(kbdDiv);
+          // Order matters here!  There's a bit of style-sheet pollution where one keyboard's font styles
+          // can override some of the others.
+          await documentKeyboard("gff_amharic", "am", "phone", "default");
+          await documentKeyboard("sil_euro_latin", "no", "phone", "shift");
+          await documentKeyboard("lao_2008_basic", "lo", "tablet", "default");
+          await documentKeyboard("lao_2008_basic", "lo", "desktop", "default");
+          await documentKeyboard("sil_cameroon_azerty", "pny", "tablet", "default");
+          await documentKeyboard("khmer_angkor", "km", "desktop", "default");
         });
     </script>
 

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -20,6 +20,7 @@
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
       #KeymanWebControl {width:50%;min-width:600px;}
+      code {line-height: 1.6; font-style: oblique; }
     </style>
 
     <!-- Insert uncompiled KeymanWeb source scripts -->
@@ -71,6 +72,9 @@
         label = document.createElement('h3');
         docTarget.appendChild(label);
 
+        let idLabel = document.createElement('code');
+        docTarget.appendChild(idLabel);
+
         const container = document.createElement('div');
 
         await kmw.addKeyboards(`${kbdid}@${langid}`);
@@ -78,6 +82,7 @@
         docBase = keyman.BuildVisualKeyboard(kbdid, 1, formFactor, layer);
 
         label.textContent = `${keyman.getKeyboard(kbdid).Name} - ${formFactor} - ${layer} layer`;
+        idLabel.textContent = `${kbdid.replace(/^Keyboard_/)}`;
         container.appendChild(docBase);
 
         docTarget.appendChild(container);

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -99,9 +99,6 @@
 
       kmw.init({
         }).then(async function() {
-
-          // Order matters here!  There's a bit of style-sheet pollution where one keyboard's font styles
-          // can override some of the others.
           await documentKeyboard("gff_amharic", "am", "phone", "default");
           await documentKeyboard("sil_euro_latin", "no", "phone", "shift");
           await documentKeyboard("lao_2008_basic", "lo", "tablet", "default");

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -52,23 +52,28 @@
 
       kmw.init({
         }).then(async function() {
-          await kmw.addKeyboards('gff_amharic');
-
-          await kmw.setActiveKeyboard("gff_amharic", "am");
-
           var docTarget = document.getElementById("docTarget");
+
+          await kmw.addKeyboards('gff_amharic');
+          await kmw.setActiveKeyboard("gff_amharic", "am");
           var kbdDiv = keyman.BuildVisualKeyboard("gff_amharic", 1, "phone", "default");
+
+          // await kmw.addKeyboards('sil_euro_latin@no');
+          // await kmw.setActiveKeyboard("sil_euro_latin", "no");
+          // var kbdDiv = keyman.BuildVisualKeyboard("sil_euro_latin", 1, "phone", "default");
+
+          // await kmw.addKeyboards('lao_2008_basic');
+          // await kmw.setActiveKeyboard("lao_2008_basic", "lo");
+          // var kbdDiv = keyman.BuildVisualKeyboard("lao_2008_basic", 1, "phone", "default");
+
           docTarget.appendChild(kbdDiv);
         });
     </script>
 
-    <!-- Add keyboard management script for local selection of keyboards to use -->
-    <script src="../commonHeader.js"></script>
-
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Keyboard documentation rendering</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -50,12 +50,9 @@
                 platform == 'phone' ? 240 : 360;
       };
 
-      let shadowfy = function(container) {
+      let shadowfy = function(container, style) {
         const docBase = container.children[0];
         container.removeChild(docBase);
-
-        const style = docBase.children[1];
-        docBase.removeChild(style);
 
         const shadow = container.attachShadow({ mode: "open" });
         shadow.appendChild(docBase);
@@ -86,7 +83,13 @@
         docTarget.appendChild(container);
 
         await Promise.resolve(); // Trigger message queue:  let the mutation observer do its thing.
-        shadowfy(container);
+
+        // Grab the stylesheet element that was inserted; there should be no intervening additions,
+        // so the newly-added stylesheet element should be the last element in the <head> section.
+        const stylesheet = document.head.lastChild;
+        stylesheet.parentElement.removeChild(stylesheet);
+
+        shadowfy(container, stylesheet);
       }
 
       kmw.init({

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -87,7 +87,10 @@
 
         docTarget.appendChild(container);
 
-        await Promise.resolve(); // Trigger message queue:  let the mutation observer do its thing.
+        // Trigger message queue:  let the mutation observer do its thing.
+        // In case it's not obvious:  this is only really safe because this test page is a
+        // highly-controlled environment.
+        await Promise.resolve();
 
         // Grab the stylesheet element that was inserted; there should be no intervening additions,
         // so the newly-added stylesheet element should be the last element in the <head> section.

--- a/web/testing/build-visual-keyboard/index.html
+++ b/web/testing/build-visual-keyboard/index.html
@@ -2,44 +2,44 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    
-    <!-- Set the viewport width to match phone and tablet device widths -->                         
-    <meta name="viewport" content="width=device-width,user-scalable=no" /> 
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
 
     <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+
     <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> 
-      
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
     <title>KeymanWeb Testing Page - Basic IFrames</title>
 
-    <!-- Your page CSS --> 
-    <style type='text/css'>   
+    <!-- Your page CSS -->
+    <style type='text/css'>
       body {font-family: Tahoma,helvetica;}
       h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
       .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
-      #KeymanWebControl {width:50%;min-width:600px;}       
-    </style> 
- 
-    <!-- Insert uncompiled KeymanWeb source scripts -->              
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
     <script src="../../release/unminified/web/keymanweb.js" type="application/javascript"></script>
 
-    <!-- 
+    <!--
       For desktop browsers, a script for the user interface must be inserted here.
-       
-      Standard UIs are toggle, button, float and toolbar.  
-      The toolbar UI is best for any page designed to support keyboards for 
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
       a large number of languages.
     -->
     <script src="../../release/unminified/web/kmwuitoggle.js"></script>
- 
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       var kmw=window.keyman;
 
       var platform = 'desktop';
-      
+
       keyman.getOskWidth = function() {
         return platform == 'desktop' ? 960 :
                 platform == 'phone' ? 520 : 720;
@@ -51,55 +51,57 @@
       };
 
       kmw.init({
-        }).then(function() {
-          kmw.setActiveKeyboard("lao_2008_basic").then(function() {
-            var docTarget = document.getElementById("docTarget");
-            var kbdDiv = keyman.BuildVisualKeyboard("lao_2008_basic", 1, "phone", "shift");
-            docTarget.appendChild(kbdDiv);
-          });
+        }).then(async function() {
+          await kmw.addKeyboards('gff_amharic');
+
+          await kmw.setActiveKeyboard("gff_amharic", "am");
+
+          var docTarget = document.getElementById("docTarget");
+          var kbdDiv = keyman.BuildVisualKeyboard("gff_amharic", 1, "phone", "default");
+          docTarget.appendChild(kbdDiv);
         });
-    </script> 
-    
+    </script>
+
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <script src="../commonHeader.js"></script>
-  
+
   </head>
 
-<!-- Sample page HTML -->  
+<!-- Sample page HTML -->
   <body onload='loadKeyboards(1);'>
     <h2>KeymanWeb:  Keyboard documentation rendering</h2>
 
     <div id='DynamicTextboxes'>
-    <!-- 
+    <!--
       The following DIV is used to position the Button or Toolbar User Interfaces on the page.
       If omitted, those User Interfaces will appear at the top of the document body.
       (It is ignored by other User Interfaces.)
     -->
-    <div id='KeymanWebControl'></div>                                                                                   
+    <div id='KeymanWebControl'></div>
 	<h3>This test page exists for testing KMW's keyboard-documentation rendering system.</h3>
 	<!--<iframe src="hello-world.html" height=100></iframe>-->
   <hr>
   <div id="docTarget"></div>
-  </div> 	
+  </div>
    <h3><a href="../">Return to testing home page</a></h3>
 
-  
- 
+
+
   </body>
-  
-  <!-- 
+
+  <!--
     *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
     *
     * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
-    * to display the special characters used in the On-Screen Keyboard. 
-    * 
-    * To work around this Firefox bug, navigate to <b>about:config</b> 
-    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b> 
-    * while testing. 
-    * 
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
     * Firefox resolves website-based CSS URI references correctly without needing
     * any configuration change, so this change should only be made for file-based testing.
-    *   
-    ***   
-  -->     
+    *
+    ***
+  -->
 </html>


### PR DESCRIPTION
Fixes #7691.
Also provides some initial exploration & experimentation toward #4881.
Addresses a couple of points from #7268.

There are four total bugs addressed by this PR:

1.  Keyboard documentation elements were not being given their appropriate styling.
    a. The top-level keyboard-documentation object was not marked with a CSS class corresponding to the keyboard.
    b. Even if it were, the corresponding CSS stylesheet was never applied; it had only ever been inserted as part of a live, non-static OSK.  (The code was in `OSKView`, not `VisualKeyboard`, and so the doc-keyboard functionality never touched it.)

2. Row height was not being properly set for documentation keyboards, leaving an ugly 'blank row" on four-row layouts.

3.  The layer ID specified for documentation keyboards was never validated, with errors being "silently handled"... and returning a malformed "default" layer instead.  (Noted in #7268.)

4. Certain cases could cause a `NaN` value to appear in layout logic, which can easily lead to unintended side-effects if not properly caught and handled properly.

------

To help validate these changes, I've tweaked the "Tests keyboard documentation rendering" test page.

![image](https://user-images.githubusercontent.com/25213402/201560332-dde7d6d9-8616-4cab-8d4a-1aab403b4ea1.png)

I did run into a fun issue while making the test page - displaying documentation for multiple different keyboards at once would result in font styling being stomped on by the last keyboard to be processed.  The cleanest way to resolve that tidbit... was to experiment with and utilize Shadow DOM on the test page to isolate each one's stylesheet within its own "shadow root" that also contained the OSK.  (This is **only** for the testing page, not within KeymanWeb itself.)  So, parts of this should be _very_ useful for #4881; it just makes the necessary changes "in post" on an isolated test page, rather than within KMW.

## User Testing

These tests should utilize the following two test pages:
- "Tests keyboard documentation rendering"
- "Test unminified Keymanweb"

**TEST_AMHARIC**:  Compare `gff_amharic`'s phone form-factor _default_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `gff_amharic` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page on an Android or iOS phone form-factor device.
    1. Type `gff_amharic` into the text box beside the first "Add" button, then click "Add".
    2.  Click the "Type here" textbox and swap to the Amharic keyboard to display its OSK.
3. Compare the two renders of the OSK.  If any special formatting is missing from the version on "Tests keyboard documentation rendering" page, _**FAIL**_ this test.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if there is no spacebar text.
    - **_FAIL_** if the font used for the keys does not match.

**TEST_EUROLATIN**:  Compare `sil_euro_latin`'s phone form-factor _shift_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `sil_euro_latin` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page on an Android or iOS phone form-factor device.
    1. `sil_euro_latin` should be pre-loaded.
    2.  Click the "Type here" textbox and swap to Norwegian (the SIL EuroLatin keyboard) to display its OSK.
    3. Activate the _shift_ layer.
4. Compare the two renders of the OSK.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if there is no spacebar text.
    - **_FAIL_** if the font used for the keys does not match.

**TEST_LAO_TABLET**:  Compare `lao_2008_basic`'s tablet form-factor _default_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `lao_2008_basic` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page on an Android or iOS tablet form-factor device.
    1.  `lao_2008_basic` should be pre-loaded.
    2.  Click the "Type here" textbox and swap to Lao to display its OSK.
3. Compare the two renders of the OSK.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if there is no spacebar text.
    - **_FAIL_** if the font used for the keys does not match.

**TEST_LAO_DESKTOP**:  Compare `lao_2008_basic`'s desktop form-factor _default_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `lao_2008_basic` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page via standard desktop browser (Chrome / Firefox / Edge / Safari).
    1.  `lao_2008_basic` should be pre-loaded.
    2.  Click the "Type here" textbox and swap to Lao to display its OSK.
3. Compare the two renders of the OSK.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if the orange border elements are missing; we're only testing the actual keyboard part of the OSK.
    - **_FAIL_** if the font used for the keys does not match.

**TEST_CAM_AZERTY**:  Compare `sil_cameroon_azerty`'s tablet form-factor _default_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `gff_amharic` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page on an Android or iOS tablet form-factor device.
    1. Type `sil_cameroon_azerty` into the text box beside the first "Add" button, then click "Add".
    2.  Click the "Type here" textbox and swap to the first language entry (Afade) to display its OSK.
3. Compare the two renders of the OSK.  If any special formatting is missing from the version on "Tests keyboard documentation rendering" page, _**FAIL**_ this test.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if there is no spacebar text.
    - **_FAIL_** if the font used for the keys does not match.

**TEST_KHMER**:  Compare `khmer_angkor`'s desktop form-factor _default_ layer for the two test pages.

1. Load the "Tests keyboard documentation rendering" test page and verify that an OSK is rendered for `khmer_angkor` under its header.
2. Load the keyboard on the "Test unminified Keymanweb" test page via standard desktop browser (Chrome / Firefox / Edge / Safari).
    1.  `khmer_angkor` should be pre-loaded.
    2.  Click the "Type here" textbox and swap to Khmer to display its OSK.
3. Compare the two renders of the OSK.
    - If testing via iOS (simulated or not), the two versions should be near-perfect matches.
    - **_Do not fail_** if the orange border elements are missing; we're only testing the actual keyboard part of the OSK.
    - **_FAIL_** if the font used for the keys does not match.