### PR TITLE
feat(linux): Add optional bcp47 parameter to km-package-install

### DIFF
--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -87,10 +87,13 @@ def list_keyboards():
 def main():
     parser = argparse.ArgumentParser(
       description='Install a Keyman keyboard package, either a local .kmp file or specify a ' +
-      'keyboard id to download and install')
+      'keyboard id to download and install, optionally specifying a language for which to ' +
+      'install the keyboard.',
+      epilog='Example: km-package-install -s -p sil_el_ethiopian_latin --bcp47 ssy-latn')
     parser.add_argument('-s', '--shared', action='store_true', help='Install to shared area /usr/local')
     parser.add_argument('-f', '--file', metavar='KMPFILE', help='Keyman kmp file')
     parser.add_argument('-p', '--package', metavar='PACKAGE', help='Keyman package id')
+    parser.add_argument('--bcp47', metavar='LANGTAG', help='bcp47 language tag')
     parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
     parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
@@ -119,9 +122,9 @@ def main():
     if os.path.exists(os.path.join(keyman_cache_dir(), 'kmpdirlist')):
         os.remove(os.path.join(keyman_cache_dir(), 'kmpdirlist'))
 
-    def try_install_kmp(inputfile, arg, online=False, sharedarea=False):
+    def try_install_kmp(inputfile, arg, language=None, online=False, sharedarea=False):
         try:
-            install_kmp(inputfile, online, sharedarea)
+            install_kmp(inputfile, online, sharedarea, language)
         except InstallError as e:
             if e.status == InstallStatus.Abort:
                 logging.error("km-package-install: error: Failed to install %s", arg)
@@ -141,7 +144,7 @@ def main():
             logging.error("km-package-install: Keyman kmp file %s not found.", args.file)
             logging.error("km-package-install -f <kmpfile>")
             sys.exit(2)
-        try_install_kmp(args.file, "file " + args.file, False, args.shared)
+        try_install_kmp(args.file, "file " + args.file, args.bcp47, False, args.shared)
     elif args.package:
         installed_kmp_v = get_kmp_version(args.package)
         kbdata = get_keyboard_data(args.package)
@@ -164,7 +167,7 @@ def main():
 
         kmpfile = get_kmp(args.package)
         if kmpfile:
-            try_install_kmp(kmpfile, "keyboard package " + args.package, True, args.shared)
+            try_install_kmp(kmpfile, "keyboard package " + args.package, args.bcp47, True, args.shared)
         else:
             logging.error("km-package-install: error: Could not download keyboard package %s", args.package)
             sys.exit(2)

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-s', '--shared', action='store_true', help='Install to shared area /usr/local')
     parser.add_argument('-f', '--file', metavar='KMPFILE', help='Keyman kmp file')
     parser.add_argument('-p', '--package', metavar='PACKAGE', help='Keyman package id')
-    parser.add_argument('--bcp47', metavar='LANGTAG', help='bcp47 language tag')
+    parser.add_argument('-l', '--bcp47', metavar='LANGTAG', help='bcp47 language tag')
     parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
     parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')


### PR DESCRIPTION
This change adds a `--bcp47 <TAG>` parameter to km-package-install. This allows to specify a language tag which will be used to install the keyboard for that language.

Closes #7725.

# User Testing

## Preparations

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_INSTALL**: Install keyboard for specific language from command line

- open terminal window and run
  ```
  km-package-install -p sil_el_ethiopian_latin --bcp47 ssy-latn
  ```
- verify that this installed `Saho - SIL EL Ethiopian Latin` keyboard