### PR TITLE
chore(android): Update Target SDK Version to 31

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -10,7 +10,7 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.2"
 
     // Don't compress kmp files so they can be copied via AssetManager
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.tavultesoft.kmapro"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         //println "===DUMPING PROPERTIES==="
         //dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
     android:usesCleartextTraffic="true"
     android:theme="@style/AppTheme"
     android:supportsRtl="true">
-    <receiver android:name=".NetworkStateReceiver">
+    <receiver android:name=".NetworkStateReceiver"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
       </intent-filter>
@@ -39,6 +40,7 @@
 
     <service
       android:name="com.keyman.android.SystemKeyboard"
+      android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:permission="android.permission.BIND_INPUT_METHOD">
       <intent-filter>
@@ -56,6 +58,7 @@
 
     <activity
       android:name=".SplashScreenActivity"
+      android:exported="true"
       android:label="@string/app_name"
       android:theme="@style/AppTheme.BrandedLaunch">
       <intent-filter>
@@ -66,6 +69,7 @@
     </activity>
     <activity
       android:name=".MainActivity"
+      android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"
       android:launchMode="singleTask">

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -7,12 +7,12 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.2"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         // VERSION_CODE and VERSION_NAME from version.gradle but Gradle removes them for libraries
         buildConfigField "String", "KEYMAN_ENGINE_VERSION_NAME", "\""+VERSION_NAME+"\""
@@ -69,7 +69,7 @@ dependencies {
 
     // Robolectric
     testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.robolectric:robolectric:4.5.1'
 
     // Generate QR Codes

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
         <activity
             android:name="com.tavultesoft.kmea.KeyboardPickerActivity"
+            android:exported="true"
             android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
@@ -28,24 +29,28 @@
         </activity>
         <activity
             android:name="com.tavultesoft.kmea.KeyboardInfoActivity"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Light.Dialog" >
         </activity>
         <activity
             android:name="com.tavultesoft.kmea.KMKeyboardDownloaderActivity"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label=""
             android:theme="@style/AppTheme.Light.Dialog">
         </activity>
         <activity
             android:name="com.tavultesoft.kmea.ModelPickerActivity"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Light.Dialog">
         </activity>
         <activity
             android:name="com.tavultesoft.kmea.ModelInfoActivity"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Light.Dialog" >
@@ -55,6 +60,7 @@
         Ref https://stackoverflow.com/questions/40650643/timed-out-waiting-on-iinputcontextcallback-with-custom-keyboard-on-android -->
         <activity
             android:name="com.tavultesoft.kmea.KMHelpFileActivity"
+            android:exported="true"
             android:process=":KMHelpFileActivity"
             android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample1"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize" >
             <intent-filter>

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample2"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
         <service
             android:name="com.keyman.kmsample2.SystemKeyboard"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:permission="android.permission.BIND_INPUT_METHOD" >
             <intent-filter>
@@ -23,6 +24,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize" >
             <intent-filter>

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         // VERSION_CODE and VERSION_NAME from version.gradle
         versionCode VERSION_CODE as Integer

--- a/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
+++ b/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize" >
             <intent-filter>

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId "com.firstvoices.keyboards"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
 
         // VERSION_CODE and VERSION_NAME from version.gradle
         versionCode VERSION_CODE as Integer

--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
 
         <service
             android:name="com.firstvoices.keyboards.SystemKeyboard"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:permission="android.permission.BIND_INPUT_METHOD" >
             <intent-filter>
@@ -42,6 +43,7 @@
 
         <activity
             android:name="com.firstvoices.keyboards.MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:configChanges="orientation|screenSize">
             <intent-filter>


### PR DESCRIPTION
Fixes #7745 
Normally these updates are done at the start of alpha development, but the Play Store blocked the latest build
> "Your app currently targets API level 30 and must target at least API level 31."

This updates the Gradle files to use SDK version 31, which involves some AndroidManifest.xml changes involving
https://developer.android.com/about/versions/12/behavior-changes-12#exported
* Activities, services, and broadcast receivers that use intent filters require the attribute: `android:exported="true|false"`
* Only updating androidx.test.ext:junit dependency to 1.1.3 (fixes those "exported" calls in the merged manifest)

## User Testing
Setup - Install PR build of Keyman for Android on an Android emulator/device of Android 12 (SDK version 31)

* **TEST_KEYMAN_FUNCTIONALITY** - Verifies Keyman can download keyboards and be used as system keyboard
1. Launch Keyman
2. On the "Get Started" menu, add a keyboard for your language from keyman.com
3. Search for and install the "khmer_angkor" keyboard package
4. Verify the khmer_angkor keyboard successfully installs (along with the dictionary)
5. Go to Keyman Settings --> "Get Started" --> enable Keyman as system-wide keyboard and set Keyman as default keyboard
6. Dismiss the "Get Started" menu
7. Launch the Chrome browser app and click on the search box
8. Set the Keyboard to Keyman
9. Verify the Keyman OSK appears and that you can type with it.
