### PR TITLE
fix(linux): set DEB_VERSION

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -12,6 +12,10 @@ export KEYMAN_PKG_BUILD=1
 # xenial needs this to be explicit
 export LC_ALL=C.UTF-8
 
+# Definitions from /usr/share/dpkg/pkg-info.mk
+dpkg_late_eval ?= $(or $(value DPKG_CACHE_$(1)),$(eval DPKG_CACHE_$(1) := $(shell $(2)))$(value DPKG_CACHE_$(1)))
+DEB_VERSION = $(call dpkg_late_eval,DEB_VERSION,dpkg-parsechangelog -SVersion)
+
 # Unfortunately dh-python 3.20180325 (bionic) doesn't provide the virtual dh-sequence-python3
 # package, so we'll have to pass --with-python3 here
 %:


### PR DESCRIPTION
DEB_VERSION is used to set `pkgversion` in the `override_dh_auto_build` build step. When we moved to the consolidated source package and thus could no longer use the default debhelper build tools we lost the automatic setting of DEB_VERSION, so this change adds the relevant definitions.

Fixes #7724.

@keymanapp-test-bot skip