### PR TITLE
fix(android/engine): Remove duplicate file suffix when installing .kmp

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -72,7 +72,7 @@ public class PackageProcessor {
   public String getPackageID(File path) {
     // Sometimes, downloading a kmp multiple times results in a filename with a suffix:
     // " (#).kmp" or "-#.kmp" in the filename, so strip out the number
-    String filename = path.getName().toLowerCase().replaceAll("(\\s+\\(|-)\\d+\\)?", "");
+    String filename = path.getName().toLowerCase().replaceAll("(\\s+\\(|-)\\d+\\)?.kmp$", ".kmp");
 
     if(resourceRoot == null) {
       throw new IllegalStateException("The PackageProcessor has not been initialized!");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -70,7 +70,9 @@ public class PackageProcessor {
    * @throws IllegalArgumentException
    */
   public String getPackageID(File path) {
-    String filename = path.getName().toLowerCase();
+    // Sometimes, downloading a kmp multiple times results in a filename with a suffix:
+    // " (#).kmp" or "-#.kmp" in the filename, so strip out the number
+    String filename = path.getName().toLowerCase().replaceAll("(\\s+\\(|-)\\d+\\)?", "");
 
     if(resourceRoot == null) {
       throw new IllegalStateException("The PackageProcessor has not been initialized!");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -72,7 +72,8 @@ public class PackageProcessor {
   public String getPackageID(File path) {
     // Sometimes, downloading a kmp multiple times results in a filename with a suffix:
     // " (#).kmp" or "-#.kmp" in the filename, so strip out the number
-    String filename = path.getName().toLowerCase().replaceAll("(\\s+\\(|-)\\d+\\)?.kmp$", ".kmp");
+    String filename = path.getName().toLowerCase().replaceAll(
+      "\\s*((\\(\\d+\\))|(-\\d+))\\.kmp$", ".kmp");
 
     if(resourceRoot == null) {
       throw new IllegalStateException("The PackageProcessor has not been initialized!");

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -245,10 +245,12 @@ public class PackageProcessorTest {
     Assert.assertEquals(TEST_EN_CUSTOM_MODEL_NAME, PP.getPackageID(TEST_EN_CUSTOM_MODEL_KMP_FILE));
 
     // Test trimming " (#)" from kmp name
+    Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor(10).kmp")));
     Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor (10).kmp")));
 
     // Test trimming "-#" from kmp name
     Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor-10.kmp")));
+    Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor -10.kmp")));
   }
 
   @Test

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/packages/PackageProcessorTest.java
@@ -243,6 +243,12 @@ public class PackageProcessorTest {
     Assert.assertEquals(TEST_GFF_KMP_NAME, PP.getPackageID(TEST_GFF_KMP_FILE));
     Assert.assertNotEquals(TEST_GFF_KBD_ID, PP.getPackageID(TEST_GFF_KMP_FILE));
     Assert.assertEquals(TEST_EN_CUSTOM_MODEL_NAME, PP.getPackageID(TEST_EN_CUSTOM_MODEL_KMP_FILE));
+
+    // Test trimming " (#)" from kmp name
+    Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor (10).kmp")));
+
+    // Test trimming "-#" from kmp name
+    Assert.assertEquals("khmer_angkor", PP.getPackageID(new File("khmer_angkor-10.kmp")));
   }
 
   @Test


### PR DESCRIPTION
While investigating this [Sentry issue](https://sentry.io/organizations/keyman/issues/3738919593/?project=5983520) I saw the user was attempting to install a keyboard package of packageID `obolo_chwerty-1`.

Since packageID is determined by the filename of the .kmp file, it seems to be a case where a .kmp file is downloaded multiple times, and the system appended `-1` to make the filename `obolo_chwerty-1.kmp` (On my Samsung device, it appends ` (1)` so it would be `obolo_chwerty (1).kmp`).

This updates PackageProcessor to strip out the extra numbers in the filename (packageID should never contain spaces or hyphens).

In addition to adding a unit test, I verified with Android Studio that installing "khmer_angkor-1.kmp" and "khmer_angkor (1).kmp" results in the correct packageID "khmer_angkor".

## User Testing
Setup
1. Install the PR build of Keyman for Android
2. From the Chrome browser, download the [khmer_angkor.kmp](https://downloads.keyman.com/keyboards/khmer_angkor/1.3/khmer_angkor.kmp) file multiple times without overwriting filenames. This should result in Downloads/ containing:
    * khmer_angkor.kmp
    * khmer_angkor (1).kmp or khmer_angkor-1.kmp (depending on the vendor)


* **TEST_KHMER_ANGKOR_1** - Verifies khmer_angkor (1).kmp installs correctly
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. From Keyman Settings --> Install Keyboard or Dictionary --> Install from local file --> Browse to the Downloads/ folder and select "khmer_angkor (1).kmp" or khmer_angkor-1.kmp (depending on how your device handled the multiple files
3. Install the keyboard package
4. When the welcome.htm file is displayed, verify the title is "Welcome to khmer_angkor" 
5. Click OK and finish the keyboard package installation