### PR TITLE
fix(windows): Download Keyboard blue footer

### DIFF
--- a/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
@@ -47,7 +47,7 @@
               height: <xsl:value-of select="$dialoginfo_downloadkeyboard/footerheight" />px;
               width: 100%;
               overflow: hidden;
-              background: #dcdcdc;
+              background: #79C3DA;
               padding: 8px 8px 8px 8px;
             }
         </style>


### PR DESCRIPTION
Fixes #7753.

@keymanapp-test-bot skip

![image](https://user-images.githubusercontent.com/4498365/202580063-a7b69ffb-e7af-4db7-9099-02957b302e0c.png)
