### PR TITLE
fix(windows): Fix text selectable configuration

### DIFF
--- a/windows/src/desktop/kmshell/kmshell_project.tvsconfig
+++ b/windows/src/desktop/kmshell/kmshell_project.tvsconfig
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<TgConfig Version="3" SubLevelDisabled="False" />

--- a/windows/src/desktop/kmshell/kmshell_project.tvsconfig
+++ b/windows/src/desktop/kmshell/kmshell_project.tvsconfig
@@ -1,2 +1,0 @@
-<?xml version="1.0"?>
-<TgConfig Version="3" SubLevelDisabled="False" />

--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -25,7 +25,6 @@
   overflow-y: hidden;
   z-index: 10;
   outline: none;
- /* background: #79C3DA;*/
   user-select: none;
 }
 #contentframe

--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -1135,7 +1135,6 @@ th
 #keepintouch_content {
   height: 100%;
   overflow: hidden;
-  user-select: none;
 }
 
 #keepintouch_frame {
@@ -1143,6 +1142,7 @@ th
   width:100%;
   height:100%;
   border:none;
+  user-select: none;
 }
 
 /* QRCodes */

--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -26,6 +26,7 @@
   z-index: 10;
   outline: none;
  /* background: #79C3DA;*/
+  user-select: none;
 }
 #contentframe
 {
@@ -36,6 +37,7 @@
   height: 100%;
   overflow: hidden;
   border-bottom: 1px solid #6D6C6F;
+  user-select: none;
 }
 #footerframe
 {
@@ -46,11 +48,13 @@
   overflow: hidden;
   background: #79C3DA;
   padding: 10px 8px 8px 8px;
+  user-select: none;
 }
 
 .contentpage
 {
   display: none;
+  user-select: none;
 }
 
 .header
@@ -1131,6 +1135,7 @@ th
 #keepintouch_content {
   height: 100%;
   overflow: hidden;
+  user-select: none;
 }
 
 #keepintouch_frame {


### PR DESCRIPTION
Fixes #7747 

Version 15 is also broken (possibly the update libcef as chrome use to inherit the behaviour).

I have added the user-select: none property to `#keepintouch_frame` for completeness however the embedded webpage overrides it. Using the developer tools I could set the property for the embedded page and the text was no longer selectable. So we need to update the source web page property for embedded. 

# User Testing

* TEST_SELECT_TEXT

Open Windows Configuration.
Select the Support Tag.
Verify you can no longer select the text in the header, the side tabs or the footer. (as seen in issue #7747)
The mouse pointer stays as a pointer and does not turn to a text cursor. 
Repeat for the other tabs.
Note for the `Keep in touch tab` you can still select the webpage text this is a separate issue.

