### PR TITLE
chore(windows): remove unused options from locales and UI

### DIFF
--- a/oem/firstvoices/windows/src/xml/keyman_options.xsl
+++ b/oem/firstvoices/windows/src/xml/keyman_options.xsl
@@ -14,7 +14,7 @@
 					<xsl:sort select="sort" />
           <div class="options_list_header"><xsl:value-of select="$locale/string[@name=current()/name]"/></div>
           <xsl:for-each select="//KeymanOption[group=current()/name]">
-            <xsl:if test="optiontype = 1 and id != 'koAutoSwitchOSKPages'">
+            <xsl:if test="optiontype = 1 and id != 'koAutoSwitchOSKPages' and id != 'koSwitchLanguageForAllApplications'">
               <xsl:call-template name="option" />
             </xsl:if>
           </xsl:for-each>
@@ -97,5 +97,5 @@
       </div>
     </div>
   </xsl:template>
-  
+
   </xsl:stylesheet>

--- a/oem/firstvoices/windows/src/xml/strings.xml
+++ b/oem/firstvoices/windows/src/xml/strings.xml
@@ -23,7 +23,7 @@
   <string name="SK_UIFontSize" comment="The standard font size">9</string>
 
 
-  
+
 
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
@@ -74,7 +74,7 @@
   <!-- String Type: FormatString -->
   <!-- Introduced: 14.0.234 -->
   <string name="SKBalloonKeymanIsRunning" comment="Balloon that shows when user tries to start Keyman but it is already running">Keyman for FirstVoices is already running. Click the Keyman for FirstVoices icon in the system notification area to use your language keyboard</string>
-  
+
   <!-- Context: Configuration Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -85,7 +85,7 @@
   <!-- Introduced: 7.0.239.0 -->
   <string name="S_Caption_Help" comment="Configuration dialog link to Help">Help</string>
 
-  
+
 
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
@@ -137,8 +137,8 @@
   <!-- Introduced: 9.0.492.0 -->
   <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">T</string>
 
-  
-  
+
+
 
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
@@ -274,7 +274,7 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 14.0 -->
   <string name="S_Footer_ChangesImmediate" comment="Short-term (14.0) message explaining why Ok and Cancel buttons are no longer present">Changes are applied immediately</string>
-  
+
   <!-- Context: Configuration Dialog - Footer -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -321,7 +321,7 @@
   <!-- Introduced: 13.0.40.0 -->
   <string name="S_Keyboard_Share_LinkSuffix" comment="Keyboard Layouts - suffix for link to share"/>
 
-  
+
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
@@ -416,39 +416,14 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Turn on Unicode supplementary character display (requires restart)</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Turn on \'Unknown\' language</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Switch Windows language when a FirstVoices keyboard is selected</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Select keyboard layout for all applications</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Always elevate user permissions when running in Windows Vista</string>
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->
   <string name="S_Button_BaseKeyboard" comment="Options tab - base keyboard button">Base Keyboard...</string>
 
-  
+
 
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
@@ -515,7 +490,7 @@
   <!-- Introduced: 7.1.274.0 -->
   <string name="S_Hotkey_Keyboard_Title" comment="Hotkey - Keyboard Title">Keyboard Layouts</string>
 
-  
+
 
   <!-- Context: Configuration Dialog - Support tab -->
   <!-- String Type: PlainText -->
@@ -572,7 +547,7 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_Diagnostics_Diagnostics" comment="Support button submenu - performs a diagnostic report">Diagnostics</string>
 
-  
+
 
   <!-- Context: Download Keyboard Dialog -->
   <!-- String Type: PlainText -->
@@ -594,8 +569,8 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 14.0 -->
   <string name="S_Button_Back" comment="Back button">&lt; Back</string>
-  
-  
+
+
 
   <!-- Context: Install Keyboard Dialog -->
   <!-- String Type: PlainText -->
@@ -617,8 +592,8 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_InstallKeyboard_Button_Install" comment="Install keyboard/package - install button">Install</string>
 
-  
-  
+
+
 
   <!-- Context: Proxy Configuration Dialog -->
   <!-- String Type: PlainText -->
@@ -645,8 +620,8 @@
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_ProxyConfiguration_Password" comment="Proxy dialog - fillable-field password">Password: </string>
 
-  
-  
+
+
 
   <!-- Context: Base Keyboard Dialog -->
   <!-- String Type: PlainText -->
@@ -659,7 +634,7 @@
   <string name="S_BaseKeyboard_Text" comment="Base keyboard dialog description">Select the base Latin script
 keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatically to your preferred layout.</string>
 
-  
+
 
 
   <!-- Context: Hotkey Dialog -->
@@ -696,8 +671,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- String Type: FormatString -->
   <string name="SKHotkeyConflicts_Interface" comment="Hotkey dialog - warning of hotkey conflict with hotkey for another interface hotkey">The hotkey %1$s conflicts with another hotkey.  If you continue, the other hotkey will be cleared.  Continue\?</string>
 
-  
-  
+
+
 
   <!-- Context: Online Update Dialog -->
   <!-- String Type: PlainText -->
@@ -787,8 +762,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 8.0.288.0 -->
   <string name="SKUpdate_IconMenuExit" comment="Update icon - exit menu item">E&amp;xit online update check</string>
 
-  
-  
+
+
 
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->
@@ -815,8 +790,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 9.0.341.0 -->
   <string name="S_Splash_ShowAtStartup" comment="Show at Startup toggle">Show this screen at startup</string>
 
-  
-  
+
+
 
   <!-- Context: _LanguageInfo -->
   <!-- String Type: PlainText -->
@@ -858,8 +833,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 7.0.230.0 -->
   <string name="SKShortApplicationTitle" comment="Product name">Keyman for FirstVoices</string>
 
-  
-  
+
+
 
   <!-- Context: Hints -->
   <!-- String Type: PlainText -->
@@ -900,8 +875,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 10.0.836.0 -->
   <string name="S_HintDialog_DontShowHintAgain" comment="Hint dialog - caption of checkbox at bottom of dialog">Don\'t show this hint again</string>
 
-  
-  
+
+
 
   <!-- Context: Help Dialog -->
   <!-- String Type: PlainText -->
@@ -953,8 +928,8 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Toolbar_CloseOnScreenKeyboard" comment="Toolbar help - Close OSK pop-up text">Close On Screen Keyboard</string>
 
-  
-  
+
+
 
   <!-- Context: System Tray Menu Items -->
   <!-- String Type: PlainText -->
@@ -1017,7 +992,7 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <string name="S_OSKContext_Print" comment="OSK right-click menu - print diagram of active keyboard layout">Print...</string>
 
 
-  
+
 
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
@@ -1035,7 +1010,7 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 7.0.239.0 -->
   <string name="SKButtonPrint" comment="Print button in Welcome dialog for keyboards">&amp;Print...</string>
 
-  
+
 
   <!-- Parameters: %1$s = Package to be uninstalled -->
   <!-- Context: Formatted Messages -->
@@ -1097,7 +1072,7 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 7.0.230.0 -->
   <string name="SKDownloadProgress_Title" comment="Notice of file downloading">Downloading File</string>
 
-  
+
 
 
   <!-- Parameters: %1$s = Keyboard name -->
@@ -1129,7 +1104,7 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <!-- Introduced: 7.0.230.0 -->
   <string name="SKUnicodeData_Build" comment="Request to build Unicode Character Map database">The Character Map has a database of characters that needs to be built before it can be used.  Build it now\?</string>
 
-  
+
 
 
   <!-- Parameters: %1$s = Error detail string -->
@@ -1188,7 +1163,7 @@ keyboard that you use in Windows.  Keyman for FirstVoices will adapt automatical
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font helper choose keyboard">Please select a FirstVoices keyboard to find related fonts.</string>
 
 
-  
+
   <!-- Context: Text Editor -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 10.0.836.0 -->

--- a/windows/src/desktop/branding/messages.txt
+++ b/windows/src/desktop/branding/messages.txt
@@ -511,23 +511,6 @@ object Messages: TStockMessages
           Parameters = <>
         end
         item
-          Name = 'koRunElevatedInVista'
-          DefStr = 'Always elevate user permissions when running in Windows Vista'
-          Parameters = <>
-        end
-        item
-          Name = 'koTurnOnSurrogates'
-          DefStr =
-            'Turn on Unicode supplementary character display (requires restar' +
-            't)'
-          Parameters = <>
-        end
-        item
-          Name = 'koUnknownLanguage'
-          DefStr = 'Turn on '#39'Unknown'#39' language'
-          Parameters = <>
-        end
-        item
           Name = 'koDebugging'
           DefStr = 'Debugging'
           Parameters = <>

