### PR TITLE
fix(android/engine): Update versions of matching package and keyboard ID

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -450,6 +450,8 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         return true;
       case R.id.action_update_keyboards:
         KMManager.getUpdateTool().executeOpenUpdates();
+        // Dismiss icon
+        updateUpdateCountIndicator(0);
         return true;
       default:
         return super.onOptionsItemSelected(item);

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KeyboardPickerActivity.java
@@ -18,6 +18,7 @@ import com.tavultesoft.kmea.data.Dataset;
 import com.tavultesoft.kmea.data.Keyboard;
 import com.tavultesoft.kmea.data.KeyboardController;
 import com.tavultesoft.kmea.data.LexicalModel;
+import com.tavultesoft.kmea.util.FileUtils;
 import com.tavultesoft.kmea.util.KMLog;
 import com.tavultesoft.kmea.util.KMString;
 import com.tavultesoft.kmea.util.MapCompat;
@@ -362,6 +363,17 @@ public final class KeyboardPickerActivity extends BaseActivity {
 
       keyboardInfo.setNewKeyboard(true);
       KeyboardController.getInstance().add(keyboardInfo);
+      // Check if "other" keyboards of the same packageID and keyboardID need to update version
+      // Don't use forEach because we might be updating entries
+      for (int i=0; i<KeyboardController.getInstance().get().size(); i++) {
+        Keyboard otherKeyboard = KeyboardController.getInstance().getKeyboardInfo(i);
+        if (!otherKeyboard.equals(keyboardInfo) && otherKeyboard.getPackageID().equals(keyboardInfo.getPackageID())
+            && otherKeyboard.getKeyboardID().equals(keyboardInfo.getKeyboardID())
+            && (FileUtils.compareVersions(otherKeyboard.getVersion(), keyboardInfo.getVersion()) == FileUtils.VERSION_LOWER)) {
+          otherKeyboard.setVersion(keyboardInfo.getVersion());
+          KeyboardController.getInstance().set(i, otherKeyboard);
+        }
+      }
       result = KeyboardController.getInstance().save(context);
       if (!result) {
         KMLog.LogError(TAG, "addKeyboard failed to save");

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/LanguageResource.java
@@ -55,6 +55,9 @@ public abstract class LanguageResource implements Serializable {
   }
 
   public String getVersion() { return version; }
+  public void setVersion(String version) {
+    this.version = version;
+  }
 
   public String getPackageID() { return packageID; }
 


### PR DESCRIPTION
This fixes the two parts of #7739 about what happens when downloading keyboard package updates (Does **not** address #6731 for tablets)
* Existing keyboard versions aren't getting updated
* The "Install Updates" icon doesn't go away after installing updates. (It does disappear if you cancel the download dialog)

The `Keyboard.equals()` check is a  Keyboard comparison for matching languageID and keyboardID
https://github.com/keymanapp/keyman/blob/54fd732b01561486cb3c72fb73e3ca55fa790189/android/KMEA/app/src/main/java/com/tavultesoft/kmea/data/Keyboard.java#L136-L145


## User Testing
Setup - Use Android 5.0 emulator for Phone (e.g. not tablet and not a device > 600dp wide)

* **TEST_KEYBOARD_UPDATE**
1. Download an [old version of sil_cameroon_qwerty](https://downloads.keyman.com/keyboards/sil_cameroon_qwerty/6.0.4/sil_cameroon_qwerty.kmp)
2. On the device, set airplane mode on (turns off internet access)
3. On the device, go to settings, and manually set the date to 1 year in the past (e.g. Oct 2021)
4. Start Keyman for Android
5. From the Keyman Settings, install the local kmp file sil_cameroon_qwerty.kmp (will be an old version 6.0.4) for Akum language (any language besides Afade)
6. Close Keyman
7. On the device, go to settings and set the date to automatically update from internet
8. On the device, turn off airplane mode (turns on internet access)
9. On the device, go to settings and verify the date is updated
10. Launch Keyman for Android
11. Dismiss "Get Started" and wait for the catalog to update
12. After a while, there should be a notification of a keyboard update being available
13. Click the Keyman overflow menu
14. Verify keyboard update is available; there should be an icon of a cloud with a down arrow at the top right.
15. Click on that button - "Install Updates"
16. Accept the confirmation dialog to download the keyboard update for Cameroon QWERTY
17. The keyboard package will download and install for the Afade language (listed first in the keyboard package)
18. On Keyman, long-press the globe key to display the Keyboard Picker menu
19. On the Keyboard Picker menu,  click the info for Cameroon QWERTY - Akum
20. Verify the keyboard version is updated to the current version 6.0.8
21. Return to the Keyboard pPicker menu, click the info for Cameroon QWERTY - Afade
22. Verify the keyboard version is also 6.0.8
23. Exit the Keyboard picker menu
24. On Keyman, click the overflow menu  
25. Verify the "Install Updates" icon is no longer visible (There may still be a system notification about Keyman Resource Update being available - that's independent of the menu)
