### PR TITLE
fix(mac): Enable right-alt/option key mapping

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
@@ -78,7 +78,7 @@
   } else {
     // set completionHandler to be called after privacyDialog is dismissed
     _completionHandler = withCompletionHandler;
-   NSLog(@"do not have Accessibility, present Privacy Dialog");
+    NSLog(@"do not have Accessibility, present Privacy Dialog");
     [self showPrivacyDialog];
   }
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
@@ -62,7 +62,6 @@
  */
 - (void)requestPrivacyAccess:(void (^)(void))withCompletionHandler
 {
-  _completionHandler = withCompletionHandler;
   BOOL hasAccessibility = NO;
   
   // check if we already have accessibility
@@ -74,8 +73,12 @@
   
   if (hasAccessibility) {
     NSLog(@"already have Accessibility: no need to make request.");
+    // call completionHandler immediately -> privacyDialog will not be presented
+    withCompletionHandler();
   } else {
-    NSLog(@"do not have Accessibility, present Privacy Dialog");
+    // set completionHandler to be called after privacyDialog is dismissed
+    _completionHandler = withCompletionHandler;
+   NSLog(@"do not have Accessibility, present Privacy Dialog");
     [self showPrivacyDialog];
   }
 }


### PR DESCRIPTION
Fixes #7476 

When typing the right option key (Mac equivalent for the Alt key) ensure that it produces the correct character for the active Keyman keyboard.

# User Testing

* **TEST_RIGHT_ALT:** - Verify that the right option key with Keyman for Mac produces the correct character

1. Remove old version of Keyman **after** first removing its permissions from Security & Privacy > Privacy > Accessibility
2. Install the Keyman build for this PR
3. Restart the system
4. Select Keyman from the system input source menu
5. Enable privacy settings as prompted
6. Restart the system (again)
7. Install the Khmer Angkor keyboard 
8. Switch to a text editor like TextEdit or Pages
9. With Keyman running, hold down the right option key and type the K key
10. Verify that the character ឝ is emitted

* **TEST_RIGHT_ALT_SHIFT:** - Verify that the right option key + shift with Keyman for Mac produces the correct character

1. Switch to a text editor like TextEdit or Pages
2. With Keyman running with the Khmer Angkor keyboard, hold down right option and shift keys and type the K key
3. Verify that the character ᧳ is emitted


