### PR TITLE
fix(linux): Don't crash if `und` is specified without `fonipa`

### DIFF
--- a/linux/keyman-config/keyman_config/canonical_language_code_utils.py
+++ b/linux/keyman-config/keyman_config/canonical_language_code_utils.py
@@ -30,7 +30,7 @@ class CanonicalLanguageCodeUtils():
             return None
 
         # Special case for IPA keyboards otherwise we'd end up with und-Zyyy-fonipa
-        if bcp47Tag.language == 'und' and bcp47Tag.variant[0] == 'fonipa':
+        if bcp47Tag.language == 'und' and bcp47Tag.variant and bcp47Tag.variant[0] == 'fonipa':
             return 'und-fonipa'
 
         # First, canonicalize any unnecessary ISO639-3 codes


### PR DESCRIPTION
Fixes #7723.

# User Testing

**TEST_NOCRASH**: install  a keyboard from the command line, specifying `bcp47=und`

- open a terminal and run
  ```
  km-config -i keyman://download/keyboard/sil_el_ethiopian_latin?bcp47=und
  ```
- verify that no crash shows in the terminal (i.e. no call stack shows up)