### PR TITLE
chore(android/engine): Add more logging for keyboard restart

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/KeyboardController.java
@@ -191,10 +191,11 @@ public class KeyboardController {
   public int getKeyboardIndex(String key) {
     int index = INDEX_NOT_FOUND;
     if (!isInitialized || list == null) {
-      KMLog.LogError(TAG, "getIndexOfKey while KeyboardController() not initialized");
+      KMLog.LogError(TAG, "getKeyboardIndex while KeyboardController() not initialized");
       return index;
     }
     if (key == null || key.isEmpty()) {
+      KMLog.LogError(TAG, "getKeyboardIndex while key is null");
       return index;
     }
 


### PR DESCRIPTION
For analyzing #7712 
This adds an additional log to try to get more insight on why some users can't load en_sil_euro_latin

@keymanapp-test-bot skip
