### PR TITLE
chore(windows): Add safecall for internal CustomisationStorage API interface

### DIFF
--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -168,7 +168,7 @@ type
     procedure Refresh;
 
     { IKeymanCustomisationAccess }
-    function KeymanCustomisation: IKeymanCustomisation;
+    function KeymanCustomisation: IKeymanCustomisation; safecall;
   public
     constructor Create(AContext: TKeymanContext);
     destructor Destroy; override;

--- a/windows/src/engine/kmcomapi/util/internalinterfaces.pas
+++ b/windows/src/engine/kmcomapi/util/internalinterfaces.pas
@@ -103,7 +103,7 @@ type
     procedure SetAutoApply(Value: Boolean);
     property AutoApply: Boolean read GetAutoApply write SetAutoApply;
     procedure Refresh;
-    function KeymanCustomisation: IKeymanCustomisation;
+    function KeymanCustomisation: IKeymanCustomisation; safecall;
   end;
 
   IIntKeymanKeyboardsPackageInstalled = interface(IIntKeymanInterface)

--- a/windows/src/global/delphi/cust/custinterfaces.pas
+++ b/windows/src/global/delphi/cust/custinterfaces.pas
@@ -161,7 +161,7 @@ type
 
   IKeymanCustomisationAccess = interface
     ['{CE1EEB3F-3CF3-46C0-B7AF-C64040F6CFD9}']
-    function KeymanCustomisation: IKeymanCustomisation;
+    function KeymanCustomisation: IKeymanCustomisation; safecall;
   end;
 
 const


### PR DESCRIPTION
This makes it easier to track what is happening for errors where otherwise we found that exception messages were being cropped; for example:

* [KEYMAN-WINDOWS-X](https://sentry.io/organizations/keyman/issues/2700324563/?project=5983518&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d)
* [KEYMAN-WINDOWS-BR](https://sentry.io/organizations/keyman/issues/2830726485/?project=5983518&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d)

The error messages were being cropped because the exception handler was in the exe module, but the exception was being raised in kmcomapi module. When the exception was handled, the handler tested to see if the exception object inherited from exemodule.Exception, but it was inheriting from kmcomapi.Exception instead, and so it did not attempt to load the message detail.

By adding `safecall` calling convention to `KeymanCustomisation`, we move responsibility for handling the exception to the `TKeymanAutoObject.SafeCallException` function, and we get full detail for the exception.

@keymanapp-test-bot skip