--- a/windows/src/desktop/kmshell/locale/am-ET/strings.xml
+++ b/windows/src/desktop/kmshell/locale/am-ET/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">የዩኒኮድ ተጨማሪ የባህርይ ማሳያ ያብሩ (ኪይማኑ ዳግም ማስጀመር ያስፈልጋል)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">\'ያልታወቀውን\' ቋንቋ ያብሩ</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">የኪማኑን ስህተቶች ፈልግ</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">የኪይማኑን የፊደል ሰሌዳ ሲመረጥ የዊንዶውን ቋንቋ ቀይር</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">ለሁሉም ፕሮግራሞች የቁልፍ ሰሌዳውን ንድፍ ይምረጥ</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">ሁልጊዜ በዊንዶውስ ቪስታ ውስጥ በሚሰራበት ጊዜ የተጠቃሚውን ፍቃድ ከፍ አድርግ</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Unicode əlavə xarakterli ekranı aktiv etmək (yenidən başlamağı tələb edir)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">\'Naməlum\' dili aktiv etmək</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Hata düzəltməsi</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Keyman klaviaturası seçildikdə Windows dilini dəyişdirmək</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Bütün tətbiqlər üçün klaviatura düzeni seçmək</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Windows Vista-da işləyərkən həmişə istifadəçi icazələrini artır</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/bwr-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/bwr-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Pali suna ncang Unicode supplementary character (ata bara ka mdǝ jaktǝ kǝlani)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Kǝla hulfur mnya na ar \'Unknown\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Kǝla hulfur mnya ar Windows sakatǝ mdǝ car keyboard ar Keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Car keyboard layout aka shanga applicationyeri</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Kǝlara saka kara jakǝngkǝr dunar mdǝ na ana kǝthlǝr ka su ni saka tǝ Windows Vista akwa hara kǝthlǝr</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/ckl-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ckl-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Turn on Unicode supplementary character display (requires restart)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Mburnta \'Nya ʻnam kura waima ta zǝndi</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Pali nyar Windows saka namtǝ ndǝ tsarba Keyman kibod</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Tsarba keyboard layout kadǝbar shanga applicationyere</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Always elevate user permissions when running in Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/de/strings.xml
+++ b/windows/src/desktop/kmshell/locale/de/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Die Unicode ergänzender Zeichen-Display einschalten (Neustart erforderlich)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">In Windows \"unbekannte Sprache\" einschalten</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Fehlersuchen einschalten</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Windows-Tastatur automatisch wechseln, wenn eine Keyman-Tastatur ausgewählt wird</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Tastaturlayout für alle Anwendungen auswählen</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Benutzer Berechtigungen werden immer in Windows Vista erhöht</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/es-419/strings.xml
+++ b/windows/src/desktop/kmshell/locale/es-419/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Activar la visualización de caracteres Unicode suplementarios (requiere reinicio)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Activar idioma \'desconocido\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Depurar</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Cambiar el idioma de Windows cuando se seleccione un teclado de Keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Seleccionar distribución de teclado para todas las aplicaciones</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Aumentar siempre los permisos de usuario cuando se ejecute en Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/ff-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ff-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Kunnu alaama Unikod holla (ɗo mari haaje lora kunna)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Kunnu dow ʻƊemngalʻ ngam andaaka</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugin</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">A` kunna ɗemngal komputa to kibod keyman man suptaama</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">A` supta mawnugo kibod dow manhajaji fuu</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Koonday teddina daama naftirol to ɗo naftira bee man dow Windo Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/ff-ZA/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ff-ZA/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Hurmin jaytingol karfe Unicode goɗɗe (kurmitinal ena waɗɗii)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Hurmin ɗengal \"Maaniwal\"</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Buggitagol</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Lomtin ɗemngal Windows so tappirde Keyman suɓaama</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Suɓo tappirde wonande jaaɓɗe fof</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Ƴellit jamirooje kuutoro oo sahaa kala so jaaɓnirgal ngal ena doga e Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->
@@ -889,9 +869,9 @@ Jokku\?</string>
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="SKDebuggingWarning" comment="Warning upon starting debugging in the Options tab">L\'information de débogage de Keyman sera stockée sur le Bureau dans un fichier texte nommé %LOCALAPPDATA%\Keyman\Diag\system#.etl.  Vous devez quitter Keyman avant de lire ou de supprimer ce fichier.
-  
+
   ATTENTION. Ce fichier peut devenir important très rapidement.  Activer le débogage ralentira le sytème et ne doit être fait qu\'à la demande du support Tavultesoft.
-  
+
   CONFIDENTIALITÉ: Veuillez noter que le fichier journal de débogage enregistre toutes les frappes que vous exécutez.  Vous ne devez activer le journal de débogage que pendant la durée de la session de débogage ou de diagnostic, et vous devez effacer le fichier  [Bureau]\keymanlog\system.log file dès que possible.</string>
   <!-- Context: OSK Font Helper -->
   <!-- String Type: FormatString -->

--- a/windows/src/desktop/kmshell/locale/fr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/fr/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Activer l\'affichage des caractères Unicode supplémentaires (redémarage nécessaire)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Activer la langue \"Inconnue\"</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debogage</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Changer de langue Windows quand un clavier Keyman est sélectionné</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Sélectionner la disposition du clavier pour toutes les applications</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Toujours élever les permissions de l\'utilisateur quand le programme fonctionne sous Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/ha-HG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ha-HG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Kunna ƙarin harafin Unicode (yana buƙatar farawa)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Kunna Yaren \'Da ba a sani ba\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Cire kuskure</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Canja yaren Windows lokacin da aka zaɓi madannin Keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Zaɓi shirin madanni domin dukkanin manhajojin</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Nemi izinin masu amfani kowane lokaci yayin shiga Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/hia-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/hia-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Turn on Unicode supplementary character display (requires restart)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">A gunat \'Gwaɗa luwunda\' kol sinantalo</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Klun tina magal kol ɗughwana</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">A guna tinaha gwaɗa luwaha vita Keyman keyboard kas kilalo</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Abklat keyboard layout anga thlinaha sma</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Ko ngawa na afklat izniya magata vita mog ka thlina nda Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/id-ID/strings.xml
+++ b/windows/src/desktop/kmshell/locale/id-ID/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Nyalakan tampilan karakter tambahan Unicode (perlu mulai ulang)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Nyalakan bahasa \'Tidak diketahui\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Ganti ke bahasa di Windows ketika papan tombol Keyman dipilih</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Pilih tata letak papan tombol untuk semua aplikasi</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Selalu angkat izin pengguna (ke admin) ketika menjalankan di Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/it-IT/strings.xml
+++ b/windows/src/desktop/kmshell/locale/it-IT/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Attiva la visualizzazione dei caratteri aggiuntivi Unicode (richiede riavvio)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Attiva lingua \'Sconosciuta\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debug</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Cambia lingua di Windows quando viene selezionata una tastiera Keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Seleziona il layout della tastiera per tutte le applicazioni</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Accelera sempre i permessi dell\'utente quando viene eseguito in Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/kan-Knda-IN/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kan-Knda-IN/strings.xml
@@ -88,12 +88,7 @@
   <string name="koReleaseShiftKeysAfterKeyPress" comment="/FormatString: ">"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ"ಯಲ್ಲಿ ಯಾವುದೆ ಕೀಲಿಯನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿದ ನಂತರ Shift/Ctrl/Alt ಅನ್ನು ಬಿಡುಗಡೆ ಮಾಡು</string>
   <string name="koAutoOpenOSK" comment="/FormatString: ">ಹೊಸ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿದಾಗ ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆಯನ್ನು ತೋರಿಸು</string>
   <string name="koAutoSwitchOSKPages" comment="/FormatString: ">ಬೇರೆ ಕೀಲಿಮಣೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಹಾಯ ಅಥವಾ ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆಯನ್ನು ಬದಲಿಸು</string>
-  <string name="koTurnOnSurrogates" comment="/FormatString: ">ಯುನಿಕೋಡ್ ಪೂರಕ ಅಕ್ಷರ ಪ್ರದರ್ಶನವನ್ನು ಆನ್ ಮಾಡಿ (ರೀಸ್ಟಾರ್ಟ್ ಅಗತ್ಯವಿದೆ)</string>
-  <string name="koUnknownLanguage" comment="/FormatString: ">'ಅಜ್ಞಾತ' ಭಾಷೆಯನ್ನು ಆನ್ ಮಾಡಿ</string>
   <string name="koDebugging" comment="/FormatString: ">ಡೀಬಗ್ ಮಾಡುವುದು</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="/FormatString: ">ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆ ಆಯ್ಕೆಮಾಡಿದಾಗ ವಿಂಡೋಸ್ ಭಾಷೆಯನ್ನು ಬದಲಿಸು</string>
-  <string name="koSwitchLanguageForAllApplications" comment="/FormatString: ">ಕೀಮ್ಯಾನ್‌ನಲ್ಲಿ ಅಥವಾ ಸಿಸ್ಟಮ್ ಟ್ರೇನಲ್ಲಿ ಆಯ್ಕೆ ಮಾಡಿದ ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ, ಎಲ್ಲಾ ಅಪ್ಲಿಕೇಶನ್‌ಗಳಿಗೂ ಅನ್ವಯಿಸುವಂತೆ ಮಾಡು</string>
-  <string name="koRunElevatedInVista" comment="/FormatString: ">ವಿಂಡೋಸ್ ವಿಸ್ಟಾದಲ್ಲಿ ಚಾಲನೆ ಮಾಡುವಾಗ ಯಾವಾಗಲೂ ಬಳಕೆದಾರರ ಅನುಮತಿಗಳನ್ನು ಎತ್ತಿ ಹಿಡಿಯಿರಿ</string>
   <string name="S_Button_UILanguage" comment="/PlainText: ">ಬಳಕೆದಾರ ಇಂಟರ್ಫೇಸ್ ಭಾಷೆ...</string>
   <string name="S_Button_BaseKeyboard" comment="/PlainText: ">ಮೂಲ(ಬೇಸ್) ಕೀಲಿಮಣೆ...</string>
   <string name="S_Hotkey_None" comment="/PlainText: ">(ಯಾವುದೂ ಇಲ್ಲ)</string>
@@ -200,8 +195,8 @@
   <string name="S_Button_ResetHints" comment="/PlainText: ">ಸುಳಿವುಗಳನ್ನು ಮರುಹೊಂದಿಸು</string>
   <string name="SKHintsReset" comment="/PlainText: ">ಎಲ್ಲಾ ಸುಳಿವು ಸಂದೇಶಗಳನ್ನು ಮರುಹೊಂದಿಸಲಾಗಿದೆ ಮತ್ತು ಮತ್ತೆ ಪ್ರದರ್ಶಿಸಲಾಗುತ್ತದೆ.</string>
   <string name="HintTitle_KH_EXITPRODUCT" comment="/HintTitle: ">ನಿರ್ಗಮನ Keyman?</string>
