### PR TITLE
fix(linux): Fix installation if shared kbd already installed

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -27,7 +27,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
 from keyman_config.install_kmp import (InstallError, InstallStatus,
                                        extract_kmp, get_metadata, install_kmp)
 from keyman_config.kmpmetadata import get_fonts
-from keyman_config.list_installed_kmp import get_kmp_version
+from keyman_config.list_installed_kmp import get_kmp_version_user
 from keyman_config.uninstall_kmp import uninstall_kmp
 from keyman_config.welcome import WelcomeView
 
@@ -55,7 +55,7 @@ class InstallKmpWindow(Gtk.Dialog):
         self.accelerators = None
         self.language = language
         keyboardid = os.path.basename(os.path.splitext(kmpfile)[0])
-        installed_kmp_ver = get_kmp_version(keyboardid)
+        installed_kmp_ver = get_kmp_version_user(keyboardid)
         if installed_kmp_ver:
             logging.info("installed kmp version %s", installed_kmp_ver)
 

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -164,3 +164,21 @@ def get_kmp_version_user(packageID):
         return user_kmp[packageID]['version']
     else:
         return None
+
+
+def get_kmp_version_shared(packageID):
+    """
+    Get version of the kmp for a kmp ID.
+    This only checks the shared area.
+
+    Args:
+        packageID (dict): kmp ID
+    Returns:
+        str: kmp version if kmp ID is installed
+        None: if not found
+    """
+    shared_kmp = get_installed_kmp(InstallLocation.Shared)
+    if packageID in shared_kmp:
+        return shared_kmp[packageID]['version']
+    else:
+        return None

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -114,7 +114,7 @@ def main():
                                        keyman_cache_dir)
     from keyman_config.install_kmp import (InstallError, InstallStatus,
                                            install_kmp)
-    from keyman_config.list_installed_kmp import get_kmp_version
+    from keyman_config.list_installed_kmp import get_kmp_version_shared, get_kmp_version_user
 
     if os.path.exists(os.path.join(keyman_cache_dir(), 'kmpdirlist')):
         os.remove(os.path.join(keyman_cache_dir(), 'kmpdirlist'))
@@ -143,7 +143,10 @@ def main():
             sys.exit(2)
         try_install_kmp(args.file, "file " + args.file, False, args.shared)
     elif args.package:
-        installed_kmp_v = get_kmp_version(args.package)
+        if args.shared:
+            installed_kmp_v = get_kmp_version_shared(args.package)
+        else:
+            installed_kmp_v = get_kmp_version_user(args.package)
         kbdata = get_keyboard_data(args.package)
         if not kbdata:
             logging.error("km-package-install: error: Could not download keyboard data for %s", args.package)

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -144,8 +144,14 @@ def main():
         try_install_kmp(args.file, "file " + args.file, False, args.shared)
     elif args.package:
         if args.shared:
+            if get_kmp_version_user(args.package):
+                print("km-package-install: Warning: Keyboard %s is also installed for the current user."
+                      % args.package)
             installed_kmp_v = get_kmp_version_shared(args.package)
         else:
+            if get_kmp_version_shared(args.package):
+                print("km-package-install: Warning: Keyboard %s is already installed in the shared area."
+                      % args.package)
             installed_kmp_v = get_kmp_version_user(args.package)
         kbdata = get_keyboard_data(args.package)
         if not kbdata:


### PR DESCRIPTION
Fixes #7722.

# User Testing

## Preparations

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- install a shared keyboard
  ```
  sudo km-package-install -s -p sil_el_ethiopian_latin
  ```

## Tests

**TEST_INSTALL**: Install the same keyboard for a different language

- open a terminal window and run
  ```
  km-config -i keyman://download/keyboard/sil_el_ethiopian_latin?bcp47=ssy-latn
  ```
- verify that the dialog "Keyboard is installed already. Do you want to uninstall then reinstall it?" doesn't show up
- verify that there is no error `ERROR:Keyboard directory for sil_el_ethiopian_latin does not exist. Aborting` output in the terminal window