### PR TITLE
chore(windows): add sentry traces for unsolved crashes

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.js
+++ b/windows/src/desktop/kmshell/xml/config.js
@@ -412,6 +412,10 @@ function keyboard_toggle(keyboard_name) {
 
 function showKeyboardLink(id) {
   var e = document.getElementById('qrcode-'+id);
+  if(window.Sentry) {
+    // trace for KEYMAN-WINDOWS-4R
+    window.Sentry.addBreadcrumb({category:'trace', message:`showKeyboardLink:id=${id}, e=${e?'defined':'undefined'}`, level: 'info'});
+  }
   e.className='qrcode qrcode_visible';
 }
 

--- a/windows/src/desktop/kmshell/xml/menu-frame.js
+++ b/windows/src/desktop/kmshell/xml/menu-frame.js
@@ -19,6 +19,13 @@
     var p = menuframe_items[menuframe_activeindex], c = menuframe_items[n];
     var itemtype, list_array;
 
+    if(window.Sentry) {
+      // trace for KEYMAN-WINDOWS-62, KEYMAN-WINDOWS-6H(?)
+      window.Sentry.addBreadcrumb({category:'trace', message:`menuframe_activate:n=${n}, activeindex=${menuframe_activeindex}, c=${JSON.stringify(c)}, p=${JSON.stringify(p)}`, level: 'info'});
+      if(!document.getElementById('content_'+p.menu_name)) window.Sentry.addBreadcrumb({category:'trace', message:`menuframe_activate:p:content_${p.menu_name} is undefined`, level: 'info'});
+      if(!document.getElementById('content_'+c.menu_name)) window.Sentry.addBreadcrumb({category:'trace', message:`menuframe_activate:c:content_${c.menu_name} is undefined`, level: 'info'});
+    }
+
     p.className='menuframe';
     c.className='menuframe_active';
     menuframe_activeindex=n;

--- a/windows/src/desktop/kmshell/xml/menu.js
+++ b/windows/src/desktop/kmshell/xml/menu.js
@@ -25,6 +25,11 @@ var menudiv = null, global_menu_elem_name = null;
     var menu = document.getElementById('menu_'+name), button = document.getElementById('button_'+name);
     var index = name.substr(8,2);
 
+    if(window.Sentry) {
+      // trace for KEYMAN-WINDOWS-7J
+      window.Sentry.addBreadcrumb({category:'trace', message:`ShowMenu:name=${name}, menu=${menu?'defined':'undefined'} menudiv=${menudiv?'defined':'undefined'}`, level: 'info'});
+    }
+
     menudiv.innerHTML = menu.innerHTML;
     menudiv.style.width = menu.offsetWidth + 'px';
     menudiv.style.overflowY = 'auto';
@@ -192,17 +197,15 @@ var menudiv = null, global_menu_elem_name = null;
     }
   }
 
-  function menu_doAttachEvent(obj, e, f)
-  {
-    if(obj.attachEvent) return obj.attachEvent('on'+e, f);
-    return obj.addEventListener(e, f, false);
-  }
-
   function menusetup() {
     menudiv = document.createElement('SPAN');
     menudiv.className='menu';
-    menu_doAttachEvent(menudiv, 'mouseup', HideMenu);
+    menudiv.addEventListener('mouseup', HideMenu);
     document.body.appendChild(menudiv);
+    if(window.Sentry) {
+      // trace for KEYMAN-WINDOWS-7J
+      window.Sentry.addBreadcrumb({category:'trace', message:`menusetup: menudiv defined`, level: 'info'});
+    }
   }
-  menu_doAttachEvent(window, 'load', menusetup);
+  window.addEventListener('load', menusetup);
 


### PR DESCRIPTION
Adds Sentry breadcrumbs for the following crash reports:
* KEYMAN-WINDOWS-62
* KEYMAN-WINDOWS-6H (? no reports in recent releases, so may be resolved)
* KEYMAN-WINDOWS-7J
* KEYMAN-WINDOWS-4R

The source of these crashes is hard to pinpoint, so hoping that this additional data sheds some light.

@keymanapp-test-bot skip