### PR TITLE
fix(linux): Ignore dbus exception when testing for fcitx

### DIFF
--- a/linux/keyman-config/keyman_config/fcitx_util.py
+++ b/linux/keyman-config/keyman_config/fcitx_util.py
@@ -4,10 +4,13 @@ import dbus
 
 
 def is_fcitx_running():
-    for service in dbus.SessionBus().list_names():
-        if service == 'org.fcitx.Fcitx5':
-            return True
-    return False
+    try:
+        for service in dbus.SessionBus().list_names():
+            if service == 'org.fcitx.Fcitx5':
+                return True
+        return False
+    except Exception:
+        return False
 
 
 def restart_fcitx():


### PR DESCRIPTION
Fixes KEYMAN-LINUX-3H.

@keymanapp-test-bot skip