-  <string name="Hint_KH_EXITPRODUCT" comment="/Hint: ">ನೀವು Keyman ನಿರ್ಗಮಸಲು ಬಯಸುತ್ತೀರಾ? 
-ವಿಂಡೋಸ್ ಕೀಲಿಮಣೆಗಳ ಪಟ್ಟಿಯಲ್ಲಿ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಗಳನ್ನು ಸೇರಿಸಲಾಗಿದೆ. 
+  <string name="Hint_KH_EXITPRODUCT" comment="/Hint: ">ನೀವು Keyman ನಿರ್ಗಮಸಲು ಬಯಸುತ್ತೀರಾ?
+ವಿಂಡೋಸ್ ಕೀಲಿಮಣೆಗಳ ಪಟ್ಟಿಯಲ್ಲಿ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಗಳನ್ನು ಸೇರಿಸಲಾಗಿದೆ.
 ಆದರೆ ನೀವು Keyman ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸುವವರೆಗೆ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಗಳು ಕ್ರಿಯಾತ್ಮಕವಾಗಿರುವುದಿಲ್ಲ.</string>
   <string name="HintTitle_KH_CLOSEOSK" comment="/HintTitle: ">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ ಮುಚ್ಚಲಾಗಿದೆ</string>
   <string name="Hint_KH_CLOSEOSK" comment="/Hint: ">ನೀವು "ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ"ಅನ್ನು ಮುಚ್ಚಿದ್ದೀರಿ. Keyman ಇನ್ನೂ ಚಾಲನೆಯಲ್ಲಿದೆ. Keyman ಚಿತ್ರ(ಐಕಾನ್) ಮೇಲೆ ನೀವು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಿ ಮತ್ತು "ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ" ಆಯ್ಕೆಮಾಡುವ ಮೂಲಕ; "ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ"ಅನ್ನು ತೆರೆಯಬಹುದು.</string>

--- a/windows/src/desktop/kmshell/locale/km-KH/strings.xml
+++ b/windows/src/desktop/kmshell/locale/km-KH/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">បើក​ការបង្ហាញ​តួ​អក្សរ​បន្ថែមរបស់យូនីកូដ (តម្រូវ​ឱ្យ​បិទ​រួច​បើក​ឡើង​វិញ)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">បើក​ភាសា \'ដែល​មិន​ស្គាល់\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">ការប្រមូល​ព័ត៌មានសម្រាប់​ដោះស្រាយ​បញ្ហា</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">ប្ដូរ​ភាសារបស់ Windows នៅ​ពេល​ក្ដារចុច Keyman ណាមួយ​ត្រូវ​បាន​ជ្រើសរើស</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">ជ្រើសរើស​ប្លង់​ក្ដារចុចសម្រាប់​កម្មវិធី​ទាំង​អស់</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">បើក​ការអនុញ្ញាត​របស់​អ្នក​ប្រើប្រាស់​ជានិច្ច នៅពេល​កំពុង​ដំណើរការលើ Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/kr-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kr-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Kalakkǝne Unicode supplementary character dǝga turinno (waltǝm baditǝ muradǝzǝna)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Kalakkǝne kǝla tǝlam \'Notǝyi\' dǝro</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Kadau dǝga kulasne tuluye</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Kalakkǝne tǝlam Windows yedǝ sa Keyman keyboard dǝ karnǝma lan</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Karne keyboard dǝye layout zǝ applicationna samma soro</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Sambisoro kǝla izǝnu kǝnjoye dǝga wune sa kǝla Windows Vista yen</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/mfi-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/mfi-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Kunnante-kunne Unicode naza mara umbulé gé karakta ŋanna (a kátá fantuhe adaliya)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Kunnante-kunne Naru ʻdiyakandeʻ</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Kunnante-kunne nare Windows aza Keyman keyboard a ksante nde ŋanna</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Ksa jiba ndra keyboard ŋanna gé baɗumma appications</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Ba kullume mmaga slera an izinin ma ká maga slera an Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/mrt-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/mrt-NG/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Kuga pahu Unicode supplementay character display (maja ayu restart)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Pahu ŋya kuku du mji ʻkra siniʻ</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Kuga pubila alu ŋya nur Windows ma mji ga caɗu keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Kuga caɗu layout nur keyboard anu ca applications</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Kuga ja\'u hungiri nur mduku vur iu thlir duri ma nagu vur iu thli aga Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/my/strings.xml
+++ b/windows/src/desktop/kmshell/locale/my/strings.xml
@@ -19,16 +19,11 @@
   <string name="kogStartup" comment="/FormatString: ">အစပြု</string>
   <string name="koKeyboardHotkeysAreToggle" comment="/FormatString: ">ကီးဘုတ် hotkeys togggle ကီးဘုတ် အသက်သွင်းခြင်း</string>
   <string name="koReleaseShiftKeysAfterKeyPress" comment="/FormatString: ">Screenမှာပေါ်မှာမြင်ရမည့်ကီးဘုတ်တွင် ကီးကိုနှိပ်ပြီးလျှင်Shift/Ctrl/Alt ကိုလွှတ်လိုက်ပါ</string>
-  <string name="koRunElevatedInVista" comment="/FormatString: ">ဝင်းဒိုး Vista မှာသုံးတိုင်း အသုံးပြုသူရဲ့ခွင့်ပြုချက်ကို အမြင့်ဆုံးအထိ ခွင့်ပြုပါ</string>
   <string name="koShowHints" comment="/FormatString: ">အရိပ်အမွက် စကားစုကိုပြပါ</string>
   <string name="koShowStartup" comment="/FormatString: ">splash screen ကိုပြပါ</string>
   <string name="koShowWelcome" comment="/FormatString: ">Welcome screen ကိုပြပါ</string>
   <string name="koStartWithWindows" comment="/FormatString: ">ဝင်းဒိုးစတက်တာနဲ့ စသုံးပါ</string>
-  <string name="koSwitchLanguageForAllApplications" comment="/FormatString: ">application အားလုံးအတွက် ကီးဘုတ်လက်ကွက်ကို ရွေးချယ်ပါ</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="/FormatString: ">ကီးမန်းကီးဘုတ်ကို ရွေးပြီးလျှင် ဝင်းဒိုးဘာသာစကားကို ဖွင့်ပါ</string>
   <string name="koTestKeymanFunctioning" comment="/FormatString: ">Keymanစသည့်အချိန် တွင် အဆင်မပြေပဲညိနိုင်သော application များကို စစ်ဆေးခြင်း </string>
-  <string name="koTurnOnSurrogates" comment="/FormatString: ">ယူနီကုဒ် အပို အက္ခရာ ဖော်ပြမှုကို ဖွင့်ပါ( Restart လုပ်ရန်လိုသည်)</string>
-  <string name="koUnknownLanguage" comment="/FormatString: ">"အမည်မသိ"ဘာသာစကားကိုဖွင့်ပါ</string>
   <string name="S_Menu_OnScreenKeyboard" comment="/PlainText: ">&amp;Screen ပေါ်ကီးဘုတ်</string>
   <string name="S_Toolbar_OpenHelp" comment="/PlainText: ">အကူအညီကိုဖွင့်ပါ</string>
   <string name="S_Toolbar_OpenConfiguration" comment="/PlainText: ">Keymanရဲ့စနစ်ပိုင်းဆိုင်ရာကို ဖွင့်ပါ</string>

--- a/windows/src/desktop/kmshell/locale/nl-NL/strings.xml
+++ b/windows/src/desktop/kmshell/locale/nl-NL/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Unicode-aanvullend tekenscherm inschakelen (herstart vereist)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Schakel \'Onbekende\' taal in</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Foutopsporing</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Wissel de taal van Windows wanneer een toetsenbord is geselecteerd</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Toetsenbordindeling selecteren voor alle programma\'s</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Gebruikersrechten altijd verhogen wanneer deze worden uitgevoerd in Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/pl-PL/strings.xml
+++ b/windows/src/desktop/kmshell/locale/pl-PL/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Włącz wyświetlanie dodatkowych znaków Unicode (wymagane ponowne uruchomienie)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Włącz język \'Nieznany\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugowanie</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Przełącz język systemu Windows po wybraniu klawiatury Keyman</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Wybierz układ klawiatury dla wszystkich aplikacji</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Zawsze uruchamiaj ze zwiększonymi uprawnieniami w systemie Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/pt-BR/strings.xml
+++ b/windows/src/desktop/kmshell/locale/pt-BR/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Turn on Unicode supplementary character display (requires restart)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Turn on \'Unknown\' language</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Switch Windows language when a Keyman keyboard is selected</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Select keyboard layout for all applications</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Always elevate user permissions when running in Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/pt-PT/strings.xml
+++ b/windows/src/desktop/kmshell/locale/pt-PT/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Ativar tela de caracteres suplementares Unicode (é necessário reiniciar)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Ativar o idioma \"Desconhecido\"</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Depuração</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Mudar idioma do Windows quando um teclado Keyman for selecionado.</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Selecionar layout do teclado para todas as aplicações</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Sempre elevar as permissões do usuário em Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/qqq/locale.xml
+++ b/windows/src/desktop/kmshell/locale/qqq/locale.xml
@@ -3,7 +3,7 @@
 <!ENTITY Name "Keyman">
 ]>
 <Locale>
-  
+
 <!--
 locale.dtd: Contains all localizable strings from Keyman Configuration XML files.
 
@@ -11,7 +11,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 -->
 
 <String Group="System" Type="PlainText" Id="S_LocaleAuthors" Version="7.1.266.0" Description="Name(s) of people who created this translation - i.e. your name">[!!Ķēɏmãŋ!!]</String>
-  
+
 <String Group="_Font" Type="PlainText" Id="SK_UIFontName" Version="7.0.230.0" Description="The standard font">Segoe UI</String>
 <String Group="_Font" Type="PlainText" Id="SK_UIFontSize" Version="7.0.230.0" Description="The standard font size">9</String>
 
@@ -44,7 +44,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 
 <String Group="Formatted Messages" Type="FormatString" Id="SKBalloonClickToSelectKeyboard" Version="8.0.330.0" Description="Balloon that shows when Keyman Desktop icon is first shown during the tutorial">[!!Ċłīċķ ţħĭš ĭċơŋ ťō şȇŀȅćţ ȁ ƙěɏƅŏáŗď!!]</String>
 <String Group="Formatted Messages" Type="FormatString" Id="SKBalloonOSKClosed" Version="8.0.330.0" Description="Balloon that shows when OSK is closed">&Name;[!! ıś ŝťıĺĺ ŕūŉňīńġ.  Ċŀĩćķ ţħıŝ įĉőň ťơ űśē ŷōūř ļāņğųãğě ƙȇƴƃŏǻřđ ąť āŉɏ ŧĩmė!!]</String>
-  
+
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Configuration Dialog              -->
 <!-- - - - - - - - - - - - - - - - - - -->
@@ -60,7 +60,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Configuration Dialog" Type="PlainText" Id="S_Caption_GettingStarted" Version="7.0.239.0" Description="Configuration dialog link to Getting Started">[!!Ġĕţŧīńģ Ŝţářťěď!!]</String>
 <String Group="Configuration Dialog" Type="PlainText" Id="S_Caption_Help" Version="7.0.239.0" Description="Configuration dialog link to Help">[!!Ħēļƿ!!]</String>
 
-<!-- Tab names and shortcut keys -->  
+<!-- Tab names and shortcut keys -->
 
 <String Group="Configuration Dialog - Tab names" Type="PlainText" Id="S_Keyboards" Version="7.0.230.0" Description="Keyboard Layouts tab name">[!!Ƙėƴɓŏäŗď Łǻŷơŭţš!!]</String>  <String Group="Configuration Dialog - Tab names" Type="PlainText" Id="S_Keyboards_AccessChar" Version="7.0.230.0" Description="Direct access to the Keyboard Layouts tab using alt+">[!!Ķ!!]</String>
 <String Group="Configuration Dialog - Tab names" Type="PlainText" Id="S_Options" Version="7.0.230.0" Description="Options tab name">[!!Ōƿťĩőƞş!!]</String>      <String Group="Configuration Dialog - Tab names" Type="PlainText" Id="S_Options_AccessChar" Version="7.0.230.0" Description="Direct access to the Options tab using alt+">[!!Ŏ!!]</String>
@@ -96,7 +96,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Caption_Languages" Version="9.0.420.0" Description="Text preceding linked language profiles">[!!Ĺǻƞĝůǻĝęŝ:!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Languages_Uninstall" Version="9.0.420.0" Description="Remove language profile">[!!✕!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Languages_Install" Version="9.0.420.0" Description="Add language profile">[!!Āđđ ļàŉğũåĝē!!]</String>
-  
+
 <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Caption_OnScreenKeyboard" Version="7.0.230.0" Description="Term for the On Screen Keyboard">[!!Őƞ Ŝĉŗȇȅň Ķȅƴƀŏȁřď:!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_OnScreenKeyboard_Custom" Version="8.0.306.0" Description="(OSK) Custom term">[!!Ĉŭŝťŏm!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_OnScreenKeyboard_Installed" Version="7.0.230.0" Description="(OSK) Installed term">[!!Įŋŝťăļļėđ!!]</String>
@@ -105,7 +105,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Caption_Documentation" Version="8.0.306.0" Description="Term for the Documentation">[!!Ďơĉũměŋťáťĩŏŉ:!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Documentation_Installed" Version="8.0.306.0" Description="(Documentation) Installed term">[!!İƞśţąļļĕď!!]</String>
   <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Documentation_NotInstalled" Version="8.0.306.0" Description="(Documentation) Not installed term">[!!Ɲőţ įńşťǻĺłȅđ!!]</String>
-  
+
 <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Caption_Message" Version="7.0.230.0" Description="Keyboard download window, etc. - term for additional messages">[!!Mȅşśäģę:!!]</String>
 <String Group="Configuration Dialog - Captions" Type="PlainText" Id="S_Caption_Copyright" Version="7.0.230.0" Description="Keyboard download window, etc. - term for copyright">[!!Čőƥȳŕīğĥť:!!]</String>
 
@@ -150,17 +150,12 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koAutoOpenOSK" Version="7.0.244.0" Description="OSK options - auto-open OSK">[!!Äľŵȁƴŝ ŝĥŏŵ Őƞ Šċŕėěń ĶĕƴƄōãřđ Ŵīƞďơŵ ŵĥėń Ķěɏmàƞ ķȇƴƃőáŗď ĩš śēļĕĉţěď!!]</String>
 <String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koAutoSwitchOSKPages" Version="7.0.244.0" Description="OSK options - when a keyboard is activated, switch to most appropriate page in OSK">[!!Šŵĭŧčĥ ŧơ āƥƿřőƥŕįáŧė Őŋ Šćŗěėń ƘȅƴƄőãŗđ/Ħȅĺƿ áųťơmăŧĭĉåłŀŷ ŵĥȅņ ȃ ķęȳƀōāŕđ ĭŝ śĕļȇćţȇđ!!]</String>
 
-<String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koTurnOnSurrogates" Version="7.0.230.0" Description="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">[!!Ŧũřŉ őŋ Ūńĩĉơđȅ ŝŭƿƥļēmȇňŧāŕɏ ćħāŗãĉŧěř ďıŝƥľäȳ (řȇǫŭīŗęš ŗĕşţâřť)!!]</String>
-<String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koUnknownLanguage" Version="7.0.230.0" Description="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">[!!Ŧũŕŉ őŉ 'Ůńƙňŏŵŉ' ĺǻŋġůǻğě!!]</String>
 <String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koDebugging" Version="7.0.230.0" Description="Advanced options - turn on debugging (which creates a very large file)">[!!ĎēƄŭģġįƞĝ!!]</String>
-<String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koSwitchLanguageWithKeyboard" Version="7.0.244.0" Description="Advanced options - switch Windows language when keyboard selected">[!!Śŵįţċħ Ŵīńďőŵŝ łǻŉġūäģę ŵĥęŉ ā Ƙĕƴmāņ ĸęȳƀőàřđ ĭŝ ŝėľĕčťȅđ!!]</String>
-  <String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koSwitchLanguageForAllApplications" Version="7.1.274.0" Description="Advanced options - selected language applies to all applications">[!!Šęŀĕćť ƙēƴƅŏàŗď ļáƴōůť ƒōř āĺŀ ȁƥƥłĭċąťįŏńş!!]</String>
-<String Group="Configuration Dialog - Options tab" Type="FormatString" Id="koRunElevatedInVista" Version="7.0.230.0" Description="Advanced options - elevate user permission to highest permisable level">[!!Ąŀŵąɏš ěĺěvȃŧȇ ũŝĕř ƥěŗmĩšşıōńş ŵħėń ŗŭńňĩƞģ ĩń Ŵįŋđőŵş Vıŝţă!!]</String>
 
 <String Group="Configuration Dialog - Options tab" Type="PlainText" Id="S_Button_UILanguage" Version="7.0.230.0" Description="Options button - changes user interface language/localization">[!!Ůšēř ĩŋţĕŗƒāĉē łáņģůȃġė...!!]</String>
 
 <String Group="Configuration Dialog - Options tab" Type="PlainText" Id="S_Button_BaseKeyboard" Version="9.0.445.0" Description="Options tab - base keyboard button">[!!Ɓâśȇ Ƙȇƴɓŏäŕđ...!!]</String>
-  
+
 <!-- Hotkeys tab -->
 
 <String Group="Configuration Dialog - Hotkeys tab" Type="PlainText" Id="S_Hotkey_Keyboard_Prefix" Version="7.0.230.0" Description="Hotkey - activation term preceding Keyman keyboard layout name. Note: include a space following."></String> <!-- e.g. "Activate [Korean KORDA] Keyboard" -->
@@ -181,10 +176,10 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Configuration Dialog - Hotkeys tab" Type="PlainText" Id="S_Hotkey_OpenTextEditor" Version="7.1.275.0" Description="Hotkey - open text editor">[!!Ơƥĕŉ Ţěxţ Ęđĩţŏŕ!!]</String>
 
 <String Group="Configuration Dialog - Hotkeys tab" Type="PlainText" Id="S_Hotkey_SwitchLanguage" Version="8.0.294.0" Description="Hotkey - switch language window">[!!Ŏƿĕŉ Łåƞġűãĝě Śŵīţċĥĕŕ!!]</String>
-  
+
 <String Group="Configuration Dialog - Hotkeys tab" Type="PlainText" Id="S_Hotkey_Control_Title" Version="7.1.274.0" Description="Hotkey - Control Title">[!!Ğēņĕŕáŀ Ĥơťĸęŷŝ!!]</String>
 <String Group="Configuration Dialog - Hotkeys tab" Type="PlainText" Id="S_Hotkey_Keyboard_Title" Version="7.1.274.0" Description="Hotkey - Keyboard Title">[!!Ƙȅŷƅŏȁřđ Łãƴơųţś!!]</String>
-  
+
 <!-- Languages tab -->
 
 <String Group="Configuration Dialog - Languages tab" Type="PlainText" Id="S_Languages_InstalledLanguage" Version="7.0.230.0" Description="Languages - Windows installed languages column header">[!!Ĩňšťăłĺęđ Ŀāŉĝŭāģė!!]</String>
@@ -232,7 +227,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <!-- Note: this dialog uses captions from the Configuration dialog as well -->
-  
+
 <Dialog Id="InstallKeyboard" Width="600" Height="300"/>
 
 <String Group="Install Keyboard Dialog" Type="PlainText" Id="S_InstallKeyboard_Title" Version="7.0.230.0" Description="Install keyboard/package dialog title">[!!Īňśťąľĺ Ķėȳƅőåřď/Ƥàčĸąĝė!!]</String>
@@ -286,22 +281,22 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 
 <String Group="Select Keyboard for Install Dialog" Type="FormatString" Id="SKSelectKeyboardsTitle" Version="7.0.241.0" Description="Select Keyboards for Install dialog title">[!!Şȇłěčţ ƘęŷƂŏȁřďš ŧő Įňśţãļľ!!]</String>
 <String Group="Select Keyboard for Install Dialog" Type="FormatString" Id="SKSelectKeyboardsBlurb" Version="7.0.241.0" Parameters="%0:s: Number of keyboards user can still install" Description="Select Keyboards for Install text">[!!Ÿőū ċȃƞņŏŧ įƞśťåłļ āŀŀ ŧħę ƙĕŷƂőǻŗďś įŋ ťħĩš ƥȁčķáĝē.  Ƴŏũ ċãň īƞşťāĺľ à máxĩmūm őƒ %0:d àďđıŧıōŉąļ ĸēɏƄōȃŕďš.  Ƥļĕąšȇ šȅľĕċť ŧħē ĸȇƴƀơåŗđŝ ŷőū ŵįşħ ťő īŉśŧăļĺ ƒŕŏm ťĥīś ƿàĉĸăģȅ.!!]</String>
-  
+
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Online Update Dialog              -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <Dialog Id="OnlineUpdate" Width="470" Height="260"/>
-  
+
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_Title" Version="7.0.230.0" Description="Update dialog title, where &Name; = product name">[!!Ŭƥđăţĕď !!]&Name;[!! Ċơmƥơƞȅƞŧś Ãváīŀâɓļĕ!!]</String>
 
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_NewVersionAvailable" Version="7.0.230.0" Description="Update dialog - updates available text">[!!Ůƥđäţęş ƒōŕ !!]&Name;[!! àŕė ŋơŵ ävàıłàƄľē!!]</String>
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_NewVersionPrompt" Version="7.1.255.0" Description="Update dialog - prompt to select updates">[!!Ƥłęāşȅ šĕĺěčţ ŧħę űƥđáŧěš ȳőŭ ŵīŝħ ŧō ĭńšťąľŀ:!!]</String>
-  
+
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_InstallQuery" Version="7.0.230.0" Description="Update dialog - install query">[!!Đō ȳőů ŵãŉŧ ťŏ ďơŵńĺơăď ăńď ĭŋśţȁŀļ ťħīš ƿăŧċħ ƞōŵ?!!]</String>
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_DownloadFrom" Version="7.0.230.0" Description="Update dialog - download information">[!!Ŷŏů ċâƞ ďőŵŋłŏãđ ŧĥě ňȅŵ věŗşıŏƞ ƒŕŏm:!!]</String>
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_DownloadQuery" Version="7.0.230.0" Description="Update dialog - keyman.com website visiting query">[!!Đő ƴơų ŵǻňť ťŏ vīšįť ŧħę ŵȅƄŝįťĕ ŉőŵ?!!]</String>
-  
+
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_Button_InstallNow" Version="7.0.230.0" Description="Update dialog - install now button">[!!Įŉšŧąłļ Ɲōŵ!!]</String>
 <String Group="Online Update Dialog" Type="PlainText" Id="S_Update_Button_InstallLater" Version="7.0.230.0" Description="Update dialog - cancel button">[!!Čáńĉĕļ!!]</String>
 
@@ -319,7 +314,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Online Update Dialog" Type="FormatString" Id="SKUpdate_IconText" Version="8.0.288.0" Description="Update icon - text">[!!Ċłıćķ ťħįŝ ĭĉơņ ţő đơŵŉłōåđ åƞď ĭŉŝťåĺľ űƿđàŧĕŝ!!]</String>
 <String Group="Online Update Dialog" Type="FormatString" Id="SKUpdate_IconMenuText" Version="8.0.288.0" Description="Update icon - install menu item">[!!Vĭėŵ ȃŉđ &amp;ĩńŝţáĺľ !!]&Name;[!! ũƿďąţēş!!]</String>
 <String Group="Online Update Dialog" Type="FormatString" Id="SKUpdate_IconMenuExit" Version="8.0.288.0" Description="Update icon - exit menu item">[!!Ė&amp;xīť őŋľĩńē ŭƥđǻŧĕ ċħěĉƙ!!]</String>
-  
+
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Splash Dialog                     -->
 <!-- - - - - - - - - - - - - - - - - - -->
@@ -331,12 +326,12 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 
 <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_Start" Version="8.0.294.0" Description="Start Keyman Desktop button">[!!Ŝŧăŕŧ Ƙęƴmâņ!!]</String>
 <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_Exit" Version="8.0.294.0" Description="Exit button">[!!Ĕxīţ!!]</String>
-  
+
 <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_OtherTasks" Version="8.0.294.0" Description="Other tasks heading">[!!Őţĥĕŗ ţäśķš!!]</String>
   <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_Configuration" Version="8.0.294.0" Description="Keyman Configuration link">[!!Čơŉƒīĝůřȁťīőņ!!]</String>
   <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_ShowAtStartup" Version="9.0.341.0" Description="Show at Startup toggle">[!!Śĥőŵ ŧħıš šćŗęȇň ăť ŝţǻŗŧųƥ!!]</String>
   <String Group="Splash Dialog" Type="PlainText" Id="S_Splash_HideAtStartup" Version="9.0.431.0" Description="Hide at Startup toggle">[!!Ĥĩďė ťħış ŝćŕēėň ąŧ śťǻŗŧŭƿ!!]</String>
-      
+
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- UI Languages & Localization       -->
 <!-- - - - - - - - - - - - - - - - - - -->
@@ -362,7 +357,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <Dialog Id="LangSetup" Width="650" Height="375"></Dialog>
-	
+
 <String Group="Language Setup Dialog" Type="PlainText" Id="S_LangSetup_Title" Version="7.0.230.0" Description="Language configuration tasks dialog title">[!!Ĺǻŉģųâġē Ċőńƒığųŗȃťıŏƞ Ťāşƙś!!]</String>
 
 <String Group="Language Setup Dialog" Type="PlainText" Id="S_LangSetup_TitleInnerPrefix" Version="7.0.230.0" Description="LCT dialog - subtitle text preceding language name(s)">[!!Ċōƞƒĩĝůŕę ƴơŭŗ ĉōmƿūŧȅŕ ťő ŵőŕĸ ŵĭŧĥ!!]</String>
@@ -425,7 +420,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <!-- Menu Items                        -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_SwitchKeymanOff" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - Switch Keyman Desktop Off">[!!Şŵıţčħ !!]&Name;[!! &amp;Ōƒƒ!!]</String> 
+<String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_SwitchKeymanOff" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - Switch Keyman Desktop Off">[!!Şŵıţčħ !!]&Name;[!! &amp;Ōƒƒ!!]</String>
 <String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_OnScreenKeyboard" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - OSK">[!!Ōń Ŝćŗĕėň &amp;ĶȇȳƂőářď!!]</String>
 <String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_KeyboardUsage" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - Keyboard Usage">[!!Ķȇƴƃơăřď &amp;Ůšăĝė!!]</String>
 <String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_FontHelper" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - Font Helper">[!!&amp;Ƒōńť Ħȇŀƥěŕ!!]</String>
@@ -437,7 +432,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="System Tray Menu Items" Type="PlainText" Id="S_Menu_Exit" Version="7.0.230.0" Parameters="&amp; precedes alt + access-character" Description="Systray item - Exit">[!!Ĕ&amp;xĩŧ!!]</String>
 
 <String Group="System Tray Menu Items" Type="PlainText" Id="SKMenu_NoKeyboardsInstalled" Version="7.0.230.0" Description="Systray - notice of no keyboard layouts installed">[!!Ňơ ƙěƴɓőȃřď ŀāƴőůťš āŕĕ ıŋşţāłłěď.
-Ĉĥơơšȇ "Čőŉƒįğűŗäťīŏƞ" ŧơ īňŝŧǻłľ á 
+Ĉĥơơšȇ "Čőŉƒįğűŗäťīŏƞ" ŧơ īňŝŧǻłľ á
 ķȅɏƂőäŗđ ļąɏōůţ ƒőř ɏŏūŕ ĺáňġųáĝę.!!]</String>
 
 <String Group="On Screen Keyboard Menu Items" Type="PlainText" Id="S_OSKContext_FadeWhenInactive" Version="7.0.230.0" Description="OSK right-click menu - fade OSK when mouse is elsewhere">[!!Ƒȁďȅ Ŵĥęń Ĭŉàčţĭvē!!]</String>
@@ -458,7 +453,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Usage Page" Type="HTML" Id="S_Usage_KeyboardDocumentation" Version="7.1.261.0" Description="Usage page - Text shown when keyboard has documentation">[!!Čļīćƙ ťĥȅ ƅŭťŧŏňś ƃȅłơŵ ťơ vıęŵ åďďįŧĩōņāľ ďŏĉųmȅņŧāŧīơƞ ąŉđ/őř Őń Şčřȇęŉ Ƙȇƴƃŏȁŗď.!!]</String>
 <String Group="Usage Page" Type="HTML" Id="S_Usage_KeymanOff" Version="7.1.261.0" Description="Usage page - Text shown when no Keyman keyboard is active">[!!Ňơ ƙęƴƃŏàŕđ ĺȁƴơųŧ ĭś ćũřŗęńţľȳ ŝȇľěćŧĕđ ĩņ !!]&Name;[!!.  Ĉŀĩĉƙ őƞ àŋɏ őƒ ŧĥē ƙěŷƀőăřď ıćőņš ıƞ ŧħĕ ŧŏơŀƀąŗ åƄơvȇ ťơ ćħőŏşȅ ã ĸȅɏƀơáŕď ĺãŷōūţ.!!]</String>
 <String Group="Usage Page" Type="HTML" Id="S_Usage_NoKeyboardsInstalled" Version="7.1.261.0" Description="Usage page - Text shown when no Keyman keyboards are installed">[!!Ŋō ķĕŷƄőàřđ ľãƴŏųŧŝ ąřė ċůŕŕěŋťĺŷ įƞšťàļľĕď ơŗ ŀơȃđȅđ.  Ŭşē !!]&Name;[!! Čōŉƒīĝűŗāťĩőň ŧơ ıƞšŧȃľļ à ķȅɏƂơâřď ĺãɏōũť.!!]</String>
-  
+
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 <!-- Formatted messages, assorted                                              -->
 <!-- These messages cannot contain HTML tags and are plain text                -->
@@ -490,8 +485,8 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Formatted Messages" Type="FormatString" Id="SKANSIEncoding" Version="7.0.230.0" Description="Keyboard with an ANSI or Codepage encoding">[!!Ćōđȅƥăġė!!]</String>
 <String Group="Formatted Messages" Type="FormatString" Id="SKUnicodeEncoding" Version="7.0.230.0" Description="Keyboard with a Unicode encoding">[!!Ūņıčŏďĕ!!]</String>
 <String Group="Formatted Messages" Type="FormatString" Id="SKDownloadProgress_Title" Version="7.0.230.0" Description="Notice of file downloading">[!!Ďŏŵŉľŏąđįńġ Ƒĩłē!!]</String>
-    
-  
+
+
 <!-- Confirmation Requests -->
 
 <String Group="Formatted Messages" Type="FormatString" Id="SKUninstallOnScreenKeyboard" Version="7.0.230.0" Parameters="%0:s = Keyboard name" Description="Request for confirmation to uninstall OSK for a keyboard layout">[!!Ąřĕ ȳőŭ ŝŭŗȅ ɏŏů ŵåňţ ŧő ŗěmōvȅ ŧĥĕ ơƞ śćŕēęƞ ķēȳƀőȁŗď ĭņŝťäľļėď ƒŏŗ %0:s?!!]</String>
@@ -540,7 +535,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <String Group="Formatted Messages" Type="FormatString" Id="SKLangCheck_WindowsLanguage_Install" Version="7.1.259.0" Parameters="%0:s = language name, %1:s = keyboard name" Description="Shown when Keyman wants to install  a Windows language and link it to a Keyman keyboard so that when one is selected by the user, the other automatically switches in">[!!Ĩňŝŧąŀĺ ļăŉģųåğē %0:s ąŉď łĩňƙ ţŏ Ƙėƴmàŉ ķĕɏƂōäřđ %1:s!!]</String>
 
 <!-- OSK Font Helper -->
-  
+
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_PleaseWait1" Description="OSK Font helper loading message part 1">[!!Ƥłęäśȇ ŵàįŧ ŵħĭĺę !!]&Name;[!! ƒıńďŝ ŧħě ƒōňţŝ ŧĥåţ ŵĩĺľ ŵŏřķ ŵĭţħ!!]</String>
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_PleaseWait2" Description="OSK Font helper loading message part 2">[!!ķȅɏɓơăŗď.!!]</String>
 
@@ -557,10 +552,10 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_NoFonts1a" Description="OSK Font helper no fonts part 1">[!!Ńő ƒŏŋŧş ŵĕřě ƒōũŉđ ơņ ȳơŭŗ ŝƴśťȅm ťĥȃţ ŵōŕķ ŵīţĥ !!]</String>
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_NoFonts1b" Description="OSK Font helper no fonts part 2">[!!.  Ƥľȇāšē !!]<a href="keyman:welcome">[!!čħēċƙ ťħė ďŏĉūmęņţǻţīŏņ!!]</a>[!! ţơ ƒıńď ƒơňţś ƒōŕ ťĥış ķȇɏƀōãřď.!!]</String>
-  
+
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_NoKeyboards" Description="OSK Font helper no keyboards">[!!Ńŏ ĸęƴƅơāŗđ ŀåƴōůŧś äŕȅ ćųŗŕęņťĺȳ īņśťâłłēđ ōŕ łőäđĕď.  Ŭŝě !!]&Name;[!! Ĉőŋƒįğűřąŧīŏņ ŧơ ıŉŝťȃĺľ ä ƙĕɏƃōąŗđ łâƴơŭŧ.!!]</String>
 <String Group="OSK Font Helper" Type="HTML" Version="8.0.294.0" Id="S_OSK_FontHelper_ChooseKeyboard" Description="OSK Font helper choose keyboard">[!!Ƥľęǻśĕ ćħōŏšě å !!]&Name;[!! ķēƴƄŏȃřđ ţő ƒīƞď ţħė ƒőƞŧş ŧĥáŧ ŵįĺĺ ŵőŗĸ ŵıŧħ īŧ.!!]</String>
-  
+
 <!-- OSK Hints -->
 
 <String Group="OSK Hints" Type="Plain Text" Version="8.0.294.0" Id="S_OSK_Hint_Title" Description="On Screen Keyboard Hintbar title">[!!Ħīŉť:!!]</String>
@@ -578,5 +573,5 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
 <!-- - - - - - - - - - - - - - - - - - -->
 
 <String Group="Text Editor" Type="FormatString" Version="10.0.836.0" Id="SKTextEditorCaption" Description="Caption of Text Editor">[!!Ţęxŧ Ęďĭŧŏŗ - !!]&Name;</String>
-  
+
 </Locale>

--- a/windows/src/desktop/kmshell/locale/qqq/strings.xml
+++ b/windows/src/desktop/kmshell/locale/qqq/strings.xml
@@ -106,12 +106,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="koReleaseShiftKeysAfterKeyPress" comment="Configuration Dialog - Options tab/FormatString: OSK options - Releases shift/ctrl/alt on OSK after key press (introduced 7.0.236.0)">[!!Ŕěŀęàšĕ Şĥıƒţ/Ĉţřŀ/Ȁľŧ ōň Őņ Ŝčŗėěń Ķēŷƃơâŕđ ȃƒţēŕ ćŀĭċĸīňģ å ĸȅȳ!!]</string>
   <string name="koAutoOpenOSK" comment="Configuration Dialog - Options tab/FormatString: OSK options - auto-open OSK (introduced 7.0.244.0)">[!!Äľŵȁƴŝ ŝĥŏŵ Őƞ Šċŕėěń ĶĕƴƄōãřđ Ŵīƞďơŵ ŵĥėń Ķěɏmàƞ ķȇƴƃőáŗď ĩš śēļĕĉţěď!!]</string>
   <string name="koAutoSwitchOSKPages" comment="Configuration Dialog - Options tab/FormatString: OSK options - when a keyboard is activated, switch to most appropriate page in OSK (introduced 7.0.244.0)">[!!Šŵĭŧčĥ ŧơ āƥƿřőƥŕįáŧė Őŋ Šćŗěėń ƘȅƴƄőãŗđ/Ħȅĺƿ áųťơmăŧĭĉåłŀŷ ŵĥȅņ ȃ ķęȳƀōāŕđ ĭŝ śĕļȇćţȇđ!!]</string>
-  <string name="koTurnOnSurrogates" comment="Configuration Dialog - Options tab/FormatString: Advanced options - turn on Unicode suplementary character display (not needed in Vista) (introduced 7.0.230.0)">[!!Ŧũřŉ őŋ Ūńĩĉơđȅ ŝŭƿƥļēmȇňŧāŕɏ ćħāŗãĉŧěř ďıŝƥľäȳ (řȇǫŭīŗęš ŗĕşţâřť)!!]</string>
-  <string name="koUnknownLanguage" comment="Configuration Dialog - Options tab/FormatString: Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts). (introduced 7.0.230.0)">[!!Ŧũŕŉ őŉ 'Ůńƙňŏŵŉ' ĺǻŋġůǻğě!!]</string>
   <string name="koDebugging" comment="Configuration Dialog - Options tab/FormatString: Advanced options - turn on debugging (which creates a very large file) (introduced 7.0.230.0)">[!!ĎēƄŭģġįƞĝ!!]</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="Configuration Dialog - Options tab/FormatString: Advanced options - switch Windows language when keyboard selected (introduced 7.0.244.0)">[!!Śŵįţċħ Ŵīńďőŵŝ łǻŉġūäģę ŵĥęŉ ā Ƙĕƴmāņ ĸęȳƀőàřđ ĭŝ ŝėľĕčťȅđ!!]</string>
-  <string name="koSwitchLanguageForAllApplications" comment="Configuration Dialog - Options tab/FormatString: Advanced options - selected language applies to all applications (introduced 7.1.274.0)">[!!Šęŀĕćť ƙēƴƅŏàŗď ļáƴōůť ƒōř āĺŀ ȁƥƥłĭċąťįŏńş!!]</string>
-  <string name="koRunElevatedInVista" comment="Configuration Dialog - Options tab/FormatString: Advanced options - elevate user permission to highest permisable level (introduced 7.0.230.0)">[!!Ąŀŵąɏš ěĺěvȃŧȇ ũŝĕř ƥěŗmĩšşıōńş ŵħėń ŗŭńňĩƞģ ĩń Ŵįŋđőŵş Vıŝţă!!]</string>
   <string name="S_Button_UILanguage" comment="Configuration Dialog - Options tab/PlainText: Options button - changes user interface language/localization (introduced 7.0.230.0)">[!!Ůšēř ĩŋţĕŗƒāĉē łáņģůȃġė...!!]</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">[!!Ɓâśȇ Ƙȇƴɓŏäŕđ...!!]</string>
   <!-- Hotkeys tab -->
@@ -295,7 +290,7 @@ Create a user interface translation for Keyman Desktop at http://www.tavultesoft
   <string name="S_Menu_Help" comment="System Tray Menu Items/PlainText: Systray item - Help [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!&amp;Ħęłƥ...!!]</string>
   <string name="S_Menu_Exit" comment="System Tray Menu Items/PlainText: Systray item - Exit [&amp; precedes alt + access-character] (introduced 7.0.230.0)">[!!Ĕ&amp;xĩŧ!!]</string>
   <string name="SKMenu_NoKeyboardsInstalled" comment="System Tray Menu Items/PlainText: Systray - notice of no keyboard layouts installed (introduced 7.0.230.0)">[!!Ňơ ƙěƴɓőȃřď ŀāƴőůťš āŕĕ ıŋşţāłłěď.
-Ĉĥơơšȇ "Čőŉƒįğűŗäťīŏƞ" ŧơ īňŝŧǻłľ á 
+Ĉĥơơšȇ "Čőŉƒįğűŗäťīŏƞ" ŧơ īňŝŧǻłľ á
 ķȅɏƂőäŗđ ļąɏōůţ ƒőř ɏŏūŕ ĺáňġųáĝę.!!]</string>
   <string name="S_OSKContext_FadeWhenInactive" comment="On Screen Keyboard Menu Items/PlainText: OSK right-click menu - fade OSK when mouse is elsewhere (introduced 7.0.230.0)">[!!Ƒȁďȅ Ŵĥęń Ĭŉàčţĭvē!!]</string>
   <string name="S_OSKContext_ShowToolbar" comment="On Screen Keyboard Menu Items/PlainText: OSK right-click menu - show/hide OSK toolbar (introduced 7.0.230.0)">[!!Ŝĥŏŵ Ťōōĺƀåř!!]</string>

--- a/windows/src/desktop/kmshell/locale/shu-latn/strings.xml
+++ b/windows/src/desktop/kmshell/locale/shu-latn/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Fukkal shu\'ul hana Unicode albinshaf (bidor einbada gadey kula)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Fukkal lugga \'almi ma\'aruf\'</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Abdulal lugga hanal komfita kan azzal Keyman Keyboard</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Azzul shabal binshaf hanal keyboard ley kulli albinnaf beya</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Matakula zidal izin hana nadum albinnaf beya kan tannaf beya fi Windows Vista</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/locale/ta/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ta/strings.xml
@@ -3,7 +3,7 @@
   <!--
 
 locale.dtd: Contains all localizable strings from Keyman Configuration XML files.
-            
+
 Please see the documentation for information on how to edit this file and where it
 should go.
 
@@ -261,12 +261,6 @@ Entries not in this file will be sourced from the default locale.xml file in the
   <!--    -->
   <string name="koAltGrCtrlAlt" comment="/FormatString: ">Simulate AltGr with Ctrl+Alt</string>
   <!--    -->
-  <string name="koRunElevatedInVista" comment="/FormatString: ">பயனாளர் உபயோகத்தை "Windows Vista" பதிப்பிலும் தொடர</string>
-  <!--    -->
-  <string name="koTurnOnSurrogates" comment="/FormatString: ">யுனிகோடுக்கான கூடுதல் எழுத்தை தெரிவிக்க (திரும்ப இயக்க வேண்டி வரும்)</string>
-  <!--    -->
-  <string name="koUnknownLanguage" comment="/FormatString: ">தெரியாத மொழியை ஆன் செய்ய</string>
-  <!--    -->
   <string name="koDebugging" comment="/FormatString: ">தவறை சரி செய்ய</string>
   <!--   Title of the Change Hotkey dialog box -->
   <string name="SKChangeHotkeyTitle" comment="/FormatString: ">ஹாட் கீயை மாற்றவும்.</string>
@@ -327,8 +321,6 @@ Entries not in this file will be sourced from the default locale.xml file in the
   <string name="koReleaseShiftKeysAfterKeyPress" comment="Configuration Dialog - Options tab/FormatString: OSK options - Releases shift/ctrl/alt on OSK after key press (introduced 7.0.236.0)">Release Shift/Ctrl/Alt on On Screen Keyboard after clicking a key</string>
   <string name="koAutoOpenOSK" comment="Configuration Dialog - Options tab/FormatString: OSK options - auto-open OSK (introduced 7.0.244.0)">Always show On Screen Keyboard Window when Keyman keyboard is selected</string>
   <string name="koAutoSwitchOSKPages" comment="Configuration Dialog - Options tab/FormatString: OSK options - when a keyboard is activated, switch to most appropriate page in OSK (introduced 7.0.244.0)">Switch to appropriate On Screen Keyboard/Help automatically when a keyboard is selected</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="Configuration Dialog - Options tab/FormatString: Advanced options - switch Windows language when keyboard selected (introduced 7.0.244.0)">Switch Windows language when a Keyman keyboard is selected</string>
-  <string name="koSwitchLanguageForAllApplications" comment="Configuration Dialog - Options tab/FormatString: Advanced options - selected language applies to all applications (introduced 7.1.274.0)">Select keyboard layout for all applications</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
   <string name="S_Hotkey_Language_Prefix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - activation term preceding Windows language name. Note: include a space following. (introduced 7.0.241.0)"/>
   <string name="S_Hotkey_Language_Suffix" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - language term following Windows language name. Note: include an initial space. (introduced 7.0.241.0)"/>
@@ -402,7 +394,7 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <string name="S_Help_Keyboard_Prefix" comment="Help Dialog/PlainText: Help - text preceding keyboard name (introduced 7.0.230.0)">Help on "</string>
   <string name="S_Help_Keyboard_Suffix" comment="Help Dialog/PlainText: Help - text following keyboard name (introduced 7.0.230.0)">" keyboard</string>
   <string name="SKMenu_NoKeyboardsInstalled" comment="System Tray Menu Items/PlainText: Systray - notice of no keyboard layouts installed (introduced 7.0.230.0)">No keyboard layouts are installed.
-Choose "Configuration" to install a 
+Choose "Configuration" to install a
 keyboard layout for your language.</string>
   <string name="SKButtonPrint" comment="Formatted Messages/FormatString: Print button in Welcome dialog for keyboards (introduced 7.0.239.0)">&amp;Print...</string>
   <string name="SKButtonDownload" comment="Formatted Messages/FormatString: Download button in Locale Selection dialog (introduced 7.0.240.0)">&amp;Download...</string>

--- a/windows/src/desktop/kmshell/locale/tr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/tr/strings.xml
@@ -20,16 +20,11 @@
   <string name="kogStartup" comment="/FormatString: ">Açılış</string>
   <string name="koKeyboardHotkeysAreToggle" comment="/FormatString: ">Klavye kısayol tuşları, etkin klavyeyi değiştirir</string>
   <string name="koReleaseShiftKeysAfterKeyPress" comment="/FormatString: ">Bir tuşa tıkladıktan sonra Ekran Klavyesinde Shift/Ctrl/Alt tuşlarını bırakın</string>
-  <string name="koRunElevatedInVista" comment="/FormatString: ">Windows Vista'da çalışırken daima kullanıcı izinlerini yükseltin</string>
   <string name="koShowHints" comment="/FormatString: ">İpucu iletileri göster</string>
   <string name="koShowStartup" comment="/FormatString: ">Karşılama ekranı göster</string>
   <string name="koShowWelcome" comment="/FormatString: ">Hoş Geldiniz ekranı</string>
   <string name="koStartWithWindows" comment="/FormatString: ">Windows başladığında başla</string>
-  <string name="koSwitchLanguageForAllApplications" comment="/FormatString: ">Tüm uygulamalar için klavye düzenini seçin</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="/FormatString: ">Bir Keyman klavye seçildiğinde Windows dilini değiştir</string>
   <string name="koTestKeymanFunctioning" comment="/FormatString: ">Keyman başladığında çakışan uygulamaları test et</string>
-  <string name="koTurnOnSurrogates" comment="/FormatString: ">Unicode ek karakter ekranını açın (yeniden başlatmayı gerektirir)</string>
-  <string name="koUnknownLanguage" comment="/FormatString: ">'Bilinmiyor' dili açın</string>
   <string name="S_Menu_OnScreenKeyboard" comment="/PlainText: ">&amp;Ekran Klavyesi</string>
   <string name="S_Toolbar_OpenHelp" comment="/PlainText: ">Yardım Açın</string>
   <string name="S_Toolbar_OpenConfiguration" comment="/PlainText: ">Keyman Yapılandırma Açın</string>

--- a/windows/src/desktop/kmshell/locale/vec/strings.xml
+++ b/windows/src/desktop/kmshell/locale/vec/strings.xml
@@ -19,15 +19,11 @@
   <string name="kogStartup" comment="/FormatString: ">Startup</string>
   <string name="koKeyboardHotkeysAreToggle" comment="/FormatString: ">I botoni de funsion de tastièra i pasa indretamente da inpisà a destuà e vicevèrsa</string>
   <string name="koReleaseShiftKeysAfterKeyPress" comment="/FormatString: ">Dexativa  Shift/Ctrl/Alt so ƚa Tastièra so Schèrmo dapò ver clicà un tasto</string>
-  <string name="koRunElevatedInVista" comment="/FormatString: ">Inalsa senpre i parmesi utente co' se laora in Windows Vista</string>
   <string name="koShowHints" comment="/FormatString: ">Mostra mesaji de suxerimento</string>
   <string name="koShowStartup" comment="/FormatString: ">Mostra schermada de invìo</string>
   <string name="koShowWelcome" comment="/FormatString: ">Mostra schermada de benvignù</string>
   <string name="koStartWithWindows" comment="/FormatString: ">Invìa Keyman Desktop co se invìa Windows</string>
-  <string name="koSwitchLanguageWithKeyboard" comment="/FormatString: ">Canbia lengua de Windows co xé desernìo na tastièra Keyman</string>
   <string name="koTestKeymanFunctioning" comment="/FormatString: ">Verìfega se ghe xé confliti co' programi co se invìa Keyman</string>
-  <string name="koTurnOnSurrogates" comment="/FormatString: ">Inpisa ƚa mostra de i caràteri suplementar Unicode (senghe vol de inviar da novo)</string>
-  <string name="koUnknownLanguage" comment="/FormatString: ">Inpisa lengua 'desconosesta'</string>
   <string name="S_Menu_OnScreenKeyboard" comment="/PlainText: ">Tastièra so schèrmo</string>
   <string name="S_Toolbar_OpenHelp" comment="/PlainText: ">Vèrxi àida</string>
   <string name="S_Toolbar_OpenConfiguration" comment="/PlainText: ">Vèrxi confegurasion Keyman Desktop</string>
@@ -235,7 +231,6 @@
   <string name="S_Documentation_NotInstalled" comment="Configuration Dialog - Captions/PlainText: (Documentation) Not installed term (introduced 8.0.306.0)">Not installed</string>
   <string name="S_Menu_Options" comment="Configuration Dialog - Keyboard Layouts tab/PlainText: KL option button submenu - keyboard options (introduced 8.0.287.0)">Keyboard options</string>
   <string name="koDeadkeyConversion" comment="Configuration Dialog - Options tab/FormatString: Advanced options - Base keyboard deadkeys are treated as normal keys (introduced 9.0.480.0)">Treat hardware deadkeys as plain keys</string>
-  <string name="koSwitchLanguageForAllApplications" comment="Configuration Dialog - Options tab/FormatString: Advanced options - selected language applies to all applications (introduced 7.1.274.0)">Select keyboard layout for all applications</string>
   <string name="S_Button_BaseKeyboard" comment="Configuration Dialog - Options tab/PlainText: Options tab - base keyboard button (introduced 9.0.445.0)">Base Keyboard...</string>
   <string name="S_Hotkey_ShowFontHelper" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show font helper in OSK (introduced 7.1.275.0)">Show Font Helper Pane</string>
   <string name="S_Hotkey_ShowCharacterMap" comment="Configuration Dialog - Hotkeys tab/PlainText: Hotkey - show character map in OSK (introduced 7.1.275.0)">Show Character Map Pane</string>

--- a/windows/src/desktop/kmshell/locale/zh-CN/strings.xml
+++ b/windows/src/desktop/kmshell/locale/zh-CN/strings.xml
@@ -324,27 +324,7 @@
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">打开 Unicode 辅助字符显示 (需要重启)</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">打开“未知”语言</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">调试中</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">选择键盘时切换Windows语言</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">选择所有应用程序的键盘布局</string>
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">在 Windows Vista 中运行时总是提高用户权限</string>
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.445.0 -->

--- a/windows/src/desktop/kmshell/xml/keyman_options.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_options.xsl
@@ -14,7 +14,7 @@
 					<xsl:sort select="sort" />
           <div class="options_list_header"><xsl:value-of select="$locale/string[@name=current()/name]"/></div>
           <xsl:for-each select="//KeymanOption[group=current()/name]">
-            <xsl:if test="optiontype = 1 and id != 'koAutoSwitchOSKPages'">
+            <xsl:if test="optiontype = 1 and id != 'koAutoSwitchOSKPages' and id != 'koSwitchLanguageForAllApplications'">
               <xsl:call-template name="option" />
             </xsl:if>
           </xsl:for-each>
@@ -97,5 +97,5 @@
       </div>
     </div>
   </xsl:template>
-  
+
   </xsl:stylesheet>

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -434,38 +434,8 @@
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koAutoSwitchOSKPages" comment="OSK options - when a keyboard is activated, switch to most appropriate page in OSK">Switch to appropriate On Screen Keyboard/Help automatically when a keyboard is selected</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koTurnOnSurrogates" comment="Advanced options - turn on Unicode suplementary character display (not needed in Vista)">Turn on Unicode supplementary character display (requires restart)</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koUnknownLanguage" comment="Advanced options - installs Unknown Language in Windows Control Panel (should only be used for legacy layouts).">Turn on \'Unknown\' language</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.244.0 -->
-  <string name="koSwitchLanguageWithKeyboard" comment="Advanced options - switch Windows language when keyboard selected">Switch Windows language when a Keyman keyboard is selected</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.1.274.0 -->
-  <string name="koSwitchLanguageForAllApplications" comment="Advanced options - selected language applies to all applications">Select keyboard layout for all applications</string>
-
-  <!-- Context: Configuration Dialog - Options tab -->
-  <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koRunElevatedInVista" comment="Advanced options - elevate user permission to highest permissible level">Always elevate user permissions when running in Windows Vista</string>
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: PlainText -->

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -434,6 +434,11 @@
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koAutoSwitchOSKPages" comment="OSK options - when a keyboard is activated, switch to most appropriate page in OSK">Switch to appropriate On Screen Keyboard/Help automatically when a keyboard is selected</string>
+
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">Debugging</string>
 

--- a/windows/src/test/manual-tests/test_i2605/locale-tam.xml
+++ b/windows/src/test/manual-tests/test_i2605/locale-tam.xml
@@ -4,10 +4,10 @@
   <!ENTITY ProductName "Keyman Desktop">
   <!ENTITY Edition "Professional">
   <!ENTITY Version "7.0">
-  
+
   <!ENTITY EvaluationPeriod "30">
 
-  
+
   <!ENTITY Name "&ProductName;">
   <!ENTITY Name_CNV "&Company;&#160;&ProductName;&#160;&Version;">
   <!ENTITY Name_CN "&Company;&#160;&ProductName;">
@@ -17,7 +17,7 @@
 	<!--
 
 locale.dtd: Contains all localizable strings from Keyman Configuration XML files.
-            
+
 Please see the documentation for information on how to edit this file and where it
 should go.
 
@@ -150,10 +150,10 @@ Entries not in this file will be sourced from the default locale.xml file in the
 	<Dialog Id="Welcome" Width="462" Height="372"/>
 	<String Type="PlainText" Id="S_Welcome_Title">&amp;Name_NV;க்கு வரவேற்கிறோம்</String>
 	<String Type="HTML" Id="S_Welcome_Steps">
- 
+
   To get started using &amp;Name;, follow these simple steps:
 	<ol>
-		</ol>Download and install a keyboard from the 
+		</ol>Download and install a keyboard from the
 		    </String>
 	<String Type="HTML" Id="S_Welcome_StartTyping">பிறகு தட்டச்சு செய்க!</String>
 	<String Type="HTML" Id="S_Welcome_ProductName">&Name_NV;</String>
@@ -178,7 +178,7 @@ Entries not in this file will be sourced from the default locale.xml file in the
 	<!-- - - - - - - - - - - - - - - - - - -->
 	<Dialog Id="Activate" Width="309" Height="308"/>
 	<String Type="PlainText" Id="S_Activate_Title">பதிவு &amp;Name_CN;</String>
-	<String Type="PlainText" Id="S_Activate_Description">&amp;Name;, ஐ நீங்கள் விலைக்கு வாங்கினால் 
+	<String Type="PlainText" Id="S_Activate_Description">&amp;Name;, ஐ நீங்கள் விலைக்கு வாங்கினால்
    &amp;Company;யிடமிருந்து இதைப்போன்ற activation code உடன் கூடிய மின்னஞ்சல் கிடைக்கப்பெறுவீர்.
 </String>
 	<String Type="PlainText" Id="S_Activate_Enter">நீங்கள் பெற்ற உரிம எண்ணை உள்ளீடு செய்யவும்.</String>
@@ -349,12 +349,6 @@ Entries not in this file will be sourced from the default locale.xml file in the
 	<String Type="FormatString" Id="koKeyboardHotkeysAreToggle">தட்டச்சுப்பலகைக்கான ஹாட் கீ </String>
 	<!--    -->
 	<String Type="FormatString" Id="koAltGrCtrlAlt">Simulate AltGr with Ctrl+Alt</String>
-	<!--    -->
-	<String Type="FormatString" Id="koRunElevatedInVista">பயனாளர் உபயோகத்தை "Windows Vista" பதிப்பிலும் தொடர</String>
-	<!--    -->
-	<String Type="FormatString" Id="koTurnOnSurrogates">யுனிகோடுக்கான கூடுதல் எழுத்தை தெரிவிக்க (திரும்ப இயக்க வேண்டி வரும்)</String>
-	<!--    -->
-	<String Type="FormatString" Id="koUnknownLanguage">தெரியாத மொழியை ஆன் செய்ய</String>
 	<!--    -->
 	<String Type="FormatString" Id="koDebugging">தவறை சரி செய்ய</String>
 	<!--   Title of the Change Hotkey dialog box -->


### PR DESCRIPTION
Fixes #7759.

Removes `koRunElevatedInVista`, `koSwitchLanguageForAllApplications`, `koSwitchLanguageWithKeyboard`, `koUnknownLanguage`, `koTurnOnSurrogates` from localizations and from UI.

These options are no longer relevant, mostly due to improved operating system support.

Only one option was still visible, `koSwitchLanguageForAllApplications`, so this has been hidden in keyman_options.xsl, for future full removal.

This does not remove any of these options from the Engine code. This may be done as a future chore outside of a beta cycle.

# User Testing

* TEST_UX: Verify that the "Switch language for all applications" option has been removed from the user interface.
* TEST_LOCALE: Verify that switching user interface language continues to work correctly.